### PR TITLE
fix(chat): use the menu keyboard contract for busy send

### DIFF
--- a/website/src/components/BusySendButton.tsx
+++ b/website/src/components/BusySendButton.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { ArrowUpFromLine, Check, ChevronDown, Target } from 'lucide-react'
-import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
+import { useMenuKeyboard } from '../hooks/useMenuKeyboard'
 import { safeGetItem, safeSetItem } from '../utils/safeStorage'
 
 import { i18nT } from '../i18n/t'
@@ -125,27 +125,16 @@ export default function BusySendButton({
   const splitRef = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
   const caretRef = useRef<HTMLButtonElement>(null)
-  // This menu has no filter input; the ref stays null so useListboxKeyboard
-  // treats ArrowUp from the first option as a no-op instead of a focus jump.
-  const noInputRef = useRef<HTMLElement | null>(null)
 
   const closeToTrigger = useCallback(() => {
     setMenuOpen(false)
     caretRef.current?.focus()
   }, [])
 
-  // Keyboard operability for the portaled menu (WAI-ARIA menu pattern):
-  // focus moves into the first option on open, ArrowUp/Down + Home/End roam,
-  // Escape/Tab close and return focus to the caret trigger.
-  const { onListKeyDown } = useListboxKeyboard({
-    open: menuOpen,
-    dropdownRef: menuRef,
-    inputRef: noInputRef,
-    hasFilterInput: false,
-    filteredCount: BUSY_SEND_MODES.length,
-    onEnterSingleMatch: () => {},
-    closeToTrigger,
-  })
+  // The portaled picker advertises role="menu", so it uses the shared menu
+  // contract: arrows wrap, Home/End jump, and Tab stays within the open rows.
+  // Escape remains host-owned because closing must restore the caret trigger.
+  useMenuKeyboard({ enabled: menuOpen, containerRef: menuRef })
 
   useEffect(() => {
     if (!menuOpen) return
@@ -202,7 +191,13 @@ export default function BusySendButton({
         <div
           ref={menuRef}
           role="menu"
-          onKeyDown={onListKeyDown}
+          tabIndex={-1}
+          onKeyDown={event => {
+            if (event.key !== 'Escape') return
+            event.preventDefault()
+            event.stopPropagation()
+            closeToTrigger()
+          }}
           className="fixed w-[250px] rounded-xl bg-bg-elevated border border-border shadow-xl p-1.5 animate-slide-up z-[60]"
           style={{ left: Math.max(8, Math.min(menuRect.right - 250, window.innerWidth - 250 - 8)), bottom: window.innerHeight - menuRect.top + 8 }}
         >

--- a/website/src/test/BusySendButton.menuKeyboard.test.tsx
+++ b/website/src/test/BusySendButton.menuKeyboard.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import BusySendButton from '../components/BusySendButton'
+
+function renderButton() {
+  render(
+    <BusySendButton
+      mode="steer"
+      onModeChange={vi.fn()}
+      onFire={vi.fn()}
+    />,
+  )
+}
+
+async function openMenu() {
+  renderButton()
+  const trigger = screen.getByTestId('busy-send-caret')
+  fireEvent.click(trigger)
+  const menu = await screen.findByRole('menu')
+  const rows = screen.getAllByRole('menuitemradio')
+  await waitFor(() => expect(rows[0]).toHaveFocus())
+  return { menu, rows, trigger }
+}
+
+describe('BusySendButton menu keyboard contract', () => {
+  it('wraps ArrowUp from the first row to the last row', async () => {
+    const { rows } = await openMenu()
+
+    rows[0].focus()
+    fireEvent.keyDown(rows[0], { key: 'ArrowUp' })
+
+    expect(rows[1]).toHaveFocus()
+  })
+
+  it('contains Tab inside the open menu', async () => {
+    const { menu, rows } = await openMenu()
+
+    rows[1].focus()
+    fireEvent.keyDown(rows[1], { key: 'Tab' })
+
+    expect(screen.getByRole('menu')).toBe(menu)
+    expect(rows[0]).toHaveFocus()
+
+    fireEvent.keyDown(rows[0], { key: 'Tab', shiftKey: true })
+
+    expect(screen.getByRole('menu')).toBe(menu)
+    expect(rows[1]).toHaveFocus()
+  })
+
+  it('closes on Escape and restores focus to the trigger', async () => {
+    const { rows, trigger } = await openMenu()
+
+    fireEvent.keyDown(rows[0], { key: 'Escape' })
+
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(trigger).toHaveFocus()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The busy-send picker declares `role="menu"`, but it is wired through the
listbox keyboard hook. That gives it listbox behavior: ArrowUp clamps at the
first row and Tab closes the picker. Other menu surfaces use the shared menu
contract, where arrows wrap and Tab stays within the open menu.

## Why it matters

Keyboard and assistive-technology users are told this is a menu, then receive a
different navigation model. At the first row ArrowUp appears broken, and Tab
dismisses the picker instead of cycling through its two choices.

## What changed (motivation → approach → change)

The picker now uses the existing `useMenuKeyboard` hook. That supplies the
repository's one `role="menu"` contract: focus enters on open, arrows wrap,
Home/End select the boundaries, Tab and Shift-Tab remain contained, and the
document-level IME latch protects navigation keys.

Escape remains owned by `BusySendButton`, because this host must close the
portal and restore focus to its caret trigger. Selection, portal positioning,
outside-click dismissal, and the persisted busy-send mode are unchanged.

## Tests

- Added `BusySendButton.menuKeyboard.test.tsx` for ArrowUp wrap, bidirectional
  Tab containment while the menu remains open, and Escape focus restoration.
- Red on the old implementation: 2 failed, 1 passed (ArrowUp clamped; Tab
  closed the menu).
- Green after the fix: 3 passed.
- Relevant focused set: 24 passed across the new test, the busy-send slot-scope
  tests, and the shared menu-hook tests.
- Exact-file ESLint: clean.
- `tsc -b` was attempted with the reused local dependency tree; that tree lacks
  the `yaml` package and reports only untouched `SkillForm.tsx` diagnostics.
  Authoritative CI will run against the lockfile-complete install.
- Full repository suites run: 0.

## Manual verification

N/A — real-DOM focus assertions exercise every changed keyboard transition,
including the portaled menu and trigger focus restoration.

## Screenshots / video

<!-- no-visual-delta -->
No pixel or layout changes. The delta is keyboard focus behavior inside the
existing two-row picker, which a still image cannot demonstrate; the focused
DOM tests record the transitions directly.

## Related Issues

Follow-up to the accepted-and-deferred `BusySendButton` menu adoption noted by
the First Principles review on merged PR #6547.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a `role="menu"` surface must use `useMenuKeyboard` or document why its
host-specific keyboard contract differs.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — the shared menu hook already owns this contract)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
