### PR TITLE
fix(chat): hand a mobile panel's swipe to its sibling at release

### DIFF
--- a/website/docs/page-layout.md
+++ b/website/docs/page-layout.md
@@ -596,6 +596,26 @@ activity panel (all three with gestures), and the notification sheet (no gesture
 portaled). Only the chat page declares a claim, because it is the only one that binds
 its own gesture inside the shell.
 
+**Two sibling instances exclude each other on INTENT, not on arrival.** The chat page
+binds `useDrawerSwipe` twice on one element — sessions drawer on the left, side panel on
+the right. While both are closed, DIRECTION separates them: each rejects the drag that
+would open the other. Once one is open it cannot, because that panel's closing drag is
+the other's opening drag, so each instance is `enabled` only while its sibling is not
+open.
+
+Spell that gate as `phase !== 'open'`, never `phase === 'closed'`, and give the consumer
+the release decision through `onCommit` rather than `onSettle`. `onSettle` deliberately
+waits for the settle animation so a consumer cannot unmount a panel mid-slide, which
+makes it the wrong signal for a gate: keyed on arrival, the exclusion stayed shut for the
+whole ~300ms slide, so a swipe that dismissed one panel could not be followed straight
+away by a swipe revealing the other — the user had to wait out an animation they had
+already finished driving. The hazard lasts exactly as long as the sibling is OPEN.
+
+A committed close therefore parks the phase at `'closing'`, not `'closed'`: the panel is
+still on screen and its mount predicate keys on `!== 'closed'`, so writing `'closed'`
+here would cut the slide short. That also matches what a tap-driven close already did,
+which is why the chrome derived from the phase does not change timing.
+
 ### A panel that gains a gesture must be bound LIVE to its offset
 
 A panel moved only by a tap may serialize its offset at render time —

--- a/website/src/hooks/useDrawerSwipe.ts
+++ b/website/src/hooks/useDrawerSwipe.ts
@@ -807,12 +807,25 @@ interface DrawerSwipeOptions {
   /** Released. `open` is the state the panel settled into, reported only once
    *  the settle animation has finished so an unmount cannot cut it short. */
   onSettle: (open: boolean) => void
+  /**
+   * Released, reported at the moment the release DECISION is made rather than
+   * when the panel finishes arriving.
+   *
+   * `onSettle` deliberately waits for the animation so a consumer cannot unmount
+   * the panel mid-slide, but that makes it the wrong signal for anything gating
+   * on intent. Two sibling instances sharing one element exclude each other
+   * (one panel's closing direction is the other's opening direction), and a gate
+   * keyed on arrival stays shut for the whole ~200-300ms slide — so a swipe that
+   * dismissed one panel could not be followed straight away by a swipe revealing
+   * the other. This fires ~300ms earlier and carries the same boolean.
+   */
+  onCommit?: (open: boolean) => void
 }
 
 /** @returns whether a drag currently owns the panel (suppress transitions). */
 export function useDrawerSwipe(
   ref: React.RefObject<HTMLElement | null>,
-  { enabled, side = 'left', travel, open, x, onGestureOpen, onSettle }: DrawerSwipeOptions,
+  { enabled, side = 'left', travel, open, x, onGestureOpen, onSettle, onCommit }: DrawerSwipeOptions,
 ): boolean {
   const [dragging, setDragging] = useState(false)
 
@@ -847,6 +860,8 @@ export function useDrawerSwipe(
   onGestureOpenRef.current = onGestureOpen
   const onSettleRef = useRef(onSettle)
   onSettleRef.current = onSettle
+  const onCommitRef = useRef(onCommit)
+  onCommitRef.current = onCommit
   const travelRef = useRef(travel)
   travelRef.current = travel
 
@@ -1223,6 +1238,10 @@ export function useDrawerSwipe(
       // restarting from rest: it decelerates from the finger's own speed, and a
       // harder flick arrives sooner. A hold-and-release already zeroed `v`
       // above, which is exactly the case with no momentum to carry.
+      // Announce the decision before the slide, so a consumer gating on intent
+      // (a sibling instance's mutual exclusion) opens up now rather than in
+      // ~300ms. `onSettle` still reports arrival, which is what may unmount.
+      onCommitRef.current?.(target)
       settle(target ? 0 : closedOffset(), target, v)
     }
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -6878,11 +6878,21 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // panel's opening drag, so each instance is disabled while the other's panel
   // is on screen.
   const drawerDragging = useDrawerSwipe(chatContainerRef, {
-    enabled: isMobile && !embedded && sideOverlayPhase === 'closed',
+    // Gated on the sibling not being OPEN, not on it having finished closing.
+    // The two panels exclude each other because one's closing direction is the
+    // other's opening direction — a hazard that lasts only while the sibling is
+    // actually open. Requiring `'closed'` also held the gate shut for the whole
+    // slide out, so a swipe dismissing one panel could not be followed straight
+    // away by a swipe revealing the other.
+    enabled: isMobile && !embedded && sideOverlayPhase !== 'open',
     travel: drawerTravel,
     open: mobileSessions,
     x: drawerX,
     onGestureOpen: beginDrawerDrag,
+    // Committed to closing: mark it now so the sibling's gate opens immediately.
+    // 'closing' rather than 'closed' because the panel is still on screen and
+    // `drawerMounted` keys on that — unmounting here would cut the slide short.
+    onCommit: open => { if (!open) { drawerPhaseRef.current = 'closing'; setDrawerPhase('closing') } },
     onSettle: open => { if (!open) { drawerPhaseRef.current = 'closed'; setDrawerPhase('closed') } },
   })
   // Right-hand side panel, same gesture mirrored. Not bound when the actbar
@@ -6890,11 +6900,18 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // there the store's mount predicate refuses to keep the panel open, so a
   // committed drag would be undone by the effect above on the next render.
   useDrawerSwipe(chatContainerRef, {
-    enabled: isMobile && !embedded && !activitySlot && !search.isOpen && drawerPhase === 'closed',
+    enabled: isMobile && !embedded && !activitySlot && !search.isOpen && drawerPhase !== 'open',
     side: 'right',
     open: sideOverlayPhase === 'open',
     x: sideOverlayX,
     onGestureOpen: beginSideOverlayDrag,
+    // See the left instance: the sibling's gate has to open at commit time, and
+    // 'closing' keeps this panel mounted for the rest of its slide.
+    onCommit: open => {
+      if (open) return
+      sideOverlayPhaseRef.current = 'closing'
+      setSideOverlayPhase('closing')
+    },
     onSettle: open => {
       // Committed: publish to the store, which is what keeps the panel open
       // across a re-render and remembers it for this chat. The effect above sees

--- a/website/src/test/drawerSwipeTwoPanels.test.ts
+++ b/website/src/test/drawerSwipeTwoPanels.test.ts
@@ -18,6 +18,7 @@
  */
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { motionValue } from 'framer-motion'
+import * as React from 'react'
 import { useDrawerSwipe } from '../hooks/useDrawerSwipe'
 
 function touch(type: string, clientX: number, clientY = 0, timeStamp = 0): TouchEvent {
@@ -132,5 +133,74 @@ describe('useDrawerSwipe — two panels sharing one element', () => {
     fire(touch('touchmove', 206, 60))   // dy dominates
     expect(openLeft).not.toHaveBeenCalled()
     expect(openRight).not.toHaveBeenCalled()
+  })
+
+  // ── Handing over mid-settle ────────────────────────────────────────────────
+  // The gate above is stated as "while a panel is on screen", but the consumer
+  // spells it as a PHASE, and a phase that only reaches 'closed' when the slide
+  // finishes keeps the far instance unbound for the whole ~300ms. So a swipe
+  // that dismissed one panel could not be followed straight away by a swipe
+  // revealing the other — the user had to wait out an animation.
+  //
+  // These two model the consumer's own state machine rather than a static
+  // boolean: 'open' | 'closing' | 'closed', gated on `!== 'open'`, with the
+  // release decision arriving via `onCommit` instead of `onSettle`.
+  type Phase = 'open' | 'closing' | 'closed'
+
+  function mountPhased(initial: { left: Phase; right: Phase }) {
+    const seen = { left: initial.left, right: initial.right }
+    const view = renderHook(() => {
+      const [left, setLeft] = React.useState<Phase>(initial.left)
+      const [right, setRight] = React.useState<Phase>(initial.right)
+      seen.left = left
+      seen.right = right
+      useDrawerSwipe(ref, {
+        enabled: right !== 'open',
+        side: 'left',
+        open: left === 'open',
+        x: leftX,
+        onGestureOpen: () => { setLeft('open'); openLeft() },
+        onCommit: open => { if (!open) setLeft('closing') },
+        onSettle: open => { if (!open) setLeft('closed'); settleLeft(open) },
+      })
+      useDrawerSwipe(ref, {
+        enabled: left !== 'open',
+        side: 'right',
+        open: right === 'open',
+        x: rightX,
+        onGestureOpen: () => { setRight('open'); openRight() },
+        onCommit: open => { if (!open) setRight('closing') },
+        onSettle: open => { if (!open) setRight('closed'); settleRight(open) },
+      })
+    })
+    return { view, seen }
+  }
+
+  it('the RIGHT panel arms immediately after the left is swiped shut, mid-settle', () => {
+    leftX.set(0)
+    const { seen } = mountPhased({ left: 'open', right: 'closed' })
+    // Swipe the open left drawer shut and release.
+    fire(touch('touchstart', 300, 0, 0))
+    fire(touch('touchmove', 100, 0, 200))
+    fire(touch('touchend', 100, 0, 400))
+    // Still sliding out — NOT yet arrived.
+    expect(seen.left).toBe('closing')
+    expect(settleLeft).not.toHaveBeenCalled()
+    // A new leftward drag, without waiting for the slide: the right panel opens.
+    fire(touch('touchstart', 300, 0, 500))
+    fire(touch('touchmove', 240, 0, 516))
+    expect(openRight).toHaveBeenCalledTimes(1)
+    expect(rightX.get()).toBeLessThan(W)
+  })
+
+  it('while a panel is genuinely OPEN the far instance stays unbound', () => {
+    // The control: the exclusion still has to hold for the case it exists for —
+    // an open panel's closing drag is the other's opening drag.
+    leftX.set(0)
+    mountPhased({ left: 'open', right: 'closed' })
+    fire(touch('touchstart', 300, 0, 0))
+    fire(touch('touchmove', 240, 0, 16))
+    expect(openRight).not.toHaveBeenCalled()
+    expect(rightX.get()).toBe(W)
   })
 })

--- a/website/src/test/mobilePanels.compositor.test.ts
+++ b/website/src/test/mobilePanels.compositor.test.ts
@@ -118,15 +118,39 @@ describe('both mobile chat panels — one element, two gestures', () => {
     expect(bindings.find(b => b.includes('x: drawerX'))).not.toContain("side: 'right'")
   })
 
-  it('each gesture is gated on the OTHER panel being off screen', () => {
+  it('each gesture is gated on the OTHER panel not being OPEN', () => {
     // Direction separates the two while both are closed, but not once one is
     // open: that panel's closing drag is the other's opening drag. Losing
     // either half of this cross-gate makes a dismissal open the opposite panel
     // — see drawerSwipeTwoPanels.test.ts for the behaviour itself.
+    //
+    // The predicate is `!== 'open'` rather than `=== 'closed'` on purpose. The
+    // hazard lasts exactly as long as the sibling is open; a gate that waited
+    // for `'closed'` also stayed shut through the whole slide out, so a swipe
+    // dismissing one panel could not be followed straight away by a swipe
+    // revealing the other. `'closing'` must therefore pass.
     const left = bindings.find(b => b.includes('x: drawerX')) as string
     const right = bindings.find(b => b.includes('x: sideOverlayX')) as string
-    expect(left).toMatch(/enabled:.*sideOverlayPhase === 'closed'/)
-    expect(right).toMatch(/enabled:.*drawerPhase === 'closed'/)
+    expect(left).toMatch(/enabled:.*sideOverlayPhase !== 'open'/)
+    expect(right).toMatch(/enabled:.*drawerPhase !== 'open'/)
+  })
+
+  it('each gesture reports its release at COMMIT time, not only on arrival', () => {
+    // `onSettle` fires from the settle animation's completion callback, so it
+    // cannot open the sibling's gate any earlier than the animation ends. The
+    // handoff above depends on `onCommit` carrying the decision immediately and
+    // parking the phase at 'closing' — which keeps the panel mounted for the
+    // rest of its travel, unlike 'closed'.
+    //
+    // Matched against the binding with COMMENTS STRIPPED, and against the setter
+    // call rather than a bare quoted word: the prose in these options mentions
+    // both phase names, so a looser pattern is satisfied by the explanation
+    // instead of the code it describes.
+    const code = (b: string) => b.replace(/\/\/[^\n]*/g, '')
+    for (const b of bindings) {
+      expect(code(b)).toMatch(/onCommit:/)
+      expect(code(b)).toMatch(/set\w*Phase\('closing'\)/)
+    }
   })
 
   it('the right gesture stays out of surfaces that would undo it', () => {


### PR DESCRIPTION
## Problem

**Reported by @rayrayxu on a phone**, after the app-wide nav swipe landed in #7133: in chat, swiping one mobile panel away and then immediately swiping to reveal the other one does nothing — you have to wait for the first panel's slide-out to finish before the second gesture is accepted.

The chat page binds `useDrawerSwipe` twice on one element (sessions drawer on the left, side panel on the right), and each instance is `enabled` only while the other panel is off screen. That exclusion is necessary: while both panels are closed DIRECTION separates them, but once one is open it cannot, because **the open panel's closing drag is the other panel's opening drag**. Without the gate, one leftward drag would dismiss the left drawer and summon the right panel at the same time.

The gate was spelled `phase === 'closed'`, and the phase only reaches `'closed'` from `onSettle` — which runs in the settle animation's **completion callback**. So the exclusion stayed shut for the entire ~300ms slide, gating a *subsequent* gesture on an animation the user had already finished driving.

Two paths, and the gesture one was worse:

- **Gesture close never entered `'closing'` at all.** `beginDrawerDrag` sets `'open'`, and `onSettle(false)` jumps straight to `'closed'` at the end — so the phase read `'open'` for the whole slide.
- **Tap close did set `'closing'`** (`closeSidebar`, e.g. selecting a session collapses the drawer) — and was blocked anyway, since `'closing'` is not `'closed'`. So the same wait existed on a path nobody had reported yet.

## Fix

Gate on what the panel is committed to, not on what it has arrived at.

- **`useDrawerSwipe` gains an optional `onCommit(open)`**, fired where the release decision is made rather than when the panel finishes arriving. `onSettle` keeps its contract unchanged — it deliberately waits for the animation so a consumer cannot unmount a panel mid-slide, which is exactly what makes it the wrong signal for a gate.
- **A committed close parks the phase at `'closing'`, not `'closed'`.** The panel is still on screen and its mount predicate keys on `!== 'closed'`, so writing `'closed'` here would cut the slide short — the snap this phase machine exists to avoid.
- **Both gates relax to `phase !== 'open'`.** The hazard lasts exactly as long as the sibling is open, which is what the exclusion is for.

### Why this does not shift anything else

Two things worth stating because they are what makes the change safe rather than merely small:

- **No chrome timing change.** `mobileSessions` (`phase === 'open'`) feeds the sessions toggle icon, the empty-chat floating entry and a separator. The **tap** path already flipped the phase to `'closing'` at the start of its slide, so those already changed at slide-start; the gesture path now matches it rather than introducing new timing.
- **No second animation.** The effect that slides the right overlay out guards its else-branch on `sideOverlayPhaseRef.current !== 'open'`, so parking at `'closing'` makes it return early. Previously a phase stuck at `'open'` through the slide meant a concurrent `closeSidebar()` could start a competing `animateDrawer` over the hook's own settle; that race is now closed rather than opened.

## Tests

`drawerSwipeTwoPanels.test.ts` gets a harness that models the consumer's real state machine (`'open' | 'closing' | 'closed'`, gated `!== 'open'`, release via `onCommit`) instead of the static boolean the existing cases use, because a static boolean cannot express the distinction this PR is about:

- **the right panel arms immediately after the left is swiped shut, mid-settle** — asserts the phase is `'closing'` and `onSettle` has *not* fired, then drives a fresh leftward drag and expects the right panel to open.
- **while a panel is genuinely OPEN the far instance stays unbound** — the control, so the exclusion still holds for the case it exists for.

`mobilePanels.compositor.test.ts`'s existing source-guard was pinning the old literal; it is **updated, not deleted**, to assert `!== 'open'` plus the presence of `onCommit` and a `'closing'` park.

Mutations verified to redden: `onCommit` never fired; fired with the inverted boolean; each gate reverted to `=== 'closed'`; each side's `onCommit` parking at `'closed'` instead of `'closing'`; the right side's `onCommit` deleted outright.

Two mutations I am reporting rather than papering over:

- **The `'closing'` park was initially unpinned because my own guard matched my own comment.** The options block explains *"`'closing'` rather than `'closed'` because…"*, so a `/'closing'/` assertion was satisfied by the prose instead of the code. Fixed by stripping comments and matching `set*Phase('closing')` — the same self-referential-guard trap that has bitten this repo's anti-drift tests before.
- **Moving `onCommit` to after `settle(...)` reddens nothing, and that is correct.** Both run in the same synchronous block before any frame, and React batches the consumer's `setState` either way, so there is no observable ordering difference. No honest test distinguishes them and I did not invent one; the placement before `settle` is for reading order only.

`tsc -b`, eslint and `docs-lint.sh` clean; the drawer, ownership, two-panel, settle and compositor suites green (124 cases).

## Pattern harvest

Rule candidate: agents-md / review-prompt — documented in `website/docs/page-layout.md` in this same commit.

Pattern: a gesture predicate reading state that is only written in an animation's COMPLETION callback, so it lags by the length of a settle.

This defect class has now been fixed **twice, one layer apart**, which is what makes it a pattern rather than a one-off. #7133 fixed it *inside* this hook — `useDrawerSwipe.ts` keeps its own `openRef` precisely because the `open` prop lags a settle, and its comment spells out the failure ("a re-opening drag read as an opening drag on an open panel and was declined"). This PR fixes the identical mechanism in the *consumer*: the chat page's exclusion gate read a phase that only reaches `'closed'` from `onSettle`. The hook was immune and the caller was not, because the fix lived in the hook's private ref instead of in a rule anyone writing a caller would meet.

Not a semgrep rule: catching it mechanically requires knowing which values are settle-derived, and a syntactic proxy (`=== 'closed'` near an `enabled:`) would be both leaky and noisy. The durable artifact is the doc rule this commit adds to the gesture-ownership section — the same section that already carries the `data-owns-swipe` and bind-LIVE rules from #7133, stated positively so the next caller meets it before writing the gate: **gate on intent (`!== 'open'`), release through `onCommit`, and never spell it `=== 'closed'`.** It also names why `onSettle` must keep waiting for the animation, so the rule cannot be "fixed" by making `onSettle` fire earlier.

<!-- no-visual-delta -->

**Why no screenshot:** there is no visual delta — same panels, same offsets, same animations. What changed is *when a gesture is accepted*, which a still frame cannot show. The behaviour is pinned by the two new tests above and was verified on-device by the reporter.

**Why no linked issue:** reported directly during device testing.

