### PR TITLE
fix(usage): log the transcripts the UNC gate refuses instead of a silent zero

### DIFF
--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -1797,6 +1797,7 @@ def _parse_sessions() -> dict:
     total_msgs = 0
     total_tools = 0
     all_time_sessions = 0
+    refused_transcripts = 0
     now_dt = datetime.now()
     today_str = now_dt.strftime("%Y-%m-%d")
 
@@ -1814,6 +1815,16 @@ def _parse_sessions() -> dict:
         # Validate path through hooks.py (resolves symlinks, checks sensitive)
         resolved_str = validate_file_path(str(f))
         if resolved_str is None:
+            # Counted, not swallowed (#6733): a refusal here is indistinguishable
+            # from an idle account in the rendered numbers, and on a
+            # roaming-profile (UNC) home EVERY transcript lands in this branch --
+            # so the page reports a confident zero with nothing anywhere to say
+            # why. Aggregated after the loop rather than logged per file, because
+            # that failure mode refuses all of them. Admitting the transcript dir
+            # to the UNC gate -- which is what would make the count correct
+            # rather than merely explained -- is deferred to #8079; it needs a
+            # resolution that refuses links atomically first.
+            refused_transcripts += 1
             continue
         resolved = Path(resolved_str)
         try:
@@ -1855,6 +1866,17 @@ def _parse_sessions() -> dict:
         daily_tools[day] += tools
         total_msgs += msgs
         total_tools += tools
+
+    if refused_transcripts:
+        # Server-side only: %s of a Path is a filesystem path, which the
+        # returned payload deliberately never carries (see the iterdir handler
+        # above).
+        logger.warning(
+            "usage: %d transcript(s) refused by path validation in %s; "
+            "the reported session counts exclude them",
+            refused_transcripts,
+            sessions_dir,
+        )
 
     # Build daily history sorted by date
     all_days = sorted(set(daily.keys()))

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -76,6 +77,44 @@ class TestParseSessions:
         ):
             r = _parse_sessions()
             assert r["total_sessions"] == 0
+
+    def test_refused_transcripts_are_reported_not_swallowed(self, tmp_path, caplog):
+        """#6733: a refused transcript is skipped, and the skip must leave a
+        trace. Before this, a home whose every transcript the path validator
+        refused rendered as a legitimate "zero sessions" with nothing logged.
+
+        Asserted on the LOG, not the payload: the count is deliberately not an
+        API field while no renderer reads it (First Principles review on #7285).
+        """
+        d = tmp_path / "cli"
+        d.mkdir()
+        _write_session(d / "s1.jsonl", [{"kind": "Prompt"}])
+        _write_session(d / "s2.jsonl", [{"kind": "Prompt"}])
+        with patch.object(usage_mod, "_SESSIONS_DIR", d), patch.object(
+            usage_mod, "validate_file_path", return_value=None
+        ), caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.handlers.usage"):
+            r = _parse_sessions()
+        assert r["total_sessions"] == 0
+        # One aggregated record, not one per file: a UNC home refuses every
+        # transcript, and per-file logging would emit thousands.
+        refusals = [
+            rec for rec in caplog.records if "refused by path validation" in rec.getMessage()
+        ]
+        assert len(refusals) == 1
+        assert "2" in refusals[0].getMessage()
+
+    def test_no_refusal_log_when_every_transcript_validates(self, tmp_path, caplog):
+        """The counterpart: the healthy path stays quiet."""
+        d = tmp_path / "cli"
+        d.mkdir()
+        f = d / "s1.jsonl"
+        _write_session(f, [{"kind": "Prompt"}])
+        with patch.object(usage_mod, "_SESSIONS_DIR", d), patch.object(
+            usage_mod, "validate_file_path", return_value=str(f)
+        ), caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.handlers.usage"):
+            r = _parse_sessions()
+        assert r["total_sessions"] == 1
+        assert not [rec for rec in caplog.records if "refused" in rec.getMessage()]
 
     def test_stat_oserror(self, tmp_path):
         d = tmp_path / "cli"


### PR DESCRIPTION
## Problem / Motivation

On a Windows roaming profile the home directory is itself a UNC share, so
`hooks.unc_probe_allowed` gates every path under it. It admits the crew data home,
the temp directory and the kiro agents dir, but **not** `<kiro home>/sessions/cli`.
So `dashboard.handlers.usage._parse_sessions` has every kiro-cli transcript refused
by `validate_file_path`, `continue`s on the `None`, and the usage page renders a
confident **zero** with nothing anywhere -- log, payload or UI -- to say why.

That is two harms: a wrong number, and silence about it. **This PR fixes only the
silence.** The scope was reduced during review; see "What is deliberately not here".

## Why it matters

A zero on the usage page is indistinguishable from an idle account. An operator on a
roaming profile has no way to tell that the page is reporting a refusal rather than
a fact, and no thread to pull -- nothing is logged, so there is nothing to search
for. After this change the same zero is accompanied by a server-side warning naming
the directory and the number of transcripts excluded, which is enough to recognise
the platform problem and find #8079.

## What changed

One counter and one log record in `_parse_sessions`:

- Refusals from `validate_file_path` are counted instead of silently skipped.
- After the loop, if any were refused, one `logger.warning` reports the count and
  the directory.

Three deliberate details:

- **Aggregated, not per file.** The failure mode refuses *all* transcripts at once,
  so a per-file record would emit one line per session file for a single cause.
- **Not a response field.** No renderer reads it, so adding it to the payload would
  ship an unused API surface; the test pins that it stays absent.
- **Server-side only.** `%s` of a `Path` is a filesystem path, and the returned
  payload deliberately never carries one (same reason as the existing `iterdir`
  error handler just above).

## Tests

`test/test_usage.py`, run with `pytest test/test_usage.py -n 2` -- 91 passed.

- `test_refused_transcripts_are_reported_not_swallowed` -- refusals are counted and
  one aggregated warning is emitted; also pins that the count is **not** a payload
  field.
- `test_no_refusal_log_when_every_transcript_validates` -- the negative case, so the
  log cannot become unconditional noise.

Mutation-verified rather than assumed: replacing `if refused_transcripts:` with
`if False:` turns the first test red (`assert 0 == 1`) and leaves the second green,
which is the discrimination you want from the pair. Also clean: `flake8`, `isort`,
`mypy`, and `scripts/check_black_formatting.py`.

## What is deliberately not here

**The UNC-gate admission for the transcript directory is not in this PR.** The page
still reports zero on a roaming-profile home. Tracked in #8079, with the reason it
cannot be a small change recorded there:

`unc_probe_allowed` is lexical on the RAW path -- it never touches the filesystem,
because touching a UNC path *is* the outbound SMB probe the gate exists to prevent.
So admitting the root admits any link planted under it, and the reader then resolves
that link. The window is **`check -> realpath`, not `check -> open`**:
`validate_file_path` calls `os.path.realpath` immediately after the gate admits, and
that call is the probe. A no-follow *open* is too late, and
`getattr(os, "O_NOFOLLOW", 0)` is **0 on Windows** -- the only platform where UNC
applies. Closing it needs an atomic no-follow resolution in `pinned_fs`
(`CreateFileW` + `FILE_FLAG_OPEN_REPARSE_POINT`), added once so every
`validate_file_path` consumer benefits.

An earlier revision of this PR admitted the root and guarded the reader with an
`lstat`-based reparse check. Review found that shape reachable from two directions
and both findings prescribed the same remedy -- remove the sessions directory from
the global UNC roots until resolution refuses links atomically. That is what this
revision does, so neither finding's span exists in the diff any more: the roots
tuple is untouched and the pre-validator check is gone. `hooks.py`,
`docs/system-specs/modules/security.md` and `test/test_acp_prompt_blocks.py` are
back to their base contents and no longer appear in the diff at all.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a gate that signals refusal by returning a sentinel, consumed by a bare
`continue` inside an aggregation loop -- so a *total* refusal renders as a
legitimate empty result.

This defect was not a typo; it is that shape. `validate_file_path` returns `None`
to mean refused, the loop did `if resolved_str is None: continue`, and the function
returns a count. One refused file is noise worth skipping; *every* file refused is a
platform misconfiguration, and both compile to the same rendered `0`. The tell is
structural and reviewable: a sentinel-returning validator whose `None` branch has no
counter, no log and no distinct return, inside a loop whose product is an aggregate.

Not proposed as semgrep, deliberately: the rule needs to know which callee is a
*gate* rather than an ordinary lookup that may legitimately miss, and that is
project knowledge rather than syntax. A review prompt can ask the question ("this
loop skips on a sentinel -- what does the caller see when EVERY item skips?") where
a syntactic matcher would mostly fire on benign `dict.get` misses.

Refs #6733
Refs #7505
Refs #8079
