### PR TITLE
fix(tailnet): model a stopped daemon as not usable (#7244)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -115,9 +115,11 @@ def _derive_step(
     1. ``pinned`` — an administrator's ceiling forbids tailnet access. Dead end;
        nothing below is actionable, and offering a toggle would be a lie.
     2. ``install`` / ``start_daemon`` / ``sign_in`` / ``enable_magicdns`` — the
-       four ways there is no usable tailnet name, kept apart because "install
-       Tailscale", "start it", "sign in" and "turn MagicDNS on" are four
-       different errands.
+       ways there is no usable tailnet name, kept apart because "install
+       Tailscale", "start it", "sign in" and "turn MagicDNS on" are different
+       errands. ``start_daemon`` covers both a daemon that does not answer and
+       one that answers as stopped (``BackendState "Stopped"``): the errand is
+       the same, and the verbatim probe detail tells the two apart.
     3. ``enable_https`` — the name exists but the tailnet has not granted
        certificate provisioning for it. This is a tailnet-wide administrator
        consent and cannot safely be performed by a gateway process.
@@ -140,6 +142,15 @@ def _derive_step(
     if not probe.installed:
         return "install"
     if not probe.reachable:
+        return "start_daemon"
+    # A stopped daemon (``BackendState "Stopped"``) answers status reads but the
+    # tailnet is down: nothing can reach this host and serve writes cannot take
+    # effect, so every later branch — including ``ready`` — would be a lie. Same
+    # errand as an unreachable daemon (get Tailscale running), so it reuses that
+    # step; the card renders the probe's detail, which names the stopped state
+    # precisely. The step's "no tailnet name" copy holds because ``probe_daemon``
+    # always returns ``name=""`` for the Stopped state.
+    if probe.stopped:
         return "start_daemon"
     if not probe.logged_in:
         return "sign_in"

--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -327,11 +327,13 @@ class DaemonProbe:
     Exists because :func:`self_dns_name` deliberately collapses every failure to
     ``None`` — right for its caller (which only wants "a name or nothing") and
     useless for an onboarding UI, which has to tell the operator WHICH thing to
-    go fix. The three negatives have three different remedies and must not be
+    go fix. These negatives have different remedies and must not be
     rendered as one "Tailscale not working":
 
     * ``installed=False`` — install Tailscale.
     * ``reachable=False`` — the daemon is not answering; start it.
+    * ``stopped=True`` — the daemon answers but Tailscale is stopped
+      (``BackendState "Stopped"``, e.g. after ``tailscale down``); bring it up.
     * ``logged_in=False`` — signed out; sign in.
     * all true but ``name=""`` — signed in, but MagicDNS is off for the tailnet.
     * ``https_enabled=False`` — the tailnet has not granted certificate
@@ -353,6 +355,12 @@ class DaemonProbe:
     reachable: bool
     logged_in: bool
     detail: str
+    #: ``BackendState "Stopped"``: the daemon answered but Tailscale is stopped,
+    #: so the tailnet is unreachable and nothing can be published or withdrawn.
+    #: A separate field rather than a ``_BACKEND_STATES_NEEDING_LOGIN`` entry
+    #: because the remedy differs — start Tailscale, not sign in — and folding it
+    #: into ``reachable`` would misname the state: the daemon IS answering.
+    stopped: bool = False
     #: Login owning this machine, validated from ``Self.UserID`` -> ``User``.
     #: Kept server-side; the status API does not expose it to the renderer.
     login: str = ""
@@ -410,6 +418,21 @@ def probe_daemon() -> DaemonProbe:
             detail="Tailscale is installed, but its daemon did not answer.",
         )
     backend_state = status.get("BackendState")
+    # "Stopped" is the daemon running with Tailscale down (`tailscale down`), so
+    # it passes the needing-login test below — the machine may well still be
+    # signed in — while nothing on the tailnet can reach this host and no serve
+    # write can take effect. Modeled as its own state, checked first, because a
+    # stopped daemon blocks everything the later branches would send the
+    # operator to fix.
+    if backend_state == "Stopped":
+        return DaemonProbe(
+            name="",
+            installed=True,
+            reachable=True,
+            logged_in=True,
+            detail="Tailscale is stopped, so this machine is not connected to its tailnet.",
+            stopped=True,
+        )
     logged_in = not (
         isinstance(backend_state, str) and backend_state in _BACKEND_STATES_NEEDING_LOGIN
     )

--- a/src/kiro_crew/dashboard/tailnet_serve.py
+++ b/src/kiro_crew/dashboard/tailnet_serve.py
@@ -247,7 +247,18 @@ def _classify(output: str) -> ResultCode:
         return "no_permission"
     if any(
         s in low
-        for s in ("not running", "cannot connect", "connection refused", "logged out", "not logged in")
+        for s in (
+            "not running",
+            "cannot connect",
+            "connection refused",
+            "logged out",
+            "not logged in",
+            # `tailscale serve` against a stopped daemon (`tailscale down`)
+            # fails with exactly "Tailscale is stopped." (issue #7244). The
+            # needle keeps the product name so an unrelated message that merely
+            # ends "... is stopped" is not handed the start-Tailscale remedy.
+            "tailscale is stopped",
+        )
     ):
         return "daemon_unavailable"
     return "failed"
@@ -649,7 +660,25 @@ def unpublish(port: int, *, audit_tool: str = "tailnet_unpublish") -> ServeResul
     if rc != 0:
         said = _daemon_output(out=out, err=err)
         code = _classify(err.strip() or out.strip())
-        return ServeResult(False, code, said or f"tailscale serve exited {rc}")
+        # Mirrors the publish path's hint branch. It matters more here: a failed
+        # withdrawal's verbatim output can read like a status line ("Tailscale
+        # is stopped.") rather than like a failure, so without the appended hint
+        # the operator has no way to tell that nothing was withdrawn (issue
+        # #7244). Hints are appended to — never replace — the daemon's words.
+        hint = ""
+        if code == "no_permission":
+            hint = (
+                " Nothing was withdrawn. Changing serve configuration needs root "
+                "or a standing grant: try `sudo tailscale serve …`, or grant this "
+                "user once with `sudo tailscale set --operator=$USER`."
+            )
+        elif code == "daemon_unavailable":
+            hint = (
+                " Nothing was withdrawn. Check `tailscale status`; the daemon may "
+                "be stopped or logged out — bring Tailscale back up, then turn "
+                "this off again."
+            )
+        return ServeResult(False, code, (said or f"tailscale serve exited {rc}") + hint)
     return ServeResult(
         True, "ok", "The dashboard is no longer published on this machine's tailnet."
     )

--- a/test/test_tailnet_mobile.py
+++ b/test/test_tailnet_mobile.py
@@ -80,6 +80,7 @@ def _probe(
     logged_in: bool = True,
     https_enabled: bool | None = True,
     detail: str = "",
+    stopped: bool = False,
 ) -> DaemonProbe:
     return DaemonProbe(
         name=name,
@@ -88,6 +89,7 @@ def _probe(
         logged_in=logged_in,
         detail=detail,
         login=login,
+        stopped=stopped,
         https_enabled=https_enabled,
     )
 
@@ -136,6 +138,38 @@ class TestProbeDistinguishesCauses:
         assert p.reachable is True
         assert p.logged_in is False
         assert p.name == ""
+
+    def test_stopped_backend_state_is_its_own_not_usable_state(self) -> None:
+        """``BackendState "Stopped"`` must not read as healthy (issue #7244).
+
+        A stopped daemon answers status reads and is not in the needing-login
+        set, so before this field it passed every probe check and the flow
+        reported a ready tailnet whose URL nothing could reach. The remedy
+        (start Tailscale) differs from signing in, so it is a distinct signal,
+        not a ``logged_in`` overload.
+        """
+        with (
+            patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"),
+            patch.object(
+                tailnet, "_run_json_detail", return_value=({"BackendState": "Stopped"}, False)
+            ),
+        ):
+            p = tailnet.probe_daemon()
+        assert p.stopped is True
+        assert p.reachable is True  # the daemon DID answer; only Tailscale is down
+        assert p.name == ""
+        assert "stopped" in p.detail.lower()
+
+    def test_running_backend_state_reports_not_stopped(self) -> None:
+        with (
+            patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"),
+            patch.object(
+                tailnet, "_run_json_detail", return_value=({"BackendState": "Running"}, False)
+            ),
+            patch.object(tailnet, "self_dns_name", return_value=_HOST),
+        ):
+            p = tailnet.probe_daemon()
+        assert p.stopped is False
 
     def test_signed_in_without_name_reports_magicdns_gap(self) -> None:
         """Reachable + logged in + no name is the MagicDNS-off case, and it must be
@@ -337,6 +371,16 @@ class TestStepPrecedence:
 
     def test_unreachable_daemon_is_its_own_step(self) -> None:
         assert _step(probe=_probe(name="", reachable=False, logged_in=False)) == "start_daemon"
+
+    def test_stopped_daemon_derives_start_daemon(self) -> None:
+        assert _step(probe=_probe(name="", stopped=True)) == "start_daemon"
+
+    def test_stopped_daemon_is_never_ready(self) -> None:
+        """The issue-#7244 shape: serve status still returns the stale config
+        with exit 0 while the daemon is stopped, so ``published=True`` arrives
+        alongside a stopped probe — and must not derive ``ready`` (the card
+        would show Active for a URL nothing can reach)."""
+        assert _step(probe=_probe(stopped=True), published=True) == "start_daemon"
 
     def test_signed_out_is_its_own_step(self) -> None:
         assert _step(probe=_probe(name="", logged_in=False)) == "sign_in"

--- a/test/test_tailnet_serve.py
+++ b/test/test_tailnet_serve.py
@@ -199,6 +199,9 @@ class TestFailureReporting:
             ("must be run as root", "no_permission"),
             ("tailscaled is not running", "daemon_unavailable"),
             ("cannot connect to local tailscaled", "daemon_unavailable"),
+            # The exact wording a stopped daemon fails with (issue #7244);
+            # previously fell through to generic "failed" and no hint fired.
+            ("Tailscale is stopped.", "daemon_unavailable"),
             ("something nobody predicted", "failed"),
         ],
     )
@@ -626,6 +629,41 @@ class TestWithdrawalSafety:
         result, run = self._unpublish_with_state(ServeState(False, False, "no config"))
         assert result.ok
         run.assert_not_called()
+
+    def _unpublish_write_fails(self, stderr: str):
+        cli, run = _patch_cli(return_value=_proc(returncode=1, stderr=stderr))
+        with cli, run, patch.object(
+            tailnet_serve, "serve_state", return_value=ServeState(True, True, "ours")
+        ):
+            return tailnet_serve.unpublish(_PORT)
+
+    def test_failed_withdrawal_against_stopped_daemon_names_failure_and_remedy(self) -> None:
+        """The issue-#7244 silent failure: the daemon's whole answer is
+        "Tailscale is stopped.", which reads like a status line, so without an
+        appended hint the operator cannot tell that nothing was withdrawn. The
+        verbatim daemon words must survive alongside the hint, never be
+        replaced by it."""
+        result = self._unpublish_write_fails("Tailscale is stopped.")
+        assert not result.ok
+        assert result.code == "daemon_unavailable"
+        assert "Tailscale is stopped." in result.detail
+        assert "Nothing was withdrawn" in result.detail
+        assert "tailscale status" in result.detail
+
+    def test_failed_withdrawal_permission_refusal_names_the_remedy(self) -> None:
+        result = self._unpublish_write_fails("access denied: serve config")
+        assert not result.ok
+        assert result.code == "no_permission"
+        assert "access denied: serve config" in result.detail
+        assert "--operator" in result.detail
+
+    def test_failed_withdrawal_with_unclassified_output_stays_verbatim(self) -> None:
+        """No hint branch fires for an unrecognized failure — the daemon's own
+        words remain the whole answer, unchanged from before the hints."""
+        result = self._unpublish_write_fails("something nobody predicted")
+        assert not result.ok
+        assert result.code == "failed"
+        assert result.detail == "something nobody predicted"
 
 
 class TestPublishedDetection:


### PR DESCRIPTION
## Summary

Tailscale `BackendState "Stopped"` (the state `tailscale down` leaves, distinct from logged out) was not modeled anywhere in the tailnet flow, so a stopped daemon read as healthy end to end:

- `"Stopped"` is not in `_BACKEND_STATES_NEEDING_LOGIN`, so `probe_daemon` returned a healthy-looking probe.
- `tailscale serve status --json` keeps answering the stale serve config with exit 0 while stopped, so `_derive_step` returned `ready` and the Phone access card showed **Active** with a URL nothing could reach, misreading the empty peer list as "no other device has joined".
- A failed **Turn off** printed the daemon's whole answer — `Tailscale is stopped.` — which reads like a status line: `_classify` did not match that wording (so the existing `daemon_unavailable` hint never fired), and the unpublish path had no hint branch at all.

## Changes

1. **`src/kiro_crew/dashboard/tailnet.py`** — `DaemonProbe` gains a distinct `stopped` field, set when `BackendState == "Stopped"`. Deliberately NOT an entry in `_BACKEND_STATES_NEEDING_LOGIN` (that frozenset lists only the not-signed-in half because the remedy differs: start Tailscale, not sign in), and not a `reachable` overload (the daemon IS answering).
2. **`src/kiro_crew/dashboard/handlers/tailnet_mobile.py`** — `_derive_step` returns `start_daemon` while stopped, never `ready`. Reuses the existing step: the errand is the same, the copy already says "make sure it reports Running", the step renders the probe's detail (which names the stopped state), and the peers advisory no longer fires. No frontend or i18n change needed — the card is fully step-driven.
3. **`src/kiro_crew/dashboard/tailnet_serve.py`** — `_classify` matches `"tailscale is stopped"` as `daemon_unavailable` (needle keeps the product name so an unrelated "... is stopped" message is not handed the wrong remedy).
4. **`src/kiro_crew/dashboard/tailnet_serve.py`** — the unpublish failure path gains the hint branch the publish path already had (`daemon_unavailable` / `no_permission`), each stating "Nothing was withdrawn" plus the remedy. Hints are appended to — never replace — the daemon's verbatim words, per the #6583/#6603 contract.

## Notes for reviewers

- While the daemon is stopped the card derives `start_daemon`, so the **Turn off** button (rendered only under `ready`) is not offered — which is correct: withdrawal cannot succeed while the daemon is down, and the old card offered a button that could not work. The new unpublish hint is therefore reached via `kirocrew tailnet down` (CLI prints `result.detail`) or a click racing the card's 30s poll, not via a steady-state UI path.
- Not covered by the #6583/#6603 fix: that rewrote the `TimeoutExpired` path; this is a plain non-zero exit.

## Testing

- 8 new tests: `probe_daemon` on `BackendState "Stopped"` yields the distinct not-usable state; `Running` reports not-stopped; `_derive_step` derives `start_daemon` while stopped and never `ready` even with `published=True` (the exact issue shape); `_classify("Tailscale is stopped.") == "daemon_unavailable"`; unpublish failure carries the verbatim daemon words + hint for both classified codes; unclassified failures stay verbatim with no hint.
- Local gates green: isort, flake8, mypy (1216 files), diff-scoped black gate, `test_tailnet_mobile.py` + `test_tailnet_serve.py` (185 passed). Full backend suite: 98 environment-dependent failures proven pre-existing (identical set fails on clean `main` on this host); zero tailnet-related failures.
- Pre-push blind review: GPT lane PASS (0 findings); Opus lane PASS (0 blocking, 4 advisories — 3 adopted in this commit, the fourth is the reviewer note above).

## Pattern harvest

Rule candidate: review checklist (possibly semgrep on `in _.*_STATES` membership tests)
Pattern: an upstream status enum consumed through a deny-set (`logged_in = state not in _BACKEND_STATES_NEEDING_LOGIN`) treats every unlisted value as healthy — fail-open enum handling. `"Stopped"` fell through exactly this way and the whole downstream flow (`_derive_step`, the card, the QR mint) inherited the false "healthy". A probe classifying an external tool's state should either allowlist the known-good states or model each not-usable state as its own field, so an unknown future enum value degrades to "not ready" rather than to "ready".

no linked issue check: linked below.

Closes #7244
