### PR TITLE
feat(metrics): install-inventory gauges and OTLP export verification

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,6 +16,7 @@ system is built, see [../architecture/](../architecture/README.md).
 | [slack-setup.md](slack-setup.md) | Creating and configuring the Slack app. |
 | [enterprise-mcp-governance.md](enterprise-mcp-governance.md) | Running Kiro Crew on an enterprise Kiro account (IAM Identity Center / API key) whose administrator allow-lists MCP servers through a registry: why features go silently missing, and the two-sided fix. Also the admin-facing rollout for **central policy distribution** — publishing one `security_policy.json` that every host fetches, caches and re-fetches. |
 | [secrets-env.md](secrets-env.md) | Passing secrets (API keys, tokens) to MCP servers via systemd environment directives or a shell wrapper — interim workarounds pending the encrypted vault. |
+| [telemetry-otlp-export.md](telemetry-otlp-export.md) | Pushing Kiro Crew's OpenTelemetry metrics to a collector and on to CloudWatch, Datadog, or any OTLP-compatible backend: the two separate consent switches, collector config samples, the temporality setting that decides whether a backend accepts the data, what is and is not exported, and how to verify the path end to end. |
 | — | Other chat channels (Discord, Telegram, Teams, Webex, WeCom, WeChat) are documented in [../../src/kiro_crew/docs/](../../src/kiro_crew/docs/README.md); the channel-neutral transport contract is [messaging.md](../system-specs/modules/messaging.md). |
 
 `assets/` holds the copy-pasteable service unit, launchd plist, and setup script

--- a/docs/guides/telemetry-otlp-export.md
+++ b/docs/guides/telemetry-otlp-export.md
@@ -1,0 +1,401 @@
+# Exporting Kiro Crew metrics over OTLP
+
+Kiro Crew records its metrics through the OpenTelemetry SDK. By default they go
+nowhere but this machine: a local JSONL sink under `~/.kiro/crew/metrics`, which
+the dashboard's Telemetry panel reads. This page is about the other option —
+pushing the same metrics to an **OpenTelemetry Collector**, and from there to
+whatever backend you already run (Amazon CloudWatch, Datadog, or any service that
+accepts OTLP).
+
+Nothing here is on by default, and turning it on takes two separate decisions:
+collection, then egress.
+
+## Default posture
+
+| | Default | What it means |
+|---|---|---|
+| `telemetry.enabled` | `false` | Nothing is recorded. Metric call sites are cheap no-ops. |
+| `telemetry.otlp_endpoint` | `""` (empty) | Nothing leaves the machine. Local JSONL sink only. |
+| `kirocrew[otlp]` extra | not installed | The OTLP exporter is not even importable. |
+
+Collection and egress are deliberately separate switches. Enabling collection
+gives you the local sink and the Telemetry panel; it does **not** send anything
+anywhere. Egress needs the endpoint set *and* the extra installed.
+
+The local sink is never replaced by OTLP — it is additive. When you configure an
+endpoint you get both readers, so the dashboard keeps working and you keep a
+local copy.
+
+## Turning it on
+
+### 1. Install the exporter
+
+```bash
+pip install "kirocrew[otlp]"
+```
+
+This pulls `opentelemetry-exporter-otlp-proto-http`. Transport is **OTLP over
+HTTP only** — there is no gRPC exporter, so your collector needs its OTLP
+receiver's `http` protocol enabled (port 4318 by convention, not 4317).
+
+If the extra is missing but an endpoint is configured, Kiro Crew logs a warning
+and stays local-only rather than failing to start.
+
+### 2. Enable collection
+
+Either edit `~/.kiro/crew/config.json`:
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "otlp_endpoint": "http://localhost:4318/v1/metrics"
+  }
+}
+```
+
+or set the environment variable, which overrides the config flag in both
+directions and is the convenient form for containers and one-off debugging:
+
+```bash
+KIROCREW_TELEMETRY=1 kirocrew gateway
+```
+
+**`otlp_endpoint` is the full signal URL, including `/v1/metrics`.** It is passed
+to the exporter as-is; no path is appended for you. `http://localhost:4318` alone
+will not work.
+
+### 3. Confirm egress started
+
+On startup the gateway logs the local sink and, separately, the fact that metrics
+are leaving the machine:
+
+```
+telemetry enabled; local JSONL sink at /home/you/.kiro/crew/metrics (otlp=on)
+telemetry OTLP export active; metrics leave this machine (default)
+```
+
+The second line is the one to look for. The endpoint value is never logged — only
+the destination name — so a credential embedded in the URL does not end up in the
+journal.
+
+### Other settings worth knowing
+
+| Key | Default | Notes |
+|---|---|---|
+| `telemetry.export_interval_seconds` | `60` | Applies to both readers. |
+| `telemetry.local_dir` | `~/.kiro/crew/metrics` | Local JSONL shard directory. |
+| `telemetry.retention_days` | `0` | `0` never prunes by age. |
+| `telemetry.max_total_mb` | `0` | `0` never prunes by size. |
+
+## Temporality: the setting that decides whether your backend accepts the data
+
+Counters can be exported two ways. **Cumulative** sends the running total every
+interval; **delta** sends only what changed since the last export. Backends
+disagree about which they want, and sending the wrong one is the most common
+reason metrics arrive but look wrong — a cumulative counter graphed as a rate, or
+a delta counter treated as a total that appears to reset constantly.
+
+Kiro Crew deliberately passes **no** temporality preference to the exporter. That
+is what leaves the OpenTelemetry standard environment variable in control, so you
+can match your backend without a code change:
+
+```bash
+# Cumulative — the OpenTelemetry default. CloudWatch, Prometheus-style backends.
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=CUMULATIVE
+
+# Delta — what Datadog and most product-analytics ingests expect.
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=DELTA
+
+# Delta for counters, cumulative for up-down counters.
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=LOWMEMORY
+```
+
+Set it in the gateway's environment, not the collector's — it governs how Kiro
+Crew *encodes* what it sends.
+
+Two things are unaffected by this setting, and knowing that saves debugging time:
+
+- **Gauges have no temporality at all.** Every instrument reporting a
+  point-in-time reading (thread counts, memory, install inventory) is a gauge, so
+  the preference does not apply to them.
+- **The local JSONL sink is always cumulative** for counters. It is a separate
+  reader with its own encoding, and the dashboard aggregator depends on it.
+
+You can also convert temporality inside the collector with the
+`cumulativetodelta` processor, which is the better lever when one collector feeds
+two backends that disagree.
+
+## Collector configuration
+
+The examples below are collector configs. Point Kiro Crew at the collector's OTLP
+HTTP receiver and let the collector fan out.
+
+**Distribution matters.** The `otelcol` core distribution ships the OTLP receiver
+and a small set of exporters. The vendor exporters below (`awsemf`, `datadog`)
+are only in **`otelcol-contrib`**. Using core and wondering why an exporter is
+"unknown type" is the usual first mistake.
+
+**These samples are illustrative, not tracked.** Vendor exporter options change
+with collector and vendor releases that this repository does not follow, so treat
+each vendor's own collector documentation as authoritative and these blocks as a
+starting shape. What is stable — and what this page actually owns — is the Kiro
+Crew side: the two consent switches, the full-signal-URL requirement, and the
+temporality preference.
+
+### Shared receiver
+
+Every example starts here:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:4318
+```
+
+Bind to `127.0.0.1` when the collector runs on the same host as the gateway. A
+`0.0.0.0` bind accepts metrics from anywhere on the network and needs its own
+authentication story.
+
+### Amazon CloudWatch
+
+The `awsemf` exporter writes CloudWatch Embedded Metric Format, which turns each
+metric into a CloudWatch metric via a log group.
+
+```yaml
+exporters:
+  awsemf:
+    region: us-west-2
+    namespace: KiroCrew
+    log_group_name: /kirocrew/metrics
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [awsemf]
+```
+
+Use `CUMULATIVE` temporality with this path. Credentials come from the
+collector's own environment via the standard AWS chain, so the collector needs
+`logs:PutLogEvents` and `logs:CreateLogStream` on that log group.
+
+### Datadog
+
+```yaml
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: datadoghq.com
+
+processors:
+  # Datadog expects delta counters. Convert here if you would rather not set the
+  # temporality preference on every gateway.
+  cumulativetodelta: {}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [cumulativetodelta]
+      exporters: [datadog]
+```
+
+Set `DD_API_KEY` in the collector's environment rather than inlining it.
+
+### Any other OTLP-compatible backend
+
+Most analytics and observability services accept OTLP/HTTP directly. Forward with
+`otlphttp` and add whatever authentication header that service documents:
+
+```yaml
+exporters:
+  otlphttp/vendor:
+    endpoint: https://otlp.example-vendor.com
+    headers:
+      authorization: ${env:VENDOR_API_KEY}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlphttp/vendor]
+```
+
+Check that vendor's documentation for three things, because they vary: the exact
+endpoint (some want the base URL and append `/v1/metrics` themselves, others want
+the full signal path), the header name, and the temporality they expect.
+
+One pipeline can also carry several exporters, which is the reason to run a
+collector at all rather than pointing the gateway straight at a vendor.
+
+## What gets exported
+
+Two families of instruments, all under the `kirocrew.` namespace:
+
+- **`kirocrew.process.*`** — this process's own resource behavior: Python and OS
+  thread counts, open file descriptors, current and peak RSS, cumulative CPU
+  seconds, and per-generation GC counters.
+- **`kirocrew.inventory.*`** — what this install has configured: active cron jobs,
+  armed monitor loops, installed skills, whether memory has been migrated,
+  knowledge-source and lesson counts, MCP server counts by class, and a
+  fixed set of feature switches. Plus `kirocrew.inventory.probe.failures`, which is
+  absent on a healthy host and appears only when a probe cannot read its source —
+  that is how you tell a broken probe from a host that stopped exporting, since
+  both otherwise look like a missing series.
+
+Two thresholds are worth knowing when you set alerts on the counts, because they
+are the product's own limits rather than round numbers: `50` is the
+`knowledge.max_sources` default, so a host above it is past the default source cap,
+and `200` is the point the lesson store starts pruning. The gauges publish the raw
+number and leave the banding to your queries, so you can move those lines without
+a Kiro Crew change.
+
+Resource attributes identify the sending process and are attached to every
+series, so they are what you group by. `service.name` is always `kirocrew`.
+
+### Before you build a per-host dashboard
+
+One limitation to know up front, because it will bite a dashboard rather than
+announce itself. Separating machines depends entirely on the resource attributes,
+and today the only identity there comes from the OpenTelemetry SDK's own detector:
+a `service.instance.id` that is **generated fresh for each process**. Two hosts are
+therefore distinguishable at any given moment, but a single host's series *restarts
+whenever its gateway restarts*, so a longitudinal "this machine over time" panel
+will show a new series after every restart rather than one continuous line.
+
+That id comes from the SDK's default resource, so whether you have it at all depends
+on your installed SDK: current versions supply it (including `1.44.0`, the version
+pinned for the `kirocrew[otlp]` extra), while the declared floor is
+`opentelemetry-sdk>=1,<2` and an older SDK in that range may contribute none — in
+which case two hosts are not separable either. Check yours before building on it:
+
+```bash
+python -c "from opentelemetry.sdk.resources import Resource; print(Resource.create({}).attributes)"
+```
+
+This applies to every `kirocrew.*` metric, not just the inventory family, and it is
+closed by giving the resource a persisted install-scoped identity. Until then,
+prefer panels that group by the current instance and read point-in-time state, and
+treat cross-restart continuity as unavailable.
+
+### What these can and cannot tell you
+
+They describe **the machines you run and have opted in**, and nothing wider. Both
+switches default off and OTLP additionally needs the `kirocrew[otlp]` extra, so an
+aggregate over these gauges is a statement about your own fleet — useful for
+spotting a host that stopped scheduling crons or whose skills tree drifted, not a
+measurement of how a feature is used in general. Kiro Crew's own install analytics
+are a separate, deliberately unrelated channel (`beacon.py`), for reasons its
+docstring sets out.
+
+One practical consequence: `kirocrew.inventory.*` comes from the **gateway process
+only**, while `kirocrew.process.*` comes from every telemetry-enabled process
+(gateway, MCP gateway daemon, spawned agents). Install-level facts are identical
+across those processes, so publishing them from each one would count a single host
+once per process. If you see process metrics from a host but no inventory metrics,
+the gateway on that host is not running or not exporting — that is the signal, not
+a gap in collection.
+
+### What is deliberately not exported
+
+Reading these metrics should not tell you what a user is working on:
+
+- **No MCP server names.** The MCP gauge publishes two counts, `first_party` and
+  `third_party`. Server names are read to classify and then discarded, because a
+  roster is user-chosen text — unbounded as a label and revealing as data.
+- **No knowledge or lesson content.** Those two gauges publish a count and nothing
+  else: no source titles, paths, or text, and no per-document attributes. The count
+  is deliberately raw rather than banded — the destination is your own collector
+  describing your own machines, and a band would hide exactly the growth the gauge
+  is there to show.
+- **No paths, endpoints, prompts, message content, or session identifiers**
+  anywhere in a metric name or attribute value.
+- **A subsystem that cannot answer produces no data point** rather than a zero.
+  A missing series means "could not read"; a `0` means a real zero. If a series
+  you expect is absent, that is the gauge telling you something.
+
+## Verifying it end to end
+
+### Automated
+
+```bash
+pytest test/metrics/test_otlp_wire_e2e.py
+```
+
+Two tiers. The first drives a real build through a real exporter and asserts the
+instrument roster, resource-attribute fidelity, attribute values, and
+temporality. The second stands up an in-process OTLP receiver on loopback, exports
+to it with the real OTLP exporter, and decodes the protobuf — that tier skips
+unless `kirocrew[otlp]` is installed.
+
+### Against a real collector
+
+The automated tiers stop at the process boundary: they prove what Kiro Crew
+serializes and puts on the wire, not what a collector does with it. Closing that
+last gap needs a collector binary and outbound network, so it is a manual step —
+and one worth doing once against whatever collector you actually run, rather than
+against a stand-in.
+
+Point a collector at Kiro Crew using the [Shared receiver](#shared-receiver)
+config above, and give it an exporter you can read directly instead of a vendor
+backend, so the payload is inspectable:
+
+```yaml
+exporters:
+  # `debug` ships in every collector distribution; `file` needs a distribution
+  # that bundles the contrib file exporter (the standard `otelcol` build does).
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]
+```
+
+Then start the gateway with `otlp_endpoint` set to that collector, wait one export
+interval, and read what arrived. Expect the `kirocrew.process.*` and
+`kirocrew.inventory.*` families and the resource attributes described above.
+
+Some instruments are legitimately absent and their silence is not a failure: the
+Linux-only thread and file-descriptor gauges on macOS, and the knowledge, MCP, and
+monitor-loop gauges on an install that has never ingested a document, configured a
+server, or armed a loop. `kirocrew.inventory.probe.failures` is the series that
+distinguishes a probe that broke from a source that is simply not there.
+
+If you fetch a collector binary rather than using one you already run, verify it
+against the checksums published with that release; each release also publishes
+cosign `.sig` and `.pem` files, which are the stronger check and worth using if you
+are vendoring the binary into your own infrastructure.
+
+### By hand, with no collector at all
+
+The quickest smoke test is to watch the local sink, which is fed by the same
+recorder:
+
+```bash
+KIROCREW_TELEMETRY=1 kirocrew gateway
+# after one export interval (60s by default)
+ls ~/.kiro/crew/metrics/
+python3 -m json.tool < ~/.kiro/crew/metrics/metrics-*.jsonl | head -40
+```
+
+If instruments appear there but not at your backend, the problem is the endpoint,
+the collector, or temporality — not collection.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| No `telemetry OTLP export active` line | `otlp_endpoint` empty, or `kirocrew[otlp]` not installed — check for the warning naming the missing extra. |
+| `OTLP exporter init failed` warning | Malformed endpoint. The message deliberately omits the URL, since it can carry a credential. |
+| Local shards fill, nothing at the backend | Endpoint missing `/v1/metrics`, collector on 4317 (gRPC) instead of 4318 (HTTP), or the collector's `http` protocol not enabled. |
+| Metrics arrive but counters look like resets | Temporality mismatch. See the temporality section. |
+| `unknown type: "awsemf"` at collector startup | Running the core `otelcol`; vendor exporters need `otelcol-contrib`. |
+| One expected series is absent | That probe could not read its source. Absence is a gap, never a zero. |
+| Nothing recorded at all | Collection consent: `telemetry.enabled` is `false` and `KIROCREW_TELEMETRY` is unset. |

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -307,7 +307,19 @@ future pause-state change cannot land in only one reader and drift.
 
 `count_enabled_from_disk()` is a **read-only** parse of `crons.json`: it counts
 enabled jobs via `_record_is_enabled` and never mutates loop-owned state
-(`self._jobs`, `self._last_mtime`) or the asyncio timer. It exists specifically
+(`self._jobs`, `self._last_mtime`) or the asyncio timer. The reduction itself
+lives one level down, in the module function `enabled_count_from_disk(path)` — a
+sibling of `unhealthy_jobs_from_disk` that returns `(count, loadable)` and is the
+single owner of the "loadable record AND enabled" loop. Two callers want
+different halves of that pair: this method keeps the count and degrades an
+unloadable store to `0`, because its caller is a status pusher that must always
+have a number to render; the telemetry probe
+(`metrics/inventory_gauges.read_active_crons`) needs `loadable` so it can report a
+present-but-unreadable store as a fault rather than as a plausible count. Before
+the split each side carried its own spelling of the loop, capped only by the
+shared predicates.
+
+It exists specifically
 for the dashboard WS status pusher, which needs an enabled-job count off the
 event loop. The pusher MUST NOT run `list_jobs` off-thread: `list_jobs` calls
 `_sync()` → `_load()` → `_arm_timer()`, and `_arm_timer` both calls

--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -306,11 +306,89 @@ presence without the endpoint string),
 | `kirocrew.process.memory.rss_bytes` / `.peak_rss_bytes` | gauge (By) | — | Same module; delegate to `platform_compat.proc_rss_bytes` (current) / `proc_peak_rss_bytes` (high-water mark), both cross-platform. A 0 return maps to None: gap, never a fake zero sample. |
 | `kirocrew.process.cpu.seconds` | counter (s) | — | Same module; `platform_compat.proc_cpu_seconds` cumulative user+system CPU, exported CUMULATIVE (rebuild-idempotent; see exporter row). |
 | `kirocrew.process.gc.collections` / `.collected` / `.uncollectable` | counter | `generation` (`0`/`1`/`2`) | Same module; `gc.get_stats()` per generation. Rules GC in/out of a leak diagnosis (rising uncollectable = reference cycles; flat collected with rising RSS = native leak). |
+| `kirocrew.inventory.crons.active` | gauge | — | `metrics/inventory_gauges.py::register_inventory_gauges`, callbacks run only at reader collection. The enabled-count reduction is `cron.enabled_count_from_disk`, a module-level sibling of `unhealthy_jobs_from_disk` that returns `(count, loadable)` and is the single owner of that loop — `CronService.count_enabled_from_disk` calls it too and keeps only the count, so the probe cannot drift from what the scheduler considers enabled, and neither needs a running gateway. Deliberately NOT `list_jobs`: that re-arms the asyncio timer, which from a reader thread with no running loop raises AND cancels the live timer first, stopping every scheduled job. A missing store is a genuine `0` and no fault (a fresh install has no crons). A store that is present but unparseable yields a gap **and increments `probe.failures{probe="crons"}`** — `_read_job_records` calls that case a fault, and a silent gap would be indistinguishable from a host that stopped exporting, which is the confusion the counter exists to resolve. |
+| `kirocrew.inventory.monitor_loops.active` | gauge | — | Same module; `autonudge.get_instance()` then a materialized `list(...)` snapshot of the loop registry counting `active`. The registry is mutated only under an `asyncio.Lock` on the event loop, which gives a reader thread no protection and cannot be acquired from it; the snapshot is safe anyway because each dict op is atomic under the GIL and a gauge stale by one loop is fine. `get_instance()` returning None (spawned agent process, unit test, auto-nudge off) yields a gap — a `0` there would be indistinguishable from a running service with none armed. |
+| `kirocrew.inventory.skills.installed` | gauge | — | Same module; one module-global `SkillsLoader(install_builtins=False)` (`install_builtins=True` would make a metrics probe perform a content-hashing write sync). Listing is a recursive walk, so it is cached for `_EXPENSIVE_TTL_SECS` (300s) — five collection cycles on the default interval. One combined total, NOT a builtin/user split: builtins are copied onto disk into the same tree, so nothing in the listing distinguishes them and a split would be a guess. |
+| `kirocrew.inventory.memory.migrated` | gauge | — | Same module; `memory.migrated` as 0/1. Reports the migration bit rather than a "memory enabled" switch because no such switch exists — the embedding provider is coerced to a real value on load, so memory is structurally always on and an "enabled" gauge could only read 1. The bit flips on the first boot that initialises vector memory, fresh installs included, so 1 is the healthy reading and a **0 on a live install is a fault**: vector memory never initialised, migration aborted before the flip, or the flag write was skipped on an unparseable `config.json`. That is what keeps it from being a rollout metric that goes quiet once a fleet converges. |
+| `kirocrew.inventory.knowledge.documents` | gauge | — | Same module; the raw source count. Deliberately NOT a constant 1 under a magnitude-band attribute: the quasi-identifying argument for banding does not hold when the only destination is the operator's own collector describing their own machines, while the band costs a series per band, hides growth inside a band (the drift the gauge exists for), and fixes the boundaries at emit time — a backend can band a raw count at query time and cannot recover a count from a band. Counts the `sources` table, not `items` (an item is one chunk, so counting items would report a chunking artifact as a document count), via a **read-only** `sqlite3` URI guarded on `exists()`: constructing a `KnowledgeStore` would run schema init plus graph load and would CREATE the database on an install that never ingested anything. Cached 300s. Absent database yields a gap. |
+| `kirocrew.inventory.lessons` | gauge | — | Same module; the raw lesson count, same shape and rationale. Reads through one module-global `LessonStore`, whose own mtime cache makes a repeated read on an unchanged file a single `stat` — reused across ticks because that cache lives on the instance, and left uncached here because a second cache would add only staleness. An absent file is a genuine `0` (an install that never saved a lesson), unlike the knowledge database. |
+| `kirocrew.inventory.mcp.servers` | gauge | `class` (`first_party` / `third_party`) | Same module; the roster merged from the agent config and `_load_mcp_json_by_source`, classified against `mcp_discovery._MANAGED_SERVER_NAMES` — reused rather than restated, since a second name list here would drift silently the first time a managed server is added or renamed. **Server names are read to classify and then discarded: no name ever reaches an attribute.** A roster is user-chosen free-form text, so publishing it would be both a cardinality bomb and a disclosure of what the user has installed. An empty merged roster yields a gap: the loaders fail soft to `{}`, so empty cannot be told apart from an unwritten config, and the managed servers are always present once installed. |
+| `kirocrew.inventory.config.toggle` | gauge | `key` (closed enum, `inventory_gauges.CONFIG_TOGGLES`) | Same module; each declared feature switch as 0/1. Config is read ONCE for the whole set, so the gauge costs one fingerprint-cached load per collection instead of one per key. `telemetry.enabled` is deliberately absent — this module only runs inside the consent gate, so it could report nothing but 1. `memory.migrated` is absent because it has its own gauge. A key whose field cannot be resolved is OMITTED rather than reported as 0 (a renamed config field must read as a missing series, never as a switch someone turned off); `test_every_declared_toggle_resolves_against_a_real_config` is what keeps that from being a silent hole. |
 
-All nine registrations are wired in `provider.py::_build_recorder` (live path only)
-and wrapped so a gauge failure can never disable telemetry as a whole; each
-reader callback is individually guarded — a failing probe yields a gap for that
-cycle, never an exporter error.
+| `kirocrew.inventory.probe.failures` | counter | `probe` (closed enum, `inventory_gauges.ALL_PROBES`) | Same module; times a probe raised, per probe. **Absent on a healthy install** — it publishes only once something has failed, so a healthy host adds no series, and roster assertions must exempt it (`_HEALTHY_ABSENT` in `test_otlp_wire_e2e.py`). It exists because absence has TWO readings that this family cannot afford to conflate: a missing series can mean the probe broke OR that the host stopped exporting, and distinguishing a drifted host from a dark host is the job these gauges were added to do. A broken probe therefore presents as data — the failure series is present and climbing, which a host that went dark cannot produce. The first failure per probe also logs at WARNING (a default install's journal keeps WARNING and above, so debug would be invisible on exactly the installs that need it); repeats drop to debug so a permanently broken probe cannot emit one WARNING per export interval for the process lifetime. Cumulative, like the process counters. |
+
+All eighteen registrations are wired in `provider.py::_build_recorder` (live path
+only) and wrapped so a gauge failure can never disable telemetry as a whole. The
+two families register in SEPARATE `try` blocks — they read entirely different
+subsystems, and the process gauges must not go dark because, say, the skills tree
+is unreadable. Each reader callback is individually guarded — a failing probe
+yields a gap for that cycle, never an exporter error.
+
+Because the inventory probes read subsystems rather than process counters, cost is
+the binding constraint: a callback runs once per export interval **per reader**, so
+an install with an OTLP destination configured enters them on two ticker threads
+concurrently. Every probe is O(1) in-memory, a single small file parse, or
+explicitly TTL-cached (`_ttl_cached`, whose produce call runs OUTSIDE its lock so a
+second reader misses the cache rather than blocking on the first). A `None`
+reading is cached like any other answer, so an install that can never answer does
+not re-pay an expensive failing probe every cycle.
+
+Scope of the `kirocrew.inventory.*` family, stated here because the names invite
+the opposite reading: it is OPERATOR-fleet telemetry, not project-wide adoption
+analytics. Collection is off by default, egress is a second opt-in, and OTLP needs
+the `kirocrew[otlp]` extra, so any aggregate describes one operator's opted-in
+machines. Adoption data structurally cannot ride this trunk — see "Why it is NOT
+part of the OTEL trunk" above, whose four reasons apply to these instruments
+exactly as they do to the beacon's payload. Do not later "promote" these to answer
+install-population questions.
+
+**One publisher per install (`mark_install_reporter`).** `_build_recorder` runs in
+every process that touches telemetry, and an install runs several at once — the
+gateway, `gatewayd`, spawned agents and apps (which is why the local exporter
+shards per PID). That is correct for process-scoped instruments and WRONG for
+install-scoped ones: each process would publish the same "this install has 14
+crons" under its own resource, so an aggregate over installs counts one install
+once per running process, and the bucketed gauges (whose shape is "publish 1, sum
+by bucket") would make one install look like N. Deduplicating downstream is not
+available, because that needs an install-scoped resource identity and the resource
+carries only a per-process id today. So exactly one process publishes: the gateway
+calls `inventory_gauges.mark_install_reporter()` during startup, and every callback
+checks it at COLLECT time (not at registration), so it does not matter whether a
+recorder was built before or after the claim. A process that never claims it
+registers the same instruments and publishes nothing. The election is an EXPLICIT
+call rather than inferred from, say, `autonudge.get_instance()` being non-None
+(true only in the gateway today) — an inference stops holding the moment that
+service's startup moves or becomes conditional, and the failure mode is inventory
+silently disappearing.
+
+That failure mode applies to the explicit call too, which is why the call SITE is
+part of the contract: it sits in `GatewayOrchestrator.run()` at a point no branch
+guards. A feature-flagged host does the same damage an inference would — the claim
+first shipped inside `_init_autonudge()`, which returns early under
+`KIROCREW_AUTONUDGE=0`, so one env var left no process publishing inventory at all.
+Nothing reported it, either: the callbacks return before probing, so `probe.failures`
+stays empty and the whole subsystem reads like a host that stopped exporting.
+`test_reporter_claim_is_unconditional` parses the gateway and asserts the call is
+reached from `run()` without passing through a conditional (`try` is allowed —
+telemetry must never block boot).
+
+A persisted install-scoped resource id is the precondition for ever removing this
+mechanism, but it is not by itself a replacement. With one, an install CAN be
+deduplicated downstream (`max by (install)` over its processes) — but that is
+query-time discipline: the exported data would still contain one copy per process,
+and a naively written fleet `sum` would read N times the truth. The election makes
+the data correct at the point of emit, which no consumer has to remember. So
+retiring it is a deliberate trade (fewer moving parts here, a rule every dashboard
+must follow there), not something that falls out of the identity work landing.
+
+Scope of the guarantee: it elects one GATEWAY PROCESS, which is one install wherever
+the product runs one gateway per data home. Two gateways sharing a data home on
+different ports would both claim, because the dashboard's singleton is per port, not
+per data home — a pre-existing property of that configuration that duplicates every
+install-scoped fact, and one no flag can detect (a second gateway double-counts
+whether or not it runs crons). A pod is not this case: it boots with its own
+`KIROCREW_HOME` and copies no crons, sessions, or databases, so its inventory belongs
+to a different install and publishing it is correct.
 
 ### Histogram bucket boundaries: per instrument, not shared
 

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -1033,6 +1033,34 @@ def unhealthy_jobs_from_disk() -> tuple[list[tuple[str, str]], list[tuple[str, s
     return (auto_paused, errored, loadable)
 
 
+def enabled_count_from_disk(path: Path) -> tuple[int, bool]:
+    """Return ``(enabled count, loadable)`` for the store at *path*.
+
+    A sibling of :func:`unhealthy_jobs_from_disk`: read-only, non-raising, needs
+    no running scheduler, and carries ``loadable`` on the SAME read for the same
+    reason — a store the scheduler cannot load counts 0, which is
+    indistinguishable from a healthy empty store in the number alone.
+
+    Single owner of the enabled-count reduction. Two callers need it and want
+    different halves: :meth:`CronService.count_enabled_from_disk` takes the count
+    and degrades a fault to 0 (its caller is a status pusher that must keep
+    running), while the telemetry probe needs ``loadable`` to report a fault as a
+    fault rather than as a plausible number. Both spellings of the loop existed
+    before this; the shared ``_is_loadable_record`` / ``_record_is_enabled``
+    predicates capped the drift, but only one loop removes it.
+    """
+    count = 0
+    records, loadable = _read_job_records(path)
+    for j in records:
+        # Same skip decision as _load (#4664): a record _job_from_record rejects
+        # is not a schedulable job, so it must not be counted.
+        if not _is_loadable_record(j):
+            continue
+        if _record_is_enabled(j):
+            count += 1
+    return (count, loadable)
+
+
 def _job_from_record(j: dict[str, Any]) -> CronJob:
     """Build one :class:`CronJob` from its serialized record.
 
@@ -2922,17 +2950,12 @@ class CronService:
         and deeply nested JSON (``RecursionError``, a ``RuntimeError``) both
         escaped and killed the pusher. A count of 0 is the correct degrade: an
         unreadable store has no jobs anyone can schedule.
+
+        The reduction itself lives in :func:`enabled_count_from_disk`, whose
+        ``loadable`` half this method deliberately discards — the status pusher
+        wants a number it can always render, not a fault to handle.
         """
-        count = 0
-        for j in _read_job_records(self._path)[0]:
-            # Same skip decision as _load (#4664): a record _job_from_record
-            # rejects is not a schedulable job, so it must not be counted.
-            # One spelling of loadability for the whole module.
-            if not _is_loadable_record(j):
-                continue
-            if _record_is_enabled(j):
-                count += 1
-        return count
+        return enabled_count_from_disk(self._path)[0]
 
     def get_job(self, job_id: str) -> CronJob | None:
         """Find a job by its id in the in-memory snapshot — CACHE-ONLY, no disk I/O.

--- a/src/kiro_crew/metrics/inventory_gauges.py
+++ b/src/kiro_crew/metrics/inventory_gauges.py
@@ -1,0 +1,793 @@
+"""Install-inventory observable instruments -- what this install has configured.
+
+``process_gauges`` answers "how is this process behaving"; nothing answers "what
+does this install actually have set up". An operator running Kiro Crew across
+more than one machine has no way to see that a host stopped scheduling crons, or
+that skills and knowledge documents are piling up on one box and absent on
+another: the dashboard shows one machine's counts on request, and nothing samples
+them over time, so a config drift between hosts is only visible by opening each
+dashboard in turn.
+
+WHAT THESE CANNOT ANSWER, and it matters because the metric names invite the
+mistake: they are NOT project-wide feature-adoption analytics. Collection is
+off by default, egress is a second opt-in, and OTLP export additionally requires
+the ``kirocrew[otlp]`` extra, so any aggregate over these gauges describes one
+operator's own opted-in fleet and nothing else. That is not an accident to be
+fixed later -- ``beacon.py`` is the project's install-analytics channel, and its
+docstring lists four independently disqualifying reasons adoption data cannot
+ride the metrics trunk (the redaction guardrail eats an install id, the extra
+skews the population, ``telemetry.enabled`` is a published no-egress promise, and
+pre-aggregated points cannot be deduped per install). Every instrument here
+serves the same job the rest of ``kirocrew.*`` serves: an operator observing
+machines they run.
+
+HOST ATTRIBUTION IS BOUNDED BY THE RESOURCE, not by anything in this module, and
+the bound is worth knowing before building a per-host dashboard on it. These
+gauges carry no host attribute of their own -- deliberately, since a hostname is
+free-form and routinely embeds an employee alias -- so separating two machines
+depends entirely on the ``Resource`` ``provider.py`` builds. Today that resource
+is ``service.name`` plus whatever the SDK's own detector contributes. On the
+version this project pins, that includes a ``service.instance.id``, but the SDK
+generates it FRESH PER PROCESS: two hosts are distinguishable at any instant,
+while a single host's series restarts whenever its gateway does, so
+"watch this machine's cron count over time" is not something a reader should
+assume works yet. The dependency range also permits SDK versions that contribute
+no instance id at all, in which case two hosts are genuinely indistinguishable.
+Both are properties of the shared resource -- every ``kirocrew.process.*`` gauge
+has them already -- and both are closed by giving the resource a persisted,
+install-scoped identity rather than by anything here; these instruments inherit
+that the moment the resource gains it.
+
+These instruments close that gap the same way ``process_gauges`` does — OTEL
+*observable* (asynchronous) instruments, whose callbacks run only when a
+``PeriodicExportingMetricReader`` collects, on that reader's own ticker thread.
+No sampler thread of our own, no work at rest, and nothing at all unless
+telemetry is enabled: registration happens on ``provider._build_recorder()``'s
+live path only, so the ``telemetry.enabled`` consent gate covers these gauges
+too.
+
+Instruments (all in the core ``kirocrew.`` namespace, validated against
+``schema.validate_name`` at registration):
+
+=========================================  =========  ==============  ==================
+name                                       value      attributes      source
+=========================================  =========  ==============  ==================
+``kirocrew.inventory.crons.active``        count      —               ``crons.json``
+``kirocrew.inventory.monitor_loops.active`` count     —               ``autonudge`` service
+``kirocrew.inventory.skills.installed``    count      —               skills loader
+``kirocrew.inventory.memory.migrated``     0/1        —               ``memory.migrated``
+``kirocrew.inventory.knowledge.documents`` count      —               ``knowledge.db``
+``kirocrew.inventory.lessons``             count      —               ``lessons.jsonl``
+``kirocrew.inventory.mcp.servers``         count      ``class``       MCP roster
+``kirocrew.inventory.config.toggle``       0/1        ``key``         config flags
+``kirocrew.inventory.probe.failures``      count      ``probe``       this module
+=========================================  =========  ==============  ==================
+
+A probe that cannot answer returns ``None`` and its instrument yields **no
+observation** for that cycle. That distinction is load-bearing: "the monitor
+service is not running in this process" and "the service is running with zero
+loops armed" are different facts, and a fake ``0`` would merge them.
+
+But absence has a second reading, and it is the one that would undermine this
+module: a series that is not there could equally mean the probe BROKE, or that the
+host stopped exporting altogether -- and telling a drifted host from a dark host
+is exactly the job these gauges exist to do. That is why a raising probe
+increments :data:`COUNTER_PROBE_FAILURES` instead of only logging. A broken probe
+then presents as DATA -- the failure series is present and climbing, which a host
+that stopped exporting cannot produce -- and the first failure of each probe is
+logged at WARNING, which a default install actually collects, rather than at debug
+where it would be invisible on precisely the installs that need it.
+
+So ``None`` alone is not the test for whether something is wrong. The line is
+whether the SOURCE is absent or unreadable, and each reader draws it explicitly:
+an absent source is a silent gap, because nothing is broken (no auto-nudge service
+in this process, a knowledge database on an install that never ingested). A source
+that is PRESENT and unreadable is a fault, so those readers count a failure before
+returning ``None`` -- an unparseable ``crons.json`` is the case in point, and
+``cron._read_job_records`` names it a fault in as many words.
+
+That line is drawn wherever the source lets it be drawn, which is not everywhere.
+:func:`read_mcp_server_classes` is the one probe that cannot: the discovery loaders
+it calls swallow a malformed or unreadable config internally and merge ``{}``, so an
+empty roster and a broken config arrive identical and its ``None`` covers both. Its
+docstring says so. Reading a silent ``None`` as "nothing to report" is therefore
+sound for every probe whose source can distinguish the two, and for the MCP probe it
+is the best available answer rather than a guarantee -- which is worth knowing before
+building an alert on that series' absence.
+
+Every one of them reports a **raw count**, including the two that read a store
+rather than a config field. Publishing those two as a constant 1 under a
+magnitude-band attribute is the tempting alternative, on the theory that a precise
+document or lesson count is quasi-identifying -- but that theory does not survive
+this module's own scope. These metrics go only where the operator points the
+exporter: their own collector, about their own machines, and an operator can
+already identify their own hosts by far more than a document count. Meanwhile the
+band costs exactly what the gauge is for. Growth from 51 to 200 sources is the
+drift worth seeing and a band renders it as a flat line; a band attribute is up to
+five series where an integer value is one; and fixing the boundaries at emit time
+is a one-way door once dashboards read them. A backend can band a raw count at
+query time, and cannot recover a count from a band. The product's own thresholds
+are still worth knowing when reading these -- 50 is the ``knowledge.max_sources``
+default and 200 the lesson-store prune ceiling -- so the operator guide names them
+instead of the wire format hard-coding them.
+
+**Cost is the whole design constraint here.** A callback runs on every export
+interval (60s by default) and, with an OTLP destination configured, once per
+reader — so two ticker threads can enter the same callback concurrently. Every
+probe is therefore either O(1) in-memory or explicitly cached, and the two
+genuinely expensive sources are the reason :func:`_ttl_cached` exists:
+
+=========================  ===========================================  ==========
+probe                      cost                                         cache
+=========================  ===========================================  ==========
+crons                      one small ``json.loads`` of ``crons.json``   none
+monitor loops              in-memory dict snapshot                      none
+skills                     recursive ``os.walk`` of the skills tree     300s TTL
+memory / config toggles    fingerprint-cached config read (2 stats)     none
+knowledge documents        ``sqlite3`` connect + one indexed COUNT(*)   300s TTL
+lessons                    mtime-cached JSONL read                      store's own
+MCP servers                a few small ``json.loads``                   none
+=========================  ===========================================  ==========
+
+Nothing here walks a whole data directory, opens a write connection, or creates a
+file. The knowledge probe in particular opens SQLite **read-only** and only when
+the database already exists: constructing a ``KnowledgeStore`` would run schema
+init and graph load, and would *create* the database on an install that has never
+ingested anything — a telemetry gauge must never bring a subsystem into being.
+
+Where the underlying source can only say "empty" rather than distinguishing empty
+from unavailable, the docstring on that reader says so.
+
+Cardinality: every metric name is a constant, and the only attribute values are
+closed enums -- two ``class`` buckets, the fixed :data:`CONFIG_TOGGLES` key set,
+and the fixed :data:`ALL_PROBES` names. Counts ride in the VALUE, which costs no
+series at all. An MCP server's NAME is never an attribute, by design: the roster
+is user-chosen free-form text, so it is both a cardinality bomb and a disclosure
+of what the user has installed. Only the two-way first-party/third-party split
+leaves the machine.
+
+First-party imports are deferred into the readers rather than taken at module
+scope. ``metrics`` sits below ``cron``/``skills``/``autonudge``/``knowledge`` in
+the dependency order, so importing them here would invert it and risk a cycle;
+deferring also keeps the default-off path from paying for imports it never uses.
+The opentelemetry import is deferred into :func:`register_inventory_gauges` for
+the reason ``process_gauges`` gives — the module stays importable when the SDK is
+absent.
+
+OSS-CLEAN: opentelemetry (Apache-2.0) + stdlib + first-party helpers only.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional
+
+from kiro_crew.metrics.schema import validate_name
+
+if TYPE_CHECKING:  # annotation-only; never imported at runtime
+    from opentelemetry.metrics import CallbackOptions, Meter, Observation
+
+logger = logging.getLogger(__name__)
+
+GAUGE_CRONS_ACTIVE = "kirocrew.inventory.crons.active"
+GAUGE_MONITOR_LOOPS_ACTIVE = "kirocrew.inventory.monitor_loops.active"
+GAUGE_SKILLS_INSTALLED = "kirocrew.inventory.skills.installed"
+GAUGE_MEMORY_MIGRATED = "kirocrew.inventory.memory.migrated"
+GAUGE_KNOWLEDGE_DOCUMENTS = "kirocrew.inventory.knowledge.documents"
+GAUGE_LESSONS = "kirocrew.inventory.lessons"
+GAUGE_MCP_SERVERS = "kirocrew.inventory.mcp.servers"
+GAUGE_CONFIG_TOGGLE = "kirocrew.inventory.config.toggle"
+COUNTER_PROBE_FAILURES = "kirocrew.inventory.probe.failures"
+
+ALL_METRIC_NAMES = (
+    GAUGE_CRONS_ACTIVE,
+    GAUGE_MONITOR_LOOPS_ACTIVE,
+    GAUGE_SKILLS_INSTALLED,
+    GAUGE_MEMORY_MIGRATED,
+    GAUGE_KNOWLEDGE_DOCUMENTS,
+    GAUGE_LESSONS,
+    GAUGE_MCP_SERVERS,
+    GAUGE_CONFIG_TOGGLE,
+    COUNTER_PROBE_FAILURES,
+)
+
+#: Probe identities for the ``probe`` attribute on :data:`COUNTER_PROBE_FAILURES`.
+#: A closed set, one per reader, so the attribute stays enum-like.
+PROBE_CRONS = "crons"
+PROBE_MONITOR_LOOPS = "monitor_loops"
+PROBE_SKILLS = "skills"
+PROBE_MEMORY = "memory"
+PROBE_KNOWLEDGE = "knowledge"
+PROBE_LESSONS = "lessons"
+PROBE_MCP = "mcp"
+PROBE_CONFIG_TOGGLES = "config_toggles"
+
+ALL_PROBES = (
+    PROBE_CRONS,
+    PROBE_MONITOR_LOOPS,
+    PROBE_SKILLS,
+    PROBE_MEMORY,
+    PROBE_KNOWLEDGE,
+    PROBE_LESSONS,
+    PROBE_MCP,
+    PROBE_CONFIG_TOGGLES,
+)
+
+#: The knowledge table this module counts. A named constant rather than a literal
+#: buried in the query, so a test can assert the real ``KnowledgeStore`` schema
+#: still has it: the probe deliberately never constructs a store (that would create
+#: the database), which is exactly why nothing else would notice the owner renaming
+#: what is counted, and the resulting gap is cached and indistinguishable from
+#: "never ingested".
+KNOWLEDGE_SOURCES_TABLE = "sources"
+
+#: Attribute values for :data:`GAUGE_MCP_SERVERS`.
+MCP_CLASS_FIRST_PARTY = "first_party"
+MCP_CLASS_THIRD_PARTY = "third_party"
+
+#: The closed toggle enum for :data:`GAUGE_CONFIG_TOGGLE`, as
+#: ``(attribute key, config section, boolean field)``. Adding a row is the only
+#: way to widen it, which is what keeps the ``key`` attribute bounded.
+#:
+#: ``telemetry.enabled`` is deliberately absent: this module only ever runs
+#: inside the consent gate, so it could report nothing but 1 — a tautology
+#: dressed as a measurement. ``memory`` is absent for the opposite reason: it has
+#: its own gauge (see :func:`read_memory_migrated`). Every row is a plain feature
+#: switch; none carries a path, an endpoint, or any user-chosen string.
+CONFIG_TOGGLES: tuple[tuple[str, str, str], ...] = (
+    ("beacon", "telemetry", "beacon_enabled"),
+    ("knowledge_auto_ingest", "knowledge", "auto_ingest_artifacts"),
+    ("mcp_gateway", "mcp_gateway", "enabled"),
+    ("session_sharing", "agent", "session_sharing"),
+    ("tool_search", "agent", "tool_search"),
+    ("session_control", "agent", "session_control"),
+    ("skills_auto_create", "skills", "auto_create_from_sessions"),
+    ("session_summary", "session_summary", "enabled"),
+    ("instances", "instances", "enabled"),
+    ("stt", "stt", "enabled"),
+)
+
+#: TTL for the two probes that cannot be made cheap (a recursive skills walk and
+#: a SQLite connect). Five minutes rather than the 60s export interval: these
+#: answer "what is installed", which changes on the scale of a user action, so a
+#: reading up to one TTL stale is indistinguishable in a fleet aggregate while
+#: costing a fifth as much on the default interval.
+_EXPENSIVE_TTL_SECS = 300.0
+
+# Guards the TTL cache and the lazily-built loader singletons below. A real lock
+# rather than "the callbacks all share one thread": each metric reader collects
+# on its OWN ticker thread, so an install with an OTLP destination configured
+# runs these callbacks on two threads concurrently.
+_lock = threading.Lock()
+_cache: dict[str, tuple[float, Any]] = {}
+
+# Reused across ticks so the recursive skills walk is not re-constructed (and its
+# own internal cache not discarded) on every collection. Built lazily under
+# ``_lock`` and touched by nothing else in the process.
+_skills_loader: Any = None
+_lesson_store: Any = None
+
+# Per-probe failure counts, published as COUNTER_PROBE_FAILURES. This exists
+# because a broken probe and a host that stopped exporting look IDENTICAL at a
+# backend -- both are a series that simply is not there -- and telling those apart
+# is the whole job these gauges were added to do. A failure count turns the first
+# case into DATA: the series is present and climbing, which a missing host cannot
+# produce. Written under ``_lock``.
+_probe_failures: dict[str, int] = {}
+# Probes already reported at WARNING. The first failure of each probe is loud
+# enough for a default install to collect (the journal keeps WARNING and above, so
+# a debug line would be invisible on exactly the installs that need it); repeats
+# drop to debug so a permanently broken probe cannot flood the log once per export
+# interval for the life of the process.
+_warned_probes: set[str] = set()
+
+
+def _note_probe_failure(probe: str) -> None:
+    """Record that *probe* could not answer, and say so once at WARNING."""
+    with _lock:
+        _probe_failures[probe] = _probe_failures.get(probe, 0) + 1
+        first = probe not in _warned_probes
+        if first:
+            _warned_probes.add(probe)
+    if first:
+        logger.warning(
+            "inventory probe %r failed; its gauge will report no value until it "
+            "recovers (see %s for the count)",
+            probe,
+            COUNTER_PROBE_FAILURES,
+            exc_info=True,
+        )
+    else:
+        logger.debug("inventory probe %r failed again", probe, exc_info=True)
+
+
+def read_probe_failures() -> dict[str, int]:
+    """Snapshot of per-probe failure counts. Empty until something fails."""
+    with _lock:
+        return dict(_probe_failures)
+
+
+# Whether THIS process is the one that publishes install-scoped inventory.
+#
+# The problem this solves: ``_build_recorder`` runs in every process that touches
+# telemetry, and an install runs several at once -- the gateway, the MCP gateway
+# daemon, spawned agents and apps (which is why the local exporter shards per
+# PID). Process-scoped instruments want exactly that. Install-scoped ones do NOT:
+# every process would report the SAME "this install has 14 crons", each under its
+# own resource, so an aggregate over installs counts one install once per running
+# process -- a fleet sum reads N times the truth, and a fleet average is dragged
+# toward whichever installs happen to run the most processes.
+#
+# Deduplicating downstream is not available: that needs an install-scoped resource
+# identity, and the resource carries only a per-process id today (see the module
+# docstring). So exactly one process must publish, and it is ELECTED EXPLICITLY by
+# the gateway calling :func:`mark_install_reporter` rather than inferred here. An
+# inference was the alternative -- ``autonudge.get_instance()`` is non-None only in
+# the gateway, so it would work today -- but it silently stops being true if that
+# service's startup moves or becomes conditional, and the failure mode is inventory
+# quietly disappearing. A named call is a contract a reader can find.
+#
+# What the election does and does not cover: it elects ONE GATEWAY PROCESS, which is
+# one install everywhere the product runs one gateway per data home. Two gateways
+# sharing a data home on different ports would both claim and both publish, because
+# the dashboard's singleton is per PORT, not per data home -- a pre-existing property
+# of that configuration (every install-scoped fact duplicates, not just these), and
+# not something a flag can detect: a second gateway double-counts whether or not it
+# runs crons. Closing it needs either cross-process arbitration or, more cheaply, the
+# persisted install-scoped resource id that lets a consumer dedupe. A POD is NOT this
+# case: it boots with its own ``KIROCREW_HOME`` and never copies crons, sessions or
+# the databases, so its inventory is a genuinely different install's and publishing
+# it is correct.
+_is_install_reporter = False
+
+
+def mark_install_reporter() -> None:
+    """Declare THIS process the publisher of install-scoped inventory.
+
+    Called once from the gateway's startup, from a point no branch guards: a
+    flag-gated call site means no process claims the role and every
+    ``kirocrew.inventory.*`` series is absent, with nothing to say why (see
+    ``test_reporter_claim_is_unconditional``). Every other telemetry-enabled
+    process in the install leaves it unset and publishes no ``kirocrew.inventory.*``
+    series, so install-level aggregates count each install once.
+
+    Idempotent, and deliberately has no "unmark": a process that has claimed the
+    role keeps it for its lifetime. Consulted at COLLECT time rather than at
+    registration, so it does not matter whether the first recorder is built before
+    or after this call -- a recorder built early simply publishes nothing until the
+    claim lands, which is at worst one export interval of absence.
+    """
+    global _is_install_reporter
+    with _lock:
+        _is_install_reporter = True
+
+
+def is_install_reporter() -> bool:
+    """Whether this process publishes install-scoped inventory."""
+    with _lock:
+        return _is_install_reporter
+
+
+def reset_for_testing() -> None:
+    """Drop the TTL cache and the loader singletons.
+
+    Exists because both are module state that outlives a test: a cached count
+    from one temp home would otherwise be served to the next.
+    """
+    global _skills_loader, _lesson_store, _is_install_reporter
+    with _lock:
+        _cache.clear()
+        _probe_failures.clear()
+        _warned_probes.clear()
+        _skills_loader = None
+        _lesson_store = None
+        _is_install_reporter = False
+
+
+def _ttl_cached(key: str, ttl: float, produce: Callable[[], "int | None"]) -> "int | None":
+    """Return a cached value for *key*, refreshing *produce* no more than once per *ttl*.
+
+    Not a strict "exactly once": *produce* runs OUTSIDE the lock, so two reader
+    threads arriving on a cold entry can both call it. That is deliberate --
+    holding the lock across a filesystem walk or a SQLite open would make the
+    second reader block on the first -- and a benign double-produce is the
+    accepted cost.
+
+    Every outcome is cached, including failure. A ``None`` return and a raised
+    exception both store ``None``: the reasons an expensive probe fails here (no
+    database yet, an unreadable tree) are install-level states, so re-running it
+    every cycle would pay the full cost precisely on the installs that can never
+    answer. The exception is swallowed rather than propagated because the caller's
+    contract is already "None means no observation"; letting it through would
+    reach the same gap by a costlier route.
+    """
+    now = time.monotonic()
+    with _lock:
+        hit = _cache.get(key)
+        if hit is not None and hit[0] > now:
+            return hit[1]
+    try:
+        value = produce()
+    except Exception:  # noqa: BLE001 -- an unreadable source is a gap, not a crash
+        _note_probe_failure(key)
+        value = None
+    with _lock:
+        _cache[key] = (time.monotonic() + ttl, value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Raw readers — plain callables returning values (or None for "cannot answer"),
+# kept SDK-free so they are unit-testable without an OTEL pipeline.
+# ---------------------------------------------------------------------------
+
+
+def read_active_crons() -> Optional[int]:
+    """Count of scheduled cron jobs that are neither user- nor auto-paused.
+
+    Reads ``crons.json`` directly instead of asking the live ``CronService``,
+    because there is no process-global handle for it (it is owned by the
+    dashboard state object) and because ``list_jobs`` re-arms the asyncio timer —
+    calling that from a ticker thread with no running loop would raise, and worse,
+    it cancels the existing timer first, which would stop every scheduled job.
+    The reduction is ``cron.enabled_count_from_disk``, the single owner that
+    ``CronService.count_enabled_from_disk`` also calls, so this cannot drift from
+    what the scheduler considers enabled. That method keeps only the count; this
+    probe needs the ``loadable`` half too.
+
+    Returns ``None`` when the store exists but does not parse, and records a
+    ``crons`` probe failure on the way out. Both halves matter: a count would be
+    a lie (the scheduler loaded nothing either), and a silent gap would be
+    indistinguishable from a host that stopped exporting, which is the one thing
+    ``probe.failures`` exists to prevent. ``_read_job_records`` calls this case a
+    fault in as many words, and its ``loadable`` flag is what separates it from a
+    **missing** store — a genuine 0, since a fresh install has no crons.
+    """
+    from kiro_crew.cron import _CRONS_FILE, _default_dir, enabled_count_from_disk
+
+    count, loadable = enabled_count_from_disk(_default_dir() / _CRONS_FILE)
+    if not loadable:
+        _note_probe_failure(PROBE_CRONS)
+        return None
+    return count
+
+
+def read_active_monitor_loops() -> Optional[int]:
+    """Count of armed monitor / auto-nudge loops in this process.
+
+    Returns ``None`` when the service never started — a spawned agent process, a
+    unit test, or a gateway with auto-nudge off — which is the case a fake 0
+    would hide. A running service with nothing armed returns a real 0.
+
+    The loop registry is mutated only under an ``asyncio.Lock`` on the event
+    loop, which offers this thread no protection and cannot be acquired from it.
+    Materialising ``list(...)`` first is what makes the read safe anyway: each
+    dict operation is atomic under the GIL, so a snapshot cannot raise "changed
+    size during iteration", and a gauge that is stale by one loop is fine.
+    """
+    from kiro_crew.autonudge import get_instance
+
+    service = get_instance()
+    if service is None:
+        return None
+    return sum(1 for loop in list(service._loops.values()) if loop.active)
+
+
+def _read_installed_skills_uncached() -> Optional[int]:
+    """Uncached skill count — a recursive walk. See :func:`read_installed_skills`."""
+    global _skills_loader
+    from kiro_crew.skills import SkillsLoader
+
+    with _lock:
+        if _skills_loader is None:
+            # install_builtins=False: syncing builtins onto disk is a write path
+            # with content hashing, and a metrics probe must not perform it.
+            _skills_loader = SkillsLoader(install_builtins=False)
+        loader = _skills_loader
+    return len(loader._iter_visible())
+
+
+def read_installed_skills() -> Optional[int]:
+    """Count of skills visible to the loader, cached for :data:`_EXPENSIVE_TTL_SECS`.
+
+    One total, not a builtin/user split: builtin skills are *copied onto disk*
+    into the same tree as user-installed ones, so nothing in the listing
+    distinguishes them and any split would be a guess presented as a fact.
+
+    Returns ``None`` only if the walk raises. An empty tree is a real 0.
+    """
+    return _ttl_cached(PROBE_SKILLS, _EXPENSIVE_TTL_SECS, _read_installed_skills_uncached)
+
+
+def read_memory_migrated() -> Optional[int]:
+    """Whether this install's memory has been migrated to the vector store (0/1).
+
+    Reports ``memory.migrated`` rather than a "memory enabled" switch, because no
+    such switch exists: the embedding provider is coerced to a real value on
+    load, so memory is structurally always on and an "enabled" gauge could only
+    ever read 1.
+
+    Reading 0 is the point, which is why this is not a rollout metric that goes
+    quiet once a fleet converges. The gateway flips the bit on the first boot that
+    initialises vector memory, fresh installs included, so a healthy install reads
+    1 and keeps reading 1; it stays 0 when the subsystem did not come up -- vector
+    memory never initialised, migration aborted before the flip, or the flag write
+    was skipped because ``config.json`` is unparseable (that write fails closed
+    rather than clobber the file, and retries next boot). In a converged fleet a 0
+    is therefore an install whose memory subsystem is broken, and no other
+    inventory series would show it.
+
+    Returns ``None`` only if the config read raises; the field itself is always a
+    concrete bool.
+    """
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    return int(bool(KiroCrewConfig.load().memory.migrated))
+
+
+def _read_knowledge_documents_uncached() -> Optional[int]:
+    """Uncached knowledge-source count. See :func:`read_knowledge_documents`."""
+    from kiro_crew.config.paths import config_dir
+
+    db_path = config_dir() / "workspace" / "knowledge" / "knowledge.db"
+    if not db_path.exists():
+        # Never ingested: the database is created on first write, and this probe
+        # must not be what creates it.
+        return None
+    # Read-only URI so this cannot create, migrate, or lock the database, and a
+    # short timeout so a busy writer degrades to a gap instead of stalling the
+    # export cycle.
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2.0)
+    try:
+        # Table name from a module constant, not inlined: see KNOWLEDGE_SOURCES_TABLE.
+        # It is a constant of ours, never user input, so it cannot carry injection.
+        query = f"SELECT COUNT(*) FROM {KNOWLEDGE_SOURCES_TABLE}"  # noqa: S608
+        return int(conn.execute(query).fetchone()[0])
+    finally:
+        conn.close()
+
+
+def read_knowledge_documents() -> Optional[int]:
+    """Count of knowledge SOURCES, cached for :data:`_EXPENSIVE_TTL_SECS`.
+
+    Sources rather than the ``items`` table: an item is one chunk of a document,
+    so counting items would report a chunking artifact as a document count.
+
+    Returns ``None`` when the database does not exist yet (nothing ingested) or
+    cannot be read.
+    """
+    return _ttl_cached(PROBE_KNOWLEDGE, _EXPENSIVE_TTL_SECS, _read_knowledge_documents_uncached)
+
+
+def read_lessons() -> Optional[int]:
+    """Count of saved lessons.
+
+    Uncached here on purpose: the store already caches by file mtime, so a
+    repeated read on an unchanged file is one ``stat``. A second cache would only
+    add staleness. The store instance is reused across ticks because that mtime
+    cache lives on the instance — a fresh one per tick would re-read every time.
+
+    An absent file returns 0 rather than ``None``: unlike a knowledge database,
+    "no lessons file" is the honest steady state of an install that has never
+    saved one, not an uninitialised subsystem.
+    """
+    global _lesson_store
+    from kiro_crew.learn import LessonStore
+
+    with _lock:
+        if _lesson_store is None:
+            _lesson_store = LessonStore()
+        store = _lesson_store
+    return len(store.load_all())
+
+
+def read_mcp_server_classes() -> Optional[dict[str, int]]:
+    """MCP server counts split into first-party and third-party.
+
+    The first-party set is ``mcp_discovery._MANAGED_SERVER_NAMES``, the roster
+    the installer itself manages, reused rather than restated: a second list of
+    server names in this module would be a duplicate that drifts silently the
+    first time a managed server is added or renamed.
+
+    Server names are read to classify and then discarded. No name reaches an
+    attribute — a user's MCP roster is free-form text, so publishing it would be
+    both unbounded cardinality and a disclosure of what they have installed.
+
+    Returns ``None`` when the merged roster is empty. The underlying loaders fail
+    soft to ``{}``, so an empty result cannot be told apart from an unwritten
+    config — and because the managed servers are always present once installed,
+    empty means "not configured yet" far more often than "genuinely none".
+    """
+    from kiro_crew.mcp_discovery import (
+        _MANAGED_SERVER_NAMES,
+        _load_agent_config,
+        _load_mcp_json_by_source,
+    )
+
+    names: set[str] = set(_load_agent_config().get("mcpServers", {}) or {})
+    for entries in (_load_mcp_json_by_source() or {}).values():
+        names.update(entries or {})
+    if not names:
+        return None
+    first_party = len(names & set(_MANAGED_SERVER_NAMES))
+    return {
+        MCP_CLASS_FIRST_PARTY: first_party,
+        MCP_CLASS_THIRD_PARTY: len(names) - first_party,
+    }
+
+
+def read_config_toggles() -> Optional[dict[str, int]]:
+    """The :data:`CONFIG_TOGGLES` switches as 0/1, keyed by attribute key.
+
+    Config is read ONCE for the whole set rather than per toggle, so the gauge
+    costs one fingerprint-cached load per collection instead of ten.
+
+    A key whose field cannot be resolved is omitted rather than reported as 0 —
+    a renamed config field must read as a missing series, never as a switch
+    someone turned off. ``test_every_declared_toggle_resolves`` is what keeps
+    that from being a silent hole.
+    """
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    cfg = KiroCrewConfig.load()
+    out: dict[str, int] = {}
+    for key, section_name, field_name in CONFIG_TOGGLES:
+        section = getattr(cfg, section_name, None)
+        if section is None:
+            continue
+        value = getattr(section, field_name, None)
+        if not isinstance(value, bool):
+            continue
+        out[key] = int(value)
+    return out or None
+
+
+# ---------------------------------------------------------------------------
+# OTEL registration
+# ---------------------------------------------------------------------------
+
+
+def _observations(
+    probe: str,
+    reader: Callable[[], Optional[int]],
+) -> "Callable[[CallbackOptions], Iterable[Observation]]":
+    """Wrap a raw reader as an OTEL observable callback.
+
+    A None (or raising) reader yields no observation for the cycle -- a gap in
+    the series is honest, a zero would be a lie, and an exception would spam
+    SDK error logs every export interval. A raise additionally increments
+    *probe*'s failure count, which is what keeps "the probe broke" from being
+    indistinguishable from "this host stopped exporting".
+    """
+    from opentelemetry.metrics import Observation
+
+    def _callback(options: "CallbackOptions") -> "Iterator[Observation]":
+        if not is_install_reporter():
+            return
+        try:
+            value = reader()
+        except Exception:  # noqa: BLE001 -- never let a probe break the exporter
+            _note_probe_failure(probe)
+            return
+        if value is None:
+            return
+        yield Observation(value, attributes={})
+
+    return _callback
+
+
+def _keyed_observations(
+    probe: str,
+    reader: Callable[[], Optional[dict[str, int]]],
+    attr_name: str,
+) -> "Callable[[CallbackOptions], Iterable[Observation]]":
+    """Observable callback fanning a mapping out to one observation per key."""
+    from opentelemetry.metrics import Observation
+
+    def _callback(options: "CallbackOptions") -> "Iterator[Observation]":
+        if not is_install_reporter():
+            return
+        try:
+            values = reader()
+        except Exception:  # noqa: BLE001 -- never let a probe break the exporter
+            _note_probe_failure(probe)
+            return
+        if not values:
+            return
+        for key, value in values.items():
+            yield Observation(value, attributes={attr_name: key})
+
+    return _callback
+
+
+def _failure_observations() -> "Callable[[CallbackOptions], Iterable[Observation]]":
+    """Observable-counter callback for per-probe failure counts.
+
+    Publishes nothing until a probe has actually failed, so a healthy install adds
+    no series. Cumulative like the process counters: the aggregator reduces it
+    window-relative, and a provider rebuild re-observes the same in-process totals.
+    """
+    from opentelemetry.metrics import Observation
+
+    def _callback(options: "CallbackOptions") -> "Iterator[Observation]":
+        for probe, count in read_probe_failures().items():
+            yield Observation(count, attributes={"probe": probe})
+
+    return _callback
+
+
+def register_inventory_gauges(meter: "Meter") -> None:
+    """Register all install-inventory instruments on *meter*.
+
+    Called once per live ``MeterProvider`` build (instruments die with their
+    provider, so a consent-driven rebuild re-registers on the new meter — that
+    is per-provider construction, not duplication). Best-effort: a failure
+    disables these gauges, never telemetry as a whole.
+    """
+    try:
+        for name in ALL_METRIC_NAMES:
+            validate_name(name)
+
+        meter.create_observable_gauge(
+            GAUGE_CRONS_ACTIVE,
+            callbacks=[_observations(PROBE_CRONS, read_active_crons)],
+            unit="1",
+            description="Scheduled cron jobs that are neither user- nor auto-paused",
+        )
+        meter.create_observable_gauge(
+            GAUGE_MONITOR_LOOPS_ACTIVE,
+            callbacks=[_observations(PROBE_MONITOR_LOOPS, read_active_monitor_loops)],
+            unit="1",
+            description="Armed monitor / auto-nudge loops in this process",
+        )
+        meter.create_observable_gauge(
+            GAUGE_SKILLS_INSTALLED,
+            callbacks=[_observations(PROBE_SKILLS, read_installed_skills)],
+            unit="1",
+            description="Skills visible to the loader (builtin and user, combined)",
+        )
+        meter.create_observable_gauge(
+            GAUGE_MEMORY_MIGRATED,
+            callbacks=[_observations(PROBE_MEMORY, read_memory_migrated)],
+            unit="1",
+            description="1 when memory has been migrated to the vector store",
+        )
+        meter.create_observable_gauge(
+            GAUGE_KNOWLEDGE_DOCUMENTS,
+            callbacks=[_observations(PROBE_KNOWLEDGE, read_knowledge_documents)],
+            unit="1",
+            description="Knowledge sources this install has ingested",
+        )
+        meter.create_observable_gauge(
+            GAUGE_LESSONS,
+            callbacks=[_observations(PROBE_LESSONS, read_lessons)],
+            unit="1",
+            description="Lessons this install has saved",
+        )
+        meter.create_observable_gauge(
+            GAUGE_MCP_SERVERS,
+            callbacks=[_keyed_observations(PROBE_MCP, read_mcp_server_classes, "class")],
+            unit="1",
+            description="Configured MCP servers per class (names are never published)",
+        )
+        meter.create_observable_gauge(
+            GAUGE_CONFIG_TOGGLE,
+            callbacks=[_keyed_observations(PROBE_CONFIG_TOGGLES, read_config_toggles, "key")],
+            unit="1",
+            description="Feature-switch state (0/1) per key, over a closed key set",
+        )
+        meter.create_observable_counter(
+            COUNTER_PROBE_FAILURES,
+            callbacks=[_failure_observations()],
+            unit="1",
+            description=(
+                "Times a probe could not answer, per probe. Absent on a healthy "
+                "install; present and climbing distinguishes a broken probe from a "
+                "host that stopped exporting"
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 — telemetry must never break boot
+        logger.warning("inventory gauge registration failed: %s", exc)

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -528,6 +528,17 @@ def _build_recorder() -> _Build:
             register_process_gauges(meter)
         except Exception:
             logger.warning("process gauges unavailable", exc_info=True)
+        # Install-inventory gauges (crons/skills/knowledge/MCP/toggles) ride the
+        # same consent gate and the same observable-callback contract. Registered
+        # in its OWN try so a failure in either set cannot cost the other one —
+        # they read entirely different subsystems, and the process gauges must
+        # not go dark because, say, the skills tree is unreadable.
+        try:
+            from kiro_crew.metrics.inventory_gauges import register_inventory_gauges
+
+            register_inventory_gauges(meter)
+        except Exception:
+            logger.warning("inventory gauges unavailable", exc_info=True)
         return _Build(MetricsRecorder(meter), provider, consent)
     except Exception as exc:
         logger.warning("telemetry init failed; metrics disabled: %s", exc)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -10322,6 +10322,28 @@ class GatewayOrchestrator:
                 register_post_install_hook(reproject_for_ceiling_change)
                 await asyncio.to_thread(start_refresher)
 
+        # Claim the install-scoped telemetry reporter role for this process.
+        # Install-level inventory (crons, skills, knowledge, config toggles) is the
+        # same for every process in the install, so if each telemetry-enabled
+        # process published it -- the gateway, gatewayd, spawned agents -- an
+        # aggregate over installs would count this install once per process. This
+        # is the gateway, so it is the one that publishes.
+        #
+        # It lives in run() itself, unconditionally: the claim belongs to being the
+        # gateway, not to any single service, and a feature-flagged host would take
+        # the whole subsystem down with it. _init_autonudge() below returns early
+        # under KIROCREW_AUTONUDGE=0, so a claim made in there means no process ever
+        # publishes inventory -- and nothing says so, because the gauge callbacks
+        # bail before probing and leave probe.failures empty, which reads exactly
+        # like a host that stopped exporting. test_reporter_claim_is_unconditional
+        # pins the call site. Best-effort: telemetry is never a boot blocker.
+        try:
+            from kiro_crew.metrics.inventory_gauges import mark_install_reporter
+
+            mark_install_reporter()
+        except Exception:  # noqa: BLE001 -- telemetry must never break gateway boot
+            logger.debug("could not claim the telemetry inventory role", exc_info=True)
+
         # AutoNudge must run after dashboard init — _fire callback dereferences
         # self.dashboard_state. In --no-dashboard mode the guard inside _fire
         # early-returns so persisted loops are harmless until a dashboard

--- a/test/metrics/test_inventory_gauges.py
+++ b/test/metrics/test_inventory_gauges.py
@@ -1,0 +1,854 @@
+"""Tests for the kirocrew.inventory.* observable instrument contract.
+
+Four layers, mirroring the module's structure:
+  * raw readers — a real value from a crafted source, and None (never a raise)
+    when the subsystem is absent, with the None-vs-zero split pinned per probe;
+  * OTEL registration — a real in-memory pipeline collects every expected metric
+    name with the expected attribute shape, a raising reader produces a gap
+    rather than an exporter failure, and no MCP server NAME ever reaches the
+    wire;
+  * the gateway call site — the reporter claim is reached unconditionally, since
+    an unclaimed install publishes nothing and says nothing about why;
+  * provider wiring — the live build path registers the gauges, and a
+    registration blow-up does not take telemetry (or the process gauges) down.
+"""
+
+import json
+import logging
+import sqlite3
+from unittest.mock import patch
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from kiro_crew.metrics import inventory_gauges as ig
+from kiro_crew.metrics.schema import validate_name
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect(register=ig.register_inventory_gauges):
+    """Build a real SDK pipeline, register, force one collection cycle.
+
+    Claims the install-reporter role, because a process that has not claimed it
+    publishes no inventory at all -- that election is asserted separately in
+    ``test_only_the_install_reporter_publishes_inventory``.
+    """
+    ig.mark_install_reporter()
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    register(provider.get_meter("test"))
+    data = reader.get_metrics_data()
+    provider.shutdown()
+    out: dict[str, list] = {}
+    if data is None:
+        return out
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                out[metric.name] = list(metric.data.data_points)
+    return out
+
+
+def _cron_record(job_id, **overrides):
+    """A record shaped the way the scheduler's own loader requires.
+
+    ``schedule`` is a nested object, not a flat ``every``: a record the loader
+    rejects is reported as unloadable, so a flat fixture would silently exercise
+    the corrupt-store path instead of the counting path.
+    """
+    record = {
+        "id": job_id,
+        "name": job_id,
+        "message": "m",
+        "schedule": {"kind": "every", "every_secs": 60},
+    }
+    record.update(overrides)
+    return record
+
+
+def _write_crons(tmp_path, records):
+    # The store is an OBJECT holding a `jobs` list; a bare top-level list is a
+    # shape failure the reader reports as unloadable.
+    (tmp_path / "crons.json").write_text(json.dumps({"jobs": records}), encoding="utf-8")
+
+
+def _nudge_service(tmp_path, active_flags):
+    """A REAL ``AutoNudgeService`` holding REAL ``NudgeLoop`` objects.
+
+    The probe reaches into `service._loops` and reads `loop.active`; a stubbed
+    object with those names would keep the test passing after the owner renamed
+    either one, leaving production with a permanent gap. Constructing the real
+    classes means a rename fails at this line. Construction alone touches no event
+    loop -- only `start()` does -- so this stays safe in a sync test.
+    """
+    from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+
+    service = AutoNudgeService(base_dir=tmp_path)
+    for i, active in enumerate(active_flags):
+        loop = NudgeLoop(id=f"loop-{i}", slot_key=f"chat-{i}", message="m", active=active)
+        service._loops[loop.id] = loop
+    return service
+
+
+# ---------------------------------------------------------------------------
+# raw readers — crons
+# ---------------------------------------------------------------------------
+
+
+def test_active_crons_counts_only_unpaused_jobs(tmp_path, monkeypatch):
+    from kiro_crew import cron
+
+    monkeypatch.setattr(cron, "_DEFAULT_DIR", tmp_path, raising=False)
+    _write_crons(
+        tmp_path,
+        [
+            _cron_record("a"),
+            _cron_record("b", user_paused=True),
+            _cron_record("c", auto_paused=True),
+            _cron_record("d"),
+        ],
+    )
+    assert ig.read_active_crons() == 2
+
+
+def test_active_crons_missing_store_is_a_genuine_zero(tmp_path, monkeypatch):
+    from kiro_crew import cron
+
+    ig.reset_for_testing()
+    try:
+        monkeypatch.setattr(cron, "_DEFAULT_DIR", tmp_path, raising=False)
+        assert ig.read_active_crons() == 0
+        # An ABSENT source is not a fault: a fresh install has no crons, and a
+        # failure here would put every new install permanently in the broken bucket.
+        assert ig.read_probe_failures() == {}
+    finally:
+        ig.reset_for_testing()
+
+
+def test_active_crons_unparseable_store_is_a_gap_AND_a_counted_fault(tmp_path, monkeypatch):
+    """A corrupt store cannot answer, and must not do so silently.
+
+    Two assertions, and the second is the one that matters. A 0 would claim the
+    user scheduled nothing. But a bare gap is just as bad in the other direction:
+    it is indistinguishable from a host that stopped exporting, which is the exact
+    confusion probe.failures exists to resolve -- so the present-but-unreadable
+    case counts a failure, unlike the missing-store case above.
+    """
+    from kiro_crew import cron
+
+    ig.reset_for_testing()
+    try:
+        monkeypatch.setattr(cron, "_DEFAULT_DIR", tmp_path, raising=False)
+        (tmp_path / "crons.json").write_text("{not json", encoding="utf-8")
+        assert ig.read_active_crons() is None
+        assert ig.read_probe_failures() == {ig.PROBE_CRONS: 1}
+    finally:
+        ig.reset_for_testing()
+
+
+def test_unparseable_crons_publishes_the_failure_series_and_no_count(tmp_path, monkeypatch):
+    """End to end: the fault is visible as DATA, not only as a missing gauge."""
+    from kiro_crew import cron
+
+    ig.reset_for_testing()
+    try:
+        monkeypatch.setattr(cron, "_DEFAULT_DIR", tmp_path, raising=False)
+        (tmp_path / "crons.json").write_text("{not json", encoding="utf-8")
+        metrics = _collect()
+        assert ig.GAUGE_CRONS_ACTIVE not in metrics or not metrics[ig.GAUGE_CRONS_ACTIVE]
+        failures = {dp.attributes["probe"]: dp.value for dp in metrics[ig.COUNTER_PROBE_FAILURES]}
+        assert failures.get(ig.PROBE_CRONS) == 1, f"crons fault not published: {failures}"
+    finally:
+        ig.reset_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# raw readers — monitor loops
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_loops_counts_armed_loops_only(tmp_path):
+    service = _nudge_service(tmp_path, [True, False, True])
+    with patch("kiro_crew.autonudge.get_instance", return_value=service):
+        assert ig.read_active_monitor_loops() == 2
+
+
+def test_monitor_loops_service_absent_yields_none_but_running_empty_yields_zero(tmp_path):
+    """The None-vs-zero split this module exists to preserve, on one probe."""
+    with patch("kiro_crew.autonudge.get_instance", return_value=None):
+        assert ig.read_active_monitor_loops() is None
+    with patch("kiro_crew.autonudge.get_instance", return_value=_nudge_service(tmp_path, [])):
+        assert ig.read_active_monitor_loops() == 0
+
+
+def test_monitor_loop_probe_reads_the_real_registry_shape(tmp_path):
+    """Pin the two private names the probe reaches into, so a rename fails here."""
+    from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+
+    service = AutoNudgeService(base_dir=tmp_path)
+    assert isinstance(service._loops, dict), "AutoNudgeService._loops is no longer a dict"
+    loop = NudgeLoop(id="i", slot_key="s", message="m")
+    assert isinstance(loop.active, bool), "NudgeLoop.active is no longer a bool flag"
+
+
+# ---------------------------------------------------------------------------
+# raw readers — skills
+# ---------------------------------------------------------------------------
+
+
+def test_installed_skills_counts_the_loader_listing(tmp_path):
+    from kiro_crew.skills import SkillsLoader
+
+    for name in ("alpha", "beta", "gamma"):
+        skill = tmp_path / name
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: d\n---\n\nbody\n", encoding="utf-8"
+        )
+    ig.reset_for_testing()
+    try:
+        ig._skills_loader = SkillsLoader(skills_path=tmp_path, install_builtins=False)
+        assert ig.read_installed_skills() == 3
+    finally:
+        ig.reset_for_testing()
+
+
+def test_installed_skills_is_cached_within_the_ttl():
+    """The walk is the expensive probe; a second tick inside the TTL must not pay."""
+    ig.reset_for_testing()
+    try:
+        with patch.object(ig, "_read_installed_skills_uncached", return_value=7) as uncached:
+            assert ig.read_installed_skills() == 7
+            assert ig.read_installed_skills() == 7
+            assert ig.read_installed_skills() == 7
+            uncached.assert_called_once()
+    finally:
+        ig.reset_for_testing()
+
+
+def test_ttl_cache_expiry_re_produces():
+    ig.reset_for_testing()
+    try:
+        calls = []
+
+        def produce():
+            calls.append(1)
+            return len(calls)
+
+        assert ig._ttl_cached("k", 1000.0, produce) == 1
+        assert ig._ttl_cached("k", 1000.0, produce) == 1
+        # Expire the entry by rewriting its deadline into the past, which is what
+        # the monotonic clock advancing past the TTL does.
+        with ig._lock:
+            _, value = ig._cache["k"]
+            ig._cache["k"] = (0.0, value)
+        assert ig._ttl_cached("k", 1000.0, produce) == 2
+    finally:
+        ig.reset_for_testing()
+
+
+def test_ttl_cache_caches_a_none_answer():
+    """An install that can never answer must not re-pay the probe every cycle."""
+    ig.reset_for_testing()
+    try:
+        with patch.object(ig, "_read_knowledge_documents_uncached", return_value=None) as uncached:
+            assert ig.read_knowledge_documents() is None
+            assert ig.read_knowledge_documents() is None
+            uncached.assert_called_once()
+    finally:
+        ig.reset_for_testing()
+
+
+def test_ttl_cache_caches_a_raised_failure_as_a_gap():
+    """A probe that RAISES must be cached too, not re-run every cycle.
+
+    The None case alone is not enough: the expensive probes fail by raising (an
+    unreadable tree, a locked database), and without this an install that can never
+    answer would pay the full walk or SQLite open on every export interval forever.
+    """
+    ig.reset_for_testing()
+    try:
+        with patch.object(
+            ig, "_read_installed_skills_uncached", side_effect=OSError("unreadable")
+        ) as uncached:
+            assert ig.read_installed_skills() is None
+            assert ig.read_installed_skills() is None
+            assert ig.read_installed_skills() is None
+            uncached.assert_called_once()
+    finally:
+        ig.reset_for_testing()
+
+
+def test_ttl_cached_never_propagates_a_probe_exception():
+    """The caller's contract is "None means no observation", so nothing escapes."""
+    ig.reset_for_testing()
+    try:
+
+        def boom():
+            raise RuntimeError("probe exploded")
+
+        assert ig._ttl_cached("boom", 1000.0, boom) is None
+    finally:
+        ig.reset_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# raw readers — memory / config toggles
+# ---------------------------------------------------------------------------
+
+
+def test_memory_migrated_reports_the_config_bit():
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    cfg = KiroCrewConfig()
+    cfg.memory.migrated = True
+    with patch.object(KiroCrewConfig, "load", return_value=cfg):
+        assert ig.read_memory_migrated() == 1
+    cfg.memory.migrated = False
+    with patch.object(KiroCrewConfig, "load", return_value=cfg):
+        assert ig.read_memory_migrated() == 0
+
+
+def test_every_declared_toggle_resolves_against_a_real_config():
+    """A renamed config field must fail HERE, not silently publish a wrong 0.
+
+    ``read_config_toggles`` omits a key it cannot resolve, which is the right
+    runtime behavior (a missing series beats a fabricated "off") but would hide a
+    typo forever. This is the ratchet that makes the omission observable.
+    """
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    cfg = KiroCrewConfig()
+    for key, section_name, field_name in ig.CONFIG_TOGGLES:
+        section = getattr(cfg, section_name, None)
+        assert section is not None, f"toggle {key!r}: no config section {section_name!r}"
+        value = getattr(section, field_name, None)
+        assert isinstance(
+            value, bool
+        ), f"toggle {key!r}: {section_name}.{field_name} is {value!r}, expected a bool"
+
+
+def test_config_toggle_keys_are_unique_and_exclude_the_tautologies():
+    keys = [key for key, _, _ in ig.CONFIG_TOGGLES]
+    assert len(keys) == len(set(keys)), "duplicate toggle key"
+    # telemetry.enabled is always true inside the consent gate, and memory has
+    # its own gauge — either one here would be a metric that cannot vary.
+    paths = {(section, field) for _, section, field in ig.CONFIG_TOGGLES}
+    assert ("telemetry", "enabled") not in paths
+    assert ("memory", "migrated") not in paths
+
+
+def test_config_toggles_reports_zero_and_one():
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    cfg = KiroCrewConfig()
+    with patch.object(KiroCrewConfig, "load", return_value=cfg):
+        toggles = ig.read_config_toggles()
+    assert toggles
+    assert set(toggles) == {key for key, _, _ in ig.CONFIG_TOGGLES}
+    assert set(toggles.values()) <= {0, 1}
+
+
+def test_config_toggles_omits_an_unresolvable_key():
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    cfg = KiroCrewConfig()
+    with patch.object(ig, "CONFIG_TOGGLES", (("ghost", "telemetry", "no_such_field"),)):
+        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+            assert ig.read_config_toggles() is None
+
+
+# ---------------------------------------------------------------------------
+# raw readers — knowledge / lessons
+# ---------------------------------------------------------------------------
+
+
+def _make_knowledge_db(root, source_count):
+    """Build the database THROUGH the real ``KnowledgeStore``, not by hand.
+
+    A hand-written ``CREATE TABLE sources`` would keep agreeing with the probe's
+    ``SELECT COUNT(*) FROM sources`` after the owning schema renamed that table --
+    probe and test drifting together in silence, while production emitted a
+    permanently CACHED gap indistinguishable from "never ingested". Going through
+    the real store makes this test the place a schema rename fails.
+    """
+    from kiro_crew.knowledge.store import KnowledgeStore
+
+    db_dir = root / "workspace" / "knowledge"
+    db_dir.mkdir(parents=True)
+    db_path = db_dir / "knowledge.db"
+    store = KnowledgeStore(str(db_path))
+    for i in range(source_count):
+        store.add_source(f"doc-{i}.md", "local_file", f"/docs/doc-{i}.md")
+    return db_path
+
+
+def test_knowledge_documents_counts_sources(tmp_path):
+    """Counts through a schema the REAL store built, which is the drift ratchet.
+
+    The fixture goes through ``KnowledgeStore``, so this is where a rename on either
+    side of the coupling fails: the store renaming its table, or this module's
+    ``KNOWLEDGE_SOURCES_TABLE`` pointing at one that no longer exists. That matters
+    because the probe deliberately never constructs a store (doing so would create
+    the database), so nothing else observes the coupling -- and a drifted probe
+    returns a CACHED gap indistinguishable from "never ingested".
+    """
+    _make_knowledge_db(tmp_path, 12)
+    ig.reset_for_testing()
+    try:
+        with patch("kiro_crew.config.paths.config_dir", return_value=tmp_path):
+            assert ig.read_knowledge_documents() == 12, (
+                f"the probe could not count {ig.KNOWLEDGE_SOURCES_TABLE!r} in a schema "
+                "KnowledgeStore itself created; read_knowledge_documents would gap forever"
+            )
+    finally:
+        ig.reset_for_testing()
+
+
+def test_knowledge_probe_never_creates_the_database(tmp_path):
+    """A telemetry probe must not bring a subsystem into existence."""
+    ig.reset_for_testing()
+    try:
+        with patch("kiro_crew.config.paths.config_dir", return_value=tmp_path):
+            assert ig.read_knowledge_documents() is None
+        assert not (tmp_path / "workspace" / "knowledge" / "knowledge.db").exists()
+        assert not (tmp_path / "workspace").exists()
+    finally:
+        ig.reset_for_testing()
+
+
+def test_knowledge_probe_opens_read_only(tmp_path):
+    """A write through THE PROBE'S OWN connection must be refused.
+
+    Deliberately not "open a ``mode=ro`` connection here and watch sqlite refuse a
+    write" — that asserts sqlite's behaviour and stays green if the probe drops
+    ``mode=ro`` entirely, which is the only thing worth guarding. So the write is
+    attempted on the connection the probe just obtained, by intercepting
+    ``sqlite3.connect`` on the way back out.
+    """
+    db_path = _make_knowledge_db(tmp_path, 1)
+    real_connect = sqlite3.connect
+    refused: list[bool] = []
+
+    def _spy(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        try:
+            # Schema-independent on purpose: an INSERT into `sources` would hit that
+            # table's NOT NULL constraints on a WRITABLE connection, so the mutation
+            # case would fail with an IntegrityError instead of reporting that the
+            # write got through. A CREATE is refused by a read-only connection and
+            # accepted by a writable one, with nothing else in the way.
+            conn.execute("CREATE TABLE _probe_rw_check (x)")
+            refused.append(False)
+        except sqlite3.OperationalError:
+            refused.append(True)
+        return conn
+
+    ig.reset_for_testing()
+    try:
+        with (
+            patch("kiro_crew.config.paths.config_dir", return_value=tmp_path),
+            patch.object(sqlite3, "connect", _spy),
+        ):
+            assert ig.read_knowledge_documents() == 1, "the probe did not run"
+        assert refused == [True], f"the probe's own connection accepted a write: {refused}"
+    finally:
+        ig.reset_for_testing()
+    assert db_path.exists()
+
+
+def test_lessons_counts_saved_lessons(tmp_path):
+    from kiro_crew.learn import Lesson, LessonStore
+
+    store = LessonStore(base_dir=tmp_path)
+    store.save(Lesson(ts="2026-01-01T00:00:00Z", rule="always X", category="preference"))
+    store.save(Lesson(ts="2026-01-02T00:00:00Z", rule="always Z", category="tool"))
+    ig.reset_for_testing()
+    try:
+        ig._lesson_store = store
+        assert ig.read_lessons() == 2
+    finally:
+        ig.reset_for_testing()
+
+
+def test_lessons_absent_file_is_a_genuine_zero(tmp_path):
+    from kiro_crew.learn import LessonStore
+
+    ig.reset_for_testing()
+    try:
+        ig._lesson_store = LessonStore(base_dir=tmp_path)
+        assert ig.read_lessons() == 0
+    finally:
+        ig.reset_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# raw readers — MCP classes
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_classes_split_managed_from_user_added():
+    from kiro_crew.mcp_discovery import _MANAGED_SERVER_NAMES
+
+    managed = sorted(_MANAGED_SERVER_NAMES)
+    assert managed, "the managed-server constant must not be empty"
+    agent_cfg = {"mcpServers": {name: {} for name in managed[:2]}}
+    by_source = {"user": {"acme-internal-tool": {}, "some-other-server": {}}}
+    with patch("kiro_crew.mcp_discovery._load_agent_config", return_value=agent_cfg):
+        with patch("kiro_crew.mcp_discovery._load_mcp_json_by_source", return_value=by_source):
+            classes = ig.read_mcp_server_classes()
+    assert classes == {ig.MCP_CLASS_FIRST_PARTY: 2, ig.MCP_CLASS_THIRD_PARTY: 2}
+
+
+def test_mcp_classes_empty_roster_yields_none():
+    with patch("kiro_crew.mcp_discovery._load_agent_config", return_value={}):
+        with patch("kiro_crew.mcp_discovery._load_mcp_json_by_source", return_value={}):
+            assert ig.read_mcp_server_classes() is None
+
+
+def test_mcp_first_party_set_is_the_installer_constant_not_a_local_copy():
+    """Reusing mcp_discovery's constant is what stops a silent drift."""
+    import inspect
+
+    from kiro_crew.mcp_discovery import _MANAGED_SERVER_NAMES
+
+    source = inspect.getsource(ig.read_mcp_server_classes)
+    assert "_MANAGED_SERVER_NAMES" in source
+    for name in _MANAGED_SERVER_NAMES:
+        assert name not in inspect.getsource(ig), f"{name!r} is restated in this module"
+
+
+# ---------------------------------------------------------------------------
+# OTEL registration + collection
+# ---------------------------------------------------------------------------
+
+
+def test_all_names_pass_core_namespace_validation():
+    for name in ig.ALL_METRIC_NAMES:
+        assert validate_name(name) == name
+
+
+def test_collection_yields_every_instrument_with_the_expected_shape():
+    with (
+        patch.object(ig, "read_active_crons", return_value=3),
+        patch.object(ig, "read_active_monitor_loops", return_value=1),
+        patch.object(ig, "read_installed_skills", return_value=42),
+        patch.object(ig, "read_memory_migrated", return_value=1),
+        patch.object(ig, "read_knowledge_documents", return_value=12),
+        patch.object(ig, "read_lessons", return_value=300),
+        patch.object(
+            ig,
+            "read_mcp_server_classes",
+            return_value={ig.MCP_CLASS_FIRST_PARTY: 4, ig.MCP_CLASS_THIRD_PARTY: 1},
+        ),
+        patch.object(ig, "read_config_toggles", return_value={"beacon": 1, "stt": 0}),
+    ):
+        metrics = _collect()
+
+    for name in ig.ALL_METRIC_NAMES:
+        if name == ig.COUNTER_PROBE_FAILURES:
+            # Absent by design on a healthy install: it publishes only once a probe
+            # has failed, so a healthy host adds no series. Covered positively by
+            # test_probe_failure_publishes_a_counter_series.
+            assert (
+                name not in metrics or not metrics[name]
+            ), "the failure counter must publish nothing when every probe answers"
+            continue
+        assert name in metrics, f"{name} missing from collection"
+        assert metrics[name], f"{name} produced no data points"
+
+    assert metrics[ig.GAUGE_CRONS_ACTIVE][0].value == 3
+    assert metrics[ig.GAUGE_MONITOR_LOOPS_ACTIVE][0].value == 1
+    assert metrics[ig.GAUGE_SKILLS_INSTALLED][0].value == 42
+    assert metrics[ig.GAUGE_MEMORY_MIGRATED][0].value == 1
+
+    # The store-backed counts ride in the VALUE with no attribute at all. A
+    # magnitude-band attribute would cost a series per band and would render
+    # growth inside a band -- the drift these exist to show -- as a flat line.
+    (docs,) = metrics[ig.GAUGE_KNOWLEDGE_DOCUMENTS]
+    assert docs.value == 12
+    assert dict(docs.attributes or {}) == {}
+    (lessons,) = metrics[ig.GAUGE_LESSONS]
+    assert lessons.value == 300
+    assert dict(lessons.attributes or {}) == {}
+
+    classes = {dp.attributes["class"]: dp.value for dp in metrics[ig.GAUGE_MCP_SERVERS]}
+    assert classes == {ig.MCP_CLASS_FIRST_PARTY: 4, ig.MCP_CLASS_THIRD_PARTY: 1}
+
+    toggles = {dp.attributes["key"]: dp.value for dp in metrics[ig.GAUGE_CONFIG_TOGGLE]}
+    assert toggles == {"beacon": 1, "stt": 0}
+
+
+def test_no_mcp_server_name_reaches_any_attribute():
+    """The privacy ratchet: a user's roster classifies, then is discarded."""
+    secret = "acme-confidential-internal-mcp"
+    with patch(
+        "kiro_crew.mcp_discovery._load_agent_config",
+        return_value={"mcpServers": {secret: {}}},
+    ):
+        with patch("kiro_crew.mcp_discovery._load_mcp_json_by_source", return_value={}):
+            metrics = _collect()
+    points = metrics.get(ig.GAUGE_MCP_SERVERS) or []
+    assert points, "the MCP gauge must still publish a count"
+    for dp in points:
+        for key, value in (dp.attributes or {}).items():
+            assert secret not in str(key)
+            assert secret not in str(value)
+    # And the third-party count did observe it.
+    classes = {dp.attributes["class"]: dp.value for dp in points}
+    assert classes.get(ig.MCP_CLASS_THIRD_PARTY) == 1
+
+
+def test_raising_reader_yields_gap_not_failure():
+    """A blown-up probe skips its observation; every other metric survives."""
+    with patch.object(ig, "read_active_crons", side_effect=RuntimeError("boom")):
+        with patch.object(ig, "read_memory_migrated", return_value=1):
+            metrics = _collect()
+    assert ig.GAUGE_CRONS_ACTIVE not in metrics or not metrics[ig.GAUGE_CRONS_ACTIVE]
+    assert metrics[ig.GAUGE_MEMORY_MIGRATED][0].value == 1
+
+
+def test_raising_store_and_keyed_readers_also_yield_gaps():
+    with (
+        patch.object(ig, "read_lessons", side_effect=RuntimeError("boom")),
+        patch.object(ig, "read_config_toggles", side_effect=RuntimeError("boom")),
+        patch.object(ig, "read_memory_migrated", return_value=0),
+    ):
+        metrics = _collect()
+    assert ig.GAUGE_LESSONS not in metrics or not metrics[ig.GAUGE_LESSONS]
+    assert ig.GAUGE_CONFIG_TOGGLE not in metrics or not metrics[ig.GAUGE_CONFIG_TOGGLE]
+    assert metrics[ig.GAUGE_MEMORY_MIGRATED][0].value == 0
+
+
+def test_unavailable_reader_yields_no_observation():
+    with patch.object(ig, "read_active_monitor_loops", return_value=None):
+        metrics = _collect()
+    assert (
+        ig.GAUGE_MONITOR_LOOPS_ACTIVE not in metrics or not metrics[ig.GAUGE_MONITOR_LOOPS_ACTIVE]
+    )
+
+
+def test_probe_failure_publishes_a_counter_series():
+    """A broken probe must present as DATA, not merely as a missing gauge.
+
+    This is what separates "the probe broke" from "this host stopped exporting" at
+    a backend: the failure series is present and climbing, which a host that went
+    dark cannot produce.
+    """
+    ig.reset_for_testing()
+    try:
+        with patch.object(ig, "read_active_crons", side_effect=RuntimeError("boom")):
+            metrics = _collect()
+        assert ig.GAUGE_CRONS_ACTIVE not in metrics or not metrics[ig.GAUGE_CRONS_ACTIVE]
+        points = metrics.get(ig.COUNTER_PROBE_FAILURES) or []
+        assert points, "a failed probe published no failure series"
+        counts = {p.attributes["probe"]: p.value for p in points}
+        assert counts == {ig.PROBE_CRONS: 1}
+    finally:
+        ig.reset_for_testing()
+
+
+def test_probe_failure_attribute_values_are_the_closed_probe_set():
+    ig.reset_for_testing()
+    try:
+        for probe in ig.ALL_PROBES:
+            ig._note_probe_failure(probe)
+        assert set(ig.read_probe_failures()) == set(ig.ALL_PROBES)
+        assert len(set(ig.ALL_PROBES)) == len(ig.ALL_PROBES), "duplicate probe name"
+    finally:
+        ig.reset_for_testing()
+
+
+def test_first_probe_failure_warns_then_falls_back_to_debug(caplog):
+    """A default install collects WARNING and above, so the first failure must be loud.
+
+    Repeats drop to debug: a permanently broken probe would otherwise emit one
+    WARNING per export interval for the life of the process.
+    """
+    ig.reset_for_testing()
+    try:
+        with caplog.at_level(logging.WARNING, logger=ig.logger.name):
+            ig._note_probe_failure(ig.PROBE_SKILLS)
+            assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
+            ig._note_probe_failure(ig.PROBE_SKILLS)
+            ig._note_probe_failure(ig.PROBE_SKILLS)
+            assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
+        assert ig.read_probe_failures()[ig.PROBE_SKILLS] == 3
+    finally:
+        ig.reset_for_testing()
+
+
+def test_ttl_cached_failure_counts_against_its_probe():
+    """The cached-failure path must also increment, not just the wrapper path."""
+    ig.reset_for_testing()
+    try:
+        with patch.object(ig, "_read_knowledge_documents_uncached", side_effect=OSError("locked")):
+            assert ig.read_knowledge_documents() is None
+        assert ig.read_probe_failures() == {ig.PROBE_KNOWLEDGE: 1}
+    finally:
+        ig.reset_for_testing()
+
+
+def test_only_the_install_reporter_publishes_inventory():
+    """A process that never claimed the role must publish NO inventory series.
+
+    This is what keeps an install from being counted once per telemetry-enabled
+    process. The gateway claims the role; gatewayd, spawned agents and apps do not,
+    and their recorders must stay silent on install-scoped facts even though they
+    register the same instruments.
+    """
+    ig.reset_for_testing()
+    try:
+        assert not ig.is_install_reporter(), "the role must default to unclaimed"
+        reader = InMemoryMetricReader()
+        provider = MeterProvider(metric_readers=[reader])
+        ig.register_inventory_gauges(provider.get_meter("test"))
+        data = reader.get_metrics_data()
+        provider.shutdown()
+        published = set()
+        if data is not None:
+            for rm in data.resource_metrics:
+                for sm in rm.scope_metrics:
+                    for metric in sm.metrics:
+                        if metric.data.data_points:
+                            published.add(metric.name)
+        assert not published, f"unclaimed process published inventory: {sorted(published)}"
+    finally:
+        ig.reset_for_testing()
+
+
+def test_claiming_the_role_is_idempotent_and_enables_publication():
+    ig.reset_for_testing()
+    try:
+        ig.mark_install_reporter()
+        ig.mark_install_reporter()
+        assert ig.is_install_reporter()
+        # _collect claims the role itself, so this is the positive counterpart of
+        # the test above: the same registration now does publish.
+        metrics = _collect()
+        assert metrics.get(ig.GAUGE_MEMORY_MIGRATED), "reporter published nothing"
+    finally:
+        ig.reset_for_testing()
+
+
+def test_registration_failure_is_swallowed():
+    """register_inventory_gauges never raises, even on a hostile meter."""
+
+    class _HostileMeter:
+        def __getattr__(self, name):
+            raise RuntimeError("no instruments for you")
+
+    ig.register_inventory_gauges(_HostileMeter())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# gateway call site
+# ---------------------------------------------------------------------------
+
+
+def test_reporter_claim_is_unconditional():
+    """The gateway's claim must be reached without passing through a branch.
+
+    The election has no runtime enforcement: nothing raises when a process forgets
+    to claim the role, and an unclaimed process's callbacks return before probing,
+    so ``probe.failures`` stays empty too. The whole subsystem then reads exactly
+    like a host that stopped exporting -- silent, and indistinguishable from
+    healthy. That makes the call SITE the invariant, so it is pinned here instead
+    of left to review: it shipped inside ``_init_autonudge()``, which returns early
+    under ``KIROCREW_AUTONUDGE=0``, and one env var darkened all eight gauges.
+
+    ``try`` is allowed (telemetry is best-effort and must not block boot); a
+    conditional or a loop is not, because that is the shape a feature flag arrives
+    in.
+    """
+    import ast
+    from pathlib import Path
+
+    from kiro_crew.slack import gateway as gateway_mod
+
+    tree = ast.parse(Path(gateway_mod.__file__).read_text(encoding="utf-8"))
+    branching = (ast.If, ast.IfExp, ast.For, ast.AsyncFor, ast.While, ast.Match)
+    sites: list[tuple[str, bool]] = []
+
+    def _walk(node, func: str, branched: bool) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                _walk(child, child.name, False)
+                continue
+            if isinstance(child, ast.Lambda):
+                continue
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "mark_install_reporter"
+            ):
+                sites.append((func, branched))
+            _walk(child, func, branched or isinstance(child, branching))
+
+    _walk(tree, "<module>", False)
+
+    assert sites == [("run", False)], (
+        "mark_install_reporter() must be called exactly once, unconditionally, from "
+        f"GatewayOrchestrator.run(); found (function, is_conditional) = {sites}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# provider wiring
+# ---------------------------------------------------------------------------
+
+
+def _enable_telemetry(monkeypatch):
+    monkeypatch.setenv("KIROCREW_TELEMETRY", "1")
+
+
+def test_live_build_registers_inventory_gauges(monkeypatch):
+    from kiro_crew.metrics import provider as provider_mod
+
+    _enable_telemetry(monkeypatch)
+    provider_mod.reset_for_testing()
+    try:
+        with patch("kiro_crew.metrics.inventory_gauges.register_inventory_gauges") as register:
+            rec = provider_mod.get_recorder()
+            assert rec.enabled
+            register.assert_called_once()
+    finally:
+        provider_mod.reset_for_testing()
+
+
+def test_gauge_registration_failure_keeps_telemetry_alive(monkeypatch):
+    from kiro_crew.metrics import provider as provider_mod
+
+    _enable_telemetry(monkeypatch)
+    provider_mod.reset_for_testing()
+    try:
+        with patch(
+            "kiro_crew.metrics.inventory_gauges.register_inventory_gauges",
+            side_effect=RuntimeError("boom"),
+        ):
+            rec = provider_mod.get_recorder()
+            assert rec.enabled, "gauge failure must not disable telemetry"
+    finally:
+        provider_mod.reset_for_testing()
+
+
+def test_inventory_failure_does_not_cost_the_process_gauges(monkeypatch):
+    """Separate try blocks: one subsystem's probe cannot dark the other's."""
+    from kiro_crew.metrics import provider as provider_mod
+
+    _enable_telemetry(monkeypatch)
+    provider_mod.reset_for_testing()
+    try:
+        with patch(
+            "kiro_crew.metrics.inventory_gauges.register_inventory_gauges",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch("kiro_crew.metrics.process_gauges.register_process_gauges") as process:
+                rec = provider_mod.get_recorder()
+                assert rec.enabled
+                process.assert_called_once()
+    finally:
+        provider_mod.reset_for_testing()

--- a/test/metrics/test_otlp_wire_e2e.py
+++ b/test/metrics/test_otlp_wire_e2e.py
@@ -1,0 +1,546 @@
+"""End-to-end verification that telemetry actually reaches an exporter.
+
+``test_local_exporter.py`` already proves that serialization works, but it proves
+it of the exporter alone: it constructs a ``JsonlMetricExporter`` directly, feeds
+it from a provider assembled in the test, and asserts valid JSONL, shard
+lifecycle, and resource-level identity. What no test covered is the same question
+asked of the LIVE BUILD -- that the roster ``provider._build_recorder()`` actually
+registers arrives, carrying the attribute values the modules declare, at the
+temporality each instrument kind requires. That gap is real: an instrument can be
+missing, and an attribute value or a temporality setting can be correct in the
+SDK's in-memory view and still be wrong, dropped, or unencodable by the time it
+leaves the process. These tests close it by driving that live path and reading
+what an exporter actually received.
+
+Two tiers, because the OTLP exporter is an optional extra
+(``pip install "kirocrew[otlp]"``) that a default dev/CI environment does not
+have:
+
+* **Tier 1 — serialization (always runs).** The live build's own JSONL exporter
+  writes real records to disk. Asserts the full instrument roster arrives, that
+  resource attributes survive with fidelity, that attribute values are the closed
+  enums the modules declare, and that temporality is what each instrument kind
+  requires.
+* **Tier 2 — OTLP wire (skipped without the extra).** A real
+  ``OTLPMetricExporter`` posts to an in-process HTTP receiver bound to loopback,
+  whose protobuf body is decoded and asserted. No container, no downloaded
+  binary, and no egress off the machine, so it runs anywhere the extra is
+  installed.
+
+A third tier — a genuine ``otel-collector`` process — is deliberately NOT here: it
+needs a downloaded binary and outbound network, so it cannot run in a
+network-isolated CI. ``docs/guides/telemetry-otlp-export.md`` describes how to do
+that check by hand against whichever collector you actually run.
+"""
+
+import gzip
+import http.server
+import json
+import os
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.metrics import inventory_gauges as ig
+from kiro_crew.metrics import process_gauges as pg
+from kiro_crew.metrics import provider as pm
+from kiro_crew.metrics.schema import RESOURCE_ATTR_PROCESS_START_TIME
+
+# OTEL AggregationTemporality, as it appears in serialized output.
+_DELTA = 1
+_CUMULATIVE = 2
+
+#: Instruments that are ABSENT on a healthy install by design, so a roster
+#: assertion must not require them. ``probe.failures`` publishes only once a probe
+#: has failed -- its presence is the signal, so demanding it here would invert the
+#: contract. Its positive path is covered in ``test_inventory_gauges.py``.
+_HEALTHY_ABSENT = frozenset({ig.COUNTER_PROBE_FAILURES})
+
+#: Process gauges whose SOURCE is Linux-only: ``process_gauges`` maps an
+#: unavailable ``/proc`` surface to None, which is a gap by design. Exempted only
+#: where that surface is actually missing, so the roster stays fully asserted on
+#: Linux and a Windows or macOS runner does not read a correct gap as a regression.
+_LINUX_ONLY = frozenset({pg.GAUGE_THREADS_OS, pg.GAUGE_OPEN_FDS})
+
+
+def _platform_absent() -> frozenset:
+    return frozenset() if os.path.isdir("/proc/self/task") else _LINUX_ONLY
+
+
+def _not_required() -> frozenset:
+    """Instruments a roster assertion must not demand on THIS host."""
+    return _HEALTHY_ABSENT | _platform_absent()
+
+
+#: Sentinel for "keep this probe's real implementation" in a readings override.
+_REAL = object()
+
+#: Instruments whose kind carries a temporality (observable counters are Sums).
+#: Observable GAUGES must carry none — a temporality on a gauge would mean the
+#: exporter is treating a point-in-time reading as an accumulating one.
+_COUNTER_NAMES = (
+    pg.COUNTER_CPU_SECONDS,
+    pg.COUNTER_GC_COLLECTIONS,
+    pg.COUNTER_GC_COLLECTED,
+    pg.COUNTER_GC_UNCOLLECTABLE,
+)
+
+
+# ---------------------------------------------------------------------------
+# tier 1 — real live build, real exporter, records read back off disk
+# ---------------------------------------------------------------------------
+
+
+#: Fixed readings installed over the real probes for the duration of a driven
+#: build. What these tiers verify is the SERIALIZATION contract — roster,
+#: resource fidelity, attribute enums, temporality — and every probe's own
+#: behavior is pinned in ``test_inventory_gauges.py``. Leaving the real probes in
+#: place would make these assertions depend on whether the host running them
+#: happens to have a knowledge database, any crons, or an MCP roster, which is a
+#: flake rather than a contract. Values are distinct from one another so a
+#: mixed-up instrument shows as a wrong number rather than a coincidence.
+_PINNED_READINGS = {
+    "read_active_crons": 3,
+    "read_active_monitor_loops": 2,
+    "read_installed_skills": 41,
+    "read_memory_migrated": 1,
+    "read_knowledge_documents": 12,
+    "read_lessons": 300,
+    "read_mcp_server_classes": {
+        ig.MCP_CLASS_FIRST_PARTY: 4,
+        ig.MCP_CLASS_THIRD_PARTY: 1,
+    },
+    "read_config_toggles": {"beacon": 1, "stt": 0},
+}
+
+
+class _Exported:
+    """Flattened view of everything one live build wrote."""
+
+    def __init__(self, resources, metrics):
+        self.resources = resources
+        self.metrics = metrics
+
+    def points(self, name):
+        return self.metrics.get(name, {}).get("points", [])
+
+    def temporality(self, name):
+        return self.metrics.get(name, {}).get("temporality")
+
+    def attr_values(self, name, key):
+        return {p.get("attributes", {}).get(key) for p in self.points(name)}
+
+
+def _drive_live_build(tmp_path, monkeypatch, readings=None):
+    """Enable telemetry, build for real, force one export, read the shards back.
+
+    Patches only the metrics DIRECTORY and the probe readings, so the provider,
+    the meter, the gauge registrations and the exporter are all the production
+    objects. *readings* maps reader name to its pinned value; a name mapped to
+    the sentinel ``_REAL`` keeps its real implementation. Returns the live
+    provider's own resource alongside the serialized one, which is what lets the
+    fidelity assertion compare them rather than restate a fixed list.
+    """
+    monkeypatch.setenv("KIROCREW_TELEMETRY", "1")
+    for name, value in (readings if readings is not None else _PINNED_READINGS).items():
+        if value is _REAL:
+            continue
+        monkeypatch.setattr(ig, name, lambda _v=value: _v)
+
+    ig.reset_for_testing()
+    # Stand in for the gateway's own claim: install-scoped inventory publishes only
+    # from the elected reporter, so without this the roster below would be empty.
+    ig.mark_install_reporter()
+    pm.reset_for_testing()
+    live_resource = None
+    try:
+        with patch.object(pm, "_default_metrics_dir", return_value=tmp_path):
+            recorder = pm.get_recorder()
+            assert recorder.enabled, "live build did not enable telemetry"
+            provider = pm._provider
+            assert provider is not None, "live build produced no MeterProvider"
+            live_resource = dict(provider._sdk_config.resource.attributes)
+            provider.force_flush()
+    finally:
+        pm.reset_for_testing()
+        ig.reset_for_testing()
+
+    shards = sorted(tmp_path.glob("metrics-*.jsonl"))
+    assert shards, "the live build wrote no metric shard"
+
+    resources: list[dict] = []
+    metrics: dict[str, dict] = {}
+    for shard in shards:
+        for line in shard.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            for rm in payload.get("resource_metrics") or []:
+                resources.append((rm.get("resource") or {}).get("attributes") or {})
+                for sm in rm.get("scope_metrics") or []:
+                    for metric in sm.get("metrics") or []:
+                        data = metric.get("data") or {}
+                        entry = metrics.setdefault(
+                            metric["name"],
+                            {"points": [], "temporality": data.get("aggregation_temporality")},
+                        )
+                        entry["points"].extend(data.get("data_points") or [])
+    return _Exported(resources, metrics), live_resource
+
+
+@pytest.fixture(scope="module")
+def exported(tmp_path_factory):
+    """One live build shared by the tier-1 assertions.
+
+    Module-scoped because building the provider registers observable instruments
+    and forces an export; doing that once and asserting many things about the
+    result is both faster and closer to how a real export cycle behaves than
+    rebuilding per test.
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()
+    try:
+        yield _drive_live_build(tmp_path_factory.mktemp("otlp-e2e"), mp)
+    finally:
+        mp.undo()
+
+
+def test_every_declared_instrument_reaches_the_exporter(exported):
+    """The roster contract: nothing declared may be missing from the wire."""
+    data, _ = exported
+    expected = (set(pg.ALL_METRIC_NAMES) | set(ig.ALL_METRIC_NAMES)) - _not_required()
+    missing = sorted(name for name in expected if not data.points(name))
+    assert not missing, f"declared but never exported: {missing}"
+    for name in _HEALTHY_ABSENT:
+        assert not data.points(name), f"{name} must publish nothing on a healthy build"
+
+
+def test_a_probe_that_cannot_answer_yields_a_gap_not_a_zero(tmp_path, monkeypatch):
+    """A None reading must produce NO series, all the way through the exporter.
+
+    The reader-level test proves the callback yields nothing; this proves the
+    absence survives to the wire, which is where a fake 0 would actually mislead
+    — it would be indistinguishable from a running install with none armed.
+    """
+    readings = dict(_PINNED_READINGS)
+    readings["read_active_monitor_loops"] = None
+    data, _ = _drive_live_build(tmp_path, monkeypatch, readings)
+    assert not data.points(ig.GAUGE_MONITOR_LOOPS_ACTIVE)
+    # The rest of the roster is unaffected — one dark probe is not an outage.
+    assert data.points(ig.GAUGE_CRONS_ACTIVE)
+
+
+def test_resource_attributes_survive_serialization_with_fidelity(exported):
+    """Every attribute the live provider set must appear on the wire, unchanged.
+
+    Compared against the provider's OWN resource rather than a hardcoded list, so
+    this keeps holding as the resource attribute set grows: an attribute added to
+    ``_build_recorder``'s ``Resource`` is covered here the moment it lands, and an
+    attribute that the exporter silently drops fails here instead of going
+    unnoticed in a backend.
+    """
+    data, live_resource = exported
+    assert live_resource, "the live provider exposed no resource attributes"
+    assert data.resources, "no resource block reached the exporter"
+    for serialized in data.resources:
+        for key, value in live_resource.items():
+            assert key in serialized, f"resource attribute {key!r} lost in serialization"
+            assert serialized[key] == value, (
+                f"resource attribute {key!r} changed on the wire: "
+                f"{value!r} -> {serialized[key]!r}"
+            )
+
+
+def test_service_name_identifies_the_product_on_the_wire(exported):
+    data, _ = exported
+    for serialized in data.resources:
+        assert serialized.get("service.name") == "kirocrew"
+
+
+def test_local_shards_carry_the_process_identity_token(exported):
+    """The local sink stamps process identity so counter resets are detectable.
+
+    This is a LOCAL-sink contract: the token is host-local and the exporter adds
+    it per record. Pinned here because it is the only thing that makes a
+    cumulative counter's reset distinguishable from a decrease within one shard.
+    """
+    data, _ = exported
+    for serialized in data.resources:
+        assert RESOURCE_ATTR_PROCESS_START_TIME in serialized
+
+
+def test_observable_counters_export_cumulative(exported):
+    data, _ = exported
+    for name in _COUNTER_NAMES:
+        assert data.temporality(name) == _CUMULATIVE, (
+            f"{name} must export CUMULATIVE: its delta baseline lives in the "
+            "provider, which telemetry consent changes rebuild in-process"
+        )
+
+
+def test_observable_gauges_carry_no_temporality(exported):
+    data, _ = exported
+    for name in ig.ALL_METRIC_NAMES:
+        if not data.points(name):
+            continue
+        assert data.temporality(name) is None, (
+            f"{name} is a gauge; a temporality would mean the exporter is "
+            "treating a point-in-time reading as accumulating"
+        )
+
+
+def test_inventory_attribute_values_are_the_declared_closed_enums(exported):
+    """Attribute VALUES on the wire must be exactly the declared enums."""
+    data, _ = exported
+    assert data.attr_values(ig.GAUGE_MCP_SERVERS, "class") == {
+        ig.MCP_CLASS_FIRST_PARTY,
+        ig.MCP_CLASS_THIRD_PARTY,
+    }
+    assert data.attr_values(ig.GAUGE_CONFIG_TOGGLE, "key") == {"beacon", "stt"}
+
+
+def test_plain_count_gauges_carry_their_reading(exported):
+    data, _ = exported
+    assert data.points(ig.GAUGE_CRONS_ACTIVE)[0]["value"] == 3
+    assert data.points(ig.GAUGE_MONITOR_LOOPS_ACTIVE)[0]["value"] == 2
+    assert data.points(ig.GAUGE_SKILLS_INSTALLED)[0]["value"] == 41
+    assert data.points(ig.GAUGE_MEMORY_MIGRATED)[0]["value"] == 1
+
+
+def test_store_backed_counts_cross_the_wire_unaggregated(exported):
+    """The exact reading arrives, under no attribute.
+
+    These two are the counts that could plausibly have been banded at emit time.
+    Asserting the raw value here is what makes the shape a contract rather than an
+    implementation detail: a reintroduced band would show up as a constant 1 plus
+    an attribute, and both halves of that fail below.
+    """
+    data, _ = exported
+    for name, expected in (
+        (ig.GAUGE_KNOWLEDGE_DOCUMENTS, _PINNED_READINGS["read_knowledge_documents"]),
+        (ig.GAUGE_LESSONS, _PINNED_READINGS["read_lessons"]),
+    ):
+        points = data.points(name)
+        assert points, f"{name} published nothing"
+        # One series, not one point: the fixture drives more than one export cycle,
+        # so the invariant is that every point shares the single empty attribute set.
+        assert {tuple(sorted((p.get("attributes") or {}).items())) for p in points} == {
+            ()
+        }, f"{name} must be a single attribute-free series, got {points}"
+        assert {p["value"] for p in points} == {expected}
+
+
+def test_config_toggle_values_are_boolean_shaped(exported):
+    data, _ = exported
+    for point in data.points(ig.GAUGE_CONFIG_TOGGLE):
+        assert point["value"] in (0, 1)
+
+
+def test_no_mcp_server_name_appears_anywhere_on_the_wire(tmp_path, monkeypatch):
+    """Privacy ratchet at the serialization boundary, not just at the reader.
+
+    Runs the REAL classification (the one probe left unpinned here) over an
+    injected roster carrying a distinctive name, then asserts that name occurs
+    nowhere in the exported payload. The reader-level test proves the
+    classification discards names; this proves nothing between the reader and the
+    wire puts them back.
+    """
+    secret = "acme-confidential-internal-mcp"
+    readings = dict(_PINNED_READINGS)
+    readings["read_mcp_server_classes"] = _REAL
+
+    with patch(
+        "kiro_crew.mcp_discovery._load_agent_config",
+        return_value={"mcpServers": {secret: {}}},
+    ):
+        with patch("kiro_crew.mcp_discovery._load_mcp_json_by_source", return_value={}):
+            data, _ = _drive_live_build(tmp_path, monkeypatch, readings)
+
+    points = data.points(ig.GAUGE_MCP_SERVERS)
+    assert points, "the MCP gauge must still publish a count"
+    serialized = json.dumps({name: entry["points"] for name, entry in data.metrics.items()})
+    assert secret not in serialized, f"MCP server name {secret!r} leaked onto the wire"
+    assert secret not in json.dumps(data.resources), "server name leaked into the resource"
+    classes = {p["attributes"]["class"]: p["value"] for p in points}
+    assert classes.get(ig.MCP_CLASS_THIRD_PARTY) == 1, "the roster was not actually observed"
+
+
+# ---------------------------------------------------------------------------
+# tier 2 — real OTLP/HTTP export into an in-process receiver
+# ---------------------------------------------------------------------------
+
+
+def _otlp_available():
+    """Whether the optional OTLP extra and its protobuf decoder are importable."""
+    try:
+        import opentelemetry.exporter.otlp.proto.http.metric_exporter  # noqa: F401
+        from opentelemetry.proto.collector.metrics.v1 import (  # noqa: F401
+            metrics_service_pb2,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+requires_otlp = pytest.mark.skipif(
+    not _otlp_available(),
+    reason='OTLP wire tier needs the optional extra: pip install "kirocrew[otlp]"',
+)
+
+
+class _CollectingHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal OTLP/HTTP metrics receiver. Bodies land on the server object."""
+
+    def do_POST(self):  # noqa: N802 — BaseHTTPRequestHandler's required spelling
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length)
+        if self.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+        self.server.received.append((self.path, body))  # type: ignore[attr-defined]
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-protobuf")
+        self.end_headers()
+        self.wfile.write(b"")
+
+    def log_message(self, *args):  # keep pytest output clean
+        return
+
+
+class _Receiver:
+    """Loopback-only OTLP receiver, started for the duration of one test."""
+
+    def __init__(self):
+        # 127.0.0.1 explicitly: this listens for our own export and must never be
+        # reachable off the machine.
+        self._server = http.server.HTTPServer(("127.0.0.1", 0), _CollectingHandler)
+        self._server.received = []  # type: ignore[attr-defined]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=10)
+
+    @property
+    def endpoint(self):
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}/v1/metrics"
+
+    @property
+    def received(self):
+        return self._server.received  # type: ignore[attr-defined]
+
+
+@requires_otlp
+def test_otlp_export_delivers_every_instrument_and_the_resource(monkeypatch, tmp_path):
+    """A real OTLP/HTTP POST, decoded from protobuf and asserted.
+
+    Drives the production destination seam (``telemetry.otlp_endpoint`` ->
+    ``_build_otlp_reader`` -> ``OTLPMetricExporter``) rather than constructing an
+    exporter by hand, so what is verified is the path an operator actually
+    configures.
+    """
+    from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2
+
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    with _Receiver() as receiver:
+        cfg = KiroCrewConfig()
+        cfg.telemetry.enabled = True
+        cfg.telemetry.otlp_endpoint = receiver.endpoint
+        cfg.telemetry.export_interval_seconds = 3600  # only force_flush should export
+
+        monkeypatch.setenv("KIROCREW_TELEMETRY", "1")
+        for name, value in _PINNED_READINGS.items():
+            monkeypatch.setattr(ig, name, lambda _v=value: _v)
+        ig.reset_for_testing()
+        ig.mark_install_reporter()  # stand in for the gateway's claim
+        pm.reset_for_testing()
+        try:
+            with patch.object(KiroCrewConfig, "load", return_value=cfg):
+                with patch.object(pm, "_default_metrics_dir", return_value=tmp_path):
+                    recorder = pm.get_recorder()
+                    assert recorder.enabled
+                    provider = pm._provider
+                    assert provider is not None
+                    provider.force_flush()
+        finally:
+            pm.reset_for_testing()
+            ig.reset_for_testing()
+
+        assert receiver.received, "no OTLP request reached the receiver"
+
+        names = set()
+        resource_keys = set()
+        for path, body in receiver.received:
+            assert path.endswith("/v1/metrics")
+            request = metrics_service_pb2.ExportMetricsServiceRequest()
+            request.ParseFromString(body)
+            for rm in request.resource_metrics:
+                for attr in rm.resource.attributes:
+                    resource_keys.add(attr.key)
+                for sm in rm.scope_metrics:
+                    for metric in sm.metrics:
+                        names.add(metric.name)
+
+    assert "service.name" in resource_keys, "resource attributes did not reach the wire"
+    # The process-identity token is a LOCAL-sink contract: the JSONL exporter stamps
+    # it per record, and it is host-local and reboot-unique, so it must never
+    # egress. Tier 1 asserts it IS on the local shard; this asserts the same token
+    # is absent from the OTLP payload. Both halves are needed -- either one alone
+    # would pass while the attribute sat on the wrong side of the boundary.
+    assert RESOURCE_ATTR_PROCESS_START_TIME not in resource_keys, (
+        f"{RESOURCE_ATTR_PROCESS_START_TIME} egressed over OTLP; it is a host-local "
+        "token stamped by the local exporter only"
+    )
+    expected = (set(pg.ALL_METRIC_NAMES) | set(ig.ALL_METRIC_NAMES)) - _not_required()
+    missing = sorted(expected - names)
+    assert not missing, f"instruments absent from the OTLP payload: {missing}"
+
+
+@requires_otlp
+def test_otlp_temporality_preference_is_honored(monkeypatch, tmp_path):
+    """``OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`` must reach the exporter.
+
+    Asserted through ``_build_otlp_reader``, not against a hand-built exporter.
+    The claim is about OUR builder: it passes no explicit temporality, deliberately,
+    so the exporter keeps its own env-var fallback — which is what lets an operator
+    match a backend that requires DELTA (Datadog, Statsig) without a code change,
+    and what the guide documents. A hand-built exporter would only pin the SDK's
+    env handling, leaving an explicit preference added in the builder undetected;
+    reaching into the reader the builder returned is what makes that regression
+    visible here.
+    """
+    from opentelemetry.sdk.metrics import Counter
+
+    from kiro_crew.metrics.provider import _build_otlp_reader
+    from kiro_crew.platform.interfaces import OtlpDestination
+
+    class _Cfg:
+        export_interval_seconds = 60
+
+    def _temporality_for(preference):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", preference)
+        dest = OtlpDestination("test", "http://127.0.0.1:1/v1/metrics", frozenset({"metrics"}))
+        reader = _build_otlp_reader(dest, _Cfg())
+        assert reader is not None, "the extra is installed, so the builder must produce a reader"
+        try:
+            return reader._exporter._preferred_temporality[Counter].value
+        finally:
+            reader.shutdown()
+
+    # Both directions, so the assertion cannot pass on a builder that pins one of
+    # them: an explicit preference in _build_otlp_reader fails whichever value it
+    # is not, and ignoring the env entirely fails one of the two.
+    assert (
+        _temporality_for("DELTA") == _DELTA
+    ), "DELTA not honored: the builder is overriding the exporter's env-var fallback"
+    assert (
+        _temporality_for("CUMULATIVE") == _CUMULATIVE
+    ), "CUMULATIVE not honored: the builder is overriding the exporter's env-var fallback"


### PR DESCRIPTION
## Problem / Motivation

Nothing samples what an install has actually configured. `process_gauges` answers
"how is this process behaving" -- threads, file descriptors, RSS, GC -- but an
operator running Kiro Crew on more than one machine has no way to see that a host
stopped scheduling crons, that skills and knowledge documents are piling up on one
box and absent on another, or that a feature switch differs between hosts. The
dashboard shows one machine's counts on request; nothing samples them over time, so
config drift between hosts is only visible by opening each dashboard in turn.

**Scope, stated up front because the metric names invite the opposite reading:**
this is operator-fleet telemetry, not project-wide adoption analytics. Collection is
off by default, egress is a second opt-in, and OTLP needs the `kirocrew[otlp]`
extra, so any aggregate over these gauges describes one operator's own opted-in
machines. Install analytics structurally cannot ride this trunk -- `beacon.py` is
that channel, and its docstring plus the spec's "Why it is NOT part of the OTEL
trunk" section give four independently disqualifying reasons. That boundary is now
written into the module docstring, the spec, and the operator guide so it is not
re-litigated later.

**What this answers today, and what it does not.** Hosts are separable at a moment:
`service.instance.id` comes from the SDK's default resource, and the version pinned
for the `kirocrew[otlp]` extra (1.44.0) supplies it. What is NOT available yet is the
longitudinal per-host view, because that id is regenerated per process, so a host's
series restarts with its gateway. The fix is a persisted install-scoped resource
identity and it is already in flight as #7266, which makes `service.instance.id` the
persisted `beacon.install_id`. Nothing here needs to change when it lands: the
resource assertions in this PR compare against the provider's own resource rather
than a fixed list, so new attributes are covered the moment they appear. That work
is also the precondition for ever removing the reporter election below, though not a
drop-in replacement for it: a stable install id makes downstream dedup possible
(`max by (install)`), but that is query-time discipline -- the data would still carry
one copy per process, and a naively written fleet `sum` would read N times the truth,
where the election makes it correct at the point of emit. Until then
these gauges are honest as fleet aggregates and as point-in-time per-instance
readings, and the operator guide says so where an operator will hit it.

There is a second, narrower gap. `test/metrics/test_local_exporter.py` already proves
serialization, but it proves it of the exporter alone: built directly and fed from a
provider assembled in the test. Nothing asked the same question of the **live build**
-- that the roster `provider._build_recorder()` registers actually arrives, carrying
the attribute values the modules declare, at the temporality each instrument kind
requires. An instrument can be missing outright, and an attribute value or a
temporality setting can be correct in the SDK's in-memory view and still be dropped
or wrong by the time it leaves the process, and nothing would catch it.

## Why it matters

An operator cannot currently distinguish a host that is idle from one whose cron
store stopped loading, or notice that one machine's skills tree drifted, without
checking each dashboard by hand. These are exactly the questions a time series
answers cheaply and a point-in-time panel cannot.

Without a serialization test, the failure mode is silent and lands on operators:
metrics appear to work locally, then arrive at a backend missing a label or with
counters that look like they reset constantly. That is the class of defect that
survives to production because the in-memory assertion passed.

## What changed (motivation -> approach -> change)

**Inventory gauges.** `src/kiro_crew/metrics/inventory_gauges.py` adds eight
observable gauges under `kirocrew.inventory.*`, mirroring `process_gauges`
deliberately rather than inventing a second pattern: callbacks run only when a
reader collects, registration happens on `_build_recorder`'s live path so the
`telemetry.enabled` consent gate covers them, raw readers stay SDK-free so they are
unit-testable without a pipeline, and a probe that cannot answer yields **no
observation** rather than a fake zero.

Cost drove most of the design. A callback runs once per export interval *per
reader*, so an install with an OTLP destination configured enters these on two
ticker threads concurrently. Every probe is O(1) in-memory, one small file parse, or
explicitly TTL-cached, and the module documents the cost class of each:

- crons: reads `crons.json` through cron's own record helpers -- the same ones
  `count_enabled_from_disk` uses, so it cannot drift from what the scheduler
  considers enabled. Deliberately not `list_jobs`, which re-arms the asyncio timer
  and from a reader thread would raise *after* cancelling the live timer, stopping
  every scheduled job.
- skills and knowledge are the two genuinely expensive probes (a recursive walk, a
  SQLite open) and are cached 300s. The knowledge probe opens SQLite **read-only**
  and only when the database already exists: constructing a `KnowledgeStore` runs
  schema init plus graph load and would *create* the database on an install that
  never ingested anything.
- monitor loops read the auto-nudge registry via a materialized snapshot, which is
  safe from a foreign thread even though the registry's `asyncio.Lock` is not.

Privacy shaped one choice, and rejected a second. MCP server names are read to
classify and then discarded -- only `first_party` / `third_party` counts leave,
because a roster is user-chosen text and would be both unbounded cardinality and a
disclosure of what the user has installed. Knowledge and lesson counts, by contrast,
publish the **raw number**: banding them was the tempting move on the theory that an
exact count is a slowly-changing fingerprint, but that argument does not survive the
scope above. These metrics only reach the collector the operator configured, about
machines that operator already owns and can identify by far more than a document
count -- so the band protects nobody, while it costs a series per band, renders
growth inside a band (the drift the gauge exists for) as a flat line, and fixes the
boundaries at emit time. A backend can band a raw count at query time; it cannot
recover a count from a band. The product's own thresholds (50 = `knowledge.max_sources`
default, 200 = lesson prune ceiling) are named in the operator guide instead.

**One publisher per install.** Install-level facts are identical across the several
processes an install runs at once -- gateway, MCP gateway daemon, spawned agents -- so
publishing them from each would count one install once per process: a fleet sum reads
N times the truth, and a fleet average is dragged toward whichever installs happen to
run the most processes.
Deduplicating downstream needs an install-scoped resource identity that does not exist
yet, so exactly one process publishes: the gateway calls `mark_install_reporter()`, and
every callback checks the claim at COLLECT time rather than at registration, so a
recorder built before the claim publishes nothing until it lands instead of publishing
wrongly.

Its placement is part of that contract, not an incidental detail. Nothing enforces the
election at runtime, and an unclaimed install is silent in both directions -- the
callbacks return before probing, so even `probe.failures` stays empty and the family
reads exactly like a host that stopped exporting. So the claim sits in
`GatewayOrchestrator.run()` at a point no branch guards, and
`test_reporter_claim_is_unconditional` parses the gateway to assert that: called
exactly once, from `run()`, without passing through a conditional (`try` is allowed --
telemetry must never block boot).

Three points where the intended design did not survive contact with the code, all
resolved toward reporting something true rather than something convenient:

1. There is **no `memory.enabled` flag**. The embedding provider is coerced to a
   real value on load, so memory is structurally always on and an "enabled" gauge
   could only ever read 1. The gauge reports `memory.migrated` instead, which is a
   real question (how far the vector-store migration has reached).
2. `telemetry.enabled` is **excluded** from the toggle set: this module only runs
   inside the consent gate, so it is a tautology dressed as a measurement.
3. The first-party MCP set reuses `mcp_discovery._MANAGED_SERVER_NAMES` rather than
   restating a name list that would drift silently the first time a managed server
   is renamed.

**Verification.** `test/metrics/test_otlp_wire_e2e.py` closes the serialization gap
in two tiers. Tier 1 drives the real `_build_recorder` live path through its real
exporter and asserts the instrument roster, resource-attribute *fidelity*, the
closed attribute enums, and temporality. Fidelity is asserted by comparing the
serialized resource against the live provider's own resource rather than a hardcoded
list, so an attribute added to the resource later is covered the moment it lands and
one the exporter silently drops fails here. Tier 2 posts through a real
`OTLPMetricExporter` to an in-process receiver bound to loopback and decodes the
protobuf; it skips unless the optional `kirocrew[otlp]` extra is installed.

The two tiers together also pin a boundary neither could pin alone:
`kirocrew.process.start_time` is a host-local, reboot-unique token the JSONL
exporter stamps per record, so tier 1 asserts it IS on the local shard and tier 2
asserts it is absent from the OTLP payload. Either assertion alone passes while the
attribute sits on the wrong side of the boundary.

Those two tiers are the whole automated surface, and they stop at the process
boundary. Driving a real collector needs a downloaded binary and outbound network, so
it cannot be a test in a network-isolated CI, and this PR does not ship a script for
it either: the operator guide describes how to do that check by hand against whatever
collector you already run, which is the form that survives a version bump. See the
Tests section for the one-time run that was done during development, and what it is
and is not evidence of.

Production wiring outside the new module is three hunks. `provider.py` registers the
inventory gauges next to the process ones, in its **own** `try` block so a failure in
either family cannot cost the other -- they read entirely different subsystems.
`slack/gateway.py` claims the reporter role, as above. And `cron.py` gains
`enabled_count_from_disk(path) -> (count, loadable)`, a module-level sibling of
`unhealthy_jobs_from_disk` that becomes the single owner of the enabled-count
reduction: `CronService.count_enabled_from_disk` now calls it and keeps the count,
this probe calls it and needs `loadable` too. Both sides previously carried their own
spelling of that loop.

Docs: `docs/guides/telemetry-otlp-export.md` covers pointing the exporter at a
collector and on to CloudWatch, Datadog, or any OTLP-compatible backend, with
collector config samples (explicitly marked illustrative and not tracked, since
vendor options drift with releases this repo does not follow), the two separate
consent switches, what is and is not exported, and
`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` -- the setting that decides
whether a backend accepts the data, which works precisely because the reader builder
passes no explicit temporality. `docs/system-specs/modules/metrics.md` gains a row
per new instrument, so the spec moves with the code.

## Tests

`test/metrics/test_inventory_gauges.py` (43 cases), four layers matching the
module:

- **Raw readers**: each probe's happy path, and its None-vs-zero split individually
  pinned. The split is not just none-vs-zero but SILENT-vs-COUNTED: an absent source
  is a quiet gap because nothing is broken (no auto-nudge service in this process, a
  knowledge database on an install that never ingested, a missing cron store on a
  fresh install), while a source that is PRESENT and unreadable is a fault and
  increments `probe.failures` before returning None. An unparseable `crons.json` is
  the case in point -- cron's own `_read_job_records` calls it a fault, and a silent
  gap there would be indistinguishable from a host that stopped exporting, which is
  the confusion the counter exists to resolve. Pinned at the reader level and again
  through a real collection.
- **Cost contract**: the TTL cache produces once within its window, re-produces
  after expiry, and caches a `None` answer so an install that can never answer does
  not re-pay an expensive probe every cycle.
- **Side-effect ratchet**: the knowledge probe must not create the database, and its
  read-only connection must refuse a write.
- **Anti-typo ratchet**: `test_every_declared_toggle_resolves_against_a_real_config`
  asserts every declared toggle resolves against a real config. The runtime omits an
  unresolvable key (a renamed field must read as a missing series, never as a switch
  someone turned off), which is right but would hide a typo forever; this is what
  makes the omission observable.
- **Drift ratchet**: asserts no managed server name is restated in this module, so
  the constant stays the single owner.
- **Privacy ratchet**: an injected distinctive server name must appear in no
  attribute key or value.
- **Series-shape ratchet**: the two store-backed counts must arrive as one
  attribute-free series carrying the pinned reading, at the reader level and again on
  the wire -- a reintroduced band fails both halves (constant 1, plus an attribute).
- **Call-site ratchet**: `test_reporter_claim_is_unconditional` parses the gateway and
  asserts `mark_install_reporter()` is called exactly once, from `run()`, without
  passing through a conditional -- the one invariant that has no runtime enforcement
  and no failure signal when it breaks.
- **Failure isolation**: a raising or unavailable reader yields a gap while every
  other metric survives; registration never raises even on a hostile meter; and an
  inventory registration failure does not cost the process gauges.

`test/metrics/test_otlp_wire_e2e.py` (14 cases) as described above, including the
privacy ratchet repeated at the serialization boundary -- the reader-level test
proves names are discarded, this proves nothing downstream puts them back.

Both e2e tiers pin their probe readings rather than reading host state, so the
assertions are about the serialization contract and cannot flake on whether the
machine running them happens to have a knowledge database or any crons.

## Manual verification

- `pytest test/metrics/ -q` run three times: 549 passed each time.
- flake8, isort, mypy clean on the changed files; the repo's own
  `scripts/check_black_formatting.py` passes with the changed files in scope, and
  `scripts/docs-lint.sh` passes.
- Per-file coverage on the new module: 98% (195 statements, 2 missed), against the
  80% floor.
- OTLP tier 2 was run with the optional extra installed locally (it skips without
  it), so the skipped-in-CI tier is not untested code.
- A real `otelcol` was driven end to end ONCE during development -- checksum verified,
  collector started, one export pushed through it, 16 instruments confirmed received.
  That is a one-time result, not a gate: nothing in this PR re-runs it, and it does not
  protect against a future regression. It is reported here because it is the only
  evidence that a real collector accepts this payload; the repeatable half of that
  check is tier 2, which decodes the real exporter's protobuf in CI.
- Semgrep suppressions were verified locally in both directions (each rule fires
  under `--disable-nosem` and is silent without it), rather than by re-running CI.

## Related Issues

Refs #7232 #7257






