### PR TITLE
fix(subagent): say when a run is parked on an unanswered spawn approval

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -329,7 +329,6 @@ src/kiro_crew/mcp_tools/artifacts.py
 src/kiro_crew/mcp_tools/control.py
 src/kiro_crew/mcp_tools/knowledge.py
 src/kiro_crew/mcp_tools/skills.py
-src/kiro_crew/mcp_tools/spawn.py
 src/kiro_crew/mcp_utils.py
 src/kiro_crew/metrics/http_metrics.py
 src/kiro_crew/metrics/provider.py

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -222,8 +222,16 @@ def _spawn(args: argparse.Namespace) -> None:
             print("No subagents.")
             return
         for a in agents:
-            status = "✅" if a.get("done") else "⏳"
-            print(f"  {status} {a['id']}  {a.get('task', '')[:60]}")
+            if a.get("done"):
+                status, note = "✅", ""
+            elif a.get("awaiting_approval"):
+                # A run parked on its spawn-approval prompt used to render the
+                # same bare hourglass as one that is executing, so `spawn list`
+                # could not answer "is this working or waiting for me?" (#6484).
+                status, note = "🔐", "  — waiting for spawn approval"
+            else:
+                status, note = "⏳", ""
+            print(f"  {status} {a['id']}  {a.get('task', '')[:60]}{note}")
         return
 
     if action == "run":
@@ -269,6 +277,7 @@ def _spawn_run(args: argparse.Namespace, base: str) -> None:
     print(f"Spawned subagent {agent_id}, waiting for result...", file=sys.stderr)
     poll_url = f"{base}/api/spawn/{agent_id}"
     secret = _internal_secret(args.port)
+    told_awaiting = False
     while True:
         _time.sleep(2)
         poll_req = urllib.request.Request(poll_url, headers={"X-Internal-Secret": secret})
@@ -278,6 +287,18 @@ def _spawn_run(args: argparse.Namespace, base: str) -> None:
         except Exception:
             print("Error: lost connection to gateway", file=sys.stderr)
             sys.exit(1)
+        # Say WHY the wait is not progressing. A spawn with no parent session
+        # raises its approval prompt unowned, so it appears only on the global
+        # approvals surface -- not in any chat tab -- and this loop would
+        # otherwise sit on "waiting for result..." indefinitely with nothing to
+        # act on (#6484). Announced once, not every 2s poll.
+        if status.get("awaiting_approval") and not told_awaiting:
+            told_awaiting = True
+            print(
+                "Waiting for spawn approval: approve it in the dashboard "
+                "(Approvals) to start this run.",
+                file=sys.stderr,
+            )
         if status.get("done"):
             if status.get("error"):
                 print(f"Error: {status['error']}", file=sys.stderr)

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -663,7 +663,49 @@ async def api_spawn_status(request: web.Request) -> web.Response:
         data["turns"] = info.turns
         data["last_tool"] = _redact(info.last_tool)
         data["elapsed"] = round(time.time() - info.started)
+        # Same predicate, same present-only-while-true convention as
+        # api_spawn_list. This endpoint is the one a blocking `kirocrew spawn
+        # run` polls every 2s (cli_commands.py), so leaving it out is what kept
+        # the CLI reproduction of #6484 silent: the caller sat on "waiting for
+        # result..." while the answer ("a prompt is waiting for you") was only
+        # discoverable from a separate `spawn list` or a log grep.
+        if _awaiting_spawn_approval(info):
+            data["awaiting_approval"] = True
     return web.json_response(data)
+
+
+def _awaiting_spawn_approval(info: object) -> bool:
+    """True only while a run is parked on the SPAWN-approval gate.
+
+    ``_awaiting_approval`` alone is NOT sufficient: ``run.py`` sets the same
+    flag for TOOL approvals raised INSIDE a running subagent (three sites), so
+    reading it bare would report a run at turn 5 waiting on a tool prompt as
+    though it were waiting to START -- rendering "waiting for spawn approval"
+    and telling a caller to approve it "to start this run" that already
+    started. ``_exec_started`` is the permanent discriminator: it is stamped
+    once when execution begins, so ``None`` means the run never entered
+    execution, which for a registered run is only reachable via the spawn gate.
+
+    Both read paths go through this ONE predicate rather than repeating the
+    pair, because the two handlers build their payloads independently and a
+    drift between them is invisible to a behavioural test.
+
+    ``subagent_manager/terminal.py`` computes the same pair for the reap message
+    (#7325). Deliberately not extracted onto ``SubagentInfo``: that read is a
+    plain attribute read on a live run inside the manager package, whereas this
+    one must survive the info doubles the handlers are tested with (below), and
+    unifying them would mean editing a reap path this change does not otherwise
+    touch. The duplication is two lines and both sites name each other.
+
+    ``getattr`` with a strict ``is True`` / ``is None``: these handlers are
+    exercised with lightweight info doubles (SimpleNamespace / MagicMock) that
+    carry only the fields a case cares about, so a bare attribute read raises
+    and a truthy Mock would otherwise advertise a wait that isn't happening.
+    """
+    return (
+        getattr(info, "_awaiting_approval", False) is True
+        and getattr(info, "_exec_started", None) is None
+    )
 
 
 async def api_spawn_list(request: web.Request) -> web.Response:
@@ -690,6 +732,14 @@ async def api_spawn_list(request: web.Request) -> web.Response:
             entry["turns"] = info.turns
             entry["last_tool"] = _redact(info.last_tool)
             entry["elapsed"] = round(time.time() - info.started)
+            # Present only while the run is parked on its spawn-approval
+            # prompt, so the default payload is unchanged. Without it a run
+            # waiting for a human is byte-identical to one that is executing --
+            # which is how #6484 presented: `kirocrew spawn list` showed the
+            # same hourglass for a run that had no child process and was only
+            # ever waiting to be approved.
+            if _awaiting_spawn_approval(info):
+                entry["awaiting_approval"] = True
         # Present only when a group was actually withheld, so the default
         # (everything on) payload is unchanged.
         withheld = [

--- a/src/kiro_crew/mcp_tools/spawn.py
+++ b/src/kiro_crew/mcp_tools/spawn.py
@@ -544,7 +544,9 @@ def spawn_run(name: str, args: dict[str, Any]) -> str:
     inc_lessons = args.get("include_lessons", True) is not False
     inc_project = args.get("include_project", True) is not False
     if agents_list and len(agents_list) != len(task_list):
-        return f"Error: agents length ({len(agents_list)}) must match tasks length ({len(task_list)})"
+        return (
+            f"Error: agents length ({len(agents_list)}) must match tasks length ({len(task_list)})"
+        )
 
     agent_ids: list[str] = []
     agent_names: list[str] = []
@@ -739,8 +741,7 @@ def spawn_run(name: str, args: dict[str, Any]) -> str:
             )
         else:
             spawn_lines.append(
-                f"Error: acceptance status is unknown for "
-                f"{len(transport_errors)} task(s):"
+                f"Error: acceptance status is unknown for " f"{len(transport_errors)} task(s):"
             )
         for e in transport_errors:
             spawn_lines.append(f"  - {e}")
@@ -843,7 +844,17 @@ def spawn_list(name: str, args: dict[str, Any]) -> str:
         lines.append("No subagents running.")
     else:
         for a in agents:
-            status = "done" if a.get("done") else "running"
+            # A run parked on an unanswered spawn-approval prompt has launched
+            # no process and produced no turn, so reporting it as "running" is
+            # actively misleading to a caller this module itself points here
+            # ("Check spawn_list", above) -- it reads as work in progress when
+            # the truth is that a human has not approved it yet (#6484).
+            if a.get("done"):
+                status = "done"
+            elif a.get("awaiting_approval"):
+                status = "awaiting-approval"
+            else:
+                status = "running"
             err = f" error: {_redact(a['error'])}" if a.get("error") else ""
             progress = ""
             if not a.get("done"):
@@ -858,9 +869,7 @@ def spawn_list(name: str, args: dict[str, Any]) -> str:
                 progress = f" ({', '.join(parts)})"
             _withheld = a.get("context_withheld") or []
             scope = f"  ctx-withheld: {','.join(_withheld)}" if _withheld else ""
-            lines.append(
-                f"{a['id']}  [{status}]{err}{progress}{scope}  {_redact(a['task'])[:60]}"
-            )
+            lines.append(f"{a['id']}  [{status}]{err}{progress}{scope}  {_redact(a['task'])[:60]}")
     # Always append available agents (fresh read from disk). Same grammar filter and
     # redaction as the two rosters above, via the shared helper: this output is a
     # tool RESULT, so it lands in the same model context, and a spec's ``name``

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -729,6 +729,21 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             # spawn approval from a mid-run tool prompt and report the accurate
             # cause.
             info._awaiting_approval = True
+            # Name the wait as well as marking it. The flag above is machine
+            # state read by the reaper and (now) by the wire; this is the line an
+            # operator gets. #6484's reporter had no lead at all because
+            # ``kirocrew logs`` held no record keyed to the affected run id —
+            # while a wait with no deadline of its own held the run at turn 0.
+            # ``parent_session_key`` is in the record on purpose: an unowned
+            # spawn (the CLI posts none) raises its prompt with ``slot=""``, so
+            # it is surfaced only on the global approvals feed and appears in no
+            # chat tab, which is the case with the least other evidence.
+            logger.info(
+                "Subagent %s awaiting spawn approval (request_id=%s, parent=%s)",
+                info.id,
+                request_id,
+                info.parent_session_key or "<unowned>",
+            )
             try:
                 approved: bool = await self._manager._on_spawn_approval(
                     request_id, f"spawn_run({task_preview})", info.parent_session_key

--- a/test/test_subagent_spawn_approval_parked_6484.py
+++ b/test/test_subagent_spawn_approval_parked_6484.py
@@ -1,0 +1,361 @@
+"""Regression tests for issue #6484 — a subagent parked on an unanswered
+spawn approval must say so.
+
+A default install has no YOLO override, no ``auto_approve_subagent_spawn``
+and no session trust, so every ``spawn_run`` is gated behind the interactive
+approval callback. While that prompt is unanswered the run is registered in
+``_agents`` and counted by ``count``, so it is reported exactly like an agent
+that is actually executing:
+
+  * ``subagents`` (status API) counts it, ``subagents_spawned`` does not
+  * no child ACP process exists
+  * nothing in the run's state, the ``/api/spawn`` payload or the log names
+    the approval gate as the reason
+
+That combination is the whole content of the bug report: the reporter's only
+lead was that no log line and no field mentioned the run. These tests pin the
+observable state so the parked run is distinguishable from a running one.
+
+Two adjacent halves of the report have since landed separately on main and are
+NOT re-tested here: the reap of such a run no longer blames an execution
+deadline it never reached (#7325, which is what put ``_awaiting_approval`` on
+the spawn gate in the first place), and a chat tab no longer renders an owned
+parked run as executing (#7477, which derives its cue from the WS ``approval``
+event, not from this payload). What is left, and what this file covers, is
+every reader that goes through ``/api/spawn`` — the two HTTP shapes, the CLI's
+``spawn list`` and blocking poll, and MCP ``spawn_list`` — including the
+unowned CLI spawn that reaches no chat tab at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.subagent import SubagentManager
+
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
+
+def _mock_sessions() -> MagicMock:
+    """Minimal SessionManager double: no trust, no live provider stream."""
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    provider = AsyncMock()
+    provider.start = AsyncMock()
+    provider.shutdown = AsyncMock()
+    provider.context_usage_pct = lambda: 0.0
+
+    async def _empty_stream(*_args: object, **_kwargs: object):  # type: ignore[no-untyped-def]
+        return
+        yield  # noqa: unreachable — makes this an async generator
+
+    provider.stream = MagicMock(side_effect=lambda *a, **kw: _empty_stream())
+    sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.record_success = MagicMock()
+    sessions.get_agent = MagicMock(return_value="")
+    # NOT "auto": a default install has no session trust, so the spawn falls
+    # through to the interactive approval callback.
+    sessions.get_approval_policy = MagicMock(return_value="ask")
+    return sessions
+
+
+def _mock_ctx_builder() -> MagicMock:
+    """ContextBuilder double with the default hooks posture."""
+    ctx = MagicMock()
+    ctx.build_message = MagicMock(return_value=("built_message", None))
+    ctx.hooks.on_tool_call = MagicMock()
+    ctx.hooks.auto_approve_subagent_spawn = False
+    return ctx
+
+
+class _ParkedApproval:
+    """Spawn-approval callback that parks until the test releases it.
+
+    Models the reported environment: the prompt is raised on a surface nobody
+    is watching (an unowned CLI spawn carries ``slot=""`` and is surfaced only
+    on the global approvals feed), so it is never answered.
+    """
+
+    def __init__(self) -> None:
+        self.gate = asyncio.Event()
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(
+        self, request_id: str, description: str, parent_session_key: str = ""
+    ) -> bool:
+        self.calls.append((request_id, description, parent_session_key))
+        await self.gate.wait()
+        return True
+
+
+def _manager(approval: _ParkedApproval, **kw: object) -> SubagentManager:
+    return SubagentManager(
+        sessions=_mock_sessions(),
+        ctx_builder=_mock_ctx_builder(),
+        on_spawn_approval=approval,
+        is_yolo=lambda: False,
+        **kw,  # type: ignore[arg-type]
+    )
+
+
+async def _park(
+    mgr: SubagentManager, task: str = "Return only the result of 1+1", parent: str = ""
+):
+    """Spawn and let the approval task reach its await."""
+    info = mgr.spawn(task, parent_session_key=parent)
+    assert info is not None
+    for _ in range(20):
+        await asyncio.sleep(0)
+    return info
+
+
+async def _drain(mgr: SubagentManager, approval: _ParkedApproval) -> None:
+    approval.gate.set()
+    for t in list(mgr._tasks.values()):
+        t.cancel()
+    await asyncio.sleep(0)
+
+
+@asynccontextmanager
+async def _parked(parent: str = ""):
+    """Yield ``(mgr, info, approval)`` for a run parked on its spawn prompt.
+
+    The drain is in a ``finally`` on purpose: a failing assertion must not
+    leave the approval coroutine suspended on its event, which surfaces as
+    "Task was destroyed but it is pending!" and attributes the noise to
+    whichever test runs next.
+    """
+    approval = _ParkedApproval()
+    mgr = _manager(approval)
+    try:
+        info = await _park(mgr, parent=parent)
+        yield mgr, info, approval
+    finally:
+        await _drain(mgr, approval)
+
+
+class TestSpawnParkedOnApprovalIsObservable:
+    """The parked run must be distinguishable from one that is executing."""
+
+    @pytest.mark.asyncio
+    async def test_parked_run_is_marked_awaiting_approval(self) -> None:
+        """``_awaiting_approval`` is set while the spawn prompt is unanswered.
+
+        This is a PRECONDITION pin, not new behaviour: the spawn gate began
+        setting the flag in #7325, for the reaper's terminal message. The wire
+        predicate added by this change reads that same flag, and every payload
+        test below feeds the predicate a hand-built ``SubagentInfo`` — so if the
+        gate stopped setting it, those tests would still pass while the field
+        went dark in production. Nothing else covers the seam, because #7325's
+        own tests assert on the reap message rather than on the flag.
+
+        The other assertions record the reported state itself: a run that is
+        counted like an executing one while owning no process and no turn.
+        """
+        async with _parked() as (mgr, info, approval):
+            assert approval.calls, "the interactive spawn prompt must have been raised"
+            registered = mgr._agents[info.id]
+            # Preconditions: this is the reported state, not an executing agent.
+            assert registered.done is False
+            assert registered.turns == 0
+            assert registered._pid is None
+            assert registered._exec_started is None
+            assert mgr.count == 1, "status API counts it exactly like a running agent"
+
+            assert registered._awaiting_approval is True
+
+    @pytest.mark.asyncio
+    async def test_parked_run_logs_under_its_run_id(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        """An operator grepping the logs for a stuck run id finds the reason.
+
+        The report's dead-end was "``kirocrew logs`` contained no error or
+        warning keyed by the affected run ID". #7325 later marked this wait in
+        machine state, for the reaper — but a mark is not a message, and still
+        nothing was WRITTEN when a spawn parked, so the single most useful
+        diagnostic (which run is waiting, and for what) did not exist. This is
+        the only assertion in this file that covers a change to
+        ``admission.py``; everything else covers a reader of the state.
+        """
+        approval = _ParkedApproval()
+        mgr = _manager(approval)
+        # Captured at root, not at a named logger: the coordinator modules
+        # receive ``logger`` by injection (``bind_component_globals``), so the
+        # record is emitted under ``kiro_crew.subagent`` rather than under
+        # ``admission``'s own module name. What matters to the operator is that
+        # SOME record names the run and the gate.
+        try:
+            with caplog.at_level(logging.INFO):
+                info = await _park(mgr)
+                keyed = [r for r in caplog.records if info.id in r.getMessage()]
+                assert keyed, f"no log record mentions run id {info.id}"
+                assert any(
+                    "approval" in r.getMessage().lower() for r in keyed
+                ), f"no log record names the approval gate: {[r.getMessage() for r in keyed]}"
+        finally:
+            await _drain(mgr, approval)
+
+    @pytest.mark.asyncio
+    async def test_approval_flag_clears_once_answered(self) -> None:
+        """The flag is a wait marker, not a sticky one: it clears on answer.
+
+        The second half of the precondition above. The wire predicate reports a
+        wait purely from state, so a flag left set after the answer would
+        advertise "waiting for your approval" on a run that is executing.
+        """
+        async with _parked() as (mgr, info, approval):
+            assert mgr._agents[info.id]._awaiting_approval is True
+
+            approval.gate.set()
+            for _ in range(20):
+                await asyncio.sleep(0)
+            assert mgr._agents[info.id]._awaiting_approval is False
+
+
+class TestParkedRunIsVisibleOnBothReadPaths:
+    """Both /api/spawn shapes must carry the wait, not just the list one.
+
+    A blocking ``kirocrew spawn run`` polls the SINGLE-run status endpoint
+    (``/api/spawn/<id>``) every 2s, not the list. Reporting the wait only on the
+    list left the CLI reproduction of #6484 exactly as silent as before: the
+    caller sat on "waiting for result..." while the reason was discoverable only
+    from a separate ``spawn list`` or a log grep.
+    """
+
+    def _payload_flag(self, *, awaiting: bool, exec_started: float | None) -> bool:
+        """What the two handlers now emit, via their shared predicate."""
+        from kiro_crew.dashboard.handlers.messaging import _awaiting_spawn_approval
+        from kiro_crew.subagent import SubagentInfo
+
+        info = SubagentInfo(id="parked01", task="Return only the result of 1+1")
+        info._awaiting_approval = awaiting
+        info._exec_started = exec_started
+        return _awaiting_spawn_approval(info)
+
+    def test_field_present_only_while_parked_on_the_spawn_gate(self) -> None:
+        assert self._payload_flag(awaiting=True, exec_started=None) is True
+        # Not parked at all -> absent, so the payload of an ordinary executing
+        # run is unchanged.
+        assert self._payload_flag(awaiting=False, exec_started=None) is False
+
+    def test_mid_run_tool_approval_is_not_reported_as_the_spawn_gate(self) -> None:
+        """The flag is shared; the wire read must not be.
+
+        ``run.py`` sets ``_awaiting_approval`` at three in-run TOOL-approval
+        sites, and ``_exec_started`` is stamped once when execution begins (in
+        ``_run_inner_impl``). Reading the flag bare would render a run at turn 5
+        waiting on a tool prompt as "waiting for spawn approval" and tell a
+        still-polling caller to approve it "to start this run" that already
+        started. ``_exec_started is None`` is what separates the two — the same
+        pair ``terminal.py`` uses to pick the reap message.
+        """
+        assert self._payload_flag(awaiting=True, exec_started=1.0) is False
+
+    def test_both_endpoints_use_the_shared_predicate(self) -> None:
+        """Source ratchet: neither read path may inline its own condition.
+
+        A behavioural test cannot cover this -- the two handlers build their own
+        dicts independently, so one of them dropping the field, or drifting to a
+        bare flag read, looks identical to a run that simply is not parked.
+        """
+        from pathlib import Path
+
+        import kiro_crew.dashboard.handlers.messaging as messaging
+
+        src = Path(messaging.__file__).read_text(encoding="utf-8")
+        assert src.count("if _awaiting_spawn_approval(info):") == 2, (
+            "expected both api_spawn_status and api_spawn_list to gate on the "
+            "shared _awaiting_spawn_approval predicate"
+        )
+        assert src.count('"awaiting_approval"] = True') == 2
+        # No bare flag read may creep back into a payload builder: that is the
+        # exact drift that mislabels an in-run tool approval.
+        assert 'getattr(info, "_awaiting_approval", False) is True' not in src.replace(
+            'getattr(info, "_awaiting_approval", False) is True\n        and getattr(info, "_exec_started", None) is None',
+            "<predicate>",
+        )
+
+    def test_cli_poll_announces_the_wait_once(self) -> None:
+        """The blocking CLI must tell the user, and only once per run."""
+        from pathlib import Path
+
+        import kiro_crew.cli_commands as cli
+
+        src = Path(cli.__file__).read_text(encoding="utf-8")
+        assert 'status.get("awaiting_approval")' in src, (
+            "the blocking spawn-run poll does not consult awaiting_approval, so "
+            "a parked run still reports nothing to the waiting caller"
+        )
+        # Guarded by a one-shot flag rather than printing on every 2s poll.
+        assert "told_awaiting" in src
+
+    def test_mcp_spawn_list_does_not_call_a_parked_run_running(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """The MCP roster is the 4th read surface, and an LLM's one.
+
+        ``spawn.py`` itself tells a caller whose spawn POST failed to "Check
+        spawn_list", so answering ``[running]`` for a run that has launched
+        nothing and is waiting on a human misinforms the agent at exactly the
+        moment it is trying to reconcile.
+        """
+        from kiro_crew.mcp_tools import spawn as spawn_tools
+
+        def _fake_get(path: str) -> dict:
+            assert path == "/api/spawn"
+            return {
+                "agents": [
+                    {
+                        "id": "parked01",
+                        "task": "Return only the result of 1+1",
+                        "done": False,
+                        "awaiting_approval": True,
+                        "turns": 0,
+                        "elapsed": 12,
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(spawn_tools.mcp_core, "_get", _fake_get)
+        out = spawn_tools.spawn_list("spawn_list", {})
+        assert "awaiting-approval" in out, f"parked run not reported as waiting: {out!r}"
+        assert "[running]" not in out, f"parked run still reported as running: {out!r}"
+
+    def test_mcp_spawn_list_still_says_running_for_a_live_run(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """The new status must not swallow the ordinary one."""
+        from kiro_crew.mcp_tools import spawn as spawn_tools
+
+        monkeypatch.setattr(
+            spawn_tools.mcp_core,
+            "_get",
+            lambda _p: {
+                "agents": [
+                    {"id": "live0001", "task": "real work", "done": False, "turns": 3, "elapsed": 9}
+                ]
+            },
+        )
+        out = spawn_tools.spawn_list("spawn_list", {})
+        assert "[running]" in out
+        assert "awaiting-approval" not in out
+
+
+# NOTE on the two halves of #6484 that are NOT covered here, because main
+# already carries them.
+#
+# The terminal message ("Reaped after Ns (exceeded Ns deadline)" on a run that
+# never executed) was fixed by #7325, which reads
+# `_awaiting_approval and _exec_started is None` in `subagent_manager/
+# terminal.py` — the same pair as the wire predicate above, arrived at
+# independently. That is also where the spawn gate's own
+# `info._awaiting_approval = True` comes from, so this change no longer needs to
+# set the flag; it names the wait (the log line) and reports it (the field).
+#
+# The chat-tab rendering was fixed by #7477, which is frontend-only: it derives
+# its cue from the WS `approval` event routed into `sseSubagentPending`, i.e.
+# `status === 'pending' && approval_id`, NOT from this payload. It is therefore
+# scoped to a slot, and an unowned spawn (`slot=""`) still reaches no chat tab —
+# which is precisely the run the CLI and MCP surfaces above are for.


### PR DESCRIPTION
## Problem / Motivation

On a default install a `spawn_run` can sit forever showing "waiting" while no child ACP process is ever created, and nothing that reads the run through `/api/spawn` says why. The reporter's status API showed the contradiction exactly:

```
top-level subagents: 1
stats.subagents_spawned: 0
```

Registered and counted as running, but never spawned: no error, no failure event, no log line keyed by the run id, and `kirocrew spawn list` showing the same hourglass it shows for a healthy agent. The only way out was restarting the gateway.

The cause is not a queueing race. A default install has no YOLO override, `auto_approve_subagent_spawn` defaults to `False`, and a fresh session has no trust, so every `spawn_run` falls through the approval ladder to the interactive spawn-approval prompt. Until that prompt is answered the run parks in `_spawn_with_approval`: registered in `_agents`, counted by the manager's running count, `turns == 0`, `_pid is None`, `_exec_started is None`.

`count` filters `_agents` on `not done and not queued`, so the reporter's own numbers pin the location: `subagents: 1` proves the run passed registration, and `subagents_spawned: 0` proves it never reached `_log_spawned`. Between those two points there is only the approval wait.

Both reported reproductions collapse to this one mechanism. The CLI half is worse: `kirocrew spawn run` posts `{"task": ...}` with no `parent_session`, so the prompt resolves to `slot=""` and is surfaced only on the global approvals feed. It appears in no chat tab, while the CLI prints "waiting for result..." and polls.

## Why it matters

The failure is silent, so a two-second click turns into a full investigation.

- **No diagnostic exists.** The report's dead end was verbatim: "`kirocrew logs` contained no error or warning keyed by the affected run ID." That is still true on main today.
- **The run lies about itself** on four surfaces a user or an agent actually reads: `GET /api/spawn`, `GET /api/spawn/<id>`, `kirocrew spawn list`, and MCP `spawn_list`. Each reports it byte-identically to an executing agent, so none can answer "is this working, or waiting for me?"
- **The blocking CLI is the worst case.** `kirocrew spawn run` polls the single-run endpoint every 2s and prints "waiting for result..." while the prompt it needs is on a surface it never mentions.
- **It looks like a hang, so users restart the gateway**, which discards the run with no completion or failure event, exactly as reported.

## What changed (motivation -> approach -> change)

Symptom to cause: *no child process* -> the run never reached `_run` -> it never reached `_log_spawned` (hence `subagents_spawned: 0`) -> it is parked in `_spawn_with_approval` -> and that wait is marked in memory but is not named in the log and not reported on the wire. So the change names the wait and reports it, on every path that reads a run.

**Two adjacent halves of #6484 already landed on main and are deliberately not redone here.** #7325 stopped the reap of such a run blaming a deadline it never reached, and in doing so put `info._awaiting_approval = True` on the spawn gate. #7477 stopped a chat tab rendering an owned parked run as executing; it is frontend-only and derives its cue from the WS `approval` event (`status === 'pending' && approval_id`), not from this payload, so it is scoped to a slot and the unowned CLI spawn still reaches no tab. What is left is every reader that goes through `/api/spawn`.

| file | change |
|---|---|
| `subagent_manager/admission.py` | +15, one statement: `_spawn_with_approval` logs at INFO under the run id, with the parent or `<unowned>`. The flag beside it is #7325's; an earlier revision of this branch set it too, and that duplication was removed on rebase. |
| `dashboard/handlers/messaging.py` | BOTH `/api/spawn` read paths carry `awaiting_approval` while parked, via one shared predicate `_awaiting_spawn_approval(info)`. Present only while true, so the default payload is unchanged (same convention as the existing `context_withheld`). |
| `cli_commands.py` | `kirocrew spawn list` renders a lock glyph and the wait instead of the bare hourglass it shared with a running agent; the blocking `spawn run` poll announces the pending approval once, not on every 2s poll. |
| `mcp_tools/spawn.py` | MCP `spawn_list` reports `[awaiting-approval]` rather than `[running]`. This is the surface an LLM reads, and `spawn.py` itself tells a caller whose spawn POST failed to "Check spawn_list". |
| `.github/black-baseline.txt` | Prunes one entry, `src/kiro_crew/mcp_tools/spawn.py`: touching the file made it black-clean, and the baseline is shrink-only, so the gate requires the graduated entry be removed. |

Two details in the predicate are load-bearing:

- **`_exec_started is None` as well as the flag.** `_awaiting_approval` is shared: `run.py` sets it at three in-run TOOL-approval sites, so a bare read would render a run at turn 5 waiting on a tool prompt as "waiting for spawn approval" and tell a still-polling caller to approve it "to start this run" that already started. `_exec_started` is stamped once when execution begins (`_run_inner_impl`), so `None` means the run never entered execution. `terminal.py` picks its reap message off the same pair, arrived at independently in #7325.
- **One predicate, not two inlined conditions.** The handlers build their payloads independently, so a drift between them is invisible to a behavioural test, which is exactly how the status endpoint came to be missed in an earlier revision. A source ratchet pins both call sites and forbids a bare flag read creeping back into either.

Not extracted onto `SubagentInfo` to share with `terminal.py`: that read is a plain attribute read on a live run inside the manager package, while this one must survive the `SimpleNamespace`/`MagicMock` info doubles the handlers are tested with, and unifying them would mean editing a reap path this change does not otherwise touch. Two lines, and both sites name each other.

Covering both endpoints matters: `api_spawn_list` feeds `kirocrew spawn list`, but `api_spawn_status` is what a blocking `kirocrew spawn run` polls every 2s, so reporting the wait on the list alone would have left the CLI reproduction exactly as silent as before.

Deliberately not changed: the approval requirement itself, the approval window values, and the decision to leave a human prompt without a deadline of its own. Those are policy.

## Tests

New file `test/test_subagent_spawn_approval_parked_6484.py`, 9 tests.

- The parked run is marked `_awaiting_approval`, with the reported state (`done is False`, `turns == 0`, `_pid is None`, `_exec_started is None`, `count == 1`) asserted as preconditions so the test cannot drift onto a different state.
- Some log record names both the run id and the gate. This is the only assertion covering a change to `admission.py`; everything else covers a reader of the state.
- The flag clears once answered, so a wire read cannot advertise a wait on a run that is executing.
- The shared predicate is true only while parked on the spawn gate, and false for a mid-run tool approval (`_exec_started` set).
- Source ratchet: both `/api/spawn` handlers gate on the shared predicate, and no bare flag read may creep back into either.
- The blocking CLI poll consults `awaiting_approval` and announces it once.
- MCP `spawn_list` reports `awaiting-approval` for a parked run and still reports `running` for a live one.

**Two of the nine are deliberately precondition pins, not new behaviour.** The flag set/clear pair now passes on main, because #7325 put the flag on the spawn gate. They are kept because every payload test feeds the predicate a hand-built `SubagentInfo`: if the gate stopped setting the flag, those tests would still pass while the field went dark in production, and #7325's own tests assert on the reap message rather than on the flag. Their docstrings say so rather than claiming credit.

Scoped suites, all green: 9/9 in the new file; 724 passed / 2 skipped across `test_subagent_startup_watchdog` (#7325's own), `test_handlers_messaging_coverage`, `test_spawn_list_redaction`, `test_mcp_core_spawn_sub_agents`, `test_spawn_agent_roster`, `test_agent_roster_shared`, `test_subagent_reap_race`, `test_subagent_stall`, `test_cli`; 493 passed across `test_api_server`, `test_subagent_coverage`, `test_subagent_persistence`, `test_subagent_context_group_plumbing`, `test_messaging_commands`.

## Manual verification

**Rebased first, then re-verified rather than trusting the automerge.** The branch was 164 commits behind main and the rebase reported zero conflicts, but main had landed overlapping work in the same function, so a clean merge was not evidence of a correct result. Reading the rebased file found this PR's `_awaiting_approval` set/clear pair sitting next to #7325's, plus prose claims main had made false. Both were fixed before pushing.

**A/B against pristine main, measured not asserted.** A detached worktree at main tip with only the new test file copied in: 6 failed, 3 passed. The 3 that pass are the flag set/clear pair and the "a live run still says `[running]`" control. The 6 that fail are the log line, the four predicate/wire assertions, and the CLI poll, i.e. exactly this diff.

**Mutation-verified, three probes**, because a test that passes both ways proves nothing:

| mutation | result |
|---|---|
| remove the `logger.info` from `admission.py` | 1 failed (the log test) |
| weaken the predicate to a bare `_awaiting_approval` read | 2 failed (the mid-run tool case, and the ratchet's bare-read guard) |
| drop the `api_spawn_status` call site | 1 failed (the source ratchet) |

**Gates, all green:** flake8, isort, mypy (1259 files), the black gate (6 files in scope, baseline honoured), agent-sdk-boundary, loop-bound-locks, sync-io-in-async, subprocess-encoding, lockdown-before-publish, brand-name, focus-cue, builtin-skill-scope, testpaths-coverage.

**One CI red on this head was diagnosed and is not this diff's.** `Backend Tests (3.12, 3)` failed on `test/test_security.py::TestKeystoneVariableLeafNativeSpellings::test_an_absolute_home_spelled_with_backslashes_is_refused`. The diff touches neither `security.py` nor `test_security.py`; `git log HEAD..main` on those two paths is empty, so the file is identical in this branch and in main; the test class predates this base; it passes locally in isolation; and only the 3.12 shard failed while every 3.10 shard was green on the same head. A rerun went green, consistent with order dependence (the test builds its input from `os.path.expanduser("~")`, while `security.py` anchors home via `Path.home()` behind a cache keyed on resolved roots). Nothing was folded into this diff for it.

No UI change, so no screenshots, no i18n key, and no eslint or bundle-size exposure.

## Related Issues

- Closes the diagnostic half of #6484 (see the trailer below).
- #7325 landed the reap-message half and put `_awaiting_approval` on the spawn gate.
- #7477 landed the chat-tab rendering half, frontend-only and slot-scoped.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a status field added to one serializer of a run/job object but not to its siblings

Only the second of this defect's two layers generalizes.

The surface layer is close to a one-off: one particular wait, the spawn-approval gate, was marked in memory but never named in the log.

The layer underneath is a class. `/api/spawn` has two read paths that build their payloads independently, so a field a caller acts on can land on one and be silently absent from the other, and the gap is invisible to a behavioural test because "field absent" and "the run is not in that state" are the same bytes on the wire. An earlier revision of this very PR shipped exactly that bug: the field was on the list endpoint only, which left the blocking `kirocrew spawn run` reproduction as silent as it was before the fix, because that path polls the single-run endpoint. The only guard available was a hand-written per-file source ratchet pinning both call sites, and needing to hand-write one is itself the argument for a shared rule.

Suggested prompt line: when a PR adds a status field to a run/job payload, name every serializer of that object and confirm the field reaches all of them, or say why it deliberately does not.

Deliberately not proposed as semgrep or lint: "sibling serializer" is not structurally detectable here. The two handlers share no type and no base class, so any pattern broad enough to catch them would fire on every optional key in the codebase.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no user-facing doc or spec surface changes; the two adjacent halves that carried spec edits landed separately as #7325 and #7477
- [x] No secrets, credentials, or internal references in the diff

Fixes #6484
