### PR TITLE
fix(dashboard): scope slot-trust bulk auto-approve to the target session

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -6259,63 +6259,81 @@ async def api_chat_mode(request: web.Request) -> web.Response:
 
     # If any slot has a pending approval and mode is trust/yolo, auto-approve it
     if mode in ("trust", "yolo"):
-        for slot in state._slots.values():
-            for aid, fut in list(slot._approval_futures.items()):
+        # A slot-scoped ``trust`` grants auto-approval to ONE session only (the
+        # target slot and any slot sharing its effective key). The pending-approval
+        # sweep MUST honour that scope: sweeping every slot's pending prompt would
+        # clear the approval card in unrelated chats — making them LOOK approved —
+        # while their ``_trust`` flag stays False, so their very next tool call
+        # prompts again. ``yolo`` is process-global and an unscoped ``trust`` (no
+        # slot named = the documented all-slots request) still sweeps everything,
+        # including background and channel approvals. Only a slot-scoped ``trust``
+        # narrows.
+        scoped = mode == "trust" and slot is not None
+        _target_key = effective_session_key(slot) if slot is not None and scoped else None
+        for _slot in state._slots.values():
+            if scoped and effective_session_key(_slot) != _target_key:
+                continue
+            for aid, fut in list(_slot._approval_futures.items()):
                 if not fut.done():
                     fut.set_result("approved")
                     # Persist resolved state into the permission message. The
                     # periodic flush skips non-dirty slots, so the mark must
                     # flag the slot or the write can be lost on restart.
-                    if _mark_permission_resolved(slot.messages, aid, mode):
-                        slot._dirty = True
+                    if _mark_permission_resolved(_slot.messages, aid, mode):
+                        _slot._dirty = True
                     # ``slot`` keys the frame for the slot-scoped WS gate — an
                     # app token cannot receive its own resolution without it.
                     state.broadcast_ws(
                         "approval_resolved",
-                        {"id": aid, "approved": True, "slot": slot.key},
+                        {"id": aid, "approved": True, "slot": _slot.key},
                     )
                     try:
                         sel().log_api_access(
-                            caller=f"dashboard:{slot.key}",
+                            caller=f"dashboard:{_slot.key}",
                             operation=f"tool_approval:bulk_{mode}",
                             outcome="approved",
                             resources=aid,
                         )
                     except Exception:
                         logger.warning("SEL audit failed for bulk approval %s", aid, exc_info=True)
-        # Also auto-approve all pending background approvals (cron/subagent/taskrunner)
-        for aid in list(state._approval_futures):
-            fut = state._approval_futures[aid]
-            if not fut.done():
-                state.resolve_approval(aid, True)
-                try:
-                    sel().log_api_access(
-                        caller="dashboard:background",
-                        operation=f"tool_approval:bulk_{mode}",
-                        outcome="approved",
-                        resources=aid,
-                    )
-                except Exception:
-                    logger.warning("SEL audit failed for bulk approval %s", aid, exc_info=True)
-        # Auto-approve pending channel approvals
-        mgr = getattr(state, "channel_manager", None)
-        if mgr:
-            for ch in mgr._channels.values():
-                for agent in ch.members.values():
-                    fut = agent._approval_future
-                    if fut and not fut.done():
-                        fut.set_result("approved")
-                        try:
-                            sel().log_api_access(
-                                caller=f"channel:{ch.id}:{agent.agent_name}",
-                                operation=f"tool_approval:bulk_{mode}",
-                                outcome="approved",
-                                resources=getattr(fut, "_approval_id", "unknown"),
-                            )
-                        except Exception:
-                            logger.warning(
-                                "SEL audit failed for channel bulk approval", exc_info=True
-                            )
+        # Background (cron/subagent/taskrunner) and channel approvals are NOT
+        # slot-scoped, so a slot-scoped ``trust`` must leave them pending — it
+        # asked for auto-approval on one session and cannot answer for unrelated
+        # background work. Only ``yolo`` and an all-slots ``trust`` sweep them.
+        if not scoped:
+            for aid in list(state._approval_futures):
+                fut = state._approval_futures[aid]
+                if not fut.done():
+                    state.resolve_approval(aid, True)
+                    try:
+                        sel().log_api_access(
+                            caller="dashboard:background",
+                            operation=f"tool_approval:bulk_{mode}",
+                            outcome="approved",
+                            resources=aid,
+                        )
+                    except Exception:
+                        logger.warning("SEL audit failed for bulk approval %s", aid, exc_info=True)
+            # Auto-approve pending channel approvals
+            mgr = getattr(state, "channel_manager", None)
+            if mgr:
+                for ch in mgr._channels.values():
+                    for agent in ch.members.values():
+                        fut = agent._approval_future
+                        if fut and not fut.done():
+                            fut.set_result("approved")
+                            try:
+                                sel().log_api_access(
+                                    caller=f"channel:{ch.id}:{agent.agent_name}",
+                                    operation=f"tool_approval:bulk_{mode}",
+                                    outcome="approved",
+                                    resources=getattr(fut, "_approval_id", "unknown"),
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "SEL audit failed for channel bulk approval",
+                                    exc_info=True,
+                                )
 
     # Propagate trust/yolo to session approval policies so subagents inherit.
     #

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -8996,6 +8996,78 @@ class TestBulkApproveBroadcast:
         assert "req-1" in ids
         assert "req-2" in ids
 
+    @pytest.mark.asyncio
+    async def test_slot_scoped_trust_leaves_other_slots_pending(self, tmp_path, monkeypatch):
+        """A slot-scoped ``trust`` must NOT sweep other slots' pending approvals.
+
+        Regression: bulk auto-approve iterated EVERY slot regardless of scope, so
+        trusting one chat resolved the pending approval card in unrelated chats
+        (making them LOOK approved) while their ``_trust`` flag stayed False — so
+        their next tool call prompted again. Scope the sweep to the target
+        session; other slots keep their pending future AND their untrusted state.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat.sel", lambda: MagicMock())
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.broadcast_ws = MagicMock()
+        s1 = state.get_or_create_slot("s1")
+        s2 = state.get_or_create_slot("s2")
+        loop = asyncio.get_running_loop()
+        f1: asyncio.Future[str] = loop.create_future()
+        f2: asyncio.Future[str] = loop.create_future()
+        s1._approval_futures["req-1"] = f1
+        s2._approval_futures["req-2"] = f2
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": "trust", "slot": "s1"})
+            assert (await resp.json())["ok"] is True
+
+        # Target slot: approved + broadcast + trusted.
+        assert f1.done() and f1.result() == "approved"
+        assert s1._trust is True
+        # Other slot: still pending, never broadcast, still untrusted.
+        assert not f2.done()
+        assert s2._trust is False
+        resolved_ids = {
+            c.args[1]["id"]
+            for c in state.broadcast_ws.call_args_list
+            if c.args[0] == "approval_resolved"
+        }
+        assert "req-1" in resolved_ids
+        assert "req-2" not in resolved_ids
+        # Clean up the still-pending future so the loop does not warn on GC.
+        f2.set_result("rejected")
+
+    @pytest.mark.asyncio
+    async def test_unscoped_trust_still_sweeps_all_slots(self, tmp_path, monkeypatch):
+        """An all-slots ``trust`` (no slot named) keeps sweeping every slot."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat.sel", lambda: MagicMock())
+        state = _make_state(tmp_path)
+        state.push_slots_update = MagicMock()
+        state.broadcast_ws = MagicMock()
+        s1 = state.get_or_create_slot("s1")
+        s2 = state.get_or_create_slot("s2")
+        loop = asyncio.get_running_loop()
+        f1: asyncio.Future[str] = loop.create_future()
+        f2: asyncio.Future[str] = loop.create_future()
+        s1._approval_futures["req-1"] = f1
+        s2._approval_futures["req-2"] = f2
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/mode", json={"mode": "trust"})
+            assert (await resp.json())["ok"] is True
+
+        assert f1.done() and f2.done()
+        assert s1._trust is True and s2._trust is True
+        resolved_ids = {
+            c.args[1]["id"]
+            for c in state.broadcast_ws.call_args_list
+            if c.args[0] == "approval_resolved"
+        }
+        assert {"req-1", "req-2"} <= resolved_ids
+
 
 # ── Coverage: multi-pending approval 400 and trust auto-approve ──
 


### PR DESCRIPTION
## Problem / Motivation

When several chats each have a pending tool-approval prompt, selecting **Trust** on **one** chat makes the UI look like the approval was cleared in **every** chat. But the other chats are not actually trusted: open one of them and it is still pending approval, and its next tool call prompts again.

## Why it matters

The Trust picker is per-chat by design. The bug makes a single-chat Trust silently reach into every other open chat (and all background cron/subagent/task-runner and channel approvals), resolving their pending prompts. Users see approvals "disappear" everywhere and reasonably assume those chats are now trusted — they are not, so the very next tool call re-prompts. It also means a scoped grant resolves unrelated background work the user never intended to auto-approve.

## What changed (motivation → approach → change)

- **Symptom:** trusting one chat clears the pending approval card in all chats, but only the target chat becomes trusted.
- **Root cause:** in `api_chat_mode` (`src/kiro_crew/dashboard/chat_handlers.py`), the trust branch sets the per-slot `_trust` flag correctly (target slot + slots sharing its effective session key), but the bulk auto-approve block that runs next iterated **every** slot regardless of scope — resolving and broadcasting `approval_resolved` for each — and also resolved **all** background and channel approvals. Since `_trust` was never set on the other slots, their next tool call prompts again.
- **Change:** scope the bulk pending-approval sweep. A slot-scoped `trust` now only resolves pending approvals for the target slot and slots sharing its effective session key, and skips the global background + channel sweep. `yolo` (process-global) and an unscoped `trust` (no slot named = the documented all-slots request) still sweep everything, unchanged.

Flow:

```
Trust picker on chat A  →  POST /api/chat/mode {mode:"trust", slot:A}
    _trust=True on A (and session-sharing slots)          ← unchanged, already correct
    bulk auto-approve:
        before →  every slot's pending prompt resolved + all background/channel   ← BUG
        after  →  only A's session's pending prompts resolved                      ← fix
```

## Tests

`test/test_dashboard_chat.py`:

- `test_slot_scoped_trust_leaves_other_slots_pending` — two independent slots each with a pending approval; a slot-scoped `trust` on one resolves + broadcasts only that slot's approval and sets its `_trust`, while the other slot's future stays pending, gets no `approval_resolved` broadcast, and keeps `_trust=False`. Proven to fail without the production hunk (`prove.py` → `PROVEN`).
- `test_unscoped_trust_still_sweeps_all_slots` — an all-slots `trust` (no slot named) still resolves both slots and trusts both, locking in that the narrowing does not regress the documented all-slots behavior.

Existing `TestApiChatModePropagation` / `TestApproveYoloPropagation` / `TestBulkApproveBroadcast` continue to pass (720/720 in the file).

## Manual verification

N/A — unit coverage exercises the handler end-to-end via the aiohttp test client, including the exact multi-slot scenario from the bug report.

## Screenshots / video

Real capture on an isolated gateway (real frontend + real `POST /api/chat/mode` handler; only the backend handler differs between the two builds). Two chats each show a pending tool-approval card; Trust is toggled on **Chat 1** only.

**Before (buggy):** trusting Chat 1 also clears Chat 2's "Needs approval" (Sessions badge drops to 1) — the bug.

![Before: trusting Chat 1 wrongly clears Chat 2](https://raw.githubusercontent.com/RohanK6/KiroCrew/d0d7095db0cbe1118ca66d6aab0e6bb2c708ed9b/trust-scope/trust-scope-before.gif)

**After (fixed):** trusting Chat 1 leaves Chat 2 still showing "Needs approval" — only the trusted chat clears.

![After: trusting Chat 1 leaves Chat 2 pending](https://raw.githubusercontent.com/RohanK6/KiroCrew/d0d7095db0cbe1118ca66d6aab0e6bb2c708ed9b/trust-scope/trust-scope-after.gif)

<sub>GIFs hosted on the fork's `pr-media` branch (SHA-pinned), not committed to this PR's diff.</sub>

## Related Issues

Fixes #7275

## Pattern harvest

Rule candidate: review-prompt
Pattern: a scope-carrying request (a slot-scoped grant) whose primary effect is correctly scoped, but a secondary side-effect loop in the same handler (the bulk auto-approve) iterates the whole collection unscoped — the two fall out of sync. Review-prompt check: when a handler narrows an action to a subset, verify every follow-on loop in that handler respects the same subset.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


