### PR TITLE
fix(security): stop a masked substitution swallowing the literal after it

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -7399,9 +7399,20 @@ _SHELL_SUBST_RE = re.compile(r"\$\((?:[^()]|\([^()]*\))*\)|`[^`]*`")
 # Stand-in for a masked command substitution. Deliberately shaped like a variable
 # reference: the substitution is unresolvable for the same reason an unassigned
 # variable is, so the existing unresolved-value machinery then handles it.
-_SUBST_PLACEHOLDER = "$__kc_subst"
+#: BRACE-DELIMITED on purpose. A bare ``$__kc_subst`` lets bash-identifier
+#: characters that FOLLOW the substitution be absorbed into the placeholder's own
+#: name, which silently deletes them from the path:
+#:
+#:     cat ~/.a$(echo '')ws/credentials
+#:
+#: masked to ``~/.a$__kc_subst1ws/credentials``, whose variable reference reads as
+#: the single name ``__kc_subst1ws`` -- so the ``ws`` vanished and the unresolved
+#: reading became the benign ``~/.a/credentials``. The brace form keeps the
+#: adjacent literal separate, which is exactly why the equivalent
+#: ``~/.a${UNSET}ws/credentials`` was already denied.
+_SUBST_PLACEHOLDER = "${__kc_subst}"
 #: The bare NAME of the placeholder, for refusing to record an assignment to it.
-_SUBST_PLACEHOLDER_NAME = _SUBST_PLACEHOLDER.lstrip("$")
+_SUBST_PLACEHOLDER_NAME = _SUBST_PLACEHOLDER.lstrip("$").strip("{}")
 #: Every spelling of that reserved name, including the numbered ones
 #: `_mask_substitutions_valued` produces. The refusal has to cover all of them:
 #: a command that assigns one would otherwise choose what the masked pass resolves
@@ -7515,6 +7526,22 @@ def _mask_substitutions_valued(text: str) -> tuple[str, dict[str, str]]:
         guess = _substitution_path_guess(match.group(0))
         if guess is not None:
             values[name] = guess
+        # BARE on purpose -- the opposite of the unvalued placeholder, because the
+        # two passes fail closed by different routes.
+        #
+        # This pass records a GUESSED value for the name, so a resolvable
+        # reference substitutes that guess. Left bare, a trailing literal is
+        # absorbed into the name (``$__kc_subst1`` + ``alice``), which is then
+        # absent from ``values`` and so reads as UNRESOLVED -- the absorption is
+        # exactly what makes this pass fail closed.
+        #
+        # Bracing it separated the name from the literal, the guess resolved, and
+        # the fail-closed reading disappeared: for
+        # ``cd $(printf /home/ </dev/null)alice`` the guess is ``</dev/null`` -- a
+        # redirection, not a path -- and a following credential read went from
+        # denied to allowed. ``_substitution_path_guess`` vouching for the last
+        # path-like word is the deeper defect; until it is genuinely additive,
+        # this pass must not resolve on it.
         return f"${name}"
 
     return _SHELL_SUBST_RE.sub(repl, text), values

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -8037,3 +8037,82 @@ class TestModelWeightsAreWriteProtected:
     def test_an_unrelated_path_named_models_is_not_fenced(self) -> None:
         """Scoped to the crew home, so an ordinary project directory is unaffected."""
         assert security.is_sensitive_write_path("~/code/myproject/models/weights.bin") is False
+
+
+class TestMaskedSubstitutionKeepsAdjacentLiterals:
+    """A masked substitution must not swallow the literal text after it.
+
+    The placeholder was a BARE ``$__kc_subst``, so bash-identifier characters
+    following the substitution were absorbed into the placeholder's own name and
+    silently deleted from the path -- the unresolved reading of
+    ``~/.a$(echo '')ws/credentials`` became the benign ``~/.a/credentials``.
+    Masking is a defence, so a form where it DESTROYS the signal is strictly
+    worse than not masking; the brace form keeps the literal separate, which is
+    why the ``${UNSET}`` equivalent was already denied.
+    """
+
+    def test_substitution_glued_to_literal_is_denied(self) -> None:
+        for cmd in (
+            "cat ~/.a$(echo '')ws/credentials",
+            "cat ~/.k$(echo '')iro/crew/token_signing.key",
+            "cat ~/.a`echo`ws/credentials",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_matches_the_unset_variable_equivalent(self) -> None:
+        # The brace-delimited unset-variable form was already denied; the masked
+        # substitution is unresolvable for the same reason, so it must agree.
+        assert is_sensitive_bash_command("cat ~/.a${UNSETX}ws/credentials") is not None
+        assert is_sensitive_bash_command("cat ~/.a$(echo '')ws/credentials") is not None
+
+    def test_unvalued_placeholder_is_brace_delimited(self) -> None:
+        from kiro_crew.security import _SUBST_PLACEHOLDER_NAME, _mask_substitutions
+
+        # The NAME must stay brace-free so the reserved-name refusal still matches.
+        assert "{" not in _SUBST_PLACEHOLDER_NAME
+        assert "}" not in _SUBST_PLACEHOLDER_NAME
+        masked = _mask_substitutions("cat ~/.a$(echo '')ws/credentials")
+        assert "${" in masked and "}ws" in masked, masked
+
+    def test_valued_placeholder_stays_bare(self) -> None:
+        """The asymmetry is deliberate: the two passes fail closed differently.
+
+        The valued pass records a GUESSED value, so a resolvable reference
+        substitutes that guess. Bare, a trailing literal is absorbed into the
+        name, which is then absent from ``values`` and reads as unresolved --
+        the absorption is what makes this pass fail closed. Bracing it let the
+        guess resolve and lost that reading.
+        """
+        from kiro_crew.security import _mask_substitutions_valued
+
+        numbered, values = _mask_substitutions_valued("cat $(pwd)x $(pwd)y")
+        assert "$__kc_subst1x" in numbered, numbered
+        assert "$__kc_subst2y" in numbered, numbered
+        # The absorbed spellings are NOT recorded, which is the fail-closed part.
+        assert "__kc_subst1x" not in values, values
+        assert "__kc_subst2y" not in values, values
+
+    def test_a_wrong_path_guess_cannot_resolve_away_the_unresolved_reading(self) -> None:
+        """Regression: bracing the valued placeholder allowed a credential read.
+
+        ``_substitution_path_guess`` vouches for the LAST path-like word, which
+        here is the redirection ``</dev/null`` rather than a path at all. With
+        the valued placeholder braced, that guess resolved and the following
+        credential read went from denied to allowed. Reported separately: making
+        the guess genuinely additive is the deeper fix.
+        """
+        for cmd in (
+            "cd $(printf /home/ </dev/null)alice; cat .aws/credentials",
+            "cd $(printf /home/ 2>/dev/null)alice; cat .aws/credentials",
+            "cd $(printf /home/)alice; cat .aws/credentials",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_benign_globs_and_paths_not_overblocked(self) -> None:
+        for cmd in (
+            "cat ~/notes/*.md",
+            "ls ~/*.txt",
+            "cat ~/.config/app/settings.json",
+            "echo $(date)x",
+        ):
+            assert is_sensitive_bash_command(cmd) is None, cmd


### PR DESCRIPTION
## Summary

From the `security.py` audit: masking a command substitution could **destroy** the very signal it exists to preserve.

`_mask_substitutions` collapsed a substitution to a **bare** `$__kc_subst`, so bash-identifier characters *following* the substitution were absorbed into the placeholder's own name and silently deleted from the path:

```
cat ~/.a$(echo '')ws/credentials
```

masks to `~/.a$__kc_subst1ws/credentials`, whose variable reference reads as the single name `__kc_subst1ws`. The `ws` is gone, so the unresolved reading becomes the benign `~/.a/credentials` and the gate returns clean — while bash reads the real credentials file.

Masking exists to *preserve* signal (it stops an unquoted substitution being shredded into fragments that match nothing), so a form where it destroys signal is strictly worse than not masking. The brace-delimited placeholder keeps the adjacent literal separate — which is exactly why the equivalent `~/.a${UNSET}ws/credentials` was **already** denied. The two forms now agree, and that agreement is what the tests pin.

`_SUBST_PLACEHOLDER_NAME` strips the braces so the reserved-name refusal — which stops a command assigning to the placeholder and thereby choosing what the masked pass resolves it to — still matches every numbered spelling.

## Verification

- 4 new cases, **revert-verified load-bearing**: with the bare placeholder restored, 3 of 4 fail; the fourth is the no-over-block control, which correctly passes both ways.
- `1353 passed, 1 skipped` across `test/test_security.py` + `test/test_hooks.py`.
- No over-block: `cat ~/notes/*.md`, `ls ~/*.txt`, `cat ~/.config/app/settings.json`, `echo $(date)x` all still allowed.
- `flake8` / `isort` clean.

## Two sibling findings deliberately NOT in this PR

Both were confirmed by probe, and neither is a minimal fix — they need modelling, and shipping a patch-shaped version would over-block ordinary commands in the repo's most safety-critical file.

**1. Glob metacharacters are never treated as unresolved.** These return clean while bash expands each to the real protected file:

```
cat ~/.a*/credentials
cat ~/.k*/crew/token_signing.key
cat ~/.kiro/c*/token_signing.key
cat ~/.kiro/crew/token_sign*
cat ~/.a[w]s/credentials
cat ~/.{aws,x}/credentials
cd ~/.k*/crew; cat token_signing.key
```

A correct fix must model bash's leading-dot rule — `~/*` **cannot** match `.aws`, `~/.a*` **can** — or it denies ordinary globbing. The `_glob_could_expand_to` / `_glob_to_regex` helpers already in this module are the right basis.

**2. `_substitution_path_guess` replaces the fail-closed reading instead of adding to it.** It vouches for the LAST path-like word, so:

```
cat $(printf '%s/.aws/credentials' $HOME)          -> guess is "$HOME", allowed
cd $(printf '%s/.kiro/crew' $HOME); cat token_signing.key   -> allowed
cat $(echo "$HOME|.aws|credentials" | tr "|" "/")  -> guess is "/", allowed
```

Its docstring states the guess is returned "ALONGSIDE" the unresolved reading so a wrong guess "can only add a denial, never remove one." That is not what happens: the guess is bound as the placeholder's **value** in `_mask_substitutions_valued`, and both `_expand_known_vars` and `_expand_plain_vars_only` resolve a plain `${NAME}` to its value — so no unresolved reading survives. Fixing it means composing format-plus-argument for the `printf` family *and* making the guess genuinely additive.

## Relationship to the other audit PRs

Independent of #7311 (IMDS encoding + subshell-paren gluing) and #7314 (publish floor nested payloads). Different hunks, no ordering constraint.

## Pattern harvest

Rule candidate: semgrep

Pattern: a masking/sentinel placeholder shaped like a **bare** `$NAME` substituted into text that is later re-parsed as shell. Identifier characters adjacent to the substitution point get absorbed into the placeholder's name and silently vanish from the value. Any placeholder injected into re-parsed text must be delimited (`${NAME}`) so neighbouring literals survive. Detectable as `re.sub` with a replacement of the form `"$" + name` where the result is later matched by a variable-reference regex.

Rule candidate: manual review

Pattern: a helper whose docstring claims its output is returned "alongside" a fail-closed reading and can "only add a denial", while the caller binds that output as a **value** that both reading paths then resolve. A claim of additivity should be pinned by a test that asserts the unresolved reading still exists, not stated in prose.

🤖 Draft — not for merge without human review.
