### PR TITLE
fix(acp): diagnose a missing Kiro CLI by search path, not a bare in-PATH message (#6497)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -337,6 +337,55 @@ async def _resolve_kiro_bin_for_spawn(
     return await asyncio.to_thread(_resolve_kiro_bin, environ=environ, home=home)
 
 
+def kiro_cli_not_found_message(
+    *,
+    environ: Mapping[str, str],
+    home: Path,
+) -> str:
+    """The one message for "the Kiro CLI is not where we looked".
+
+    Every spawn path that resolves the CLI has to answer the same two-way
+    question a bare name cannot: is the binary not installed, or is its install
+    directory outside the search? :func:`env.describe_search_path` exists for
+    that, and this function is where the ACP paths get it, so the client and the
+    runtime cannot drift into reporting the same failure differently (the same
+    single-source rule ``_resolve_kiro_bin_for_spawn`` and
+    ``_drain_oversize_line`` are already shared under).
+
+    Two properties are deliberate:
+
+    * The directories are computed from the *caller's* ``environ`` and ``home``,
+      not a fresh read. ``known_kiro_cli_dirs`` is a pure function of
+      ``(platform, home, environ)``, so a caller that passes the same mapping it
+      resolved against gets a message naming the directories actually searched —
+      the guarantee #5048 established for the Claude adapter.
+    * The message never says "in PATH". Resolution also walks
+      ``%LOCALAPPDATA%\\Kiro-Cli``, ``%ProgramFiles%\\Kiro-Cli`` and the
+      ``KIROCREW_KIRO_BIN`` override, so "not found in PATH" sent a reader whose
+      install was simply uncovered off to check the one thing that was not the
+      question. In #6497 it sent them further: ``where kiro-cli`` found nothing,
+      the app bundle did contain a ``kirocrew.exe`` — Kiro Crew's OWN console
+      script — and the conclusion drawn was that the agent CLI had been renamed
+      and this lookup left stale. Naming the searched directories and the
+      override makes both wrong turns unavailable.
+
+    Off the event loop when called from async code: expanding the inherited PATH
+    touches the filesystem.
+    """
+    # Local import: ``kiro_prerequisite`` pulls in the sandbox plane that this
+    # module also feeds, and the sibling ``snapshot_trusted_acp_executable``
+    # import above is deferred for the same acyclicity reason.
+    from kiro_crew.kiro_prerequisite import OFFICIAL_INSTALL_DOCS_URL
+
+    searched_dirs = known_kiro_cli_dirs(sys.platform, home, environ)
+    return (
+        f"{KIRO_CLI_BIN} not found "
+        f"({describe_search_path(os.pathsep.join(searched_dirs))}). "
+        f"Kiro CLI is a separate prerequisite Kiro Crew does not bundle: install it "
+        f"from {OFFICIAL_INSTALL_DOCS_URL}, or point KIROCREW_KIRO_BIN at the binary."
+    )
+
+
 def _mise_which(tool: str) -> str | None:
     """Ask mise for the resolved path of *tool*.
 
@@ -2898,15 +2947,12 @@ class AcpClient:
                 # Pure function of the arguments, so this reproduces exactly the
                 # set the resolution above walked. Still off-loop: it expands the
                 # inherited PATH.
-                searched_dirs = await asyncio.to_thread(
-                    known_kiro_cli_dirs,
-                    sys.platform,
-                    spawn_home,
-                    spawn_environ,
-                )
                 raise AcpError(
-                    f"{KIRO_CLI_BIN} not found "
-                    f"({describe_search_path(os.pathsep.join(searched_dirs))})"
+                    await asyncio.to_thread(
+                        kiro_cli_not_found_message,
+                        environ=spawn_environ,
+                        home=spawn_home,
+                    )
                 )
             # Self-heal (B): ensure the managed default agent file exists before
             # this --agent spawn, so kiro-cli registers the mode and step 4's

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -47,6 +47,7 @@ from kiro_crew.acp.client import (
     _resolve_kiro_bin_for_spawn,
     finish_suspended_spawn,
     is_auth_failure_output,
+    kiro_cli_not_found_message,
 )
 from kiro_crew.acp.kas_agents import (
     KasAgentTranslationError,
@@ -1051,25 +1052,42 @@ class AcpRuntime:
             self._discard_sandbox_cleanup()
             raise
 
+    @staticmethod
+    async def _kiro_cli_missing(environ: dict[str, str], home: Path) -> str:
+        """Off-loop wrapper over the shared missing-CLI message.
+
+        Off-loop because building it expands the inherited PATH (filesystem
+        work), the same reason AcpClient._spawn defers its own call.
+        """
+        return await asyncio.to_thread(kiro_cli_not_found_message, environ=environ, home=home)
+
     async def _resolve_spawn_argv(self) -> list[str]:
         """Pre-sandbox argv for this runtime's backend.
 
         Explicit per-backend construction: the two agents share no flags, and
         only kiro-cli needs its agent file materialized first.
         """
+        # ONE reading of the environment drives both the search and the message
+        # that reports it, so a "not found (searched ...)" line here cannot name
+        # directories the resolve never walked -- the property AcpClient._spawn
+        # already holds, and the reason both go through
+        # kiro_cli_not_found_message instead of formatting their own text.
+        spawn_environ = dict(os.environ)
+        spawn_home = Path.home()
+
         if self._acp_backend == ACP_BACKEND_KAS:
             # KAS is reached through kiro-cli's own ACP relay, so it resolves the
             # same trusted binary as the kiro backend. No --agent: KAS takes
             # custom agents over the wire in session/new
             # (_meta.kiro.customAgents), not from a CLI flag.
-            kas_bin = await _resolve_kiro_bin_for_spawn()
+            kas_bin = await _resolve_kiro_bin_for_spawn(environ=spawn_environ, home=spawn_home)
             if not kas_bin:
-                raise AcpRuntimeError(f"{KIRO_CLI_BIN} not found in PATH")
+                raise AcpRuntimeError(await self._kiro_cli_missing(spawn_environ, spawn_home))
             return build_kas_argv(kas_bin)
 
-        kiro_bin = await _resolve_kiro_bin_for_spawn()
+        kiro_bin = await _resolve_kiro_bin_for_spawn(environ=spawn_environ, home=spawn_home)
         if not kiro_bin:
-            raise AcpRuntimeError(f"{KIRO_CLI_BIN} not found in PATH")
+            raise AcpRuntimeError(await self._kiro_cli_missing(spawn_environ, spawn_home))
 
         # Self-heal (B): kiro-cli discovers its selectable modes at startup from
         # ~/.kiro/agents/*.json, so the managed default agent file must exist

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -832,6 +832,60 @@ def test_runtime_uses_clients_augmented_kiro_bin_resolver():
     assert runtime_mod._resolve_kiro_bin_for_spawn is client_mod._resolve_kiro_bin_for_spawn
 
 
+@pytest.mark.parametrize("backend", [None, ACP_BACKEND_KAS])
+@pytest.mark.asyncio
+async def test_runtime_missing_kiro_bin_reports_the_directories_it_searched(backend):
+    """The runtime spawn path must DIAGNOSE a missing Kiro CLI, not just name it.
+
+    ``AcpClient._spawn`` already separates "this binary is not installed" from
+    "its install directory is outside the search" by naming every directory it
+    walked (see ``test_spawn_kiro_missing_bin_reports_only_resolver_search_dirs``
+    and ``env.describe_search_path``). The runtime sibling raised a bare
+    ``kiro-cli not found in PATH``, which is both less information and factually
+    wrong: resolution also walks ``%LOCALAPPDATA%\\Kiro-Cli``,
+    ``%ProgramFiles%\\Kiro-Cli`` and the ``KIROCREW_KIRO_BIN`` override, none of
+    which is PATH.
+
+    That gap is what produced #6497. A Windows reporter read "not found in PATH",
+    ran ``where kiro-cli``, got nothing, saw the gateway's OWN ``kirocrew.exe``
+    in the app bundle, and concluded the agent CLI had been renamed and this
+    lookup left stale. It had not been: ``kirocrew`` is Kiro Crew's own console
+    script and ``kiro-cli`` is a separate prerequisite the message never said it
+    was looking for anywhere but PATH.
+
+    Both spawn branches are covered because both resolve the same binary and both
+    have to answer the same question.
+    """
+    import kiro_crew.acp.client as client_mod
+    import kiro_crew.acp.runtime as runtime_mod
+
+    searched = [os.path.join(os.sep, "managed-bin"), os.path.join(os.sep, "path-bin")]
+    unsearched = os.path.join(os.sep, "never-checked")
+    rt = AcpRuntime(work_dir="/tmp")
+    if backend is not None:
+        rt._acp_backend = backend
+
+    async def _no_bin(*, environ=None, home=None):
+        return None
+
+    with (
+        patch.object(runtime_mod, "_resolve_kiro_bin_for_spawn", _no_bin),
+        patch.object(client_mod, "known_kiro_cli_dirs", return_value=searched),
+    ):
+        with pytest.raises(AcpRuntimeError) as raised:
+            await rt._resolve_spawn_argv()
+
+    message = str(raised.value)
+    assert "searched 2 directories" in message
+    assert searched[0] in message
+    assert searched[1] in message
+    assert unsearched not in message
+    # The remedy travels with the diagnosis, the rule env.MCP_PATH_HINT exists
+    # for: a reader who learns the search missed their install needs the one
+    # knob that covers it named here, not only in the source.
+    assert "KIROCREW_KIRO_BIN" in message
+
+
 async def _wait_for_queued(admission: _ColdStartAdmission, expected: int) -> None:
     """Yield to scheduled starters until the coordinator exposes the queue."""
     for _ in range(100):
@@ -1039,7 +1093,7 @@ async def test_runtime_spawn_passes_installed_path_through_exact_wrappers(
         wrapped["spawn_kwargs"] = kwargs
         raise _StopSpawn()
 
-    async def resolve_installed():
+    async def resolve_installed(*, environ=None, home=None):
         return launch_path
 
     monkeypatch.setattr(
@@ -5916,7 +5970,7 @@ async def test_runtime_spawn_scrubs_sensitive_env_on_default_auto(monkeypatch):
         captured["env"] = kwargs.get("env")
         raise _StopSpawn()
 
-    async def resolve_kiro_bin():
+    async def resolve_kiro_bin(*, environ=None, home=None):
         return "/fake/kiro"
 
     monkeypatch.setattr(
@@ -5976,7 +6030,7 @@ async def test_runtime_spawn_names_its_own_browser_session(monkeypatch):
         captured["env"] = kwargs.get("env")
         raise _StopSpawn()
 
-    async def resolve_kiro_bin():
+    async def resolve_kiro_bin(*, environ=None, home=None):
         return "/fake/kiro"
 
     monkeypatch.setattr(runtime_mod, "_resolve_kiro_bin_for_spawn", resolve_kiro_bin)

--- a/test/test_acp_spawn_offload.py
+++ b/test/test_acp_spawn_offload.py
@@ -264,7 +264,7 @@ class TestRuntimeSpawnOffLoop:
         class _StopSpawn(Exception):
             pass
 
-        async def resolve_bin() -> str:
+        async def resolve_bin(*, environ=None, home=None) -> str:
             return "/usr/bin/kiro-cli"
 
         async def stop_spawn(*args, **kwargs):
@@ -361,7 +361,7 @@ class TestSpawnCancellationSandboxCleanup:
     ) -> None:
         sandbox_file = self._sandbox_file(tmp_path)
 
-        async def resolve_bin() -> str:
+        async def resolve_bin(*, environ=None, home=None) -> str:
             return "/usr/bin/kiro-cli"
 
         def _cgroup(argv):
@@ -526,7 +526,7 @@ class TestRuntimeShieldSurvivesAFailedAppend:
 
     @staticmethod
     def _patch_prelude(monkeypatch, tmp_path, mock_proc):
-        async def resolve_bin() -> str:
+        async def resolve_bin(*, environ=None, home=None) -> str:
             return "/usr/bin/kiro-cli"
 
         monkeypatch.setattr(runtime_mod, "_resolve_kiro_bin_for_spawn", resolve_bin)

--- a/test/test_kas_mode_binding.py
+++ b/test/test_kas_mode_binding.py
@@ -104,7 +104,7 @@ def mode_stub(tmp_path, monkeypatch):
     launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}"\n')
     launcher.chmod(0o755)
 
-    async def fake_bin() -> str:
+    async def fake_bin(*, environ=None, home=None) -> str:
         return str(launcher)
 
     monkeypatch.setattr(

--- a/test/test_kas_spawn.py
+++ b/test/test_kas_spawn.py
@@ -236,7 +236,7 @@ class TestSandboxClassification:
             captured.update(kwargs)
             raise self._Abort
 
-        async def fake_bin():
+        async def fake_bin(*, environ=None, home=None):
             return "/usr/bin/kiro-cli"
 
         monkeypatch.setattr("kiro_crew.acp.runtime._resolve_kiro_bin_for_spawn", fake_bin)
@@ -354,7 +354,7 @@ def kas_stub(tmp_path, monkeypatch):
     launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}"\n')
     launcher.chmod(0o755)
 
-    async def fake_bin() -> str:
+    async def fake_bin(*, environ=None, home=None) -> str:
         return str(launcher)
 
     monkeypatch.setattr("kiro_crew.acp.runtime._resolve_kiro_bin_for_spawn", fake_bin)
@@ -419,7 +419,7 @@ class TestKasInvocation:
         """No kiro-cli means no relay, and the message must say which binary."""
         from kiro_crew.acp.session_handle import AcpRuntimeError
 
-        async def no_bin() -> None:
+        async def no_bin(*, environ=None, home=None) -> None:
             return None
 
         monkeypatch.setattr("kiro_crew.acp.runtime._resolve_kiro_bin_for_spawn", no_bin)


### PR DESCRIPTION
## 1. What is the problem?

When the gateway cannot resolve the Kiro CLI, both ACP spawn paths raised the
bare message `kiro-cli not found in PATH`. That message is wrong about where it
looked and gives the reader nothing to act on: CLI resolution
(`kiro_cli.find_kiro_cli_candidates`) does not only walk `PATH` -- it also
searches the per-platform install directories (`%LOCALAPPDATA%\Kiro-Cli`,
`%ProgramFiles%\Kiro-Cli`, `~/.local/bin`, `~/.cargo/bin`, the macOS app
bundles) and honours the `KIROCREW_KIRO_BIN` override.

## 2. Why this issue matters to the user

A "not found in PATH" line sends a user whose install is simply *outside the
search* off to check the one thing that is not the question. In #6497 it sent
them further down a wrong path entirely: a Windows user on 0.5.0-insider.1 read
the banner, ran `where kiro-cli`, got nothing, then spotted `kirocrew.exe` in
the app's own `backend-dist` bundle and concluded the agent CLI had been
*renamed* to `kirocrew` while an internal lookup was left stale -- and filed the
issue on that premise. It had not been renamed: `kirocrew` is Kiro Crew's own
console script (`pyproject.toml` `[project.scripts]`), and `kiro-cli` is a
separate prerequisite the message never admitted it was searching for anywhere
but PATH. A truthful diagnosis would have prevented the whole detour.

## 3. How our fix solves it

Root cause: two spawn sites (`AcpRuntime._resolve_spawn_argv`'s KAS and Kiro
branches) formatted their own bare `f"{KIRO_CLI_BIN} not found in PATH"`, while
the third site (`AcpClient._spawn`) already used the richer
`env.describe_search_path`. Symptom -> cause chain: the wrong conclusion in the
issue traces directly to a message that (a) named only PATH and (b) named no
directories at all, so "not installed" and "installed somewhere uncovered"
read identically.

The fix introduces one shared `kiro_cli_not_found_message(environ, home)` in
`acp/client.py` and routes all three raise sites through it. The message:

- names the directories actually searched, via the existing
  `env.describe_search_path` (same "searched N directories: ..." rendering the
  Claude adapter and the client path already use);
- states the remedy -- install from the official docs URL, or set
  `KIROCREW_KIRO_BIN` -- so diagnosis and fix arrive together;
- is computed from **one pinned reading** of the environment (the same
  `environ`/`home` the resolve used), so it can never name directories the
  search never walked -- the guarantee #5048 established for the Claude sibling,
  now held for the Kiro sibling the runtime left recomputing.

No behaviour changes for a *successful* resolve; this only replaces the text of
the failure. The premise in the issue title ("CLI renamed") is false on main --
the resolver is byte-identical between 0.4.0-insider.12 and 0.5.0-insider.1
(`git diff` on `kiro_cli.py` is empty) -- so this is scoped to the real remaining
defect: an unactionable diagnosis, not a stale lookup.

## 4. What tests we did

- Added `test_runtime_missing_kiro_bin_reports_the_directories_it_searched`
  (parametrized over both the Kiro and KAS backends) in `test/test_acp_runtime.py`.
  Verified **RED** on baseline (`assert 'searched 2 directories' in 'kiro-cli
  not found in PATH'` fails), **GREEN** after the fix.
- Updated the resolver stubs in `test_acp_runtime.py`, `test_acp_spawn_offload.py`,
  `test_kas_spawn.py`, and `test_kas_mode_binding.py` to the resolver's real
  keyword-only `(*, environ=None, home=None)` signature (the runtime now passes
  the pinned environment through).
- Targeted suites green: `test_acp_runtime.py`, `test_acp_client.py`,
  `test_unresolved_command_message.py`, `test_acp_spawn_offload.py`,
  `test_kas_spawn.py`, `test_kas_mode_binding.py`, `test_kiro_spawn_readiness_gate.py`,
  `test_session_usage.py`, `test_image_primitives.py`, `test_api_models_entitlement.py`,
  `test_api_models_retry.py`.
- `flake8` clean on all changed files; `mypy` clean on the two source files;
  repo black gate passes (nothing in scope unformatted outside the baseline).

## 5. Any other suggestions on the work

`runtime.py` remains in the repo black baseline, so its pre-existing formatting
is untouched by design; the new code was hand-formatted to the 100-col style.

Fixes #6497

## Pattern harvest

Rule candidate: a user-facing "not found" error for a binary that is resolved from a candidate set (not just PATH) must render the directories actually searched and the remedy, never a bare "in PATH". The generalizable pattern is that one resolver already had two more raise sites formatting their own text; the fix is to route every raise site through a single message builder (as `describe_search_path` / `kiro_cli_not_found_message` now do) so no sibling can drift back to a bare, misleading string. The concrete miss worth a lint: an f-string literal `"... not found in PATH"` where the resolver it guards searches non-PATH locations.
