### PR TITLE
fix(session-digest): bound the record reads over agent-writable session trees

### DIFF
--- a/src/kiro_crew/session_digest.py
+++ b/src/kiro_crew/session_digest.py
@@ -1,21 +1,109 @@
 """Lazy per-session detail: first message, real turn count, image count.
 
-Called once when a row expands in the storage inventory UI.  Streams files
-line-by-line so multi-GB sessions never load into memory.  Degrades to
-empty/zero on any malformed or unreadable file rather than raising.
+Called once when a row expands in the storage inventory UI.  Reads files one
+capped record at a time so neither a multi-GB session nor a single crafted
+newline-free line loads into memory.  Degrades to empty/zero on any malformed,
+over-cap, or unreadable file rather than raising.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import IO
 
 from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.history import ARCHIVE_DIR_NAME, ARCHIVE_SEGMENT_DELIMITER, SESSIONS_DIR_NAME
 
 logger = logging.getLogger(__name__)
+
+# Longest record this module will materialise, in BYTES (terminator excluded: the
+# threshold applies to the record without its newline, so a cap-length record plus
+# its terminator is accepted and the peak read is cap+1). Both trees read here are
+# agent-writable, so `for line in handle` would hand one crafted newline-free line
+# a single allocation the size of the whole file.
+#
+# The bound is in bytes, not characters, and the files are opened binary for that
+# reason: a character cap is not a memory bound, because one astral code point is
+# four bytes of `str` under PEP 393, so a 256 MiB CHARACTER cap admits a gibibyte
+# of resident text. Decoding cannot widen a record past its byte count -- UTF-8
+# spends at least as many bytes per code point as CPython's widest string
+# representation -- so capping the read at N bytes caps the decoded `str` at N
+# bytes too, and the transient peak is a small constant multiple of this value,
+# flat in file size.
+#
+# The cap CANNOT be session_storage's ``_MANIFEST_RECORD_CAP`` (8 MiB): a manifest
+# record is a header or one session's file list, while these files carry whole
+# conversation turns. A legitimate record's ceiling is ~90 MB -- image_artifacts'
+# ``MAX_IMAGE_BYTES_PER_MESSAGE`` (64 MiB) base64-expands to ~85 MB, plus text --
+# and the largest observed on a live install (30,351 kiro-cli logs, 27 GB) is
+# 77,920,032 bytes, itself load-bearing: it carries an image content item, and the
+# largest ``Prompt`` record (turns and first_message) is 56,203,168 bytes. A cap
+# below those would silently undercount the biggest sessions, so 128 MiB is the
+# smallest round value that clears the derived ceiling with margin. This constant
+# is the dial if a legitimate record ever grows past it.
+_RECORD_CAP = 128 * 1024 * 1024
+
+
+def _bounded_lines(handle: IO[bytes], path: Path) -> Iterator[str]:
+    """Yield *handle*'s lines decoded, skipping any record over ``_RECORD_CAP`` bytes.
+
+    *handle* is BINARY so the cap can be a memory bound rather than a code-point
+    count (see ``_RECORD_CAP``). Decoding per record is equivalent to decoding the
+    whole file, because ``\\n`` is never part of a UTF-8 multi-byte sequence -- lead
+    and continuation bytes are all >= 0x80 -- so no sequence can straddle a record
+    boundary and be replaced differently than it would have been.
+
+    Record boundaries are ``readline``'s, which is what the ``for line in handle``
+    iteration this replaces used: a record containing an exotic line boundary
+    (``\\u2028``, ``\\x1c``, ...) stays one record and still parses. Using
+    ``str.splitlines`` here -- the shape
+    :func:`kiro_crew.session_storage._manifest_records` needs, because its reader
+    replaced a whole-file ``splitlines`` -- would split such a record in two and
+    lose the turn it describes. Binary reads narrow this in one direction only:
+    a lone ``\\r`` no longer ends a record, since universal-newline translation is
+    gone. Neither writer of these files emits one, and a planted file that does is
+    read as one over-cap record and skipped, which is the safe direction. A
+    ``\\r\\n`` terminator survives, because every caller strips the record first --
+    it only shifts the boundary by one byte, since the ``\\r`` counts toward the
+    read and a ``\\r\\n``-terminated record is therefore refused one byte sooner
+    than an ``\\n``-terminated one. Immaterial at this cap; stated so a future
+    reader does not read the threshold as byte-exact on a CRLF file.
+
+    An over-cap record is SKIPPED and its tail drained without being kept, so a
+    hostile file costs time proportional to its length and memory proportional to
+    the cap. Skipping is the right posture for these three callers and the wrong
+    one for the manifest reader: nothing here feeds a rewrite, the digest is
+    read-only per-row detail that already skips a malformed line and keeps going
+    (see the module docstring), so an over-cap record degrades exactly one row's
+    counts. ``restore()`` in session_storage rewrites the manifest from what it
+    parsed, which is why an over-cap record there aborts the whole read instead.
+    """
+    oversized = 0
+    while True:
+        # Reading cap+1 makes the verdict unambiguous: a returned chunk shorter
+        # than that either ended on a newline or hit EOF, so it is a whole record.
+        raw = handle.readline(_RECORD_CAP + 1)
+        if not raw:
+            break
+        if len(raw) > _RECORD_CAP and not raw.endswith(b"\n"):
+            oversized += 1
+            while True:
+                tail = handle.readline(_RECORD_CAP + 1)
+                if not tail or tail.endswith(b"\n"):
+                    break
+            continue
+        yield raw.decode("utf-8", errors="replace")
+    if oversized:
+        # %r: *path* names a file in an agent-writable tree, and the archive
+        # segments are discovered with iterdir(), so a planted name can embed a
+        # newline. The repr keeps one log record from forging others.
+        logger.debug(
+            "digest: skipped %d record(s) over %d bytes in %r", oversized, _RECORD_CAP, path
+        )
 
 
 @dataclass(frozen=True)
@@ -100,14 +188,15 @@ def digest(uid: str, stems: tuple[str, ...], sid: str) -> SessionDigest:
 def _scan_transcript(path: Path) -> tuple[str, int]:
     """Stream a transcript file and extract (first_user_message, user_turn_count).
 
-    Skips metadata/archive header lines. Never raises.
+    Skips metadata/archive header lines, and any record over ``_RECORD_CAP``
+    bytes (see :func:`_bounded_lines`, which also owns the decode). Never raises.
     """
     first_msg = ""
     turn_count = 0
 
     try:
-        with open(path, encoding="utf-8", errors="replace") as f:
-            for line in f:
+        with open(path, "rb") as f:
+            for line in _bounded_lines(f, path):
                 line = line.strip()
                 if not line:
                     continue
@@ -115,7 +204,7 @@ def _scan_transcript(path: Path) -> tuple[str, int]:
                     record = json.loads(line)
                 except ValueError:
                     # Malformed line: skip, don't lose the rest
-                    logger.debug("digest: skipping malformed line in %s", path)
+                    logger.debug("digest: skipping malformed line in %r", path)
                     continue
 
                 if not isinstance(record, dict):
@@ -132,7 +221,7 @@ def _scan_transcript(path: Path) -> tuple[str, int]:
                         if not first_msg and content.strip():
                             first_msg = _collapse_whitespace(content, 280)
     except OSError:
-        logger.debug("digest: cannot read transcript %s", path)
+        logger.debug("digest: cannot read transcript %r", path)
 
     return first_msg, turn_count
 
@@ -142,14 +231,15 @@ def _scan_cli_log(path: Path) -> tuple[int, int]:
 
     User turns are lines with ``kind == "Prompt"``.
     Images are content items with ``kind == "image"`` in any record.
+    Records over ``_RECORD_CAP`` bytes are skipped (see :func:`_bounded_lines`).
     Never raises.
     """
     turns = 0
     images = 0
 
     try:
-        with open(path, encoding="utf-8", errors="replace") as f:
-            for line in f:
+        with open(path, "rb") as f:
+            for line in _bounded_lines(f, path):
                 line = line.strip()
                 if not line:
                     continue
@@ -174,7 +264,7 @@ def _scan_cli_log(path: Path) -> tuple[int, int]:
                             if isinstance(item, dict) and item.get("kind") == "image":
                                 images += 1
     except OSError:
-        logger.debug("digest: cannot read cli log %s", path)
+        logger.debug("digest: cannot read cli log %r", path)
 
     return turns, images
 
@@ -183,11 +273,12 @@ def _first_message_from_cli(path: Path) -> str:
     """Extract the first user message text from a kiro-cli event log.
 
     Returns the text of the first Prompt record's first text content item.
+    Records over ``_RECORD_CAP`` bytes are skipped (see :func:`_bounded_lines`).
     Never raises.
     """
     try:
-        with open(path, encoding="utf-8", errors="replace") as f:
-            for line in f:
+        with open(path, "rb") as f:
+            for line in _bounded_lines(f, path):
                 line = line.strip()
                 if not line:
                     continue
@@ -218,7 +309,7 @@ def _first_message_from_cli(path: Path) -> str:
                 # Prompt found but no text content
                 return ""
     except OSError:
-        logger.debug("digest: cannot read cli log %s for first_message", path)
+        logger.debug("digest: cannot read cli log %r for first_message", path)
 
     return ""
 

--- a/test/test_session_digest.py
+++ b/test/test_session_digest.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from kiro_crew import session_digest
 from kiro_crew.session_digest import SessionDigest, _collapse_whitespace, digest
 
 
@@ -489,3 +490,341 @@ class TestMultipleStems:
         assert result.turns == 2
         # First message comes from the first stem's file (ordered by stems tuple)
         assert result.first_message == "First msg on legacy stem"
+
+
+class _SpyHandle:
+    """Wraps a real file handle, recording how the reader draws bytes from it."""
+
+    def __init__(self, real: object) -> None:
+        self._real = real
+        self.readline_limits: list[int] = []
+        self.iterated = False
+
+    def readline(self, limit: int = -1) -> str:
+        self.readline_limits.append(limit)
+        return self._real.readline(limit)  # type: ignore[attr-defined]
+
+    def __iter__(self) -> object:
+        # `for line in handle` — the unbounded shape this fix removes.
+        self.iterated = True
+        return iter(self._real)  # type: ignore[call-overload]
+
+    def __enter__(self) -> _SpyHandle:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._real.__exit__(*exc)  # type: ignore[attr-defined]
+
+
+def _user_record_of_length(total: int) -> str:
+    """A JSON user record whose serialized form is exactly *total* characters."""
+    pad = total - len(json.dumps({"role": "user", "content": ""}))
+    assert pad >= 0, "requested length is shorter than the record envelope"
+    return json.dumps({"role": "user", "content": "x" * pad})
+
+
+class TestBoundedRecords:
+    """A crafted newline-free record must not be materialised (#6345).
+
+    Both trees read here are agent-writable, so `for line in handle` let one
+    line without a newline in it allocate the whole file. These tests pin the
+    cap's behaviour with a small patched cap; the real one is 256 MiB.
+    """
+
+    def test_over_cap_transcript_record_is_skipped(self, sessions_dir: Path, cli_dir: Path) -> None:
+        """An over-cap user record contributes neither a turn nor first_message."""
+        path = sessions_dir / "over_cap.jsonl"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"_type": "metadata", "created_at": "x"}) + "\n")
+            f.write(json.dumps({"role": "user", "content": "H" * 400}) + "\n")
+            f.write(json.dumps({"role": "user", "content": "kept"}) + "\n")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", 200, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("over_cap", ("over_cap",), "sid-nope")
+
+        assert result.turns == 1
+        assert result.first_message == "kept"
+
+    def test_transcript_handle_is_never_read_unbounded(
+        self, sessions_dir: Path, cli_dir: Path
+    ) -> None:
+        """Every read carries a limit, and the handle is never iterated."""
+        _write_transcript(
+            sessions_dir / "bounded.jsonl",
+            [
+                {"_type": "metadata", "created_at": "x"},
+                {"role": "user", "content": "hello"},
+            ],
+        )
+        spies: list[_SpyHandle] = []
+        real_open = open
+
+        def _spy_open(*args: object, **kwargs: object) -> _SpyHandle:
+            spy = _SpyHandle(real_open(*args, **kwargs))  # type: ignore[arg-type]
+            spies.append(spy)
+            return spy
+
+        with (
+            patch("kiro_crew.session_digest.open", _spy_open),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("bounded", ("bounded",), "sid-nope")
+
+        assert result.turns == 1
+        assert spies, "the transcript was never opened"
+        for spy in spies:
+            assert not spy.iterated, "the handle was iterated, so one line is unbounded"
+            assert spy.readline_limits, "no bounded read was issued"
+            cap = session_digest._RECORD_CAP
+            assert all(0 < limit <= cap + 1 for limit in spy.readline_limits)
+
+    def test_record_exactly_at_cap_survives(self, sessions_dir: Path, cli_dir: Path) -> None:
+        """The cap is inclusive: a record of exactly cap bytes still counts."""
+        cap = 200
+        path = sessions_dir / "at_cap.jsonl"
+        # newline="" so the terminator is one byte on every platform: text mode
+        # would write CRLF on Windows, pushing a cap-byte record to cap+1 bytes
+        # with no LF in the first read and making it look over-cap.
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(_user_record_of_length(cap) + "\n")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("at_cap", ("at_cap",), "sid-nope")
+
+        assert result.turns == 1
+
+    def test_record_one_over_cap_is_skipped(self, sessions_dir: Path, cli_dir: Path) -> None:
+        """One byte past the cap is already over it."""
+        cap = 200
+        path = sessions_dir / "over_by_one.jsonl"
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(_user_record_of_length(cap + 1) + "\n")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("over_by_one", ("over_by_one",), "sid-nope")
+
+        assert result.turns == 0
+
+    def test_drain_resumes_at_the_next_record(self, sessions_dir: Path, cli_dir: Path) -> None:
+        """A record several caps long is drained, not lost mid-way, and the scan continues."""
+        cap = 100
+        path = sessions_dir / "deep_drain.jsonl"
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(json.dumps({"role": "user", "content": "H" * (cap * 7)}) + "\n")
+            f.write(json.dumps({"role": "user", "content": "first kept"}) + "\n")
+            f.write(json.dumps({"role": "user", "content": "second kept"}) + "\n")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("deep_drain", ("deep_drain",), "sid-nope")
+
+        assert result.turns == 2
+        assert result.first_message == "first kept"
+
+    def test_unterminated_final_record_still_parses(
+        self, sessions_dir: Path, cli_dir: Path
+    ) -> None:
+        """A crash mid-append leaves no trailing newline; a within-cap tail still counts."""
+        path = sessions_dir / "no_terminator.jsonl"
+        path.write_text(json.dumps({"role": "user", "content": "tail"}), encoding="utf-8")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", 200, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("no_terminator", ("no_terminator",), "sid-nope")
+
+        assert result.turns == 1
+        assert result.first_message == "tail"
+
+    def test_exotic_line_boundary_stays_one_record(self, sessions_dir: Path, cli_dir: Path) -> None:
+        """U+2028 inside a message is not a record boundary, so the turn survives.
+
+        `str.splitlines` — the shape session_storage's manifest reader needs —
+        would split here and lose the record; `readline` matches the iteration
+        this replaced.
+        """
+        path = sessions_dir / "exotic.jsonl"
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(json.dumps({"role": "user", "content": "a\u2028b"}, ensure_ascii=False) + "\n")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", 200, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("exotic", ("exotic",), "sid-nope")
+
+        assert result.turns == 1
+
+    def test_over_cap_record_cannot_forge_a_record_from_its_tail(
+        self, sessions_dir: Path, cli_dir: Path
+    ) -> None:
+        """A refused record must not smuggle a valid record out of its own tail.
+
+        The whole file below is ONE line. Its first cap+1 characters are junk, and
+        a complete user record sits immediately after that boundary. Draining the
+        refused record is what keeps the tail from being read as a record of its
+        own: without the drain, the next bounded read starts on the forged object,
+        ends on the real newline, and the reader counts a turn inside a record it
+        reported as skipped.
+        """
+        cap = 100
+        forged = json.dumps({"role": "user", "content": "phantom"})
+        path = sessions_dir / "forged_tail.jsonl"
+        path.write_text("H" * (cap + 1) + forged + "\n", encoding="utf-8", newline="")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("forged_tail", ("forged_tail",), "sid-nope")
+
+        assert result.turns == 0
+        assert result.first_message == ""
+
+    def test_cap_counts_bytes_not_characters(self, sessions_dir: Path, cli_dir: Path) -> None:
+        """A record under the cap in code points but over it in bytes is refused.
+
+        The cap has to be a memory bound, and one astral code point costs four
+        bytes of `str` under PEP 393 -- so counting characters would admit four
+        times the resident text the number promises. The record below is ~86 code
+        points and 266 bytes against a 200-byte cap.
+        """
+        cap = 200
+        content = "\U0001f600" * 60  # 60 code points, 240 UTF-8 bytes
+        record = json.dumps({"role": "user", "content": content}, ensure_ascii=False)
+        assert len(record) <= cap < len(record.encode("utf-8"))
+        path = sessions_dir / "astral.jsonl"
+        path.write_text(record + "\n", encoding="utf-8", newline="")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("astral", ("astral",), "sid-nope")
+
+        assert result.turns == 0
+
+    def test_crlf_terminated_records_still_parse(self, sessions_dir: Path, cli_dir: Path) -> None:
+        """Reading binary drops universal-newline translation; CRLF must still work.
+
+        `readline` splits on the LF, so the CR rides on the end of the record and
+        every caller's `strip()` removes it before `json.loads`.
+        """
+        path = sessions_dir / "crlf.jsonl"
+        body = "".join(
+            json.dumps({"role": "user", "content": text}) + "\r\n"
+            for text in ("first crlf", "second crlf")
+        )
+        path.write_text(body, encoding="utf-8", newline="")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", 4096, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("crlf", ("crlf",), "sid-nope")
+
+        assert result.turns == 2
+        assert result.first_message == "first crlf"
+
+    def test_crlf_record_at_the_cap_boundary_is_refused_by_one_byte(
+        self, sessions_dir: Path, cli_dir: Path
+    ) -> None:
+        """A CRLF-terminated record of exactly cap bytes is refused, by one byte.
+
+        The carriage return counts toward the bounded read, so `readline(cap + 1)`
+        returns cap+1 bytes ending on the CR rather than the LF and the record
+        reads as over-cap. Pinned rather than fixed: it shifts the threshold by one
+        byte on a 128 MiB cap, and buying the byte back would cost the reader its
+        single invariant (a return shorter than cap+1 is a whole record). This is
+        also the shape that makes a text-mode test fixture fail on Windows and pass
+        on Linux, which is why the fixtures above pass `newline=""`.
+        """
+        cap = 200
+        path = sessions_dir / "crlf_at_cap.jsonl"
+        path.write_bytes(_user_record_of_length(cap).encode("utf-8") + b"\r\n")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            refused = digest("crlf_at_cap", ("crlf_at_cap",), "sid-nope")
+
+        assert refused.turns == 0
+
+        # One byte shorter and the same CRLF record is accepted, which locates the
+        # shift precisely instead of asserting only that something was refused.
+        shorter = sessions_dir / "crlf_under_cap.jsonl"
+        shorter.write_bytes(_user_record_of_length(cap - 1).encode("utf-8") + b"\r\n")
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            accepted = digest("crlf_under_cap", ("crlf_under_cap",), "sid-nope")
+
+        assert accepted.turns == 1
+
+    def test_over_cap_cli_record_drops_its_turn_and_images(
+        self, sessions_dir: Path, cli_dir: Path
+    ) -> None:
+        """An over-cap kiro-cli record contributes neither a turn nor an image."""
+        path = cli_dir / "sid-big.jsonl"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "kind": "Prompt",
+                        "data": {
+                            "content": [
+                                {"kind": "image", "data": "B" * 400},
+                                {"kind": "text", "data": "oversized"},
+                            ]
+                        },
+                    }
+                )
+                + "\n"
+            )
+            f.write(
+                json.dumps(
+                    {
+                        "kind": "Prompt",
+                        "data": {"content": [{"kind": "text", "data": "small kept"}]},
+                    }
+                )
+                + "\n"
+            )
+
+        with (
+            patch("kiro_crew.session_digest._RECORD_CAP", 200, create=True),
+            patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
+            patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
+        ):
+            result = digest("cli_big", ("no_transcript",), "sid-big")
+
+        assert result.turns == 1
+        assert result.images == 0
+        assert result.first_message == "small kept"


### PR DESCRIPTION
## Problem / Motivation

`session_digest`'s three scanners iterated their file handle directly (`for line in f` at `session_digest.py:110/152/190`), so a single line with no newline in it was materialised in one allocation the size of the whole file. Both trees they read are agent-writable -- KiroCrew's own session transcripts under the data home, and the kiro-cli event logs under the kiro home -- and neither is on `security._CREW_SECRET_LEAVES`, so an agent's own file tools can write them. PR #6312 closed exactly this hole for the trash manifest readers; these are the sibling readers the First Principles lane named when it found it.

The module docstring claimed "Streams files line-by-line so multi-GB sessions never load into memory". That was true of a well-formed file and false of a crafted one.

## Why it matters

Expanding one row in the storage inventory UI is enough to trigger the read. A planted or corrupt multi-GB newline-free line turns that click into a file-sized allocation inside the gateway process -- not a degraded row, an OOM that takes every session on the host with it. The digest already degrades to `""`/`0` on a malformed or unreadable file, so the safe posture was reachable; it was just not reachable for length.

## What changed (motivation -> approach -> change)

Symptom: one hostile line, one file-sized allocation. Root cause: `for line in handle` carries no length bound -- the reader trusted the writer to insert newlines. Change: a module-private `_bounded_lines(handle, path)` generator that all three scanners iterate instead. Each read is `handle.readline(_RECORD_CAP + 1)`, which makes the verdict unambiguous: a shorter return either ended on a newline or hit EOF, so it is a whole record. An over-cap record is skipped, its tail drained without being kept, and the count logged at debug.

The cap is in **bytes**, and the three scanners open their file binary so that it can be. A character cap is not a memory bound: one astral code point is four bytes of `str` under PEP 393, so a character cap admits four times the resident text its number promises (GPT 5.6 raised this in round 2 against a first revision that capped code points and merely *disclosed* the widening in a comment). With a bytes stream the read limit is a byte limit structurally, and the reverse direction holds too -- UTF-8 spends at least as many bytes per code point as CPython's widest string representation, so an N-byte read caps the decoded `str` at N bytes as well.

Two properties that moving off text mode changes, both deliberate:

- **Per-record decoding equals whole-file decoding.** `\n` is never part of a UTF-8 multi-byte sequence (lead and continuation bytes are all `>= 0x80`), so no sequence can straddle a record boundary and be `errors="replace"`d differently than before.
- **Universal-newline translation is gone**, which narrows boundaries in one direction only: a lone `\r` no longer ends a record. Neither writer of these files emits one, and a planted file that does is read as a single over-cap record and skipped -- the safe direction. `\r\n` survives, because every caller strips the record before parsing.

Two deliberate divergences from #6312's `_manifest_records` -- which is why this is a sibling reader rather than a call into that one:

1. **Skip, not abort.** #6312 aborts because `restore()` rewrites the manifest from the records it parsed, so a skipped record would orphan staged files. Nothing here feeds a rewrite: the digest is read-only per-row detail that already skips a malformed line and keeps going, so an over-cap record degrades exactly one row's counts. This is the skip-safe half of the classification the issue asks for.
2. **`readline` boundaries, not `str.splitlines`.** #6312 needs splitlines-equivalence because its reader replaced a whole-file `.splitlines()`. The code replaced here is handle iteration, which splits only on the newline. Reusing the splitlines shape would turn a message containing `U+2028` (legal raw inside a JSON string) into two unparseable fragments and lose the turn it describes.

The cap is 128 MiB, not #6312's 8 MiB, and it is derived rather than picked. A legitimate record's ceiling is ~90 MB: `image_artifacts.MAX_IMAGE_BYTES_PER_MESSAGE` is 64 MiB of image bytes per message, which base64-expands to ~85 MB, plus text. Measured against that, the largest record on a live install (30,351 kiro-cli logs, 27 GB) is 77,920,032 bytes and is itself load-bearing -- it carries an image content item, and the largest `Prompt` record (which drives turns and `first_message`) is 56,203,168 bytes. A manifest record is a header or one session's file list; these carry whole conversation turns, an order of magnitude larger. An 8 MiB cap here would not be a bound -- it would be a silent undercount on exactly the biggest sessions. 128 MiB is the smallest round value that clears the derived ceiling with margin.

Also: every scanned path is now logged with `%r`. GPT 5.6 raised this on the reader's new skip counter, and the mechanism it named -- archive segments are discovered with `iterdir()`, so a planted filename can embed a newline and forge a log record -- applies verbatim to the four pre-existing debug lines in the same functions, which are fixed in the same pass rather than left as identical holes beside a closed one. `_manifest_records` already logs its batch name with `%r` for this reason.

### Site audit (the issue's ~26 hits)

| Sites | Tree | Class | This PR |
|---|---|---|---|
| `session_digest.py:110/152/190` | data-home sessions, kiro-home cli logs | agent-writable, skip-safe | converted |
| `handlers_system.py:270/510/597`, `platform_compat.py:4656/5172`, `sandbox.py:3455/5463`, `acp/runtime.py:433` | `/proc/meminfo`, `/proc/net/dev`, `/proc/<pid>/status`, `/proc/<pid>/mountinfo`, `/proc/self/cgroup` | kernel-owned, not agent-writable | outside the threat model; unchanged |
| `usage.py:198/405/623/685/806/1607/1803`, `events/backfill.py:254/497`, `telemetry.py:605`, `history_search.py:1211`, `snapshot.py:2152/2159`, `members.py:447`, `mcp_gateway/stub.py:1524` | data-home shards and rotated logs | agent-writable, same pattern | not converted -- see scope |
| `session_storage.py` instances | trash and session store | agent-writable | out of this issue's scope by its own text (tracker #6285-#6291) |

Every site the issue names still exists at the line it names.

**Scope, stated plainly.** This PR converts the three sites the issue confirms and delivers the audit it asks for. The 15 remaining agent-writable sites are the same pattern but not the same judgement -- a shard reader whose output feeds a rewrite needs #6312's abort, not this skip -- so they are enumerated above rather than swept in, and the issue stays open for them. Hence `Refs`, not `Fixes`. Ordering note: the triage comments asked to wait for #6312, which merged on 2026-08-27 as `52067ce28`, so that block is cleared.

## Tests

Eleven tests in `TestBoundedRecords`. Six are red on the pre-fix source for behavioural reasons, not a missing symbol:

- `test_over_cap_transcript_record_is_skipped` -- an over-cap user record contributes no turn and no `first_message`. Pre-fix: `assert 2 == 1`.
- `test_transcript_handle_is_never_read_unbounded` -- a spy handle asserts every read carries a limit `<= cap + 1` and that the handle is never iterated. Pre-fix: "the handle was iterated, so one line is unbounded".
- `test_record_one_over_cap_is_skipped` -- one byte past the cap is already over it. Pre-fix: `assert 1 == 0`.
- `test_drain_resumes_at_the_next_record` -- a record seven caps long is drained and both following records still count. Pre-fix: `assert 3 == 2`.
- `test_over_cap_cli_record_drops_its_turn_and_images` -- an over-cap kiro-cli record contributes neither a turn nor an image. Pre-fix: `assert 2 == 1`.
- `test_cap_counts_bytes_not_characters` -- a record of 86 code points and 266 bytes against a 200-byte cap is refused. This is the guard for the round-2 finding, and it is red against the character-capping revision `314beae49` as well as against `main` (`assert 1 == 0` -- that revision accepted the record and counted a turn).

Five pin behaviour the fix must not change, and pass on the pre-fix source by design:

- `test_record_exactly_at_cap_survives` -- the cap is inclusive.
- `test_unterminated_final_record_still_parses` -- a crash mid-append leaves no trailing newline; a within-cap tail still counts.
- `test_exotic_line_boundary_stays_one_record` -- `U+2028` inside a message is not a record boundary.
- `test_crlf_terminated_records_still_parse` -- binary reads drop universal-newline translation, so this pins that a CRLF-terminated file still parses (the carriage return rides on the record end and `strip()` removes it).
- `test_over_cap_record_cannot_forge_a_record_from_its_tail` -- the whole file is ONE line whose first `cap + 1` bytes are junk and whose tail is a complete user record. This is the drain's real job: without it the next bounded read starts on the forged object, ends on the real newline, and a turn is counted inside a record the reader reported as skipped.

Mutation-verified, 4/4 killed: cap made exclusive by one byte; the `endswith(b"\n")` terminator check dropped; `readline` stripped of its limit; the drain loop removed. Two mutants are worth reporting because they changed what the tests say:

- The drain mutant SURVIVED the first pass -- the four original tests could not tell it apart, because each fragment of an over-cap record is itself over-cap and skipped anyway. `test_over_cap_record_cannot_forge_a_record_from_its_tail` was written for that gap and kills it.
- A mutant restoring code-point counting in the `len(raw) > _RECORD_CAP` comparison also SURVIVED, and correctly so: with a bytes stream `readline(cap + 1)` never returns more than `cap + 1` bytes whatever the comparison then decides, so that mutant only makes the reader misjudge an already-bounded buffer, and the truncated fragment fails `json.loads` and is skipped regardless. The byte bound is enforced by opening the handle binary, not by the comparison -- so this mutant was dropped as non-discriminating, and the check against revision `314beae49` above stands as the evidence in its place.

`pytest test/test_session_digest.py`: 31 passed (20 pre-existing, 11 new). black, isort and flake8 clean on both files; `scripts/check_black_formatting.py` passes; mypy reports nothing in `session_digest.py` (its two errors are pre-existing in `transcribe.py`, reached by follow-imports).

## Manual verification

The cap's floor is the one thing unit tests cannot supply, so it was measured on a live install rather than guessed -- `wc -L` over both trees for the longest record of any kind, then `grep -h '"kind":"Prompt"' | wc -L` and the same for `'"kind":"image"'` to find the longest *load-bearing* ones. Those numbers are the ones quoted above and in the constant's comment, and they are what ruled out reusing 8 MiB. Everything else is asserted directly: the allocation bound by the spy-handle test, the boundary by the cap-inclusive and one-over tests, the byte-versus-code-point distinction by a record that the previous revision provably accepted -- so a run against a real multi-gigabyte planted file would add no evidence.

## Related Issues

Refs #6345
Refs #6312 (the manifest-reader instance this generalises from, merged as `52067ce28`)

## Pattern harvest

Rule candidate: review-prompt
Pattern: `for line in <handle>` over a tree any agent can write is an unbounded allocation -- one record's length is attacker-controlled, so the reader must pass a limit to `readline` and then decide, per call site, whether an over-cap record is skipped (read-only and degradable) or aborts the read (its output feeds a rewrite). Second half of the same rule, learned in review here: the limit must be in BYTES, which means reading the handle binary and decoding per accepted record -- a limit in characters is not a memory bound, because one astral code point costs four bytes of `str`.
