### PR TITLE
docs: stop the windows guide claiming a ci gateway check it skips

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -122,10 +122,17 @@ Current status:
   Defender's post-install scanning. macOS and Linux still redirect bytecode out
   of the signed/read-only app tree. The loading screen retains its extended
   Windows handoff window as a slow-machine fallback; a child exit or spawn error
-  still fails immediately and includes the launch-log cause. CI starts the
-  just-installed bundled interpreter against an isolated data home and requires
-  `/api/ready` within 30 seconds, so both the packaged caches and the full gateway
-  handoff are covered rather than only a synthetic import benchmark.
+  still fails immediately and includes the launch-log cause.
+  `.github/scripts/test-windows-installer.ps1` can start the just-installed
+  bundled interpreter against an isolated data home and require `/api/ready`
+  within 30 seconds, covering both the packaged caches and the full gateway
+  handoff — but it is a **real-artifact check, not a CI gate**: the installer
+  job builds the NSIS package over a synthetic backend stub, so it has no
+  bundled interpreter to start and runs the script with
+  `-SkipGatewayValidation`. What CI enforces on every push is the native
+  installer's performance ceiling and its install-location contract; run the
+  script without that switch against a genuine backend payload to exercise the
+  gateway handoff.
 
 The source install below remains the fully supported path.
 

--- a/test/test_windows_installer_doc_contract.py
+++ b/test/test_windows_installer_doc_contract.py
@@ -1,0 +1,119 @@
+"""The Windows install guide may not claim CI coverage the workflow skips.
+
+``.github/scripts/test-windows-installer.ps1`` can start the just-installed
+bundled interpreter and wait for ``/api/ready``. The installer job in
+``build.yml`` cannot use that: it compiles the NSIS package over a synthetic
+``@echo off`` backend payload, so there is no bundled Python and no bytecode
+cache to probe, and it therefore passes ``-SkipGatewayValidation``.
+
+``docs/guides/windows-install.md`` asserted the opposite — that CI runs the
+readiness probe "rather than only a synthetic import benchmark". A reader (or a
+maintainer weighing a packaging change) would take that as a standing guarantee.
+
+These tests pin the two halves against each other so the claim cannot drift
+back: what the workflow actually invokes, and what the guide is allowed to say
+about it. If a future change makes CI run the probe for real, the first test
+fails and the guide can be restored in the same commit.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "build.yml"
+INSTALLER_SCRIPT = ROOT / ".github" / "scripts" / "test-windows-installer.ps1"
+INSTALL_GUIDE = ROOT / "docs" / "guides" / "windows-install.md"
+
+# Every read is explicit UTF-8: these files carry em dashes and box-drawing
+# characters, and a non-UTF-8 default codepage would fail the decode instead of
+# the assertion.
+_ENCODING = "utf-8"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding=_ENCODING)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> str:
+    return _read(BUILD_WORKFLOW)
+
+
+@pytest.fixture(scope="module")
+def guide() -> str:
+    return _read(INSTALL_GUIDE)
+
+
+def test_the_installer_job_skips_gateway_validation(workflow: str) -> None:
+    """The premise the guide's wording depends on, asserted rather than assumed."""
+    invocations = re.findall(r"test-windows-installer\.ps1[^\n']*", workflow)
+    assert invocations, "build.yml no longer invokes the Windows installer script"
+    assert all(
+        "-SkipGatewayValidation" in call for call in invocations
+    ), f"an installer invocation now runs gateway validation: {invocations}"
+
+
+def test_the_synthetic_payload_is_why_it_is_skipped(workflow: str) -> None:
+    """The skip is a property of the payload, not an arbitrary flag."""
+    assert "kirocrew.cmd" in workflow
+    assert "@echo off" in workflow
+
+
+def _readiness_sentences(guide: str) -> list[str]:
+    """Every sentence of the guide that mentions the readiness probe."""
+    return [s for s in re.split(r"(?<=[.])\s+", guide) if "/api/ready" in s]
+
+
+def test_the_guide_discloses_that_ci_skips_the_readiness_probe(guide: str) -> None:
+    """The residual this file exists for.
+
+    Phrased as a positive requirement rather than "must not say CI": the guide
+    is allowed — and now expected — to mention CI here, provided it says in the
+    same breath that the installer job passes ``-SkipGatewayValidation``.
+    Reinstating the old unqualified claim drops that token and reddens this.
+    """
+    sentences = _readiness_sentences(guide)
+    assert sentences, "the guide no longer describes the readiness probe at all"
+    for sentence in sentences:
+        assert "SkipGatewayValidation" in sentence, (
+            "the guide describes the readiness probe without disclosing that the "
+            f"installer job skips it: {sentence.strip()!r}"
+        )
+
+
+def test_the_readiness_probe_still_exists_for_real_artifact_runs() -> None:
+    """The guide's replacement wording is also load-bearing.
+
+    It says the check runs on a real artifact rather than in CI. That is only
+    honest while the script still carries the probe behind the flag.
+    """
+    script = _read(INSTALLER_SCRIPT)
+    assert "SkipGatewayValidation" in script
+    assert "/api/ready" in script
+
+
+def test_the_guide_check_can_actually_fail(guide: str) -> None:
+    """Self-check: a scan that matches nothing would pass as green.
+
+    Re-runs the guide predicate against the exact sentence this change removed,
+    so a future edit that breaks the split or the pattern is caught here rather
+    than silently exempting the guide.
+    """
+    removed = (
+        "CI starts the just-installed bundled interpreter against an isolated "
+        "data home and requires `/api/ready` within 30 seconds, so both the "
+        "packaged caches and the full gateway handoff are covered rather than "
+        "only a synthetic import benchmark."
+    )
+    # The predicate above must reject this sentence, or it proves nothing: it
+    # is picked up as a readiness sentence and carries no skip disclosure.
+    assert _readiness_sentences(removed) == [removed]
+    assert "SkipGatewayValidation" not in removed
+    # Compare on collapsed whitespace: the guide hard-wraps and indents its
+    # bullets, so a raw substring test would pass without the sentence ever
+    # having been removed.
+    assert removed not in re.sub(r"\s+", " ", guide)


### PR DESCRIPTION
## Problem / Motivation

`docs/guides/windows-install.md` told the reader that CI verifies the packaged
Windows gateway end to end:

> CI starts the just-installed bundled interpreter against an isolated data home and
> requires `/api/ready` within 30 seconds, so both the packaged caches and the full
> gateway handoff are covered rather than only a synthetic import benchmark.

It does not. `.github/scripts/test-windows-installer.ps1` is invoked exactly once in
the repository — `.github/workflows/build.yml:122` — and that invocation passes
`-SkipGatewayValidation`. The script then prints, in its own words:

> Skipping bundled gateway validation for the synthetic CI backend payload.

The skip is not an oversight. Two steps earlier the same job writes the backend it
packages:

```yaml
- name: Create minimal backend payload
  run: |
    New-Item -ItemType Directory -Force backend-dist/kirocrew-backend/bin | Out-Null
    @('@echo off', 'exit /b 0') | Set-Content -Encoding ascii backend-dist/kirocrew-backend/bin/kirocrew.cmd
```

There is no bundled `python.exe` to launch and no `.pyc` cache to count, so the
validation block *cannot* run in that job. The guide's claim is the exact inverse of
what happens, and the clause it ends on — "rather than only a synthetic import
benchmark" — describes precisely what CI does run.

## Why it matters

This is a claim about the repository's own verification guarantees, in the guide
`AGENTS.md` routes contributors to for anything Windows or cross-platform. Someone
changing the packaging path — pruning the import closure, moving the bytecode caches,
touching the launcher handoff — reads it as "CI will catch me if I break the gateway
start", and CI will not. That is the failure mode where a wrong doc is worse than no
doc.

Two independent First Principles reviews counted it on two different PRs (#6047 and
#6097), each with `count: 1`, and neither PR was the right place to fix it.

## What changed (motivation → approach → change)

**Symptom** → the guide asserts a CI gate that does not exist.
**Root cause** → the readiness probe is real, but it lives behind a switch the only CI
caller sets; the guide describes the script's capability as if it were the workflow's
behavior.
**Change** → say which is which, and pin it.

- `docs/guides/windows-install.md` — the bullet now names the probe as a
  **real-artifact check, not a CI gate**, gives the reason (the synthetic backend
  stub), names the switch (`-SkipGatewayValidation`), states what CI *does* enforce on
  every push (the native installer performance ceiling and the install-location
  contract), and tells the reader how to actually run the probe.
- `test/test_windows_installer_doc_contract.py` — a new ratchet holding the two halves
  against each other.

**The CI side is deliberately unchanged.** The other conceivable fix — drop
`-SkipGatewayValidation` so the claim becomes true — cannot work: the job has no real
backend payload to validate, by construction. Building one there is a packaging-scope
change with its own cost, not a documentation correction. Fixing the doc is the only
option that is correct today.

## Tests

`test/test_windows_installer_doc_contract.py`, five tests. Deterministic red-before
against pristine `main`: **2 failed / 3 passed**.

| Test | Locks in |
|---|---|
| `test_the_installer_job_skips_gateway_validation` | the premise itself: *every* `test-windows-installer.ps1` invocation in `build.yml` carries `-SkipGatewayValidation`. If CI ever runs the probe for real, this reddens and the stronger wording can be restored in the same commit |
| `test_the_synthetic_payload_is_why_it_is_skipped` | the skip is a property of the `@echo off` payload, not an arbitrary flag |
| `test_the_guide_discloses_that_ci_skips_the_readiness_probe` | the residual: any sentence describing `/api/ready` must also name `SkipGatewayValidation`. Phrased as a positive requirement, so the guide may still mention CI here — it just cannot claim the coverage without disclosing the skip |
| `test_the_readiness_probe_still_exists_for_real_artifact_runs` | the *replacement* wording is load-bearing too: it says the check exists for real artifacts, which is only honest while the script still carries it |
| `test_the_guide_check_can_actually_fail` | self-check. Re-runs the guide predicate against the exact sentence this change removes and asserts it is rejected — a scan that matched nothing would otherwise pass as green. Compares on collapsed whitespace, because the guide hard-wraps its bullets and a raw substring test would pass without the sentence ever having been removed |

Both red-before failures are the two assertions about the guide; the three premise
tests pass on both sides, which is what shows the workflow was read rather than
assumed.

Every file read passes `encoding="utf-8"` explicitly — these files carry em dashes and
box-drawing characters, and a non-UTF-8 default codepage would fail the decode instead
of the assertion.

Gates: `flake8`, `isort` and `black --target-version py310` clean on the new test file;
`scripts/check_black_formatting.py` passes in scope; `scripts/docs-lint.sh` and
`scripts/scrub-lint.sh` both pass.

## Manual verification

N/A — unit coverage sufficient: the change is one documentation paragraph, and the
tests read the real `build.yml`, the real `.ps1` and the real guide rather than
fixtures, so the claim they pin is the shipped one.

## Related Issues

Follows up the residual counted by the First Principles reviews on #6047 and #6097.

no linked issue: doc-accuracy fix found during review residual triage; no tracking issue was filed.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a doc that credits CI with a check should be read against the *invocation*,
not the script — a capability behind a `-Skip…` switch that the only caller sets is
documentation of an intent, not of a gate.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

