### PR TITLE
fix(agent-discovery): attribute project-dir denials to the caller

### DIFF
--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -12,6 +12,7 @@ Each agent is identified by its ``modeId`` — the value passed to
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -373,7 +374,12 @@ def _project_signature(project_dir: str | Path) -> tuple[_ListAgentsSig, ...]:
     )
 
 
-def project_agent_names(project_dir: str | Path | None) -> frozenset[str]:
+def project_agent_names(
+    project_dir: str | Path | None,
+    *,
+    operation: str = "project_agent_names",
+    source: str = "project_agent_names",
+) -> frozenset[str]:
     """Dispatchable agent names declared by a project, cached on a stat signature.
 
     Only ``<project>/.kiro/agents/*.json`` contributes, because only those names are
@@ -385,6 +391,17 @@ def project_agent_names(project_dir: str | Path | None) -> frozenset[str]:
     resolver calls this on EVERY turn of a project-agent-bound session: bounding the
     file count is not enough on its own, since the cost that stalls a caller is the
     reads, not the count.
+
+    *operation*/*source* label the SEL denial event emitted on a sensitive
+    project directory, exactly as on :func:`_read_agent_spec` (#6764 mirrors
+    #6722): the calling surface names itself so the security trail attributes
+    the refusal to the request that triggered it. ``source`` is the interface
+    channel (``SecurityEvent.source`` vocabulary: dashboard, cli, slack, cron,
+    ...; ``"unknown"`` when the caller serves multiple channels) — every call
+    site passes it explicitly, enforced by the call-site ratchet test. Both
+    defaults exist ONLY so a bare call reproduces the historical event
+    byte-for-byte (a forgotten future call site degrades to exactly today's
+    trail); they are not for new call sites.
 
     Never raises; an unreadable checkout yields an empty set.
     """
@@ -399,8 +416,8 @@ def project_agent_names(project_dir: str | Path | None) -> frozenset[str]:
     if is_sensitive_path(key):
         logger.debug("Skipping sensitive project dir for agent discovery: %s", project_dir)
         _audit_denied(
-            operation="project_agent_names",
-            source="project_agent_names",
+            operation=operation,
+            source=source,
             resources=key,
             error="sensitive project dir rejected",
         )
@@ -457,7 +474,12 @@ def clear_project_agent_cache() -> None:
     _PROJECT_NAMES_CACHE.clear()
 
 
-async def warm_project_agent_names(project_dir: str | Path | None) -> None:
+async def warm_project_agent_names(
+    project_dir: str | Path | None,
+    *,
+    operation: str = "warm_project_agent_names",
+    source: str = "unknown",
+) -> None:
     """Populate the project name cache from the discovery pool, off the event loop.
 
     The counterpart to :func:`cached_project_agent_names`: an async caller runs this
@@ -469,6 +491,13 @@ async def warm_project_agent_names(project_dir: str | Path | None) -> None:
     ``StopIteration`` in particular cannot be delivered through a ``Future``, which
     hangs the awaiting caller instead of surfacing the error.
 
+    *operation*/*source* forward to :func:`project_agent_names` so a denial hit
+    during the warm names the surface that requested it rather than echoing the
+    helper's own name (#6764). The defaults name this hop truthfully: the warm
+    itself is the operation, and the helper serves several channels (dashboard
+    chat, spawn admission), so its channel is ``"unknown"`` unless the caller
+    says otherwise.
+
     A no-op without a *project_dir*. Best-effort and never raises: failing to warm
     costs one turn's fallback, and must not break turn handling.
     """
@@ -476,7 +505,8 @@ async def warm_project_agent_names(project_dir: str | Path | None) -> None:
         return
     try:
         await asyncio.get_running_loop().run_in_executor(
-            discovery_executor(), project_agent_names, project_dir
+            discovery_executor(),
+            functools.partial(project_agent_names, project_dir, operation=operation, source=source),
         )
     except Exception:  # noqa: BLE001 — a warm failure only costs a fallback
         logger.debug("Failed to warm project agent names for %s", project_dir, exc_info=True)

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -10119,7 +10119,9 @@ def _project_declares_agent(agent_name: str, project_dir: str) -> bool:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            return agent_name in project_agent_names(project_dir)
+            return agent_name in project_agent_names(
+                project_dir, operation="project_declares_agent", source="unknown"
+            )
         names = cached_project_agent_names(project_dir)
         if names is None:
             logger.debug(

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -433,7 +433,9 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                 # fall back to default bindings and falsely equate a
                 # project-agent slot with a request naming the default alias.
                 # Warm the cache off-loop first so the on-loop lookup is a hit.
-                await warm_project_agent_names(slot.project or None)
+                await warm_project_agent_names(
+                    slot.project or None, operation="api_chat", source="dashboard"
+                )
                 _stored = resolve_agent_bindings(_cfg, slot.agent, slot.project or None)
                 _requested = resolve_agent_bindings(_cfg, agent, slot.project or None)
                 # Identity itself lives on ResolvedBindings, next to the field
@@ -4252,7 +4254,9 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
                 # PREVIOUS agent's project — latent until app agents could dispatch.
                 # Resolve WITH the slot's project scope (warmed off-loop first) so a
                 # project agent counts as resolved rather than falling back.
-                await warm_project_agent_names(slot.project or None)
+                await warm_project_agent_names(
+                    slot.project or None, operation="api_chat_slot_agent", source="dashboard"
+                )
                 bindings = resolve_agent_bindings(cfg, agent_name, slot.project or None)
                 ws_name = _workspace_name_for_dir(cfg, bindings.workspace_dir)
                 new_workspace = ws_name

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5250,7 +5250,10 @@ async def _run_chat(
             # the warm is offloaded: resolve_agent_bindings can raise StopIteration
             # on a malformed config, and StopIteration cannot be delivered through a
             # Future, so awaiting it would hang instead of surfacing the error.
-            await warm_project_agent_names(slot.project)
+            # source="unknown", not "dashboard": Slack-triggered turns reach
+            # _run_chat too (slack/gateway.py and slack/handler.py call it
+            # directly), so this hop serves multiple channels (#6764).
+            await warm_project_agent_names(slot.project, operation="chat_turn", source="unknown")
             bindings = resolve_agent_bindings(cfg, slot.agent or None, slot.project or None)
             kiro_agent = bindings.kiro_agent
             crew_alias = bindings.resolved_alias

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -1874,7 +1875,13 @@ async def api_kirocrew_agents(request: web.Request) -> web.Response:
     if project_dir:
         try:
             project_names = await asyncio.get_running_loop().run_in_executor(
-                discovery_executor(), project_agent_names, project_dir
+                discovery_executor(),
+                functools.partial(
+                    project_agent_names,
+                    project_dir,
+                    operation="api_kirocrew_agents",
+                    source="dashboard",
+                ),
             )
         except Exception:
             logger.warning("Failed to list project agents for %s", project_dir, exc_info=True)

--- a/src/kiro_crew/dashboard/handlers/side.py
+++ b/src/kiro_crew/dashboard/handlers/side.py
@@ -361,7 +361,7 @@ async def _run_side_turn(
             # Warm off-loop, resolve inline — same reasoning as the main chat path
             # (offloading the resolver itself would swallow a StopIteration into a
             # Future and hang the await).
-            await warm_project_agent_names(slot.project)
+            await warm_project_agent_names(slot.project, operation="side_panel", source="dashboard")
             bindings = resolve_agent_bindings(cfg, slot.agent or None, slot.project or None)
             kiro_agent = bindings.kiro_agent
             # SELF-HEAL an app-owned slot whose agent did not resolve, on the same

--- a/src/kiro_crew/spawn_warm.py
+++ b/src/kiro_crew/spawn_warm.py
@@ -57,4 +57,7 @@ async def warm_project_agents_for_spawn(state: Any, cwd: str) -> None:
     else:
         warm_dir = str(getattr(state.sessions, "_pool_cwd", "") or "")
     if warm_dir:
-        await warm_project_agent_names(warm_dir)
+        # Spawns arrive from several channels (dashboard, slack, cron, ...), so
+        # the channel is genuinely unknown here; the operation still names the
+        # surface that triggered the scan (#6764).
+        await warm_project_agent_names(warm_dir, operation="spawn_warm", source="unknown")

--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -765,6 +765,110 @@ class TestDenialAttribution:
         assert events[0]["source"] == "list_agents"
 
 
+class TestProjectNamesDenialAttribution:
+    """Sensitive-project-dir denials name the surface that asked (#6764).
+
+    Same contract as :class:`TestDenialAttribution`, for the OTHER denial path
+    in the module: ``project_agent_names`` refuses a sensitive project
+    directory before any filesystem access, and the SEL row it emits must
+    attribute the refusal to the request that triggered it rather than echoing
+    the helper's own name into the ``source`` vocabulary.
+    """
+
+    @staticmethod
+    def _denial_events(tmp_path, monkeypatch):
+        """Return a sensitive project dir and a spy collecting SEL fields."""
+        from types import SimpleNamespace
+
+        from kiro_crew import agent_discovery
+
+        project_dir = tmp_path / "protected-project"
+        project_dir.mkdir()
+        monkeypatch.setattr(
+            agent_discovery, "is_sensitive_path", lambda p: str(project_dir) in str(p)
+        )
+        events: list[dict] = []
+        monkeypatch.setattr(
+            agent_discovery,
+            "_sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        return project_dir, events
+
+    def test_default_call_shape_emits_exactly_the_historical_event(self, tmp_path, monkeypatch):
+        """The compatibility defaults preserve the pre-attribution event."""
+        from kiro_crew.agent_discovery import project_agent_names
+
+        project_dir, events = self._denial_events(tmp_path, monkeypatch)
+
+        assert project_agent_names(project_dir) == frozenset()
+        assert events == [
+            {
+                "caller": "agent_discovery",
+                "operation": "project_agent_names",
+                "outcome": "denied",
+                "source": "project_agent_names",
+                "resources": str(project_dir),
+                "error": "sensitive project dir rejected",
+            }
+        ]
+
+    def test_labelled_call_attributes_the_denial_to_that_surface(self, tmp_path, monkeypatch):
+        from kiro_crew.agent_discovery import project_agent_names
+
+        project_dir, events = self._denial_events(tmp_path, monkeypatch)
+
+        result = project_agent_names(
+            project_dir, operation="api_kirocrew_agents", source="dashboard"
+        )
+        assert result == frozenset()
+        assert len(events) == 1
+        assert events[0]["operation"] == "api_kirocrew_agents"
+        assert events[0]["source"] == "dashboard"
+        assert events[0]["caller"] == "agent_discovery"
+        assert events[0]["outcome"] == "denied"
+
+    def test_source_defaults_independently_of_operation(self, tmp_path, monkeypatch):
+        """Supplying an operation must not corrupt the source vocabulary."""
+        from kiro_crew.agent_discovery import project_agent_names
+
+        project_dir, events = self._denial_events(tmp_path, monkeypatch)
+
+        assert project_agent_names(project_dir, operation="project_declares_agent") == frozenset()
+        assert events[0]["operation"] == "project_declares_agent"
+        assert events[0]["source"] == "project_agent_names"
+
+    def test_warm_hop_forwards_the_labels_to_the_scan(self, tmp_path, monkeypatch):
+        """The executor hop must not erase the caller's attribution."""
+        import asyncio
+
+        from kiro_crew.agent_discovery import warm_project_agent_names
+
+        project_dir, events = self._denial_events(tmp_path, monkeypatch)
+
+        asyncio.run(
+            warm_project_agent_names(project_dir, operation="chat_turn", source="dashboard")
+        )
+        assert len(events) == 1
+        assert events[0]["operation"] == "chat_turn"
+        assert events[0]["source"] == "dashboard"
+
+    def test_bare_warm_emits_the_wrapper_defaults(self, tmp_path, monkeypatch):
+        """A forgotten future warm caller degrades to the wrapper's own truthful
+        labels (operation names the warm, channel unknown) -- pinned so the
+        default pair cannot drift unrecorded."""
+        import asyncio
+
+        from kiro_crew.agent_discovery import warm_project_agent_names
+
+        project_dir, events = self._denial_events(tmp_path, monkeypatch)
+
+        asyncio.run(warm_project_agent_names(project_dir))
+        assert len(events) == 1
+        assert events[0]["operation"] == "warm_project_agent_names"
+        assert events[0]["source"] == "unknown"
+
+
 # Exact direct-call inventory. A new caller must name its user-facing operation
 # and interface channel (or ``unknown`` for a helper shared across interfaces).
 # Forwarding helpers are pinned as forwarding rather than forced to use a fixed
@@ -809,17 +913,49 @@ _EXPECTED_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
 }
 
 
-def _read_agent_spec_call_sites() -> dict[str, list[tuple[str | None, str | None]]]:
-    """Return every ``_read_agent_spec`` call site and its label pair.
+# Same contract for ``project_agent_names`` (#6764): its sensitive-project-dir
+# denial carries operation/source, so every scan-reaching call site must name
+# its user-facing operation and interface channel. ``warm_project_agent_names``
+# is pinned as forwarding -- a fixed literal there would erase the attribution
+# of whichever surface requested the warm. ``cached_project_agent_names`` is
+# absent by design: it is a pure in-memory lookup that performs no filesystem
+# work and can never reach the denial log line.
+_EXPECTED_PROJECT_NAMES_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
+    "kiro_crew/agent_discovery.py": [("forward:operation", "forward:source")],
+    "kiro_crew/config/loader.py": [("project_declares_agent", "unknown")],
+    "kiro_crew/dashboard/handlers/agents.py": [("api_kirocrew_agents", "dashboard")],
+}
 
-    A site that hands the reader off by REFERENCE counts too. ``asyncio.to_thread(
-    _read_agent_spec, path, operation=..., source=...)`` never produces a Call
-    node named ``_read_agent_spec``, so matching only direct calls left every
-    off-loop caller invisible to this ratchet -- and one such site really did
-    sit behind the reader's defaults, recording its denials as an agent-listing
-    cache warm. Any call that merely PASSES the reader is therefore a site as
+
+# The warm wrapper's own callers are held to the same contract: the wrapper
+# forwards to ``project_agent_names``, so an unlabelled warm caller would land
+# every denial on the wrapper's defaults -- and the warm path is the
+# highest-traffic route to the scan (a chat turn's ``slot.project`` reaches it
+# every turn), so it is exactly where attribution matters most.
+_EXPECTED_WARM_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
+    "kiro_crew/dashboard/chat_handlers.py": [
+        ("api_chat", "dashboard"),
+        ("api_chat_slot_agent", "dashboard"),
+    ],
+    "kiro_crew/dashboard/chat_runner.py": [("chat_turn", "unknown")],
+    "kiro_crew/dashboard/handlers/side.py": [("side_panel", "dashboard")],
+    "kiro_crew/spawn_warm.py": [("spawn_warm", "unknown")],
+}
+
+
+def _labelled_call_sites(target: str) -> dict[str, list[tuple[str | None, str | None]]]:
+    """Return every *target* call site and its label pair.
+
+    A site that hands the *target* off by REFERENCE counts too: handing it to
+    ``asyncio.to_thread`` / ``functools.partial`` / an executor never produces
+    a Call node named after the target, so matching only direct calls leaves
+    every off-loop caller invisible to this ratchet. That is not hypothetical:
+    one such site (an executor hop handing off ``_read_agent_spec``) really did
+    sit behind the callee's defaults, recording its denials as an agent-listing
+    cache warm. Any call that merely PASSES the target is therefore a site as
     well, and its labels are read from the handing-off call, which is where the
-    forwarded kwargs are written.
+    forwarded kwargs are written. This applies to every entry in
+    ``_RATCHET_INVENTORY``, not to any one callee.
     """
     src = Path(__file__).resolve().parent.parent / "src"
     sites: dict[str, list[tuple[str | None, str | None]]] = {}
@@ -834,14 +970,12 @@ def _read_agent_spec_call_sites() -> dict[str, list[tuple[str | None, str | None
                 if isinstance(func, ast.Name)
                 else func.attr if isinstance(func, ast.Attribute) else ""
             )
-            if name != "_read_agent_spec":
-                # Not the reader itself -- but it is a site if it hands the
-                # reader off to be invoked elsewhere (to_thread, partial, an
+            if name != target:
+                # Not the callee itself -- but it is a site if it hands the
+                # callee off to be invoked elsewhere (to_thread, partial, an
                 # executor). Positional only: a callee is never passed by
                 # keyword in these shapes.
-                if not any(
-                    isinstance(arg, ast.Name) and arg.id == "_read_agent_spec" for arg in node.args
-                ):
+                if not any(isinstance(arg, ast.Name) and arg.id == target for arg in node.args):
                     continue
             labels: dict[str, str | None] = {"operation": None, "source": None}
             for kw in node.keywords:
@@ -860,18 +994,29 @@ def _read_agent_spec_call_sites() -> dict[str, list[tuple[str | None, str | None
     }
 
 
+# The ratchet's coverage: every attribution-labelled helper in the module, with
+# its exact call-site inventory. Extending attribution to a new helper means
+# adding it here so its callers keep the two vocabularies separate too (#6764
+# added ``project_agent_names``, mirroring #6722's ``_read_agent_spec``).
+_RATCHET_INVENTORY: dict[str, dict[str, list[tuple[str, str]]]] = {
+    "_read_agent_spec": _EXPECTED_CALL_SITE_LABELS,
+    "project_agent_names": _EXPECTED_PROJECT_NAMES_CALL_SITE_LABELS,
+    "warm_project_agent_names": _EXPECTED_WARM_CALL_SITE_LABELS,
+}
+
+
 class TestCallSiteLabelRatchet:
     """Every direct reader call is enumerated and explicitly attributed."""
 
-    def test_every_call_site_carries_the_expected_label(self):
-        assert _read_agent_spec_call_sites() == _EXPECTED_CALL_SITE_LABELS
+    @pytest.mark.parametrize("target", sorted(_RATCHET_INVENTORY))
+    def test_every_call_site_carries_the_expected_label(self, target):
+        assert _labelled_call_sites(target) == _RATCHET_INVENTORY[target]
 
-    def test_no_call_site_is_silently_unlabelled(self):
-        for path, pairs in _read_agent_spec_call_sites().items():
+    @pytest.mark.parametrize("target", sorted(_RATCHET_INVENTORY))
+    def test_no_call_site_is_silently_unlabelled(self, target):
+        for path, pairs in _labelled_call_sites(target).items():
             for operation, source in pairs:
                 assert (
                     operation is not None
-                ), f"{path} calls _read_agent_spec without an explicit operation label"
-                assert (
-                    source is not None
-                ), f"{path} calls _read_agent_spec without an explicit source label"
+                ), f"{path} calls {target} without an explicit operation label"
+                assert source is not None, f"{path} calls {target} without an explicit source label"

--- a/test/test_api_server.py
+++ b/test/test_api_server.py
@@ -125,7 +125,9 @@ class TestApiServerSpawn:
         agent that verifiably exists.
         """
         order: list[str] = []
-        warm = AsyncMock(side_effect=lambda _d: order.append("warm"))
+        # The stub takes **kw because the warm forwards keyword-only SEL
+        # attribution labels (#6764) that this ordering test does not care about.
+        warm = AsyncMock(side_effect=lambda _d, **kw: order.append("warm"))
         monkeypatch.setattr("kiro_crew.spawn_warm.warm_project_agent_names", warm)
         # The warm only ever touches an ALLOWLISTED cwd; stand in for a config
         # whose allowed_roots admit tmp_path.
@@ -147,7 +149,7 @@ class TestApiServerSpawn:
                 json={"task": "hi", "agent": "proj-agent", "cwd": str(tmp_path)},
             )
             assert resp.status == 200
-        warm.assert_awaited_once_with(str(tmp_path))
+        warm.assert_awaited_once_with(str(tmp_path), operation="spawn_warm", source="unknown")
         assert order == ["warm", "spawn"], f"warm did not precede spawn: {order}"
 
     @pytest.mark.asyncio

--- a/test/test_slot_create_default_agent.py
+++ b/test/test_slot_create_default_agent.py
@@ -198,7 +198,9 @@ class TestSameBindingGuard:
             lambda name, project: name == "proj-agent" and project == "/proj",
         )
 
-        async def _noop_warm(project: Any) -> None:
+        async def _noop_warm(project: Any, **kw: Any) -> None:
+            # **kw: the warm takes keyword-only SEL attribution labels (#6764)
+            # that this guard test does not care about.
             return None
 
         monkeypatch.setattr(chat_handlers, "warm_project_agent_names", _noop_warm)


### PR DESCRIPTION
## Problem / Motivation

The shared agent-discovery helper `project_agent_names` fills BOTH the `operation` and `source` fields of its sensitive-project-dir SEL denial event with its own function name (`agent_discovery.py`). Per `sel.py`, `source` is supposed to name the calling surface (`dashboard`, `cli`, `slack`, `cron`, ..., or `unknown` for multi-channel helpers), not echo the operation. Every refusal — for example a dashboard slot whose project is pointed at a protected tree such as `~/.aws` — records as an unattributable `("project_agent_names", "project_agent_names")` row, so an operator auditing the security trail cannot tell which request triggered the probe.

## Why it matters

The SEL denial row is the record designed to let an operator see a probe at a protected path and attribute it to the surface that made it. With both fields echoing the helper's name, the highest-value security signal in this module — "someone pointed a project at a credential directory" — carries no attribution at all. Merged PR #6760 fixed the sibling reader `_read_agent_spec` in this same module for exactly this reason (#6722); this closes the remaining denial path.

## What changed (motivation → approach → change)

Symptom: operation-echoing `source` on `project_agent_names` denials. Root cause: the labels were hardcoded at the emit site instead of being supplied by the caller. Change — mirror PR #6760's pattern exactly:

- `project_agent_names` gains keyword-only `operation`/`source` parameters whose defaults reproduce the historical event byte-for-byte, so the change is additive and a forgotten future call site degrades to exactly today's trail.
- Real attribution is threaded through every call site that can reach the log line:
  - `warm_project_agent_names` accepts and forwards the same keyword-only params through its executor hop (`functools.partial`, since `run_in_executor` takes no kwargs). Its five callers each pass their true surface: `api_chat` and `api_chat_slot_agent` (`chat_handlers.py`, dashboard-only HTTP routes, `source="dashboard"`), `side_panel` (`handlers/side.py`, called only from its dashboard HTTP handler, `source="dashboard"`), `chat_turn` (`chat_runner.py`, `source="unknown"`: Slack-triggered turns reach `_run_chat` too, via `slack/gateway.py` and `slack/handler.py`), and `spawn_warm` (`spawn_warm.py`, `source="unknown"`: spawns arrive from several channels). The warm is the highest-traffic route to the scan (a chat turn's `slot.project` reaches it every turn), so labelling only the wrapper would have left the most reachable denial unattributed.
  - The `api_kirocrew_agents` executor hop (`dashboard/handlers/agents.py`) labels itself `operation="api_kirocrew_agents"`, `source="dashboard"`.
  - The `_project_declares_agent` sync call (`config/loader.py`) labels itself `operation="project_declares_agent"`, `source="unknown"` (it serves multiple channels).
- `cached_project_agent_names` is untouched: it is a pure in-memory lookup with no filesystem work and never reaches the denial line (and the cache can never hold a sensitive key, because the denial returns before the cache is populated).

## Tests

- The call-site AST ratchet in `test/test_agent_spec_hardened_reads.py` is generalized from `_read_agent_spec`-specific to target-parametrized, and now covers `project_agent_names` and `warm_project_agent_names` alongside `_read_agent_spec` — every direct call or by-reference handoff of any of the three must carry an explicit label pair, so future call sites keep the operation and source vocabularies separate.
- `TestProjectNamesDenialAttribution` locks the emitted fields for the rejected-directory path: the bare-call compatibility shape (historical event byte-for-byte), labelled attribution, source-independence from operation, warm-hop forwarding through the executor, and the warm wrapper's own pinned defaults. Proven red-before-green: on unmodified source the labelled-call, warm-forwarding, and source-independence tests fail with `TypeError` and the ratchet fails on unlabelled sites, while the compatibility test passes by design.
- Two existing test stubs that monkeypatch the warm gained `**kw` (`test_api_server.py`, `test_slot_create_default_agent.py`), the same shape as PR #6760's `test_cli_doctor.py` stub update; the `test_api_server.py` assertion was strengthened to pin the exact labels `spawn_warm.py` passes.

## Manual verification

N/A — unit coverage sufficient: the change is label threading through existing call paths, and the denial-attribution tests assert the exact emitted SEL fields for every shape (bare, labelled, forwarded).

## Related Issues

Closes #6764

## Pattern harvest

Rule candidate: review-prompt
Pattern: an audit/telemetry helper that fills a caller-attribution field with its own name — attribution fields must be supplied by the caller and enforced by a call-site ratchet.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
