### PR TITLE
fix(settings): scope aws consent cache invalidation

### DIFF
--- a/website/src/components/AwsConsentGate.test.tsx
+++ b/website/src/components/AwsConsentGate.test.tsx
@@ -63,6 +63,19 @@ describe('AwsConsentGate', () => {
     await waitFor(() => expect(onConsentChange).toHaveBeenCalled())
   })
 
+  it('does not invalidate the Polly catalogue for another AWS service', async () => {
+    vi.mocked(api.awsConsent).mockResolvedValue(
+      status({ service: 's3', serviceLabel: 'Amazon S3' }),
+    )
+    const { queryClient } = renderWithProviders(<AwsConsentGate service="s3" />)
+    queryClient.setQueryData(['voiceVoices'], { voices: [{ id: 'Ruth' }] })
+
+    fireEvent.click(await screen.findByRole('button', { name: /confirm and enable/i }))
+    await waitFor(() => expect(api.grantAwsConsent).toHaveBeenCalledWith('s3', expect.any(Object)))
+
+    expect(queryClient.getQueryState(['voiceVoices'])?.isInvalidated).toBe(false)
+  })
+
   it('shows the service, region, credential source and account before confirming', async () => {
     vi.mocked(api.awsConsent).mockResolvedValue(status())
     renderWithProviders(<AwsConsentGate service="polly" />)

--- a/website/src/components/AwsConsentGate.tsx
+++ b/website/src/components/AwsConsentGate.tsx
@@ -18,8 +18,8 @@ import { i18nT } from '../i18n/t'
  * this component cannot manufacture consent by rendering a button.
  *
  * `onConsentChange` exists because a grant gates data this component cannot
- * name. It invalidates its own status and the voice catalogue, but a caller's
- * surfaces may also be reading refusals out of cache -- the AWS Control console
+ * name. It invalidates its own status, while callers invalidate only the
+ * service-specific surfaces they own. The AWS Control console, for example,
  * decides whether to show the ask from a cached 409 on the drive read and from
  * `costs.consentMissing`. Without a way to invalidate those too, withdrawing
  * leaves the operator with no receipt, no ask, and a stale drive row: nothing
@@ -42,9 +42,6 @@ export default function AwsConsentGate({
 
   const invalidate = () => {
     qc.invalidateQueries({ queryKey: ['awsConsent', service] })
-    // The Polly voice catalogue is fetched through the same gate, so a grant
-    // change flips that request between a real catalogue and a refusal.
-    qc.invalidateQueries({ queryKey: ['voiceVoices'] })
     onConsentChange?.()
   }
 

--- a/website/src/pages/settings/VoicePanel.tsx
+++ b/website/src/pages/settings/VoicePanel.tsx
@@ -150,7 +150,10 @@ export function VoicePanel() {
               <SettingsSelect label={i18nT('pages.settings.voicePanel.provider')} description={i18nT('pages.settings.voicePanel.piper_runs_locally_and_offline_polly_uses_aws_cr')} value={voiceCfg.provider} options={PROVIDER_OPTIONS} optionLabels={PROVIDER_OPTIONS.map(p => i18nT(PROVIDER_LABEL_KEY[p]))} onChange={v => setVoice({ provider: v })} disabled={voiceDisabled} />
               {isPolly ? (
                 <>
-                  <AwsConsentGate service="polly" />
+                  <AwsConsentGate
+                    service="polly"
+                    onConsentChange={() => qc.invalidateQueries({ queryKey: ['voiceVoices'] })}
+                  />
                   <SettingsSelect label={i18nT('pages.settings.voicePanel.voice')} description={i18nT('pages.settings.voicePanel.amazon_polly_voice_for_tts')} value={voiceCfg.voice} options={voiceOptions.map(o => o.value)} optionLabels={voiceOptions.map(o => o.label)} onChange={v => { const engines = voiceOptions.find(o => o.value === v)?.engines ?? ENGINE_OPTIONS; const patch: Partial<VoiceConfig> = { voice: v }; if (!engines.includes(voiceCfg.engine)) patch.engine = engines[0]; setVoice(patch) }} disabled={voiceDisabled} />
                   <SettingsSelect label={i18nT('pages.settings.voicePanel.engine')} description={i18nT('pages.settings.voicePanel.polly_engine_type')} value={voiceCfg.engine} options={selectedVoiceEngines} onChange={v => setVoice({ engine: v })} disabled={voiceDisabled} />
                   <SettingsSelect label={i18nT('pages.settings.voicePanel.speed')} description={i18nT('pages.settings.voicePanel.speech_rate')} value={voiceCfg.rate} options={SPEED_OPTIONS} onChange={v => setVoice({ rate: v })} disabled={voiceDisabled} />


### PR DESCRIPTION
## Problem / Motivation

`AwsConsentGate` invalidates the Polly voice catalogue after any AWS consent
change, including S3, Cost Explorer, and Transcribe confirmations. The shared
gate therefore owns a cache that only the Voice settings caller understands.

## Why it matters

React Query marks the hour-cached Polly catalogue stale after unrelated AWS
consent changes. A later visit to Voice settings then performs an unnecessary
provider request instead of reusing the still-valid catalogue.

## What changed (motivation → approach → change)

The shared gate now invalidates only its own service-scoped consent query and
continues to invoke its existing `onConsentChange` callback. Voice settings
uses that callback to invalidate `voiceVoices` for Polly changes, keeping the
cache dependency at its sole consumer.

No consent API, rendered state, or user-facing copy changes.

## Tests

- Added a focused regression proving an S3 confirmation leaves the Polly voice
  catalogue valid.
- Red on the old implementation: 1 failed, 8 passed; the catalogue was marked
  invalidated.
- Green focused gate and directly relevant VoicePanel suites: 33 passed.
- Exact-file ESLint: clean.
- `tsc -b` produced no diagnostics but did not complete within the bounded
  local run against a reused dependency tree; lockfile-complete server CI owns
  the authoritative TypeScript result.
- Full repository suites run: 0.

## Manual verification

N/A — this is cache ownership with no rendered delta; focused QueryClient and
component tests exercise the changed behavior directly.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** rendered UI is unchanged; only which query cache a
consent mutation invalidates has changed.

## Related Issues

Follow-up to the accepted subtraction in the First Principles review on merged
PR #6536.

no linked issue: this is a reviewer-counted residual rather than a tracked
issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a shared mutation component must invalidate only caches it owns; route
caller-specific cache refreshes through its existing callback seam.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — this changes an internal cache-ownership detail documented at the call site)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
