### PR TITLE
fix: redact stderr before the bound in themes and dev_fleet (#7374)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
@@ -1236,7 +1236,9 @@ async def _worktree_remove_locked(
                         force,
                         (verdict_oid or "").strip()[:12] if verdict_oid else "none",
                     )
-                _err = runtime._redact((stderr or stdout).strip()[:300])
+                # Redact the FULL text, then bound: slicing first can cut a
+                # credential into fragments no redaction regex matches.
+                _err = runtime._redact((stderr or stdout).strip())[:300]
                 if pending_discard is not None:
                     # The discard already ran. Every failure mode we can name in
                     # advance is refused earlier (lock, protection, dirt), but a
@@ -1992,7 +1994,9 @@ async def _rebase_locked(target: dict) -> dict:
         g = await repository._git_info(path)
         return {"ok": True, "rebased": True, "head": g["head"], "behind": g["behind"]}
     abort_res = await repository._git(path, "rebase", "--abort", timeout=30, mode="strict")
-    tail = runtime._redact((stdout + stderr).strip()[-200:])
+    # Redact the FULL text, then take the tail: a tail cut of already-redacted
+    # text can at worst split a redaction marker, never a secret.
+    tail = runtime._redact((stdout + stderr).strip())[-200:]
     if abort_res is None:
         # Abort itself failed/timed out — the worktree is still mid-rebase.
         # Never report "aborted" when it is not; manual recovery required.

--- a/src/kiro_crew/dashboard/handlers/themes.py
+++ b/src/kiro_crew/dashboard/handlers/themes.py
@@ -79,8 +79,7 @@ from kiro_crew.sandbox import (
 )
 from kiro_crew.security import (
     is_sensitive_path,
-    redact_credentials,
-    redact_exfiltration_urls,
+    redact_and_truncate,
 )
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
@@ -303,8 +302,10 @@ def _clone_github(url: str, dest: Path) -> str | None:
         if cleanup:
             Path(cleanup).unlink(missing_ok=True)
     if proc.returncode != 0:
-        _red, _ = redact_credentials(proc.stderr.strip()[:200])
-        _red, _ = redact_exfiltration_urls(_red)
+        # Redact the FULL text before the bound: a credential straddling the
+        # slice would otherwise be cut into fragments no redaction regex can
+        # match (same class as PR #7316 / #7350).
+        _red = redact_and_truncate(proc.stderr.strip(), 200)
         return f"git clone failed: {_red}"
     return None
 

--- a/test/test_dev_fleet_stderr_redact_before_bound.py
+++ b/test/test_dev_fleet_stderr_redact_before_bound.py
@@ -1,0 +1,122 @@
+"""Redact-before-bound on subprocess stderr in the dev_fleet worktree ops.
+
+Two sites bound git stderr to a fixed character count before returning it in an
+error payload: the worktree-removal failure (head cut, ``[:300]``) and the
+rebase-conflict tail (``[-200:]``). Bounding BEFORE redaction can cut a
+credential mid-match, leaving a fragment no redaction regex recognises — a tail
+cut keeps the credential's RIGHT half, which equally matches nothing. The fix
+(issue #7374, same class as PR #7316 / PR #7350) feeds ``_redact`` the FULL
+text and applies the bound to its result: a cut of already-redacted text can at
+worst split a redaction marker, never a secret.
+
+The behavioral test pins the reachable tail-cut site (``_rebase_locked``'s
+conflict path) with the straddle layout: the secret is placed so the tail
+window's left edge falls INSIDE it, so a raw slice AND a slice-then-redact
+reorder both go red. The structural test then pins the whole module — the
+head-cut removal site included — without driving the full locked removal flow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from test_theme_clone_stderr_redact_before_bound import _find_slice_before_redact_offenders
+
+import kiro_crew.apps.builtins.dev_fleet.repository as repository
+import kiro_crew.apps.builtins.dev_fleet.runtime as runtime
+import kiro_crew.apps.builtins.dev_fleet.worktree_ops as worktree_ops
+
+# The bound applied at the rebase-conflict tail site in _rebase_locked.
+_REBASE_TAIL_BOUND = 200
+
+_MODULE_PATH = Path(worktree_ops.__file__)
+
+
+class TestRebaseConflictTailIsRedactedBeforeTheBound:
+    """The rebase-conflict error must never carry a raw credential fragment."""
+
+    async def _rebase_with_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stdout: str
+    ) -> dict:
+        # Route the flow to the conflict branch without a real repository:
+        # status is clean, the fetch succeeds, the rebase fails with the
+        # crafted output, and the abort succeeds. ``_rebase_locked`` reaches
+        # these helpers as ``repository.X`` / ``runtime.X`` attribute lookups,
+        # so patching the owning modules takes effect.
+        rebase_calls: list[list[str]] = []
+
+        async def _git(path: str, *args: str, **kw: object) -> str | None:
+            return ""
+
+        async def _run_cmd(cmd: list[str], **kw: object) -> tuple[int, str, str]:
+            rebase_calls.append(cmd)
+            assert "rebase" in cmd, f"unexpected _run_cmd before the rebase: {cmd}"
+            return 1, stdout, ""
+
+        monkeypatch.setattr(repository, "_git", _git)
+        monkeypatch.setattr(runtime, "_run_cmd", _run_cmd)
+
+        async def _remote() -> str:
+            return "origin"
+
+        monkeypatch.setattr(repository, "_upstream_remote", _remote)
+        out = await worktree_ops._rebase_locked({"path": str(tmp_path)})
+        assert rebase_calls, "the rebase was never attempted, so this exercised nothing"
+        return out
+
+    @pytest.mark.asyncio
+    async def test_a_rebase_conflict_does_not_leak_a_credential(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        token = "s3cr3t-remote-token"  # a fake secret, only asserted absent
+        stdout = f"fatal: could not read from 'https://ci-bot:{token}@github.example/r.git'\n"
+        out = await self._rebase_with_output(monkeypatch, tmp_path, stdout)
+        assert out["ok"] is False and out["conflict"] is True
+        assert token not in str(out["error"])
+        assert "[REDACTED" in str(out["error"])
+
+    @pytest.mark.asyncio
+    async def test_the_credential_is_redacted_before_the_tail_cut(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Straddle layout: the tail window's left edge falls INSIDE the token.
+
+        A raw ``[-200:]`` slice keeps the token's RIGHT half verbatim, and the
+        cut drops the ``https://user:`` head the userinfo regex needs to
+        match, so a slice-then-redact reorder leaks it too. Only
+        redact-then-bound scrubs it, so this test goes red if the two steps
+        are ever reordered.
+        """
+        token = "TOKENedge9876543210"  # a fake secret, only asserted absent
+        head = f"fatal: could not read from 'https://ci-bot:{token}"
+        # Pad AFTER the credential so the tail window opens mid-token: the
+        # window's left edge lands ten characters into the token.
+        cut_in_token = 10
+        tail_len = len("@github.example/r.git'") + (len(token) - cut_in_token)
+        pad = "x" * (_REBASE_TAIL_BOUND - tail_len)
+        line = f"{head}@github.example/r.git'{pad}"
+        # Premise guards: the layout must actually straddle, or this test
+        # silently stops pinning the invariant.
+        start = line.index(token)
+        cut = len(line) - _REBASE_TAIL_BOUND
+        assert start < cut < start + len(token)
+        assert line.index("https://") < cut
+
+        out = await self._rebase_with_output(monkeypatch, tmp_path, line)
+        err = str(out["error"])
+        assert token not in err
+        # The exact fragment a bound-before-redact implementation would leak —
+        # everything of the token right of the cut — must be absent too.
+        leaked_suffix = token[cut - start :]
+        assert leaked_suffix and leaked_suffix not in err
+
+
+class TestNoRawBoundedStderrSliceInTheModule:
+    """Structural class pin covering BOTH fixed sites: a bounded char slice of
+    a DIRECT stderr/stdout expression is sanctioned only when applied to the
+    RESULT of a redact call. (A slice of a renamed local assigned from such an
+    expression is beyond this scan — the behavioral tests carry that case.)"""
+
+    def test_no_slice_before_redaction(self) -> None:
+        assert _find_slice_before_redact_offenders(_MODULE_PATH) == []

--- a/test/test_theme_clone_stderr_redact_before_bound.py
+++ b/test/test_theme_clone_stderr_redact_before_bound.py
@@ -1,0 +1,150 @@
+"""Redact-before-bound on ``_clone_github``'s stderr (dashboard themes).
+
+``_clone_github`` reaches git with a user-supplied URL, and on an auth failure
+git echoes that URL — userinfo and all — to stderr. Bounding BEFORE redaction
+can cut the credential mid-match, leaving a fragment that no longer matches any
+credential regex, so it escapes redaction and lands in the returned error text.
+The fix (issue #7374, same class as PR #7316 / PR #7350) is
+``security.redact_and_truncate``: scrub the FULL text first, bound after.
+
+The behavioral test pins the site with the straddle layout: the secret is
+placed so the 200-char bound falls INSIDE it, so a raw slice AND a
+slice-then-redact reorder both go red. The structural test then pins the whole
+module: any bounded char slice of a stderr/stdout expression must be applied to
+the RESULT of a redact call, never before it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.dashboard.handlers import themes as th
+
+# The bound applied at the clone-failure site in _clone_github.
+_CLONE_BOUND = 200
+
+_MODULE_PATH = Path(th.__file__)
+
+
+class TestCloneFailureStderrIsRedactedBeforeTheBound:
+    """The clone failure path must never return a raw credential fragment."""
+
+    @pytest.fixture(autouse=True)
+    def _no_real_sandbox(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # `sandboxed_spawn_argv` raises SandboxUnavailableError on hosts
+        # without an OS sandbox backend (every CI runner), so stub it to a
+        # passthrough — only the error-mapping branch is under test.
+        monkeypatch.setattr(
+            th, "sandboxed_spawn_argv", lambda argv, *a, **k: (list(argv), {}, None)
+        )
+
+    def _clone_with_stderr(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stderr: str
+    ) -> str | None:
+        class _Proc:
+            returncode = 128
+            stdout = ""
+
+        _Proc.stderr = stderr
+
+        # Patch the module's own run_limited seam: narrower than stubbing the
+        # stdlib subprocess.run underneath it, and it states the seam under
+        # test explicitly.
+        monkeypatch.setattr(th, "run_limited", lambda argv, **kw: _Proc())
+        return th._clone_github("https://github.com/o/r", tmp_path / "clone")
+
+    def test_a_clone_failure_does_not_leak_a_credential(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        token = "s3cr3t-remote-token"  # a fake secret, only asserted absent
+        stderr = f"fatal: could not read from 'https://ci-bot:{token}@github.example/r.git'\n"
+        err = self._clone_with_stderr(monkeypatch, tmp_path, stderr)
+        assert err is not None and err.startswith("git clone failed:")
+        assert token not in err
+        assert "[REDACTED" in err
+
+    def test_the_credential_is_redacted_before_it_is_bounded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Straddle layout: the 200-char bound falls INSIDE the token.
+
+        A raw slice keeps the token's left half verbatim. A slice-then-redact
+        reorder keeps it too, because the cut drops the ``@host`` tail the
+        userinfo regex needs to match. Only redact-then-bound scrubs it, so
+        this test goes red if the two steps are ever reordered.
+        """
+        token = "TOKENedge9876543210"  # a fake secret, only asserted absent
+        userinfo = "https://ci-bot:"
+        # Lay the token out to START ten characters shy of the bound, so the
+        # bound cuts into it and the '@host' tail lands beyond the bound.
+        pad = "x" * (_CLONE_BOUND - 10 - len("fatal: ") - len(userinfo))
+        line = f"fatal: {pad}{userinfo}{token}@github.example/r.git"
+        # Premise guards: the layout must actually straddle, or this test
+        # silently stops pinning the invariant.
+        start = line.index(token)
+        assert start < _CLONE_BOUND < start + len(token)
+        assert line.index("@") > _CLONE_BOUND
+
+        err = self._clone_with_stderr(monkeypatch, tmp_path, line + "\n")
+        assert err is not None
+        assert token not in err
+        # The exact fragment a bound-before-redact implementation would leak —
+        # everything of the token left of the bound — must be absent too.
+        leaked_prefix = token[: _CLONE_BOUND - start]
+        assert leaked_prefix and leaked_prefix not in err
+
+
+class TestNoRawBoundedStderrSliceInTheModule:
+    """Structural class pin: a bounded char slice of subprocess output text is
+    sanctioned only when applied to the RESULT of a redact call (redaction ran
+    over the full text; the cut can at worst split a redaction marker)."""
+
+    def test_no_slice_before_redaction(self) -> None:
+        assert _find_slice_before_redact_offenders(_MODULE_PATH) == []
+
+
+def _find_slice_before_redact_offenders(path: Path) -> list[str]:
+    """AST scan: bounded char slices over DIRECT stderr/stdout expressions.
+
+    A ``Subscript`` slice whose value expression mentions stderr/stdout is an
+    offender unless the sliced value IS a redact call. Deliberate limits: a
+    slice of a renamed local assigned from such an expression, or of a
+    string-keyed subscript (``out["stderr"]``), is beyond this scan — the
+    behavioral straddle tests carry those shapes. Numeric bounds under 10
+    are ignored to keep the legitimate line-list idiom (``splitlines()[-1:]``)
+    out of scope: a whole-line cut severs no secret, it is the CHAR slice that
+    does. Shared by the themes and dev_fleet redact-before-bound tests.
+    """
+    offenders: list[str] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript) or not isinstance(node.slice, ast.Slice):
+            continue
+        bound = None
+        for edge in (node.slice.lower, node.slice.upper):
+            if isinstance(edge, ast.Constant) and isinstance(edge.value, int):
+                bound = edge.value
+            elif (
+                isinstance(edge, ast.UnaryOp)
+                and isinstance(edge.op, ast.USub)
+                and isinstance(edge.operand, ast.Constant)
+                and isinstance(edge.operand.value, int)
+            ):
+                bound = edge.operand.value
+        if bound is None or bound < 10:
+            continue
+        mentioned = {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+        mentioned |= {a.attr for a in ast.walk(node.value) if isinstance(a, ast.Attribute)}
+        if not any("stderr" in name or "stdout" in name for name in mentioned):
+            continue
+        value = node.value
+        sanctioned = isinstance(value, ast.Call) and (
+            (isinstance(value.func, ast.Name) and "redact" in value.func.id)
+            or (isinstance(value.func, ast.Attribute) and "redact" in value.func.attr)
+        )
+        if not sanctioned:
+            offenders.append(f"{path.name}:{node.lineno}")
+    return offenders


### PR DESCRIPTION
## Summary

Three subprocess-stderr logging sites redacted credentials AFTER slicing to a fixed bound, so a credential straddling the slice was cut into fragments no redaction regex can match. This is the remainder of the defect class fixed by PR #7316 (`deps.py`) and PR #7350 (auto_improvement app); the First Principles lane on #7350 named these three sites.

The fix is the established mechanical reorder: feed the redactor the FULL text, apply the bound AFTER redaction.

- `src/kiro_crew/dashboard/handlers/themes.py` (`_clone_github`, head cut `[:200]`): switched to the shared `security.redact_and_truncate(text, 200)` — the exact idiom PR #7316 introduced. Both redactors (exfiltration URLs + credentials) still run, now over the full text; the two now-unused imports are swapped for `redact_and_truncate`.
- `src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py` (worktree-removal failure, head cut `[:300]`): slice moved outside the `runtime._redact()` call. (The issue named these sites in `dev_fleet/server.py`; main has since refactored that module into a package, and the sites now live in `worktree_ops.py` — relocated by pattern per the issue's own instruction.)
- `src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py` (rebase-conflict tail, `[-200:]`): slice moved outside `runtime._redact()`. A tail cut of already-redacted text can at worst split a redaction marker, never a secret.

## Regression tests

Two new test files follow the straddle pattern from #7316/#7350:

- `test/test_theme_clone_stderr_redact_before_bound.py` — behavioral straddle test for `_clone_github` (premise-guarded: the secret provably straddles the 200 bound and the `@host` tail lands beyond it) plus an AST-based structural pin for the module.
- `test/test_dev_fleet_stderr_redact_before_bound.py` — behavioral straddle test for the rebase-conflict tail cut (the tail window's left edge falls inside the secret, so a raw slice keeps the right half) plus the same structural pin covering both dev_fleet sites.

The structural pin scans direct stderr/stdout slice expressions via AST: a bounded char slice is sanctioned only when applied to the RESULT of a redact call. Mutation-verified: reverting the tail-cut site makes both the behavioral test and the structural pin fail.

No `NON_EGRESS_REDACTION_MODULES` / `_REDACTION_SINKS` posture change: all three modules already called a redactor — `test/test_security_posture.py` passes unchanged.

## Testing

- `isort`, `flake8`, `mypy` (1217 files), diff-scoped black gate: all green.
- Full backend `pytest`: green except failures reproduced identically at pristine base `283625e16` on this host (environmental: home-dir spelling, AF_UNIX path length), none in changed files' modules.
- Targeted modules (themes, dev_fleet, security posture, new tests): 728 passed.

## Deferred follow-up (deliberately out of scope)

- The issue's optional suggestion to promote the app-scoped structural sweep to a repo-wide CI scan is DROPPED: the general class (a bounded slice applied before a redact call) still has ~15 pre-existing sibling sites, and — as the First Principles lane correctly pointed out — most live in CORE paths (`channel.py`, `dashboard/chat_runner.py`, `dashboard/handlers/artifacts.py`, `mcp_tools/control.py`, `vector_memory.py`, …), not in auto_improvement. Only the auto_improvement subset is covered by open PR #7350. A repo-wide sweep would red on all of them, so this PR ships only the three subprocess-stderr sites named by issue #7374 plus straddle tests.
- The core-path sibling set now has a named owner: follow-up issue #7390 lists every site with the suggested fix shape. Promote the sweep once that lands.
- Pre-push review also noted `auto_improvement/backend/clone_setup.py` returns bounded raw stderr with no redaction at all; that file is covered by open PR #7350.

## Pattern harvest

Rule candidate: AST/structural test (shipped in this PR as `_find_slice_before_redact_offenders`, module-scoped)
Pattern: a bounded char slice applied to a subprocess stderr/stdout expression BEFORE the redaction call (`redact*(text[:N])` / `redact*(text[-N:])` or a raw `stderr...[:N]`) — redaction regexes cannot match a credential cut in half. Sanctioned form: slice the RESULT of the redact call, or use `security.redact_and_truncate(text, N)`. Repo-wide promotion deliberately deferred: ~15 core-path sibling sites remain (tracked in follow-up issue #7390) plus the auto_improvement subset on open PR #7350; promote once the baseline is empty.

Closes #7374
