### PR TITLE
fix(remote-crew): show the crew list on Windows instead of a provisioning error

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -758,6 +758,19 @@ account without dropping to the CLI. `dashboard/handlers_cloud.py` exposes the
 launcher behind the same owner-only guard as `/api/instances/*`: an
 authenticated owner (`request["user"]`), non-Slack, POSIX only, `403` otherwise.
 
+**The two read-only launch routes are the POSIX exception.** `GET
+/api/cloud/launch` and `GET /api/cloud/launch/{id}` parse a local job store and
+shell to nothing, so they answer on every platform (`_guard(..., posix_only=False)`);
+everything that can provision, stop or terminate stays POSIX-gated with
+`400 posix_host_required`. The list is what makes the crew rows classifiable
+(cloud-launched vs hand-added), and the panel waits for it before rendering
+anything — so gating it on Windows replaced the whole Remote Crew list, SSH rows
+included, with a cloud-provisioning error and no way to connect or remove
+anything. On a Windows host the route answers with whatever launch history is
+persisted in the config dir — normally nothing, since nothing there could have
+created a job, though a config dir carried over from a POSIX host still reports
+its real jobs.
+
 | Method and path | Purpose |
 |---|---|
 | `GET /api/cloud/preflight?profile=&region=` | AWS reachability + the prerequisite checklist (the doctor checks as JSON). |

--- a/src/kiro_crew/dashboard/handlers_cloud.py
+++ b/src/kiro_crew/dashboard/handlers_cloud.py
@@ -12,6 +12,9 @@ process carries no ``KIROCREW_SESSION_KEY``, so the destructive verbs
 (stop/start/destroy) are allowed here but blocked from any agent subprocess.
 
 POSIX-only: the deploy engine shells to ``bash``/``aws``; Windows returns 400.
+The exception is the two read-only launch-history routes, which parse a local
+job store and shell to nothing — they answer on every platform so a Windows
+dashboard can still render its Remote Crew list (see :func:`_guard`).
 No new AWS logic lives here — it reuses the tested ``cloud/`` engine.
 """
 
@@ -61,8 +64,23 @@ def _audit(operation: str, outcome: str, *, request_id: str = "", error: str = "
         logger.debug("SEL audit failed for cloud_%s", operation, exc_info=True)
 
 
-def _guard(request: web.Request, operation: str) -> Optional[web.Response]:
-    """Owner-only (non-Slack) + POSIX. Returns a denial Response or None."""
+def _guard(
+    request: web.Request, operation: str, *, posix_only: bool = True
+) -> Optional[web.Response]:
+    """Owner-only (non-Slack) + POSIX. Returns a denial Response or None.
+
+    ``posix_only=False`` is for the two read-only launch-history routes, which
+    only parse a local job store and shell to nothing. Failing those on Windows
+    is not a harmless "unsupported" answer: the Remote Crew list deliberately
+    waits for BOTH the instances and the launch history before rendering (a
+    row's cloud-vs-manual identity decides what its delete button does), so a
+    400 here replaced the whole list — including hand-added SSH crews that need
+    no cloud provisioning at all — with the POSIX error. Reading the history
+    reports whatever this host has persisted rather than guessing on the
+    client's behalf: normally nothing after Windows-only use, since the write
+    routes below stay POSIX-gated, but a config dir carried over from a POSIX
+    host still answers with its real jobs, which is the honest reply.
+    """
     if request.headers.get("X-Session-Key", "").startswith("slack:"):
         _audit(operation, "denied", error="slack-origin rejected")
         return web.json_response(
@@ -90,7 +108,7 @@ def _guard(request: web.Request, operation: str) -> Optional[web.Response]:
             "not an app or an allowed Slack user)",
             "cloud_owner_only",
         )
-    if sys.platform.startswith("win"):
+    if posix_only and sys.platform.startswith("win"):
         _audit(operation, "denied", error="windows unsupported")
         return web.json_response(
             {
@@ -219,7 +237,7 @@ async def api_cloud_iam_policy(request: web.Request) -> web.Response:
 
 async def api_cloud_launch_list(request: web.Request) -> web.Response:
     """GET /api/cloud/launch — all launch jobs (newest first)."""
-    denied = _guard(request, "launch_list")
+    denied = _guard(request, "launch_list", posix_only=False)
     if denied is not None:
         return denied
     # list() globs the job dir and parses every file: cheap for a handful, but it
@@ -232,7 +250,7 @@ async def api_cloud_launch_list(request: web.Request) -> web.Response:
 
 async def api_cloud_launch_get(request: web.Request) -> web.Response:
     """GET /api/cloud/launch/{id} — one job's live state (progress + sign-in)."""
-    denied = _guard(request, "launch_get")
+    denied = _guard(request, "launch_get", posix_only=False)
     if denied is not None:
         return denied
     store = await _astore(request.app["state"])

--- a/test/test_cloud_handlers.py
+++ b/test/test_cloud_handlers.py
@@ -120,6 +120,48 @@ class TestGuards:
         assert resp.status == 400
         assert "POSIX" in _body(resp)["error"]
 
+    async def test_windows_may_still_read_launch_history(self, tmp_path, monkeypatch):
+        """The two read-only launch routes answer on Windows; the writes do not.
+
+        The Remote Crew list waits for BOTH the instances and the launch history
+        before it renders anything, so POSIX-gating this read replaced the whole
+        list — hand-added SSH crews included — with a cloud-provisioning error,
+        leaving no way to connect, edit or remove any of them. The route parses a
+        local job store and shells to nothing, so there is nothing to gate.
+        """
+        state = _state(tmp_path)
+        monkeypatch.setattr(hc.sys, "platform", "win32")
+
+        lst = await hc.api_cloud_launch_list(_req("GET", "/api/cloud/launch", state=state))
+        assert lst.status == 200
+        # Empty because THIS store is tmp-rooted and untouched — the route reports
+        # whatever is persisted, so it is not asserting "Windows is always empty".
+        assert _body(lst)["jobs"] == []
+
+        got = await hc.api_cloud_launch_get(
+            _req("GET", "/api/cloud/launch/nope", state=state, match_info={"id": "nope"})
+        )
+        assert got.status == 404  # reached the store, not the platform gate
+
+        # Provisioning itself stays refused — the deploy engine needs bash/aws.
+        created = await hc.api_cloud_launch_create(
+            _req(
+                "POST", "/api/cloud/launch", state=state,
+                body={"profile": "dev", "region": "us-east-1", "size_key": "balanced"},
+            )
+        )
+        assert created.status == 400
+        assert _body(created)["code"] == "posix_host_required"
+
+    async def test_windows_launch_read_still_owner_only(self, tmp_path, monkeypatch):
+        """Dropping the POSIX gate must not drop the owner gate with it."""
+        monkeypatch.setattr(hc.sys, "platform", "win32")
+        resp = await hc.api_cloud_launch_list(
+            _req("GET", "/api/cloud/launch", state=_state(tmp_path), slack=True)
+        )
+        assert resp.status == 403
+        assert _body(resp)["code"] == "cloud_owner_only"
+
     async def test_app_token_rejected(self, tmp_path):
         """token_auth sets request["app"] alongside request["user"], so checking
         "user" alone would let an app that declares /api/cloud in its manifest

--- a/website/src/pages/settings/RemoteCrewPanel.tsx
+++ b/website/src/pages/settings/RemoteCrewPanel.tsx
@@ -62,6 +62,7 @@ import {
 import ErrorNotice from '../../components/ErrorNotice'
 import AskAgentButton from '../../components/AskAgentButton'
 import type { ErrorReport } from '../../utils/errorReport'
+import { parseErrorCode } from '../../utils/errorReport'
 import { reportInstanceFailure } from '../../utils/instanceFailureReport'
 import { readPersistedString, usePersistedString } from '../../hooks/usePersistedString'
 import { copyToClipboard } from '../../utils/clipboard'
@@ -766,13 +767,32 @@ export function RemoteCrewPanel() {
   const launches = useMemo(() => launchesQuery.data?.jobs ?? [], [launchesQuery.data])
   const inProgress = useMemo(() => launches.filter(isInProgress), [launches])
 
+  // An OLDER gateway POSIX-gates the read-only launch-history route too, so a
+  // Windows host answers 400 posix_host_required for it. That is not a load
+  // failure — the gateway is refusing a capability, not failing to read — and
+  // letting it reach `loadError` below replaced the entire crew list, hand-added
+  // SSH rows included, with a cloud-provisioning error and no way to connect,
+  // edit or remove anything. Current gateways answer the route on every
+  // platform; this keeps the panel usable against one that does not.
+  //
+  // Safe to proceed with no launch history — and it does NOT rest on the host
+  // having no cloud crews, which a carried-over config dir would break. The row
+  // itself does not assume: an SSM target with no matching job renders as
+  // `unverifiedCloud`, keeping the confirm step and the copy about what Remove
+  // does not do.
+  const cloudUnsupported =
+    launchesQuery.error instanceof ApiError &&
+    launchesQuery.error.status === 400 &&
+    parseErrorCode(launchesQuery.error.body) === 'posix_host_required'
+
   // Both queries gate the crew list: a row's cloud-vs-manual identity comes from the
   // launch history, and the two destructive actions are NOT interchangeable. Treating
   // absent launch data as [] makes a real cloud crew render as "added by you", whose
   // trash button is a single unconfirmed click that unregisters the instance and
   // leaves the EC2 stack running and billing, invisible to the dashboard. So the list
   // waits until both are known, and surfaces either failure instead of guessing.
-  const loadError = !disabled && (instancesQuery.isError || launchesQuery.isError)
+  const loadError =
+    !disabled && (instancesQuery.isError || (launchesQuery.isError && !cloudUnsupported))
   const authExpired =
     isAuthExpiredError(instancesQuery.error) || isAuthExpiredError(launchesQuery.error)
   const listLoading = !disabled && (instancesQuery.isLoading || launchesQuery.isLoading)

--- a/website/src/test/RemoteCrewPanel.test.tsx
+++ b/website/src/test/RemoteCrewPanel.test.tsx
@@ -9,9 +9,14 @@ import { __resetInstanceFailuresForTests } from '../utils/instanceFailureReport'
 vi.mock('../api/client', () => {
   class ApiError extends Error {
     status: number
-    constructor(status: number, message: string) {
+    // The real class carries the raw response body so a caller can read the
+    // structured `code` the human message collapses away — the panel branches
+    // on it to tell an unsupported-platform refusal from a load failure.
+    body: string
+    constructor(status: number, message: string, body = '') {
       super(message)
       this.status = status
+      this.body = body
     }
   }
   return {
@@ -195,6 +200,42 @@ describe('RemoteCrewPanel', () => {
     await u.click(screen.getByRole('menuitem', { name: /Remove Kiro Crew Cloud/i }))
     expect(await screen.findByText(/keeps running and billing/i)).toBeInTheDocument()
     expect(api.removeInstance).not.toHaveBeenCalled()
+  })
+
+  it('still lists the crews when the gateway cannot do cloud provisioning at all', async () => {
+    // A Windows gateway POSIX-gates the launch-history route, so the launches query
+    // fails with 400 posix_host_required. Treating that as a load failure replaced
+    // the whole list — hand-added SSH crews included — with a cloud-provisioning
+    // error, leaving no way to connect, edit or remove anything the user had saved.
+    // It is not a failure: it means this host cannot have launched a cloud crew.
+    vi.mocked(api.listInstances).mockResolvedValue({
+      active: true, warm_set_cap: 5, instances: [MANUAL_INSTANCE, CLOUD_INSTANCE],
+    })
+    vi.mocked(api.cloudLaunches).mockRejectedValue(
+      new ApiError(
+        400,
+        'cloud provisioning requires a POSIX host (Linux/macOS); use WSL on Windows',
+        JSON.stringify({
+          error: 'cloud provisioning requires a POSIX host (Linux/macOS); use WSL on Windows',
+          code: 'posix_host_required',
+        }),
+      ),
+    )
+    renderWithProviders(<RemoteCrewPanel />)
+
+    // Both saved crews render, each with its own Connect button.
+    expect(await screen.findByText('dev-box-1')).toBeInTheDocument()
+    expect(screen.getByText(/Kiro Crew Cloud/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Connect$/i })).toBeInTheDocument()
+    // The POSIX message belongs on the Set-up tab, not over the crew list.
+    expect(screen.queryByText(/requires a POSIX host/i)).not.toBeInTheDocument()
+
+    // With no launch history, the SSM row must NOT be downgraded to "added by you":
+    // the CLI launcher registers real cloud crews the same way, so it stays
+    // possibly-cloud with the confirm step and the honest copy.
+    expect(
+      screen.getByText(/cannot verify whether this machine has AWS resources/i),
+    ).toBeInTheDocument()
   })
 
   it('shows the install command the gateway reported, not a hardcoded macOS one', async () => {

--- a/website/src/test/SettingsRemoteCrewPanelCoverage.test.tsx
+++ b/website/src/test/SettingsRemoteCrewPanelCoverage.test.tsx
@@ -23,9 +23,14 @@ import { RemoteCrewPanel } from '../pages/settings/RemoteCrewPanel'
 vi.mock('../api/client', () => {
   class ApiError extends Error {
     status: number
-    constructor(status: number, message: string) {
+    // The real class carries the raw response body so a caller can read the
+    // structured `code` the human message collapses away — the panel branches
+    // on it to tell an unsupported-platform refusal from a load failure.
+    body: string
+    constructor(status: number, message: string, body = '') {
       super(message)
       this.status = status
+      this.body = body
     }
   }
   return {


### PR DESCRIPTION
## Problem / Motivation

On a Windows gateway the **Remote Crew** settings page lists no crews at all.

A user reported it: the tab header counted their saved records ("Your crews **2**"), but where the list should be they got a red error instead —

> ⚠ cloud provisioning requires a POSIX host (Linux/macOS); use WSL on Windows

so there was no connection state, no **Connect**, no **Edit** and no **Remove** for either crew. One of the two was a hand-added SSH machine that needs no cloud provisioning at all. Their crews were saved and their gateway was reachable; the page simply would not show them.

## Why it matters

Remote Crew *works* on Windows — nothing in the SSH-tunnel path is platform-gated. Only the settings page was broken, and it was broken in the way that costs the most: the page that manages crews is also the only place to connect, rename or remove one, so every saved crew became unreachable from the UI. The reporter's workaround was to connect from the top-header instance switcher or hand-edit `~/.kiro/crew/instances.json`.

The error is also actively misleading: it names cloud provisioning, which the user had not asked for and does not need.

## What changed (motivation → approach → change)

**Symptom** — the whole crew list is replaced by a cloud-provisioning error on Windows.

**Root cause** — two independent pieces meeting:

1. `handlers_cloud.py::_guard` refused **every** `/api/cloud/*` route on Windows with `400 posix_host_required`, including the read-only `GET /api/cloud/launch`. That route only parses a local job store and shells to nothing, so it had no POSIX dependency to gate.
2. `RemoteCrewPanel` deliberately waits for **both** the instances list and the launch history before it renders a row — a row's cloud-vs-manual identity decides what its delete button does, and the two teardowns are not interchangeable. So that one 400 landed in `loadError` and took the entire list with it, hand-added SSH rows included.

**Change** — one fix per piece:

- The two read-only launch-history routes (`GET /api/cloud/launch`, `GET /api/cloud/launch/{id}`) now pass `posix_only=False`. Everything that can provision, stop or terminate stays POSIX-gated, and the owner / Slack / auth checks are untouched on every route — they run before the platform check, and `posix_only` gates only the `sys.platform` branch.
- The panel no longer treats a `posix_host_required` launches failure as a load error, so an **older** gateway degrades instead of blanking the list rather than needing a lockstep upgrade.

Neither half assumes the host has no cloud crews — which a config dir carried over from a POSIX machine would break. Safety comes from the row instead: an SSM target with no matching launch job already renders as *possibly-cloud*, keeping its confirm step and the copy stating what **Remove** does not do. The read route reports whatever history is actually persisted.

## Tests

- `test_windows_may_still_read_launch_history` — on a simulated `win32` host the list route answers `200` and the by-id route reaches the store (`404` for an unknown id) rather than the platform gate, while `POST /api/cloud/launch` still refuses with `posix_host_required`. Locks in that the exemption covers exactly the two reads.
- `test_windows_launch_read_still_owner_only` — a Slack-origin caller is still refused `403 cloud_owner_only` on the now-ungated read. Locks in that dropping the POSIX gate did not drop the owner gate with it.
- `still lists the crews when the gateway cannot do cloud provisioning at all` — with the launches query rejecting `400 posix_host_required`, both saved crews render with their **Connect** button, no POSIX error appears over the list, and the SSM row is **not** downgraded to "added by you" (it stays possibly-cloud with its confirm step).

Both regression tests were verified RED on unmodified code before the fix: stashing `handlers_cloud.py` fails the backend case, stashing `RemoteCrewPanel.tsx` fails the frontend case.

Also updated the mocked `ApiError` in the two panel suites to carry `body`, matching the production class — the panel reads the structured `code` out of it, so a mock without `body` could not exercise the branch.

## Manual verification

Not performed end-to-end: the broken state only occurs on a **Windows gateway**, and this was developed on macOS. The reporter's screenshot of the failure is the "before"; the "after" needs a Windows host to confirm visually.

What was verified here: the full 44-gate local suite, the three regression tests above, and the two AI review lanes (GPT + Opus) run locally against the CI contracts. The backend suite's pre-existing failures on this host (missing optional deps `openpyxl`/`qrcode`, host CPU-shape assertions in `test_xdist_host_budget.py`) were confirmed identical — 75 in both cases — on unmodified `origin/main`, so none belong to this diff.

## Screenshots / video

**Not included, and not waived as a non-visual change** — the change *does* have a rendered delta (a red error block becomes the crew list). It is only reachable on a Windows gateway, which I cannot drive from this host, so an honest before/after pair is not available to me.

A maintainer has two ways forward: the reporter can supply the Windows "after" shot, or apply the `no-screenshots` label if the frontend test above (which asserts the rendered outcome: both rows present, Connect present, POSIX error absent, SSM row not downgraded) is sufficient evidence for a Windows-only surface.

## Related Issues

no linked issue: reported directly in chat, not filed as a GitHub issue.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a shared guard that refuses an unsupported *capability* also refuses the read-only *status* call a client needs in order to render, so an unsupported feature escalates into a broken page — gate the writes, let the reads answer.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
