### PR TITLE
fix(subagent): serialize state.json rewrites for off-loop writers

### DIFF
--- a/src/kiro_crew/subagent_manager/run.py
+++ b/src/kiro_crew/subagent_manager/run.py
@@ -1076,9 +1076,11 @@ class RunEventCoordinator(ManagerComponent):
                 # FS must not freeze the gateway/heartbeat (#6288; same shape
                 # as the provenance and CC-refinement writes above). Drained on
                 # cancellation: cancelling a to_thread await detaches the
-                # worker, and update_state is an unlocked read-merge-replace,
-                # so a stale detached worker could overwrite newer state
-                # written by a cancel-respawn recovery run. Hold cancellation
+                # worker, and update_state's per-agent lock serializes OFF-loop
+                # writers only, so a stale detached worker's whole-file rewrite
+                # can still roll back the PID / session-id state a
+                # cancel-respawn recovery run writes ON the loop without that
+                # lock. Hold cancellation
                 # open until the worker finishes — but BOUNDED: cancel_all()
                 # gathers run tasks with no timeout, so an unbounded drain on
                 # a wedged FS would hold gateway shutdown forever, and this
@@ -1123,8 +1125,9 @@ class RunEventCoordinator(ManagerComponent):
                                 )
                                 # The abandoned worker is a live stale writer: a
                                 # cancel-respawn recovery run would write fresh
-                                # PID/session state that the zombie's read-merge-
-                                # replace could then roll back. Consume the
+                                # PID/session state ON the loop, which takes no
+                                # per-agent lock, so the zombie's read-merge-
+                                # replace can still roll it back. Consume the
                                 # one-shot recovery so this cancellation finalizes
                                 # instead of respawning — losing one best-effort
                                 # auto-continue on an FS already wedged past the

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -8,12 +8,15 @@ Each subagent gets a folder at ``~/.kiro/crew/subagents/{id}/`` containing:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 import shutil
 import tempfile
+import threading
 import time
+import weakref
 from pathlib import Path
 
 from kiro_crew.acp.types import PROVIDER_LABEL_DEFAULT
@@ -141,6 +144,112 @@ def read_state(agent_id: str) -> dict | None:
         return None
 
 
+# ── per-agent write serialization ────────────────────────────────────
+
+#: ``update_state`` is a read / merge / rewrite, and its two halves are split by
+#: a blocking ``_atomic_write`` (fsync + rename). Two writers on one ``agent_id``
+#: therefore interleave: the second one's read predates the first one's write, so
+#: its rewrite restores a stale WHOLE-FILE snapshot and silently rolls back every
+#: field the first writer had just landed. Losing the other writer's fields is
+#: the visible half; rolling back fields NEITHER writer touched is the damaging
+#: half.
+#:
+#: The overlap is structural, not hypothetical. A run writes state from the event
+#: loop (PID, session id, provider, retention ``keep``) AND from the thread pool
+#: (model provenance, CC-path model refinement, per-turn diagnostics -- each via
+#: ``asyncio.to_thread``), so two pool writers overlap during a run and a
+#: loop-side write executes while the run's coroutine is suspended inside a
+#: pool-side one (#6298). Cancellation widens it: cancelling a ``to_thread``
+#: await DETACHES the worker rather than stopping it, so it finishes carrying a
+#: read that is already stale (#6308).
+#:
+#: SCOPE -- OFF-LOOP WRITERS ONLY. Serializing every writer would mean a
+#: loop-side caller waiting on a pool thread's fsync, i.e. a new blocking call
+#: on the event loop, which this repo's ``no-blocking-call-on-event-loop`` anchor
+#: forbids and which a bounded wait only shrinks rather than removes. So the lock
+#: is taken only by callers that are NOT on the loop, where blocking is legal;
+#: on-loop callers keep exactly their pre-existing behaviour (an unserialized
+#: rewrite). That closes pool-vs-pool interleaving completely and leaves the
+#: loop-side half untouched -- see :func:`update_state` for what remains open and
+#: the issue tracking the loop-side offload (#6288's class).
+#:
+#: The acquire is UNBOUNDED, and can be, precisely because no on-loop caller ever
+#: waits on it: the only threads that block here are pool workers whose own write
+#: (read + fsync + rename) already exposes them to a wedged FS, so waiting on the
+#: lock adds no parking risk the write itself did not already carry. No holder is
+#: ever an on-loop caller.
+#:
+#: In-process only, mirroring the per-key ``threading.Lock`` registry this repo
+#: already uses to serialize file read-modify-write (``learn._lock_for``,
+#: ``artifacts._lock_for_root``, ``history.ConversationLog._file_locks``). A
+#: filesystem lock is the tool for cross-process contention and there is none
+#: here: every ``update_state`` caller lives in the gateway process that owns the
+#: run. Keyed by agent id so unrelated runs never queue behind one agent's fsync,
+#: SELF-CLEANING, with no explicit eviction anywhere. The values are held
+#: WEAKLY and every caller keeps a strong reference for the length of its
+#: critical section, so an entry lives exactly as long as some writer is using
+#: it and then disappears on its own. That is a correctness property, not a
+#: tidiness one: removing an entry explicitly while another writer still holds
+#: or is queued on it SPLITS the lock's identity -- the next caller mints a
+#: fresh lock and enters ``state.json`` alongside the writer still inside it,
+#: which is the very loss this lock exists to prevent. Any hook that evicts
+#: without holding the lock (a folder delete, the tombstone pruner) can do
+#: exactly that, and the pruner's case is not even hypothetical: ``_atomic_write``
+#: re-creates the parent directory, so a writer already inside its critical
+#: section resurrects the folder the pruner just removed. Weak values make that
+#: unrepresentable -- an entry cannot be dropped while anyone can still reach
+#: it -- and agent ids are per-run uuids, so nothing accumulates either.
+_STATE_LOCKS: "weakref.WeakValueDictionary[str, _AgentLock]" = weakref.WeakValueDictionary()
+_STATE_LOCKS_GUARD = threading.Lock()
+
+
+class _AgentLock:
+    """A ``threading.Lock`` that can be weakly referenced.
+
+    ``threading.Lock`` itself cannot, so the registry stores this one-field
+    wrapper instead. Callers must retain the WRAPPER (not just ``.lock``) for
+    the whole critical section: it is the strong reference that keeps the
+    registry entry alive, and therefore keeps every concurrent writer on the
+    same lock.
+    """
+
+    __slots__ = ("lock", "__weakref__")
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+
+
+def _on_event_loop() -> bool:
+    """True when the calling thread is running an asyncio event loop.
+
+    The seam that keeps the lock off the loop. A thread ``asyncio.to_thread`` /
+    ``run_in_executor`` dispatched to has no running loop, so pool writers
+    serialize; a synchronous call made from a coroutine does, so it does not
+    wait. Chosen over an explicit caller flag because ``update_state`` takes
+    ``**fields``: any keyword flag would be indistinguishable from a state field
+    a caller means to persist.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _lock_for_agent(agent_id: str) -> "_AgentLock":
+    """Return the process-wide ``state.json`` lock holder for *agent_id*.
+
+    The caller MUST keep the returned object alive for its whole critical
+    section -- see :data:`_STATE_LOCKS`.
+    """
+    with _STATE_LOCKS_GUARD:
+        holder = _STATE_LOCKS.get(agent_id)
+        if holder is None:
+            holder = _AgentLock()
+            _STATE_LOCKS[agent_id] = holder
+        return holder
+
+
 def update_state(agent_id: str, **fields: object) -> bool:
     """Merge *fields* into state.json (atomic rewrite).
 
@@ -150,16 +259,40 @@ def update_state(agent_id: str, **fields: object) -> bool:
     the reaper deleted -- but callers with a durability contract (the pre-spawn
     provenance write, #5394) need to see the skip to retry rather than mistake
     a silent no-op for success.
+
+    The read / merge / rewrite is serialized per agent for OFF-LOOP callers (see
+    :data:`_STATE_LOCKS`), so two pool writers can no longer rewrite a snapshot
+    that predates the other's write.
+
+    KNOWN LIMITATION: an ON-LOOP caller does not take the lock, because waiting
+    on a pool thread's fsync from the event loop is exactly the blocking call the
+    repo's anchor forbids. So an interleave in which ONE participant is on the
+    loop is still open, unchanged from before this lock existed -- the loop-side
+    retention (``keep``) write against an in-flight pool write (#6298), and a
+    detached pool worker against the on-loop PID / session-id writes a
+    cancel-respawn recovery run makes (#6308). Closing those needs the loop-side
+    callers moved off-loop (#6288's class), tracked separately.
     """
     p = _agent_dir(agent_id) / "state.json"
+    # Off-loop callers serialize; on-loop callers keep pre-existing behaviour.
+    # ``holder`` stays referenced for the whole critical section -- that strong
+    # reference is what keeps every concurrent writer on one lock (see
+    # :data:`_STATE_LOCKS`), so it must not be narrowed to ``holder.lock``.
+    holder = None if _on_event_loop() else _lock_for_agent(agent_id)
+    if holder is not None:
+        holder.lock.acquire()
     try:
-        state = json.loads(p.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        logger.debug("update_state: cannot read state for %s, skipping", agent_id)
-        return False
-    state.update(fields)
-    state["updated_at"] = time.time()
-    _atomic_write(p, state)
+        try:
+            state = json.loads(p.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            logger.debug("update_state: cannot read state for %s, skipping", agent_id)
+            return False
+        state.update(fields)
+        state["updated_at"] = time.time()
+        _atomic_write(p, state)
+    finally:
+        if holder is not None:
+            holder.lock.release()
     return True
 
 

--- a/test/test_subagent_state_write_serialization.py
+++ b/test/test_subagent_state_write_serialization.py
@@ -1,0 +1,348 @@
+"""``update_state`` serializes its read/merge/rewrite for OFF-LOOP writers.
+
+``update_state`` is a read / merge / rewrite whose two halves are separated by a
+blocking ``_atomic_write`` (fsync + rename). A run writes ``state.json`` from
+BOTH the event loop (PID, session id, provider, retention ``keep``) and the
+thread pool (model provenance, CC-path model refinement, per-turn diagnostics --
+all via ``asyncio.to_thread``). Without serialization the second writer's read
+predates the first writer's write, so its rewrite restores a stale WHOLE-FILE
+snapshot and silently rolls back every field the first writer had just landed.
+
+The lock is taken by OFF-LOOP callers only: making an on-loop caller wait on a
+pool thread's fsync would be a blocking call on the event loop. So these tests
+pin two things -- that two pool writers do serialize, and that an on-loop caller
+does NOT wait on the lock (the on-loop interleave stays open, tracked separately
+as the loop-side offload).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from kiro_crew import subagent_persistence as sp
+
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
+#: How long a parked writer waits for the other writer to finish. Unserialized,
+#: the other writer lands immediately and the wait returns early, which is what
+#: produces the clobber. Serialized, the other writer is blocked on the lock, so
+#: this wait is expected to time out -- that timeout is the fix working, and it
+#: bounds the test instead of deadlocking it.
+_PARK_TIMEOUT = 1.0
+
+
+def _new_agent(agent_id: str) -> None:
+    sp.create_agent_folder(
+        agent_id,
+        task="t",
+        agent="kirocrew",
+        parent_session="dashboard:default",
+        max_turns=10,
+    )
+
+
+@pytest.fixture()
+def agent_root(tmp_path, monkeypatch):
+    """Point persistence at a temp directory."""
+    monkeypatch.setattr("kiro_crew.subagent_persistence._SUBAGENTS_DIR", tmp_path)
+    return tmp_path
+
+
+def _park_first_writer(monkeypatch, released: threading.Event, inside: threading.Event):
+    """Patch ``_atomic_write`` so the FIRST writer parks before it writes.
+
+    Only the first call parks; every later writer goes straight through, so the
+    second writer in each test is never itself delayed.
+    """
+    real_atomic_write = sp._atomic_write
+    seen: list[str] = []
+    guard = threading.Lock()
+
+    def instrumented(path, data):
+        with guard:
+            first = not seen
+            if first:
+                seen.append("parked")
+        if first:
+            inside.set()
+            released.wait(timeout=_PARK_TIMEOUT)
+        real_atomic_write(path, data)
+
+    monkeypatch.setattr(sp, "_atomic_write", instrumented)
+
+
+class TestPoolWriterAgainstPoolWriter:
+    """Two off-loop writers on one agent: neither may lose the other's fields.
+
+    A run has three pool writers -- pre-spawn provenance, CC-path model
+    refinement, and the per-turn diagnostics write -- and the last two overlap
+    in time during a run.
+    """
+
+    def test_provenance_write_survives_a_concurrent_pool_write(self, agent_root, monkeypatch):
+        _new_agent("a1")
+        released = threading.Event()
+        inside = threading.Event()
+        _park_first_writer(monkeypatch, released, inside)
+
+        # Writer A: the pre-spawn provenance write, parked mid transaction.
+        pool_a = threading.Thread(
+            target=lambda: sp.update_state(
+                "a1", requested_model="req-model", resolved_model="res-model"
+            )
+        )
+        pool_a.start()
+        assert inside.wait(timeout=5.0), "writer A never reached its write"
+
+        # Writer B: the per-turn diagnostics write, also off-loop.
+        pool_b = threading.Thread(
+            target=lambda: sp.update_state("a1", turns=7, last_tool="fs_read")
+        )
+        pool_b.start()
+        pool_b.join(timeout=10.0)
+        assert not pool_b.is_alive()
+
+        released.set()
+        pool_a.join(timeout=10.0)
+        assert not pool_a.is_alive()
+
+        state = sp.read_state("a1")
+        assert state is not None
+        assert state["requested_model"] == "req-model"
+        assert state["resolved_model"] == "res-model"
+        # Writer B's fields: rolled back by A's stale whole-file rewrite when the
+        # two are not serialized.
+        assert state["turns"] == 7
+        assert state["last_tool"] == "fs_read"
+
+    def test_a_detached_worker_cannot_roll_back_another_pool_write(self, agent_root, monkeypatch):
+        """Cancelling a ``to_thread`` await detaches the worker, it does not stop it.
+
+        A detached worker keeps an already-stale read; the lock stops its rewrite
+        restoring the snapshot around it.
+        """
+        _new_agent("a2")
+        released = threading.Event()
+        inside = threading.Event()
+        _park_first_writer(monkeypatch, released, inside)
+
+        detached = threading.Thread(
+            target=lambda: sp.update_state("a2", resolved_model="stale-worker-model")
+        )
+        detached.start()
+        assert inside.wait(timeout=5.0), "detached worker never reached its write"
+
+        recovery = threading.Thread(
+            target=lambda: sp.update_state("a2", turns=3, last_tool="recovered")
+        )
+        recovery.start()
+        recovery.join(timeout=10.0)
+        assert not recovery.is_alive()
+
+        released.set()
+        detached.join(timeout=10.0)
+        assert not detached.is_alive()
+
+        state = sp.read_state("a2")
+        assert state is not None
+        assert state["resolved_model"] == "stale-worker-model"
+        assert state["turns"] == 3
+        assert state["last_tool"] == "recovered"
+
+
+class TestOnLoopCallerDoesNotWait:
+    """The split: an on-loop caller must not block on the per-agent lock.
+
+    Serializing it too would mean the event loop waiting on a pool thread's
+    fsync, which the repo's no-blocking-call-on-event-loop anchor forbids. The
+    cost is that an interleave with one on-loop participant stays open; that is
+    the loop-side offload, tracked separately.
+    """
+
+    def test_a_coroutine_does_not_wait_on_a_held_lock(self, agent_root):
+        _new_agent("a3")
+        held = sp._lock_for_agent("a3")
+        # The holder must be ANOTHER thread. Holding it here would make the
+        # coroutine re-acquire a non-reentrant lock on its own thread, so a
+        # regression would DEADLOCK instead of failing -- a useless signal. With
+        # a separate holder that releases on a timer, a regression instead shows
+        # up as elapsed time and the test always terminates.
+        holder_release = threading.Event()
+        holding = threading.Event()
+
+        def holder() -> None:
+            held.lock.acquire()
+            holding.set()
+            holder_release.wait(timeout=10.0)
+            held.lock.release()
+
+        keeper = threading.Thread(target=holder, daemon=True)
+        keeper.start()
+        assert holding.wait(timeout=5.0), "holder never took the lock"
+
+        # Release the lock well after the assertion window: if the on-loop
+        # caller wrongly waits, it waits this long and fails on elapsed.
+        timer = threading.Timer(1.5, holder_release.set)
+        timer.daemon = True
+        timer.start()
+        try:
+
+            async def on_loop_write() -> tuple[bool, float]:
+                begin = time.monotonic()
+                ok = sp.update_state("a3", keep=True)
+                return ok, time.monotonic() - begin
+
+            wrote, elapsed = asyncio.run(on_loop_write())
+        finally:
+            timer.cancel()
+            holder_release.set()
+            keeper.join(timeout=10.0)
+
+        # Did not queue behind the holder.
+        assert elapsed < 0.5, f"on-loop caller waited {elapsed:.2f}s on the lock"
+        assert wrote is True
+        state = sp.read_state("a3")
+        assert state is not None
+        assert state["keep"] is True
+
+    def test_an_off_loop_caller_does_wait(self, agent_root):
+        """The mirror: the same call from a plain thread DOES serialize.
+
+        Pins that the seam is the running loop and not something incidental, so
+        a change making every caller skip the lock cannot pass.
+        """
+        _new_agent("a3b")
+        held = sp._lock_for_agent("a3b")
+        held.lock.acquire()
+        entered = threading.Event()
+
+        def off_loop_write() -> None:
+            entered.set()
+            sp.update_state("a3b", keep=True)
+
+        worker = threading.Thread(target=off_loop_write)
+        worker.start()
+        assert entered.wait(timeout=5.0)
+        # Still blocked while we hold the lock.
+        worker.join(timeout=0.5)
+        assert worker.is_alive(), "off-loop caller did not wait on the lock"
+
+        held.lock.release()
+        worker.join(timeout=10.0)
+        assert not worker.is_alive()
+        state = sp.read_state("a3b")
+        assert state is not None
+        assert state["keep"] is True
+
+
+class TestConcurrentWriters:
+    def test_no_off_loop_writer_loses_its_field(self, agent_root, monkeypatch):
+        """Every concurrent pool writer's field survives the merge.
+
+        All writers are released from a barrier so their reads coincide, which
+        is the interleaving the production writers hit by accident.
+        """
+        _new_agent("a4")
+        writers = 8
+        real_atomic_write = sp._atomic_write
+
+        def slow(path, data):
+            # Widen the read -> write window every writer already has.
+            threading.Event().wait(timeout=0.005)
+            real_atomic_write(path, data)
+
+        monkeypatch.setattr(sp, "_atomic_write", slow)
+        barrier = threading.Barrier(writers)
+
+        def writer(n: int) -> None:
+            barrier.wait(timeout=10.0)
+            sp.update_state("a4", **{f"field_{n}": n})
+
+        threads = [threading.Thread(target=writer, args=(n,)) for n in range(writers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15.0)
+            assert not t.is_alive()
+
+        state = sp.read_state("a4")
+        assert state is not None
+        missing = [f"field_{n}" for n in range(writers) if f"field_{n}" not in state]
+        assert not missing, f"writers lost their fields: {missing}"
+
+
+class TestLockRegistry:
+    def test_lock_is_per_agent_and_stable_while_referenced(self, agent_root):
+        """One lock per agent id -- not one global lock for every run.
+
+        A single process-wide lock would also pass the races above while making
+        every unrelated run queue behind one agent's fsync.
+        """
+        from kiro_crew.subagent_persistence import _lock_for_agent
+
+        a = _lock_for_agent("agent-a")
+        assert _lock_for_agent("agent-a") is a
+        assert _lock_for_agent("agent-b") is not a
+
+    def test_entry_disappears_once_no_writer_holds_it(self, agent_root):
+        """The registry is self-cleaning: no explicit eviction anywhere.
+
+        Agent ids are per-run uuids, so an entry that outlived its writers would
+        leak one lock per subagent ever spawned.
+        """
+        _new_agent("selfclean1")
+        sp.update_state("selfclean1", pid=1)
+        # The writer has returned, so nothing references the holder any more.
+        assert "selfclean1" not in sp._STATE_LOCKS
+
+        # Same after the folder is deleted, and for an id with no folder at all
+        # -- neither needs a hook, because neither leaves a reference behind.
+        sp.delete_agent_folder("selfclean1")
+        assert sp.update_state("selfclean1", turns=9) is False
+        assert "selfclean1" not in sp._STATE_LOCKS
+        assert sp.update_state("never-existed", turns=1) is False
+        assert "never-existed" not in sp._STATE_LOCKS
+
+    def test_entry_survives_while_a_writer_still_references_it(self, agent_root):
+        """The property that makes explicit eviction unnecessary AND unsafe.
+
+        While any writer holds or is queued on the lock, the entry must stay --
+        otherwise the next caller mints a FRESH lock and enters state.json
+        alongside the writer still inside it. Dropping an entry explicitly (a
+        folder delete, the tombstone pruner) is exactly that bug, which is why
+        the registry holds its values weakly instead.
+        """
+        _new_agent("held1")
+        holder = sp._lock_for_agent("held1")
+        holder.lock.acquire()
+        entered = threading.Event()
+        try:
+
+            def queued_writer() -> None:
+                entered.set()
+                sp.update_state("held1", turns=2)
+
+            worker = threading.Thread(target=queued_writer, daemon=True)
+            worker.start()
+            assert entered.wait(timeout=5.0)
+            worker.join(timeout=0.5)
+            assert worker.is_alive(), "writer should be queued on the held lock"
+
+            # Referenced by us and by the queued writer -> same object, so the
+            # writer cannot be stranded on an orphaned lock.
+            assert "held1" in sp._STATE_LOCKS
+            assert sp._lock_for_agent("held1") is holder
+
+            # Even a folder delete mid-flight must not orphan it.
+            sp.delete_agent_folder("held1")
+            assert sp._lock_for_agent("held1") is holder
+        finally:
+            holder.lock.release()
+            worker.join(timeout=10.0)
+        assert not worker.is_alive()


### PR DESCRIPTION
## 1. What is the problem?

`update_state` (`src/kiro_crew/subagent_persistence.py`) reads `state.json`, merges the caller's fields and rewrites the whole file. Between the read and the write sits a blocking `_atomic_write` (fsync + rename). Nothing serialized two writers on the same `agent_id`, so the second writer's read could predate the first writer's write -- and its rewrite then restored a stale **whole-file** snapshot. Losing the other writer's fields is the visible half; silently rolling back fields **neither** writer touched is the damaging half.

One run writes state from both sides at once:

| Thread | Writers |
|---|---|
| event loop | retention `keep` (`subagent_manager/continuation.py`), PID, session id + provider, shared-session PID |
| thread pool | pre-spawn model provenance, CC-path model refinement, per-turn diagnostics -- each `await asyncio.to_thread(update_state, ...)` |

The three pool writers overlap each other during a run: CC-path refinement fires on the first text chunk and the diagnostics write fires on every tool event, while the provenance write's own bounded retry can still be in flight. Cancellation widens the window further -- cancelling a `to_thread` await *detaches* the worker rather than stopping it, so it finishes carrying a read that is already stale.

This PR closes the **pool-vs-pool** half of that. See section 3 for the deliberate scope split and the Known limitation below it for what stays open.

## 2. Why this issue matters to the user

The fields that get rolled back are the ones recovery depends on. `pid` and `session_id` are what orphan recovery and `spawn_continue` read from disk to find a run again; `turns` and `last_tool` are the orphan-recovery diagnostics; `resolved_model` is the run's served-model provenance (#5394).

Concretely, within the pool-vs-pool half this PR fixes: the per-turn diagnostics write and the CC-path model refinement both fire during a normal run. Unserialized, whichever renames second restores its own earlier snapshot -- so a run can end up with diagnostics that never advanced, or with `resolved_model` reverted to the spawn-time value, or with a field written by an earlier pool writer simply absent. Nothing logs and the file stays valid JSON; the fields are just not there.

## 3. How our fix solves it

Symptom -> cause chain:

1. A field written by one pool writer disappears, or state reverts to an earlier snapshot.
2. Because `update_state` rewrites the **whole** file from a snapshot it read earlier, so its write carries stale values for every key it was not asked to change.
3. Because the read and the write are separated by a blocking fsync, leaving a wide window.
4. Because nothing serialized two callers on the same `agent_id` -- the root.

The fix closes (4) for off-loop callers, which makes (3) and (2) harmless between them: each pool writer's read now observes its predecessor's write, so a merge cannot resurrect a pre-write snapshot.

**Scope split -- off-loop writers only.** Serializing on-loop callers too would mean the event loop waiting on a pool thread's fsync, which is the repo's `no-blocking-call-on-event-loop` anchor. An earlier revision of this PR bounded that wait; review was correct that bounding shrinks the violation without removing it, and that on expiry the caller pays the wait *and* writes unserialized. So the lock is now taken only by callers not on the loop, where blocking is legal, and on-loop callers keep exactly their pre-existing behaviour. The finding is structurally unobservable rather than tuned: no event-loop caller can wait on this lock, and no on-loop caller is ever a holder.

Two consequences worth naming:

- **No timeout, no fail-open path.** Because only pool workers ever block here, and their own write (read + fsync + rename) already exposes them to a wedged FS, waiting on the lock adds no parking risk the write did not already carry. That deleted the bounded budget, the unserialized-write warning, and its test -- the mechanism review objected to is gone, not adjusted.
- **The seam is a running-loop check**, not a caller flag, because `update_state` takes `**fields`: any keyword flag would be indistinguishable from a state field a caller means to persist. `asyncio.to_thread` / `run_in_executor` threads have no running loop and so serialize; a synchronous call from a coroutine does and so does not wait. The documented `returns whether the merge was written` contract is untouched, so the #5394 provenance retry still sees a skipped merge.

The two open questions triage flagged are both answered in-tree, so this mirrors an established pattern rather than inventing one:

- **Lock nature.** A per-key `threading.Lock` registry (`dict` + guard lock) is what this repo already uses to serialize file read-modify-write in three places: `learn._lock_for`, `artifacts._lock_for_root`, `history.ConversationLog._file_locks`. `learn.py` documents the same in-process-only reasoning verbatim. A filesystem lock is the tool for cross-process contention (`session_ledger._locked`, `history`'s flock layer) and there is none here -- every `update_state` caller lives in the gateway process that owns the run.
- **Nobody evicts: the registry is self-cleaning.** Values are held **weakly** and every caller keeps a strong reference for the length of its critical section, so an entry lives exactly as long as some writer is using it and then disappears on its own. Keyed per agent, so unrelated runs never queue behind one agent's fsync, and agent ids are per-run `uuid4().hex[:8]`, so nothing accumulates.

  This is a correctness property, not tidiness. Removing an entry explicitly while another writer still holds or is queued on it **splits the lock's identity** -- the next caller mints a fresh lock and enters `state.json` alongside the writer still inside it, which is precisely the loss this lock exists to prevent. Earlier revisions of this PR carried three such hooks (`delete_agent_folder`, `prune_stale_tombstones`, and a read-failure path) and review found the class twice; all three are now gone. The pruner's case is not hypothetical: `_atomic_write` calls `mkdir(parents=True)`, so a writer already inside its critical section re-creates the folder the pruner just removed, and the pruner holds no lock so it cannot know. Weak values make the whole class unrepresentable rather than guarded case by case. (`threading.Lock` cannot be weakly referenced, hence the one-field `_AgentLock` wrapper the registry stores; callers must retain the wrapper, not just `.lock`.)

  A write for an id whose folder is already gone still creates an entry -- `_lock_for_agent` runs before the read that discovers the folder is missing -- but it evaporates when that writer returns, so no hook is needed and none exists.

## Known limitation

**An interleave with one ON-LOOP participant is still open, unchanged from before this PR.** Specifically:

- the loop-side retention `keep` write against an in-flight pool write -- the defect **#6298** is titled for;
- a detached pool worker against the PID / session-id writes a cancel-respawn recovery run makes **on the loop** (`subagent_manager/run.py`) -- the scenario **#6308**'s drain defends against.

Neither is closed here, because the on-loop participant does not take the lock. Both drain comments in `run.py` were corrected to say so, rather than claiming a guarantee this PR does not deliver: the whole-file rollback that the #6306 shield-and-drain exists to bound is still reachable.

Closing that half means moving the loop-side callers off-loop -- #6288's defect class, which #6306 deliberately scoped to a single site and which five triage passes on #6298/#6308 parked as needing a human ruling. It is filed separately rather than bundled in here. Because of this, the trailers are `Refs`, not `Fixes`: both issues' titled defects name an interleave with an on-loop participant, so neither is closed by this PR. Noted on both issues.

## 4. What tests we did

New file `test/test_subagent_state_write_serialization.py` (8 tests). Each race test parks one writer between its read and its write and drives the other writer meanwhile, with a bounded park so the test terminates instead of deadlocking. The two split tests are a matched pair: an on-loop caller must NOT wait on a held lock, and the same call from a plain thread MUST wait -- so a change that made every caller skip the lock cannot pass either.

The pool-vs-pool tests were verified RED before the lock existed, failing on the mechanism rather than a missing symbol (a rolled-back `keep`, a reverted `pid`, and `writers lost their fields: ['field_0', 'field_1', 'field_3', ...]` for 8 barrier-released writers).

Mutation matrix, each reversion reddening its own axis and nothing else:

| Mutation | Result |
|---|---|
| no serialization at all | 5 failed / 3 passed |
| collapse the registry to one global lock | 2 failed / 6 passed |
| serialize EVERY caller (the off-loop split removed) | 1 failed / 7 passed |
| strong-ref registry instead of weak (never self-cleans) | 1 failed / 7 passed |
| restored | 8 passed, file byte-identical |

The global-lock mutation pins the lock as genuinely per-agent: one process-wide lock also passes the race tests while making every unrelated run queue behind one agent's fsync. The split-removed mutation pins the split itself -- and the on-loop test is deliberately built with a separate holder thread on a timed release, because holding the lock on the test's own thread would make that mutation *deadlock* instead of fail, which is not a usable signal. The strong-ref mutation pins the self-cleaning registry from one side; a matched test pins it from the other, asserting the entry SURVIVES while a queued writer still references it (including across a mid-flight folder delete), which is the property that makes explicit eviction both unnecessary and unsafe.

Targeted suites, **806 passed, 0 failed** (630 + 176 across two batches) -- every test file that references `subagent_persistence`, plus the adjacent subagent suites: `test_subagent`, `test_subagent_persistence`, `test_subagent_state_write_serialization`, `test_subagent_provenance_write`, `test_subagent_continuable`, `test_continuable_followups`, `test_session_cleanup`, `test_subagent_delivery_ttl_anchor`, `test_subagent_reap_race`, `test_subagent_resolved_model`, `test_subagent_manager_boundaries`, `test_subagent_coverage`, `test_lazy_data_home_paths`, `test_members`, `test_subagent_context_group_plumbing`, `test_subagent_error_detail`, `test_subagent_result_path_spelling`, `test_subagent_scale`, `test_ci_surface_tests`.

Gates: `isort`, `flake8` and `black` clean on every changed file. `mypy` reports 2 errors, both in `transcribe.py`, a file this diff never touches (boto3-stub env drift).

## Pattern harvest

Rule candidate: semgrep
Pattern: whole-file read / merge / rewrite with no serialization on the record's key

The defect is not a typo and it is not the first of its kind here. The shape is a function that reads a JSON document, merges caller fields into the parsed dict, and rewrites the whole file, with a blocking fsync between the read and the write and no lock keyed on the record. Any second writer's rewrite then restores a pre-write snapshot, so the loss is not confined to the fields either caller passed. This repo has hit the family repeatedly: #6017 and #6290 on the session ledger, #5244 (`config.json` materializes every key, so a stored value beats a changed default), #4955 (the `kirocrew.json` rebuild reads back its own computed values as if user-authored). Three modules already carry the per-key-lock remedy (`learn._lock_for`, `artifacts._lock_for_root`, `history.ConversationLog._file_locks`) and two carry the filesystem-lock variant (`session_ledger._locked`, `history`'s flock layer). The remedy is settled; it is the detection that is missing.

A useful rule flags a function that both reads a path (`read_text` / `json.loads`) and writes that same path, where the enclosing module defines no lock guarding the pair. The signal to key on is the round trip through a parsed dict, not the write primitive: `_atomic_write` makes each individual write atomic, which is exactly what makes the missing serialization easy to mistake for handled. Two refinements keep it honest -- exempt a writer that never reads first (`create_agent_folder` builds a fresh document and cannot lose a merge), and require the lock to be per-key rather than module-global, since one process-wide lock is a correct-but-costly answer a naive check would accept.

## 5. Any other suggestions on the work

- **`create_agent_folder` is not locked.** It writes a fresh `state.json` for an id that has no other writer yet, so it cannot lose a merge. Worth folding in if the invariant is ever stated as "every `state.json` write serializes" rather than "every read-modify-write serializes".
- **Cross-process is still last-writer-wins.** A `threading.Lock` does not span processes. No caller outside the gateway writes subagent state today, so this is a note on what the fix does not claim, not a gap -- `learn.py` carries the same caveat.
- **The split is invisible at the call site.** A reader of `continuation.py` cannot tell that its `update_state` call is the unserialized one. If the loop-side offload does not land soon, an explicit named wrapper for the on-loop callers would make the asymmetry legible.
- **`delete_agent_folder` has no production callers** (First Principles noted this; grep confirms tests and docs only). This PR no longer touches it at all, but the dead function itself is worth removing -- out of scope here.

Refs #6298
Refs #6308



