### PR TITLE
fix(mochi): switch lottie to the light player, dropping eval (#6549)

### DIFF
--- a/.github/coverage-baselines/frontend.txt
+++ b/.github/coverage-baselines/frontend.txt
@@ -44,7 +44,6 @@ src/apps/mochi/mochiLanguage.tsx 0.0   # 0/16
 src/apps/mochi/panel/MochiSnipHost.tsx 0.0   # 0/48
 src/apps/mochi/pet/main.tsx 0.0   # 0/21
 src/apps/mochi/snip/main.tsx 0.0   # 0/54
-src/apps/mochi/src/renderer/LottieRenderer.tsx 32.7   # 16/49
 src/apps/mochi/src/renderer/PetdexImporter.tsx 0.0   # 0/40
 src/apps/mochi/src/renderer/SpriteRenderer.tsx 39.6   # 19/48
 src/apps/mochi/src/shared/appearanceTypes.ts 8.7   # 6/69

--- a/website/src/apps/mochi/src/renderer/LottieRenderer.tsx
+++ b/website/src/apps/mochi/src/renderer/LottieRenderer.tsx
@@ -4,7 +4,24 @@
  * when animationData changes. Notifies parent via onReady callback.
  */
 import React, { useEffect, useRef } from 'react'
-import lottie from 'lottie-web'
+/*
+ * The LIGHT player, deliberately — the same call crew-companion's renderer
+ * makes, for the same reason. The package-main build compiles animation
+ * expressions with a direct `eval()`, and the JSON reaching `loadAnimation`
+ * here includes imported appearance packs — third-party authored — running in
+ * the gateway's origin. Nothing mochi draws needs expressions (SVG renderer
+ * only, expressions stripped below), so the smaller player removes the sink
+ * rather than shipping it disarmed.
+ *
+ * Known tradeoff, accepted with eyes open: the light build also registers no
+ * SVG EFFECT renderers (tint, drop shadow, blur, mattes…). The shipped clips
+ * carry none (pinned in mochiLottieAssets.test.ts); an imported pack that
+ * uses them still loads and draws, minus those effects, with a console
+ * breadcrumb naming the cause (see countEffects). crew-companion accepted the
+ * same tradeoff for the same third-party content class. The type-only import
+ * stays on the package root: types live there, not under build/player/.
+ */
+import lottie from 'lottie-web/build/player/lottie_light'
 import type { AnimationItem } from 'lottie-web'
 
 interface LottieRendererProps {
@@ -18,24 +35,32 @@ interface LottieRendererProps {
 /**
  * Remove Lottie EXPRESSIONS from a parsed clip, returning how many went.
  *
- * lottie-web compiles an expression with `eval()` (lottie.js — search
- * `_expression_function`), and the dashboard CSP is `script-src 'self'
- * 'unsafe-inline'` with NO `'unsafe-eval'`. So an expression does not merely
- * misbehave under this policy — it THROWS, the clip never finishes building, and
- * the slot paints nothing. That is what made three of the four Kiro Ghost clips
- * render as empty boxes while the fourth (the only one with no expression) was
- * fine: `idle`, `walking`, `thinking`, `working` were blank and `error` /
- * `offline` worked, which reads like "the pack is broken" rather than "one
- * feature is unavailable".
+ * This file imports the LIGHT player, which has no expression support at all —
+ * the expression compiler (an `eval()` in the full build; lottie.js — search
+ * `_expression_function`) simply is not shipped. The light player IGNORES an
+ * expression rather than throwing, so without this strip a clip that leaned on
+ * one would silently animate less, with nothing in the console naming the
+ * cause. Stripping keeps the count in hand so the warning below can say
+ * exactly what was dropped and why.
  *
- * Stripping loses NOTHING that could have run: under this CSP no expression can
- * ever evaluate. A clip whose motion depended on one animates less; a clip whose
- * expression was redundant (`loopOut()` over a track that already spans the comp,
- * which is what the shipped ghost used) is unchanged. Both beat invisible.
+ * The concrete history, from when this app still loaded the full player under
+ * the dashboard CSP (`script-src 'self' 'unsafe-inline'`, no `'unsafe-eval'`):
+ * the compiler's `eval` THREW mid-build and the slot painted nothing, which
+ * made three of the four Kiro Ghost clips render as empty boxes while the
+ * fourth (the only one with no expression) was fine: `idle`, `walking`,
+ * `thinking`, `working` were blank and `error` / `offline` worked, which reads
+ * like "the pack is broken" rather than "one feature is unavailable".
  *
- * Widening the CSP with `'unsafe-eval'` is the alternative and is rejected: it
- * would hand every script on the page a code-execution primitive to make a
- * companion bob.
+ * Stripping loses NOTHING that could have run: the light player evaluates no
+ * expression anyway. A clip whose motion depended on one animates less; a clip
+ * whose expression was redundant (`loopOut()` over a track that already spans
+ * the comp, which is what the shipped ghost used) is unchanged. Both beat
+ * silent divergence.
+ *
+ * Loading the full player (or widening the CSP with `'unsafe-eval'`) to make
+ * expressions work is the alternative and is rejected: it would wire an
+ * attacker-authored pack's strings to a code-execution primitive in the
+ * gateway's origin, to make a companion bob.
  *
  * Only a STRING `x` is an expression. A numeric/array/object `x` is a coordinate
  * or a bezier easing handle and MUST survive — deleting those would corrupt every
@@ -57,6 +82,40 @@ function stripExpressions(node: unknown): number {
   }
   return removed
 }
+
+/**
+ * Count effect-bearing nodes (a non-empty `ef` array) in a parsed clip.
+ *
+ * The light player registers NO SVG effect implementations (tint, fill,
+ * stroke, drop shadow, gaussian blur, mattes, transform — nine classes in the
+ * full build, zero here), so an effect-bearing pack draws with those effects
+ * skipped. The full player did render them, which makes this the one visible
+ * difference an imported pack can hit after the light-player switch — the
+ * shipped clips carry none (pinned in mochiLottieAssets.test.ts). Nothing is
+ * deleted and the clip still loads; this count only feeds the console
+ * breadcrumb below, same philosophy as stripExpressions: degrade loudly,
+ * never silently.
+ */
+function countEffects(node: unknown): number {
+  if (Array.isArray(node)) {
+    return node.reduce<number>((n, item) => n + countEffects(item), 0)
+  }
+  if (node !== null && typeof node === 'object') {
+    const obj = node as Record<string, unknown>
+    const here = Array.isArray(obj.ef) && obj.ef.length > 0 ? 1 : 0
+    // A counted `ef` holds effect objects whose parameters are themselves `ef`
+    // arrays — recursing into it would count one drop shadow as 2+. Prune at
+    // the counted key so the breadcrumb's number means "effect-bearing nodes".
+    return Object.entries(obj).reduce<number>(
+      (n, [key, v]) => (here === 1 && key === 'ef' ? n : n + countEffects(v)),
+      here,
+    )
+  }
+  return 0
+}
+
+/** Clips (bytes + head, the pair the other logs key on) already warned about. */
+const warnedEffectClips = new Set<string>()
 
 const LottieRendererInner: React.FC<LottieRendererProps> = ({
   animationData,
@@ -110,15 +169,36 @@ const LottieRendererInner: React.FC<LottieRendererProps> = ({
 
     let anim: AnimationItem
     try {
-      // Before loading, not after: an expression throws during the build, so
-      // there is no post-hoc recovery — see stripExpressions.
+      // Before loading, not after: `loadAnimation` consumes the parsed object,
+      // so the strip must land first to count what was dropped — see
+      // stripExpressions.
       const stripped = stripExpressions(parsed)
       if (stripped > 0) {
         // eslint-disable-next-line no-console
         console.warn(
-          `[mochi] removed ${stripped} lottie expression(s) — they cannot run under ` +
-            'the dashboard CSP (no unsafe-eval) and would render the clip blank',
+          `[mochi] removed ${stripped} lottie expression(s) — the light lottie ` +
+            'player has no expression support, so motion that depended on them ' +
+            'will not play',
         )
+      }
+      const effectNodes = countEffects(parsed)
+      if (effectNodes > 0) {
+        // Once per distinct clip, not per load: unlike the expression warn
+        // (which fires only when something was stripped), this fires for ANY
+        // effect-bearing pack — and PetWidget swaps animationData on every pet
+        // state change while GalleryPanel mounts one renderer per tile, which
+        // would repeat an identical line until it crowds out the three
+        // genuinely diagnostic messages this file exists to make findable.
+        const clipKey = `${animationData.length}:${animationData.slice(0, 40)}`
+        if (!warnedEffectClips.has(clipKey)) {
+          warnedEffectClips.add(clipKey)
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[mochi] clip carries ${effectNodes} effect-bearing node(s) — the light ` +
+              'lottie player ships no SVG effect renderers, so they will draw ' +
+              'without those effects',
+          )
+        }
       }
       anim = lottie.loadAnimation({
         container,

--- a/website/src/apps/mochi/test/mochiLottieAssets.test.ts
+++ b/website/src/apps/mochi/test/mochiLottieAssets.test.ts
@@ -1,12 +1,16 @@
 /**
- * Lottie clips must be free of EXPRESSIONS to render at all.
+ * Lottie clips must be free of EXPRESSIONS to render fully.
  *
- * lottie-web compiles an expression with `eval()`, and the dashboard CSP ships
- * `script-src 'self' 'unsafe-inline'` with no `'unsafe-eval'` — so an expression
- * throws mid-build and the slot paints nothing. Three of the four built-in Kiro
- * Ghost clips carried a redundant `loopOut()` and were therefore invisible, while
- * the one without an expression rendered fine; the pack read as "broken" rather
- * than "one Lottie feature is unavailable".
+ * Mochi loads the LIGHT lottie player (see renderer/LottieRenderer.tsx), which
+ * ships no expression support at all — an expression is ignored, so motion that
+ * depended on one silently does not play. Historically, when this app still
+ * loaded the full player, it was worse: the expression compiler's `eval()`
+ * threw under the dashboard CSP (`script-src 'self' 'unsafe-inline'`, no
+ * `'unsafe-eval'`) mid-build and the slot painted nothing. Three of the four
+ * built-in Kiro Ghost clips carried a redundant `loopOut()` and were therefore
+ * invisible, while the one without an expression rendered fine; the pack read
+ * as "broken" rather than "one Lottie feature is unavailable". Either way —
+ * throw then, ignore now — an expression in a shipped clip is a defect.
  *
  * Two pins here: the SHIPPED assets stay expression-free (so this cannot regress
  * when the art is re-exported from After Effects, which adds `loopOut()` freely),
@@ -59,9 +63,34 @@ function countDataXKeys(node: unknown): number {
   return 0
 }
 
+/** Every node carrying a non-empty `ef` array — a Lottie SVG effect. */
+function findEffects(node: unknown, path = ''): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, i) => findEffects(item, `${path}[${i}]`))
+  }
+  if (node !== null && typeof node === 'object') {
+    const obj = node as Record<string, unknown>
+    const here = Array.isArray(obj.ef) && obj.ef.length > 0 ? [`${path}.ef`] : []
+    return [
+      ...here,
+      ...Object.entries(obj).flatMap(([k, v]) => findEffects(v, `${path}.${k}`)),
+    ]
+  }
+  return []
+}
+
 describe('built-in Lottie packs', () => {
   it.each(CLIPS)('%s carries no expressions', (_name, clip) => {
     expect(findExpressions(clip)).toEqual([])
+  })
+
+  it.each(CLIPS)('%s carries no SVG effects', (_name, clip) => {
+    // The light player ships no SVG effect renderers, so an effect on a
+    // shipped clip would render skipped — the one visible regression class the
+    // light-player switch knowingly accepts for IMPORTED packs must never
+    // apply to the built-in art. After Effects adds effects as freely as it
+    // adds `loopOut()`, so pin it against re-exports.
+    expect(findEffects(clip)).toEqual([])
   })
 
   it.each(CLIPS)('%s keeps its non-expression x keys', (_name, clip) => {

--- a/website/src/apps/mochi/test/mochiLottieLightPlayer.test.ts
+++ b/website/src/apps/mochi/test/mochiLottieLightPlayer.test.ts
@@ -1,0 +1,75 @@
+/**
+ * App code must load the LIGHT lottie player, never the full one.
+ *
+ * The full player (`lottie-web`'s package main, `build/player/lottie.js`)
+ * carries the animation-expression compiler and a direct `eval()`. The apps
+ * render imported appearance-pack JSON — third-party authored — in the
+ * gateway's origin, request only the SVG renderer, and strip expressions
+ * before loading, so nothing they draw needs the full build. A bare
+ * `lottie-web` value import resolves to that full player and re-ships the
+ * dead sink (~135 KB minified of expression compiler and unused renderers);
+ * the light entry removes the sink instead of shipping it disarmed. See
+ * #6549; crew-companion and mochi both made this call deliberately.
+ *
+ * Structural pin, same pattern as lottieTeardownGuard's setup.ts pin: the
+ * property under guard is which module SPECIFIER value imports name, and that
+ * is invisible at runtime under the suite's mocks (integration/setup.ts mocks
+ * both specifiers identically), so assert on the source text. Reads happen
+ * inside the tests so a resolution problem fails as a named assertion, not as
+ * collection-time noise.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+// Resolved from cwd: vitest runs with cwd at the website root (where
+// vite.config.ts lives). import.meta.url is not usable here — under happy-dom
+// it carries the environment's http URL, not a file: URL.
+const APPS_DIR = () => resolve(process.cwd(), 'src/apps')
+const RENDERER = () =>
+  resolve(process.cwd(), 'src/apps/mochi/src/renderer/LottieRenderer.tsx')
+
+/** Every production (non-test) .ts/.tsx file under src/apps, recursively. */
+function productionSources(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return entry.name === 'test' ? [] : productionSources(full)
+    }
+    if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) return []
+    return [full]
+  })
+}
+
+/** Drop block and line comments so a prose mention cannot false-positive. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+}
+
+describe('lottie player choice across src/apps', () => {
+  it('mochi LottieRenderer value-imports the light player', () => {
+    const source = readFileSync(RENDERER(), 'utf8')
+    expect(source).toMatch(
+      /import\s+lottie\s+from\s+'lottie-web\/build\/player\/lottie_light'/,
+    )
+  })
+
+  it('no production module names the bare specifier outside a type-only import', () => {
+    // The type-only import may — and should — stay on the package root: types
+    // live there, not under build/player/. Only a VALUE binding pulls code
+    // into the bundle, and every value path to it — static `from`, dynamic
+    // `import()`, `require()`, a multi-line import with the specifier on its
+    // own line — has to name the bare quoted specifier somewhere. Type-only
+    // statements are removed as whole statements (not line-matched) so a
+    // wrapped `import type {…} from 'lottie-web'` cannot false-positive.
+    const offenders = productionSources(APPS_DIR()).flatMap((file) => {
+      const withoutTypeOnly = stripComments(readFileSync(file, 'utf8')).replace(
+        /(?:import|export)\s+type(?:(?!\bfrom\b)[\s\S])*?from\s*['"]lottie-web['"]/g,
+        '',
+      )
+      const residual = withoutTypeOnly.match(/[^\n]*['"]lottie-web['"][^\n]*/g) ?? []
+      return residual.map((snippet) => `${file}: ${snippet.trim()}`)
+    })
+    expect(offenders).toEqual([])
+  })
+})

--- a/website/src/apps/mochi/test/mochiLottieRenderer.test.tsx
+++ b/website/src/apps/mochi/test/mochiLottieRenderer.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Behavior pins for mochi's LottieRenderer diagnostics under the LIGHT player.
+ *
+ * The renderer's job splits in two: hand a sanitized clip to
+ * `lottie.loadAnimation`, and leave a console breadcrumb for every way a clip
+ * can degrade silently (expressions the light player cannot run, SVG effects it
+ * cannot draw, JSON that does not parse, a load that throws, a load that
+ * succeeds but paints nothing). Each pin here renders the real component
+ * against the suite's lottie mock (integration/setup.ts mocks BOTH specifiers)
+ * and asserts the observable outcome: what reached `loadAnimation` and what
+ * landed on the console — including that the effect warning fires ONCE per
+ * distinct clip, not once per mount or per state swap.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, act } from '@testing-library/react'
+import React from 'react'
+
+import lottie from 'lottie-web/build/player/lottie_light'
+
+import { LottieRenderer } from '../src/renderer/LottieRenderer'
+
+const loadAnimation = vi.mocked(lottie.loadAnimation)
+
+/** A minimal well-formed clip; `seed` makes each test's clip key distinct so
+ *  the module-level once-per-clip warn dedupe cannot leak between tests. */
+function clip(seed: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ v: '5.13.0', seed, op: 60, layers: [], ...extra })
+}
+
+describe('mochi LottieRenderer', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    loadAnimation.mockClear()
+  })
+
+  it('loads a clean clip with the svg renderer and no warnings', () => {
+    render(<LottieRenderer animationData={clip('clean')} width={64} height={64} />)
+    expect(loadAnimation).toHaveBeenCalledTimes(1)
+    expect(loadAnimation.mock.calls[0][0]).toMatchObject({ renderer: 'svg', loop: true })
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('strips a string-x expression before loading and warns with the light-player reason', () => {
+    render(
+      <LottieRenderer
+        animationData={clip('expr', { layers: [{ ks: { p: { x: 'loopOut()' } } }] })}
+        width={64}
+        height={64}
+      />,
+    )
+    const passed = loadAnimation.mock.calls[0][0].animationData as Record<string, any>
+    expect(passed.layers[0].ks.p).not.toHaveProperty('x')
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('removed 1 lottie expression(s)'),
+    )
+    // A numeric/array x is a coordinate, not an expression — it must survive.
+    expect(clip('expr')).toBeTruthy()
+  })
+
+  it('keeps non-string x keys: coordinates and easing handles survive the strip', () => {
+    render(
+      <LottieRenderer
+        animationData={clip('data-x', { layers: [{ ks: { p: { x: [0.5], y: 1 } } }] })}
+        width={64}
+        height={64}
+      />,
+    )
+    const passed = loadAnimation.mock.calls[0][0].animationData as Record<string, any>
+    expect(passed.layers[0].ks.p.x).toEqual([0.5])
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns ONCE per distinct effect-bearing clip, across remounts and data swaps', () => {
+    const effectClip = clip('fx', { layers: [{ ef: [{ ty: 25, ef: [{ v: { k: 1 } }] }] }] })
+    const { rerender, unmount } = render(
+      <LottieRenderer animationData={effectClip} width={64} height={64} />,
+    )
+    const effectWarns = () =>
+      warnSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('effect-bearing node(s)'),
+      )
+    expect(effectWarns()).toHaveLength(1)
+    // The nested parameter `ef` inside the counted effect must not double-count.
+    expect(effectWarns()[0][0]).toContain('carries 1 effect-bearing node(s)')
+
+    // Remount with the same clip (PetWidget swaps animationData every state
+    // change; GalleryPanel mounts one renderer per tile): still one warn.
+    rerender(<LottieRenderer animationData={clip('other')} width={64} height={64} />)
+    rerender(<LottieRenderer animationData={effectClip} width={64} height={64} />)
+    unmount()
+    render(<LottieRenderer animationData={effectClip} width={64} height={64} />)
+    expect(effectWarns()).toHaveLength(1)
+
+    // A DIFFERENT effect-bearing clip is new information: it gets its own warn.
+    render(
+      <LottieRenderer
+        animationData={clip('fx2', { layers: [{ ef: [{ ty: 21 }] }] })}
+        width={64}
+        height={64}
+      />,
+    )
+    expect(effectWarns()).toHaveLength(2)
+  })
+
+  it('leaves a parse-failure breadcrumb instead of an invisible blank', () => {
+    render(<LottieRenderer animationData="{not json" width={64} height={64} />)
+    expect(loadAnimation).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[mochi] lottie JSON parse failed',
+      expect.objectContaining({ bytes: 9 }),
+      expect.anything(),
+    )
+  })
+
+  it('leaves a load-failure breadcrumb when loadAnimation throws', () => {
+    loadAnimation.mockImplementationOnce(() => {
+      throw new Error('unsupported layer')
+    })
+    render(<LottieRenderer animationData={clip('boom')} width={64} height={64} />)
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[mochi] lottie loadAnimation failed',
+      expect.objectContaining({ bytes: expect.any(Number) }),
+      expect.any(Error),
+    )
+  })
+
+  it('reports a load that succeeded but painted nothing, then calls onReady', () => {
+    let ready: (() => void) | undefined
+    loadAnimation.mockImplementationOnce(
+      () =>
+        ({
+          destroy: () => {},
+          addEventListener: (event: string, cb: () => void) => {
+            if (event === 'DOMLoaded') ready = cb
+          },
+          removeEventListener: () => {},
+        }) as never,
+    )
+    const onReady = vi.fn()
+    render(
+      <LottieRenderer
+        animationData={clip('empty-paint')}
+        width={64}
+        height={64}
+        onReady={onReady}
+      />,
+    )
+    expect(ready).toBeDefined()
+    act(() => ready!())
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[mochi] lottie loaded but painted nothing',
+      expect.objectContaining({ hasSvg: false }),
+    )
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys the animation and detaches the DOMLoaded listener on unmount', () => {
+    const destroy = vi.fn()
+    const removeEventListener = vi.fn()
+    loadAnimation.mockImplementationOnce(
+      () =>
+        ({
+          destroy,
+          addEventListener: () => {},
+          removeEventListener,
+        }) as never,
+    )
+    const { unmount } = render(
+      <LottieRenderer animationData={clip('teardown')} width={64} height={64} />,
+    )
+    unmount()
+    expect(destroy).toHaveBeenCalled()
+    expect(removeEventListener).toHaveBeenCalledWith('DOMLoaded', expect.any(Function))
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The mochi app's `LottieRenderer` value-imports bare `lottie-web`, which resolves to the package main entry `build/player/lottie.js` -- the FULL player, carrying the animation-expression compiler and its direct `eval()` call. That is a dead sink today (the dashboard CSP grants no `unsafe-eval`, and mochi strips expressions pre-load), but it ships ~135 KB of unused expression compiler and renderers in the same origin that renders third-party appearance-pack JSON. The sibling app crew-companion already imports `lottie-web/build/player/lottie_light` deliberately, with a comment explaining why -- so the two apps disagreed on a decision one of them documented. Surfaced by rolldown's `[EVAL]` build warning after the vite 8.2.0 upgrade (not a regression; the bare import predates the warning).

## Why it matters

An `eval` sink co-resident with attacker-authored JSON is exactly the kind of latent primitive defense-in-depth exists to remove: today's CSP and pre-load strip make it unreachable, but either could drift, and the dead code costs bundle weight on every load. It also keeps the `[EVAL]` diagnostic firing on every website build, training people to ignore it.

## What changed (motivation → approach → change)

Bare `lottie-web` import → the full player with the eval-bearing expression compiler → switch mochi's value import to `lottie-web/build/player/lottie_light`, the same call crew-companion documents (both apps use only `renderer: 'svg'`, which the light player fully supports; the type-only `AnimationItem` import stays on the package root, where the types live).

Two consequences of the light player are handled rather than ignored:

- **Expressions**: the light player has no expression support at all -- it IGNORES an expression rather than throwing. `stripExpressions()` is kept for its diagnostic: the strip count feeds a console warning naming the cause, so an expression-bearing pack reads as "one Lottie feature is unavailable" instead of silently animating wrong. Its doc comment now states the light-player reason instead of the stale CSP-throw one.
- **SVG effects**: the light build registers no SVG effect renderers (tint, fill, drop shadow, blur, mattes...). An effect-bearing imported pack still loads and draws, minus those effects, with a once-per-clip console breadcrumb naming the cause (`countEffects`). crew-companion accepted the same tradeoff for the same third-party content class; the shipped built-in clips carry no effects, and that is now pinned by test.

A guard test (`mochiLottieLightPlayer.test.ts`) asserts from source text that no production module under `src/apps` value-imports the bare specifier -- same structural-pin pattern as `lottieTeardownGuard`'s setup pin and `hljsCoreOnly`'s barrel guard.

## Tests

- `mochiLottieAssets.test.ts` -- new `carries no SVG effects` pin per shipped clip (the effect-freeness the light-player tradeoff rests on; After Effects re-exports add effects as freely as `loopOut()`), alongside the existing no-expressions / data-`x`-survival / loop-span pins.
- `mochiLottieLightPlayer.test.ts` (new) -- (1) no production module under `src/apps` value-imports bare `lottie-web` (comment-stripped, type-only-import-aware source scan; the type-only strip is bounded so a type-import-first file cannot mask a later value import); (2) mochi's renderer value-imports the light specifier exactly.
- Existing suites: `lottieTeardownGuard` already pins that integration/setup.ts mocks BOTH specifiers, so the switch cannot unmask the real bundle under test. Full frontend suite green locally (1700 files / 26912 tests).

## Manual verification

- `npm run build`: the rolldown `[EVAL]` diagnostic for lottie-web is gone; the only lottie chunk emitted is `lottie_light` (169 KB, 47 KB gzip).
- Verified against pinned `lottie-web@5.13.0`: `lottie_light.js` contains zero `eval(` occurrences vs one in `lottie.js`; the light build ships `SVGRenderer` + text-layer support (two shipped clips use text layers) and no effect filters.
- All four shipped Kiro Ghost clips render identically under the light player: no expressions (stripped or otherwise), no effects, loop tracks span the composition.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** import-specifier and diagnostics-only change; the shipped clips carry no expressions or effects, so rendered output is pixel-identical under the light player.

## Related Issues

Fixes #6549

## Pattern harvest

Rule candidate: lint (no-restricted-imports) -- Pattern: "bare `lottie-web` value import resolves to the eval-bearing full player; runtime callers must import `lottie-web/build/player/lottie_light`" (the new guard test enforces this structurally; an eslint `no-restricted-imports` entry mirroring the existing `highlight.js` barrel rule would catch it at edit time too).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
