### PR TITLE
fix(voice): quote the codesign team id, and say a retired STT provider once

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -4829,6 +4829,16 @@ _VALID_STT_MODELS = tuple(m.name for m in _STT_CATALOG)
 _VALID_CHANNEL_PREFIXES = ("C", "D", "G")
 
 
+# Provider values already warned about in this process. The gateway loads config
+# repeatedly, so an unusable stored provider is per-install information, not
+# per-load: without this the retirement notice repeats several times a second for
+# the whole session, which is how it was reported. Keyed on ``repr`` rather than
+# the value itself because this arrives from ``config.json`` and may be
+# unhashable (a list or dict), which must not raise on the degrade path. Exposed
+# for tests to reset.
+_WARNED_STT_PROVIDERS: set[str] = set()
+
+
 def _validated_stt_provider(value: object) -> str:
     """Return *value* if it is selectable, else degrade to ``local`` with a reason.
 
@@ -4839,6 +4849,10 @@ def _validated_stt_provider(value: object) -> str:
     """
     if value in _VALID_STT_PROVIDERS:
         return str(value)
+    seen = repr(value)
+    if seen in _WARNED_STT_PROVIDERS:
+        return STT_PROVIDER_LOCAL
+    _WARNED_STT_PROVIDERS.add(seen)
     if value in _RETIRED_STT_PROVIDERS:
         logger.warning(
             "STT provider %r is retired; using %r instead. It needed a separate "

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -174,8 +174,15 @@ _MAX_SIGNED_FFMPEG_BYTES = 192 * 1024 * 1024
 # ties the chain to Apple's root, so only a certificate Apple issued to THIS team
 # satisfies the requirement -- a self-signed or ad-hoc replacement does not.
 _MACOS_SIGNING_TEAM_ID = "94KV3E626L"
+# The team identifier MUST stay quoted. In the requirement language a bare token
+# beginning with a digit is not a valid identifier, so an unquoted 94KV3E626L is
+# a SYNTAX ERROR rather than a comparison: codesign exits non-zero without ever
+# evaluating the signature, which this function cannot tell apart from a genuine
+# authenticity failure. That made every signed macOS release refuse its own
+# decoder -- the digest anchor cannot cover a signed artifact by construction,
+# so with the signature anchor unparseable both anchors were unreachable.
 _MACOS_FFMPEG_REQUIREMENT = (
-    f"anchor apple generic and certificate leaf[subject.OU] = {_MACOS_SIGNING_TEAM_ID}"
+    f'anchor apple generic and certificate leaf[subject.OU] = "{_MACOS_SIGNING_TEAM_ID}"'
 )
 
 

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -2350,6 +2350,13 @@ class TestSttRetiredProviders:
     provider" without the name is unactionable.
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_warn_once(self):
+        """The degrade log is once-per-value-per-process, so tests must not inherit it."""
+        loader_module._WARNED_STT_PROVIDERS.clear()
+        yield
+        loader_module._WARNED_STT_PROVIDERS.clear()
+
     @pytest.mark.parametrize("retired", loader_module._RETIRED_STT_PROVIDERS)
     def test_retired_provider_degrades_to_local(self, retired: str, caplog) -> None:
         with caplog.at_level(logging.WARNING, logger="kiro_crew.config.loader"):
@@ -2396,6 +2403,31 @@ class TestSttRetiredProviders:
         assert "whispr" in caplog.text
         for selectable in loader_module._VALID_STT_PROVIDERS:
             assert selectable in caplog.text
+
+    def test_the_same_unusable_provider_is_only_said_once(self, caplog) -> None:
+        """A stored retired name must not narrate itself on every config load.
+
+        The gateway loads config repeatedly -- several times a second under normal
+        dashboard traffic -- and this degrade sits on that path, so without
+        deduplication one stale ``config.json`` value fills the log for the whole
+        session and buries everything else. The retirement is per-install
+        information: saying it once is what makes it readable.
+        """
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.config.loader"):
+            for _ in range(25):
+                assert _validated_stt_provider("whisper") == STT_PROVIDER_LOCAL
+        assert caplog.text.count("retired") == 1
+
+    def test_each_distinct_unusable_provider_still_gets_its_own_line(self, caplog) -> None:
+        """Deduplication is per VALUE, not a single global latch -- otherwise the
+        first bad value would silence the explanation for every later one."""
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.config.loader"):
+            assert _validated_stt_provider("whisper") == STT_PROVIDER_LOCAL
+            assert _validated_stt_provider("parakeet") == STT_PROVIDER_LOCAL
+            assert _validated_stt_provider("whispr") == STT_PROVIDER_LOCAL
+        assert "whisper" in caplog.text
+        assert "parakeet" in caplog.text
+        assert "whispr" in caplog.text
 
     def test_a_non_string_provider_degrades_rather_than_raising(self, tmp_path: Path) -> None:
         """The membership tests take an ``object``, so a hand-edited number or a

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -13,6 +13,7 @@ import asyncio
 import importlib.machinery
 import importlib.util
 import os
+import subprocess
 import sys
 import threading
 import types
@@ -26,6 +27,7 @@ import pytest
 from kiro_crew import platform_compat as _pc
 from kiro_crew import stt, transcribe
 from kiro_crew.config.loader import SttConfig
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 from kiro_crew.transcribe import (
     _ProfileCredentialResolver,
     availability_detail,
@@ -1489,8 +1491,49 @@ class TestBundledFfmpeg:
         replacement cannot satisfy it."""
         assert transcribe._MACOS_SIGNING_TEAM_ID == "94KV3E626L"
         assert transcribe._MACOS_FFMPEG_REQUIREMENT == (
-            "anchor apple generic and certificate leaf[subject.OU] = 94KV3E626L"
+            'anchor apple generic and certificate leaf[subject.OU] = "94KV3E626L"'
         )
+
+    def test_codesign_requirement_quotes_the_team_identifier(self):
+        """The team id must be a QUOTED string constant, not a bare token.
+
+        A requirement-language identifier cannot begin with a digit, so an
+        unquoted 94KV3E626L does not parse as a comparison operand at all --
+        codesign rejects the whole requirement and exits non-zero before it looks
+        at any signature. :func:`_macos_developer_id_authentic` only sees that
+        exit status, so the malformed constant is indistinguishable there from an
+        inauthentic binary, and every signed release refused its own decoder.
+        Asserting the exact string above cannot catch this on its own: the old
+        assertion pinned the unparseable form and passed.
+        """
+        assert f'"{transcribe._MACOS_SIGNING_TEAM_ID}"' in transcribe._MACOS_FFMPEG_REQUIREMENT
+
+    @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="codesign is macOS-only")
+    def test_codesign_accepts_the_requirement_as_parseable(self):
+        """Let codesign itself judge the syntax -- the only oracle that counts.
+
+        Run against a binary the OS signs (never our team), so a PARSEABLE
+        requirement is simply unsatisfied while an unparseable one reports a
+        syntax error. Only the latter is asserted against: this test is about the
+        requirement compiling, not about /bin/ls being authentic.
+        """
+        result = subprocess.run(
+            [
+                "/usr/bin/codesign",
+                "--verify",
+                "--strict",
+                "-R",
+                f"={transcribe._MACOS_FFMPEG_REQUIREMENT}",
+                "--",
+                "/bin/ls",
+            ],
+            check=False,
+            capture_output=True,
+            timeout=120,
+            **UTF8_TEXT,
+        )
+        assert "syntax error" not in result.stderr.lower()
+        assert "invalid or corrupted code requirement" not in result.stderr.lower()
 
     def test_codesign_is_invoked_by_absolute_path_with_requirement_source_text(
         self, monkeypatch, tmp_path


### PR DESCRIPTION
Two defects reported from one session on a signed 0.6.0 macOS release: voice transcode refused to start, and the log filled with the same warning.

## 1. The bundled decoder was refused on every signed macOS release

`_MACOS_FFMPEG_REQUIREMENT` interpolated the team identifier **unquoted**:

```
anchor apple generic and certificate leaf[subject.OU] = 94KV3E626L
```

A requirement-language identifier cannot begin with a digit, so this is not a comparison at all — codesign rejects the whole requirement before it looks at any signature:

```
error: invalid or corrupted code requirement(s)
Requirement syntax error(s):
line 1:55: unexpected token: =
line 1:57: expecting EOF, found '94'
```

`_macos_developer_id_authentic` only observes the exit status (stderr is `DEVNULL`), so a malformed constant of ours was indistinguishable from an inauthentic binary.

The digest anchor cannot cover a signed artifact by construction — signing rewrites the bytes, which is the whole reason `_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS` exists — so with the signature anchor unparseable **both anchors were unreachable**, `_open_packaged_ffmpeg_resource` returned `None`, and users got *"The bundled audio decoder is missing or damaged. Reinstall the Kiro Crew desktop app"*. Reinstalling cannot help: a rebuild produces the same signed bytes.

### Verified on a released app, both directions

The shipped binary is intact and does satisfy the intended requirement once it parses:

```
codesign -dv --verbose=4:
  Authority=Developer ID Application: ... (94KV3E626L)
  TeamIdentifier=94KV3E626L
  CodeDirectory v=20500 flags=0x10000(runtime)

unquoted  -> exit 1, "invalid or corrupted code requirement(s)"
quoted    -> exit 0
```

The build-time gate could not catch this: `local_voice_runtime_gate` probes the wheel's **unsigned** bytes, which match the digest pin, and signing happens afterwards. Only the runtime path breaks.

### Why the existing test did not catch it

`test_codesign_requirement_pins_the_release_team` asserted the exact string, so it pinned the unparseable form and passed. It is corrected, and two tests are added that the old assertion could not express:

- the identifier must be **quoted**;
- codesign itself judges that the requirement **compiles** (macOS-gated, run against a binary the OS signs, asserting only on the absence of a syntax error — "unsatisfied" is the expected outcome there and is deliberately not asserted against).

## 2. A retired STT provider narrated itself several times a second

`_validated_stt_provider` logged on every call and the gateway loads config repeatedly, so one stale `provider: whisper` produced a wall of identical lines — 15 in 32 seconds in the report, two of them 11 ms apart — burying every other message for the session.

The retirement is per-install information, not per-load, so it is now said **once per distinct value**, following the existing `_WARNED_RESOURCE_LIMIT_KEYS` / `_REPORTED_SUPERSEDED_KEYS` idiom. Deduplication is per value rather than a single latch, so a second unusable value still gets its own explanation, and the key is the `repr` because this arrives from `config.json` and may be unhashable — which must not raise on a degrade path.

Tests pin both halves and reset the set between cases as the other warn-once suites do; without that fixture the pre-existing retirement tests would start inheriting each other's state.

## Testing

- `test_transcribe.py`, `test_config_loader.py`, `test_apple_speech.py`: **703 passed, 5 skipped**
- `test_spawn_audit.py`: **12 passed**
- flake8 clean

## Deliberately not in this PR

`_macos_developer_id_authentic` sends stderr to `DEVNULL`, which is why a 100%-reproducible failure shipped silently. The new tests close this specific class at build time; making that call distinguish "requirement failed to parse" from "signature not authentic" at runtime is a separate behavioural change and is left out.

## Pattern harvest

Both defects here are instances of a class, not one-offs.

Rule candidate: review-prompt / agents-md — when a constant is **source text for an external parser** (a codesign requirement, a seccomp filter, SQL, a regex, a cron expression), a test asserting the string's exact value does not test it. The parser must be the oracle. This defect survived because `test_codesign_requirement_pins_the_release_team` asserted the literal and therefore pinned the unparseable form; the string was "covered" and 100% broken. Where the parser is platform-gated, gate the test rather than dropping it.

Rule candidate: lint/semgrep — an authenticity or authorization predicate must not collapse "the check could not run" into "the check said no". `_macos_developer_id_authentic` returned `returncode == 0` with stderr discarded, so a malformed argument of ours was indistinguishable from a hostile binary. Flag a security predicate that returns a bare exit-status comparison while discarding stderr.

Rule candidate: lint/semgrep — a `logger.warning` reached from config load or validation coercion must be deduplicated. The repository already carries three hand-rolled instances of this idiom (`_WARNED_RESOURCE_LIMIT_KEYS`, `_REPORTED_SUPERSEDED_KEYS`, `_warned_env_keys`), each added after the same symptom was reported; a rule would have caught the fourth before a user did. Candidate shape: warn/error calls inside `config/loader.py` coercion helpers require a module-level seen-set guard.
