### PR TITLE
fix(security): make the publish floor descend into nested shell payloads

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3279,8 +3279,30 @@ def _nested_shell_payloads(tokens: "list[str]") -> "list[str]":
                     payloads.append(tokens[j].split("=", 1)[1])
                     break
         elif base in _NESTED_SHELL_VERBS or token in _NESTED_SHELL_VERBS:
-            if i + 1 < len(tokens):
-                payloads.append(tokens[i + 1])
+            # ``--`` ends option parsing, so ``eval -- '<script>'`` runs the token
+            # AFTER it. Taking ``tokens[i + 1]`` blindly yielded the literal ``--``
+            # as the payload and the real script was never walked. Skip any run of
+            # them, exactly as the ``-c`` branch above already does.
+            j = i + 1
+            while j < len(tokens) and tokens[j] == "--":
+                j += 1
+            if j < len(tokens):
+                payloads.append(tokens[j])
+                # ``eval`` CONCATENATES all of its arguments with a space and
+                # evaluates the RESULT, so a command split across several words
+                # is one command line at run time while no single word looks
+                # like one.  Taking only the first argument let
+                # ``eval '<program>' '<verb and args>'`` through: the hooks saw
+                # the bare program name and the publish never appeared.  The
+                # joined form is added ALONGSIDE the first argument, so the
+                # single-argument reading is unchanged.
+                #
+                # ``eval`` only.  ``source``/``.`` take a FILE as the first
+                # argument and pass the rest as positional parameters, so
+                # joining them would invent a command line bash never runs.
+                verb = base if base in _NESTED_SHELL_VERBS else token
+                if verb == "eval" and j + 1 < len(tokens):
+                    payloads.append(" ".join(tokens[j:]))
     # ``bash<<<'<payload>'`` glues the program, the operator and the payload into ONE
     # token, so the program never appears as a token of its own for the walk above to
     # recognise.  Split on the operator and check the left half.
@@ -3472,13 +3494,22 @@ def _decode_printf_escapes(text: str) -> str:
     return _NUMERIC_ESCAPE_RE.sub(_numeric_escape_char, text)
 
 
-def _self_token_frames(text_lower: str) -> "list[list[str]]":
-    """The command's own argv plus the argv of every nested shell payload.
+def _shell_payload_walk(text_lower: str) -> "list[tuple[str, list[str]]]":
+    """``(source, argv)`` for *text_lower* and every nested shell payload in it.
 
     ``bash -c "kirocrew token"`` tokenizes to ``['bash', '-c', 'kirocrew token']``
-    -- the dangerous command is a single opaque token, so the direct scan cannot
-    see it.  Re-tokenizing the payload and checking that argv too closes the
+    -- the dangerous command is a single opaque token, so a direct scan cannot
+    see it.  Re-tokenizing the payload and checking that view too closes the
     class rather than one spelling of it.
+
+    Both the SOURCE text and its argv are returned because the two floors that
+    consume this need different views of the same frame: the self-protection
+    predicates match argv structurally, while the git-publish gate is a
+    verb-anchored scan over command text.  Walking once and handing out both is
+    what keeps the two floors from drifting -- the publish gate previously did
+    its own top-level-only text match, so every wrapper form
+    (``bash -c '<push>'``, ``eval '<push>'``) bypassed the ONLY enforcement
+    pushes have.
 
     Descends to ANY depth.  A numeric depth cap is itself a bypass -- whatever the
     number, one more wrapper defeats it -- so the walk is bounded structurally: a
@@ -3486,7 +3517,7 @@ def _self_token_frames(text_lower: str) -> "list[list[str]]":
     than the parent's source text, and a chain of strictly shorter strings is
     finite.
     """
-    frames: list[list[str]] = []
+    out: list[tuple[str, list[str]]] = []
     seen: set[str] = set()
     pending: list[tuple[str, int]] = [(text_lower, len(text_lower) + 1)]
     while pending:
@@ -3494,7 +3525,7 @@ def _self_token_frames(text_lower: str) -> "list[list[str]]":
         tokens = _self_tokens(source)
         if not tokens:
             continue
-        frames.append(tokens)
+        out.append((source, tokens))
         # Every substitution body is itself a command line -- command substitution
         # (``$( )``, backticks) and PROCESS substitution (``<( )``, ``>( )``) alike, since
         # bash runs the inner command in all of them.  Walking them here means the
@@ -3508,7 +3539,17 @@ def _self_token_frames(text_lower: str) -> "list[list[str]]":
                 continue
             seen.add(payload)
             pending.append((payload, len(source)))
-    return frames
+    return out
+
+
+def _self_token_frames(text_lower: str) -> "list[list[str]]":
+    """The command's own argv plus the argv of every nested shell payload."""
+    return [tokens for _source, tokens in _shell_payload_walk(text_lower)]
+
+
+def _shell_payload_sources(text_lower: str) -> "list[str]":
+    """*text_lower* plus the source text of every nested shell payload in it."""
+    return [source for source, _tokens in _shell_payload_walk(text_lower)]
 
 
 def _substitution_depth_delta(token: str) -> int:
@@ -11076,9 +11117,20 @@ def is_denied(
     # applies), and we record the allow INTENT now — the ``push_allowed`` audit
     # is emitted only at a SUCCESS return path below, so the SEL trail reflects
     # the FINAL outcome (never an allow for a command ultimately denied).
+    #
+    # Evaluated over the whole string AND the source of every nested shell payload
+    # (``_shell_payload_sources``), because this floor is the SOLE enforcement for
+    # pushes -- every git-publish rule is stripped from the regex tier just above.
+    # A top-level-only text match therefore meant one wrapper was a complete
+    # bypass: ``bash -c 'git push origin main'`` and ``eval '<push>'`` reached no
+    # check at all, while the self-protection floor beside it was already immune
+    # because it re-tokenizes payloads. Same walk, same depth guarantee, so a
+    # wrapper cannot buy anything here either.
     push_allow_pending = False
-    if _is_git_publish(lower):
-        if _is_push_to_protected_branch(lower):
+    for payload_source in _shell_payload_sources(lower):
+        if not _is_git_publish(payload_source):
+            continue
+        if _is_push_to_protected_branch(payload_source):
             _emit_deny_event(tool_name, _GIT_PUBLISH_DENY_LABEL, lower)
             return _reason(_GIT_PUBLISH_DENY_LABEL)
         push_allow_pending = True

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -3894,7 +3894,17 @@ class TestSelfModuleIndexIsLinear:
 
     def test_the_scan_is_linear_not_quadratic(self):
         """Asserted two ways: a doubling ratio, which catches the quadratic regardless
-        of machine speed, and an absolute budget it could not meet on any runner."""
+        of machine speed, and an absolute budget it could not meet on any runner.
+
+        The ratio is taken over the BEST of several samples per size, not a single
+        pair. A ratio of two one-shot wall-clock samples is sensitive to machine
+        NOISE as well as machine speed: the true ratio is 2.0, so a lone slow
+        ``small`` sample on a runner hosting parallel shards pushes it past 3 with
+        no change in complexity (observed: 0.0642s -> 0.2020s, ratio 3.14, while
+        the same code measures 2.00 on a quiet machine). Best-of-N removes the
+        noise and keeps the power -- a quadratic scan cannot produce a passing
+        ratio even on its luckiest sample.
+        """
         import time
 
         from kiro_crew import security
@@ -3905,8 +3915,11 @@ class TestSelfModuleIndexIsLinear:
             security._is_self_restart(text)
             return time.perf_counter() - start
 
+        def best(n: int, samples: int = 3) -> float:
+            return min(elapsed(n) for _ in range(samples))
+
         elapsed(250)
-        small, large = elapsed(1000), elapsed(2000)
+        small, large = best(1000), best(2000)
         assert large < small * 3, f"{small:.4f}s -> {large:.4f}s looks super-linear"
         # Base spent 1.94 s here; a quadratic scan cannot come near this ceiling.
         assert large < 0.5, f"2k tokens took {large:.3f}s"

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -8037,3 +8037,157 @@ class TestModelWeightsAreWriteProtected:
     def test_an_unrelated_path_named_models_is_not_fenced(self) -> None:
         """Scoped to the crew home, so an ordinary project directory is unaffected."""
         assert security.is_sensitive_write_path("~/code/myproject/models/weights.bin") is False
+
+
+class TestPublishFloorNestedPayloads:
+    """The publish floor must descend into nested shell payloads.
+
+    Every git-publish rule is stripped from the regex tier, so
+    ``_is_git_publish`` is the SOLE enforcement for pushes. It matched only the
+    top-level text, so a single wrapper was a complete bypass -- while the
+    self-protection floor beside it was already immune because it re-tokenizes
+    payloads through the same walk. These pin that the two floors now share it.
+    """
+
+    WRAPPED_PROTECTED = (
+        "bash -c 'git push origin main'",
+        "sh -c 'git push origin main'",
+        "bash -lc 'git push --force origin main'",
+        "bash -c -- 'git push origin mainline'",
+        "eval 'git push origin main'",
+        "bash <<< 'git push origin main'",
+        "bash -c 'bash -c \"git push origin main\"'",  # nested two deep
+        "$SHELL -c 'git push origin mainline'",
+        "bash -c 'git push --mirror origin'",
+        "echo 'git push origin main' | bash",
+    )
+
+    def test_wrapped_protected_push_denied(self) -> None:
+        from kiro_crew.security import is_denied
+
+        for cmd in self.WRAPPED_PROTECTED:
+            assert is_denied(cmd) is not None, cmd
+
+    def test_end_of_options_terminator_does_not_hide_the_payload(self) -> None:
+        """``--`` ends option parsing, so the script is the token AFTER it.
+
+        ``eval -- '<script>'`` yielded the literal ``--`` as the payload, so the
+        real script was never walked and the push executed. The ``-c`` branch
+        already skipped the terminator; the verb branch did not.
+        """
+        from kiro_crew.security import _shell_payload_sources, is_denied
+
+        assert "git push origin main" in _shell_payload_sources("eval -- 'git push origin main'")
+        for cmd in (
+            "eval -- 'git push origin main'",
+            "eval -- -- 'git push origin mainline'",
+            "bash -c -- 'git push origin main'",
+        ):
+            assert is_denied(cmd) is not None, cmd
+
+    def test_eval_concatenates_its_arguments_into_one_command(self) -> None:
+        """``eval a b c`` evaluates ``a b c``, so no single argument looks like one.
+
+        Taking only the first argument let the publish through: the walk handed
+        the hooks the bare program name and the verb sat in the next word, which
+        no check ever saw. Splitting across MORE words was already caught, because
+        each word then appears as its own token -- the gap was specifically the
+        program alone in one word and the whole verb-and-args tail glued into the
+        next.
+        """
+        from kiro_crew.security import _shell_payload_sources, is_denied
+
+        assert "git push origin main" in _shell_payload_sources("eval 'git' 'push origin main'")
+        for cmd in (
+            "eval 'git' 'push origin main'",
+            "eval -- 'git' 'push origin main'",
+            "eval 'git' 'push --force origin mainline'",
+            "eval 'git push' 'origin main'",
+        ):
+            assert is_denied(cmd) is not None, cmd
+
+    def test_eval_join_does_not_over_block_ordinary_multi_word_eval(self) -> None:
+        from kiro_crew.security import is_denied
+
+        for cmd in (
+            "eval 'ls' '-la'",
+            "eval 'echo' 'hello world'",
+            "eval 'git' 'status'",
+            "eval 'git' 'push origin my-feature'",
+        ):
+            assert is_denied(cmd) is None, cmd
+
+    def test_source_arguments_are_not_joined(self) -> None:
+        """``source``/``.`` take a FILE; the rest are positional parameters.
+
+        Joining them would invent a command line bash never runs, so the
+        concatenation is scoped to ``eval`` alone.
+        """
+        from kiro_crew.security import _nested_shell_payloads, normalize_shell_command
+
+        for cmd in ("source setup.sh arg1 arg2", ". setup.sh arg1 arg2"):
+            payloads = _nested_shell_payloads(normalize_shell_command(cmd))
+            assert payloads == ["setup.sh"], (cmd, payloads)
+
+    def test_prefix_forms_of_a_real_push_still_denied(self) -> None:
+        """Guards against narrowing detection to fix the ``echo`` false positive.
+
+        Requiring ``git`` to sit in ``_argv_programs`` command position was tried
+        and silently broke all five of these, so the walk deliberately still
+        scans every token.
+        """
+        from kiro_crew.security import is_denied
+
+        for cmd in (
+            "/usr/bin/git push origin main",
+            "env FOO=1 git push origin main",
+            "sudo git push origin main",
+            "nohup git push origin main",
+            "command git push origin main",
+            "bash -c 'env X=1 git push origin mainline'",
+        ):
+            assert is_denied(cmd) is not None, cmd
+
+    def test_wrapped_feature_push_still_allowed(self) -> None:
+        from kiro_crew.security import is_denied
+
+        # The floor decides protected-vs-feature, so widening DETECTION must not
+        # turn ordinary work into a denial.
+        for cmd in (
+            "bash -c 'git push origin my-feature'",
+            "sh -c 'git push origin fix/thing'",
+        ):
+            assert is_denied(cmd) is None, cmd
+
+    def test_wrapped_benign_not_overblocked(self) -> None:
+        from kiro_crew.security import is_denied
+
+        for cmd in (
+            "bash -c 'echo remember to push later'",
+            "bash -c 'git fetch origin main'",
+            "bash -c 'ls -la'",
+            "git stash push -m wip",
+        ):
+            assert is_denied(cmd) is None, cmd
+
+    def test_self_protection_floor_shares_the_walk(self) -> None:
+        from kiro_crew.security import is_denied
+
+        # Same walk now feeds both floors; the self-protection side must not
+        # regress when the publish side starts consuming it.
+        for cmd in (
+            "bash -c 'kirocrew token'",
+            "bash -c 'kirocrew restart'",
+            "cat <(kirocrew token)",
+        ):
+            assert is_denied(cmd) is not None, cmd
+
+    def test_payload_sources_and_frames_agree(self) -> None:
+        from kiro_crew.security import _self_token_frames, _shell_payload_sources
+
+        # The two views are projections of ONE walk, so they must stay the same
+        # length -- a drift here is the class of bug this refactor removes.
+        cmd = "bash -c 'git push origin main'"
+        assert len(_shell_payload_sources(cmd)) == len(_self_token_frames(cmd))
+        assert cmd in _shell_payload_sources(cmd)
+        assert "git push origin main" in _shell_payload_sources(cmd)


### PR DESCRIPTION
## Summary

Closes the CRITICAL finding from the `security.py` audit: the git-publish floor never descended into nested shell payloads, and it is the **only** enforcement pushes have.

Every git-publish rule is stripped from the regex tier (`_GIT_PUBLISH_RULE_PATTERNS` — ReDoS-prone under backtracking), so `_is_git_publish` is the sole gate. It matched only top-level command text, making one wrapper a complete bypass. All of these were **allowed** before this change:

```
bash -c 'git push origin main'
sh -c 'git push origin main'
bash -lc 'git push --force origin main'
bash -c -- 'git push origin master'
eval 'git push origin main'
bash <<< 'git push origin main'
bash -c 'bash -c "git push origin main"'      # nested two deep
$SHELL -c 'git push origin mainline'
bash -c 'git push --mirror origin'
echo 'git push origin main' | bash
```

## Why this was a wiring gap, not a hard problem

The self-protection floor sitting immediately beside it was already immune to this exact class — `bash -c 'kirocrew token'` is denied — because it re-tokenizes payloads through `_self_token_frames`. The two floors need *different views* of the same walk (argv for the structural predicates, command text for the verb-anchored publish scan), and only one of them was consuming it.

So `_self_token_frames` is split into `_shell_payload_walk`, returning `(source, argv)` for the command and every nested payload, plus two thin projections:

- `_self_token_frames` — argv view, behaviour unchanged
- `_shell_payload_sources` — source-text view, consumed by the publish gate

Termination is unchanged and still **structural, not a depth cap**: a payload is carried inside one token of its parent, so it is strictly shorter, and a chain of strictly shorter strings is finite. A numeric cap would itself be a bypass.

## Safety of the widening

Widening *detection* cannot permit a push — the allow/deny decision still rests entirely with `_is_push_to_protected_branch`. Asserted in tests:

- wrapped **feature-branch** pushes stay allowed (`bash -c 'git push origin my-feature'`)
- wrapped benign commands untouched (`bash -c 'git fetch origin main'`, `bash -c 'echo remember to push later'`, `git stash push -m wip`)
- the self-protection floor does not regress now that it shares the walk

## Verification

- 5 new test cases, **revert-verified load-bearing** (reverting the loop to the top-level-only match fails the suite).
- `1353 passed, 1 skipped` across `test/test_security.py` + `test/test_hooks.py`.
- `flake8` / `isort` clean. `black --check` fails identically on the base file under local py312 (repo targets py314), so that is inherited.

## Known remaining, deliberately out of scope

Each needs a mechanism this walk does not have, and bundling them would grow the diff in the repo's most safety-critical file:

1. `python -c "os.system('git push origin main')"` — interpreter payload; needs the inline-interpreter extraction the self-protection rules use.
2. `git config alias.p 'push origin main' && git p` — git-alias indirection; needs git-config awareness.
3. `ssh host 'git push origin main'` — runs on the **remote** host, so a different threat model rather than a hole in this gate.

## Relationship to the other audit PR

Complementary and non-overlapping with #7311 (IMDS encoding + subshell-paren gluing). This PR closes the *wrapper* class; #7311 closes the *paren-gluing* class. Neither depends on the other; they touch different hunks.

## Pattern harvest

Rule candidate: grep

Pattern: two enforcement floors in the same module where one re-tokenizes nested shell payloads (`bash -c '<script>'`, `eval`, herestrings) and its sibling matches only top-level text. The asymmetry is the bug: whichever floor is the *sole* enforcement for its rule class is the one that must descend. Detectable by finding a payload-walk helper and checking which of the module's gates call it — here `_self_token_frames` had exactly one caller while a second floor beside it needed the same walk.

Not generalizable: the specific ReDoS reason the publish rules are stripped from the regex tier is local to this module's rule catalogue.

🤖 Draft — not for merge without human review.
