### PR TITLE
docs: point setup guides to supported installs

### DIFF
--- a/docs/guides/slack-setup.md
+++ b/docs/guides/slack-setup.md
@@ -24,7 +24,7 @@ Both paths require a Slack workspace where you can install apps (see [Prerequisi
 ## Prerequisites
 
 - A **Slack workspace** where you have permission to install apps. If you don't have one, create a free workspace at <https://slack.com/get-started>. You can install your own apps in a workspace you own.
-- Python and Kiro Crew installed (`pip install kirocrew`), so you can run the `kirocrew` CLI.
+- Python and Kiro Crew installed through a [supported install path](install.md#install-paths), so you can run the `kirocrew` CLI.
 
 > **Tip**: Use a personal or test workspace for your first run. You can always export the app manifest and recreate the app in another workspace later (see [Reusing the App in Another Workspace](#reusing-the-app-in-another-workspace)).
 

--- a/website/electron/README.md
+++ b/website/electron/README.md
@@ -235,7 +235,7 @@ Open via **Tab menu → Open Config File** or tray menu.
 | Issue | Fix |
 |-------|-----|
 | "SSH token fetch failed" | Check `ssh YOUR_HOST` works from Terminal |
-| "kirocrew binary not found in any of …" | Install kirocrew (`pip install kirocrew`), or set a custom path |
+| "kirocrew binary not found in any of …" | Install Kiro Crew through a [supported install path](../../docs/guides/install.md#install-paths), or set a custom path |
 | "command not found: kiro-cli" | Set Remote PATH to include `~/.toolbox/bin` (default does this) |
 | "command not found: dirname" | Remote PATH missing `/usr/bin` — reset to default or add it |
 | Token fetched but 403 | Gateway may need restart — `ssh host systemctl --user restart kirocrew` |


### PR DESCRIPTION
## Problem / Motivation

Two setup guides recommended `pip install kirocrew`, but Kiro Crew is not published to PyPI.

## Why it matters

Following either guide leaves users without the `kirocrew` CLI needed to continue setup.

## What changed (motivation → approach → change)

Linked both stale instructions to the repository’s supported-install paths so readers get the maintained installation guidance.

## Tests

No runtime tests — documentation-only change.

## Manual verification

Ran `python scripts/docs_lint.py` successfully.

## Screenshots / video

N/A — documentation-only change.

## Related Issues

Fixes #7334

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — no repository-provided CLA wording is available in the template.
