### PR TITLE
fix(dashboard): admit 'wasm-unsafe-eval' in the CSP for shiki-wasm highlighting

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -702,7 +702,17 @@ _BASE_CSP = (
     # imports are blocked no matter what the per-app srcdoc <meta> CSP says
     # (when two policies apply, the most restrictive wins per directive).
     # Same pattern as the widget CDN allowances (tailwind/jsdelivr/cdnjs).
-    "script-src 'self' 'unsafe-inline' "
+    # 'wasm-unsafe-eval': the Pierre highlight workers tokenize with the
+    # shiki-wasm engine (website/src/pierre/config.ts, PIERRE_REGEX_ENGINE —
+    # chosen there because the JS engine has no backtracking ceiling and a
+    # pathological grammar match kills the renderer as a cage OOM).
+    # WebAssembly.compile/instantiate requires this source expression in the
+    # executing context's script-src, and a same-origin worker takes its CSP
+    # from its own script RESPONSE — this header — not from the document that
+    # spawned it. Without it the tokenizer worker's WASM instantiation is
+    # refused and every diff surface dies on first highlight. It permits ONLY
+    # WebAssembly compilation, never JS eval ('unsafe-eval' stays out).
+    "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' "
     "https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com "
     "https://esm.sh; "
     # https://fonts.googleapis.com + https://fonts.gstatic.com: index.html loads

--- a/test/test_dashboard_security_headers.py
+++ b/test/test_dashboard_security_headers.py
@@ -123,6 +123,22 @@ class TestApplySecurityHeaders:
         assert "http://*.localhost:*" not in csp
         assert "frame-ancestors 'self'" in csp
 
+    def test_csp_script_src_admits_wasm_but_not_eval(self) -> None:
+        """The Pierre highlight workers tokenize with the shiki-wasm engine
+        (website/src/pierre/config.ts, PIERRE_REGEX_ENGINE), and a same-origin
+        worker takes its CSP from its own script response — this header.
+        WebAssembly.instantiate needs 'wasm-unsafe-eval' in script-src or the
+        tokenizer worker dies on first highlight and every diff surface
+        unmounts. The expression admits ONLY WASM compilation: JS eval stays
+        banned, which the second assertion pins so a future edit cannot
+        silently widen this into 'unsafe-eval'."""
+        resp = _make_response()
+        _apply_security_headers(resp, _make_app(with_instances=False))
+        csp = resp.headers["Content-Security-Policy"]
+        script_src = next(d for d in csp.split(";") if d.strip().startswith("script-src"))
+        assert "'wasm-unsafe-eval'" in script_src
+        assert "'unsafe-eval'" not in script_src.replace("'wasm-unsafe-eval'", "")
+
     def test_csp_connect_src_allows_loopback_liveness_probe(self) -> None:
         """WebPreviewPanel polls the framed dev server with a no-cors ``fetch``
         because a cross-origin iframe cannot report that its server died. When


### PR DESCRIPTION
## Problem

The switch of Pierre's highlight workers to the **shiki-wasm** engine (`PIERRE_REGEX_ENGINE` in `website/src/pierre/config.ts`) broke every diff surface: expanding a file in the Changes panel flashes its loading state and then unmounts, for **every provider** (GitHub, GitLab, and downstream-registered ones), on every reload.

That commit's comment reasoned *"both engines are already in the worker bundle, so nothing new is fetched"* — but fetching was never the constraint. **CSP is**: `WebAssembly.compile/instantiate` requires `'wasm-unsafe-eval'` (or `'unsafe-eval'`) in the executing context's `script-src`, and a same-origin worker takes its CSP from **its own script response**, which carries the dashboard's `_BASE_CSP`. That policy had neither expression, so the browser refuses the WASM instantiation inside the tokenizer worker and the highlight pipeline dies on first tokenize.

## Fix

One token: add `'wasm-unsafe-eval'` to `script-src` in `_BASE_CSP`. Per spec it permits **only WebAssembly compilation, never JS `eval`**, and the module being compiled is same-origin bundle content served by this very server. `'unsafe-eval'` stays banned.

## Testing

- Reproduced on a live gateway: worker refused WASM instantiation, diff surface unmounted after the loading flash; with this header change the expanders render highlighted diffs again.
- New regression test `test_csp_script_src_admits_wasm_but_not_eval` pins both facts: `'wasm-unsafe-eval'` present, `'unsafe-eval'` still absent — so a future edit cannot silently widen the allowance.
- `test/test_dashboard_security_headers.py`: 24 passed. `black --check` clean.

No test previously pinned the dashboard `script-src` value (the `test_publish_sync.py` CSP assertions target the separate publish CSP, untouched here).

## Pattern harvest
Rule candidate: pair every runtime-capability switch with its serving policy. The shiki-wasm commit changed what the worker bundle *executes* without checking what the dashboard's CSP *permits* — and a worker takes its CSP from its own script response, so the gap was invisible in local dev servers that send no CSP header. The new regression test (`test_csp_script_src_admits_wasm_but_not_eval`) pins the pairing for this instance; a generalizable check would assert that every source expression a bundled runtime needs (`wasm-unsafe-eval`, `worker-src blob:`, …) is present in `_BASE_CSP`, driven from a small manifest next to `website/src/pierre/config.ts`.

no linked issue: regression found by direct use of a deployed build; no tracking issue was filed before the fix.
