### PR TITLE
fix(memory): redact pip stderr before logging install failures (#7279)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -49,7 +49,7 @@ from kiro_crew.sandbox import (
     wrap_argv,
     wrap_argv_async,
 )
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact_and_truncate, redact_credentials, redact_exfiltration_urls
 
 from ._shared import _get_memory, _is_restricted_session, _redact_memory_field, read_bounded_json
 from .cron import _recognize_session
@@ -71,6 +71,12 @@ _history_write_lock = LoopBoundLock()
 # would 409. Safe to bound ONLY because the candidate is gated — an abandoned
 # loader publishes into an embedder we close, and close() is terminal.
 _MODEL_LOAD_TIMEOUT_SECS = 600.0
+
+# Log-line budget for pip/ensurepip stderr in the warnings below. The bound is
+# applied by redact_and_truncate AFTER redaction runs over the FULL decoded
+# stderr, so a credential straddling the boundary cannot survive as an
+# unredacted fragment (the redact-before-bound invariant; see security.py).
+_PIP_STDERR_LOG_CHARS = 500
 
 
 def _sel():
@@ -894,7 +900,10 @@ async def _ensure_pip_available() -> tuple[bool, str]:
             logger.warning("ensurepip bootstrap timed out")
             return False, "pip bootstrap (ensurepip) timed out"
         if proc.returncode != 0:
-            logger.warning("ensurepip bootstrap failed: %s", stderr.decode()[:500])
+            logger.warning(
+                "ensurepip bootstrap failed: %s",
+                redact_and_truncate(stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS),
+            )
             return False, "pip bootstrap (ensurepip) failed"
         importlib.invalidate_caches()
         logger.info("Bootstrapped pip via ensurepip")
@@ -1045,7 +1054,12 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
                             {"error": "faiss-cpu install timed out."}, status=500,
                         )
                     if proc.returncode != 0:
-                        logger.warning("faiss-cpu install failed: %s", stderr.decode()[:500])
+                        logger.warning(
+                            "faiss-cpu install failed: %s",
+                            redact_and_truncate(
+                                stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS
+                            ),
+                        )
                         _embedding_setup_status = {
                             "step": "idle",
                             "error": "faiss-cpu installation failed — click Enable to retry",

--- a/test/test_enable_embeddings_faiss.py
+++ b/test/test_enable_embeddings_faiss.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -523,3 +524,112 @@ class TestSetMigratedFailClosed:
             await mem_mod._set_migrated(True)
         data = json.loads(cfg_path.read_text(encoding="utf-8"))
         assert data["memory"]["migrated"] is True
+
+
+class TestPipStderrRedaction:
+    """Regression for issue #7279: pip/ensurepip stderr reached the gateway log
+    unredacted. A private index configured with userinfo credentials leaks the
+    token into pip's stderr on an auth failure; both warning sites must route
+    the decoded stderr through ``redact_and_truncate`` (redact the FULL text
+    first, then bound) so the token never lands in the log."""
+
+    _SECRET = "LEAKY7279TOKEN"
+    _MASK = "[REDACTED: credential]"
+
+    def _auth_failure_stderr(self) -> bytes:
+        return (
+            "ERROR: HTTP error 401 while getting "
+            "https://ci-bot:" + self._SECRET + "@pypi.corp.example/simple/faiss-cpu/\n"
+            "ERROR: Could not install requirement faiss-cpu"
+        ).encode()
+
+    @pytest.mark.asyncio
+    async def test_faiss_install_failure_log_masks_userinfo_credential(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cfg_path = tmp_path / "kirocrew.json"
+        cfg_path.write_text("{}", encoding="utf-8")
+        patches, store, proc, mgr = _common_patches(
+            cfg_path, faiss_available=False, proc_rc=1, proc_stderr=self._auth_failure_stderr()
+        )
+
+        with patches["mgr"], patches["model_present"], patches["cfg_load"], \
+             patches["cfg_path"], patches["subprocess"], patches["faiss"], \
+             patches["store"], patches["wrap_argv"], \
+             caplog.at_level(logging.WARNING, logger=_MOD):
+            async with TestClient(TestServer(_make_app())) as c:
+                resp = await c.post("/api/memory/enable-embeddings")
+                assert resp.status == 500
+
+        messages = [r.getMessage() for r in caplog.records if "faiss-cpu install failed" in r.getMessage()]
+        assert messages, "expected the faiss-cpu install-failed warning to be logged"
+        for msg in messages:
+            assert self._SECRET not in msg
+            assert self._MASK in msg
+
+    @pytest.mark.asyncio
+    async def test_ensurepip_failure_log_masks_userinfo_credential(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        proc = _mock_proc(rc=1, stderr=self._auth_failure_stderr())
+        with patch.dict("sys.modules", {"pip": None}), \
+             patch(f"{_MOD}.wrap_argv", side_effect=lambda argv, **kw: (argv, None)), \
+             patch("asyncio.create_subprocess_exec", return_value=proc), \
+             caplog.at_level(logging.WARNING, logger=_MOD):
+            ok, err = await mem_mod._ensure_pip_available()
+
+        assert ok is False
+        messages = [r.getMessage() for r in caplog.records if "ensurepip bootstrap failed" in r.getMessage()]
+        assert messages, "expected the ensurepip bootstrap-failed warning to be logged"
+        for msg in messages:
+            assert self._SECRET not in msg
+            assert self._MASK in msg
+
+    @pytest.mark.asyncio
+    async def test_non_utf8_stderr_does_not_raise(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A pip failure on a non-UTF-8 console (Windows codepage, mangled index
+        # response) must not raise UnicodeDecodeError on the failure path:
+        # decode(errors="replace") keeps the warning best-effort.
+        proc = _mock_proc(rc=1, stderr=b"\xff\xfe broken " + self._auth_failure_stderr())
+        with patch.dict("sys.modules", {"pip": None}), \
+             patch(f"{_MOD}.wrap_argv", side_effect=lambda argv, **kw: (argv, None)), \
+             patch("asyncio.create_subprocess_exec", return_value=proc), \
+             caplog.at_level(logging.WARNING, logger=_MOD):
+            ok, err = await mem_mod._ensure_pip_available()
+
+        assert ok is False
+        assert "ensurepip" in err
+        messages = [r.getMessage() for r in caplog.records if "ensurepip bootstrap failed" in r.getMessage()]
+        assert messages
+        for msg in messages:
+            assert self._SECRET not in msg
+
+    @pytest.mark.asyncio
+    async def test_credential_straddling_log_bound_does_not_leak_fragment(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Redact-before-bound invariant: plant the credential so it straddles
+        # the log bound. The old ``stderr.decode()[:500]`` head slice
+        # would have emitted a raw unredacted prefix of the token; redacting the
+        # full text first means no fragment of the secret can survive.
+        bound = mem_mod._PIP_STDERR_LOG_CHARS
+        prefix = "E" * (bound - len("https://ci-bot:") - 5)  # token crosses the bound
+        stderr = (
+            prefix + "https://ci-bot:" + self._SECRET + "@pypi.corp.example/simple/\n"
+        ).encode()
+        proc = _mock_proc(rc=1, stderr=stderr)
+        with patch.dict("sys.modules", {"pip": None}), \
+             patch(f"{_MOD}.wrap_argv", side_effect=lambda argv, **kw: (argv, None)), \
+             patch("asyncio.create_subprocess_exec", return_value=proc), \
+             caplog.at_level(logging.WARNING, logger=_MOD):
+            ok, _ = await mem_mod._ensure_pip_available()
+
+        assert ok is False
+        messages = [r.getMessage() for r in caplog.records if "ensurepip bootstrap failed" in r.getMessage()]
+        assert messages
+        for msg in messages:
+            # No prefix of the token may appear (the old slice leaked one).
+            for n in range(3, len(self._SECRET) + 1):
+                assert self._SECRET[:n] not in msg


### PR DESCRIPTION
## Summary

`handlers/memory.py` logged pip/ensurepip subprocess stderr into the gateway log unredacted (`stderr.decode()[:500]`) at two warning sites. On the faiss-cpu install path the child pip inherits the gateway environment, so a private index configured with userinfo credentials reaches pip, and on an auth failure pip writes the raw request URL — including the token — to stderr, which then landed verbatim in the gateway log.

Both sites now route the **full** decoded stderr through `security.redact_and_truncate` before logging:

- Redaction runs over the complete text **before** the length bound (the redact-before-bound invariant from #4402 / #5574), so a credential straddling the old 500-char slice boundary cannot survive as an unredacted fragment.
- The log budget is kept at 500 chars via a named constant `_PIP_STDERR_LOG_CHARS`.
- `stderr.decode(errors="replace")` on both touched lines so a non-UTF-8 pip stderr (Windows codepage, mangled index response) cannot raise `UnicodeDecodeError` on the failure path and wedge `_embedding_setup_status` at `installing_faiss` (accepted pre-push Opus advisory; the site's own comments document that wedge class).
- The ensurepip site (no index-URL vector — ensurepip never consults an index) is fixed for shape consistency on the same code path.

Out of scope: the head-vs-tail anchor policy for which 500 chars to keep is tracked in #5555; this PR only introduces the missing redaction.

## Tests

`test/test_enable_embeddings_faiss.py::TestPipStderrRedaction` (4 new tests, all mutation-verified red against the raw-slice code):

- faiss-cpu install failure with a userinfo credential in stderr → logged warning contains `[REDACTED: credential]`, raw token absent (end-to-end through the handler, subprocess mocked).
- ensurepip bootstrap failure, same assertion, direct `_ensure_pip_available` path.
- credential planted to straddle the 500-char bound → **no prefix** of the token (3..14 chars) appears in the log; the old head-slice leaked one, and a truncate-then-redact mutation also fails this test because the sliced text loses the `@` the userinfo pattern requires.
- non-UTF-8 stderr bytes → no `UnicodeDecodeError`, warning still logged and redacted.

Local gates (CI-pinned tools): black-baseline, isort, flake8, mypy (1216 files clean), brand-name, harness-parity, subprocess-encoding — all green. Targeted pytest: 23 passed.

## Pre-push review dispositions

- GPT lane (`gpt-5.6-sol` hollow-returned; `gpt-5.6-terra` fallback): NO BLOCKING FINDINGS, evidence-backed.
- Opus lane (`claude-opus-5`): NO BLOCKING. Advisory 1 (strict `decode()` crash on the failure path) **accepted and fixed** (`errors="replace"` + regression test). Advisory 2 (redaction now scans the whole stderr buffer, O(n·matches) CPU) **no action in-diff**: the shape is shared by every existing `redact_and_truncate` caller, `create_subprocess_limited` already rlimits the child, and pre-capping the input would re-introduce a bound ahead of redaction — the exact ordering this fix removes.

Closes #7279

## Pattern harvest

Rule candidate: semgrep
Pattern: subprocess stderr reaching a logging call without redaction — `logger.<level>(..., stderr.decode(...))` (or a sliced variant) not routed through `security.redact_and_truncate`. This PR fixes two sites; unredacted siblings of the same shape exist elsewhere (e.g. `voice_reply.py:364`, `chat_voice.py:360`, `apps/routes.py:3236`) with lower credential exposure than the pip/index path but the identical mechanism, so a lint that flags `stderr.decode` flowing into a log call without the redaction shim would catch the class at review time.


Supersedes #7292, which made the same fix but decoded with a bare `stderr.decode()`
(raises on non-UTF-8 pip stderr) and repeated a bare `max_chars=500` at both call sites.
