### PR TITLE
refactor: simplify the width hooks to bare callback refs (#7220)

### DIFF
--- a/website/src/hooks/useColumnCount.ts
+++ b/website/src/hooks/useColumnCount.ts
@@ -5,15 +5,9 @@ import { useState, useMemo, useRef } from 'react'
  *  Only used to seed the column estimate below; the real width is measured. */
 const PAGE_GUTTER = 16
 
-/** Callback ref that also carries `.current`, so it stays assignable where a
- *  `React.RefObject` is expected (e.g. `LibraryMasonry`'s `widthRef` prop) while
- *  React invokes it as a function on attach/detach. */
-export type ColumnCountRef = React.RefCallback<HTMLDivElement> & React.RefObject<HTMLDivElement>
-
-/** Internal spelling of the same shape with a writable `current`. */
-type MutableColumnCountRef = React.RefCallback<HTMLDivElement> & { current: HTMLDivElement | null }
-
-export function useColumnCount(minColWidth = 300): readonly [ColumnCountRef, number] {
+export function useColumnCount(
+  minColWidth = 300,
+): readonly [React.RefCallback<HTMLDivElement>, number] {
   // Seeded from the viewport instead of a constant because the page reads this
   // count to decide WHO OWNS THE SCROLL AXIS: a wrong first value hands the axis
   // over and takes it back a frame later, which reads as a jump. This is only an
@@ -33,30 +27,26 @@ export function useColumnCount(minColWidth = 300): readonly [ColumnCountRef, num
   // to observe. Recreated when `minColWidth` changes: React then detaches the old
   // callback (null) and attaches the new one, which re-measures with the current
   // width — the same re-run the old effect got from its `[minColWidth]` deps.
-  const refFn = useMemo<ColumnCountRef>(() => {
-    const fn: MutableColumnCountRef = Object.assign(
-      (el: HTMLDivElement | null) => {
-        fn.current = el
-        observerRef.current?.disconnect()
-        observerRef.current = null
-        if (!el || typeof ResizeObserver === 'undefined') return
-        // A zero clientWidth means the element has no layout yet (hidden, or a
-        // layout-less test DOM): `floor(0 / minColWidth)` would collapse the
-        // masonry to one column on a width nobody measured. Keep the current
-        // estimate instead; the observer corrects it as soon as a real width
-        // exists.
-        const measure = () => {
-          const w = el.clientWidth
-          if (w > 0) setCols(Math.max(1, Math.floor(w / minColWidth)))
-        }
-        measure()
-        const ro = new ResizeObserver(measure)
-        ro.observe(el)
-        observerRef.current = ro
-      },
-      { current: null as HTMLDivElement | null },
-    )
-    return fn
-  }, [minColWidth])
+  const refFn = useMemo<React.RefCallback<HTMLDivElement>>(
+    () => el => {
+      observerRef.current?.disconnect()
+      observerRef.current = null
+      if (!el || typeof ResizeObserver === 'undefined') return
+      // A zero clientWidth means the element has no layout yet (hidden, or a
+      // layout-less test DOM): `floor(0 / minColWidth)` would collapse the
+      // masonry to one column on a width nobody measured. Keep the current
+      // estimate instead; the observer corrects it as soon as a real width
+      // exists.
+      const measure = () => {
+        const w = el.clientWidth
+        if (w > 0) setCols(Math.max(1, Math.floor(w / minColWidth)))
+      }
+      measure()
+      const ro = new ResizeObserver(measure)
+      ro.observe(el)
+      observerRef.current = ro
+    },
+    [minColWidth],
+  )
   return [refFn, cols] as const
 }

--- a/website/src/hooks/useContainerWidth.ts
+++ b/website/src/hooks/useContainerWidth.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 /**
  * Observe an element's content-box width via ResizeObserver.
@@ -8,23 +8,31 @@ import { useEffect, useRef, useState } from 'react'
  * forever when ResizeObserver is unavailable (older test DOMs) — the caller's
  * null-handling then picks the default layout.
  *
- * The ref is typed as React 18's non-null `RefObject<T>` (via the
- * `useRef<T>(null)` overload) so it is directly assignable to a JSX `ref`
- * prop — `RefObject<T | null>` is not, under @types/react 18.
+ * Returns a CALLBACK ref, for the same reason `useColumnCount` does: an effect
+ * that reads `ref.current` once on mount never observes an element rendered
+ * conditionally (behind query data or a collapsed branch) after that first
+ * commit. The callback runs whenever the element actually mounts or unmounts,
+ * so the observer attaches exactly when there is something to observe and
+ * disconnects when it leaves.
  */
-export function useContainerWidth<T extends HTMLElement>(): [React.RefObject<T>, number | null] {
-  const ref = useRef<T>(null)
+export function useContainerWidth<T extends HTMLElement>(): [React.RefCallback<T>, number | null] {
   const [width, setWidth] = useState<number | null>(null)
+  const observerRef = useRef<ResizeObserver | null>(null)
 
-  useEffect(() => {
-    const el = ref.current
+  const ref = useCallback((el: T | null) => {
+    observerRef.current?.disconnect()
+    observerRef.current = null
     if (!el || typeof ResizeObserver === 'undefined') return
     const ro = new ResizeObserver(entries => {
       const w = entries[0]?.contentRect.width
-      if (typeof w === 'number') setWidth(w)
+      // Zero-width guard: an element attached but not laid out yet (hidden
+      // ancestor, layout-less test DOM) reports 0 — keep the last real
+      // measurement (or the initial null = "assume wide") rather than
+      // switching layouts on a width nobody rendered.
+      if (typeof w === 'number' && w > 0) setWidth(w)
     })
     ro.observe(el)
-    return () => ro.disconnect()
+    observerRef.current = ro
   }, [])
 
   return [ref, width]

--- a/website/src/pages/ArtifactsPage.tsx
+++ b/website/src/pages/ArtifactsPage.tsx
@@ -620,7 +620,7 @@ function LibraryMasonry({
   cols: number
   /** Attached to the width-defining wrapper below so the page's measurement is
    *  taken from the element that actually lays the columns out. */
-  widthRef: React.RefObject<HTMLDivElement>
+  widthRef: React.Ref<HTMLDivElement>
   /** The page's scrolling column. A ref, not the resolved element: the
    *  virtualizer takes `externalScrollerRef` and reads it when it needs it, so
    *  nothing has to re-render just because the element appeared. */

--- a/website/src/test/useContainerWidth.callbackRef.test.tsx
+++ b/website/src/test/useContainerWidth.callbackRef.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * useContainerWidth attaches its ResizeObserver from a CALLBACK ref, not a
+ * mount-time effect.
+ *
+ * The old shape read `ref.current` once in a mount-only effect; an element
+ * rendered conditionally (behind query data or a collapsed branch) after that
+ * first commit was never observed, so the width stayed null for the life of
+ * the component — latent only while every caller attaches unconditionally.
+ * These tests pin the callback-ref contract: attach-after-mount observes,
+ * detach disconnects, and a zero-width report does not evict the
+ * "assume wide" null.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, act } from '@testing-library/react'
+import { useContainerWidth } from '../hooks/useContainerWidth'
+
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = []
+  observed: Element[] = []
+  disconnected = false
+  constructor(public callback: ResizeObserverCallback) {
+    MockResizeObserver.instances.push(this)
+  }
+  observe(el: Element) {
+    this.observed.push(el)
+  }
+  unobserve() {}
+  disconnect() {
+    this.disconnected = true
+  }
+}
+
+/** Drive one observer callback with a content-box width, as layout would. */
+function fire(ro: MockResizeObserver, width: number) {
+  act(() => {
+    ro.callback(
+      [{ contentRect: { width } } as ResizeObserverEntry],
+      ro as unknown as ResizeObserver,
+    )
+  })
+}
+
+function Probe({ show }: { show: boolean }) {
+  const [ref, width] = useContainerWidth<HTMLDivElement>()
+  return (
+    <div>
+      <span data-testid="width">{width === null ? 'null' : width}</span>
+      {show ? <div data-testid="box" ref={ref} /> : null}
+    </div>
+  )
+}
+
+describe('useContainerWidth callback ref', () => {
+  beforeEach(() => {
+    MockResizeObserver.instances = []
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it('observes an element that mounts AFTER the hook (conditional render flips on)', () => {
+    const { rerender } = render(<Probe show={false} />)
+    expect(screen.getByTestId('width').textContent).toBe('null')
+    // The defect shape: a mount-time effect saw null once and never returned.
+    expect(MockResizeObserver.instances).toHaveLength(0)
+
+    rerender(<Probe show={true} />)
+    const ro = MockResizeObserver.instances.at(-1)!
+    expect(ro.observed).toContain(screen.getByTestId('box'))
+
+    fire(ro, 640)
+    expect(screen.getByTestId('width').textContent).toBe('640')
+  })
+
+  it('disconnects the observer when the element unmounts', () => {
+    const { rerender } = render(<Probe show={true} />)
+    const ro = MockResizeObserver.instances.at(-1)!
+    expect(ro.disconnected).toBe(false)
+
+    rerender(<Probe show={false} />)
+    expect(ro.disconnected).toBe(true)
+  })
+
+  it('keeps null ("assume wide") when the observer reports a zero width', () => {
+    render(<Probe show={true} />)
+    const ro = MockResizeObserver.instances.at(-1)!
+    fire(ro, 0)
+    expect(screen.getByTestId('width').textContent).toBe('null')
+    // A later real layout still lands.
+    fire(ro, 512)
+    expect(screen.getByTestId('width').textContent).toBe('512')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Two mechanical leftovers flagged by the First Principles review on PR #7215 (the #7193 callback-ref change):

1. `useColumnCount` returns a dual-shape ref — a `RefCallback` that also carries a writable `.current` via `Object.assign` — but no caller ever reads `.current`: all five call sites (`ArtifactsPage.tsx:259,1349`, `DrivePage.tsx:278,698,1063`) pass it straight to a JSX `ref=`. The dual shape exists only to satisfy `LibraryMasonry`'s `widthRef: React.RefObject<HTMLDivElement>` prop type (`ArtifactsPage.tsx:623`).
2. `useContainerWidth` still reads `ref.current` in a mount-only effect — the same never-attaches pattern the #7193 change removed from `useColumnCount`. It is latent only because its sole caller (`SettingsSubNav.tsx:310`) attaches the ref unconditionally on first render; any future conditionally rendered caller would silently never be measured.

## Why it matters

The dual-shape ref is extra API surface that invites `.current` reads nobody audits, and the `Object.assign` construction obscures the plain callback the file itself documents. The `useContainerWidth` mount-only effect is a defect class this repo already shipped once (#7193): reusing the hook in any conditionally rendered surface produces a layout stuck on its "assume wide" default, with no error anywhere.

## What changed (motivation → approach → change)

- `useColumnCount` now returns a bare `React.RefCallback<HTMLDivElement>` (the same shape `useMeasuredHeight` returns); the `ColumnCountRef` / `MutableColumnCountRef` types, the `Object.assign`, and the `fn.current = el` write are deleted. Runtime behavior — viewport seed, zero-width guard, re-measure on `minColWidth` change — is unchanged.
- `LibraryMasonry`'s `widthRef` prop (`ArtifactsPage.tsx:623`) widens from `React.RefObject<HTMLDivElement>` to `React.Ref<HTMLDivElement>`: the component only forwards it to a JSX `ref=`, which accepts any `Ref`. Every other call site compiles unchanged.
- `useContainerWidth` attaches its ResizeObserver from a callback ref (attach/detach) instead of the mount-only effect, with a zero-width guard: an element that is attached but has no layout yet reports 0, which must keep the last real measurement (or the initial null = "assume wide") rather than switching layouts on a width nobody rendered.

## Tests

- New `useContainerWidth.callbackRef.test.tsx`, mirroring the existing `useColumnCount.callbackRef.test.tsx` contract: attach-after-mount observes an element that appears after first render (the defect shape a mount-only effect misses); detach disconnects the observer; a zero-width report keeps the "assume wide" null while a later real width still lands.
- Existing `useColumnCount.callbackRef.test.tsx` (5 tests) passes unchanged — the refactor preserves the callback-ref contract it pins.
- Local gates: `npx tsc -b`, full `npx vitest run` (1695 files / 26879 tests), eslint ratchet, jscpd, i18n, brand-name, focus-cue and phantom-token gates all green.

## Manual verification

N/A — unit coverage sufficient: the diff is a type-level widening plus an attach-timing refactor with no rendered delta, and both hooks' observable behavior is pinned by the two callback-ref test files.

## Related Issues

Closes #7220

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
