### PR TITLE
fix(secrets): migration remediation named CLI subcommands that do not exist

### DIFF
--- a/src/kiro_crew/secrets/migrate.py
+++ b/src/kiro_crew/secrets/migrate.py
@@ -122,7 +122,7 @@ class MigrationReport:
     whether this pass wrote anything. ``orphaned_vault_keys`` names any keys
     whose rollback-delete raised an error during a failed apply — those vault
     entries may still exist and could shadow future rotations; manual cleanup
-    via ``kirocrew secrets rm <key>`` is recommended.
+    under Settings > Secrets in the dashboard is recommended.
     """
 
     env_file: Path
@@ -322,7 +322,8 @@ def migrate_env_secrets(
                 f"vault already has an entry for {key!r} whose value differs "
                 f"from the plaintext in the .env; refusing to migrate so neither "
                 f"value is silently discarded. Reconcile them (update the .env to "
-                f"match the vault, or `kirocrew secrets set {key}`), then re-run "
+                f"match the vault, or overwrite the vault entry under "
+                f"Settings > Secrets in the dashboard), then re-run "
                 f"`kirocrew secrets import --apply`."
             )
         already_in_vault.add(key)
@@ -562,12 +563,12 @@ def migrate_env_secrets(
                                 logger.warning(
                                     "secrets import rollback: failed to delete vault"
                                     " entry for %r (%s: %s). The entry may persist"
-                                    " and shadow future rotations — run"
-                                    " `kirocrew secrets rm %s` to clean it up.",
+                                    " and shadow future rotations — delete it under"
+                                    " Settings > Secrets in the dashboard to clean"
+                                    " it up.",
                                     _k,
                                     type(_rb_exc).__name__,
                                     _rb_exc,
-                                    _k,
                                 )
 
                     _rollback_loop.run_until_complete(_rollback())

--- a/test/test_secrets_migrate.py
+++ b/test/test_secrets_migrate.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import os
+import re
 import stat
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+import kiro_crew
+from kiro_crew import cli
 from kiro_crew.secrets import SecretVault
 from kiro_crew.secrets.migrate import (
     MigrationConflictError,
@@ -1081,5 +1085,116 @@ def test_rollback_delete_failure_records_orphaned_key_and_propagates_error(
         "JIRA_API_TOKEN" in str(m) for m in warning_msgs
     ), f"Expected WARNING naming orphaned key; got: {warning_msgs}"
     assert any(
-        "kirocrew secrets rm" in str(m) for m in warning_msgs
-    ), "WARNING must mention cleanup command"
+        "Settings > Secrets" in str(m) for m in warning_msgs
+    ), "WARNING must name a cleanup surface that exists (the CLI has no `secrets rm`)"
+    # The remediation half of this format string carried a fourth `%s` for the
+    # key name; dropping it without dropping its argument would leave the
+    # message half-interpolated (logging swallows the mismatch to stderr).
+    assert not any("%s" in str(m) or "%r" in str(m) for m in warning_msgs), (
+        f"WARNING left an uninterpolated placeholder — format args and "
+        f"placeholders disagree: {warning_msgs}"
+    )
+
+
+class TestRemediationNamesOnlyRealCliSubcommands:
+    """Every ``kirocrew secrets <verb>`` a shipped message tells an operator to
+    run must be a verb the CLI actually registers.
+
+    The defect this pins (#6889): the importer's remediation strings named
+    ``kirocrew secrets set`` and ``kirocrew secrets rm``, but the ``secrets``
+    parser registers only ``import`` — so an operator who followed the message
+    at the exact moment a migration aborted got ``invalid choice`` and no way
+    forward. A dead instruction on a data-loss-adjacent path is worse than no
+    instruction, because it costs the operator a round trip before they start
+    looking for the real surface.
+
+    Scope is all of ``src/``, not just ``migrate.py``: the same wording is
+    reachable from the resolution path, and a per-file check would let the next
+    site re-introduce it. The oracle is the REAL parser (``cli.main()``), not a
+    hand-maintained list, so a verb that later ships genuinely passes with no
+    edit here.
+    """
+
+    _CMD_RE = re.compile(r"kirocrew secrets ([a-z][a-z0-9-]*)")
+
+    @classmethod
+    def _referenced_verbs(cls) -> dict[str, list[str]]:
+        """Map each ``secrets`` verb named under ``src/`` to the files naming it."""
+        src_root = Path(kiro_crew.__file__).resolve().parent
+        found: dict[str, list[str]] = {}
+        for path in sorted(src_root.rglob("*.py")):
+            for verb in cls._CMD_RE.findall(path.read_text(encoding="utf-8")):
+                found.setdefault(verb, []).append(str(path.relative_to(src_root)))
+        return found
+
+    @staticmethod
+    def _verb_is_registered(verb: str, monkeypatch, tmp_path, capsys) -> bool:
+        """True when ``kirocrew secrets <verb> --help`` parses.
+
+        ``--help`` makes argparse exit 0 during parsing, so the verb's handler
+        never runs (nothing is read, written or migrated). An unregistered verb
+        exits 2 with ``invalid choice`` instead.
+
+        ``main()`` mutates PROCESS-GLOBAL state before it reaches argparse, and
+        none of it is monkeypatch's to restore, so a bare call would leak into
+        every later test in the same worker:
+
+        * ``ensure_utf8_console`` overwrites ``PYTHONUTF8`` /
+          ``PYTHONIOENCODING`` on EVERY platform (not only Windows — see
+          ``_ensure_utf8_process_environment``, "Overwrite inherited settings
+          deliberately") and on Windows also replaces ``sys.stdout`` /
+          ``sys.stderr``, which fights pytest's capture. Stubbed: this probe
+          reads argparse's exit code, never the encoding of what it printed.
+        * ``main()`` unconditionally pops ``KIROCREW_SANDBOX_ACTIVE`` and
+          ``KIROCREW_SANDBOX_LEVEL`` to refuse an inherited sandbox-bypass
+          marker. ``delenv`` first so MONKEYPATCH owns the deletion and restores
+          any inherited value at teardown, leaving the pop a no-op.
+        """
+        monkeypatch.setattr(cli.platform_compat, "ensure_utf8_console", lambda: None)
+        for marker in ("KIROCREW_SANDBOX_ACTIVE", "KIROCREW_SANDBOX_LEVEL"):
+            monkeypatch.delenv(marker, raising=False)
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "data"))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(cli, "boot_platform", lambda *_a, **_k: None)
+        monkeypatch.setattr(cli, "_setup_cli_logging", lambda *_a, **_k: None)
+        monkeypatch.setattr(sys, "argv", ["kirocrew", "secrets", verb, "--help"])
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main()
+        capsys.readouterr()
+        return excinfo.value.code == 0
+
+    def test_probe_does_not_clobber_inherited_encoding_env(self, monkeypatch, tmp_path, capsys):
+        """The probe must not leave the worker's UTF-8 contract rewritten.
+
+        ``main()`` overwrites both names on every platform, and monkeypatch
+        cannot restore what it never set — so dropping the
+        ``ensure_utf8_console`` stub silently hands every later test in this
+        worker a different encoding environment. Sentinels catch that.
+        """
+        monkeypatch.setenv("PYTHONUTF8", "sentinel-utf8")
+        monkeypatch.setenv("PYTHONIOENCODING", "sentinel-ioencoding")
+        self._verb_is_registered("import", monkeypatch, tmp_path, capsys)
+        assert os.environ["PYTHONUTF8"] == "sentinel-utf8"
+        assert os.environ["PYTHONIOENCODING"] == "sentinel-ioencoding"
+
+    def test_oracle_rejects_a_verb_that_does_not_exist(self, monkeypatch, tmp_path, capsys):
+        """Guard the guard: the probe must be able to FAIL, or the scan below
+        is vacuous and would pass on any wording at all."""
+        assert not self._verb_is_registered("no-such-verb-xyz", monkeypatch, tmp_path, capsys)
+
+    def test_the_scan_finds_something(self):
+        """A regex that stops matching (a rewording to prose, say) would make
+        this file silently stop guarding anything."""
+        assert self._referenced_verbs(), "no `kirocrew secrets <verb>` reference found under src/"
+
+    def test_every_referenced_verb_is_registered(self, monkeypatch, tmp_path, capsys):
+        dead = {
+            verb: files
+            for verb, files in self._referenced_verbs().items()
+            if not self._verb_is_registered(verb, monkeypatch, tmp_path, capsys)
+        }
+        assert not dead, (
+            "shipped remediation text tells the operator to run a `kirocrew secrets` "
+            f"subcommand the CLI does not register: {dead}. Point the message at a real "
+            "surface (Settings > Secrets in the dashboard, or `kirocrew secrets import`)."
+        )


### PR DESCRIPTION
## 1. What is the problem?

The secrets migration importer's remediation text tells the operator to run CLI
subcommands that do not exist. Three shipped messages name `kirocrew secrets set`
or `kirocrew secrets rm`:

- `migrate.py:125` -- the `MigrationReport` docstring on `orphaned_vault_keys`:
  "manual cleanup via `kirocrew secrets rm <key>` is recommended".
- `migrate.py:325` -- the value-divergence `MigrationConflictError`: "update the
  .env to match the vault, or `kirocrew secrets set {key}`".
- `migrate.py:566` -- the rollback WARNING for an orphaned vault entry: "run
  `kirocrew secrets rm <key>` to clean it up".

The `secrets` parser (`cli.py:1709-1717`) registers exactly one subcommand,
`import`. Its own comment says so: "Only the migration importer lives here; the
set/list/rm surface is owned by a separate change." So every one of those three
instructions exits 2 with `invalid choice`.

## 2. Why this issue matters to the user

All three messages fire at the worst possible moment. Two of them (`:325`,
`:566`) are emitted on an abort where the operator's plaintext credential is
still in `.env` and a vault entry may now shadow a future rotation -- the
message is the only thing telling them how to get unstuck. A dead instruction
there is worse than no instruction: the operator pays a round trip discovering
that the command they were just told to run does not exist, while the state the
message warned about is still live.

The real surface exists and is reachable -- the dashboard's Settings > Secrets
panel lists, overwrites and deletes vault entries (`SecretsPanel.tsx`,
`/api/secrets` GET/POST/DELETE in `dashboard/handlers/secrets.py`). Nothing was
missing; the messages just pointed at the wrong place.

## 3. How our fix solves it

Symptom: `kirocrew secrets rm JIRA_API_TOKEN` -> `invalid choice: 'rm'`.
Cause: the remediation strings were written against a `set`/`list`/`rm` CLI
surface that was split into a separate change and never landed, while the
messages shipped as if it had.
Fix: point all three at the surface that did ship.

- `:325` -> "update the .env to match the vault, or overwrite the vault entry
  under Settings > Secrets in the dashboard".
- `:566` -> "delete it under Settings > Secrets in the dashboard to clean it up"
  (and drop the now-unused fourth `%s` argument; the entry name is still in the
  message via the leading `%r`).
- `:125` -> "manual cleanup under Settings > Secrets in the dashboard".

The wording is not invented for this PR: it matches what already shipped on the
resolution path in `mcp_gateway/secret_uri.py:93,113` ("Store it under Settings >
Secrets in the dashboard (or migrate it with `kirocrew secrets import`)"), so the
two paths now say the same thing. `secrets import --apply`, which the same
messages also name, is a real subcommand and is left alone.

No behaviour outside the message text changes: same guards, same aborts, same
rollback ordering.

## 4. What tests we did

New ratchet `TestRemediationNamesOnlyRealCliSubcommands` in
`test/test_secrets_migrate.py`. It scans every `.py` under `src/kiro_crew` for
`kirocrew secrets <verb>` and resolves each verb against the REAL parser --
`cli.main()` with `secrets <verb> --help`, which argparse answers with exit 0
when the verb is registered and exit 2 (`invalid choice`) when it is not.
`--help` exits during parsing, so no handler runs and nothing is read, written
or migrated.

- RED on baseline, naming the exact sites:
  `{'rm': ['secrets/migrate.py', 'secrets/migrate.py'], 'set': ['secrets/migrate.py']}`.
  GREEN after the fix.
- Two guards keep the ratchet from going vacuous: one asserts the probe rejects
  a verb that does not exist (so it can still fail), one asserts the scan finds
  at least one reference (so a rewording cannot silently disable it).
- Scope is all of `src/`, not just `migrate.py`, so the next site to name a dead
  verb fails too -- including on the resolution path.

Retargeted the one existing assertion that pinned the old string
(`test_rollback_delete_failure_records_orphaned_key_and_propagates_error` had
asserted `"kirocrew secrets rm" in ...`). It now asserts the cleanup surface,
plus a new check that no `%s`/`%r` placeholder survives interpolation -- the
specific risk of removing a format argument, since logging swallows an arg-count
mismatch to stderr rather than raising.

Ran: `test_secrets_migrate.py`, `test_secret_uri_resolution.py`,
`test_secrets_handler.py`, `test_secrets_vault.py` -- 120 passed. black, isort,
flake8, mypy clean on both touched files; brand-name gate clean against
`kirocrew/main`.

## 5. Any other suggestions on the work

**Part 2 of the issue (per-name `vault.get` loops) is deliberately not in this
PR.** Two corrections to what the issue thread says about it:

`SecretVault.get_many` DOES exist on main now (`secrets/vault.py:106`) -- the
earlier triage comment that it does not was verified against `ebc392a`, before
the spawn-path hardening landed. So part 2 is not blocked on a missing API.

It is blocked on something else: per-key error attribution. `_decrypt_entry`
deliberately omits the entry name from its `ValueError` ("names are
caller-supplied strings that may contain anything, and this error propagates
into spawn logs"). A batch read that hits one corrupt entry therefore aborts
without saying WHICH key to repair -- and naming that key is the entire purpose
of both loops. The first (`:295-330`) tells the operator which vault entry to
repair BEFORE the still-usable plaintext is rewritten away; the second
(`:455-476`) is the post-store re-verify running inside the vault's
cross-process lock immediately before the `.env` commit. Recovering attribution
needs either a batch-then-per-key-fallback branch inside that critical section,
or a per-name error mode on `get_many` (a semantics change to a
security-critical class). Both are design calls, not a mechanical swap.

The win does not pay for that. `_should_migrate` admits only `JIRA_API_TOKEN`
plus per-host `JIRA_TOKEN_<HEX>`, so K is one to three keys, read twice, in a
one-shot CLI command -- and the issue itself gates part 2 on "if the loops ever
show up in profiles" and rates it low priority. No profile evidence exists.

Recommend part 2 be treated as declined rather than deferred: it is on the
record here with the reason, so a follow-up should only be opened if a profile
ever shows the loops, and it should decide the `get_many` error-reporting shape
first.

## Pattern harvest

Rule candidate: lint
Pattern: shipped remediation prose names a CLI subcommand the parser does not register

This generalizes, and the mechanism that produced it will recur: a subcommand
group lands with its verbs deliberately "owned by a separate change" (the
comment at `cli.py:1707-1708`), the messages are written against the intended
surface, and the separate change never lands -- leaving prose that instructs the
operator to run something argparse rejects. Nothing in CI noticed for either
site.

The ratchet in this PR is the narrow half of the harvest: it resolves every
`kirocrew secrets <verb>` in `src/` against the real parser. The general rule is
the same check over every `kirocrew <group> <verb>` named in shipped prose, which
needs the top-level parser factored out of `main()` (it is built inline at
`cli.py:1100-1146`) so a test can walk the subparser tree instead of probing one
group at a time with `--help`. That refactor is out of scope for a fix PR;
raising it as a follow-up rather than smuggling it in here.

Fixes #6889
