### PR TITLE
fix(sandbox): fail closed when the seccomp escape filter cannot be installed

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2505,6 +2505,23 @@ def main():
 
         _PR_SET_NO_NEW_PRIVS = 38
         _PR_CAPBSET_DROP = 24
+        if not _libc.prctl:
+            # prctl(2) is how BOTH remaining controls are applied: the
+            # capability-bounding drop plus NO_NEW_PRIVS here, and the
+            # seccomp-BPF install in Step 6. Without it the child keeps
+            # CAP_SYS_ADMIN over this mount namespace and can umount the
+            # credential masks, so refuse for the same reason the unknown-arch
+            # branch below does.
+            sys.exit(
+                "sandbox: BLOCKED — libc exposes no prctl(2), so neither the "
+                "capability-bounding drop nor the seccomp-BPF namespace-escape "
+                "filter can be applied. The agent would keep CAP_SYS_ADMIN in "
+                "this mount namespace and could unmount the credential masks, "
+                "so this spawn is refused. To run anyway WITHOUT OS-level "
+                "isolation, set agent.sandbox='off' or "
+                "agent.sandbox_allow_unsandboxed_exec=true in "
+                "~/.kiro/crew/config.json."
+            )
         if _libc.prctl:
             # Linux CAP_LAST_CAP is currently 41 (kernel 6.x); iterate 0..63 for
             # forward-compatibility — dropping a non-existent cap just returns -1.
@@ -2582,8 +2599,29 @@ def main():
                 _DENY_SYSCALLS = (40, 39, 97, 268, 41)
                 _KILL_NR = 129
             else:
-                _DENY_SYSCALLS = ()  # unknown arch — skip seccomp
-                _KILL_NR = None
+                # No syscall table for this arch, so the filter that keeps the
+                # child from undoing the credential masks cannot be built.
+                # Refuse rather than skip: with unshare(2) still permitted the
+                # child can enter a nested user namespace, hold CAP_SYS_ADMIN
+                # over a copy of this mount tree, and umount every mask — the
+                # exact escape Step 6 exists to deny. _inside_kirocrew_sandbox()
+                # and docs/system-specs/modules/security.md both state that a
+                # sandboxed tree is confined "by the outer namespace + seccomp",
+                # so a silent skip makes that claim false while every caller
+                # still reads the spawn as isolated. sandbox_level="off" (or
+                # agent.sandbox_allow_unsandboxed_exec) is the explicit opt-out
+                # for a host that cannot be confined; a silent one is not.
+                sys.exit(
+                    "sandbox: BLOCKED — no seccomp syscall table for machine "
+                    "%r, so the namespace-escape filter (mount/umount2/unshare/"
+                    "setns/pivot_root) cannot be installed. The agent would run "
+                    "able to unshare a new namespace and unmount the credential "
+                    "masks, so this spawn is refused. Supported: x86_64, "
+                    "aarch64. To run anyway WITHOUT OS-level isolation, set "
+                    "agent.sandbox='off' or "
+                    "agent.sandbox_allow_unsandboxed_exec=true in "
+                    "~/.kiro/crew/config.json." % _machine
+                )
 
             if _DENY_SYSCALLS:
                 # Architecture constants for seccomp arch validation

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
 import time
 from pathlib import Path
@@ -677,6 +678,70 @@ class TestBuildLauncherScript:
         # link=86/linkat=265 (x86_64) and linkat=37 (aarch64) must be gone
         assert "308, 155, 86, 265)" not in script
         assert "268, 41, 37)" not in script
+
+    @_POSIX_ONLY
+    def test_launcher_refuses_when_seccomp_cannot_be_installed(self):
+        """An arch with no syscall table, or a libc without prctl(2), must make
+        the launcher EXIT -- not skip Step 5/6 and exec the agent anyway.
+
+        Skipping leaves ``unshare`` permitted, so the child can enter a nested
+        user namespace, hold CAP_SYS_ADMIN over a copy of this mount tree, and
+        umount every credential mask -- the escape the filter exists to deny.
+        Both ``_inside_kirocrew_sandbox`` and
+        ``docs/system-specs/modules/security.md`` state that a sandboxed tree is
+        confined "by the outer namespace + seccomp", so a silent skip makes that
+        claim false while every caller still reads the spawn as isolated.
+        """
+        script = _build_launcher_script("strict")
+        # The generated launcher must stay valid Python at every tier.
+        for level in ("standard", "cc", "strict"):
+            compile(_build_launcher_script(level), "<launcher-%s>" % level, "exec")
+        assert "no seccomp syscall table for machine" in script
+        assert "libc exposes no prctl(2)" in script
+        # The old fail-open marker must not come back.
+        assert "unknown arch" not in script
+
+        # Execute the arch-dispatch block itself, so this proves the refusal
+        # FIRES rather than that its message is present as text.
+        lines = script.splitlines()
+        start = -1
+        end = -1
+        for index, line in enumerate(lines):
+            if start < 0 and line.strip() == "import platform as _plat":
+                start = index
+            elif start >= 0 and "if _DENY_SYSCALLS:" in line:
+                end = index
+                break
+        assert start >= 0 and end > start, "arch-dispatch block not found"
+        block = textwrap.dedent("\n".join(lines[start:end]))
+        block = block.replace("import platform as _plat", "")
+
+        class _FakePlat:
+            def __init__(self, machine):
+                self._machine = machine
+
+            def machine(self):
+                return self._machine
+
+        supported = (
+            ("x86_64", (165, 166, 272, 308, 155)),
+            ("aarch64", (40, 39, 97, 268, 41)),
+        )
+        for machine, table in supported:
+            namespace = {"sys": sys, "_plat": _FakePlat(machine)}
+            exec(block, namespace)  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected -- runs this repo's OWN generated launcher source, never external input  # noqa: E501  # fmt: skip
+            assert namespace["_DENY_SYSCALLS"] == table
+
+        for machine in ("riscv64", "armv7l", "ppc64le", "s390x"):
+            namespace = {"sys": sys, "_plat": _FakePlat(machine)}
+            with pytest.raises(SystemExit) as excinfo:
+                exec(block, namespace)  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected -- runs this repo's OWN generated launcher source, never external input  # noqa: E501  # fmt: skip
+            message = str(excinfo.value)
+            assert "sandbox: BLOCKED" in message
+            assert repr(machine) in message
+            # The refusal must name the explicit opt-out, or an operator on such
+            # a host is left with no way forward.
+            assert "agent.sandbox_allow_unsandboxed_exec" in message
 
     @_POSIX_ONLY
     def test_standard_script_excludes_aws(self):


### PR DESCRIPTION
## Problem

The Linux namespace launcher's Step 6 installs a seccomp-BPF filter denying `mount`/`umount2`/`unshare`/`setns`/`pivot_root`, so the sandboxed child cannot undo the credential bind-masks over `~/.aws`, `~/.ssh`, `~/.kiro/crew/.vault` and the rest. Two paths silently skipped it and exec'd the agent anyway.

```python
elif _machine == "aarch64":
    _DENY_SYSCALLS = (40, 39, 97, 268, 41)
    _KILL_NR = 129
else:
    _DENY_SYSCALLS = ()  # unknown arch — skip seccomp
    _KILL_NR = None

if _DENY_SYSCALLS:      # whole block, including its own sys.exit on failure
```

1. **Unknown arch.** Any Linux that is not `x86_64`/`aarch64` — `armv7l`, `riscv64`, `ppc64le`, `s390x` — got an empty deny list, and `if _DENY_SYSCALLS:` gated the entire install *including* the `sys.exit` that reports a failed install.
2. **No `prctl(2)`.** `if _libc.prctl:` gates both the capability-bounding drop plus `NO_NEW_PRIVS` (Step 5) and the seccomp install (Step 6); a libc that does not export it skipped both.

In either case there was no `sys.exit`, no stderr line, and control fell through to `os.execvp`. With `unshare` still permitted the child can enter a nested user namespace, hold `CAP_SYS_ADMIN` over a copy of the mount tree, and `umount` every mask — the exact escape the filter exists to deny.

The skip was also invisible to callers. `detect_backend` still returns `"namespace"`, so `wrap_argv` reports success and every spawn site reads the child as isolated. Two places state the stronger claim outright:

- `_inside_kirocrew_sandbox()`: *"the Linux launcher's seccomp filter denies `unshare`/`setns` precisely so the sandboxed tree cannot manipulate namespaces"* — this is what makes the nested-sandbox passthrough safe.
- `docs/system-specs/modules/security.md`: *"the outer namespace + seccomp still confine every descendant"*.

It contradicted the launcher's own rule too. `_mount_or_die`'s docstring: *"both `unshare` calls, the seccomp-BPF install, and the hardlink scan all `sys.exit`"* — the install only exited when the arch was already known.

No test pinned the skip; `test_sandbox_argv.py` asserts only the `x86_64` and `aarch64` tables.

## Change

Both paths now `sys.exit` with a `sandbox: BLOCKED` message that names the mechanism, the supported arches, and the explicit opt-out (`agent.sandbox='off'` or `agent.sandbox_allow_unsandboxed_exec=true`). That matches what this launcher already does for every other control it cannot establish.

**This is a behaviour change on unsupported arches.** Such a host now runs no agent subprocess until the operator opts out explicitly, rather than running one that reads as sandboxed but is not. That is the same posture a host with no user namespaces already gets, and the refusal names the opt-out so the operator is not stuck.

Extending the syscall table to more arches would preserve availability, but a wrong syscall number denies the wrong call — worse than no filter, and silently so. Fail-closed first; adding tables is a separate, individually-verifiable change.

## Verification

- New test executes the generated arch-dispatch block under a stubbed `platform.machine()`, so it proves the refusal *fires* rather than that its text is present: `x86_64`/`aarch64` still yield their tables, and `riscv64`/`armv7l`/`ppc64le`/`s390x` raise `SystemExit` naming the machine and the opt-out. It also compiles the generated launcher at all three tiers, which is what caught an escaped-quote bug in the first draft of the message.
- Revert-verified both ways: restoring the arch skip fails the test, and removing only the `prctl` refusal fails it too.
- 321 passed / 3 skipped across `test_sandbox_argv.py`, `test_sandbox_cc_mode.py`, `test_sandbox_mount_checked.py`, `test_sandbox_hardlink_scan.py`, `test_sandbox_launcher_libc_load.py`, `test_sandbox_no_isolation.py`, `test_sandbox_first_party_exec.py`, `test_sandbox_nested_tier.py`; `test_spawn_audit.py` 12 passed.
- `flake8`, `isort`, `mypy` clean; brand gate clean with `BRAND_BASE_REF` scoped to the merge base.

The test's two `exec()` calls carry a scoped `nosemgrep` for `exec-detected`: they execute this repo's own `_build_launcher_script` output, never external input, and executing it is the whole point — a string-presence assertion would pass even if the refusal never fired.

## Pattern harvest

Rule candidate: semgrep

Pattern: in the generated sandbox launcher, a security control gated on a capability probe whose negative branch neither `sys.exit`s nor raises — concretely, an `else:`/`if not …:` branch that empties a name a later `if <name>:` uses as the install gate (`_DENY_SYSCALLS`), or a bare `if <capability>:` wrapping a control with no refusing companion (`if _libc.prctl:`). The launcher's stated contract is that every control it cannot establish refuses, so a fall-through in that position is always a silent downgrade, and `detect_backend` keeps reporting the backend as present either way.

This is generalizable because the launcher already has four such controls (two `unshare` calls, the mount masks, the seccomp install) and the arch table was the one place the contract was applied by convention rather than by structure.

Found during a scoped security audit of `src/kiro_crew/sandbox.py` + the `platform/` sandboxed-spawn path.
