### PR TITLE
fix(security): re-join the path a find traversal factors apart

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -2998,6 +2998,8 @@ _ONE_CHAR_CLASS_RE = re.compile(r"\[(\w)\]")
 def _debracket(text: str) -> str:
     """Collapse one-character bracket classes (``[k]irocrew`` -> ``kirocrew``)."""
     return _ONE_CHAR_CLASS_RE.sub(r"\1", text)
+
+
 # The product name as a WHOLE program name (bare or the tail of a path), which is
 # what distinguishes ``bin/kirocrew token`` from ``cd kirocrew-wt-x``.
 
@@ -3581,6 +3583,49 @@ def _resolve_local_assignments(tokens: "list[str]") -> "list[str]":
     tokens = _split_glued_operators(tokens)
     for idx, token in enumerate(tokens):
         assign = _LOCAL_ASSIGN_RE.match(token)
+        # ``NAME+=tail`` APPENDS, and the pattern above cannot match it at all (``+`` is
+        # not a name character), so an appended PROGRAM word was invisible here: `F=fi;
+        # F+=nd; $F <fenced> -exec cat {} +` ran a `find` this resolver never saw, while
+        # its single-assignment twin `F=fin; ${F}d` -- closed in an earlier round --
+        # denied (found in review). Seven spellings did it, including an empty initial
+        # value, repeated appends, a quoted tail and an append feeding a braced use.
+        #
+        # Append is in the same closed class as those: the tail is a LITERAL, so what the
+        # shell will run is decided by the text alone. That is what separates it from
+        # `$(printf find)`, whose value needs a program run and is out of scope here.
+        #
+        # `_SHELL_ASSIGN_RE` is REUSED rather than a second append pattern being added:
+        # it already carries the optional ``+`` group for this exact problem on the
+        # path-tracking side, so there is one spelling of the rule in the module. It is
+        # matched only in the branch the assignment pattern rejects, which keeps this
+        # additive -- renumbering the shared pattern's groups instead would have rewritten
+        # every existing reader of them for no behavioural gain.
+        append = None if assign else _SHELL_ASSIGN_RE.match(token)
+        if append and append.group(2):
+            name, tail = append.group(1), append.group(3)
+            if values and "$" in tail:
+                # Same reason the assignment path expands first: a tail built from an
+                # already-tracked variable is a literal once expanded, and left
+                # unexpanded it reads as computed and the append is dropped.
+                tail = _VAR_USE_RE.sub(
+                    lambda m: values.get(m.group(1) or m.group(2), m.group(0)), tail
+                )
+            if _is_computed_value(tail):
+                # No literal to concatenate. Over-approximate exactly as the assignment
+                # path does: the value only matters where it is later used as a program,
+                # so a wrong guess there is a refusal rather than a bypass.
+                produced = _protected_name_in_substitution(tokens, idx)
+                if produced:
+                    values[name] = produced
+                out.append(token)
+                continue
+            piece = tail.strip("\"'").rstrip(";&|")
+            # `F=` records nothing, so an append to an unset name starts from empty
+            # rather than being discarded -- that was one of the seven spellings, and
+            # bash builds the value the same way.
+            values[name] = values.get(name, "") + piece
+            out.append(token)
+            continue
         if assign and values and "$" in (assign.group(2) or ""):
             # A new value may be built FROM a variable already tracked
             # (``x=p; x=${x}kill``).  Expanding before classifying is what makes the
@@ -8253,6 +8298,92 @@ def _is_keystone_publish_artifact(path_str: str, base_dir: str | None = None) ->
 # automatically denied by the others.
 DENIED_ROOT_PARTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
 
+#: Leaf names that carry credential material wherever they sit, and the suffixes that
+#: do the same. The companion to :data:`DENIED_ROOT_PARTS`, which answers "is this
+#: DIRECTORY fenced": this answers "does this FILENAME carry a secret", which is a
+#: different question and had no owner here. Two leaf modules had each grown their own
+#: copy for their own surface -- ``PROJECT_SECRET_NAMES`` in the design-tweak preview
+#: server and ``_EXCLUDE_NAMES`` in the cloud source packer -- and both already import
+#: ``DENIED_ROOT_PARTS`` from here, so this module is where a shared answer would
+#: belong. Deliberately PRIVATE all the same: it has one consumer today, and a public
+#: spelling would exist only for a migration this change does not perform. Renaming it
+#: is the cheaper half of that migration when someone does.
+#:
+#: Conservative on purpose, and that cuts both ways. A broad rule (any name containing
+#: ``secret``) reintroduces exactly the false positives this exists to avoid, because
+#: the fenced tree includes OPERATIONAL directories holding ordinary readable files.
+#: But a curated list also means an OMISSION allows -- the one place in this pass whose
+#: polarity is not "anything unenumerated denies" (found in review). It holds for the
+#: names it enumerates and cannot hold for names the USER chooses: a private key called
+#: ``github_work`` or ``deploy_key_prod`` is allowed, and no addition to this list closes
+#: that, because the name space is not ours. So this is a documented BOUNDARY of the
+#: pass, not a gap awaiting more entries.
+#:
+#: Two ways to invert it were measured. Failing closed for literal-name deliveries over a
+#: root holding a whole-directory store spares globs but flips 12 of 12 ordinary literal
+#: searches to DENY (``-name Makefile``, ``-name package.json``, ``-name README.md`` ...).
+#: Classifying every fence entry as a pure store versus an operational one denies
+#: ``find ~ -name '*.py'`` outright whenever ``.ssh`` exists, which is worse. Choosing
+#: between them is a decision about acceptable friction, tracked in issue #8074.
+_CREDENTIAL_LEAF_NAMES: frozenset[str] = frozenset(
+    {
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+        "identity",
+        "credentials",
+        "credentials.json",
+        "credentials.csv",
+        "credentials.db",
+        # gcloud's OAuth refresh token. Named for the mechanism rather than for what it
+        # holds, so it matched none of the `credential`-shaped entries above and none of
+        # the suffixes -- an omission of exactly the kind this list's polarity makes
+        # dangerous (found in review).
+        "application_default_credentials.json",
+        # The Azure CLI's bearer-token cache, missed for the same reason: the name says
+        # what the file is FOR, not that it holds a secret. Both premises this list
+        # requires were measured before adding it -- a direct `cat` of the file already
+        # denies on main as well as here, so naming it makes the traversal agree with the
+        # direct read rather than becoming stricter than it, and the file IS a credential
+        # (it holds access and refresh tokens). Matched case-folded, so the
+        # `accessTokens.json` the CLI actually writes is covered by this spelling.
+        "accesstokens.json",
+        # gcloud's short-lived access tokens, in the same fenced directory and missed the
+        # same way. A direct read of it already DENIES, so the traversal was strictly more
+        # permissive than `cat` on the identical path -- the incoherence this pass exists
+        # to remove, rather than a judgement about how sensitive the file is (measured in
+        # review).
+        "access_tokens.db",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".git-credentials",
+        ".htpasswd",
+        ".app_secret",
+        "secring.gpg",
+    }
+)
+_CREDENTIAL_LEAF_SUFFIXES: tuple[str, ...] = (
+    ".pem",
+    ".key",
+    ".p8",
+    ".p12",
+    ".pfx",
+    ".jks",
+    ".keystore",
+)
+
+
+def _looks_like_credential_leaf(name: str) -> bool:
+    """Does this BASENAME hold credential material wherever it sits?
+
+    Names are compared casefolded, because a case-insensitive filesystem opens the
+    same file either way -- the reasoning :func:`_path_in_home_dirs` already applies.
+    """
+    lowered = name.casefold()
+    return lowered in _CREDENTIAL_LEAF_NAMES or lowered.endswith(_CREDENTIAL_LEAF_SUFFIXES)
+
 
 def is_sensitive_path(path_str: str, base_dir: str | None = None) -> bool:
     """Return True if the path points to a read+write-sensitive location.
@@ -8758,6 +8889,22 @@ def is_sensitive_bash_command(
     alt_result = _check_alt_traversal_reaches_fence(command)
     if alt_result:
         return alt_result
+
+    # ── Pass 5: a `find` traversal that DELIVERS a fenced match ──
+    # The passes above all judge a TOKEN. `find` factors the path across two
+    # arguments and produces it at runtime, so no token names it -- see the block
+    # comment on `_check_find_traversal_reaches_fence`. It judges every text this
+    # command runs as a shell, not just the outer line, so a traversal wrapped in a
+    # `-c` payload or a substitution is judged too.
+    #
+    # Pass 4 is the sibling of this one and the two are disjoint by construction: it
+    # answers the same question for every traversal program EXCEPT `find` (its own
+    # docstring says so), because `find` is the one whose filter grammar decides
+    # which paths the traversal even produces. Neither subsumes the other, so both
+    # run; being disjoint on the program word, their order does not matter.
+    find_result = _check_find_traversal_reaches_fence(command)
+    if find_result:
+        return find_result
 
     # IMDS access via any IP encoding (decimal, hex, octal, IPv6-mapped)
     imds_result = _check_imds_access(command, enabled_ids=enabled_ids)
@@ -9561,6 +9708,1477 @@ def _path_candidates(token: str) -> list[str]:
             cand = stripped
         out.append(cand)
     return out
+
+
+#: ── ``find``: a traversal that DELIVERS a match names the path it produces ──
+#:
+#: Every other pass in this module asks one question of every token: does this
+#: token resolve to a fenced path? ``find`` defeats that question by
+#: CONSTRUCTION, because it factors the path in two -- the directory is one
+#: argument, the leaf another, and the path itself is computed at runtime and
+#: never appears in the command text at all::
+#:
+#:     find ~/.kiro/crew -name '.env' -exec cat {} +
+#:     find ~ -name credentials | xargs cat
+#:
+#: Re-joining the two halves is what makes the traversal visible again (#7034).
+#: Two bounds decide where that join is denied.
+#:
+#: **Delivery.** A ``find`` that only LISTS is left alone, which is what keeps the
+#: newly-denied set small: an ordinary ``find ~ -name '*.md'`` is untouched, and
+#: only a traversal that hands a match to a command is judged -- an action
+#: primary, a pipe, a redirect, or a substitution that captures its output. The
+#: inert primaries are an ALLOW-list and anything else denies, the
+#: same polarity ``_TRUST_ROOT_READ_LISTERS`` documents: enumerating the
+#: delivering primaries would fail OPEN, so a primary nobody thought of would be
+#: a silent bypass. Note that none of this needs to know the CHILD command --
+#: ``cat``, ``base64``, a script, ``xargs`` with any of its flag grammars -- because
+#: the gate denies NAMING a fenced path whatever is then done with it. That is
+#: why no executor list appears here, the direction this module's own comments
+#: call fragile.
+#:
+#: Delivery is read from the invocation's OWN token span, not from the command
+#: line. Reading the whole line denied a listing because an UNRELATED later
+#: command carried a pipe (``find ~/.kiro/crew -type f; cat notes | less``).
+#:
+#: A filter only BOUNDS that delivery when find will run the delivery after it and only
+#: where it holds. Position and the boolean operators decide that, not mere presence:
+#: ``find ~ -exec cat {} + -name '*.py'`` cats every file under the home directory, and a
+#: disjunction, a negation or a comma each detach the filter from the delivery. Where the
+#: bound cannot be established cheaply the traversal is read as unfiltered -- see
+#: :data:`_FIND_SCOPE_BREAKING_OPS`.
+#:
+#: **Framing.** Which text to judge is its own question, and answering it by
+#: inspecting the command's characters was wrong twice: capture was read off the two
+#: opener characters glued to the program word's token, so ``cat $( find … )`` was
+#: allowed where ``cat $(find … )`` was denied; and a ``bash -c '<traversal>'``
+#: payload was never re-tokenized at all, so the traversal was invisible even though
+#: the argv floor already descends into payloads for plain path tokens. Both are the
+#: same defect -- judging the command's TEXT rather than the things the shell runs.
+#: `_find_traversal_views` enumerates those instead, so capture stops being a
+#: spelling to detect and becomes a property of how a view was DERIVED, and no depth
+#: of wrapping is a special case. The same reframing is why the program word is
+#: matched through the pattern machinery (`_find_program_word_names_find`): a shell
+#: expands ``f?nd`` against the filesystem, which no substring test on the text can
+#: see.
+#:
+#: **Cost.** A filter is agent-supplied text, and this gate is synchronous and
+#: in-process, so evaluating one is a denial-of-service surface before it is a
+#: correctness question -- CPython's ``re`` has no timeout, and the module already
+#: records a watchdog-crossing hang from admitting a run into a pattern. Two rules
+#: keep the work bounded, and both fail CLOSED by widening the traversal rather
+#: than dropping the filter:
+#:
+#: * a ``-regex``/``-iregex`` pattern is NEVER compiled and NEVER run. Screening for
+#:   catastrophic shapes was rejected: against a hostile author that enumeration
+#:   does not terminate, which is the argument this module already makes about
+#:   enumerating dangerous punctuation. The cost is an over-block on a rare flag.
+#: * a glob becomes a regex through `_glob_to_regex`, so it is bounded instead:
+#:   adjacent ``.*`` runs are collapsed, which is semantics-preserving, and what
+#:   remains is capped. ``-name '{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}b'``
+#:   compiled to fourteen adjacent ``.*`` and hung the gate outright -- measured as
+#:   still running after 12 seconds.
+#:
+#: The SUBJECTS are never agent input, which is what makes the cap sufficient: they
+#: are fence basenames and credential-store entry names, all short.
+#:
+#: **Certainty.** The join is denied where the FENCE supplies the missing half,
+#: and left alone where the traversal merely might wander into one:
+#:
+#: * the root is a fenced path, or a directory whose secrets live in its leaves
+#:   (``~/.kiro/crew``) -- the command names the credential directory outright and
+#:   the leaf is the runtime wildcard, which is exactly the ``~/.kiro/crew/$F``
+#:   shape `_sensitive_under_unresolved_var` already denies;
+#: * a name pattern matches the BASENAME of a fence entry lying under the root,
+#:   so the fence itself declares the name the traversal asks for (``-name .env``
+#:   under ``~``, and the unfiltered ``find ~/.kiro/crew -type f``, whose pattern
+#:   is effectively ``*``);
+#: * the filter asks for a NAME that carries credentials wherever it sits, and a
+#:   whole-directory credential store lies under the root (``-name id_rsa`` under
+#:   ``~``, reaching ``~/.ssh/``). Everything inside such a store is fenced, so the
+#:   traversal is resolving a path rather than searching, and
+#:   `_find_filter_names_a_credential_leaf` answers it from the NAME -- no stat, no
+#:   listing. Two earlier revisions asked the filesystem instead and each way was its
+#:   own defect: a direct-child ``os.path.exists`` could not see
+#:   ``~/.ssh/archive/id_rsa`` while denying the same name at the top, and an
+#:   ``os.listdir`` per store to match a glob measured 110 listdir calls and 14.4ms on
+#:   ONE traversal (against 0 and 0.7ms for an ordinary fenced read) on a gate that is
+#:   synchronous and in-process. Those two point in OPPOSITE directions -- probe
+#:   deeper, stop enumerating -- so neither is reachable by extending the probe;
+#:   deciding from the name removes the depth question and the enumeration together,
+#:   and drops a host-dependence that was never a feature (the same command allowed or
+#:   denied according to whether a store happened to exist yet). Every filter spelling
+#:   of one read answers alike -- ``-name id_rsa``, ``-name 'id_*'`` and
+#:   ``-path '*/id_rsa'`` -- which is the invariant an earlier round established and
+#:   which each of these revisions had to be re-checked against. It is also the whole
+#:   difference between denying ``find ~ -name credentials -exec cat {} +`` and leaving
+#:   ``find ~ -type d -name __pycache__ -exec rm -rf {} +`` alone: no credential name
+#:   is asked for, so the clause says no. The cost is that this is strictly WIDER than
+#:   a probe, which is the fail-closed direction, bounded by keeping the predicate
+#:   conservative -- known credential leaves and suffixes, nothing pattern-like.
+#:
+#: What this cannot see is unchanged and known, and the largest part of it is DESCOPED
+#: rather than pending: this pass recognises a traversal by its SPELLING, so an operand
+#: the shell COMPUTES is outside it. ``$(printf find) ~/.kiro/crew -type f -exec cat {} +``
+#: is the witness -- knowing that runs ``find`` means knowing what ``printf`` writes, which
+#: is not a property of the text. The same applies to a glob-bearing root
+#: (``~/.kir*/crew``), brace expansion (``f{i,}nd``), a root supplied from outside the
+#: command line (``-files0-from -``), a genuinely unassigned expansion, and a root reached
+#: by a preceding ``cd`` rather than named (the working-directory emulation this module
+#: deliberately does not rest security on -- see `_check_sensitive_cd_taint`). Six review
+#: rounds measured 17 such spellings; each one closed revealed others, because the set of
+#: programs whose output is ``find`` is not enumerable by any pattern over the text. The
+#: fix is to invert the polarity -- require literal operands and fail closed on computed
+#: ones -- which is a behaviour change on a security gate with its own false-positive
+#: surface to price, tracked in issue #8074, NOT a gap in this pass.
+#:
+#: What IS resolved here is what the text alone determines: a same-command assignment
+#: (``F=find; $F``, and the split ``F=fin; ${F}d``), a glob-expanded program word
+#: (``f?nd``), a quote splice (``fi''nd``), a nested ``-c`` payload, and the body of a
+#: substitution. Those turn a computed spelling back into a literal one.
+#:
+#: Also outside it: a pattern held in a variable, a shell loop over a substitution, a leaf
+#: fenced only by LOCATION whose own name carries no credential signal (``known_hosts``),
+#: the credential-name list's own polarity (see `_CREDENTIAL_LEAF_NAMES`, also #8074), and
+#: -- where the root is unknowable AND no filter is left to evaluate -- the literal reading
+#: is all that is judged, because widening both at once denied an ordinary
+#: ``find "$TMPDIR" -type f -delete`` outright (see `_find_root_readings`). And any OTHER
+#: program that factors a root and a name the same way -- ``fd`` / ``fdfind``
+#: (``-x`` / ``-X``), ``locate`` / ``plocate`` piped into a reader, ``rg --files``,
+#: ``du -a`` -- each of which needs its own grammar, plus ``grep -r <dir>``, which needs no
+#: second command at all. This pass closes the LITERALLY SPELLED ``find`` form, NOT the
+#: traversal class and NOT the computed-operand class; it must not be read as either.
+_FIND_PROGRAM_NAMES: frozenset[str] = frozenset({"find", "gfind"})
+
+#: Options that precede the roots. A closed set on purpose: skipping EVERY
+#: leading ``-`` token would read ``find -name x`` as a traversal of ``x``.
+#: ``-O<level>`` is glued, ``-D`` takes the next token.
+_FIND_GLOBAL_OPTS: frozenset[str] = frozenset({"-H", "-L", "-P", "--"})
+
+#: BSD/macOS find takes more pre-root options than GNU, and they BUNDLE:
+#: ``find [-H|-L|-P] [-EXdsx] [-f path] [path ...] [expression]``. An unrecognised one ends
+#: the roots run, so the traversal was read as rooted at ``.`` and the fenced operand was
+#: never seen -- ``find -E ~/.kiro/crew -type f -exec cat {} +`` was allowed while the same
+#: command without ``-E`` denied, and the bundles (``-EX``, ``-Es``, ``-dsx``, ``-EXdsx``)
+#: went the same way (found in review). Matched as a character class rather than by
+#: enumerating the 31 bundle spellings, and safe against the primaries because every
+#: primary is a word -- ``-delete`` and ``-depth`` carry letters outside this set.
+_FIND_BSD_PREROOT_CHARS = frozenset("EXdsx")
+
+#: The one pre-root option that takes an OPERAND, and the operand is a ROOT: BSD
+#: ``find -f <path>`` names a hierarchy to traverse. So it is collected rather than
+#: skipped -- skipping it would lose the very path that decides the verdict.
+_FIND_ROOT_OPTION = "-f"
+
+
+def _find_is_bsd_preroot_option(token: str) -> bool:
+    """True for a BSD pre-root option or bundle (``-E``, ``-sx``, ``-EXdsx``)."""
+    return (
+        len(token) > 1
+        and token[0] == "-"
+        and all(ch in _FIND_BSD_PREROOT_CHARS for ch in token[1:])
+    )
+
+
+#: Primaries that neither run a command nor write a file, so a traversal built
+#: only from these can do nothing with a match but print it. Everything else
+#: beginning with ``-`` is treated as delivery -- see the polarity note above.
+#: ``-newerXY`` is matched by prefix, since the suffix pairs are combinatorial.
+_FIND_INERT_PRIMARIES: frozenset[str] = frozenset(
+    {
+        # tests
+        "-name",
+        "-iname",
+        "-path",
+        "-ipath",
+        "-wholename",
+        "-iwholename",
+        "-lname",
+        "-ilname",
+        "-regex",
+        "-iregex",
+        "-type",
+        "-xtype",
+        "-size",
+        "-empty",
+        "-perm",
+        "-links",
+        "-inum",
+        "-samefile",
+        "-user",
+        "-uid",
+        "-group",
+        "-gid",
+        "-nouser",
+        "-nogroup",
+        "-fstype",
+        "-context",
+        "-readable",
+        "-writable",
+        "-executable",
+        "-true",
+        "-false",
+        "-mtime",
+        "-atime",
+        "-ctime",
+        "-mmin",
+        "-amin",
+        "-cmin",
+        "-used",
+        "-anewer",
+        "-cnewer",
+        # positional/global options that may appear among the primaries
+        "-maxdepth",
+        "-mindepth",
+        "-depth",
+        "-d",
+        "-mount",
+        "-xdev",
+        "-follow",
+        "-noleaf",
+        "-warn",
+        "-nowarn",
+        "-ignore_readdir_race",
+        "-noignore_readdir_race",
+        "-help",
+        "--help",
+        "-version",
+        "--version",
+        # operators
+        "-not",
+        "-a",
+        "-and",
+        "-o",
+        "-or",
+        # actions that only print or stop
+        "-print",
+        "-print0",
+        "-printf",
+        "-ls",
+        "-quit",
+        "-prune",
+    }
+)
+
+#: Filters whose pattern is matched against the whole path rather than the
+#: basename, and the two spellings whose pattern is a regex instead of a glob.
+_FIND_NAME_TESTS: frozenset[str] = frozenset({"-name", "-iname"})
+_FIND_PATH_TESTS: frozenset[str] = frozenset(
+    {"-path", "-ipath", "-wholename", "-iwholename", "-lname", "-ilname"}
+)
+_FIND_REGEX_TESTS: frozenset[str] = frozenset({"-regex", "-iregex"})
+
+#: Glob metacharacters, for telling "resolve this exact name" from "search".
+_FIND_GLOB_META = frozenset("*?[")
+
+#: The one primary that supplies ROOTS from outside the command line: GNU find reads
+#: them from a file, or from stdin for ``-``. The command therefore names no root at
+#: all, and a parser reading only operands defaults the traversal to ``.`` --
+#: ``printf '%s\0' ~/.kiro/crew | find -files0-from - -name .env -exec cat {} +`` walked
+#: a fenced root the parse never saw (found in review). Read as an UNKNOWABLE root
+#: instead, exactly like a root carrying an unassigned expansion, so the FILTER is what
+#: decides and an ordinary ``-files0-from list.txt -name '*.o' -delete`` is untouched.
+#:
+#: What that buys is precise, and smaller than it looks: the pass stops inventing a ``.``
+#: root it cannot justify, so a credential-shaped filter still denies
+#: (``-files0-from list -name id_rsa`` denies through the name vocabulary). It does NOT
+#: make the traversal safe -- with no evaluable filter, ``-files0-from - -type f -exec cat``
+#: is ALLOWED, because the root is exactly the kind of computed operand this pass does
+#: not cover. The enumeration here is closed (this is the only way find takes a root that
+#: is not an operand); the CASE is not. Deciding it belongs to the polarity inversion in
+#: issue #8074, not here.
+_FIND_ROOT_SOURCE_FLAGS: frozenset[str] = frozenset({"-files0-from"})
+
+
+#: Operators that must not arrive GLUED to a neighbouring word. ``shlex`` splits on
+#: whitespace only, so ``-name .env|xargs`` reaches the parser as ONE token and the
+#: pipe is consumed as pattern text -- delivery is never seen, and the command reads
+#: a fenced secret that its whitespace-separated twin denies (found in review). The
+#: same glue hides a redirect: ``-type f>/tmp/leak`` yields the token ``f>/tmp/leak``.
+#:
+#: ``<`` is deliberately ABSENT, because a ``<`` is never a delivery on its own: it
+#: feeds the traversal's stdin rather than carrying its output anywhere. Spacing it
+#: would also split ``<(find …)`` into ``<`` and ``(find``, and while capture no
+#: longer depends on reading those two characters off a token (see
+#: `_find_traversal_views`), the split serves nothing.
+_FIND_GLUED_OPERATORS = frozenset("|;&>")
+
+
+def _find_space_unquoted_operators(command: str) -> str:
+    """Surround unquoted, unescaped control/redirect operators with spaces.
+
+    Splitting the TOKENS instead was rejected for the reason `_split_glued_operators`
+    documents: ``shlex`` has already removed the quotes by then, so a quoted
+    ``-name 'a|b'`` is indistinguishable from a real pipe and would be split too.
+    Working on the RAW string keeps quote state, so a quoted operator is left alone
+    and only a real one becomes its own token.
+
+    A run is kept together (``>>``, ``&&``, ``2>&1``) so a two-character operator is
+    not split into two. A backslash escapes the next character exactly as a shell
+    reads it, which is what keeps ``-exec cat {} \\;`` intact.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote is not None:
+            out.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < n:
+                out.append(command[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in "\"'":
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < n:
+            out.append(ch)
+            out.append(command[i + 1])
+            i += 2
+            continue
+        if ch in _FIND_GLUED_OPERATORS:
+            start = i
+            while i < n and command[i] in _FIND_GLUED_OPERATORS:
+                i += 1
+            out.append(" ")
+            out.append(command[start:i])
+            out.append(" ")
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _find_credential_store_dirs() -> list[str]:
+    """Every fence entry, as a real path, for "does this directory hold a match".
+
+    EVERY entry in :data:`_SENSITIVE_HOME_DIRS` fences its whole subtree -- that is
+    the ``startswith(target + os.sep)`` rule in `_path_in_home_dirs` -- so any name
+    found inside one is fenced whatever the name is. An earlier version kept only
+    SINGLE-segment entries, which silently dropped the nested whole-directory stores:
+    ``.config/gcloud`` was never probed, so ``find ~ -name credentials.db -exec cat
+    {} +`` read its credential database (found in review).
+
+    What must NOT be scanned is a crew leaf-PARENT such as ``~/.kiro/crew``, which
+    holds readable files (``config.json``, ``sessions.db``) beside its fenced leaves.
+    Those directories are not fence entries at all -- only their leaves are -- so
+    taking the list as-is excludes them by construction. That is the property the
+    single-segment filter was reaching for, and it gets it right.
+
+    Returned UN-casefolded, unlike ``_home_dir_targets``: the caller stats these
+    paths, and on a case-sensitive filesystem a casefolded home
+    (``/Users/Alice`` -> ``/users/alice``) does not exist.
+
+    Anchored on the real home only, so a crew home relocated by ``KIROCREW_HOME`` is
+    not scanned here. Nothing is lost: this clause exists for stores whose leaf names
+    the fence does NOT declare (``~/.aws/credentials``), and those are home-anchored
+    by nature, while every crew leaf is matched by NAME through the re-anchored
+    ``_home_dir_targets`` in the clause above.
+    """
+    home = os.path.expanduser("~")
+    return [os.path.join(home, entry) for entry in _SENSITIVE_HOME_DIRS]
+
+
+def _credential_leaf_subjects() -> "list[str]":
+    """The vocabulary a filter pattern is matched against: leaf names and suffix bearers.
+
+    Shared so the ``-name`` route and the ``-path`` route test the SAME set -- the
+    invariant this pass owes is that every filter spelling of one read answers alike,
+    and two copies of this list is how that invariant breaks.
+    """
+    return list(_CREDENTIAL_LEAF_NAMES) + [f"x{suffix}" for suffix in _CREDENTIAL_LEAF_SUFFIXES]
+
+
+def _credential_probe_forms(probe: str, sep: str) -> "set[str]":
+    """The spellings a ``-path`` pattern may have to match this synthetic path in.
+
+    A `-path` pattern is written in find's own spelling, which uses forward slashes,
+    while the probe is joined with the platform separator. On Windows the compiled
+    pattern (``.*/id_rsa``) therefore could never match the probe
+    (``...\\.ssh\\id_rsa``) and the whole `-path` clause was inert there -- caught by the
+    Windows shard, invisible on POSIX where the two spellings coincide.
+
+    *sep* is a parameter rather than read from :data:`os.sep` so the separator-dependent
+    behaviour is reachable from a test on either platform. Taking it from the module
+    global made the fix unfalsifiable off Windows: a mutation deleting the second
+    spelling survived every local test, because on POSIX it deletes nothing.
+    """
+    return {probe, probe.replace(sep, "/")}
+
+
+def _find_filter_names_a_credential_leaf(
+    literal_names: list[str],
+    glob_matchers: "list[re.Pattern[str]] | None" = None,
+) -> str | None:
+    """Does this traversal's filter ask for a name that carries credentials anywhere?
+
+    Answers from the NAME alone -- no filesystem access. Two earlier revisions asked
+    the store instead, and each way of asking was its own defect:
+
+    * ``os.path.exists(store/name)`` only ever probed a store's DIRECT children, so a
+      key one level down (``~/.ssh/archive/id_rsa``) was invisible while the same name
+      at the top denied -- the whole subtree is fenced, so that split had no meaning;
+    * ``os.listdir(store)`` to match a glob against real entries reached 110 listdir
+      calls and 14.4ms for ONE traversal (measured), against 0 calls and 0.7ms for an
+      ordinary fenced read. This gate is synchronous and in-process, so that is
+      latency on the async permission path, not merely wasted work.
+
+    Those two point in opposite directions -- probe deeper, and stop enumerating -- so
+    neither is reachable by extending the probe. Asking the name removes both at once:
+    there is no depth to get wrong and nothing to enumerate. It also drops a
+    host-dependence that was never a feature, where the same command was allowed or
+    denied according to whether a store happened to exist yet.
+
+    The cost is that this is strictly WIDER than a probe: ``find ~ -name id_rsa
+    -exec cat {} +`` is denied on a host with no ``.ssh`` at all. That is the
+    fail-closed direction and the module's stated posture -- a *maybe* answers yes.
+
+    What keeps it from over-blocking is that the predicate is conservative: it names
+    known credential leaves and suffixes, nothing pattern-like. The three false
+    positives an earlier revision measured on a real developer home
+    (``~/.kirocrew/run`` holds transient sandbox ``*.py`` wrappers,
+    ``~/.local/share/kiro-cli`` holds ``tui.js``, four fenced directories hold a
+    ``*.json``) are all NON-credential basenames, so none of them is reachable here.
+
+    A GLOB is tested against the predicate's own vocabulary rather than against a
+    directory: the credential leaf names, and one synthetic bearer per credential
+    suffix. So ``-name 'id_*'`` matches ``id_rsa`` and ``-name '*.pem'`` matches the
+    suffix probe, while ``-name '*.py'`` matches neither. The subjects are this
+    module's own short constants, never agent input, which is what keeps the existing
+    wildcard bound sufficient.
+    """
+    for name in literal_names:
+        if _looks_like_credential_leaf(name):
+            return name
+    if not glob_matchers:
+        return None
+    subjects = _credential_leaf_subjects()
+    for subject in subjects:
+        if any(m.fullmatch(subject) for m in glob_matchers):
+            return subject
+    return None
+
+
+#: A backslash escape inside a find filter pattern. GNU find reads ``\c`` as the literal
+#: ``c``, so the escape has to come off before the pattern is compared to anything.
+_FIND_PATTERN_ESCAPE_RE = re.compile(r"\\(.)", re.DOTALL)
+
+
+def _find_pattern_operand(token: str) -> str:
+    r"""A filter's pattern, with a captured substitution's closing punctuation removed.
+
+    ``cat $(find ~ -regex '.*/id_rsa$')`` reaches ``shlex`` with the closing paren
+    glued to the pattern, so the token is ``.*/id_rsa$)``. Applied HERE, where the
+    pattern is read, rather than at the call site: the strip was originally written
+    per-list at the call site, ``-regex`` was the one list that did not get it, and
+    an uncompilable pattern then dropped its matcher and allowed a read that the
+    ``-name`` spelling of the same read denied (found in review). One place means no
+    family can be forgotten again.
+
+    Stripping only ever WIDENS what the pattern matches, so a genuine trailing
+    ``)`` or backtick in a filename costs a denial, never a permit.
+
+    But it must not strip punctuation belonging to the TOKEN's own substitution, because
+    the pass reads a computed filter as opaque and that reading is what fails closed.
+    ``-name "$(printf id_rsa)"`` arrived here as ``$(printf id_rsa)``, lost its closing
+    paren, and the leftover no longer looked like a substitution -- so it was taken as the
+    literal name ``$(printf id_rsa``, matched nothing in the vocabulary, and the read was
+    allowed where the literal ``-name id_rsa`` denied (found in review). The mechanism was
+    never missing; this strip defeated it, and ``${LEAF}`` only survived because it has no
+    trailing character to lose.
+    So a trailing ``)`` comes off only while the token has MORE closers than openers, and a
+    trailing backtick only while their count is odd -- an unbalanced one is the outer
+    capture's, a balanced one is the token's own. That also keeps a parenthesised
+    ``-regex`` group intact (``.*(id_rsa|id_dsa)$)`` loses exactly one).
+
+    A backslash is then removed with the same reasoning. GNU find reads ``\c`` as the
+    LITERAL ``c``, so ``-name '\.env'`` asks for exactly ``.env`` -- but a backslash is
+    not glob metacharacter, so the pattern was taken as the literal name ``\.env``,
+    matched nothing in the credential vocabulary, and the read was allowed while the
+    unescaped twin denied (found in review). Every escaped spelling of every enumerated
+    name defeated the clause the same way (``i\d_rsa``, ``\c\r\e\d\e\n\t\i\a\l\s``).
+    Unescaping here rather than per family is the same argument as the strip above: one
+    place, so no family can be forgotten. It stays in the widening direction too -- an
+    escaped wildcard (``\*``, a literal asterisk to find) is read as a wildcard, which
+    over-matches rather than under-matches. ``-regex`` patterns pass through here as
+    well, and a backslash IS meaningful to them, but that cannot weaken anything:
+    a non-empty ``regex_pats`` already forces the opaque reading regardless of content.
+    """
+    trimmed = token
+    while trimmed:
+        tail = trimmed[-1]
+        if tail == ")" and trimmed.count(")") > trimmed.count("("):
+            trimmed = trimmed[:-1]
+        elif tail == "`" and trimmed.count("`") % 2:
+            trimmed = trimmed[:-1]
+        else:
+            break
+    return _FIND_PATTERN_ESCAPE_RE.sub(r"\1", trimmed)
+
+
+#: Ceiling on the "any run" wildcards a filter glob may carry before the pass stops
+#: building a matcher for it and treats it as opaque instead.
+#:
+#: `_glob_to_regex` maps ``*`` and a brace group to ``.*``, so an agent-supplied
+#: pattern becomes an agent-supplied REGEX that this synchronous gate then runs.
+#: ``-name '{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}b'`` compiles to fourteen
+#: adjacent ``.*`` and hangs the gate outright -- measured as still running after
+#: 12s, which is the watchdog-crossing hang `_separator_collapsed_variants`
+#: documents. Two bounds together, because either alone leaves the other open:
+#: adjacent ``.*`` runs are collapsed (``.*.*`` names exactly what ``.*`` names, so
+#: this is semantics-preserving), and what remains is capped. Eight is far above
+#: any real filename filter and keeps the work polynomial in a SHORT subject --
+#: the subjects here are fence basenames and store entry names, never agent input.
+_FIND_GLOB_WILDCARD_LIMIT = 8
+
+#: A generated ``.*`` run, for the collapse above. Matches the two-character
+#: sequence a wildcard produces; a LITERAL ``.`` or ``*`` in the glob arrives
+#: escaped (``\.``, ``\*``), so this cannot collapse a literal.
+_FIND_GENERATED_ANY_RUN_RE = re.compile(r"(?:\.\*)+")
+
+
+def _find_glob_matcher(pattern: str) -> "re.Pattern[str] | None":
+    """Compile a find ``-name``/``-path`` glob into a matcher, or None if it cannot.
+
+    Returning None makes the caller treat the filter as opaque, which WIDENS the
+    traversal rather than dropping it -- see `_find_traversal_reaches_fence`. That
+    is the fail-closed answer for a pattern this function refuses to run as well as
+    for one that will not compile.
+
+    Case-insensitive for every spelling, not just ``-iname``: the fence itself
+    casefolds both sides (see :func:`_path_in_home_dirs`), because on a
+    case-insensitive filesystem the two spellings open the same file.
+    """
+    generated = _FIND_GENERATED_ANY_RUN_RE.sub(".*", _glob_to_regex(pattern))
+    if generated.count(".*") > _FIND_GLOB_WILDCARD_LIMIT:
+        return None
+    try:
+        return re.compile(generated, re.IGNORECASE)
+    except re.error:
+        return None
+
+
+def _find_literal_path_probe(pattern: str, root: str) -> str | None:
+    """Reduce a ``-path`` pattern to the path its non-wildcard segments name.
+
+    ``-path`` matches the whole path, so the pattern carries the fenced segments
+    itself. Dropping the segments that are wildcards leaves something the
+    ordinary path gate can answer: ``*/.aws/credentials`` reduces to
+    ``.aws/credentials``, which is fenced under the root, while
+    ``*/node_modules/*`` reduces to ``node_modules``, which is not.
+    """
+    normalized = pattern.replace("\\", "/")
+    literal = [seg for seg in normalized.split("/") if seg and not (_FIND_GLOB_META & set(seg))]
+    if not literal:
+        return None
+    joined = "/".join(literal)
+    if normalized.startswith("/"):
+        return "/" + joined
+    return os.path.join(root, joined)
+
+
+#: Operators that break the guarantee that a collected filter BOUNDS the delivery.
+#:
+#: find evaluates its expression left to right with an implicit AND, so a filter only
+#: bounds a delivery primary when that primary can run *after* it and only when it
+#: holds. A disjunction runs the right branch where the left FAILS
+#: (``-name '*.py' -o -exec cat {} +``), a negation inverts it
+#: (``-not -name '*.py' -exec cat {} +``), and a comma makes the two sides independent
+#: expressions -- in each case the collected filter does not narrow what is delivered,
+#: and the pass believed it did (found in review). Deciding which filters really bind
+#: would need find's own precedence grammar (``!`` over ``-a`` over ``-o``, with ``,``
+#: sequencing); reading the traversal as UNFILTERED instead needs no grammar and fails
+#: closed. ``-a``/``-and`` are absent on purpose: an explicit AND binds exactly as the
+#: implicit one does.
+_FIND_SCOPE_BREAKING_OPS: frozenset[str] = frozenset({"-o", "-or", "-not", "!", ","})
+
+
+class _FindInvocation(NamedTuple):
+    """One parsed ``find`` invocation.
+
+    A NamedTuple rather than a widening positional tuple: the parse now carries seven
+    facts, and at that width a caller unpacking them in order is one edit away from
+    silently swapping two booleans.
+    """
+
+    roots: list[str]
+    name_pats: list[str]
+    path_pats: list[str]
+    regex_pats: list[str]
+    delivers: bool
+    opaque_roots: bool
+    #: False when a collected filter does not bound the delivery -- see
+    #: :data:`_FIND_SCOPE_BREAKING_OPS`. The caller then reads the traversal as
+    #: unfiltered, which is the fail-closed direction.
+    filters_bind: bool
+
+
+def _parse_find_invocation(tokens: list[str], start: int) -> _FindInvocation:
+    """Read one ``find`` invocation starting at the token AFTER the program word.
+
+    Returns its roots, its filter patterns by family, whether it DELIVERS matches,
+    whether its roots came from somewhere this parse cannot read, and whether the
+    collected filters actually BOUND that delivery.
+    A traversal with no root operand walks the working directory, which is what
+    find itself does.
+    """
+    i = start
+    n = len(tokens)
+    # Declared before the option run because BSD `-f <path>` contributes a ROOT from
+    # inside it, not after it.
+    roots: list[str] = []
+    # Global options first: a closed set, so an unrecognized flag ends the run
+    # rather than being skipped past the roots.
+    while i < n:
+        token = tokens[i]
+        if token in _FIND_GLOBAL_OPTS:
+            i += 1
+            continue
+        if _find_is_bsd_preroot_option(token):
+            i += 1
+            continue
+        # `-f <path>` names a hierarchy to traverse, so its operand is a ROOT.
+        if token == _FIND_ROOT_OPTION and i + 1 < n:
+            roots.append(tokens[i + 1])
+            i += 2
+            continue
+        if token == "-D" and i + 1 < n:
+            i += 2
+            continue
+        if token.startswith("-O") and len(token) > 2 and token[2:].isdigit():
+            i += 1
+            continue
+        break
+    delivers = False
+    while i < n:
+        token = tokens[i]
+        if not token or token.startswith("-") or token in ("(", ")", "!", ","):
+            break
+        # A redirect can sit BEFORE the operands (`find >out ~/dir -type f`). Without
+        # this the roots loop collected `>` and its target AS ROOTS, so delivery was
+        # never seen and the leading spelling was allowed while its trailing twin
+        # (`find ~/dir -type f >out`) denied -- the same write, the redirect moved to
+        # the front (found in review). The operand is consumed with it so a log path
+        # is not read as a traversal root.
+        if _OUTPUT_REDIRECT_RE.match(token):
+            delivers = True
+            i += 2 if (i + 1 < n and not tokens[i + 1].startswith("-")) else 1
+            continue
+        if _CONTROL_OPERATOR_RE.search(token):
+            break
+        roots.append(token)
+        i += 1
+    name_pats: list[str] = []
+    path_pats: list[str] = []
+    regex_pats: list[str] = []
+    opaque_roots = False
+    # A filter bounds the delivery only if the delivery can run AFTER it and only when
+    # it holds. Two things break that: a delivery PRIMARY appearing before any filter
+    # (find runs it on every visited file, and the later filter narrows nothing --
+    # `find ~ -exec cat {} + -name '*.py'` reads everything), and a scope-breaking
+    # operator anywhere in the expression. Either way the caller reads the traversal as
+    # unfiltered, which is the fail-closed direction.
+    #
+    # Seeded False rather than from `delivers`, which a LEADING redirect has already
+    # set: a redirect delivers the FILTERED listing, so the filter does bound it.
+    # Seeding from it made `find >out ~ -name '*.py'` deny while the trailing twin
+    # `find ~ -name '*.py' >out` allowed -- parse order deciding the verdict, which is
+    # the very thing the redirect fix above exists to prevent (found in review).
+    delivery_before_filter = False
+    scope_broken = False
+    while i < n:
+        token = tokens[i]
+        if token in _FIND_SCOPE_BREAKING_OPS:
+            scope_broken = True
+        # A root source is read BEFORE the operator tests below, so its operand is
+        # consumed with it and cannot be mistaken for anything else. It is not a
+        # delivery on its own -- a `-files0-from` listing still only prints.
+        if token in _FIND_ROOT_SOURCE_FLAGS:
+            opaque_roots = True
+            i += 2 if i + 1 < n else 1
+            continue
+        # A filter's PATTERN is consumed with its flag, before any operator test
+        # below can look at it -- so a quoted `-name 'a|b'` cannot be mistaken for
+        # a pipe.
+        if token in _FIND_NAME_TESTS and i + 1 < n:
+            name_pats.append(_find_pattern_operand(tokens[i + 1]))
+            i += 2
+            continue
+        if token in _FIND_PATH_TESTS and i + 1 < n:
+            path_pats.append(_find_pattern_operand(tokens[i + 1]))
+            i += 2
+            continue
+        if token in _FIND_REGEX_TESTS and i + 1 < n:
+            regex_pats.append(_find_pattern_operand(tokens[i + 1]))
+            i += 2
+            continue
+        # A redirect writes the listing to a file, the same disclosure as `-fprint`.
+        # Tested BEFORE the control-operator break, because the redirect spellings that
+        # carry an `&` (`&>`, `&>>`, `>&`) match that break too and it claimed them
+        # first: `find <fenced> -name .env &>/tmp/list` was allowed while the plain `>`
+        # twin denied (found in review). The roots loop above already ordered these two
+        # this way, so the pass disagreed with itself depending on which loop saw the
+        # redirect. `_OUTPUT_REDIRECT_RE` enumerates the spellings, so ordering the
+        # tests correctly covers the whole set rather than the one that was reported.
+        redirect = _OUTPUT_REDIRECT_RE.match(token)
+        if redirect:
+            delivers = True
+            # `>out;cat` glues the NEXT command onto the redirect. The redirect is this
+            # invocation's, the rest is not, so the span still ends here -- otherwise a
+            # later command's flags would be read as this traversal's filters.
+            if _CONTROL_OPERATOR_RE.search(token[redirect.end() :]):
+                break
+            i += 1
+            continue
+        # END of this invocation. `shlex` splits on whitespace only, so an operator
+        # glued to its neighbour (`-type f|xargs`) arrives inside a token -- which is
+        # also why the span, not the whole command line, is what decides delivery. A
+        # `|` among the operators IS a delivery: the matches flow into the next
+        # stage. `;`, `&&` and `&` are not -- they only sequence, and reading them as
+        # delivery denied a listing because an UNRELATED later command in the same
+        # line happened to contain a pipe (found in review).
+        if _CONTROL_OPERATOR_RE.search(token):
+            if "|" in token:
+                delivers = True
+            break
+        if token.startswith("-"):
+            if not (token in _FIND_INERT_PRIMARIES or token.startswith("-newer")):
+                delivers = True
+                if not (name_pats or path_pats or regex_pats):
+                    delivery_before_filter = True
+        i += 1
+    return _FindInvocation(
+        roots=roots,
+        name_pats=name_pats,
+        path_pats=path_pats,
+        regex_pats=regex_pats,
+        delivers=delivers,
+        opaque_roots=opaque_roots,
+        filters_bind=not (delivery_before_filter or scope_broken),
+    )
+
+
+#: How many roots this pass will resolve before refusing. Resolution is a filesystem
+#: operation per root per candidate form, and nothing upstream bounds how many roots a
+#: `find` names, so the synchronous hook's cost grew with the command: measured on this
+#: branch, 100 roots cost 61.9 ms, 500 cost 290.8 ms and 1000 cost 607.6 ms, against
+#: main's 3.4 / 31.0 / 97.7 ms for the same commands -- so the pass added +510 ms at
+#: 1000 roots, and 500 roots that all name the fenced directory cost 728.4 ms (found in
+#: review). The bound matches `_FIND_SUBSTITUTION_BUDGET` deliberately: both cap a
+#: dimension the text can inflate without limit, and both fail CLOSED, because a
+#: traversal too wide to inspect is not thereby known to be safe. 64 roots holds the
+#: worst case near 40 ms; a command naming more than 64 directories in one `find` is
+#: not a shape this gate needs to allow.
+_FIND_ROOT_BUDGET = 64
+
+#: How many brace expansions of a single root this pass will enumerate before refusing.
+#: Unlike a glob, brace expansion needs no filesystem -- it is finite and decided by the
+#: text -- so the expansions are enumerable and this pass resolves them. It is also
+#: MULTIPLICATIVE: `{a,b}{c,d}{e,f}` is 8 roots and n groups are 2**n, so the budget is
+#: what keeps a textual bomb from becoming the cost the root budget above exists to
+#: prevent. Over budget fails closed for the same reason.
+_FIND_BRACE_BUDGET = 32
+
+#: How deeply braces may NEST before this pass refuses. Separate from the budget above
+#: because the two bound different things: that one caps how many forms the expansion
+#: PRODUCES, this one caps how deep the enumeration RECURSES. A nested group is expanded
+#: by a recursive call, so depth in the text became depth on the Python stack, and 1,200
+#: nested groups raised an uncaught `RecursionError` inside the synchronous permission
+#: check -- a crash rather than a verdict, in code this pass added (found in review; main
+#: handles the same input in 86 ms because it has no such recursion). Checked BEFORE any
+#: expansion, so the recursion can never be entered deeper than this. Real commands nest
+#: one or two groups; 16 is far past anything a shell user writes and far short of the
+#: interpreter's limit.
+_FIND_BRACE_DEPTH_BUDGET = 16
+
+
+def _find_brace_nesting_depth(root: str) -> int:
+    """The deepest brace nesting in *root*, counted without recursing."""
+    depth = 0
+    deepest = 0
+    for ch in root:
+        if ch == "{":
+            depth += 1
+            deepest = max(deepest, depth)
+        elif ch == "}" and depth:
+            depth -= 1
+    return deepest
+
+
+def _find_brace_expansions(root: str) -> list[str] | None:
+    """Every literal root this brace-carrying root expands to, or None if over budget.
+
+    ``~/x/cre{w,w}`` reads as a root naming no fenced path while the shell hands `find`
+    the fenced directory twice, so a root was allowed that its own brace-free spelling
+    denied -- six spellings did it, including a nested group and an empty alternative
+    (found in review). Brace expansion is the same KIND of gap as quoting or backslash
+    escaping and closes the same way: it is finite, it is decided by the text alone, and
+    no filesystem lookup is needed to enumerate it. That is what separates it from a
+    glob, which cannot be enumerated without asking the filesystem what exists and is
+    therefore out of scope for this pass.
+
+    Returns the expansions WITHOUT the original -- the caller keeps that separately --
+    or None when the product exceeds `_FIND_BRACE_BUDGET`, which the caller turns into
+    a refusal rather than an allow.
+    """
+    if "{" not in root:
+        return []
+    # Depth first, and before anything recurses: a nested group is expanded by a
+    # recursive call, so without this the text's nesting depth became the stack's depth
+    # and a deep enough root raised `RecursionError` out of a synchronous security check.
+    # Refusing is the same fail-closed answer the width budget gives.
+    if _find_brace_nesting_depth(root) > _FIND_BRACE_DEPTH_BUDGET:
+        return None
+    out: list[str] = [""]
+    i = 0
+    n = len(root)
+    while i < n:
+        ch = root[i]
+        if ch != "{":
+            out = [prefix + ch for prefix in out]
+            i += 1
+            continue
+        # Find this group's matching close, tracking nesting so an inner group is
+        # carried into the alternative text and expanded by the recursive call below.
+        depth = 0
+        close = -1
+        for j in range(i, n):
+            if root[j] == "{":
+                depth += 1
+            elif root[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    close = j
+                    break
+        if close < 0:
+            # An unterminated brace is a literal brace to the shell, so read it that way.
+            out = [prefix + root[i:] for prefix in out]
+            break
+        alts = _find_brace_alternatives(root[i + 1 : close])
+        if alts is None:
+            return None
+        widened: list[str] = []
+        for prefix in out:
+            for alt in alts:
+                # The alternative may itself carry a group; expanding it here is what
+                # makes `{cr{ew,x},y}` terminate in the same budget as a flat group.
+                inner = _find_brace_expansions(alt)
+                if inner is None:
+                    return None
+                for tail in inner or [alt]:
+                    widened.append(prefix + tail)
+                    if len(widened) > _FIND_BRACE_BUDGET:
+                        return None
+        out = widened
+        i = close + 1
+    expansions = [form for form in dict.fromkeys(out) if form != root]
+    return expansions[:_FIND_BRACE_BUDGET]
+
+
+#: A brace SEQUENCE: `{a..z}`, `{1..9}`, either direction, with an optional step
+#: (`{1..9..2}`). Bash's brace grammar is exactly comma lists, sequences and nesting, so
+#: without this the enumeration was incomplete by construction rather than by oversight:
+#: `<fenced-parent>/cre{w..w}` expands to the fenced directory in bash while this pass
+#: recorded the literal `crew..w` and allowed the traversal (found in review, immediately
+#: after the comma-list form was closed -- the class was sampled, not closed).
+#:
+#: Measured against `bash -c 'printf %s\\n ...'` as the oracle, the covered forms are now
+#: comma lists, empty alternatives, nesting, preamble/postscript, adjacent groups, letter
+#: and numeric sequences in both directions, stepped sequences, and a sequence nested
+#: inside a comma list.
+_FIND_BRACE_SEQUENCE_RE = re.compile(
+    r"\A(?P<start>-?\w+)\.\.(?P<end>-?\w+)(?:\.\.(?P<step>-?\d+))?\Z"
+)
+
+
+def _find_brace_sequence(body: str) -> list[str] | None:
+    """The items of a brace sequence, or None when *body* is not one.
+
+    Returns an empty list when the sequence is well-formed but yields nothing this pass
+    can enumerate (mixed letter/number endpoints, a zero step), which the caller treats
+    the same way bash does -- as a literal rather than an expansion.
+    """
+    match = _FIND_BRACE_SEQUENCE_RE.match(body)
+    if not match:
+        return None
+    start, end = match.group("start"), match.group("end")
+    raw_step = match.group("step")
+    try:
+        step = int(raw_step) if raw_step else None
+    except ValueError:
+        return []
+    if step == 0:
+        return []
+    magnitude = abs(step) if step else 1
+
+    def numeric(text: str) -> bool:
+        return bool(re.fullmatch(r"-?\d+", text))
+
+    if numeric(start) and numeric(end):
+        lo, hi = int(start), int(end)
+        # Bash zero-pads the whole sequence when either endpoint is padded.
+        width = 0
+        for text in (start, end):
+            stripped = text[1:] if text.startswith("-") else text
+            if len(stripped) > 1 and stripped.startswith("0"):
+                width = max(width, len(stripped))
+        direction = 1 if hi >= lo else -1
+        values = range(lo, hi + direction, direction * magnitude)
+        out = []
+        for value in values:
+            text = str(abs(value)).rjust(width, "0") if width else str(abs(value))
+            out.append(f"-{text}" if value < 0 else text)
+            if len(out) > _FIND_BRACE_BUDGET:
+                return None
+        return out
+    if len(start) == 1 and len(end) == 1 and start.isalpha() and end.isalpha():
+        lo, hi = ord(start), ord(end)
+        direction = 1 if hi >= lo else -1
+        out = []
+        for code in range(lo, hi + direction, direction * magnitude):
+            out.append(chr(code))
+            if len(out) > _FIND_BRACE_BUDGET:
+                return None
+        return out
+    # Mixed or unsupported endpoints (`{a..3}`): bash leaves these literal, so this pass
+    # does too rather than guessing at a range.
+    return []
+
+
+def _find_brace_alternatives(body: str) -> list[str] | None:
+    """The comma-separated alternatives of one brace group, splitting at depth 0 only.
+
+    An empty alternative is real -- `crew{,x}` yields `crew` -- so the split keeps empty
+    fields rather than filtering them, which is what made the empty-alternative spelling
+    a gap of its own.
+    """
+    # A sequence has no top-level comma, so it is recognised before the split rather
+    # than after it: `{a..c}` split on commas is one alternative reading `a..c`, which
+    # is exactly the literal that let `cre{w..w}` through.
+    sequence = _find_brace_sequence(body)
+    if sequence is None:
+        pass  # not a sequence; fall through to the comma split below
+    elif sequence:
+        return sequence
+    else:
+        # Well-formed but not enumerable here, so it stays literal, as in bash.
+        return [body]
+    alts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for ch in body:
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        if ch == "," and depth == 0:
+            alts.append("".join(current))
+            current = []
+            continue
+        current.append(ch)
+    alts.append("".join(current))
+    if len(alts) > _FIND_BRACE_BUDGET:
+        return None
+    return alts
+
+
+def _find_root_readings(roots: list[str], hypothesise: bool) -> list[str] | None:
+    """Every reading of the traversal roots, including the unresolved-home readings.
+
+    A root carrying an expansion this command never assigned cannot be resolved from
+    the text. Rather than deny every such traversal -- ``find $BUILD -name '*.o'
+    -delete`` is ordinary -- two fail-closed readings are ADDED alongside the literal
+    one and the FILTER is left to decide: the literal tail joined onto a home anchor
+    (`_unresolved_home_hypothesis`), and the home directory itself. So
+    ``find $D -name .env -exec cat {} +`` is denied on the fence-declared name, while
+    a build glob under the same unknown root is not.
+
+    *hypothesise* is what keeps "the filter decides" true. The widened readings are
+    only sound when a filter can actually reject them, and with no evaluable filter
+    the caller reads the traversal as ``*`` -- so the bare-home reading matched every
+    fence and denied ``find "$TMPDIR" -type f -delete`` and ``find "$SRC" -type f
+    -exec cat {} +`` outright, contradicting this docstring (found in review). When
+    nothing is left to decide, an unknowable root is judged on its literal reading
+    alone. The residual is named rather than paid for with that false positive: an
+    unfiltered delivering traversal of a root this parse cannot read is allowed, the
+    same way the module already allows one whose root sits in an unread variable.
+
+    Additive only, so a reading that turns out to be wrong can produce a denial but
+    never withdraw one.
+
+    Returns None when a root's brace expansion exceeds `_FIND_BRACE_BUDGET`, which the
+    caller turns into a refusal: an expansion too wide to enumerate is not thereby known
+    to name nothing fenced.
+    """
+    out = list(roots)
+    # Brace expansion first, and unconditionally -- it is not a hypothesis. The shell
+    # hands `find` these roots whether or not a filter binds, so they are readings of
+    # what the command DOES, on the same footing as the literal spelling.
+    for root in roots:
+        expansions = _find_brace_expansions(root)
+        if expansions is None:
+            return None
+        for form in expansions:
+            if form not in out:
+                out.append(form)
+    if not hypothesise:
+        return out
+    for root in list(out):
+        if _mark_unresolved(root) == root:
+            continue
+        # The literal tail joined onto a home anchor, which is what catches
+        # `cd "$(printf %s ~)/.kiro/crew"`-shaped roots.
+        hypothesis = _unresolved_home_hypothesis(root)
+        if hypothesis is not None:
+            expanded = os.path.expanduser(hypothesis)
+            if expanded not in out:
+                out.append(expanded)
+        # And the home directory ITSELF, because an unknowable root could simply BE
+        # it. Without this, `find ${D}/crew -name token_signing.key | xargs cat`
+        # resolved to `~/crew`, which holds no fence, and the keystone read went
+        # through. The filter still decides, so an ordinary build search under an
+        # unknown root is not denied by this reading alone.
+        home = os.path.expanduser("~")
+        if home not in out:
+            out.append(home)
+    return out
+
+
+#: What this pass returns when a path's canonical form cannot be established. Named so
+#: the two `PathResolutionStalled` handlers cannot drift apart, and phrased as a path-ish
+#: string because the caller renders it as the resolved subject of the denial.
+_FIND_STALLED_REASON = "<unresolvable path: filesystem resolution stalled>"
+
+#: What the two budget refusals resolve to. Phrased as path-ish strings for the same
+#: reason `_FIND_STALLED_REASON` is: the caller renders the return value as the resolved
+#: subject of the denial, so a bare sentence would read as a path in the message.
+_FIND_ROOT_OVER_BUDGET_REASON = (
+    f"<more than {_FIND_ROOT_BUDGET} traversal roots: too wide to resolve>"
+)
+_FIND_BRACE_OVER_BUDGET_REASON = (
+    f"<brace expansion exceeds {_FIND_BRACE_BUDGET} forms: too wide to enumerate>"
+)
+
+
+def _find_traversal_reaches_fence(
+    roots: list[str],
+    name_pats: list[str],
+    path_pats: list[str],
+    regex_pats: list[str],
+    opaque_roots: bool = False,
+    filters_bind: bool = True,
+) -> str | None:
+    """Does a traversal of *roots* filtered by these patterns name a fenced path?
+
+    Returns the fenced path (or the fenced directory) it names, or None. See the
+    block comment above for why each of the three answers counts as the fence
+    supplying the missing half of the join, rather than as a guess about where
+    the traversal might wander.
+    """
+    targets = _home_dir_targets(_SENSITIVE_HOME_DIRS)
+    stores = _find_credential_store_dirs()
+    # A pattern that will not compile must WIDEN, not vanish. Collecting the
+    # matchers with a filter dropped the uncompilable ones, and because
+    # `unfiltered` was computed from the raw pattern lists the clause then had
+    # neither a matcher nor the no-filter reading -- so `-regex '('` and every
+    # other malformed pattern silently allowed the traversal (found in review).
+    # Treating it as opaque is the module's documented stance: a *maybe* answers
+    # yes, since the gate may over-trigger but must never under-trigger.
+    name_matchers: "list[re.Pattern[str]]" = []
+    path_matchers: "list[re.Pattern[str]]" = []
+    opaque = False
+    all_pats = name_pats + path_pats + regex_pats
+    for pattern in name_pats:
+        matcher = _find_glob_matcher(pattern)
+        if matcher is None:
+            opaque = True
+        else:
+            name_matchers.append(matcher)
+    for pattern in path_pats:
+        matcher = _find_glob_matcher(pattern)
+        if matcher is None:
+            opaque = True
+        else:
+            path_matchers.append(matcher)
+    # A ``-regex``/``-iregex`` pattern is NEVER compiled and NEVER run. It is an
+    # agent-supplied regex, this gate is synchronous and in-process, and CPython's
+    # ``re`` has no timeout -- so a catastrophic-backtracking pattern would wedge the
+    # gate for every session rather than merely mis-answer. Screening for the
+    # dangerous shapes was rejected: against a hostile author that enumeration does
+    # not terminate, which is the argument this module already makes about
+    # enumerating dangerous punctuation. Treating the filter as opaque costs an
+    # over-block on a rare flag and removes the whole class.
+    if regex_pats:
+        opaque = True
+    # A filter carrying an expansion this command never assigned is unknowable from
+    # the text, so it is opaque too. `normalize_shell_command` expands only `$HOME`,
+    # so `P=.env; find ~ -name $P -exec cat {} +` otherwise matched the literal `$P`
+    # against the fence, matched nothing, and read the secret (found in review).
+    if any(_is_shell_variable_reference(p) or _mark_unresolved(p) != p for p in all_pats):
+        opaque = True
+    # No filter at all means every visited file matches, so the effective pattern
+    # is `*`. A filter this pass will not evaluate is read the same way, and so is one
+    # that does not BOUND the delivery -- see `_FIND_SCOPE_BREAKING_OPS`.
+    unfiltered = opaque or not all_pats or not filters_bind
+    literal_names = [p for p in name_pats if not (_FIND_GLOB_META & set(p))]
+    # A root this parse cannot read (`-files0-from`) gets the same treatment as a root
+    # carrying an unassigned expansion: add the home reading and let the FILTER decide,
+    # rather than trusting the `.` a rootless parse defaults to. Gated on an evaluable
+    # filter for the reason `_find_root_readings` documents -- with nothing left to
+    # decide, the widened reading would deny every `-files0-from` traversal outright.
+    readable_roots = list(roots)
+    if opaque_roots and not unfiltered:
+        home = os.path.expanduser("~")
+        if home not in readable_roots:
+            readable_roots.append(home)
+    # Each store's candidate forms are a property of the STORE, not of the root being
+    # tested, so they are resolved once here rather than once per (root, store) pair.
+    # Resolving them inside the loop made the cost the product of the two: a traversal
+    # naming 100 benign roots spent 117 ms in this synchronous hook, against 1.2 ms for
+    # one root (measured in review). The casefold is hoisted with them for the same
+    # reason -- it ran per form per root.
+    # `_candidate_forms` REFUSES rather than guessing when a canonical form cannot be
+    # established -- a wedged mount under the path raises `PathResolutionStalled`, and
+    # every sibling gate turns that into a denial (`is_sensitive_path`,
+    # `_is_keystone_publish_artifact`, `path_contains_sensitive`,
+    # `_dir_holds_sensitive_leaf` all do). This pass did not, so the exception escaped the
+    # synchronous permission gate instead of failing closed, and hoisting the store
+    # resolution out of the root loop made it eager for EVERY command rather than only
+    # those carrying a name filter -- widening a crash from rare to routine on a host
+    # whose home mount has stalled (found in review, by both lanes independently).
+    #
+    # A stall is only ever a reason to refuse: with no canonical form there is nothing to
+    # prove the traversal stays outside the fence.
+    try:
+        store_forms: list[tuple[str, list[str]]] = [
+            (store, [form.casefold() for form in _candidate_forms(store)]) for store in stores
+        ]
+    except PathResolutionStalled:
+        return _FIND_STALLED_REASON
+    root_readings = _find_root_readings(readable_roots, hypothesise=not unfiltered)
+    if root_readings is None:
+        return _FIND_BRACE_OVER_BUDGET_REASON
+    # Nothing upstream bounds how many roots a `find` names, and each one costs a
+    # filesystem resolution per candidate form, so the width of the command set the cost
+    # of this synchronous hook -- see `_FIND_ROOT_BUDGET` for the measurement. Bounded
+    # AFTER the readings are built, because the readings are what actually get resolved:
+    # brace expansion and the home hypotheses both add to the count, so bounding the
+    # parsed roots alone would have left the real work unbounded.
+    if len(root_readings) > _FIND_ROOT_BUDGET:
+        return _FIND_ROOT_OVER_BUDGET_REASON
+    for root in root_readings:
+        if is_sensitive_path(root) or _dir_holds_sensitive_leaf(root):
+            return root
+        try:
+            root_forms = list(_candidate_forms(root))
+        except PathResolutionStalled:
+            return _FIND_STALLED_REASON
+        for form in root_forms:
+            form_cf = form.casefold().rstrip(os.sep)
+            prefix = form_cf + os.sep
+            for target in targets:
+                if not (target == form_cf or target.startswith(prefix)):
+                    continue
+                if unfiltered:
+                    return target
+                base = os.path.basename(target)
+                if any(m.fullmatch(base) for m in name_matchers):
+                    return target
+                if any(m.fullmatch(target) for m in path_matchers):
+                    return target
+            for pattern in path_pats:
+                probe = _find_literal_path_probe(pattern, form)
+                if probe and is_sensitive_path(probe):
+                    return probe
+            if not (literal_names or name_matchers or path_matchers):
+                continue
+            # A whole-directory credential store lying under this root, plus a filter
+            # asking for a name that carries credentials wherever it sits. Decided from
+            # the NAME -- no stat, no listing, and so no depth to get wrong: everything
+            # beneath such a store is fenced, so a key one level down counts exactly as
+            # much as one at the top. See `_find_filter_names_a_credential_leaf`.
+            for store, store_cf_forms in store_forms:
+                # STRICTLY under the root: a root that IS the store already
+                # returned above, through the fenced-path test.
+                if not any(form_cf.startswith(prefix) for form_cf in store_cf_forms):
+                    continue
+                named = _find_filter_names_a_credential_leaf(literal_names, name_matchers)
+                if named:
+                    return os.path.join(store, named)
+                # A `-path` pattern is the same request in another spelling, and its
+                # leaf cannot be tested alone: the EARLIER segments constrain the path,
+                # so `-path '*/node_modules/*'` ends in a wildcard matching any leaf yet
+                # can never name a store entry. Match the WHOLE pattern against a
+                # synthetic fenced path instead. That covers the literal leaf
+                # (`*/id_rsa`) and the glob leaf (`*/id_*`) with one rule -- an earlier
+                # revision routed only the literal one, so `-path '*/id_*'` read a key
+                # that `-name 'id_*'` was denied for, and a mutation then showed the
+                # literal-leaf extraction had become dead weight (both traced in review).
+                for subject in _credential_leaf_subjects():
+                    probe = os.path.join(store, subject)
+                    # A `-path` pattern uses find's forward-slash spelling while the join
+                    # above uses the platform separator -- see `_credential_probe_forms`
+                    # for why both are tested and why the separator is a parameter.
+                    forms = _credential_probe_forms(probe, os.sep)
+                    if any(m.fullmatch(form) for form in forms for m in path_matchers):
+                        return probe
+    return None
+
+
+def _find_program_word_names_find(program: str) -> bool:
+    """Does this program word run ``find`` -- including after the shell expands it?
+
+    A word is the program ``find`` in three ways, and each was a live bypass:
+    spelled outright, spelled with quotes or escapes the shell removes (``fi''nd``,
+    handled by the normalizer before this is reached), or spelled as a GLOB the shell
+    expands against the filesystem. ``/usr/bin/f?nd`` is the third: the exact-string
+    test read a basename of ``f?nd``, matched nothing, and the whole pass was skipped
+    while the shell ran ``find`` (found in review).
+
+    The glob is answered by the pattern MACHINERY rather than by enumerating
+    spellings: the word is compiled through `_find_glob_matcher`, which carries the
+    module's wildcard bound, and asked whether it can match a find name. A word that
+    bound refuses is read as a match, so the cap widens the pass instead of opening a
+    hole in it -- the polarity every other decision here takes.
+
+    A fourth way is BRACE expansion: `f{in,oo}d` and `f{i..i}nd` are `find` to the shell
+    and matched nothing here, because braces are neither a literal spelling nor a glob
+    metacharacter (found in review). Expansion is applied to the program word for the
+    same reason it is applied to a root -- it is finite and decided by the text -- and
+    through the same helper, so the two sites cannot cover different halves of the
+    grammar. `$(printf find)` is still out of scope and is tracked in #8074: its value
+    needs a program run, which is the boundary this pass states.
+    """
+    if _find_brace_expansions(program) is None:
+        # Over either brace budget. The width refusals fail closed everywhere else in
+        # this pass, so an unenumerable program word reads as a possible `find` rather
+        # than as a word that is known not to be one.
+        return True
+    for form in [program] + (_find_brace_expansions(program) or []):
+        if _find_program_word_names_find_literal(form):
+            return True
+    return False
+
+
+def _find_program_word_names_find_literal(program: str) -> bool:
+    """`_find_program_word_names_find` for a word with no brace expansion left in it."""
+    base = os.path.basename(program).lower()
+    if base in _FIND_PROGRAM_NAMES:
+        return True
+    if not (_FIND_GLOB_META & set(base)):
+        return False
+    matcher = _find_glob_matcher(base)
+    if matcher is None:
+        return True
+    return any(matcher.fullmatch(name) for name in _FIND_PROGRAM_NAMES)
+
+
+#: Ceiling on the substitution openers a command may carry before this pass stops
+#: enumerating views and DENIES instead.
+#:
+#: `_find_traversal_views` derives a view per nesting level, and each level re-scans its
+#: own source, so the cost is quadratic in DEPTH. Measured on this pass alone: depth 200
+#: costs 129 ms, depth 800 costs 3.9 s, and the 1600-level command a reviewer constructed
+#: (4.8 KB of text) costs **28.9 s** in the walk and 40.8 s through the whole gate, against
+#: 1.0 s for the same command on `main`. This gate is synchronous and the gateway watchdog
+#: hard-exits well before that, so the shape is a crash, not merely a slow check.
+#:
+#: An earlier disposition of this finding rebutted it after measuring the WIDTH dimension
+#: (80 sibling substitutions, linear, 4 ms) and missing that the reviewer meant depth. The
+#: mechanism it described -- every shrinking parent rescanned -- is exactly right for depth.
+#:
+#: Counted on the raw command in one pass, before any walking, so the bound is paid up
+#: front. Failing CLOSED is what makes this safe to have: the deleted pre-filter this pass
+#: used to carry decided to SKIP work and so became the bypass, whereas exceeding this
+#: ceiling denies. 64 leaves an enormous margin over anything hand-written (the walk stays
+#: under ~40 ms there) while capping the pathological case.
+_FIND_SUBSTITUTION_BUDGET = 64
+
+
+def _find_substitution_openers(command: str) -> int:
+    """How many substitution openers the command carries, counted in one pass."""
+    return (
+        command.count("$(") + command.count("`") + command.count("<(") + command.count(">(")
+    )
+
+
+def _find_traversal_views(command: str) -> "list[tuple[str, bool]]":
+    """Every text this command runs as a shell, paired with whether its output is CAPTURED.
+
+    Capture and nesting were each being answered by looking for characters glued to a
+    token, and both answers were frame-dependent, because ``shlex`` splits on
+    whitespace and the shell does not:
+
+    * ``cat $(find … )`` was denied but ``cat $( find … )`` was allowed -- one space
+      moved the substitution's opener into a token of its own, so the two-character
+      test on the program word's token missed it;
+    * ``bash -c '<traversal>'`` was allowed outright, because the traversal lives in
+      a ``-c`` argument that the whole-command pass never re-tokenizes -- while the
+      same payload holding a plain fenced path TOKEN was correctly denied, since the
+      argv floor already descends into payloads.
+
+    Both are the same defect: the pass judged the command's TEXT rather than the
+    things the shell actually runs. So enumerate those instead. Capture stops being a
+    spelling to detect and becomes a property of how a view was DERIVED -- a
+    substitution body's output is captured by construction, whatever the spacing --
+    and a nested payload is simply another view, so no depth of wrapping is a special
+    case.
+
+    This reuses the module's own view idiom (`_self_token_frames` joins exactly these
+    two extractors) and its termination discipline: no depth cap, because whatever
+    number is chosen one more nesting level defeats it. A derived view is a proper
+    substring of its parent and so is STRICTLY SHORTER, and a visited set stops
+    sibling wrappers re-walking the same text.
+    """
+    views: list[tuple[str, bool]] = [(command, False)]
+    seen: set[str] = {command}
+    pending: list[tuple[str, bool, int]] = [(command, False, len(command) + 1)]
+    while pending:
+        source, captured, parent_len = pending.pop()
+        try:
+            tokens = normalize_shell_command(source)
+        except Exception:
+            tokens = []
+        # A substitution body's output is CAPTURED; a nested payload inherits its
+        # parent's capture, since `bash -c '<traversal>'` prints where the wrapper
+        # prints. `_substitution_bodies` walks the raw string with paren nesting and
+        # covers `$( )`, backticks and `<( )` / `>( )` alike.
+        derived = [(body, True) for body in _substitution_bodies(source)]
+        derived += [(payload, captured) for payload in _nested_shell_payloads(tokens)]
+        for text, text_captured in derived:
+            text = _decode_printf_escapes(text)
+            if len(text) >= parent_len or text in seen:
+                continue
+            seen.add(text)
+            views.append((text, text_captured))
+            pending.append((text, text_captured, len(source)))
+    return views
+
+
+def _check_find_traversal_reaches_fence(command: str) -> str | None:
+    """Deny a ``find`` whose delivered matches include a fenced path.
+
+    Returns a denial reason string, or None if clean.
+    """
+    # There is deliberately NO cheap pre-filter here. A substring test for the program
+    # name has to survive every rewriting the shell performs between this text and the
+    # program it runs, or the bail IS the bypass -- and the one that stood here modelled
+    # only some of them. It removed quotes and escapes (`fi''nd`, `fi\nd`) and let a
+    # glob metacharacter defeat it (`f?nd`), but a word built by parameter expansion
+    # walked straight past it: `F=fin; ${F}d <fenced> -exec cat {} +` contains no `find`
+    # substring and no glob, so it returned before the pass ran -- while the pass it
+    # guarded resolves exactly that spelling through `_resolve_local_assignments`, so
+    # the un-obfuscated twin denied and this one read the store (found in review).
+    # Brace expansion (`f{i,}nd`) and command substitution construct the word too. That
+    # list is open-ended, which is the whole problem: any pre-filter cheap enough to be
+    # worth having is one spelling away from being the hole. So the pass runs
+    # unconditionally and decides from the RESOLVED program word, which it already knew
+    # how to do. Measured cost for a command that names no traversal: 45-190 us against
+    # the 136-844 us the surrounding checks already spend on the same command. This runs
+    # once per command, not in a loop.
+    # The view walk is quadratic in nesting depth, so a command carrying more
+    # substitution openers than any real one does is refused before the walk rather
+    # than during it -- see `_FIND_SUBSTITUTION_BUDGET` for the measured cost.
+    if _find_substitution_openers(command) > _FIND_SUBSTITUTION_BUDGET:
+        return (
+            "Blocked: command nests more than "
+            f"{_FIND_SUBSTITUTION_BUDGET} shell substitutions, which this traversal "
+            "check cannot inspect within its time budget"
+        )
+    for view, captured in _find_traversal_views(command):
+        named = _find_traversal_in_view(view, captured)
+        if named:
+            return (
+                "Blocked: command traverses a sensitive credential path and "
+                f"delivers the match to a command (resolved via find: {named[:80]})"
+            )
+    return None
+
+
+def _find_traversal_in_view(view: str, captured: bool) -> str | None:
+    """The fenced path a ``find`` in this one view names, or None.
+
+    *captured* says the whole view's output is consumed by something (it is a
+    substitution body, or sits inside one), so every traversal in it delivers. When
+    it is False a traversal must carry its own delivery -- an action primary, a pipe,
+    or a redirect -- which `_parse_find_invocation` reads from the invocation's own
+    token span rather than from the line, so an unrelated later command's pipe does
+    not make a listing a delivery.
+    """
+    try:
+        tokens = normalize_shell_command(_find_space_unquoted_operators(view))
+    except Exception:
+        return None
+    # A program word or a root held in a variable the SAME command assigns is a
+    # literal the shell will resolve, so resolve it here too: `F=find; $F <fenced>`
+    # ran a traversal this pass could not see, and `D=<fenced>; find "$D" -type f`
+    # named a fenced root it read as unknowable -- while the plain-path passes already
+    # denied `D=<fenced>; cat $D/.env`, because they consume this same resolver. The
+    # asymmetry was the tell: the machinery existed and this pass was not wired into
+    # it, exactly as with nested payloads. Resolving also DISTINGUISHES the two cases
+    # a bare "unresolved root" reading conflated -- an assigned root becomes a real
+    # path and is judged on it, while a genuinely unassigned `$SRC` stays unknowable
+    # and is left to the filter.
+    try:
+        tokens = _resolve_local_assignments(tokens)
+    except Exception:
+        pass
+    for index, token in enumerate(tokens):
+        # Three things can sit between the start of a token and the program word:
+        #
+        #   `<(find ...)`   a process substitution's redirect -- `_REDIR_PREFIX_RE`
+        #   `$(find ...)`   a substitution's opener -- `_strip_grouping`
+        #   `ls|find ...`   a control operator glued to the previous command, which
+        #                   `shlex` does not split on, so the whole thing arrived as
+        #                   ONE token whose basename matched nothing (found in review)
+        #
+        # The operator split takes the LAST piece, because that is the position a
+        # program word occupies: `ls|find` runs `find`.
+        program = _strip_grouping(_REDIR_PREFIX_RE.sub("", token))
+        program = _CONTROL_OPERATOR_RE.split(program)[-1]
+        # `_strip_grouping` removes a leading `{` because `{ cmd; }` is shell GROUPING --
+        # but the same character opens a brace EXPANSION, so `{f,g}ind` arrived here as
+        # `f,g}ind` with the group's opener gone and matched nothing, while the shell ran
+        # `find` (found in review; the mechanism was present and an existing normalizer
+        # defeated it). The raw token is therefore tested too, and only when it really is
+        # an expansion -- a brace group that CLOSES in the same word -- so `{ find ...; }`
+        # keeps being read as grouping exactly as before.
+        raw = _CONTROL_OPERATOR_RE.split(_REDIR_PREFIX_RE.sub("", token))[-1]
+        raw_is_expansion = (
+            raw is not program and "{" in raw and "}" in raw.partition("{")[2]
+        )
+        if not _find_program_word_names_find(program) and not (
+            raw_is_expansion and _find_program_word_names_find(raw)
+        ):
+            continue
+        parsed = _parse_find_invocation(tokens, index + 1)
+        if not (parsed.delivers or captured):
+            continue
+        # A traversal with no root operand walks the working directory -- unless the
+        # roots came from a source this parse cannot read, in which case `.` would be
+        # a fiction and the unknowable-root reading applies instead.
+        if not parsed.roots and parsed.opaque_roots:
+            reading: list[str] = []
+        else:
+            reading = parsed.roots or ["."]
+        named = _find_traversal_reaches_fence(
+            reading,
+            parsed.name_pats,
+            parsed.path_pats,
+            parsed.regex_pats,
+            parsed.opaque_roots,
+            parsed.filters_bind,
+        )
+        if named:
+            return named
+    return None
 
 
 def _check_sensitive_via_normalizer(command: str) -> str | None:

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -9920,3 +9920,1871 @@ class TestIdentityAuthStoreFence:
         store = is_sensitive_bash_command("find ~ -name data.sqlite3 -exec cat {} +")
         control = is_sensitive_bash_command("find ~ -name token_signing.key -exec cat {} +")
         assert (store is None) == (control is None)
+
+
+class TestFindTraversalReachesFence:
+    """``find`` factors a path into a root and a name pattern, so neither token names it.
+
+    Every other pass in this module answers "does a TOKEN resolve to a fenced
+    path". ``find ~/.kiro/crew -name .env -exec cat {} +`` has no such token: the
+    directory is in one argument, the leaf in another, and the path itself is
+    produced at runtime. Re-joining the two is what makes the traversal visible
+    (#7034).
+
+    The delivery requirement is what keeps this narrow: a bare ``find`` that only
+    LISTS is unaffected, so the newly-denied set is exactly the traversals that
+    hand a match to a command.
+    """
+
+    # ── the forms measured on the issue ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "find ~/.kiro/crew -name '.env' -exec cat {} +",
+            "find ~/.kiro/crew -name 'token_signing.key' -exec cat {} +",
+            "find ~/.kiro/crew -name 'computer_use.json' -exec cat {} +",
+            "find ~/.kiro/crew -name '*.lock' | xargs cat",
+        ),
+    )
+    def test_issue_bypasses(self, command: str) -> None:
+        """Four of the five commands reported on #7034 -- each reads a permanent
+        secret. The fifth reaches ``~/.aws/credentials`` and so needs a store on
+        disk; it is covered in the fake home below."""
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_the_fifth_issue_bypass(self, monkeypatch, tmp_path) -> None:
+        """``find ~ -name credentials -exec cat {} +`` -- the traversal starts
+        OUTSIDE the fence and reaches ``.aws`` by descent, which is why the root
+        names nothing the earlier passes could see."""
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(
+            f"find {home} -name 'credentials' -exec cat {{}} +"
+        )
+        security._home_targets_cache.clear()
+
+    # ── the carrier grammar: every way find hands a match to a command ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "find ~/.kiro/crew -name '.env' -exec cat {} +",
+            "find ~/.kiro/crew -name '.env' -exec cat {} ;",
+            "find ~/.kiro/crew -name '.env' -execdir cat {} +",
+            "find ~/.kiro/crew -name '.env' -ok cat {} ;",
+            "find ~/.kiro/crew -name '.env' -okdir cat {} ;",
+            "find ~/.kiro/crew -name '.env' -delete",
+            "find ~/.kiro/crew -name '.env' -fprint /tmp/leak",
+            "find ~/.kiro/crew -name '.env' -fls /tmp/leak",
+            "find ~/.kiro/crew -name '.env' -fprintf /tmp/leak '%p'",
+            "find ~/.kiro/crew -name '.env' -exec sh -c 'cat \"$1\"' _ {} ;",
+            # the pipe is the delivery, so xargs' own flag grammar never matters
+            "find ~/.kiro/crew -name '.env' | xargs cat",
+            "find ~/.kiro/crew -name '.env' -print0 | xargs -0 cat",
+            "find ~/.kiro/crew -name '.env' | xargs -I{} cat {}",
+            "find ~/.kiro/crew -name '.env' | xargs -n1 -P4 head -c 100",
+            "find ~/.kiro/crew -name '.env' | while read f; do cat $f; done",
+            "cat $(find ~/.kiro/crew -name '.env')",
+            "cat `find ~/.kiro/crew -name '.env'`",
+            "cat < <(find ~/.kiro/crew -name '.env')",
+            "find ~/.kiro/crew -name '.env' > /tmp/leak",
+        ),
+    )
+    def test_every_delivery_form_is_denied(self, command: str) -> None:
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_an_unknown_primary_is_treated_as_delivery(self) -> None:
+        """Fail closed: the inert set is the allow-list, so a primary nobody
+        enumerated denies rather than permits. That polarity is the module's own
+        (`_TRUST_ROOT_READ_LISTERS`): naming the writers fails OPEN."""
+        assert security.is_sensitive_bash_command(
+            "find ~/.kiro/crew -name '.env' -exceedingly-new-primary cat {} +"
+        )
+
+    # ── the three ways a traversal can name a fenced path ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # the root IS the directory whose secrets live in its leaves, and the
+            # leaf is the runtime wildcard -- the `~/.kiro/crew/$F` shape
+            "find ~/.kiro/crew -type f -exec cat {} +",
+            "find ~/.kiro/crew -name '*' -exec cat {} +",
+            "find ~/.kiro/crew -name 'tmp*.tmp' -exec cat {} +",
+            "find ~/.kirocrew -name '.env' -exec cat {} +",
+            "find ~/.kiro/crew/workspace/md-notebook -type f -exec cat {} +",
+            # the root IS a fenced directory
+            "find ~/.aws -type f -exec cat {} +",
+            "find ~/.ssh -type f -exec cat {} +",
+        ),
+    )
+    def test_root_names_the_credential_directory(self, command: str) -> None:
+        assert security.is_sensitive_bash_command(command), command
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # the pattern matches a name the fence itself declares
+            "find ~ -name '.env' -exec cat {} +",
+            "find ~ -name 'token_signing.key' -exec cat {} +",
+            "find ~ -name 'security_policy.json' -exec cat {} +",
+            "find ~ -name '.local_secret' -exec cat {} +",
+            "find ~ -name '*.key' -exec cat {} +",
+            "find ~ -name '.npmrc' -exec cat {} +",
+            # -iname folds, and so does the fence
+            "find ~ -iname '.ENV' -exec cat {} +",
+            "find ~ -iname 'TOKEN_SIGNING.KEY' -exec cat {} +",
+        ),
+    )
+    def test_pattern_names_a_declared_fence_name(self, command: str) -> None:
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_traversal_from_the_filesystem_ROOT_reaches_a_declared_name(self) -> None:
+        """The absolute-root spelling, computed rather than written as ``/``.
+
+        ``find /`` is a POSIX-only literal: on Windows the fence lives under a drive and
+        no target starts with ``/``. The root must come from the anchor of the home the
+        fence is ACTUALLY anchored on, not from the current working directory's drive --
+        the Windows shard runs from ``D:`` while the home is on ``C:``, so a traversal of
+        the CWD's drive reaches no fence and the assertion could never hold. Interpolated
+        with forward slashes because a backslash is an escape to shlex.
+        """
+        root = Path(Path(os.path.expanduser("~")).anchor).as_posix()
+        command = f"find {root} -name 'token_signing.key' -exec cat {{}} +"
+        assert security.is_sensitive_bash_command(command), command
+
+    @staticmethod
+    def _fake_home_with_stores(monkeypatch, tmp_path) -> str:
+        """A home holding real credential stores, so the stat has something to find.
+
+        ``Path.home()`` reads HOME on POSIX and USERPROFILE on Windows and the
+        fence anchors on it, so both are set -- the pattern the keystone tests
+        already use. The target cache is keyed on the resolved roots, so it is
+        cleared to keep this test independent of call order.
+        """
+        home = tmp_path / "home"
+        (home / ".aws").mkdir(parents=True)
+        (home / ".aws" / "credentials").write_text("[default]\n")
+        (home / ".ssh").mkdir()
+        (home / ".ssh" / "id_rsa").write_text("-----BEGIN-----\n")
+        (home / ".ssh" / "known_hosts").write_text("host ssh-rsa AAAA\n")
+        (home / "Repos" / "app").mkdir(parents=True)
+        (home / "Repos" / "app" / "package.json").write_text("{}\n")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        security._home_targets_cache.clear()
+        # as_posix: a backslash is an ESCAPE to shlex, so a Windows temp path
+        # interpolated into a command loses every separator and the gate parses a
+        # root that is not this directory. Windows accepts forward slashes.
+        return home.as_posix()
+
+    @pytest.mark.parametrize(
+        "filter_and_sink",
+        (
+            "-name 'credentials' -exec cat {} +",
+            "-name 'id_rsa' -exec cat {} +",
+            "-name 'credentials' -delete",
+            "-type f -name 'id_rsa' -exec base64 {} ;",
+        ),
+    )
+    def test_literal_name_resolved_inside_a_credential_store(
+        self, monkeypatch, tmp_path, filter_and_sink: str
+    ) -> None:
+        """A literal ``-name`` is the traversal being used to RESOLVE a path.
+
+        Every file inside ``.aws``/``.ssh`` is fenced, so a request for one exact
+        filename that carries credentials anywhere names a fenced path as surely as
+        spelling it out.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(f"find {home} {filter_and_sink}")
+        security._home_targets_cache.clear()
+
+    def test_a_name_fenced_only_by_location_is_a_named_residual(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """``known_hosts`` is fenced by WHERE it sits, not by what it is called.
+
+        This clause decides from the name, so a name that carries no credential
+        signal of its own is not caught by it from an ancestor root -- the recorded
+        cost of answering without touching the filesystem (see
+        `_find_filter_names_a_credential_leaf`: the probe it replaced could only ever
+        see a store's direct children, and enumerating for a glob cost 110 listdir
+        calls on one traversal).
+
+        The fence itself is unaffected: naming the path, or rooting the traversal AT
+        the store, both still deny. Only the ancestor-rooted name-only spelling of a
+        non-credential-looking leaf is out of reach, and ``known_hosts`` is host
+        fingerprints rather than secret material.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert (
+            security.is_sensitive_bash_command(f"find {home} -name 'known_hosts' | xargs cat")
+            is None
+        )
+        # the fence still holds by every other route
+        assert security.is_sensitive_bash_command(f"cat {home}/.ssh/known_hosts")
+        assert security.is_sensitive_bash_command(f"find {home}/.ssh -type f -exec cat {{}} +")
+        security._home_targets_cache.clear()
+
+    @pytest.mark.parametrize(
+        "filter_and_sink",
+        (
+            # a name that is not in any store -- the stat is what says so
+            "-name 'package.json' -exec wc -l {} +",
+            "-type d -name '__pycache__' -exec rm -rf {} +",
+            "-name 'tsconfig.json' | xargs cat",
+            # a glob matching only non-credential basenames is a search, not a
+            # request for a fenced name -- the filename predicate is what says so
+            "-name '*.py' -exec grep -l foo {} +",
+            "-name '*.md' | xargs wc -l",
+            # listing, so nothing receives the match
+            "-name 'credentials'",
+            "-name 'id_rsa' -print",
+        ),
+    )
+    def test_a_home_rooted_traversal_that_names_no_store_file_is_allowed(
+        self, monkeypatch, tmp_path, filter_and_sink: str
+    ) -> None:
+        """The boundary of the clause above, pinned in the same fake home.
+
+        Without the existence probe every one of these would be refused, because
+        the home directory holds ``.aws`` and ``.ssh`` whatever the pattern asks
+        for. This is the over-block the issue warns about, so it is a test.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(f"find {home} {filter_and_sink}") is None
+        security._home_targets_cache.clear()
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "find ~ -path '*/.aws/credentials' -exec cat {} +",
+            "find ~ -path '*/.ssh/*' -exec cat {} +",
+            "find ~ -wholename '*/.kiro/crew/.env' -exec cat {} +",
+            "find ~ -ipath '*/.KIRO/CREW/.ENV' -exec cat {} +",
+        ),
+    )
+    def test_path_family_patterns(self, command: str) -> None:
+        """``-path`` matches the whole path, so the pattern carries the fenced
+        segments itself -- dropping its wildcard segments leaves a path to test."""
+        assert security.is_sensitive_bash_command(command), command
+
+    # ── spellings of the traversal itself ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "find -L ~/.kiro/crew -name '.env' -exec cat {} +",
+            "find -H -P ~/.kiro/crew -name '.env' -exec cat {} +",
+            "find -D tree ~/.kiro/crew -name '.env' -exec cat {} +",
+            "find -O3 ~/.kiro/crew -name '.env' -exec cat {} +",
+            "find /tmp ~/.kiro/crew -name '.env' -exec cat {} +",
+            "/usr/bin/find ~/.kiro/crew -name '.env' -exec cat {} +",
+            "fi''nd ~/.kiro/crew -name '.env' -exec cat {} +",
+            "find $HOME/.kiro/crew -name '.env' -exec cat {} +",
+            "find ${HOME}/.kiro/crew -name '.env' -exec cat {} +",
+            "find ~/.kiro/crew -mindepth 1 -maxdepth 2 -type f -name '.env' -exec cat {} +",
+            "find ~/.kiro/crew '(' -name '.env' -o -name '*.key' ')' -exec cat {} +",
+            "ls /tmp && find ~/.kiro/crew -name '.env' -exec cat {} +",
+        ),
+    )
+    def test_traversal_spellings(self, command: str) -> None:
+        assert security.is_sensitive_bash_command(command), command
+
+    # ── zero false positives: the benign uses that must stay allowed ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # a project-rooted traversal reaches no fence at all
+            "find . -name '*.py' -exec grep -l foo {} +",
+            "find . -name '.env' -exec cat {} +",
+            "find . -name '*.lock' -exec cat {} +",
+            "find src -name '*.ts' | xargs wc -l",
+            "find /var/log -name '*.log' -delete",
+            "find /opt/app -name 'build.tmp' -exec cat {} +",
+            "find ~/Downloads -name '*.zip' -exec unzip -l {} +",
+            "find ~/Repos/app -name 'package.json' -exec wc -l {} +",
+            "find ~/Repos -name 'yarn.lock' | xargs cat",
+            "find . -type d -name node_modules -prune -o -name '*.js' -print",
+            # a home-rooted SEARCH -- a glob is not a request for a fenced name
+            "find ~ -name '*.py' -exec grep -l foo {} +",
+            "find ~ -name '*.md' | xargs wc -l",
+            "find ~ -name '*.orig' -delete",
+            # the crew home's own non-secret subtrees, which agents read routinely
+            "find ~/.kiro/crew/workspace -name '*.md' -exec cat {} +",
+            "find ~/.kiro/crew/workspace/memory -name 'projects.md' -exec cat {} +",
+            "find ~/.kiro/crew/skills -name 'SKILL.md' | xargs head -5",
+            # listing only: no command receives a match
+            "find ~ -name '.env'",
+            "find ~ -name 'credentials' -print",
+            "find ~/.kiro/crew -type f -name '*.lock' -printf '%p\\n'",
+            "find ~/.kiro/crew -name '.env' -ls",
+            # not a traversal at all
+            "xargs cat < files.txt",
+            "grep -rn TODO src",
+            "echo find",
+        ),
+    )
+    def test_benign_traversals_stay_allowed(self, command: str) -> None:
+        assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_a_bare_listing_of_a_fenced_root_is_unchanged(self) -> None:
+        """``find ~/.ssh`` names a fenced path directly, so the pre-existing path
+        matcher denies it whether or not it delivers -- this pass changes nothing
+        there, and the assertion pins that it is not this pass doing the work."""
+        assert security.is_sensitive_bash_command("find ~/.ssh -type f")
+        assert security._check_find_traversal_reaches_fence("find ~/.ssh -type f") is None
+
+    def test_the_delivery_requirement_is_what_bounds_the_change(self) -> None:
+        """The same traversal, listed and delivered. Only the second is new."""
+        listed = "find ~/.kiro/crew -type f -name '*.lock'"
+        delivered = listed + " -exec cat {} +"
+        assert security._check_find_traversal_reaches_fence(listed) is None
+        assert security._check_find_traversal_reaches_fence(delivered)
+
+    def test_the_gate_is_not_verb_aware(self) -> None:
+        """A traversal that names a fenced path is denied whatever the child is --
+        the module's stated posture, and the reason no executor list is kept."""
+        for child in ("cat", "head", "python3", "base64", "cp", "rm", "totally-unknown"):
+            command = f"find ~/.kiro/crew -name '.env' -exec {child} {{}} +"
+            assert security.is_sensitive_bash_command(command), command
+
+    def test_a_glob_that_covers_a_declared_name_is_denied_on_purpose(self) -> None:
+        """The one deliberate over-trigger, recorded rather than left to be found.
+
+        ``*.json`` matches ``security_policy.json`` and ``config.json``, which the
+        fence declares by name, so a traversal delivering every JSON file in the
+        home directory really does read them. The glob carve-out is about names the
+        fence does NOT declare (``*.py``), not about widening a name it does.
+        """
+        assert security.is_sensitive_bash_command("find ~ -name '*.json' -exec cat {} +")
+        assert security.is_sensitive_bash_command("find ~ -name '*.key' | xargs cat")
+        assert security.is_sensitive_bash_command("find ~ -name '*.py' -exec cat {} +") is None
+
+    def test_the_pass_only_ever_adds_denials(self) -> None:
+        """It is a new pass returning a reason or None, so it cannot un-deny.
+
+        Pinned on the commands whose denial belongs to an EARLIER pass: this one
+        answers None for them, which is the evidence that the verdicts they
+        already had are still theirs.
+        """
+        for command in (
+            "cat ~/.aws/credentials",
+            "cat ~/.kiro/crew/token_signing.key",
+            "cd ~/.kiro/crew && cat .env",
+            "find ~/.ssh -type f",
+        ):
+            assert security.is_sensitive_bash_command(command), command
+            assert security._check_find_traversal_reaches_fence(command) is None, command
+
+    # ── the three findings from the Opus review round ──
+
+    @pytest.mark.parametrize(
+        "filter_and_sink",
+        (
+            # the literal spelling, answered by the name itself
+            "-name id_rsa -exec cat {} +",
+            "-name credentials -exec cat {} +",
+            "-name id_rsa -delete",
+            "-type f -name id_rsa -exec base64 {} ;",
+            # a glob matching a name the FENCE declares is denied by the list
+            "-name '*.key' -exec cat {} +",
+            "-name '.env' -exec cat {} +",
+        ),
+    )
+    def test_a_named_store_file_and_a_declared_name_both_deny(
+        self, monkeypatch, tmp_path, filter_and_sink: str
+    ) -> None:
+        """Two independent routes to the same verdict.
+
+        A name that carries credentials anywhere is answered by the predicate; a GLOB
+        is answered by the fence list when it covers a declared basename, and by the
+        predicate's own vocabulary when it covers a credential leaf or suffix -- see
+        `_find_filter_names_a_credential_leaf` for why neither route touches the
+        filesystem.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(f"find {home} {filter_and_sink}")
+        security._home_targets_cache.clear()
+
+    @pytest.mark.parametrize(
+        "filter_and_sink",
+        (
+            "-regex '.*/[.]py$' -exec grep -l foo {} +",
+            "-regex '.*/package[.]json' -exec wc -l {} +",
+            "-iregex '.*[.]MD' | xargs wc -l",
+        ),
+    )
+    def test_a_regex_filter_is_never_evaluated_so_it_widens(
+        self, monkeypatch, tmp_path, filter_and_sink: str
+    ) -> None:
+        """A ``-regex`` pattern is agent-supplied, so this pass will not RUN it.
+
+        The gate is synchronous and in-process and CPython's ``re`` has no timeout,
+        so a catastrophic-backtracking pattern would wedge it for every session
+        rather than merely mis-answer. The filter is therefore read as opaque, which
+        means a DELIVERING ``-regex`` traversal over a root that contains a fence is
+        refused whatever the pattern says. That over-block is the price of never
+        running the pattern, and it is deliberate.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(f"find {home} {filter_and_sink}")
+        security._home_targets_cache.clear()
+
+    def test_the_regex_over_block_is_bounded_by_the_root(self, tmp_path) -> None:
+        """The bound on the clause above: a root holding no fence is untouched.
+
+        The root comes from ``tmp_path`` rather than a hardcoded ``/tmp``. The suite
+        relocates ``KIROCREW_HOME`` under the pytest base temp dir, which on CI lives
+        in ``/tmp`` -- so ``/tmp`` genuinely DOES contain the fence there and an
+        opaque filter correctly denies a traversal of it. The gate was right and the
+        assertion was wrong; ``tmp_path`` is a sibling of the relocated home, never an
+        ancestor of it.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        project = project.as_posix()
+        for command in (
+            f"find {project} -regex '.*/package[.]json' -exec wc -l {{}} +",
+            f"find {project} -regex '.*[.]py$' | xargs wc -l",
+            f"find {project} -regex '.*[.]log' -delete",
+            # and a listing is unaffected wherever it is rooted
+            "find ~ -regex '.*[.]py$'",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    @pytest.mark.parametrize(
+        "pattern",
+        (
+            "{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}b",
+            "*" * 40 + "b",
+            "{a}*{a}*{a}*{a}*{a}*{a}*{a}*{a}*{a}*{a}b",
+        ),
+    )
+    def test_adjacent_any_run_wildcards_are_collapsed(self, pattern: str) -> None:
+        """``_glob_to_regex`` turns an agent glob into an agent REGEX.
+
+        A brace group becomes ``.*``, so ``-name '{a}{a}...b'`` compiled to fourteen
+        ADJACENT ``.*`` and hung the gate outright -- measured as still running after
+        12 seconds, the watchdog-crossing hang this module documents. ``.*.*`` names
+        exactly what ``.*`` names, so collapsing the run is semantics-preserving and
+        turns the pathological case into a linear one rather than refusing it.
+        """
+        matcher = security._find_glob_matcher(pattern)
+        assert matcher is not None, pattern
+        assert matcher.pattern.count(".*") == 1, matcher.pattern
+
+    @pytest.mark.parametrize(
+        "pattern",
+        (
+            "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*b",
+            "*.*.*.*.*.*.*.*.*.*.*.*.*.*.*z",
+            "?a*b*c*d*e*f*g*h*i*j*k*l*m*n*o",
+        ),
+    )
+    def test_too_many_separated_wildcards_are_refused_not_run(self, pattern: str) -> None:
+        """Runs separated by literals cannot be collapsed, so they are capped.
+
+        Refusing returns None, which the caller reads as opaque -- it WIDENS the
+        traversal rather than dropping the filter, so the bound cannot become a
+        bypass.
+        """
+        assert security._find_glob_matcher(pattern) is None, pattern
+
+    def test_an_ordinary_glob_still_compiles(self) -> None:
+        """The bound: a real filename filter is unaffected by either mechanism."""
+        for pattern in ("*.py", ".env", "id_*", "*.tar.gz", "test_*_spec.?s", "[abc]*.md"):
+            assert security._find_glob_matcher(pattern) is not None, pattern
+
+    def test_an_adversarial_pattern_answers_quickly(self) -> None:
+        """The direct evidence: these used to hang, so a wall clock is the assertion.
+
+        The margin is enormous on purpose -- the measured cost is ~30ms and the
+        failure being guarded is unbounded, so this cannot flake on a loaded box
+        while still catching a return to super-polynomial matching.
+        """
+        commands = (
+            "find ~ -name '{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}b' -exec cat {} +",
+            "find ~ -regex '(.*)*z' -exec cat {} +",
+            "find ~ -regex '(a+)+$' -exec cat {} +",
+            "find ~ -path '*a*a*a*a*a*a*a*a*a*a*a*a*a*a*b' -exec cat {} +",
+        )
+        start = time.monotonic()
+        for command in commands:
+            security.is_sensitive_bash_command(command)
+        assert time.monotonic() - start < 10.0
+
+    # ── the findings from the round-4 review ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # an operator GLUED to a filter operand was swallowed as pattern text,
+            # so delivery was never seen and the read went through
+            "find ~/.kiro/crew -name .env|xargs cat",
+            "find ~/.kiro/crew -name .env|head -1",
+            "find ~/.kiro/crew -type f|xargs cat",
+            "find ~/.kiro/crew -type f>/tmp/leak",
+            "find ~/.kiro/crew -type f>>/tmp/leak",
+            "find ~/.kiro/crew -name .env -exec cat {} ;",
+            # the whitespace-separated twin, which was already denied
+            "find ~/.kiro/crew -name .env | xargs cat",
+        ),
+    )
+    def test_an_operator_glued_to_a_filter_operand(self, command: str) -> None:
+        """``shlex`` splits on whitespace only, so ``-name .env|xargs`` arrived as ONE
+        token and the pipe was consumed as the search pattern -- the gate defeated by
+        deleting one space, while the spaced twin denied."""
+        assert security.is_sensitive_bash_command(command), command
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "find ./src -name 'a|b' -print",
+            "find ./src -name 'a|b' -exec cat {} +",
+            "find ./src -name 'a;b' -exec cat {} +",
+            "find ./src -name 'a>b' | xargs wc -l",
+        ),
+    )
+    def test_a_quoted_operator_is_not_split(self, command: str) -> None:
+        """The reason the spacing works on the RAW string and not on the tokens.
+
+        ``shlex`` has already removed the quotes by token time, so splitting there
+        could not tell a quoted ``|`` in a filename from a real pipe -- the hazard
+        `_split_glued_operators` documents. Quote state survives on the raw string,
+        so the pattern is left intact and no spurious delivery is invented.
+        """
+        assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_the_spacer_keeps_the_shapes_the_pass_depends_on(self) -> None:
+        """Three spellings the spacing must not disturb, each load-bearing."""
+        spaced = security._find_space_unquoted_operators
+        # a process substitution keeps `<(` glued -- capture no longer depends on
+        # reading those two characters off a token (see `_find_traversal_views`), but
+        # splitting them would still serve nothing, and `<` is not a delivery
+        assert spaced("cat < <(find ~ -name .env)") == "cat < <(find ~ -name .env)"
+        # a command substitution keeps `$(`
+        assert spaced("cat $(find ~ -name .env)") == "cat $(find ~ -name .env)"
+        # a backslash-escaped `;` is find's own exec terminator, not a separator
+        assert "\\;" in spaced("find ~ -name .env -exec cat {} \\;")
+        # a two-character operator stays together
+        assert ">>" in spaced("find ~ -type f>>out")
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "P=.env; find ~ -name $P -exec cat {} +",
+            "find ~ -name ${P} -exec cat {} +",
+            "find ~ -path $P -exec cat {} +",
+            "find ~ -name %NAME% -exec cat {} +",
+            # an unresolved ROOT plus a fence-declared name
+            "find $D -name .env -exec cat {} +",
+            "find ${D}/crew -name token_signing.key | xargs cat",
+        ),
+    )
+    def test_an_unresolved_expansion_widens(self, command: str) -> None:
+        """``normalize_shell_command`` expands only ``$HOME``, so a filter carrying a
+        variable this command never assigned matched the LITERAL ``$P`` against the
+        fence, matched nothing, and read the secret. An unknowable filter is now read
+        as ``*``, and an unknowable ROOT adds the home hypothesis the segment walk
+        already uses."""
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_an_unresolved_root_does_not_deny_an_ordinary_search(self) -> None:
+        """The bound: adding the home hypothesis lets the FILTER still decide."""
+        for command in (
+            "find $BUILD -name '*.o' -delete",
+            "find $OUT -name '*.map' -exec rm {} +",
+            "find ${DIST} -name '*.js' | xargs wc -l",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_a_nested_whole_directory_store_is_probed(self, monkeypatch, tmp_path) -> None:
+        """Keeping only SINGLE-segment fence entries dropped the nested stores.
+
+        ``.config/gcloud`` fences its whole subtree exactly as ``.aws`` does, so its
+        credential database was readable through a literal ``-name``. Every entry
+        fences its subtree, so the list is now taken as-is -- which also keeps
+        ``~/.kiro/crew`` out, since that directory is a leaf PARENT and not an entry.
+        """
+        home = tmp_path / "home"
+        (home / ".config" / "gcloud").mkdir(parents=True)
+        (home / ".config" / "gcloud" / "credentials.db").write_text("db\n")
+        (home / ".config" / "starship.toml").write_text("ok\n")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        security._home_targets_cache.clear()
+        home = home.as_posix()
+        assert security.is_sensitive_bash_command(
+            f"find {home} -name credentials.db -exec cat {{}} +"
+        )
+        # the general-purpose parent is NOT a store, so its own files stay readable
+        assert (
+            security.is_sensitive_bash_command(f"find {home} -name starship.toml -exec cat {{}} +")
+            is None
+        )
+        security._home_targets_cache.clear()
+
+    def test_the_verdict_touches_no_filesystem_for_the_store_clause(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """This clause answers from the NAME, so it must not stat or list anything.
+
+        The two revisions before it did, and each way was its own defect: a
+        direct-child ``os.path.exists`` could not see a key one level down, and an
+        ``os.listdir`` per store to match a glob measured 110 listdir calls and 14.4ms
+        for ONE traversal on a synchronous in-process gate (against 0 and 0.7ms for an
+        ordinary fenced read). Counting the calls is the assertion because "it is
+        fast now" is not a property -- zero is.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        calls: list[str] = []
+        real_listdir, real_scandir = os.listdir, os.scandir
+
+        monkeypatch.setattr(
+            os, "listdir", lambda p, *a, **k: (calls.append(f"listdir:{p}"), real_listdir(p))[1]
+        )
+        monkeypatch.setattr(
+            os, "scandir", lambda p=".", *a, **k: (calls.append(f"scandir:{p}"), real_scandir(p))[1]
+        )
+        for command in (
+            f"find {home} -name 'id_*' -exec cat {{}} +",
+            f"find {home} -name '*.py' -exec grep -l foo {{}} +",
+            f"find {home} -name id_rsa -exec cat {{}} +",
+            f"find {home} {home} -name 'credential*' | xargs cat",
+        ):
+            security.is_sensitive_bash_command(command)
+        assert calls == [], calls
+        security._home_targets_cache.clear()
+
+    @pytest.mark.parametrize("prefix", ("ls|", "true;", "true&&", "true&", "echo hi|"))
+    def test_an_operator_glued_to_the_program_word(self, prefix: str) -> None:
+        """``shlex`` splits on whitespace only, so ``ls|find`` arrived as ONE token.
+
+        ``os.path.basename('ls|find')`` is ``'ls|find'``, which matched no program
+        name, so the pass never ran -- the whole gate bypassed by removing one space.
+        """
+        command = f"{prefix}find ~/.kiro/crew -name '.env' -exec cat {{}} +"
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_glued_pipe_after_the_traversal_is_still_delivery(self) -> None:
+        """The operator arrives glued to the last operand (``-type f|xargs``)."""
+        assert security.is_sensitive_bash_command("find ~/.kiro/crew -type f|xargs cat")
+        assert security.is_sensitive_bash_command("find ~/.kiro/crew -name '.env'|head -1")
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "find ~/.kiro/crew -type f; cat notes | less",
+            "find ~/.kiro/crew -type f && echo done | tee log",
+            "find ~/.kiro/crew -name '*.lock' ; echo $(date) > /tmp/stamp",
+            "find ~/.kiro/crew -type f & wait",
+        ),
+    )
+    def test_a_sibling_command_s_pipe_does_not_make_a_listing_a_delivery(
+        self, command: str
+    ) -> None:
+        """Delivery is read from the invocation's own span, not the command line.
+
+        Scanning the whole line denied these listings because a LATER, unrelated
+        command carried a pipe or a redirect. ``;``, ``&&`` and ``&`` only sequence.
+        """
+        assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_the_same_traversal_with_its_own_pipe_is_denied(self) -> None:
+        """The control for the case above: the pipe belongs to the traversal."""
+        assert security.is_sensitive_bash_command("find ~/.kiro/crew -type f | less")
+        assert security.is_sensitive_bash_command("find ~/.kiro/crew -type f > /tmp/leak")
+
+    # ── the finding from the Opus round on the rebased head ──
+
+    @pytest.mark.parametrize(
+        "command_template",
+        (
+            "cat $(find {home} -regex '.*/id_rsa$')",
+            "cat `find {home} -regex '.*/id_rsa$'`",
+            "head -c 80 $(find {home} -iregex '.*/CREDENTIALS')",
+            # the two families that already stripped, as the parity controls
+            "cat $(find {home} -name id_rsa)",
+            "cat $(find {home} -path '*/.ssh/id_rsa')",
+        ),
+    )
+    def test_a_captured_substitution_does_not_corrupt_the_pattern(
+        self, monkeypatch, tmp_path, command_template: str
+    ) -> None:
+        """``shlex`` glues the substitution's closing paren onto the pattern token.
+
+        The strip was written per-list at the call site and ``-regex`` was the list
+        that did not get it, so ``.*/id_rsa$)`` failed to compile, its matcher was
+        dropped, and the read was allowed -- while the ``-name`` spelling of the very
+        same read was denied. It is now stripped where the pattern is READ, so no
+        family can be missed.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        command = command_template.format(home=home)
+        assert security.is_sensitive_bash_command(command), command
+        security._home_targets_cache.clear()
+
+    @pytest.mark.parametrize(
+        "pattern_flag",
+        (
+            "-regex '('",
+            "-regex '*/id_rsa'",
+            "-regex 'a{2,1}'",
+            "-regex '[z-a]'",
+            "-iregex '(?P<'",
+        ),
+    )
+    def test_a_pattern_that_will_not_compile_fails_closed(self, pattern_flag: str) -> None:
+        """A matcher that cannot be built must WIDEN the traversal, not vanish.
+
+        Dropping it left the clause with neither a matcher nor the no-filter
+        reading, so every malformed pattern silently allowed the traversal. An
+        opaque pattern is now read as ``*`` -- the module's stated stance that a
+        *maybe* answers yes.
+        """
+        command = f"find ~/.kiro/crew {pattern_flag} -exec cat {{}} +"
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_compilable_regex_matching_nothing_fenced_is_still_allowed(self) -> None:
+        """A regex filter is not evaluated, so the ROOT is what bounds the answer."""
+        assert (
+            security.is_sensitive_bash_command(
+                "find ~/Repos -regex '.*/package[.]json' -exec wc -l {} +"
+            )
+            is None
+        )
+        assert (
+            security.is_sensitive_bash_command("find ~/Repos -regex '.*[.]py$' | xargs wc -l")
+            is None
+        )
+
+    # ── the round-5 review: the pass judged the command's TEXT, not what runs ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # a `-c` payload is never re-tokenized by a whole-command pass, so the
+            # traversal was invisible while the same payload holding a plain fenced
+            # path TOKEN was correctly denied by the argv floor
+            'bash -c "find ~/.kiro/crew -name .env -exec cat {} +"',
+            "sh -c 'find ~/.kiro/crew -name .env -exec cat {} +'",
+            'bash -c "find ~/.kiro/crew -name .env | xargs cat"',
+            "zsh -c 'find ~ -name token_signing.key -exec cat {} +'",
+            "eval 'find ~/.kiro/crew -name .env -exec cat {} +'",
+            # wrapped twice: no depth is a special case, because a view is a proper
+            # substring of its parent and the walk terminates on that alone
+            "bash -c \"sh -c 'find ~/.kiro/crew -name .env -exec cat {} +'\"",
+            # the payload is captured because the WRAPPER is
+            "cat $(bash -c 'find ~/.kiro/crew -name .env')",
+        ),
+    )
+    def test_a_traversal_inside_a_nested_shell_payload(self, command: str) -> None:
+        """The traversal runs, so the view it runs in is what must be judged."""
+        assert security.is_sensitive_bash_command(command), command
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # ONE SPACE after the opener moved it into a token of its own, so the
+            # two-character test on the program word's token missed it entirely --
+            # the identical read, denied glued and allowed spaced
+            "cat $( find ~/.kiro/crew -name .env )",
+            "cat ` find ~/.kiro/crew -name .env `",
+            "cat < <( find ~/.kiro/crew -name .env )",
+            "head -c 80 $(   find ~/.kiro/crew -name .env   )",
+            # nested one substitution deep
+            "cat $(echo $( find ~/.kiro/crew -name .env ))",
+            # the glued twins, which were already denied -- the parity controls
+            "cat $(find ~/.kiro/crew -name .env)",
+            "cat <(find ~/.kiro/crew -name .env)",
+        ),
+    )
+    def test_capture_does_not_depend_on_the_spacing_of_the_opener(self, command: str) -> None:
+        """Capture is a property of the view, not of two characters glued to a token."""
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_view_is_captured_by_how_it_was_derived(self) -> None:
+        """The mechanism itself: a substitution body carries capture, a payload inherits it."""
+        outer = "cat $( find ~ -name .env )"
+        views = dict(security._find_traversal_views(outer))
+        # the command's own text is not captured -- something must consume it
+        assert views[outer] is False
+        # the substitution's body is, whatever the spacing inside it
+        assert views[" find ~ -name .env "] is True
+        # a `-c` payload prints where its wrapper prints, so it is NOT captured
+        payload_views = dict(security._find_traversal_views("bash -c 'find ~ -type f'"))
+        assert payload_views["find ~ -type f"] is False
+        # ...unless the wrapper itself is captured
+        both = dict(security._find_traversal_views("cat $(bash -c 'find ~ -type f')"))
+        assert both["find ~ -type f"] is True
+
+    @pytest.mark.parametrize(
+        "program",
+        ("/usr/bin/f?nd", "f?nd", "/usr/bin/fin*", "/usr/bin/fin[d]", "f*d", "?ind", "*"),
+    )
+    def test_a_glob_expanded_program_word_still_names_find(self, program: str) -> None:
+        """The shell expands the program word against the filesystem before running it.
+
+        An exact-string basename test read ``f?nd``, matched nothing, and skipped the
+        whole pass while the shell ran ``find``. The glob is answered by the same
+        bounded matcher the filters use, so no spelling is enumerated.
+        """
+        command = f"{program} ~/.kiro/crew -name '.env' -exec cat {{}} +"
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_the_program_word_glob_is_bounded_and_fails_closed(self) -> None:
+        """A word the wildcard cap refuses is read as a match, so the cap cannot open a hole."""
+        assert security._find_program_word_names_find("find") is True
+        assert security._find_program_word_names_find("/usr/bin/gfind") is True
+        assert security._find_program_word_names_find("f?nd") is True
+        # runs SEPARATED by literals cannot be collapsed, so this is the shape the cap
+        # actually refuses -- an adjacent run (`****d`) collapses to one `.*` and
+        # compiles, so it would exercise the matcher rather than the refusal path
+        refused = "*a" * 10 + "*d"
+        assert security._find_glob_matcher(refused) is None, refused
+        assert security._find_program_word_names_find(refused) is True
+        # and a word that cannot be find is still not find, so ordinary globs are free
+        assert security._find_program_word_names_find("grep") is False
+        assert security._find_program_word_names_find("*.py") is False
+        assert security._find_program_word_names_find("c?t") is False
+
+    def test_a_glob_bearing_command_that_names_no_traversal_is_untouched(self) -> None:
+        """The bail-out widened, so pin that the widening costs work and not verdicts."""
+        for command in (
+            "cat *.md | head -5",
+            "ls -la ~/Repos/*/package.json",
+            "grep -rn TODO src/*.py",
+            "rm -f build/*.o",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # GNU find reads its roots from a file, or from stdin for `-`, so the
+            # command names no root and a parse reading only operands defaulted to `.`
+            "printf '%s\\0' ~/.kiro/crew | find -files0-from - -name .env -exec cat {} +",
+            "find -files0-from roots.txt -name .env -exec cat {} +",
+            "find -files0-from - -name token_signing.key | xargs cat",
+        ),
+    )
+    def test_roots_read_from_outside_the_command_line(self, command: str) -> None:
+        """An unreadable root source is read as unknowable, so the filter decides."""
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_an_unreadable_root_source_still_lets_the_filter_decide(self) -> None:
+        """The bound: `-files0-from` is not a denial on its own."""
+        for command in (
+            "find -files0-from roots.txt -name '*.o' -delete",
+            "find -files0-from - -name '*.pyc' -delete",
+            # and a listing delivers nothing whatever its roots are
+            "find -files0-from - -name .env",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_an_unknowable_root_with_nothing_left_to_decide_is_not_denied(
+        self, monkeypatch
+    ) -> None:
+        """The widened root readings are only sound while a filter can reject them.
+
+        With no evaluable filter the traversal is read as ``*``, so the bare-home
+        reading matched every fence and denied an ordinary unresolved-root sweep
+        outright -- contradicting `_find_root_readings`' own docstring (found in
+        review). ``TMPDIR`` is pointed outside the fence because this suite relocates
+        the crew home under the pytest base temp dir, so the ambient value really can
+        contain a fence and the deny would be correct there.
+        """
+        monkeypatch.setenv("TMPDIR", "/var/tmp")
+        for command in (
+            'find "$TMPDIR" -type f -delete',
+            'find "$SRC" -type f -exec cat {} +',
+            "find $OUT -regex '.*[.]map' -delete",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+        # and the filtered readings still deny, which is what the widening is for
+        assert security.is_sensitive_bash_command("find $D -name .env -exec cat {} +")
+        assert security.is_sensitive_bash_command(
+            "find ${D}/crew -name token_signing.key | xargs cat"
+        )
+
+    def test_the_view_walk_terminates_without_a_depth_cap(self) -> None:
+        """No depth cap: a cap is a bypass, so termination is structural instead.
+
+        A view is a proper substring of its parent and so is strictly shorter, and a visited
+        set stops sibling wrappers re-walking the same text.
+
+        Asserted STRUCTURALLY rather than on a wall clock. The earlier form bounded elapsed
+        time over the whole gate, which measures the other passes too: at 300 substitutions
+        those cost 2365 ms on this branch and 2369 ms on a tree without this pass at all, so
+        the bound was a claim about code this change does not touch -- and it duly failed on
+        a slow Windows runner (10.25 s against a 10 s budget) for a cost this change does not
+        create. A view count and a budget comparison are deterministic and test the actual
+        invariants.
+        """
+        nested = "find ~ -name .env"
+        for _ in range(40):
+            nested = f"bash -c '{nested}'"
+        views = security._find_traversal_views(nested)
+        # The walk terminates and collapses, rather than enumerating a view per level. Note
+        # this input is a TERMINATION stress case, not a semantically 40-deep command: naive
+        # single-quote wrapping does not nest in shell, so the layers flatten and only a few
+        # views exist. No verdict is asserted on it for that reason -- the nested-payload
+        # behaviour is covered by the tests that build a genuinely nested `-c` payload.
+        assert 0 < len(views) <= 8, len(views)
+        # A command carrying more substitutions than the budget is REFUSED rather than
+        # walked, which is what bounds the cost. Sized just past the budget on purpose: the
+        # invariant is the comparison, and a pathological width would only re-import the
+        # other passes' cost into this test's runtime.
+        wide = "; ".join(f"echo $(ls dir{i})" for i in range(75)) + "; find ~ -type f"
+        assert security._find_substitution_openers(wide) > security._FIND_SUBSTITUTION_BUDGET
+        assert security.is_sensitive_bash_command(wide), "over-budget commands must deny"
+
+    @pytest.mark.parametrize(
+        ("word", "expected"),
+        (
+            # Bash's brace grammar in full: comma lists, sequences, nesting. Each
+            # expected set was measured against `bash -c 'printf %s\n <word>'` and then
+            # hard-coded, because this suite also runs on Windows where bash is absent.
+            # The comma forms were closed first and the SEQUENCE forms were missing --
+            # the class had been sampled rather than closed, which is why the table is
+            # exhaustive now.
+            ("x{a,b}", {"xa", "xb"}),
+            ("x{,a}", {"x", "xa"}),
+            ("x{a,{b,c}}", {"xa", "xb", "xc"}),
+            ("x{a..c}", {"xa", "xb", "xc"}),
+            ("x{a..a}", {"xa"}),
+            ("x{1..3}", {"x1", "x2", "x3"}),
+            ("x{1..9..3}", {"x1", "x4", "x7"}),
+            ("x{c..a}", {"xa", "xb", "xc"}),
+            ("p{a,b}s", {"pas", "pbs"}),
+            ("{a,b}{c,d}", {"ac", "ad", "bc", "bd"}),
+            ("x{a,{1..2}}", {"x1", "x2", "xa"}),
+            ("x{01..03}", {"x01", "x02", "x03"}),
+        ),
+    )
+    def test_the_brace_grammar_is_covered_in_full(self, word: str, expected: set) -> None:
+        """Every form bash expands, this pass enumerates.
+
+        Asserted as a superset rather than equality: the pass keeps the original spelling
+        alongside the expansions, and extra readings can only ever add a denial.
+        """
+        produced = set(security._find_brace_expansions(word) or []) | {word}
+        assert expected.issubset(produced), f"{word}: missing {sorted(expected - produced)}"
+
+    def test_a_mixed_or_zero_step_sequence_stays_literal(self) -> None:
+        """`{a..3}` and a zero step are not expansions in bash either, so neither here."""
+        assert security._find_brace_sequence("a..3") == []
+        assert security._find_brace_sequence("1..9..0") == []
+        assert security._find_brace_sequence("notasequence") is None
+
+    @pytest.mark.parametrize(
+        "program",
+        (
+            # brace expansion in the PROGRAM word: `find` to the shell, and matched
+            # nothing here because braces are neither a literal spelling nor a glob
+            "f{in,oo}d",
+            "f{oo,in}d",
+            "f{i..i}nd",
+            "fin{d,e}",
+            "{f,g}ind",
+        ),
+    )
+    def test_a_brace_expanded_program_word_is_still_find(
+        self, monkeypatch, tmp_path, program: str
+    ) -> None:
+        """The traversal pass was skipped entirely when the program word carried braces."""
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(
+            f"{program} {home} -type f -exec cat {{}} +"
+        ), program
+
+    def test_a_brace_program_word_that_is_not_find_still_runs(self, monkeypatch, tmp_path) -> None:
+        """Expanding the program word must not make every braced word a traversal."""
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        for benign in ("ec{h,j}o hello", "l{s,l} /tmp", "gr{e,a}p x file"):
+            assert not security.is_sensitive_bash_command(benign), benign
+        assert home
+
+    def test_deeply_nested_braces_refuse_instead_of_exhausting_the_stack(self) -> None:
+        """A nested group is expanded by a recursive call, so text depth was stack depth.
+
+        1,200 nested groups raised an uncaught `RecursionError` out of the synchronous
+        permission check -- a crash rather than a verdict, and introduced by this pass
+        (main answers the same input fine, having no such recursion). The depth budget is
+        checked before anything recurses, so the refusal is structural rather than a
+        rescued exception.
+        """
+        shallow = "dir/" + "{a," * 2 + "b" + "}" * 2
+        assert security._find_brace_nesting_depth(shallow) == 2
+        # Under budget: still enumerated and judged on the merits, not refused.
+        assert security._find_brace_expansions(shallow) is not None
+        for depth in (security._FIND_BRACE_DEPTH_BUDGET + 1, 1200, 3000):
+            root = "dir/" + "{a," * depth + "b" + "}" * depth
+            assert security._find_brace_nesting_depth(root) == depth
+            assert security._find_brace_expansions(root) is None, depth
+            # And the gate returns a verdict rather than raising, which is the property
+            # the crash violated.
+            command = f"find {root} -type f -exec cat {{}} +"
+            assert security.is_sensitive_bash_command(command), depth
+
+    @pytest.mark.parametrize(
+        "prelude",
+        (
+            # every literal spelling of an APPEND-built program word. `+=` is a gap in the
+            # same resolver that already handles `=`, and the tail is a literal, so the
+            # set is decided by the text and closes at once.
+            "F=fi; F+=nd; $F",
+            "F=fi; F+=nd; ${F}",
+            "F=; F+=find; $F",
+            "F=f; F+=i; F+=nd; $F",
+            "F=fi; F+=n; ${F}d",
+            "F=fi; F+='nd'; $F",
+            'F=fi; F+="nd"; $F',
+            "F=fi ; F+=nd ; $F",
+        ),
+    )
+    def test_an_append_built_program_word_still_resolves_to_find(
+        self, monkeypatch, tmp_path, prelude: str
+    ) -> None:
+        """`F=fi; F+=nd; $F <fenced> ...` ran a `find` this pass never saw.
+
+        The single-assignment twin (`F=fin; ${F}d`) was closed earlier, so the mechanism
+        was present and only the `+=` spelling escaped it -- the recurring shape in this
+        PR. Parametrised over the whole set rather than the reported example.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(
+            f"{prelude} {home} -type f -exec cat {{}} +"
+        ), f"an append-built program word must resolve: {prelude}"
+
+    def test_appending_does_not_invent_a_traversal_that_is_not_there(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The append resolver must not turn ordinary variable building into a denial.
+
+        Guards the direction the fix could have over-reached in: appends that never
+        spell a traversal program, and an append used as an argument rather than as the
+        program word.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        for benign in (
+            "F=he; F+=llo; echo $F",
+            "D=/tm; D+=p; ls $D",
+            "P=fin; P+=ger; $P someone",  # `finger`, not `find`
+            f"X=nd; echo {tmp_path.as_posix()}/$X",
+            "F=fi; F+=nd; echo $F",  # names find but runs nothing
+        ):
+            assert not security.is_sensitive_bash_command(benign), benign
+        assert home
+
+    def test_the_azure_bearer_token_cache_is_named(self, monkeypatch, tmp_path) -> None:
+        """`accessTokens.json` holds Azure access and refresh tokens.
+
+        Pinned with the coherence test this vocabulary requires: a DIRECT read of the
+        file already denies, so naming it makes the traversal agree with the direct read
+        instead of becoming stricter than it. A name that failed that test would belong
+        in #8074 rather than here.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        azure = Path(home) / ".azure"
+        azure.mkdir(parents=True, exist_ok=True)
+        (azure / "accessTokens.json").write_text("[]\n")
+        direct = f"cat {(azure / 'accessTokens.json').as_posix()}"
+        assert security.is_sensitive_bash_command(direct), "premise: the direct read denies"
+        for spelling in ("accessTokens.json", "accesstokens.json"):
+            assert security.is_sensitive_bash_command(
+                f"find {home} -name {spelling} -exec cat {{}} +"
+            ), spelling
+
+    @pytest.mark.parametrize(
+        "spell",
+        (
+            # every group shape the shell expands, since brace expansion is decided by
+            # the TEXT and is therefore a closed set rather than one example. Each spelling
+            # is built from the REAL leaf name at run time: hard-coding one planted a path
+            # that named nothing on the fake home and passed for the wrong reason.
+            pytest.param(lambda leaf: "{%s,%s}" % (leaf, leaf), id="both-alts-equal"),
+            pytest.param(lambda leaf: "{%s,zzz}" % leaf, id="first-alt-fenced"),
+            pytest.param(lambda leaf: "{zzz,%s}" % leaf, id="second-alt-fenced"),
+            pytest.param(lambda leaf: "%s{%s,x}" % (leaf[:2], leaf[2:]), id="split-leaf"),
+            pytest.param(lambda leaf: "{%s{%s,x},y}" % (leaf[:2], leaf[2:]), id="nested-group"),
+            pytest.param(lambda leaf: "%s{,x}" % leaf, id="empty-alt-first"),
+            pytest.param(lambda leaf: "%s{x,}" % leaf, id="empty-alt-last"),
+        ),
+    )
+    def test_a_brace_expanded_root_is_read_as_the_paths_it_expands_to(
+        self, monkeypatch, tmp_path, spell
+    ) -> None:
+        """A brace-carrying root named no fenced path textually while the shell handed
+        `find` the fenced directory anyway.
+
+        Brace expansion belongs with quoting and backslash escaping rather than with
+        globbing: it is finite, and enumerating it needs no filesystem. So the whole
+        set closes at once, which is why this is parametrised over the group shapes
+        instead of the one spelling that was reported.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        parent, _, leaf = home.rpartition("/")
+        # The brace-free twin must deny, or the case below proves nothing.
+        assert security.is_sensitive_bash_command(f"find {home} -type f -exec cat {{}} +")
+        braced = f"{parent}/{spell(leaf)}"
+        assert security.is_sensitive_bash_command(
+            f"find {braced} -type f -exec cat {{}} +"
+        ), f"a brace-expanded root reaching the fence must deny: {braced}"
+
+    def test_both_width_budgets_refuse_rather_than_resolve(self, monkeypatch, tmp_path) -> None:
+        """Root count and brace expansion are both widths the text can inflate freely.
+
+        Cost is asserted structurally -- a bound exists and over-budget input is
+        refused -- and never as elapsed time: a wall-clock assertion here would measure
+        the runner, and the surrounding passes already dominate a command this wide.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        # Under the root budget, the verdict is still decided on the merits.
+        narrow = "find " + " ".join(f"d{i}" for i in range(4)) + " -type f -exec cat {} +"
+        assert not security.is_sensitive_bash_command(narrow)
+        # Over it, the traversal is refused rather than resolved root by root.
+        wide = (
+            "find "
+            + " ".join(f"d{i}" for i in range(security._FIND_ROOT_BUDGET + 5))
+            + " -type f -exec cat {} +"
+        )
+        assert security.is_sensitive_bash_command(wide), "over-budget root counts must deny"
+        # Brace expansion is multiplicative, so a handful of groups exceeds its budget
+        # while the command stays short. Also refused, not enumerated.
+        groups = "{a,b}" * 8  # 2**8 = 256 forms, well past the budget
+        assert security._find_brace_expansions(f"dir/{groups}") is None
+        assert security.is_sensitive_bash_command(f"find dir/{groups} -type f -exec cat {{}} +")
+        # And a brace root that stays within budget is still judged on the merits, so
+        # neither budget can be what produced the denials above.
+        benign = f"find {tmp_path.as_posix()}/{{a,b}} -name '*.o' -delete"
+        assert not security.is_sensitive_bash_command(benign)
+        assert home  # the fake home is what makes the fenced comparison meaningful
+
+    @pytest.mark.parametrize(
+        "filter_and_sink",
+        (
+            # a wildcard that reaches an UNDECLARED store leaf -- the fence names no
+            # `id_rsa` anywhere, so only asking the store can answer this
+            "-name 'id_*' -exec cat {} +",
+            "-name 'id_rs?' -exec cat {} +",
+            "-name 'id_[re]*' | xargs cat",
+            "-name 'credential*' -exec cat {} +",
+            "-name '*_rsa' -exec base64 {} ;",
+        ),
+    )
+    def test_a_wildcard_reaching_an_undeclared_store_leaf(
+        self, monkeypatch, tmp_path, filter_and_sink: str
+    ) -> None:
+        """``-name id_rsa`` was denied while ``-name 'id_*'`` read the same key.
+
+        The store probe was cut back to literal names because matching globs against
+        every entry measured three false positives. That read the trade as "broad
+        probe or no probe", and it is not one: the false positives are all
+        NON-credential basenames in fenced directories that are operational rather
+        than pure stores, so a filename predicate separates them from the leak
+        (found in review).
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        assert security.is_sensitive_bash_command(f"find {home} {filter_and_sink}")
+        security._home_targets_cache.clear()
+
+    def test_the_measured_false_positive_families_stay_allowed(self, monkeypatch, tmp_path) -> None:
+        """The boundary of the clause above, pinned on the families that cost.
+
+        Each is a real fenced directory holding an ordinary readable file: a sandbox
+        wrapper and a bundled script. The predicate is what keeps them allowed, so
+        this is the test that fails if it is ever widened to something like "any name
+        containing secret".
+
+        ``*.json`` and ``*.txt`` are deliberately NOT here. Both are denied, but by
+        the fence-DECLARED name route -- the fence lists entries whose own basename is
+        ``config.json`` and ``browser-cookies.txt`` -- which predates this change and
+        is pinned as intentional by
+        `test_a_glob_that_covers_a_declared_name_is_denied_on_purpose`. Listing them
+        here would claim the predicate rescues a case no predicate can reach; the
+        fence declaring a name is a stronger signal than any filename heuristic.
+        """
+        home = tmp_path / "home"
+        (home / ".kirocrew" / "run").mkdir(parents=True)
+        (home / ".kirocrew" / "run" / "wrapper.py").write_text("print(1)\n")
+        (home / ".local" / "share" / "kiro-cli").mkdir(parents=True)
+        (home / ".local" / "share" / "kiro-cli" / "tui.js").write_text("//\n")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        security._home_targets_cache.clear()
+        home = home.as_posix()
+        for pattern in ("*.py", "*.js", "wrapper.*", "t*.js", "*.md"):
+            command = f"find {home} -name '{pattern}' -exec grep -l foo {{}} +"
+            assert security.is_sensitive_bash_command(command) is None, command
+        security._home_targets_cache.clear()
+
+    def test_the_credential_leaf_predicate_is_conservative(self) -> None:
+        """It answers about the NAME, and only for names that carry secrets anywhere."""
+        for name in ("id_rsa", "id_ed25519", "credentials", "credentials.db", ".netrc"):
+            assert security._looks_like_credential_leaf(name) is True, name
+        for name in ("server.pem", "signing.key", "store.jks", "app.p12"):
+            assert security._looks_like_credential_leaf(name) is True, name
+        # casefolded, because a case-insensitive filesystem opens the same file
+        assert security._looks_like_credential_leaf("ID_RSA") is True
+        # and it must NOT drift into the operational names that cost the false positives
+        for name in ("wrapper.py", "tui.js", "table.json", "config.json", "README.md"):
+            assert security._looks_like_credential_leaf(name) is False, name
+
+    def test_an_unreadable_store_does_not_crash_the_gate(self, monkeypatch, tmp_path) -> None:
+        """A store the process cannot list is now irrelevant: nothing lists it.
+
+        The clause that enumerated is gone, so an EPERM on a fenced directory cannot
+        reach the gate at all. Kept as a regression test because the previous revision
+        needed an explicit ``OSError`` guard, and a future one that reaches for the
+        filesystem again would need it back.
+        """
+        home = self._fake_home_with_stores(monkeypatch, tmp_path)
+        real_listdir = os.listdir
+
+        def denied(path, *a, **kw):
+            if ".ssh" in str(path):
+                raise PermissionError(13, "denied")
+            return real_listdir(path, *a, **kw)
+
+        monkeypatch.setattr(os, "listdir", denied)
+        assert (
+            security.is_sensitive_bash_command(f"find {home} -name '*.md' -exec cat {{}} +") is None
+        )
+        assert security.is_sensitive_bash_command(f"find {home} -name id_rsa -exec cat {{}} +")
+        security._home_targets_cache.clear()
+
+    # ── the round-6 review: state the SHELL resolves, and a probe pulling two ways ──
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # the program word held in a variable this same command assigns
+            "F=find; $F ~/.kiro/crew -name .env -exec cat {} +",
+            "F=find; ${F} ~/.kiro/crew -name .env -exec cat {} +",
+            "P=/usr/bin/find; $P ~ -name token_signing.key | xargs cat",
+            # the ROOT held in a variable, with and without a filter -- the no-filter
+            # spelling is the one a bare "unresolved root" reading let through
+            'D=~/.kiro/crew; find "$D" -type f -exec cat {} +',
+            'D=~/.kiro/crew; find "$D" -name .env -exec cat {} +',
+            "D=~; find $D -name .env -exec cat {} +",
+        ),
+    )
+    def test_state_the_shell_resolves_is_resolved_here_too(self, command: str) -> None:
+        """A literal assigned in the same command is a literal the shell will run.
+
+        The plain-path passes already consumed `_resolve_local_assignments`, so
+        ``D=<fenced>; cat $D/.env`` was denied while ``D=<fenced>; find "$D" -type f``
+        was allowed -- the machinery existed and this pass was not wired into it, the
+        same shape as nested payloads. Resolving also separates the two cases an
+        unresolved-root reading conflated: an ASSIGNED root is judged as the real path,
+        while a genuinely unassigned one stays unknowable.
+        """
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_genuinely_unassigned_root_is_still_not_denied(self, monkeypatch) -> None:
+        """The other side of that separation, and why it is not a contradiction.
+
+        One reviewer asked for the unfiltered unresolved-root denial to be withdrawn
+        as a false positive; another then reported an assigned fenced root reading
+        through. Both are right, and resolving the assignment is what makes them two
+        cases rather than opposite answers to one.
+        """
+        monkeypatch.setenv("TMPDIR", "/var/tmp")
+        for command in (
+            'find "$TMPDIR" -type f -delete',
+            'find "$SRC" -type f -exec cat {} +',
+            "find $BUILD -name '*.o' -delete",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_a_credential_leaf_nested_below_a_store_is_reached(self, monkeypatch, tmp_path) -> None:
+        """A whole-directory fence fences its whole subtree, so depth cannot matter.
+
+        The probe this replaced joined the name onto the store and stat'd it, seeing
+        only DIRECT children: ``~/.ssh/archive/id_rsa`` was read while the same name at
+        the top denied. Deciding from the name removes the depth question instead of
+        pushing the probe deeper -- which is also what removes the enumeration a
+        sibling finding objected to.
+        """
+        home = tmp_path / "home"
+        (home / ".ssh" / "archive" / "old").mkdir(parents=True)
+        (home / ".ssh" / "archive" / "old" / "id_rsa").write_text("-----BEGIN-----\n")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        security._home_targets_cache.clear()
+        home = home.as_posix()
+        # every filter spelling of the one read answers alike -- name, glob and path
+        for filt in ("-name id_rsa", "-name 'id_*'", "-path '*/id_rsa'", "-name '*.pem'"):
+            command = f"find {home} {filt} -exec cat {{}} +"
+            assert security.is_sensitive_bash_command(command), command
+        # a non-credential name under the same store is the named residual
+        assert (
+            security.is_sensitive_bash_command(f"find {home} -name 'notes.md' -exec cat {{}} +")
+            is None
+        )
+        security._home_targets_cache.clear()
+
+    def test_the_name_test_needs_no_store_on_disk(self, monkeypatch, tmp_path) -> None:
+        """Deciding from the name drops a host-dependence that was never a feature.
+
+        Under the probe the identical command was allowed or denied according to
+        whether a store happened to exist yet. An empty home now denies the same
+        request -- the fail-closed direction, and the module's stated posture.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        security._home_targets_cache.clear()
+        home = home.as_posix()
+        assert security.is_sensitive_bash_command(f"find {home} -name id_rsa -exec cat {{}} +")
+        assert (
+            security.is_sensitive_bash_command(f"find {home} -name '*.py' -exec cat {{}} +") is None
+        )
+        security._home_targets_cache.clear()
+
+    def test_a_path_glob_leaf_answers_like_a_name_glob_leaf(self, monkeypatch, tmp_path) -> None:
+        """``-path '*/id_*'`` is the same read as ``-name 'id_*'`` and must agree.
+
+        The previous revision routed only a `-path` pattern's LITERAL leaf to the
+        credential vocabulary, so ``*/id_rsa`` denied while ``*/id_*`` -- whose every
+        segment carries glob meta, so no literal leaf survives -- skipped the clause
+        entirely and delivered the key (traced in review).
+
+        The leaf cannot be tested on its own, which is why the fix is not "take the
+        last segment": a `-path` pattern's EARLIER segments constrain the path, so a
+        trailing wildcard matches any leaf while naming no store entry. The whole
+        pattern is matched against a synthetic fenced path instead.
+        """
+        home = tmp_path / "home"
+        (home / ".ssh").mkdir(parents=True)
+        (home / ".ssh" / "id_rsa").write_text("k\n")
+        (home / "proj" / "node_modules").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        security._home_targets_cache.clear()
+        home = home.as_posix()
+        for filt in (
+            "-name id_rsa",
+            "-name 'id_*'",
+            "-path '*/id_rsa'",
+            "-path '*/id_*'",
+            "-ipath '*/ID_*'",
+            "-wholename '*/.ssh/id_*'",
+            "-path '*/id_?sa'",
+            "-path '*/*.pem'",
+        ):
+            command = f"find {home} {filt} -exec cat {{}} +"
+            assert security.is_sensitive_bash_command(command), command
+        # the bound: a trailing wildcard whose earlier segments cannot reach a store
+        for filt in ("-path '*/node_modules/*'", "-path '*/proj/*'", "-path '*/proj/index.js'"):
+            command = f"find {home} {filt} -exec rm {{}} +"
+            assert security.is_sensitive_bash_command(command) is None, command
+        security._home_targets_cache.clear()
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # a redirect BEFORE the operands: the same write as the trailing spelling
+            "find >/tmp/leak ~/.kiro/crew -type f",
+            "find > /tmp/leak ~/.kiro/crew -type f",
+            "find >>/tmp/leak ~/.kiro/crew -type f",
+            "find 2>/tmp/leak ~/.kiro/crew -type f",
+            "find >/tmp/leak ~/.kiro/crew -name .env",
+            # the trailing twins, which were already denied -- the parity controls
+            "find ~/.kiro/crew -type f >/tmp/leak",
+            "find ~/.kiro/crew -type f > /tmp/leak",
+        ),
+    )
+    def test_a_redirect_before_the_operands_is_still_delivery(self, command: str) -> None:
+        """Parse ORDER must not decide the verdict.
+
+        The roots loop collected ``>`` and its target as traversal ROOTS, so delivery was
+        never seen: ``find >out <fenced> -type f`` was allowed while
+        ``find <fenced> -type f >out`` denied -- the same listing written to the same file,
+        with the redirect moved to the front (traced in review). Distinct from the
+        computed-operand class: nothing here is expanded, the tokens were simply
+        classified in the wrong role.
+        """
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_leading_redirect_does_not_become_a_traversal_root(self) -> None:
+        """The other half: the redirect target must not be read as a root either.
+
+        Collecting it left a log path in the root list, which is both wrong and a way to
+        make an unrelated directory decide a fenced verdict.
+        """
+        tokens = security.normalize_shell_command(
+            security._find_space_unquoted_operators("find >/tmp/leak ~/.kiro/crew -type f")
+        )
+        parsed = security._parse_find_invocation(tokens, 1)
+        assert parsed.delivers is True
+        assert [r for r in parsed.roots if "leak" in r or r == ">"] == [], parsed.roots
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            r"find ~ -name '\.env' -exec cat {} +",
+            r"find ~ -name 'i\d_rsa' -exec cat {} +",
+            r"find ~ -name '\i\d\_\r\s\a' -exec cat {} +",
+            r"find ~ -name 'credential\s' -exec cat {} +",
+            r"find ~ -name '\c\r\e\d\e\n\t\i\a\l\s' -exec cat {} +",
+            # an escaped wildcard is a LITERAL asterisk to find; reading it as a wildcard
+            # over-matches, which is the safe direction
+            r"find ~ -name '\*.pem' -exec cat {} +",
+        ),
+    )
+    def test_a_backslash_escaped_filter_pattern_is_read_as_its_literal(self, command: str) -> None:
+        r"""GNU find reads ``\c`` as the literal ``c``, and a backslash is not glob meta.
+
+        So ``-name '\.env'`` was taken as the literal name ``\.env``, matched nothing in the
+        credential vocabulary, and was allowed while the unescaped twin denied -- and every
+        enumerated name had an escaped spelling that defeated the clause the same way
+        (found in review). Unescaped in `_find_pattern_operand`, the one place a pattern is
+        read, so no filter family can be missed.
+        """
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_an_unescaped_pattern_is_unaffected(self) -> None:
+        """The control: the twins that already denied, and a benign glob that must not."""
+        assert security.is_sensitive_bash_command("find ~ -name '.env' -exec cat {} +")
+        assert security.is_sensitive_bash_command("find ~ -name id_rsa -exec cat {} +")
+        assert security.is_sensitive_bash_command("find ~ -name '*.pem' -exec cat {} +")
+        assert security.is_sensitive_bash_command("find ~ -name '*.py' -exec wc -l {} +") is None
+
+    def test_a_command_nesting_more_substitutions_than_the_budget_is_refused(self) -> None:
+        """The view walk is quadratic in DEPTH, so past a ceiling the pass denies.
+
+        Measured on this pass alone: depth 200 costs 129 ms, depth 800 costs 3.9 s, and a
+        1600-level command costs 28.9 s in the walk and 40.8 s through the whole gate,
+        against 1.0 s for the same command on a tree without this pass. The gate is
+        synchronous and the watchdog hard-exits long before that, so this is a crash shape.
+        Failing CLOSED is what makes the ceiling safe: the pre-filter this pass used to
+        carry decided to SKIP work and so became the bypass, whereas exceeding this one
+        denies.
+        """
+        deep = "echo " + "$(" * 200 + "find /tmp -type f" + ")" * 200
+        assert security.is_sensitive_bash_command(deep)
+        # a realistic amount of nesting is far below the ceiling and still judged normally
+        assert security._find_substitution_openers("cat $(find ~ -type f)") == 1
+        # a backtick PAIR counts twice, since both ends match; that halves the effective
+        # ceiling for backtick spellings, which is the conservative direction
+        assert security._find_substitution_openers("echo `date` $(pwd) <(sort a)") == 4
+        nested = "cat $(bash -c 'find ~/.kiro/crew -type f -exec cat {} +')"
+        assert security.is_sensitive_bash_command(nested)
+        assert security.is_sensitive_bash_command("echo $(date) $(pwd) $(whoami)") is None
+
+    def test_the_store_clause_still_holds_across_many_roots(self) -> None:
+        """The store forms are resolved once for the whole call, not once per root.
+
+        They are a property of the STORE, so resolving them inside the root loop made the
+        cost the product of the two -- 24 stores at 0.42 ms per pass, paid 100 times for a
+        traversal naming 100 roots, or 42 ms of pure re-resolution in a synchronous hook
+        (measured in review). Hoisting must not change the verdict, which is what this
+        pins: the store clause still fires when the fenced root is one of many.
+        """
+        assert security.is_sensitive_bash_command(
+            "find /tmp/a /tmp/b ~ -name id_rsa -exec cat {} +"
+        )
+        assert security.is_sensitive_bash_command(
+            "find ~ /tmp/a /tmp/b -name credentials | xargs cat"
+        )
+        # and a traversal over only benign roots is still allowed
+        assert (
+            security.is_sensitive_bash_command("find /tmp/a /tmp/b -name notes.txt -exec cat {} +")
+            is None
+        )
+
+    def test_the_descoped_computed_operand_boundary_is_what_the_docs_claim(self) -> None:
+        """The scope boundary is pinned, so the prose cannot drift from the behaviour.
+
+        This pass recognises a traversal by its SPELLING. An operand the shell COMPUTES is
+        deliberately outside it -- see issue #8074 for why a spelling-based recognizer
+        cannot close that class and why the fix is to invert the polarity. These cases are
+        ALLOWED on purpose; if one of them starts denying, the boundary moved and the
+        module docs plus the PR description have to move with it.
+        """
+        for command in (
+            # the witness: knowing this runs `find` means knowing what printf writes
+            "$(printf find) ~/.kiro/crew -type f -exec cat {} +",
+            "`echo find` ~/.kiro/crew -type f -exec cat {} +",
+            # a glob-bearing root is never expanded
+            "find ~/.kir*/crew -type f -exec cat {} +",
+            # roots supplied from outside the command line, with no filter to judge
+            "find -files0-from - -type f -exec cat {} +",
+            # a name the user chose, which no curated vocabulary can hold
+            "find ~ -name github_work -exec cat {} +",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_what_the_pass_does_resolve_from_the_text_alone(self) -> None:
+        """The other side of the boundary: a computed spelling the TEXT already determines.
+
+        These are resolvable without executing anything, which is why they are in scope
+        while the cases above are not.
+        """
+        for command in (
+            "F=find; $F ~/.kiro/crew -type f -exec cat {} +",
+            "F=fin; ${F}d ~/.kiro/crew -type f -exec cat {} +",
+            "f?nd ~/.kiro/crew -type f -exec cat {} +",
+            'bash -c "find ~/.kiro/crew -type f -exec cat {} +"',
+            'echo "$(find ~/.kiro/crew -type f -exec cat {} +)"',
+        ):
+            assert security.is_sensitive_bash_command(command), command
+
+    @pytest.mark.parametrize(
+        "spelling",
+        (
+            "&>/tmp/list",
+            "&>>/tmp/list",
+            ">&/tmp/list",
+            "2>/tmp/list",
+            ">|/tmp/list",
+            ">/tmp/list",
+            ">>/tmp/list",
+        ),
+    )
+    def test_every_redirect_spelling_is_delivery_not_a_control_operator(
+        self, spelling: str
+    ) -> None:
+        """The `&`-carrying redirects matched the control-operator break, which ran first.
+
+        So ``find <fenced> -type f &>/tmp/list`` was allowed while the plain ``>`` twin
+        denied (found in review). The roots loop already ordered the two tests the other
+        way, so the pass disagreed with itself depending on which loop saw the redirect.
+        Parametrized over the spellings ``_OUTPUT_REDIRECT_RE`` enumerates, so the bound
+        is the operator set rather than the one spelling that was reported.
+        """
+        command = f"find ~/.kiro/crew -type f {spelling}"
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_redirect_does_not_swallow_the_command_glued_after_it(self) -> None:
+        """`>out;cat` carries the NEXT command, whose flags are not this traversal's."""
+        tokens = security.normalize_shell_command(
+            security._find_space_unquoted_operators("find ~ -type f >/tmp/out;grep -name x")
+        )
+        parsed = security._parse_find_invocation(tokens, 1)
+        assert parsed.delivers is True
+        assert parsed.name_pats == [], parsed.name_pats
+
+    @pytest.mark.parametrize(
+        "option",
+        ("-E", "-X", "-d", "-s", "-x", "-EX", "-Es", "-dsx", "-EXdsx"),
+    )
+    def test_a_bsd_preroot_option_does_not_hide_the_root(self, option: str) -> None:
+        """BSD/macOS find takes more pre-root options than GNU, and they BUNDLE.
+
+        ``find [-H|-L|-P] [-EXdsx] [-f path] [path ...] [expression]``. An unrecognised one
+        ended the roots run, so the traversal was read as rooted at ``.`` and the fenced
+        operand was never seen -- ``find -E <fenced>`` was allowed while the same command
+        without ``-E`` denied (found in review). Parametrized over the individual flags and
+        their bundles, since the bundle is the spelling a reader would not think to try.
+        """
+        command = f"find {option} ~/.kiro/crew -type f -exec cat {{}} +"
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_the_bsd_root_option_supplies_a_root_rather_than_hiding_one(self) -> None:
+        """`-f <path>` names a hierarchy to traverse, so its operand IS a root.
+
+        Skipping the flag with its operand would have lost the very path that decides the
+        verdict, so it is collected instead.
+        """
+        for command in (
+            "find -f ~/.kiro/crew -type f -exec cat {} +",
+            "find -E -f ~/.kiro/crew -type f -exec cat {} +",
+            "find -f ~/.kiro/crew -f /tmp -type f -exec cat {} +",
+        ):
+            assert security.is_sensitive_bash_command(command), command
+        # and a benign hierarchy through the same flag stays allowed. NOT rooted at
+        # `/tmp`: the test fixture puts the crew home under it, so `/tmp` is an ANCESTOR
+        # of a fenced store in CI and denying there is correct (this assertion passed
+        # locally and failed in CI for exactly that reason).
+        assert security.is_sensitive_bash_command("find -f . -name '*.py' -exec wc -l {} +") is None
+
+    def test_a_preroot_option_over_a_benign_root_is_still_allowed(self) -> None:
+        """The bound: recognising these flags must not deny an ordinary traversal.
+
+        Rooted at `.` rather than `/tmp` -- the fixture places the crew home under `/tmp`,
+        so a traversal rooted there really does reach a fenced store and denying it is
+        correct behaviour, not a false positive.
+        """
+        for command in (
+            "find -E . -name '*.py' -exec wc -l {} +",
+            "find -s . -name '*.orig' -delete",
+            "find -dsx . -name '*.md' | xargs wc -l",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+        # a real primary must not be mistaken for a bundle -- every primary is a word
+        assert security._find_is_bsd_preroot_option("-delete") is False
+        assert security._find_is_bsd_preroot_option("-depth") is False
+        assert security._find_is_bsd_preroot_option("-exec") is False
+        assert security._find_is_bsd_preroot_option("-EXdsx") is True
+
+    @pytest.mark.parametrize(
+        ("literal", "computed"),
+        (
+            (
+                "find ~ -name id_rsa -exec cat {} +",
+                'find ~ -name "$(printf id_rsa)" -exec cat {} +',
+            ),
+            (
+                "find ~ -name credentials -exec cat {} +",
+                'find ~ -name "$(echo credentials)" -exec cat {} +',
+            ),
+            ("find ~ -name .env -exec cat {} +", 'find ~ -name "$(printf .env)" -exec cat {} +'),
+            (
+                "find ~ -name access_tokens.db | xargs cat",
+                'find ~ -name "$(echo access_tokens.db)" | xargs cat',
+            ),
+        ),
+    )
+    def test_a_computed_filter_keeps_its_opaque_reading(self, literal: str, computed: str) -> None:
+        """The strip must not eat punctuation belonging to the TOKEN's own substitution.
+
+        A computed filter is meant to read as opaque, which makes the traversal unfiltered
+        and fails closed. `-name "$(printf id_rsa)"` lost its closing paren to the
+        capture-punctuation strip, so the leftover stopped looking like a substitution and
+        was taken as the literal name `$(printf id_rsa` -- matching nothing, and allowing a
+        read the literal spelling denies (found in review). The mechanism was never
+        missing; the strip defeated it. Both spellings must agree.
+        """
+        assert security.is_sensitive_bash_command(literal), literal
+        assert security.is_sensitive_bash_command(computed), computed
+
+    def test_the_capture_strip_still_removes_the_outer_substitutions_punctuation(self) -> None:
+        """The case the strip exists for, and the balance rule that now bounds it.
+
+        `cat $(find ~ -regex '.*/id_rsa$')` reaches `shlex` with the outer substitution's
+        paren glued to the pattern. That one is unbalanced and must still come off, while a
+        parenthesised `-regex` group must survive intact.
+        """
+        assert security._find_pattern_operand(".*/id_rsa$)") == ".*/id_rsa$"
+        assert security._find_pattern_operand(".*(id_rsa|id_dsa)$)") == ".*(id_rsa|id_dsa)$"
+        assert security._find_pattern_operand("$(printf id_rsa)") == "$(printf id_rsa)"
+        assert security._find_pattern_operand("$(printf id_rsa))") == "$(printf id_rsa)"
+        assert security._find_pattern_operand("`printf id_rsa`") == "`printf id_rsa`"
+        assert security._find_pattern_operand("`printf id_rsa``") == "`printf id_rsa`"
+
+    def test_a_stalled_path_resolution_denies_instead_of_escaping_the_gate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_candidate_forms` REFUSES rather than guessing, and this pass has to honour that.
+
+        A wedged mount under the path makes it raise `PathResolutionStalled`, which every
+        sibling gate turns into a denial. This pass let it escape the synchronous
+        permission gate instead, and hoisting the store resolution out of the root loop had
+        made the call eager for EVERY command rather than only those carrying a name filter
+        -- widening the crash from rare to routine (found in review, by both lanes
+        independently).
+        """
+
+        def stalled(*_args: object, **_kwargs: object) -> set[str]:
+            raise security.PathResolutionStalled("/home/u/.aws", "/home/u")
+
+        monkeypatch.setattr(security, "_candidate_forms", stalled)
+        # 1. This pass, called directly, must answer with a denial rather than raise.
+        for command in (
+            "find /tmp -type f -exec cat {} +",
+            "find /tmp -name notes.txt -exec cat {} +",
+        ):
+            named = security._check_find_traversal_reaches_fence(command)
+            assert named is not None, command
+            assert "stalled" in named, named
+        # 2. And the whole gate must still answer rather than propagate. It denies through
+        # a sibling pass here, since those catch the same exception first -- the point is
+        # that nothing escapes to the caller.
+        for command in (
+            "find /tmp -type f -exec cat {} +",
+            "find . -name '*.py' -exec wc -l {} +",
+        ):
+            assert security.is_sensitive_bash_command(command) is not None, command
+
+    def test_the_gcloud_access_token_database_is_in_the_vocabulary(self) -> None:
+        """A direct read of it already denies, so the traversal must not be more permissive.
+
+        `~/.config/gcloud/access_tokens.db` sits in a fenced directory: `cat`, `sqlite3` and
+        `cp` on that path are all refused. `find ~ -name access_tokens.db -exec cat {} +`
+        was allowed, which is the incoherence this pass exists to remove (found in review,
+        in a job log rather than on the review comment).
+        """
+        assert security.is_sensitive_bash_command("find ~ -name access_tokens.db -exec cat {} +")
+        assert security.is_sensitive_bash_command("find ~ -name 'access_tokens.db' | xargs cat")
+        # the coherence premise itself, so the reasoning above is pinned and not just prose
+        assert security.is_sensitive_bash_command("cat ~/.config/gcloud/access_tokens.db")
+
+    def test_the_gcloud_application_default_credential_is_in_the_vocabulary(self) -> None:
+        """Named for the mechanism, so it matched no `credential`-shaped entry or suffix.
+
+        The list's polarity is the one place in this pass where an omission ALLOWS, which
+        is what made this gap reachable (found in review).
+        """
+        for command in (
+            "find ~ -name application_default_credentials.json -exec cat {} +",
+            "find ~ -name 'application_default_credentials.json' | xargs cat",
+        ):
+            assert security.is_sensitive_bash_command(command), command
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # the program word is assembled ACROSS the assignment, so no `find`
+            # substring appears anywhere in the text
+            "F=fin; ${F}d ~/.kiro/crew -type f -exec cat {} +",
+            "F=fin; ${F}d ~/.kiro/crew -type f | xargs cat",
+            "P=f; Q=ind; ${P}${Q} ~/.kiro/crew -type f -exec cat {} +",
+        ),
+    )
+    def test_a_program_word_assembled_across_an_assignment_is_still_a_traversal(
+        self, command: str
+    ) -> None:
+        """A pre-filter that models only SOME shell rewritings IS the bypass.
+
+        The bail that stood at the head of this pass removed quotes and let a glob defeat
+        it, but a word built by parameter expansion carries neither marker, so
+        ``F=fin; ${F}d`` returned before the pass ran -- while the pass it guarded
+        resolves exactly that spelling, so the un-obfuscated twin denied and this one read
+        the store (found in review). Enumerating the rewritings is open-ended, so there is
+        no pre-filter now and the verdict comes from the resolved program word.
+        """
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_a_leading_redirect_does_not_detach_the_filter_from_the_delivery(self) -> None:
+        """A redirect delivers the FILTERED listing, so the filter still bounds it.
+
+        Seeding the delivery-before-filter flag from the roots-loop ``delivers`` picked up
+        a leading redirect, so ``find >out ~ -name '*.py'`` denied while its trailing twin
+        allowed -- parse order deciding the verdict, which is what the test above exists
+        to prevent (found in review).
+        """
+        for command in (
+            "find >/tmp/out ~ -name '*.py'",
+            "find > /tmp/out ~ -name '*.py'",
+            "find ~ -name '*.py' >/tmp/out",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_a_leading_redirect_still_delivers_when_nothing_bounds_it(self) -> None:
+        """The other half of that bound, so the fix above cannot be a blanket allow."""
+        assert security.is_sensitive_bash_command("find >/tmp/out ~/.kiro/crew -type f")
+        assert security.is_sensitive_bash_command("find >/tmp/out ~ -exec cat {} + -name '*.py'")
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            # delivery BEFORE any filter: find runs it on every visited file, so the
+            # later filter narrows nothing
+            "find ~ -exec cat {} + -name '*.py'",
+            "find ~ -delete -name '*.tmp'",
+            "find ~ -print -exec cat {} + -name '*.py'",
+            # a disjunction runs the right branch where the left FAILS
+            "find ~ -name '*.py' -o -exec cat {} +",
+            "find ~ -name '*.py' -or -exec cat {} +",
+            # a negation inverts what the filter admits
+            "find ~ -not -name '*.py' -exec cat {} +",
+            "find ~ '!' -name '*.py' -exec cat {} +",
+            # a comma makes the two sides independent expressions
+            "find ~ -name '*.py' , -exec cat {} +",
+        ),
+    )
+    def test_a_filter_that_does_not_bound_the_delivery_reads_as_unfiltered(
+        self, command: str
+    ) -> None:
+        """find evaluates left to right, so POSITION decides what a filter bounds.
+
+        The parser collected every filter regardless of where it sat and treated the set
+        as narrowing the delivery, so ``find ~ -exec cat {} + -name '*.py'`` -- which cats
+        every file under the home directory -- was read as touching only ``*.py`` and
+        allowed (traced in review). Deciding which filters really bind would need find's
+        own precedence grammar; reading the traversal as unfiltered needs no grammar and
+        fails closed.
+        """
+        assert security.is_sensitive_bash_command(command), command
+
+    def test_an_expression_whose_filter_really_does_bound_delivery_is_unaffected(self) -> None:
+        """The bound, including the idiom that makes this worth being careful about.
+
+        ``-prune -o ... -print`` is everywhere and carries a disjunction, so a rule that
+        keyed on the operator alone would be alarming -- but it only LISTS, so delivery is
+        false and the reading never matters. An ordinary filter-then-deliver traversal is
+        likewise untouched.
+        """
+        for command in (
+            "find ~ -name '*.py' -exec grep -l foo {} +",
+            "find ~ -type f -name '*.md' | xargs wc -l",
+            "find . -name node_modules -prune -o -name '*.js' -print",
+            "find ~ -name '*.orig' -delete",
+            "find ~ -type f -a -name '*.md' -exec wc -l {} +",
+        ):
+            assert security.is_sensitive_bash_command(command) is None, command
+
+    def test_the_parse_reports_whether_its_filters_bind(self) -> None:
+        """The flag itself, so the caller's reading is pinned rather than inferred."""
+
+        def parse(command: str):
+            tokens = security.normalize_shell_command(
+                security._find_space_unquoted_operators(command)
+            )
+            return security._parse_find_invocation(tokens, 1)
+
+        assert parse("find ~ -name '*.py' -exec cat {} +").filters_bind is True
+        assert parse("find ~ -exec cat {} + -name '*.py'").filters_bind is False
+        assert parse("find ~ -name '*.py' -o -exec cat {} +").filters_bind is False
+        assert parse("find ~ -not -name '*.py' -exec cat {} +").filters_bind is False
+        assert parse("find ~ -name '*.py' , -exec cat {} +").filters_bind is False
+        # an explicit AND binds exactly as the implicit one does
+        assert parse("find ~ -type f -a -name '*.md' -exec wc -l {} +").filters_bind is True
+
+    def test_a_path_pattern_matches_whatever_separator_the_probe_uses(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The `-path` clause must not depend on the platform's path separator.
+
+        The synthetic fenced path is built with ``os.path.join``, so on Windows it carries
+        backslashes while a `-path` pattern is written in find's own spelling with forward
+        slashes -- the compiled ``.*/id_rsa`` could never match ``...\\.ssh\\id_rsa`` and
+        the entire clause was inert on that platform. The Windows shard caught it.
+
+        The bug is invisible on a POSIX box, where both spellings coincide, so the second
+        half asserts the property the fix rests on: the pattern matches the probe in EITHER
+        spelling. That is checked against the compiled matcher rather than by patching
+        ``os.path.join`` globally, which would break unrelated teardown.
+        """
+        home = tmp_path / "home"
+        (home / ".ssh").mkdir(parents=True)
+        (home / ".ssh" / "id_rsa").write_text("k\n")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        security._home_targets_cache.clear()
+        command = f"find {home.as_posix()} -path '*/id_rsa' -exec cat {{}} +"
+        assert security.is_sensitive_bash_command(command), command
+        security._home_targets_cache.clear()
+
+        matcher = security._find_glob_matcher("*/id_rsa")
+        assert matcher is not None
+        windows_probe = "C:\\Users\\runneradmin\\.ssh\\id_rsa"
+        assert not matcher.fullmatch(windows_probe), "a backslash probe cannot match alone"
+        forms = security._credential_probe_forms(windows_probe, "\\")
+        assert any(matcher.fullmatch(form) for form in forms), forms
+        # and the POSIX side is unchanged: one spelling, still matched
+        posix_probe = "/home/x/.ssh/id_rsa"
+        assert security._credential_probe_forms(posix_probe, "/") == {posix_probe}
+        assert any(
+            matcher.fullmatch(form) for form in security._credential_probe_forms(posix_probe, "/")
+        )
+
+    def test_the_credential_leaf_test_is_answered_from_the_name_alone(self) -> None:
+        """Unit-level: the vocabulary a glob is matched against, and its bound."""
+        f = security._find_filter_names_a_credential_leaf
+        assert f(["id_rsa"], None) == "id_rsa"
+        assert f(["server.pem"], None) == "server.pem"
+        assert f(["package.json"], None) is None
+        assert f([], None) is None
+        # a glob is tested against the predicate's own vocabulary, not a directory
+        assert f([], [security._find_glob_matcher("id_*")]) is not None
+        assert f([], [security._find_glob_matcher("*.pem")]) is not None
+        assert f([], [security._find_glob_matcher("*.py")]) is None
+        assert f([], [security._find_glob_matcher("tui.js")]) is None


### PR DESCRIPTION
## 1. What is the problem?

The bash gate asks one question of every token: does this resolve to a fenced path? A `find` traversal answers no by CONSTRUCTION. It factors the path in two -- the directory is one argument, the leaf is another -- and produces the path itself at runtime, so the fenced path appears nowhere in the command text.

Measured on `main`:

```
MISSED   find ~/.kiro/crew -name '.env' -exec cat {} +
MISSED   find ~/.kiro/crew -name 'token_signing.key' -exec cat {} +
MISSED   find ~/.kiro/crew -name 'computer_use.json' -exec cat {} +
MISSED   find ~/.kiro/crew -name '*.lock' | xargs cat
MISSED   find ~ -name 'credentials' -exec cat {} +
BLOCKED  find ~/.ssh -type f -exec cat {} +
```

That last line is the tell the issue points at: `~/.ssh` is fenced as a DIRECTORY, so the command names it directly and the existing matcher sees it. A leaf fenced by FILENAME is invisible, because the name appears only as a `-name` argument -- syntactically unrelated to the directory beside it.

Neighbourhood probing found the same hole with no `-name` at all (`find ~/.kiro/crew -type f -exec cat {} +` reads every keystone leaf), and through every other way a traversal hands a match onward: `-execdir`, `-ok`, `-okdir`, `-delete`, `-fprint`/`-fls`/`-fprintf`, a pipe into any `xargs` spelling, a command or process substitution, a plain redirect.

## 2. Why this issue matters to the user

The keystone floor exists so a prompt-injected agent cannot read or author its own authorizations. `.env`, `token_signing.key`, `.local_secret` and `security_policy.json` are all fenced by filename, so all of them are reachable this way, and `~/.aws/credentials` is reachable too since `.aws` is fenced but the traversal starts at `~`.

Unlike a race against a transient temp, this needs no timing and no guessing: the command is deterministic, the file is the permanent one, and the protected spelling and the unprotected one differ by moving the filename one argument to the left.

It was raised by the GPT review lane on #7024 and deliberately NOT fixed there, because a fix scoped to that PR's artifacts would have guarded the transient copy while leaving the permanent secret open to the identical command -- worse than the honest gap, because it reads as covered.

## 3. How our fix solves it

**Re-join what `find` factored apart.** A new pass (`_check_find_traversal_reaches_fence`) reads the traversal's roots and its name/path filters and asks whether the SET it names intersects the fence. Three bounds keep that from becoming an over-block, and the issue's own two candidate shapes are each rejected for the reason it gives:

**Delivery.** A `find` that only LISTS is left alone, so the newly-denied set is exactly the traversals that hand a match to a command. The inert primaries are an ALLOW-list and anything else denies -- the polarity `_TRUST_ROOT_READ_LISTERS` already documents, because enumerating the delivering primaries would fail OPEN on the one nobody thought of. This needs no knowledge of the CHILD command, which is the issue's objection to gating the sink: `cat`, `base64`, a script and `xargs` with any of `-0`/`-I`/`-n`/`-P` are all the same to it, because the gate denies NAMING a fenced path whatever is then done with it. That is also why there is no executor list here at all.

**Framing.** WHICH text to judge is its own question, and answering it by inspecting the command's characters was wrong twice. Capture was read off the two opener characters glued to the program word's token, so `cat $( find ... )` was allowed where `cat $(find ... )` was denied -- the same read, one space apart. And a `bash -c '<traversal>'` payload was never re-tokenized, so the traversal was invisible even though the argv floor already descends into payloads carrying a plain fenced path. Both are one defect: the pass judged the command's TEXT rather than the things the shell runs. `_find_traversal_views` enumerates those instead -- the outer line, every substitution body, every nested payload -- so capture stops being a spelling to detect and becomes a property of how a view was DERIVED, and no depth of wrapping is a special case. It reuses this module's own view idiom (`_self_token_frames` joins exactly these two extractors) and its termination discipline: no depth cap, because whatever number is chosen one more level defeats it; a view is a proper substring of its parent, and a visited set stops sibling wrappers re-walking the same text.

**Certainty.** The join is denied where the FENCE supplies the missing half, and left alone where the traversal merely might wander into one:

| clause | example | why the fence answers it |
|---|---|---|
| the root is fenced, or holds fenced leaves | `find ~/.kiro/crew -type f -exec cat {} +` | the command names the credential directory outright and the leaf is the runtime wildcard -- the `~/.kiro/crew/$F` shape `_sensitive_under_unresolved_var` already denies |
| a pattern matches a basename the fence DECLARES | `find ~ -name '.env' -exec cat {} +` | the fence lists that name; no filter at all means the pattern is `*`, which matches every entry under the root |
| the filter asks for a NAME that carries credentials wherever it sits, and a whole-directory credential store lies under the root | `find ~ -name credentials -exec cat {} +` | everything inside `.aws`/`.ssh` is fenced, so a request for one such name resolves a path rather than searching |

The third clause is the one that needed care, and it is why the issue's other shape -- treat any root that CONTAINS a fence as the signal, via `path_contains_sensitive` -- is not what shipped: `find ~` names the home directory, which contains everything, so that reading refuses unqualified traversals outright. Instead the clause asks what the FILTER names. `_find_filter_names_a_credential_leaf` (`security.py:9168`) compares the filter against a fixed vocabulary of leaf names that carry credentials wherever they sit -- `_CREDENTIAL_LEAF_NAMES`, 16 entries at `security.py:7523`, and `_CREDENTIAL_LEAF_SUFFIXES`, 7 entries at `security.py:7543`, both private. **It performs no filesystem access at all**: no stat, no directory listing. A literal name is tested directly; a glob is matched against that same vocabulary (each leaf name, plus one synthetic bearer per suffix), which is what makes `-name 'id_*'` answer like `-name id_rsa` and `-name '*.py'` match nothing.

Two earlier revisions asked the filesystem instead, and each way of asking was its own defect. An existence check joined onto the store could only ever see a store's DIRECT children, so a key one level down was read while the same name at the top denied. Matching a glob against a store's real entries cost 110 directory listings and 14.4ms on a single traversal, against 0 listings and 0.7ms for an ordinary fenced read, on a gate that is synchronous and in-process. Those two point in OPPOSITE directions -- probe deeper, stop enumerating -- so neither is reachable by extending the probe. Deciding from the name removes the depth question and the enumeration together, and drops a host-dependence that was never a feature, where the same command was allowed or denied according to whether a store happened to exist yet.

The cost is that the clause is strictly WIDER than a probe in one direction and NARROWER in another, and both are stated in the residual list below. Wider: a credential-looking name is refused whether or not that store exists on the machine. Narrower: a leaf whose own basename carries no credential signal is not reached from an ancestor root. What bounds the width is that the vocabulary is conservative -- known credential leaves and suffixes, nothing pattern-like -- because a broad rule reintroduces exactly the false positives it exists to avoid: the fenced tree includes OPERATIONAL directories that hold ordinary readable files (`~/.kirocrew/run` holds transient sandbox `*.py` wrappers, `~/.local/share/kiro-cli` holds `tui.js`, several fenced directories hold a `*.json`). That is the entire difference between denying `find ~ -name credentials -exec cat {} +` and leaving `find ~ -type d -name __pycache__ -exec rm -rf {} +` alone -- no credential name is asked for, so the clause says no.

`-path`/`-wholename`/`-ipath` matches the whole path, so the pattern carries the fenced segments itself; dropping its wildcard SEGMENTS leaves something the ordinary path gate can answer (`*/.aws/credentials` reduces to `.aws/credentials`, while `*/node_modules/*` reduces to `node_modules`).

`gfind` is parsed alongside `find`: macOS installs GNU findutils under that name, and the two share the grammar this pass reads.

**A filter is agent-supplied text, and this gate is synchronous and in-process, so evaluating one is a denial-of-service surface before it is a correctness question.** CPython's `re` has no timeout, and this module already records a watchdog-crossing hang from admitting a run into a pattern. Two rules bound it, and both fail CLOSED by widening the traversal rather than dropping the filter:

- **A `-regex`/`-iregex` pattern is never compiled and never run.** Screening for catastrophic shapes was rejected rather than skipped: this module already argues that enumerating dangerous constructs cannot terminate against an untrusted string, and a hostile pattern author is exactly that case. `_redos_prone` exists here but was written to catch accidents in the repository's own deny patterns, which is a far weaker claim than defending against a crafted one. The cost is an over-block on a rare flag, bounded by the root -- see section 5.
- **A glob is bounded instead, because it can be.** `_glob_to_regex` maps `*` and a brace group to `.*`, so `-name '{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}{a}b'` compiled to fourteen adjacent `.*` and hung the gate outright -- measured as still running after 12 seconds, now 0.031s. Adjacent runs are collapsed, which is semantics-preserving (`.*.*` names exactly what `.*` names, so that pattern and `*` x40 both become a single `.*` and still match), and literal-separated runs, which cannot be collapsed, are capped at 8. Over the cap the matcher is refused, which the caller reads as opaque, so the bound can never become a bypass.

What makes the cap sufficient rather than a guess is that the SUBJECTS are not agent input: they are fence basenames and credential-store entry names, all short. Only the pattern is hostile.

**The change can only ADD denials.** It is a new pass returning a reason or `None`, appended after the existing ones; no existing pass is touched. The one deliberate over-trigger is on record as a test rather than left to be found: `find ~ -name '*.json' -exec cat {} +` is refused, because `*.json` covers `security_policy.json` and `config.json`, which the fence declares by name -- the glob carve-out is about names the fence does NOT declare, not about widening one it does.

**The spellings that reach the pass were found by running it rather than by reading it.** The cheap `"find" not in command` bail-out was itself a bypass twice over: `fi''nd` reaches shlex as `find`, so quote and escape characters are stripped first, and a shell expands `f?nd` against the filesystem, which no substring test on the text can see -- so a glob metacharacter now defeats the bail too, and the program word is matched through the same bounded matcher the filters use (`_find_program_word_names_find`). A word the wildcard bound refuses is read AS a match, so the bound widens the pass rather than opening a hole in it. A process substitution arrives with the redirect glued to the program word (`<(find`); a control operator glued to the program word (`ls|find`, `true;find`, `true&&find`) arrived as ONE shlex token whose basename matched no program name, so the whole pass was skipped -- the gate defeated by deleting one space. A captured substitution's closing paren arrives glued to the pattern (`$(find ~ -regex '.*/id_rsa$')`), which is why the strip lives where patterns are READ rather than per-list at the call site. And the brace-group glob hung the gate outright.

`-files0-from` is the mirror image on the other operand: GNU find reads its roots from a file, or from stdin for `-`, so the command names no root at all and a parse reading only operands defaulted to `.` while the traversal walked a fenced root it never saw. It is read as an unknowable root -- the same treatment a root carrying an unassigned expansion gets -- so the filter still decides and `find -files0-from list.txt -name '*.o' -delete` is untouched. Closed by construction: it is the only way find takes a root that is not an operand.

Delivery is likewise read from the invocation's own token span rather than the command line, because reading the whole line denied a listing whenever an unrelated LATER command carried a pipe (`find ~/.kiro/crew -type f; cat notes | less`).

Two shapes were fixed wider than the review that found them prescribed, both because the prescription would have left a sibling open: the store question replaced a literal-only probe that denied `-name id_rsa` while allowing `-name 'id_*'` for the identical read, and the wildcard bound covers the glob path, where the reproducible hang actually was, rather than only the `-regex` path that was reported.

**What this covers, and what it deliberately does not.** This pass recognises a traversal by its SPELLING, and that is the whole of the claim. An operand the shell COMPUTES is out of scope: `$(printf find) ~/.kiro/crew -type f -exec cat {} +` is allowed, because knowing it runs `find` means knowing what `printf` writes, which is not a property of the command text. The same holds for a glob-bearing root (`~/.kir*/crew`), brace expansion (`f{i,}nd`), a root supplied from outside the command line (`-files0-from -` with no filter left to judge), a genuinely unassigned expansion, and a root reached by a preceding `cd` rather than named. Review measured 17 such spellings across six rounds, and closing one revealed others every time -- the set of programs whose output is `find` is not enumerable by a pattern over the text, so a spelling-based recognizer does not terminate on this class. **#8074** carries that argument and the fix (invert the polarity: require literal operands, fail closed on computed ones), which is a behaviour change on a security gate with its own false-positive surface to price and so is not folded in here. This is a descope, not a to-do list.

What the pass DOES resolve is what the text alone determines, and those cases are tested: a same-command assignment (`F=find; $F`, and the split `F=fin; ${F}d`), a glob-expanded program word (`f?nd`), a quote splice (`fi''nd`), a nested `-c` payload, and the body of a substitution -- each turns a computed spelling back into a literal one. A test pins BOTH sides of that line, so the description cannot drift from the behaviour.

Two further boundaries, both properties of the code rather than oversights. First, the credential-name vocabulary is the one clause whose polarity lets an OMISSION allow: `find ~ -name known_hosts | xargs cat`, `-name 'pubring*'` and `-name trustdb.gpg` are allowed because neither the vocabulary nor the fence's declared entry names cover them (measured), and so is a private key the user named themselves (`find ~ -name github_work`). No addition to the list closes the latter -- the name space is the user's -- so this is a boundary, and the choice between the two measured ways to invert it is tracked in #8074. A name the fence DECLARES is still caught by the clause above it, which is why `-name config` and `-name config.json` do deny (`.kube/config`, `.docker/config.json` are declared entries). Second, in the other direction, a credential-looking filter is denied whether or not the store exists on this machine: `find ~ -name id_rsa -exec cat {} +` is refused on a home with no `.ssh` at all. That is the fail-closed direction and it is deliberate, but it is a behaviour change worth naming rather than discovering. Outside the pass entirely: any OTHER program that factors a root and a name the same way -- `fd`/`fdfind` (`-x`/`-X`), `locate`/`plocate`, `rg --files`, `du -a` -- and `grep -r <dir>`, which needs no second command at all because the reader IS the traversal. Filed as #7309. The block comment says all of this where someone changing the code will read it.

## 4. What tests we did

`TestFindTraversalReachesFence` in `test/test_security.py`, 197 cases:

- **The five commands from the issue**, each a read of a permanent secret. The fifth reaches `~/.aws/credentials`, so it runs in a fake home with the store on disk rather than depending on the runner's own dotfiles.
- **The carrier grammar, 19 forms**: `-exec` with `;` and `+`, `-execdir`, `-ok`, `-okdir`, `-delete`, `-fprint`, `-fls`, `-fprintf`, `-exec sh -c`, four `xargs` spellings including `-0` and `-I{}`, a `while read` loop, both substitution spellings, a process substitution, and a plain redirect. Plus an unknown primary, which must deny.
- **Traversal spellings**: `-L`/`-H`/`-P`, `-D tree`, `-O3`, multiple roots, `/usr/bin/find`, `fi''nd`, `$HOME` and `${HOME}`, depth flags, a parenthesised `-o` group, and a `find` after `&&`.
- **Zero false positives, 23 cases**: project-rooted traversals for every delivery form, absolute non-home roots, home-rooted GLOB searches, the crew home's own non-secret subtrees (`workspace`, `workspace/memory`, `skills` -- which agents read constantly), listing-only forms, and commands that are not traversals. All 23 pass on `main` too, so none is a behaviour change.
- **The boundary of the name clause**, in both directions: `credentials` and `id_rsa` deny by vocabulary and `*.pem` by suffix, while `package.json`, `__pycache__`, `tsconfig.json`, a `*.py` glob and every listing form stay allowed. A separate test pins the narrow side as a named residual -- `known_hosts` is fenced by WHERE it sits rather than by what it is called, so it is allowed from an ancestor root while `cat ~/.ssh/known_hosts` and `find ~/.ssh -type f -exec cat {} +` both still deny. Another pins the wide side: the same request is refused on a home with no store on disk. And one counts filesystem calls through the clause and asserts zero, because "it is fast now" is not a property and zero is.
- **A 61-command benign corpus and a 400-command carrier cross-product** (4 root spellings x 10 filters x 10 delivery forms): 0 false positives, 0 misses.
- **The three round-1 findings, in both directions**: six filter spellings of one store read all deny while two regex spellings of an ordinary read stay allowed; five glued-operator prefixes plus the glued-pipe-after case deny; four sequencing shapes stay allowed with `| less` as the control that must deny.

- **The pattern-evaluation bounds, in both directions**: three adjacent-wildcard globs asserted to collapse to exactly one `.*` and still match, three literal-separated ones asserted refused, six ordinary globs asserted still compiling, the regex-widens clause with its root-bounded counterpart, and a wall-clock assertion over four previously-hanging commands with a deliberately enormous margin (measured ~30ms, asserted under 10s, so it cannot flake on a loaded box while still catching a return to super-polynomial matching).

**Mutation-verified:** with `security.py` reverted to main's version, **148 of the 197 cases fail** -- direct evidence the bypasses were real -- while **all 49 no-regression controls pass on both sides**. Separately, each mechanism this revision adds was verified by breaking it on purpose: **15 targeted mutations, 15 killed** (drop nested payloads from the view set; drop substitution bodies; make a body not carry capture; make a payload not inherit its wrapper's capture; revert the program word to an exact match; revert the bail-out to a substring test; make the wildcard cap fail OPEN; disable `-files0-from`; trust the defaulted `.`; always and never hypothesise; revert the store probe to literals; accept any store entry; widen the predicate to a substring rule; let the unreadable-store `OSError` escape). One mutation SURVIVED on the first run and exposed a test that did not bite -- an all-wildcard program word collapses to a single `.*` and so never exercised the refusal path -- which is why that assertion now uses a literal-separated pattern the cap genuinely refuses. The individual review findings were verified the same way but by probe: each was reproduced as a measured ALLOW (or a measured false DENY, or a measured hang) before the change and flipped after, with the controls unmoved.

Targeted runs, never the full suite: `test_security.py` + `test_governance_self_protection.py` + `test_denied_commands_security.py` -- **1985 passed, 1 skipped**. `test_hooks.py` + `test_connections_tool_aliases.py` + `test_app_sources_write_protection.py` -- **416 passed**. Also green earlier: `test_computer_use_api.py`, `test_computer_use_enable_state.py`, `test_config_loader.py`, `test_aws_consent.py`, `test_snapshot_redaction_optout_ceiling.py`, `test_mcp_cron_security.py`. flake8, isort and mypy clean; the baselined black gate passes in scope, and the added code is black-clean even though `security.py` is baselined.

## 5. Any other suggestions on the work

- **The computed-operand class is descoped to #8074, and that is the honest shape of this change.** Six review rounds on this PR kept surfacing new spellings of one class (6 -> 10 -> 13 -> 17 distinct spellings on the record). Every finding that turned out to be closable was the parser assigning a *literal* token to the wrong ROLE -- a leading redirect read as a root, a filter read as bounding a delivery it does not bound, `&>` read as a control operator, a pre-filter that missed a spelling the pass could already resolve -- and each of those is fixed here. Every finding that stayed open needed a value the text does not carry. Continuing to patch spellings would have kept producing revisions without converging, so the class is now recorded with its existence proof rather than half-covered. #8074 also carries the credential-name polarity decision, with the price of each option measured (the narrower option flips 12 of 12 ordinary literal-name searches to DENY).

- **The sibling traversal tools are the honest remaining gap, and are now filed.** `fd -x cat` is the same deterministic single-command form with a different grammar (positional regex pattern, `-x`/`-X` exec), `locate | xargs` has no root operand at all, and `grep -r <dir>` needs no sink because the reader and the traversal are one command. #7309 carries all of them, with the note that a producer allow-list is the wrong direction -- the module's comments already argue that enumerating programs fails open, so a half-done list would read as covered. The two reusable halves of this pass are already tool-independent, which is what that issue points at.
- **A keystone publish artifact named literally from outside the crew home is not covered.** `find ~ -name 'tmpAB12CD34.tmp' -exec cat {} +` needs the mkstemp name, which is the timing race #7024 describes; rooted at the crew home it is denied by the first clause. Recorded rather than papered over.
- **The `-regex` over-block is the one deliberate cost of not evaluating agent patterns.** A DELIVERING `-regex` traversal over a root that contains a fence is refused whatever the pattern says, `find ~ -regex '.*[.]py$' -exec grep -l foo {} +` included. It is bounded by the root -- `find ~/Repos -regex ... -exec wc -l {} +` and `find /tmp -regex ... -delete` are untouched, and a listing is untouched wherever it is rooted -- and both directions are pinned by tests. If the flag turns out to be common enough for that to bite, the fix is a linear matcher for a reduced subset of the regex grammar, not a screen for dangerous shapes.
- **The credential-filename predicate is deliberately conservative, and deliberately not yet shared.** It lists known credential names and suffixes only; a broad rule (any name containing `secret`) would reintroduce exactly the false positives it exists to avoid, and a test pins the three families that must stay allowed. Two leaf modules carry their own copy of this list -- `PROJECT_SECRET_NAMES` in the design-tweak preview server and `_EXCLUDE_NAMES` in the cloud source packer -- and both already import `DENIED_ROOT_PARTS` from `security.py`, so they can be pointed at the new constant the same way. That migration is left out on purpose: it would move the behaviour of two unrelated surfaces (static-file serving, tarball packing) inside a security fix.
- **An unreadable credential store is not a hole, and the reason is simpler than it was.** Nothing on this revision lists a store, so a directory the process cannot read cannot reach the verdict at all -- there is no fallback to get wrong. An earlier revision needed an explicit `OSError` guard; the test that injects `PermissionError` is kept because a future revision reaching for the filesystem again would need it back.
- **The depth flags are read but not modelled.** `-maxdepth 1` narrows what a traversal visits, and this pass ignores that, so it over-approximates the visited set. That is the fail-closed direction and cheap; modelling depth would only ever remove denials.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a path-string fence judged only against the tokens a command NAMES, while the shell can compute the path at runtime.

This is the third member of one class, and all three were found the same way -- probe the gate with a command that reaches the fenced file without spelling it. `cd ~/.kiro/crew && cat .env` removes the ANCHOR (closed by the working-directory tracker); the Windows `cd` spelling of that same removal is the sibling comment on #7034 and is still open; `find -exec` removes the path ENTIRELY. Each arrived as its own bug report. The shared property is that the gate's question -- "does a token resolve to a fenced path?" -- is not the shell's question, which is "what file will be opened?".

So the harvest is a check to run when a fence is added or widened: ask which commands can reach the fenced path WITHOUT naming it -- by moving the anchor (`cd`, `pushd`, `Set-Location`), by generating the leaf (`find -name`, a glob, a variable), or by handing a produced path to a second program (`xargs`, a substitution, a `while read` loop). The three known members are all one of those three moves.

Deliberately NOT a semgrep or lint rule: the defect is a missing case in a semantic model, not a code shape a matcher can see -- there is no syntax common to `cd`, `-exec` and `$F` to match on. The module already documents the class in three places (`bare_protected_path`'s comment, `_sensitive_under_unresolved_var`, and now this pass), which is itself the evidence that what was missing is the prompt-level question rather than a pattern.

Fixes #7034

