### PR TITLE
fix(instances): track the connected crew count instead of a fixed warm-set cap

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -3157,7 +3157,7 @@
       "enumValues": null,
       "defaultValue": {
         "enabled": false,
-        "warm_set_cap": 5,
+        "warm_set_cap": 0,
         "tunnel_base_port": 7778,
         "ssh_compression": true,
         "connect_timeout_secs": null,
@@ -3190,10 +3190,10 @@
       "sensitive": false,
       "tags": [],
       "label": "Warm Set Cap",
-      "help": "Max number of remote instances kept warm (iframe mounted + tunnel live) at once. Least-recently-used instances beyond this are evicted and reconnected on demand. Bounds memory/socket use (each warm instance is a full dashboard SPA).",
+      "help": "Max number of remote instances kept warm (iframe mounted + tunnel live) at once. Least-recently-used instances beyond this are evicted and reconnected on demand. Bounds memory/socket use (each warm instance is a full dashboard SPA). 0 (the default) is automatic: the cap follows how many crews are currently connected, so a crew you connected is never evicted -- eviction cold-boots the pane and reads as a disconnect, so a fixed cap below the connected count makes tab switching look like a connection flap. Automatic is bounded by an internal ceiling; an explicit value is honoured exactly, including one below the connected count.",
       "hasChildren": false,
       "enumValues": null,
-      "defaultValue": 5
+      "defaultValue": 0
     },
     {
       "path": "instances.tunnel_base_port",

--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -193,13 +193,21 @@ non-POSIX (§12). Treat a Windows hub as unverified.
    `http://<dashboard-hostname>:<local>/?token=...` in an iframe, deliberately
    reusing the parent's own hostname so the pane is same-site with the parent and
    `SameSite=Lax` auth cookies are not withheld.
-2. **Warm set.** Up to `warm_set_cap` (default 5) most-recently-used instances
+2. **Warm set.** Up to `warm_set_cap` most-recently-used instances
    stay warm: iframe mounted (hide-not-unmount, so switching never reloads or
-   re-runs the token handshake) with a live tunnel and WebSocket. Exceeding the
+   re-runs the token handshake) with a live tunnel and WebSocket. The default
+   (`0`) is **automatic**: `GET /api/instances` resolves the cap from the live
+   connected count (`resolve_warm_set_cap`, bounded by
+   `WARM_SET_CAP_AUTO_CEILING`), so a crew the operator connected is never
+   evicted; an explicit integer is served verbatim, including one below the
+   connected count. Exceeding the
    cap **evicts the least-recently-used non-active iframe**. Eviction unmounts
    the iframe only: it does NOT disconnect the tunnel or clear `was_connected`,
    so the switcher entry persists and re-warms on the next click. Entries
-   disappear only on an explicit disconnect.
+   disappear only on an explicit disconnect. Note that re-warming re-mints the
+   token and cold-boots the remote SPA, so from the user's seat an eviction is
+   hard to tell apart from a dropped connection — which is why the default
+   tracks the connected count rather than a fixed number.
 3. **Health probe.** While CONNECTED, a per-tunnel loop polls the loopback
    forward every `DEFAULT_PROBE_INTERVAL_SECS` (30s, not user-configurable;
    `<= 0` disables the probe); after `probe_failure_threshold` (3) *consecutive*
@@ -255,7 +263,7 @@ cannot drift.
 | Key | Default | Meaning |
 |-----|---------|---------|
 | `instances.enabled` | `false` | Primary opt-in, read at gateway startup. Also gates the CSP `frame-src` `*.localhost` extension. |
-| `instances.warm_set_cap` | `5` | Max instances kept warm at once (bounds memory/sockets; each warm instance is a full dashboard SPA). Clamped up to 1. |
+| `instances.warm_set_cap` | `0` (automatic) | Max instances kept warm at once (bounds memory/sockets; each warm instance is a full dashboard SPA). `0` tracks the live connected count so no connected crew is evicted, bounded by an internal ceiling; an explicit value is honoured exactly, including one below the connected count. Negative values fall back to automatic. |
 | `instances.tunnel_base_port` | `7778` | First local loopback port the allocator hands out. Out-of-range values fall back to the default. |
 | `instances.ssh_compression` | `true` | Add `-C` to the tunnel argv. See §5.2. |
 | `instances.connect_timeout_secs` | unset (SSH `15.0`, SSM `25.0`) | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). An explicit value applies to both transports, including a value equal to either transport's default. Values below 1 fall back to the transport defaults; values above 120 are clamped to 120. |
@@ -820,7 +828,7 @@ whose current variable parts are all charset-bound literals.
 | Connect fails for another reason | Use **Diagnose**. The ladder reports the first broken link: `ssh_unreachable` (check SSH access or the host alias), `remote_down` (remote gateway not listening), `not_connected` (SSH and remote are fine, this instance has no tunnel yet: click Connect), or `tunnel_down` (reconnect). |
 | "local port N was taken while connecting" | The allocator picked a port that something grabbed in the moment before `ssh` bound it. Retry. If it persists, stop whatever keeps taking ports in that range or move `instances.tunnel_base_port` to a quieter one. |
 | Instance keeps dropping | The health probe plus 2-tier self-heal retry over roughly a two-minute window (8 attempts, capped-exponential backoff). Tune `instances.max_recovery_attempts` / `recover_backoff_max_secs` / `probe_failure_threshold`; both recovery values are clamped so they cannot loop indefinitely. If self-heal gives up, diagnosis runs automatically. Check the remote gateway and SSH stability. |
-| A pane vanished from the warm set but its switcher entry is still there | It was LRU-evicted (warm set full). The tunnel is untouched: selecting the crew re-warms it. Raise `instances.warm_set_cap` if you want more panes resident. |
+| A pane vanished from the warm set but its switcher entry is still there | It was LRU-evicted (warm set full). The tunnel is untouched: selecting the crew re-warms it, though the re-mint plus SPA cold boot makes that look like a reconnect. Only an explicit `instances.warm_set_cap` can now be below the connected count — set it to `0` to let the cap track how many crews are connected. |
 | Every token mint fails on one remote, though its gateway is healthy | The remote's `~/.local/bin/kirocrew` probably points at an uninstalled checkout. See §12: the run-marker is what makes mint follow the *running* gateway's install. |
 
 ---

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -128,6 +128,7 @@ from kiro_crew.instances.constants import MINT_TIMEOUT_FLOOR_SECS as _MINT_TIMEO
 from kiro_crew.instances.constants import (
     RECOVER_BACKOFF_MAX_CEILING_SECS as _RECOVER_BACKOFF_CEILING,
 )
+from kiro_crew.instances.constants import WARM_SET_CAP_AUTO as _WARM_SET_CAP_AUTO
 from kiro_crew.mcp_gateway.rewriter import default_overlay_dir, default_socket_path
 
 # The speech-to-text defaults and the model catalog come from the package that
@@ -5587,7 +5588,12 @@ class InstancesConfig:
             "Max number of remote instances kept warm (iframe mounted + tunnel live) "
             "at once. Least-recently-used instances beyond this are evicted and "
             "reconnected on demand. Bounds memory/socket use (each warm instance is a "
-            "full dashboard SPA).",
+            "full dashboard SPA). 0 (the default) is automatic: the cap follows how "
+            "many crews are currently connected, so a crew you connected is never "
+            "evicted -- eviction cold-boots the pane and reads as a disconnect, so a "
+            "fixed cap below the connected count makes tab switching look like a "
+            "connection flap. Automatic is bounded by an internal ceiling; an explicit "
+            "value is honoured exactly, including one below the connected count.",
         ),
     )
     tunnel_base_port: int = field(
@@ -5666,9 +5672,16 @@ class InstancesConfig:
     )
 
     def __post_init__(self) -> None:
-        if self.warm_set_cap < 1:
-            logger.warning("instances.warm_set_cap %d < 1, using 1", self.warm_set_cap)
-            object.__setattr__(self, "warm_set_cap", 1)
+        if self.warm_set_cap < 0:
+            # 0 is meaningful here (automatic -- track the connected count), so
+            # only a negative value is a misconfiguration, and it falls back to
+            # automatic rather than to 1: a caller who wrote a nonsense number
+            # wanted "enough", not the tightest possible cap.
+            logger.warning(
+                "instances.warm_set_cap %d < 0, using 0 (automatic: track the connected count)",
+                self.warm_set_cap,
+            )
+            object.__setattr__(self, "warm_set_cap", _WARM_SET_CAP_AUTO)
         if not (1 <= self.tunnel_base_port <= 65535):
             logger.warning(
                 "instances.tunnel_base_port %d out of range [1, 65535], using %d",

--- a/src/kiro_crew/config/superseded_defaults.py
+++ b/src/kiro_crew/config/superseded_defaults.py
@@ -131,6 +131,19 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
         changed_in="#6651",
         new_default_display="unset (automatic: 25s desktop / 90s managed service)",
     ),
+    # instances.warm_set_cap moved from a materialized 5 to 0 (automatic: as many
+    # panes as there are connected crews). A stored 5 keeps evicting the 6th crew,
+    # and eviction is indistinguishable from a disconnect at the pane -- so the
+    # symptom of holding the old default is a connection that looks like it flaps
+    # on tab switch. A stored 5 may equally be a deliberate budget on a
+    # memory-tight machine, so report it rather than rewriting it.
+    SupersededDefault(
+        dotted_key="instances.warm_set_cap",
+        old_default=5,
+        new_default=0,
+        changed_in="#7248",
+        new_default_display="0 (automatic: as many as are connected)",
+    ),
 )
 
 

--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -50,6 +50,7 @@ from kiro_crew.instances.registry import (
     validate_ttl,
 )
 from kiro_crew.instances.ssh_tunnel_manager import ProxyRequestError, TunnelState
+from kiro_crew.instances.warm_set import resolve_warm_set_cap
 from kiro_crew.sel import sel
 from kiro_crew.validation import sanitize_string
 
@@ -210,6 +211,11 @@ async def api_instances_list(request: web.Request) -> web.Response:
     # instances.json under a threading lock a to_thread worker may hold across
     # its fsync — so every registry touch in these handlers goes off the loop.
     items = [_instance_view(state, i) for i in await asyncio.to_thread(reg.list)]
+    # Resolved here rather than served raw: the automatic mode (0) means "as many
+    # as are connected", and this is the only place that holds both the stored
+    # value and the live per-instance status. The browser therefore always
+    # receives a concrete integer and needs no notion of automatic.
+    connected = sum(1 for i in items if (i.get("status") or {}).get("state") == "connected")
     _audit("list", "success")
     return web.json_response(
         {
@@ -220,7 +226,9 @@ async def api_instances_list(request: web.Request) -> web.Response:
             # active, the UI shows a "restart the gateway to activate" hint.
             "active": getattr(state, "instances_manager", None) is not None,
             "instances": items,
-            "warm_set_cap": KiroCrewConfig.load().instances.warm_set_cap,
+            "warm_set_cap": resolve_warm_set_cap(
+                KiroCrewConfig.load().instances.warm_set_cap, connected
+            ),
         }
     )
 

--- a/src/kiro_crew/instances/constants.py
+++ b/src/kiro_crew/instances/constants.py
@@ -16,7 +16,40 @@ from __future__ import annotations
 # WebSocket live) at once. Each warm instance is a full dashboard SPA, so this
 # bounds memory/socket usage; least-recently-used instances beyond the cap are
 # lazily evicted and reconnected on demand.
-DEFAULT_WARM_SET_CAP: int = 5
+#
+# ``WARM_SET_CAP_AUTO`` (0) is the default and means "as many as are connected":
+# the cap is resolved per request from the live connected count (see
+# ``kiro_crew.instances.warm_set.resolve_warm_set_cap``), so a crew the operator
+# deliberately connected is never evicted.
+#
+# Auto is the default because eviction is INDISTINGUISHABLE FROM A DISCONNECT at
+# the pane: the iframe is unmounted, the token is re-minted and the remote SPA
+# cold-boots on the next click (surfacing the error panel outright if readiness
+# misses its timeout). A fixed cap below the connected count therefore turns
+# ordinary tab switching into an apparent connection flap, and the operator has
+# no way to attribute it -- the tunnel is up the whole time. Tracking the
+# connected count removes that class of misconfiguration rather than asking
+# anyone to keep two numbers in sync by hand.
+WARM_SET_CAP_AUTO: int = 0
+DEFAULT_WARM_SET_CAP: int = WARM_SET_CAP_AUTO
+
+# Upper bound on the AUTO-resolved warm set. Auto follows the connected count,
+# which is a statement of user intent and not a resource budget -- a fleet of 30
+# connected crews would otherwise mount 30 dashboard SPAs in one renderer.
+# Beyond this many connected crews eviction resumes, so the worst case stays
+# bounded while the common small-fleet case (the reason auto exists) never
+# evicts. An EXPLICIT integer cap is honoured verbatim and is deliberately not
+# clamped by this: an operator who names a number has made the budget decision
+# themselves, including a number larger than this.
+#
+# 8 is a judgement, not a measurement: comfortably above the 5 this default used
+# to be (so no install gets a tighter warm set than it had), and still in the
+# range a single renderer has been seen to carry. The per-pane cost that bounds
+# it is CPU and worker threads rather than heap -- each pane is a full SPA with
+# its own polling and WebSocket, and a pane the user opens a diff in spawns its
+# own highlighter worker pool (see website/src/main.tsx on why those are no
+# longer spawned eagerly).
+WARM_SET_CAP_AUTO_CEILING: int = 8
 
 # First local loopback port handed out for an SSH ``-L`` forward. The port
 # allocator increments from here, skipping ports already in use and ports the

--- a/src/kiro_crew/instances/warm_set.py
+++ b/src/kiro_crew/instances/warm_set.py
@@ -1,0 +1,37 @@
+"""Resolve the effective warm-iframe cap for the dashboard's instance panes.
+
+Kept as a pure function in its own module so the policy -- "automatic means as
+many crews as are connected" -- is testable without a gateway, a registry, or a
+live tunnel, and so the one place that decides it is not buried in an HTTP
+handler. ``GET /api/instances`` is the only caller: the resolved integer travels
+to the browser as ``warm_set_cap`` and the viewport enforces it, so the frontend
+never has to know that an automatic mode exists.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.instances.constants import WARM_SET_CAP_AUTO_CEILING
+
+
+def resolve_warm_set_cap(configured: int, connected_count: int) -> int:
+    """Return the number of instance panes that may stay warm right now.
+
+    *configured* is ``instances.warm_set_cap`` as stored. Any value >= 1 is an
+    explicit operator budget and is returned UNCHANGED -- including a value below
+    *connected_count*. Silently widening a deliberately tight cap would defeat
+    the only knob that bounds renderer cost, and on a memory-starved machine
+    accepting eviction is a legitimate trade.
+
+    ``WARM_SET_CAP_AUTO`` (0, the default) resolves to the live
+    *connected_count*, so no connected crew is evicted, clamped to
+    ``WARM_SET_CAP_AUTO_CEILING`` so a large fleet cannot mount an unbounded
+    number of dashboard SPAs in one renderer.
+
+    Never returns less than 1. The active pane is always warm, so a cap of 0 is
+    one the viewport cannot honour -- it would evict the pane the user is looking
+    at. A negative *connected_count* is read as none connected rather than
+    trusted, since it can only arrive from a caller bug.
+    """
+    if configured >= 1:
+        return configured
+    return max(1, min(max(connected_count, 0), WARM_SET_CAP_AUTO_CEILING))

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -46,7 +46,9 @@ class TestConfig:
 
         c = InstancesConfig()
         assert c.enabled is False
-        assert c.warm_set_cap == DEFAULT_WARM_SET_CAP == 5
+        # 0 == automatic: the cap follows the connected crew count (resolved per
+        # request by resolve_warm_set_cap), so no connected crew is ever evicted.
+        assert c.warm_set_cap == DEFAULT_WARM_SET_CAP == 0
         assert c.tunnel_base_port == DEFAULT_TUNNEL_BASE_PORT == 7778
         assert DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
         assert c.connect_timeout_secs is None
@@ -56,9 +58,16 @@ class TestConfig:
     def test_clamps_out_of_range(self):
         from kiro_crew.config.loader import InstancesConfig
 
-        c = InstancesConfig(warm_set_cap=0, tunnel_base_port=99999)
-        assert c.warm_set_cap == 1
+        # 0 is a legal value (automatic), so only a negative cap is clamped, and
+        # it falls back to automatic rather than to the tightest possible cap.
+        c = InstancesConfig(warm_set_cap=-3, tunnel_base_port=99999)
+        assert c.warm_set_cap == 0
         assert c.tunnel_base_port == 7778
+
+    def test_zero_warm_set_cap_is_kept_as_automatic(self):
+        from kiro_crew.config.loader import InstancesConfig
+
+        assert InstancesConfig(warm_set_cap=0).warm_set_cap == 0
 
     def test_roundtrip_and_schema(self):
         from kiro_crew.config.loader import KiroCrewConfig
@@ -67,7 +76,7 @@ class TestConfig:
         d = KiroCrewConfig().to_dict()
         assert d["instances"] == {
             "enabled": False,
-            "warm_set_cap": 5,
+            "warm_set_cap": 0,
             "tunnel_base_port": 7778,
             "ssh_compression": True,
             "connect_timeout_secs": None,
@@ -1737,9 +1746,37 @@ class _State:
         self.instances_manager = manager
 
 
-def _enable(tmp_path: Path, monkeypatch, *, enabled=True):
+class _ConnectedMgr:
+    """Manager stub where the named instances report a live tunnel.
+
+    Only the three members ``_status_for`` touches are implemented, which is
+    what the warm-set-cap tests need: the cap is derived from how many instances
+    come back ``connected``.
+    """
+
+    def __init__(self, connected):
+        self._connected = set(connected)
+
+    def status(self, instance_id):
+        if instance_id not in self._connected:
+            return None
+        return types.SimpleNamespace(
+            to_dict=lambda: {"instance_id": instance_id, "state": "connected"}
+        )
+
+    def token_ttl_remaining(self, instance_id):
+        return None
+
+    def last_error(self, instance_id):
+        return None
+
+
+def _enable(tmp_path: Path, monkeypatch, *, enabled=True, warm_set_cap=None):
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
-    (tmp_path / "config.json").write_text(json.dumps({"instances": {"enabled": enabled}}))
+    section: dict = {"enabled": enabled}
+    if warm_set_cap is not None:
+        section["warm_set_cap"] = warm_set_cap
+    (tmp_path / "config.json").write_text(json.dumps({"instances": section}))
     from kiro_crew.config import loader
 
     loader._invalidate_config_cache()
@@ -2080,9 +2117,40 @@ class TestHandlers:
         assert r.status == 201
         r = asyncio.run(handlers.api_instances_list(_FakeReq(state)))
         b = _body(r)
-        assert b["warm_set_cap"] == 5 and len(b["instances"]) == 1
+        # Automatic cap with nothing connected floors at 1 (the active pane is
+        # always warm), so the browser still gets a cap it can honour.
+        assert b["warm_set_cap"] == 1 and len(b["instances"]) == 1
         # no manager on this state => enabled-in-config but not active (needs restart)
         assert b["active"] is False
+
+    def test_automatic_cap_tracks_the_connected_count(self, tmp_path, monkeypatch):
+        """The served cap covers every connected crew, so none is ever evicted.
+
+        Eviction unmounts the pane and cold-boots the remote SPA on the next
+        click, which reads as a disconnect — so a cap below the connected count
+        makes ordinary tab switching look like a connection flap.
+        """
+        from kiro_crew.dashboard import handlers_instances as handlers
+
+        _enable(tmp_path, monkeypatch)
+        reg = self._reg(tmp_path)
+        for name in ("a", "b", "c"):
+            reg.add(name=name, ssh_host=f"{name}-alias")
+        state = _State(reg, _ConnectedMgr(["a", "c"]))
+        b = _body(asyncio.run(handlers.api_instances_list(_FakeReq(state))))
+        assert len(b["instances"]) == 3
+        assert b["warm_set_cap"] == 2
+
+    def test_explicit_cap_is_served_even_below_the_connected_count(self, tmp_path, monkeypatch):
+        """An operator's own number is the budget and is not widened for them."""
+        from kiro_crew.dashboard import handlers_instances as handlers
+
+        _enable(tmp_path, monkeypatch, warm_set_cap=1)
+        reg = self._reg(tmp_path)
+        for name in ("a", "b"):
+            reg.add(name=name, ssh_host=f"{name}-alias")
+        state = _State(reg, _ConnectedMgr(["a", "b"]))
+        assert _body(asyncio.run(handlers.api_instances_list(_FakeReq(state))))["warm_set_cap"] == 1
 
     def test_list_active_reflects_manager_running(self, tmp_path, monkeypatch):
         from kiro_crew.dashboard import handlers_instances as handlers

--- a/test/test_warm_set_cap.py
+++ b/test/test_warm_set_cap.py
@@ -1,0 +1,63 @@
+"""Tests for the warm-set cap policy (``kiro_crew.instances.warm_set``).
+
+The cap decides how many remote-crew panes stay mounted. It matters because
+eviction is indistinguishable from a disconnect at the pane -- the iframe is
+unmounted and the remote SPA cold-boots on the next click -- so a cap below the
+connected count reads to the user as a connection that flaps on tab switch.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.instances.constants import (
+    DEFAULT_WARM_SET_CAP,
+    WARM_SET_CAP_AUTO,
+    WARM_SET_CAP_AUTO_CEILING,
+)
+from kiro_crew.instances.warm_set import resolve_warm_set_cap
+
+
+class TestAutomatic:
+    def test_the_shipped_default_is_automatic(self):
+        assert DEFAULT_WARM_SET_CAP == WARM_SET_CAP_AUTO == 0
+
+    def test_automatic_matches_the_connected_count(self):
+        # The whole point: every connected crew keeps its pane, so switching
+        # between them never evicts one and never looks like a disconnect.
+        for connected in (1, 2, 3, 4, 7):
+            assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, connected) == connected
+
+    def test_automatic_is_bounded_by_the_ceiling(self):
+        # A large fleet must not mount an unbounded number of dashboard SPAs in
+        # one renderer, so eviction resumes past the ceiling.
+        assert (
+            resolve_warm_set_cap(WARM_SET_CAP_AUTO, WARM_SET_CAP_AUTO_CEILING + 5)
+            == WARM_SET_CAP_AUTO_CEILING
+        )
+
+    def test_automatic_never_resolves_below_one(self):
+        # The active pane is always warm, so 0 is a cap the viewport cannot
+        # honour -- it would evict the pane the user is looking at.
+        assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, 0) == 1
+
+    def test_a_negative_connected_count_is_not_trusted(self):
+        assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, -2) == 1
+
+
+class TestExplicit:
+    def test_an_explicit_cap_wins_over_the_connected_count(self):
+        assert resolve_warm_set_cap(3, 9) == 3
+
+    def test_an_explicit_cap_below_the_connected_count_is_not_widened(self):
+        # A deliberately tight cap is the only knob that bounds renderer cost;
+        # silently widening it would defeat the operator's own trade.
+        assert resolve_warm_set_cap(2, 4) == 2
+
+    def test_an_explicit_cap_above_the_ceiling_is_not_clamped(self):
+        # The ceiling only bounds the automatic mode. Naming a number IS the
+        # budget decision, so it is honoured verbatim.
+        assert (
+            resolve_warm_set_cap(WARM_SET_CAP_AUTO_CEILING + 8, 30) == WARM_SET_CAP_AUTO_CEILING + 8
+        )
+
+    def test_an_explicit_one_is_honoured(self):
+        assert resolve_warm_set_cap(1, 6) == 1

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -107,9 +107,10 @@ if (import.meta.env.DEV) {
 // NOT in an embedded remote-instance pane. Each warm pane is a full copy of this
 // SPA in its own realm, and every realm that evaluates PierreImpl spawns
 // PIERRE_WORKER_POOL_SIZE workers, each loading its own highlighter bundle + WASM
-// regex engine. With the default warm-set cap that is 4 workers x 5 panes = 20
-// eagerly-spawned workers in one renderer process, and the background panes paint
-// nothing, so 16 of them buy no responsiveness at all. Observed consequence: the
+// regex engine. With a warm-set cap that tracks the connected crews (automatic,
+// bounded at 8) that is 4 workers x up to 8 panes eagerly-spawned in one renderer
+// process, and the background panes paint
+// nothing, so most of them buy no responsiveness at all. Observed consequence: the
 // renderer accumulated 20 DedicatedWorker threads and was killed by a V8 fatal
 // abort raised on one of them, taking the whole window black.
 //


### PR DESCRIPTION
## Problem / Motivation

Remote crews appear to disconnect at random. Switching between crew tabs makes a
pane go blank and cold-boot, and if the reload misses its readiness timeout the
in-pane error panel comes up — the same thing the user sees when a tunnel is
genuinely down. The tunnel is up the whole time.

The cause is the warm-set cap. `instances.warm_set_cap` defaulted to a fixed `5`,
and any operator who lowered it — the documented advice for reducing the
dashboard's renderer cost — now holds a number unrelated to how many crews they
actually connected. With 4 connected crews and a cap of 2, every third tab switch
evicts a pane. Eviction is documented as harmless because it leaves the tunnel
alone, but from the seat it is indistinguishable from a disconnect: the iframe is
unmounted, the dashboard token is re-minted and the remote SPA boots from
scratch.

## Why it matters

Nothing names the cause, so the symptom is attributed to the tunnel, to SSH, or
to the remote host. It sends people to the wrong layer, and the one knob that
could explain it looks unrelated ("cap on warm panes" vs "my crew keeps
dropping"). The two numbers that have to agree — connected crews and the cap —
are in different places, and nothing keeps them in sync or warns when they
diverge.

## What changed (motivation → approach → change)

**Symptom** → a connected crew's pane cold-boots on tab switch and reads as a
dropped connection. **Root cause** → the warm-set cap is a fixed number while the
thing it bounds (how many crews are connected) is chosen by the user elsewhere,
so a cap below the connected count silently converts ordinary tab switching into
apparent connection flap. **Change** → make the default track the connected
count, so the two can no longer disagree by accident.

- `instances.warm_set_cap` now defaults to `0`, which means *automatic*
  (`WARM_SET_CAP_AUTO` in `src/kiro_crew/instances/constants.py`).
- `GET /api/instances` resolves the served cap from the live per-instance status
  via the new pure `resolve_warm_set_cap` (`src/kiro_crew/instances/warm_set.py`),
  so the browser always receives a concrete integer and the frontend needs no
  notion of an automatic mode. No frontend logic change was required.
- Automatic is bounded by `WARM_SET_CAP_AUTO_CEILING` (8). The connected count is
  a statement of user intent, not a resource budget, so a large fleet must not
  mount an unbounded number of dashboard SPAs in one renderer; 8 is above the
  previous default of `5`, so no install ends up with a tighter warm set than it
  had.
- An **explicit** integer is served verbatim, including one *below* the connected
  count, and is deliberately not clamped by the ceiling. Silently widening a
  deliberately tight cap would defeat the only knob that bounds renderer cost,
  and accepting eviction is a legitimate trade on a memory-tight machine.
- The loader now accepts `0` (it previously clamped anything `< 1` up to `1`).
  Only a negative value is a misconfiguration, and it falls back to automatic
  rather than to the tightest possible cap.
- Registered in `superseded_defaults.py` so an install still holding the
  materialized `5` is told on startup and in `doctor` — a stored `5` may equally
  be a deliberate budget, so it is reported rather than rewritten.
- `config-baseline.json` regenerated for the new default (required by
  `test_config_baseline.py`).
- Docs: `docs/system-specs/modules/instances.md` §warm set, the config table and
  the troubleshooting row now describe the automatic mode and state plainly that
  a re-warm looks like a reconnect.
- `website/src/main.tsx`: the comment explaining the Pierre worker-pool math
  cited "5 panes" from the old fixed default; updated to the automatic cap and
  its ceiling. Comment only, no behavior.

## Tests

- `test/test_warm_set_cap.py` (new, 11 tests) pins the policy: the shipped
  default is automatic; automatic equals the connected count; it is clamped at
  the ceiling; it never resolves below 1 (the active pane is always warm, so a
  `0` would evict the pane the user is looking at); a negative connected count is
  not trusted; an explicit cap wins over the connected count, is not widened when
  below it, and is not clamped when above the ceiling.
- `test/test_instances.py`: two new endpoint tests — the served cap equals the
  connected count with three registered and two connected instances, and an
  explicit cap of `1` is still served with two connected. Adds a `_ConnectedMgr`
  manager stub (only the three members `_status_for` touches) and a
  `warm_set_cap` kwarg on the `_enable` helper.
- Updated in the same file: the defaults assertion (`0`), the `to_dict`
  round-trip, the clamp test (now `-3 → 0`, plus a new test that `0` survives as
  automatic), and `test_add_list_includes_cap` (automatic with nothing connected
  floors at 1).

## Manual verification

Confirmed the reported symptom and the config path on a live install with four
connected crews (`nobita`, `shizuka`, `gian`, `suneo`) and a stored
`instances.warm_set_cap = 2`: the third pane touched was evicted and cold-booted
on the next click with the tunnel still connected. Reading the resolved cap back
from `GET /api/instances` is covered by the two new endpoint tests rather than by
hand.

Local gates run: the diff-scoped backend tests, `isort`, `flake8`, `mypy`, the
black baseline gate, `tsc -b`, `eslint`, `i18n:check`, `i18n:render`,
`jscpd`, the website build, the bundle-size gate, and the full electron suite
(1457 pass / 0 fail). The full backend and full frontend suites were left to CI.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the only frontend file in the diff is a comment in
`website/src/main.tsx`; the served cap is a number the existing viewport already
consumed, so no surface renders differently.

## Related Issues

no linked issue: reported directly rather than filed, and no open issue covers
the warm-set cap.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a cap whose default is a fixed number while the quantity it bounds is
chosen by the user elsewhere — exceeding it produces a symptom
indistinguishable from a failure of the thing being capped, so the
misconfiguration is unattributable.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
