### PR TITLE
refactor(dashboard): sweep tranche 3 onto read_bounded_json (#5587)

### DIFF
--- a/.github/coverage-baselines/backend.txt
+++ b/.github/coverage-baselines/backend.txt
@@ -65,7 +65,6 @@ src/kiro_crew/computer_use/cli.py 68.8   # 130/189
 src/kiro_crew/computer_use/macos_skylight.py 54.8   # 142/259
 src/kiro_crew/conpty.py 27.9   # 12/43
 src/kiro_crew/dashboard/_types.py 0.0   # 0/3
-src/kiro_crew/dashboard/handlers/cron.py 70.9   # 400/564
 src/kiro_crew/dashboard/handlers/portability.py 17.0   # 15/88
 src/kiro_crew/dashboard/handlers/weixin_qr.py 47.0   # 119/253
 src/kiro_crew/dashboard/handlers/workflows.py 20.4   # 23/113

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1195,
+    "missing_code": 1151,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1572,
+  "_compliant": 1563,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -37,7 +37,7 @@
       "missing_code": 21
     },
     "dashboard/chat_handlers.py": {
-      "missing_code": 64
+      "missing_code": 49
     },
     "dashboard/chat_mirror.py": {
       "missing_code": 7
@@ -76,13 +76,13 @@
     },
     "dashboard/handlers/cron.py": {
       "dynamic_status": 6,
-      "missing_code": 38
+      "missing_code": 30
     },
     "dashboard/handlers/discover.py": {
       "missing_code": 15
     },
     "dashboard/handlers/files.py": {
-      "missing_code": 100
+      "missing_code": 90
     },
     "dashboard/handlers/kiro_prerequisite.py": {
       "missing_code": 1
@@ -92,7 +92,7 @@
     },
     "dashboard/handlers/mcp.py": {
       "dynamic_status": 1,
-      "missing_code": 34
+      "missing_code": 26
     },
     "dashboard/handlers/mcp_apps.py": {
       "dynamic_status": 1,
@@ -155,7 +155,7 @@
     },
     "dashboard/handlers/workflows.py": {
       "dynamic_status": 3,
-      "missing_code": 14
+      "missing_code": 11
     },
     "dashboard/handlers/worktree.py": {
       "dynamic_status": 1,

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -92,6 +92,7 @@ from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
     subagents_attached,
 )
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.state import (
     DashboardState,
     _ChatSlot,
@@ -193,10 +194,10 @@ def _sweep_stale_permissions(slot: "_ChatSlot") -> None:
 async def api_chat(request: web.Request) -> web.StreamResponse:
     """POST /api/chat — send message to a slot, stream response via SSE."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     message = body.get("message", "").strip()
     agent = body.get("agent", "")
     slot_name = body.get("slot")
@@ -691,7 +692,10 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     # to honour it for widget-origin turns and let the text fall through to a
     # normal, fully-gated _run_chat turn instead. Mode changes and tool
     # approvals live on separate endpoints a widget iframe cannot reach.
-    _widget_origin = bool(user_meta) and user_meta.get("origin") == "widget"
+    # `is not None` (not truthiness): user_meta is normalized to dict-or-None
+    # above, and with the body typed by read_bounded_json, mypy narrows the
+    # Optional only through an explicit None check.
+    _widget_origin = user_meta is not None and user_meta.get("origin") == "widget"
     if (
         getattr(slot, "mode", "") == "orchestrator"
         and message.strip().lower() in ("go", "go all")
@@ -2002,10 +2006,10 @@ _CREATABLE_MODES = ("", "orchestrator", "crew", "design-critique")
 async def api_chat_slot_create(request: web.Request) -> web.Response:
     """POST /api/chat/slots — create a new chat slot."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name = body.get("name")
     agent = body.get("agent", "")
     model = body.get("model", "")
@@ -3182,15 +3186,10 @@ async def api_chat_slot_end_wait(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_end_wait")
     if denied is not None:
         return denied
-    try:
-        body = await request.json() if request.content_length else {}
-    except Exception:
-        body = {}
-    # `request.json()` happily returns a list or a scalar for well-formed JSON
-    # that simply is not an object, and `.get` on one of those raises past the
-    # except above into a 500. Normalize the shape, not just the parse.
-    if not isinstance(body, dict):
-        body = {}
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     wait_id = str(body.get("wait_id") or "").strip()
     if not wait_id:
         return web.json_response(
@@ -3261,19 +3260,37 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
 
     # Claim the stop slot synchronously BEFORE the await below: the
     # idempotency guard above is check-then-act, and a concurrent /interrupt
-    # arriving during `await request.json()` would otherwise still see
+    # arriving during the awaited body read below would otherwise still see
     # _stop_state == "idle" and slip past the guard (double stop_turn +
     # double SEL audit for one logical press). /stop is race-safe because it
     # has no await between guard and claim; this makes /interrupt match.
+    prev_auto_run = slot._auto_run
     slot._stop_state = "soft_pending"
     slot._auto_run = False
 
-    # Optionally promote a specific queue item to front
+    # Optionally promote a specific queue item to front. The except is not a
+    # parse guard (read_bounded_json owns that): it rolls the claimed stop
+    # state back when the body read fails in transit, and the refused-body
+    # branch below rolls it back the same way. Both paths also restore
+    # _auto_run: a refused request must not leave orchestrator auto-run
+    # disabled when no interrupt actually happened. The rollback is
+    # conditional on our claim being intact: a concurrent /stop arriving
+    # during the body await may escalate _stop_state (e.g. to "killing"),
+    # and an unconditional reset to "idle" would erase that escalation and
+    # admit another stop while the hard kill is still running.
     try:
-        body = await request.json() if request.content_length else {}
+        body, body_err = await read_bounded_json(request, allow_absent=True)
     except Exception:
-        slot._stop_state = "idle"
+        if slot._stop_state == "soft_pending":
+            slot._stop_state = "idle"
+            slot._auto_run = prev_auto_run
         raise
+    if body_err is not None:
+        if slot._stop_state == "soft_pending":
+            slot._stop_state = "idle"
+            slot._auto_run = prev_auto_run
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     queue_id = body.get("queue_id")
     if queue_id:
         # Wire-side field is `queue_id`; stored items carry `id` (the key
@@ -3390,10 +3407,10 @@ async def api_chat_slot_queue_edit(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_queue_edit")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     content = body.get("content")
     if not isinstance(content, str) or not content.strip():
         return web.json_response({"error": "content must be a non-empty string"}, status=400)
@@ -3435,10 +3452,10 @@ async def api_chat_slot_queue_reorder(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_queue_reorder")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     order = body.get("order")
     if not isinstance(order, list) or not all(isinstance(x, str) for x in order):
         return web.json_response({"error": "order must be a list of queue id strings"}, status=400)
@@ -3720,15 +3737,16 @@ async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response
     # however long a slow body takes to arrive. The guards must be the last thing
     # that happens before the teardown.
     #
-    # A malformed or absent body is not an error. This route took no body before,
-    # so refusing one would break every existing caller for a parameter they do
-    # not send.
+    # An absent body is not an error: this route took no body before, so
+    # refusing one would break every existing caller for a parameter they do
+    # not send. A present-but-malformed body IS refused — "sent nothing" and
+    # "sent garbage" are different facts, and only the first can be defaulted.
     replay = True
-    try:
-        body = await request.json()
-    except Exception:
-        body = None
-    if isinstance(body, dict) and "replay" in body:
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
+    if "replay" in body:
         replay = bool(body.get("replay"))
 
     # A turn in flight on the SESSION, which ``slot.running`` cannot see: that
@@ -4114,10 +4132,10 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
     Skips the active slot and pinned sessions.
     """
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     max_days = 3
     try:
         max_days = max(1, int(body.get("max_inactive_days", 3)))
@@ -4332,10 +4350,10 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_agent")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     agent_name = body.get("agent", "")
     if agent_name and not _AGENT_NAME_RE.match(agent_name):
         return web.json_response({"error": "invalid agent name"}, status=400)
@@ -4694,10 +4712,10 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_model")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     model_name = _normalize_model(body.get("model", ""))
     reason = _model_rejected_reason(model_name)
     if reason:
@@ -5057,10 +5075,10 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
     ``failed`` and keeps its old model) rather than aborting the whole switch.
     """
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     model_name = _normalize_model(body.get("model", ""))
     reason = _model_rejected_reason(model_name)
     if reason:
@@ -5165,10 +5183,10 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_reasoning_effort")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     effort = body.get("reasoning_effort", "")
     valid_efforts = get_reasoning_effort_values()
     if not isinstance(effort, str) or effort not in valid_efforts:
@@ -5359,10 +5377,10 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_workspace")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     ws_name = body.get("workspace", "default")
     # Block workspace change after conversation has started
     if slot.total_messages > 0:
@@ -5390,10 +5408,10 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
     denied = _deny_cross_app_slot_access(request, slot, name, "slot_project")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     project = body.get("project", "")
     if not isinstance(project, str):
         return web.json_response({"error": "project must be a string"}, status=400)
@@ -5598,12 +5616,10 @@ async def api_chat_slot_followup(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     try:
         cleaned = validate_tool_args(body, SUGGEST_FOLLOWUP_SCHEMA)
     except ValidationError as exc:
@@ -5975,10 +5991,10 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
             error="app cannot access member slots",
         )
         return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     history_key = body.get("key", name)
 
     # If slot already exists (active session), just return it — no duplicate.
@@ -6545,10 +6561,10 @@ async def api_chat_mode(request: web.Request) -> web.Response:
     denied = deny_non_dashboard_caller(request, "chat_mode")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     mode = body.get("mode", "normal")
     raw_slot = body.get("slot")
     slot_key = raw_slot or None
@@ -6859,10 +6875,10 @@ async def api_chat_slot_approve(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     action = body.get("action", "rejected")
     original_action = action
     request_id = body.get("request_id", "")
@@ -7072,10 +7088,10 @@ async def api_chat_slot_color(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     has_ci = "color_index" in body
     has_ch = "color_hex" in body
     ci = body.get("color_index")
@@ -7498,14 +7514,10 @@ async def api_chat_slot_context(request: web.Request) -> web.Response:
     if denied is not None:
         return denied
 
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response(
-            {"error": "body must be a JSON object", "code": "invalid_body"}, status=400
-        )
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     content = body.get("content", "")
     bad = (
@@ -7625,16 +7637,10 @@ async def api_chat_slot_note(request: web.Request) -> web.Response:
     if denied is not None:
         return denied
 
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
-    # A scalar or array parses cleanly and then makes `.get` raise past the
-    # except above into a 500, so the SHAPE needs its own rejection.
-    if not isinstance(body, dict):
-        return web.json_response(
-            {"error": "body must be a JSON object", "code": "invalid_body"}, status=400
-        )
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     content = body.get("content", "")
     bad = (

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -52,6 +52,7 @@ from ._shared import (
     _is_restricted_session,
     _probe_persisted_session,
     _redact_memory_field,
+    read_bounded_json,
 )
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,15 @@ logger = logging.getLogger(__name__)
 # should retry rather than treat it as a hard failure. See CronService mutators.
 _CRON_BUSY_STATUS = 409
 _CRON_BUSY_BODY = {"error": "cron store busy, please retry", "retryable": True}
+
+# Byte ceiling for a cron create/update body. The message field is bounded at
+# MAX_CRON_MESSAGE characters, and one character costs at most 12 bytes on the
+# wire: a client may send it JSON-escaped, and an astral character escapes to a
+# \uXXXX\uXXXX surrogate pair (12 bytes), wider than raw UTF-8's 4-byte max. So
+# this bounds the largest message the field validator will accept; the 64 KB of
+# headroom covers the remaining short fields. Explicit rather than the shared
+# default because a maximal multibyte message legitimately exceeds 64 KB.
+_MAX_CRON_BODY_BYTES = 12 * MAX_CRON_MESSAGE + 64 * 1024
 
 # Returned when the store cannot be WRITTEN because the last read of it failed
 # (CronStoreUnreadable). 409 for the same reason as busy above -- the request
@@ -230,12 +240,13 @@ async def _resolve_and_supersede(
 async def api_crons_create(request: web.Request) -> web.Response:
     """POST /api/crons — create a cron job."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response({"error": "request body must be a JSON object"}, status=400)
+    # Per-route cap: the body carries the job's full agent message/prompt text,
+    # whose field bound (MAX_CRON_MESSAGE chars) can exceed the shared 64 KB
+    # default in multibyte UTF-8 -- _MAX_CRON_BODY_BYTES sizes the ceiling to it.
+    body, body_err = await read_bounded_json(request, max_bytes=_MAX_CRON_BODY_BYTES)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     # Type-validate every string field BEFORE calling string methods on it.
     # A JSON array/dict/int in these fields would otherwise raise AttributeError
     # (.strip() on a non-str) -> HTTP 500. validate_string_field enforces
@@ -379,12 +390,11 @@ async def api_cron_batch_delete(request: web.Request) -> web.Response:
     single ``crons`` refresh is pushed after the batch instead of one per id.
     """
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response({"error": "request body must be a JSON object"}, status=400)
+    # Default cap: the body is a bounded list of short job ids.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     ids = body.get("ids")
     if not isinstance(ids, list) or not ids:
         return web.json_response({"error": "ids must be a non-empty array"}, status=400)
@@ -441,18 +451,16 @@ async def api_cron_update(request: web.Request) -> web.Response:
     job_id = request.match_info["job_id"]
     if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
         return _e
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    # A syntactically valid scalar or array parses fine and then has no .get,
-    # so the field reads below would raise AttributeError and surface as a 500.
-    # This route already refuses an unparseable body; a non-object is refused
-    # the same way rather than by crashing.
-    if not isinstance(body, dict):
-        return web.json_response(
-            {"error": "request body must be a JSON object", "code": "invalid_json"}, status=400
-        )
+    # Per-route cap: a partial update can carry the job's full agent
+    # message/prompt text, whose field bound (MAX_CRON_MESSAGE chars) can
+    # exceed the shared 64 KB default in multibyte UTF-8. The helper also owns
+    # the non-object 400: a syntactically valid scalar or array parses fine
+    # and then has no .get, so the field reads below would raise
+    # AttributeError and surface as a 500.
+    body, body_err = await read_bounded_json(request, max_bytes=_MAX_CRON_BODY_BYTES)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     kwargs: dict[str, Any] = {}
     for key in (
         "name",
@@ -679,16 +687,13 @@ async def api_cron_enable(request: web.Request) -> web.Response:
     job_id = request.match_info["job_id"]
     if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
         return _e
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
-    # This route tolerates a missing or unreadable body and falls back to its
-    # defaults. A scalar or array parses but carries no fields, so it gets the
-    # same tolerance -- reading .get off it would raise AttributeError -> 500,
-    # which is a harsher answer than the one an unparseable body already gets.
-    if not isinstance(body, dict):
-        body = {}
+    # Default cap: the body is a single flag. allow_absent keeps the
+    # missing-body-means-defaults contract; a body that is PRESENT but
+    # malformed is a 400; only an absent body defaults.
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     enabled = body.get("enabled", True)
     try:
         ok = await state.crons.enable_job_async(job_id, enabled=enabled)
@@ -707,12 +712,12 @@ async def api_cron_ack(request: web.Request) -> web.Response:
     job_id = request.match_info["job_id"]
     if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
         return _e
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
-    if not isinstance(body, dict):
-        body = {}  # same tolerance as an unparseable body; see api_cron_enable
+    # Default cap: the body is a short summary + notification ts. allow_absent
+    # keeps the missing-body-means-defaults contract; see api_cron_enable.
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     summary = body.get("summary", "acknowledged")
     notification_ts = body.get("ts", "")
     try:
@@ -1108,12 +1113,11 @@ async def api_lessons_create(request: web.Request) -> web.Response:
     from kiro_crew.learn import Lesson  # noqa: F811
 
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response({"error": "request body must be a JSON object"}, status=400)
+    # Default cap: lesson fields are short strings (MAX_SHORT_STRING-bounded).
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     # Block lesson writes from restricted (incognito/temporary/guest) sessions.
     sk = request.headers.get("X-Session-Key", "")
     refusal = await _recognize_session(
@@ -1311,14 +1315,11 @@ async def api_lessons_delete(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "Memory writes are not allowed in this session mode."}, status=403
         )
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response(
-            {"error": "request body must be a JSON object", "code": "invalid_json"}, status=400
-        )
+    # Default cap: the body is a rule substring plus scope/workspace selectors.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     rule_sub = body.get("rule", "").strip()
     if not rule_sub:
         return web.json_response({"error": "rule substring required"}, status=400)
@@ -1450,11 +1451,12 @@ async def api_cron_folders(request: web.Request) -> web.Response:
 async def api_cron_folders_create(request: web.Request) -> web.Response:
     """POST /api/cron-folders — create a new cron folder."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
-    if not isinstance(body, dict) or not isinstance(body.get("name"), str):
+    # Default cap: the body is a single short folder name.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
+    if not isinstance(body.get("name"), str):
         return web.json_response(
             {"error": "name must be a string", "code": "name_required"}, status=400
         )
@@ -1483,11 +1485,12 @@ async def api_cron_folders_update(request: web.Request) -> web.Response:
     folder_id = request.match_info["folder_id"]
     if (_e := _invalid_path_id_response(folder_id, "folder_id")) is not None:
         return _e
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
-    if not isinstance(body, dict) or not isinstance(body.get("name"), str):
+    # Default cap: the body is a single short folder name.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
+    if not isinstance(body.get("name"), str):
         return web.json_response(
             {"error": "name must be a string", "code": "name_required"}, status=400
         )

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -39,7 +39,7 @@ from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir,
 from kiro_crew.dashboard import part_stream, upload_destination
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
 from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
-from kiro_crew.dashboard.handlers._shared import _probe_persisted_session
+from kiro_crew.dashboard.handlers._shared import _probe_persisted_session, read_bounded_json
 from kiro_crew.dashboard.origin import is_direct_local_request
 from kiro_crew.dashboard.state import DashboardState, append_and_surface
 from kiro_crew.doc_parser import extract_text
@@ -126,12 +126,28 @@ def _audit_file_send(
     )
 
 
+def _body_err_code(body_err: web.Response) -> str:
+    """SEL error label for a refused body read.
+
+    Derived from the guard response's machine-readable ``code`` so the audit
+    record distinguishes a parse failure from an oversized body (413
+    ``payload_too_large``) instead of filing every refusal as a JSON error.
+    """
+    try:
+        parsed = json.loads(body_err.text or "")
+    except ValueError:
+        return "invalid_json_body"
+    code = parsed.get("code") if isinstance(parsed, dict) else None
+    return str(code) if code else "invalid_json_body"
+
+
 async def api_reveal_path(request: web.Request) -> web.Response:
     """POST /api/reveal — reveal a file/folder in Finder or open with default app."""
-    try:
-        body = await request.json()
-    except ValueError:
-        return web.json_response({"error": "invalid JSON body"}, status=400)
+    # Default cap: the body is a path and an action flag (issue #5587 sweep).
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     path = body.get("path", "")
     action = body.get("action", "reveal")  # "reveal" or "open"
     if not path or ".." in Path(path).parts:
@@ -185,19 +201,20 @@ async def api_reveal_path(request: web.Request) -> web.Response:
 async def api_outbox_notify(request: web.Request) -> web.Response:
     """POST /api/outbox/notify — agent sent a file, notify the user."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except ValueError:
-
+    # Default cap: the body names an outbox file (path, filename, short
+    # description, size) — the file bytes themselves never travel in it.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
         _sel().log_tool_invocation(
             session_key="api",
             source="api",
             tool_name="file_send",
             tool_kind="notify",
             outcome="denied",
-            error="invalid_json_body",
+            error=_body_err_code(body_err),
         )
-        return web.json_response({"error": "Invalid JSON body"}, status=400)
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     raw_path = body.get("path", "")
     raw_filename = body.get("filename", "")
@@ -652,11 +669,13 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
     if not slack:
         _audit_file_send(leg="slack", outcome="skipped", error="no_slack_client")
         return web.json_response({"ok": True, "skipped": "no_slack"})
-    try:
-        body = await request.json()
-    except ValueError:
-        _audit_file_send(leg="slack", outcome="denied", error="invalid_json_body")
-        return web.json_response({"error": "Invalid JSON body"}, status=400)
+    # Default cap: the body carries a file path, a filename, and Slack routing
+    # ids — the file bytes are read from disk, never from this body.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        _audit_file_send(leg="slack", outcome="denied", error=_body_err_code(body_err))
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     file_path_raw = body.get("file_path", "")
     filename = body.get("filename", "")
     # Off-loop: the gate reads up to MAX_FILE_BYTES and regex-scans the content
@@ -756,11 +775,13 @@ async def api_channel_upload_file(request: web.Request) -> web.Response:
     and the Slack leg exactly as before this endpoint existed.
     """
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except ValueError:
-        _audit_file_send(leg="channel", outcome="denied", error="invalid_json_body")
-        return web.json_response({"error": "Invalid JSON body"}, status=400)
+    # Default cap: same shape as the Slack leg — a path, a filename, and a
+    # short description; the file bytes are read from disk by the gate.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        _audit_file_send(leg="channel", outcome="denied", error=_body_err_code(body_err))
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     def _skip(reason: str) -> web.Response:
         _audit_file_send(leg="channel", outcome="skipped", error=reason)
@@ -1462,10 +1483,11 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
 
     from kiro_crew.validation import WORKSPACE_NAME_RE  # noqa: F811
 
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "Invalid JSON body"}, status=400)
+    # Default cap: the body is a workspace name plus optional dir/copy_from.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name = body.get("name", "").strip()
     if not name:
         return web.json_response({"error": "Workspace name is required"}, status=400)
@@ -1620,10 +1642,11 @@ async def api_workspaces_update(request: web.Request) -> web.Response:
     cfg = KiroCrewConfig.load()
     if name not in cfg.workspaces:
         return web.json_response({"error": f"Workspace '{name}' not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "Invalid JSON body"}, status=400)
+    # Default cap: the body is a single directory field.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     if "dir" in body:
         new_dir = body["dir"]
         _abs = Path(new_dir).expanduser().is_absolute()
@@ -2943,13 +2966,12 @@ async def api_file_write(request: web.Request) -> web.Response:
         validate_tool_args,
     )
 
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON body"}, status=400)
-
-    if not isinstance(body, dict):
-        return web.json_response({"error": "invalid JSON body"}, status=400)
+    # max_bytes=None: the body carries the file's whole contents, which has no
+    # defensible byte ceiling (issue #5587 sweep).
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     try:
         validate_tool_args(
@@ -3746,18 +3768,17 @@ async def api_dashboard_config(request: web.Request) -> web.Response:
         )
         raise
     if request.method == "PUT":
-        try:
-            body = await request.json()
-        except Exception:
+        # Default cap: the body is a fixed set of dashboard toggles and numbers.
+        body, body_err = await read_bounded_json(request)
+        if body_err is not None:
             _sel().log_tool_invocation(
-                session_key="dashboard", tool_name="dashboard_config_write", outcome="failure"
+                session_key="dashboard",
+                tool_name="dashboard_config_write",
+                outcome="failure",
+                error=_body_err_code(body_err),
             )
-            return web.json_response({"error": "invalid JSON"}, status=400)
-        if not isinstance(body, dict):
-            _sel().log_tool_invocation(
-                session_key="dashboard", tool_name="dashboard_config_write", outcome="failure"
-            )
-            return web.json_response({"error": "request body must be a JSON object"}, status=400)
+            return body_err
+        assert body is not None  # read_bounded_json returns (dict, None) on success
         _allowed = {"restore_sessions", "restore_window_minutes", "merge_queued_messages", "widget_density", "use_builtin_browser", "verbosity", "quick_send", "session_grid", "tail_fork_enabled", "link_previews", "mcp_app_panel", "auto_open_git_panel", "folder_suggestions_enabled", "session_card_source_links"}
         # One-release backward-compat shim for removed key; delete after all clients update.
         deprecated_ignored_keys = {"tail_fork_head_handling"}

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -29,6 +29,7 @@ from kiro_crew.config.loader import (
     _resolve_stub_servers,
 )
 from kiro_crew.config.paths import data_home, kiro_agents_dir
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.env import emit_env
 from kiro_crew.loop_lock import LoopBoundLock
@@ -94,6 +95,14 @@ _KIRO_GLOBAL_SURFACE = "~/.kiro/settings/mcp.json"
 # size) for a single apply call rather than lock-hold time. The
 # dashboard applies at most one change per visible server, so this is generous.
 _MCP_APPLY_MAX_CHANGES = 200
+
+# Byte ceiling for one /api/mcp/apply body. The change count above bounds
+# cardinality but runs only AFTER the body is decoded, so the read itself
+# needs a pre-decode ceiling. Each change is scope flags plus a per-tool
+# toolOverrides map; 1 MB comfortably covers _MCP_APPLY_MAX_CHANGES changes
+# over even a tool-heavy server while still refusing an arbitrarily large
+# body before it is buffered.
+_MCP_APPLY_MAX_BODY_BYTES = 1024 * 1024
 
 # Max server names accepted by one /api/mcp-gateway/servers/stub call. The
 # batch form exists for the UI's "toggle all", whose upper bound is the number of
@@ -1005,17 +1014,10 @@ async def api_mcp_quarantine_clear(request: web.Request) -> web.Response:
     off by hand stays off. It does not mount or unmount anything either -- the
     server was never unmounted (issue #6171).
     """
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
-    if not isinstance(body, dict):
-        # A JSON array or bare null parses fine and then reaches ``.get`` on the
-        # identifier read, which surfaces as a 500 for what is a malformed
-        # request.
-        return web.json_response(
-            {"error": "body must be a JSON object", "code": "body_not_object"}, status=400
-        )
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name, err = _string_identifier(body, "name")
     if err is not None:
         return err
@@ -1255,10 +1257,10 @@ async def api_mcp_toggle(request: web.Request) -> web.Response:
     1. Sets ``disabled`` in ``~/.kiro/settings/mcp.json`` (ACP runtime).
     2. Syncs ``tools``/``allowedTools`` in ``kirocrew.json`` (non-ACP mode).
     """
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name, err = _string_identifier(body, "name")
     if err is not None:
         return err
@@ -1321,10 +1323,10 @@ async def api_mcp_toggle_tool(request: web.Request) -> web.Response:
 
     Updates ``disabledTools`` in ``~/.kiro/settings/mcp.json``.
     """
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     server, err = _string_identifier(body, "server")
     if err is not None:
         return err
@@ -1386,10 +1388,10 @@ async def api_mcp_toggle_tool(request: web.Request) -> web.Response:
 
 async def api_mcp_toggle_all(request: web.Request) -> web.Response:
     """POST /api/mcp/toggle-all — enable or disable all MCP servers."""
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     enabled = body.get("enabled", True)
 
     async with _get_mcp_lock():
@@ -1433,10 +1435,10 @@ async def api_mcp_remove(request: web.Request) -> web.Response:
     on PATH it is also asked to uninstall (best-effort); on a vanilla
     machine ``aim`` is absent and that step is skipped gracefully.
     """
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name, err = _string_identifier(body, "name")
     if err is not None:
         return err
@@ -1556,10 +1558,10 @@ async def api_mcp_server_detail(request: web.Request) -> web.Response:
             status=400,
         )
 
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     command = body.get("command", "")
     if not command:
@@ -2152,10 +2154,10 @@ async def _do_mcp_apply(request: web.Request) -> web.Response:
     ``~/.claude/agents/kirocrew.md`` + ``kirocrew.mcp.json``) reflect the
     new merged state.  Returns a summary with per-change outcomes.
     """
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=_MCP_APPLY_MAX_BODY_BYTES)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     changes = body.get("changes")
     if not isinstance(changes, list):
         return web.json_response({"error": "changes must be a list"}, status=400)
@@ -2681,10 +2683,10 @@ async def api_mcp_gateway_enable(request: web.Request) -> web.Response:
     from kiro_crew.config.loader import config_path  # circular import
     from kiro_crew.dashboard.handlers.agents import _get_config_lock  # circular import
 
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     enabled = body.get("enabled")
     if not isinstance(enabled, bool):
         return web.json_response({"error": "enabled must be a boolean"}, status=400)
@@ -3217,14 +3219,10 @@ async def api_mcp_gateway_set_stub(request: web.Request) -> web.Response:
         update_config_locked,
     )
 
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response(
-            {"error": "body must be an object", "code": "body_not_object"}, status=400
-        )
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name = str(body.get("name", "")).strip()
     raw_names = body.get("names")
     stub = body.get("stub")

--- a/src/kiro_crew/dashboard/handlers/workflows.py
+++ b/src/kiro_crew/dashboard/handlers/workflows.py
@@ -27,6 +27,7 @@ from typing import Any, Optional
 
 from aiohttp import web
 
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -161,12 +162,10 @@ async def api_workflow_definitions_create(request: web.Request) -> web.Response:
     svc = _svc(request)
     if svc is None:
         return _error("workflows not available", "workflows_unavailable", 503)
-    try:
-        body = await request.json()
-    except Exception:
-        return _error("invalid JSON", "invalid_json", 400)
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     source = body.get("source")
     if not isinstance(source, str) or not source.strip():
         return _error("source is required", "workflow_source_required", 400)
@@ -229,12 +228,10 @@ async def api_workflow_definition_update(request: web.Request) -> web.Response:
     svc = _svc(request)
     if svc is None:
         return _error("workflows not available", "workflows_unavailable", 503)
-    try:
-        body = await request.json()
-    except Exception:
-        return _error("invalid JSON", "invalid_json", 400)
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     source = body.get("source")
     expected_revision = body.get("expected_revision")
     if not isinstance(source, str) or not source.strip():
@@ -289,12 +286,10 @@ async def api_workflow_definition_run(request: web.Request) -> web.Response:
     svc = _svc(request)
     if svc is None:
         return _error("workflows not available", "workflows_unavailable", 503)
-    try:
-        body = await request.json()
-    except Exception:
-        return _error("invalid JSON", "invalid_json", 400)
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     input_text = body.get("input", "")
     if not isinstance(input_text, str):
         return _error("input must be a string", "workflow_input_invalid", 400)
@@ -336,12 +331,10 @@ async def api_workflow_author(request: web.Request) -> web.Response:
     svc = _svc(request)
     if svc is None:
         return web.json_response({"error": "workflows not available"}, status=503)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     intent = (body.get("intent") or "").strip()
     if not intent:
         return web.json_response({"error": "intent is required"}, status=400)
@@ -366,12 +359,10 @@ async def api_workflow_run(request: web.Request) -> web.Response:
     svc = _svc(request)
     if svc is None:
         return web.json_response({"error": "workflows not available"}, status=503)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     source = body.get("source", "")
     if not isinstance(source, str) or not source.strip():
         return web.json_response({"error": "source is required"}, status=400)
@@ -401,12 +392,10 @@ async def api_workflow_run_intent(request: web.Request) -> web.Response:
     svc = _svc(request)
     if svc is None:
         return web.json_response({"error": "workflows not available"}, status=503)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     intent = (body.get("intent") or "").strip()
     if not intent:
         return web.json_response({"error": "intent is required"}, status=400)
@@ -454,12 +443,12 @@ async def api_workflow_run_promote(request: web.Request) -> web.Response:
     svc = _svc(request)
     if svc is None:
         return _error("workflows not available", "workflows_unavailable", 503)
-    try:
-        body = await request.json()
-    except Exception:
-        return _error("invalid JSON", "invalid_json", 400)
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    # Default cap: the body is fixed metadata fields (name, description, slug);
+    # the promoted source comes from the completed run, not this request.
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     run_id = request.match_info.get("run_id", "")
     try:
         out = await svc.promote_run_definition(
@@ -511,12 +500,11 @@ async def api_workflow_run_rerun(request: web.Request) -> web.Response:
     if svc is None:
         return web.json_response({"error": "workflows not available"}, status=503)
     run_id = request.match_info.get("run_id", "")
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
-    if not isinstance(body, dict):
-        return _error("JSON body must be an object", "invalid_json", 400)
+    # allow_absent: every field defaults, so a bodyless rerun replays from index 0.
+    body, body_err = await read_bounded_json(request, max_bytes=None, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     from_index = body.get("from_index", 0)
     if not isinstance(from_index, int):
         from_index = 0

--- a/test/body_stream_helpers.py
+++ b/test/body_stream_helpers.py
@@ -1,0 +1,61 @@
+"""Shared request body-stream stand-ins for handler unit tests.
+
+Handlers converted to ``_shared.read_bounded_json``'s capped path enforce the
+byte ceiling BEFORE decoding by draining ``request.content`` incrementally --
+so a mocked ``request.json`` alone no longer feeds them, and every harness for
+such a handler must supply real body bytes through a stream double. This
+module is that double, extracted from the near-identical ``_Payload`` copies
+the converted test files each grew.
+
+Only the *uncapped* path (``read_bounded_json(request, max_bytes=None)``)
+still calls ``request.json()``; a harness that serves such a handler must keep
+its ``request.json`` mock alongside the stream.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class BodyStreamPayload:
+    """Minimal stand-in for the aiohttp request body stream.
+
+    The union of what the capped read path and ``request.read()`` consume:
+    ``iter_chunked`` (the bounded incremental drain), ``read`` (whole-body),
+    ``set_read_chunk_size`` (stream configuration before draining), and
+    ``at_eof`` -- ``request.can_read_body`` is ``not payload.at_eof()``, and
+    the ``allow_absent`` handlers branch on it, so reporting EOF while bytes
+    are waiting would make every request look bodyless and silently default.
+    """
+
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    async def iter_chunked(self, n: int):
+        for i in range(0, len(self._raw), n):
+            yield self._raw[i : i + n]
+
+    async def read(self) -> bytes:
+        return self._raw
+
+    def set_read_chunk_size(self, size: int) -> None:
+        return None
+
+    def at_eof(self) -> bool:
+        return not self._raw
+
+
+def attach_body(request: Any, body: Any, *, raw: bytes | None = None) -> None:
+    """Attach a real body stream to a mocked request.
+
+    JSON-encodes *body* (or uses *raw* verbatim when given) and sets the four
+    attributes the bounded read consults: ``content``, ``content_length``,
+    ``charset``, and ``can_read_body``.
+    """
+    if raw is None:
+        raw = json.dumps(body).encode()
+    request.content = BodyStreamPayload(raw)
+    request.content_length = len(raw)
+    request.charset = None
+    request.can_read_body = bool(raw)

--- a/test/test_api_input_validation.py
+++ b/test/test_api_input_validation.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.dashboard.handlers import api_crons_create, api_lessons_create
 
@@ -25,7 +26,9 @@ def _crons_request(body: object) -> MagicMock:
     mock_state.crons.add_job_async = AsyncMock(return_value=mock_job)
     request = MagicMock()
     request.app = {"state": mock_state}
-    request.json = AsyncMock(return_value=body)
+    # api_crons_create reads through read_bounded_json's capped path, which
+    # drains request.content -- feed real bytes, not a mocked json.
+    attach_body(request, body)
     return request
 
 
@@ -40,7 +43,7 @@ def _lessons_request(body: object) -> MagicMock:
     request = MagicMock()
     request.app = {"state": mock_state}
     request.headers = {"X-Session-Key": "dashboard:ui"}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 
@@ -128,14 +131,26 @@ class TestLessonsCreateTypeValidation:
 
     @pytest.mark.asyncio
     async def test_oversized_rule_returns_400(self):
-        """A 100KB+ rule exceeds the schema length bound and is rejected."""
-        request = _lessons_request({"rule": "x" * 100_000, "category": "tool"})
+        """A rule over the schema length bound (but under the byte cap) is a 400."""
+        request = _lessons_request({"rule": "x" * 1_000, "category": "tool"})
         with (
             patch("kiro_crew.dashboard.handlers.cron._sel"),
             patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
         ):
             resp = await api_lessons_create(request)
         assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_returns_413(self):
+        """A 100KB+ body now exceeds read_bounded_json's byte cap before any
+        field-level bound is consulted."""
+        request = _lessons_request({"rule": "x" * 100_000, "category": "tool"})
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 413
 
     @pytest.mark.asyncio
     async def test_non_object_body_returns_400(self):

--- a/test/test_auto_approve.py
+++ b/test/test_auto_approve.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
+from body_stream_helpers import BodyStreamPayload
 
 from kiro_crew.dashboard.handlers.taskrunner import (
     api_taskrunner_execute_plan,
@@ -101,34 +102,6 @@ def _plain_provider(text: str = "done"):
 # ══════════════════════════════════════════════════════════════════════
 # (i) default
 # ══════════════════════════════════════════════════════════════════════
-
-
-class _Payload:
-    """Minimal stand-in for the request body stream.
-
-    ``api_taskrunner_start`` and ``api_taskrunner_execute_plan`` read their body
-    through ``_shared.read_bounded_json`` with the shared 64 KB cap, which
-    enforces the ceiling BEFORE decoding by draining ``request.content`` -- so a
-    mocked ``request.json`` alone no longer feeds them.
-    """
-
-    def __init__(self, raw: bytes) -> None:
-        self._raw = raw
-
-    async def iter_chunked(self, n: int):
-        for i in range(0, len(self._raw), n):
-            yield self._raw[i : i + n]
-
-    async def read(self) -> bytes:
-        return self._raw
-
-    def set_read_chunk_size(self, size: int) -> None:
-        return None
-
-    def at_eof(self) -> bool:
-        # ``request.can_read_body`` is ``not payload.at_eof()``, and the
-        # allow_absent handlers branch on it.
-        return not self._raw
 
 
 class TestAutoApproveDefault:
@@ -491,9 +464,11 @@ class TestAutoApproveProvenanceGating:
         }
         req = make_mocked_request(
             "POST", "/api/taskrunner", app=app,
-            payload=_Payload(json.dumps(start_body).encode()),
+            payload=BodyStreamPayload(json.dumps(start_body).encode()),
         )
         req["app"] = request_app  # set by token_auth_middleware; "" == dashboard itself
+        # Kept alive: ``api_taskrunner_start`` reads uncapped (``max_bytes=None``)
+        # and consumes ``request.json()``.
         req.json = AsyncMock(return_value=start_body)
         await api_taskrunner_start(req)
         return runner.start_background.call_args.kwargs["auto_approve"]
@@ -524,10 +499,9 @@ class TestAutoApproveProvenanceGating:
         raw = json.dumps(exec_body).encode()
         req = make_mocked_request(
             "POST", "/api/taskrunner/t1/execute", app=app, match_info={"task_id": "t1"},
-            headers={"Content-Length": str(len(raw))}, payload=_Payload(raw),
+            headers={"Content-Length": str(len(raw))}, payload=BodyStreamPayload(raw),
         )
         req["app"] = request_app
-        req.json = AsyncMock(return_value=exec_body)
         await api_taskrunner_execute_plan(req)
         return runner.execute_plan.call_args.kwargs["auto_approve"]
 
@@ -558,10 +532,9 @@ class TestAutoApproveProvenanceGating:
         raw = json.dumps({"auto_approve": True}).encode()
         req = make_mocked_request(
             "POST", "/api/taskrunner/t1/execute", app=app, match_info={"task_id": "t1"},
-            headers={"Content-Length": str(len(raw))}, payload=_Payload(raw),
+            headers={"Content-Length": str(len(raw))}, payload=BodyStreamPayload(raw),
         )
         req["app"] = ""  # dashboard context → requested trust is honored, so the gate audits
-        req.json = AsyncMock(return_value={"auto_approve": True})
 
         boom = MagicMock()
         boom.log_tool_invocation.side_effect = RuntimeError("sel backend down: SECRET-INTERNAL-DETAIL")
@@ -604,9 +577,11 @@ class TestInlineSpecCleanup:
         app["state"] = SimpleNamespace(task_runner=runner)
         req = make_mocked_request(
             "POST", "/api/taskrunner", app=app,
-            payload=_Payload(json.dumps(body).encode()),
+            payload=BodyStreamPayload(json.dumps(body).encode()),
         )
         req["app"] = ""
+        # Kept alive: ``api_taskrunner_start`` reads uncapped (``max_bytes=None``)
+        # and consumes ``request.json()``.
         req.json = AsyncMock(return_value=body)
         return await api_taskrunner_start(req), runner
 

--- a/test/test_chat_slot_end_wait.py
+++ b/test/test_chat_slot_end_wait.py
@@ -174,17 +174,12 @@ class TestChatSlotEndWait:
             "json-null",
         ],
     )
-    async def test_well_formed_non_object_body_returns_400_not_500(
-        self, _patch_sel, raw
-    ):
+    async def test_well_formed_non_object_body_returns_400_not_500(self, _patch_sel, raw):
         """A body that is valid JSON but not an object.
 
-        ``request.json()`` returns it happily, so the ``except`` around the parse
-        never fires — the shape only becomes a problem one line later, at
-        ``.get``, which a list/str/int/bool/None does not have. Left unnormalized
-        that AttributeError escapes the handler as a 500, i.e. an
-        agent-reachable body shape turning a rejected request into a server
-        error. Every shape here has to land on the same 400 the empty body gets.
+        ``read_bounded_json`` owns the shape guard: a list/str/int/bool/None
+        parses cleanly but is refused as ``body_not_object`` before the handler
+        ever calls ``.get`` on it, so no shape can escape as a 500.
         """
         slot = _sleeping_slot()
         state = _mock_state(slot)
@@ -198,7 +193,7 @@ class TestChatSlotEndWait:
             assert resp.status != 500
             assert resp.status == 400
             payload = await resp.json()
-            assert payload["code"] == "wait_id_required"
+            assert payload["code"] == "body_not_object"
 
         # The body reached the handler with a length, so the parse really ran:
         # this is not the content_length==0 short circuit answering 400 for us.

--- a/test/test_chat_slot_reset_conversation.py
+++ b/test/test_chat_slot_reset_conversation.py
@@ -142,7 +142,7 @@ class TestTheReplayParameter:
     def test_the_body_is_read_before_the_busy_guards(self):
         """Source-order guard: reading the body must not widen the teardown race.
 
-        ``await request.json()`` is a suspension whose duration the CLIENT
+        ``await read_bounded_json(...)`` is a suspension whose duration the CLIENT
         controls. Every busy guard below it protects work that can START during a
         suspension — a turn admitted after ``has_active_turn()`` answered False is
         then torn down mid-write by the discard. Parsing the body after the guards
@@ -160,7 +160,7 @@ class TestTheReplayParameter:
         from kiro_crew.dashboard import chat_handlers
 
         src = inspect.getsource(chat_handlers.api_chat_slot_reset_conversation)
-        body_read = src.index("await request.json()")
+        body_read = src.index("await read_bounded_json(")
         first_guard = src.index("state.sessions.get_provider(key)")
         discard = src.index("discard_conversation(key, replay=")
 

--- a/test/test_cron_handler_json_contract.py
+++ b/test/test_cron_handler_json_contract.py
@@ -7,17 +7,16 @@ list or an int, so the read raises out of the handler and aiohttp answers
 **500** -- an internal-server error for a request the caller malformed, and one
 that reports nothing a client can act on.
 
-The two contracts already in this module are both kept, because a handler's
-answer to a non-object body should match its answer to a body it could not read
-at all:
+The handlers route through ``read_bounded_json`` (issue #5587), which owns
+both the parse guard and the object-shape guard:
 
-* ``api_cron_update`` and ``api_lessons_delete`` already refuse an unparseable
-  body with 400, so a non-object is refused the same way, with the
-  ``invalid_json`` code the module uses elsewhere.
-* ``api_cron_enable`` and ``api_cron_ack`` already fall back to their defaults
-  when the body cannot be read, so a non-object gets that same tolerance. A
-  scalar carries no fields either way, and answering it with a 500 while
-  answering unreadable bytes with 200 is the asymmetry, not the rule.
+* ``api_cron_update`` and ``api_lessons_delete`` refuse an unparseable body
+  with the helper's 400 ``invalid_json`` and a non-object with 400
+  ``body_not_object``.
+* ``api_cron_enable`` and ``api_cron_ack`` keep their defaults only for an
+  ABSENT body (``allow_absent``): "the client sent nothing" and "the client
+  sent garbage" are different facts, so a body that is present but not an
+  object is a 400; only an absent body defaults.
 """
 
 from __future__ import annotations
@@ -71,7 +70,7 @@ async def test_cron_update_refuses_a_non_object_body(payload) -> None:
         body = await response.json()
 
     assert response.status == 400
-    assert body == {"error": "request body must be a JSON object", "code": "invalid_json"}
+    assert body == {"error": "body must be a JSON object", "code": "body_not_object"}
     update.assert_not_awaited()
 
 
@@ -90,14 +89,29 @@ async def test_cron_update_keeps_the_object_path() -> None:
 
 
 @pytest.mark.parametrize("payload", NON_OBJECT_BODIES)
-async def test_cron_enable_treats_a_non_object_body_as_no_body(payload) -> None:
-    """The tolerant contract: the same answer an unreadable body already gets --
-    the route's default, not a 500."""
+async def test_cron_enable_refuses_a_non_object_body(payload) -> None:
+    """A present non-object body is a 400, not a silent default: only an
+    ABSENT body keeps the route's tolerance (``allow_absent``)."""
     enable = AsyncMock(return_value=True)
     app = _cron_app(api_cron_enable, "/api/crons/{job_id}/enable", enable_job_async=enable)
 
     async with TestClient(TestServer(app)) as client:
         response = await client.post("/api/crons/job-1/enable", data=payload, headers=JSON_HEADERS)
+        body = await response.json()
+
+    assert response.status == 400
+    assert body == {"error": "body must be a JSON object", "code": "body_not_object"}
+    enable.assert_not_awaited()
+
+
+async def test_cron_enable_treats_an_absent_body_as_defaults() -> None:
+    """No body at all still means the route's defaults -- the tolerant half
+    of the old contract that ``allow_absent`` preserves."""
+    enable = AsyncMock(return_value=True)
+    app = _cron_app(api_cron_enable, "/api/crons/{job_id}/enable", enable_job_async=enable)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post("/api/crons/job-1/enable")
 
     assert response.status == 200
     enable.assert_awaited_once_with("job-1", enabled=True)
@@ -115,12 +129,26 @@ async def test_cron_enable_still_reads_an_object_body() -> None:
 
 
 @pytest.mark.parametrize("payload", NON_OBJECT_BODIES)
-async def test_cron_ack_treats_a_non_object_body_as_no_body(payload) -> None:
+async def test_cron_ack_refuses_a_non_object_body(payload) -> None:
     ack = AsyncMock(return_value=True)
     app = _cron_app(api_cron_ack, "/api/crons/{job_id}/ack", ack_job_async=ack)
 
     async with TestClient(TestServer(app)) as client:
         response = await client.post("/api/crons/job-1/ack", data=payload, headers=JSON_HEADERS)
+        body = await response.json()
+
+    assert response.status == 400
+    assert body == {"error": "body must be a JSON object", "code": "body_not_object"}
+    ack.assert_not_awaited()
+    app["state"].ack_notification.assert_not_awaited()
+
+
+async def test_cron_ack_treats_an_absent_body_as_defaults() -> None:
+    ack = AsyncMock(return_value=True)
+    app = _cron_app(api_cron_ack, "/api/crons/{job_id}/ack", ack_job_async=ack)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post("/api/crons/job-1/ack")
 
     assert response.status == 200
     ack.assert_awaited_once_with("job-1", "acknowledged")
@@ -170,7 +198,7 @@ async def test_lessons_delete_refuses_a_non_object_body(payload) -> None:
             body = await response.json()
 
     assert response.status == 400
-    assert body == {"error": "request body must be a JSON object", "code": "invalid_json"}
+    assert body == {"error": "body must be a JSON object", "code": "body_not_object"}
     app["state"].lessons.remove.assert_not_called()
 
 

--- a/test/test_cron_message_cap.py
+++ b/test/test_cron_message_cap.py
@@ -14,9 +14,10 @@ A cron job's message is a task prompt, so it gets its own generous cap
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers import api_cron_update, api_crons_create
@@ -147,7 +148,7 @@ def _create_request(body: dict, crons: CronService) -> MagicMock:
     state.crons = crons
     request = MagicMock()
     request.app = {"state": state}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 

--- a/test/test_cron_name_cap.py
+++ b/test/test_cron_name_cap.py
@@ -25,9 +25,10 @@ Locks in that the persistence owner now binds every caller:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers import api_cron_update, api_crons_create
@@ -105,7 +106,7 @@ def _create_request(body: dict, crons: CronService) -> MagicMock:
     state.crons = crons
     request = MagicMock()
     request.app = {"state": state}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 

--- a/test/test_cron_patch_name_validation.py
+++ b/test/test_cron_patch_name_validation.py
@@ -13,9 +13,10 @@ diverge.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers import api_cron_update
@@ -35,7 +36,7 @@ def _create_request(body: dict, crons: CronService) -> MagicMock:
     state.crons = crons
     request = MagicMock()
     request.app = {"state": state}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 
@@ -88,8 +89,6 @@ class TestDashboardUpdateName:
         (zero-width space) is stripped before persistence, matching create."""
         crons = CronService(base_dir=tmp_path)
         job = crons.add_job(name="old", message="m", every_secs=3600)
-        resp = await api_cron_update(
-            _update_request({"name": "new\u200bname"}, crons, job.id)
-        )
+        resp = await api_cron_update(_update_request({"name": "new\u200bname"}, crons, job.id))
         assert resp.status == 200
         assert crons.list_jobs()[0].name == "newname"

--- a/test/test_dashboard_cron_approval.py
+++ b/test/test_dashboard_cron_approval.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.cron import CronSchedule
 from kiro_crew.dashboard.handlers import api_crons, api_crons_create
@@ -23,7 +24,7 @@ class TestCronCreateApprovalMode:
         mock_state.crons.add_job_async = AsyncMock(return_value=mock_job)
         request = MagicMock()
         request.app = {"state": mock_state}
-        request.json = AsyncMock(return_value=body)
+        attach_body(request, body)
         return request
 
     @pytest.mark.asyncio
@@ -89,7 +90,7 @@ class TestCronCreateTimezonePersistenceOwner:
         mock_state.crons.add_job_async = AsyncMock(return_value=mock_job)
         request = MagicMock()
         request.app = {"state": mock_state}
-        request.json = AsyncMock(return_value=body)
+        attach_body(request, body)
         return request, mock_state
 
     @pytest.mark.asyncio
@@ -142,7 +143,7 @@ class TestCronCreateModel:
         mock_state.crons.add_job_async = AsyncMock(return_value=mock_job)
         request = MagicMock()
         request.app = {"state": mock_state}
-        request.json = AsyncMock(return_value=body)
+        attach_body(request, body)
         return request
 
     @pytest.mark.asyncio

--- a/test/test_dashboard_cron_channel.py
+++ b/test/test_dashboard_cron_channel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.dashboard.handlers import api_crons_create
 
@@ -19,8 +20,9 @@ class TestCronCreateChannel:
         mock_state.crons.add_job_async = AsyncMock(return_value=mock_job)
         request = MagicMock()
         request.app = {"state": mock_state}
-        request.json = AsyncMock(
-            return_value={"name": "test", "message": "msg", "every": 300, "channel": "C0AP77JJSN6"}
+        attach_body(
+            request,
+            {"name": "test", "message": "msg", "every": 300, "channel": "C0AP77JJSN6"},
         )
         resp = await api_crons_create(request)
         assert resp.status == 200
@@ -36,8 +38,9 @@ class TestCronCreateChannel:
         mock_state = MagicMock()
         request = MagicMock()
         request.app = {"state": mock_state}
-        request.json = AsyncMock(
-            return_value={"name": "test", "message": "msg", "every": 300, "channel": "not-valid"}
+        attach_body(
+            request,
+            {"name": "test", "message": "msg", "every": 300, "channel": "not-valid"},
         )
         resp = await api_crons_create(request)
         assert resp.status == 400

--- a/test/test_dashboard_cron_concurrent_create.py
+++ b/test/test_dashboard_cron_concurrent_create.py
@@ -21,9 +21,10 @@ save when any optional field was set) and pass against the remediation.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers import api_crons_create
@@ -34,7 +35,7 @@ def _create_request(body: dict, crons: CronService) -> MagicMock:
     state.crons = crons
     request = MagicMock()
     request.app = {"state": state}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 

--- a/test/test_dashboard_cron_folder_id.py
+++ b/test/test_dashboard_cron_folder_id.py
@@ -11,6 +11,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers import api_cron_update, api_crons_create
@@ -27,7 +28,7 @@ def _create_request(body: dict, crons: CronService) -> MagicMock:
     state.crons = crons
     request = MagicMock()
     request.app = {"state": state}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 
@@ -81,7 +82,7 @@ class TestCronUpdateFolderId:
         request = MagicMock()
         request.app = {"state": state}
         request.match_info = {"job_id": job_id}
-        request.json = AsyncMock(return_value=body)
+        attach_body(request, body)
         return request
 
     @pytest.mark.asyncio

--- a/test/test_dashboard_cron_folders.py
+++ b/test/test_dashboard_cron_folders.py
@@ -11,6 +11,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from body_stream_helpers import BodyStreamPayload
 
 from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers.cron import (
@@ -51,8 +52,10 @@ def _make_state(tmp_path) -> MagicMock:
 def _request(state, body=None, match_info=None):
     request = MagicMock()
     request.app = {"state": state}
-    if body is not None:
-        request.json = AsyncMock(return_value=body)
+    raw = json.dumps(body).encode() if body is not None else b""
+    request.content = BodyStreamPayload(raw)
+    request.content_length = len(raw) or None
+    request.charset = None
     if match_info:
         request.match_info = match_info
     return request
@@ -664,14 +667,9 @@ class TestCronFoldersConcurrency:
         state._cron_folders = []
         state.push_refresh = MagicMock()
 
-        # Build mock requests
-        req_a = MagicMock()
-        req_a.app = {"state": state}
-        req_a.json = AsyncMock(return_value={"name": "FolderA"})
-
-        req_b = MagicMock()
-        req_b.app = {"state": state}
-        req_b.json = AsyncMock(return_value={"name": "FolderB"})
+        # Build mock requests (real body bytes: the handler streams request.content)
+        req_a = _request(state, body={"name": "FolderA"})
+        req_b = _request(state, body={"name": "FolderB"})
 
         # Fire both concurrently
         results = await asyncio.gather(
@@ -702,9 +700,7 @@ class TestCronFoldersConcurrency:
         state.crons.list_jobs = MagicMock(return_value=[])
         state.save_cron_folders()  # persist initial state
 
-        req_create = MagicMock()
-        req_create.app = {"state": state}
-        req_create.json = AsyncMock(return_value={"name": "NewFolder"})
+        req_create = _request(state, body={"name": "NewFolder"})
 
         req_delete = MagicMock()
         req_delete.app = {"state": state}

--- a/test/test_dashboard_cron_hide_in_chat.py
+++ b/test/test_dashboard_cron_hide_in_chat.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers import api_cron_update, api_crons_create
@@ -29,7 +30,7 @@ def _create_request(body: dict, crons: CronService) -> MagicMock:
     state.crons = crons
     request = MagicMock()
     request.app = {"state": state}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 
@@ -83,7 +84,7 @@ class TestCronUpdateHideInChat:
         request = MagicMock()
         request.app = {"state": state}
         request.match_info = {"job_id": job_id}
-        request.json = AsyncMock(return_value=body)
+        attach_body(request, body)
         return request
 
     @pytest.mark.asyncio

--- a/test/test_dashboard_cron_update_agent.py
+++ b/test/test_dashboard_cron_update_agent.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.dashboard.handlers import api_cron_update
 
@@ -26,7 +27,7 @@ def _make_request(body: dict, job_id: str = "abc123") -> MagicMock:
     request = MagicMock()
     request.app = {"state": mock_state}
     request.match_info = {"job_id": job_id}
-    request.json = AsyncMock(return_value=body)
+    attach_body(request, body)
     return request
 
 

--- a/test/test_dashboard_files_coverage.py
+++ b/test/test_dashboard_files_coverage.py
@@ -286,14 +286,14 @@ class TestFileWrite:
                 "/api/file-write", data="not json", headers={"Content-Type": "application/json"}
             )
             assert resp.status == 400
-            assert (await resp.json())["error"] == "invalid JSON body"
+            assert (await resp.json())["error"] == "invalid JSON"
 
     @pytest.mark.asyncio
     async def test_non_object_body_is_400(self, mock_sel):
         async with TestClient(TestServer(self._client_app())) as client:
             resp = await client.post("/api/file-write", json=["a", "list"])
             assert resp.status == 400
-            assert (await resp.json())["error"] == "invalid JSON body"
+            assert (await resp.json())["error"] == "body must be a JSON object"
 
     @pytest.mark.asyncio
     async def test_schema_violation_is_400(self, mock_sel):
@@ -796,7 +796,7 @@ class TestRevealPath:
                 "/api/reveal", data="{", headers={"Content-Type": "application/json"}
             )
             assert resp.status == 400
-            assert (await resp.json())["error"] == "invalid JSON body"
+            assert (await resp.json())["error"] == "invalid JSON"
 
     @pytest.mark.asyncio
     async def test_traversal_in_path_is_400(self, mock_sel):

--- a/test/test_gateway_appkit_endpoints.py
+++ b/test/test_gateway_appkit_endpoints.py
@@ -338,9 +338,9 @@ class TestContextInjection:
 
     @pytest.mark.asyncio
     async def test_scalar_json_body_is_a_400_not_a_500(self, tmp_path: Path):
-        """`null` is VALID json: it survives the parse and then makes `.get`
-        raise into a 500. The shape needs its own rejection. Shared with
-        /note, which reaches the same validators."""
+        """`null` is VALID json: it survives the parse and would make `.get`
+        raise into a 500. ``read_bounded_json`` refuses the shape as
+        ``body_not_object``. Shared with /note, which reads the same guard."""
         state = _make_state(tmp_path)
         state._slots["s1"] = _ChatSlot("s1")
         async with self._make_client(state) as client:
@@ -351,7 +351,7 @@ class TestContextInjection:
                     headers={"Content-Type": "application/json"},
                 )
                 assert resp.status == 400, f"{raw!r} should be a 400, got {resp.status}"
-                assert (await resp.json())["code"] == "invalid_body"
+                assert (await resp.json())["code"] == "body_not_object"
 
     @pytest.mark.asyncio
     async def test_huge_integer_max_age_is_a_400_not_a_500(self, tmp_path: Path):
@@ -1486,8 +1486,8 @@ class TestNoteEndpoint:
 
     @pytest.mark.asyncio
     async def test_note_scalar_json_body_is_a_400_not_a_500(self, tmp_path: Path):
-        """`null` is VALID json, so it survives the parse and then makes `.get`
-        raise. The shape needs its own rejection or the endpoint 500s."""
+        """`null` is VALID json, so it survives the parse and would make `.get`
+        raise. ``read_bounded_json`` refuses the shape as ``body_not_object``."""
         state = _make_state(tmp_path)
         state._slots["s1"] = _ChatSlot("s1")
         async with self._make_client(state) as client:
@@ -1498,7 +1498,7 @@ class TestNoteEndpoint:
                     headers={"Content-Type": "application/json"},
                 )
                 assert resp.status == 400, f"{raw!r} should be a 400, got {resp.status}"
-                assert (await resp.json())["code"] == "invalid_body"
+                assert (await resp.json())["code"] == "body_not_object"
 
     @pytest.mark.asyncio
     async def test_note_huge_integer_max_age_is_a_400_not_a_500(self, tmp_path: Path):

--- a/test/test_handlers_mcp_coverage.py
+++ b/test/test_handlers_mcp_coverage.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
+from body_stream_helpers import BodyStreamPayload
 
 from kiro_crew.dashboard.handlers import mcp as mcp_mod
 from kiro_crew.mcp_discovery import McpServerInfo
@@ -43,9 +44,19 @@ def _request(
     """Minimal aiohttp request double, matching the suite's existing style."""
     req = MagicMock(spec=web.Request)
     if isinstance(body, Exception):
+        # Malformed body: real undecodable bytes for the streaming (capped)
+        # path, a raising mock for the ``request.json()`` (uncapped) path.
+        raw = b"{not json"
         req.json = AsyncMock(side_effect=body)
     else:
+        raw = json.dumps(body).encode() if body is not None else b""
+        # Kept alive: ``api_mcp_server_detail`` reads uncapped
+        # (``max_bytes=None``) and consumes ``request.json()``.
         req.json = AsyncMock(return_value=body)
+    req.content = BodyStreamPayload(raw)
+    req.content_length = len(raw) if raw else None
+    req.charset = None
+    req.can_read_body = bool(raw)
     req.app = {"state": state if state is not None else _State()}
     req.query = query or {}
     req.match_info = match_info or {}

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
+from body_stream_helpers import BodyStreamPayload
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK, AcpEvent
 from kiro_crew.dashboard.handlers.taskrunner import (
@@ -99,38 +100,6 @@ def _state(runner: MagicMock | None) -> SimpleNamespace:
     return SimpleNamespace(task_runner=runner)
 
 
-class _Payload:
-    """Minimal stand-in for the request body stream.
-
-    Five of this module's handlers now read their body through
-    ``_shared.read_bounded_json`` with the shared 64 KB cap, which enforces the
-    ceiling BEFORE decoding by draining ``request.content`` incrementally --
-    so a mocked ``request.json`` alone no longer feeds them. Supplying a real
-    payload serves both paths: the capped handlers drain this stream, and the
-    uncapped ones still go through ``request.json()``.
-    """
-
-    def __init__(self, raw: bytes) -> None:
-        self._raw = raw
-
-    async def iter_chunked(self, n: int):
-        for i in range(0, len(self._raw), n):
-            yield self._raw[i : i + n]
-
-    async def read(self) -> bytes:
-        return self._raw
-
-    def set_read_chunk_size(self, size: int) -> None:
-        # ``request.read()`` configures the stream before draining it.
-        return None
-
-    def at_eof(self) -> bool:
-        # ``request.can_read_body`` is ``not payload.at_eof()``, and the
-        # allow_absent handlers branch on it: reporting EOF while bytes are
-        # waiting would make every request look bodyless and silently default.
-        return not self._raw
-
-
 def _request(
     state: Any,
     method: str = "POST",
@@ -162,9 +131,12 @@ def _request(
         app=app,
         match_info=match_info or {},
         headers=headers,
-        payload=_Payload(raw),
+        payload=BodyStreamPayload(raw),
     )
     req["app"] = request_app
+    # Kept alive: the uncapped handlers (``max_bytes=None`` -- start, plan,
+    # update_plan, update_task, from_chat, refine) consume ``request.json()``;
+    # the capped ones drain the payload stream instead.
     if raw_json_error:
         req.json = AsyncMock(side_effect=ValueError("bad json"))  # type: ignore[method-assign]
     elif json_body is not None or body_present:

--- a/test/test_json_object_body_guard.py
+++ b/test/test_json_object_body_guard.py
@@ -253,6 +253,87 @@ _CAP_REGISTER: dict[str, tuple[str, str]] = {
     "chat_tags.py::api_chat_tag_column_update": ("<default>", _BOUNDED_CONTROL_FIELDS),
     "chat_tags.py::api_chat_tag_columns_reorder": ("<default>", _BOUNDED_CONTROL_FIELDS),
     "chat_tags.py::api_chat_slot_drop": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    # ---- tranche 3 ----
+    # chat_handlers.py: control-field slot mutations take the cap; the sites
+    # that carry a chat message, queued-edit text, follow-up prompts, or
+    # injected context/note content stay uncapped.
+    "chat_handlers.py::api_chat": ("None", _UNBOUNDED_USER_CONTENT),
+    "chat_handlers.py::api_chat_slot_create": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_end_wait": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_interrupt": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_queue_edit": ("None", _UNBOUNDED_USER_CONTENT),
+    "chat_handlers.py::api_chat_slot_queue_reorder": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_reset_conversation": (
+        "<default>",
+        _BOUNDED_CONTROL_FIELDS,
+    ),
+    "chat_handlers.py::api_chat_slots_cleanup": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_agent": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_model": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slots_model": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_reasoning_effort": (
+        "<default>",
+        _BOUNDED_CONTROL_FIELDS,
+    ),
+    "chat_handlers.py::api_chat_slot_workspace": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_project": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_followup": ("None", _UNBOUNDED_USER_CONTENT),
+    "chat_handlers.py::api_chat_slot_resume": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_mode": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_approve": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_color": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_handlers.py::api_chat_slot_context": ("None", _UNBOUNDED_USER_CONTENT),
+    "chat_handlers.py::api_chat_slot_note": ("None", _UNBOUNDED_USER_CONTENT),
+    # handlers/mcp.py: identifier/flag mutations take the cap; a full server
+    # config (PUT detail) and per-server toolOverrides maps (apply) do not.
+    "handlers/mcp.py::api_mcp_quarantine_clear": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/mcp.py::api_mcp_toggle": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/mcp.py::api_mcp_toggle_tool": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/mcp.py::api_mcp_toggle_all": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/mcp.py::api_mcp_remove": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/mcp.py::api_mcp_server_detail": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/mcp.py::_do_mcp_apply": ("_MCP_APPLY_MAX_BODY_BYTES", _BOUNDED_EXPLICIT),
+    "handlers/mcp.py::api_mcp_gateway_enable": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/mcp.py::api_mcp_gateway_set_stub": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    # handlers/cron.py: create/update carry the job's full agent message,
+    # whose MAX_CRON_MESSAGE character bound can exceed the shared 64 KB
+    # default in multibyte UTF-8 -- so they take a per-route ceiling sized to
+    # the field bound; everything else is ids and flags.
+    "handlers/cron.py::api_crons_create": ("_MAX_CRON_BODY_BYTES", _BOUNDED_EXPLICIT),
+    "handlers/cron.py::api_cron_batch_delete": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/cron.py::api_cron_update": ("_MAX_CRON_BODY_BYTES", _BOUNDED_EXPLICIT),
+    "handlers/cron.py::api_cron_enable": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/cron.py::api_cron_ack": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/cron.py::api_lessons_create": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/cron.py::api_lessons_delete": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/cron.py::api_cron_folders_create": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/cron.py::api_cron_folders_update": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    # handlers/workflows.py: workflow bodies carry a script source or a
+    # free-form intent/input, so only promote (fixed metadata) takes the cap.
+    "handlers/workflows.py::api_workflow_definitions_create": (
+        "None",
+        _UNBOUNDED_USER_CONTENT,
+    ),
+    "handlers/workflows.py::api_workflow_definition_update": (
+        "None",
+        _UNBOUNDED_USER_CONTENT,
+    ),
+    "handlers/workflows.py::api_workflow_definition_run": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/workflows.py::api_workflow_author": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/workflows.py::api_workflow_run": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/workflows.py::api_workflow_run_intent": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/workflows.py::api_workflow_run_promote": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/workflows.py::api_workflow_run_rerun": ("None", _UNBOUNDED_USER_CONTENT),
+    # handlers/files.py: bodies name paths and routing fields -- the file
+    # bytes travel in api_file_write's body, which is the one uncapped site.
+    "handlers/files.py::api_reveal_path": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/files.py::api_outbox_notify": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/files.py::api_slack_upload_file": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/files.py::api_channel_upload_file": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/files.py::api_workspaces_create": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/files.py::api_workspaces_update": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/files.py::api_file_write": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/files.py::api_dashboard_config": ("<default>", _BOUNDED_CONTROL_FIELDS),
 }
 
 _DASHBOARD_DIR = Path(shared.__file__).resolve().parent.parent

--- a/test/test_lesson_contradiction.py
+++ b/test/test_lesson_contradiction.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
@@ -355,7 +356,8 @@ class TestApiLessonsCreateSchedulesSweep:
         request = MagicMock()
         request.app = {"state": state}
         request.headers = {"X-Session-Key": "dashboard:ui"}
-        request.json = AsyncMock(return_value={"rule": "a real rule", "category": "knowledge"})
+        body = {"rule": "a real rule", "category": "knowledge"}
+        attach_body(request, body)
         return request
 
     async def _run(self, candidates, wrote=True):
@@ -435,13 +437,12 @@ class TestApiLessonsCreateForwardsNegative:
         request = MagicMock()
         request.app = {"state": state}
         request.headers = {"X-Session-Key": "dashboard:ui"}
-        request.json = AsyncMock(
-            return_value={
-                "rule": self._RULE,
-                "category": "tool",
-                "negative": self._NEGATIVE,
-            }
-        )
+        body = {
+            "rule": self._RULE,
+            "category": "tool",
+            "negative": self._NEGATIVE,
+        }
+        attach_body(request, body)
         return request
 
     async def _post(self, state, vector_store):
@@ -521,7 +522,8 @@ class TestApiLessonsDeleteOffloadsRemove:
         request = MagicMock()
         request.app = {"state": state}
         request.headers = {"X-Session-Key": "dashboard:ui"}
-        request.json = AsyncMock(return_value={"rule": "pin the port"})
+        body = {"rule": "pin the port"}
+        attach_body(request, body)
 
         with patch.object(cron, "_get_memory", return_value=MagicMock(vector_store=None)), \
              patch.object(cron, "_is_restricted_session", return_value=False), \

--- a/test/test_lesson_write_outcome.py
+++ b/test/test_lesson_write_outcome.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from body_stream_helpers import attach_body
 
 from kiro_crew.vector_memory import (
     LessonWriteOutcome,
@@ -354,7 +355,8 @@ class TestLessonsRouteReportsTheOutcome:
         state._background_tasks = set()
         request.app = {"state": state}
         request.headers = {"X-Session-Key": "dashboard:ui"}
-        request.json = AsyncMock(return_value={"rule": "a real rule", "category": "knowledge"})
+        body = {"rule": "a real rule", "category": "knowledge"}
+        attach_body(request, body)
         return request, state
 
     async def _post(self, result):

--- a/test/test_mcp_apply.py
+++ b/test/test_mcp_apply.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from aiohttp import web
+from body_stream_helpers import attach_body
 
 from kiro_crew.platform.interfaces import McpScope
 
@@ -23,16 +24,17 @@ class _NoSyncLock:
 
 
 def _make_request(body: dict) -> MagicMock:
-    """Build a fake aiohttp request for the api_mcp_apply handler."""
+    """Build a fake aiohttp request for the api_mcp_apply handler.
+
+    Carries real body bytes: the handler reads through ``read_bounded_json``'s
+    capped path (``_MCP_APPLY_MAX_BODY_BYTES``), which drains
+    ``request.content`` instead of calling ``request.json()``.
+    """
     state = MagicMock()
     state._background_tasks = set()
     request = MagicMock(spec=web.Request)
     request.app = {"state": state}
-
-    async def _json() -> dict:
-        return body
-
-    request.json = _json
+    attach_body(request, body)
     return request
 
 
@@ -529,12 +531,30 @@ def _make_stub_request(body: dict) -> MagicMock:
     request = MagicMock(spec=web.Request)
     request.app = {"state": state}
     request.get = MagicMock(return_value="dashboard")
-
-    async def _json() -> dict:
-        return body
-
-    request.json = _json
+    attach_body(request, body)
     return request
+
+
+class TestApplyBodyCeiling:
+    @pytest.mark.asyncio
+    async def test_oversized_apply_body_is_413_before_decoding(self):
+        """The declared-length precheck refuses an over-ceiling body outright.
+
+        The change-count cap runs only after decoding, so the byte ceiling is
+        what stops an arbitrarily large body from being buffered whole.
+        """
+        from kiro_crew.dashboard.handlers.mcp import (
+            _MCP_APPLY_MAX_BODY_BYTES,
+            _do_mcp_apply,
+        )
+
+        request = _make_request({"changes": []})
+        request.content_length = _MCP_APPLY_MAX_BODY_BYTES + 1
+
+        resp = await _do_mcp_apply(request)
+
+        assert resp.status == 413
+        assert json.loads(resp.text)["code"] == "payload_too_large"
 
 
 class TestSetStubNameGate:

--- a/test/test_mcp_gateway_control_plane.py
+++ b/test/test_mcp_gateway_control_plane.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
+from body_stream_helpers import attach_body
 
 from kiro_crew.dashboard.handlers import mcp as mcp_mod
 from kiro_crew.slack.gateway import GatewayOrchestrator
@@ -23,7 +24,7 @@ from kiro_crew.slack.gateway import GatewayOrchestrator
 
 def _make_request(state: object, body: dict) -> web.Request:
     req = MagicMock(spec=web.Request)
-    req.json = AsyncMock(return_value=body)
+    attach_body(req, body)
     req.app = {"state": state}
     req.get = lambda key, default=None: default
     return req

--- a/test/test_mcp_mutation_identifiers.py
+++ b/test/test_mcp_mutation_identifiers.py
@@ -19,14 +19,21 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
+from body_stream_helpers import BodyStreamPayload
 
 from kiro_crew.dashboard.handlers import mcp as h
 
 
 def _req(body: object) -> web.Request:
     app = web.Application()
-    req = make_mocked_request("POST", "/api/mcp/toggle", app=app)
-    req.json = AsyncMock(return_value=body)
+    raw = json.dumps(body).encode()
+    req = make_mocked_request(
+        "POST",
+        "/api/mcp/toggle",
+        app=app,
+        headers={"Content-Length": str(len(raw))},
+        payload=BodyStreamPayload(raw),
+    )
     return req
 
 

--- a/test/test_stop_addresses_linked_session.py
+++ b/test/test_stop_addresses_linked_session.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
+from body_stream_helpers import BodyStreamPayload
 
 LINKED_KEY = "slack:1730000000.123456"
 
@@ -68,14 +69,20 @@ class _FakeState:
         return 0
 
 
-def _request(state, query=None, caller_app=""):
+def _request(state, query=None, caller_app="", raw: bytes = b""):
     app = web.Application()
     app["state"] = state
     request = MagicMock()
     request.app = app
     request.match_info = {"slot": "test-slot"}
     request.query = query or {}
-    request.json = AsyncMock(return_value={})
+    # The bounded body read consumes these instead of ``request.json``. An
+    # empty ``raw`` reads as "no body sent", which the allow_absent handlers
+    # default to an empty object.
+    request.content = BodyStreamPayload(raw)
+    request.content_length = len(raw)
+    request.can_read_body = bool(raw)
+    request.charset = None
     # The auth middleware stashes the calling app's name here; a dashboard user
     # leaves it absent, which `request.get("app", "")` reads as "".
     request.get = lambda key, default="": caller_app if key == "app" else default
@@ -524,16 +531,18 @@ class TestTheAuthorizedSessionCannotMoveMidFlight:
         slot = _FakeSlot(app="auto-research")
         slot._queue.append({"queue_id": "q1", "content": "next"})
         state = _FakeState(slot)
-        request = _request(state, caller_app="auto-research")
-        request.content_length = 2
+        request = _request(state, caller_app="auto-research", raw=b"{}")
 
-        async def _bind_then_return_body():
-            # Stands in for the concurrent to-chat handler resuming inside this
-            # await; it only assigns the field, exactly as that handler does.
-            slot.linked_session_key = "cron:nightly-report"
-            return {}
+        class _BindingPayload(BodyStreamPayload):
+            # Stands in for the concurrent to-chat handler resuming inside the
+            # awaited body read; it only assigns the field, exactly as that
+            # handler does.
+            async def iter_chunked(self, n: int):
+                slot.linked_session_key = "cron:nightly-report"
+                async for chunk in super().iter_chunked(n):
+                    yield chunk
 
-        request.json = _bind_then_return_body
+        request.content = _BindingPayload(b"{}")
         with patch("kiro_crew.dashboard.chat_handlers.sel") as mock_sel:
             mock_sel.return_value.log_tool_invocation = MagicMock()
             mock_sel.return_value.log = MagicMock()

--- a/test/test_stop_handler_idempotent.py
+++ b/test/test_stop_handler_idempotent.py
@@ -9,6 +9,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from body_stream_helpers import BodyStreamPayload
 
 
 class _FakeSlot:
@@ -174,6 +175,92 @@ class TestInterruptHandlerIdempotent:
         assert body.get("info") == "stop already in progress"
         # Queue unchanged
         assert len(slot._queue) == 1
+
+    @pytest.mark.asyncio
+    async def test_refused_body_restores_auto_run(self):
+        """A 400-refused body rolls back BOTH claimed fields.
+
+        The handler claims ``_stop_state`` and disables ``_auto_run`` before
+        the body await; a request refused by the body guard must restore both,
+        or a malformed /interrupt permanently disables orchestrator auto-run
+        without interrupting anything.
+        """
+        from aiohttp import web
+
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot()
+        slot.running = True
+        slot._queue = [{"id": "q1", "content": "hello"}]
+        slot._auto_run = True
+
+        state = _FakeState(slot)
+        app = web.Application()
+        app["state"] = state
+
+        request = MagicMock()
+        request.get = lambda key, default="": default
+        request.app = app
+        request.match_info = {"slot": "test-slot"}
+        raw = b'["not", "an", "object"]'
+        request.content = BodyStreamPayload(raw)
+        request.content_length = len(raw)
+        request.can_read_body = True
+        request.charset = None
+
+        resp = await api_chat_slot_interrupt(request)
+
+        assert resp.status == 400
+        assert slot._stop_state == "idle"
+        assert slot._auto_run is True
+
+    @pytest.mark.asyncio
+    async def test_refused_body_does_not_erase_a_concurrent_hard_stop(self):
+        """A rollback must not overwrite a stop escalated during the body await.
+
+        The handler claims ``_stop_state = "soft_pending"`` before awaiting the
+        body. A concurrent /stop landing during that await escalates the state
+        (e.g. to ``"killing"``). When the body is then refused, rolling back to
+        ``"idle"`` would erase the escalation and admit another stop while the
+        hard kill still runs -- so the rollback fires only while the handler's
+        own claim is intact, and the escalated stop keeps ``_auto_run`` too.
+        """
+        from aiohttp import web
+
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot()
+        slot.running = True
+        slot._queue = [{"id": "q1", "content": "hello"}]
+        slot._auto_run = True
+
+        class EscalatingPayload(BodyStreamPayload):
+            """Body stream that simulates a concurrent /stop mid-read."""
+
+            async def iter_chunked(self, n: int):
+                slot._stop_state = "killing"
+                async for chunk in super().iter_chunked(n):
+                    yield chunk
+
+        state = _FakeState(slot)
+        app = web.Application()
+        app["state"] = state
+
+        request = MagicMock()
+        request.get = lambda key, default="": default
+        request.app = app
+        request.match_info = {"slot": "test-slot"}
+        raw = b'["not", "an", "object"]'
+        request.content = EscalatingPayload(raw)
+        request.content_length = len(raw)
+        request.can_read_body = True
+        request.charset = None
+
+        resp = await api_chat_slot_interrupt(request)
+
+        assert resp.status == 400
+        assert slot._stop_state == "killing"
+        assert slot._auto_run is False
 
 
 def _seed_stop_card(slot, stop_id="stop-race"):
@@ -531,6 +618,9 @@ class TestStopCancelsTheSessionTheTurnRunsOn:
 
         request = self._request(state)
         request.content_length = 0
+        # No body sent: read_bounded_json branches on can_read_body, which a
+        # bare MagicMock answers truthy — model the absent body explicitly.
+        request.can_read_body = False
 
         with patch("kiro_crew.dashboard.chat_handlers.sel"), patch(
             "kiro_crew.dashboard.chat_handlers._reject_pending_approvals"

--- a/test/test_workflow_definition_handlers.py
+++ b/test/test_workflow_definition_handlers.py
@@ -320,7 +320,7 @@ async def test_definition_create_rejects_non_object_json() -> None:
         body = await response.json()
 
     assert response.status == 400
-    assert body["code"] == "invalid_json"
+    assert body["code"] == "body_not_object"
 
 
 async def test_definition_create_write_failure_has_machine_readable_code() -> None:

--- a/test/test_workflow_handler_json_contract.py
+++ b/test/test_workflow_handler_json_contract.py
@@ -52,7 +52,7 @@ async def test_mutation_handlers_reject_non_object_json(
         body = await response.json()
 
     assert response.status == 400
-    assert body == {"error": "JSON body must be an object", "code": "invalid_json"}
+    assert body == {"error": "body must be a JSON object", "code": "body_not_object"}
     method.assert_not_awaited()
 
 

--- a/test/test_workspace_crud_handlers.py
+++ b/test/test_workspace_crud_handlers.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from body_stream_helpers import BodyStreamPayload
 
 from kiro_crew.config.loader import (
     KiroCrewAgentConfig,
@@ -26,16 +29,18 @@ from kiro_crew.dashboard.handlers import (
 # ── Helpers ──
 
 
-def _req(body: dict | None = None, match_info: dict | None = None) -> MagicMock:
-    """Build a mock aiohttp.web.Request."""
-    r = MagicMock()
-    if body is not None:
-        r.json = AsyncMock(return_value=body)
-    else:
-        r.json = AsyncMock(side_effect=json.JSONDecodeError("bad", "", 0))
-    r.get = MagicMock(return_value="test")
-    r.match_info = match_info or {}
-    return r
+def _req(body: dict | None = None, match_info: dict | None = None) -> web.Request:
+    """Build a mocked aiohttp.web.Request carrying real body bytes."""
+    # ``body=None`` means "malformed JSON": the capped read parses the bytes
+    # itself, so the malformed case is expressed as malformed bytes.
+    raw = json.dumps(body).encode() if body is not None else b"{bad json"
+    return make_mocked_request(
+        "POST",
+        "/api/workspaces",
+        match_info=match_info or {},
+        headers={"Content-Length": str(len(raw))},
+        payload=BodyStreamPayload(raw),
+    )
 
 
 def _cfg(**kw: object) -> KiroCrewConfig:
@@ -64,7 +69,7 @@ class TestCreateHandler:
     async def test_invalid_json_returns_400(self) -> None:
         resp = await api_workspaces_create(_req(body=None))
         assert resp.status == 400
-        assert b"Invalid JSON" in resp.body
+        assert b"invalid JSON" in resp.body
 
     @pytest.mark.asyncio
     async def test_empty_name_returns_400(self) -> None:
@@ -166,7 +171,7 @@ class TestUpdateHandler:
         with patch(_LOAD, return_value=cfg):
             resp = await api_workspaces_update(_req(body=None, match_info={"name": "default"}))
         assert resp.status == 400
-        assert b"Invalid JSON" in resp.body
+        assert b"invalid JSON" in resp.body
 
     @pytest.mark.asyncio
     async def test_update_dir_success(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Tranche 3 of the #5587 sweep. Routes the 55 bare `await request.json()` sites in `chat_handlers.py` and `handlers/{mcp,cron,workflows,files}.py` through the shared body guard `read_bounded_json`, so a valid-JSON-non-object body (`[]`, `"s"`, `5`, `null`) answers **400 `body_not_object`** instead of the AttributeError 500 the follow-on `.get()` raised.

Refs #5587 — **partial fix, do not close**. Out of scope per the issue: the four deliberately-divergent guards (`handlers_channel._json_object`, `handlers/hooks.py::_json_object`, `handlers/artifacts.py::_read_json_body`, `handlers/session_storage.py::_json_body`) and their fold decision.

## Cap decisions (all recorded in the guard test's `_CAP_REGISTER`)

- **38 sites** with fixed control-field bodies take the shared 64 KB cap.
- **3 sites** take explicit per-route ceilings sized to their own declared bounds: `api_crons_create` / `api_cron_update` (`_MAX_CRON_BODY_BYTES` = 4×`MAX_CRON_MESSAGE` + 64 KB headroom, since a maximal multibyte message exceeds 64 KB) and `_do_mcp_apply` (`_MCP_APPLY_MAX_BODY_BYTES` = 1 MB, its change-count cap runs only after decoding).
- **14 sites** whose bodies carry a chat message, queued-edit text, follow-up prompts, injected context/notes, workflow script source, NL intent, a full MCP server config, or file contents stay uncapped via explicit `max_bytes=None`.
- **Zero new cap deferrals** — the `_CONTROL_FIELDS_CAP_PENDING` ratchet stays at 13.

## Behavior changes

- Non-object bodies: 400 `body_not_object` (was a 500, or a custom 400 message on a few routes).
- Capped sites answer **413 `payload_too_large`** for oversized bodies, enforced before decoding.
- Sites that defaulted an ABSENT body keep doing so (`allow_absent`), but a present-and-malformed body is a 400 instead of silently collapsing to defaults (`api_cron_enable`, `api_cron_ack`, `api_workflow_run_rerun` — the same defect class #5587 originally fixed in `api_memory_promote`).
- SEL denial audits in `handlers/files.py` derive their error label from the guard response's `code`, so a 413 is audited as `payload_too_large`, not as a JSON parse failure.
- Frontend leg checked: no `website/src` code switches on the retired `invalid_body` / per-route `invalid_json` codes (remaining greps are unrelated i18n keys), so no frontend change rides along.

## Testing

- Capped sites stream `request.content`, so every affected mocked-`json` harness now feeds real bytes via the new shared `test/body_stream_helpers.py` (`BodyStreamPayload` / `attach_body`), which also collapses what would have been ~13 copy-pasted stream stubs.
- New pinning tests: refused `/interrupt` body restores both `_stop_state` and `_auto_run`; oversized `/api/mcp/apply` body is 413 before decoding.
- Full backend suite: 77,363 passed; the 93 remaining reds are host-environmental on this dev box (identical set fails on a pristine main worktree at the same base).
- Gates: isort, flake8, mypy (1216 files), diff-scoped black / brand / subprocess-encoding / harness-parity all green. `error-code-baseline.json` regenerated per its own `--update` remedy (removed codeless 400 literals).

## Pre-push blind review

Two model-pinned read-only lanes on the staged diff:
- GPT lane: 2 Medium findings, both fixed — `/interrupt` left `_auto_run` disabled on a refused body; `_do_mcp_apply` opted out of the cap despite bounded control data.
- Opus lane: 1 blocking finding fixed — cron create/update filed under the terminal uncapped reason despite a declared field bound (now explicit ceilings); 5 advisories adopted (narration comments, SEL 413 labels, dead mocks dropped, `_Payload` consolidation, `user_meta` narrowing comment), 1 verified-no-action.

## Remaining files (tracked on #5587)

~131 bare sites remain across ~51 dashboard files, largest first: `handlers/messaging.py` (27), `handlers/prompts.py` (6), `handlers/security.py` (6), `handlers/source_providers.py` (6), `handlers/core.py` (5), `handlers/updates.py` (5), `chat_folders.py` (5), `handlers/agents.py` (4), `handlers/hooks.py` (4), `handlers/side.py` (4), plus ~41 files with 1–3 sites each.
