### PR TITLE
fix(session-directive): deliver directives out of band so the control plane works on any ACP backend

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -62,6 +62,7 @@ from kiro_crew.context_management import (
     strip_plan_markers,
     validate_plan_format,
 )
+from kiro_crew.dashboard import directive_queue
 from kiro_crew.dashboard.chat_persistence import _build_history_prefix, save_slot_off_loop
 from kiro_crew.dashboard.chat_summary import generate_session_summary
 from kiro_crew.dashboard.chat_title import (
@@ -4941,6 +4942,10 @@ async def _run_chat(
     # text and overwrite the applied outcome in the transcript. Replaying the
     # stored output keeps every frame consistent and marker-free.
     _dir_consumed_out: dict[str, str] = {}
+    # When this turn began, for bounding an out-of-band directive claim to it.
+    # A directive belongs to the turn that asked for it: a record parked by a turn
+    # that was cancelled before consuming it must not be claimable by a later one.
+    _turn_started = time.monotonic()
     # session_id -> {started, done, agent, task} for native kiro-cli subagents,
     # reconciled from `_kiro.dev/subagent/list_update` (one card per sub-agent).
     # The slot holds the same live dict so reconnect snapshots can restore cards.
@@ -6539,17 +6544,160 @@ async def _run_chat(
                     and event.tool_call_id not in _dir_consumed_out
                     and session_directive.has_marker(_out)
                 ):
-                    logger.warning(
-                        "session-directive NOT APPLIED: marker present but the tool "
-                        "call carried no core-MCP identity "
-                        "(tool_call_id=%s, mcp_server_name=%r, tool_name=%r, "
-                        "expected mcp_server_name=%r). Either a forged marker, or "
-                        "this ACP backend does not emit _meta.kiro identity.",
-                        event.tool_call_id,
-                        _seen_tool_identity.get(event.tool_call_id, ("", ""))[0],
-                        _seen_tool_identity.get(event.tool_call_id, ("", ""))[1],
-                        session_directive.CORE_MCP_SERVER,
-                    )
+                    # The identity gate found nothing to trust. Before treating
+                    # that as a lost directive, look for the OUT-OF-BAND record:
+                    # the tool publishes its validated payload straight to the
+                    # gateway, so on a backend that emits no ``_meta.kiro`` this is
+                    # the delivery path that still works.
+                    #
+                    # The marker SELECTS the record; it never supplies one. `peek`
+                    # reads the (kind, args) this frame names and `claim` returns
+                    # only a record parked with that same payload, during THIS
+                    # turn — then the RECORD's payload is what gets applied. So the
+                    # two channels must agree: a record aimed at another session
+                    # (the header is not kernel-attested over TCP, and Windows has
+                    # no AF_UNIX at all) waits for a marker that session's model
+                    # never emits, and a forged marker looks up a record no tool
+                    # ever validated. See directive_queue's module docstring.
+                    #
+                    # ISOLATION FIRST, though: a NATIVE sub-agent's tool calls
+                    # surface as flat events on this parent stream (tagged in
+                    # _native_tc_card) and have no independently bindable slot of
+                    # their own. On a backend that emits no ``_meta.kiro`` such a
+                    # frame reaches here with _dir_tool == "", while the record the
+                    # child's tool parked is keyed by the PARENT's session — so
+                    # claiming it would apply the child's directive to the parent,
+                    # the exact mutation the marker path below refuses. Refuse it
+                    # here too, on the same terms and with the same audit, BEFORE
+                    # the claim: a claim is destructive (it removes the record), so
+                    # ordering the check first also keeps a legitimate parent
+                    # directive from being consumed by a child's frame.
+                    #
+                    # Read the selector ONCE, HERE, from the RAW provider text —
+                    # not from ``_out`` — and note both halves of that, because
+                    # each is load-bearing:
+                    #
+                    # * ONCE, before either branch: every path below rewrites
+                    #   ``_out`` through ``strip_marker``, which removes the very
+                    #   marker ``peek`` reads, so a call placed after that rewrite
+                    #   returns None forever. One pre-mutation read serves both
+                    #   branches and makes that ordering mistake unavailable.
+                    # * RAW, because ``_out`` is ``_redact_tool_field``'d at the
+                    #   top of this handler, and that runs the exfil-URL and
+                    #   credential scrubbers (and a 1 MB truncation) over the whole
+                    #   string INCLUDING the marker's JSON. The record was parked
+                    #   with the args the tool validated, unredacted, so peeking at
+                    #   the redacted copy compares a scrubbed payload against a raw
+                    #   one: a directive whose args merely CONTAIN something
+                    #   token-shaped — or one long enough to be truncated — would
+                    #   match no record and be dropped as "nothing was parked",
+                    #   audited as a denial, on exactly the backends this path
+                    #   exists to serve. Reproduced with a token-shaped
+                    #   ``monitor_start`` message before this line was changed.
+                    #
+                    # Reading raw here widens nothing: the marker is untrusted on
+                    # both paths and is only ever a SELECTOR, so a forged raw
+                    # marker still finds no parked record, and the payload that
+                    # gets APPLIED is still the record's. Redaction protects the
+                    # transcript and the WS broadcast, which still receive the
+                    # redacted ``_out`` — it was never a filter on the lookup.
+                    _sel_pair = session_directive.peek(event.tool_output)
+                    if event.tool_call_id in _native_tc_card:
+                        sel().log_tool_invocation(
+                            session_key=session_key,
+                            source="mcp-directive",
+                            tool_name=_seen_tool_identity.get(event.tool_call_id, ("", ""))[1],
+                            outcome="denied",
+                        )
+                        _out = _redact_tool_field(
+                            session_directive.strip_marker(_out)
+                            + (
+                                "\n\n[Not applied: a session-bound tool called "
+                                "from a sub-agent has no session to act on.]"
+                            )
+                        )
+                        _dir_consumed_out[event.tool_call_id] = _out
+                        # Refusing to APPLY is not enough on its own: the record
+                        # the child's tool parked is keyed by the PARENT, so
+                        # leaving it queued would only defer the mutation to the
+                        # next frame naming that payload. Retire it — but retire
+                        # exactly it, by the same (kind, args) correlation the
+                        # normal path claims on, so a directive the parent
+                        # legitimately parked in this same turn survives.
+                        if _sel_pair:
+                            directive_queue.claim(
+                                session_key,
+                                _sel_pair[0],
+                                _sel_pair[1],
+                                not_before=_turn_started,
+                            )
+                        _oob = None
+                    else:
+                        _oob = (
+                            directive_queue.claim(
+                                session_key,
+                                _sel_pair[0],
+                                _sel_pair[1],
+                                not_before=_turn_started,
+                            )
+                            if _sel_pair
+                            else None
+                        )
+                    if _oob:
+                        _applied_one = await apply_session_directive(
+                            state,
+                            slot,
+                            session_key,
+                            str(_oob.get("kind") or ""),
+                            dict(_oob.get("args") or {}),
+                            producer_is_user_facing=_directive_user_origin,
+                        )
+                        logger.info(
+                            "session-directive applied OUT OF BAND for %s "
+                            "(tool_call_id=%s, kind=%s): this backend emits no "
+                            "_meta.kiro identity, so the marker could not be "
+                            "trusted and the marker-selected, gateway-parked "
+                            "payload was used.",
+                            session_key,
+                            event.tool_call_id,
+                            _oob.get("kind"),
+                        )
+                        # Same surface contract as the marker path: the applier's
+                        # real outcome replaces the tool's own (deliberately
+                        # non-committal) text, re-redacted because that string
+                        # interpolates LLM-derived values.
+                        _out = _redact_tool_field(
+                            session_directive.strip_marker(_out) + "\n\n" + _applied_one
+                        )
+                        _dir_consumed_out[event.tool_call_id] = _out
+                    elif event.tool_call_id not in _dir_consumed_out:
+                        # A refusal, so audit it like one. This branch is where a
+                        # FORGED marker lands — the identity gate recorded nothing
+                        # and no record was parked — and the sibling refusals
+                        # (native sub-agent, here and on the marker path) already
+                        # emit a denied event. Leaving this one to a logger line
+                        # meant the single most security-relevant outcome of the
+                        # gate was the only one absent from the SEL trail, so an
+                        # operator auditing denials saw every case but the attack.
+                        sel().log_tool_invocation(
+                            session_key=session_key,
+                            source="mcp-directive",
+                            tool_name=_seen_tool_identity.get(event.tool_call_id, ("", ""))[1],
+                            outcome="denied",
+                        )
+                        logger.warning(
+                            "session-directive NOT APPLIED: marker present but the "
+                            "tool call carried no core-MCP identity and no "
+                            "out-of-band record was parked "
+                            "(tool_call_id=%s, mcp_server_name=%r, tool_name=%r, "
+                            "expected mcp_server_name=%r). Either a forged marker, "
+                            "or this ACP backend emits no _meta.kiro identity AND "
+                            "could not reach the gateway to park the payload.",
+                            event.tool_call_id,
+                            _seen_tool_identity.get(event.tool_call_id, ("", ""))[0],
+                            _seen_tool_identity.get(event.tool_call_id, ("", ""))[1],
+                            session_directive.CORE_MCP_SERVER,
+                        )
                 if not _dir_tool and event.tool_call_id in _dir_consumed_out:
                     # A LATER frame for a directive we already consumed: replay
                     # the output we produced instead of letting the raw marker
@@ -6637,6 +6785,12 @@ async def _run_chat(
                             # a mid-stream partial frame must not burn the
                             # mapping the final frame still needs.
                             _pending_dir_tool.pop(event.tool_call_id, None)
+                            # The tool ALSO parked this payload out of band (one
+                            # publish per emit, unconditionally — the tool cannot
+                            # know which consumer will run). Applying both would
+                            # arm two loops or render two cards, so retire the
+                            # twin now that the marker path has taken it.
+                            directive_queue.discard(session_key)
                             _out = _redact_tool_field(
                                 await apply_session_directive(
                                     state,

--- a/src/kiro_crew/dashboard/directive_queue.py
+++ b/src/kiro_crew/dashboard/directive_queue.py
@@ -1,0 +1,293 @@
+"""Provider-neutral delivery for session directives.
+
+The directive marker (:mod:`kiro_crew.session_directive`) is model-visible text,
+so the consumer may only honour it when the tool CALL it arrived under was
+recorded as an MCP call served by Kiro Crew's own core server. That recording
+comes from the provider's out-of-band ``_meta.kiro`` channel, which is a
+kiro-cli engine feature: an ACP backend that does not emit it leaves the gate
+with no trusted source, and a gate with no trusted source correctly refuses
+every directive. The whole control plane (loops, project changes, cards) then
+fails closed on that backend — silently, until #6970 added the diagnostic.
+
+This module is the second delivery path, and it carries the payload OUT OF BAND
+rather than through the model's tool result. The MCP tool, having validated its
+arguments, POSTs them to the gateway over Kiro Crew's own internal API declaring
+its ``X-Session-Key``; the gateway parks the record here; the turn's consumer
+claims it. The marker is still emitted (the kiro-cli path is unchanged and
+remains authoritative there), but on a backend without ``_meta.kiro`` the marker
+is reduced to a HINT that a record may be waiting — its CONTENT is never read.
+
+Why this is not weaker than the marker gate it backs up
+------------------------------------------------------
+TWO channels must agree, and neither is trusted alone. That is the whole design:
+
+* The RECORD carries the payload and is unforgeable in CONTENT — it is what the
+  tool validated, delivered out of band, never lifted from model-visible text.
+  Its weak point is its TARGET: the session is named by an ``X-Session-Key``
+  header, and the header is only kernel-attested on an AF_UNIX peer whose /proc
+  ancestry resolves. Over TCP loopback (Windows has no AF_UNIX at all), or from a
+  pooled backend whose ancestry does not resolve, a same-uid caller holding the
+  internal secret could name somebody else's session.
+* The MARKER is bound to the right session by construction — it arrives inside
+  the tool result of a call made in THAT turn, on that session's own event
+  stream. Its weak point is CONTENT: it is model-visible text, so a model can
+  type one.
+* So a directive applies only where BOTH hold: :func:`claim` requires a parked
+  record whose ``(kind, args)`` equal the ones the frame's marker names, parked
+  during the CLAIMING turn. A record aimed at another session waits for a marker
+  that session's model never emits; a forged marker looks up a record that no
+  tool ever validated. The applied payload is always the RECORD's, so the marker
+  never contributes a value — only the choice of which record to look up.
+
+A model can still drive its OWN session by publishing and marking honestly, which
+is exactly what calling the tool does. No privilege is gained.
+
+Deliberately NOT persisted. A directive is turn-scoped: the turn that requested
+it is what gives it meaning. Surviving a gateway restart would let a loop arm, or
+a project change land, against a turn that no longer exists — so records live in
+memory and are additionally dropped on age.
+
+In-memory means the store has to be bounded in BOTH dimensions, and the reclaim
+runs on PUBLISH because for most sessions there is no read path at all: only the
+dashboard consumer claims, while the messaging ``TurnDriver`` applies directives
+from the verified marker and never calls in here. Records expire by age
+(:data:`MAX_AGE_SECS`), a bucket is capped (:data:`MAX_PER_SESSION`), and a bucket
+whose records have all expired is DELETED rather than left empty — so the map
+holds only sessions that published recently, with :data:`MAX_SESSIONS` as the
+backstop for a burst inside one expiry window.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from typing import Any
+
+from kiro_crew.session_directive import DIRECTIVE_TOOLS
+
+logger = logging.getLogger(__name__)
+
+#: Records older than this are dropped unclaimed. A directive belongs to the turn
+#: that asked for it; a turn does not outlive this by any normal margin, and a
+#: record that does has lost the context that made it meaningful.
+MAX_AGE_SECS = 300.0
+
+#: Per-session cap. One record is claimed per directive tool call, so depth
+#: beyond this means records are not being claimed at all (a tabless session, a
+#: backend emitting neither path). Bounding it keeps an unclaimed queue from
+#: growing without limit; the OLDEST is dropped, so a live session always retains
+#: its most recent intent.
+MAX_PER_SESSION = 8
+
+#: Process-wide cap on how many SESSIONS may hold a bucket at once — the second
+#: dimension, and the one a per-session cap cannot bound. Only the dashboard
+#: consumer claims or discards; the messaging ``TurnDriver`` (Slack, Discord,
+#: Telegram, …) applies directives from the verified marker and never touches this
+#: module, so every distinct channel conversation that calls a directive tool would
+#: otherwise leave a bucket behind that nothing ever removes. Records expire on
+#: age, so :func:`_sweep_locked` alone keeps the map to sessions that published
+#: recently; this cap is the backstop for a burst inside one expiry window.
+MAX_SESSIONS = 256
+
+_lock = threading.Lock()
+_pending: dict[str, list[dict[str, Any]]] = {}
+
+
+def publish(session_key: str, kind: str, args: dict[str, Any]) -> str:
+    """Park a validated directive for *session_key*; return its record id.
+
+    Raises :class:`ValueError` for an unknown *kind* or an empty *session_key* —
+    the caller is the gateway handler, and an unrecognized kind means the request
+    did not come from one of Kiro Crew's own directive tools.
+    """
+    if kind not in DIRECTIVE_TOOLS:
+        raise ValueError(f"unknown directive kind: {kind!r}")
+    if not session_key:
+        raise ValueError("session_key required")
+    rec_id = uuid.uuid4().hex
+    now = time.monotonic()
+    record: dict[str, Any] = {
+        "id": rec_id,
+        "kind": kind,
+        "args": dict(args or {}),
+        "at": now,
+    }
+    with _lock:
+        queue = _pending.setdefault(session_key, [])
+        queue.append(record)
+        while len(queue) > MAX_PER_SESSION:
+            dropped = queue.pop(0)
+            logger.warning(
+                "session-directive queue full for %s: dropped unclaimed %s "
+                "(cap %d). Nothing claimed these — the session may hold no "
+                "consumer.",
+                session_key,
+                dropped.get("kind"),
+                MAX_PER_SESSION,
+            )
+        # Reclaim on the write path, because for many sessions there is no read
+        # path: a claim only ever runs for a session whose turn reaches the
+        # dashboard consumer, so a bucket belonging to any other surface is never
+        # visited again and would live for the gateway's whole lifetime.
+        _sweep_locked(now)
+    return rec_id
+
+
+def _sweep_locked(now: float) -> None:
+    """Drop expired records, and the buckets they leave empty. Caller holds ``_lock``.
+
+    Bounds the store in BOTH dimensions. Records inside a bucket are bounded by
+    age; the number of BUCKETS is bounded because a bucket whose records have all
+    expired is DELETED rather than left as an empty list — so the map holds only
+    sessions that published within :data:`MAX_AGE_SECS`. Total work is bounded by
+    ``MAX_SESSIONS * MAX_PER_SESSION``.
+
+    The publisher that triggers a sweep is safe from it without needing to be
+    named: it has just appended a record stamped *now*, so its bucket always has a
+    fresh member and cannot be deleted, and that record is the newest in the store,
+    so its bucket sorts last for eviction. Both fall out of the ordering, which is
+    why there is no exemption argument to get wrong.
+    """
+    for key in list(_pending):
+        fresh = [r for r in _pending[key] if now - float(r.get("at", 0.0)) <= MAX_AGE_SECS]
+        if fresh:
+            _pending[key] = fresh
+        else:
+            del _pending[key]
+    if len(_pending) <= MAX_SESSIONS:
+        return
+    # Backstop: more distinct sessions published inside one expiry window than the
+    # cap allows. Evict whole buckets, least-recently-published first, so the
+    # sessions most likely to still have a live turn are the ones retained.
+    victims = sorted(
+        _pending,
+        key=lambda k: max((float(r.get("at", 0.0)) for r in _pending[k]), default=0.0),
+    )
+    for key in victims[: len(_pending) - MAX_SESSIONS]:
+        dropped = _pending.pop(key, [])
+        logger.warning(
+            "session-directive store full: evicted %s unclaimed record(s) for %s "
+            "(cap %d sessions). Nothing claimed them — that surface holds no "
+            "out-of-band consumer.",
+            len(dropped),
+            key,
+            MAX_SESSIONS,
+        )
+
+
+def _canonical(args: dict[str, Any] | None) -> str:
+    """Order-independent comparable form of a directive's ``args``.
+
+    The two channels serialize independently — the marker through
+    ``session_directive.encode``, the record through the internal API's JSON body
+    — so the dicts are equal in value but not necessarily in key order. Sorting
+    keys makes the comparison about the payload rather than about how either side
+    happened to emit it, and ``default=str`` mirrors ``encode`` so a value only
+    one side could serialize compares equal instead of raising.
+    """
+    return json.dumps(args or {}, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def claim(
+    session_key: str,
+    kind: str,
+    args: dict[str, Any] | None,
+    *,
+    not_before: float | None = None,
+) -> dict[str, Any] | None:
+    """Remove and return the ONE record for *session_key* matching *kind*/*args*.
+
+    CORRELATED by construction, which is what makes the out-of-band path safe to
+    act on (see the module docstring): the caller passes the ``(kind, args)`` its
+    frame's marker named, and only a record parked with that same payload is
+    returned. An uncorrelated drain would apply whatever happened to be queued —
+    including a record another session's caller parked here, or one left by a turn
+    that was cancelled before it could consume it.
+
+    *not_before* bounds the record to the claiming TURN (pass the turn's start
+    from ``time.monotonic()``). A directive belongs to the turn that asked for it:
+    without this bound, a record whose turn was abandoned stays claimable by any
+    later frame naming the same payload, so a cancelled intent could land minutes
+    later.
+
+    Single-consume: the match is removed under the lock, so two consumers racing
+    the same session cannot both apply it. Returns ``None`` when nothing matches.
+    """
+    if not session_key or kind not in DIRECTIVE_TOOLS:
+        return None
+    now = time.monotonic()
+    want = _canonical(args)
+    with _lock:
+        queue = _pending.get(session_key)
+        if not queue:
+            return None
+        hit: dict[str, Any] | None = None
+        keep: list[dict[str, Any]] = []
+        for record in queue:
+            at = float(record.get("at", 0.0))
+            age = now - at
+            if age > MAX_AGE_SECS:
+                logger.info(
+                    "session-directive dropped as stale for %s: %s (age %.0fs > %.0fs)",
+                    session_key,
+                    record.get("kind"),
+                    age,
+                    MAX_AGE_SECS,
+                )
+                continue
+            # FIFO among equals: a repeated identical directive in one turn (the
+            # model calling monitor_start twice with the same message) parks two
+            # equal records, and each frame must consume its OWN. The queue is
+            # oldest-first, so taking the first match pairs frame N with record N
+            # while `keep` retains the rest for the sibling frames.
+            if (
+                hit is None
+                and record.get("kind") == kind
+                and _canonical(record.get("args")) == want
+                and (not_before is None or at >= not_before)
+            ):
+                hit = record
+                continue
+            keep.append(record)
+        if hit is None:
+            # Nothing matched. Keep what survived the staleness sweep so a
+            # sibling frame in this same turn can still find its own record.
+            if keep:
+                _pending[session_key] = keep
+            else:
+                _pending.pop(session_key, None)
+            return None
+        if keep:
+            _pending[session_key] = keep
+        else:
+            _pending.pop(session_key, None)
+    return hit
+
+
+def discard(session_key: str) -> int:
+    """Drop any parked directives for *session_key*; return how many.
+
+    The kiro-cli path applies the directive from the marker under a verified
+    ``_meta.kiro`` identity. The out-of-band record for that same call is then a
+    DUPLICATE, and applying both would arm two loops or render two cards — so the
+    marker path calls this to retire its twin.
+    """
+    if not session_key:
+        return 0
+    with _lock:
+        return len(_pending.pop(session_key, []))
+
+
+def depth(session_key: str) -> int:
+    """Parked record count for *session_key* — diagnostics only, no claim."""
+    with _lock:
+        return len(_pending.get(session_key, []))
+
+
+def reset() -> None:
+    """Drop every parked record. For tests and gateway shutdown."""
+    with _lock:
+        _pending.clear()

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -363,6 +363,7 @@ from kiro_crew.dashboard.handlers.sessions import (  # noqa: E402, F401
     api_session_archive_read,
     api_session_delete,
     api_session_detail,
+    api_session_directive,
     api_session_keepalive,
     api_session_tool_policy,
     api_sessions,

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -27,6 +27,7 @@ import kiro_crew.dashboard.handlers as _h
 from kiro_crew import session_ledger
 from kiro_crew.acp.client import _resolve_kiro_bin_for_spawn
 from kiro_crew.config.paths import kiro_agents_dir
+from kiro_crew.dashboard import directive_queue
 from kiro_crew.dashboard.handlers import kiro_usage_api
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.session_memory import SessionMemorySampler
@@ -1488,6 +1489,72 @@ async def api_approval_resolve(request: web.Request) -> web.Response:
     if not ok:
         return web.json_response({"error": "not found or expired"}, status=404)
     return web.json_response({"ok": True})
+
+
+async def api_session_directive(request: web.Request) -> web.Response:
+    """POST /api/session-directive — park a validated session directive.
+
+    The provider-neutral leg of the session-directive protocol. Its only caller is
+    a Kiro Crew directive tool (``mcp_tools.control._emit_directive``), which has
+    already validated the payload; this route carries that payload to the gateway
+    OUT OF BAND so the turn's consumer can apply it without having to trust the
+    model-visible marker in the tool result. See
+    :mod:`kiro_crew.dashboard.directive_queue` for why that is not weaker than the
+    marker gate it backs up.
+
+    Authenticated via X-Internal-Secret, and the session is selected by the
+    X-Session-Key header every MCP subprocess already sends — the SAME shape as
+    ``api_session_keepalive``. The header is not taken on faith: on the unix
+    socket ``token_auth`` kernel-verifies the peer and denies 403 when it resolves
+    to a session key other than the declared one, which is the check that stops a
+    caller parking a directive against somebody else's session.
+
+    Unknown ``kind`` is a 400, not a silent drop: the only legitimate callers are
+    Kiro Crew's own directive tools, so an unrecognized kind means the request did
+    not come from one and the caller should hear about it.
+    """
+    # Re-assert the caller's locality BEFORE the header is read. The route is in
+    # server.py's strict allowlist, but a ``local_only=False`` deployment
+    # reclassifies strict paths as MIXED — so the auth middleware also admits a
+    # cookie/token-authenticated browser caller here, and such a caller picks its
+    # own ``X-Session-Key``. That is somebody else's session: a parked record is
+    # applied verbatim by the next consumer frame in the named turn, so accepting
+    # it would hand a remote cookie holder a cross-session mutation (arm a loop,
+    # retarget a project). ``internal_auth`` is set only after a constant-time
+    # ``X-Internal-Secret`` match on a same-machine transport; ``peer_verified``
+    # only after the kernel-attested AF_UNIX peer resolved to the DECLARED key —
+    # either one is positive proof of a local caller, and a cookie carries
+    # neither. Same predicate as ``handlers/updates.py``'s host-locality gate.
+    if not (request.get("internal_auth") or request.get("peer_verified")):
+        return web.json_response(
+            {"error": "local caller required", "code": "not_local_caller"},
+            status=403,
+        )
+    session_key = request.headers.get("X-Session-Key", "").strip()
+    if not session_key:
+        return web.json_response(
+            {"error": "X-Session-Key required", "code": "session_key_required"},
+            status=400,
+        )
+    body: dict = {}
+    try:
+        if request.can_read_body:
+            parsed = await request.json()
+            if isinstance(parsed, dict):
+                body = parsed
+    except Exception:
+        return web.json_response(
+            {"error": "malformed JSON body", "code": "invalid_body"}, status=400
+        )
+    kind = str(body.get("kind") or "").strip()
+    args = body.get("args")
+    if not isinstance(args, dict):
+        args = {}
+    try:
+        record_id = directive_queue.publish(session_key, kind, args)
+    except ValueError as exc:
+        return web.json_response({"error": str(exc), "code": "invalid_directive"}, status=400)
+    return web.json_response({"ok": True, "id": record_id})
 
 
 async def api_session_keepalive(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -375,6 +375,15 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         # ``local_only=False`` deployment reclassifies strict paths as mixed.
         "/api/computer-use/frame",
         "/api/session-keepalive",
+        # Session directives: the provider-neutral leg of the directive
+        # protocol. STRICT for the same reasons as its sibling above — the
+        # only legitimate caller is a Kiro Crew directive tool in an MCP
+        # subprocess, and the route's whole point is that the payload arrives
+        # somewhere the model's tool result is not trusted. A cookie
+        # fall-through would let a browser bearer park a directive against a
+        # session it merely has a tab on, bypassing the unix-socket peer check
+        # that makes the declared X-Session-Key trustworthy.
+        "/api/session-directive",
         # In-app update approval (RFC OQ7 step-up). STRICT: its only legitimate
         # caller is `kirocrew update approve` on the gateway host presenting the
         # trust/-fenced nonce plus X-Local-Secret; no browser ever posts to it —
@@ -1341,6 +1350,7 @@ def _register_mcp_routes(app: web.Application) -> None:
     # dashboard-less state simply has no owner sockets to deliver to.
     app.router.add_post("/api/computer-use/frame", handlers.api_computer_use_frame)
     app.router.add_post("/api/session-keepalive", handlers.api_session_keepalive)
+    app.router.add_post("/api/session-directive", handlers.api_session_directive)
     app.router.add_get("/api/session-tool-policy", handlers.api_session_tool_policy)
     app.router.add_post("/api/slack-profile", handlers.api_slack_profile)
     app.router.add_get("/api/notifications", handlers.api_notifications)

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -749,6 +749,44 @@ def register_hook(name: str, args: dict[str, Any]) -> str:
     )
 
 
+def _emit_directive(kind: str, args: dict[str, Any], human: str) -> str:
+    """Encode a validated directive AND publish it out of band; return the text.
+
+    Two delivery paths, one each way round:
+
+    * The MARKER in the returned text is the original path. A consumer that can
+      verify the call's ``_meta.kiro`` identity (kiro-cli) decodes and applies it
+      from there, exactly as before — this function changes nothing for that
+      backend.
+    * The out-of-band POST is the provider-neutral path. ``_post`` already carries
+      ``X-Session-Key`` (and the gateway kernel-verifies that claim on the unix
+      socket), so the gateway parks the payload for the RIGHT session without the
+      model's tool result being trusted for anything. A backend that emits no
+      ``_meta.kiro`` identity has no other way to reach its own control plane.
+
+    Order matters: encode FIRST. ``encode`` refuses an oversized payload by
+    returning a marker-less error string, and a refused directive must NOT be
+    published — otherwise the model is told "nothing was applied" while a record
+    sits waiting to apply it.
+
+    Fail-soft on the POST, and SILENT by design. An older gateway with no such
+    route, or one that is simply down, must not turn a working tool call into an
+    error: the marker is already in hand and the kiro-cli path still works. There
+    is no log line because this module runs as a stdio MCP server, where the
+    process's own streams are the protocol channel — and because the failure that
+    matters is reported at the CONSUMER, which is the side that knows whether a
+    directive actually landed.
+    """
+    out = session_directive.encode(kind, args, human)
+    if session_directive.is_refusal(out):
+        return out
+    try:
+        mcp_core._post("/api/session-directive", {"kind": kind, "args": args})
+    except Exception:
+        pass
+    return out
+
+
 def autonudge_stop(name: str, args: dict[str, Any]) -> str:
     args = validate_tool_args(args, AUTONUDGE_STOP_SCHEMA)
 
@@ -768,7 +806,7 @@ def autonudge_stop(name: str, args: dict[str, Any]) -> str:
             "a dashboard, Slack, or Discord session "
             f"(current session_key={sk!r})."
         )
-    return session_directive.encode(
+    return _emit_directive(
         "autonudge_stop",
         {"reason": args.get("reason", "").strip()},
         # NOT a confirmation, and worded so a model cannot read it as one: this
@@ -802,7 +840,7 @@ def ask_question(name: str, args: dict[str, Any]) -> str:
             "turn with an [OPTIONS: a | b | c] tag instead — it renders "
             "clickable buttons on every channel that supports them."
         )
-    return session_directive.encode(
+    return _emit_directive(
         "ask_question",
         # Encode the AUTHORITATIVELY-validated + normalized questions (deep
         # per-question/option checks), not the shallow-schema args: a
@@ -848,7 +886,7 @@ def monitor_start(name: str, args: dict[str, Any]) -> str:
     # the runaway backstop; the runtime budget is for callers that need a
     # hard TIME bound (e.g. "babysit this for at most 2 hours").
     max_runtime_secs = int(args.get("max_runtime_secs") or 0)
-    return session_directive.encode(
+    return _emit_directive(
         "monitor_start",
         {
             "message": message,
@@ -914,7 +952,7 @@ def monitor_update(name: str, args: dict[str, Any]) -> str:
             "monitor_update: nothing to change — pass at least one of "
             "message, interval_secs, max_cycles, max_runtime_secs."
         )
-    return session_directive.encode(
+    return _emit_directive(
         "monitor_update",
         {"patch": patch},
         f"Monitor-loop update requested for this session "
@@ -927,7 +965,7 @@ def set_project(name: str, args: dict[str, Any]) -> str:
     args = validate_tool_args(args, SET_PROJECT_SCHEMA)
     # Stateless: the session-aware consumer (chat_runner) applies the
     # project change to ITS OWN slot — no session identity resolved here.
-    return session_directive.encode(
+    return _emit_directive(
         "set_project",
         {"project": args.get("path", ""), "clear": bool(args.get("clear"))},
         "Project change requested for this session; if the path is valid "
@@ -944,7 +982,7 @@ def reset_conversation(name: str, args: dict[str, Any]) -> str:
     # empty because there is nothing to choose: a caller asking for a clean
     # context always wants a clean one, and the HTTP route carries a replay flag
     # for the rare caller that does not.
-    return session_directive.encode(
+    return _emit_directive(
         "reset_conversation",
         {},
         "Conversation reset requested for this session; if this turn is "
@@ -961,7 +999,7 @@ def suggest_followup(name: str, args: dict[str, Any]) -> str:
     # the card to ITS OWN slot; no session identity resolved here. The card
     # is broadcast-only (dropped if no client attached), so the confirmation
     # stays cautious — restate the follow-ups in reply text if they matter.
-    return session_directive.encode(
+    return _emit_directive(
         "suggest_followup",
         {"items": items},
         "Follow-up card requested for this session. It is delivered to a "

--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -184,6 +184,41 @@ def decode(text: str, expected_tool: str) -> dict[str, Any] | None:
     return args if isinstance(args, dict) else {}
 
 
+def peek(text: str) -> tuple[str, dict[str, Any]] | None:
+    """Parse the marker's ``(kind, args)`` with NO identity check, or ``None``.
+
+    A SELECTOR, never a grant — and the distinction is the whole reason this is
+    separate from :func:`decode`. ``decode`` answers "may I apply what this text
+    says?" and therefore demands the trusted tool identity. This answers "which
+    parked record is this frame talking about?", and its answer is only ever used
+    to look one up: a caller matches it against a record the TOOL validated and
+    the gateway parked, then applies the RECORD's payload. Nothing read here
+    reaches an effect, so a model editing the JSON can only fail to find a record
+    — it cannot smuggle a value past the tool's validation.
+
+    Consequently ``kind`` is returned unvalidated except for being a known
+    directive tool: an unknown kind can match no record anyway, and rejecting it
+    here would only duplicate the lookup's own failure.
+    """
+    if not text:
+        return None
+    idx = text.find(_SENTINEL)
+    if idx < 0:
+        return None
+    line = text[idx + len(_SENTINEL):].split("\n", 1)[0]
+    try:
+        block = json.loads(line)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(block, dict):
+        return None
+    kind = block.get("kind")
+    if not isinstance(kind, str) or kind not in DIRECTIVE_TOOLS:
+        return None
+    args = block.get("args")
+    return kind, (args if isinstance(args, dict) else {})
+
+
 def match_tool(raw: str) -> str:
     """Return the directive-tool name a recorded CANONICAL tool name refers to,
     or ``""``.

--- a/test/test_directive_queue.py
+++ b/test/test_directive_queue.py
@@ -1,0 +1,484 @@
+"""Provider-neutral session-directive delivery.
+
+The marker path can only be trusted when the provider stamps the tool call with
+``_meta.kiro`` identity. A backend that omits it leaves the forgery gate with no
+trusted source, so the gate refuses every directive and the whole control plane
+(loops, project changes, cards) fails closed. These cover the out-of-band path
+that carries the validated payload to the gateway instead, and — the part that
+matters most with several chat slots live at once — that a record can only ever
+be claimed by the session it was published for.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from kiro_crew import session_directive
+from kiro_crew.dashboard import directive_queue
+from kiro_crew.dashboard.chat_utils import _redact_tool_field
+from kiro_crew.dashboard.handlers.sessions import api_session_directive
+
+
+@pytest.fixture(autouse=True)
+def _clean_queue():
+    """Every test starts and ends with an empty store — the module holds process
+    state, so a leaked record would make a later test pass for the wrong reason."""
+    directive_queue.reset()
+    yield
+    directive_queue.reset()
+
+
+class TestPublishAndClaim:
+    def test_a_published_directive_is_claimable(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "check CI"})
+        rec = directive_queue.claim("sess-a", "monitor_start", {"message": "check CI"})
+        assert rec is not None
+        assert rec["kind"] == "monitor_start"
+        assert rec["args"] == {"message": "check CI"}
+
+    def test_claim_is_single_consume(self):
+        """Two consumers racing one session must not both apply the same record —
+        that is two armed loops from one request."""
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "x"}) is not None
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "x"}) is None
+
+    def test_claim_of_an_unknown_session_is_none_not_an_error(self):
+        assert directive_queue.claim("never-published", "monitor_start", {}) is None
+
+    def test_unknown_kind_is_refused(self):
+        """The only legitimate publishers are Kiro Crew's own directive tools, so
+        an unrecognized kind means the request did not come from one."""
+        with pytest.raises(ValueError, match="unknown directive kind"):
+            directive_queue.publish("sess-a", "rm_rf_everything", {})
+
+    def test_empty_session_key_is_refused(self):
+        with pytest.raises(ValueError, match="session_key required"):
+            directive_queue.publish("", "monitor_start", {})
+
+    def test_args_are_copied_not_aliased(self):
+        """The publisher's dict must not stay live inside the store: a later
+        mutation would change what gets applied."""
+        args = {"message": "original"}
+        directive_queue.publish("sess-a", "monitor_start", args)
+        args["message"] = "mutated after publish"
+        rec = directive_queue.claim("sess-a", "monitor_start", {"message": "original"})
+        assert rec is not None
+        assert rec["args"]["message"] == "original"
+
+
+class TestCorrelation:
+    """The record is unforgeable in CONTENT but its TARGET is a header; the marker
+    is bound to the right session but is model-visible text. A directive applies
+    only where both agree, which is what these lock in."""
+
+    def test_a_record_parked_for_another_session_cannot_be_activated(self):
+        """The cross-session attack: a same-uid caller over TCP (or on Windows,
+        where there is no AF_UNIX peer to attest) names the victim's session. The
+        victim's own turn never emits that payload, so nothing applies."""
+        directive_queue.publish("victim", "reset_conversation", {})
+        # The victim's turn is doing something else entirely.
+        assert directive_queue.claim("victim", "monitor_start", {"message": "mine"}) is None
+        # And the planted record is still not applicable by its own kind unless
+        # the victim's marker names it -- which is the whole point.
+        assert directive_queue.depth("victim") == 1
+
+    def test_a_mismatched_payload_does_not_claim(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "real"})
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "forged"}) is None
+        assert directive_queue.depth("sess-a") == 1
+
+    def test_a_mismatched_kind_does_not_claim(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        assert directive_queue.claim("sess-a", "reset_conversation", {"message": "x"}) is None
+        assert directive_queue.depth("sess-a") == 1
+
+    def test_key_order_does_not_defeat_the_match(self):
+        """The two channels serialize independently, so the comparison must be
+        about the payload rather than about emission order."""
+        directive_queue.publish("sess-a", "monitor_start", {"a": 1, "b": 2})
+        assert directive_queue.claim("sess-a", "monitor_start", {"b": 2, "a": 1}) is not None
+
+    def test_an_unknown_kind_claims_nothing(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        assert directive_queue.claim("sess-a", "rm_rf_everything", {"message": "x"}) is None
+        assert directive_queue.depth("sess-a") == 1
+
+    def test_a_redacted_marker_must_not_be_used_as_the_selector(self):
+        """The consumer redacts the tool output before broadcasting it, and that
+        scrubber rewrites credential-shaped runs anywhere in the string -- the
+        marker's JSON included. The record was parked with the args the tool
+        validated, so selecting on the REDACTED copy compares a scrubbed payload
+        against a raw one and loses a legitimate directive. Pins the asymmetry so
+        the consumer cannot drift back to peeking at the redacted text."""
+        args = {"message": "watch with token ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"}
+        raw_out = session_directive.encode("monitor_start", args, "human line")
+        redacted_out = _redact_tool_field(raw_out)
+
+        # The premise: redaction really does alter this marker.
+        assert redacted_out != raw_out
+
+        # Selecting on the redacted copy finds nothing -- the defect.
+        sel_redacted = session_directive.peek(redacted_out)
+        assert sel_redacted is not None
+        directive_queue.publish("sess-a", "monitor_start", args)
+        assert directive_queue.claim("sess-a", sel_redacted[0], sel_redacted[1]) is None
+
+        # Selecting on the raw provider text finds the record -- the fix.
+        sel_raw = session_directive.peek(raw_out)
+        assert sel_raw is not None
+        assert directive_queue.claim("sess-a", sel_raw[0], sel_raw[1]) is not None
+
+    def test_a_truncated_marker_must_not_be_used_as_the_selector(self):
+        """Same asymmetry by the other route: the redactor also caps the field, so
+        a long-but-legal directive can lose its marker tail entirely."""
+        args = {"message": "x" * 400}
+        raw_out = session_directive.encode("monitor_start", args, "human line")
+        truncated_out = raw_out[: len(raw_out) // 2]
+
+        directive_queue.publish("sess-a", "monitor_start", args)
+        assert session_directive.peek(truncated_out) is None
+        sel_raw = session_directive.peek(raw_out)
+        assert sel_raw is not None
+        assert directive_queue.claim("sess-a", sel_raw[0], sel_raw[1]) is not None
+
+    def test_a_record_from_an_abandoned_turn_is_not_claimable_by_a_later_turn(self):
+        """A cancelled turn leaves its record parked. Bounding the claim to the
+        claiming turn is what stops a stale reset/project/loop landing later."""
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        later_turn_started = time.monotonic() + 1.0
+        assert (
+            directive_queue.claim(
+                "sess-a", "monitor_start", {"message": "x"}, not_before=later_turn_started
+            )
+            is None
+        )
+
+    def test_a_record_from_this_turn_is_claimable(self):
+        this_turn_started = time.monotonic()
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        assert (
+            directive_queue.claim(
+                "sess-a", "monitor_start", {"message": "x"}, not_before=this_turn_started
+            )
+            is not None
+        )
+
+    def test_a_sibling_record_survives_a_claim_that_matches_neither(self):
+        """Two directives in one turn: a lookup for something else must not drain
+        the queue, or the sibling frame finds nothing."""
+        directive_queue.publish("sess-a", "monitor_start", {"message": "first"})
+        directive_queue.publish("sess-a", "suggest_followup", {"items": []})
+        assert directive_queue.claim("sess-a", "ask_question", {}) is None
+        assert directive_queue.depth("sess-a") == 2
+
+    def test_each_frame_claims_its_own_record(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "first"})
+        directive_queue.publish("sess-a", "suggest_followup", {"items": []})
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "first"}) is not None
+        assert directive_queue.depth("sess-a") == 1
+        assert directive_queue.claim("sess-a", "suggest_followup", {"items": []}) is not None
+        assert directive_queue.depth("sess-a") == 0
+
+    def test_two_identical_directives_are_consumed_one_per_frame(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "same"})
+        directive_queue.publish("sess-a", "monitor_start", {"message": "same"})
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "same"}) is not None
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "same"}) is not None
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "same"}) is None
+
+
+class TestSessionIsolation:
+    """The concurrency case: several chat slots arming at once.
+
+    Records are keyed by the session that published them, and a directive only
+    ever affects the session that claims it — so nothing can land in the wrong
+    slot. Nothing here is shared between the two sessions, which is the point.
+    """
+
+    def test_two_sessions_do_not_see_each_others_records(self):
+        directive_queue.publish("slot-a", "monitor_start", {"message": "for A"})
+        directive_queue.publish("slot-b", "monitor_start", {"message": "for B"})
+
+        rec_a = directive_queue.claim("slot-a", "monitor_start", {"message": "for A"})
+        rec_b = directive_queue.claim("slot-b", "monitor_start", {"message": "for B"})
+
+        assert rec_a is not None and rec_a["args"]["message"] == "for A"
+        assert rec_b is not None and rec_b["args"]["message"] == "for B"
+
+    def test_a_session_cannot_claim_a_record_parked_for_another(self):
+        directive_queue.publish("slot-b", "monitor_start", {"message": "for B"})
+        assert directive_queue.claim("slot-a", "monitor_start", {"message": "for B"}) is None
+        assert directive_queue.depth("slot-b") == 1
+
+    def test_one_session_claiming_does_not_drain_another(self):
+        directive_queue.publish("slot-a", "monitor_start", {"message": "for A"})
+        directive_queue.publish("slot-b", "suggest_followup", {"items": []})
+
+        directive_queue.claim("slot-a", "monitor_start", {"message": "for A"})
+
+        assert directive_queue.depth("slot-b") == 1
+
+    def test_discard_is_scoped_to_one_session(self):
+        directive_queue.publish("slot-a", "monitor_start", {"message": "a"})
+        directive_queue.publish("slot-b", "monitor_start", {"message": "b"})
+
+        assert directive_queue.discard("slot-a") == 1
+
+        assert directive_queue.claim("slot-a", "monitor_start", {"message": "a"}) is None
+        assert directive_queue.claim("slot-b", "monitor_start", {"message": "b"}) is not None
+
+
+class TestDiscard:
+    def test_discard_drops_without_applying(self):
+        """The kiro-cli path applies from the verified marker; the out-of-band
+        twin must be retired or the effect lands twice."""
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        assert directive_queue.discard("sess-a") == 1
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "x"}) is None
+
+    def test_discard_of_nothing_is_zero(self):
+        assert directive_queue.discard("sess-a") == 0
+
+    def test_discard_of_empty_key_is_zero(self):
+        assert directive_queue.discard("") == 0
+
+
+class TestBounds:
+    def test_the_queue_is_capped_and_keeps_the_newest(self):
+        """An unclaimed queue must not grow without limit, and a live session's
+        most recent intent is the one worth keeping."""
+        for i in range(directive_queue.MAX_PER_SESSION + 3):
+            directive_queue.publish("sess-a", "monitor_start", {"message": f"m{i}"})
+
+        assert directive_queue.depth("sess-a") == directive_queue.MAX_PER_SESSION
+        # The three oldest were dropped, so m2 is gone and m3 survives.
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "m2"}) is None
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": "m3"}) is not None
+        newest = f"m{directive_queue.MAX_PER_SESSION + 2}"
+        assert directive_queue.claim("sess-a", "monitor_start", {"message": newest}) is not None
+
+    def test_a_bucket_whose_records_all_expired_is_deleted_not_left_empty(self):
+        """The unbounded-growth case. Only the dashboard consumer claims -- a
+        channel session (Slack/Discord, driven by the marker path) never calls in
+        here, so its bucket has no read path and would live for the gateway's whole
+        lifetime. Reclaim therefore runs on PUBLISH."""
+        directive_queue.publish("channel-sess", "monitor_start", {"message": "x"})
+        assert "channel-sess" in directive_queue._pending
+
+        with patch.object(
+            directive_queue.time,
+            "monotonic",
+            return_value=time.monotonic() + directive_queue.MAX_AGE_SECS + 1,
+        ):
+            directive_queue.publish("someone-else", "monitor_start", {"message": "y"})
+
+        assert "channel-sess" not in directive_queue._pending
+
+    def test_the_publishing_session_is_never_swept_out_from_under_itself(self):
+        """A publish must not lose the record it is parking, even when that
+        session's earlier records are all expired."""
+        directive_queue.publish("sess-a", "monitor_start", {"message": "old"})
+        with patch.object(
+            directive_queue.time,
+            "monotonic",
+            return_value=time.monotonic() + directive_queue.MAX_AGE_SECS + 1,
+        ):
+            directive_queue.publish("sess-a", "monitor_start", {"message": "new"})
+            assert directive_queue.depth("sess-a") == 1
+            rec = directive_queue.claim("sess-a", "monitor_start", {"message": "new"})
+        assert rec is not None
+
+    def test_a_fresh_bucket_for_another_session_is_not_swept(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "a"})
+        directive_queue.publish("sess-b", "monitor_start", {"message": "b"})
+        assert directive_queue.depth("sess-a") == 1
+        assert directive_queue.depth("sess-b") == 1
+
+    def test_the_session_count_is_capped_and_keeps_the_most_recent(self):
+        """The backstop: more distinct sessions publishing inside one expiry window
+        than the cap allows. Whole buckets go, least-recently-published first."""
+        for i in range(directive_queue.MAX_SESSIONS + 5):
+            directive_queue.publish(f"sess-{i:04d}", "monitor_start", {"message": "x"})
+
+        assert len(directive_queue._pending) <= directive_queue.MAX_SESSIONS
+        # The publisher of the newest record is always retained.
+        newest = f"sess-{directive_queue.MAX_SESSIONS + 4:04d}"
+        assert newest in directive_queue._pending
+        # The oldest buckets were the ones evicted.
+        assert "sess-0000" not in directive_queue._pending
+
+    def test_a_stale_record_is_dropped_rather_than_applied(self):
+        """A directive belongs to the turn that asked for it. Applying one long
+        after that turn ended would arm a loop nobody is waiting on."""
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        with patch.object(
+            directive_queue.time,
+            "monotonic",
+            return_value=time.monotonic() + directive_queue.MAX_AGE_SECS + 1,
+        ):
+            assert directive_queue.claim("sess-a", "monitor_start", {"message": "x"}) is None
+
+    def test_a_fresh_record_survives_the_age_check(self):
+        directive_queue.publish("sess-a", "monitor_start", {"message": "x"})
+        with patch.object(
+            directive_queue.time,
+            "monotonic",
+            return_value=time.monotonic() + (directive_queue.MAX_AGE_SECS / 2),
+        ):
+            assert directive_queue.claim("sess-a", "monitor_start", {"message": "x"}) is not None
+
+
+def _request(headers: dict, body: object, can_read: bool = True, local: bool = True):
+    """A request double for the endpoint.
+
+    ``local`` models what the auth middleware stamped on the request: an
+    internal-secret / kernel-verified peer caller (True) versus a
+    cookie-authenticated browser caller on a ``local_only=False`` deployment
+    (False). The ``.get`` mapping is backed by a REAL dict on purpose — a bare
+    ``MagicMock.get`` returns a truthy mock, which would silently satisfy the
+    handler's locality re-assert and make every test here vacuous.
+    """
+    req = MagicMock(spec=web.Request)
+    req.headers = headers
+    req.can_read_body = can_read
+    req.json = AsyncMock(return_value=body)
+    req.app = {"state": MagicMock()}
+    _scope: dict = {"internal_auth": True} if local else {}
+    req.get = _scope.get
+    return req
+
+
+class TestEndpoint:
+    @pytest.mark.asyncio
+    async def test_happy_path_parks_the_record_for_the_declared_session(self):
+        resp = await api_session_directive(
+            _request(
+                {"X-Session-Key": "slot-a"},
+                {"kind": "monitor_start", "args": {"message": "go"}},
+            )
+        )
+        assert resp.status == 200
+        rec = directive_queue.claim("slot-a", "monitor_start", {"message": "go"})
+        assert rec is not None
+        assert rec["args"] == {"message": "go"}
+
+    @pytest.mark.asyncio
+    async def test_missing_session_key_is_400_with_a_code(self):
+        resp = await api_session_directive(_request({}, {"kind": "monitor_start", "args": {}}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_kind_is_400_and_parks_nothing(self):
+        resp = await api_session_directive(
+            _request({"X-Session-Key": "slot-a"}, {"kind": "not_a_directive"})
+        )
+        assert resp.status == 400
+        assert directive_queue.depth("slot-a") == 0
+
+    @pytest.mark.asyncio
+    async def test_cookie_caller_cannot_park_a_directive_for_a_chosen_session(self):
+        """The locality re-assert. On a ``local_only=False`` deployment the auth
+        middleware admits a cookie/token caller onto this strict route, and such
+        a caller picks its own ``X-Session-Key`` — which would be a cross-session
+        mutation once the named turn's consumer applies the record. 403, and the
+        queue must stay empty."""
+        resp = await api_session_directive(
+            _request(
+                {"X-Session-Key": "victim-slot"},
+                {"kind": "monitor_start", "args": {"message": "go"}},
+                local=False,
+            )
+        )
+        assert resp.status == 403
+        assert directive_queue.depth("victim-slot") == 0
+
+    @pytest.mark.asyncio
+    async def test_kernel_verified_peer_without_the_secret_is_accepted(self):
+        """``peer_verified`` alone is enough: the kernel attested the AF_UNIX
+        peer's ancestry resolves to the DECLARED key, which is stronger evidence
+        for this route than the shared secret."""
+        req = _request(
+            {"X-Session-Key": "slot-a"},
+            {"kind": "monitor_start", "args": {"message": "go"}},
+            local=False,
+        )
+        req.get = {"peer_verified": True}.get
+        resp = await api_session_directive(req)
+        assert resp.status == 200
+        assert directive_queue.depth("slot-a") == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_body_is_400_and_parks_nothing(self):
+        req = _request({"X-Session-Key": "slot-a"}, None)
+        req.json = AsyncMock(side_effect=ValueError("not json"))
+        resp = await api_session_directive(req)
+        assert resp.status == 400
+        assert directive_queue.depth("slot-a") == 0
+
+    @pytest.mark.asyncio
+    async def test_non_dict_args_degrade_to_empty_not_a_crash(self):
+        resp = await api_session_directive(
+            _request(
+                {"X-Session-Key": "slot-a"},
+                {"kind": "reset_conversation", "args": "not-a-dict"},
+            )
+        )
+        assert resp.status == 200
+        rec = directive_queue.claim("slot-a", "reset_conversation", {})
+        assert rec is not None
+        assert rec["args"] == {}
+
+
+class TestEmitHelperPublishes:
+    """``control._emit_directive`` must park the payload as well as return the
+    marker — the marker alone is what a provider-less backend cannot use."""
+
+    def test_emit_publishes_and_still_returns_the_marker(self):
+        from kiro_crew.mcp_tools import control
+
+        posted: list[tuple] = []
+
+        with patch.object(
+            control.mcp_core, "_post", side_effect=lambda p, b: posted.append((p, b))
+        ):
+            out = control._emit_directive("monitor_start", {"message": "hi"}, "Monitor requested.")
+
+        assert posted == [
+            ("/api/session-directive", {"kind": "monitor_start", "args": {"message": "hi"}})
+        ]
+        from kiro_crew import session_directive
+
+        assert session_directive.has_marker(out)
+
+    def test_a_refused_oversized_directive_is_never_published(self):
+        """``encode`` refuses an over-limit payload and tells the model nothing was
+        applied. Publishing anyway would leave a record that contradicts that."""
+        from kiro_crew import session_directive
+        from kiro_crew.mcp_tools import control
+
+        posted: list[tuple] = []
+        huge = {"message": "x" * (session_directive.MAX_DIRECTIVE_CHARS + 100)}
+
+        with patch.object(
+            control.mcp_core, "_post", side_effect=lambda p, b: posted.append((p, b))
+        ):
+            out = control._emit_directive("monitor_start", huge, "Monitor requested.")
+
+        assert session_directive.is_refusal(out)
+        assert posted == []
+
+    def test_a_publish_failure_does_not_break_the_tool(self):
+        """An older gateway with no such route, or one that is down, must not turn
+        a working tool call into an error — the marker path may still work."""
+        from kiro_crew import session_directive
+        from kiro_crew.mcp_tools import control
+
+        with patch.object(control.mcp_core, "_post", side_effect=RuntimeError("gateway down")):
+            out = control._emit_directive("monitor_start", {"message": "hi"}, "Monitor requested.")
+
+        assert session_directive.has_marker(out)

--- a/test/test_session_directive.py
+++ b/test/test_session_directive.py
@@ -246,3 +246,54 @@ class TestHasMarker:
         assert sd.has_marker(forged) is True
         assert sd.directive_tool_for("", "execute_bash") == ""
         assert sd.decode(forged, "execute_bash") is None
+
+
+class TestPeek:
+    """``peek`` is the out-of-band path's SELECTOR: it reads the marker's
+    ``(kind, args)`` with no identity check so a caller can look up the record the
+    tool validated. It must never be usable as a grant -- what it returns is only
+    ever compared against a parked record, and the record's payload is applied."""
+
+    def test_peek_reads_the_kind_and_args(self):
+        out = sd.encode("monitor_start", {"message": "check CI"}, "human")
+        assert sd.peek(out) == ("monitor_start", {"message": "check CI"})
+
+    def test_peek_of_plain_text_is_none(self):
+        assert sd.peek("just a normal tool result") is None
+        assert sd.peek("") is None
+
+    def test_peek_of_a_refusal_is_none(self):
+        """A refused directive published nothing, so there is no record to select."""
+        refusal = sd.encode("monitor_start", {"message": "x" * 5000}, "human")
+        assert sd.peek(refusal) is None
+
+    def test_peek_rejects_an_unknown_kind(self):
+        forged = sd._SENTINEL + '{"kind":"rm_rf_everything","args":{}}'
+        assert sd.peek(forged) is None
+
+    def test_peek_of_malformed_json_is_none(self):
+        assert sd.peek(sd._SENTINEL + "{not json") is None
+
+    def test_peek_of_a_non_dict_block_is_none(self):
+        assert sd.peek(sd._SENTINEL + '["monitor_start"]') is None
+
+    def test_peek_degrades_non_dict_args_to_empty(self):
+        forged = sd._SENTINEL + '{"kind":"monitor_start","args":"nope"}'
+        assert sd.peek(forged) == ("monitor_start", {})
+
+    def test_peeking_grants_nothing_on_its_own(self):
+        """The forged-marker case, for the selector: peek succeeds and the
+        directive still cannot be applied, because applying requires a record the
+        gateway parked for THIS session in THIS turn."""
+        forged = sd.encode("monitor_start", {"message": "x"}, "human")
+        assert sd.peek(forged) is not None
+        assert sd.decode(forged, "execute_bash") is None
+
+    def test_peek_of_stripped_text_is_none(self):
+        """The ordering trap, pinned. ``strip_marker`` removes the very marker
+        ``peek`` reads, so a consumer MUST read its selector before it rewrites
+        the tool output -- a ``peek`` placed after the strip returns None forever
+        and whatever it was guarding silently never runs."""
+        out = sd.encode("monitor_start", {"message": "x"}, "human")
+        assert sd.peek(out) is not None
+        assert sd.peek(sd.strip_marker(out)) is None


### PR DESCRIPTION
## Problem

On an ACP backend that does not emit `_meta.kiro` identity, **every** session
directive is silently discarded — `monitor_start`, `monitor_update`,
`autonudge_stop`, `set_project`, `suggest_followup`, `ask_question` and
`reset_conversation`. The whole control plane fails closed.

The forgery gate (`session_directive.directive_tool_for`) checks two things in
order:

```python
if mcp_server_name != CORE_MCP_SERVER:   # check 1
    return ""
return match_tool(tool_name or "")        # check 2
```

Both arguments must come from the provider's out-of-band `_meta.kiro` channel.
Observed live on a KAS-backed session:

```
session-directive NOT APPLIED: marker present but the tool call carried no
core-MCP identity (mcp_server_name='', tool_name='',
expected mcp_server_name='kirocrew-core'). Either a forged marker, or this
ACP backend does not emit _meta.kiro identity.
```

Empty, so check 1 returns `""` before check 2 ever runs. The tool executed and
validated its arguments; only the consumer's decision to act was lost.

**The gate is right to fail closed.** The marker is model-visible text (it comes
back as the tool result), so a model could type the bytes itself; trusting the
marker alone would let a shell command titled `monitor_start` drive a directive.
The defect is not the refusal — it is that the gate's ONE trusted signal is a
kiro-cli engine feature, so on any other backend it has no trusted source at all.

Two recently-merged PRs did not and could not fix this:

* **#7143** projects `mcpServers` on the OUTBOUND `session/new` frame, so the tool
  *exists* and can be called. This failure is on the INBOUND path, reading frames
  that describe a call that already happened.
* **#6970** fixed a real bug in **check 2** (`mcp__kirocrew-core__monitor_start`
  not resolving). Check 1 short-circuits first, so check 2 never runs here. What
  #6970 did deliver is the diagnostic quoted above — before it, this failure
  produced zero log output, which is why it stayed hidden.

## What changed

A second delivery path that Kiro Crew owns end to end. `mcp_tools.control`
directive tools now route through `_emit_directive`, which encodes the marker as
before **and** POSTs the validated payload to a new internal route
(`/api/session-directive`). The gateway parks it in
`dashboard.directive_queue`, keyed by session. The turn's consumer claims it.

The kiro-cli path is untouched and still authoritative there.

### Why this is not weaker than the gate it backs up

**Two channels must agree, and neither is trusted alone.** That is the whole
design, and each channel exists to cover the other's weak point:

| | Carries | Bound correctly to | Weak point |
|---|---|---|---|
| **Record** (out of band) | the payload | — | its **target** is an `X-Session-Key` header, kernel-attested only for an AF_UNIX peer whose /proc ancestry resolves |
| **Marker** (tool result) | nothing that is applied | the **session and turn**, by arriving on that session's own event stream | its **content** is model-visible text, so a model can type one |

`directive_queue.claim(session_key, kind, args, not_before=turn_start)` returns
only a record whose `(kind, args)` equal the ones **this frame's marker names**,
parked during **this turn** — and the payload applied is always the RECORD's.
So:

* A record aimed at **another session** waits for a marker that session's model
  never emits. Nothing applies. (This is why the header not being attested over
  TCP loopback — and not at all on Windows, which has no AF_UNIX — is not
  sufficient for an attack.)
* A **forged marker** looks up a record no tool ever validated, and finds nothing.
* A record left by a **cancelled turn** is outside the next turn's window, so a
  stale reset / project change / loop cannot land minutes later.
* A model can still drive its **own** session by publishing and marking honestly,
  which is exactly what calling the tool does. No privilege gained.

The marker therefore contributes only the *choice of which record to look up* —
never a value. `session_directive.peek()` is deliberately separate from `decode()`
for that reason: `decode` answers "may I apply this?" and demands the trusted tool
identity; `peek` answers "which record is this frame talking about?" and grants
nothing.

A ticket/nonce carried inside the marker was designed first and **rejected**: the
internal API authenticates on `.local_secret`, which the agent can read, so a
model could mint its own ticket. That would have been *weaker* than kiro-cli's
current guarantee, where the engine writes the identity and the model cannot.

### Sub-agent isolation

A native sub-agent's tool calls surface as flat events on the parent's stream
(tagged in `_native_tc_card`) with no independently bindable slot, and the record
its tool parked is keyed by the **parent**. Those frames are refused rather than
applied — the same refusal the marker path already made, with the same
`sel().log_tool_invocation(outcome="denied")` audit — and the child's own record is
retired by the same `(kind, args)` correlation, so a directive the parent
legitimately parked in that turn survives.

### Concurrency across chat slots

Structural, not coordinated. Records are stored per session key **and** matched by
payload within the claiming turn, so two slots arming at once produce two
independent records and neither can land in the other's slot. There is no shared
token to mix up.

### Bounds and lifetime

* **In-memory, never persisted.** A directive belongs to the turn that asked for
  it; surviving a gateway restart would arm a loop, or land a project change,
  against a turn that no longer exists.
* **Age-bounded** (`MAX_AGE_SECS = 300`) — a stale record is dropped on claim.
* **Turn-bounded** — `not_before` pins a claim to the turn that asked for it.
* **Capped per session** (`MAX_PER_SESSION = 8`), oldest dropped, so an unclaimed
  queue cannot grow without limit while a live session keeps its newest intent.
* **`discard()`** retires the duplicate on the kiro-cli path. The tool publishes
  unconditionally (it cannot know which consumer will run), so applying both paths
  would arm two loops or render two cards.
* **Fail-soft publish.** An older gateway with no such route, or one that is down,
  must not turn a working tool call into an error. Silent by design: this module
  runs as a stdio MCP server where the process's streams are the protocol channel,
  and the failure that matters is reported at the consumer.

Route registration is STRICT-internal, beside its sibling `/api/session-keepalive`
— same caller class (an MCP subprocess), same auth. **The handler additionally
re-asserts locality itself** (`internal_auth` or `peer_verified`, the same
predicate as `handlers/updates.py`) before reading the session key, because a
`local_only=False` deployment reclassifies strict paths as MIXED and would
otherwise admit a cookie-authenticated browser caller here.

## Tests

40 in `test/test_directive_queue.py` + 9 for `peek` in `test/test_session_directive.py`:

* publish/claim round trip, single-consume, unknown session, args copied not
  aliased
* **correlation** — a record parked for another session cannot be activated, a
  mismatched payload or kind claims nothing, key order does not defeat the match,
  an unknown kind claims nothing, a record from an abandoned turn is not claimable
  by a later turn, each frame claims its own record, two identical directives are
  consumed one per frame
* **cross-session isolation** — two slots do not see each other's records, a
  session cannot claim another's record, one claiming does not drain another,
  `discard` is scoped to one session
* **bounds in both dimensions** — per-session cap keeps the newest, stale dropped,
  fresh survives, a bucket whose records all expired is deleted rather than left
  empty, the publishing session is never swept out from under itself, a fresh
  bucket for another session is not swept, the session count is capped and keeps
  the most recent
* endpoint — happy path parks for the declared session; a cookie caller cannot
  park for a chosen session; a kernel-verified peer without the secret is
  accepted; missing key, unknown kind, malformed body and non-dict args all refuse
  without parking
* emit helper — publishes and still returns the marker; a **refused** oversized
  payload is never published; a publish failure does not break the tool
* `peek` — reads the selector, refuses plain text / a refusal / an unknown kind /
  malformed JSON, degrades non-dict args, grants nothing on its own, and returns
  `None` once `strip_marker` has run (the ordering trap)

Every new behaviour **mutation-checked**: each guard reverted in isolation, each
caught by a pinning test, then restored.

```
CAUGHT: claim is not single-consume (peek instead of pop)
CAUGHT: claim ignores session scoping (drains every session)
CAUGHT: discard does not remove the twin
CAUGHT: per-session cap not enforced
CAUGHT: stale records applied instead of dropped
CAUGHT: unknown directive kind accepted
CAUGHT: args aliased instead of copied
CAUGHT: a REFUSED oversized directive is published anyway
CAUGHT: claim drops the args match (uncorrelated drain)
CAUGHT: claim drops the kind match
CAUGHT: claim drops the turn window
CAUGHT: claim drops the staleness sweep
CAUGHT: publish does not sweep
CAUGHT: expired buckets left in place as empty lists
CAUGHT: process-wide session cap not enforced
CAUGHT: eviction order reversed (newest evicted first)
CAUGHT: the endpoint's locality re-assert removed
```

127 tests green across the new file plus the existing `test_session_directive`,
`test_driver_session_directives` and `test_session_keepalive` suites. flake8,
isort, mypy and the black gate all clean.

## Known gap

The consumer edit in `chat_runner.py` is **not** directly covered. Reaching that
branch means driving `_run_chat`'s `EVENT_TOOL_RESULT` loop, which no existing
test harness does. The applier it calls (`apply_session_directive`) and the queue
it claims from are both covered; the wiring between them is verified only by the
live reproduction above plus manual verification. Stated rather than papered over.

## Manual verification

Before this change, on a KAS-backed session: `monitor_start` answered "Monitor
loop requested", `monitor_armed.py` reported **NOT ARMED** (zero loops in the
store), and the gateway logged the identity-gate drop quoted at the top. That is
the failure this fixes, captured on real traffic.

## Pattern harvest

The gate was correct and its comment was accurate; what went wrong is that its one
source of truth belonged to somebody else. `_meta.kiro` is written by the kiro-cli
engine, so the security property "only our own MCP server can drive a directive"
was really "only this one provider can drive a directive" — and nothing in the
design said so, because when it was written there was only one provider.

The near-miss worth recording is the fix I almost shipped. A nonce inside the
marker looks like textbook anti-forgery and would have passed review on shape
alone. It fails on one fact that lives nowhere near the design: the mint endpoint
authenticates on a secret the agent can read. Checking *who can produce the
credential* is what separated it from the version that works.

Rule candidate: when a check's trusted input comes from outside the component,
name the producer in the comment, not just the field. "Requires
`_meta.kiro.mcpServerName`" reads like a schema note; "requires the kiro-cli
engine to have stamped this frame" states the coupling, and a second backend then
arrives as an obvious question instead of a silent, logless failure.

Second candidate: before adding a token to prove provenance, ask who else can mint
one. A token whose issuing path is reachable by the party you are defending
against is decoration, and if it replaces a stronger check it is a regression.

no linked issue: found while driving #7143 to green on a live KAS session, not from a filed report. The `#7143` / `#6970` references above are prior PRs on the same path, not issues this closes.

---

**Rebased** onto `2ba6fb53e4bc` (17 commits, zero conflicts). Single commit
`ecbd70bc4887`, diff unchanged. All gates re-verified on the new base: 127 tests,
flake8, isort, mypy, black.

Two CI reds on this head are **inherited main breakage**, reproduced on a pristine
`origin/main` worktree with no PR changes:

* `Backend Tests (3.10, 3)` / `(3.12, 3)` — `test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor`, census drift behind main's own `#7283` in `dashboard/handlers/memory.py`.
* `Backend Tests (Windows) (3)` — `test_session_storage.py` sidecar move, from main's `3510362ef`.

Neither file is touched by this PR.
