### PR TITLE
fix(dashboard): guard the two path-param readers whose sibling already does

### DIFF
--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -1532,6 +1532,30 @@ async def api_mcp_server_detail(request: web.Request) -> web.Response:
         return web.json_response({"ok": removed, "name": name, "removed": removed}, status=status)
 
     # PUT — register or update
+    #
+    # Validate the name on the WRITE path only. ``_is_valid_mcp_name`` is the
+    # predicate the validation-dependent readers enforce — several call sites in
+    # this module, plus ``mcp_custom``, ``mcp_discover`` and ``connections`` — so
+    # a key written outside it is filtered out by those and the entry cannot be
+    # managed through them. The listing, toggle and remove paths do not apply it,
+    # which is what keeps such an entry visible and clearable. Checked before the
+    # body is parsed so a malformed name costs no further work.
+    #
+    # The removal paths stay permissive: DELETE above and ``api_mcp_remove`` both
+    # accept a name this guard would reject, which is how a junk key — including
+    # one written before this guard existed — can still be cleared. Guarding a
+    # remover would strand exactly what the writer guard is meant to prevent.
+    # Same writer-validates / remover-does-not split that ``security.py``'s
+    # trusted-app grant and revoke pair documents.
+    if not _is_valid_mcp_name(name):
+        return web.json_response(
+            {
+                "error": f"invalid server name '{name[:64]}'",
+                "code": "invalid_server_name",
+            },
+            status=400,
+        )
+
     try:
         body = await request.json()
     except Exception:

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -50,6 +50,10 @@ logger = logging.getLogger(__name__)
 # its own terminals (frontend MAX_TERMINALS_PER_CHAT); this is the server-side
 # backstop. Override via config.json dashboard.terminal.max_sessions.
 _MAX_SESSIONS = 12
+# Bound on a ``{session_id}`` URL path param, applied by BOTH routes that read
+# one. Named rather than repeated because the two call sites drifted while the
+# bound was a bare literal: WS-open enforced it and DELETE did not.
+_MAX_SESSION_ID_LEN = 64
 _ORPHAN_TIMEOUT_S = 900  # 15 min with no WS → reap PTY (grace window for reload/network drops; in-app nav keeps the WS alive)
 _SCROLLBACK_MAX = 50 * 1024  # 50KB ring buffer per session for reconnect replay
 
@@ -601,7 +605,7 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
         return web.Response(status=403, text="Terminal panel disabled")
 
     session_id = request.match_info.get("session_id", "")
-    if not session_id or len(session_id) > 64:
+    if not session_id or len(session_id) > _MAX_SESSION_ID_LEN:
         _sel().log_api_access(
             caller=caller,
             operation="terminal.ws.open",
@@ -1667,6 +1671,21 @@ async def api_terminal_delete(request: web.Request) -> web.Response:
         return web.Response(status=403, text="Terminal panel disabled")
 
     session_id = request.match_info.get("session_id", "")
+    # Same bound ``api_terminal_ws`` applies when a session is created, so an id
+    # outside it provably keys nothing in this registry. Rejecting it here means
+    # a malformed request is told so, rather than being answered "no such
+    # session" after the lookup. Plaintext 400 to match this handler's other
+    # responses (401/403/404 above and below are all plaintext).
+    if not session_id or len(session_id) > _MAX_SESSION_ID_LEN:
+        _sel().log_api_access(
+            caller=caller,
+            operation="terminal.session.delete",
+            outcome="denied",
+            source="dashboard",
+            resources=f"invalid_session_id={session_id!r}",
+        )
+        return web.Response(status=400, text="Invalid session_id")
+
     registry = _get_registry(request)
     sess = registry.pop(session_id, None)  # type: ignore[arg-type]
     if not sess:

--- a/test/test_handlers_mcp_coverage.py
+++ b/test/test_handlers_mcp_coverage.py
@@ -523,6 +523,70 @@ class TestServerDetail:
         assert "server name is required" in _payload(resp)["error"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "name",
+        ["../../evil", "..", "a/../b", "a" * 129, "-leading-dash"],
+        ids=["traversal", "bare-dotdot", "embedded-dotdot", "overlong", "bad-leading-char"],
+    )
+    async def test_put_rejects_a_name_the_rest_of_the_tree_would_refuse(
+        self, sandbox: SimpleNamespace, name: str
+    ) -> None:
+        """PUT is the writer, so it must not plant a key nothing else can address.
+
+        ``_is_valid_mcp_name`` is the predicate the validation-dependent readers
+        in this tree enforce (several call sites in ``mcp.py`` itself, plus
+        ``mcp_custom.py``, ``mcp_discover.py`` and ``connections.py``). A name
+        carrying ``..`` or exceeding ``_MAX_MCP_NAME_LEN`` written through this
+        route is invisible to those, so the entry cannot be managed through them.
+        """
+        _write_global(sandbox, {})
+        resp = await mcp_mod.api_mcp_server_detail(
+            _request({"command": "node"}, match_info={"name": name}, method="PUT")
+        )
+        assert resp.status == 400
+        assert _payload(resp)["code"] == "invalid_server_name"
+        # The refusal must land before the write, not after it.
+        assert _read_global(sandbox) == {}
+
+    @pytest.mark.asyncio
+    async def test_delete_still_removes_a_malformed_junk_key(
+        self, sandbox: SimpleNamespace
+    ) -> None:
+        """DELETE stays permissive on purpose, so a junk key remains clearable.
+
+        This mirrors the documented grant/revoke asymmetry in ``security.py``:
+        the writer validates, the remover does not, because guarding a remover
+        would strand exactly the entries the writer guard prevents. ``DELETE``
+        and ``api_mcp_remove`` are both such removers. Guarding this handler's
+        DELETE half is the specific regression this test forbids.
+        """
+        _write_global(sandbox, {"../../evil": {"command": "x"}})
+        resp = await mcp_mod.api_mcp_server_detail(
+            _request(None, match_info={"name": "../../evil"}, method="DELETE")
+        )
+        assert resp.status == 200
+        assert _payload(resp)["removed"] is True
+        assert _read_global(sandbox) == {}
+
+    @pytest.mark.asyncio
+    async def test_put_accepts_the_names_the_validator_allows(
+        self, sandbox: SimpleNamespace
+    ) -> None:
+        """The guard must not narrow the accepted set beyond the shared validator.
+
+        ``_VALID_MCP_NAME_RE`` deliberately admits ``@``, ``/``, ``.``, ``:`` and
+        ``_`` so scoped package ids (``@scope/pkg``) keep working.
+        """
+        _write_global(sandbox, {})
+        resp = await mcp_mod.api_mcp_server_detail(
+            _request(
+                {"command": "node"}, match_info={"name": "@scope/pkg.name_v2:1"}, method="PUT"
+            )
+        )
+        assert resp.status == 200
+        assert "@scope/pkg.name_v2:1" in _read_global(sandbox)
+
+    @pytest.mark.asyncio
     async def test_delete_absent_is_404(self, sandbox: SimpleNamespace) -> None:
         _write_global(sandbox, {})
         resp = await mcp_mod.api_mcp_server_detail(

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -1588,6 +1588,30 @@ class TestApiTerminalDelete:
         assert resp.status == 404
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("session_id", ["", "x" * 65], ids=["empty", "overlong"])
+    async def test_rejects_an_id_the_create_route_could_never_have_minted(
+        self, session_id
+    ):
+        """Reject at the same bound the WS-open route applies, before the lookup.
+
+        ``api_terminal_ws`` refuses ``not session_id or len(session_id) > 64``
+        when a session is created, so an id outside that bound provably keys
+        nothing in the registry. Today this route does the ``registry.pop``
+        first and reports 404 — correct, but it answers "no such session" to a
+        request that was malformed, and it is the only one of this file's two
+        ``session_id`` readers without the guard.
+        """
+        sess = _make_session()
+        registry = {"abc123": sess}
+        req = _make_request(session_id=session_id, registry=registry)
+        with patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            resp = await terminal.api_terminal_delete(req)
+        assert resp.status == 400
+        # The refusal lands before any registry mutation.
+        assert registry == {"abc123": sess}
+
+    @pytest.mark.asyncio
     async def test_deletes_existing_session(self):
         sess = _make_session()
         registry = {"abc123": sess}


### PR DESCRIPTION
## 1. What is the problem?

Two dashboard routes read a URL path param that a sibling reader in the same module already validates, and neither applied the check.

**`PUT /api/mcp/servers/{name}`** (`handlers/mcp.py`) accepted `name` after only `.strip()`, then wrote it as a key into the global `~/.kiro/settings/mcp.json`. `_is_valid_mcp_name` — which rejects `..`, enforces a charset, and caps length at `_MAX_MCP_NAME_LEN` (128) — is defined in *this same module* at line 77 and applied by eleven other call sites across `mcp.py` itself, `mcp_custom.py`, `mcp_discover.py` and `connections.py`. The one route that *writes* the key was the one that skipped it. (Listing, toggle and remove deliberately do not apply it, which is what keeps a bad key clearable — see §3.)

**`DELETE /api/terminal/sessions/{session_id}`** (`handlers/terminal.py`) went straight into `registry.pop(session_id, None)` and reported 404 on a miss. Its sibling `api_terminal_ws` — the route that *creates* a session — refuses the same param at `not session_id or len(session_id) > 64`. These were the only two `session_id` path-param readers in the file, and the bound lived as a bare literal in one of them.

## 2. Why this issue matters to the user

For the MCP route, a name written outside the shared invariant is refused by the surfaces that enforce it: `_do_mcp_apply` — the batch endpoint the dashboard commits changes through — and `api_mcp_gateway_set_stub`, plus the `mcp_custom`, `mcp_discover` and `connections` handlers. So the entry cannot be applied, stubbed, or edited through those paths. To be precise about the blast radius: it *does* still show up in a plain listing and it can still be removed, because those paths do not apply the predicate. The write is the step that creates the state, which is why the guard belongs there.

For the terminal route, the effect is smaller and honest to state as such: an over-long id already produced a correct-looking 404. But it was the wrong answer to the question asked — the request was malformed, not pointing at a missing session — and it reached that answer only after a registry lookup, while the sibling route rejects the identical input up front. The 64-char bound existing in one reader and not the other is also a latent drift hazard: nothing tied the two together.

Neither is a security fix. No traversal, no unhandled 500, no injection is reachable through either route today (`name` becomes a JSON dict key, not a path; `pop` has a default). This is invariant and consistency work.

## 3. How our fix solves it

Symptom → root cause for each:

**MCP.** Symptom: a malformed name lands in `mcp.json` and cannot be managed through the surfaces that enforce the invariant. Cause: the write path never consulted the module's own validator. Fix: call `_is_valid_mcp_name(name)` at the top of the PUT branch, before `request.json()` is even awaited, returning `400` with `code: "invalid_server_name"`.

The fix is deliberately **asymmetric — DELETE is left unguarded**, and that is the substantive design point. Both removal paths stay permissive: this DELETE and `api_mcp_remove` each accept a name the new guard rejects, which is how a junk key — including one written before the guard existed — remains clearable. Guarding a remover would strand exactly the entries the writer guard prevents. The listing and toggle paths do not apply the predicate either, which is what keeps such an entry visible. This mirrors a split this codebase already documents: `security.py`'s trusted-app *grant* gates `name` on `APP_NAME_RE` while *revoke* deliberately does not, with the in-code rationale that "revoke's un-validated name is for removing junk config entries." A test pins the permissiveness so a later sweep cannot 'tidy' it away.

**Terminal.** Symptom: a malformed id gets a post-lookup 404. Cause: the bound was a bare literal in the WS-open reader, with nothing binding the DELETE reader to it. Fix: promote it to `_MAX_SESSION_ID_LEN = 64`, use it in both readers, and apply the same predicate in `api_terminal_delete` before `_get_registry`. The refusal is a plaintext `400` to match that handler's other responses (its 401/403/404 are all plaintext); it also emits the same `outcome="denied"` SEL record the WS-open guard does. Rejecting here is sound rather than merely tidy: because creation enforces the bound, an id outside it provably keys nothing in the registry.

## 4. What tests we did

Regression tests were written first and confirmed RED on the unmodified base (`23c99c0f1`): 7 failures — the 5 MCP cases asserting `200 == 400`, which is direct evidence the base really does write the malformed key, and the 2 terminal cases asserting `404 == 400`. All 7 are GREEN after the change. The RED run is the mutation evidence: removing either guard reproduces it exactly.

Two of the new tests **pass on the base and must keep passing** — they exist to catch over-fixing rather than under-fixing:
- `test_delete_still_removes_a_malformed_junk_key` — forbids guarding the DELETE half.
- `test_put_accepts_the_names_the_validator_allows` — pins `@scope/pkg.name_v2:1`, so the guard cannot narrow the accepted set below `_VALID_MCP_NAME_RE` (which admits `@`, `/`, `.`, `:`, `_`).

Run, all green on the rebased base:
- `test_handlers_mcp_coverage.py` + `test_terminal_handler.py` — 387 passed, 1 skipped.
- Plus every other file touching these routes (`test_agent_config_owner_gate_invariant.py`, `test_gateway_appkit_endpoints.py`, `test_mochi_routes.py`) — 598 passed, 1 skipped.
- Gates as CI runs them: `scripts/check_black_formatting.py` (4 files in scope, passed), `isort --check-only`, `flake8` — all clean. `mypy src/kiro_crew/` reports 4 pre-existing boto3-stub errors in `transcribe.py`/`cloudwatch.py`; none in the changed files.

## 5. Any other suggestions on the work

**On the trailer:** this uses `Refs #6301`, not a closing keyword, on purpose. #6301 asks for validation across *all* routes and is labelled `needs-investigation` pending a shape decision; these are 2 sites out of roughly 200. Closing it on this PR would retire a parked architecture question that this change does not answer.

**What the full inventory showed** (posted in detail on #6301): I classified every `match_info` read across the 28 handler files rather than re-counting them — 205 at the base I measured on (`23c99c0f1`), 207 after the rebase onto current `main` — and the systemic sweep the issue proposes does not look advisable as framed:

- **No real-failure sites anywhere.** Every filesystem-bound path param is already contained at its sink — `is_relative_to` in `files.py:300` and `diagnostics.py:93`, `_SLUG_RE` in `webapp_preview.py`, `within_root` in `steering.py:683`, `O_NOFOLLOW` + fd containment in `themes.py`, `resolve()`-in-`parents` in `core.py:503`. The only bare `dict[path_param]` subscripts are all preceded by membership checks.
- **Most reads are already guarded, at a different seam.** `artifacts.py`'s 76 reads — 37% of the inventory — pass `_validate_slug` at the *store* boundary with an 80-char cap, stricter than the cron helper's 500. Applying the cron guard there would be weaker and redundant.
- **There is no single "established pattern" to sweep onto.** At least four shapes coexist: cron's json `invalid_<name>` at ≤500, terminal's plaintext at >64, the domain regexes in `themes`/`members`/`prompts`, and `artifacts`' store-boundary check. They disagree on body shape, on the bound, and on which seam owns the check.
- **A mechanical sweep would regress `security.py:1368`**, whose un-validated name is documented as deliberate.

So the two sites in this PR are the subset that needed no shape decision, because each reuses a predicate its own module already defines. The remaining question on #6301 is a design call and is left to a human.

**Follow-up worth considering, not done here:** `mcp.py`'s pre-existing blank-name 400 (`{"error": "server name is required"}`) carries no `code` field, and `mcp_custom.py`'s two refusals do not either. Adding codes there is a separate, purely additive change and did not belong in this diff.

## Pattern harvest

Rule candidate: semgrep (plus an AGENTS.md/review-prompt line)

Pattern: a module defines a path-param validator or bound, and one reader in that same module does not apply it.

Both defects here are that single shape, and it is the part of #6301 that is actually statically decidable. The guard already existed *in the module* and one reader skipped it — so the rule needs no policy call about what the correct predicate is, which is exactly what blocks the general version.

Two detectable forms:
- A handler reads `request.match_info[...]` while the enclosing module defines a `_is_valid_*` / `_safe_*` predicate that at least one *other* handler in that module applies to the same param name — and this one does not. (`mcp.py` PUT vs the twelve `_is_valid_mcp_name` call sites.)
- The same numeric bound appears as a bare literal in a `len(<path param>) >` comparison in one reader and is absent from a sibling reader of the identically-named param. (The `64` in `terminal.py` before this PR.)

The second form is preventable more cheaply than with semgrep: flagging a bare integer literal in a `len(<path param>) >` comparison would have forced the named constant, and the named constant is the thing that ties the two readers together. That is a lint rule, not a review instruction.

Deliberately **not** proposed as a rule: "every `match_info` read must be validated." The full classification on #6301 shows it would fire on roughly 120 sites already guarded at a stricter seam (`artifacts.py`'s store-boundary `_validate_slug` at 80 chars, `themes.py`'s allowlists, the containment checks in `files.py`/`diagnostics.py`/`steering.py`/`webapp_preview.py`), and it would demand a change at the trusted-app revoke handler in `security.py` where the *absence* of validation is documented as deliberate. A rule with that false-positive rate gets switched off, which is worse than no rule.

Refs #6301
