### PR TITLE
test(cron): pin the full agent roster reaching the schedule form

### DIFF
--- a/website/src/test/JobForm.agentRoster.test.tsx
+++ b/website/src/test/JobForm.agentRoster.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, fireEvent, within } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import JobForm from '../components/JobForm'
+import type { KiroCrewAgent } from '../components/AgentSelector'
+import type { CronJob } from '../types'
+
+vi.mock('../api/client', () => ({
+  api: {
+    updateCron: vi.fn(),
+    createCron: vi.fn(),
+    models: vi.fn().mockResolvedValue({ models: [] }),
+    kirocrewAgents: vi.fn().mockResolvedValue({ agents: [], default_agent: '' }),
+  },
+}))
+
+/**
+ * A roster with more than one entry, and whose DEFAULT is not first — a
+ * default-only regression and an accidental `[agents[0]]` truncation are
+ * different bugs, and this shape fails on either.
+ */
+const roster: KiroCrewAgent[] = [
+  { name: 'kirocrew', kiro_agent: 'kirocrew', workspace: 'default', memory_store: 'default', description: 'built-in', source: 'kirocrew' },
+  { name: 'gpu-research', kiro_agent: 'gpu-research', workspace: 'research', memory_store: 'research', description: 'internal research', source: 'package' },
+  { name: 'oncall', kiro_agent: 'oncall-agent', workspace: 'oncall', memory_store: 'oncall-kb', description: 'paging', source: 'package' },
+  { name: 'wiki', kiro_agent: 'gpu-wiki', workspace: 'wiki', memory_store: 'wiki', description: 'wiki edits', source: 'package' },
+]
+
+function messageJob(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: 'j1', name: 'nightly', message: 'do the thing', schedule: '', enabled: true,
+    cron_expr: '0 3 * * *', ...overrides,
+  } as CronJob
+}
+
+/** Open the selector and return the option names it offers. */
+function openRosterOptions(): string[] {
+  fireEvent.click(screen.getByLabelText('Switch agent'))
+  const listbox = screen.getByRole('listbox')
+  return within(listbox).getAllByRole('option').map(o => o.textContent || '')
+}
+
+describe('cron JobForm agent selector roster (#5990)', () => {
+  it('offers the WHOLE roster in the side-panel (vertical) edit form, not just the default', () => {
+    renderWithProviders(
+      <JobForm job={messageJob()} agents={roster} defaultAgent="kirocrew" onSaved={() => {}} layout="vertical" />,
+    )
+    const options = openRosterOptions()
+    expect(options).toHaveLength(roster.length)
+    for (const a of roster) {
+      expect(options.some(text => text.includes(a.name))).toBe(true)
+    }
+  })
+
+  it('offers the WHOLE roster in the inline (horizontal) create form', () => {
+    renderWithProviders(
+      <JobForm agents={roster} defaultAgent="kirocrew" onSaved={() => {}} layout="horizontal" />,
+    )
+    const options = openRosterOptions()
+    expect(options).toHaveLength(roster.length)
+    for (const a of roster) {
+      expect(options.some(text => text.includes(a.name))).toBe(true)
+    }
+  })
+
+  it('honours a stored NON-default agent and still offers the rest of the roster', () => {
+    renderWithProviders(
+      <JobForm job={messageJob({ agent: 'oncall' })} agents={roster} defaultAgent="kirocrew" onSaved={() => {}} layout="vertical" />,
+    )
+    const trigger = screen.getByLabelText('Switch agent')
+    // The job's stored agent survives into the form — a default-only regression
+    // would show the default here even when the job names another agent.
+    expect(trigger).toHaveTextContent('oncall')
+
+    fireEvent.click(trigger)
+    const listbox = screen.getByRole('listbox')
+    // Exactly one "default" badge, and it marks the default rather than the
+    // stored selection.
+    expect(within(listbox).getAllByText('default')).toHaveLength(1)
+    // Switching AWAY to a third agent is offered.
+    expect(within(listbox).getByText('gpu-research')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What is the problem?

The Schedule page's agent selector had no test coverage capable of detecting a regression in the roster it offers.

`website/src/test/SchedulePage.test.tsx:35` mocks the roster as `{ agents: [], default_agent: '' }`. An empty list cannot distinguish "offers every configured agent" from "offers only the default" -- both render zero options, so every assertion in that file passes either way. The whole path from `/api/agents` to the rendered dropdown was therefore unpinned:

- `handlers/agents.py` returns every `cfg.agents` entry
- `SchedulePage.tsx:211` reads it via `useAgents(0)` and passes it through at `:957` / `:1207`
- `JobForm.tsx:255` / `:320` hand it to `AgentSelector`
- `AgentSelector.tsx` renders all of `filtered`

Four hops, any of which could narrow the list, with nothing in CI watching.

## Why this issue matters to the user

A cron job that can only run as the default agent is the difference between a usable scheduler and a broken one. The whole point of picking an agent per job is that scheduled work often belongs to a different crew than the chat you created it from. #5990 reports precisely this symptom.

It does **not** reproduce on `main` (traced separately; the roster arrives complete, and the repository's root commit already had this wiring). But the report describes a failure that CI was structurally blind to, so a future regression would ship silently and land on users as "my scheduled jobs all run as the wrong agent" -- a symptom that is awkward to diagnose from the outside, because the bug would be in the frontend while the config and the API are both correct.

## How our fix solves it

This is test-only; no behaviour changes.

`JobForm.agentRoster.test.tsx` pins the contract at the component boundary, where a regression in any of the four hops above becomes visible. It hands `JobForm` a four-agent roster whose default is deliberately **not** first, so the same test catches both a default-only filter and an accidental `agents[0]` truncation, which are different bugs with the same look. It asserts:

1. The vertical side-panel edit form offers all four.
2. The horizontal inline create form offers all four (a separate `AgentSelector` call site, separately regressable).
3. A job storing a **non-default** agent shows that agent on the trigger and still offers the others, so a regression that silently substitutes the default is caught rather than looking like a correct default.

Chain from symptom to root cause: the reported symptom is "only the default is offered"; the root cause of the *coverage* gap is that the only test touching this path asserts against an empty roster, which is vacuously satisfied by the buggy and the correct behaviour alike. Replacing that vacuous fixture with a populated one at the component boundary is what closes it.

`Refs #5990` rather than `Fixes`: the reported defect does not reproduce, so this PR must not claim to close it. The issue needs a triage decision, not this patch.

## What tests we did

- The three new tests pass on unmodified `main` (`23c99c0f1`): `3 passed (3)`.
- **Mutation-verified**, so they are a ratchet and not a tautology: changing `filtered` in `AgentSelector.tsx` to `agents.filter(a => a.name === defaultAgent)`, the exact reported bug, turns all three red with the reported symptom (`expected [ 'kirocrew...' ] to have a length of 4 but got 1`). Reverting restores green.
- `eslint src/test/JobForm.agentRoster.test.tsx` clean.
- Targeted runs only. No new user-facing strings, so no i18n additions.

## Any other suggestions on the work?

Two adjacent gaps found while tracing, both left alone here because each is a design call rather than a fix:

1. **Project-scoped agents are structurally excluded from the cron picker.** `SchedulePage` passes no `sessionKey`, so `active_project_dir` resolves nothing and `scope="project"` rows are omitted. This looks deliberate: `CronJob` carries `agent_id` / `session_key` / `model` but no project field, and a project-scoped agent only resolves when kiro-cli runs with that project as cwd, so offering one here would let a user save a job that cannot dispatch at fire time. Worth an explicit decision (and a comment recording it) rather than leaving it as an implicit consequence of the missing argument.
2. **`useAgents` swallows sync failures** (`api.syncKirocrewAgents().catch(() => {})`). Since package-installed agents only become global rows after that sync writes them into `config.json`, a silently failing sync produces exactly #5990's symptom, but on the chat picker and the cron form equally, so it is cross-surface rather than cron-specific. Surfacing that failure is its own change.

Refs #5990
