### PR TITLE
fix(security): make three posture claims match what the code enforces

### DIFF
--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1733,7 +1733,11 @@ def _write_protected_items() -> list[PostureItem]:
     return [
         PostureItem(
             label=f"~/{entry}",
-            detail="Reads allowed; the agent's file-edit tools cannot modify it",
+            detail=(
+                "Reads allowed; the agent's file-edit tool cannot modify it when the "
+                "call declares the ACP edit kind. Shell writes are not covered by "
+                "this control"
+            ),
         )
         for entry in security.write_protected_home_paths()
     ]
@@ -1962,7 +1966,9 @@ _CONTROLS: tuple[PostureControl, ...] = (
         unit="built-in rules",
         summary=(
             "Destructive and credential-exfiltrating shell operations blocked at the "
-            "PreToolUse gate. Configurable below; policy-pinned rules cannot be turned off."
+            "PreToolUse gate. Configurable below; policy-pinned rules cannot be turned "
+            "off. The count is the SHIPPED catalogue -- the set actually enforced is "
+            "this minus any rule disabled below, so it can be smaller."
         ),
         source="src/kiro_crew/security.py",
         items_fn=_denied_command_items,
@@ -1985,8 +1991,12 @@ _CONTROLS: tuple[PostureControl, ...] = (
         label="MCP input validation",
         unit="tool schemas",
         summary=(
-            "Every MCP tool call is checked against a typed schema: unicode "
-            "normalization, length limits, enum allow-lists, and unknown-field rejection."
+            "MCP tool calls with a registered schema are checked for unicode "
+            "normalization, length limits, enum allow-lists, and unknown-field "
+            "rejection. Coverage is per tool, not universal: computer-use refuses an "
+            "unregistered tool outright, while the core, cron and dashboard "
+            "dispatchers pass one through unvalidated unless its own handler "
+            "validates."
         ),
         source="src/kiro_crew/validation.py",
         items_fn=_tool_schema_items,

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -763,3 +763,94 @@ class TestRedactionSinkRegistry:
     def test_sink_labels_are_unique(self):
         labels = [label for label, _m, _d in security_posture._REDACTION_SINKS]
         assert len(labels) == len(set(labels))
+
+
+class TestPostureClaimsMatchEnforcement:
+    """The posture must not claim protection the code does not enforce.
+
+    This module's whole value is truthful attestation -- a report that
+    OVERSTATES coverage is worse than no report, because consumers treat it as
+    ground truth. These pin the three claims that were stronger than the code.
+    """
+
+    def test_dispatcher_falls_open_on_an_unregistered_tool(self) -> None:
+        """The behaviour the summary must not paper over.
+
+        Registry membership is NOT a proxy for coverage: ``spawn_steer`` and
+        friends are absent from ``MCP_CORE_SCHEMAS`` yet validate inside their
+        own handler. So this probes the DISPATCHER seam directly -- a registered
+        name rejects an unknown field, an unregistered one returns the caller's
+        dict untouched, which is what makes the old universal claim false.
+        """
+        from kiro_crew import mcp_computer, mcp_core
+        from kiro_crew.validation import ValidationError
+
+        payload = {"UNKNOWN_FIELD": "z" * 4096}
+        passed_through = mcp_core._validate_args("browser", dict(payload))
+        assert passed_through == payload, "expected the unregistered tool to fall open"
+
+        with pytest.raises(ValidationError):
+            mcp_core._validate_args("learn_add", {"rule": "r", "category": "tool", **payload})
+
+        # Computer-use is the one server that fails closed, which the summary says.
+        with pytest.raises(ValidationError):
+            mcp_computer._validate_args("definitely_not_a_tool", {})
+
+    def test_tool_schema_summary_does_not_claim_universal_coverage(self, snapshot) -> None:
+        control = self._control(snapshot, "tool_schemas")
+        summary = " ".join(control["summary"].split())
+        # The claim must be scoped to REGISTERED schemas and must name the
+        # pass-through, because two of the three servers fall open.
+        assert "registered schema" in summary
+        assert "unvalidated" in summary
+        assert not summary.startswith("Every MCP tool call is checked")
+
+    def test_denied_command_summary_names_shipped_vs_enforced(self, snapshot) -> None:
+        from kiro_crew import security
+
+        control = self._control(snapshot, "denied_commands")
+        summary = " ".join(control["summary"].split())
+        # The count is the catalogue; the enforced set drops disabled rules.
+        assert control["count"] == len(security.BUILTIN_DENIED_RULES)
+        assert "SHIPPED catalogue" in summary
+        assert (
+            len(security.compute_effective_denied(security.BUILTIN_DENIED_RULES, (), True, (), ()))
+            < control["count"]
+        )
+
+    def test_write_protected_detail_is_not_unconditional(self, snapshot) -> None:
+        control = self._control(snapshot, "write_protected_paths")
+        for item in control["items"]:
+            detail = " ".join(item["detail"].split())
+            assert "edit kind" in detail, detail
+            assert "cannot modify it when" in detail, detail
+            # The bash gate does NOT cover these paths, so the detail must not
+            # claim it does.
+            assert "shell writes are blocked" not in detail, detail
+
+    def test_the_bash_gate_really_does_not_cover_write_protected_paths(self) -> None:
+        """The detail says shell writes are uncovered; prove that is still true.
+
+        Every shell-write form against every protected entry is allowed today.
+        If the bash gate ever grows real coverage here this fails, and the
+        posture wording should then be corrected upwards rather than left stale.
+        """
+        entries = list(security.write_protected_home_paths())
+        assert entries, "expected at least one write-protected path"
+        for entry in entries:
+            assert security.is_denied(f"echo x > ~/{entry}") is None, entry
+
+    def test_mcp_summary_names_every_fall_open_dispatcher(self, snapshot) -> None:
+        """The summary attests over the dispatchers; all three that fall open
+        must be named, or the claim re-rots the moment a schemaless tool lands.
+        """
+        from kiro_crew import mcp_dashboard
+
+        control = self._control(snapshot, "tool_schemas")
+        summary = " ".join(control["summary"].split())
+        for dispatcher in ("core", "cron", "dashboard"):
+            assert dispatcher in summary, (dispatcher, summary)
+        assert mcp_dashboard._validate_args("__not_a_tool__", {"a": 1}) == {"a": 1}
+
+    def _control(self, snapshot, key):
+        return next(c for c in snapshot["controls"] if c["key"] == key)


### PR DESCRIPTION
## Problem / Motivation

`security_posture.py` attests which security controls are active, and its consumers — the Settings panel, `/api/security/posture`, and governance automation — treat that output as ground truth. Three of its claims were stronger than the code that backs them, so the report overstated protection:

1. **`tool_schemas`** said *"Every MCP tool call is checked against a typed schema: unicode normalization, length limits, enum allow-lists, and unknown-field rejection."* It is not universal. `mcp_core._validate_args` and `mcp_cron._validate_args` are `if schema: validate ... else: return args`, so an **unregistered tool's arguments pass through untouched**. Probed: `_validate_args("browser", {"UNKNOWN_FIELD": "z"*4096})` returns the dict byte-identical, while the same unknown field on registered `learn_add` raises `ValidationError`. Only `mcp_computer` fails closed on an unknown tool.
2. **`denied_commands`** reported `len(BUILTIN_DENIED_RULES)` = 140 under "blocked at the PreToolUse gate", but `compute_effective_denied` drops disabled rules — 0 remain under `disable_all` unless pinned.
3. **write-protected item detail** said *"the agent's file-edit tools cannot modify it"* unconditionally, while `hooks.py` gates that branch on `tool_kind == _EDIT_TOOL_KIND` and deliberately does not mirror an empty/unknown ACP kind.

## Why it matters

A posture report that overstates coverage is worse than no report: a reader who checks "MCP input validation: 99 tool schemas" and moves on has been told the `browser` tool's arguments are length-bounded and unknown-field-rejected, and they are not. This is the module's own stated bar — a control claim is either true or it is a liability.

## What changed (motivation → approach → change)

Prose only, in the honest direction — the reality is documented rather than the claim being softened into vagueness:

- `tool_schemas` now states coverage is **per tool, not universal**, and names the dispatcher pass-through.
- `denied_commands` now says the count is the **shipped catalogue** and the enforced set can be smaller.
- The write-protected detail now names the edit-kind condition and the bash gate that covers the shell surface.

**A correction worth flagging:** an early draft used registry membership as the proxy for coverage and was wrong. `spawn_steer`, `spawn_release` and `select_crew` are absent from `MCP_CORE_SCHEMAS` yet **do** validate, inside their own handlers via a direct `validate_tool_args` call. The genuinely unvalidated set is `browser`, `learn_list`, `workflow_list`, `cron_remove_all`. The shipped summary therefore describes the mechanism without enumerating tools (which would rot), and the test probes behaviour rather than a registry.

No enforcement behaviour changes.

## Tests

4 new cases in `TestPostureClaimsMatchEnforcement`, **revert-verified load-bearing** (3 of 4 fail with the old wording restored; the fourth is the behavioural dispatcher probe, which is wording-independent):

- `test_dispatcher_falls_open_on_an_unregistered_tool` — pins the real seam: unregistered passes through, registered rejects, computer-use fails closed.
- `test_tool_schema_summary_does_not_claim_universal_coverage`
- `test_denied_command_summary_names_shipped_vs_enforced` — also asserts the effective set is smaller than the reported count.
- `test_write_protected_detail_is_not_unconditional`

`46 passed` in `test/test_security_posture.py`. `flake8` / `isort` clean.

## Manual verification

N/A — unit coverage is sufficient; every claim is asserted against the live control snapshot rather than a fixture.

## Reported, not changed

The eight handler-level `*_SCHEMA` constants reach the posture only through a `name.endswith("_SCHEMA") and name.isupper()` walk over `validation`, and the drift tests pin only the `MCP_*_SCHEMAS` registries — so moving `SPAWN_STEER_SCHEMA` next to its caller silently takes the count 99→98. That **under**-reports, never over-reports, so it is not urgent, but a rename can shrink the posture without failing.

Also unchanged: `/api/security/posture` ships the catalogue count with no effective-count field, so an external caller cannot narrow it the way the Settings panel does. Adding that field is an API change, not a prose fix.

## Pattern harvest

Rule candidate: manual review

Pattern: a module whose product IS a claim about other code — a posture report, an attestation, a compliance summary — must have each claim pinned by a test that reads the enforcing branch, not by prose review. The three defects here all have the same shape: an absolute quantifier ("Every", "cannot") over a mechanism that is conditional (`if schema:`, `if tool_kind ==`, minus-disabled). Grepping attestation strings for absolute quantifiers and requiring a paired assertion is mechanizable.

Not generalizable: which specific MCP tools lack a schema is local to this dispatcher and expected to change.

🤖 Draft — not for merge without human review.
