### PR TITLE
fix(portability): vet zip inventory before import

### DIFF
--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -43,6 +43,7 @@ from kiro_crew.snapshot import (
     _merge_notifications,
     _staging_is_pinned,
 )
+from kiro_crew.zip_vet import ZipInventoryRejected, vet_zip_inventory
 
 logger = logging.getLogger(__name__)
 
@@ -490,6 +491,7 @@ def validate_import_zip(zip_path: Path) -> tuple[bool, str, dict]:
     Returns (ok, error_message, manifest_dict).
     """
     try:
+        vet_zip_inventory(zip_path, max_members=_MAX_IMPORT_MEMBERS)
         with zipfile.ZipFile(str(zip_path), "r") as zf:
             names = zf.namelist()
 
@@ -535,6 +537,12 @@ def validate_import_zip(zip_path: Path) -> tuple[bool, str, dict]:
                 return False, f"Unsupported manifest version: {version}", {}
 
             return True, "", manifest_data
+    except ZipInventoryRejected as exc:
+        if exc.reason == "too_many_members":
+            return False, f"Rejected: archive has too many entries ({exc})", {}
+        if exc.reason in {"cdir_too_large", "zip64_saturated"}:
+            return False, f"Rejected: archive inventory exceeds cap ({exc}; possible zip bomb)", {}
+        return False, "Invalid zip file", {}
     except zipfile.BadZipFile:
         return False, "Invalid zip file", {}
     except (json.JSONDecodeError, KeyError) as e:
@@ -674,6 +682,17 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
 
     Returns summary dict of what was imported.
     """
+    try:
+        vet_zip_inventory(zip_path, max_members=_MAX_IMPORT_MEMBERS)
+    except ZipInventoryRejected as exc:
+        if exc.reason == "too_many_members":
+            raise ValueError(f"Import archive has too many entries ({exc})") from exc
+        if exc.reason in {"cdir_too_large", "zip64_saturated"}:
+            raise ValueError(
+                f"Import archive inventory exceeds cap ({exc}; possible zip bomb)"
+            ) from exc
+        raise zipfile.BadZipFile("Invalid zip file") from exc
+
     mc = _mc_dir()
     # Asked once, at the top, before anything is extracted or written. Both branches
     # below mutate the data home, and the merge branch writes core files with

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -1536,6 +1536,23 @@ def test_import_zip_bomb_member_cap(tmp_path, monkeypatch):
         port.apply_import_zip(z)
 
 
+def test_import_member_inventory_is_rejected_before_zipfile(tmp_path, monkeypatch):
+    import kiro_crew.portability as port
+
+    z = _make_min_import_zip(tmp_path / "inventory.zip", extra_files=3)
+    monkeypatch.setattr(port, "_MAX_IMPORT_MEMBERS", 1)
+
+    def unexpected_zipfile(*args, **kwargs):
+        raise AssertionError("ZipFile was constructed for a refused archive")
+
+    monkeypatch.setattr(port.zipfile, "ZipFile", unexpected_zipfile)
+
+    ok, msg, _ = port.validate_import_zip(z)
+    assert ok is False and "too many entries" in msg
+    with pytest.raises(ValueError, match="too many entries"):
+        port.apply_import_zip(z)
+
+
 def test_import_zip_bomb_size_cap(tmp_path, monkeypatch):
     # SEC-7F44A198: excessive declared uncompressed size is rejected (zip bomb).
     import kiro_crew.portability as port


### PR DESCRIPTION
## Problem / Motivation

The dashboard portability import paths constructed `zipfile.ZipFile` before
checking their member caps. `ZipFile` materializes the central-directory
inventory during construction, so a crafted import could consume memory before
the existing post-open guard ran.

This is the exact portability residual counted and deferred by the merged review
on #6501.

## Why it matters

Portability archives are uploaded input. A cap that runs only after inventory
allocation does not protect preview or apply from the allocation it is meant to
bound.

## What changed (motivation → approach → change)

Uploaded archives could materialize an over-cap central-directory inventory
before rejection → `ZipFile` materializes that inventory during construction,
ahead of the existing post-open cap → run the existing shared
`vet_zip_inventory` preflight before `ZipFile` construction in both
`validate_import_zip` and the defense-in-depth `apply_import_zip` path.
Preflight rejections use each function's existing return/exception channel, and
the post-open member and uncompressed-size checks remain in place.

## Tests

- Red-before: the new regression failed because `ZipFile` was constructed for
  an archive whose declared member count exceeded the import cap.
- Green: the regression plus the existing member-cap, uncompressed-size-cap,
  and invalid-ZIP tests pass (4/4).
- Touched-file gates pass: isort, flake8, production-file Black, test-line
  Black, and `git diff --check`.
- Local mypy was unavailable in the reused dependency environment; no packages
  were installed solely for reassurance, so lockfile-complete server CI owns
  the typecheck.

## Manual verification

N/A — focused unit coverage directly asserts the pre-construction ordering and
both public import entry points.

## Related Issues

No linked issue. This is the reviewer-counted residual from merged #6501.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Archive safety caps must run before a parser/materializer performs the
allocation the cap is intended to bound.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [ ] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->