### PR TITLE
fix(doctor): stop reporting identifier flag operands as dead paths

### DIFF
--- a/src/kiro_crew/doctor_deadpath.py
+++ b/src/kiro_crew/doctor_deadpath.py
@@ -9,7 +9,10 @@ data home and surfaces ``internal_auth_mismatch``. Nothing names the dead path.
 
 This module walks every agent spec JSON in :func:`kiro_agents_dir_path` and
 stats every absolute ``command`` path, absolute path-like arg, and absolute
-path-like env value:
+path-like env value. Values that only LOOK like paths are screened out first —
+separator-joined lists, and the operands of flags that take an opaque identifier
+(see :data:`_IDENTIFIER_FLAGS`) — because a false "dead path" on a healthy
+install turns the whole check red and teaches operators to ignore it:
 
 * **Managed specs** (the ones ``install_agent`` / ``rebuild_agent_config`` own,
   i.e. :data:`~kiro_crew.agent_files.OWNED_KIRO_AGENT_FILES`) with dead paths are
@@ -239,11 +242,19 @@ _CREDENTIAL_KEY_MARKERS: tuple[str, ...] = (
     "PRIVATE",
 )
 
-# Opaque identifier flag operands that merely look like absolute paths
-# (e.g. --scope /spaces/nsp_abc123). Not filesystem paths — must not be
-# stat-ed, otherwise a healthy install is permanently red (see #7375).
-# Strict literal set: a heuristic would trade bounded false positive for
-# unbounded false negative.
+#: Flags whose OPERAND is an opaque identifier, never a filesystem path.
+#: Some namespace and scope identifiers are conventionally slash-prefixed
+#: (``--scope /spaces/ns_abc123``), which makes them absolute-path-SHAPED while
+#: being unresolvable on any host by design. That is indistinguishable from a
+#: genuinely removed directory by value alone: such an operand is absolute, is a
+#: single value, and does not exist. The only signal that separates them is
+#: POSITIONAL — which flag the value is the operand of — so the skip has to read
+#: the preceding argument rather than the value.
+#:
+#: Deliberately a short, literal set rather than a heuristic. A heuristic here
+#: would trade a guaranteed false positive for an unbounded false NEGATIVE, and a
+#: dead-path check that silently stops reporting real dead paths is worse than one
+#: that over-reports.
 _IDENTIFIER_FLAGS: frozenset[str] = frozenset({"--scope", "--namespace", "--space"})
 
 _REDACTED_VALUE = "<redacted: credential-shaped key>"
@@ -252,6 +263,19 @@ _REDACTED_VALUE = "<redacted: credential-shaped key>"
 def _credential_shaped_key(key: str) -> bool:
     upper = key.upper()
     return any(marker in upper for marker in _CREDENTIAL_KEY_MARKERS)
+
+
+def _is_identifier_operand(args: list, i: int) -> bool:
+    """Whether ``args[i]`` is the operand of an identifier-taking flag.
+
+    Read BEFORE the value is tested, so the operand is never stat-ed. Deciding it
+    afterwards reaches the same report but performs the filesystem probe the
+    module docstring promises not to perform.
+    """
+    if i == 0:
+        return False
+    prev = args[i - 1]
+    return isinstance(prev, str) and prev in _IDENTIFIER_FLAGS
 
 
 def _walk_server_paths(server: str, entry: dict) -> list[DeadPath]:
@@ -267,15 +291,10 @@ def _walk_server_paths(server: str, entry: dict) -> list[DeadPath]:
         for i, arg in enumerate(args):
             if (
                 isinstance(arg, str)
+                and not _is_identifier_operand(args, i)
                 and _looks_like_single_absolute_path(arg)
                 and _path_is_dead(arg)
             ):
-                # Skip an arg whose preceding arg is an identifier flag — the
-                # value is an opaque id, not a filesystem path. Safe on
-                # non-string / out-of-bounds / args[0]: those fall through to
-                # the normal dead-path check.
-                if i > 0 and isinstance(args[i - 1], str) and args[i - 1] in _IDENTIFIER_FLAGS:
-                    continue
                 dead.append(DeadPath(spec="", server=server, where=f"args[{i}]", path=arg))
 
     env = entry.get("env")

--- a/test/test_doctor_deadpath.py
+++ b/test/test_doctor_deadpath.py
@@ -308,6 +308,182 @@ class TestPathListIgnored:
         assert foreign[0].dead[0].path == dead_home
 
 
+# ── identifier operands of non-path flags ────────────────────────────────────
+
+
+class TestIdentifierOperandIgnored:
+    """A slash-prefixed identifier is not a path, and only position says so.
+
+    ``--scope /spaces/nsp_x`` names a remote namespace. The operand is absolute,
+    single, and absent from every filesystem by design, so it is byte-for-byte the
+    shape of a genuinely removed directory. Nothing about the VALUE can separate the
+    two; the discriminator is which flag it follows.
+    """
+
+    def test_scope_operand_is_not_flagged(self, agents_dir: Path) -> None:
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {
+                "policy-scope-server": {
+                    "command": str(agents_dir),  # live command
+                    "args": ["mcp", "start", "--scope", "/spaces/ns_abc123"],
+                }
+            },
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        assert report.foreign_dead == []
+        assert report.has_findings is False
+
+    def test_identifier_operand_is_never_stat_ed(self, agents_dir: Path, monkeypatch) -> None:
+        """The operand must not reach the filesystem probe at all.
+
+        This is the assertion the REPORT cannot make. Deciding the skip after
+        ``_path_is_dead`` produces an identical ``foreign_dead`` while still stat-ing
+        an opaque remote identifier, so a report-only test passes either way and the
+        module docstring's "must not be stat-ed" goes unenforced. Spying on the probe
+        is what separates the two orderings.
+        """
+        probed: list[str] = []
+        real = dp._path_is_dead
+
+        def spy(path: str) -> bool:
+            probed.append(path)
+            return real(path)
+
+        monkeypatch.setattr(dp, "_path_is_dead", spy)
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {
+                "policy-scope-server": {
+                    "command": str(agents_dir),
+                    "args": ["mcp", "start", "--scope", "/spaces/ns_abc123"],
+                }
+            },
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        assert report.foreign_dead == []
+        assert "/spaces/ns_abc123" not in probed, (
+            "the identifier operand was stat-ed; the screen must be read BEFORE "
+            f"_path_is_dead, not after it. probed={probed}"
+        )
+
+    @pytest.mark.parametrize("flag", ["--scope", "--namespace", "--space"])
+    def test_every_identifier_flag_operand_is_not_flagged(
+        self, agents_dir: Path, flag: str
+    ) -> None:
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {"srv": {"command": str(agents_dir), "args": ["run", flag, "/spaces/nsp_zz"]}},
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        assert report.foreign_dead == []
+
+    def test_attached_operand_spelling_is_not_flagged(self, agents_dir: Path) -> None:
+        # ``--scope=/spaces/nsp_x`` is not absolute as a whole string, so it never
+        # reached the stat anyway. Pinned so the two spellings cannot diverge if the
+        # arg walk is ever changed to split on ``=``.
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {"srv": {"command": str(agents_dir), "args": ["--scope=/spaces/nsp_zz"]}},
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        assert report.foreign_dead == []
+
+    def test_dead_path_after_an_ordinary_flag_is_still_flagged(self, agents_dir: Path) -> None:
+        # The load-bearing half: skipping identifier operands must not blind the
+        # check to a real dead path that merely happens to follow some flag.
+        dead = str(agents_dir / "gone")
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {"srv": {"command": str(agents_dir), "args": ["--config", dead]}},
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        foreign = report.foreign_dead
+        assert len(foreign) == 1
+        assert foreign[0].dead[0].where == "args[1]"
+        assert foreign[0].dead[0].path == dead
+
+    def test_dead_path_two_positions_after_an_identifier_flag_is_flagged(
+        self, agents_dir: Path
+    ) -> None:
+        # Only the IMMEDIATELY following arg is the flag's operand. A later path
+        # argument is unrelated and must keep being checked.
+        dead = str(agents_dir / "gone")
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {
+                "srv": {
+                    "command": str(agents_dir),
+                    "args": ["--scope", "/spaces/nsp_zz", dead],
+                }
+            },
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        foreign = report.foreign_dead
+        assert len(foreign) == 1
+        assert [d.path for d in foreign[0].dead] == [dead]
+
+    def test_identifier_flag_as_the_last_arg_does_not_index_past_the_end(
+        self, agents_dir: Path
+    ) -> None:
+        # A trailing flag with no operand must not raise, and the flag itself is
+        # relative so it was never a path candidate.
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {"srv": {"command": str(agents_dir), "args": ["run", "--scope"]}},
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        assert report.foreign_dead == []
+
+    def test_absolute_first_arg_is_still_checked(self, agents_dir: Path) -> None:
+        # index 0 has no preceding arg; the guard must not swallow it.
+        dead = str(agents_dir / "gone")
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {"srv": {"command": str(agents_dir), "args": [dead]}},
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        assert [d.path for d in report.foreign_dead[0].dead] == [dead]
+
+    def test_non_string_preceding_arg_does_not_crash_the_walk(self, agents_dir: Path) -> None:
+        # Spec JSON is foreign input: a non-string arg is possible and must not
+        # make the positional lookup explode.
+        dead = str(agents_dir / "gone")
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {"srv": {"command": str(agents_dir), "args": [7, dead]}},
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        assert [d.path for d in report.foreign_dead[0].dead] == [dead]
+
+
 # ── malformed JSON tolerated ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem / Motivation

`kirocrew doctor`'s dead-path check reported a healthy install as red. An
identifier flag's operand is conventionally slash-prefixed
(`--scope /spaces/ns_abc123`), which makes it absolute-path-SHAPED while being
unresolvable on any host by design, so the check stat-ed it, found nothing, and
named it a dead path.

**Scope has narrowed since this PR was opened.** The predicate itself landed
separately as 4525771ae (#7594), so `main` already returns the correct
`foreign_dead` for every input shape this PR's tests cover. What is left is the
part #7594 did not carry: the operand is screened only AFTER it has been stat-ed,
so `main`'s own comment that it "must not be stat-ed" does not hold, and there is
no test anywhere pinning the behaviour against a future refactor.

## Why it matters

A check that is permanently red on a healthy machine trains operators to ignore
it, which is precisely when a genuinely dead path stops being noticed. The
dead-path sweep exists because that failure is silent and expensive; a standing
false positive gives back the silence.

## What changed (motivation → approach → change)

**Two things remain after the rebase onto `main`.**

**1. The screen is read before the stat, not after it.** `main` places the
identifier-flag check *inside* the `_looks_like_single_absolute_path(arg) and
_path_is_dead(arg)` condition, so the operand is already stat-ed by the time the
skip runs. The reported `foreign_dead` is identical either way, which is why the
behaviour tests pass on `main` — but `main`'s comment says the operand "must not
be stat-ed", and as written that is false. This PR hoists the screen into the
condition ahead of the probe:

```python
if (
    isinstance(arg, str)
    and not _is_identifier_operand(args, i)
    and _looks_like_single_absolute_path(arg)
    and _path_is_dead(arg)
):
```

**2. A regression net.** `main` has no identifier-flag coverage at all —
`git grep` for `_IDENTIFIER`, `--scope` or `ns_` in
`origin/main:test/test_doctor_deadpath.py` exits 1 — so nothing currently stops a
refactor re-widening the false positive.

**Deduplication, in the same commit.** A naive apply would leave the fix in the
tree twice. `main`'s inner `if i > 0 and isinstance(args[i - 1], str) and
args[i - 1] in _IDENTIFIER_FLAGS: continue` block is removed, since the hoisted
predicate makes it unreachable, and there is exactly one `_IDENTIFIER_FLAGS`
constant left (`grep -c '^_IDENTIFIER_FLAGS'` returns 1), keeping the longer
rationale comment.

## Tests

`test/test_doctor_deadpath.py :: TestIdentifierOperandIgnored` — 8 test
functions, 10 cases: the three identifier flags parametrized, the attached
`--scope=/x` spelling, a dead path after an *ordinary* flag still being flagged,
a dead path two positions after an identifier flag still being flagged, an
identifier flag as the final arg not indexing past the end, an absolute first arg
still being checked, and a non-string preceding arg not crashing the walk.

**The load-bearing one is `test_identifier_operand_is_never_stat_ed`.** It spies
on `_path_is_dead` and asserts the operand is never probed, which is exactly the
property the hoist delivers and `main` does not. Measured against `main`'s
`doctor_deadpath.py` with this branch's tests:

```
FAILED test/test_doctor_deadpath.py::TestIdentifierOperandIgnored::test_identifier_operand_is_never_stat_ed
1 failed, 41 passed
```

With the hoist: `42 passed`. So the split is explicit — 41 cases pin behaviour
`main` already has, 1 proves the behaviour it does not.

## Manual verification

N/A -- unit coverage is sufficient: the defect is a pure function of the spec
document, and the tests drive the real `check_dead_paths` entry point over a
fabricated agents dir rather than the private helper alone.

## Screenshots / video

N/A -- no user-visible UI change. The diff touches one backend module and its test
file; the only surface affected is doctor's terminal output, which the tests assert
on directly.

## Related Issues

Fixes #7375

## Pattern harvest

Rule candidate: review-prompt

Pattern: a predicate that reads only one element of a sequence cannot express a
constraint that lives between adjacent elements. When a per-item shape test keeps
producing false positives on values that are *legitimately* that shape, the
missing information is positional, and widening the shape test can only trade the
false positive for a false negative.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- module docstring now states that
      values which only look like paths are screened out first
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Placeholder retained from the repository template; no CLA wording has been
supplied to fill in.


