### PR TITLE
perf(ci): gate four single-surface jobs and stop the code-review pile-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,12 @@ jobs:
 
   backend-lint:
     name: Backend Lint & Type Check
+    needs: [changes]
+    # black/flake8/isort/mypy read no file under website/, so a frontend-only
+    # diff cannot change this verdict. Gated on only_frontend (not on a
+    # positive "python changed" allowlist) so that anything the selector could
+    # not classify as frontend -- docs, a new root file, meta -- still runs it.
+    if: needs.changes.outputs.only_frontend != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -702,7 +708,6 @@ jobs:
   # run the same tests measurably slower.
   backend-test-windows:
     name: Backend Tests (Windows)
-    needs: [changes]
     runs-on: windows-latest
     # windows-latest runs the same shards measurably slower than POSIX.
     timeout-minutes: 40
@@ -739,29 +744,14 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[voice,desktop]" --group dev
 
-      - name: Select test scope
-        id: scope
-        # bash (Git Bash on windows-latest), not pwsh -- same reason as the test
-        # step below. Mirrors the POSIX backend-test selector exactly.
-        shell: bash
-        env:
-          ONLY_FRONTEND: ${{ needs.changes.outputs.only_frontend }}
-          TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
-        run: |
-          if [ "$ONLY_FRONTEND" != "true" ]; then
-            echo "reduced=false" >> "$GITHUB_OUTPUT"
-            echo "Full backend suite (diff is not frontend-only)."
-            exit 0
-          fi
-          rc=0
-          python3 scripts/ci-surface-tests.py --surface backend --summary > "$TARGETS_FILE" || rc=$?
-          if [ "$rc" != "0" ] || [ ! -s "$TARGETS_FILE" ]; then
-            echo "::warning::surface selector unusable (rc=$rc) -- running the FULL backend suite."
-            echo "reduced=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "reduced=true" >> "$GITHUB_OUTPUT"
-          echo "Reduced scope: $(wc -l < "$TARGETS_FILE") cross-surface backend file(s)."
+      # No surface selector here, unlike the POSIX backend-test job. Narrowing
+      # this job to the cross-surface subset on a frontend-only diff was
+      # measured as a PESSIMISATION: 4 shards x ~18 min = 70 job-min for the
+      # subset, against 62-67 job-min for the whole suite (runs 33412618648 vs
+      # 33406565382). `-n auto` already saturates each runner, so a smaller
+      # file list does not shorten a shard, and the cross-surface files are not
+      # the cheap ones. Running everything is both cheaper and strictly more
+      # coverage, so there is nothing to select.
 
       - name: Run tests (Windows shard ${{ matrix.group }}/${{ env.SHARD_COUNT }})
         # bash (Git Bash on windows-latest), not pwsh: the invocation shares
@@ -792,18 +782,7 @@ jobs:
         # is red either way, and a named red in 12 minutes beats an
         # uninterpretable one at the 40-minute cap.
         shell: bash
-        env:
-          REDUCED: ${{ steps.scope.outputs.reduced }}
-          TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
         run: |
-          if [ "$REDUCED" = "true" ]; then
-            TARGETS=()
-            while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
-            pytest -q -n auto --timeout=180 --no-cov --max-worker-restart=0 \
-              --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
-              "${TARGETS[@]}"
-            exit 0
-          fi
           pytest -q -n auto --timeout=180 --no-cov --max-worker-restart=0 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }}
         # Nothing is deselected here either, and the same guards carry it: Windows has no
@@ -1276,6 +1255,11 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint & Type Check
+    needs: [changes]
+    # eslint/tsc/i18n over website/** only; a backend-only diff leaves every
+    # input byte-identical. only_backend is the catch-all side of the same
+    # decision, so an unclassifiable path still runs this.
+    if: needs.changes.outputs.only_backend != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1444,6 +1428,9 @@ jobs:
   # class, and without a job on the floor nothing would notice.
   lockfile-engines-floor:
     name: Lockfile Installs On Declared Node Floor
+    needs: [changes]
+    # Reads website/package.json + website/package-lock.json and nothing else.
+    if: needs.changes.outputs.only_backend != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1489,6 +1476,10 @@ jobs:
 
   cfn-lint:
     name: CloudFormation Lint
+    needs: [changes]
+    # The templates it lints live under src/kiro_crew/deploy/, which the
+    # paths-filter counts as backend, so a frontend-only diff cannot touch one.
+    if: needs.changes.outputs.only_frontend != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1516,6 +1507,14 @@ jobs:
   # shipped DMG. That is not hypothetical: the missing macOS microphone
   # entitlement reached users this way. This job is deliberately tiny and fast —
   # pure unit tests, no Electron binary download, no packaging.
+  # NOT diff-gated, deliberately. The obvious gate (only_backend != 'true')
+  # is wrong: test/packaging.test.js pins the macOS entitlement contract
+  # against BOTH signing lanes, and one of them is
+  # packaging/signing/Entitlements.entitlements -- outside website/, so the
+  # paths-filter counts it as backend. A packaging-only diff would therefore
+  # skip the job whose absence already shipped a broken bundle once (the
+  # missing microphone entitlement above). Same for the
+  # packaging/installer-assets/* references it pins.
   electron-test:
     name: Electron Shell Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -7,6 +7,14 @@ on:
 permissions:
   contents: read
 
+# Five jobs fire per event, on `edited` as well as `synchronize`, so without a
+# group a push burst leaves every superseded revision's jobs running to
+# completion. Matches the sibling reviewers (codex-review, pr-scope,
+# cross-platform), which all key on the PR number and cancel.
+concurrency:
+  group: code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   autosde-rules:
     name: Automated Rule Check


### PR DESCRIPTION
## Problem

CI is 77% of the repository's GitHub Actions job-minutes (1.76M of 2.28M per week, measured over 2026-08-24 → 08-31), at ~224 job-min per run. Two structural causes, both measured rather than assumed:

**18 of CI's 27 jobs have no `needs: changes` at all**, so single-surface lints run in full against the opposite surface. `backend-lint` (2 cells, ~22 job-min) runs black/flake8/isort/mypy on a `website/**`-only diff; `frontend-lint` and `lockfile-engines-floor` run eslint/tsc and `npm ci` on a Python-only diff.

**`code-review.yml` is the only `pull_request`-triggered workflow in the repo with no `concurrency:` block**, and it fires 5 jobs on `opened, synchronize, reopened, edited`. A 4-push burst therefore leaves up to 20 superseded jobs running to completion. Every sibling reviewer (`codex-review`, `pr-scope`, `cross-platform`) already keys on the PR number and cancels.

Separately, the Windows surface selector turned out to **cost more than it saves**. On a frontend-only diff `backend-test-windows` narrows to the cross-surface subset and takes 4 × ~18 = **70 job-min** (run 33412618648); running the whole suite on a backend diff takes 62–67 (runs 33406565382, 33406679398). `-n auto` already saturates each runner, so a shorter file list does not shorten a shard, and the cross-surface files are not the cheap ones.

## Change

Four single-surface jobs gain `needs: [changes]` and a surface gate. Each is gated on the **catch-all** side of the flag (`only_frontend != 'true'` / `only_backend != 'true'`), not on a positive "did python change" allowlist, so an unclassifiable path — docs, a new root file, anything under `.github/` — still runs the job. That preserves the deny-by-default property the `changes` job documents: a heuristic miss costs CI time, never a skipped guard.

| job | gate | why it cannot be affected |
| --- | --- | --- |
| `backend-lint` | `only_frontend != 'true'` | every step targets `src/kiro_crew`, `test`, `conftest.py`, `xdist_budget.py`; `website/` holds no `.py` at all |
| `cfn-lint` | `only_frontend != 'true'` | templates live under `src/kiro_crew/deploy/` (backend bucket) |
| `frontend-lint` | `only_backend != 'true'` | every step is `working-directory: website` (tsc, eslint `src/`, jscpd, i18n, color tokens) |
| `lockfile-engines-floor` | `only_backend != 'true'` | single step, `working-directory: website`, `npm ci` |

`code-review.yml` gains a cancelling concurrency group matching its siblings.

`backend-test-windows` **drops** its surface selector and always runs the full suite. This is the one change here that alters coverage, and it moves it **up**: strictly more tests for strictly fewer job-minutes. The job also no longer needs `changes`, so it starts without waiting on it.

## What this is not

**`electron-test` is deliberately not gated**, and a check now pins that. The obvious gate (`only_backend != 'true'`) is wrong: `website/electron/test/packaging.test.js` asserts the macOS entitlement contract against **both** signing lanes, and one of them is `packaging/signing/Entitlements.entitlements` — outside `website/`, so the paths-filter counts it as backend. It pins `packaging/installer-assets/*` references the same way. A packaging-only diff would therefore skip the job whose absence already shipped a broken bundle once, which is the missing-microphone-entitlement incident its own header documents. Caught by GPT 5.6 review on the first revision.

Two further items from the same analysis were also **not** taken:

- **`backend-test-macos` is left alone.** Skipping it on a frontend-only diff would remove the macOS peer-identity canary (`LOCAL_PEERPID`, libproc process start id) — the only pytest coverage macOS has in CI — to save 1–2 minutes of wall time. Removing a guard is not a cost optimisation.
- **`in_progress` stays in `pr-readiness.yml`'s `workflow_run` allowlist.** It is documented in-file as a merge-safety guard, and correctly: a re-run reuses the workflow run and increments its attempt, so `requested` does not fire but `in_progress` does. Without it, readiness holds the pre-re-run `success` for the duration of a re-run, and since that status is the branch-protection handle for the whole fan-out, armed auto-merge can merge a revision whose lane is failing at that moment. `requested` was already dropped for the dispatch saving; the remaining two types are load-bearing.

## Verification

- All four diff-scoped gates run with their `BASE_REF` exported (report mode without it always exits 0): brand ✓, focus-cue ✓, changelog-history ✓, harness-parity ✓.
- Every workflow file still parses as YAML.
- A consistency check asserts (a) no job reads `needs.<job>.outputs` without declaring that job in `needs` — the silent-failure shape here, since a missing `needs` makes the expression empty and `!= 'true'` vacuously true — and (b) `electron-test` carries no `needs`/`if` at all, so the finding above cannot be reintroduced quietly.
- Revert-verified in all three directions: stripping `needs: [changes]` from `backend-lint` exits 1, dropping `in_progress` from `pr-readiness.yml` exits 1, and re-adding a surface gate to `electron-test` exits 1.
- `scripts/ci-surface-tests.py` retains its callers (POSIX `backend-test`, `frontend-test`, `run_scoped_tests.py`, `local-gate.py`) — no orphaned script.

## Known residual

Adding `needs: [changes]` widens an existing hazard rather than introducing one: if the `changes` job fails (e.g. a `paths-filter` API blip), its dependents skip rather than run, and a skipped job does not redden the workflow. `backend-test`, `frontend-test`, `coverage-combine` and `bundle-size` already carry that exposure; this adds four more jobs to it. Worth a follow-up that makes a `changes` failure fail the run rather than silently narrow it.
