### PR TITLE
refactor: one destination oracle for file_send's two legs

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1217,
+    "missing_code": 1213,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1435,
+  "_compliant": 1437,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -85,7 +85,7 @@
       "missing_code": 15
     },
     "dashboard/handlers/files.py": {
-      "missing_code": 104
+      "missing_code": 100
     },
     "dashboard/handlers/kiro_prerequisite.py": {
       "missing_code": 1

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -32,16 +32,14 @@ from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write, open_access_control_source
 from kiro_crew.config import loader as config_loader
 from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir, data_home
-from kiro_crew.dashboard import part_stream
+from kiro_crew.dashboard import part_stream, upload_destination
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
 from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
 from kiro_crew.dashboard.handlers._shared import _probe_persisted_session
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.doc_parser import extract_text
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes, safe_read_prefix
-from kiro_crew.messaging import upload_gate
 from kiro_crew.messaging.display_safety import redact_for_display
-from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.messaging.outbound_files import OutboundFile
 from kiro_crew.messaging.raster import SNIFF_BYTES, sniff_raster_mime
 from kiro_crew.platform import redact_via_context as redact
@@ -55,7 +53,6 @@ from kiro_crew.security import (
 from kiro_crew.slack.handler import is_tracked_channel
 from kiro_crew.validation import (
     FILE_READ_SCHEMA,
-    FILE_SEND_SCHEMA,
     ValidationError,
     validate_tool_args,
 )
@@ -87,6 +84,41 @@ def _sel():
     """Late-binding _sel() for test monkeypatch compatibility."""
     import kiro_crew.dashboard.handlers as _pkg  # noqa: F811
     return _pkg.sel()
+
+
+def _audit_file_send(
+    *,
+    leg: str,
+    outcome: str,
+    error: str | None = None,
+    downstream: str | None = None,
+    resources: str | None = None,
+) -> None:
+    """The one audit shape both ``file_send`` delivery legs write.
+
+    Every record the Slack and channel endpoints emit is the same tool
+    invocation under a different ``tool_kind`` (the leg), so the shape lives
+    here rather than being spelled out at each of the dozen decision sites it
+    used to be copied to -- one drifted field was previously a one-line edit
+    away. Optional fields are OMITTED when unset, exactly as the shipped call
+    sites omitted them: skips carry no ``downstream_service``, refusals and
+    deliveries do.
+    """
+    extra: dict[str, str] = {}
+    if error is not None:
+        extra["error"] = error
+    if downstream is not None:
+        extra["downstream_service"] = downstream
+    if resources is not None:
+        extra["resources"] = resources
+    _sel().log_tool_invocation(
+        session_key="api",
+        source="api",
+        tool_name="file_send",
+        tool_kind=leg,
+        outcome=outcome,
+        **extra,
+    )
 
 
 async def api_reveal_path(request: web.Request) -> web.Response:
@@ -584,34 +616,32 @@ def _gate_upload_file(
 
 
 async def api_slack_upload_file(request: web.Request) -> web.Response:
-    """POST /api/slack/upload-file — upload a file to Slack (internal, called by file_send)."""
+    """POST /api/slack/upload-file — upload a file to Slack (internal, called by file_send).
+
+    Destination and authorization come from the shared oracle
+    (:func:`kiro_crew.dashboard.upload_destination.resolve_slack`), which holds
+    this leg's ladder — request-named channel, session-map-linked thread,
+    owner-DM fallback, tracked-channel authorization — next to the non-Slack
+    leg's, so the two cannot drift apart rung by rung (issue #6060). What stays
+    here is what only this leg can answer: the Slack client, its upload verb,
+    and the response shapes.
+
+    The client-presence check stays AHEAD of the body parse, where it shipped: a
+    gateway with no Slack client answers ``skipped: no_slack`` even for a
+    malformed body.
+    """
     state: DashboardState = request.app["state"]
     slack = state.slack_client
     if not slack:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="skipped",
-            error="no_slack_client",
-        )
+        _audit_file_send(leg="slack", outcome="skipped", error="no_slack_client")
         return web.json_response({"ok": True, "skipped": "no_slack"})
     try:
         body = await request.json()
     except ValueError:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="denied",
-            error="invalid_json_body",
-        )
+        _audit_file_send(leg="slack", outcome="denied", error="invalid_json_body")
         return web.json_response({"error": "Invalid JSON body"}, status=400)
     file_path_raw = body.get("file_path", "")
     filename = body.get("filename", "")
-    thread_ts = body.get("thread_ts")
     # Off-loop: the gate reads up to MAX_FILE_BYTES and regex-scans the content
     # (no-blocking-call-on-event-loop).
     error_resp, resolved, raw = await asyncio.to_thread(
@@ -620,130 +650,56 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
     if error_resp is not None:
         return error_resp
     assert resolved is not None and raw is not None  # narrowed by the gate
-    file_path = file_path_raw
-    # Resolve thread_ts and channel from linked slot when not explicitly provided
-    target_channel = body.get("channel", "")
-    channel_from_session_map = False
-    session_key = request.headers.get("X-Session-Key", "").strip()
-    # A dashboard session carries its Slack link in the session map; a
-    # channel-born one is linked under that same channel key by the Slack
-    # handler, so both resolve their thread from the one lookup. Skipping the
-    # channel case would DM the owner instead of landing the file in the thread
-    # the conversation is happening in.
-    linkable = session_key.startswith("dashboard:") or is_channel_session_key(session_key)
-    if not thread_ts and linkable and state.sessions:
-        link_ts, link_ch = state.sessions.get_slack_link(session_key)
-        if link_ts and (not target_channel or target_channel == link_ch):
-            thread_ts = link_ts
-            if not target_channel and link_ch:
-                target_channel = link_ch
-                channel_from_session_map = True
-    # Resolve channel: use explicit channel if provided, else owner DM
-    channel = ""
-    if target_channel:
-        try:
-            validate_tool_args(
-                {"path": "x", "channel": target_channel}, FILE_SEND_SCHEMA
-            )
-        except ValidationError:
-            _sel().log_tool_invocation(
-                session_key="api",
-                source="api",
-                tool_name="file_send",
-                tool_kind="slack",
-                outcome="denied",
-                downstream_service="slack",
-                error="channel_validation_failed",
-            )
+    # ``is_tracked_channel`` is handed to the oracle rather than imported there:
+    # one binding site, and the module stays free of the Slack handler's config
+    # dependency (same contract as ``persisted_probe`` below).
+    destination = await upload_destination.resolve_slack(
+        state,
+        slack,
+        session_key=request.headers.get("X-Session-Key", "").strip(),
+        requested_channel=body.get("channel", ""),
+        thread_ts=body.get("thread_ts"),
+        tracked_probe=is_tracked_channel,
+    )
+    if isinstance(destination, upload_destination.Refusal):
+        _audit_file_send(
+            leg="slack",
+            outcome="denied",
+            error=destination.audit_error,
+            downstream=destination.downstream,
+        )
+        # One branch per literal status, body inline. `status=<expression>` and a
+        # body hoisted into a variable are both invisible to the error-code
+        # contract scanner, which counts either as its own bucket
+        # (test_error_code_contract) -- so the refusal says WHICH answer it is
+        # and each answer is spelled out here.
+        if destination.status == 400:
             return web.json_response(
-                {"error": "invalid channel value"}, status=400
+                {"error": destination.error, "code": destination.code}, status=400
             )
-        # Session-map-sourced channels are trusted (system created the link).
-        # Only enforce tracking check for user-supplied channels.
-        # Defense-in-depth: session-map channels must be DMs (D-prefix) or tracked.
-        if not channel_from_session_map:
-            try:
-                tracked = is_tracked_channel(target_channel)
-            except Exception:
-                tracked = False  # deny-by-default extends to uncertainty
-            if not tracked:
-                _sel().log_tool_invocation(
-                    session_key="api",
-                    source="api",
-                    tool_name="file_send",
-                    tool_kind="slack",
-                    outcome="denied",
-                    downstream_service="slack",
-                    error=f"channel_not_tracked: {target_channel}",
-                )
-                return web.json_response(
-                    {"error": "channel not in tracked channels"}, status=403
-                )
-        else:
-            try:
-                allowed = target_channel.startswith("D") or is_tracked_channel(target_channel)
-            except Exception:
-                allowed = False  # deny-by-default extends to uncertainty
-            if not allowed:
-                _sel().log_tool_invocation(
-                    session_key="api",
-                    source="api",
-                    tool_name="file_send",
-                    tool_kind="slack",
-                    outcome="denied",
-                    downstream_service="slack",
-                    error=f"session_map_channel_not_authorized: {target_channel}",
-                )
-                return web.json_response(
-                    {"error": "channel not authorized"}, status=403
-                )
-        channel = target_channel
-    else:
-        try:
-            creds = KiroCrewConfig.load().load_credentials()
-            owner_id = creds.get("KIROCREW_OWNER_ID", "")
-            if owner_id:
-                channel = await slack.open_dm(owner_id)
-        except Exception:
-            pass
-    if not channel:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="skipped",
-            error="no_channel",
+        return web.json_response(
+            {"error": destination.error, "code": destination.code}, status=403
         )
-        return web.json_response({"ok": True, "skipped": "no_channel"})
+    if isinstance(destination, upload_destination.Skip):
+        _audit_file_send(leg="slack", outcome="skipped", error=destination.reason)
+        return web.json_response({"ok": True, "skipped": destination.reason})
     try:
-        safe_filename = filename
-        if redact(safe_filename) != safe_filename:
-            _sel().log_tool_invocation(
-                session_key="api",
-                source="api",
-                tool_name="file_send",
-                tool_kind="slack",
-                outcome="denied",
-                downstream_service="slack",
-                error="sensitive_filename_rejected",
-            )
-            return web.json_response({"error": "filename contains sensitive content"}, status=400)
+        # The filename was already cleared by the shared admission gate above —
+        # same predicate, same value, strictly earlier in this function — so the
+        # leg no longer re-checks it. #6044 made that gate the one site for the
+        # rule; a second copy here could only drift from it.
         await slack.upload_file(
-            channel,
-            thread_ts or "",
+            destination.channel,
+            destination.thread_ts,
             str(resolved),
-            safe_filename,
-            safe_filename,
+            filename,
+            filename,
         )
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
+        _audit_file_send(
+            leg="slack",
             outcome="completed",
-            downstream_service="slack",
-            resources=f"channel={channel} file={file_path}",
+            downstream="slack",
+            resources=f"channel={destination.channel} file={file_path_raw}",
         )
         return web.json_response({"ok": True})
     except Exception as e:
@@ -752,15 +708,7 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
         # reaches the client or the audit record (see api_slack_pins).
         safe_error, _ = redact_credentials(str(e))
         safe_error, _ = redact_exfiltration_urls(safe_error)
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="error",
-            downstream_service="slack",
-            error=safe_error,
-        )
+        _audit_file_send(leg="slack", outcome="error", downstream="slack", error=safe_error)
         return web.json_response({"error": safe_error}, status=500)
 
 
@@ -768,19 +716,21 @@ async def api_channel_upload_file(request: web.Request) -> web.Response:
     """POST /api/channel/upload-file — deliver a file to the caller's own
     conversation on a non-Slack channel (internal, called by file_send).
 
-    The Slack counterpart above has its own identity ladder; this one serves
-    every transport-registry channel through the SAME send ladder the
-    cross-surface reply mirror uses (``_resolve_mirror_target``): channel-scope
-    governance, transport registration, proactive-send capability, and
-    ``may_send_to`` recipient re-authorization, all fail-closed and
-    SEL-audited in one place — plus the restricted-session ceiling the
-    renderers' extraction path enforces, on the same shared predicate. The
-    destination comes exclusively from the caller's session map entry — a
-    request cannot name an arbitrary conversation, which is what keeps this
-    endpoint from being a broadcast primitive. Delivery today: Telegram and
-    Discord, each via its own purpose-built name-preserving ``send_document``
-    (see the delivery-branch comment below); every other channel is a skip
-    until its transport grows that verb.
+    Destination and authorization come from the shared oracle
+    (:func:`kiro_crew.dashboard.upload_destination.resolve_channel`), which for
+    this leg is the SAME send ladder the cross-surface reply mirror uses
+    (``_resolve_mirror_target``): channel-scope governance, transport
+    registration, proactive-send capability, and ``may_send_to`` recipient
+    re-authorization, all fail-closed and SEL-audited in one place — plus the
+    restricted-session ceiling the renderers' extraction path enforces, on the
+    same shared predicate. The destination comes exclusively from the caller's
+    session map entry — a request cannot name an arbitrary conversation, which is
+    what keeps this endpoint from being a broadcast primitive. The oracle also
+    resolves the delivery verb, since which channels have one is part of "can
+    this file land here": Telegram and Discord today, each via its own
+    purpose-built name-preserving ``send_document``; every other channel is a
+    skip until its transport grows that verb. The Slack counterpart above
+    resolves through the same module, one rung table away (issue #6060).
 
     "Cannot deliver here" is a SKIP (``delivered: false``), not an error: most
     sessions mirror nowhere, and the caller falls back to the dashboard card
@@ -790,67 +740,21 @@ async def api_channel_upload_file(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except ValueError:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="channel",
-            outcome="denied",
-            error="invalid_json_body",
-        )
+        _audit_file_send(leg="channel", outcome="denied", error="invalid_json_body")
         return web.json_response({"error": "Invalid JSON body"}, status=400)
 
     def _skip(reason: str) -> web.Response:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="channel",
-            outcome="skipped",
-            error=reason,
-        )
+        _audit_file_send(leg="channel", outcome="skipped", error=reason)
         return web.json_response({"ok": True, "delivered": False, "skipped": reason})
 
-    session_key = request.headers.get("X-Session-Key", "").strip()
-    if not session_key or not getattr(state, "sessions", None):
-        return _skip("no_session")
-    from kiro_crew.dashboard.chat_runner import _resolve_mirror_target
-
-    # Off-loop like the admission gate below: the ladder reloads governance
-    # profiles and reads the persisted session map — synchronous filesystem
-    # work (no-blocking-call-on-event-loop). The session map's reads are
-    # lock-guarded, so the call is thread-safe.
-    target = await asyncio.to_thread(_resolve_mirror_target, state, session_key)
-    if target is None:
-        # No mirror link, a Slack link (the Slack leg owns those), a missing or
-        # capability-less transport, a governance denial, or a may_send_to
-        # refusal — the ladder audited the ones that matter; all mean the same
-        # thing here: this caller has no non-Slack conversation to deliver to.
-        return _skip("no_channel_destination")
-    link, transport = target
-    # The restricted ceiling the renderers' extraction path already enforces:
-    # an incognito/temporary session ships no local file bytes to a channel,
-    # and an explicit file_send must not be the bypass. Same shared predicate
-    # (which SEL-audits the denial), same skip shape as every other "cannot
-    # deliver here" answer. Checked before capability probing: a restricted
-    # caller learns nothing about which channels could upload.
-    if await upload_gate.uploads_restricted(
+    destination = await upload_destination.resolve_channel(
         state,
-        session_key,
-        channel_type=link.channel_type,
+        request.headers.get("X-Session-Key", "").strip(),
         persisted_probe=_probe_persisted_session,
-    ):
-        return _skip("restricted_session")
-    deliver = None
-    # Both legs resolve the SAME purpose-built verb: a name-preserving document
-    # send, distinct from each transport's extraction upload whose filename
-    # sanitizer maps any non-raster mime to `.bin` (`upload_filename`) — correct
-    # for LLM-authored reference paths, wrong for a name this endpoint's gate
-    # already scanned. A channel is listed here only once it has that verb.
-    if link.channel_type in ("telegram", "discord"):
-        deliver = getattr(transport, "send_document", None)
-    if deliver is None:
-        return _skip(f"channel_upload_unsupported:{link.channel_type}")
+    )
+    if isinstance(destination, upload_destination.Skip):
+        return _skip(destination.reason)
+    link, deliver = destination.link, destination.deliver
     # Off-loop: the gate reads up to MAX_FILE_BYTES and regex-scans the content
     # (no-blocking-call-on-event-loop).
     error_resp, resolved, raw = await asyncio.to_thread(
@@ -888,36 +792,27 @@ async def api_channel_upload_file(request: web.Request) -> web.Response:
         # reaches the client or the audit record (see api_slack_upload_file).
         safe_error, _ = redact_credentials(str(e))
         safe_error, _ = redact_exfiltration_urls(safe_error)
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="channel",
+        _audit_file_send(
+            leg="channel",
             outcome="error",
-            downstream_service=link.channel_type,
+            downstream=link.channel_type,
             error=safe_error,
         )
         return web.json_response({"error": safe_error}, status=502)
     if not mid:
         # The transport reported failure without raising (the clients return
         # an empty id on an API-level refusal).
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="channel",
+        _audit_file_send(
+            leg="channel",
             outcome="error",
-            downstream_service=link.channel_type,
+            downstream=link.channel_type,
             error="delivery_reported_no_message_id",
         )
         return web.json_response({"error": "channel delivery failed"}, status=502)
-    _sel().log_tool_invocation(
-        session_key="api",
-        source="api",
-        tool_name="file_send",
-        tool_kind="channel",
+    _audit_file_send(
+        leg="channel",
         outcome="completed",
-        downstream_service=link.channel_type,
+        downstream=link.channel_type,
         resources=f"channel_type={link.channel_type} file={body.get('file_path', '')}",
     )
     return web.json_response(

--- a/src/kiro_crew/dashboard/upload_destination.py
+++ b/src/kiro_crew/dashboard/upload_destination.py
@@ -1,0 +1,290 @@
+"""``file_send``'s destination oracle -- the one place that answers "where does
+this file go, and may this caller send it there?" for BOTH delivery legs.
+
+PR #6044 gave the two legs of ``file_send`` one shared ADMISSION gate
+(:func:`~kiro_crew.dashboard.handlers.files._gate_upload_file`: containment, the
+descriptor-safe read, the binary MIME allowlist, the content credential scans).
+Destination and authorization stayed per-leg, inline in each endpoint -- the last
+surviving sibling of the "two paths, two behaviours" root cause that gate closed
+(issue #6060). This module is the destination half of the same move: the two
+resolvers now sit side by side in one file, each endpoint keeps only its own
+delivery verb and response shape, and every rung one leg runs and the other does
+not is written down below instead of being discoverable only by reading two
+handlers 200 lines apart.
+
+This is deliberately NOT a single ``resolve(leg, ...)`` dispatcher. Each endpoint
+knows its leg statically, so a union-typed dispatcher would buy nothing and force
+both call sites to unwrap a wider result. What makes this one oracle is that both
+resolvers live here, share one refusal/skip vocabulary, and are audited through
+one shape (``_audit_file_send`` in the handlers module, which owns the
+test-patchable ``_sel``).
+
+Rung by rung, as shipped today -- the Slack column is what #6060 asks to
+converge, and the two NOT RUN rows are the parts that need the architecture
+decision in that issue's step 2 (does Slack join ``channel_transports``, or does
+the ladder grow a Slack adapter?), so they are named here, not silently changed:
+
+======================================  =============================  ===========================================
+rung                                    channel leg                    Slack leg
+======================================  =============================  ===========================================
+destination source                      session-map mirror link only    request-named ``channel``, else the
+                                                                        session-map Slack link, else the owner DM
+recipient authorization                 ``transport.may_send_to``       ``is_tracked_channel``; a session-map
+                                        (fail-closed)                   channel passes on a ``D`` prefix OR
+                                                                        tracking (both fail-closed)
+``channels``-scope governance           yes, inside                     NOT RUN (#6060 step 2)
+(``vet_and_audit``, fail-closed, SEL)   ``_resolve_channel_target``
+restricted-session ceiling              yes                             NOT RUN (#6060 step 2)
+(``upload_gate.uploads_restricted``)
+transport registration +                yes                             n/a -- Slack's dedicated client is
+``supports_proactive_send``                                             deliberately absent from
+                                                                        ``channel_transports``
+caller identity on the wire             STRICT session key, pinned by   lenient ``_resolve_session_key()``; the
+                                        the MCP tool                    tool's three-state classifier refuses an
+                                                                        unresolved caller before the leg runs
+resolution off the event loop           yes (``asyncio.to_thread``)     no -- ``open_dm`` is a coroutine, so this
+                                                                        ladder stays on the loop with its config
+                                                                        and tracking reads inline, as before
+======================================  =============================  ===========================================
+
+Ambient lookups are PARAMETERS, not imports (``tracked_probe``,
+``persisted_probe``) -- the same contract
+:func:`kiro_crew.messaging.upload_gate.uploads_restricted` uses for its probe.
+The caller keeps one place to bind (and one place for a test to patch), and this
+module stays free of both the Slack handler's tracked-channel config dependency
+and the ``handlers`` package it is called from.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.messaging import upload_gate
+from kiro_crew.messaging.link import SLACK_NAMESPACE, is_channel_session_key
+from kiro_crew.validation import FILE_SEND_SCHEMA, ValidationError, validate_tool_args
+
+logger = logging.getLogger(__name__)
+
+#: ``channel_id -> is a tracked Slack channel``. Blocking (it reads the Slack
+#: config), and a raising probe DENIES: an authorization check that errored has
+#: not authorized anybody.
+TrackedProbe = Callable[[str], bool]
+
+#: Channels whose transport carries the name-preserving ``send_document`` verb,
+#: as distinct from the extraction upload whose filename sanitizer maps any
+#: non-raster mime to ``.bin``. A channel joins this list only once it has that
+#: verb; every other channel is a skip.
+DOCUMENT_CHANNELS = ("telegram", "discord")
+
+_DASHBOARD_PREFIX = "dashboard:"
+
+
+@dataclass(frozen=True)
+class Refusal:
+    """The caller may not have the destination it named -- an HTTP error.
+
+    Distinct from :class:`Skip`: a refusal means an authorization rung said no
+    to something the caller asked for, so it is reported as a failure. *error*
+    is the advisory prose the client sees and *code* the machine-readable
+    contract it branches on (RFC 9457 3.1.3, enforced by
+    ``test_error_code_contract``); *audit_error* is what the SEL record carries,
+    and differs on purpose -- the audit names the refused channel, the response
+    does not. *downstream* is set only where the shipped record set it.
+    """
+
+    error: str
+    code: str
+    status: int
+    audit_error: str
+    downstream: str | None = None
+
+
+@dataclass(frozen=True)
+class Skip:
+    """No destination on this leg, and that is the normal case.
+
+    Most sessions mirror nowhere and most callers name no Slack channel, so
+    "cannot deliver here" is a skip the caller falls back from -- never an
+    error. Skips carry no ``downstream_service`` in the audit trail, matching
+    the shipped records on both legs.
+    """
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class SlackTarget:
+    """A resolved, authorized Slack destination."""
+
+    channel: str
+    thread_ts: str
+
+
+@dataclass(frozen=True)
+class ChannelTarget:
+    """A resolved, authorized non-Slack destination plus its delivery verb."""
+
+    link: Any
+    transport: Any
+    deliver: Callable[..., Any]
+
+
+async def resolve_slack(
+    state: Any,
+    slack: Any,
+    *,
+    session_key: str,
+    requested_channel: str,
+    thread_ts: str | None,
+    tracked_probe: TrackedProbe,
+) -> SlackTarget | Refusal | Skip:
+    """Resolve the Slack leg's destination and authorize the caller for it.
+
+    The shipped ladder, in order and unchanged: an explicitly named channel
+    wins; otherwise a linkable session's own Slack link supplies both channel
+    and thread; otherwise the owner DM. A named channel must be tracked; a
+    channel that came from the session map is accepted on a ``D`` prefix (the
+    system created that link, and a DM is not a broadcast) or on tracking.
+    Both tracking checks fail closed on a raising probe.
+
+    The session map is consulted only for a ``dashboard:`` or channel-native
+    key, and only when the request supplied no ``thread_ts`` -- an explicit
+    thread is the caller's own choice of destination. A link's thread is
+    inherited ONLY when the caller named no channel or named that same channel:
+    a thread ts belongs to one channel, so pairing it with a different one would
+    post into an unrelated conversation. ``state.sessions`` is read after the
+    linkable test, so a key that names no session never touches it.
+    """
+    target_channel = requested_channel
+    channel_from_session_map = False
+    # A dashboard session carries its Slack link in the session map; a
+    # channel-born one is linked under that same channel key by the Slack
+    # handler, so both resolve their thread from the one lookup. Skipping the
+    # channel case would DM the owner instead of landing the file in the thread
+    # the conversation is happening in.
+    linkable = session_key.startswith(_DASHBOARD_PREFIX) or is_channel_session_key(session_key)
+    if not thread_ts and linkable and state.sessions:
+        link_ts, link_ch = state.sessions.get_slack_link(session_key)
+        if link_ts and (not target_channel or target_channel == link_ch):
+            thread_ts = link_ts
+            if not target_channel and link_ch:
+                target_channel = link_ch
+                channel_from_session_map = True
+    channel = ""
+    if target_channel:
+        try:
+            validate_tool_args({"path": "x", "channel": target_channel}, FILE_SEND_SCHEMA)
+        except ValidationError:
+            return Refusal(
+                error="invalid channel value",
+                code="invalid_channel",
+                status=400,
+                audit_error="channel_validation_failed",
+                downstream=SLACK_NAMESPACE,
+            )
+        # Session-map-sourced channels are trusted (the system created the
+        # link), so only a user-supplied channel must clear the tracking check.
+        # Defense-in-depth: a session-map channel must still be a DM or tracked.
+        if not channel_from_session_map:
+            try:
+                tracked = tracked_probe(target_channel)
+            except Exception:
+                tracked = False  # deny-by-default extends to uncertainty
+            if not tracked:
+                return Refusal(
+                    error="channel not in tracked channels",
+                    code="channel_not_tracked",
+                    status=403,
+                    audit_error=f"channel_not_tracked: {target_channel}",
+                    downstream=SLACK_NAMESPACE,
+                )
+        else:
+            try:
+                allowed = target_channel.startswith("D") or tracked_probe(target_channel)
+            except Exception:
+                allowed = False  # deny-by-default extends to uncertainty
+            if not allowed:
+                return Refusal(
+                    error="channel not authorized",
+                    code="channel_not_authorized",
+                    status=403,
+                    audit_error=f"session_map_channel_not_authorized: {target_channel}",
+                    downstream=SLACK_NAMESPACE,
+                )
+        channel = target_channel
+    else:
+        try:
+            creds = KiroCrewConfig.load().load_credentials()
+            owner_id = creds.get("KIROCREW_OWNER_ID", "")
+            if owner_id:
+                channel = await slack.open_dm(owner_id)
+        except Exception:
+            pass
+    if not channel:
+        return Skip("no_channel")
+    return SlackTarget(channel=channel, thread_ts=thread_ts or "")
+
+
+async def resolve_channel(
+    state: Any,
+    session_key: str,
+    *,
+    persisted_probe: upload_gate.PersistedProbe,
+) -> ChannelTarget | Skip:
+    """Resolve the non-Slack leg's destination through the shared send ladder.
+
+    Every rung is the cross-surface reply mirror's own: channel-scope
+    governance, transport registration, proactive-send capability, and
+    ``may_send_to`` recipient re-authorization, all fail-closed and SEL-audited
+    inside ``_resolve_mirror_target`` -- plus the restricted-session ceiling the
+    renderers' extraction path enforces, on the same shared predicate. The
+    destination comes exclusively from the caller's session map entry: a request
+    cannot name a conversation, which is what keeps this leg from being a
+    broadcast primitive.
+
+    ``_resolve_mirror_target`` is imported inside the call, not at module scope:
+    ``chat_runner`` imports the dashboard world, and this module is imported
+    from a handler that ``chat_runner`` can reach.
+
+    The restricted ceiling is checked BEFORE the delivery verb is probed, so a
+    restricted caller learns nothing about which channels could have uploaded.
+    """
+    if not session_key or not getattr(state, "sessions", None):
+        return Skip("no_session")
+    from kiro_crew.dashboard.chat_runner import _resolve_mirror_target
+
+    # Off-loop like the admission gate: the ladder reloads governance profiles
+    # and reads the persisted session map -- synchronous filesystem work
+    # (no-blocking-call-on-event-loop). The session map's reads are
+    # lock-guarded, so the call is thread-safe.
+    target = await asyncio.to_thread(_resolve_mirror_target, state, session_key)
+    if target is None:
+        # No mirror link, a Slack link (the Slack leg owns those), a missing or
+        # capability-less transport, a governance denial, or a may_send_to
+        # refusal -- the ladder audited the ones that matter; all mean the same
+        # thing here: this caller has no non-Slack conversation to deliver to.
+        return Skip("no_channel_destination")
+    link, transport = target
+    # An incognito/temporary session ships no local file bytes to a channel, and
+    # an explicit file_send must not be the bypass. The predicate SEL-audits its
+    # own denial.
+    if await upload_gate.uploads_restricted(
+        state,
+        session_key,
+        channel_type=link.channel_type,
+        persisted_probe=persisted_probe,
+    ):
+        return Skip("restricted_session")
+    deliver = (
+        getattr(transport, "send_document", None)
+        if link.channel_type in DOCUMENT_CHANNELS
+        else None
+    )
+    if deliver is None:
+        return Skip(f"channel_upload_unsupported:{link.channel_type}")
+    return ChannelTarget(link=link, transport=transport, deliver=deliver)

--- a/test/test_file_send_channel.py
+++ b/test/test_file_send_channel.py
@@ -1003,3 +1003,334 @@ class TestChannelUploadEndpoint:
                 body = await resp.json()
         assert resp.status == 502
         assert body["error"] == "channel delivery failed"
+
+
+class TestDestinationOracleEquivalence:
+    """The rungs the destination oracle must keep answering exactly as the two
+    inline ladders did (issue #6060).
+
+    The classes above already pin the seven Slack destination OUTCOMES and the
+    channel leg's skip-vs-error semantics, and they run unchanged against the
+    oracle. What they never asserted is what a fold could silently change while
+    leaving those outcomes intact: the SEL record each refusal writes, the
+    fail-closed direction when the tracking probe RAISES, and which callers get
+    to consult the session map at all. Those are pinned here.
+    """
+
+    @staticmethod
+    def _state(slack, *, thread_ts=None, channel=None):
+        state = MagicMock()
+        state.slack_client = slack
+        sessions = MagicMock()
+        sessions.get_slack_link = MagicMock(return_value=(thread_ts, channel))
+        state.sessions = sessions
+        return state
+
+    @staticmethod
+    def _records(sel):
+        """The kwargs of every SEL tool-invocation the request wrote."""
+        return [c.kwargs for c in sel.log_tool_invocation.call_args_list]
+
+    async def _post_slack(self, app, payload, *, headers=None):
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/slack/upload-file", json=payload, headers=headers)
+            return resp, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_an_untracked_channel_refusal_keeps_its_audit_record(
+        self, tmp_path, outbox_file
+    ):
+        """A refused destination writes ONE denied record naming the channel,
+        with ``downstream_service`` set — the audit lane an operator greps to
+        find refused sends. The client response still does not name it."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path)
+        sel = MagicMock()
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel", return_value=False
+        ), patch(
+            "kiro_crew.dashboard.handlers.files._sel", return_value=sel
+        ):
+            resp, body = await self._post_slack(
+                app,
+                {
+                    "file_path": str(outbox_file),
+                    "filename": "report.txt",
+                    "channel": "C0UNTRACKED9",
+                },
+            )
+
+        assert resp.status == 403
+        assert body["code"] == "channel_not_tracked"
+        assert "C0UNTRACKED9" not in body.get("error", "")
+        denials = [r for r in self._records(sel) if r.get("outcome") == "denied"]
+        assert denials == [
+            {
+                "session_key": "api",
+                "source": "api",
+                "tool_name": "file_send",
+                "tool_kind": "slack",
+                "outcome": "denied",
+                "downstream_service": "slack",
+                "error": "channel_not_tracked: C0UNTRACKED9",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_skipped_send_carries_no_downstream_service(self, tmp_path, outbox_file):
+        """A skip is not a refusal: the shipped skip records carry no
+        ``downstream_service``, so an audit reader can tell "nowhere to send" from
+        "refused to send there"."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path)
+        sel = MagicMock()
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load"
+        ) as mock_cfg, patch(
+            "kiro_crew.dashboard.handlers.files._sel", return_value=sel
+        ):
+            mock_cfg.return_value.load_credentials.return_value = {}
+            resp, body = await self._post_slack(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+            )
+
+        assert resp.status == 200
+        assert body == {"ok": True, "skipped": "no_channel"}
+        skips = [r for r in self._records(sel) if r.get("outcome") == "skipped"]
+        assert skips == [
+            {
+                "session_key": "api",
+                "source": "api",
+                "tool_name": "file_send",
+                "tool_kind": "slack",
+                "outcome": "skipped",
+                "error": "no_channel",
+            }
+        ]
+        slack.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_raising_tracking_probe_denies_a_named_channel(self, tmp_path, outbox_file):
+        """Deny-by-default extends to uncertainty: a tracking check that RAISED
+        has not authorized anybody, so the named channel is refused rather than
+        treated as tracked."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path)
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel",
+            side_effect=RuntimeError("config unreadable"),
+        ):
+            resp, body = await self._post_slack(
+                app,
+                {
+                    "file_path": str(outbox_file),
+                    "filename": "report.txt",
+                    "channel": "C0TRACKED123",
+                },
+            )
+
+        assert resp.status == 403
+        assert "not in tracked channels" in body.get("error", "")
+        slack.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_raising_tracking_probe_denies_a_non_dm_session_map_channel(
+        self, tmp_path, outbox_file
+    ):
+        """Same fail-closed direction on the session-map branch, where the
+        D-prefix short-circuit does NOT apply: a raising probe refuses the
+        channel instead of letting the trusted-link path carry it."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        state = self._state(slack, thread_ts="111.222", channel="C0ROGUE999")
+        app = _make_app(slack, tmp_path, state=state)
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel",
+            side_effect=RuntimeError("config unreadable"),
+        ):
+            resp, body = await self._post_slack(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 403
+        assert "not authorized" in body.get("error", "")
+        slack.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_dm_from_the_session_map_never_consults_the_tracking_probe(
+        self, tmp_path, outbox_file
+    ):
+        """The D-prefix short-circuit is not just an alternative to tracking, it
+        is evaluated FIRST: a system-created DM link uploads even when the
+        tracking probe would raise."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        state = self._state(slack, thread_ts="111.222", channel="D0SLOTDM01")
+        app = _make_app(slack, tmp_path, state=state)
+        probe = MagicMock(side_effect=RuntimeError("must not be consulted"))
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel", new=probe
+        ):
+            resp, _ = await self._post_slack(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 200
+        probe.assert_not_called()
+        assert slack.upload_file.call_args[0][0] == "D0SLOTDM01"
+
+    @pytest.mark.asyncio
+    async def test_a_non_linkable_caller_never_reads_the_session_map(
+        self, tmp_path, outbox_file
+    ):
+        """Only a ``dashboard:`` or channel-native key owns a Slack link. A
+        ``cron:``/``subagent:``-style key must not inherit one: the lookup is
+        never made, and the send falls back to the owner DM."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        state = self._state(slack, thread_ts="111.222", channel="C0SOMEONE_ELSE")
+        app = _make_app(slack, tmp_path, state=state)
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load"
+        ) as mock_cfg:
+            mock_cfg.return_value.load_credentials.return_value = {
+                "KIROCREW_OWNER_ID": "U_OWNER"
+            }
+            resp, _ = await self._post_slack(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+                headers={"X-Session-Key": "cron:nightly"},
+            )
+
+        assert resp.status == 200
+        state.sessions.get_slack_link.assert_not_called()
+        assert slack.upload_file.call_args[0][0] == "D_OWNER_DM"
+        assert slack.upload_file.call_args[0][1] == ""
+
+    @pytest.mark.asyncio
+    async def test_the_admission_gate_runs_before_any_destination_work(self, tmp_path):
+        """Ordering the two legs share: a file that cannot ship is refused before
+        the oracle is consulted, so a rejected upload cannot open a DM or read
+        the session map as a side effect."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        state = self._state(slack, thread_ts="111.222", channel="D0SLOTDM01")
+        app = _make_app(slack, tmp_path, state=state)
+        outside = tmp_path / "elsewhere" / "secret.txt"
+        outside.parent.mkdir()
+        outside.write_text("data", encoding="utf-8")
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=tmp_path / "outbox"
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path / "workspace"
+        ):
+            resp, body = await self._post_slack(
+                app,
+                {"file_path": str(outside), "filename": "secret.txt"},
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 403 and body["code"] == "path_not_allowed"
+        state.sessions.get_slack_link.assert_not_called()
+        slack.open_dm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_credential_store_is_a_skip_not_a_500(
+        self, tmp_path, outbox_file
+    ):
+        """The owner-DM fallback is best-effort: a credential read that RAISES
+        leaves the caller with no destination, which is a skip. The request must
+        not surface a 500 (nor an exception naming the credential store) just
+        because no channel could be resolved."""
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        app = _make_app(slack, tmp_path)
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load",
+            side_effect=RuntimeError("credential store unreadable"),
+        ):
+            resp, body = await self._post_slack(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+            )
+
+        assert resp.status == 200
+        assert body == {"ok": True, "skipped": "no_channel"}
+        slack.open_dm.assert_not_called()
+        slack.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_both_legs_resolve_through_the_one_oracle_module(self):
+        """The point of the change: neither endpoint carries its own resolver any
+        more. Pinned structurally so a future edit that re-inlines a ladder in
+        one leg fails here instead of in review."""
+        import inspect
+
+        from kiro_crew.dashboard import upload_destination
+        from kiro_crew.dashboard.handlers import files
+
+        def _body(func):
+            """The function's code, with its docstring dropped — the docstrings
+            NAME these rungs to say where they live, and a text scan would flag
+            exactly the sentence documenting the move."""
+            return inspect.getsource(func).replace(func.__doc__ or "\0", "")
+
+        slack_src = _body(files.api_slack_upload_file)
+        channel_src = _body(files.api_channel_upload_file)
+        assert "upload_destination.resolve_slack(" in slack_src
+        assert "upload_destination.resolve_channel(" in channel_src
+        # The rungs themselves live in the oracle, not in either handler.
+        for rung in ("get_slack_link(", "open_dm(", "_resolve_mirror_target", "may_send_to("):
+            assert rung not in slack_src, f"{rung} is back in the Slack handler"
+            assert rung not in channel_src, f"{rung} is back in the channel handler"
+        assert "is_tracked_channel(" not in slack_src, "the tracking check is back in the handler"
+        oracle_src = inspect.getsource(upload_destination)
+        for rung in ("get_slack_link(", "open_dm(", "_resolve_mirror_target", "tracked_probe("):
+            assert rung in oracle_src


### PR DESCRIPTION
## Problem / Motivation

PR #6044 gave `file_send`'s two delivery legs one shared ADMISSION gate
(`_gate_upload_file`: containment, the descriptor-safe read, the binary MIME
allowlist, the content credential scans). Destination and authorization stayed
per-leg, inline in each endpoint:

- the channel leg (`api_channel_upload_file`) resolves exclusively through the
  shared, fail-closed, SEL-audited send ladder (`_resolve_mirror_target`);
- the Slack leg (`api_slack_upload_file`) ran its own ladder -- request-named
  channel, session-map DM bypass, thread resolution, owner-DM fallback -- about
  200 lines away, with its own copy of the audit record at each of a dozen
  decision sites.

That is the last surviving sibling of the "two paths, two behaviours" root cause
#6044 closed, flagged by its First Principles review (#6060).

## Why it matters

Nothing about the shape stops the two legs from drifting: adding a rung to one
is a local edit that leaves the other untouched, and the drift is invisible
because no file shows both ladders. The drift is not hypothetical -- the Slack
leg is missing two rungs the channel leg has run since #6044, and finding that
out required reading two handlers side by side, which is exactly the cost this
change removes.

## What changed (motivation -> approach -> change)

**Approach.** #6060 offered three shapes: register Slack in
`channel_transports`, grow a Slack adapter on the ladder, or "extract one
destination oracle both legs consult". The first two are the architecture
decision in step 2 of that issue, and either one changes Slack's authorization
semantics; two triage passes routed the issue to `needs-investigation` for
exactly that reason. The third shape needs no such decision, is
behaviour-preserving, and makes the step-2 call a one-place change afterwards.
That is what this PR does.

**Change.** New `src/kiro_crew/dashboard/upload_destination.py` holds both
resolvers behind one refusal/skip vocabulary:

- `resolve_slack(...)` -- the shipped Slack ladder, moved verbatim, returning
  `SlackTarget | Refusal | Skip`;
- `resolve_channel(...)` -- the shared send ladder plus the restricted-session
  ceiling and the delivery-verb lookup, returning `ChannelTarget | Skip`;
- a module docstring with the rung-by-rung table of what each leg runs.

Each endpoint keeps what is genuinely per-leg: the delivery verb, the HTTP
response shapes (`{"ok": true, "skipped": ...}` vs `delivered: false`), and its
`tool_kind` audit lane. `_audit_file_send` in `handlers/files.py` gives both legs
one audit shape; it omits `downstream_service`/`resources` when unset, exactly as
the shipped call sites did, so a skip still reads differently from a refusal in
the SEL trail.

Deliberately NOT a single `resolve(leg, ...)` dispatcher: each endpoint knows its
leg statically, so a union-typed dispatcher would buy nothing and force both call
sites to unwrap a wider result. What makes it one oracle is that both resolvers
live in one file, share one vocabulary, and are audited through one shape.

**Two ambient lookups are parameters, not imports** (`tracked_probe`,
`persisted_probe`) -- the contract `upload_gate.uploads_restricted` already uses
for its probe. The caller keeps one binding site, the oracle carries neither the
Slack handler's tracked-channel config dependency nor the `handlers` package it
is called from, and every existing `patch(...handlers.files.is_tracked_channel)`
target stays live, which is what let the pinning tests run unmodified.

**One deletion.** The Slack leg re-checked the filename for credentials at its
send site. The shared gate checks the same predicate on the same value strictly
earlier in the same function, so the second copy was unreachable; #6044 made
that gate the one site for the rule, and a second copy could only drift from it.

**One additive change, required by a gate.** `test_error_code_contract` counts a
`json_response(status=<expression>)` as its own bucket -- the scanner cannot see
through it -- so the refusal path does not funnel through one dynamic-status
call. Each answer is spelled out with a literal status and an inline body, and
the three Slack refusals now carry a machine-readable `code`
(`invalid_channel`, `channel_not_tracked`, `channel_not_authorized`) alongside
the prose they already returned. `error-code-baseline.json` records the
resulting improvement (`dashboard/handlers/files.py` `missing_code` 104 -> 100,
`_compliant` 1435 -> 1437); the baseline moves DOWN only. No consumer branches
on these bodies today -- the endpoint is internal to `file_send`, and no
frontend references its codes -- so the field is purely additive.

### Divergence surfaced, not silently unified

Two rungs the channel leg runs and the Slack leg does not:

| rung | channel leg | Slack leg |
| --- | --- | --- |
| `channels`-scope governance (`vet_and_audit`, fail-closed, SEL) | yes, inside `_resolve_channel_target` | NOT RUN |
| restricted-session ceiling (`upload_gate.uploads_restricted`) | yes | NOT RUN |

Closing either one denies a send that succeeds today, so both are named in the
rung table and filed as #7290 rather than changed here. #7290 also records the
identity asymmetry the same decision inherits (the Slack leg is handed a LENIENT
session key, the channel leg the STRICT one) and the shipped precedent worth
weighing first: `chat_compaction_notice._channel_egress_permitted` already vets a
Slack egress against the `channels` scope directly, for the same reason.

The two remaining rows of the table are not divergences to close: Slack's
dedicated client is deliberately absent from `channel_transports`, so the
transport-registration rung does not apply to it; and its resolution stays on the
event loop because `open_dm` is a coroutine, exactly as before.

## Tests

`test/test_file_send_channel.py`: **299 insertions, 0 deletions**. The 22
pre-existing tests -- `TestFileUploadChannel` and `TestFileUploadSlotThreading`
pinning the seven shipped Slack destination outcomes, `TestFileUploadBinary`,
`TestChannelUploadEndpoint` -- are byte-identical and pass against the oracle.
That is the equivalence evidence for this refactor; `test_slack_upload_binary.py`
(which patches the same handler symbols) passes unmodified too.

New `TestDestinationOracleEquivalence` pins what a fold could have silently
changed while leaving those outcomes intact:

- the exact SEL record an untracked-channel refusal writes (kwargs compared
  whole, including `downstream_service`), and that the response still does not
  name the channel;
- that a skip carries NO `downstream_service`, so "nowhere to send" stays
  distinguishable from "refused to send there";
- fail-closed direction when the tracking probe RAISES, on BOTH branches -- the
  request-named one and the session-map one where the `D`-prefix short-circuit
  does not apply;
- that the `D`-prefix short-circuit is evaluated FIRST (a system-created DM link
  uploads without consulting the probe at all);
- that a non-linkable key (`cron:`) never reads the session map and falls back to
  the owner DM;
- that an unreadable credential store is a skip, not a 500;
- that the admission gate runs before any destination work, so a rejected upload
  cannot open a DM or read the session map as a side effect;
- structurally, that neither handler carries `get_slack_link` / `open_dm` /
  `_resolve_mirror_target` / `may_send_to` any more and the oracle does -- so
  re-inlining a ladder fails a test instead of passing review.

Run: `pytest test/test_file_send_channel.py test/test_slack_upload_binary.py`
-> 40 passed. `test_error_code_contract.py` -> 6 passed (it caught the
dynamic-status response and the stale count in CI on the first head; both are
fixed above). Adjacent suites `test_admission_gate.py`,
`test_outbox_notify_broadcast.py`, `test_outbox_binary.py`,
`test_dashboard_files_coverage.py`, `test_no_config_dir_in_async.py`,
`test_security_posture.py` -> 182 passed. New module: 99% coverage, 0 uncovered
statements. `black` (the new file is not baselined, so it must be clean), `isort`
and `flake8` clean on all three files; `mypy` clean on both source files.

## Manual verification

N/A -- unit coverage sufficient. Every branch of both resolvers is driven through
the real aiohttp endpoints (`TestClient`/`TestServer`) rather than by calling the
oracle directly, so the tests exercise the same request path a live `file_send`
does; the only unexercised edge is the Slack SDK call itself, which was already
mocked before this change.

## Related Issues

Fixes #6060
Follow-up filed: #7290 (the two rungs the Slack leg still skips, and the
authorization decision they need)

## Pattern harvest

Rule candidate: review-prompt

Pattern: when one behaviour is implemented once per caller ("two paths, two
behaviours"), unifying the ADMISSION half and leaving the DESTINATION half
per-leg reproduces the original defect in the surviving half. A convergence
refactor should name every rung both paths must answer and record which path
skips which -- a table beats a docstring sentence, because the sentence is where
the missing rung hides.
