### PR TITLE
fix(browser): reclaim stranded playwright-cli browser daemons

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -165,12 +165,44 @@ Keeping both locations outside scratch means a daemon remains reachable after
 its agent process or scratch directory is gone. Operator cleanup supplies the
 generated session's `/s` and `/d` paths with the corresponding PWTEST variables
 and then uses the ordinary `playwright-cli -s=<name> close` protocol. Kiro Crew
-does not execute the CLI, connect to the socket, or
-signal a process automatically: proving cross-process ownership and complete
-agent-tree quiescence is not possible from agent-writable filesystem state on
-all supported platforms. Crash orphan reclamation therefore remains open under
-#5986; this change removes the permanent-unreachability root cause and enables
-operator-controlled cleanup without adding unattended close authority.
+never executes the CLI or connects to the socket on its own: a stray has no
+registry entry to resolve and its socket is unlinked by the first refused
+connect, so a registry-driven `close` reclaims nothing.
+
+### Stranded daemon reclamation
+
+Reachability alone does not reclaim a daemon whose agent died, so the orphan
+sweep (`session_pid`) carries a browser-daemon class alongside its MCP,
+gatewayd and work classes. playwright-core spawns the daemon as `node
+<...>/entry/cliDaemon.js <session-name>` with `detached: true` and no `env`
+override, which decides both halves of the identity. Detachment makes it its
+own session and process-group leader, so it is invisible to the teardown child
+snapshot, to `kill_process_tree`, and to the SID ownership test the work class
+uses. Inheriting the environment verbatim puts the generated
+`PLAYWRIGHT_CLI_SESSION` and `KIROCREW_SPAWNED` in its exec-time environ, which
+the kernel holds immutable after exec.
+
+A daemon is reclaimed only when all of these hold: a structural cliDaemon argv
+whose following element is a generated `kc-<8hex>` name; that same name in its
+exec-time environ; the `KIROCREW_SPAWNED` marker; no live process outside the
+daemon's own SID still holding that session; and an age past the work-class
+floor. Ownership is therefore proven from kernel facts alone — argv, exec-time
+environ, session id, process liveness — never from filesystem state a same-UID
+agent could write, which is what made earlier reaper attempts unsafe. The probe
+scans the whole process table rather than a manager-local set, so a peer gateway
+sharing this data home sees and protects its own live sessions. An
+operator-named session is structurally excluded and never signalled; the `kc-`
+prefix is reserved so the two populations cannot be confused. Every stage fails
+closed: non-Linux, an unreadable `/proc`, and an inconclusive per-process read
+all read as "owner alive". The kill signals the process GROUP so the Chromium
+tree goes with the supervisor, TERM first for a clean profile flush, only for a
+genuine isolated group leader, with identity re-verified before escalating to
+SIGKILL and the result SEL-audited.
+
+Deliberately not keyed on the socket path the way the gatewayd class is:
+`Session._connect` unlinks the socket whenever a connect fails, so an absent
+socket records a refused connect rather than an unreachable daemon, and the
+daemon holds its listening descriptor either way.
 
 The generated socket root is rejected when its worst-case AF_UNIX path exceeds
 the upstream 103-byte budget. Before either variable is injected, the installed
@@ -186,8 +218,9 @@ size so an upgrade invalidates it.
 Kiro-Crew-owned lifecycle directories are created
 owner-only and then restricted with the fail-loud platform helper before their
 environment variables are exported. A crash can leave a small per-session
-registry/socket namespace behind; safe connect-test-then-prune remains part of
-#5986 rather than adding unattended deletion authority in this partial fix.
+registry/socket namespace behind. Reclaiming the daemon does not delete that
+namespace: it is two empty directories, and pruning them would need its own
+liveness argument for no memory benefit.
 
 ### Auth
 

--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -1124,6 +1124,192 @@ _MARKED_MCP_LAUNCHER_MARKERS = (
     b"mcp start-server",  # generic ``<launcher> mcp start-server <name>`` shims
 )
 
+# ── Stranded playwright-cli browser daemon (issue #5986) ─────────────────────
+# playwright-core spawns its browser daemon as
+#   ``node <...>/playwright-core/lib/entry/cliDaemon.js <session-name> [flags]``
+# with ``detached: true`` and no ``env`` override (cli-client/session.js
+# ``startDaemon``). Two consequences make it its own orphan class:
+#
+# * detached => it is its own SESSION and PROCESS-GROUP leader, so it is
+#   invisible to the teardown child snapshot, to ``kill_process_tree``, and to
+#   the SID-based ownership test the work class uses (its SID is its own pid).
+# * no env override => it inherits the spawning agent's environment verbatim,
+#   so its EXEC-TIME environ carries both ``KIROCREW_SPAWNED`` and the
+#   generated ``PLAYWRIGHT_CLI_SESSION``. Exec-time environ is kernel-held and
+#   immutable after exec, so it is ownership evidence no process can forge for
+#   another -- unlike any on-disk registry or claim file, which a same-UID
+#   agent can write.
+#
+# Deliberately NOT keyed on the socket path the way the gatewayd class is:
+# ``Session._connect`` UNLINKS the socket whenever a connect fails, so an
+# absent socket means "a client already cleaned up after a refused connect",
+# not "the daemon is unreachable" -- and the daemon holds its listening fd
+# regardless, so absence proves nothing about the browser tree.
+_BROWSER_DAEMON_ENTRY = b"cliDaemon.js"
+
+#: Must track :data:`kiro_crew.browser_cli.launch.SESSION_ENV`. Duplicated as a
+#: literal rather than imported because ``session_pid`` is imported early by
+#: ``acp.runtime`` and must not pull the browser package's import graph onto
+#: that path; a test asserts the two stay equal.
+_BROWSER_SESSION_ENV = "PLAYWRIGHT_CLI_SESSION"
+
+#: Generated-session prefix from ``browser_cli.launch`` (``kc-<8hex>``).
+_BROWSER_SESSION_PREFIX = b"kc-"
+
+# Grace given to a TERMed browser-daemon GROUP before escalating to SIGKILL.
+# Chromium exits on TERM within a second or two; this leaves room for a profile
+# flush without letting a wedged tree hold the sweep's budget.
+_BROWSER_DAEMON_TERM_GRACE_SECONDS = 5.0
+
+
+def _is_generated_browser_session(name: bytes) -> bool:
+    """True for a Kiro-Crew-generated ``kc-<8hex>`` session name.
+
+    Mirrors ``browser_cli.launch._session_leaf``. ONLY generated names are
+    ever sweepable: an operator who named a session (``default``, ``chrome``,
+    an ``attach`` workflow) owns its lifetime, and the ``kc-`` prefix is
+    reserved precisely so the two populations cannot be confused.
+    """
+    if not name.startswith(_BROWSER_SESSION_PREFIX):
+        return False
+    leaf = name[len(_BROWSER_SESSION_PREFIX) :]
+    return len(leaf) == 8 and all(c in b"0123456789abcdef" for c in leaf)
+
+
+def _browser_daemon_session_arg(cmdline: bytes) -> bytes | None:
+    """Generated session name from a cliDaemon cmdline, or ``None``.
+
+    The daemon's argv is ``node <entry>/cliDaemon.js <session-name> [flags]``,
+    so the name is the element immediately following the entry script --
+    matched on the script's BASENAME so an npx/global/vendored install path
+    all resolve. NUL-separated argv ONLY: the space-joined ``ps`` fallback
+    cannot delimit a path containing spaces, and a mis-split argv could pair
+    the script with the wrong token, so anything without NULs fails closed.
+    """
+    args = [a for a in cmdline.split(b"\x00") if a]
+    if len(args) <= 1:
+        return None
+    for index, arg in enumerate(args[:-1]):
+        if arg.rsplit(b"/", 1)[-1] == _BROWSER_DAEMON_ENTRY:
+            name = args[index + 1]
+            return name if _is_generated_browser_session(name) else None
+    return None
+
+
+def _env_value(pid: int, key: str) -> bytes | None:
+    """Exec-time environment value for *key* in *pid*, or ``None`` if unset.
+
+    Deliberately PROPAGATES ``OSError`` instead of swallowing it like
+    :func:`_env_has_kirocrew_marker`: the callers here need to tell "read
+    said the key is absent" apart from "the read failed", because those two
+    outcomes must fail closed in OPPOSITE directions -- an absent owner
+    permits a kill, an unreadable one must forbid it. Linux-only; returns
+    ``None`` elsewhere so every caller fails closed off Linux.
+    """
+    if sys.platform != "linux":
+        return None
+    prefix = key.encode() + b"="
+    environ = Path(f"/proc/{pid}/environ").read_bytes()
+    for item in environ.split(b"\x00"):
+        if item.startswith(prefix):
+            return item[len(prefix) :]
+    return None
+
+
+def _browser_session_owner_alive(pid: int, session: bytes) -> bool:
+    """True while any live process OUTSIDE *pid*'s own tree holds *session*.
+
+    This is the ownership proof, and it is drawn entirely from the kernel.
+    Kiro Crew injects the generated ``PLAYWRIGHT_CLI_SESSION`` into exactly
+    one spawned agent process, so that value in a live process's EXEC-TIME
+    environ means the browser still has an owner. Scanning the whole process
+    table (not a manager-local set) is what makes a peer gateway sharing this
+    data home see its own live sessions and protect them.
+
+    The daemon's own tree is excluded by SID: it is spawned ``detached``, so
+    it is its own session leader and every Chromium child inherits that SID --
+    those inherit the variable too and must not be mistaken for owners.
+
+    FAIL-CLOSED to "alive": an unreadable ``/proc`` listing or an inconclusive
+    per-process read (EACCES, EIO) returns ``True``, so the sweep never kills
+    on a failed probe. A process that VANISHES mid-scan is simply not an
+    owner, which is the one error that is safe to skip.
+    """
+    if sys.platform != "linux":
+        return True
+    try:
+        entries = [e for e in Path("/proc").iterdir() if e.name.isdigit()]
+    except OSError:
+        return True
+    my_uid = os.getuid()
+    for entry in entries:
+        try:
+            other = int(entry.name)
+        except ValueError:
+            continue
+        if other == pid:
+            continue
+        try:
+            if entry.stat().st_uid != my_uid:
+                continue
+        except _PID_VANISHED_ERRORS:
+            continue
+        except OSError:
+            return True
+        if _linux_pid_sid(other) == pid:
+            continue  # the daemon's own detached tree, not an owner
+        try:
+            if _env_value(other, _BROWSER_SESSION_ENV) == session:
+                return True
+        except _PID_VANISHED_ERRORS:
+            continue
+        except OSError:
+            return True
+    return False
+
+
+def _is_sweepable_orphan_browser_daemon(pid: int, cmdline: bytes, age_seconds: float) -> bool:
+    """Fifth positive-identity path: a browser daemon whose owner is gone.
+
+    Positive identity is the conjunction of:
+
+    1. a structural cliDaemon argv carrying a GENERATED ``kc-<8hex>`` session
+       name (:func:`_browser_daemon_session_arg`, NUL-argv only) -- an
+       operator-named session is structurally excluded and never signalled;
+    2. that same name in the process's exec-time environ, which ties this
+       daemon to a name Kiro Crew itself generated rather than one an agent
+       passed with ``-s=``;
+    3. the ``KIROCREW_SPAWNED`` environ marker, proving Kiro Crew spawned the
+       tree (:func:`_env_has_kirocrew_marker`, Linux-only, fail-closed);
+    4. NO live process outside the daemon's own tree still holding that
+       session (:func:`_browser_session_owner_alive`);
+    5. age past :data:`_ORPHAN_WORK_MIN_AGE_SECONDS` -- the generous work-class
+       floor, not the 120s MCP one, so a daemon whose agent is mid-spawn or
+       briefly detached is never raced.
+
+    Every signal is a kernel fact (argv, exec-time environ, SID, process
+    liveness). Nothing here reads agent-writable filesystem state, which is
+    what made the previously withdrawn reapers unsafe.
+    """
+    if age_seconds < _ORPHAN_WORK_MIN_AGE_SECONDS:
+        return False
+    if not cmdline:
+        return False  # kernel thread / zombie — nothing meaningful to kill
+    normalized = cmdline.replace(b"\x00", b" ")
+    if any(marker in normalized for marker in _GATEWAY_MARKERS):
+        return False
+    session = _browser_daemon_session_arg(cmdline)
+    if session is None:
+        return False
+    try:
+        if _env_value(pid, _BROWSER_SESSION_ENV) != session:
+            return False
+    except OSError:
+        return False  # inconclusive — fail closed
+    if not _env_has_kirocrew_marker(pid):
+        return False
+    return not _browser_session_owner_alive(pid, session)
+
 
 def _our_orphan_pids() -> list[int]:
     """PIDs owned by current user whose parent is init (pid 1) or systemd --user.
@@ -1392,6 +1578,57 @@ def _kill_orphan_gatewayd(pid: int, cmdline: bytes) -> int:
     except (ProcessLookupError, OSError):
         pass
     _sel_orphan_kill(pid, pid, cmdline, "sigterm+sigkill")
+    return 1
+
+
+def _kill_orphan_browser_daemon(pid: int, cmdline: bytes) -> int:
+    """Group-TERM a stranded browser daemon, escalating to a group SIGKILL.
+
+    Signals the process GROUP, not the pid. The daemon is spawned
+    ``detached``, so it is its own group leader and its Chromium children
+    inherit that group -- the browser tree is the whole point of the reclaim
+    (it is where the gigabytes are), and a pid-only signal would kill the
+    supervisor and leave Chromium reparented to init as a fresh, now
+    completely unattributable leak.
+
+    TERM first so Chromium exits through its own shutdown path and flushes
+    its profile. The group is signalled only when the daemon is genuinely an
+    isolated leader (``pgid == pid``, not our own group, not init's), so
+    ``killpg`` can never reach a foreign process; identity is re-verified
+    before the escalation so a PID recycled inside the grace window is never
+    SIGKILLed.
+    """
+    try:
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        return 0
+    if not (pgid == pid and pgid != os.getpgrp() and pgid > 1):
+        # Not an isolated group leader: killpg would reach processes this
+        # predicate never identified. Leave it for a later sweep.
+        return 0
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        return 0
+    deadline = time.monotonic() + _BROWSER_DAEMON_TERM_GRACE_SECONDS
+    while time.monotonic() < deadline:
+        # platform_compat.pid_exists, not a raw `os.kill(pid, 0)`: on Windows a
+        # signal-zero "probe" TERMINATES the target instead of testing it. This
+        # path is POSIX-only in practice, but routing through the shim keeps it
+        # correct on its own terms rather than depending on a caller's early-out.
+        if not platform_compat.pid_exists(pid):
+            _sel_orphan_kill(pid, pgid, cmdline, "browser-daemon-sigterm")
+            return 1
+        time.sleep(0.1)
+    try:
+        if sys.platform == "linux":
+            if Path(f"/proc/{pid}/cmdline").read_bytes() != cmdline:
+                _sel_orphan_kill(pid, pgid, cmdline, "browser-daemon-sigterm")
+                return 1
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    _sel_orphan_kill(pid, pgid, cmdline, "browser-daemon-sigterm+sigkill")
     return 1
 
 
@@ -1679,6 +1916,7 @@ def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
             _is_sweepable_orphan_mcp(pid, cmdline)
             or _is_sweepable_orphan_gatewayd(cmdline)
             or _is_sweepable_orphan_work(pid, cmdline, pid_age)
+            or _is_sweepable_orphan_browser_daemon(pid, cmdline, pid_age)
         ):
             continue
         candidates.append(pid)
@@ -1812,6 +2050,14 @@ def kill_orphan_mcps(pids: list[int]) -> int:
                 killed += _kill_orphan_work_tree(
                     pid, cmdline, work_age, budget=_ORPHAN_SWEEP_MAX_KILLS - killed
                 )
+                continue
+            # Stranded browser daemon. Re-verify the FULL identity — argv
+            # shape, exec-time environ, live-owner probe and the age floor —
+            # immediately before signalling, so a PID recycled since the find
+            # phase cannot inherit the verdict.
+            daemon_age = _linux_pid_age(pid, time.time()) if sys.platform == "linux" else 0.0
+            if _is_sweepable_orphan_browser_daemon(pid, cmdline, daemon_age):
+                killed += _kill_orphan_browser_daemon(pid, cmdline)
         except (
             ProcessLookupError,
             PermissionError,

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -2754,3 +2754,230 @@ class TestUntrackedRuntimeReportIntegration:
 
         assert result == []
         assert [r for r in caplog.records if "4646" in r.getMessage()] == []
+
+
+# ── Orphaned playwright-cli browser daemon sweep (issue #5986) ───────────────
+
+#: A realistic NUL-separated cliDaemon argv. playwright-core spawns the daemon
+#: as ``node <...>/entry/cliDaemon.js <sessionName> [flags]`` (see
+#: cli-client/session.js ``startDaemon``), so the session name is the argv
+#: element immediately after the entry script.
+_DAEMON_CMDLINE = (
+    b"/usr/bin/node\x00"
+    b"/home/u/.npm/_npx/e41f/node_modules/playwright-core/lib/entry/cliDaemon.js\x00"
+    b"kc-1a2b3c4d\x00--headed"
+)
+_OPERATOR_DAEMON_CMDLINE = (
+    b"/usr/bin/node\x00"
+    b"/home/u/.npm/_npx/e41f/node_modules/playwright-core/lib/entry/cliDaemon.js\x00"
+    b"chrome"
+)
+
+
+class TestBrowserDaemonSessionArg:
+    """Structural extraction of the generated session name from daemon argv."""
+
+    def test_extracts_generated_session_name(self) -> None:
+        from kiro_crew.session_pid import _browser_daemon_session_arg
+
+        assert _browser_daemon_session_arg(_DAEMON_CMDLINE) == b"kc-1a2b3c4d"
+
+    def test_rejects_operator_named_session(self) -> None:
+        """Only Kiro-Crew-generated ``kc-<8hex>`` names are ever sweepable."""
+        from kiro_crew.session_pid import _browser_daemon_session_arg
+
+        assert _browser_daemon_session_arg(_OPERATOR_DAEMON_CMDLINE) is None
+
+    def test_rejects_space_joined_cmdline(self) -> None:
+        """A ps-style space-joined cmdline cannot delimit argv safely."""
+        from kiro_crew.session_pid import _browser_daemon_session_arg
+
+        assert _browser_daemon_session_arg(_DAEMON_CMDLINE.replace(b"\x00", b" ")) is None
+
+    def test_rejects_non_daemon_cmdline(self) -> None:
+        from kiro_crew.session_pid import _browser_daemon_session_arg
+
+        assert _browser_daemon_session_arg(b"/usr/bin/node\x00server.js\x00kc-1a2b3c4d") is None
+
+    def test_session_env_name_matches_launch_module(self) -> None:
+        """Drift ratchet: the local constant must track the real env var."""
+        from kiro_crew.browser_cli.launch import SESSION_ENV
+        from kiro_crew.session_pid import _BROWSER_SESSION_ENV
+
+        assert _BROWSER_SESSION_ENV == SESSION_ENV
+
+
+class TestBrowserDaemonOrphanSweep:
+    """A stranded generated-session daemon is reclaimed; a live one never is."""
+
+    def test_dead_owner_daemon_is_a_candidate(self) -> None:
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[800]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_DAEMON_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=900.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch("kiro_crew.session_pid._env_value", return_value=b"kc-1a2b3c4d"),
+            patch(
+                "kiro_crew.session_pid._browser_session_owner_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            assert find_orphan_mcp_candidates(active_pids=set()) == [800]
+
+    def test_live_owner_daemon_is_never_a_candidate(self) -> None:
+        """The safety invariant: a live agent's browser is never reclaimed."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[801]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_DAEMON_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=900.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch("kiro_crew.session_pid._env_value", return_value=b"kc-1a2b3c4d"),
+            patch(
+                "kiro_crew.session_pid._browser_session_owner_alive",
+                return_value=True,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            assert find_orphan_mcp_candidates(active_pids=set()) == []
+
+    def test_operator_session_daemon_is_never_a_candidate(self) -> None:
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[802]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_OPERATOR_DAEMON_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=900.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch("kiro_crew.session_pid._env_value", return_value=b"chrome"),
+            patch(
+                "kiro_crew.session_pid._browser_session_owner_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            assert find_orphan_mcp_candidates(active_pids=set()) == []
+
+    def test_unmarked_daemon_is_never_a_candidate(self) -> None:
+        """No ``KIROCREW_SPAWNED`` marker means we did not spawn this tree."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[803]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_DAEMON_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=900.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=False),
+            patch("kiro_crew.session_pid._env_value", return_value=b"kc-1a2b3c4d"),
+            patch(
+                "kiro_crew.session_pid._browser_session_owner_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            assert find_orphan_mcp_candidates(active_pids=set()) == []
+
+    def test_young_daemon_is_never_a_candidate(self) -> None:
+        """The work-class age floor applies: a fresh daemon is never raced."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[804]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_DAEMON_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=200.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch("kiro_crew.session_pid._env_value", return_value=b"kc-1a2b3c4d"),
+            patch(
+                "kiro_crew.session_pid._browser_session_owner_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            assert find_orphan_mcp_candidates(active_pids=set()) == []
+
+    def test_env_argv_session_mismatch_is_never_a_candidate(self) -> None:
+        """argv name must be the generated name this process was exec'd with."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[805]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_DAEMON_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=900.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch("kiro_crew.session_pid._env_value", return_value=b"kc-99999999"),
+            patch(
+                "kiro_crew.session_pid._browser_session_owner_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            assert find_orphan_mcp_candidates(active_pids=set()) == []
+
+
+class TestBrowserSessionOwnerAlive:
+    """The ownership probe reads only exec-time environ, never on-disk state."""
+
+    def test_live_peer_holding_the_session_reads_as_alive(self) -> None:
+        from kiro_crew import session_pid as sp
+
+        with (
+            patch.object(sp, "sys") as mock_sys,
+            patch.object(Path, "iterdir", return_value=[Path("/proc/900"), Path("/proc/901")]),
+            patch.object(Path, "stat", return_value=Mock(st_uid=os.getuid())),
+            patch.object(sp, "_linux_pid_sid", return_value=1),
+            patch.object(sp, "_env_value", return_value=b"kc-1a2b3c4d"),
+        ):
+            mock_sys.platform = "linux"
+            assert sp._browser_session_owner_alive(900, b"kc-1a2b3c4d") is True
+
+    def test_only_the_daemons_own_tree_reads_as_dead(self) -> None:
+        """Chromium children share the daemon's SID and are not owners."""
+        from kiro_crew import session_pid as sp
+
+        with (
+            patch.object(sp, "sys") as mock_sys,
+            patch.object(Path, "iterdir", return_value=[Path("/proc/900"), Path("/proc/901")]),
+            patch.object(Path, "stat", return_value=Mock(st_uid=os.getuid())),
+            patch.object(sp, "_linux_pid_sid", return_value=900),
+            patch.object(sp, "_env_value", return_value=b"kc-1a2b3c4d"),
+        ):
+            mock_sys.platform = "linux"
+            assert sp._browser_session_owner_alive(900, b"kc-1a2b3c4d") is False
+
+    def test_unreadable_peer_fails_closed_to_alive(self) -> None:
+        from kiro_crew import session_pid as sp
+
+        def _boom(pid: int, key: str) -> bytes | None:
+            raise PermissionError("inconclusive")
+
+        with (
+            patch.object(sp, "sys") as mock_sys,
+            patch.object(Path, "iterdir", return_value=[Path("/proc/901")]),
+            patch.object(Path, "stat", return_value=Mock(st_uid=os.getuid())),
+            patch.object(sp, "_linux_pid_sid", return_value=1),
+            patch.object(sp, "_env_value", side_effect=_boom),
+        ):
+            mock_sys.platform = "linux"
+            assert sp._browser_session_owner_alive(900, b"kc-1a2b3c4d") is True
+
+    def test_non_linux_fails_closed_to_alive(self) -> None:
+        from kiro_crew import session_pid as sp
+
+        with patch.object(sp, "sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            assert sp._browser_session_owner_alive(900, b"kc-1a2b3c4d") is True


### PR DESCRIPTION
## What is the problem?

A `playwright-cli` browser daemon started by an agent is never reclaimed. It
outlives its agent, reparents away, and keeps a Chromium tree resident
indefinitely. Measured on one long-running gateway host: **19 `cliDaemon`
processes**, oldest **4 days 8 hours**, with roughly **10.7 GB** belonging to
daemons no live session claimed.

Nothing on `main` can reach them. `playwright-core` spawns the daemon with
`detached: true`, so it becomes its own **session and process-group leader**.
That single fact defeats every existing reclamation path at once:

- the teardown child snapshot in `AcpClient._kill_process` walks descendants of
  the agent pid, and a process that detached at launch was never a descendant;
- `kill_process_tree` signals the agent's group, which the daemon left;
- `_is_sweepable_orphan_work` proves ownership through the session id, but the
  daemon's SID is its own pid, so SID carries no owner information;
- the MCP orphan sweep gates on `@playwright/mcp` / `mcp start-server` launcher
  shapes, and a `cliDaemon.js` cmdline matches neither.

PR #6083 fixed *reachability* (moving the socket and registry out of per-process
scratch) and said so explicitly: crash-orphan reclamation stayed open here.

## Why this issue matters to the user

This is the single largest resident-memory leak on a long-lived host, and it is
invisible: the processes are attributable to nobody, so a user sees the box
slowly fill with gigabytes and has no way to tell a stray from a live browser.
The only routine remedy today is `playwright-cli close-all` by hand, which also
destroys the browsers of every live session.

It also compounds: on this repo's own hosts, memory pressure in
`kirocrew-agents.slice` is what turns into ACP timeouts and throttling, so
stranded browser trees degrade unrelated work.

## How our fix solves it

The hard part was never killing the process, it was **proving ownership**. Two
earlier attempts were withdrawn for exactly that reason, and this fix is shaped
by both failures:

- a sweep that releases via `playwright-cli -s=<name> close` (removed in #5960)
  reclaims *nothing*: only 5 of the 19 strays had a registry entry at all, and
  `close` resolves a name through that registry, so it answers "not open";
- a reaper authorized from scratch/registry state (withdrawn in #6083) is
  forgeable, because those files are writable by a same-UID agent.

The unforgeable signal comes from how the daemon is spawned. `startDaemon`
passes **no `env` override**, so the daemon inherits the agent's environment
verbatim and its **exec-time environ** carries both the generated
`PLAYWRIGHT_CLI_SESSION` and `KIROCREW_SPAWNED`. The kernel holds exec-time
environ immutable, so no process can rewrite it: not for itself after exec, and
not for another process ever.

This adds a fifth positive-identity class to the existing orphan sweep, keyed
only on kernel facts. A daemon is reclaimed only when **all** hold:

1. a structural `cliDaemon.js` argv whose following element is a Kiro-Crew
   **generated** `kc-<8hex>` session name (NUL-argv only, since a space-joined
   `ps` line cannot delimit a path safely, so it fails closed);
2. that same name in the process's exec-time environ, tying it to a name the
   gateway generated rather than one an agent passed with `-s=`;
3. the `KIROCREW_SPAWNED` marker, proving Kiro Crew spawned the tree;
4. **no live process outside the daemon's own SID** still holding that session;
5. age past the generous work-class floor, not the 120s MCP one.

Two properties answer the objections that sank the previous attempts. The owner
probe scans the **whole process table**, not a manager-local set, so a peer
gateway sharing this data home sees and protects its own live sessions. And
**operator-named sessions are structurally excluded**: the `kc-` prefix is
reserved, so a `default`/`chrome`/`attach` session is never a candidate.

Every stage fails closed to "owner alive". Non-Linux, an unreadable `/proc`, and
an inconclusive per-process read all decline to sweep. A process that vanishes
mid-scan is simply not an owner, which is the one error safe to skip.

The kill signals the **process group**, not the pid. The Chromium tree is where
the gigabytes are, and a pid-only signal would kill the supervisor and leave the
browser reparented to init as a fresh, now completely unattributable leak. TERM
first for a clean profile flush, only for a genuine isolated group leader
(`pgid == pid`, not our group, not init's) so `killpg` can never reach a
stranger, with identity re-verified before escalating to SIGKILL, and the result
SEL-audited.

Deliberately **not** keyed on the socket path the way the gatewayd class is:
`Session._connect` unlinks the socket whenever a connect fails, so an absent
socket records a refused connect rather than an unreachable daemon, and the
daemon holds its listening descriptor either way. Reusing that predicate here
would have been actively wrong.

## What tests we did

`test/test_pid_lifecycle.py`, 15 new tests, deterministic, with a faked process
table (no real daemons spawned), following the established
`patch(_our_orphan_pids) + Path.read_bytes` style:

- a stranded generated-session daemon **is** a candidate;
- a daemon whose session is still held by a live process is **never** a
  candidate (the core safety invariant);
- operator-named, unmarked, too-young, and env/argv-mismatched daemons are never
  candidates;
- the argv extractor accepts only generated names and only NUL-separated argv;
- the owner probe excludes the daemon's own tree by SID, and fails closed to
  "alive" on both an inconclusive read and off Linux;
- a drift ratchet asserts the local env-var constant still equals
  `browser_cli.launch.SESSION_ENV`.

Verified **RED on baseline first** (15 failed before the fix), then green.

**Mutation-verified.** Each safety guard was removed in turn and the intended
test reddened, then restored:

| Mutation | Test that caught it |
|---|---|
| drop the live-owner check | `test_live_owner_daemon_is_never_a_candidate` |
| accept any session name | `test_rejects_operator_named_session` plus `test_operator_session_daemon_is_never_a_candidate` |
| allow space-joined argv | `test_rejects_space_joined_cmdline` |
| drop the SID exclusion | `test_only_the_daemons_own_tree_reads_as_dead` |
| drop the env/argv cross-check | `test_env_argv_session_mismatch_is_never_a_candidate` |

The name-gate mutation initially survived the integration test, which was
passing for an unrelated reason; that test was strengthened until the mutation
killed it.

Gates: `test/test_pid_lifecycle.py` 168 passed, `test/test_spawn_audit.py` 12
passed, isort and flake8 clean, `black` clean on the new code under the pinned
`26.3.1` (the 6 hunks it reports in `test_pid_lifecycle.py` are pre-existing,
all between lines 475 and 1972; the added block starts at 2759 and draws none).
`mypy --platform linux` reports 2 errors in `transcribe.py` only, pre-existing
boto3-stub drift, untouched here; `session_pid.py` itself is clean.

## Any other suggestions on the work

- **macOS and Windows are unreclaimed.** The ownership proof needs exec-time
  environ, which only `/proc` provides, so both fail closed to "never sweep".
  That is the correct posture, and the same one `_is_sweepable_orphan_work` and
  `_env_has_kirocrew_marker` already ship, but the leak persists there and
  deserves its own issue rather than a weaker authority here.
- **Two strays sharing one generated name protect each other.** If a daemon's
  socket was unlinked and the same agent spawned a second daemon under the same
  name, each reads as the other's live owner and both are kept. Fail-safe, and
  narrow (names are per-agent-process), but worth recording.
- **The leftover namespace is not pruned.** A crash leaves two empty
  directories under `<data-home>/pw/<8hex>/`. Reclaiming the process does not
  delete them; pruning would need its own liveness argument for no memory
  benefit.
- I did **not** re-litigate the withdrawn process-table reaper and added no CLI
  execution or socket connection. The `browser.md` spec sentence that declared
  automatic signalling a non-goal was narrowed rather than deleted: its stated
  reason was that ownership cannot be proven *from agent-writable filesystem
  state*, which this mechanism never reads.

## Pattern harvest

Rule candidate: review checklist, deliberately not semgrep
Pattern: an orphan-reclamation predicate that draws its kill authority from
filesystem state the judged process can itself write.

This is the third attempt at this fix and the first two died of exactly that,
which makes it a pattern rather than a one-off: #5960 keyed release on the
playwright registry, #6083 keyed it on scratch metadata, and both are writable
by a same-UID agent, so each turned a fail-closed verb into a forgeable
unattended kill.

The obvious mechanical rule -- flag `os.stat` / `Path.exists` on a
`config_dir()`-derived path inside an `_is_sweepable_orphan_*` body -- would
**misfire on the legitimate case**, so I am not proposing it. The gatewayd class
stats exactly such a path, and that is sound there: gatewayd creates its own
socket and self-exits on ENOENT, so the path is self-owned evidence rather than
third-party state. A rule that cannot tell those apart would train reviewers to
dismiss it.

The durable form is a question asked of every new reap class: **name the kernel
fact that proves ownership, and show the judged process cannot alter it.** Here
that is exec-time `/proc/<pid>/environ`, which the kernel freezes at exec.

**Second, narrower pattern, mechanically checkable:** *a third-party process we
spawn that detaches (`detached: true` / `start_new_session=True`) is unreachable
by every lineage-based teardown at once.* Four independent mechanisms failed
here for one shared reason -- descendant snapshot, `kill_process_tree`, SID
ownership, and launcher-shape matching -- because all four key on lineage the
detach severs. Worth a grep over spawn sites of third-party binaries for
detach flags, each of which needs an explicit ownership channel injected at
spawn plus its own reclamation class.

Fixes #5986
