### PR TITLE
docs(session-storage): record the read-only-resume gap in the revival guard

### DIFF
--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -107,14 +107,16 @@ making the authority check the freshest view available. The two active sets are
 **unioned**, so a re-read can only ever add protection, and a re-read that fails
 refuses the operation rather than proceeding on the stale view.
 
-The move loop then closes most of what the re-read cannot. Every source file is
-stat'd there anyway, to record its size in the manifest, and that same stat carries
-an mtime. A candidate qualified by being untouched for `MIN_RECLAIM_AGE_DAYS`, so a
-source whose mtime is newer than the instant the reclaim began has been written to
-since every read that certified it — which an idle session's file cannot be. The
-whole session is left in place, whatever already moved for it is rolled back, and it
-is named in `TrashBatch.revived` so the caller can report it. This costs no extra
-syscall: the detection rides on a stat the loop already performs.
+The move loop then closes part of what the re-read cannot, for a resume that
+**writes**. Every source file is stat'd there anyway, to record its size in the
+manifest, and that same stat carries an mtime. A candidate qualified by being
+untouched for `MIN_RECLAIM_AGE_DAYS`, so a source whose mtime is newer than the
+instant the reclaim began has been written to since every read that certified it —
+which an idle session's file cannot be. The whole session is left in place, whatever
+already moved for it is rolled back, and it is named in `TrashBatch.revived` so the
+caller can report it. This costs no extra syscall: the detection rides on a stat the
+loop already performs. A resume that only READS is invisible to it — see Known
+Limitations.
 
 Naming a session in `revived` is a claim -- "this one was left where it was" -- so it
 is only made when the rollback actually completed. Putting a file back is
@@ -133,9 +135,11 @@ loop, which is most of the elapsed time. Taking it early adds no false positives
 because a candidate has to be untouched for `MIN_RECLAIM_AGE_DAYS` to qualify at all.
 
 Detection, not prevention: a session revived *after* its last file was stat'd and
-moved is still staged. The window is therefore the gap between one file's stat and
-its rename rather than the whole loop, and what lands in that gap lands in the
-trash — fully restorable, with destruction still needing a second explicit `empty`.
+moved is still staged. For a resume that writes, the window is therefore the gap
+between one file's stat and its rename rather than the whole loop. For a resume that
+only reads it is still the whole loop, because there is no write for the stat to see.
+Either way what lands in that gap lands in the trash — fully restorable, with
+destruction still needing a second explicit `empty`.
 
 ## What is reclaimable
 
@@ -574,11 +578,13 @@ distinguish it from a malformed request without reading the code, and retrying i
 the only recovery.
 
 A session that goes live *later still* — after the `refresh`, while the move loop is
-running — is not all-or-nothing. The loop's mtime check leaves that one session in
-place and the rest of the batch proceeds, and the handler folds each such uid into
-the same `refused` list under `in_use`. The mechanism differs from the pre-pass
-(caught by a stat during the move rather than by the index before it) but the reason
-a reader needs is identical, so it carries no new code.
+running — is not all-or-nothing, provided the resume writes. The loop's mtime check
+leaves that one session in place and the rest of the batch proceeds, and the handler
+folds each such uid into the same `refused` list under `in_use`. The mechanism differs
+from the pre-pass (caught by a stat during the move rather than by the index before
+it) but the reason a reader needs is identical, so it carries no new code. A resume
+that only reads writes nothing for that stat to catch, so it is staged instead of
+refused — the gap recorded in Known Limitations.
 
 **The guarantee is not weakened.** `move_to_trash()` still re-reads the session map
 inside the mutation lock and still unions the active sets, so the pre-pass can only
@@ -641,7 +647,7 @@ instead of the trash over-deleting. `TestEmptyTrash` and
 
 ## Known Limitations
 
-- **A much smaller residual race with session-map writes remains.** The authority
+- **A much smaller residual race remains for a resume that writes.** The authority
   check is re-read after the scan and inside the reclaim lock, and the move loop then
   rejects any source whose mtime is newer than the batch's validation instant, so a
   session resumed *during* the loop is left in place and reported rather than staged.
@@ -651,6 +657,23 @@ instead of the trash over-deleting. `TestEmptyTrash` and
   restorable — nothing is destroyed without a second explicit action. Removing it
   entirely still requires the session/slot code and this module to share one lock,
   which is a wider change than this surface.
+- **A resume that only READS the transcript is not detected at all, and its window is
+  the whole loop.** The bullet above describes a resume that writes; the mtime check
+  has nothing to see when the resume writes nothing. The sequence: a retired session's files
+  are certified reclaimable, the session is resumed, the resume reads the old transcript
+  to rebuild history, and the turn that follows is recorded under a newly mapped SID
+  without rewriting that old transcript. Every one of the session's files therefore
+  still carries its original mtime, all of them pass the validation-instant check, and
+  the live slot's durable history is staged out from under it. Detection would need the
+  index re-read to happen inside the loop rather than once before it, and the naive form
+  of that is not affordable: `refresh` is `_build_index`, which costs a file read plus a
+  full json parse — about 0.26 ms even against a 100-entry map — so at the
+  `_MAX_SELECTION` cap of 200,000 units it is ~56 s at that floor and hours against a
+  realistic map, and it would take `SessionMap._MAP_LOCK` once per unit while the
+  reclaim lock is held. Making it affordable means the caller memoizing its own index on
+  a change token, which is a contract change to `refresh` rather than an adjustment to
+  the loop. Like the write-shaped gap this stays restorable: the history lands in the
+  trash, and destruction still needs a second explicit `empty`.
 - Reclaiming is offered both by age (`cleanup`) and by explicit selection
   (`trash`). Neither can take a session the map still lists, so targeting one large
   conversation only works if that conversation is unmapped.


### PR DESCRIPTION
## What is the problem?

`docs/system-specs/modules/session-storage.md` records the residual race in
`move_to_trash`'s revival guard as microseconds wide. It is only that wide for a resume
that WRITES. A resume that only reads the old transcript is not detected at all, and its
window is the whole move loop.

Four spans in the doc say or imply the loop catches a resume without qualifying which
kind:

- "The move loop then closes most of what the re-read cannot."
- "The window is therefore the gap between one file's stat and its rename rather than
  the whole loop."
- "The loop's mtime check leaves that one session in place and the rest of the batch
  proceeds."
- the Known Limitations bullet, which is the one a triager reads.

## Why this issue matters to the user

Not to an end user directly - to whoever reads this spec to decide whether the gap is
already handled. Two independent triage passes on #7118 both concluded the residual was
already documented and routed the issue on that basis. It is not documented: what is
documented is a different, far narrower race that happens to sit in the same paragraph.
An incomplete Known Limitations entry is worse than an absent one, because it converts
"nobody has looked at this" into "someone looked and accepted it".

## How our fix solves it

Docs only - no behaviour change.

The Known Limitations entry is split in two. The existing bullet is scoped to a resume
that writes and otherwise left alone. A second bullet records the read-only case: the
sequence that produces it (files certified reclaimable, session resumed, resume reads the
old transcript to rebuild history, the turn that follows recorded under a newly mapped
SID without rewriting that transcript), why the mtime check cannot see it (every file
still carries its original mtime, so all of them pass the validation-instant check), and
why it is not simply fixed by moving the index re-read inside the loop.

That last part is measured rather than asserted, because the reason the fix is deferred
is a cost: `refresh` is `_build_index`, which is a file read plus a full json parse, so
it has a floor of about 0.26 ms however small the map. At the `_MAX_SELECTION` cap of
200,000 units that is ~56 s at the floor and hours against a realistic map size, and it
would take `SessionMap._MAP_LOCK` once per unit while the reclaim lock is held. The
affordable form needs the caller to memoize its index on a change token, which is a
contract change to `refresh` rather than an adjustment to the loop - so the entry says
that, instead of leaving the next reader to re-derive it.

The three prose spans above get a scoping clause each and a pointer to Known Limitations.
Correcting only the bullet would have left the body of the same document contradicting it.

## What tests we did

No test ships with this. The gap was reproduced first - a regression test in
`TestASessionResumedWhileStagingIsLeftAlone` where the second session becomes mapped
mid-loop while writing nothing fails on `kirocrew/main` at `23c99c0f1` with
`AssertionError: assert () == ('bbbb2222',)`, confirming the live session is staged. That
test cannot land here: with no fix it is permanently red, so it is attached to #7118 for
whoever ships the fix rather than committed.

The measurement quoted in the new bullet is the median of 5 runs of `_build_index()` plus
the two set unions the pre-loop code already performs, at map sizes 100 / 1,000 / 10,000
/ 100,000, projected to the cap. Full table on #7118.

Verified no CI gate reads this file: no test references `session-storage.md`, Screenshot
Evidence scopes to user-visible frontend surfaces, and First Principles skips a docs-only
diff.

## Any other suggestions on the work

#7118 itself should stay open and stay parked. Of the two shapes it proposed, the
per-unit refresh is ruled out by the measurement above and the post-loop-refresh-plus-
rollback shape needs a manifest tombstone honoured by `_read_manifest`,
`_summarize_manifest`, `_restore_locked`, `_manifest_rels`, `_listed_bytes`,
`staged_targets` and `_empty_trash_locked` - every one of which is inside #7011's
unmerged diff. The third shape (caller-memoized refresh) is a contract change and wants a
maintainer's call.

One thing found while measuring, worth its own look eventually: `_build_index()` reads the
session map FILE, but `SessionMap._save()` debounces by `_FLUSH_DEBOUNCE_SECS = 0.05`. So
any file-based refresh - including the pre-loop one already on main - is blind to a resume
for up to ~50 ms after it happens. That bounds how well any of the three shapes can do
without consulting the live in-process map.

Refs #7118
