### PR TITLE
fix(auto_improvement): redact pip stderr before bounding in install_deps (#7307)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/deps.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/deps.py
@@ -114,9 +114,12 @@ def install_deps() -> dict[str, Any]:
         tail = (proc.stderr or "").strip().splitlines()[-1:] or [""]
         # pip inherits the gateway environment, so an authenticated private
         # index echoes its request URL — token and all — to stderr on an auth
-        # failure. This payload surfaces in the dashboard, so scrub the full
-        # tail line before it is bounded: redact_and_truncate redacts over the
-        # whole string first, so a credential straddling the 200-char boundary
-        # cannot leak as an unredacted fragment (bound-before-redact would).
-        return {"ok": False, "installed": [], "error": f"pip failed: {redact_and_truncate(tail[0], 200)}"}
+        # failure. The dashboard route that serves this payload redacts what
+        # it sends, but its regexes need the full credential shape to match:
+        # bounding first can cut a token mid-match, leaving a fragment no
+        # downstream pass can recognise. redact_and_truncate scrubs the whole
+        # line BEFORE its bound, so a recognised credential straddling the
+        # 200-char boundary cannot leak as an unredacted partial.
+        safe_tail = redact_and_truncate(tail[0], 200)
+        return {"ok": False, "installed": [], "error": f"pip failed: {safe_tail}"}
     return {"ok": True, "installed": ["ruff"], "detail": "ruff installed"}

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/deps.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/deps.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 from typing import Any
 
+from kiro_crew.security import redact_and_truncate
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 logger = logging.getLogger(__name__)
@@ -111,5 +112,11 @@ def install_deps() -> dict[str, Any]:
         return {"ok": False, "installed": [], "error": f"install failed: {exc}"}
     if proc.returncode != 0:
         tail = (proc.stderr or "").strip().splitlines()[-1:] or [""]
-        return {"ok": False, "installed": [], "error": f"pip failed: {tail[0][:200]}"}
+        # pip inherits the gateway environment, so an authenticated private
+        # index echoes its request URL — token and all — to stderr on an auth
+        # failure. This payload surfaces in the dashboard, so scrub the full
+        # tail line before it is bounded: redact_and_truncate redacts over the
+        # whole string first, so a credential straddling the 200-char boundary
+        # cannot leak as an unredacted fragment (bound-before-redact would).
+        return {"ok": False, "installed": [], "error": f"pip failed: {redact_and_truncate(tail[0], 200)}"}
     return {"ok": True, "installed": ["ruff"], "detail": "ruff installed"}

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_backend_deps_cov80.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_backend_deps_cov80.py
@@ -249,21 +249,34 @@ class TestInstallDeps:
     def test_a_pip_failure_credential_is_redacted_before_it_is_bounded(
         self, which: dict[str, str], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Redact-before-bound invariant: with the credential pushed so its tail
-        straddles the 200-char slice, a bound-before-redact fix would leave an
-        unredacted prefix fragment. Redacting the full line first prevents that.
+        """Redact-before-bound invariant: the credential is laid out so the
+        200-char bound falls INSIDE the token. Bound-before-redact would keep
+        an unredacted token prefix that no longer matches the credential regex
+        — the exact fragment shape the serving route's own redaction pass
+        cannot recognise — so this test goes red if the redact and the bound
+        are ever reordered.
         """
         token = "TOKENedge9876543210"  # a fake secret, only asserted absent
-        # Pad so the credential sits right on the 200-char boundary.
-        prefix = "ERROR: " + "pad " * 45
-        stderr = f"{prefix}https://ci-bot:{token}@pypi.internal.example.com/simple/ruff/\n"
+        userinfo = "https://ci-bot:"
+        # Lay the token out to START at index 190 of the tail line, so the
+        # 200-char bound cuts ten characters into it.
+        pad = "x" * (190 - len("ERROR: ") - len(userinfo))
+        line = f"ERROR: {pad}{userinfo}{token}@pypi.internal.example.com/simple/ruff/"
+        stderr = f"warming up\n{line}\n"
+        # Premise guards: the guarded line must be the tail line the bound is
+        # actually applied to, and the token must straddle the boundary — or
+        # this test silently stops pinning the invariant.
+        assert stderr.strip().splitlines()[-1] == line
+        start = line.index(token)
+        assert start < 200 < start + len(token)
         monkeypatch.setattr(deps.subprocess, "run", lambda *a, **k: _proc(1, stderr=stderr))
         out = deps.install_deps()
         assert out["ok"] is False
         assert token not in out["error"]
-        # No partial fragment of the token survives either.
-        for frag_len in (12, 8, 6):
-            assert token[:frag_len] not in out["error"]
+        # The exact fragment a bound-before-redact implementation would leak —
+        # everything of the token left of the bound — must be absent too.
+        leaked_prefix = token[: 200 - start]
+        assert leaked_prefix and leaked_prefix not in out["error"]
 
     @pytest.mark.parametrize(
         "exc",

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_backend_deps_cov80.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_backend_deps_cov80.py
@@ -224,6 +224,47 @@ class TestInstallDeps:
         out = deps.install_deps()
         assert out["error"] == "pip failed: " + "x" * 200
 
+    def test_a_pip_failure_does_not_leak_index_credentials_to_the_payload(
+        self, which: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The child pip inherits the gateway env, so an authenticated private
+        index reaches it; on an auth failure pip echoes the raw request URL —
+        token and all — to stderr. That tail line is returned in the handler's
+        ``error`` payload, which surfaces in the dashboard, so the token must
+        never survive into it.
+        """
+        token = "s3cr3t-index-token"  # a fake secret, only asserted absent
+        stderr = (
+            "WARNING: Retrying (Retry(total=0)) after connection broken\n"
+            f"ERROR: Could not install ruff from "
+            f"https://ci-bot:{token}@pypi.internal.example.com/simple/ruff/\n"
+        )
+        monkeypatch.setattr(deps.subprocess, "run", lambda *a, **k: _proc(1, stderr=stderr))
+        out = deps.install_deps()
+        assert out["ok"] is False
+        assert out["installed"] == []
+        assert token not in out["error"]
+        assert "[REDACTED" in out["error"]
+
+    def test_a_pip_failure_credential_is_redacted_before_it_is_bounded(
+        self, which: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redact-before-bound invariant: with the credential pushed so its tail
+        straddles the 200-char slice, a bound-before-redact fix would leave an
+        unredacted prefix fragment. Redacting the full line first prevents that.
+        """
+        token = "TOKENedge9876543210"  # a fake secret, only asserted absent
+        # Pad so the credential sits right on the 200-char boundary.
+        prefix = "ERROR: " + "pad " * 45
+        stderr = f"{prefix}https://ci-bot:{token}@pypi.internal.example.com/simple/ruff/\n"
+        monkeypatch.setattr(deps.subprocess, "run", lambda *a, **k: _proc(1, stderr=stderr))
+        out = deps.install_deps()
+        assert out["ok"] is False
+        assert token not in out["error"]
+        # No partial fragment of the token survives either.
+        for frag_len in (12, 8, 6):
+            assert token[:frag_len] not in out["error"]
+
     @pytest.mark.parametrize(
         "exc",
         [OSError("no pip"), subprocess.TimeoutExpired(cmd="pip", timeout=300.0)],

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1333,6 +1333,15 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # scan hits, and the change degrades to the local queue instead. Lives in
         # push_policy because all three push paths share this one implementation.
         "apps/builtins/auto_improvement/spine/push_policy.py",
+        # Source-side pre-pass, same shape as the aws_control scrubbers: pip's
+        # stderr tail is scrubbed with redact_and_truncate at the point the
+        # install-failure payload is BUILT, so the 200-char bound can never cut
+        # a credential mid-match (a sliced fragment no longer matches the
+        # credential regex, and the route's own redaction pass cannot catch
+        # it). It owns no output — the payload reaches the dashboard only
+        # through ``_handle_deps_install`` in routes.py, the registered sink
+        # for this app.
+        "apps/builtins/auto_improvement/backend/deps.py",
         # Inbound: the crew worker's slot title is derived from an issue title,
         # which is untrusted text anyone who can open an issue wrote. It is
         # scrubbed before it becomes a slot title (and fails CLOSED to the slot


### PR DESCRIPTION
Closes #7307.

## Problem
`install_deps()` in `src/kiro_crew/apps/builtins/auto_improvement/backend/deps.py` returned pip's stderr tail line in the handler's `error` payload with two defects:

- **No redaction at the source:** the stderr text never passed a scrubber in this module. The child pip inherits the gateway environment, so an authenticated private index (userinfo credentials in `PIP_INDEX_URL`) echoes its request URL — token and all — to stderr on an auth failure.
- **Bound before redact:** `tail[0][:200]` sliced *first*. This is the defect that stays **reachable end to end**: the serving route (`_handle_deps_install` in `routes.py`) does redact what it sends, but its credential regexes need the full credential shape to match. A token straddling the 200-char boundary is cut mid-match (e.g. `https://ci-bot:TOKENedg`, no trailing `@host`), so the fragment sails through the route's `redact()` and renders in the dashboard. Verified empirically: the sliced fragment survives `redact()` on the old code; the issue's stronger claim that the payload reaches the UI with *no* redaction pass at all does not hold (the route is fail-closed), but the partial-fragment leak does.

This is the same mechanism fixed for `handlers/memory.py` in #7283 (issue #7279); `deps.py` was the only remaining pip-stderr site with the slice-first shape (it evaded the `stderr.decode` grep because it uses `text=True`).

## Fix
- Redact the **full** tail line, then let `redact_and_truncate(tail[0], 200)` apply the bound — the redact-before-bound invariant documented on `redact_and_truncate` itself (`security.py`). No manual slice remains anywhere in the expression.
- Import follows the existing `from kiro_crew.security import …` convention used by sibling backend modules (commit.py, mcp_server.py, routes.py). No import cycle: the module imports cleanly at module scope.
- Registered `apps/builtins/auto_improvement/backend/deps.py` in `NON_EGRESS_REDACTION_MODULES` (security_posture.py): it is a source-side pre-pass, not an egress boundary — the payload reaches the dashboard only through `routes.py`, the registered sink for this app. This is what the posture drift-guard (`test_every_redactor_call_site_is_a_registered_sink_or_allowlisted`) requires of every new redactor call site, and it is the test that failed on the first revision of this PR.

**Scope note (exception branch):** the `install failed: {exc}` branch two lines earlier is left unchanged deliberately. An `OSError`/`SubprocessError` string is a spawn failure (strerror, argv); pip credentials ride the *environment* (`PIP_INDEX_URL`), never argv, so that string cannot carry the index token, and the route's fail-closed `redact()` already covers it as defense in depth. Wrapping it would widen the diff without a reachable defect behind it.

## Tests
Two regression tests in `TestInstallDeps` (`test_backend_deps_cov80.py`), stubbing `subprocess.run` (no real network/pip):
1. `test_a_pip_failure_does_not_leak_index_credentials_to_the_payload` — a credential-bearing URL in stderr must not survive into `error` (pins defect 1 at the source).
2. `test_a_pip_failure_credential_is_redacted_before_it_is_bounded` — lays the token out to **start at index 190** so the 200-char bound cuts ten characters into it, asserts the exact prefix fragment a bound-before-redact implementation would leak (`token[:10]`) is absent, and carries a premise guard (`assert start < 200 < start + len(token)`) so the test can never silently stop straddling the boundary. The first revision's version of this test padded the token to start at index 202 — entirely past the bound — so it passed even on the unfixed code; this revision repairs the layout and locks the premise into the test itself.

**Mutation-verified** both ways: reverting the fix to the raw slice (`tail[0][:200]`) fails both tests; reordering to slice-then-redact (`redact_and_truncate(tail[0][:200], 200)`) fails the straddle test. Restored code passes.

## Verification
- Full backend suite: `python -m pytest` 77379 passed / 339 skipped; 96 failures + 2 errors, all in the known host-environment baseline classes (AF_UNIX path length, sandbox contention), zero in the touched areas — verified by failure-file histogram.
- CI-pinned lint quad green: `isort 6.0.0` / `flake8 7.1.0` (0 findings) / `mypy 1.14.1` (no issues in 1216 files) / `scripts/check_black_formatting.py` (CI-identical two-direction gate) all pass.
- Posture suite: `test/test_security_posture.py` 42 passed (including the drift-guard that failed on the first revision).

## Pattern harvest
Rule candidate: semgrep — flag a subscript slice (`x[:N]`) applied to `subprocess` stderr/stdout that is formatted into a returned or served payload string unless the expression is wrapped by `redact_and_truncate` (redact-before-bound invariant). The `security_posture` drift-guard already harvests the sibling half of this class: every new redactor call site must be classified as sink or non-egress, so an unregistered fix like this one cannot land silently.
