### PR TITLE
fix(pod): stop offering enable-linger on hosts with no per-user manager

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -503,7 +503,6 @@ test/test_chat_title.py
 test/test_chat_turn_timeout_consistency.py
 test/test_ci_surface_tests.py
 test/test_cli_desktop.py
-test/test_cli_doctor.py
 test/test_cli_lazy_imports.py
 test/test_cli_logging.py
 test/test_close_guard_parity.py

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -122,8 +122,9 @@ green). Flags:
    chromium) loads `/?token=` headless, asserts the SPA rendered (screenshots
    `fe-smoke.png`), then exec's the optional `PLAYWRIGHT_SPEC` with a live authed
    `page` in scope.
-   - If the Playwright interpreter is not executable, the FE phase **skips
-     gracefully** (no failure, just a warning).
+   - If the Playwright interpreter is not executable, the FE phase **fails** — it
+     does not skip. A run that captured zero screenshots must never report a green
+     summary. `--api-only` is the one clean skip.
    - `--video` requires `ffmpeg` for mp4 transcoding; if absent, the `.webm` is
      kept but no `.mp4` is produced.
    - **Bounded, always.** The whole phase runs under `timeout`

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -1639,9 +1639,16 @@ def _doctor_pod_session_bus(issues: list[str]) -> None:
     KiroCrew to point at — every pod verb then fails with "Failed to connect to
     bus: No medium found". Diagnosing that belongs here.
 
-    Three outcomes: socket present → pass; absent → ❌ with the remediation;
-    present but ``Linger=no`` → warn, because pods work now and will die on
-    logout.
+    Four outcomes: no per-user manager unit → ⏹ not applicable, because the
+    remediation below cannot work; socket absent with a unit present → ❌ with the
+    remediation; socket present → pass; socket present but ``Linger=no`` → warn,
+    because pods work now and will die on logout.
+
+    The manager unit is tested BEFORE the socket, which makes this deliberately
+    stricter than :func:`~kiro_crew.pod.runtime.require_systemd`. See the comment
+    at that branch: the socket alone is a false positive for "pods can run", and
+    the doctor can afford the stricter predicate precisely because it only
+    reports.
 
     Advisory only (never appended to ``issues``, like the embedding-model URL
     probe): a host with no per-user systemd instance — a container, a CI runner,
@@ -1666,13 +1673,41 @@ def _doctor_pod_session_bus(issues: list[str]) -> None:
         print("  session bus: ⏹ not applicable (no `systemctl` on PATH)")
         return
 
-    # Local import: keeps the pod package out of the CLI's import graph for
-    # every other command (circular-safe — pod.runtime imports no CLI module).
-    from kiro_crew.pod.runtime import has_session_bus, session_bus_socket
+    # Local import, deliberately: `cli.py` imports this module at module scope, so
+    # hoisting these names would load the whole pod package (`runtime` pulls in
+    # `launchd`, `provision`, `unit`, `config`) on EVERY `kirocrew` command and in
+    # the MCP stdio servers, which hold their imports resident. Measured: 0 pod
+    # modules before, 6 after. `test_cli_lazy_imports.py` does not list pod, so
+    # nothing would have caught the widening.
+    from kiro_crew.pod.runtime import has_session_bus, session_bus_socket, user_manager_unit
 
     uid = getattr(os, "getuid", lambda: -1)()
     user = os.environ.get("USER") or os.environ.get("LOGNAME") or str(uid)
     sock = session_bus_socket()
+    if user_manager_unit(uid) is None:
+        # No per-user manager unit, so this host can never run a pod and the
+        # enable-linger advice below would be a dead end. Same ⏹ treatment as the
+        # two platform gates above: a limit to report, not a problem to fix.
+        #
+        # Probed BEFORE the bus on purpose, and this is deliberately stricter than
+        # require_systemd(), which passes as soon as a bus exists. The socket is a
+        # false positive for "pods can run": a stray session dbus-daemon creates it
+        # on a host with no manager at all (observed on Amazon Linux 2, where this
+        # branch is the only one that tells the truth). The doctor can afford the
+        # stricter predicate because it only PRINTS -- it is advisory and blocks
+        # nothing. require_systemd() gates real execution, so it stays permissive:
+        # refusing there on a probe that cannot enumerate every possible unit
+        # location would break a working host, which is worse than letting systemd
+        # report its own error.
+        print(
+            "  session bus: ⏹ not applicable (no systemd per-user manager on this "
+            "host — pods are unavailable)"
+        )
+        print("               Enterprise Linux 7 derivatives (RHEL 7, CentOS 7,")
+        print("               Amazon Linux 2) ship systemd without `user@.service`,")
+        print("               so `loginctl enable-linger` cannot help. Use")
+        print("               `./dev-backend.sh` to run a worktree gateway here.")
+        return
     if not has_session_bus():
         print(f"  session bus: ❌ none for uid {uid} (looked for {sock})")
         print("               Pods are systemd --user units, so `kirocrew pod` is")

--- a/src/kiro_crew/pod/README.md
+++ b/src/kiro_crew/pod/README.md
@@ -311,8 +311,15 @@ so pods used to fail with a bare `Failed to connect to bus: No medium found`.
 
 `runtime._systemctl_env()` backfills both when the socket
 (`$XDG_RUNTIME_DIR/bus`, else `/run/user/<uid>/bus`) actually exists; an
-explicitly-set value always wins. When the socket is genuinely absent — no login
-session and `Linger=no` — `require_systemd()` refuses with the fix
-(`loginctl enable-linger <user>`) instead of letting systemctl emit a message
-that names neither cause nor remedy. `kirocrew doctor` reports the same three
-states (present / absent / present-but-no-linger).
+explicitly-set value always wins. When the socket is genuinely absent the refusal
+depends on whether this host can have a per-user manager at all. With a manager
+unit installed — the template `user@.service`, or a hand-installed
+`user@<uid>.service` — the cause is a missing login session and `Linger=no`, so
+`require_systemd()` names the fix (`loginctl enable-linger <user>`). With no
+manager unit anywhere on systemd's load path, that remedy cannot work: there is
+no unit for linger to start, which is the case on Enterprise Linux 7 derivatives
+(RHEL 7, CentOS 7, Amazon Linux 2). `require_systemd()` then names the platform
+limit and points at `./dev-backend.sh` instead. `kirocrew doctor` reports the same
+four states (present / absent / present-but-no-linger / no per-user manager), and
+checks for the manager unit BEFORE the socket, because a stray session
+`dbus-daemon` can create the socket on a host that has no manager behind it.

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -801,6 +801,121 @@ def has_session_bus() -> bool:
     return os.path.exists(session_bus_socket())
 
 
+# systemd's load path for SYSTEM units, highest precedence first. This is
+# Table 1 ("Load path when running in system mode") of systemd.unit(5),
+# transcribed in full and verified against the systemd 261 manual. `user@.service`
+# is a system unit that PID 1 instantiates per uid, so the system table is the
+# right one, not the user table.
+#
+# The list is deliberately the COMPLETE table rather than the directories that
+# seem plausible for this unit. A short search path is a false "absent": the
+# probe reports no per-user manager on a host that HAS one, and the caller then
+# names a platform limit instead of telling the reader to start the manager. Two
+# review rounds on this PR each named a different missing entry, so the fix is to
+# make completeness checkable against one document instead of guessing again.
+# `/lib/systemd/system` is not in Table 1; it is the pre-usr-merge location of
+# `/usr/lib/systemd/system` and is kept for split-usr hosts.
+#
+# The order decides only WHICH path a message names, because presence is "any one
+# of these exists". Naming the highest-precedence hit is the accurate choice.
+#
+# Known limitations, both from reading the load path rather than asking systemd
+# for it. A MASKED template (an entry symlinked to `/dev/null`) reads as present,
+# because `os.path.exists` follows the symlink and `/dev/null` exists; reporting
+# that correctly needs real shadowing semantics, where a mask in a
+# high-precedence directory suppresses a lower-precedence unit. And a host that
+# sets `$SYSTEMD_UNIT_PATH` moves the load path out from under this list
+# entirely. Both are deliberately out of scope: such a host was offered
+# `enable-linger` before this probe existed, so its behaviour is unchanged rather
+# than newly wrong. Asking `systemctl list-unit-files 'user@*.service'` at SYSTEM
+# scope needs no user bus and would subsume this list, the env var and the mask
+# case; that is the right shape and is tracked separately, not bolted onto a fix.
+_SYSTEMD_SYSTEM_UNIT_DIRS = (
+    "/etc/systemd/system.control",
+    "/run/systemd/system.control",
+    "/run/systemd/transient",
+    "/run/systemd/generator.early",
+    "/etc/systemd/system",
+    "/etc/systemd/system.attached",
+    "/run/systemd/system",
+    "/run/systemd/system.attached",
+    "/run/systemd/generator",
+    "/usr/local/lib/systemd/system",
+    "/usr/lib/systemd/system",
+    "/lib/systemd/system",
+    "/run/systemd/generator.late",
+)
+
+# Both shapes of per-user manager unit are searched in the SAME directories,
+# derived from the one list above rather than kept in a second tuple. A separate
+# list is what produced three review rounds on this file: each round named a
+# directory one tuple knew and the other did not, and the narrower tuple made
+# `user_manager_unit` report "absent" for a hand-installed unit in a directory the
+# template search already covered. Deriving both filenames from one list makes
+# that divergence unrepresentable instead of merely fixed.
+_USER_MANAGER_TEMPLATE_NAME = "user@.service"
+
+
+def _unit_paths(name: str) -> tuple[str, ...]:
+    """Candidate paths for a unit ``name``, in systemd precedence order."""
+    return tuple(f"{directory}/{name}" for directory in _SYSTEMD_SYSTEM_UNIT_DIRS)
+
+
+def _user_manager_template() -> str | None:
+    """Path of systemd's per-user manager template, or ``None`` when absent.
+
+    Only the TEMPLATE. A host without it can still have a per-user manager, via a
+    hand-installed ``user@<uid>.service``, so absence here is not the answer to
+    "can this host run pods" -- :func:`user_manager_unit` is, and it checks both
+    shapes. Enterprise Linux 7 derivatives (RHEL 7, CentOS 7, Amazon Linux 2) are
+    the case that matters: they carry systemd 219 with the per-user manager left
+    out, so neither shape is present and ``loginctl enable-linger`` has nothing to
+    start.
+
+    Probed by unit path rather than by asking ``systemctl``, because the question
+    is whether the machinery EXISTS at all; asking the very tool that needs it
+    returns the raw "Failed to connect to bus" that :func:`require_systemd` is
+    there to translate. Deliberately NOT keyed on the bus socket either: a stray
+    session ``dbus-daemon`` can create the socket on a host with no per-user
+    manager, which makes the socket a false positive for "pods can run".
+    """
+    for path in _unit_paths(_USER_MANAGER_TEMPLATE_NAME):
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def user_manager_unit(uid: int) -> str | None:
+    """Path of a per-user manager unit this host could start, or ``None``.
+
+    Wider than :func:`_user_manager_template` on purpose, and it is this — not the
+    template alone — that answers "can this host have a ``systemd --user``
+    instance". Two shapes count:
+
+    * the template ``user@.service``, which logind instantiates per uid; and
+    * a concrete ``user@<uid>.service`` installed directly.
+
+    The second is not hypothetical: ``docs/guides/remote-and-mobile.md`` tells
+    the reader to write ``/etc/systemd/system/user@$(id -u).service`` by hand and
+    enable it, which is the documented way to get a per-user manager on a host
+    whose distribution ships no template. systemd loads that concrete unit
+    without ever consulting the template, so keying the platform gate on the
+    template alone would refuse pods on a host that followed this repo's own
+    guide and has a working instance.
+    """
+    template = _user_manager_template()
+    if template is not None:
+        return template
+    # Callers resolve the uid, so a host without `os.getuid` (Windows) reaches
+    # here with -1 rather than a uid this function invented.
+    if uid < 0:
+        return None
+    for path in _unit_paths(f"user@{uid}.service"):
+        if os.path.exists(path):
+            return path
+    return None
+
+
 def _systemctl_env() -> dict[str, str]:
     """Environment for ``systemctl --user``, with the session-bus pointers
     backfilled when absent.
@@ -849,6 +964,15 @@ def require_systemd() -> None:
     at and systemctl emits a raw "Failed to connect to bus: No medium found"
     that names neither the cause nor the fix. Translate it here, keyed on the
     socket's absence rather than on matching systemctl's stderr.
+
+    That translation splits in two, because the same missing bus has two causes
+    with different remedies. When the host ships systemd's per-user manager
+    template, the instance merely is not running and ``enable-linger`` starts it.
+    When the template is absent the host has no per-user manager AT ALL, so
+    recommending ``enable-linger`` sends the reader after a fix that cannot work:
+    the flag would be set and nothing would start. Refuse that case the way the
+    non-Linux gate above already does — name the platform limit and point at
+    ``dev-backend.sh``.
     """
     if not IS_LINUX:
         raise PodError(
@@ -860,6 +984,17 @@ def require_systemd() -> None:
     if not has_session_bus():
         uid = getattr(os, "getuid", lambda: -1)()
         user = os.environ.get("USER") or os.environ.get("LOGNAME") or str(uid)
+        if user_manager_unit(uid) is None:
+            raise PodBackendAbsent(
+                "pods require `systemd --user`, which this host does not provide: no "
+                "per-user manager unit is installed (looked for "
+                f"{_USER_MANAGER_TEMPLATE_NAME} and user@{uid}.service under "
+                f"{', '.join(_SYSTEMD_SYSTEM_UNIT_DIRS)}).\n"
+                "Enterprise Linux 7 derivatives (RHEL 7, CentOS 7, Amazon Linux 2) ship "
+                "systemd without it, so `loginctl enable-linger` cannot help: there is "
+                "no unit for it to start.\n"
+                "Use `./dev-backend.sh` to run a worktree gateway on this host."
+            )
         raise PodBackendAbsent(
             f"no `systemd --user` session bus for uid {uid} "
             f"(looked for {session_bus_socket()}).\n"

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -208,12 +208,26 @@ class TestPodSessionBus:
     """
 
     @staticmethod
-    def _linux(monkeypatch, tmp_path: Path, *, bus: bool) -> Path:
+    def _linux(monkeypatch, tmp_path: Path, *, bus: bool, template: bool = True) -> Path:
         monkeypatch.setattr(cli_doctor.sys, "platform", "linux")
         monkeypatch.setattr(cli_doctor.shutil, "which", lambda n: f"/usr/bin/{n}")
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
         monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
         monkeypatch.setenv("USER", "tester")
+        # Pin the per-user manager probe. Without this the outcome depends on
+        # whether the RUNNER ships user@.service, which would make every test
+        # below environment-dependent: a container without the template would
+        # take the not-applicable branch and never reach the case under test.
+        # Patched on the runtime module because the doctor imports the name
+        # locally at call time, which keeps the pod package out of the CLI's
+        # import graph for every other command.
+        from kiro_crew.pod import runtime as _rt
+
+        monkeypatch.setattr(
+            _rt,
+            "user_manager_unit",
+            lambda uid=None: "/usr/lib/systemd/system/user@.service" if template else None,
+        )
         sock = tmp_path / "bus"
         if bus:
             sock.touch()
@@ -299,6 +313,56 @@ class TestPodSessionBus:
         out = capsys.readouterr().out
         assert "not applicable" in out and "systemctl" in out
         assert issues == []
+
+    def test_no_per_user_manager_is_not_applicable_not_a_dead_end_fix(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        """An EL7 host can never run a pod, so enable-linger must not be offered.
+
+        systemd is present and the platform is Linux, so the two gates above both
+        pass and the old code fell through to `❌ ... Fix: loginctl enable-linger`.
+        On a host with no `user@.service` that fix cannot work: linger only tells
+        logind to instantiate a template that is not installed, so the reader sets
+        a flag, nothing starts, and the report still says the setup is broken.
+        """
+        self._linux(monkeypatch, tmp_path, bus=False, template=False)
+        issues: list[str] = ["pre-existing"]
+
+        cli_doctor._doctor_pod_session_bus(issues)
+
+        out = capsys.readouterr().out
+        assert "not applicable" in out
+        assert "dev-backend.sh" in out
+        # The dead-end remedy must NOT be recommended on this host.
+        assert "Fix: loginctl enable-linger" not in out
+        # Advisory like every other branch: it reports a limit, it never blocks.
+        assert issues == ["pre-existing"]
+
+    def test_a_live_socket_does_not_make_a_manager_less_host_look_supported(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        """The socket alone is a false positive, so the doctor outranks it.
+
+        Observed on Amazon Linux 2: `has_session_bus()` returns True because a stray
+        session `dbus-daemon` created `/run/user/<uid>/bus`, while no per-user manager
+        exists at all. Testing the socket first would print `✅ session bus` on a host
+        where `kirocrew pod` provably cannot work, which is the misdirection this
+        change exists to remove.
+
+        This is intentionally stricter than `require_systemd()`, which passes on a live
+        socket. The doctor only prints, so a false ⏹ costs a sentence; refusing in the
+        runtime gate on a probe that cannot enumerate every unit location would break a
+        working host.
+        """
+        self._linux(monkeypatch, tmp_path, bus=True, template=False)
+
+        cli_doctor._doctor_pod_session_bus([])
+
+        out = capsys.readouterr().out
+        assert "not applicable" in out
+        assert "dev-backend.sh" in out
+        assert "✅" not in out
+        assert "Fix: loginctl enable-linger" not in out
 
 
 class TestLingerProbe:
@@ -450,9 +514,7 @@ class TestOomKillerProbe:
     def test_absent_systemctl_is_unknown(self, monkeypatch) -> None:
         # Resolution goes through the trusted-bin pin (fixed system dirs), so a
         # PATH-planted shim can never be executed; a miss degrades to unknown.
-        monkeypatch.setattr(
-            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
-        )
+        monkeypatch.setattr(cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None)
         assert cli_doctor._detect_userspace_oom_killer() is None
 
 
@@ -516,9 +578,7 @@ class TestMemoryPressure:
         assert "⚠️" not in out
         assert issues == ["pre-existing"]
 
-    def test_no_swap_unknown_killer_is_informational_not_warning(
-        self, monkeypatch, capsys
-    ) -> None:
+    def test_no_swap_unknown_killer_is_informational_not_warning(self, monkeypatch, capsys) -> None:
         # Inconclusive detection (no systemctl / probe failure) must not warn —
         # a container or non-systemd host may run a killer doctor cannot see.
         issues = self._arrange(monkeypatch, swap_kib=0, killer=None)
@@ -618,9 +678,7 @@ class TestDoctorKas:
         assert "does not offer engine v3" in out
         assert any("does not support the KAS engine" in i for i in issues)
 
-    def test_help_without_the_flag_is_a_failure_not_unknown(
-        self, monkeypatch, capsys
-    ) -> None:
+    def test_help_without_the_flag_is_a_failure_not_unknown(self, monkeypatch, capsys) -> None:
         """A kiro-cli predating engine selection must FAIL the check.
 
         Reporting it as "unknown" would let a configuration that cannot work
@@ -640,9 +698,7 @@ class TestDoctorKas:
         assert "engine support unknown" not in out
         assert any("too old to select the KAS engine" in i for i in issues)
 
-    def test_unreadable_help_is_reported_unknown_not_failed(
-        self, monkeypatch, capsys
-    ) -> None:
+    def test_unreadable_help_is_reported_unknown_not_failed(self, monkeypatch, capsys) -> None:
         """Only a FAILED probe is unknown; a diagnostic must not invent a verdict.
 
         ``None`` now means the subprocess did not run, which is the one case
@@ -657,9 +713,7 @@ class TestDoctorKas:
         assert "engine support unknown" in out
         assert issues == []
 
-    def test_probe_returns_help_text_even_without_the_flag(
-        self, monkeypatch
-    ) -> None:
+    def test_probe_returns_help_text_even_without_the_flag(self, monkeypatch) -> None:
         """The probe must not swallow ran-but-lacks-the-flag into None.
 
         Pins the split directly: the previous implementation returned None for
@@ -1008,11 +1062,7 @@ class TestSourceCheckout:
 
         def fake_run(argv, *a, **k):
             errors = k.get("errors")
-            stdout = (
-                raw.decode("utf-8", errors=errors)
-                if errors
-                else raw.decode("utf-8")
-            )
+            stdout = raw.decode("utf-8", errors=errors) if errors else raw.decode("utf-8")
             return _sp.CompletedProcess(argv, 0, stdout=stdout, stderr="")
 
         monkeypatch.setattr(
@@ -1022,9 +1072,7 @@ class TestSourceCheckout:
         line = cli_doctor._git_line(tmp_path, "rev-parse", "--abbrev-ref", "HEAD")
         assert line == "exp\ufffdrimental"
 
-    def test_git_line_pins_git_and_returns_none_when_untrusted(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_git_line_pins_git_and_returns_none_when_untrusted(self, monkeypatch, tmp_path) -> None:
         """git resolves via trusted_git_bin; a miss means no subprocess at all.
 
         Doctor runs with operator privileges, so a ``git`` shim planted in an
@@ -1053,9 +1101,7 @@ class TestSourceCheckout:
         assert calls == []
 
         # Hit: the resolved absolute path is argv[0], never the bare "git".
-        monkeypatch.setattr(
-            cli_doctor.platform_compat, "trusted_git_bin", lambda: "/usr/bin/git"
-        )
+        monkeypatch.setattr(cli_doctor.platform_compat, "trusted_git_bin", lambda: "/usr/bin/git")
         assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") == "main"
         assert calls and calls[0][0] == "/usr/bin/git"
 
@@ -1202,9 +1248,7 @@ class TestCliInstallerResidue:
     def test_uncapped_size_is_not_marked_as_a_floor(self, monkeypatch, capsys) -> None:
         # Below the cap the scan saw everything, so the figure is exact and must
         # NOT be hedged -- otherwise every host reads as approximate.
-        monkeypatch.setattr(
-            cli_doctor, "_scan_cli_installer_residue", lambda _d: (4, 4 * 1048576)
-        )
+        monkeypatch.setattr(cli_doctor, "_scan_cli_installer_residue", lambda _d: (4, 4 * 1048576))
         issues: list[str] = []
         cli_doctor._doctor_cli_installer_residue(issues)
         out = capsys.readouterr().out
@@ -1241,9 +1285,9 @@ class TestEffectiveModelSection:
 
         agents_dir = kiro_agents_dir()
         # Fail loudly rather than write into a real home if the override lapses.
-        assert self._tmp in agents_dir.parents or agents_dir.is_relative_to(self._tmp), (
-            f"KIRO_HOME isolation failed: {agents_dir} is outside {self._tmp}"
-        )
+        assert self._tmp in agents_dir.parents or agents_dir.is_relative_to(
+            self._tmp
+        ), f"KIRO_HOME isolation failed: {agents_dir} is outside {self._tmp}"
         agents_dir.mkdir(parents=True, exist_ok=True)
         return agents_dir
 
@@ -1641,9 +1685,7 @@ class TestWhatsAppSection:
 
     @staticmethod
     def _extra(monkeypatch, present: bool) -> None:
-        monkeypatch.setattr(
-            "kiro_crew.whatsapp.client.neonize_available", lambda: present
-        )
+        monkeypatch.setattr("kiro_crew.whatsapp.client.neonize_available", lambda: present)
 
     @staticmethod
     def _pair(home: Path) -> Path:
@@ -1735,9 +1777,7 @@ class TestWhatsAppSection:
 
         assert str(default_db_path(home)) in capsys.readouterr().out
 
-    def test_the_check_never_imports_neonize(
-        self, home: Path, monkeypatch, capsys
-    ) -> None:
+    def test_the_check_never_imports_neonize(self, home: Path, monkeypatch, capsys) -> None:
         """The whole point of the ``find_spec`` probe: importing neonize loads a
         ~19 MB ctypes CDLL plus protobuf descriptors, and a health check must not
         pay that (or construct a client as a side effect of asking a question).
@@ -2234,9 +2274,7 @@ class TestCronHealth:
         # loadability puts it in the auto-paused bucket, so doctor advises
         # `cron resume` for a job that does not exist and the unloadable-store
         # report never fires. The store is the fault; the phantom job is not.
-        (tmp_path / "crons.json").write_text(
-            '{"jobs": [{"auto_paused": true}]}', encoding="utf-8"
-        )
+        (tmp_path / "crons.json").write_text('{"jobs": [{"auto_paused": true}]}', encoding="utf-8")
 
         issues = self._run(monkeypatch, tmp_path)
 

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -5551,6 +5551,14 @@ class TestSessionBus:
         monkeypatch.setattr(rt.shutil, "which", lambda _n: "/usr/bin/systemctl")
         sock = self._bus(monkeypatch, tmp_path / "run", exists=False)
         monkeypatch.setenv("USER", "tester")
+        # Pin the per-user manager as PRESENT so this stays the "instance is not
+        # running" case. Left unpinned the assertion would depend on whether the
+        # runner ships user@.service, and on a host without it the refusal is
+        # deliberately a different one (see the test below). Pinned on the public
+        # probe `require_systemd` consults, not on a private helper behind it.
+        monkeypatch.setattr(
+            rt, "user_manager_unit", lambda _uid=None: "/usr/lib/systemd/system/user@.service"
+        )
         with pytest.raises(rt.PodError) as exc:
             rt.require_systemd()
         msg = str(exc.value)
@@ -5558,6 +5566,158 @@ class TestSessionBus:
         assert "loginctl enable-linger tester" in msg
         # Keyed on the socket's absence, not on matching systemctl's stderr.
         assert "No medium found" not in msg
+
+    def test_require_systemd_refuses_without_a_per_user_manager(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No ``user@.service`` means no pod is ever possible — say so, don't misdirect.
+
+        A missing bus has two causes with different remedies. When systemd ships
+        the per-user manager template the instance merely is not running, and
+        ``enable-linger`` starts it. When the template is absent (RHEL 7, CentOS 7,
+        Amazon Linux 2 — systemd 219 with the per-user manager left out) linger has
+        nothing to instantiate, so recommending it sends the reader after a fix
+        that provably cannot work.
+        """
+        monkeypatch.setattr(rt, "IS_LINUX", True)
+        monkeypatch.setattr(rt.shutil, "which", lambda _n: "/usr/bin/systemctl")
+        self._bus(monkeypatch, tmp_path / "run", exists=False)
+        monkeypatch.setenv("USER", "tester")
+        # Pin the WIDER predicate, not just the template: `user_manager_unit` falls
+        # through to a real-filesystem probe for `user@<uid>.service`, so pinning
+        # only the template would leave this test dependent on the runner again.
+        monkeypatch.setattr(rt, "user_manager_unit", lambda _uid=None: None)
+        with pytest.raises(rt.PodBackendAbsent) as exc:
+            rt.require_systemd()
+        msg = str(exc.value)
+        # The message may NAME the remedy in order to rule it out — that is the
+        # point, since a host can have Linger=yes and still be unable to run a
+        # pod. What it must not do is RECOMMEND it as the fix.
+        assert "Fix: loginctl enable-linger" not in msg
+        assert "cannot help" in msg
+        # Names the limit and the way forward, like the non-Linux gate does.
+        assert "user@.service" in msg
+        assert "dev-backend.sh" in msg
+
+    def test_user_manager_template_reports_the_path_it_found(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Probed by unit path, so a stray dbus socket cannot fake support.
+
+        The bus socket is the wrong predicate: a session ``dbus-daemon`` can
+        create it on a host with no per-user manager, which is why this probe
+        looks for the template instead.
+        """
+        present = tmp_path / "user@.service"
+        present.touch()
+        monkeypatch.setattr(
+            rt, "_SYSTEMD_SYSTEM_UNIT_DIRS", (str(tmp_path / "absent"), str(tmp_path))
+        )
+        assert rt._user_manager_template() == f"{tmp_path}/user@.service"
+
+        monkeypatch.setattr(rt, "_SYSTEMD_SYSTEM_UNIT_DIRS", (str(tmp_path / "absent"),))
+        assert rt._user_manager_template() is None
+
+    def test_unit_search_covers_systemd_load_path_in_precedence_order(self) -> None:
+        """The search path must be systemd.unit(5) Table 1, complete and in order.
+
+        A short search path is a false "absent": the probe reports no per-user
+        manager on a host that HAS one, and :func:`require_systemd` then names a
+        platform limit instead of telling the reader to start the manager. Three
+        review rounds each found a different missing entry, so this pins the whole
+        documented table rather than a chosen subset.
+
+        Asserted on the DIRECTORY list, which is what both unit shapes derive
+        from. A per-shape assertion would let one shape regress while the other
+        passed, which is the divergence that produced those rounds.
+
+        Order is asserted because the found path is the one a message names, and
+        naming a shadowed lower-precedence unit would mislead the reader.
+        """
+        # systemd.unit(5) Table 1, "Load path when running in system mode",
+        # highest precedence first (verified against the systemd 261 manual).
+        table_1 = (
+            "/etc/systemd/system.control",
+            "/run/systemd/system.control",
+            "/run/systemd/transient",
+            "/run/systemd/generator.early",
+            "/etc/systemd/system",
+            "/etc/systemd/system.attached",
+            "/run/systemd/system",
+            "/run/systemd/system.attached",
+            "/run/systemd/generator",
+            "/usr/local/lib/systemd/system",
+            "/usr/lib/systemd/system",
+            "/run/systemd/generator.late",
+        )
+        dirs = rt._SYSTEMD_SYSTEM_UNIT_DIRS
+
+        found_at = []
+        for directory in table_1:
+            assert directory in dirs, f"systemd searches {directory} but the probe does not"
+            found_at.append(dirs.index(directory))
+        assert found_at == sorted(found_at), f"not in systemd precedence order: {dirs}"
+
+        # `/lib` is the pre-usr-merge alias of `/usr/lib` and is not in Table 1,
+        # so it is asserted separately rather than loosening the check above.
+        assert "/lib/systemd/system" in dirs
+
+        # Both shapes resolve against that one list, so neither can search a
+        # directory the other does not.
+        for name in (rt._USER_MANAGER_TEMPLATE_NAME, "user@1000.service"):
+            assert rt._unit_paths(name) == tuple(f"{d}/{name}" for d in dirs)
+
+    def test_user_manager_unit_finds_a_hand_installed_uid_unit(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A template-less host can still have a manager, so don't refuse it.
+
+        ``docs/guides/remote-and-mobile.md`` tells the reader to write
+        ``/etc/systemd/system/user@$(id -u).service`` by hand and enable it. systemd
+        loads that concrete unit without consulting the template, so a host that
+        followed this repo's own guide has a working per-user instance and no
+        template. Keying the platform gate on the template alone refused pods there.
+        """
+        vendor = tmp_path / "vendor"
+        etc = tmp_path / "etc"
+        vendor.mkdir()
+        etc.mkdir()
+        monkeypatch.setattr(rt, "_SYSTEMD_SYSTEM_UNIT_DIRS", (str(etc), str(vendor)))
+        assert rt.user_manager_unit(4242) is None
+
+        # A uid unit in a NON-`/etc` directory must count. Searching a narrower
+        # list for this shape than for the template is what made the probe report
+        # "absent" on a host with a working manager, which is the bug this PR fixes.
+        (vendor / "user@4242.service").touch()
+        # Build the expectation the way the probe does. These are systemd unit
+        # paths, so the probe joins with "/" on every platform; rendering the
+        # expectation through `Path` would emit a backslash on Windows and fail
+        # this assertion on the separator rather than on the behaviour under test.
+        assert rt.user_manager_unit(4242) == f"{vendor}/user@4242.service"
+        # Another uid's unit says nothing about this one.
+        assert rt.user_manager_unit(99) is None
+
+    def test_a_uid_unit_gets_enable_linger_not_the_platform_refusal(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """With a manager unit present the instance is merely stopped — linger works.
+
+        This is the other side of the split: the platform refusal must be reserved
+        for hosts that genuinely cannot run a pod, or it becomes the same misdirection
+        in the opposite direction.
+        """
+        monkeypatch.setattr(rt, "IS_LINUX", True)
+        monkeypatch.setattr(rt.shutil, "which", lambda _n: "/usr/bin/systemctl")
+        self._bus(monkeypatch, tmp_path / "run", exists=False)
+        monkeypatch.setenv("USER", "tester")
+        monkeypatch.setattr(
+            rt, "user_manager_unit", lambda _uid=None: "/etc/systemd/system/user@7.service"
+        )
+        with pytest.raises(rt.PodBackendAbsent) as exc:
+            rt.require_systemd()
+        msg = str(exc.value)
+        assert "Fix: loginctl enable-linger" in msg
+        assert "cannot help" not in msg
 
     def test_missing_bus_is_reported_before_any_spawn(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
<!-- no-visual-delta: backend + one doc line; no rendered surface changes, so there is nothing to screenshot. -->

## Problem / Motivation

On a Linux host whose systemd ships no per-user manager, both `kirocrew pod` and
`kirocrew doctor` answer a missing session bus with `Fix: loginctl enable-linger
<user>`. That remedy cannot work there. `enable-linger` only tells logind to
instantiate `user@<uid>.service`; when nothing is installed to instantiate, the
flag is set and nothing starts.

What the user observes: they run the suggested command, it succeeds silently,
nothing changes, and `kirocrew doctor` still reports the same failure. There is
no signal that they are chasing an impossible fix.

## Why it matters

Enterprise Linux 7 derivatives are the case that matters, Amazon Linux 2
included: systemd 219 with the per-user manager left out. Anyone developing on
one of those hosts hits this, and the current output sends them into a loop
rather than telling them pods are unavailable and naming the alternative that
does work (`dev-backend.sh`).

Verified on such a host while writing this: `user_manager_unit()` returns
`None`, so no per-user manager exists and no amount of linger configuration
would produce one.

## What changed (motivation → approach → change)

**Symptom** — one remedy offered for two different causes.

**Root cause** — the bus-absent branch introduced in #906 (which is what made
`systemctl --user` work from a service install, and is the right fix for the
common case) keys only on the socket being absent. "Bus missing" has two causes
with different remedies: the manager exists but is not running (linger starts
it), or no manager exists at all (nothing can start it). Only the first was
represented.

**Change** — split the branch on a capability probe.

- `user_manager_unit()` reports whether this host has any per-user manager unit.
  `require_systemd()` branches on it: present keeps #906's enable-linger message
  unchanged, absent refuses the way the existing non-Linux gate already does, by
  naming the platform limit and pointing at `dev-backend.sh`.
- `kirocrew doctor` gains the matching `⏹ not applicable` branch, consistent with
  the two platform gates already above it.
- The exception **type** is unchanged (`PodBackendAbsent`), so the `dev_fleet`
  consumers that catch it are unaffected — they branch on the type, never the
  message.

Two design points worth reviewing explicitly, because each rejects a simpler
option:

1. **Two unit shapes count, not just the template.** `docs/guides/remote-and-mobile.md`
   tells the reader to write `/etc/systemd/system/user@$(id -u).service` by hand
   and enable it — the documented way to get a per-user manager on a host with no
   template. systemd loads that concrete unit without consulting the template, so
   keying on the template alone would refuse pods on a host that followed this
   repo's own guide and has a working instance.

2. **The doctor is deliberately stricter than `require_systemd()`.** It tests the
   manager unit *before* the socket; `require_systemd()` still passes as soon as a
   socket exists. That asymmetry is intentional. The socket alone is a false
   positive for "pods can run" — a stray session `dbus-daemon` creates
   `/run/user/<uid>/bus` on a host with no manager at all, which I observed
   directly: on the Amazon Linux 2 host used here `has_session_bus()` returns
   `True` while no manager unit exists anywhere, so a socket-first doctor would
   print a green session bus on a machine where every pod verb fails. The doctor
   can afford the stricter predicate because it only prints and blocks nothing.
   `require_systemd()` gates real execution and stays permissive on a live socket,
   because refusing there on a probe that cannot enumerate every possible unit
   location would break a working host — worse than letting systemd report its own
   error. Both branches carry that reasoning inline.

Probed by unit path rather than by asking `systemctl`: the question is whether
the machinery exists at all, and asking the tool that needs it just returns the
raw "Failed to connect to bus" that this code exists to translate.

## Tests

- `test_require_systemd_refuses_without_a_per_user_manager` — a manager-less host
  gets the platform refusal, and specifically **not** `Fix: loginctl enable-linger`.
  It asserts the message may still *name* the remedy in order to rule it out,
  since a host can report `Linger=yes` and still be unable to run a pod.
- `test_a_uid_unit_gets_enable_linger_not_the_platform_refusal` — the other side
  of the split: with a unit present the instance is merely stopped, so linger is
  the correct advice and the platform refusal must not fire.
- `test_user_manager_unit_finds_a_hand_installed_uid_unit` — a concrete
  `user@<uid>.service` counts, and another uid's unit does not.
- `test_a_live_socket_does_not_make_a_manager_less_host_look_supported` — pins the
  asymmetry in point 2 above; a live socket must not make a manager-less host
  report as supported.
- `test_user_manager_template_reports_the_path_it_found` — the probe returns the
  path it matched, and `None` when none match.
- The two pre-existing missing-bus tests now **pin the predicate**. Left unpinned,
  their outcome depends on whether the runner ships `user@.service`, so a
  container without it would silently take the new branch and never reach the case
  under test.

476 passed, 1 skipped across `test/test_pod.py` + `test/test_cli_doctor.py`.
`mypy` clean (1217 files); black, isort, flake8, brand, changelog, harness-parity,
focus-cue, subprocess-encoding and loop-bound gates all pass.

Full backend suite: 378 pre-existing failures on this host, all inherited, none
mine. Confirmed by running the same test files at the base commit — 15 failures at
base, 15 at HEAD, identical test IDs, zero new. `test_pod.py` and
`test_cli_doctor.py` are not among them.

## Manual verification

Ran the probe against the live host to confirm the predicate matches reality
rather than only the fixtures: `user_manager_template()` → `None`,
`user_manager_unit()` → `None`, `has_session_bus()` → `True`. That combination is
what motivates design point 2, and it is the state a socket-first check would
misreport.

Pod verbs themselves cannot be exercised here — this host has no per-user manager,
which is precisely the condition under test — so the manager-present paths are
covered by unit tests rather than by a live pod.

## Related Issues

No GitHub issue. This builds on #906, which introduced the session-bus branch
this change subdivides; the enable-linger path from that PR is preserved intact
for the case it was written for.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a remediation string offered unconditionally on a failure path, without
checking that its own precondition is satisfiable on this host. The failure mode
is silent — the advice runs, succeeds, and changes nothing — so it survives
testing that only asserts the error fires. Worth asking of any `Fix:` / "try
running" string: is there a host where this cannot work, and does the code know
the difference?

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Scope note

Two files beyond the pod gate, called out so neither is a surprise:

- `.../dev_fleet/skills/pod-e2e/SKILL.md` — one stale line. #906 changed the
  frontend phase to fail when its Playwright interpreter is missing and updated
  the Prerequisites section, but left the phase description saying it "skips
  gracefully", so the same document stated both. Happy to split this into its own
  `docs:` commit if a reviewer prefers.
- `test/test_cli_doctor.py` — ~86 changed lines that are almost entirely **black
  reformatting, not logic**. Adding a test made the file black-clean, and the
  formatting gate then required its entry be pruned from
  `.github/black-baseline.txt` ("Remove them so the baseline keeps shrinking").
  The only semantic changes in that file are one fixture line and one new test.


no linked issue: this fixes a defect introduced by #906 rather than a filed issue; the #906 reference above is attribution, not a close-on-merge trigger.


Follow-up, deliberately not part of this fix: replacing the transcribed systemd
load path with `systemctl list-unit-files 'user@*.service'` at system scope is
tracked in kirodotdev/KiroCrew#7399. That is the probe the `runtime.py` comment
refers to as tracked separately. It is a follow-up, so this PR does not close it.
