### PR TITLE
fix(slack): report the real dashboard link-click window, not the constant

### DIFF
--- a/src/kiro_crew/slack/allowlist.py
+++ b/src/kiro_crew/slack/allowlist.py
@@ -204,8 +204,10 @@ async def send_dashboard_link(
     Returns the generated URL (for logging), or an empty string on failure.
     The link is always sent as a DM to prevent token leakage in channels.
 
-    The URL must be clicked within 5 minutes. Once opened, the session
-    cookie lasts for *ttl* seconds (capped at ``MAX_SESSION_TTL_SECS``).
+    The URL must be clicked within 5 minutes, or within the session TTL when
+    that is shorter — the mint clamps the click window so the link never
+    authenticates past the session it grants. Once opened, the session cookie
+    lasts for *ttl* seconds (capped at ``MAX_SESSION_TTL_SECS``).
     """
     session_ttl = min(ttl, MAX_SESSION_TTL_SECS)
     cfg = KiroCrewConfig.load()
@@ -288,7 +290,10 @@ async def send_dashboard_link(
     if proxy:
         proxy_line = f"\n🔗 <{proxy}/?token={token}|Open via DevSpaces Proxy>"
 
-    link_mins = LINK_WINDOW_SECS // 60
+    # ``generate_token`` clamps the link-click ``exp`` to the session TTL, so a
+    # sub-window session gets a link that dies with it. Report the clamped value,
+    # not the constant, or the countdown promises minutes the link does not have.
+    link_mins = min(LINK_WINDOW_SECS, session_ttl) // 60
     session_mins = session_ttl // 60
     # Mirrors the guidance the boot log gives, because this is the one case where
     # the link cannot work anywhere but the host and will not start working later.

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -318,7 +318,11 @@ async def _handle_dashboard(
     assert orch.slack is not None
     url = await send_dashboard_link(orch.slack, caller_id, session_ttl)
     if url:
-        blks = dashboard_link_block(url, LINK_WINDOW_SECS // 60, session_ttl // 60)
+        # Same clamp the mint applies (``exp = now + min(LINK_WINDOW_SECS,
+        # session_ttl)``) and the same one the DM reports, so the ephemeral
+        # block cannot outlast the link it describes.
+        link_mins = min(LINK_WINDOW_SECS, session_ttl) // 60
+        blks = dashboard_link_block(url, link_mins, session_ttl // 60)
         await respond("🔗 Dashboard link sent to your DMs.", blocks=blks)
     else:
         await respond("❌ Failed to send dashboard link.")

--- a/test/test_slack_dashboard_link_window.py
+++ b/test/test_slack_dashboard_link_window.py
@@ -1,0 +1,151 @@
+"""The Slack reporters of the dashboard link-click window must not overstate it.
+
+``generate_token`` mints ``exp = now + min(LINK_WINDOW_SECS, session_ttl)`` so a
+raw link can never authenticate past the session it grants. Both Slack surfaces
+that *report* that window — the DM sent by
+:func:`kiro_crew.slack.allowlist.send_dashboard_link` and the ephemeral block
+built by :func:`kiro_crew.slack.events._handle_dashboard` — printed the
+unclamped constant, so ``/kirocrew dashboard 1m`` told the user "Click within
+5m" about a link that dies in one.
+
+Each test asserts the reported minutes against the minted token's own ``exp``,
+not against a second hard-coded constant, so the assertion cannot pass by
+agreeing with a copy of the bug. A full-length caller is the control: its text
+is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.token_auth import LINK_WINDOW_SECS, _b64url_decode
+
+
+def _click_window_secs(url: str) -> float:
+    """Return the real click window of the token carried in *url*."""
+    token = url.split("token=", 1)[1].split("&", 1)[0]
+    payload = json.loads(_b64url_decode(token.split(".", 1)[0]))
+    return float(payload["exp"]) - float(payload["iat"])
+
+
+def _reported_link_mins(text: str) -> int:
+    """Return N from ``⏱ Click within Nm · session lasts ...``."""
+    return int(text.split("Click within ", 1)[1].split("m", 1)[0])
+
+
+async def _send_dm(ttl: int) -> str:
+    """Drive ``send_dashboard_link`` for *ttl* and return the DM body."""
+    from kiro_crew.slack import allowlist as al
+
+    slack = MagicMock()
+    slack.open_dm = AsyncMock(return_value="D_DM")
+    slack.post_message = AsyncMock(return_value=None)
+
+    cfg = MagicMock()
+    cfg.dashboard.url = "http://127.0.0.1:5476"
+    cfg.slack.use_tunnel_url = False
+
+    with (
+        patch.object(al.KiroCrewConfig, "load", return_value=cfg),
+        patch.object(al, "get_tunnel_url", return_value=""),
+        patch.object(al, "sel", return_value=MagicMock()),
+        patch("kiro_crew.dashboard.origin.socket.gethostbyname", return_value="10.0.0.1"),
+        patch("kiro_crew.dashboard.origin.socket.getaddrinfo", side_effect=socket.gaierror),
+        patch.dict(os.environ, {}, KIROCREW_PORT=""),
+    ):
+        await al.send_dashboard_link(slack, "U1", ttl=ttl)
+
+    return str(slack.post_message.call_args[0][1])
+
+
+class TestSendDashboardLinkDm:
+    @pytest.mark.asyncio
+    async def test_a_short_session_is_not_promised_the_full_click_window(self) -> None:
+        dm = await _send_dm(60)
+        assert _reported_link_mins(dm) == 1
+        assert "session lasts 1m" in dm
+
+    @pytest.mark.asyncio
+    async def test_the_reported_click_window_matches_the_minted_token(self) -> None:
+        """The DM's countdown is derived from the same clamp the token uses."""
+        from kiro_crew.slack import allowlist as al
+
+        slack = MagicMock()
+        slack.open_dm = AsyncMock(return_value="D_DM")
+        slack.post_message = AsyncMock(return_value=None)
+
+        cfg = MagicMock()
+        cfg.dashboard.url = "http://127.0.0.1:5476"
+        cfg.slack.use_tunnel_url = False
+
+        with (
+            patch.object(al.KiroCrewConfig, "load", return_value=cfg),
+            patch.object(al, "get_tunnel_url", return_value=""),
+            patch.object(al, "sel", return_value=MagicMock()),
+            patch("kiro_crew.dashboard.origin.socket.gethostbyname", return_value="10.0.0.1"),
+            patch("kiro_crew.dashboard.origin.socket.getaddrinfo", side_effect=socket.gaierror),
+            patch.dict(os.environ, {}, KIROCREW_PORT=""),
+        ):
+            url = await al.send_dashboard_link(slack, "U1", ttl=120)
+
+        dm = str(slack.post_message.call_args[0][1])
+        assert _reported_link_mins(dm) == int(_click_window_secs(url)) // 60
+
+    @pytest.mark.asyncio
+    async def test_a_full_length_session_still_reads_five_minutes(self) -> None:
+        """Control: the clamp only ever tightens, so the ordinary text is unchanged."""
+        dm = await _send_dm(3600)
+        assert _reported_link_mins(dm) == LINK_WINDOW_SECS // 60
+        assert "session lasts 60m" in dm
+
+
+class TestHandleDashboardBlock:
+    @staticmethod
+    def _orch() -> MagicMock:
+        orch = MagicMock()
+        orch.slack = MagicMock()
+        orch.slack_command = "kirocrew"
+        return orch
+
+    @pytest.mark.asyncio
+    async def test_a_short_session_is_not_promised_the_full_click_window(self) -> None:
+        from kiro_crew.slack import events as ev
+
+        respond = AsyncMock()
+        with patch.object(
+            ev, "send_dashboard_link", new_callable=AsyncMock, return_value="https://x/?token=t"
+        ):
+            await ev._handle_dashboard(self._orch(), "U_OWNER", "1m", respond)
+
+        text = respond.call_args.kwargs["blocks"][0]["text"]["text"]
+        assert _reported_link_mins(text) == 1
+        assert "session lasts 1m" in text
+
+    @pytest.mark.asyncio
+    async def test_a_full_length_session_still_reads_five_minutes(self) -> None:
+        from kiro_crew.slack import events as ev
+
+        respond = AsyncMock()
+        with patch.object(
+            ev, "send_dashboard_link", new_callable=AsyncMock, return_value="https://x/?token=t"
+        ):
+            await ev._handle_dashboard(self._orch(), "U_OWNER", "", respond)
+
+        text = respond.call_args.kwargs["blocks"][0]["text"]["text"]
+        assert _reported_link_mins(text) == LINK_WINDOW_SECS // 60
+
+
+def test_the_helpers_read_a_real_payload() -> None:
+    """Self-check: the decoder is exercised against a live mint, not a fixture."""
+    from kiro_crew.dashboard.token_auth import generate_token
+
+    before = time.time()
+    window = _click_window_secs(f"https://x/?token={generate_token('u', ttl_seconds=90)}")
+    assert time.time() >= before
+    assert window == 90


### PR DESCRIPTION
## Problem / Motivation

`/kirocrew dashboard 1m` tells the user **"⏱ Click within 5m · session lasts 1m"**
about a link that stops working after one minute. The same overstatement appears in
the DM and in the ephemeral block that follows it.

Since #6172, `generate_token` clamps the link-click expiry to the session it grants:

```python
"exp": now + min(LINK_WINDOW_SECS, session_ttl),
```

#6172 fixed the two *reporters* it owned — `expires_in` (`handlers/auth_mobile.py`)
and `link_window_secs` (`handlers/tailnet_mobile.py`) — and its GPT 5.6 review named
the two it did not:

> `slack/events.py:_handle_dashboard` sets `ttl = parsed` with **no floor** … So
> `/<cmd> dashboard 1m` gives `session_ttl = 60` → … post-clamp `exp = now + 60`,
> while both the DM and the ephemeral block still read `⏱ Click within 5m · session
> lasts 1m`. A 5× overstatement of a window the user has to act inside, which is the
> same defect class the PR just declared worth fixing.
>
> **Ask:** either clamp those two call sites the same way (`min(LINK_WINDOW_SECS,
> session_ttl)`), or say why the Slack countdown is allowed to keep overstating.

That ask was never dispositioned, and both sites still print the constant on `main`
(`af21fbc9c`).

## Why it matters

The number is the only thing telling the user how long they have to act. A 5×
overstatement means the honest failure — "you took too long" — arrives as a link
that silently does not work, on the surface the reviewer describes as the one a
reader "will reasonably assume was swept" after finding the two fixed reporters.

Telegram, Teams and Webex are **not** affected and deliberately unchanged: they print
only `format_ttl(ttl_secs)`, the session TTL, which post-clamp is also the click
window, so they make no claim that is now false.

## What changed (motivation → approach → change)

**Symptom** → the countdown promises minutes the link does not have.
**Root cause** → the mint applies `min(LINK_WINDOW_SECS, session_ttl)`; the two Slack
reporters re-derive the window from the bare constant instead of that clamp.
**Change** → apply the mint's own clamp at both reporters, exactly as the reviewer
asked and exactly as #6172 fixed its own two:

- `src/kiro_crew/slack/allowlist.py` — `link_mins = min(LINK_WINDOW_SECS,
  session_ttl) // 60` for the DM body, plus the docstring line that still asserted a
  flat 5 minutes.
- `src/kiro_crew/slack/events.py` — the same clamp for the first argument of
  `dashboard_link_block`.

`blocks.dashboard_link_block` is unchanged: it renders whatever minutes it is handed,
and the wrong value was the caller's.

For a full-length caller both strings are byte-identical to before, because the clamp
only ever tightens. No new symbol, config key, flag or public surface.

**Deliberately not in scope, and why:** the same review notes that
`_handle_dashboard` has no *floor* at all, so `parse_duration("0m")` answers a real
`0` and mints a link that is dead on arrival. That is a pre-existing product decision
about what a Slack user may ask for — the reviewer's own words are "Not this PR's to
fix" — and it is orthogonal to whether the countdown tells the truth. After this
change such a link reports `Click within 0m`, which is accurate rather than
misleading. The sub-minute rendering floor the review raises separately (`🔵 3`)
lives in the two React cards, not here.

## Tests

New file `test/test_slack_dashboard_link_window.py`, six tests, deterministic
red-before on `main` (**3 failed / 3 passed**, the three failures being exactly the
clamp assertions: `assert 5 == 1`, `assert 5 == (120 // 60)`, `assert 5 == 1`):

| Test | Locks in |
|---|---|
| `TestSendDashboardLinkDm::test_a_short_session_is_not_promised_the_full_click_window` | a 60s session DMs `Click within 1m`, not `5m` |
| `TestSendDashboardLinkDm::test_the_reported_click_window_matches_the_minted_token` | the reported minutes are derived from the **minted token's own `exp - iat`**, decoded from the returned URL — not compared against a second hard-coded constant, so the assertion cannot pass by agreeing with a copy of the bug |
| `TestSendDashboardLinkDm::test_a_full_length_session_still_reads_five_minutes` | control: the ordinary 3600s DM is unchanged |
| `TestHandleDashboardBlock::test_a_short_session_is_not_promised_the_full_click_window` | `/kirocrew dashboard 1m`'s ephemeral block reads `1m` |
| `TestHandleDashboardBlock::test_a_full_length_session_still_reads_five_minutes` | control: the ordinary block is unchanged |
| `test_the_helpers_read_a_real_payload` | self-check that the payload decoder runs against a live mint, so a broken parser cannot make the suite green |

The three controls pass on both sides; they are what proves the change is a
tightening and not a rewrite of the ordinary text.

Neighbouring suites, all green after: `test_slack_dashboard_link_window.py` +
`test_slack_events_coverage.py` + `test_slack_handler_coverage.py` +
`test_tunnel_manager.py` + `test_token_auth.py` → **745 passed, 1 skipped**.

`flake8` and `isort` clean on all three files; `mypy` clean on both source files.
`black` reports `events.py` as needing reformatting at lines 446, 741 and 2625 —
**all pre-existing on `main`, none within this diff**; reformatting them would be
undeclared collateral, so they are left alone.

## Manual verification

N/A — unit coverage sufficient: both reporters are pure string construction driven
entirely by `session_ttl`, and the strongest test asserts against the real minted
token rather than a restatement of the expected value.

## Related Issues

Follows up the unaddressed GPT 5.6 ask 1 on #6172.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: when a mint starts clamping a value it previously took from a constant,
every surface that *reports* that value is part of the change — grep the constant,
not just the call sites of the function that changed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
