### PR TITLE
feat(metrics): identity, version, and environment resource attributes

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -278,6 +278,64 @@ still winning after a config edit), `test/test_collection_status_endpoint.py`
 presence without the endpoint string),
 `test/metrics/test_schema.py` (redaction / namespace).
 
+### Resource attributes: what identifies a series (and what egresses)
+
+The SDK `Resource` is the payload contract for both sinks: it labels every
+series on the local JSONL line AND, when `otlp_endpoint` is set, everything
+pushed to that collector. `_resource_attributes()` in `provider.py` is the
+single place it is built, and every value there is either a closed set or an
+explicit clamp, because a resource attribute is a label on EVERY series this
+process exports — one unbounded value there multiplies every instrument.
+
+| Attribute | Value | Bound |
+|-----------|-------|-------|
+| `service.name` | `kirocrew` | constant |
+| `service.instance.id` | the persisted anonymous install id (`beacon.install_id`) | one per install |
+| `process.pid` | `os.getpid()` | one per live process |
+| `service.version` | build version, release-clamped via `beacon.release` | `major.minor.patch`, no build stamp |
+| `os.type` | `linux` / `darwin` / `windows` | CLOSED, else `other` |
+| `host.arch` | `amd64` / `arm64` / `x86` | CLOSED, else `other` |
+| `process.runtime.name` | `cpython` / `pypy` / `jython` / `ironpython` | CLOSED, else `other` |
+| `process.runtime.version` | `beacon.python_minor()` | `major.minor`, never the patch |
+| `host.cpu.logical_count` | `os.cpu_count()` | small integer |
+
+Two identities, deliberately separate. `service.instance.id` counts DEVICES: a
+random UUID persisted on disk, never derived from hostname or username (which
+on a corporate desktop routinely embed the employee's alias), and stable across
+restarts so "this install over time" survives them. `process.pid` counts
+PROCESSES: one install runs several telemetry-enabled processes at once (the
+gateway plus spawned agents/apps each build their own recorder), and with an
+install-scoped resource alone their gauges and cumulative counters would
+interleave into one corrupted series at a backend. Collapsing the two would
+report one machine's 6-8 processes as 6-8 machines.
+
+**Why the install id may egress while `kirocrew.process.start_time` may not.**
+The start-time token is a host-local process fingerprint that exists only to
+make the aggregator's cumulative-reset detection deterministic; it has no
+fleet-level question to answer, so it is stamped on the JSONL line and kept off
+the `Resource` (see `local_exporter.py` above). The install id is the opposite:
+it is the only thing that can answer "how many distinct devices", it is random
+rather than derived, and it is the SAME id the beacon already sends. Note that
+omitting the key does not yield an unlabelled resource — the SDK substitutes
+its own per-process uuid4, i.e. a fresh series set per restart — so the choice
+is between a stable anonymous id and per-restart churn, not between an id and
+no id.
+
+The id is MINTED in `_build_recorder()`'s live branch, immediately before the
+resource is assembled, so the first export already carries it and no startup
+window can leak the SDK's substitute. That branch runs only under consent True,
+so an install with telemetry off creates nothing. Consequence to know: enabling
+metrics is what creates the beacon's install-id file, even on a host that has
+the beacon itself disabled.
+
+Deliberately ABSENT: the distribution channel (the beacon's data-minimization
+pass removed its channel field, because channel sharply narrows the crowd a
+stable id hides in — stamping it on every metric payload would quietly undo
+that decision) and an install type (no reliable detection today; a guessed
+label would be confidently wrong). Both are guarded by a regression test.
+
+Tests: `test/metrics/test_resource_attrs.py`.
+
 ## Instrumented signals
 
 | Metric | Type | Attrs | Site |

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -34,11 +34,13 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+import platform
 import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
+from kiro_crew import __version__, beacon
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
 from kiro_crew.metrics.recorder import MetricsRecorder
@@ -149,6 +151,28 @@ logger = logging.getLogger(__name__)
 
 _SERVICE_NAME = "kirocrew"
 _SCOPE = "kiro_crew"
+
+# ``platform.machine()`` spellings -> OTel semantic-convention ``host.arch``
+# values. Every environment attribute below is a CLOSED set: a spelling this
+# map does not know folds to :data:`_ATTR_OTHER` rather than passing through,
+# so an exotic platform cannot mint a label of its own.
+_ARCH_BY_MACHINE = {
+    "x86_64": "amd64",
+    "amd64": "amd64",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+    "i386": "x86",
+    "i686": "x86",
+}
+_KNOWN_OS_TYPES = frozenset({"linux", "darwin", "windows"})
+#: ``platform.python_implementation()`` spellings, lowercased -- the four the
+#: stdlib documents it can return. An interpreter outside this set folds to
+#: :data:`_ATTR_OTHER` like every other environment reading, so a patched or
+#: exotic runtime cannot mint a label of its own.
+_KNOWN_RUNTIME_NAMES = frozenset({"cpython", "pypy", "jython", "ironpython"})
+#: Fold target for any environment reading outside its known set. One shared
+#: bucket, so "unknown" stays a single bounded label per attribute.
+_ATTR_OTHER = "other"
 
 # Explicit histogram bucket boundaries (milliseconds), applied PER INSTRUMENT via
 # MeterProvider Views. OTEL's default boundaries top out at 10s, so anything
@@ -393,6 +417,125 @@ def _default_metrics_dir() -> Path:
     return config_dir() / "metrics"
 
 
+def _resource_attributes() -> "dict[str, str | int]":
+    """Resource attributes for the MeterProvider.
+
+    A resource attribute becomes a LABEL on every series this process exports,
+    which cuts both ways: it is the only place fleet-level GROUP BYs can come
+    from, and any unbounded value here multiplies every instrument's series
+    count. So every attribute is a closed set or explicitly clamped, and every
+    probe fails soft -- a failed read omits the attribute rather than losing
+    telemetry or inventing a value.
+
+    ``service.instance.id`` is set EXPLICITLY to the persisted install id
+    rather than left to the SDK, whose default identifies a PROCESS: a fresh
+    UUID per restart starts a brand-new series set every time -- fast,
+    pure-cost growth on desktops, which restart constantly -- and it severs
+    "this install over time" across restarts. Machines must still be separable
+    (a fleet percentile is computed ACROSS series; identical labels would
+    collide every host into one series), which is why the id exists at all.
+    It is a random UUID persisted on disk, deliberately NOT derived from
+    hostname or username, which on a corporate desktop routinely embed the
+    employee's alias.
+
+    ``process.pid`` (OTel semconv) carries the PROCESS identity SEPARATELY:
+    one install runs several telemetry-enabled processes at once (the gateway
+    plus spawned agents/apps each build their own recorder -- the reason the
+    local exporter shards per PID), and with an install-scoped resource alone
+    their per-process gauges and cumulative counters would interleave into one
+    corrupted series at any OTLP backend. The pid makes each process its own
+    resource; the install id groups them back together for fleet questions
+    (distinct devices, per-install rollups). PID reuse across restarts reads
+    as an ordinary counter reset downstream.
+
+    This function only ever READS the install id (``create=False``: one stat
+    + a 32-byte read, the same class as the config fingerprint check). The
+    single WRITE that can create it lives in :func:`_build_recorder`'s live
+    branch, immediately before this call, so a resource is labelled from the
+    very first export rather than acquiring its identity mid-life -- a
+    mid-life resource swap reads downstream as a brand-new series set, which
+    is a worse outcome than the ~1ms it would save. Keeping the mint in the
+    build path rather than in a rebuild worker is also what lets this module
+    hold no backfill state at all. Residual, accepted: omitting the key does
+    NOT yield an unlabelled resource -- the SDK substitutes its own
+    per-process UUID (measured: a dashed 36-char uuid4, versus our 32-char
+    hex) -- so a host whose mint FAILS (unwritable data dir) falls back to
+    exactly the per-restart series churn this attribute exists to prevent.
+    That is the cost of a broken data dir, not of a fresh install: minting
+    before the first build means there is no startup window in which the
+    substitute can reach an export at all. Local shards stay unambiguous
+    either way, because the exporter stamps per-process identity on every
+    line.
+
+    ``service.version`` is the release-clamped build version
+    (:func:`beacon.release`, the same clamp the beacon ships). Without it
+    nothing in a payload identifies the build that produced it, so
+    release-over-release comparison degenerates to comparing time ranges --
+    which a gradual rollout muddies, since both versions report into the same
+    buckets. With the label it is a GROUP BY. The clamp matters as much as the
+    field: a raw dev/nightly ``__version__`` carries a per-build stamp, so an
+    unclamped value would mint a new series set per build.
+
+    The environment attributes (``os.type``, ``host.arch``,
+    ``process.runtime.name``/``version``) follow the OTel semantic conventions
+    and are CLOSED sets: readings outside the known values fold to
+    :data:`_ATTR_OTHER`, and the runtime version is clamped to ``major.minor``
+    (the patch level adds cardinality without answering anything the minor
+    does not -- the beacon's rule). ``host.cpu.logical_count`` is what lets
+    ``kirocrew.process.cpu.seconds`` be normalized into a machine percentage
+    downstream: the core count exists only client-side, so it must travel
+    with the data.
+
+    Deliberately absent:
+
+      * the distribution channel. The beacon's data-minimization pass REMOVED
+        its channel field because channel sharply narrows the crowd a stable id
+        hides in (a nightly population is small by definition). Stamping it on
+        every metric payload would quietly undo that decision; re-adding it is
+        a consent-inventory question, not a code convenience.
+      * an install type (desktop / cli / remote-gateway). There is no reliable
+        detection today; a guessed label would be confidently wrong.
+    """
+    attrs: "dict[str, str | int]" = {"service.name": _SERVICE_NAME}
+    try:
+        # Process identity, SEPARATE from install identity: several
+        # telemetry-enabled processes run per install, and without a
+        # per-process resource their gauges/counters interleave into one
+        # corrupted series at any OTLP backend.
+        attrs["process.pid"] = int(os.getpid())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("process.pid resource attr unavailable: %s", exc)
+    try:
+        attrs["service.version"] = beacon.release(__version__)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("service.version resource attr unavailable: %s", exc)
+    try:
+        os_type = platform.system().lower()
+        attrs["os.type"] = os_type if os_type in _KNOWN_OS_TYPES else _ATTR_OTHER
+        machine = platform.machine().lower()
+        attrs["host.arch"] = _ARCH_BY_MACHINE.get(machine, _ATTR_OTHER)
+        runtime = platform.python_implementation().lower()
+        attrs["process.runtime.name"] = (
+            runtime if runtime in _KNOWN_RUNTIME_NAMES else _ATTR_OTHER
+        )
+        # beacon.python_minor() owns the major.minor clamp and records why the
+        # patch level is dropped; a second spelling here would be a rule with
+        # two owners.
+        attrs["process.runtime.version"] = beacon.python_minor()
+        cores = os.cpu_count()
+        if cores:
+            attrs["host.cpu.logical_count"] = int(cores)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("environment resource attrs unavailable: %s", exc)
+    try:
+        install_id = beacon.install_id(create=False)
+        if install_id:
+            attrs["service.instance.id"] = install_id
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("stable install id unavailable: %s", exc)
+    return attrs
+
+
 class _Build(NamedTuple):
     """What a build produced, for a caller to install under ``_lock``.
 
@@ -482,9 +625,24 @@ def _build_recorder() -> _Build:
                 started_readers.append(reader)
                 otlp_names.append(dest.name)
         otlp_active = bool(otlp_names)
+        # Mint the persisted install id HERE, in the live branch, so the
+        # resource below is labelled from the very first export instead of
+        # acquiring its identity mid-life. This is the one write on this path:
+        # mkdir + mkstemp + link, race-safe per ``beacon.install_id``, once per
+        # install ever, and only ever under consent True (a disabled build
+        # returns before reaching this branch, so turning telemetry OFF still
+        # creates nothing). It is noise against what this same path already
+        # pays synchronously -- ~14ms for a changed-config load plus ~57ms of
+        # SDK import, both documented in docs/system-specs/modules/metrics.md
+        # -- and a failed mint costs only the attribute, never the recorder.
+        try:
+            beacon.install_id(create=True)
+        except Exception:
+            logger.debug("install id mint failed", exc_info=True)
+        resource_attrs = _resource_attributes()
         provider = MeterProvider(
             metric_readers=started_readers,
-            resource=Resource.create({"service.name": _SERVICE_NAME}),
+            resource=Resource.create(resource_attrs),
             # One View per instrument, from histogram_bounds() (the ms families
             # plus the non-ms ones). Deliberately NOT a catch-all
             # `instrument_type=Histogram` View: the OTEL SDK applies every

--- a/test/metrics/test_resource_attrs.py
+++ b/test/metrics/test_resource_attrs.py
@@ -1,0 +1,280 @@
+"""``_resource_attributes`` — identity, version, and environment labels.
+
+Every attribute asserted here becomes a label on EVERY exported series, so
+these tests pin four properties: the values are clamped/bounded (a raw
+dev-build version, a patch-level runtime version, or a pass-through exotic
+architecture would mint unbounded series), every probe fails soft (a broken
+probe omits its attribute, never loses telemetry), the install id exists by
+the time the FIRST resource is built (the probe itself is read-only; the one
+write lives in ``_build_recorder``'s live branch, so no export can carry the
+SDK's per-process substitute and no mid-life resource swap is needed), and the
+deliberately-absent attributes stay absent (the distribution channel was
+removed from the beacon by a data-minimization pass; re-adding it here would
+quietly undo that decision).
+"""
+
+import json
+import os
+import platform
+import re
+
+import kiro_crew
+from kiro_crew import beacon
+from kiro_crew.config.loader import KiroCrewConfig, TelemetryConfig
+from kiro_crew.metrics import provider
+from kiro_crew.metrics.provider import get_recorder, reset_for_testing
+from kiro_crew.metrics.provider import shutdown as provider_shutdown
+
+
+def _patch_config(monkeypatch, **tel_kwargs):
+    fake = KiroCrewConfig(telemetry=TelemetryConfig(**tel_kwargs))
+    monkeypatch.setattr(KiroCrewConfig, "load", classmethod(lambda cls: fake))
+    monkeypatch.delenv("KIROCREW_TELEMETRY", raising=False)
+
+
+def _own_home(monkeypatch, tmp_path):
+    """Give this test its OWN data home, so the install-id file is per-test.
+
+    Every test that asserts the id file is absent (or that something created
+    it) reads one shared piece of on-disk state, and a sibling test that mints
+    would otherwise decide the outcome -- an order-dependent pass. ``KIROCREW_HOME``
+    is the seam: ``config_dir()`` memoizes keyed on its raw value, so setting it
+    re-resolves rather than serving the previous test's home.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    assert beacon.install_id(create=False) == "", "the home was not actually fresh"
+    return home
+
+
+def test_attrs_carry_identity_version_and_environment():
+    # The build path is read-only for the id, so materialize it first — the
+    # way every non-fresh install already has it on disk.
+    beacon.install_id(create=True)
+    attrs = provider._resource_attributes()
+
+    assert attrs["service.name"] == "kirocrew"
+
+    # Release-clamped, never a raw dev/nightly stamp: same clamp the beacon
+    # ships, so the two surfaces can never disagree about one build.
+    assert attrs["service.version"] == beacon.release(kiro_crew.__version__)
+    version = str(attrs["service.version"])
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version) or version == beacon.UNKNOWN_VERSION
+
+    assert attrs["os.type"] == platform.system().lower()
+    runtime = platform.python_implementation().lower()
+    assert attrs["process.runtime.name"] == (
+        runtime if runtime in provider._KNOWN_RUNTIME_NAMES else provider._ATTR_OTHER
+    )
+    # major.minor ONLY — the patch level would add cardinality without
+    # answering anything the minor does not. beacon.python_minor() is the
+    # single owner of that clamp; a second spelling here could drift from it.
+    assert attrs["process.runtime.version"] == beacon.python_minor()
+    assert re.fullmatch(r"\d+\.\d+", str(attrs["process.runtime.version"]))
+
+    # The core count is what lets cpu.seconds become a machine percentage
+    # downstream; it exists only client-side.
+    assert attrs["host.cpu.logical_count"] == os.cpu_count()
+    assert isinstance(attrs["host.cpu.logical_count"], int)
+
+    # Stable install id, not the SDK's per-process UUID — and the process
+    # identity travels SEPARATELY so concurrent processes of one install
+    # cannot interleave their series at a backend.
+    install_id = str(attrs["service.instance.id"])
+    assert len(install_id) == 32
+    assert all(c in "0123456789abcdef" for c in install_id)
+    assert attrs["process.pid"] == os.getpid()
+    assert isinstance(attrs["process.pid"], int)
+
+
+def test_arch_aliases_fold_to_one_label():
+    # One architecture must not appear as two labels across OSes.
+    assert provider._ARCH_BY_MACHINE["x86_64"] == "amd64"
+    assert provider._ARCH_BY_MACHINE["amd64"] == "amd64"
+    assert provider._ARCH_BY_MACHINE["aarch64"] == "arm64"
+    assert provider._ARCH_BY_MACHINE["arm64"] == "arm64"
+    machine = platform.machine().lower()
+    expected = provider._ARCH_BY_MACHINE.get(machine, provider._ATTR_OTHER)
+    assert provider._resource_attributes().get("host.arch") == expected
+
+
+def test_unknown_environment_readings_fold_to_other(monkeypatch):
+    # The docstring promises CLOSED sets: an exotic platform must fold to the
+    # shared "other" bucket, never pass its own spelling through as a label.
+    monkeypatch.setattr(provider.platform, "system", lambda: "SunOS")
+    monkeypatch.setattr(provider.platform, "machine", lambda: "riscv64")
+    monkeypatch.setattr(provider.platform, "python_implementation", lambda: "MicroPython")
+    attrs = provider._resource_attributes()
+    assert attrs["os.type"] == provider._ATTR_OTHER
+    assert attrs["host.arch"] == provider._ATTR_OTHER
+    # process.runtime.name is in the same closed set as the other two: a
+    # patched or exotic interpreter must not mint a label of its own.
+    assert attrs["process.runtime.name"] == provider._ATTR_OTHER
+
+
+def test_version_probe_failure_omits_only_that_attribute(monkeypatch):
+    def _boom(_version):
+        raise RuntimeError("release parse failed")
+
+    monkeypatch.setattr(beacon, "release", _boom)
+    attrs = provider._resource_attributes()
+    assert "service.version" not in attrs
+    # The other groups are untouched by the failed probe.
+    assert attrs["service.name"] == "kirocrew"
+    assert "os.type" in attrs
+
+
+def test_id_read_failure_omits_the_attribute(monkeypatch):
+    def _boom(*, create=True):
+        raise OSError("disk unreadable")
+
+    monkeypatch.setattr(beacon, "install_id", _boom)
+    attrs = provider._resource_attributes()
+    assert "service.instance.id" not in attrs
+    assert "service.version" in attrs
+
+
+def test_the_probe_is_read_only_and_the_build_path_mints(tmp_path, monkeypatch):
+    # _resource_attributes itself never CREATES the id (create=False): it is a
+    # pure probe, so calling it cannot have a side effect on disk.
+    _own_home(monkeypatch, tmp_path)
+    attrs = provider._resource_attributes()
+    assert "service.instance.id" not in attrs
+    assert beacon.install_id(create=False) == "", "the probe created the id"
+
+    # The single write lives in _build_recorder's live branch, immediately
+    # before the probe, so the id exists by the time the resource is built.
+    beacon.install_id(create=True)
+    assert "service.instance.id" in provider._resource_attributes()
+
+
+def test_first_build_on_a_fresh_install_exports_the_id(tmp_path, monkeypatch):
+    # The gap an earlier round named: telemetry enabled from the very first
+    # boot (config pre-enabled, beacon disabled — a container image), so
+    # consent never flips and the consent worker never rebuilds. Minting in
+    # the build path means the FIRST export already carries the identity —
+    # no id-less window, and no mid-life resource swap (which a backend reads
+    # as a brand-new series set).
+    reset_for_testing()
+    _own_home(monkeypatch, tmp_path)
+    metrics_dir = tmp_path / "m"
+    _patch_config(
+        monkeypatch,
+        enabled=True,
+        local_dir=str(metrics_dir),
+        export_interval_seconds=3600,
+    )
+    try:
+        rec = get_recorder()  # first build: mints, then labels
+        assert rec.enabled is True
+        minted = beacon.install_id(create=False)
+        assert minted, "the build path never minted the id"
+
+        rec.counter("kirocrew.session.idle_expired", attrs={"turn_active": False})
+        provider_shutdown()
+        shards = sorted(metrics_dir.glob("metrics-*.jsonl"))
+        assert shards
+        last = json.loads(shards[-1].read_text().splitlines()[-1])
+        resource_attrs = last["resource_metrics"][0]["resource"]["attributes"]
+        assert resource_attrs["service.instance.id"] == minted
+    finally:
+        reset_for_testing()
+
+
+def test_a_failed_mint_costs_only_the_attribute(tmp_path, monkeypatch):
+    # An unwritable data dir must cost the LABEL, never the recorder: the
+    # build fails soft and keeps exporting. What it falls back to is NOT an
+    # unlabelled resource -- the SDK substitutes its own per-process uuid4 --
+    # so this pins the shape of that fallback rather than claiming absence.
+    reset_for_testing()
+    _own_home(monkeypatch, tmp_path)
+    metrics_dir = tmp_path / "m"
+    _patch_config(
+        monkeypatch,
+        enabled=True,
+        local_dir=str(metrics_dir),
+        export_interval_seconds=3600,
+    )
+
+    def _boom(*, create=False):
+        if create:
+            raise OSError("data dir unwritable")
+        return ""
+
+    monkeypatch.setattr(beacon, "install_id", _boom)
+    try:
+        rec = get_recorder()
+        assert rec.enabled is True
+        rec.counter("kirocrew.session.idle_expired", attrs={"turn_active": False})
+        provider_shutdown()
+        shards = sorted(metrics_dir.glob("metrics-*.jsonl"))
+        assert shards
+        last = json.loads(shards[-1].read_text().splitlines()[-1])
+        resource_attrs = last["resource_metrics"][0]["resource"]["attributes"]
+        # Present, but the SDK's per-process uuid4 (dashed, 36 chars) -- never
+        # mistakable for our persisted 32-char lowercase-hex install id.
+        substitute = resource_attrs["service.instance.id"]
+        assert re.fullmatch(r"[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}", substitute)
+        assert not re.fullmatch(r"[0-9a-f]{32}", substitute)
+        # The rest of the resource is untouched by the failed mint.
+        assert resource_attrs["service.name"] == "kirocrew"
+        assert "os.type" in resource_attrs
+    finally:
+        reset_for_testing()
+
+
+def test_a_disabled_install_never_creates_the_id(tmp_path, monkeypatch):
+    # The mint sits in the live branch only, so turning telemetry OFF creates
+    # nothing on disk — enabling metrics is what consents to the id existing.
+    reset_for_testing()
+    _own_home(monkeypatch, tmp_path)
+    _patch_config(monkeypatch, enabled=False, local_dir=str(tmp_path / "m"))
+    try:
+        assert get_recorder().enabled is False
+        assert beacon.install_id(create=False) == "", "a disabled build minted the id"
+    finally:
+        reset_for_testing()
+
+
+def test_channel_and_install_type_stay_absent():
+    # Deliberate exclusions (see the function docstring): the distribution
+    # channel narrows the anonymity crowd a stable id hides in, and there is
+    # no reliable install-type detection. Their absence is a decision, so it
+    # gets a regression guard.
+    attrs = provider._resource_attributes()
+    for key in attrs:
+        lowered = key.lower()
+        assert "channel" not in lowered
+        assert "distribution" not in lowered
+        assert "install_type" not in lowered
+
+
+def test_exported_shard_carries_the_resource(tmp_path, monkeypatch):
+    beacon.install_id(create=True)
+    reset_for_testing()
+    _patch_config(
+        monkeypatch,
+        enabled=True,
+        local_dir=str(tmp_path),
+        export_interval_seconds=3600,
+    )
+    try:
+        rec = get_recorder()
+        assert rec.enabled is True
+        rec.counter("kirocrew.session.idle_expired", attrs={"turn_active": False})
+        # shutdown() performs the final flush on the calling thread.
+        provider_shutdown()
+
+        shards = sorted(tmp_path.glob("metrics-*.jsonl"))
+        assert shards, "no shard written by the final flush"
+        record = json.loads(shards[0].read_text().splitlines()[0])
+        resource_attrs = record["resource_metrics"][0]["resource"]["attributes"]
+        assert resource_attrs["service.name"] == "kirocrew"
+        assert resource_attrs["service.version"] == beacon.release(kiro_crew.__version__)
+        assert resource_attrs["os.type"] == platform.system().lower()
+        assert resource_attrs["host.cpu.logical_count"] == os.cpu_count()
+        assert resource_attrs["process.pid"] == os.getpid()
+        assert "service.instance.id" in resource_attrs
+    finally:
+        reset_for_testing()


### PR DESCRIPTION
## What is the problem?

The MeterProvider resource carries only `service.name`. Nothing in an exported payload identifies the build that produced it, the install it came from, the process within that install, or the machine class it ran on:

- no `service.version`, so release-over-release comparison ("did the fix land") can only be done by comparing time ranges, which a gradual rollout muddies -- both versions report into the same buckets;
- no stable install identity, so any OTLP backend counting devices has nothing to count by. Worse than absent: when the key is omitted the SDK substitutes its own per-process `uuid4`, so every restart starts a brand-new series set and "this install over time" cannot be asked at all;
- no process identity either, so the several telemetry-enabled processes one install runs concurrently (gateway plus spawned agents/apps, the reason the local exporter shards per PID) would interleave their gauges and cumulative counters into one corrupted series;
- no `host.cpu.logical_count`, so `kirocrew.process.cpu.seconds` cannot be normalized into "percent of this machine" anywhere downstream -- the core count exists only client-side;
- no OS / arch / runtime attributes, so none of those work as fleet filters.

This is item 1 of #7232 and the first milestone slice of #7257.

## Why this issue matters to the user

Any consumer of the OTLP egress seam (an edition-supplied collector, CloudWatch, Datadog, or the local Telemetry page reading the JSONL sink) inherits these labels on every series. Without them a fleet dashboard cannot group by version, count devices, separate concurrent processes, or normalize CPU -- and no downstream work can add them later, because resource attributes only exist if the client stamps them at export time.

## How our fix solves it

`_resource_attributes()` is the single place the resource is built, and `Resource.create()` now consumes it. Every value is a closed set or an explicit clamp, because a resource attribute is a label on EVERY series this process exports -- one unbounded value here multiplies every instrument. Every probe fails soft: a failed read omits its attribute rather than losing telemetry or inventing a value.

| Attribute | Value | Bound |
|-----------|-------|-------|
| `service.instance.id` | persisted anonymous install id (`beacon.install_id`) | one per install |
| `process.pid` | `os.getpid()` | one per live process |
| `service.version` | release-clamped via `beacon.release` | `major.minor.patch`, no build stamp |
| `os.type` | `linux` / `darwin` / `windows` | CLOSED, else `other` |
| `host.arch` | `amd64` / `arm64` / `x86` (aliases folded) | CLOSED, else `other` |
| `process.runtime.name` | `cpython` / `pypy` / `jython` / `ironpython` | CLOSED, else `other` |
| `process.runtime.version` | `beacon.python_minor()` | `major.minor`, never the patch |
| `host.cpu.logical_count` | `os.cpu_count()` | small integer |

**Two identities, deliberately separate.** `service.instance.id` counts DEVICES: a random UUID persisted on disk, never derived from hostname or username (which routinely embed an employee alias on a corporate desktop), stable across restarts. `process.pid` counts PROCESSES. Collapsing them would report one machine's 6-8 concurrent processes as 6-8 machines; omitting the pid would interleave those processes into one corrupted series. PID reuse across restarts reads as an ordinary counter reset downstream.

**Where the id is minted, and why there.** The probe is read-only (`create=False`: one stat plus a 32-byte read). The single write -- `beacon.install_id(create=True)`, i.e. mkdir + mkstemp + link, race-safe per its own docstring, once per install ever -- sits in `_build_recorder()`'s live branch immediately before the resource is assembled. That placement is load-bearing in three ways:

1. **No window.** Because omitting the key yields the SDK's per-process `uuid4` rather than an unlabelled resource, any gap before the id lands exports exactly the per-restart churn this attribute exists to prevent. Minting before the first build means no export can carry the substitute.
2. **No mid-life swap.** Acquiring the identity later would mean replacing a live resource, which a backend reads as a second, unrelated series set -- and swapping a healthy provider invalidates any recorder reference a caller already holds, silently dropping its observations. Minting up front makes both impossible by construction, and lets this module hold no backfill state at all.
3. **Consent.** The live branch is not reached when telemetry is off, so a disabled install creates nothing on disk.

The cost is one bounded write on a path that already runs synchronously on whatever thread touched telemetry first: the same first build pays `KiroCrewConfig.load()` (~14ms on a changed file) plus ~57ms of SDK import, both documented in `docs/system-specs/modules/metrics.md`. The mint is noise against that, and a failed mint costs only the label -- never the recorder.

**Spec.** The metrics spec documented the SDK `Resource` as the payload contract for both sinks but described only what must NOT egress on it. It now carries the attribute table, the two-identities rationale, why the install id may egress while the host-local `kirocrew.process.start_time` token may not, and the disclosed consequence that enabling metrics is what creates the install-id file even where the beacon itself is disabled.

**Deliberately absent**, documented in the spec and guarded by a regression test: the distribution channel (the beacon's data-minimization pass removed its channel field because channel sharply narrows the anonymity crowd a stable id hides in; re-adding it is a consent-inventory question, not a code convenience) and an install type (no reliable detection exists today; a guessed label would be confidently wrong).

Imports (`beacon`, `__version__`, `platform`) live at module scope per the top-level-imports rule -- stdlib-or-already-loaded, and no cycle, since the config loader itself imports `kiro_crew.__version__` at module scope.

## What tests we did

`test/metrics/test_resource_attrs.py`, 11 tests:

- identity / version / environment attrs present with clamped shapes (release-shaped version, `major.minor` runtime asserted against `beacon.python_minor()` so the two surfaces cannot drift, 32-hex install id, integer core count, `process.pid == os.getpid()`);
- arch alias folding (`x86_64`/`AMD64` -> `amd64`, `aarch64` -> `arm64`);
- unknown OS / arch / runtime readings all fold to `other` (the closed-set guarantee, including `process.runtime.name`);
- the probe is read-only -- on a fresh home it omits the attribute and leaves the disk untouched -- while the build path mints;
- a fresh pre-enabled install (config on from first boot, beacon disabled) exports the id on its FIRST shard, and the exported value equals the minted id;
- a failed mint costs only the label: the recorder stays live and the resource falls back to the SDK's per-process `uuid4`, asserted by shape so it can never be mistaken for the persisted 32-hex id;
- a disabled install creates nothing on disk;
- version-probe failure omits only `service.version`; id-read failure omits only `service.instance.id`;
- channel / distribution / install_type stay absent;
- end-to-end: a live recorder's exported JSONL shard carries the resource attributes on the wire, not just in the dict.

Each behaviour is mutation-verified -- reverting the runtime closed set, or the build-path mint, turns the suite red rather than leaving a decorative assertion. Tests that assert on the install-id file are given their own `KIROCREW_HOME`, so a sibling test that mints cannot decide the outcome by execution order.

Gates: `flake8` / `isort` / `mypy` clean on the changed files; the new test file is black-clean and `provider.py` stays on the black baseline (never whole-file reformatted); `docs-lint.sh` clean.

## Any other suggestions on the work

- **`service.instance.id` semantics are worth a second opinion before this merges.** OTel semconv wants that key unique per *instance*, and Prometheus OTLP ingestion maps it to `instance` while demoting other resource attributes to `target_info` -- so at a Prometheus-family backend the gateway and its spawned agents still land on one `(job, instance)` pair despite `process.pid`. A composite (`{install_id}-{pid}`) plus a dedicated `kirocrew.install.id` for fleet GROUP BYs would satisfy both readings at no extra cardinality, since `process.pid` already turns the series set over per restart. It is a one-way door once dashboards key on the shape, which is why it is raised here rather than deferred.
- The privacy-adjacent coupling the spec now records -- enabling metrics mints the beacon's install-id file even where the beacon is disabled -- may belong in the telemetry-consent UI text, not only in the module spec. Out of scope for this PR.

Refs #7232, #7257 (milestone M0).
