### PR TITLE
refactor(agent-sdk): ask one predicate for the configured provider

### DIFF
--- a/.github/agent-sdk-boundary-baseline.txt
+++ b/.github/agent-sdk-boundary-baseline.txt
@@ -4,9 +4,17 @@
 # a consumer look migrated while still reading the backend's own types.
 #
 # The gate requires every OTHER file under src/ to be clean and none of these
-# counts to grow, so this list can only shrink. There is no inline opt-out
-# marker: "this consumer legitimately needs ACP" is the claim the boundary
-# refuses, so the baseline is the only exemption mechanism.
+# counts to grow, so the list can shrink but never grow.
+#
+# It is a floor, not a countdown to zero. Most of these consumers are expected
+# to keep reading ACP directly: ACP is the foundation the SDK is built on, not
+# a layer being hidden behind it. What the gate buys is that the dependency
+# cannot SPREAD into a file that is clean today -- which is what makes it safe
+# to consolidate provider-specific logic gradually instead of in one sweep.
+#
+# There is no inline opt-out marker: "this consumer legitimately needs ACP" is
+# the claim the boundary refuses, so the baseline is the only exemption
+# mechanism.
 #
 # Do NOT add or raise a line to make a red gate green -- route the dependency
 # through kiro_crew.agent_sdk instead. Design of record:

--- a/scripts/check_agent_sdk_boundary.py
+++ b/scripts/check_agent_sdk_boundary.py
@@ -100,8 +100,9 @@ DEFAULT_TARGETS = ("src",)
 # Import targets application code may not reach.
 FORBIDDEN_ROOTS = ("kiro_crew.acp", "kiro_crew.providers")
 
-# Source trees that ARE the boundary. providers/ is temporary -- it goes when the
-# package is deleted in the RFC's final phase.
+# Source trees that ARE the boundary: the SDK plus the two packages it is built
+# on. All three stay. ACP is the SDK's foundation rather than an implementation
+# detail being sealed off, so providers/ is not scheduled for deletion.
 EXEMPT_PREFIXES = (
     "src/kiro_crew/agent_sdk/",
     "src/kiro_crew/acp/",
@@ -117,9 +118,17 @@ HEADER = """\
 # a consumer look migrated while still reading the backend's own types.
 #
 # The gate requires every OTHER file under src/ to be clean and none of these
-# counts to grow, so this list can only shrink. There is no inline opt-out
-# marker: "this consumer legitimately needs ACP" is the claim the boundary
-# refuses, so the baseline is the only exemption mechanism.
+# counts to grow, so the list can shrink but never grow.
+#
+# It is a floor, not a countdown to zero. Most of these consumers are expected
+# to keep reading ACP directly: ACP is the foundation the SDK is built on, not
+# a layer being hidden behind it. What the gate buys is that the dependency
+# cannot SPREAD into a file that is clean today -- which is what makes it safe
+# to consolidate provider-specific logic gradually instead of in one sweep.
+#
+# There is no inline opt-out marker: "this consumer legitimately needs ACP" is
+# the claim the boundary refuses, so the baseline is the only exemption
+# mechanism.
 #
 # Do NOT add or raise a line to make a red gate green -- route the dependency
 # through kiro_crew.agent_sdk instead. Design of record:

--- a/src/kiro_crew/agent_sdk/__init__.py
+++ b/src/kiro_crew/agent_sdk/__init__.py
@@ -17,7 +17,11 @@ Layering::
     consumers        dashboard/  slack/  discord/  telegram/  messaging/
                      session.py  subagent.py  apps/  cli_*.py  workflows/
                             |
-                            |  may import ONLY kiro_crew.agent_sdk
+                            |  import kiro_crew.agent_sdk for anything
+                            |  provider-specific. A file ALREADY in the
+                            |  boundary baseline keeps its direct ACP
+                            |  imports; a file that is clean today is
+                            |  REFUSED a new one by the gate
                             v
                      kiro_crew.agent_sdk          domain types, role protocols,
                                                   capabilities, supervisor
@@ -25,10 +29,11 @@ Layering::
                             |  resolves drivers through a registry
                             v
                      kiro_crew.agent_sdk.drivers.acp
-                                                  the ONLY module permitted to
-                                                  import kiro_crew.acp
+                                                  the only module INSIDE this
+                                                  package that imports
+                                                  kiro_crew.acp
                             v
-                     kiro_crew.acp   (private)    wire, dialects, adapters,
+                     kiro_crew.acp  (foundation)  wire, dialects, adapters,
                                                   session handles, worker pool
 
 If the gate goes red you introduced a boundary violation: fix the import

--- a/src/kiro_crew/agent_sdk/provider_identity.py
+++ b/src/kiro_crew/agent_sdk/provider_identity.py
@@ -1,0 +1,71 @@
+"""Which provider a session is configured to run on.
+
+This is the ``agent.provider`` axis: the config key an operator sets, whose
+value reaches roughly a dozen branches that need to know "am I on Claude Code".
+Those branches used to spell the value inline, which made the provider-specific
+logic impossible to find by grep and impossible to change in one place.
+
+Four different things are spelled ``"claude_code"`` in this codebase and only
+the FIRST is this module's business. Consolidating the others into this one
+would be wrong, so they are named here to keep the next reader from trying:
+
+1. **This axis** -- the ``agent.provider`` config value, and the question
+   "is the configured provider Claude Code". Owned here.
+
+2. **The session-map provider label** -- ``PROVIDER_LABEL_CLAUDE`` in
+   :mod:`kiro_crew.acp.types`. Same string, different job: it indexes resume
+   compatibility, session-map persistence, and session-file cleanup routing.
+   It has its own constant already; use that one when writing a session map.
+
+3. **A model-registry index key** -- inside :mod:`kiro_crew.model_registry`,
+   ``"claude_code"`` names a registry namespace, NOT a provider check. The
+   module says so where it matters: *"Named for the registry key, NOT because
+   windows are claude_code-only."* A model's context window is a property of
+   the model, not of the provider serving it. Do not route those through the
+   predicate below -- it would assert a provider identity the code is
+   explicitly not testing.
+
+4. **An onboarding import-source id** -- in :mod:`kiro_crew.onboarding_import`,
+   ``"claude_code"`` identifies the Claude Code desktop app whose settings are
+   being imported (``~/.claude``, ``CLAUDE_CONFIG_DIR``). It describes a
+   foreign config tree on disk and is unrelated to what this process runs on.
+
+(1) and (2) hold equal values today and are pinned equal by a test rather than
+by an import, so a future divergence fails loudly instead of silently coupling
+config vocabulary to session-map vocabulary.
+
+Deliberately dependency-free: only stdlib, no ``kiro_crew`` imports, so this
+module can never be the module that closes an import cycle.
+
+Note what that does NOT buy. Importing ``kiro_crew.agent_sdk.provider_identity``
+executes the parent package's ``__init__``, which loads ``backend_install`` and
+``agent_sdk.drivers.acp`` -- naming the submodule does not skip them. What keeps
+that cheap is that the chain is import-light rather than absent: ``acp_backends``
+is stdlib-only, and ``drivers.acp`` defers every ``kiro_crew.acp`` import into a
+function body, so ``kiro_crew.acp`` itself stays unloaded. That last property is
+pinned by ``test_importing_this_module_does_not_load_the_acp_package``.
+"""
+
+from __future__ import annotations
+
+#: ``agent.provider`` value selecting the Claude Code seam (claude-agent-acp).
+#: Dormant in the public build, where the schema admits only ``PROVIDER_ACP``;
+#: an edition re-registers it.
+PROVIDER_CLAUDE_CODE = "claude_code"
+
+#: ``agent.provider`` value selecting the ACP family (kiro-cli and KAS). The
+#: default, and the only value the public build's config schema accepts.
+PROVIDER_ACP = "acp"
+
+
+def is_claude_code(provider: str | None) -> bool:
+    """Whether *provider* names the Claude Code seam.
+
+    Takes the raw ``agent.provider`` string (or a value already threaded down
+    from it) so every caller asks the question the same way, whether it read
+    config itself or received the value as an argument.
+
+    A missing or empty value is NOT Claude Code: absent config means the
+    default provider, so this answers False rather than guessing.
+    """
+    return provider == PROVIDER_CLAUDE_CODE

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -34,6 +34,7 @@ from kiro_crew.agent_discovery import (
     project_agent_files,
     project_agent_name,
 )
+from kiro_crew.agent_sdk.provider_identity import is_claude_code
 from kiro_crew.agents_janitor import sweep_agents_dir
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config import KiroCrewConfig
@@ -421,7 +422,7 @@ def _agent_spec_model_problems(
     """
     # The retained claude_code seam accepts its own registered wire ids. The
     # correction below is specifically an ACP/kiro-cli spelling audit.
-    if provider == "claude_code":
+    if is_claude_code(provider):
         return []
 
     problems: list[tuple[str, str, str]] = []

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from kiro_crew import model_registry
 from kiro_crew.agent import _prompt_path
 from kiro_crew.agent_discovery import agent_skill_globs
+from kiro_crew.agent_sdk.provider_identity import is_claude_code
 from kiro_crew.config.loader import KiroCrewConfig, workspace_dir_for
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.cron import get_local_tz
@@ -1815,7 +1816,11 @@ class ContextBuilder:
             self._bot_name = bot_name
         else:
             cfg = KiroCrewConfig.load()
-            self._bot_name = "KiroCrew" if cfg.agent.provider == "claude_code" else "Kiro"
+            provider = cfg.agent.provider
+            # The joined spelling is the {bot_name} value the prompt
+            # substitutes, not prose about the product: respelling it would
+            # change what the model is told to answer to.
+            self._bot_name = "KiroCrew" if is_claude_code(provider) else "Kiro"  # brand-ok
         # Register default memory in the workspace cache
         _memory_stores["default"] = self.memory
 
@@ -2118,7 +2123,7 @@ class ContextBuilder:
         deployment's effective window), leaving that path byte-for-byte
         unchanged.
 
-        All providers — including ``provider_type="claude_code"`` — receive the
+        All providers — including Claude Code — receive the
         same injected context (critical rules, thread history, memory, skills,
         lessons); steering files are the one exception (see below). This keeps
         Claude Code at parity with kiro so dashboard/Slack UI contracts (diff
@@ -2127,7 +2132,7 @@ class ContextBuilder:
 
         *provider_type* is consumed again for the steering gate only: the
         steering block below is injected solely on the CC backend
-        (``provider_type == "claude_code"``). kiro-cli loads an agent's
+        (``is_claude_code(provider_type)``). kiro-cli loads an agent's
         ``resources`` natively when spawned with ``--agent`` (acp/client.py
         ``_spawn``), so re-injecting steering on the ACP/kiro backend would
         duplicate what kiro already loaded; the CC backend (claude-agent-acp)
@@ -2151,7 +2156,7 @@ class ContextBuilder:
         and hooks are injected for all agents.
         """
         is_custom = agent and agent != "kirocrew"
-        is_cc = provider_type == "claude_code"
+        is_cc = is_claude_code(provider_type)
         caps = _resolve_caps(model_window)
         parts: list[str] = []
 
@@ -2664,7 +2669,7 @@ class ContextBuilder:
         # Set together with the user's text part when user_text_range is given.
         _user_bounds: tuple[int, int] | None = None
         _user_part_index: int | None = None
-        is_cc = provider_type == "claude_code"
+        is_cc = is_claude_code(provider_type)
 
         # Session context on first message only
         if is_new_session:

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -25,6 +25,7 @@ from kiro_crew import members as members_mod
 from kiro_crew import model_registry
 from kiro_crew.acp.client import AcpModelUnavailable
 from kiro_crew.agent_discovery import cached_project_agent_names, warm_project_agent_names
+from kiro_crew.agent_sdk.provider_identity import is_claude_code
 from kiro_crew.config.loader import (
     KiroCrewConfig,
     _workspace_name_for_dir,
@@ -4364,7 +4365,7 @@ def _model_rejected_reason(model_name: str, provider: str | None = None) -> str 
             provider = KiroCrewConfig.load().agent.provider
         except Exception:  # pragma: no cover - config load is resilient
             provider = ""
-    if provider == "claude_code":
+    if is_claude_code(provider):
         return None
     if model_registry.is_canonical_key(model_name):
         return (

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -39,6 +39,7 @@ from kiro_crew.acp.types import (
     STOP_REASON_TOOL_STALL,
 )
 from kiro_crew.agent_discovery import warm_project_agent_names
+from kiro_crew.agent_sdk.provider_identity import is_claude_code
 from kiro_crew.autonudge import get_instance
 from kiro_crew.config.loader import (
     KiroCrewConfig,
@@ -802,7 +803,7 @@ def _backfill_canonical_model(client: Any, provider: str) -> str:
     prov_model = getattr(getattr(client, "client", None), "_model", "") or ""
     if not (isinstance(prov_model, str) and prov_model and prov_model != "auto"):
         return ""
-    if provider != "claude_code" and _is_bedrock_profile_id(prov_model):
+    if not is_claude_code(provider) and _is_bedrock_profile_id(prov_model):
         return ""
     return model_registry.canonicalize_for_provider(prov_model, provider)
 
@@ -832,7 +833,7 @@ def _pinned_model_withheld(client: Any, model: str, provider: str) -> bool:
     (or a provider with no getter) leaves the pin alone: entitlement unknown is
     not entitlement denied.
     """
-    if not model or model == "auto" or provider == "claude_code":
+    if not model or model == "auto" or is_claude_code(provider):
         return False
     if getattr(client, "is_claude_backend", False):
         return False
@@ -5006,7 +5007,7 @@ async def _run_chat(
 
     # ── Slash commands: detect early, before session acquisition ──
     first_word = message.split()[0] if message.strip() else ""
-    _is_cc_provider = KiroCrewConfig.load().agent.provider == "claude_code"
+    _is_cc_provider = is_claude_code(KiroCrewConfig.load().agent.provider)
     # Named rather than inlined so the quick-prompt exception is one testable rule
     # instead of a condition only reachable by driving this whole function: a macro
     # must NOT be forwarded to the harness as a command.

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -36,6 +36,7 @@ from kiro_crew.agent_discovery import (
     spec_model,
     spec_str,
 )
+from kiro_crew.agent_sdk.provider_identity import is_claude_code
 from kiro_crew.apps.bridges import _mcp_lock as _agent_file_lock
 from kiro_crew.apps.bridges import _registration_source
 from kiro_crew.apps.manager import (
@@ -2003,7 +2004,7 @@ async def api_effort_levels(request: web.Request) -> web.Response:
 async def api_slash_commands(request: web.Request) -> web.Response:
     """GET /api/slash-commands — list available slash commands (provider-aware)."""
     cfg = KiroCrewConfig.load()
-    if cfg.agent.provider == "claude_code":
+    if is_claude_code(cfg.agent.provider):
         state: DashboardState = request.app["state"]
         cc_commands: list[str] = []
         for provider in state.sessions.active_providers():
@@ -2617,7 +2618,7 @@ def _model_pin_rejected(model: str, request: web.Request, provider: str) -> str 
     # intentionally map away from. Its entitlement guard lives in its own
     # provider path, where full configured ids and bare advertised ids can be
     # canonicalized before comparison.
-    if provider == "claude_code":
+    if is_claude_code(provider):
         return None
 
     # The registry knows each model under several spellings and only one is what

--- a/src/kiro_crew/knowledge/llm_pool.py
+++ b/src/kiro_crew/knowledge/llm_pool.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from kiro_crew import platform_compat
+from kiro_crew.agent_sdk.provider_identity import is_claude_code
 from kiro_crew.config.paths import config_dir
 from kiro_crew.effort import EFFORT_LEVELS, is_valid_effort
 from kiro_crew.sandbox import (
@@ -662,7 +663,7 @@ class LLMPool:
 
     async def _create_worker(self) -> Worker:
         """Create and start a new worker based on provider type."""
-        if self._provider_type == "claude_code":
+        if is_claude_code(self._provider_type):
             worker: Worker = CCWorker()
         else:
             worker = AcpWorker(

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -1056,6 +1056,7 @@ class SessionManager:
                 drain_active_turns_timeout_secs=_DRAIN_ACTIVE_TURNS_TIMEOUT_SECS,
                 unbind_reason_session_destroyed=UNBIND_REASON_SESSION_DESTROYED,
                 first_turn_nothing_armed=FirstTurnState.NOTHING_ARMED,
+                provider_label_claude=PROVIDER_LABEL_CLAUDE,
             ),
             get_unlink_session_queue=lambda: _unlink_session_queue,
             get_child_process_helpers=lambda: _load_child_process_helpers(),

--- a/src/kiro_crew/session_allocation.py
+++ b/src/kiro_crew/session_allocation.py
@@ -1074,7 +1074,7 @@ class SessionAllocationService:
                             owner._session_map.set(
                                 key,
                                 session.provider.session_id,
-                                provider="claude_code",
+                                provider=constants.provider_label_claude,
                                 cwd=session.provider.cwd,
                             )
                         # The semaphore may be held for a full turn; claim it
@@ -1373,7 +1373,7 @@ class SessionAllocationService:
                             owner._session_map.set(
                                 key,
                                 sid,
-                                provider="claude_code",
+                                provider=constants.provider_label_claude,
                                 cwd=provider_cwd,
                             )
 

--- a/src/kiro_crew/session_lifecycle.py
+++ b/src/kiro_crew/session_lifecycle.py
@@ -146,6 +146,7 @@ class SessionLifecycleConstants:
     drain_active_turns_timeout_secs: float
     unbind_reason_session_destroyed: str
     first_turn_nothing_armed: object
+    provider_label_claude: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -889,7 +890,7 @@ class SessionLifecycleService:
                         owner._session_map.set(
                             key,
                             sid,
-                            provider="claude_code",
+                            provider=constants.provider_label_claude,
                             cwd=cwd_str,
                         )
 

--- a/test/test_agent_sdk_boundary.py
+++ b/test/test_agent_sdk_boundary.py
@@ -98,6 +98,26 @@ def test_the_forbidden_roots_include_the_re_export_channel(gate):
     assert "kiro_crew.providers" in gate.FORBIDDEN_ROOTS
 
 
+def test_the_baseline_header_comes_from_the_generator(gate):
+    """The committed baseline must start with the generator's own HEADER.
+
+    ``_write_baseline`` writes ``HEADER + body``, so the script is the source of
+    truth for that prose and the committed file is only its output. Editing the
+    file directly looks like it works and then silently reverts the moment
+    anyone runs ``--update-baseline`` -- which is exactly how the "floor, not a
+    countdown" rationale was lost once already.
+
+    Keeping them equal is what lets a reader trust the committed header: it is
+    the text every future refresh will reproduce.
+    """
+    committed = BASELINE.read_text(encoding="utf-8")
+    assert committed.startswith(gate.HEADER), (
+        "the committed baseline does not begin with scripts/"
+        "check_agent_sdk_boundary.py's HEADER -- put the prose in HEADER and "
+        "regenerate with --update-baseline, rather than editing the artifact"
+    )
+
+
 def test_every_recorded_violation_still_exists(gate):
     """A paid-off entry must be pruned; a stale baseline stops shrinking."""
     baseline = gate._read_baseline(BASELINE)

--- a/test/test_agent_sdk_provider_identity.py
+++ b/test/test_agent_sdk_provider_identity.py
@@ -1,0 +1,238 @@
+"""GATE — the ``agent.provider`` identity question has exactly one spelling.
+
+``"claude_code"`` means four unrelated things in this codebase, and only one of
+them is a provider identity check. This test pins that separation so a future
+sweep cannot quietly merge them:
+
+1. **The provider-identity axis** — ``agent.provider``, asked through
+   :func:`kiro_crew.agent_sdk.provider_identity.is_claude_code`. The eleven
+   branches that used to spell the literal inline now route through it, and
+   :func:`test_no_converted_file_compares_the_literal` keeps them there.
+2. **The session-map provider label** — ``PROVIDER_LABEL_CLAUDE``. Equal in
+   value, different in job. Pinned equal by
+   :func:`test_config_value_and_session_map_label_agree` so a divergence fails
+   loudly instead of silently coupling two vocabularies.
+3. **A model-registry index key** — inside ``model_registry``, the string names
+   a namespace, not a provider. Deliberately NOT converted; a model's context
+   window is a property of the model, not of the provider serving it.
+4. **An onboarding import-source id** — the Claude Code desktop app whose
+   settings are imported. Pinned by
+   :func:`test_onboarding_import_source_id_is_left_alone` so a consolidation
+   sweep has to read the reason before changing it.
+
+The ratchet reads the AST rather than the file text, so a docstring that quotes
+the old spelling neither satisfies nor trips it.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.agent_sdk.provider_identity import (
+    PROVIDER_ACP,
+    PROVIDER_CLAUDE_CODE,
+    is_claude_code,
+)
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+#: Files whose provider-identity branches were converted. Each must ask the
+#: predicate and must not compare the literal.
+CONVERTED = (
+    "context.py",
+    "cli_doctor.py",
+    "knowledge/llm_pool.py",
+    "dashboard/chat_handlers.py",
+    "dashboard/chat_runner.py",
+    "dashboard/handlers/agents.py",
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("claude_code", True),
+        ("acp", False),
+        ("kas", False),
+        ("", False),
+        (None, False),
+        ("Claude_Code", False),
+        ("claude", False),
+    ],
+)
+def test_predicate_truth_table(value: str | None, expected: bool) -> None:
+    """Only the exact id is Claude Code.
+
+    ``"claude"`` is explicitly False: that is the ``agent.acp_backend`` value
+    for the same seam, on a different axis. Accepting it here would let a
+    caller on the wrong axis get a plausible-looking answer.
+    """
+    assert is_claude_code(value) is expected
+
+
+def test_absent_config_is_not_claude_code() -> None:
+    """A missing value means the default provider, not an unknown one."""
+    assert is_claude_code(None) is False
+    assert is_claude_code("") is False
+    assert is_claude_code(PROVIDER_ACP) is False
+
+
+def test_config_value_and_session_map_label_agree() -> None:
+    """The config value and the session-map label must stay equal.
+
+    They are two vocabularies that happen to share a spelling. This asserts the
+    equality instead of importing one from the other, so if a future change
+    moves one of them the failure names both rather than silently rewriting
+    session-map entries.
+    """
+    from kiro_crew.acp.types import PROVIDER_LABEL_CLAUDE
+
+    assert PROVIDER_CLAUDE_CODE == PROVIDER_LABEL_CLAUDE
+
+
+def test_module_is_dependency_free() -> None:
+    """No ``kiro_crew`` imports, so this module cannot be the one that closes a cycle.
+
+    Consumers include ``context.py`` and ``chat_runner.py``. If this module ever
+    imports back into the package, one of those import graphs closes a loop.
+
+    This pins the module's OWN imports only. Importing it still executes the
+    ``agent_sdk`` package ``__init__``, which loads ``backend_install`` and
+    ``drivers.acp``; that chain is safe because it is import-light, not because
+    naming the submodule avoids it.
+    """
+    tree = ast.parse((SRC / "agent_sdk" / "provider_identity.py").read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+        elif isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+    assert [m for m in imported if m.startswith("kiro_crew")] == []
+
+
+def test_importing_this_module_does_not_load_the_acp_package() -> None:
+    """Importing the predicate must not pull ``kiro_crew.acp`` into the process.
+
+    Importing this submodule DOES execute the ``agent_sdk`` package ``__init__``,
+    so ``backend_install`` and ``drivers.acp`` load -- that is expected and is
+    asserted here so the cost is visible rather than surprising. What must NOT
+    load is ``kiro_crew.acp`` itself, which stays out only because
+    ``drivers/acp.py`` defers those imports into function bodies.
+
+    The static boundary gate cannot catch a regression here: if the driver
+    stopped deferring, the new edge would sit INSIDE the exempt ``agent_sdk/``
+    tree and the gate would stay green while every consumer of the SDK began
+    loading the ACP package at import time.
+
+    Runs in a subprocess because ``sys.modules`` is process-wide -- by the time
+    this test executes, the suite has already imported half the package.
+    """
+    probe = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(SRC.parent)!r})\n"
+        "from kiro_crew.agent_sdk.provider_identity import is_claude_code\n"
+        "assert is_claude_code('claude_code') is True\n"
+        "loaded = {\n"
+        "    'backend_install': 'kiro_crew.agent_sdk.backend_install' in sys.modules,\n"
+        "    'drivers_acp': 'kiro_crew.agent_sdk.drivers.acp' in sys.modules,\n"
+        "    'acp': 'kiro_crew.acp' in sys.modules,\n"
+        "}\n"
+        "print(repr(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        cwd=str(SRC.parent.parent),
+        **UTF8_TEXT,
+    )
+    assert result.returncode == 0, f"probe failed: {result.stderr[-2000:]}"
+    loaded = ast.literal_eval(result.stdout.strip().splitlines()[-1])
+
+    assert loaded["acp"] is False, (
+        "importing agent_sdk.provider_identity loaded kiro_crew.acp; "
+        "drivers/acp.py must keep deferring its ACP imports into function bodies, "
+        "or every SDK consumer pays the ACP package at import time"
+    )
+    # Asserted, not merely tolerated: these DO load, and the module docstring
+    # says so. If a future change makes them lazy, update the docstring too.
+    assert loaded["backend_install"] is True
+    assert loaded["drivers_acp"] is True
+
+
+def _literal_comparisons(path: Path) -> list[int]:
+    """Line numbers where code compares something against ``"claude_code"``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not all(isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops):
+            continue
+        operands = [node.left, *node.comparators]
+        for operand in operands:
+            if isinstance(operand, ast.Constant) and operand.value == PROVIDER_CLAUDE_CODE:
+                hits.append(node.lineno)
+                break
+    return hits
+
+
+@pytest.mark.parametrize("rel", CONVERTED)
+def test_no_converted_file_compares_the_literal(rel: str) -> None:
+    """The converted branches must keep asking the predicate.
+
+    Reads comparisons out of the AST, so the surviving prose mentions in
+    ``context.py`` and ``chat_runner.py`` are correctly ignored -- and so are
+    the ``model_registry`` namespace arguments, which are call arguments rather
+    than comparisons.
+    """
+    hits = _literal_comparisons(SRC / rel)
+    assert hits == [], (
+        f'{rel} compares the raw "{PROVIDER_CLAUDE_CODE}" literal at line(s) '
+        f"{hits}; ask is_claude_code() instead so provider-specific logic stays "
+        f"findable in one place"
+    )
+
+
+@pytest.mark.parametrize("rel", CONVERTED)
+def test_converted_files_ask_the_predicate(rel: str) -> None:
+    """Non-vacuity guard for the ratchet above.
+
+    Without this, deleting the branch (or renaming the file) would make the
+    ratchet pass while the provider-specific logic went somewhere unwatched.
+    """
+    body = (SRC / rel).read_text(encoding="utf-8")
+    assert "is_claude_code" in body, f"{rel} no longer asks is_claude_code()"
+
+
+def test_onboarding_import_source_id_is_left_alone() -> None:
+    """``onboarding_import`` keeps its own ``"claude_code"``, on purpose.
+
+    There it identifies the Claude Code desktop app whose settings are being
+    imported (``~/.claude``, ``CLAUDE_CONFIG_DIR``) -- a foreign config tree on
+    disk, not the provider this process runs on. Routing it through the
+    predicate would assert a provider identity that has nothing to do with the
+    question being asked.
+    """
+    body = (SRC / "onboarding_import.py").read_text(encoding="utf-8")
+    assert '"claude_code"' in body
+    assert "is_claude_code" not in body
+
+
+def test_model_registry_keeps_its_index_key() -> None:
+    """``model_registry`` keeps the string as a namespace key, on purpose.
+
+    The module states the reason where the constant is defined: *"Named for the
+    registry key, NOT because windows are claude_code-only."* A model's context
+    window belongs to the model, not to the provider serving it, so these are
+    not provider checks and must not become any.
+    """
+    body = (SRC / "model_registry.py").read_text(encoding="utf-8")
+    assert '_WINDOW_INDEX = "claude_code"' in body
+    assert "is_claude_code" not in body


### PR DESCRIPTION
## Problem / Motivation

`"claude_code"` names four unrelated things in this codebase, and the eleven branches that genuinely asked "am I on Claude Code" each spelled the literal inline. That made the provider-specific logic impossible to find by grep and impossible to change in one place — the exact problem the agent-SDK boundary exists to fix.

It also made the four meanings indistinguishable, so any attempt to "consolidate the `claude_code` sites" would have swept up three groups that must not move.

## Why it matters

The goal is one place for provider-specific handling, so adding or swapping a provider does not mean auditing every call site to check whether it hides a special case. Collapsing the identity axis is the first step that actually delivers that, and it is a prerequisite for anything that later wraps it.

This is deliberately **not** a rename of API surfaces or a migration of ACP types. ACP stays the foundation and most call sites keep using it directly.

## What changed (motivation → approach → change)

**Motivation.** Eleven inline `== "claude_code"` comparisons, spread over six files, were the only way to ask which provider was configured.

**Approach.** Give the question one name, and pin the three lookalikes so a future sweep cannot merge them by accident.

**Change.**

Adds `src/kiro_crew/agent_sdk/provider_identity.py` with `is_claude_code()` and routes the eleven branches through it, in `context.py`, `cli_doctor.py`, `knowledge/llm_pool.py`, `dashboard/chat_handlers.py`, `dashboard/chat_runner.py` and `dashboard/handlers/agents.py`. No behaviour change — the predicate is the same equality test the call sites were doing.

The module imports nothing from `kiro_crew` (stdlib only), so it can never be the module that closes an import cycle. Importing it **does** execute the `agent_sdk` package `__init__`, which loads `backend_install` and `drivers.acp` — naming the submodule does not skip them. What keeps that cheap is that the chain is import-light: `acp_backends` is stdlib-only and `drivers.acp` defers every `kiro_crew.acp` import into a function body, so `kiro_crew.acp` itself stays unloaded.

Three meanings are deliberately left alone, each pinned by a test so the reason has to be read before it changes:

- **`model_registry`** uses the string as a registry *index* key, not a provider check. The module already states why: *"Named for the registry key, NOT because windows are claude_code-only."* A model's context window belongs to the model, not to the provider serving it.
- **`onboarding_import`** uses it as an import-*source* id for the Claude Code desktop app (`~/.claude`, `CLAUDE_CONFIG_DIR`) — a foreign config tree on disk, unrelated to what this process runs on.
- **`PROVIDER_LABEL_CLAUDE`** is the session-map label: equal in value, different in job (it indexes resume compatibility, session-map persistence and session-file cleanup routing). Pinned equal by test rather than by import, so a divergence fails loudly instead of silently coupling two vocabularies.

Also replaces four raw session-map labels with that existing constant. Two in `session_allocation.py`, which already carried it and already used it twelve lines away. One in `session_lifecycle.py`, threaded through its constants snapshot because that file has **zero** `kiro_crew.acp` edges and is absent from the boundary baseline — importing the constant directly would create a forbidden edge and force the shrink-only baseline to grow. The fourth, `subagent_manager/run.py`, is left for a follow-up: it needs a new plumbing path and mixes two literals, so it does not belong in a no-behaviour-change commit.

Finally, corrects three comments that still described an abandoned end-state: the baseline is a floor rather than a countdown to zero, `providers/` is not scheduled for deletion, and `kiro_crew.acp` is the SDK's foundation rather than a private layer consumers may not reach.

A fourth candidate was dropped after reading it — `acp/types.py` names `ACP_BACKENDS_SELECTABLE` as a design it **rejected**, not as a symbol that exists, so that comment is already correct.

## Tests

New `test/test_agent_sdk_provider_identity.py`, 25 tests:

- Predicate truth table, including that `"claude"` is False — that is the `agent.acp_backend` value for the same seam on a different axis, and accepting it would give a caller on the wrong axis a plausible-looking answer.
- Absent config is not Claude Code (missing value means the default provider).
- The config value and the session-map label must stay equal.
- The module's own imports contain nothing from `kiro_crew`.
- **Importing the predicate must not pull `kiro_crew.acp` into the process.** The static boundary gate cannot catch a regression here: if `drivers/acp.py` stopped deferring its ACP imports, the new edge would sit *inside* the exempt `agent_sdk/` tree, so the gate would stay green while every SDK consumer began loading ACP at import time. Runs in a subprocess because `sys.modules` is process-wide, with the decode pinned to UTF-8 via `UTF8_TEXT` so the Windows shards do not read the probe's output through the ANSI code page. It also asserts `backend_install` and `drivers.acp` **do** load, so that cost stays visible rather than surprising.
- A ratchet that no converted file compares the raw literal, reading **comparisons out of the AST** rather than the file text — so the surviving prose mentions neither satisfy nor trip it, and the registry namespace arguments are correctly ignored as call arguments.
- A non-vacuity companion asserting each converted file still asks the predicate, so deleting a branch cannot make the ratchet pass for the wrong reason.
- Guards that `model_registry` keeps its index key and `onboarding_import` keeps its source id.

**Both new ratchets verified non-vacuous.** The comparison detector was run against the pre-change blobs at `origin/main`: it finds exactly the eleven comparisons this PR removes (`context.py` 3, `chat_runner.py` 3, `handlers/agents.py` 2, and one each in `cli_doctor.py`, `llm_pool.py`, `chat_handlers.py`), and zero afterwards. The ACP-import assertion was checked both ways: `False` as shipped, `True` when an eager `import kiro_crew.acp` is added to the probe.

Targeted suite: **2261 passed, 15 skipped, 0 failed** (`-k "context or session_map or provider_label or bot_name or lifecycle or chat_runner or agent_sdk"`).

Gates: agent-sdk-boundary ✓ (108 edges unchanged), black ✓, brand ✓, changelog-history ✓, flake8 ✓, isort ✓, mypy ✓.

## Manual verification

Not required — no user-visible surface changes. The predicate is a pure equality test replacing the same equality test, and the session-map labels are replaced by a constant of equal value.

One line needed care: `context.py`'s bot-name assignment. `"KiroCrew"` there is the `{bot_name}` value substituted into the agent prompt, so respelling it would change what the model is told to answer to. The value is kept and marked `brand-ok`, with the provider read hoisted so the marker fits the 100-column limit. The brand gate flagged it only because editing the comparison made a pre-existing line count as added.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no component, layout, or user-visible string is touched.

## Related Issues

no linked issue: this is the first step of a plan tracked in conversation, not a filed issue.

Builds on the merged boundary declaration in PR #6939 (reference only, nothing to close). Design of record: `docs/request-for-change/rfc-crew-agent-sdk-boundary.md`, with the caveat that this PR follows a revised plan (consolidate provider-specific logic, then wrap; ACP stays the foundation) rather than the RFC's original six-PR migration.

## Pattern harvest

**One string, four meanings, is a measurement trap.** Counting `"claude_code"` sites suggested 38 places to consolidate. Reading them showed only 11 were the same question; converting the other 27 would have broken a registry namespace and an unrelated import-source id. The count was not the work.

**A clean file is an asset the boundary gate protects.** `session_lifecycle.py` and `subagent_manager/run.py` have zero ACP edges and are absent from the baseline. The obvious fix — import the label constant — would have created a forbidden edge on a shrink-only gate. Routing through the existing constants seam kept both files clean, and the gate is what surfaced the choice.

**Ratchets on stringly-typed patterns should read the AST, not the text.** A text ratchet here would have been tripped by two docstrings quoting the old spelling and would have false-positived on call arguments that are not comparisons at all.

**A static import gate says nothing about what actually loads.** GPT caught a false claim in this PR's own docstring: naming a submodule does not skip its package `__init__`. The corrected property is now enforced by a runtime test precisely because the static gate is blind to it — an eager ACP import inside `agent_sdk/` would be exempt from the gate and invisible to it.
