### PR TITLE
feat(ci): ratchet a gate-side log line onto the context-aware redactor

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -404,6 +404,25 @@ delegates to that same global. Wired sites:
   lazily-composed standalone default resolved per stderr line on the event loop.
   Closing this residual means handing gatewayd a composed context, the same
   remedy that module already names for the ceiling, and is a separate change.
+- **Which spelling a gate-side log line uses is gated in CI**
+  (`test_security_posture.TestGateSideLogRedactorSpelling`). The egress
+  classification (`security_posture._REDACTION_SINKS` vs
+  `NON_EGRESS_REDACTION_MODULES`) is a different axis and cannot cover this one:
+  all three sites converged above sat correctly bucketed as non-egress, with
+  accurate reasons, while reading the companion-blind baseline pass. The gate
+  scans for the PROPERTY — a baseline redactor's result reaching a log or audit
+  write, either nested in the call or through a local assigned from one in the
+  same scope — rather than for a filename or a subject name, because a grep
+  scoped to files mentioning stderr is exactly what missed `task_planner.py` and
+  `name_grant.py`. `_BASELINE_LOG_SITE_CENSUS` records the per-module residual
+  measured when the gate went up (76 sites in 26 modules, `acp/client.py` the
+  largest at 7); it is a census, NOT an approved-exception list and NOT a to-do
+  list, since for a process that never composes — gatewayd above — the baseline
+  is the honest answer. Growth in any module, or a first site in a module absent
+  from it, fails until someone either calls `redact_log_via_context` or raises
+  that number and records which PROCESS the site runs in and why the baseline is
+  correct there. A count that has fallen must be lowered, so a converted module
+  does not leave free slots behind.
 - Exfil exact-host heuristic exemption (`CredentialPolicy.exempt_exact_hosts()`) —
   `security.scan_exfiltration_urls` / `redact_exfiltration_urls` read the
   companion-supplied exact-host set and, for a URL whose domain is an EXACT

--- a/test/test_platform_context.py
+++ b/test/test_platform_context.py
@@ -429,7 +429,10 @@ class TestRedactLogViaContext:
     #: actually reachable. Deliberately NOT a list of every redaction call site --
     #: `security_posture.NON_EGRESS_REDACTION_MODULES` owns that axis. This one
     #: only pins that a site already converged cannot silently drift back, which
-    #: is how the class grew in the first place.
+    #: is how the class grew in the first place. A site born on the baseline
+    #: tomorrow is a different question, and a list cannot answer it:
+    #: `test_security_posture.TestGateSideLogRedactorSpelling` owns that half by
+    #: scanning for the property instead.
     CONVERGED_LOG_SITES = (
         "platform/update_provider.py",
         "task_planner.py",

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -14,7 +14,9 @@ make that regression structurally impossible:
 
 from __future__ import annotations
 
+import ast
 import base64
+import functools
 import re
 
 import pytest
@@ -46,6 +48,238 @@ _REDACTOR_CALL_RE = re.compile(
     r"|\b\w*redact\w*\("  # redact/redact_credentials/redact_and_truncate/_redact/...
     r"|\.redact\("  # qualified: security.redact(...), credentials.redact(...)
 )
+
+
+#: The baseline (companion-blind) redactor entry points defined in ``security.py``.
+#: A call to any of these runs the OSS credential/exfil pass and nothing else, so on
+#: a host with a companion loaded it misses whatever the companion's extra regexes
+#: would have caught. The context spellings (``redact_via_context`` for an egress
+#: sink, ``redact_log_via_context`` for a gate-side log line) are deliberately NOT
+#: here: they are the answer, not the finding.
+_BASELINE_REDACTORS = frozenset(
+    {
+        "redact",
+        "redact_credentials",
+        "redact_exfiltration_urls",
+        "redact_and_truncate",
+    }
+)
+
+#: Logger method names. Paired with a receiver whose source spells ``log`` (so
+#: ``logger.warning``, ``self._log.debug`` and ``LOG.error`` all count, while
+#: ``resp.warning`` does not).
+_LOG_LEVEL_ATTRS = frozenset({"debug", "info", "warning", "warn", "error", "exception", "critical"})
+
+
+def _is_log_write(call: ast.Call) -> bool:
+    """True when *call* writes an operational log or audit line.
+
+    Keys on how a log WRITE is spelled — a logger level method, or a ``log_*``
+    function/method such as the SEL rows ``log_tool_invocation`` /
+    ``log_api_access`` / ``log_governance_decision``. That is deliberately the
+    only name-shaped input to this scan: the SUBJECT of the line is matched
+    structurally (see :func:`_gate_side_baseline_log_sites`), because keying on
+    the subject's name is exactly what missed ``task_planner.py`` (an LLM
+    response) and ``name_grant.py`` (a model-authored title) when the class was
+    first swept with a grep scoped to files mentioning stderr.
+    """
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        if func.attr in _LOG_LEVEL_ATTRS:
+            return "log" in ast.unparse(func.value).lower()
+        return func.attr.startswith("log_")
+    if isinstance(func, ast.Name):
+        return func.id.startswith("log_")
+    return False
+
+
+def _wraps_baseline_call(node: ast.AST | None) -> bool:
+    """True when *node* is, or contains, a call to a baseline redactor."""
+    if node is None:
+        return False
+    return any(
+        isinstance(sub, ast.Call)
+        and isinstance(sub.func, (ast.Name, ast.Attribute))
+        and (sub.func.id if isinstance(sub.func, ast.Name) else sub.func.attr)
+        in _BASELINE_REDACTORS
+        for sub in ast.walk(node)
+    )
+
+
+def _scope_body(scope: ast.AST):
+    """Walk *scope*'s own statements, not those of a nested def/class.
+
+    Taint must not leak between scopes: a name redacted inside one method says
+    nothing about a same-named local in a sibling method. Lambdas and
+    comprehensions are NOT stopped at — they bind no assignments this scan cares
+    about, and stopping would hide a redactor call nested in one.
+    """
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _gate_side_baseline_log_sites(source: str) -> set[tuple[int, str]]:
+    """Find log/audit writes in *source* whose text came from a BASELINE redactor.
+
+    The property, not a name: a baseline redactor's result reaches a log write —
+    either nested directly in the call (``logger.error("%s", redact(x))``) or
+    through a local whose most recent assignment in the same scope was a baseline
+    call (the ``x, _ = redact_exfiltration_urls(x)`` / ``x, _ =
+    redact_credentials(x)`` pair idiom, which is a hand-rolled ``security.redact``
+    and the exact shape #7151 converged in three modules).
+
+    Flow-lite, and honest about it: the most recent assignment WINS, so a name
+    reassigned from an unredacted source stops counting, but branches and loops
+    are not modelled and a value redacted in a helper and logged by its caller is
+    not seen. This is a floor on the class, not a proof of its absence.
+
+    Returns ``{(lineno, "<log call>")}`` — the count is what the ratchet pins;
+    the rendering is for the failure message.
+    """
+    tree = ast.parse(source)
+    scopes: list[ast.AST] = [tree]
+    scopes += [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    ]
+    sites: set[tuple[int, str]] = set()
+    for scope in scopes:
+        # (lineno, name, came-from-a-baseline-redactor). Collection order does not
+        # matter: the line number is what decides which assignment a log write sees.
+        assignments: list[tuple[int, str, bool]] = []
+        log_writes: list[ast.Call] = []
+        for node in _scope_body(scope):
+            targets: list[ast.expr] = []
+            value: ast.expr | None = None
+            if isinstance(node, ast.Assign):
+                targets, value = list(node.targets), node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                targets, value = [node.target], node.value
+            elif isinstance(node, ast.NamedExpr):
+                targets, value = [node.target], node.value
+            for target in targets:
+                # `obj.attr = redact(...)` and `d[k] = redact(...)` do NOT make the
+                # BASE object redacted text; tainting it would fire on every later
+                # log line that merely mentions the object.
+                if isinstance(target, ast.Name):
+                    bound = [target]
+                elif isinstance(target, (ast.Tuple, ast.List)):
+                    bound = [e for e in target.elts if isinstance(e, ast.Name)]
+                else:
+                    bound = []
+                for name_node in bound:
+                    assignments.append(
+                        (name_node.lineno, name_node.id, _wraps_baseline_call(value))
+                    )
+            if isinstance(node, ast.Call) and _is_log_write(node):
+                log_writes.append(node)
+        for call in log_writes:
+            args = list(call.args) + [kw.value for kw in call.keywords]
+            if any(_wraps_baseline_call(arg) for arg in args):
+                sites.add((call.lineno, ast.unparse(call.func)))
+                continue
+            referenced = {
+                sub.id for arg in args for sub in ast.walk(arg) if isinstance(sub, ast.Name)
+            }
+            for name in sorted(referenced):
+                prior = [
+                    (lineno, tainted)
+                    for lineno, bound_name, tainted in assignments
+                    if bound_name == name and lineno <= call.lineno
+                ]
+                if prior and max(prior)[1]:
+                    sites.add((call.lineno, ast.unparse(call.func)))
+                    break
+    return sites
+
+
+#: Gate-side log/audit sites still reading the BASELINE redactor, counted per
+#: module on the commit that added this ratchet. A census, and three things it is
+#: NOT:
+#:
+#: * NOT a to-do list. For a site in a process that never composes a companion the
+#:   baseline is the honest answer, not a defect — ``mcp_gateway/backend.py`` is
+#:   exactly that case (``gatewayd`` never runs ``boot_platform``, which
+#:   ``mcp_gateway/app_call.py`` relies on for its security ceiling), and
+#:   converting it would trade every backend diagnostic for a per-line lazy
+#:   resolution on the event loop.
+#: * NOT a list of approved exceptions. No entry here has been ruled correct. The
+#:   only claim these numbers make is "this many were here when the gate went up".
+#: * NOT the egress axis. ``NON_EGRESS_REDACTION_MODULES`` and ``_REDACTION_SINKS``
+#:   decide whether a module is an output boundary; that decision says nothing
+#:   about WHICH redactor spelling a site uses, which is why all three sites #7151
+#:   converged sat correctly bucketed for years while reading the weaker pass.
+#:
+#: What the gate buys: a NEW gate-side log line cannot be born on the baseline
+#: silently. Growth in any module — or a first site in a module absent from here —
+#: fails, and clearing it means either calling ``redact_log_via_context`` or
+#: raising the number and saying which PROCESS the site runs in and why the
+#: baseline is right there, to the standard that helper's docstring sets.
+#:
+#: Two limits, stated so nobody reads more into a green run: counts do not pin
+#: identity, so converting one site while adding another inside the SAME module
+#: nets to zero (both edits land in one reviewed diff), and the scan is
+#: single-scope (see :func:`_gate_side_baseline_log_sites`).
+_BASELINE_LOG_SITE_CENSUS: dict[str, int] = {
+    "acp/client.py": 7,
+    "apps/builtins/pptx_maker/backend/routes.py": 1,
+    "dashboard/chat_nav.py": 1,
+    "dashboard/chat_orchestrator.py": 1,
+    "dashboard/chat_runner.py": 10,
+    "dashboard/chat_title.py": 1,
+    "dashboard/handlers/discover.py": 3,
+    "dashboard/handlers/files.py": 3,
+    "dashboard/handlers/hooks.py": 1,
+    "dashboard/handlers/messaging.py": 12,
+    "dashboard/handlers/updates.py": 1,
+    "dashboard/session_control.py": 1,
+    "dashboard/session_transfer.py": 1,
+    "dashboard/state.py": 1,
+    "knowledge/agent_fetch.py": 1,
+    "mcp_cron.py": 1,
+    "mcp_gateway/backend.py": 2,
+    "mcp_tools/knowledge.py": 5,
+    "mcp_tools/messaging.py": 1,
+    "mcp_tools/skills.py": 2,
+    "messaging/sessions_view.py": 1,
+    "slack/events.py": 2,
+    "slack/gateway.py": 6,
+    "slack/handler.py": 3,
+    "subagent_manager/admission.py": 4,
+    "voice_reply.py": 4,
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _package_baseline_log_census() -> "tuple[tuple[str, int], ...]":
+    """Live per-module count of gate-side log writes reading a baseline redactor.
+
+    Cached because two tests read it and the walk parses every package module;
+    returned as a tuple of pairs so the cached value cannot be mutated by a
+    caller. A ``SyntaxError`` is deliberately NOT swallowed: a module the scanner
+    cannot parse is a module it cannot see, and skipping one quietly is how a
+    scan-based gate goes blind.
+    """
+    from pathlib import Path
+
+    pkg = Path(security.__file__).resolve().parent
+    found: list[tuple[str, int]] = []
+    for path in sorted(pkg.rglob("*.py")):
+        rel = path.relative_to(pkg).as_posix()
+        if rel.startswith(("_vendor/", "testing/")):
+            continue
+        if "/tests/" in rel or rel.endswith("_test.py"):
+            continue
+        sites = _gate_side_baseline_log_sites(path.read_text(encoding="utf-8"))
+        if sites:
+            found.append((rel, len(sites)))
+    return tuple(found)
 
 
 def _mcp_schema_registry_names() -> list[str]:
@@ -763,3 +997,158 @@ class TestRedactionSinkRegistry:
     def test_sink_labels_are_unique(self):
         labels = [label for label, _m, _d in security_posture._REDACTION_SINKS]
         assert len(labels) == len(set(labels))
+
+
+class TestGateSideLogRedactorSpelling:
+    """The second axis: WHICH redactor spelling a gate-side log line reads.
+
+    ``TestOmissionDetection`` above forces every redactor call site into a bucket —
+    egress sink or not. That decision is orthogonal to this one, and all three
+    sites PR #7151 converged prove it: each was correctly listed as non-egress,
+    with an accurate reason, while reading the companion-blind baseline pass. The
+    bucket was never wrong; the redactor was, and no gate looked at that.
+
+    So this class asks the other question — does a gate-side log line reach its
+    text through ``redact_log_via_context`` — and it asks it of a PROPERTY rather
+    than of a list of already-decided sites, because a converged-sites list (the
+    narrow guard #7151 shipped, in ``test_platform_context``) is a regression
+    guard: it protects what has been decided and says nothing about a site born
+    tomorrow, which is the direction the class grew in the first place.
+    """
+
+    def test_no_new_gate_side_log_line_reads_the_baseline_redactor(self):
+        """A gate-side log line born on the baseline fails until someone decides.
+
+        The half the narrow guard cannot cover. Two ways to fail: a module absent
+        from the census growing its first site, and a module in it growing another
+        one. Either is cleared by calling ``redact_log_via_context`` — or, when the
+        site runs in a process that never composes a companion, by raising that
+        module's number and recording which process and why, to the standard
+        ``redact_log_via_context``'s own docstring sets for ``gatewayd``.
+        """
+        found = dict(_package_baseline_log_census())
+        grew = {
+            rel: (count, _BASELINE_LOG_SITE_CENSUS.get(rel, 0))
+            for rel, count in found.items()
+            if count > _BASELINE_LOG_SITE_CENSUS.get(rel, 0)
+        }
+        assert not grew, (
+            "New gate-side log/audit line(s) reading the BASELINE redactor "
+            + ", ".join(
+                f"{rel}: {now} sites, census says {was}" for rel, (now, was) in grew.items()
+            )
+            + ". A gate-side log line goes through `redact_log_via_context` so a host with a "
+            "companion loaded is not scanned with the weaker OSS pass. If the baseline is "
+            "correct here because this PROCESS never composes a companion, raise the number "
+            "in `_BASELINE_LOG_SITE_CENSUS` and say which process and why."
+        )
+
+    def test_the_census_holds_no_slack(self):
+        """A converted site must lower its number, and an emptied module must go.
+
+        Without this the census only ever ratchets one way: a module that drops
+        from 7 sites to 1 would keep 6 free slots for a future baseline line to
+        appear in silently.
+        """
+        found = dict(_package_baseline_log_census())
+        slack = {
+            rel: (found.get(rel, 0), recorded)
+            for rel, recorded in _BASELINE_LOG_SITE_CENSUS.items()
+            if found.get(rel, 0) < recorded
+        }
+        assert not slack, (
+            "`_BASELINE_LOG_SITE_CENSUS` is now looser than the code — lower or drop these: "
+            + ", ".join(
+                f"{rel}: {now} sites, census says {was}" for rel, (now, was) in slack.items()
+            )
+        )
+
+    def test_the_scanner_flags_the_shape_it_exists_to_catch(self):
+        """Teeth, proven on planted source rather than assumed.
+
+        A scan-based ratchet whose matcher silently matches nothing keeps a green
+        census forever, so each half is planted here: the pair idiom feeding an
+        audit row (``name_grant``'s shape), a lone baseline call nested in a logger
+        call (``update_provider``'s shape), and — as the control — the same lines
+        written through the context spelling, which must NOT be flagged.
+        """
+        pair_into_audit = (
+            "def log_decline(title):\n"
+            "    title, _ = redact_exfiltration_urls(title)\n"
+            "    title, _ = redact_credentials(title)\n"
+            "    sel().log_tool_invocation(session_key='s', tool_name=title)\n"
+        )
+        nested_in_logger = (
+            "def apply(stderr):\n"
+            "    logger.error('install failed: %s', redact(stderr.decode()))\n"
+        )
+        assert len(_gate_side_baseline_log_sites(pair_into_audit)) == 1
+        assert len(_gate_side_baseline_log_sites(nested_in_logger)) == 1
+
+        converged_pair = (
+            "def log_decline(title):\n"
+            "    title = redact_log_via_context(title)\n"
+            "    sel().log_tool_invocation(session_key='s', tool_name=title)\n"
+        )
+        converged_nested = (
+            "def apply(stderr):\n"
+            "    logger.error('install failed: %s', redact_log_via_context(stderr.decode()))\n"
+        )
+        assert _gate_side_baseline_log_sites(converged_pair) == set()
+        assert _gate_side_baseline_log_sites(converged_nested) == set()
+
+    def test_the_scanner_does_not_flag_what_is_not_a_log_line(self):
+        """Zero false positives on the shapes that are NOT this class.
+
+        Each of these would put an unearned entry in the census and, worse, teach
+        the next reader that the gate fires on noise: a baseline call whose result
+        never reaches a log write, an egress send (whose spelling question is
+        ``redact_via_context`` and a separate decision), a same-named local in a
+        SIBLING scope, and a redacted value written to an object ATTRIBUTE whose
+        base object is later merely mentioned in a log line.
+        """
+        not_logged = "def f(x):\n    safe, _ = redact_credentials(x)\n    return safe\n"
+        egress = (
+            "def f(x):\n"
+            "    safe, _ = redact_credentials(x)\n"
+            "    await client.chat_postMessage(text=safe)\n"
+        )
+        sibling_scope = (
+            "def a(x):\n"
+            "    text, _ = redact_credentials(x)\n"
+            "    return text\n"
+            "def b(text):\n"
+            "    logger.info('raw %s', text)\n"
+        )
+        attribute_target = (
+            "def f(job, err):\n"
+            "    job.last_error = redact(err)\n"
+            "    logger.warning('job %s paused', job.name)\n"
+        )
+        reassigned = (
+            "def f(x, raw):\n"
+            "    text, _ = redact_credentials(x)\n"
+            "    text = raw\n"
+            "    logger.info('%s', text)\n"
+        )
+        for label, source in (
+            ("not logged", not_logged),
+            ("egress send", egress),
+            ("sibling scope", sibling_scope),
+            ("attribute target", attribute_target),
+            ("reassigned from raw", reassigned),
+        ):
+            assert _gate_side_baseline_log_sites(source) == set(), label
+
+    def test_the_converged_sites_stay_out_of_the_census(self):
+        """#7151's three sites must have nothing left for this scan to find.
+
+        Ties the general rule to the narrow guard: ``test_platform_context`` pins
+        that each of these still CALLS the helper, and this pins that none of them
+        has a gate-side log line reading the baseline alongside it — a drift the
+        call-count check on its own would not see.
+        """
+        for rel in ("platform/update_provider.py", "task_planner.py", "name_grant.py"):
+            assert (
+                rel not in _BASELINE_LOG_SITE_CENSUS
+            ), f"{rel} was converged by #7151 and must not carry a baseline log site"


### PR DESCRIPTION
## Problem / Motivation

Nothing forces a gate-side log or audit line onto the context-aware redactor. A
site that calls the baseline `security.redact` (or its `redact_credentials` /
`redact_exfiltration_urls` components) compiles, passes review, and looks exactly
as deliberate as one routed through `platform.redact_log_via_context` -- so on a
host with a companion loaded it silently scans with the weaker OSS pass and writes
whatever the companion's extra regexes would have caught.

The existing posture ratchet cannot catch this, and the reason is precise. It
forces every redactor call site into a bucket -- registered `redaction_paths` sink
or `NON_EGRESS_REDACTION_MODULES` -- and that axis is **egress vs not**. All three
sites PR #7151 converged (`platform/update_provider.py`, `task_planner.py`,
`name_grant.py`) were already correctly listed as non-egress, with accurate
reasons. Their bucket was never wrong; their *redactor* was, and no gate looks at
that.

#7151 also shipped a deliberately narrow guard -- an omission check over the three
sites it converged, so a converged site cannot drift back. That is a regression
guard: it protects what has already been decided and says nothing about a site
added tomorrow, which is the direction the class grew in the first place.

## Why it matters

A credential the companion's regexes would have caught is written verbatim into
the gateway log ring, `/api/logs`, or a durable SEL audit row, on exactly the
hosts that loaded a companion because they need the wider pass. The failure is
silent at every step: the two spellings look equally deliberate at the call site,
nothing about a `redact_credentials` / `redact_exfiltration_urls` pair reads as
wrong, and the site sits in the right bucket with a true reason next to it.

The residual is real, not hypothetical. This gate measures **76 such sites across
26 modules** on `main`, `acp/client.py` the largest at 7 -- including the adapter
`stderr_tail` log the issue calls out as byte-for-byte the shape fixed in
`update_provider.py`, and a `session_control.deny` audit row whose text is raw MCP
caller input written to a sink the dashboard reads back.

## What changed (motivation → approach → change)

Goal: gate the second axis -- does a gate-side log line reach its text through
`redact_log_via_context` -- without demanding a bulk conversion, which would be
wrong (for `gatewayd`, which never runs `boot_platform`, the baseline is the
honest answer, and converting it would trade every backend diagnostic for a
per-line lazy resolution on the event loop).

Approach, and why not the two cheaper ones:

- **Not a grep for the baseline spelling.** 769 baseline calls sit inside the
  non-egress bucket alone; most are single-purpose scrubs where the pair form
  never appears and the context spelling would be meaningless. A spelling grep
  cannot tell a defect from a correct call.
- **Not a filename or subject-name key.** A grep scoped to files mentioning
  stderr is exactly what missed `task_planner.py` (an LLM response) and
  `name_grant.py` (a model-authored title into a SEL row).

So the scan keys on the **dataflow property**: a baseline redactor's result
reaching a log or audit write -- nested directly in the call
(`logger.error("%s", redact(x))`) or through a local whose most recent assignment
in the same scope was a baseline call (the `x, _ = redact_exfiltration_urls(x)` /
`x, _ = redact_credentials(x)` pair idiom, which is a hand-rolled
`security.redact`). The only name-shaped input is how a log **write** is spelled --
a logger level method, or a `log_*` function such as the SEL rows
`log_tool_invocation` / `log_api_access` / `log_governance_decision`.

What landed (`test/test_security_posture.py`, new `TestGateSideLogRedactorSpelling`):

- `_gate_side_baseline_log_sites(source)` -- the AST scan. Taint is per-scope (a
  name redacted in one method says nothing about a same-named local in a sibling),
  last-assignment-wins (a name reassigned from an unredacted source stops
  counting), and an `obj.attr = redact(...)` target does not taint the base object.
- `_BASELINE_LOG_SITE_CENSUS` -- the per-module residual measured on this commit.
  A census, and explicitly **not** a to-do list (for a non-composing process the
  baseline is correct -- `mcp_gateway/backend.py` is in the census rather than
  converted) and **not** a list of approved exceptions (no entry has been ruled
  correct; the only claim a number makes is "this many were here when the gate
  went up").
- The gate: growth in any module, or a first site in a module absent from the
  census, fails. Clearing it means calling `redact_log_via_context`, or raising
  that module's number and recording which PROCESS the site runs in and why the
  baseline is right there -- the standard that helper's own docstring sets for
  `gatewayd`. A count that has *fallen* must be lowered, so a converted module
  leaves no free slots for a future baseline line to appear in silently.

Deliberate limits, stated in the code so a green run is not over-read: counts do
not pin identity, so converting one site while adding another inside the same
module nets to zero (both edits land in one reviewed diff); the scan is
single-scope, so redact-in-helper / log-in-caller is not seen. This is a floor on
the class, not a proof of its absence.

Also updated: `docs/system-specs/modules/platform-context.md` gains the gate next
to the `gatewayd` residual it depends on, and #7151's `CONVERGED_LOG_SITES` note
in `test/test_platform_context.py` now points at the general rule instead of
implying no gate owns that half.

## Tests

Test-only change plus the spec. Five new tests, and the two that matter were
mutation-verified rather than assumed:

- `test_no_new_gate_side_log_line_reads_the_baseline_redactor` -- the ratchet.
  **Verified RED** by planting two violations: the pair idiom feeding
  `logger.error` in `task_planner.py` (a module absent from the census, 0 to 1) and
  a lone `redact()` feeding `logger.warning` in `acp/client.py` (a module that
  already carries residual sites, 7 to 8). Failure named both:
  `{'acp/client.py': (8, 7), 'task_planner.py': (1, 0)}`. The second case is the
  half a module-level allowlist would have missed. Rewriting both planted lines to
  `redact_log_via_context` returned the suite to green, so the gate accepts the
  remedy and not merely the absence of the shape. Both plants reverted.
- `test_the_census_holds_no_slack` -- **verified RED** by inflating
  `acp/client.py` to 9 (`{'acp/client.py': (7, 9)}`), then restored.
- `test_the_scanner_flags_the_shape_it_exists_to_catch` -- teeth on planted source:
  the pair idiom into an audit row and a baseline call nested in a logger call are
  both flagged; the same two lines written through the context spelling are not.
- `test_the_scanner_does_not_flag_what_is_not_a_log_line` -- five shapes that must
  stay silent: a baseline call never logged, an egress send (whose spelling
  question is `redact_via_context`, a separate decision), a same-named local in a
  sibling scope, a redacted value stored on an object attribute whose base is
  later mentioned in a log line, and a name reassigned from raw text.
- `test_the_converged_sites_stay_out_of_the_census` -- ties the general rule to
  #7151's narrow one.

`pytest test/test_security_posture.py test/test_platform_context.py -n 4` gives
**77 passed**. `black` (both the pinned 26.3.1 and local), `isort` and `flake8` are
clean on the changed files; `mypy` runs on `src/` only and no source file changed.

## Manual verification

N/A -- a CI gate whose behavior is fully expressed by the tests above, and both
directions (fires / clears) were exercised against real planted call sites rather
than only against synthetic strings.

## Related Issues

Fixes #7156

## Pattern harvest

Rule candidate: lint (this PR is that rule).
Pattern: a gate-side log or audit line reading the baseline redactor while its
module sits correctly bucketed on the orthogonal egress axis -- the class #7151
converged three instances of. Generalized here by keying a gate on the dataflow
property (redactor result reaching a log write) rather than on the enumerated
sites, because the enumerated form cannot see a site born tomorrow.
