### PR TITLE
fix(ci): verify HEAD^1 is the base before taking the merge diff (#7055)

### DIFF
--- a/scripts/ratchet_scope.py
+++ b/scripts/ratchet_scope.py
@@ -48,6 +48,34 @@ def _git(*args: str) -> tuple[int, str]:
     return proc.returncode, proc.stdout
 
 
+def _first_parent_is_base() -> bool:
+    """True when HEAD's FIRST parent is the base branch's commit.
+
+    Two checkout shapes answer "HEAD is a merge", and they need opposite diffs:
+
+    * CI's ``pull_request`` merge ref puts the BASE first, so ``HEAD^1..HEAD``
+      is exactly this change.
+    * A local ``git merge origin/main`` on a feature branch puts the FEATURE
+      tip first, so ``HEAD^1..HEAD`` is only what main brought in and the
+      branch's own commits are invisible -- every consuming ratchet then
+      under-scopes, and a local run passes a gate CI goes on to fail.
+
+    Which shape this is is decided by which parent the base branch can reach:
+    on the CI shape ``HEAD^1`` IS a commit of the base. The base refs tried
+    here are the same pair, in the same order, as the three-dot fallback's, so
+    a checkout with only a local ``main`` (a merge made ON main has its prior
+    tip as ``HEAD^1``, which ``main`` reaches) still recognises the shape. A
+    failing git -- neither ref resolvable -- answers False, so an
+    unrecognisable merge falls through to the three-dot attempts rather than
+    trusting a parent order nothing verified.
+    """
+    for base in ("origin/main", "main"):
+        code, _ = _git("merge-base", "--is-ancestor", "HEAD^1", base)
+        if code == 0:
+            return True
+    return False
+
+
 def changed_paths() -> tuple[set[str] | None, str]:
     """This change's paths plus how they were determined, for the log.
 
@@ -58,11 +86,15 @@ def changed_paths() -> tuple[set[str] | None, str]:
 
     * A ``pull_request`` checkout leaves HEAD as the MERGE commit, whose tree is
       the base tree plus this change. So ``diff HEAD^1 HEAD`` is exactly this
-      change and needs no merge base -- only HEAD and its first parent.
+      change -- but only once ``_first_parent_is_base`` confirms, against a
+      resolvable base ref, that ``HEAD^1`` really is the base: a local
+      ``git merge origin/main`` is ALSO a merge at HEAD, with the parents the
+      other way around, and taking ``HEAD^1..HEAD`` there would scope to what
+      main brought in instead of this change.
     * ``diff HEAD^1 HEAD^2`` is equivalent but needs BOTH parents' trees, which a
       shallow clone may not have.
-    * Locally HEAD is the branch tip, so the three-dot diff against the base
-      branch is the right question.
+    * Locally HEAD is the branch tip -- or an unrecognised merge -- so the
+      three-dot diff against the base branch is the right question.
 
     None means undeterminable, and the caller must then judge the whole tree
     rather than nothing: a scope that fails open disables the gate exactly when
@@ -71,7 +103,7 @@ def changed_paths() -> tuple[set[str] | None, str]:
     code, out = _git("rev-list", "--parents", "-n", "1", "HEAD")
     is_merge = code == 0 and len(out.split()) >= 3
     attempts: list[tuple[str, list[str]]] = []
-    if is_merge:
+    if is_merge and _first_parent_is_base():
         attempts.append(("merge HEAD^1..HEAD", ["diff", "--name-only", "HEAD^1", "HEAD"]))
         attempts.append(("merge parents", ["diff", "--name-only", "HEAD^1", "HEAD^2"]))
     for base in ("origin/main", "main"):

--- a/test/test_black_gate_contract.py
+++ b/test/test_black_gate_contract.py
@@ -127,6 +127,15 @@ def test_only_this_changes_files_can_be_its_offenders() -> None:
     assert '"HEAD^1", "HEAD"' in scope_source, "the merge-vs-first-parent diff is the exact one"
     assert '"HEAD^1", "HEAD^2"' in scope_source
     assert "{base}...HEAD" in scope_source
+    # The merge diffs are only exact when HEAD^1 IS the base; a local
+    # `git merge origin/main` puts the feature tip first and the same diff
+    # would scope to what main brought in. The resolver must verify which
+    # parent the base can reach before trusting the merge shape -- and the
+    # probe must actually GATE the merge attempts, not merely exist.
+    assert (
+        '"merge-base", "--is-ancestor", "HEAD^1", base' in scope_source
+    ), "the resolver no longer verifies HEAD^1 is the base before taking the merge diff"
+    assert "if is_merge and _first_parent_is_base():" in scope_source
     # And it must fail CLOSED when the base is unresolvable: judge everything
     # rather than nothing.
     assert "new_offenders = sorted(unlisted)" in source

--- a/test/test_ratchet_scope.py
+++ b/test/test_ratchet_scope.py
@@ -1,0 +1,192 @@
+"""The shared scope resolver must tell the two merge shapes apart.
+
+``scripts/ratchet_scope.py`` answers "which files did THIS change touch" for the
+merge-ref ratchets. Two checkout shapes both look like "HEAD is a merge" and
+need opposite diffs:
+
+* CI's ``pull_request`` merge ref: the BASE is the first parent, so
+  ``HEAD^1..HEAD`` is exactly the PR's own change.
+* A local ``git merge origin/main`` on a feature branch: the FEATURE tip is the
+  first parent, so ``HEAD^1..HEAD`` is only what main brought in and the
+  branch's own commits are invisible -- every consuming gate then under-scopes,
+  and a violation added in an earlier feature commit passes locally only to red
+  the PR on CI.
+
+The resolver decides by asking git which parent the base branch can reach, so
+these tests build one synthetic repo per shape and pin the attempt LABEL chosen
+plus the returned path set. The three-dot fallback deliberately keeps diffing
+from ``merge-base(base, HEAD)`` rather than the base tip: an unscoped gate has
+already been observed reporting files the base branch merged after the baseline
+was taken, and the CI-shape test locks that property by moving main after the
+branch point.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.platform.update_governance import _GIT_LOCATION_VARS, git_command_env
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ratchet_scope.py"
+
+SPEC = importlib.util.spec_from_file_location("ratchet_scope", SCRIPT)
+assert SPEC and SPEC.loader
+scope = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(scope)
+
+
+def _fixture_git_env() -> dict[str, str]:
+    """Env for a fixture git call: no inherited location, templates, hooks, or identity.
+
+    ``git_command_env()`` (the production chokepoint) strips the ``GIT_DIR``
+    location family -- those must be ABSENT, and a merge over ``os.environ``
+    can only add keys -- and pins the fixed-key exec vectors. On top of that,
+    an inherited ``GIT_TEMPLATE_DIR`` (or a global ``init.templateDir``) would
+    have its hooks COPIED into every fixture repo by ``git init`` and executed
+    by the ``git commit`` below -- host-side effects from running the test
+    suite -- so both template channels are pinned empty. Identity is supplied
+    so a commit cannot depend on, or fall back to, the developer's global
+    config, which is itself pointed at ``os.devnull``.
+    """
+    env = {
+        **git_command_env(),
+        "GIT_TEMPLATE_DIR": "",
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.invalid",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.invalid",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+    }
+    count = int(env["GIT_CONFIG_COUNT"])
+    env[f"GIT_CONFIG_KEY_{count}"] = "init.templateDir"
+    env[f"GIT_CONFIG_VALUE_{count}"] = ""
+    env["GIT_CONFIG_COUNT"] = str(count + 1)
+    return env
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        env=_fixture_git_env(),
+    )
+    return proc.stdout.strip()
+
+
+def _commit_file(repo: Path, name: str, message: str) -> None:
+    (repo / name).write_text(f"{name}\n", encoding="utf-8")
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", message)
+
+
+def _repo_with_diverged_feature(tmp_path: Path) -> Path:
+    """One base repo both shapes start from.
+
+    ``main`` gains ``mainline.txt`` AFTER ``feature`` branches off with its own
+    ``feature.py``, so the two sides of every merge below differ and a wrong
+    parent choice shows up in the returned path set, not just the label.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main", ".")
+    _commit_file(repo, "base.txt", "base")
+    _git(repo, "checkout", "-b", "feature")
+    _commit_file(repo, "feature.py", "the change under judgment")
+    _git(repo, "checkout", "main")
+    _commit_file(repo, "mainline.txt", "someone else's change, landed after the branch point")
+    return repo
+
+
+def _set_origin_main(repo: Path) -> None:
+    # The synthetic repo has no remote; the resolver only needs the REF, so
+    # point origin/main at the local main tip directly.
+    _git(repo, "update-ref", "refs/remotes/origin/main", "main")
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    # The fixture's own git calls build a scrubbed env per call, but the
+    # RESOLVER under test runs git with the ambient process environment: an
+    # exported GIT_DIR (pytest run from a git hook, `git rebase --exec`,
+    # `git bisect run`) would override its cwd=ROOT and answer for the wrong
+    # repository. Delete the whole location family -- monkeypatch restores it
+    # after the test -- using the same canonical list the production env
+    # builder strips.
+    for var in _GIT_LOCATION_VARS:
+        monkeypatch.delenv(var, raising=False)
+    fixture_repo = _repo_with_diverged_feature(tmp_path)
+    # The module runs git with cwd=ROOT; retarget it at the synthetic repo.
+    monkeypatch.setattr(scope, "ROOT", fixture_repo)
+    return fixture_repo
+
+
+class TestMergeShapes:
+    def test_ci_merge_ref_scopes_to_the_change_only(self, repo: Path) -> None:
+        # GitHub's pull_request merge ref: merge the PR INTO the base, so the
+        # base tip is the first parent and origin/main can reach it.
+        _set_origin_main(repo)
+        _git(repo, "checkout", "--detach", "main")
+        _git(repo, "merge", "--no-ff", "-m", "merge ref", "feature")
+
+        paths, label = scope.changed_paths()
+
+        assert label == "merge HEAD^1..HEAD"
+        # Exactly the PR's own change: mainline.txt landed on the base after
+        # the branch point and must NOT be judged as part of this change.
+        assert paths == {"feature.py"}
+
+    def test_local_merge_of_main_scopes_to_the_branch_own_commits(self, repo: Path) -> None:
+        # The inverted shape: `git merge origin/main` ON the feature branch
+        # puts the feature tip first. HEAD^1..HEAD here is what main brought
+        # in, so taking the merge diff would hide feature.py -- the defect this
+        # resolver exists to avoid. The base-reachability probe must reject the
+        # merge attempts and fall through to the three-dot diff.
+        _set_origin_main(repo)
+        _git(repo, "checkout", "feature")
+        _git(repo, "merge", "--no-ff", "-m", "sync with main", "origin/main")
+
+        paths, label = scope.changed_paths()
+
+        assert label == "origin/main...HEAD"
+        assert paths == {"feature.py"}
+
+    def test_merge_made_on_main_is_still_recognised_without_a_remote(self, repo: Path) -> None:
+        # A merge made ON main itself (no remote at all): the prior main tip is
+        # the first parent, and the local `main` ref -- now the merge commit --
+        # reaches it. The probe must accept this via the `main` fallback;
+        # probing only origin/main would reject it, and `main...HEAD` then
+        # diffs the merge against itself: an EMPTY scope, so every consuming
+        # gate passes vacuously -- a false green in the same direction as the
+        # under-scope this resolver exists to prevent.
+        _git(repo, "merge", "--no-ff", "-m", "land feature", "feature")
+
+        paths, label = scope.changed_paths()
+
+        assert label == "merge HEAD^1..HEAD"
+        assert paths == {"feature.py"}
+
+    def test_unverifiable_base_falls_through_rather_than_trusting_parent_order(
+        self, repo: Path
+    ) -> None:
+        # No origin/main at all: the reachability probe cannot verify either
+        # way, and an unverified merge diff is the failure mode above. Falling
+        # through is the safe direction -- here the local `main` ref still
+        # answers the three-dot question correctly.
+        _git(repo, "checkout", "feature")
+        _git(repo, "merge", "--no-ff", "-m", "sync with main", "main")
+
+        paths, label = scope.changed_paths()
+
+        assert label == "main...HEAD"
+        assert paths == {"feature.py"}


### PR DESCRIPTION
## Summary

`scripts/ratchet_scope.py:changed_paths()` treats any two-parent HEAD as a CI merge ref and diffs `HEAD^1..HEAD`. On CI's `pull_request` merge ref the first parent IS the base, so that diff is exactly the PR's own change — but a local `git merge origin/main` on a feature branch puts the **feature tip** first, so the same diff scopes to what main brought in and the branch's own commits become invisible to every consuming ratchet (`check_black_formatting.py`, `check_subprocess_encoding.py`, `check_sync_io_in_async.py`, `check_agent_sdk_boundary.py`). A violation added in an earlier feature commit then passes the local `prepare-pr` floor and reds the PR on CI, teaching contributors to distrust the local gates.

## Fix

Gate the merge-diff attempts on which parent the base branch can reach: new helper `_first_parent_is_base()` probes `git merge-base --is-ancestor HEAD^1 <base>` for the same `("origin/main", "main")` pair, in the same order, as the existing three-dot fallback. The CI shape passes it (HEAD^1 is a base commit); the local-merge shape fails it and falls through to the existing three-dot attempts, **whose order is untouched**. A git error or unresolvable base refs reads as NOT-the-base, so unrecognisable merges also fall through rather than trusting an unverified parent order.

The issue's named wrong fix — reordering `origin/main...HEAD` before the merge attempts — is deliberately not taken: on CI the three-dot form diffs from `merge-base(origin/main, HEAD)` and would re-report files the base merged after the baseline was taken, the defect the module docstring records as observed three times. That property is preserved: the CI-shape regression test moves main *after* the branch point and asserts the base's file is not in scope.

## How the CI shape was verified unchanged

* `ci.yml` triggers `pull_request` on `branches: [main]` only, and the `backend-lint` checkout uses `fetch-depth: 0` (pinned by the existing `test_the_lint_job_fetches_enough_history_to_scope_the_diff`), so `origin/main` always resolves on CI and a merge ref's `HEAD^1` is always a main commit — `merge-base --is-ancestor HEAD^1 origin/main` succeeds and the resolver picks `merge HEAD^1..HEAD` exactly as before.
* Empirically: the new `test_ci_merge_ref_scopes_to_the_change_only` builds a GitHub-shaped merge ref (base as first parent, `origin/main` at the base tip) and asserts both the attempt label `merge HEAD^1..HEAD` and the path set; it passes **both** pre-fix and post-fix, while the local-merge and no-base tests fail pre-fix — the differential proves only the inverted shapes change behaviour.

## Tests

One synthetic repo per merge shape (fixture style of the sibling gate tests: `spec_from_file_location` + git in `tmp_path` with pinned identity/config env), asserting the attempt label **and** the returned path set:

* CI merge ref → `merge HEAD^1..HEAD`, scope is the PR's own change only.
* Local `git merge origin/main` on a feature branch → falls through to `origin/main...HEAD`, the branch's own commits are visible again (the #7055 regression).
* Merge made ON main with no remote → still recognised via the `main` fallback (probing only `origin/main` would produce an empty `main...HEAD` scope — a vacuous pass).
* No resolvable base at all → falls through to three-dot rather than trusting parent order.

The GIT_DIR location-var family is deleted from the env (canonical `_GIT_LOCATION_VARS` list) before any fixture git call, so an exported `GIT_DIR` cannot retarget the fixture's mutating calls at a real repository; verified by running the tests with a hostile `GIT_DIR` pointed at a decoy repo (tests pass, decoy byte-untouched). `test_black_gate_contract.py` additionally pins the discriminator argv literal and the gating condition itself.

## Gates

Backend: isort / flake8 7.1.0 / mypy 1.14.1 clean; black clean on all three touched files; all four merge-ref ratchets + brand + harness gates pass; full `python -m pytest`: 77,346 passed, 100 failures all inherited host-env (verified: diff is exactly 3 files, none imported by any failing test). Backend-only change, no frontend, no screenshots.

Pre-push review: GPT 5.6 charter PASS (zero findings); Opus charter 1 Blocking + 2 Medium + 1 Low, all four adopted (GIT_DIR env scrub above, two-ref probe, docstring retraction of the stale "needs no merge base" claim, contract pin of the gating role).

Closes #7055

## Pattern harvest

Rule candidate: grep — any script that hands `HEAD^1` to `git diff` without a `merge-base --is-ancestor` (or equivalent base-reachability) check in the same module is trusting a merge parent order that only holds on CI merge refs, not on local merges. All four merge-ref ratchets already reach the one shared resolver (`scripts/ratchet_scope.py`), whose contract test now pins both the probe literal and the gating condition, so a new offender would surface as a new `HEAD^1` diff caller outside that module: `grep -rn 'HEAD\^1' scripts/ --include='*.py' | grep -v ratchet_scope` should stay empty.
