### PR TITLE
fix(hooks): fail closed on PreToolUse hooks that time out, crash, or are missing (#7339)

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -1621,6 +1621,51 @@ Windows script hook needs that opt-in (the same one script crons and Papyrus
 need). Without it the hook's `SandboxUnavailableError` surfaces as the result's
 `error`, naming the setting.
 
+### Fail direction of a hook that delivers no verdict (`on_error`)
+
+A script hook's exit code is its verdict: **0 = allow, 2 = deny** (stderr goes to
+the LLM). Any *other* code means the hook rendered no verdict at all —
+`ScriptHookResult.failed_to_run`. The cases are a timeout (`error` = "Timed out
+after Ns", exit `-1`), a spawn/preparation exception including a `wrap_argv` that
+fail-closes because the host has no sandbox backend (exit `-1`), and a
+missing/non-runnable binary (whatever the platform shell answers for "command not
+found" — 127 under `/bin/sh`, 9009 under `cmd.exe`). The governance-denied result
+is *not* one of these: it carries exit 2 plus an `error`, and is a clean denial.
+
+`ScriptHook.on_error` decides what a no-verdict run means. It stores the
+operator's explicit `fail_closed` / `fail_open`, or the sentinel `""` meaning
+"use the event default"; read it only through `effective_on_error()`, never raw.
+The event default is **`fail_closed` for PreToolUse** — the only event that gates
+a tool, and an unheard policy hook must not silently auto-approve — and
+`fail_open` for every other event, which cannot gate, so a failed run there is
+informational. `should_block_pre_tool_use()` is the whole decision: exit 2 blocks,
+exit 0 allows, `failed_to_run` blocks iff the resolved direction is `fail_closed`.
+
+Where that gate actually runs is the **dashboard chat path** (`chat_runner._fire`
+/ `_pre_tool_hooks_should_block`), which consults results before the tool is
+approved; it emits the same `BLOCKED:<name>:<reason>` marker exit 2 does. The
+autonomous `fire_tool_hooks` path cannot gate — kiro-cli emits `EVENT_TOOL_CALL`
+after it has already auto-approved and started the tool — so it instead logs a
+WARNING naming the hook and the tool, making the gap observable where it can no
+longer be prevented.
+
+Operator consequence, on Windows in particular: a host where a script hook cannot
+be confined and `agent.sandbox_allow_unsandboxed_exec` is unset produces no
+verdict, so a matching **PreToolUse** hook now denies the tool rather than being
+ignored. Setting the hook's `on_error` to `fail_open` restores the pass-through
+for that hook alone.
+
+Write paths differ deliberately. `validate_hook_fields` (create/update boundary)
+**raises** on an explicit unrecognized value, so a misspelled fail direction is
+never accepted silently. `from_dict` and `ScriptHookStore.update` **normalize**
+(trim, lowercase) and degrade anything unrecognized to the sentinel, because
+`hooks.json` is hand-editable and older files predate the field — and the sentinel
+resolves to `fail_closed` for PreToolUse, so junk on a policy hook still fails
+toward more protection. Both write paths normalize identically, so the same input
+stores the same value whether it arrives via create or update. The dashboard API
+accepts the field through `HOOK_CREATE_SCHEMA` / `HOOK_UPDATE_SCHEMA`
+(`validation.py`), which reject unknown fields.
+
 ### `safe_read_file(path: str) -> str`
 
 Central guarded file read. Resolves the path via `expanduser().resolve()`, checks against

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4708,9 +4708,52 @@ async def _run_chat(
                             "text": f"Hook {r.hook_name} BLOCKED: {r.stderr[:100] if r.stderr else 'denied'}",
                         },
                     )
-                elif r.exit_code not in (0, 2) and r.stderr:
-                    # Non-zero, non-block: show warning
-                    logger.warning("Hook %s warning: %s", r.hook_name, r.stderr[:200])
+                elif (
+                    event == HOOK_EVENT_PRE_TOOL_USE
+                    and r.failed_to_run
+                    and r.should_block_pre_tool_use()
+                ):
+                    # Fail-closed gate: a PreToolUse hook that could not deliver a
+                    # verdict (timeout, crash, or missing/non-runnable binary —
+                    # exit_code neither 0 nor 2) must BLOCK the tool when its
+                    # resolved fail direction is fail_closed, not be silently
+                    # dropped as a warning (the historic fail-OPEN bug, #7339). We
+                    # emit the same BLOCKED:<name>:<reason> marker exit 2 does so
+                    # _pre_tool_hooks_should_block sees it. A hook explicitly set
+                    # to on_error='fail_open' resolves to allow here and falls
+                    # through to the warning branch below, restoring old behavior.
+                    reason = (r.error or r.stderr or "").strip()[:200]
+                    if not reason:
+                        # A crashed spawn can leave both channels empty; the
+                        # marker still needs a reason the LLM and the UI can show.
+                        reason = "hook failed to deliver a verdict (fail-closed)"
+                    injected.append(f"BLOCKED:{r.hook_name}:{reason}")
+                    logger.warning(
+                        "Hook %s failed to deliver a verdict (exit=%s) - "
+                        "blocking tool (fail-closed): %s",
+                        r.hook_name,
+                        r.exit_code,
+                        reason,
+                    )
+                    state.broadcast_ws(
+                        "activity_event",
+                        {
+                            "slot": slot.key,
+                            "kind": "hook",
+                            "text": f"Hook {r.hook_name} BLOCKED (fail-closed): {reason[:100]}",
+                        },
+                    )
+                elif r.exit_code not in (0, 2) and (r.stderr or r.error):
+                    # Non-zero, non-block: show warning. This is now reached only
+                    # for a non-gating event, or for a PreToolUse hook whose
+                    # resolved fail direction is fail_open (pass-through). A
+                    # fail_open PreToolUse hook that TIMED OUT sets `r.error` but
+                    # usually leaves `r.stderr` empty (#7339); include `r.error`
+                    # in the trigger and message so an operator who opted a hook
+                    # out of blocking still gets a signal that it failed, instead
+                    # of the failure being dropped with no log at all.
+                    detail = (r.stderr or r.error or "").strip()[:200]
+                    logger.warning("Hook %s warning: %s", r.hook_name, detail)
         except Exception as exc:
             if event == HOOK_EVENT_PRE_TOOL_USE:
                 logger.warning("Hook fire error during blocking event %s: %s", event, exc)

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -3101,8 +3101,70 @@ def _normalize_hook_timeout(value: object) -> int:
     return max(HOOK_TIMEOUT_MIN, min(HOOK_TIMEOUT_MAX, ivalue))
 
 
+# Per-hook fail-direction spellings for ``ScriptHook.on_error``. ``fail_closed``
+# blocks the tool when the hook cannot deliver a verdict (timeout, crash, or a
+# missing/non-runnable binary); ``fail_open`` restores the historical
+# pass-through. ``""`` is the sentinel that means "use the event default" —
+# stored verbatim so the effective direction is resolved at read time against
+# the hook's event (PreToolUse -> fail_closed, everything else -> fail_open).
+HOOK_ON_ERROR_FAIL_CLOSED = "fail_closed"
+HOOK_ON_ERROR_FAIL_OPEN = "fail_open"
+HOOK_ON_ERROR_DEFAULT = ""  # sentinel: resolve against the event at read time
+_HOOK_ON_ERROR_VALUES = (
+    HOOK_ON_ERROR_DEFAULT,
+    HOOK_ON_ERROR_FAIL_CLOSED,
+    HOOK_ON_ERROR_FAIL_OPEN,
+)
+
+
+def _normalize_hook_on_error(value: object) -> str:
+    """Coerce a persisted/edited ``on_error`` to one of the accepted spellings.
+
+    ``hooks.json`` is hand-editable and older files predate this field, so a
+    missing / non-string / unrecognized value must degrade to the sentinel
+    ``""`` (use the event default) rather than propagate — the same fail-soft
+    contract ``_normalize_hook_timeout`` / ``_coerce_bool`` follow on load. The
+    raising ``validate_hook_fields`` is what rejects a bad EXPLICIT value at the
+    create/update boundary. Degrading to the sentinel is safe because the
+    sentinel resolves to fail_closed for PreToolUse (the gating event), so junk
+    on a policy hook still fails toward MORE protection, per the deny-by-default
+    tenet. A recognized spelling is matched case-insensitively after trimming.
+    """
+    if not isinstance(value, str):
+        return HOOK_ON_ERROR_DEFAULT
+    v = value.strip().lower()
+    if v in (HOOK_ON_ERROR_FAIL_CLOSED, HOOK_ON_ERROR_FAIL_OPEN):
+        return v
+    return HOOK_ON_ERROR_DEFAULT
+
+
+def _resolve_on_error(on_error: str, event: str) -> str:
+    """Resolve the sentinel ``on_error`` to a concrete fail direction.
+
+    An explicit ``fail_closed`` / ``fail_open`` is honored as written; the
+    sentinel ``""`` resolves to ``fail_closed`` for PreToolUse (the only event
+    that gates a tool) and ``fail_open`` for every other event (they do not
+    gate, so a failed run there is informational and must not manufacture a
+    block).
+    """
+    if on_error in (HOOK_ON_ERROR_FAIL_CLOSED, HOOK_ON_ERROR_FAIL_OPEN):
+        return on_error
+    return (
+        HOOK_ON_ERROR_FAIL_CLOSED
+        if event == HOOK_EVENT_PRE_TOOL_USE
+        else HOOK_ON_ERROR_FAIL_OPEN
+    )
+
+
 def validate_hook_fields(
-    *, event: str, timeout: object, command: str, skills: list, matcher: str, matcher_mode: str
+    *,
+    event: str,
+    timeout: object,
+    command: str,
+    skills: list,
+    matcher: str,
+    matcher_mode: str,
+    on_error: str = HOOK_ON_ERROR_DEFAULT,
 ) -> None:
     """Enforce the script-hook invariants at a WRITE boundary, raising on any breach.
 
@@ -3122,10 +3184,18 @@ def validate_hook_fields(
     * ``skills`` is combined with a ``command`` (the skills would never fire);
     * ``skills`` is paired with an event other than UserPromptSubmit/AgentSpawn
       (the "Load skills:" directive has no consumer there);
-    * ``matcher_mode`` is ``regex`` with a syntactically invalid ``matcher``.
+    * ``matcher_mode`` is ``regex`` with a syntactically invalid ``matcher``;
+    * ``on_error`` is not one of ``""`` / ``fail_closed`` / ``fail_open`` (an
+      explicit but misspelled fail direction is rejected rather than silently
+      degraded — unlike ``from_dict``, which is fail-soft on load).
     """
     if event not in HOOK_EVENTS:
         raise ValueError(f"invalid event: {event}")
+    if on_error not in _HOOK_ON_ERROR_VALUES:
+        raise ValueError(
+            f"on_error must be one of {HOOK_ON_ERROR_FAIL_CLOSED!r}, "
+            f"{HOOK_ON_ERROR_FAIL_OPEN!r}, or empty for the event default"
+        )
     if isinstance(timeout, bool) or not isinstance(timeout, int) or not (
         HOOK_TIMEOUT_MIN <= timeout <= HOOK_TIMEOUT_MAX
     ):
@@ -3243,6 +3313,17 @@ class ScriptHook:
     - Exit 0: success (stdout → context for AgentSpawn/UserPromptSubmit)
     - Exit 2: block tool (PreToolUse only, stderr → LLM)
     - Other: warning (stderr shown to user)
+
+    Fail direction (``on_error``): when a hook CANNOT deliver a verdict — it
+    times out, crashes, or its binary is missing/non-runnable — the auto-approve
+    GATE must decide whether that ambiguity blocks the tool or lets it through.
+    PreToolUse defaults to fail_closed (block: an unheard policy hook must not
+    silently auto-approve a tool), every other event defaults to fail_open (they
+    do not gate a tool, so a failed run there is informational only). ``on_error``
+    stores the operator's explicit override; the sentinel ``""`` means "use the
+    event default", resolved at read time by ``effective_on_error``. This field
+    ONLY affects the fail-direction of the auto-approve gate — it never turns a
+    non-gating event (UserPromptSubmit/AgentSpawn/PostToolUse/Stop) into a gate.
     """
 
     id: str = ""
@@ -3258,6 +3339,22 @@ class ScriptHook:
     last_status: str = ""  # "ok", "error", "timeout", "blocked"
     last_error: str = ""  # human-readable reason for the most recent non-ok status
     run_count: int = 0
+    # Fail direction for a hook that cannot deliver a verdict. "" = use the event
+    # default (PreToolUse -> fail_closed, else fail_open); "fail_closed" blocks
+    # the tool on timeout/crash/missing-binary; "fail_open" restores the historic
+    # pass-through. Declared last so existing positional construction keeps
+    # working. Resolve via effective_on_error(); never gate on the raw value.
+    on_error: str = HOOK_ON_ERROR_DEFAULT
+
+    def effective_on_error(self) -> str:
+        """Resolve ``on_error`` to a concrete ``fail_closed`` / ``fail_open``.
+
+        The sentinel ``""`` resolves against ``self.event`` (fail_closed for
+        PreToolUse, fail_open otherwise); an explicit value is honored as
+        written. This is the ONLY correct way to read the fail direction — the
+        raw ``on_error`` carries the sentinel a gate cannot act on directly.
+        """
+        return _resolve_on_error(self.on_error, self.event)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -3289,6 +3386,14 @@ class ScriptHook:
         # written so an unknown event is visibly inert rather than silently
         # remapped, matching how `matcher_mode` junk falls through to glob.
         timeout = _normalize_hook_timeout(data.get("timeout", HOOK_TIMEOUT_DEFAULT))
+        # Normalize the fail direction on load. hooks.json is hand-editable and
+        # older files predate this field, so a missing / non-string / junk value
+        # degrades to the sentinel "" (use the event default) rather than raising
+        # — deserialization stays fail-soft, matching timeout/enabled above. The
+        # sentinel resolves to fail_closed for PreToolUse, so junk on a policy
+        # hook still fails toward MORE protection. The raising validate_hook_fields
+        # is what rejects a bad explicit value at the create/update boundary.
+        on_error = _normalize_hook_on_error(data.get("on_error", HOOK_ON_ERROR_DEFAULT))
         return cls(
             id=data.get("id", str(uuid.uuid4())[:8]),
             name=data.get("name", ""),
@@ -3303,6 +3408,7 @@ class ScriptHook:
             last_status=data.get("last_status", ""),
             last_error=last_error,
             run_count=data.get("run_count", 0),
+            on_error=on_error,
         )
 
 
@@ -3431,6 +3537,13 @@ class ScriptHookResult:
     exit_code: int = -1
     error: str = ""
     duration_ms: int = 0
+    # Resolved fail direction for the hook that produced this result, threaded on
+    # at creation time (in run_script_hook / fire) so a consumer — e.g. the
+    # dashboard _fire gate — can decide the fail-direction WITHOUT looking the
+    # ScriptHook back up. "" only for a result built outside the normal fire path
+    # (e.g. a hand-constructed test result); consumers must resolve "" against the
+    # event before gating. See ScriptHook.effective_on_error / _resolve_on_error.
+    on_error: str = HOOK_ON_ERROR_DEFAULT
 
     @property
     def blocked(self) -> bool:
@@ -3440,6 +3553,45 @@ class ScriptHookResult:
     @property
     def succeeded(self) -> bool:
         return self.exit_code == 0
+
+    @property
+    def failed_to_run(self) -> bool:
+        """True when the hook did NOT deliver a clean gate signal.
+
+        A clean signal is exit 0 (allow) or exit 2 (block). Anything else means
+        the hook could not render a verdict: the timeout branch and the generic
+        exception branch (a spawn failure, a sandbox that refuses to confine the
+        hook) return the default exit_code -1, and a missing/non-runnable binary
+        surfaces as whatever the platform shell answers for "command not found"
+        — 127 under ``/bin/sh``, 9009 under ``cmd.exe``. The exit code alone
+        decides, so no non-2 spelling of a setup failure can be mistaken for a
+        verdict, while the governance-denied result — exit 2 WITH an ``error``
+        — stays a clean denial. This is the signal a fail_closed PreToolUse gate
+        blocks on; it is deliberately distinct from ``blocked`` (a clean,
+        intentional exit-2 denial).
+        """
+        if self.exit_code in (0, 2):
+            return False
+        return True
+
+    def should_block_pre_tool_use(self, on_error: str = "") -> bool:
+        """Whether this result must block the tool on the auto-approve gate.
+
+        Decision table (PreToolUse only — non-gating events never block here):
+        exit 2 -> block (a clean denial); clean exit 0 -> allow; failed_to_run ->
+        block iff the resolved fail direction is fail_closed. The direction is
+        taken from *on_error* when the caller passes one, else from the value
+        threaded onto this result, resolved against the result's event so the
+        sentinel is never acted on directly.
+        """
+        if self.blocked:
+            return True
+        if self.succeeded:
+            return False
+        if not self.failed_to_run:
+            return False
+        resolved = _resolve_on_error(on_error or self.on_error, self.event)
+        return resolved == HOOK_ON_ERROR_FAIL_CLOSED
 
 
 def _script_hooks_capability_denied(session_key: str = "") -> str | None:
@@ -3530,6 +3682,7 @@ async def run_script_hook(
             error=f"Blocked by governance policy: {gov_denied}",
             exit_code=2,  # PreToolUse "block tool" convention
             duration_ms=int((time.monotonic() - start) * 1000),
+            on_error=hook.effective_on_error(),
         )
     # Build hook event JSON for STDIN
     if hook_event is None:
@@ -3657,6 +3810,7 @@ async def run_script_hook(
             stderr=stderr_safe_full,
             exit_code=exit_code,
             duration_ms=elapsed,
+            on_error=hook.effective_on_error(),
         )
     except asyncio.TimeoutError:
         # Kill the whole process tree (shell + grandchildren) to prevent orphans.
@@ -3691,6 +3845,7 @@ async def run_script_hook(
             event=hook.event,
             error=f"Timed out after {hook.timeout}s",
             duration_ms=elapsed,
+            on_error=hook.effective_on_error(),
         )
     except Exception as exc:
         elapsed = int((time.monotonic() - start) * 1000)
@@ -3705,6 +3860,7 @@ async def run_script_hook(
             event=hook.event,
             error=safe_error,
             duration_ms=elapsed,
+            on_error=hook.effective_on_error(),
         )
 
 
@@ -3889,6 +4045,7 @@ class ScriptHookStore:
             skills=hook.skills,
             matcher=hook.matcher,
             matcher_mode=hook.matcher_mode,
+            on_error=hook.on_error,
         )
         with self._mutex, self._atomic_mutation():
             self._hooks[hook.id] = hook
@@ -3900,9 +4057,29 @@ class ScriptHookStore:
             hook = self._hooks.get(hook_id)
             if not hook:
                 return None
-            for k in ("name", "event", "matcher", "matcher_mode", "command", "timeout", "enabled"):
+            for k in (
+                "name",
+                "event",
+                "matcher",
+                "matcher_mode",
+                "command",
+                "timeout",
+                "enabled",
+                "on_error",
+            ):
                 if k in data:
-                    setattr(hook, k, data[k])
+                    # `on_error` is normalized on the way in — trimmed,
+                    # lowercased, junk degraded to the sentinel — exactly as
+                    # `create` does via `from_dict`/`_normalize_hook_on_error`,
+                    # so both write paths accept the same spellings (e.g.
+                    # " Fail_Closed ") and degrade junk identically. Without
+                    # this, `update` set the raw request value and then the
+                    # strict `validate_hook_fields` rejected a spelling `create`
+                    # would have accepted.
+                    if k == "on_error":
+                        setattr(hook, k, _normalize_hook_on_error(data[k]))
+                    else:
+                        setattr(hook, k, data[k])
             if "skills" in data:
                 skills_raw = data["skills"]
                 hook.skills = [str(s) for s in skills_raw if isinstance(s, str)] if isinstance(skills_raw, list) else []
@@ -3921,6 +4098,7 @@ class ScriptHookStore:
                 skills=hook.skills,
                 matcher=hook.matcher,
                 matcher_mode=hook.matcher_mode,
+                on_error=hook.on_error,
             )
             self._save()
         return hook
@@ -4061,6 +4239,7 @@ class ScriptHookStore:
                     stdout=f"Load skills: {skills_directive}",
                     exit_code=0,
                     duration_ms=0,
+                    on_error=hook.effective_on_error(),
                 )
                 results.append(result)
                 logger.info(
@@ -4143,21 +4322,47 @@ async def fire_tool_hooks(
     parent_session_key: str | None = None,
     agent_role: str | None = None,
 ) -> None:
-    """Fire PreToolUse hooks for an EVENT_TOOL_CALL event.
+    """Fire PreToolUse hooks for an EVENT_TOOL_CALL event (autonomous path).
 
     PostToolUse is NOT fired here because EVENT_TOOL_CALL is a notification
     that the tool is starting - the tool hasn't completed yet. PostToolUse
     should be fired on EVENT_TOOL_RESULT when available.
 
-    Note: For EVENT_TOOL_CALL, hooks are informational only. The tool is
-    already running (auto-approved by kiro-cli), so hook results cannot
-    block execution. Hook scripts can log, audit, or trigger side effects.
+    CONTRACT (read this before relying on it to gate). On the autonomous /
+    subagent surfaces (subagent_manager/run.py, task_executor.py, llm_helpers.py,
+    acp/client.py) kiro-cli emits EVENT_TOOL_CALL AFTER it has already
+    auto-approved and STARTED the tool. By the time this runs the tool is
+    already executing, so a PreToolUse hook here is *informational only* and
+    CANNOT retroactively block it — that is an architectural fact of the
+    autonomous path, not a defect. Hook scripts may log, audit, or trigger
+    side effects, but their exit code cannot stop the call.
+
+    What this function DOES guarantee: it no longer silently discards the
+    PreToolUse results. When a hook whose resolved fail direction is
+    ``fail_closed`` blocks (exit 2) or fails to deliver a verdict (timeout,
+    crash, or missing/non-runnable binary), that is surfaced LOUDLY via a
+    WARNING naming the hook and stating the tool has already run — so the
+    silent-approval failure mode (GitHub #7339) is observable on the very
+    surface where it can no longer be prevented. This inspection is
+    best-effort and NON-FATAL: any error inside it (including ``fire()``
+    raising or returning a non-list) is swallowed so observability never
+    breaks the tool-call notification path.
+
+    Where PreToolUse hooks actually GATE and fail closed is the dashboard chat
+    path — see ``dashboard/chat_runner.py`` (``_fire`` /
+    ``_pre_tool_hooks_should_block``), wired in FEAT-002 — because that surface
+    consults the results BEFORE the tool is approved. This function does not
+    and cannot provide that guarantee.
 
     Optional ``subagent_id``, ``parent_session_key``, and ``agent_role`` are
     forwarded to the underlying hook_store so hook scripts can attribute
     tool calls to the specific agent/session that fired them. Callers in
     parent contexts (dashboard chat, generic LLM helpers) leave them as
     ``None``; subagent and taskrunner callers pass real values.
+
+    Returns ``None`` in all cases (the autonomous callers do not act on a
+    return value); the fail-closed gap is reported through the logger, not the
+    return type.
     """
     if hook_store is None:
         return
@@ -4171,7 +4376,7 @@ async def fire_tool_hooks(
         except Exception:
             pass
     try:
-        await hook_store.fire(
+        results = await hook_store.fire(
             HOOK_EVENT_PRE_TOOL_USE,
             tool_name=tool_name,
             tool_input=tool_input,
@@ -4181,3 +4386,45 @@ async def fire_tool_hooks(
         )
     except Exception:
         logger.debug("PreToolUse hook error", exc_info=True)
+        return
+    # Inspect the results we would otherwise discard: a fail-closed PreToolUse
+    # hook that BLOCKED or FAILED TO RUN could not stop this already-started
+    # tool on the autonomous path, so make that gap non-silent (WARNING). Fully
+    # wrapped so this observability step can NEVER break dispatch — the
+    # "informational hooks must never break dispatch" contract (and its tests)
+    # require a no-op even when fire() returns [] or something non-iterable.
+    try:
+        for result in results or []:
+            try:
+                if result.event != HOOK_EVENT_PRE_TOOL_USE:
+                    continue
+                # Resolve the fail direction against the result's own event; the
+                # sentinel resolves to fail_closed for PreToolUse.
+                if _resolve_on_error(
+                    getattr(result, "on_error", HOOK_ON_ERROR_DEFAULT), result.event
+                ) != HOOK_ON_ERROR_FAIL_CLOSED:
+                    continue
+                if not (result.blocked or result.failed_to_run):
+                    continue
+                verb = (
+                    "would have BLOCKED"
+                    if result.blocked
+                    else "FAILED to deliver a verdict"
+                )
+                logger.warning(
+                    "PreToolUse policy hook %s %s tool %r, but this is the "
+                    "autonomous path (EVENT_TOOL_CALL): the tool was already "
+                    "auto-approved and started by kiro-cli, so execution could "
+                    "NOT be prevented (fail-closed gap, GitHub #7339). "
+                    "PreToolUse hooks only gate on the dashboard chat path.",
+                    result.hook_name or result.hook_id,
+                    verb,
+                    tool_name,
+                )
+            except Exception:
+                # A single malformed result must not stop us inspecting the rest,
+                # and must never surface to the caller.
+                logger.debug("PreToolUse result inspection error", exc_info=True)
+    except Exception:
+        # Non-iterable results, or any other unexpected shape: stay non-fatal.
+        logger.debug("PreToolUse results inspection error", exc_info=True)

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2346,6 +2346,12 @@ HOOK_CREATE_SCHEMA = ToolSchema(
         FieldSpec("skills", list, default=[], item_type=str, item_max_len=100),
         FieldSpec("timeout", int, min_val=1, max_val=300, default=30),
         FieldSpec("enabled", bool, default=True),
+        FieldSpec(
+            "on_error",
+            str,
+            default="",
+            allowed=frozenset({"", "fail_closed", "fail_open"}),
+        ),
     ],
     custom_validator=_validate_hook_create,
 )
@@ -2363,6 +2369,9 @@ HOOK_UPDATE_SCHEMA = ToolSchema(
         FieldSpec("skills", list, item_type=str, item_max_len=100),
         FieldSpec("timeout", int, min_val=1, max_val=300),
         FieldSpec("enabled", bool),
+        FieldSpec(
+            "on_error", str, allowed=frozenset({"", "fail_closed", "fail_open"})
+        ),  # optional on update
     ],
     custom_validator=_validate_hook_update,
 )

--- a/test/test_fire_tool_hooks.py
+++ b/test/test_fire_tool_hooks.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import platform
+import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,13 +15,65 @@ from kiro_crew.hooks import (
     HOOK_EVENT_PRE_TOOL_USE,
     HOOK_EVENT_STOP,
     HOOK_EVENT_USER_PROMPT_SUBMIT,
+    HOOK_ON_ERROR_DEFAULT,
+    HOOK_ON_ERROR_FAIL_CLOSED,
+    HOOK_ON_ERROR_FAIL_OPEN,
     ScriptHook,
+    ScriptHookResult,
     ScriptHookStore,
     fire_tool_hooks,
     get_global_hook_store,
     run_script_hook,
     set_global_hook_store,
+    validate_hook_fields,
 )
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+# A command name that is not on PATH on any host, so the platform shell answers
+# "command not found" rather than running something. The exit code it answers
+# with is the shell's own (127 on POSIX sh, 9009 on cmd.exe), which is why tests
+# assert the fail-direction contract portably and pin the literal 127 on POSIX.
+_MISSING_BINARY_COMMAND = "kirocrew-no-such-policy-gate --check"
+
+
+def _sleep_command(script: Path, seconds: int) -> str:
+    """Return a hook command that sleeps *seconds*, spelled for either shell.
+
+    ``sleep 8`` is POSIX-only — cmd.exe has no ``sleep`` and no ``;`` separator,
+    so on Windows it fails INSTANTLY with "not recognized" and a timeout test
+    written that way never reaches the timeout branch it claims to cover. A
+    quoted interpreter plus a quoted script path is the one shape ``/bin/sh -c``
+    and ``cmd /c`` parse identically (see ``test_script_hooks._script_command``).
+    """
+    script.write_text(f"import time\ntime.sleep({seconds})\n", encoding="utf-8")
+    return f'"{sys.executable}" "{script}"'
+
+
+def _patch_sandbox_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the OS sandbox and cgroup wrappers no-ops for a real hook spawn.
+
+    ``run_script_hook`` routes its ``/bin/sh -c`` / ``cmd /c`` argv through
+    ``sandboxed_spawn_argv``, so the process that actually runs is the sandbox
+    LAUNCHER, and the exit code ``run_script_hook`` reports is the launcher's
+    whenever the launcher refuses. A host that cannot establish a control the
+    launcher considers mandatory answers 1 ("sandbox: BLOCKED — sealing
+    read-only directory …") and a host whose ``unshare``/seccomp step dies
+    answers -1 (signal), in both cases BEFORE the hook command is exec'd. A test
+    asserting the hook's own exit code (0 allow / 2 deny / 127 missing binary)
+    therefore measures the host's sandbox backend instead of the gate, and it
+    reads differently on a developer container, a GitHub Linux runner, and a
+    Windows runner.
+
+    Patching both chokepoints to identity spawns the hook command directly, so
+    the exit code under assertion is the one the hook produced. The sandbox's own
+    refusal is not swept under the rug — it is a distinct, deliberate fail-closed
+    input, pinned by ``test_sandbox_refusal_blocks_fail_closed``. Patch the
+    ``kiro_crew.sandbox`` module, not the caller: ``run_script_hook`` imports
+    these lazily at call time to break a circular import.
+    """
+    monkeypatch.setattr("kiro_crew.sandbox.wrap_argv", lambda argv, **k: (list(argv), None))
+    monkeypatch.setattr("kiro_crew.sandbox.cgroup_scope_argv", lambda argv: list(argv))
 
 
 @pytest.fixture(autouse=True)
@@ -414,3 +468,499 @@ class TestRunScriptHookStopEnvCap:
         parsed = json.loads(stdin_bytes)
         assert parsed["assistant_text"] == full
         assert "[OPTIONS:" in parsed["assistant_text"]
+
+
+# ── FEAT-004: PreToolUse hooks fail closed (GitHub #7339) ──
+
+
+class TestPreToolUseFailsClosed:
+    """A PreToolUse hook that cannot deliver a verdict blocks under the default
+    (fail-closed) direction.
+
+    These run the REAL subprocess path (run_script_hook against tiny shell
+    commands) so the assertions exercise the true timeout / missing-binary /
+    exit-code branches, mirroring the issue repro. Against the pre-fix code
+    there was no ``failed_to_run`` / ``should_block_pre_tool_use`` at all and a
+    timed-out or crashed PreToolUse hook silently auto-approved the tool, so
+    every ``... is True`` block assertion here would fail before the fix.
+
+    Every test that spawns asserts a signal that identifies WHICH branch ran
+    (the exit code, or "Timed out" in ``error``) rather than only
+    ``failed_to_run``: any spawn failure at all satisfies ``failed_to_run``, so
+    the weaker assertion is green even when the intended branch never executed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _passthrough_sandbox(self, monkeypatch):
+        _patch_sandbox_passthrough(monkeypatch)
+
+    @pytest.mark.asyncio
+    async def test_timeout_blocks_fail_closed(self, tmp_path: Path):
+        # The command outlives its 1s timeout, so the timeout branch fires
+        # (default exit_code -1) and the hook renders no verdict.
+        hook = ScriptHook(
+            id="pt-timeout",
+            name="policy-timeout",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command=_sleep_command(tmp_path / "slow_gate.py", 10),
+            timeout=1,
+        )
+        result = await run_script_hook(hook)
+        # Pins the TIMEOUT branch specifically, not merely "something failed".
+        assert "Timed out" in result.error
+        assert result.blocked is False  # never reached a clean exit 2
+        assert result.failed_to_run is True
+        # Default (sentinel) PreToolUse hook resolves fail_closed -> must block.
+        assert result.should_block_pre_tool_use() is True
+        assert result.should_block_pre_tool_use("fail_closed") is True
+
+    @pytest.mark.asyncio
+    async def test_missing_binary_blocks_fail_closed(self):
+        hook = ScriptHook(
+            id="pt-missing",
+            name="policy-missing",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command=_MISSING_BINARY_COMMAND,
+            timeout=5,
+        )
+        result = await run_script_hook(hook)
+        # The contract is fail-direction, and it holds on whatever code the
+        # platform shell picks for "command not found": neither 0 nor 2 is a
+        # verdict, so a fail-closed PreToolUse hook must block.
+        assert result.exit_code not in (0, 2)
+        assert result.failed_to_run is True
+        assert result.should_block_pre_tool_use() is True
+        if not _IS_WINDOWS:
+            # The exit code ``failed_to_run``'s docstring names for a missing
+            # binary. cmd.exe answers 9009, so pin the literal where sh runs.
+            assert result.exit_code == 127
+
+    @pytest.mark.asyncio
+    async def test_crash_blocks_fail_closed(self, monkeypatch):
+        # Exercise the generic-exception branch of run_script_hook by making the
+        # spawn itself raise; run_script_hook must still return a result (never
+        # propagate) with the default exit_code -1, which is failed_to_run.
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("spawn exploded")
+
+        # run_script_hook imports sandboxed_spawn_argv_async from
+        # kiro_crew.sandbox at call time, so patch it at that source module.
+        # ``raising`` stays at its default True: if the symbol is ever renamed,
+        # this must go red rather than silently spawn a real shell and pass on a
+        # different failure.
+        import kiro_crew.sandbox as sandbox_mod
+
+        monkeypatch.setattr(sandbox_mod, "sandboxed_spawn_argv_async", _boom)
+        hook = ScriptHook(
+            id="pt-crash",
+            name="policy-crash",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command="exit 0",
+            timeout=5,
+        )
+        result = await run_script_hook(hook)
+        # The injected crash is what produced this result, not an unrelated
+        # spawn failure — the command itself would have exited 0 (allow).
+        assert "spawn exploded" in result.error
+        assert result.exit_code not in (0, 2)
+        assert result.failed_to_run is True
+        assert result.should_block_pre_tool_use() is True
+
+    @pytest.mark.asyncio
+    async def test_sandbox_refusal_blocks_fail_closed(self):
+        # ``wrap_argv`` RAISES when no sandbox backend is available and
+        # unsandboxed exec is not opted into, and the launcher it builds refuses
+        # (non-zero exit, no hook verdict) on a host that cannot establish a
+        # mandatory control. Either way the policy hook is unheard, so the gate
+        # must deny — a host that cannot confine a hook must not become a host
+        # that auto-approves every tool.
+        hook = ScriptHook(
+            id="pt-nosandbox",
+            name="policy-nosandbox",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command="exit 0",  # would ALLOW if it ever ran
+            timeout=5,
+        )
+        with patch(
+            "kiro_crew.sandbox.wrap_argv",
+            side_effect=RuntimeError("no sandbox backend available"),
+        ):
+            result = await run_script_hook(hook)
+        assert "no sandbox backend available" in result.error
+        assert result.failed_to_run is True
+        assert result.should_block_pre_tool_use() is True
+
+    @pytest.mark.asyncio
+    async def test_clean_exit2_blocks_and_is_not_failed_to_run(self):
+        hook = ScriptHook(
+            id="pt-deny",
+            name="policy-deny",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command="exit 2",
+            timeout=5,
+        )
+        result = await run_script_hook(hook)
+        assert result.exit_code == 2
+        assert result.blocked is True
+        # A clean, intentional denial is NOT a failed run.
+        assert result.failed_to_run is False
+        assert result.should_block_pre_tool_use() is True
+
+    @pytest.mark.asyncio
+    async def test_clean_exit0_allows(self):
+        hook = ScriptHook(
+            id="pt-allow",
+            name="policy-allow",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command="exit 0",
+            timeout=5,
+        )
+        result = await run_script_hook(hook)
+        assert result.exit_code == 0
+        assert result.succeeded is True
+        assert result.failed_to_run is False
+        assert result.should_block_pre_tool_use() is False
+
+
+class TestPerHookFailDirection:
+    """The per-hook ``on_error`` field and its event-dependent default."""
+
+    @pytest.fixture(autouse=True)
+    def _passthrough_sandbox(self, monkeypatch):
+        _patch_sandbox_passthrough(monkeypatch)
+
+    @pytest.mark.asyncio
+    async def test_explicit_fail_open_pretooluse_does_not_block_on_timeout(
+        self, tmp_path: Path
+    ):
+        # An operator who opted a PreToolUse hook into fail_open restores the
+        # historic pass-through even when the hook fails to run.
+        hook = ScriptHook(
+            id="pt-open",
+            name="policy-open",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command=_sleep_command(tmp_path / "slow_gate.py", 10),
+            timeout=1,
+            on_error=HOOK_ON_ERROR_FAIL_OPEN,
+        )
+        result = await run_script_hook(hook)
+        assert "Timed out" in result.error  # the timeout branch, not any failure
+        assert result.failed_to_run is True
+        # Resolved fail_open -> a failed run must NOT manufacture a block.
+        assert result.should_block_pre_tool_use() is False
+
+    def test_default_pretooluse_resolves_fail_closed(self):
+        hook = ScriptHook(event=HOOK_EVENT_PRE_TOOL_USE)
+        assert hook.on_error == HOOK_ON_ERROR_DEFAULT
+        assert hook.effective_on_error() == HOOK_ON_ERROR_FAIL_CLOSED
+
+    def test_default_non_pretooluse_resolves_fail_open(self):
+        hook = ScriptHook(event=HOOK_EVENT_USER_PROMPT_SUBMIT)
+        assert hook.on_error == HOOK_ON_ERROR_DEFAULT
+        assert hook.effective_on_error() == HOOK_ON_ERROR_FAIL_OPEN
+
+    @pytest.mark.asyncio
+    async def test_non_gating_event_never_blocks_on_failure(self):
+        # A non-PreToolUse hook that fails resolves fail_open and never gates.
+        hook = ScriptHook(
+            id="ups-fail",
+            name="ups-fail",
+            event=HOOK_EVENT_USER_PROMPT_SUBMIT,
+            command=_MISSING_BINARY_COMMAND,
+            timeout=5,
+        )
+        result = await run_script_hook(hook)
+        assert result.exit_code not in (0, 2)
+        assert result.failed_to_run is True
+        assert result.should_block_pre_tool_use() is False
+
+
+class TestOnErrorConfigPlumbing:
+    """from_dict fail-soft, to_dict round-trip, validate_hook_fields boundary."""
+
+    def test_from_dict_tolerates_junk_string(self):
+        hook = ScriptHook.from_dict(
+            {"event": HOOK_EVENT_PRE_TOOL_USE, "command": "true", "on_error": "nonsense"}
+        )
+        # Junk degrades to the sentinel (never raises) which still resolves
+        # fail_closed for PreToolUse — more protection, not less.
+        assert hook.on_error == HOOK_ON_ERROR_DEFAULT
+        assert hook.effective_on_error() == HOOK_ON_ERROR_FAIL_CLOSED
+
+    def test_from_dict_tolerates_non_string(self):
+        hook = ScriptHook.from_dict(
+            {"event": HOOK_EVENT_PRE_TOOL_USE, "command": "true", "on_error": 123}
+        )
+        assert hook.on_error == HOOK_ON_ERROR_DEFAULT
+
+    def test_from_dict_keeps_valid_explicit_value(self):
+        hook = ScriptHook.from_dict(
+            {
+                "event": HOOK_EVENT_PRE_TOOL_USE,
+                "command": "true",
+                "on_error": "fail_open",
+            }
+        )
+        assert hook.on_error == HOOK_ON_ERROR_FAIL_OPEN
+
+    def test_to_dict_round_trip_explicit(self):
+        hook = ScriptHook(
+            id="rt",
+            name="rt",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command="true",
+            on_error=HOOK_ON_ERROR_FAIL_OPEN,
+        )
+        d = hook.to_dict()
+        assert d["on_error"] == HOOK_ON_ERROR_FAIL_OPEN
+        restored = ScriptHook.from_dict(d)
+        assert restored.on_error == HOOK_ON_ERROR_FAIL_OPEN
+        assert restored.effective_on_error() == HOOK_ON_ERROR_FAIL_OPEN
+
+    def test_validate_hook_fields_rejects_invalid_on_error(self):
+        with pytest.raises(ValueError):
+            validate_hook_fields(
+                event=HOOK_EVENT_PRE_TOOL_USE,
+                timeout=30,
+                command="true",
+                skills=[],
+                matcher="",
+                matcher_mode="glob",
+                on_error="banana",
+            )
+
+    def test_validate_hook_fields_accepts_valid_on_error(self):
+        # Sentinel and both explicit spellings must be accepted (no raise).
+        for value in (HOOK_ON_ERROR_DEFAULT, HOOK_ON_ERROR_FAIL_CLOSED, HOOK_ON_ERROR_FAIL_OPEN):
+            validate_hook_fields(
+                event=HOOK_EVENT_PRE_TOOL_USE,
+                timeout=30,
+                command="true",
+                skills=[],
+                matcher="",
+                matcher_mode="glob",
+                on_error=value,
+            )
+
+
+class TestFireToolHooksSurfacesFailClosedGap:
+    """The autonomous path (fire_tool_hooks) surfaces a non-silent WARNING for a
+    fail-closed PreToolUse hook that blocked or failed to run, and stays
+    non-fatal.
+
+    fire_tool_hooks cannot retroactively block (the tool is already running),
+    but pre-fix it DISCARDED the results silently. These tests assert the new
+    WARNING is emitted for the fail-closed failed-to-run and blocked cases and
+    NOT for a clean allow, and that an exception inside fire() never propagates.
+    """
+
+    def _result(self, exit_code: int, *, event=HOOK_EVENT_PRE_TOOL_USE, on_error="", error=""):
+        return ScriptHookResult(
+            hook_id="h1",
+            hook_name="policy-hook",
+            event=event,
+            exit_code=exit_code,
+            error=error,
+            on_error=on_error,
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_to_run_fail_closed_emits_warning(self, hook_store, caplog):
+        # exit_code -1 (timeout/crash surrogate) on a default PreToolUse hook.
+        result = self._result(-1, error="Timed out after 1s")
+        with patch.object(
+            hook_store, "fire", new_callable=AsyncMock, return_value=[result]
+        ):
+            with caplog.at_level("WARNING", logger="kiro_crew.hooks"):
+                await fire_tool_hooks(hook_store, "Running: ReadFile")
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "policy-hook" in msg
+        assert "#7339" in msg
+
+    @pytest.mark.asyncio
+    async def test_blocked_fail_closed_emits_warning(self, hook_store, caplog):
+        result = self._result(2)  # clean deny, but tool already ran
+        with patch.object(
+            hook_store, "fire", new_callable=AsyncMock, return_value=[result]
+        ):
+            with caplog.at_level("WARNING", logger="kiro_crew.hooks"):
+                await fire_tool_hooks(hook_store, "Running: ReadFile")
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "would have BLOCKED" in warnings[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_clean_exit0_emits_no_warning(self, hook_store, caplog):
+        result = self._result(0)
+        with patch.object(
+            hook_store, "fire", new_callable=AsyncMock, return_value=[result]
+        ):
+            with caplog.at_level("WARNING", logger="kiro_crew.hooks"):
+                await fire_tool_hooks(hook_store, "Running: ReadFile")
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+    @pytest.mark.asyncio
+    async def test_fail_open_failed_to_run_emits_no_warning(self, hook_store, caplog):
+        # An explicit fail_open PreToolUse hook that failed to run is not a gap.
+        result = self._result(-1, on_error=HOOK_ON_ERROR_FAIL_OPEN, error="boom")
+        with patch.object(
+            hook_store, "fire", new_callable=AsyncMock, return_value=[result]
+        ):
+            with caplog.at_level("WARNING", logger="kiro_crew.hooks"):
+                await fire_tool_hooks(hook_store, "Running: ReadFile")
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+    @pytest.mark.asyncio
+    async def test_fire_exception_is_non_fatal(self, hook_store, caplog):
+        # An exception inside fire() must NOT propagate out of fire_tool_hooks
+        # (the "informational hooks must never break dispatch" contract).
+        with patch.object(
+            hook_store,
+            "fire",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            with caplog.at_level("WARNING", logger="kiro_crew.hooks"):
+                await fire_tool_hooks(hook_store, "Running: ReadFile")
+        # No WARNING (the gap-surfacing path is skipped) and, crucially, no raise.
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+class TestOnErrorApiSchema:
+    """The dashboard API write path must accept ``on_error`` and thread it to
+    the store.
+
+    ``validate_tool_args`` rejects unknown fields, so before ``on_error`` was
+    declared on ``HOOK_CREATE_SCHEMA`` / ``HOOK_UPDATE_SCHEMA`` a request
+    carrying it got a 400 and the per-hook override was reachable only by
+    hand-editing ``hooks.json``. These tests exercise the exact schema the
+    dashboard handlers call so the gap cannot silently reopen.
+    """
+
+    def test_create_schema_accepts_on_error(self):
+        from kiro_crew.validation import HOOK_CREATE_SCHEMA, validate_tool_args
+
+        cleaned = validate_tool_args(
+            {
+                "name": "gate",
+                "command": "true",
+                "event": HOOK_EVENT_PRE_TOOL_USE,
+                "on_error": HOOK_ON_ERROR_FAIL_OPEN,
+            },
+            HOOK_CREATE_SCHEMA,
+        )
+        assert cleaned["on_error"] == HOOK_ON_ERROR_FAIL_OPEN
+
+    def test_create_schema_defaults_on_error_to_sentinel(self):
+        from kiro_crew.validation import HOOK_CREATE_SCHEMA, validate_tool_args
+
+        cleaned = validate_tool_args(
+            {"name": "gate", "command": "true", "event": HOOK_EVENT_PRE_TOOL_USE},
+            HOOK_CREATE_SCHEMA,
+        )
+        # Absent -> included with the sentinel default (not treated as unknown).
+        assert cleaned["on_error"] == HOOK_ON_ERROR_DEFAULT
+
+    def test_create_schema_rejects_invalid_on_error(self):
+        from kiro_crew.validation import (
+            HOOK_CREATE_SCHEMA,
+            ValidationError,
+            validate_tool_args,
+        )
+
+        with pytest.raises(ValidationError):
+            validate_tool_args(
+                {
+                    "name": "gate",
+                    "command": "true",
+                    "event": HOOK_EVENT_PRE_TOOL_USE,
+                    "on_error": "banana",
+                },
+                HOOK_CREATE_SCHEMA,
+            )
+
+    def test_update_schema_accepts_on_error(self):
+        from kiro_crew.validation import HOOK_UPDATE_SCHEMA, validate_tool_args
+
+        cleaned = validate_tool_args(
+            {"on_error": HOOK_ON_ERROR_FAIL_CLOSED}, HOOK_UPDATE_SCHEMA
+        )
+        assert cleaned["on_error"] == HOOK_ON_ERROR_FAIL_CLOSED
+
+    def test_update_schema_omits_on_error_when_absent(self):
+        from kiro_crew.validation import HOOK_UPDATE_SCHEMA, validate_tool_args
+
+        # Optional on update: absent stays absent (partial-update semantics),
+        # so it never clobbers an existing value.
+        cleaned = validate_tool_args({"name": "x"}, HOOK_UPDATE_SCHEMA)
+        assert "on_error" not in cleaned
+
+    def test_create_schema_output_flows_to_store(self, hook_store):
+        from kiro_crew.validation import HOOK_CREATE_SCHEMA, validate_tool_args
+
+        cleaned = validate_tool_args(
+            {
+                "name": "gate",
+                "command": "true",
+                "event": HOOK_EVENT_PRE_TOOL_USE,
+                "on_error": HOOK_ON_ERROR_FAIL_OPEN,
+            },
+            HOOK_CREATE_SCHEMA,
+        )
+        # The handler passes `cleaned` straight to store.create; assert the
+        # field survives end to end onto the persisted hook.
+        hook = hook_store.create(cleaned)
+        assert hook.on_error == HOOK_ON_ERROR_FAIL_OPEN
+
+
+class TestOnErrorStoreNormalizationParity:
+    """``create`` and ``update`` must normalize ``on_error`` identically.
+
+    Pre-fix ``update`` set the raw request value while ``create`` normalized via
+    ``from_dict``, so ``" Fail_Closed "`` passed create but was rejected by
+    update's strict ``validate_hook_fields``. Both paths must now trim,
+    lowercase, and degrade junk to the sentinel the same way.
+    """
+
+    def test_update_normalizes_mixed_case_whitespace(self, hook_store):
+        hook = hook_store.create(
+            {"name": "gate", "command": "true", "event": HOOK_EVENT_PRE_TOOL_USE}
+        )
+        updated = hook_store.update(hook.id, {"on_error": " Fail_Open "})
+        assert updated is not None
+        assert updated.on_error == HOOK_ON_ERROR_FAIL_OPEN
+
+    def test_update_degrades_junk_to_sentinel(self, hook_store):
+        hook = hook_store.create(
+            {"name": "gate", "command": "true", "event": HOOK_EVENT_PRE_TOOL_USE}
+        )
+        updated = hook_store.update(hook.id, {"on_error": "garbage"})
+        assert updated is not None
+        # Junk degrades to the sentinel (matches create/from_dict), which still
+        # resolves fail_closed for PreToolUse — never raises, never fails open.
+        assert updated.on_error == HOOK_ON_ERROR_DEFAULT
+
+    def test_create_and_update_agree_for_same_input(self, tmp_path):
+        # Same mixed-case/whitespace input must yield the same stored value
+        # whether it arrives via create or via update.
+        raw = " FAIL_closed "
+        store_a = ScriptHookStore(tmp_path / "a")
+        created = store_a.create(
+            {
+                "name": "gate",
+                "command": "true",
+                "event": HOOK_EVENT_PRE_TOOL_USE,
+                "on_error": raw,
+            }
+        )
+
+        store_b = ScriptHookStore(tmp_path / "b")
+        base = store_b.create(
+            {"name": "gate", "command": "true", "event": HOOK_EVENT_PRE_TOOL_USE}
+        )
+        updated = store_b.update(base.id, {"on_error": raw})
+
+        assert updated is not None
+        assert created.on_error == updated.on_error == HOOK_ON_ERROR_FAIL_CLOSED


### PR DESCRIPTION
Fixes #7339.

## Problem

PreToolUse script hooks are the policy gate on the auto-approve path, but every failure mode of the hook itself resolved to *allow*. A hook that exits 2 within its window blocks correctly; the same hook made slow, killed, or removed silently stopped blocking anything.

Root cause (as diagnosed in the issue):
- `run_script_hook` (src/kiro_crew/hooks.py) maps a timed-out hook to `exit_code=-1` and a missing binary to `127`; `blocked` is defined as `exit_code == 2`, so both resolve to "no opinion."
- `_fire` (src/kiro_crew/dashboard/chat_runner.py) drops any non-0/non-2 result, and `_pre_tool_hooks_should_block` treats the empty list as pass-through, so the tool is approved.

## Design decision

The issue's maintainer-bot comment flagged that the remedy carries a design decision (default direction, per-hook override, autonomous-path contract) needing an owner. The decision made here:

- **Per-hook `on_error` field** on `ScriptHook` with values `fail_closed` / `fail_open` and a `""` sentinel that resolves at read time: **fail-closed by default for PreToolUse**, fail-open for every other (non-gating) event. This preserves historic behavior for non-gating hooks and for anyone who explicitly opts into `fail_open`.

## Changes

- **hooks.py**: added `on_error` field, `ScriptHookResult.failed_to_run`, and `should_block_pre_tool_use()`. Config parsed fail-soft in `from_dict` (junk resolves to sentinel, never raises).
- **chat_runner.py (the gating surface)**: `_fire` now emits a `BLOCKED:` marker for a fail-closed failed-to-run PreToolUse hook, so `_pre_tool_hooks_should_block` blocks it. Explicit `fail_open` hooks keep the historic pass-through.
- **subagent.py autonomous/task-runner path**: `fire_tool_hooks` receives the tool-call event *after* kiro-cli has already auto-approved and started the tool, so it architecturally cannot block. Rather than a false guarantee, it now surfaces the fail-open gap **loudly** (non-fatal WARNING naming the hook, tool, and #7339) instead of silently discarding results. Its docstring was rewritten to state this contract precisely and point to chat_runner as the gating surface.
- **validation.py + dashboard API schemas**: `on_error` validated at the write boundary (create + update), reachable via `HOOK_CREATE_SCHEMA` / `HOOK_UPDATE_SCHEMA`; `update()` normalizes identically to `create()`.

## Tests

New `test/test_fire_tool_hooks.py` covers, with real subprocesses: timeout / missing-binary / crash cases now block under the fail-closed default (assertions that fail against pre-fix code); per-hook `fail_open` override still allows; non-gating events never block; config plumbing and API-schema flow-to-store; create/update normalization parity; and the autonomous-path WARNING + non-fatal contract.

## Testing notes

This branch was developed under a network-restricted sandbox (repository access only), where PyPI is unreachable and the full pytest suite could not run (aiohttp/yarl/hypothesis/pytest-asyncio unavailable). Verification performed in-sandbox:
- `py_compile` passes on all changed files; `import kiro_crew.hooks` succeeds.
- Two standalone behavioral harnesses: 27/27 checks on the fail-closed logic and 8/8 on API-schema reachability + create/update normalization parity.
- Semantic review reached APPROVED.

**Please run `python -m pytest test/test_fire_tool_hooks.py` in CI to confirm the new tests pass with real dependencies.**

## Follow-up (non-blocking)

The dashboard UI control for `on_error` in `website/src/pages/HooksPage.tsx` was intentionally deferred (the override is reachable via the API and the fail-closed default needs no UI; the TS/i18n build could not be verified under the restricted network mode). Worth tracking as a follow-up.

## Related
- #2598 (ACP provider never fires declared hooks; different mechanism, same outcome class)
- #5443 (timeout bounds for lifecycle startup hooks)

## Pattern harvest

Rule candidate: **A test that asserts a spawned child's own exit code must first neutralize the spawn chokepoint, or it is asserting about the host.** In this repo `run_script_hook`, cron scripts, app backends and MCP spawns all route argv through `sandbox.sandboxed_spawn_argv` -> `wrap_argv` + `cgroup_scope_argv`, so the process that runs is the sandbox launcher and the reported `returncode` is the launcher's whenever it refuses — 1 with `sandbox: BLOCKED` where a hiding/sealing mount fails (dev container), -1 where `unshare(CLONE_NEWNS)` is EPERM (GitHub runners) or where there is no backend at all (Windows). If the test is about the child's semantics rather than about confinement, patch `kiro_crew.sandbox.wrap_argv` and `kiro_crew.sandbox.cgroup_scope_argv` to identity at the sandbox module (they are imported lazily at call time) and say in a docstring why. Two corollaries, both of which bit here: (a) prefer the passthrough patch over `skipif(not _sandbox_backend_available())` — that guard trusts `detect_backend()`, which answers "available" on a host whose launcher then fails at the mount step, which is exactly why `test_stop_hook_continuation.py::TestRealHookProcess` is red on main in this environment; (b) a fail-direction test must assert WHICH failure branch ran (`"Timed out" in error`, the injected exception's text, a specific exit code) and not only the umbrella predicate — `failed_to_run` is satisfied by *any* spawn failure, so three tests here were green on all three hosts while the timeout branch they claimed to cover never executed. The same reasoning kills non-portable hook commands: `sleep 8; exit 2` and `true` cannot run under `cmd /c`, so use the quoted-interpreter + quoted-script shape (`test_script_hooks._script_command`) and assert shell-specific exit codes like 127 under `if not _IS_WINDOWS`.
