### PR TITLE
perf(memory): make the background re-embed sweep stay out of the way

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1407,6 +1407,8 @@
         "embedding_provider": "llama_cpp",
         "embedding_dim": 1024,
         "embedding_threads": 4,
+        "embedding_bulk_threads": 1,
+        "embedding_bulk_duty": 0.2,
         "embed_model_url": "",
         "embed_model_path": "",
         "embed_model_id": "",
@@ -1464,6 +1466,34 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 4
+    },
+    {
+      "path": "memory.embedding_bulk_threads",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Embedding Threads (bulk)",
+      "help": "CPU threads for BACKGROUND corpus embedding — the re-embed sweep that gives imported memories semantic reach, plus imports and consolidation — as opposed to a query you are waiting on. Defaults to 1: nothing waits on this work (those rows are keyword-searchable meanwhile), so it is tuned to stay invisible rather than finish early. Raise it to get through a large backlog sooner; interactive search keeps its own pool either way. 0 means inherit Embedding Threads. Clamped to the machine's core count.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 1
+    },
+    {
+      "path": "memory.embedding_bulk_duty",
+      "kind": "core",
+      "type": "number",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Embedding Duty Cycle (bulk)",
+      "help": "Fraction of wall time a background embedding sweep targets for computing. At the default 0.2 it idles four times as long as it works, so a sweep over a freshly imported memory costs about a fifth of one core instead of several — the same total work, spread thin enough that fans never react. The sweep resumes across restarts, so it need not finish in one session. A target rather than a ceiling: one unusually slow row is capped at a 30-second pause and so runs hotter than the configured share. 1.0 runs flat out. Clamped to [0.05, 1.0]; a sweep a user explicitly starts from Settings is never paced.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 0.2
     },
     {
       "path": "memory.embed_model_url",

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_index.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_index.py
@@ -173,6 +173,15 @@ def import_pending(store: Any, *, limit: int = MAX_PER_IMPORT) -> dict[str, int]
 
     if result["written"]:
         try:
+            # PACED, even though a caller blocks on this: the only caller is the
+            # ledger-hygiene CRON (`routes.py:_handle_ledger_hygiene`, "Called by
+            # the ledger-hygiene cron"; no UI path reaches it). A cron holds the
+            # response open but nobody attends it, and the PR's rule is
+            # attendance, not blocking. Left unpaced this was a side door around
+            # the whole fix: the sweep is whole-corpus, so a post-migration
+            # backlog would be re-embedded flat out — at the full interactive
+            # thread count, since `pace=False` also selects the thread class — on
+            # the next daily tick.
             result["embedded"] = int(store.backfill_missing_embeddings() or 0)
         except Exception:  # noqa: BLE001 — rows stay keyword-searchable if this fails
             logger.exception("ops-mission-control: embedding backfill failed")

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_index.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_index.py
@@ -50,10 +50,11 @@ class _FakeStore:
         self.texts.add(text)
         return True
 
-    def backfill_missing_embeddings(self) -> int:
+    def backfill_missing_embeddings(self, *, pace: bool = True) -> int:
         if self._fail_backfill:
             raise RuntimeError("model unavailable")
         self.backfill_calls += 1
+        self.backfill_paced = pace
         return len(self.texts)
 
     def search_episodic(self, **kw: Any) -> list[dict]:
@@ -106,6 +107,11 @@ class TestIncrementalImport(_Env):
         first = ledger_index.import_pending(store)
         self.assertEqual(first["written"], 20)
         self.assertEqual(store.backfill_calls, 1, "one batched sweep, not 20")
+        self.assertTrue(
+            store.backfill_paced,
+            "the only caller is the ledger-hygiene cron, which blocks but is "
+            "unattended, so the whole-corpus sweep must stay paced",
+        )
 
         second = ledger_index.import_pending(store)
         self.assertEqual(second["written"], 0, "an unchanged ledger must re-embed nothing")

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2454,6 +2454,34 @@ class MemoryConfig:
             "Clamped to the machine's core count.",
         ),
     )
+    embedding_bulk_threads: int = field(
+        default=1,
+        metadata=_meta(
+            "Embedding Threads (bulk)",
+            "CPU threads for BACKGROUND corpus embedding — the re-embed sweep that "
+            "gives imported memories semantic reach, plus imports and consolidation — "
+            "as opposed to a query you are waiting on. Defaults to 1: nothing waits on "
+            "this work (those rows are keyword-searchable meanwhile), so it is tuned to "
+            "stay invisible rather than finish early. Raise it to get through a large "
+            "backlog sooner; interactive search keeps its own pool either way. 0 means "
+            "inherit Embedding Threads. Clamped to the machine's core count.",
+        ),
+    )
+    embedding_bulk_duty: float = field(
+        default=0.2,
+        metadata=_meta(
+            "Embedding Duty Cycle (bulk)",
+            "Fraction of wall time a background embedding sweep targets for computing. "
+            "At the default 0.2 it idles four times as long as it works, so a sweep "
+            "over a freshly imported memory costs about a fifth of one core instead of "
+            "several — the same total work, spread thin enough that fans never react. "
+            "The sweep resumes across restarts, so it need not finish in one session. "
+            "A target rather than a ceiling: one unusually slow row is capped at a "
+            "30-second pause and so runs hotter than the configured share. 1.0 runs "
+            "flat out. Clamped to [0.05, 1.0]; a sweep a user explicitly starts from "
+            "Settings is never paced.",
+        ),
+    )
     embed_model_url: str = field(
         default="",
         metadata=_meta(
@@ -8319,6 +8347,15 @@ class KiroCrewConfig:
                 ),
                 embedding_dim=memory_data.get("embedding_dim", 1024),
                 embedding_threads=_safe_int(memory_data.get("embedding_threads", 4), 4, 1, 256),
+                # 0 is the documented "inherit embedding_threads" sentinel, so the
+                # floor is 0 rather than 1 — clamping it to 1 would erase a
+                # deliberate opt-in to the interactive pool.
+                embedding_bulk_threads=_safe_int(
+                    memory_data.get("embedding_bulk_threads", 1), 1, 0, 256
+                ),
+                embedding_bulk_duty=_safe_float(
+                    memory_data.get("embedding_bulk_duty", 0.2), 0.2, 0.05, 1.0
+                ),
                 embed_model_url=memory_data.get("embed_model_url", ""),
                 embed_model_path=memory_data.get("embed_model_path", ""),
                 embed_model_id=memory_data.get("embed_model_id", ""),

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -654,7 +654,13 @@ def _apply_embedding_model(store: object, raw: str, loop: "asyncio.AbstractEvent
             embedder.dim,
             active_embedding_space_signature(),
         )
-        embedded = store.backfill_missing_embeddings(progress=prog.advance)  # type: ignore[attr-defined]
+        # pace=False: the user just applied a model change and is watching this
+        # progress bar, and semantic search stays degraded until the sweep ends.
+        # Bulk pacing exists to keep an UNATTENDED sweep quiet — spreading a wait
+        # someone explicitly asked for only doubles it.
+        embedded = store.backfill_missing_embeddings(  # type: ignore[attr-defined]
+            progress=prog.advance, pace=False
+        )
         prog.finish(embedded)
     except Exception as exc:  # noqa: BLE001 - surfaced to the dashboard, never crashes the app
         logger.warning("Applying the embedding model failed", exc_info=True)

--- a/src/kiro_crew/embeddings.py
+++ b/src/kiro_crew/embeddings.py
@@ -34,6 +34,7 @@ import hashlib
 import importlib.util
 import json
 import logging
+import math
 import os
 import platform
 import queue
@@ -126,6 +127,47 @@ _INFER_STOP_TIMEOUT_SECS = 30.0
 # suffer and cause contention. Pinned low here, overridable via
 # memory.embedding_threads.
 _DEFAULT_EMBED_THREADS = 4
+# Bulk corpus loops (the post-migration re-embed sweep above all) run for as long
+# as the corpus takes: measured 429 ms/row at 4 threads on ~500-character rows,
+# so a 3,000-row migrated memory is ~21 minutes at a SUSTAINED 3.7 cores. That is
+# indistinguishable from a runaway process to the user — laptop fans spin up and
+# stay up — even though every row is legitimate work.
+#
+# Nobody is waiting on that work. A row with a NULL embedding is still FTS5
+# keyword-searchable the moment it lands; the sweep only adds SEMANTIC reach over
+# memories the user imported from a previous install. So the sweep is optimized
+# for staying invisible, not for finishing early, and the defaults below are
+# deliberately slow: one thread at a 20% duty cycle is ~0.2 of a core, which no
+# fan reacts to. On the measured host that is ~7 s/row, so a 3,000-row backlog
+# takes hours — and that is fine. It is idempotent and resumes across restarts
+# (an unfinished row stays NULL and the next boot picks it up), so a machine that
+# is never on long enough to finish still converges over several sessions.
+#
+# Two independent dials for a deployment that wants it faster (a server, or a
+# user who wants semantic search over old memories today):
+#
+#   * ``memory.embedding_bulk_threads`` — threads for BULK jobs only, so raising
+#     it never slows a query the user is waiting on. 0 means "inherit
+#     ``embedding_threads``".
+#   * ``memory.embedding_bulk_duty`` — the fraction of wall time the loop may
+#     spend computing. 1.0 runs flat out.
+#
+# Total CPU work is unchanged either way (measured 1.39–1.57 CPU-seconds per row
+# across 1/2/4 threads); what changes is how thinly it is spread. Fans respond to
+# sustained load, so spreading it is the whole point. The one cost of spreading
+# is that the ~700MB model stays resident while the sweep runs, which is why the
+# sweep still probes for pending rows BEFORE loading anything.
+_DEFAULT_BULK_THREADS = 1
+_DEFAULT_BULK_DUTY = 0.2
+# Floor on the duty cycle. A typo of 0.001 would otherwise turn a multi-hour
+# sweep into a multi-week one, which is indistinguishable from it never running.
+_MIN_BULK_DUTY = 0.05
+# Cap on a single pace sleep. This exists ONLY so one pathological row (a
+# 6,000-character blob whose inference takes seconds) cannot park the sweep for
+# minutes; it must stay well ABOVE the delay an ordinary row produces at the
+# default duty (~5.6s at 1.39s/row and 0.2), or it would quietly override the
+# configured duty on EVERY row instead of catching the outlier it is named for.
+_MAX_BULK_PACE_SLEEP = 30.0
 # Only log an embed's queue wait at INFO once it is long enough for a waiting
 # caller to notice; below this it stays DEBUG so ordinary memory writes do not
 # emit a line each.
@@ -567,6 +609,82 @@ def _embed_threads() -> int:
     if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
         raw = _DEFAULT_EMBED_THREADS
     return max(1, min(raw, os.cpu_count() or _DEFAULT_EMBED_THREADS))
+
+
+def bulk_embed_threads() -> int:
+    """Thread count for ``PRIORITY_BULK`` inference, from ``memory``.
+
+    Defaults to :data:`_DEFAULT_BULK_THREADS` — one thread, because nothing is
+    waiting on bulk work and a single thread is what keeps it off the fans. An
+    explicit 0 means "inherit :func:`_embed_threads`", which is how a deployment
+    opts back into the interactive pool for its sweeps. A value above the
+    interactive count is honoured (a server that wants the sweep done fast is a
+    legitimate choice) but still clamped to the machine's cores.
+    """
+    raw = _read_memory_config().get("embedding_bulk_threads")
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+        raw = _DEFAULT_BULK_THREADS
+    elif raw == 0:
+        return _embed_threads()
+    return max(1, min(raw, os.cpu_count() or _DEFAULT_EMBED_THREADS))
+
+
+def bulk_duty_cycle() -> float:
+    """Fraction of wall time a bulk corpus loop targets for inference.
+
+    A target rather than a ceiling: :func:`bulk_pace_delay` caps one pause at
+    :data:`_MAX_BULK_PACE_SLEEP`, so a row slow enough to ask for more idle than
+    that runs at a higher effective duty than configured.
+
+    1.0 disables pacing (the pre-existing behaviour). Anything else is clamped to
+    ``[_MIN_BULK_DUTY, 1.0]``, so a typo cannot stretch a sweep to the point
+    where it looks stalled. Bools are rejected before ``isinstance(x, int)`` can
+    accept ``True`` as 1.
+
+    Non-finite values are rejected explicitly rather than left to the clamp. This
+    reads the RAW config section — the loader's ``_safe_float`` guard is NOT in
+    the path — and ``json.load`` accepts the ``NaN`` literal, which compares
+    false against every bound and would slip through ``max()`` unchanged.
+
+    ``float()`` itself can raise: ``json.load`` yields arbitrary-precision ints,
+    and one wider than a double (a 309-digit integer) raises ``OverflowError``.
+    That would propagate out through ``bulk_pace_delay`` into the sweep and abort
+    it, leaving every pending row NULL — a config typo must degrade to the
+    default, never stop the sweep.
+    """
+    raw = _read_memory_config().get("embedding_bulk_duty")
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raw = _DEFAULT_BULK_DUTY
+    try:
+        duty = float(raw)
+    except (OverflowError, ValueError):
+        duty = _DEFAULT_BULK_DUTY
+    if not math.isfinite(duty):
+        duty = _DEFAULT_BULK_DUTY
+    if duty >= 1.0:
+        return 1.0
+    return max(_MIN_BULK_DUTY, duty)
+
+
+def bulk_pace_delay(elapsed: float) -> float:
+    """Seconds a bulk loop should idle after a unit of work taking *elapsed*.
+
+    Duty *d* means work occupies ``d`` of the cycle, so the idle share is
+    ``elapsed * (1 - d) / d`` — at ``d = 0.5`` the loop sleeps for exactly as
+    long as it worked. Returns 0.0 when pacing is off, and never returns more
+    than :data:`_MAX_BULK_PACE_SLEEP`.
+
+    Callers sleep in their OWN thread and hold no model lock while doing so, so
+    an interactive embed arriving mid-pause is served at full speed rather than
+    waiting out the pause. That is why this returns a delay for the caller to
+    honour instead of sleeping inside the shared inference worker.
+    """
+    if elapsed <= 0:
+        return 0.0
+    duty = bulk_duty_cycle()
+    if duty >= 1.0:
+        return 0.0
+    return min(elapsed * (1.0 - duty) / duty, _MAX_BULK_PACE_SLEEP)
 
 
 def _chars_bucket(chars: int) -> str:
@@ -1220,6 +1338,15 @@ class LlamaCppEmbedder(EmbeddingBackend):
         self._jobs: "queue.PriorityQueue[tuple[int, int, _InferJob | None]]" = queue.PriorityQueue()
         self._seq = 0
         self._seq_lock = threading.Lock()
+        # Thread count currently programmed into the loaded context, and whether
+        # this backend can reprogram it at all. Both are touched ONLY by the
+        # single inference worker, under ``_lock``, so they need no lock of their
+        # own. ``None`` means "not yet known" — the count llama.cpp got at load
+        # time is _embed_threads(), but re-deriving that here would go stale if
+        # the config changed since, so the worker programs it explicitly on the
+        # first job instead of assuming.
+        self._applied_threads: int | None = None
+        self._thread_class_unsupported = False
         # Guards the DISPATCH state — (_infer_thread, _jobs) selection, worker
         # spawn, and the enqueue — as one atomic step. Deliberately NOT _lock:
         # the worker holds _lock across inference, so enqueueing under it would
@@ -1406,6 +1533,15 @@ class LlamaCppEmbedder(EmbeddingBackend):
                     except Exception:  # noqa: BLE001 - freeing must not propagate
                         logger.debug("Freeing abandoned model failed", exc_info=True)
                 return
+            # A fresh context carries llama.cpp's load-time thread count, so the
+            # count the worker last programmed no longer describes it. Clear the
+            # record BEFORE publishing, or the first job on the new context would
+            # match the stale count and skip programming entirely — leaving a
+            # bulk sweep on the interactive pool (or the reverse) with nothing to
+            # show why. Written from the loader thread and read by the inference
+            # worker; both are single plain-attribute accesses (GIL-atomic), and
+            # the only cost of racing is one redundant set_n_threads call.
+            self._applied_threads = None
             self._llm = llm  # atomic publish (GIL)
         except Exception:
             logger.warning("Failed to load embedding model %s", self._model_path, exc_info=True)
@@ -1451,7 +1587,7 @@ class LlamaCppEmbedder(EmbeddingBackend):
         strictly no more concurrent than a single caller holding it was.
         """
         while True:
-            _prio, _seq, job = jobs.get()
+            prio, _seq, job = jobs.get()
             if job is None:
                 # close() has already dropped the model. Anything queued behind
                 # the sentinel would otherwise wait on job.done forever, since
@@ -1460,12 +1596,53 @@ class LlamaCppEmbedder(EmbeddingBackend):
                 return
             try:
                 with self._lock:
+                    self._apply_thread_class(job.llm, prio)
                     job.started = time.monotonic()
                     job.result = job.llm.create_embedding(job.texts)  # type: ignore[attr-defined]
             except BaseException as exc:  # noqa: BLE001 - relayed to the caller verbatim
                 job.error = exc
             finally:
                 job.done.set()
+
+    def _apply_thread_class(self, llm: object, priority: int) -> None:
+        """Program llama.cpp's compute pools for this job's scheduling class.
+
+        A BULK job may run on fewer threads than an interactive one
+        (``memory.embedding_bulk_threads``), so a minutes-long corpus sweep does
+        not hold most of the box while a human is typing. The count is a property
+        of the CONTEXT, not of the call, so it is resolved per job — the config
+        read is a small uncached parse and the ``llama_set_n_threads`` call just
+        stores two ints, both negligible against the ~100–400 ms inference this
+        precedes on the same thread. The native call is skipped when the class
+        did not change, which is the steady state.
+
+        Fail-soft by design: a backend without a reprogrammable context (a stub,
+        a future non-llama.cpp backend) keeps whatever it loaded with, warns
+        once, and never retries. Losing the dial must never lose the embedding.
+        """
+        if self._thread_class_unsupported:
+            return
+        want = bulk_embed_threads() if priority >= PRIORITY_BULK else _embed_threads()
+        if want == self._applied_threads:
+            return
+        ctx = getattr(llm, "_ctx", None)
+        setter = getattr(ctx, "set_n_threads", None)
+        if not callable(setter):
+            self._thread_class_unsupported = True
+            logger.debug(
+                "Embedding backend cannot reprogram its thread count; "
+                "memory.embedding_bulk_threads has no effect"
+            )
+            return
+        try:
+            setter(want, want)
+        except Exception:
+            # Leave _applied_threads alone: the context is still running whatever
+            # it had, and pretending otherwise would skip the next attempt.
+            self._thread_class_unsupported = True
+            logger.debug("Could not set embedding thread count", exc_info=True)
+            return
+        self._applied_threads = want
 
     @staticmethod
     def _drain_orphans(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -150,6 +150,7 @@ from kiro_crew.executors import (
     CronQueueTimeout,
     configure_default_executor,
     cron_gate_budget,
+    embed_executor,
     maintenance_executor,
     run_in_cron_gate_pool,
     run_in_cron_pool,
@@ -8251,7 +8252,19 @@ class GatewayOrchestrator:
                 reconcile_store_embedding_space(store)
                 return store.backfill_missing_embeddings()
 
-            await loop.run_in_executor(maintenance_executor(), _wait_then_backfill)
+            # embed_executor(), NOT maintenance_executor(): pacing turns this
+            # from a ~72-minute worst case into a multi-hour one, and mc-maint is
+            # a 4-worker pool documented as "reserved for the FAST periodic
+            # sweeps + overlay rewrites" — parking one of its four slots
+            # (mostly asleep) for a working day is a regression the pacing
+            # introduced. mc-embed is the bulkhead built for exactly this: its
+            # rationale is that embed work "queues behind ITSELF instead of
+            # starving" everything else, it has 8 workers, and the same
+            # atexit shutdown hook already covers it. Interactive embeds are
+            # unaffected either way — LlamaCppEmbedder serializes every call
+            # onto one owned inference thread, so the model lock is the
+            # bottleneck there, not a pool slot.
+            await loop.run_in_executor(embed_executor(), _wait_then_backfill)
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -37,7 +37,12 @@ from snowballstemmer import stemmer as _snowball_stemmer
 # int constants, imported rather than duplicated so the two cannot drift. Safe
 # direction: ``embeddings`` reaches the store only through a Protocol, so it does
 # not import this module and there is no cycle.
-from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_INTERACTIVE, PRIORITY_NORMAL
+from kiro_crew.embeddings import (
+    PRIORITY_BULK,
+    PRIORITY_INTERACTIVE,
+    PRIORITY_NORMAL,
+    bulk_pace_delay,
+)
 
 try:
     import pysqlite3 as sqlite3
@@ -745,9 +750,7 @@ def _sanitize_decay_rates(raw: Mapping[str, object] | None) -> dict[str, float]:
     if not raw:
         return out
     if not isinstance(raw, Mapping):
-        logger.warning(
-            "memory.decay_rates ignored: expected a mapping, got %r", type(raw).__name__
-        )
+        logger.warning("memory.decay_rates ignored: expected a mapping, got %r", type(raw).__name__)
         return out
     for key, val in raw.items():
         if not isinstance(key, str) or not key.strip():
@@ -1125,7 +1128,11 @@ class VectorMemoryStore:
         # Every stored byte is therefore either raw-measured or bounded by a
         # constant (the enum member and the key envelope).
         size_basis = vj
-        if key.startswith("lesson.") and isinstance(value, dict) and _lesson_fields(value) is not None:
+        if (
+            key.startswith("lesson.")
+            and isinstance(value, dict)
+            and _lesson_fields(value) is not None
+        ):
             cat = value.get("category")
             raw_negative = value.get("negative")
             raw_scope = value.get("repo_scope")
@@ -1425,9 +1432,7 @@ class VectorMemoryStore:
                                     exc_info=True,
                                 )
                     else:
-                        logger.debug(
-                            "Dropping a semantic embedding produced in a previous space"
-                        )
+                        logger.debug("Dropping a semantic embedding produced in a previous space")
 
         # 9. Retire conflicting episodic entries that reference the old value
         # (called outside the lock — _retire_stale_episodic does a blocking embed
@@ -2653,9 +2658,7 @@ class VectorMemoryStore:
                             # Swap landed after this blob was embedded. Leave the row
                             # NULL for the post-activation backfill rather than
                             # persisting a vector from the previous space.
-                            logger.debug(
-                                "Dropping a lazy lesson backfill from a previous space"
-                            )
+                            logger.debug("Dropping a lazy lesson backfill from a previous space")
                             continue
                         self.db.execute(
                             "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (blob, bk)
@@ -2878,9 +2881,7 @@ class VectorMemoryStore:
                     )
                     if existing_emb:
                         row_blob = struct.pack(f"{len(existing_emb)}f", *existing_emb)
-                        pending_backfills.append(
-                            (row_blob, existing["key"], backfill_generation)
-                        )
+                        pending_backfills.append((row_blob, existing["key"], backfill_generation))
                     backfills_done += 1
                 if row_blob is not None:
                     sim = similarity({"embedding": row_blob})
@@ -3298,6 +3299,50 @@ class VectorMemoryStore:
             return ("pref.general", match.group(1).strip())
         return None
 
+    def _embed_bulk_row(self, text: str, *, pace: bool) -> "list[float] | None":
+        """Embed one row of a corpus sweep, then optionally pace the loop.
+
+        The sweeps below are the longest-running CPU work the gateway does
+        unattended — a migrated memory of a few thousand rows is tens of minutes
+        of continuous inference — and to a user that is indistinguishable from a
+        runaway process. ``memory.embedding_bulk_duty`` spreads the same total
+        work over more wall time by idling between rows (see
+        :func:`kiro_crew.embeddings.bulk_pace_delay`).
+
+        The sleep is HERE, on the sweep's own thread, and holds neither the DB
+        lock nor the model: an interactive embed arriving mid-pause is served
+        immediately. It also deliberately covers a row that failed to embed —
+        the delay is derived from measured elapsed time, so a no-op returns 0.0
+        and only real work is paced.
+
+        The pause falls between this row's inference and its write, which is what
+        makes it safe to interrupt: a sweep killed mid-pause leaves the row's
+        ``embedding`` NULL and the next sweep re-embeds it, exactly as it already
+        does for every row it never reached.
+
+        *pace* is False for a sweep a human explicitly asked for and is watching
+        a progress bar on; slowing that down would be paying the cost with none
+        of the benefit, since the load is expected in that case.
+
+        *pace* therefore also selects the scheduling class, because attendance —
+        not corpus size — is what both dials are really keyed on. An unattended
+        sweep embeds at ``PRIORITY_BULK``, which is what gives it the reduced
+        ``memory.embedding_bulk_threads`` pool; an attended one embeds at
+        ``PRIORITY_NORMAL`` and so keeps the full interactive pool. Without this,
+        ``pace=False`` would switch off the idling but leave the sweep on one
+        thread, making the very path this PR declares "full speed" ~3x slower
+        than before pacing existed.
+        """
+        priority = PRIORITY_BULK if pace else PRIORITY_NORMAL
+        if not pace:
+            return self._try_embed(text, priority)
+        started = time.monotonic()
+        vec = self._try_embed(text, priority)
+        delay = bulk_pace_delay(time.monotonic() - started)
+        if delay > 0:
+            time.sleep(delay)
+        return vec
+
     def _try_embed(self, text: str, priority: int = PRIORITY_NORMAL) -> list[float] | None:
         """Embed text using embed_fn if available.
 
@@ -3454,9 +3499,7 @@ class VectorMemoryStore:
         """
         return self._read_meta(_EMBED_SIG_KEY)
 
-    def reconcile_embedding_space(
-        self, signature: str, *, clear_when_unknown: bool = False
-    ) -> int:
+    def reconcile_embedding_space(self, signature: str, *, clear_when_unknown: bool = False) -> int:
         """Discard embeddings produced by a DIFFERENT model. Returns rows invalidated.
 
         Stored vectors are only comparable to each other when they came from the
@@ -3538,9 +3581,7 @@ class VectorMemoryStore:
                     # where unlink fails while another process holds the index
                     # mapped.
                     stale_removal_failed = True
-                    logger.warning(
-                        "Could not remove stale FAISS file %s", stale, exc_info=True
-                    )
+                    logger.warning("Could not remove stale FAISS file %s", stale, exc_info=True)
         invalidated = max(0, episodic) + max(0, semantic)
         if stale_removal_failed:
             # Deliberately do NOT stamp the signature. Stamping would mark the
@@ -3603,7 +3644,7 @@ class VectorMemoryStore:
         return any(self._fetch_one_locked(sql) is not None for sql in probes)
 
     def backfill_missing_embeddings(
-        self, progress: "Callable[[int, int], None] | None" = None
+        self, progress: "Callable[[int, int], None] | None" = None, *, pace: bool = True
     ) -> int:
         """Compute embeddings for episodic rows that have none, then rebuild FAISS.
 
@@ -3636,6 +3677,16 @@ class VectorMemoryStore:
         already falls back to ``_sqlite_vector_search`` (a stdlib cosine scan
         over these blobs), so the stored vectors are useful either way; the
         index rebuild below is simply skipped when faiss is absent.
+
+        *pace* (default on) idles between rows so the sweep targets
+        ``memory.embedding_bulk_duty`` of wall time — the same total CPU work
+        spread thinner, which is what keeps an unattended post-migration sweep
+        from pinning several cores for tens of minutes. It is a target rather
+        than a ceiling: a single row whose inference is slow enough to ask for
+        more than :data:`~kiro_crew.embeddings._MAX_BULK_PACE_SLEEP` of idle is
+        capped there, so that row runs at a higher effective duty. Pass
+        ``pace=False`` for a sweep a human explicitly asked for and is waiting
+        on.
         """
         if self.embed_fn is None:
             return 0
@@ -3643,18 +3694,17 @@ class VectorMemoryStore:
         # compared directly, never indexed), and they must be rebuilt even when
         # there is not a single NULL episodic row — which is exactly the state
         # after reconcile_embedding_space() on a memory that holds only lessons.
-        self._backfill_lesson_embeddings(progress)
+        self._backfill_lesson_embeddings(progress, pace=pace)
         # Same for non-lesson semantic KV rows: struct-packed, no numpy, no
         # FAISS — get_semantic_context ranks them straight from the stored blob.
         # No progress callback: the (done,total) stream belongs to the episodic
         # loop below, and a second denominator would make the dashboard bar
         # jump backward when both row types need re-embedding.
-        self._backfill_semantic_kv_embeddings()
+        self._backfill_semantic_kv_embeddings(pace=pace)
         if not _HAS_NUMPY:
             return 0
         rows = self._fetch_all_locked(
-            "SELECT id, text FROM episodic_memories "
-            "WHERE is_deleted = 0 AND embedding IS NULL"
+            "SELECT id, text FROM episodic_memories " "WHERE is_deleted = 0 AND embedding IS NULL"
         )
         if not rows:
             return 0
@@ -3665,7 +3715,14 @@ class VectorMemoryStore:
             # spin, and this loop can run for minutes on a large corpus.
             progress(0, total)
         for row in rows:
-            vec = self._try_embed(row["text"], PRIORITY_BULK)
+            # Sampled BEFORE the embed, re-checked under the lock, matching
+            # _backfill_semantic_kv_embeddings: a model swap landing across the
+            # embed must not commit a vector from the old space (reconcile has
+            # already swept past this row, so nothing would ever clear it). The
+            # window existed before pacing but was sub-second; idling between
+            # rows widens it to seconds, which makes the guard load-bearing.
+            backfill_generation = self._space_generation
+            vec = self._embed_bulk_row(row["text"], pace=pace)
             if not vec:
                 if progress is not None:
                     progress(embedded, total)
@@ -3691,8 +3748,22 @@ class VectorMemoryStore:
                 arr = arr / norm
             blob = arr.tobytes()
             with self._db_lock:
+                if backfill_generation != self._space_generation:
+                    logger.debug("Dropping an episodic backfill from a previous space")
+                    if progress is not None:
+                        progress(embedded, total)
+                    continue
+                # `embedding IS NULL` keeps this merge-only: a concurrent writer
+                # that has already filled this row's vector (in the current
+                # space) must not be overwritten by our older computation.
+                # `is_deleted = 0` keeps a vector off a row tombstoned during the
+                # pause. No text guard is needed here, unlike the semantic
+                # sweeps: `episodic_memories.text` is never rewritten in place
+                # (rows are tombstoned instead), so `id` pins the text we
+                # embedded.
                 self.db.execute(
-                    "UPDATE episodic_memories SET embedding = ? WHERE id = ?",
+                    "UPDATE episodic_memories SET embedding = ? "
+                    "WHERE id = ? AND embedding IS NULL AND is_deleted = 0",
                     (blob, row["id"]),
                 )
                 self.db.commit()
@@ -3708,7 +3779,7 @@ class VectorMemoryStore:
         return embedded
 
     def _backfill_lesson_embeddings(
-        self, progress: "Callable[[int, int], None] | None" = None
+        self, progress: "Callable[[int, int], None] | None" = None, *, pace: bool = True
     ) -> int:
         """Embed lesson rows whose vector is NULL. Returns the count embedded.
 
@@ -3754,16 +3825,33 @@ class VectorMemoryStore:
             if not text:
                 logger.debug("Skipping lesson %s with no renderable text", row["key"])
                 continue
-            vec = self._try_embed(text, PRIORITY_BULK)
+            # Same guard as the episodic and semantic-KV sweeps: sampled before
+            # the embed, re-checked under the lock, so a model swap landing
+            # across the (now paced) embed cannot commit an old-space vector.
+            lesson_generation = self._space_generation
+            vec = self._embed_bulk_row(text, pace=pace)
             if not vec:
                 continue
             # Stored un-normalized to match write_lesson(): _cosine_sim()
             # normalizes both operands itself.
             blob = struct.pack(f"{len(vec)}f", *vec)
             with self._db_lock:
+                if lesson_generation != self._space_generation:
+                    logger.debug("Dropping a lesson backfill from a previous space")
+                    continue
+                # Same three-part guard as _backfill_semantic_kv_embeddings, for
+                # the same reason: `embedding IS NULL` alone matches a row whose
+                # value was REWRITTEN during the (paced) embed — the write path
+                # clears the vector when the rule text changes — so the old
+                # rule's vector would be stamped onto the new rule and rank it by
+                # text it no longer holds. `value_json` pins the row we embedded,
+                # and `is_deleted = 0` keeps a vector off a row tombstoned in the
+                # same window.
                 self.db.execute(
-                    "UPDATE semantic_memory SET embedding = ? WHERE key = ?",
-                    (blob, row["key"]),
+                    "UPDATE semantic_memory SET embedding = ? "
+                    "WHERE key = ? AND value_json = ? AND embedding IS NULL "
+                    "AND is_deleted = 0",
+                    (blob, row["key"], row["value_json"]),
                 )
                 self.db.commit()
             embedded += 1
@@ -3774,7 +3862,7 @@ class VectorMemoryStore:
         return embedded
 
     def _backfill_semantic_kv_embeddings(
-        self, progress: "Callable[[int, int], None] | None" = None
+        self, progress: "Callable[[int, int], None] | None" = None, *, pace: bool = True
     ) -> int:
         """Embed non-lesson semantic rows whose vector is NULL. Returns the count.
 
@@ -3809,7 +3897,7 @@ class VectorMemoryStore:
             # landing across the embed must not commit a vector from the old
             # space (reconcile has already swept past this row).
             backfill_generation = self._space_generation
-            vec = self._try_embed(f"{row['key']} {row['value_json']}", PRIORITY_BULK)
+            vec = self._embed_bulk_row(f"{row['key']} {row['value_json']}", pace=pace)
             if not vec:
                 if progress is not None:
                     progress(embedded, total)
@@ -3822,9 +3910,13 @@ class VectorMemoryStore:
                 # value_json guard: a concurrent re-write of this key already
                 # cleared-and-refilled its own vector; stamping the OLD value's
                 # vector over it would rank the row by text it no longer holds.
+                # `is_deleted = 0` is the third leg, added when pacing widened
+                # this window: a row tombstoned during the pause must not come
+                # back carrying a vector.
                 self.db.execute(
                     "UPDATE semantic_memory SET embedding = ? "
-                    "WHERE key = ? AND value_json = ? AND embedding IS NULL",
+                    "WHERE key = ? AND value_json = ? AND embedding IS NULL "
+                    "AND is_deleted = 0",
                     (blob, row["key"], row["value_json"]),
                 )
                 self.db.commit()

--- a/test/test_embeddings_bulk_pacing.py
+++ b/test/test_embeddings_bulk_pacing.py
@@ -1,0 +1,270 @@
+"""Tests for bulk-embedding pacing and the bulk thread class.
+
+A post-migration re-embed sweep is the longest unattended CPU burn the gateway
+does: measured 429 ms/row at 4 threads, so a few thousand imported memory rows
+pin ~3.7 cores for tens of minutes and the machine's fans stay up. These lock in
+the two dials that spread that work thinner without changing its total.
+"""
+
+from __future__ import annotations
+
+import queue
+
+import pytest
+
+from kiro_crew import embeddings as emb
+
+
+@pytest.fixture(autouse=True)
+def _memory_cfg(monkeypatch):
+    """Drive the module's raw-config reader instead of writing a config file.
+
+    Also pins ``cpu_count``: both thread readers clamp to the machine's cores, so
+    a test asserting an explicit count is otherwise environment-dependent — it
+    passes on a 32-core dev host and fails on a 4-core CI runner. Tests that
+    exercise the clamp itself override this with their own value.
+    """
+    cfg: dict = {}
+    monkeypatch.setattr(emb, "_read_memory_config", lambda: cfg)
+    monkeypatch.setattr(emb.os, "cpu_count", lambda: 16)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# bulk_duty_cycle
+# ---------------------------------------------------------------------------
+
+
+def test_duty_defaults_to_a_fifth(_memory_cfg):
+    """Nothing waits on bulk work, so the default is tuned for invisibility."""
+    assert emb.bulk_duty_cycle() == pytest.approx(0.2)
+
+
+def test_duty_of_one_disables_pacing(_memory_cfg):
+    _memory_cfg["embedding_bulk_duty"] = 1.0
+    assert emb.bulk_duty_cycle() == 1.0
+    assert emb.bulk_pace_delay(0.4) == 0.0
+
+
+def test_duty_above_one_is_clamped_to_one(_memory_cfg):
+    _memory_cfg["embedding_bulk_duty"] = 7
+    assert emb.bulk_duty_cycle() == 1.0
+
+
+def test_duty_typo_cannot_stall_the_sweep(_memory_cfg):
+    """0.001 would stretch a multi-hour sweep into weeks; the floor prevents it."""
+    _memory_cfg["embedding_bulk_duty"] = 0.001
+    assert emb.bulk_duty_cycle() == pytest.approx(emb._MIN_BULK_DUTY)
+
+
+@pytest.mark.parametrize("bad", [True, False, "0.5", None, [], {}])
+def test_duty_rejects_non_numbers_and_bools(_memory_cfg, bad):
+    _memory_cfg["embedding_bulk_duty"] = bad
+    assert emb.bulk_duty_cycle() == pytest.approx(0.2)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_duty_rejects_non_finite(_memory_cfg, bad):
+    """json.load accepts the NaN literal, and NaN slips through max() unclamped —
+    which would silently disable pacing instead of falling back to the default."""
+    _memory_cfg["embedding_bulk_duty"] = bad
+    assert emb.bulk_duty_cycle() == pytest.approx(0.2)
+    assert emb.bulk_pace_delay(0.2) == pytest.approx(0.8)
+
+
+def test_an_integer_too_wide_for_a_double_does_not_abort_the_sweep(_memory_cfg):
+    """`float()` on a 309-digit JSON integer raises OverflowError, which would
+    propagate out through bulk_pace_delay and abort the sweep mid-corpus —
+    leaving every pending row NULL. A config typo must degrade to the default."""
+    _memory_cfg["embedding_bulk_duty"] = 10**400
+    assert emb.bulk_duty_cycle() == pytest.approx(0.2)
+    assert emb.bulk_pace_delay(0.5) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# bulk_pace_delay
+# ---------------------------------------------------------------------------
+
+
+def test_default_duty_idles_four_times_the_work(_memory_cfg):
+    assert emb.bulk_pace_delay(1.0) == pytest.approx(4.0)
+
+
+def test_half_duty_sleeps_as_long_as_it_worked(_memory_cfg):
+    _memory_cfg["embedding_bulk_duty"] = 0.5
+    assert emb.bulk_pace_delay(0.3) == pytest.approx(0.3)
+
+
+def test_quarter_duty_sleeps_three_times_the_work(_memory_cfg):
+    _memory_cfg["embedding_bulk_duty"] = 0.25
+    assert emb.bulk_pace_delay(0.2) == pytest.approx(0.6)
+
+
+def test_no_work_means_no_sleep(_memory_cfg):
+    """A row that failed to embed consumed no time and must not be paced."""
+    assert emb.bulk_pace_delay(0.0) == 0.0
+    assert emb.bulk_pace_delay(-1.0) == 0.0
+
+
+def test_the_cap_does_not_bind_an_ordinary_row_at_the_default(_memory_cfg):
+    """The cap catches outliers only. If it bound a typical row it would silently
+    override the configured duty on every row — measured worst case is ~1.4s of
+    inference per row, so ~5.6s of idle must pass through untouched."""
+    assert emb.bulk_pace_delay(1.4) == pytest.approx(5.6)
+    assert emb.bulk_pace_delay(1.4) < emb._MAX_BULK_PACE_SLEEP
+
+
+def test_one_pathological_row_cannot_park_the_sweep(_memory_cfg):
+    _memory_cfg["embedding_bulk_duty"] = 0.05
+    assert emb.bulk_pace_delay(30.0) == pytest.approx(emb._MAX_BULK_PACE_SLEEP)
+
+
+# ---------------------------------------------------------------------------
+# bulk_embed_threads
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_threads_default_to_one(_memory_cfg):
+    _memory_cfg["embedding_threads"] = 4
+    assert emb.bulk_embed_threads() == 1
+    # The interactive lane is untouched — that separation is the point.
+    assert emb._embed_threads() == 4
+
+
+def test_explicit_zero_inherits_the_interactive_count(_memory_cfg):
+    _memory_cfg["embedding_threads"] = 3
+    _memory_cfg["embedding_bulk_threads"] = 0
+    assert emb.bulk_embed_threads() == 3
+
+
+@pytest.mark.parametrize("bad", [-4, True, "2", None])
+def test_bulk_threads_rejects_junk_without_inheriting(_memory_cfg, bad):
+    """Junk falls back to the safe default, NOT to the interactive count — a typo
+    must not silently hand a sweep the whole machine."""
+    _memory_cfg["embedding_threads"] = 8
+    _memory_cfg["embedding_bulk_threads"] = bad
+    assert emb.bulk_embed_threads() == 1
+
+
+def test_bulk_threads_override_is_honoured(_memory_cfg):
+    _memory_cfg["embedding_threads"] = 4
+    _memory_cfg["embedding_bulk_threads"] = 6
+    assert emb.bulk_embed_threads() == 6
+    assert emb._embed_threads() == 4
+
+
+def test_bulk_threads_clamped_to_cores(_memory_cfg, monkeypatch):
+    monkeypatch.setattr(emb.os, "cpu_count", lambda: 8)
+    _memory_cfg["embedding_bulk_threads"] = 4096
+    assert emb.bulk_embed_threads() == 8
+
+
+# ---------------------------------------------------------------------------
+# _apply_thread_class — the per-job reprogramming
+# ---------------------------------------------------------------------------
+
+
+class _FakeCtx:
+    def __init__(self):
+        self.calls: list[tuple[int, int]] = []
+
+    def set_n_threads(self, n_threads: int, n_threads_batch: int) -> None:
+        self.calls.append((n_threads, n_threads_batch))
+
+
+class _FakeLlm:
+    def __init__(self, ctx=None):
+        self._ctx = ctx
+
+
+def _embedder() -> emb.LlamaCppEmbedder:
+    """A backend instance with no model load kicked off."""
+    return emb.LlamaCppEmbedder.__new__(emb.LlamaCppEmbedder)  # type: ignore[misc]
+
+
+def _armed_embedder() -> emb.LlamaCppEmbedder:
+    inst = _embedder()
+    inst._applied_threads = None
+    inst._thread_class_unsupported = False
+    return inst
+
+
+def test_bulk_job_programs_the_bulk_pool(_memory_cfg):
+    _memory_cfg["embedding_threads"] = 6
+    _memory_cfg["embedding_bulk_threads"] = 2
+    inst = _armed_embedder()
+    ctx = _FakeCtx()
+    inst._apply_thread_class(_FakeLlm(ctx), emb.PRIORITY_BULK)
+    assert ctx.calls == [(2, 2)]
+
+
+def test_interactive_job_restores_the_full_pool(_memory_cfg):
+    _memory_cfg["embedding_threads"] = 6
+    _memory_cfg["embedding_bulk_threads"] = 2
+    inst = _armed_embedder()
+    ctx = _FakeCtx()
+    llm = _FakeLlm(ctx)
+    inst._apply_thread_class(llm, emb.PRIORITY_BULK)
+    inst._apply_thread_class(llm, emb.PRIORITY_INTERACTIVE)
+    assert ctx.calls == [(2, 2), (6, 6)]
+
+
+def test_unchanged_class_is_not_reprogrammed(_memory_cfg):
+    _memory_cfg["embedding_threads"] = 4
+    inst = _armed_embedder()
+    ctx = _FakeCtx()
+    llm = _FakeLlm(ctx)
+    for _ in range(3):
+        inst._apply_thread_class(llm, emb.PRIORITY_BULK)
+    assert ctx.calls == [(1, 1)]
+
+
+def test_a_backend_without_the_setter_degrades_once(_memory_cfg):
+    """Losing the dial must never lose the embedding."""
+    inst = _armed_embedder()
+    inst._apply_thread_class(_FakeLlm(None), emb.PRIORITY_BULK)
+    assert inst._thread_class_unsupported is True
+    # And it never probes again, even once a usable context shows up.
+    ctx = _FakeCtx()
+    inst._apply_thread_class(_FakeLlm(ctx), emb.PRIORITY_BULK)
+    assert ctx.calls == []
+
+
+def test_a_raising_setter_does_not_record_a_count(_memory_cfg):
+    class _Boom:
+        def set_n_threads(self, *_a):
+            raise RuntimeError("no")
+
+    inst = _armed_embedder()
+    inst._apply_thread_class(_FakeLlm(_Boom()), emb.PRIORITY_BULK)
+    assert inst._applied_threads is None
+    assert inst._thread_class_unsupported is True
+
+
+def test_infer_loop_applies_the_class_before_inference(_memory_cfg):
+    """The worker — not the caller — programs the pool, under its own lock."""
+    _memory_cfg["embedding_threads"] = 6
+    _memory_cfg["embedding_bulk_threads"] = 1
+    inst = _armed_embedder()
+    import threading
+
+    inst._lock = threading.Lock()
+    ctx = _FakeCtx()
+    order: list[str] = []
+
+    class _Llm(_FakeLlm):
+        def create_embedding(self, texts):
+            order.append(f"embed:{ctx.calls[-1][0]}")
+            return {"data": [{"embedding": [0.0]}]}
+
+    jobs: "queue.PriorityQueue" = queue.PriorityQueue()
+    job = emb._InferJob(_Llm(ctx), ["hello"])
+    jobs.put((emb.PRIORITY_BULK, 1, job))
+    # Sentinel queued BEHIND the job (same class, later seq) so the worker runs
+    # the job and then exits. _PRIORITY_SENTINEL would outrank it and the loop
+    # would return having embedded nothing.
+    jobs.put((emb.PRIORITY_BULK, 2, None))
+    inst._infer_loop(jobs)
+
+    assert job.done.is_set()
+    assert order == ["embed:1"], "inference must run on the bulk pool, not the default one"

--- a/test/test_vector_memory_bulk_pacing.py
+++ b/test/test_vector_memory_bulk_pacing.py
@@ -1,0 +1,299 @@
+"""The re-embed sweeps pace themselves; an explicitly-requested one does not.
+
+Locks in the behaviour that keeps an unattended post-migration sweep from pinning
+several cores for tens of minutes: every bulk row is followed by an idle window
+proportional to the work it just did, taken on the SWEEP's thread (so it holds
+neither the DB lock nor the model), and skipped entirely when a human asked for
+the sweep and is waiting on it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew import vector_memory as vm
+from kiro_crew.vector_memory import VectorMemoryStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    st = VectorMemoryStore(db_path=tmp_path / "memory.db", embedding_dim=4)
+    st.init()
+    return st
+
+
+@pytest.fixture()
+def sleeps(monkeypatch):
+    """Record pace sleeps instead of performing them."""
+    recorded: list[float] = []
+    monkeypatch.setattr(vm.time, "sleep", lambda s: recorded.append(s))
+    return recorded
+
+
+def _deferred_rows(store, n):
+    for i in range(n):
+        assert store.write_episodic(
+            f"deferred row {i}",
+            conversation_id=f"c{i}",
+            source="import",
+            preserve_existing=True,
+            defer_embedding=True,
+        )
+
+
+def test_each_bulk_row_is_paced(store, sleeps, monkeypatch):
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.125)
+    _deferred_rows(store, 3)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    assert store.backfill_missing_embeddings() == 3
+    assert sleeps == [0.125, 0.125, 0.125]
+
+
+def test_pace_false_never_sleeps(store, sleeps, monkeypatch):
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.125)
+    _deferred_rows(store, 3)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    assert store.backfill_missing_embeddings(pace=False) == 3
+    assert sleeps == []
+
+
+def test_zero_delay_does_not_call_sleep(store, sleeps, monkeypatch):
+    """Pacing off (duty 1.0) must not add a syscall per row."""
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.0)
+    _deferred_rows(store, 2)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    assert store.backfill_missing_embeddings() == 2
+    assert sleeps == []
+
+
+def test_a_failed_row_is_still_paced_by_measured_time(store, sleeps, monkeypatch):
+    """A row that returns no vector still ran the model; pace on elapsed, not success."""
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.05)
+    _deferred_rows(store, 2)
+    store.embed_fn = lambda text: None
+
+    assert store.backfill_missing_embeddings() == 0
+    assert sleeps == [0.05, 0.05]
+
+
+def test_delay_is_derived_from_the_row_s_own_elapsed_time(store, monkeypatch):
+    seen: list[float] = []
+
+    def _record(elapsed):
+        seen.append(elapsed)
+        return 0.0
+
+    monkeypatch.setattr(vm, "bulk_pace_delay", _record)
+    _deferred_rows(store, 1)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    store.backfill_missing_embeddings()
+    assert len(seen) == 1
+    assert seen[0] >= 0.0
+
+
+def test_semantic_and_lesson_sweeps_are_paced_too(store, sleeps, monkeypatch):
+    """All three sweeps share the paced helper, not just the episodic one."""
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.01)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+    store.set_semantic_if_absent("user.city", "Seattle", 0.9, "user_explicit")
+    store.write_lesson("always pace bulk work")
+    # Clear the vectors the write paths just stored so the sweeps have work.
+    with store._db_lock:
+        store.db.execute("UPDATE semantic_memory SET embedding = NULL")
+        store.db.commit()
+
+    assert store._backfill_lesson_embeddings(pace=True) >= 1
+    assert store._backfill_semantic_kv_embeddings(pace=True) >= 1
+    assert sleeps and all(s == 0.01 for s in sleeps)
+
+
+def test_the_pause_sits_between_rows_not_inside_a_write(store, monkeypatch):
+    """The pause follows the row's INFERENCE, before its write lands.
+
+    That ordering is what makes the pause safe to interrupt: a sweep killed
+    mid-pause leaves that row's ``embedding`` NULL, and the next sweep re-embeds
+    it — the same idempotent contract every unfinished row already has. It also
+    holds no DB lock, so a concurrent writer is never blocked by pacing.
+    """
+    visible: list[int] = []
+
+    def _probe(_seconds):
+        rows = store._fetch_all_locked(
+            "SELECT count(*) AS n FROM episodic_memories WHERE embedding IS NOT NULL"
+        )
+        visible.append(int(rows[0]["n"]))
+
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.01)
+    monkeypatch.setattr(vm.time, "sleep", _probe)
+    _deferred_rows(store, 2)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    assert store.backfill_missing_embeddings() == 2
+    # One pause per row, and each sees only the rows already finished — never a
+    # partially-written one.
+    assert visible == [0, 1]
+    remaining = store._fetch_all_locked(
+        "SELECT count(*) AS n FROM episodic_memories WHERE embedding IS NULL"
+    )
+    assert int(remaining[0]["n"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# The pause widens the stale-vector window, so every paced sweep must re-check
+# the embedding space generation before it commits.
+# ---------------------------------------------------------------------------
+
+
+def test_an_episodic_vector_from_a_previous_space_is_dropped(store, monkeypatch):
+    """A model swap landing during the pause must not commit an old-space vector.
+
+    Reconcile has already swept past this row, so a stale vector written after it
+    would never be cleared — it would rank silently wrong forever.
+    """
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.01)
+    # Simulate reconcile completing inside the pause.
+    monkeypatch.setattr(vm.time, "sleep", lambda s: setattr(store, "_space_generation", 99))
+    _deferred_rows(store, 1)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    assert store.backfill_missing_embeddings() == 0
+    still_null = store._fetch_all_locked(
+        "SELECT count(*) AS n FROM episodic_memories WHERE embedding IS NULL"
+    )
+    assert int(still_null[0]["n"]) == 1, "row should stay NULL for the next sweep"
+
+
+def test_a_lesson_vector_from_a_previous_space_is_dropped(store, monkeypatch):
+    """Same guard on the lesson sweep — the sibling GPT's finding did not name."""
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+    store.write_lesson("always guard the space generation")
+    with store._db_lock:
+        store.db.execute("UPDATE semantic_memory SET embedding = NULL")
+        store.db.commit()
+
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.01)
+    monkeypatch.setattr(vm.time, "sleep", lambda s: setattr(store, "_space_generation", 99))
+
+    assert store._backfill_lesson_embeddings(pace=True) == 0
+    rows = store._fetch_all_locked(
+        "SELECT count(*) AS n FROM semantic_memory "
+        "WHERE key LIKE 'lesson.%' AND embedding IS NULL"
+    )
+    assert int(rows[0]["n"]) >= 1
+
+
+def test_a_concurrent_writer_s_vector_is_not_overwritten(store, monkeypatch):
+    """The UPDATE is merge-only: a row filled during the pause keeps its value."""
+    sentinel = b"\x01\x02\x03\x04" * 4
+
+    def _fill_during_pause(_seconds):
+        with store._db_lock:
+            store.db.execute("UPDATE episodic_memories SET embedding = ?", (sentinel,))
+            store.db.commit()
+
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.01)
+    monkeypatch.setattr(vm.time, "sleep", _fill_during_pause)
+    _deferred_rows(store, 1)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    store.backfill_missing_embeddings()
+    rows = store._fetch_all_locked("SELECT embedding FROM episodic_memories")
+    assert bytes(rows[0]["embedding"]) == sentinel
+
+
+def test_a_rewritten_lesson_does_not_receive_the_old_rule_s_vector(store, monkeypatch):
+    """The lesson UPDATE must pin value_json, not just `embedding IS NULL`.
+
+    The write path clears a lesson's vector when its rule text changes, so a
+    rewrite landing during the pause leaves a row that matches `embedding IS
+    NULL` — and stamping the OLD rule's vector onto it would rank the new rule by
+    text it no longer holds.
+    """
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+    store.write_lesson("original rule text")
+    row = store._fetch_all_locked(
+        "SELECT key, value_json FROM semantic_memory WHERE key LIKE 'lesson.%'"
+    )[0]
+    key = row["key"]
+    with store._db_lock:
+        store.db.execute("UPDATE semantic_memory SET embedding = NULL WHERE key = ?", (key,))
+        store.db.commit()
+
+    def _rewrite_during_pause(_seconds):
+        with store._db_lock:
+            store.db.execute(
+                "UPDATE semantic_memory SET value_json = ?, embedding = NULL WHERE key = ?",
+                ('{"rule": "a completely different rule"}', key),
+            )
+            store.db.commit()
+
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.01)
+    monkeypatch.setattr(vm.time, "sleep", _rewrite_during_pause)
+
+    store._backfill_lesson_embeddings(pace=True)
+    after = store._fetch_all_locked("SELECT embedding FROM semantic_memory WHERE key = ?", (key,))
+    assert after[0]["embedding"] is None, "the rewritten rule must stay NULL for the next sweep"
+
+
+def test_a_row_tombstoned_during_the_pause_gets_no_vector(store, monkeypatch):
+    """`is_deleted = 0` is the third leg of the guard on all three sweeps."""
+
+    def _tombstone_during_pause(_seconds):
+        with store._db_lock:
+            store.db.execute("UPDATE episodic_memories SET is_deleted = 1")
+            store.db.commit()
+
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.01)
+    monkeypatch.setattr(vm.time, "sleep", _tombstone_during_pause)
+    _deferred_rows(store, 1)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    store.backfill_missing_embeddings()
+    rows = store._fetch_all_locked("SELECT embedding FROM episodic_memories")
+    assert rows[0]["embedding"] is None
+
+
+def test_an_attended_sweep_keeps_the_interactive_thread_pool(store, monkeypatch):
+    """`pace=False` must switch off the thread dial too, not just the idling.
+
+    `_apply_thread_class` keys the reduced `memory.embedding_bulk_threads` pool
+    on PRIORITY_BULK, so a sweep that only skipped the pause would still run on
+    one thread — ~3x slower than before pacing existed, on exactly the path the
+    PR declares "full speed" because a human is watching its progress bar.
+    """
+    seen: list[int] = []
+    real = store._try_embed
+
+    def _record(text, priority=None):
+        seen.append(priority)
+        return real(text, priority) if priority is not None else real(text)
+
+    monkeypatch.setattr(store, "_try_embed", _record)
+    _deferred_rows(store, 1)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    store.backfill_missing_embeddings(pace=False)
+    assert seen == [vm.PRIORITY_NORMAL]
+
+
+def test_an_unattended_sweep_stays_on_the_bulk_class(store, monkeypatch):
+    """The paced path keeps PRIORITY_BULK, which is what earns it the small pool
+    and lets an interactive embed jump the shared inference queue ahead of it."""
+    seen: list[int] = []
+    real = store._try_embed
+
+    def _record(text, priority=None):
+        seen.append(priority)
+        return real(text, priority) if priority is not None else real(text)
+
+    monkeypatch.setattr(store, "_try_embed", _record)
+    monkeypatch.setattr(vm, "bulk_pace_delay", lambda elapsed: 0.0)
+    _deferred_rows(store, 1)
+    store.embed_fn = lambda text: [0.5, 0.5, 0.5, 0.5]
+
+    store.backfill_missing_embeddings()
+    assert seen == [vm.PRIORITY_BULK]


### PR DESCRIPTION
## Problem / Motivation

The background re-embed sweep runs flat out, and on a laptop that is
indistinguishable from a runaway process: fans spin up and stay up for tens of
minutes after an import or a migration, with nothing in the logs to explain it
because every row it embeds is legitimate work.

Measured on this branch's code, 32-core x86 host, bundled Qwen3-Embedding-0.6B,
rows sampled from a real `memory.db` (median 492 characters, mean 527):

| `embedding_threads` | ms/row | sustained cores | CPU-s/row |
|---|---|---|---|
| 1 | 1389 | 1.0 | 1.39 |
| 2 | 738 | 1.94 | 1.43 |
| 4 (default) | 429 | 3.7 | 1.57 |

At the default that is **~21 minutes at a sustained 3.7 cores for a 3,000-row
memory**, and the episodic cap of 10,000 rows puts the ceiling near 72 minutes.
The sweep is reached automatically at boot (`slack/gateway.py` phase 2), so the
user never asked for it and gets no signal about it.

## Why it matters

This lands on exactly the users least able to interpret it: someone who has just
imported an existing memory, whose first experience of the app is a hot, loud
machine. And it is spent on work nobody is waiting for — those rows are FTS5
keyword-searchable the moment they land, so the sweep only adds *semantic* reach
over memories from a previous install.

The only knob available today is `memory.embedding_threads`, which is shared with
interactive embedding: turning it down to quiet the fans also slows every memory
search the user is actually waiting on.

## What changed (motivation → approach → change)

Total CPU work per row is essentially constant across thread counts (1.39–1.57
CPU-seconds), so the sweep cannot be made cheaper. But fans respond to
*sustained* load rather than to total work, and nothing needs this work finished
early — so the sweep is now tuned to stay invisible instead of to finish fast.
Two dials, both defaulting low, neither touching the interactive lane:

- **`memory.embedding_bulk_duty`** (default `0.2`) paces the three backfill
  sweeps: after each row the loop idles four times as long as that row's
  inference took, so the sweep occupies a fifth of the wall clock.
- **`memory.embedding_bulk_threads`** (default `1`; `0` means inherit
  `embedding_threads`) sizes llama.cpp's pool for `PRIORITY_BULK` jobs only. The
  count is a property of the context rather than of the call, so the inference
  worker reprograms it per job via `llama_set_n_threads` and skips the call when
  the class did not change, which is the steady state.

Together that is **~0.2 of a core instead of 3.7**. The trade is duration: a
3,000-row backlog takes hours rather than 21 minutes. That is acceptable because
the sweep is idempotent and resumes across restarts — an unfinished row stays
NULL and the next boot picks it up — so a machine that is never on long enough to
finish still converges over several sessions, and keyword search works the whole
time. A deployment that wants the backlog cleared sooner raises either dial.

Two details that are load-bearing rather than incidental:

- The pace sleep is taken on the sweep's **own** thread and holds neither the DB
  lock nor the model, so an interactive embed arriving mid-pause is served at
  full speed. That is why the delay is returned to the caller
  (`bulk_pace_delay`) instead of slept inside the shared inference worker, which
  would make a user's query wait out the pause.
- The per-sleep cap is **30s**, not a couple of seconds. It exists only so one
  pathological row (a 6,000-character blob) cannot park the sweep; a cap low
  enough to bind an ordinary row would quietly override the configured duty on
  *every* row — at 1 thread and duty 0.2 an ordinary row asks for ~5.6s of idle,
  and a 2s cap would silently turn that into an effective duty of ~0.4.

A sweep a human **explicitly** started is not paced. Two callers opt out with
`pace=False`: the apply-embedding-model path in `dashboard/handlers/memory.py`
(the user is watching its progress bar and semantic search stays degraded until
it finishes) and `ops_mission_control`'s ledger index step
(`ledger_index.py:176`), which a request holds open — pacing there would stretch
a bounded batch, plus any global backlog the sweep finds, across the response.
The two onboarding imports stay paced: both document themselves as background
work with nobody watching. The distinction is "is someone holding a response or
watching a progress bar", not "is this an import".

**Attendance drives BOTH dials, not just the idling.** `pace` also selects the
scheduling class — `PRIORITY_BULK` when paced, `PRIORITY_NORMAL` when not — so an
attended sweep keeps the full interactive thread pool and stops queueing behind
other bulk work. Without that, `pace=False` would switch off the pause and leave
the sweep on one thread, making the path this PR calls "full speed" ~3.2x slower
than before pacing existed (1389 vs 429 ms/row from the table above). A
deployment that wants a backlog cleared sooner raises either dial; that is the
lever for a headless install, where clicking the never-paced Settings sweep is
not reachable.

**Pacing widens a pre-existing stale-vector window, so both newly-paced sweeps
now carry the space-generation guard** that `_backfill_semantic_kv_embeddings`
already had: sample `_space_generation` before the embed, re-check it under
`_db_lock` before the UPDATE, and leave the row NULL on a mismatch. Without it, a
model reconcile landing across the (now seconds-long) pause commits a vector from
the retired space — and since reconcile has already swept past that row, nothing
would ever clear it. Both UPDATEs are also merge-only now (`AND embedding IS
NULL`), so a concurrent writer that filled the row in the *current* space is not
overwritten by the sweep's older computation.

`llama.cpp` applies both thread pools only at context creation and never
re-applies them per call (checked in `_vendor/llama_cpp/llama.py`), so a live
reprogram sticks. Fail-soft throughout: a backend whose context cannot be
reprogrammed (a stub, a future non-llama.cpp backend) keeps whatever it loaded
with, logs once at debug, and never retries. Losing the dial must never lose the
embedding.

Two follow-ups filed rather than folded in: **#7367** (`knowledge/ingestion.py`'s
`rebuild_embeddings` is the same unattended corpus loop and neither dial reaches
it) and **#7368** (gate the sweep on idle instead of duty-cycling it, which is
the durable version of this fix and also releases the maintenance-executor slot
and the resident model).

## Tests

`test/test_embeddings_bulk_pacing.py`

- `bulk_duty_cycle`: the 0.2 default; `1.0` disables pacing; a value above 1 is
  clamped; a `0.001` typo is floored (it would otherwise stretch a multi-hour
  sweep into weeks); bools/strings/`None` fall back; **non-finite values fall
  back** — this reads the raw config section, so the loader's `_safe_float` guard
  is not in the path, and `json.load` accepts the `NaN` literal, which compares
  false against every bound and would silently disable pacing.
- `bulk_pace_delay`: the default idles 4x the work; half duty idles 1x; quarter
  duty 3x; zero/negative elapsed never sleeps; **the cap does not bind an
  ordinary row at the default** (the regression that would silently override the
  duty); a genuinely pathological row is still capped.
- `bulk_embed_threads`: defaults to 1 while the interactive count stays
  untouched; an explicit `0` inherits the interactive count; junk falls back to
  the safe default rather than inheriting (a typo must not hand a sweep the whole
  machine); an explicit higher override is honoured and clamped to the cores.
- `_apply_thread_class`: a bulk job programs the bulk pool; a following
  interactive job restores the full pool; an unchanged class is not
  reprogrammed; a backend with no setter latches off once and is never probed
  again; a raising setter records no count. `_infer_loop` asserts the pool is
  programmed *before* `create_embedding` runs, on the worker thread.

`test/test_vector_memory_bulk_pacing.py`

- Every bulk row is paced; `pace=False` never sleeps; a zero delay adds no
  syscall per row; a row that failed to embed is still paced (the delay is
  derived from measured elapsed time, not from success); the delay is computed
  from that row's own elapsed time; the lesson and semantic-KV sweeps are paced
  too, not just the episodic one; and the pause sits between a row's inference
  and its write — which is what makes it safe to interrupt, since an unfinished
  row stays NULL and the next sweep re-embeds it.
- The space-generation guard on the widened window: a reconcile simulated inside
  the pause leaves the episodic row NULL and returns 0; the same for the lesson
  sweep; and a vector written by a concurrent writer during the pause survives
  (the merge-only UPDATE).

`src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_index.py`

- The awaited ledger index step calls the sweep with `pace=False`, so a future
  refactor cannot silently re-pace a held-open request.

## Manual verification

The numbers in the table were produced by driving the real
`backfill_missing_embeddings` over synthetic rows whose length distribution was
sampled from an actual `memory.db`, measuring wall time and `getrusage` CPU time
at 1/2/4 threads. Verified separately in `_vendor/llama_cpp/llama.py` that
`n_threads`/`n_threads_batch` are consumed only when the context is built, so
per-job reprogramming is not overwritten by the next `create_embedding` call.

One known trade, stated rather than hidden: a sweep that runs for hours keeps the
~700MB embedding model resident for that whole time, where before it was
released (with the process) sooner. The sweep still probes for pending rows
*before* loading anything, so a boot with nothing to embed pays none of it, and
any ordinary memory write loads the same model anyway.

No UI change: the two new fields render in the generated Settings form from
their `_meta` descriptions, with no frontend diff.

## Related Issues

no linked issue: reported directly by users as "fans spin up after importing my
old memory"; no tracking issue was filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: an unattended background loop over a whole corpus, running flat out with
no duty-cycle bound — correct, unbounded in duration, and indistinguishable from
a runaway process to the user. Ask whether anything is waiting on the result
before optimizing such a loop for throughput.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the config fields carry their own
      `_meta` descriptions, which is where Settings and the config reference come
      from; `config-baseline.json` regenerated.
- [x] No secrets, credentials, or internal references in the diff
