### PR TITLE
fix(chat): sticky auto-scroll follow with manual disengage

### DIFF
--- a/website/src/hooks/virtualizer/FollowController.ts
+++ b/website/src/hooks/virtualizer/FollowController.ts
@@ -103,12 +103,52 @@ export function isSelfScroll(
 }
 
 /**
- * Next `stick` state after a *user-initiated* scroll: follow only if the caller
- * enabled followOutput AND the user is at the bottom. (Self-scrolls must be
- * filtered out by the caller via `isSelfScroll` before calling this.)
+ * Distance (px) from the true bottom within which a user scroll RE-ENGAGES
+ * follow. Deliberately much tighter than DEFAULT_BOTTOM_THRESHOLD: that 100px
+ * band drives the jump-to-bottom pill's visibility, and reusing it for follow
+ * meant a deliberate 3-99px scroll-up kept `stick` armed — the next content
+ * change then yanked the reader back to the bottom. Re-engaging only when the
+ * user has returned essentially to the bottom keeps "scrolled up to read"
+ * positions belonging to the user.
  */
-export function stickAfterUserScroll(atBottom: boolean, followOutput: boolean): boolean {
-  return followOutput && atBottom
+export const FOLLOW_REENGAGE_PX = 16
+
+/**
+ * Direction-aware `stick` decision for a *user-initiated* scroll (self-scrolls
+ * filtered out by the caller via `isSelfScroll`):
+ *
+ *   1. At the true bottom (within the DPR-aware epsilon) → follow. This also
+ *      absorbs the layout engine's clamp: a mid-stream content SHRINK drops
+ *      scrollTop (which reads as an upward move) but lands exactly at the new
+ *      bottom — releasing there froze streaming follow for the rest of the
+ *      turn.
+ *   2. Any other upward move → release, regardless of distance from the
+ *      bottom. The scroll position now belongs to the user; only returning to
+ *      the bottom (3) re-engages.
+ *   3. Downward arrival within FOLLOW_REENGAGE_PX of the bottom → re-engage.
+ *   4. Otherwise (downward/neutral, still away from the bottom) → keep the
+ *      previous state.
+ *
+ * `prevScrollTop < 0` means "no prior observation this session". Direction is
+ * unknowable then, so the decision is position-only and CONSERVATIVE: follow
+ * only within the re-engage band. Keeping a stale `stick` on an unattributable
+ * away-from-bottom scroll is how a reader gets yanked.
+ */
+export function resolveUserScrollStick(args: {
+  stick: boolean
+  followOutput: boolean
+  scrollTop: number
+  prevScrollTop: number
+  geom: ScrollGeom
+}): boolean {
+  const { stick, followOutput, scrollTop, prevScrollTop, geom } = args
+  if (!followOutput) return false
+  const dist = distanceFromBottom(geom)
+  if (dist <= atBottomEpsilon()) return true
+  if (prevScrollTop < 0) return dist <= FOLLOW_REENGAGE_PX
+  if (scrollTop < prevScrollTop - 0.5) return false
+  if (dist <= FOLLOW_REENGAGE_PX) return true
+  return stick
 }
 
 /** Result of an automatic (RO / append) pin evaluation. */

--- a/website/src/hooks/virtualizer/types.ts
+++ b/website/src/hooks/virtualizer/types.ts
@@ -141,6 +141,12 @@ export interface UseVirtualChatReturn<T> {
   totalHeight: number
   /** Whether the scroller is at (within bottomThreshold of) the bottom. */
   isAtBottom: boolean
+  /** Live follow ("stick to bottom") state: true while the transcript is
+   * auto-following output. Stable identity; reads the live value at call
+   * time, so effect gates see flips that happened after the last render.
+   * Distinct from `isAtBottom`: the user can be inside the at-bottom band
+   * with follow released (they scrolled up a little to read). */
+  getFollow: () => boolean
   /** Scroll the scroller so item `index` is visible. */
   scrollToIndex: (index: number, opts?: ScrollToIndexOptions) => void
   /** Scroll to the bottom (latest message). */

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -109,7 +109,7 @@ import {
   computeAtBottom,
   isSelfScroll,
   SELF_SCROLL_EPSILON,
-  stickAfterUserScroll,
+  resolveUserScrollStick,
   bottomTarget,
   evaluateAutoPin,
 } from './FollowController'
@@ -446,7 +446,14 @@ export function useVirtualChat<T>(
   }, [])
   // Timestamp (performance.now) of the last genuine USER scroll. Used to gate
   // RO-driven follow pins so they don't fire mid-fling — see SCROLL_SETTLE_MS.
-  const lastUserScrollAtRef = useRef<number>(0)
+  // Starts at -Infinity: "no input yet" must never read as "input just
+  // happened" (performance.now() can legitimately be near 0 early in a page's
+  // life, and is under fake timers in tests).
+  const lastUserScrollAtRef = useRef<number>(Number.NEGATIVE_INFINITY)
+  // scrollTop as of the last observed scroll event (self or user). Gives the
+  // user-scroll stick decision its direction: a genuine upward move releases
+  // follow even inside the 100px at-bottom band. `-1` = no observation yet.
+  const lastObservedTopRef = useRef<number>(-1)
 
   // ---- Scroll-anchor preservation ----
   //
@@ -1067,6 +1074,13 @@ export function useVirtualChat<T>(
       if (typeof el.scrollTo === 'function') el.scrollTo({ top, behavior })
       else el.scrollTop = top
       lastWriteTopRef.current = accounting === 'pin' ? top : -1
+      // The direction reference must move WITH our own writes, synchronously.
+      // A programmatic scroll's event lands asynchronously (and a fake scroller
+      // in tests dispatches none), so leaving the reference to the scroll
+      // handler alone would measure the user's next move against a position
+      // from BEFORE our pin — an upward scroll right after a pin then reads as
+      // downward and fails to release follow.
+      lastObservedTopRef.current = top
       // A SMOOTH pin animates toward `top` over many frames, and every
       // intermediate scroll event carries a scrollTop that differs from the
       // recorded target — so the passive listener would read those frames as
@@ -1167,6 +1181,12 @@ export function useVirtualChat<T>(
     writeScrollTop(el, target, 'auto', 'pin')
   }, [followOutput, scrollerRef, writeScrollTop])
 
+  // Live follow state for consumers. A stable callback rather than state:
+  // `stick` flips inside hot paths (scroll handler, RO callback) where a
+  // setState per tick would be waste, and the consumers are effect gates that
+  // need the CURRENT value at fire time, not a render-synced snapshot.
+  const getFollow = useCallback(() => stickRef.current, [])
+
   // Keep the tracked scroller element in sync after every commit, so the
   // observer effects below re-attach the moment the node appears (or changes).
   useEffect(() => {
@@ -1230,7 +1250,13 @@ export function useVirtualChat<T>(
         prevSmoothTopRef.current = el.scrollTop
       } else if (!isSelfScroll(el.scrollTop, lastWriteTopRef.current)) {
         lastUserScrollAtRef.current = performance.now()
-        stickRef.current = stickAfterUserScroll(atBottom, followOutput)
+        stickRef.current = resolveUserScrollStick({
+          stick: stickRef.current,
+          followOutput,
+          scrollTop: el.scrollTop,
+          prevScrollTop: lastObservedTopRef.current,
+          geom,
+        })
         // A scroll we did not write that leaves us EXACTLY at the bottom was the
         // layout engine's: the browser clamps scrollTop when a shrinking
         // scrollHeight drops the maximum below it, and a spacer re-estimate does
@@ -1241,14 +1267,18 @@ export function useVirtualChat<T>(
         // re-arm it.
         //
         // The test is the CLAMP — distance within SELF_SCROLL_EPSILON — and NOT
-        // the 100px `atBottom` UI band. A real 3-100px scroll-up also keeps
-        // `stick` armed via stickAfterUserScroll, so re-baselining across that
-        // band would erase the only evidence evaluateAutoPin has of it and yank
-        // the user back to the bottom on the next append.
+        // the 100px `atBottom` UI band. resolveUserScrollStick's bottom-epsilon
+        // branch is what keeps `stick` armed across the clamp; re-baselining
+        // across the wider band would erase the only evidence evaluateAutoPin
+        // has of a real 3-100px scroll-up.
         const clampedAtBottom =
           geom.scrollHeight - (geom.scrollTop + geom.clientHeight) <= SELF_SCROLL_EPSILON
         if (stickRef.current && clampedAtBottom) lastWriteTopRef.current = el.scrollTop
       }
+      // Direction reference for the next event — updated for self-scrolls too,
+      // so a user move right after our own pin is measured against where the
+      // pin actually left the viewport.
+      lastObservedTopRef.current = el.scrollTop
       // Persist the reading position once this scroll burst settles (also
       // clears it when the burst ends at the bottom). Scheduled for self-
       // scrolls too — see scheduleAnchorSave. The context snapshot is what
@@ -1269,9 +1299,24 @@ export function useVirtualChat<T>(
       }
     }
     el.addEventListener('scroll', onScroll, { passive: true })
+    // A fresh element has no direction history — do not measure its first user
+    // scroll against a previous scroller's position.
+    lastObservedTopRef.current = -1
+    // Persistent input-intent listeners (wheel / touch / scrollbar grab /
+    // scrolling keys). They only bump the settle timestamp — the stick decision
+    // itself stays with the scroll handler above. This closes a race the scroll
+    // event cannot: input lands BEFORE its scroll event dispatches, so an RO
+    // tick between the two saw a stale "settled" timestamp and pinned against
+    // the gesture (fighting a trackpad fling frame by frame). Suppression is
+    // harmless when the input does not scroll (a click, a wheel at the bottom):
+    // follow resumes SCROLL_SETTLE_MS later.
+    const detachIntent = attachUserScrollIntent(el, () => {
+      lastUserScrollAtRef.current = performance.now()
+    })
     onScroll()
     return () => {
       el.removeEventListener('scroll', onScroll)
+      detachIntent()
       // Cancel any frame queued by the last scroll so it can't fire a
       // setWindowRange after unmount/re-run. Reset the ref too, or a re-run
       // would see it stuck true and never schedule again.
@@ -1416,7 +1461,15 @@ export function useVirtualChat<T>(
       // stick released it must never move a reading user.
       const shouldFollow =
         genuineResize || ((firstMount || viewportResized) && stickRef.current)
-      if (shouldFollow && (stickRef.current || performance.now() - lastUserScrollAtRef.current >= SCROLL_SETTLE_MS)) {
+      // The settle gate applies even while following: with `stick` armed the
+      // old bypass meant every RO tick pinned instantly DURING an active
+      // gesture — the pin write and the user's input fought over scrollTop
+      // frame by frame (visible as jitter) until the scroll event finally
+      // released `stick`. Intent listeners bump the timestamp at input time,
+      // so the gate holds pins off from the first wheel/touch/key/scrollbar
+      // event; a stationary reader at the bottom is untouched (no input →
+      // timestamp stays old → pins flow).
+      if (shouldFollow && performance.now() - lastUserScrollAtRef.current >= SCROLL_SETTLE_MS) {
         pinAuto()
       }
 
@@ -2147,6 +2200,7 @@ export function useVirtualChat<T>(
     offsetAfter,
     totalHeight,
     isAtBottom,
+    getFollow,
     scrollToIndex,
     scrollToBottom,
     mountIndex,

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -68,6 +68,7 @@ import McpToolsPanel from './chat/McpToolsPanel'
 import { deriveLoadedMcpTools } from '../lib/mcpLoadedTools'
 import type { McpServer } from '../types'
 import { useScrollManager } from './chat/useScrollManager'
+import { useBubbleVanishProbe } from './chat/useBubbleVanishProbe'
 import { shouldPaginateOlder, canForkAtWindow, searchScopeIsLimited } from './chat/pagination'
 import EarlierMessagesBar from './chat/EarlierMessagesBar'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
@@ -1389,7 +1390,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // (declared before `virt` in source order) to the virtualizer's API without
   // a temporal-dead-zone hazard — they are populated right after `virt` is
   // created and only read inside callbacks/effects that run post-render.
-  const isAtBottomRef = useRef(true)
+  // `vGetFollowRef` defaults to "following" so a gate that fires on the very
+  // first commit (before the mirror populates it) behaves like the fresh-slot
+  // bottom pin it accompanies.
+  const vGetFollowRef = useRef<() => boolean>(() => true)
   const vScrollToBottomRef = useRef<(behavior?: ScrollBehavior) => void>(() => {})
   const mountIndexRef = useRef<(index: number) => boolean>(() => false)
 
@@ -3322,10 +3326,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const [surveyLayoutTick, setSurveyLayoutTick] = useState(0)
   const handleSurveyLayoutChange = useCallback(() => setSurveyLayoutTick((t) => t + 1), [])
   useEffect(() => {
-    if (!isAtBottomRef.current) return
+    // Gate on FOLLOW, not the 100px at-bottom band: a reader parked a little
+    // above the bottom has released follow, and re-anchoring for a tip/survey
+    // band would yank them (and replace the mounted window under them).
+    if (!vGetFollowRef.current()) return
     const raf = requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        if (isAtBottomRef.current) scrollBottom(true)
+        if (vGetFollowRef.current()) scrollBottom(true)
       })
     })
     return () => cancelAnimationFrame(raf)
@@ -4117,16 +4124,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     }
   }, [activeSlot, filteredSlots, searchParams, dispatch, slotStorageKey, connected, slotsLoaded, defaultAgent, mode, newSlotFailed])
 
-  // Slot switch: the virtualizer (keyed on sessionId = activeSlot) force-pins
-  // to the true bottom itself in a layout effect. Here we just re-arm the
-  // local at-bottom ref used by the gating effects below.
-  const prevSlotRef = useRef<string | null>(null)
-  useEffect(() => {
-    if (activeSlot !== prevSlotRef.current) {
-      prevSlotRef.current = activeSlot
-      isAtBottomRef.current = true
-    }
-  }, [activeSlot])
+  // Slot switch: the virtualizer (keyed on sessionId = activeSlot) owns entry
+  // placement — it force-pins to the bottom (arming follow) or restores a
+  // saved reading position (leaving follow released). The gating effects below
+  // read that live state via vGetFollowRef, so nothing here needs re-arming;
+  // forcing "at bottom" on switch used to yank a restored mid-history reader
+  // the moment a tip band or a running-state tick fired.
 
   // Auto-scroll during streaming — only when pinned to bottom
   const lastMsg = messages[messages.length - 1]
@@ -4176,7 +4179,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Scroll to show Footer when agent starts running (loading indicator appears)
   const prevRunningRef = useRef(false)
   useEffect(() => {
-    if (slotRunning && !prevRunningRef.current && isAtBottomRef.current) {
+    if (slotRunning && !prevRunningRef.current && vGetFollowRef.current()) {
       setTimeout(() => scrollBottom(), SCROLL_AFTER_RENDER_MS)
     }
     prevRunningRef.current = slotRunning
@@ -4567,7 +4570,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     }
     window.dispatchEvent(new Event('voice-stop'))
     sendingRef.current = false
-    isAtBottomRef.current = true
     setTimeout(() => scrollBottom(), SCROLL_AFTER_RENDER_MS)
     if (slot) dispatch(startLocalTurn(slot))
     const controller = new AbortController()
@@ -4765,7 +4767,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }, [tabsCtl.activeTab, activeSlot, dispatch, send])
 
   // Auto-send when navigated with ?autoSend=1 or ?token= with prompt
-  useEffect(() => { if (connected && autoSendRef.current) { const txt = autoSendRef.current; autoSendRef.current = null; send(txt) } }, [send, connected, autoSendTick])  
+  useEffect(() => { if (connected && autoSendRef.current) { const txt = autoSendRef.current; autoSendRef.current = null; send(txt) } }, [send, connected, autoSendTick])
 
   // Widget interactivity: when a mcwidget iframe fires an action, PRE-FILL the
  // composer instead of auto-submitting. Auto-submitting would be a
@@ -5867,6 +5869,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // side effect, not render-body mutation, so React's rules of render hold.
   useLayoutEffect(() => { displayItemsRef.current = displayItems }, [displayItems])
 
+  // Opt-in #7045 diagnostic: log store-vs-render counts whenever the number of
+  // mounted transcript rows drops (see useBubbleVanishProbe). Off (and free)
+  // unless the localStorage flag is set.
+  const messagesLenRef = useRef(0)
+  useLayoutEffect(() => { messagesLenRef.current = messages.length }, [messages])
+  const bubbleProbeCounts = useCallback(
+    () => ({ store: messagesLenRef.current, display: displayItemsRef.current.length }),
+    [],
+  )
+  useBubbleVanishProbe(scrollerRef, bubbleProbeCounts, activeSlot)
+
   // Pinned prompt: keep the enablement ref in sync (updatePinnedPrompt is declared
   // above chatConfig and reads it through a ref), and recompute after the list
   // changes — a new turn shifts geometry with no scroll event of its own.
@@ -6025,10 +6038,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Mirror the virtualizer's follow API into the refs the early effects/handlers
   // (declared above) read. Done in a layout effect rather than the render body
   // so a concurrent render React throws away can't write stale callbacks into
-  // the refs. Layout effects run before passive effects, so the gating effect
-  // that reads isAtBottomRef.current still sees this commit's value.
+  // the refs. Layout effects run before passive effects, so the gating effects
+  // that call vGetFollowRef.current() still see this commit's callback.
   useLayoutEffect(() => {
-    isAtBottomRef.current = isAtBottom
+    vGetFollowRef.current = virt.getFollow
     vScrollToBottomRef.current = virt.scrollToBottom
     mountIndexRef.current = virt.mountIndex
   })
@@ -7936,7 +7949,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 <div className="absolute -top-10 inset-x-0 z-10 pointer-events-none flex justify-center">
                   <button
                     className="w-8 h-8 rounded-full flex items-center justify-center cursor-pointer pointer-events-auto transition-all duration-200 bg-bg-elevated border border-border-strong text-text hover:bg-bg-hover hover:border-accent hover:scale-[1.06] active:scale-95 active:duration-75 shadow-md"
-                    onClick={() => { isAtBottomRef.current = true; scrollBottom(true) }}
+                    onClick={() => scrollBottom(true)}
                     aria-label={i18nT('pages.chatPage.scroll_to_bottom')}
                   ><ArrowDown size={14} strokeWidth={2.5} /></button>
                 </div>

--- a/website/src/pages/chat/useBubbleVanishProbe.ts
+++ b/website/src/pages/chat/useBubbleVanishProbe.ts
@@ -1,0 +1,82 @@
+// Diagnostic probe for the "recent chat bubbles briefly disappear then
+// reappear" symptom. Opt-in via localStorage (see BUBBLE_PROBE_FLAG); when the
+// flag is absent this hook attaches nothing and costs nothing.
+//
+// The one observation that splits that symptom into a store bug or a renderer
+// bug is whether the vanished rows are absent from the store at that moment or
+// present-but-unrendered. This probe captures exactly that: a MutationObserver
+// watches the transcript scroller, and whenever the number of mounted message
+// rows DROPS between frames it logs the DOM count against the store's message
+// count and the grouped display-item count at the same instant.
+//
+// Reading the log:
+//   - `storeMessages` fell with `mountedRows`     → store/fetch path.
+//   - `displayItems` fell but `storeMessages` held → grouping collapse
+//     (loose rows folding into one turn — expected while a turn accumulates).
+//   - both held while `mountedRows` fell           → windowing/render path.
+import { useEffect, type RefObject } from 'react'
+
+/** Set `localStorage[BUBBLE_PROBE_FLAG] = '1'` and reload to enable. */
+export const BUBBLE_PROBE_FLAG = 'kirocrew_debug_bubble_probe'
+
+export interface BubbleProbeCounts {
+  /** Raw message count in the store for the active slot. */
+  store: number
+  /** Grouped display-item count handed to the virtualizer. */
+  display: number
+}
+
+/**
+ * Watch `scrollerRef`'s subtree for drops in the mounted-row count and log a
+ * snapshot for each. `getCounts` must be identity-stable (read refs inside);
+ * `rearmKey` re-attaches the observer when the scroller node can have been
+ * replaced (e.g. a slot switch).
+ */
+export function useBubbleVanishProbe(
+  scrollerRef: RefObject<HTMLDivElement | null>,
+  getCounts: () => BubbleProbeCounts,
+  rearmKey?: unknown,
+): void {
+  useEffect(() => {
+    let enabled = false
+    try {
+      enabled = localStorage.getItem(BUBBLE_PROBE_FLAG) === '1'
+    } catch {
+      return // storage unavailable (privacy mode) — probe stays off
+    }
+    if (!enabled || typeof MutationObserver === 'undefined') return
+    const el = scrollerRef.current
+    if (!el) return
+    const mountedRows = () => el.querySelectorAll('[data-display-index]').length
+    let last = mountedRows()
+    let raf = 0
+    const mo = new MutationObserver(() => {
+      // Coalesce a mutation burst into one per-frame reading — a React commit
+      // fires many records for what is a single transcript state. Cancel-and-
+      // reschedule (never latch on a pending handle): a handle whose callback
+      // never fires would otherwise block every later reading permanently.
+      if (raf) cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        raf = 0
+        const now = mountedRows()
+        if (now < last) {
+          const counts = getCounts()
+          // eslint-disable-next-line no-console
+          console.warn('[bubbleProbe] mounted rows dropped', {
+            mountedBefore: last,
+            mountedAfter: now,
+            storeMessages: counts.store,
+            displayItems: counts.display,
+            at: new Date().toISOString(),
+          })
+        }
+        last = now
+      })
+    })
+    mo.observe(el, { childList: true, subtree: true })
+    return () => {
+      mo.disconnect()
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [scrollerRef, getCounts, rearmKey])
+}

--- a/website/src/test/ArtifactsPage.narrowSingleAxis.test.tsx
+++ b/website/src/test/ArtifactsPage.narrowSingleAxis.test.tsx
@@ -70,6 +70,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
       offsetAfter: 0,
       totalHeight: 0,
       isAtBottom: false,
+      getFollow: () => true,
       scrollToIndex: () => {},
       scrollToBottom: () => {},
       mountIndex: () => false,

--- a/website/src/test/ChatPage.dockSearchClose.test.tsx
+++ b/website/src/test/ChatPage.dockSearchClose.test.tsx
@@ -75,6 +75,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: true,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(),
       measureRef: () => () => {},

--- a/website/src/test/ChatPage.handleOpenDiffNoop.test.tsx
+++ b/website/src/test/ChatPage.handleOpenDiffNoop.test.tsx
@@ -61,6 +61,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: true,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(),
       measureRef: () => () => {},

--- a/website/src/test/ChatPage.lazyHistoryFetch.test.tsx
+++ b/website/src/test/ChatPage.lazyHistoryFetch.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
   useVirtualChat: () => ({
     virtualItems: [],
     isAtBottom: true,
+    getFollow: () => true,
     scrollToBottom: vi.fn(),
     mountIndex: vi.fn(),
     measureRef: () => () => {},

--- a/website/src/test/ChatPage.navFarJump.test.tsx
+++ b/website/src/test/ChatPage.navFarJump.test.tsx
@@ -57,6 +57,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: false,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       scrollToIndexSmooth: vi.fn(),
       mountIndex: vi.fn(() => true),

--- a/website/src/test/ChatPage.olderLoadingIndicator.test.tsx
+++ b/website/src/test/ChatPage.olderLoadingIndicator.test.tsx
@@ -41,6 +41,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: true,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(),
       measureRef: () => () => {},

--- a/website/src/test/ChatPage.sessionChipOffline.test.tsx
+++ b/website/src/test/ChatPage.sessionChipOffline.test.tsx
@@ -66,6 +66,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: true,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(),
       measureRef: () => () => {},

--- a/website/src/test/ChatPage.steerKeyIdentity.test.tsx
+++ b/website/src/test/ChatPage.steerKeyIdentity.test.tsx
@@ -54,6 +54,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: true,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(),
       measureRef: () => () => {},

--- a/website/src/test/ChatPage.titleRenamePin.test.tsx
+++ b/website/src/test/ChatPage.titleRenamePin.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../pages/chat', () => ({
 vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
 vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
   useVirtualChat: () => ({
-    virtualItems: [], isAtBottom: true, scrollToBottom: vi.fn(), mountIndex: vi.fn(), measureRef: () => () => {},
+    virtualItems: [], isAtBottom: true, getFollow: () => true, scrollToBottom: vi.fn(), mountIndex: vi.fn(), measureRef: () => () => {},
     topSentinelRef: { current: null }, bottomSentinelRef: { current: null },
     offsetBefore: 0, offsetAfter: 0,
   }),

--- a/website/src/test/ChatPageCoverage.test.tsx
+++ b/website/src/test/ChatPageCoverage.test.tsx
@@ -179,6 +179,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: false,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(() => false),
       measureRef: () => () => {},

--- a/website/src/test/ChatPageMoreCoverage.test.tsx
+++ b/website/src/test/ChatPageMoreCoverage.test.tsx
@@ -160,6 +160,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: true,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(() => false),
       measureRef: () => () => {},

--- a/website/src/test/ChatPageW3Coverage.test.tsx
+++ b/website/src/test/ChatPageW3Coverage.test.tsx
@@ -184,6 +184,7 @@ vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
         data,
       })),
       isAtBottom: true,
+      getFollow: () => true,
       scrollToBottom: vi.fn(),
       mountIndex: vi.fn(() => false),
       measureRef: () => () => {},

--- a/website/src/test/FollowController.test.ts
+++ b/website/src/test/FollowController.test.ts
@@ -11,11 +11,12 @@ import {
   distanceFromBottom,
   bottomTarget,
   isSelfScroll,
-  stickAfterUserScroll,
+  resolveUserScrollStick,
   evaluateAutoPin,
   atBottomEpsilon,
   SELF_SCROLL_EPSILON,
   DEFAULT_BOTTOM_THRESHOLD,
+  FOLLOW_REENGAGE_PX,
 } from '../hooks/virtualizer/FollowController'
 
 describe('geometry helpers', () => {
@@ -46,14 +47,101 @@ describe('isSelfScroll', () => {
   })
 })
 
-describe('stickAfterUserScroll', () => {
-  it('follows only when followOutput AND at bottom', () => {
+describe('resolveUserScrollStick — direction-aware follow decision', () => {
+  // 1000px content in a 400px viewport → bottom target 600.
+  const geomAt = (scrollTop: number) => ({ scrollTop, scrollHeight: 1000, clientHeight: 400 })
+
+  it('releases on ANY upward move away from the true bottom, even inside the 100px band', () => {
+    for (const dist of [3, 30, 99]) {
+      expect(
+        resolveUserScrollStick({
+          stick: true,
+          followOutput: true,
+          scrollTop: 600 - dist,
+          prevScrollTop: 600,
+          geom: geomAt(600 - dist),
+        }),
+      ).toBe(false)
+    }
+  })
+
+  it('keeps following across a layout clamp (scrollTop drops but lands at the true bottom)', () => {
+    // Content shrank 227px; the browser clamped scrollTop by the same amount.
+    const geom = { scrollTop: 373, scrollHeight: 773, clientHeight: 400 }
+    expect(
+      resolveUserScrollStick({
+        stick: true, followOutput: true, scrollTop: 373, prevScrollTop: 600, geom,
+      }),
+    ).toBe(true)
+  })
+
+  it('re-engages on a downward arrival within FOLLOW_REENGAGE_PX of the bottom', () => {
+    const dist = FOLLOW_REENGAGE_PX - 1
+    expect(
+      resolveUserScrollStick({
+        stick: false, followOutput: true, scrollTop: 600 - dist, prevScrollTop: 200,
+        geom: geomAt(600 - dist),
+      }),
+    ).toBe(true)
+  })
+
+  it('does NOT re-engage on a downward move that stops short of the re-engage band', () => {
+    // 60px above the bottom: inside the old 100px band, outside the new one.
+    expect(
+      resolveUserScrollStick({
+        stick: false, followOutput: true, scrollTop: 540, prevScrollTop: 200,
+        geom: geomAt(540),
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps the previous state for a mid-list downward move (no flapping)', () => {
+    for (const stick of [true, false]) {
+      expect(
+        resolveUserScrollStick({
+          stick, followOutput: true, scrollTop: 300, prevScrollTop: 200,
+          geom: geomAt(300),
+        }),
+      ).toBe(stick)
+    }
+  })
+
+  it('is position-only and conservative with no prior observation (prevScrollTop < 0)', () => {
+    // At the bottom → follow; away from it → release EVEN IF stick was armed
+    // (an unattributable scroll must not keep a stale follow).
+    expect(
+      resolveUserScrollStick({
+        stick: true, followOutput: true, scrollTop: 600, prevScrollTop: -1, geom: geomAt(600),
+      }),
+    ).toBe(true)
+    expect(
+      resolveUserScrollStick({
+        stick: true, followOutput: true, scrollTop: 300, prevScrollTop: -1, geom: geomAt(300),
+      }),
+    ).toBe(false)
+    expect(
+      resolveUserScrollStick({
+        stick: false, followOutput: true, scrollTop: 300, prevScrollTop: -1, geom: geomAt(300),
+      }),
+    ).toBe(false)
+  })
+
+  it('never follows with followOutput disabled', () => {
     fc.assert(
-      fc.property(fc.boolean(), fc.boolean(), (atBottom, followOutput) => {
-        expect(stickAfterUserScroll(atBottom, followOutput)).toBe(followOutput && atBottom)
+      fc.property(fc.boolean(), fc.integer({ min: 0, max: 600 }), (stick, top) => {
+        expect(
+          resolveUserScrollStick({
+            stick, followOutput: false, scrollTop: top, prevScrollTop: 600, geom: geomAt(top),
+          }),
+        ).toBe(false)
       }),
       { numRuns: 50 },
     )
+  })
+
+  it('the re-engage band is meaningfully tighter than the pill band', () => {
+    expect(FOLLOW_REENGAGE_PX).toBeLessThan(DEFAULT_BOTTOM_THRESHOLD / 2)
+    expect(FOLLOW_REENGAGE_PX).toBeGreaterThan(atBottomEpsilon())
   })
 })
 

--- a/website/src/test/useBubbleVanishProbe.test.tsx
+++ b/website/src/test/useBubbleVanishProbe.test.tsx
@@ -1,0 +1,86 @@
+// Feature: chat transcript — #7045 bubble-vanish diagnostic probe.
+//
+// The probe must be FREE when the flag is off (no observer constructed) and,
+// when on, must log exactly on a drop in mounted-row count with the store and
+// display counts captured at that instant.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+
+import {
+  useBubbleVanishProbe,
+  BUBBLE_PROBE_FLAG,
+} from '../pages/chat/useBubbleVanishProbe'
+
+function makeScrollerWithRows(n: number) {
+  const el = document.createElement('div')
+  for (let i = 0; i < n; i++) {
+    const row = document.createElement('div')
+    row.setAttribute('data-display-index', String(i))
+    el.appendChild(row)
+  }
+  document.body.appendChild(el)
+  return el
+}
+
+describe('useBubbleVanishProbe', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let rafSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Run the coalescing frame synchronously so MutationObserver microtasks
+    // and the probe's reading happen inside the same act() block.
+    rafSpy = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation(((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame)
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    rafSpy.mockRestore()
+    document.body.replaceChildren()
+  })
+
+  it('constructs no observer when the flag is off', () => {
+    const observeSpy = vi.spyOn(MutationObserver.prototype, 'observe')
+    const el = makeScrollerWithRows(3)
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    renderHook(() => useBubbleVanishProbe(ref, () => ({ store: 3, display: 3 })))
+    expect(observeSpy).not.toHaveBeenCalled()
+    observeSpy.mockRestore()
+  })
+
+  it('logs a snapshot when the mounted-row count drops, not when it grows', async () => {
+    localStorage.setItem(BUBBLE_PROBE_FLAG, '1')
+    const el = makeScrollerWithRows(4)
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const counts = { store: 10, display: 4 }
+    renderHook(() => useBubbleVanishProbe(ref, () => ({ ...counts })))
+
+    // Growth: no log.
+    await act(async () => {
+      const row = document.createElement('div')
+      row.setAttribute('data-display-index', '4')
+      el.appendChild(row)
+      await Promise.resolve() // flush the MutationObserver microtask
+    })
+    expect(warnSpy).not.toHaveBeenCalled()
+
+    // Drop: two rows unmount → one snapshot with the live counts.
+    counts.display = 3
+    await act(async () => {
+      el.removeChild(el.lastChild!)
+      el.removeChild(el.lastChild!)
+      await Promise.resolve()
+    })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const payload = warnSpy.mock.calls[0][1] as Record<string, unknown>
+    expect(payload.mountedBefore).toBe(5)
+    expect(payload.mountedAfter).toBe(3)
+    expect(payload.storeMessages).toBe(10)
+    expect(payload.displayItems).toBe(3)
+  })
+})

--- a/website/src/test/useVirtualChat.followDisengage.test.tsx
+++ b/website/src/test/useVirtualChat.followDisengage.test.tsx
@@ -1,0 +1,176 @@
+// Feature: chat-virtualizer — sticky follow with manual disengage (#7256).
+//
+// Pins the three behaviours the direction-aware follow decision adds:
+//   1. an upward user scroll INSIDE the 100px at-bottom band releases follow
+//      (observable via getFollow — this is what gates ChatPage's timer-driven
+//      scrollToBottom calls, the "streaming yanked me back" sources),
+//   2. a downward return re-engages only within the tight FOLLOW_REENGAGE_PX
+//      band, not anywhere inside the pill's 100px band,
+//   3. the ResizeObserver follow pin respects the settle gate while follow is
+//      armed: user input suppresses RO pins for SCROLL_SETTLE_MS even though
+//      stick is still true (the old bypass pinned against an active gesture,
+//      fighting the user frame by frame).
+//
+// jsdom has no layout engine: geometry is faked on a detached scroller via
+// `externalScrollerRef` (the layoutShrink suite's technique), and the RO path
+// is driven through a stubbed ResizeObserver (the viewportResize suite's).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
+import { FOLLOW_REENGAGE_PX } from '../hooks/virtualizer/FollowController'
+
+interface Geom { scrollTop: number; scrollHeight: number; clientHeight: number }
+
+function makeScroller(initial: Geom) {
+  const el = document.createElement('div')
+  const state: Geom = { ...initial }
+  const writes = { n: 0 }
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => { writes.n++; state.scrollTop = v },
+  })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = (o) => {
+    writes.n++
+    state.scrollTop = o.top
+  }
+  return { el, state, writes }
+}
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  cb: ResizeObserverCallback
+  observed = new Set<Element>()
+  constructor(cb: ResizeObserverCallback) { this.cb = cb; FakeResizeObserver.instances.push(this) }
+  observe(el: Element) { this.observed.add(el) }
+  unobserve(el: Element) { this.observed.delete(el) }
+  disconnect() { this.observed.clear() }
+  fire(entries: Partial<ResizeObserverEntry>[] = []) {
+    this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+}
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+const CH = 400
+const SH = 1000
+const BOTTOM = SH - CH // 600
+
+function mount(items: Item[], sessionId: string) {
+  const { el, state, writes } = makeScroller({ scrollTop: 0, scrollHeight: SH, clientHeight: CH })
+  const ref: RefObject<HTMLDivElement | null> = { current: el }
+  const initialProps: UseVirtualChatOptions<Item> = { items, sessionId, getKey, externalScrollerRef: ref }
+  const view = renderHook((p: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(p), { initialProps })
+  return { el, state, writes, view, ref }
+}
+
+describe('useVirtualChat: direction-aware follow disengage (#7256)', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('exposes follow armed at the bottom after slot entry', () => {
+    const { el, view } = mount(mkItems(5), 'follow-armed')
+    expect(el.scrollTop).toBe(BOTTOM)
+    expect(view.result.current.getFollow()).toBe(true)
+  })
+
+  it('releases follow on an upward scroll INSIDE the 100px band, and a later append does not yank', () => {
+    const { el, state, view, ref } = mount(mkItems(5), 'inband-release')
+    expect(view.result.current.getFollow()).toBe(true)
+
+    // 40px up: inside the pill band, previously kept stick armed.
+    act(() => { state.scrollTop = BOTTOM - 40; el.dispatchEvent(new Event('scroll')) })
+    expect(view.result.current.getFollow()).toBe(false)
+
+    // Content grows: the reader's position must belong to them now.
+    act(() => {
+      state.scrollHeight = SH + 300
+      view.rerender({ items: mkItems(6), sessionId: 'inband-release', getKey, externalScrollerRef: ref })
+    })
+    expect(state.scrollTop).toBe(BOTTOM - 40)
+    expect(view.result.current.getFollow()).toBe(false)
+  })
+
+  it('re-engages only within FOLLOW_REENGAGE_PX of the bottom, not merely inside the pill band', () => {
+    const { el, state, view } = mount(mkItems(5), 'reengage-band')
+    // Scroll far up (releases), then back DOWN to 60px above the bottom —
+    // inside the 100px pill band, outside the tight re-engage band.
+    act(() => { state.scrollTop = 200; el.dispatchEvent(new Event('scroll')) })
+    expect(view.result.current.getFollow()).toBe(false)
+    act(() => { state.scrollTop = BOTTOM - 60; el.dispatchEvent(new Event('scroll')) })
+    expect(view.result.current.getFollow()).toBe(false)
+
+    // Continue down into the tight band → re-engaged.
+    act(() => { state.scrollTop = BOTTOM - (FOLLOW_REENGAGE_PX - 1); el.dispatchEvent(new Event('scroll')) })
+    expect(view.result.current.getFollow()).toBe(true)
+  })
+
+  it('keeps following across a layout clamp that lands at the true bottom', () => {
+    const { el, state, view } = mount(mkItems(5), 'clamp-keep')
+    expect(view.result.current.getFollow()).toBe(true)
+    // Content shrinks 200px; the browser clamps scrollTop to the new bottom.
+    act(() => {
+      state.scrollHeight = SH - 200
+      state.scrollTop = BOTTOM - 200
+      el.dispatchEvent(new Event('scroll'))
+    })
+    expect(view.result.current.getFollow()).toBe(true)
+  })
+})
+
+describe('useVirtualChat: RO follow pin respects the settle gate while armed (#7256)', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let nowSpy: ReturnType<typeof vi.spyOn> | undefined
+  let now = 100_000
+
+  beforeEach(() => {
+    localStorage.clear()
+    FakeResizeObserver.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    now = 100_000
+    nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    nowSpy?.mockRestore()
+  })
+
+  /** The observer watching the scroller element (rows + viewport share it). */
+  function viewportRO(el: HTMLElement): FakeResizeObserver {
+    const inst = FakeResizeObserver.instances.find((i) => i.observed.has(el))
+    expect(inst).toBeDefined()
+    return inst!
+  }
+
+  it('holds RO pins off within SCROLL_SETTLE_MS of user input, then resumes', () => {
+    const { el, state, writes } = mount(mkItems(5), 'settle-gate')
+    expect(state.scrollTop).toBe(BOTTOM)
+    const ro = viewportRO(el)
+
+    // Wheel input lands (the intent listener bumps the settle timestamp before
+    // any scroll event dispatches). Content then grows, so a follow pin is due
+    // — but the RO tick arrives inside the settle window and must hold off
+    // instead of fighting the gesture (the old stick-armed bypass pinned here).
+    act(() => { el.dispatchEvent(new Event('wheel')) })
+    state.scrollHeight = SH + 100
+    const before = writes.n
+    act(() => { ro.fire([{ target: el } as Partial<ResizeObserverEntry>]) })
+    expect(writes.n).toBe(before) // no pin write during the settle window
+    expect(state.scrollTop).toBe(BOTTOM)
+
+    // Past SCROLL_SETTLE_MS with follow still armed and the user stationary,
+    // the same tick now pins to the new bottom.
+    now += 200
+    act(() => { ro.fire([{ target: el } as Partial<ResizeObserverEntry>]) })
+    expect(state.scrollTop).toBe(SH + 100 - CH)
+  })
+})

--- a/website/src/test/useVirtualChat.layoutShrink.test.tsx
+++ b/website/src/test/useVirtualChat.layoutShrink.test.tsx
@@ -97,10 +97,11 @@ describe('useVirtualChat: a clamp at the bottom vs a scroll away from it', () =>
     const { el, state, view, ref } = mount(mkItems(5), `small-nudge-${up}`)
     expect(el.scrollTop).toBe(BOTTOM)
 
-    // Inside the 100px `atBottom` UI band, so `stickAfterUserScroll` keeps stick
-    // armed and the only thing holding the position is evaluateAutoPin's
-    // scroll-up guard. Re-baselining on that band instead of on the clamp erases
-    // it and the next append pins to the bottom — the regression this locks out.
+    // Inside the 100px `atBottom` UI band. The upward move releases follow
+    // (direction-aware decision), and evaluateAutoPin's scroll-up guard backs
+    // it up — either way the position belongs to the user. Re-baselining on
+    // that band instead of on the clamp would erase the guard's evidence and
+    // the next append would pin to the bottom — the regression this locks out.
     // 3px is the smallest move that clears SELF_SCROLL_EPSILON and so is the
     // first that reaches this branch at all.
     act(() => { state.scrollTop = BOTTOM - up; el.dispatchEvent(new Event('scroll')) })


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** a follow-state fix with no static visual delta — the change is whether the viewport moves against the user's will across streaming commits, which a before/after still cannot show. Reproduced behaviorally instead: the disengage/re-engage/settle-gate sequences are pinned by hook-level tests driving faked scroll geometry and a stubbed ResizeObserver.

Fixes #7256. Instruments #7045 (investigation summary posted on the issue).

## Problem / Motivation

While a turn streams, the transcript's "follow the output" behavior fails in both directions (#7256, and the flicker/jitter half of user reports):

1. **Streaming yanks the reader back.** Two ChatPage timers (`activeTip`/survey re-anchor, `slotRunning` rising edge) call `scrollToBottom()` gated on the **100px at-bottom band**, not on follow state. A reader parked 3–99px above the bottom — whose follow the scroll handler had already conceptually released — was re-pinned AND had their mounted window replaced (`scrollToBottom` swaps the window to the tail). This is the reported "jumps to the middle / top, then jitters".
2. **RO pins fight live input.** The ResizeObserver follow pin bypassed the `SCROLL_SETTLE_MS` gate whenever `stick` was armed — which is exactly when a gesture *starts*. Every RO tick (streaming resizes fire constantly) wrote `scrollTop` instantly against the in-flight wheel/trackpad gesture until the scroll handler finally released stick: frame-by-frame jitter for the first ~100ms of every scroll-up during streaming.
3. **Disengage/re-engage shared one 100px band.** `stick` was recomputed as `followOutput && atBottom`, so a deliberate small scroll-up inside the band left follow armed (yank on next append), while the same band re-engaged follow on any drive-by pass near the bottom.
4. **Slot switch forced "at bottom"** unconditionally — including when the virtualizer was about to restore a saved mid-history reading position, so the first tip-band tick yanked the restored reader to the bottom.

## Field reports matching these mechanisms

Three independent internal reports this week describe exactly this cluster: "scroll up 3 messages and it jumps to the middle or the very top, then flickers/jitters between messages for ~5 seconds"; "text above the prompt area jumping between two locations with blanking from the rerender"; "the index into the session history randomly jumps backwards"; one reporter runs the predecessor UI side-by-side and sees it only on the current stack. The jitter-between-two-locations half is #6076 (PR #7198); the yank/jump-while-reading half is what this PR removes.

## Approach

All changes live in the surface disjoint from #7198's height-accounting rewrite (see "Interaction with #7198" below).

- **Direction-aware follow decision** (`FollowController.resolveUserScrollStick`, pure): any genuine upward user move releases follow regardless of distance from the bottom; a layout clamp that lands at the true bottom (DPR-aware epsilon) keeps following (the mid-stream shrink case); re-engage requires a downward return within a tight `FOLLOW_REENGAGE_PX = 16` band — the 100px band remains the jump-pill's only concern. Replaces `stickAfterUserScroll` (removed; test-only after this change).
- **User-intent settle gate**: persistent `attachUserScrollIntent` listeners (wheel / touchmove / scrollbar pointerdown / scrolling keys) bump the settle timestamp **at input time**, before the first scroll event dispatches; the RO follow pin now respects `SCROLL_SETTLE_MS` even while `stick` is armed. A stationary reader at the bottom is untouched (no input → pins flow as before).
- **Follow state exported** as `getFollow(): boolean` (stable callback, live read — effect gates need fire-time state, not a render-synced snapshot).
- **ChatPage gates flipped to follow state**: the tip/survey re-anchor and the `slotRunning` edge scroll now consult `getFollow()` instead of the 100px band; the unconditional `isAtBottomRef = true` at slot switch is removed (the virtualizer's entry placement — bottom pin or reading-position restore — is now the single source of truth), and the now-dead `isAtBottomRef` bridge is deleted.

## #7045 instrumentation (not a fix)

The issue's maintainers narrowed the suspect space to render/reconciliation and named the single cheapest discriminator: are vanished rows absent from the store, or present-but-unrendered? This PR adds `useBubbleVanishProbe` — a localStorage-gated (`kirocrew_debug_bubble_probe = 1`), zero-cost-when-off MutationObserver that logs `{mountedBefore, mountedAfter, storeMessages, displayItems}` whenever the mounted-row count drops. Investigation summary with a concrete candidate mechanism (mid-stream turn regroup swapping component type under a stable key) is on the issue.

## Interaction with PR #7198 (ghost-row jitter)

Deliberately zero overlap with its territory: no changes to `HeightCache` / `HeightIndex`, the anchor-capture/trigger classification block, `syncHeightsNow` / `scheduleHeightSync`, or the RO measure block. Both PRs touch different statements of the RO callback and different regions of `useVirtualChat.ts`; whichever lands second rebases trivially. The `evaluateAutoPin` guard, `writeScrollTop` signature, and all anchor paths are untouched.

## Testing

- `FollowController.test.ts`: 8 new cases for `resolveUserScrollStick` (in-band upward release, clamp keep, tight re-engage, no-flap mid-list, no-history fallback, followOutput-off, band-ordering property).
- `useVirtualChat.followDisengage.test.tsx` (new): hook-level — follow armed on entry; in-band upward scroll releases and a later append does not move the reader; re-engage only inside `FOLLOW_REENGAGE_PX`; clamp keeps following; RO pin held off inside the settle window after a wheel event and resuming after it.
- `useBubbleVanishProbe.test.tsx` (new): no observer when the flag is off; one snapshot per drop with live counts; growth logs nothing.
- `useVirtualChat.layoutShrink.test.tsx`: passes unchanged (comment updated to the new mechanism); full frontend suite + `tsc -b` + `eslint src/ --max-warnings 659` green locally.

## Pattern harvest

Rule candidate: none mechanical. The defect class is "an effect gated on a UI-proximity band (isAtBottom) when the semantic state it needs is user intent (follow)" — a design-level review lens, not a grep/semgrep-expressible pattern. The secondary self-caught bug (a direction reference not updated on programmatic writes) is guarded by the new hook-level tests rather than a rule.

## Lint budget rider (declared)

Five UNUSED `eslint-disable-next-line react-hooks/exhaustive-deps` directives are removed from `ChatPage.tsx` (via `eslint --fix`; trailing whitespace cleaned). Declared rationale: main's warning count crossed CI's fixed `--max-warnings 659` budget (main alone measures 660 on a clean checkout), which failed this PR's Lint check through no change of its own. These five are exactly the directives the linter itself reports as *unused* — removing them is the ratchet direction the budget comment in ci.yml asks for and changes zero behavior. The directive at ChatPage.tsx:1787 is live (suppressing a real warning) and is deliberately kept; this is a complete sweep of the unused class in this file, not a partial one.
