### PR TITLE
refactor(events): simplify the envelope and backfill validator

### DIFF
--- a/src/kiro_crew/events/backfill.py
+++ b/src/kiro_crew/events/backfill.py
@@ -237,16 +237,12 @@ def backfill_transcripts(home: Path, limit: int | None = None) -> SourceReport:
     if not sessions.exists():
         return rep
     index = _stem_to_key_index(home)
-    paths: list[tuple[Path, str]] = []
-    for path in sorted(sessions.glob("*.jsonl")):
-        paths.append((path, path.stem))
+    paths: list[tuple[Path, str]] = [(p, p.stem) for p in sorted(sessions.glob("*.jsonl"))]
     archive = sessions / "archive"
     if archive.exists():
-        for path in sorted(archive.glob("*.jsonl")):
-            # The segment suffix is appended at rotation time, so it is the
-            # LAST __-delimited token; a session key may itself contain __.
-            stem = path.stem.rsplit("__", 1)[0]
-            paths.append((path, stem))
+        # The segment suffix is appended at rotation time, so it is the LAST
+        # __-delimited token; a session key may itself contain __.
+        paths.extend((p, p.stem.rsplit("__", 1)[0]) for p in sorted(archive.glob("*.jsonl")))
     for path, stem in paths:
         key = _resolve_session_key(stem, index)
         try:
@@ -322,7 +318,7 @@ def backfill_subagents(home: Path, limit: int | None = None) -> SourceReport:
             parent_key = parent_key[len("dashboard:") :]
         tombstone = d / "tombstone.json"
         result = d / "result.txt"
-        # Read the tombstone BEFORE emitting spawned: M0's vocabulary has no
+        # Read the tombstone BEFORE emitting spawned: kinds.py registers no
         # neutral "stopped" terminal kind, so a user-stopped run is skipped
         # whole — a spawned event with no terminal would replay forever as
         # an active run.
@@ -344,10 +340,10 @@ def backfill_subagents(home: Path, limit: int | None = None) -> SourceReport:
                 continue
             # Restart reconciliation writes cause="gateway_restart" (legacy
             # paths "interrupted") for runs the gateway itself orphaned; the
-            # run may well have delivered (recovery_action records that). M0
-            # has no interrupted terminal kind, so these are skipped whole
-            # like stopped runs — recording them as subagent/failed
-            # fabricates errors for possibly-successful work.
+            # run may well have delivered (recovery_action records that).
+            # kinds.py registers no interrupted terminal kind, so these are
+            # skipped whole like stopped runs — recording them as
+            # subagent/failed fabricates errors for possibly-successful work.
             if readable and cause in ("gateway_restart", "interrupted"):
                 continue
         rep.add(
@@ -432,7 +428,12 @@ def backfill_crons(home: Path, limit: int | None = None) -> SourceReport:
                 or bool(job.get("user_paused"))
                 or bool(job.get("auto_paused"))
             )
-        kind_label = "script" if job.get("script") else "command" if job.get("command") else "llm"
+        if job.get("script"):
+            kind_label = "script"
+        elif job.get("command"):
+            kind_label = "command"
+        else:
+            kind_label = "llm"
         rep.add(
             CronRegistered(
                 key=f"cron:{job_id}",

--- a/src/kiro_crew/events/base.py
+++ b/src/kiro_crew/events/base.py
@@ -148,10 +148,14 @@ def register(cls: type[Event]) -> type[Event]:
     a programming error, not a runtime condition.
     """
     kind = cls.KIND
-    domain, sep, action = kind.partition("/")
-    valid = (
-        bool(sep) and bool(domain) and bool(action) and "/" not in action and kind == kind.lower()
-    )
+    # ``bool(action)`` already carries "a separator was present": with no "/"
+    # in *kind*, partition puts the whole string in domain and leaves BOTH the
+    # separator and the tail empty, so a non-empty action is only reachable
+    # once the slash was found. ``"/" not in action`` is a different and still
+    # necessary test — it is what forbids a SECOND slash, since partition
+    # splits at the first one.
+    domain, _, action = kind.partition("/")
+    valid = bool(domain) and bool(action) and "/" not in action and kind == kind.lower()
     if not valid:
         raise ValueError(f"event KIND must be lowercase 'domain/action', got {kind!r}")
     existing = REGISTRY.get(kind)
@@ -176,8 +180,8 @@ def serialize(event: Event, *, src: str) -> str:
         "src": src,
         "key": event.key,
         "ts_ms": event.ts_ms,
+        "data": event.data(),
     }
-    rec["data"] = event.data()
     return json.dumps(rec, separators=(",", ":"), ensure_ascii=False, default=str)
 
 
@@ -222,18 +226,15 @@ def parse(line: str) -> Parsed | None:
     v_val = rec.get("v")
     v = v_val if isinstance(v_val, int) and not isinstance(v_val, bool) else 0
     # An ABSENT data key is a legitimately empty payload; a PRESENT non-dict
-    # value — explicit null included, which rec.get() cannot distinguish
-    # from absence — violates the envelope contract (the serializer always
-    # writes a dict), and substituting {} would hand consumers a typed
-    # event with invented defaults. Corrupt like a bad ts_ms.
-    if "data" not in rec:
-        data: dict[str, Any] = {}
-    else:
-        data_val = rec.get("data")
-        if isinstance(data_val, dict):
-            data = data_val
-        else:
-            return None
+    # value — explicit null included — violates the envelope contract (the
+    # serializer always writes a dict), and substituting {} would hand
+    # consumers a typed event with invented defaults. Corrupt like a bad
+    # ts_ms. The get() default fires only on absence, which is what keeps
+    # those two cases apart.
+    data_val = rec.get("data", {})
+    if not isinstance(data_val, dict):
+        return None
+    data: dict[str, Any] = data_val
     cls = REGISTRY.get(kind)
     event: Event
     if cls is not None:

--- a/test/test_events_backfill.py
+++ b/test/test_events_backfill.py
@@ -250,8 +250,8 @@ def test_dashboard_transcript_key_is_normalized(tmp_path: Path) -> None:
 
 
 def test_stopped_subagent_emits_no_events_at_all(tmp_path: Path) -> None:
-    # M0 has no neutral "stopped" terminal kind, so a stopped run is skipped
-    # whole: a spawned with no terminal would replay forever as active.
+    # kinds.py registers no neutral "stopped" terminal kind, so a stopped run
+    # is skipped whole: a spawned with no terminal would replay forever as active.
     home = tmp_path / "home"
     d = home / "subagents" / "sa-stop"
     d.mkdir(parents=True)


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/events/` carries a handful of constructs that cost a reader more than
they need to. The module-simplification detector flags one mechanically-decidable
site — a chained ternary in `backfill_crons` that packs a three-way branch onto one
99-column line — and reading the surrounding code surfaces four more:

- `backfill_transcripts` builds its `(path, stem)` work list with two
  `append`-in-a-loop blocks, and the loop variable `path` leaks into the enclosing
  function where a later `for path, stem in paths:` rebinds it.
- `serialize()` builds a dict literal and then appends one more key on the next
  statement, so the envelope's shape is split across two places.
- `parse()`'s `data`-key handling is an eight-line nested `if/else` whose two arms
  each end in a different way.
- `register()`'s validity predicate tests the same fact twice, which forces the
  expression onto three lines.

Two comments also carry `M0` milestone tags, which `AGENTS.md` names explicitly as
task-log content that does not belong in code.

## Why it matters

`events/` is the schema half of the structured lifecycle-event track, and its
`backfill.py` is the validator that proves the v1 envelope fits real stores. It is
read far more often than it is edited — by anyone adding a kind, and by whoever
lands the first emit sites and deletes the validator. Every construct above is a
small tax on that reading, and a milestone tag will mean nothing to the next reader.

## What changed (motivation → approach → change)

Behaviour-preserving readability only. No signature, envelope field, wire format, or
validation outcome moves.

**Mechanical class (1 site, from the detector)**

- `backfill.py` `backfill_crons` — the chained ternary
  `"script" if … else "command" if … else "llm"` becomes an `if`/`elif`/`else`.
  Same branch precedence, same truthiness, same `job.get` call sequence (1 call when
  `script` is truthy, 2 otherwise — instrumented, not assumed).

**Judgment class (4 sites, in the two files already open)**

- `backfill.py` `backfill_transcripts` — the two `append` loops become a list
  comprehension plus one `paths.extend(...)`. Resulting list and order are identical
  (live transcripts first, then archive segments), which is load-bearing because
  `run_backfill` records `samples[kind]` from the *first* event of a kind. A
  generator expression evaluates its outermost iterable eagerly, so
  `sorted(archive.glob(...))` is still consumed at the same point, still inside
  `if archive.exists():` and still outside the per-file `try/except OSError`. The
  leaked `path`/`stem` bindings were dead on every reachable path: the very next
  statement rebinds both, and nothing after that loop reads them.
- `base.py` `serialize` — `rec["data"] = event.data()` folds into the dict literal
  as its last key. Insertion order is unchanged, so `json.dumps` emits the identical
  byte string; `event.key` and `event.ts_ms` are still read before `data()` runs.
- `base.py` `parse` — the nested `"data" not in rec` / `isinstance` block flattens
  to `rec.get("data", {})` plus one guard clause. `dict.get`'s default fires only on
  absence, so the three cases the envelope contract distinguishes are preserved
  exactly: absent → empty payload, present-and-dict → used as-is (still the same
  object, so the downstream `payload=data` aliasing is unchanged), and
  present-and-non-dict — explicit `null` included — → refused as corrupt. The `{}`
  default is a literal evaluated per call, not a shared mutable default.
- `base.py` `register` — the predicate drops `bool(sep)`. `str.partition` leaves
  both the separator and the tail empty when the separator is absent, so
  `bool(action)` already implies it and the conjunct could never be the sole
  rejecting one. The freed line pays for a comment that also states why
  `"/" not in action` is a *different*, still-necessary test (it forbids a second
  slash), so a later reader does not mistake it for the redundant one.

**Comment hygiene (files already being edited)**

- Two `M0` milestone tags in `backfill_subagents` become present-tense statements of
  what `events/kinds.py` registers today — which is what the surrounding reasoning
  actually depends on. Both claims re-verified against `kinds.py`: the subagent
  domain's only terminals are `completed` and `failed`; there is no neutral
  `stopped` and no `interrupted`.
- The identical phrasing in `test_events_backfill.py`'s mirroring comment is fixed
  in the same commit rather than left to drift.
- `backfill_transcripts`' rotation-suffix comment moves with the code it annotates.

Out of scope on purpose: `backfill_transcripts`' deep nesting does not flatten via
an early return without extracting a helper, which would widen a readability pass
into a restructure; and `SourceReport.ts_or_mtime`'s `if ms:` truthiness is
pre-existing behaviour, so changing it would not be behaviour-preserving.

## Tests

No test assertions change — this diff is behaviour-preserving, so the existing tests
are the assertion that it is. `test/test_events_base.py` and
`test/test_events_backfill.py` already pin every rewritten site:

- `test_register_rejects_malformed_kind` covers the no-slash and uppercase
  rejections `register`'s predicate must keep making.
- The `data`-key trio pins all three arms `parse()` distinguishes: a non-dict
  payload, an explicit `null`, and an absent key.
- `test_envelope_shape_is_stable` pins `serialize`'s envelope key set and that
  `data` is a dict.
- `test_transcript_keys_resolve_via_session_map_and_archive_folds` and
  `test_archive_stem_with_dunder_in_key_resolves_right` pin the archive-segment
  stem handling, including a session key that itself contains `__`.
- `crons[0].kind_label == "llm"` / `crons[1].kind_label == "script"` pin the
  rewritten branch.

The only test-file edit is the one comment line described above.

Result: **93 passed** across `test_events_base.py`, `test_events_backfill.py` and
`test_events_forward.py`.

The full backend suite was also run twice on the same host — once on this branch and
once on a pristine `origin/main` worktree — and the failure **sets** compared rather
than the counts, because this development host has no usable user-namespace sandbox
and reds a stable band of tests for that reason alone. Branch: 82 failed / 77,785
passed. Base: 83 failed / 77,786 passed. **Branch-only failures: zero** — the
branch's failure set is a strict subset of the base's, the one base-only extra is in
the same `sandbox: BLOCKED` family, and no `events` test fails on either side. CI,
which has a working sandbox, is the authoritative signal.

## Manual verification

N/A — unit coverage sufficient. `src/kiro_crew/events/` has no importer outside
itself, a property the package's own tripwire test
(`test_backfill_must_be_deleted_once_a_real_consumer_lands`) enforces, so the blast
radius of this diff is exactly the two test modules above. There is no runtime
surface to click through: nothing emits these events yet.

## Review

Before opening, five read-only review subagents went over the diff with distinct
lenses — `AUTOSDE.yaml` blocking rules, behaviour preservation, import/name-binding
semantics, the security keystone and boot path, and comment accuracy — each grounded
in the repo's own rule files and the CI review workflows rather than generic taste.

Every behavioural equivalence claim above was checked by differential execution, not
by reading: `register`'s predicate was brute-forced old-vs-new over every string up
to length 4 on several alphabets plus named edge cases (`""`, `"/"`, `"//"`, `"a/"`,
`"/a"`, `"a//b"`, `"a/b/c"`, mixed case, and non-ASCII where `.lower()` changes
length) with zero divergences; `parse`'s data handling over 11 payload shapes; and
`serialize`'s output diffed byte-for-byte.

Two findings survived and were fixed here rather than left for the bots:

- `register`'s new comment ended "the slash need not be tested twice", whose
  referent was the *deleted* conjunct while an explicit slash test remains on
  screen — an invitation for a later editor to delete `"/" not in action` and
  silently admit `a/b/c`. Rewritten to name the redundant pair and to say what the
  surviving test is for.
- The `M0` phrasing scrubbed from the two source comments still sat in the test
  comment that mirrored them. Fixed in the same commit, since applying a criterion
  to one file and not its twin is exactly the drift this campaign warns about.

One class of report was dropped as an artifact rather than acted on: two subagents
reported pre-existing `E231`/`E721` from a bare `flake8` invocation. Those codes are
in the repo's own ignore list, and `flake8` run with the repo config exits 0 on both
the base and this branch.

## Related Issues

no linked issue: routine readability sweep of one module, not a reported defect.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff in `src/kiro_crew/events/` plus one test
comment; nothing here renders, and there is no frontend consumer, so the `changes`
job reports `only_backend=true`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — there is no spec or user doc covering `events/`; `base.py`'s module docstring is its only specification and this diff neither touches nor contradicts it
- [x] No secrets, credentials, or internal references in the diff
