### PR TITLE
fix(whatsapp): deliver the pairing QR through neonize's qr() callback

### DIFF
--- a/src/kiro_crew/whatsapp/client.py
+++ b/src/kiro_crew/whatsapp/client.py
@@ -173,7 +173,6 @@ def _load_neonize() -> "tuple[Any, dict[str, Any]]":
         LoggedOutEv,
         MessageEv,
         PairStatusEv,
-        QREv,
         TemporaryBanEv,
     )
 
@@ -183,7 +182,6 @@ def _load_neonize() -> "tuple[Any, dict[str, Any]]":
         "LoggedOutEv": LoggedOutEv,
         "MessageEv": MessageEv,
         "PairStatusEv": PairStatusEv,
-        "QREv": QREv,
         "TemporaryBanEv": TemporaryBanEv,
     }
 
@@ -291,19 +289,34 @@ class WhatsAppClient:
         LoggedOutEv = events["LoggedOutEv"]
         MessageEv = events["MessageEv"]
         PairStatusEv = events["PairStatusEv"]
-        QREv = events["QREv"]
         TemporaryBanEv = events["TemporaryBanEv"]
+
+        # Snapshot BEFORE NewAClient: constructing the client creates the sqlite
+        # store (schema and all), so a `session_exists()` asked afterwards is
+        # ALWAYS true and the first-boot pairing state would never be announced.
+        had_session = self.session_exists()
 
         # The first positional arg doubles as the sqlite session-store path
         # (ClientFactory passes its database_name through the same slot).
         client = NewAClient(self.db_path)
         self._client = client
 
-        @client.event(QREv)
-        async def _on_qr(_client: Any, event: Any) -> None:
+        # QR does NOT travel on the numbered event stream, so it cannot be
+        # registered with `client.event(...)`: `Event.execute` only dispatches
+        # INT_TO_EVENT codes into `list_func`, and QR is never one of them. The Go
+        # core delivers each rotating code by calling `NewAClient.__onQr`, which
+        # invokes `client.event._qr` directly, and `Event.__init__` pre-seeds that
+        # slot with a default that renders the code to a terminal — which a
+        # gateway started from a desktop launcher has no reader for. `client.qr()`
+        # is the supported registration, and it hands over ONE code as bytes per
+        # emission rather than a batch carrying `.Codes`.
+        async def _on_qr(_client: Any, data_qr: Any) -> None:
             import time as _time
 
-            codes = list(getattr(event, "Codes", []) or [])
+            code = (
+                data_qr.decode("utf-8", "replace") if isinstance(data_qr, bytes) else str(data_qr)
+            )
+            codes = [code] if code else []
             self.latest_qr = codes
             self.latest_qr_at = _time.monotonic()
             self._set_state(STATE_PAIRING, "scan the QR code from your phone")
@@ -312,6 +325,8 @@ class WhatsAppClient:
                     self.on_qr(codes)
                 except Exception:  # noqa: BLE001
                     logger.warning("whatsapp: QR observer failed", exc_info=True)
+
+        client.qr(_on_qr)
 
         @client.event(PairStatusEv)
         async def _on_pair(_client: Any, event: Any) -> None:
@@ -353,7 +368,7 @@ class WhatsAppClient:
             except Exception:  # noqa: BLE001 — one bad message must not kill inbound
                 logger.exception("whatsapp: inbound handler failed")
 
-        if not self.session_exists():
+        if not had_session:
             self._set_state(STATE_PAIRING, "waiting for first QR")
         await client.connect()
         self._idle_task = asyncio.get_running_loop().create_task(

--- a/test/test_whatsapp_client.py
+++ b/test/test_whatsapp_client.py
@@ -15,6 +15,7 @@ import base64
 import io
 import sys
 import wave
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -112,13 +113,25 @@ def test_connect_raises_without_extra(monkeypatch):
 
 # ── connect(): fake neonize wiring ──────────────────────────────────────────
 class _FakeNewAClient:
-    """Captures event handlers by event class and records lifecycle calls."""
+    """Captures event handlers by event class and records lifecycle calls.
+
+    Mirrors two behaviours of the real ``NewAClient`` the channel depends on:
+
+    * constructing it CREATES the sqlite session store, so any probe of that file
+      after construction sees a non-empty session; and
+    * the rotating QR code arrives through the dedicated ``qr()`` callback slot,
+      carrying ONE code as bytes — never through the numbered event stream that
+      ``event()`` feeds, which only dispatches ``INT_TO_EVENT`` codes.
+    """
 
     def __init__(self, db_path: str) -> None:
         self.db_path = db_path
         self.handlers: dict[Any, Any] = {}
+        self.qr_callback: Any = None
         self.connected = False
         self.idled = False
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(db_path).write_bytes(b"sqlite-store")
 
     def event(self, ev_type):
         def _register(fn):
@@ -126,6 +139,10 @@ class _FakeNewAClient:
             return fn
 
         return _register
+
+    def qr(self, fn):
+        self.qr_callback = fn
+        return fn
 
     async def connect(self):
         self.connected = True
@@ -135,10 +152,6 @@ class _FakeNewAClient:
 
 
 # Event marker classes (only identity matters as dict keys).
-class QREv:  # noqa: D401
-    pass
-
-
 class PairStatusEv:
     pass
 
@@ -169,7 +182,6 @@ def _install_fake_neonize(monkeypatch):
     client_mod.NewAClient = _FakeNewAClient
     events_mod = ModuleType("neonize.aioze.events")
     for name, obj in {
-        "QREv": QREv,
         "PairStatusEv": PairStatusEv,
         "ConnectedEv": ConnectedEv,
         "DisconnectedEv": DisconnectedEv,
@@ -202,7 +214,6 @@ def test_connect_registers_handlers_and_starts_idle(monkeypatch, tmp_path):
     fake = c._client
     assert fake.connected is True
     assert set(fake.handlers) == {
-        QREv,
         PairStatusEv,
         ConnectedEv,
         DisconnectedEv,
@@ -210,20 +221,41 @@ def test_connect_registers_handlers_and_starts_idle(monkeypatch, tmp_path):
         TemporaryBanEv,
         MessageEv,
     }
-    # No session file -> pairing state announced before connect.
+    # QR is registered on the dedicated callback slot, never as a numbered event:
+    # `client.event(QR)` is never dispatched by neonize, so a handler placed there
+    # can never fire and the panel would wait for a code forever.
+    assert fake.qr_callback is not None
+    # No session file before the client was built -> pairing state announced. The
+    # fake creates the store in its constructor exactly as neonize does, so this
+    # also pins that the check is snapshotted BEFORE construction.
     assert c.state == STATE_PAIRING
     asyncio.run(c.disconnect())
 
 
-def test_qr_handler_records_codes_and_calls_observer(monkeypatch, tmp_path):
+def test_connect_with_existing_session_does_not_announce_pairing(monkeypatch, tmp_path):
+    c = _connect(monkeypatch, tmp_path, session=True)
+    assert c.state != STATE_PAIRING
+    asyncio.run(c.disconnect())
+
+
+def test_qr_callback_records_single_bytes_code_and_calls_observer(monkeypatch, tmp_path):
     c = _connect(monkeypatch, tmp_path)
     codes: list[list[str]] = []
     c.on_qr = codes.append
-    handler = c._client.handlers[QREv]
-    asyncio.run(handler(None, SimpleNamespace(Codes=["c1", "c2"])))
-    assert c.latest_qr == ["c1", "c2"]
-    assert codes == [["c1", "c2"]]
+    # neonize hands over ONE code as bytes per emission, not a batch.
+    asyncio.run(c._client.qr_callback(None, b"2@rotating,code=="))
+    assert c.latest_qr == ["2@rotating,code=="]
+    assert codes == [["2@rotating,code=="]]
     assert c.state == STATE_PAIRING
+    asyncio.run(c.disconnect())
+
+
+def test_qr_callback_replaces_previous_code(monkeypatch, tmp_path):
+    c = _connect(monkeypatch, tmp_path)
+    asyncio.run(c._client.qr_callback(None, b"first"))
+    asyncio.run(c._client.qr_callback(None, b"second"))
+    # Each emission supersedes the last, so the panel renders the live code.
+    assert c.latest_qr == ["second"]
     asyncio.run(c.disconnect())
 
 
@@ -234,8 +266,7 @@ def test_qr_handler_swallows_observer_error(monkeypatch, tmp_path):
         raise RuntimeError("qr observer failed")
 
     c.on_qr = boom
-    handler = c._client.handlers[QREv]
-    asyncio.run(handler(None, SimpleNamespace(Codes=["c1"])))  # must not raise
+    asyncio.run(c._client.qr_callback(None, b"c1"))  # must not raise
     asyncio.run(c.disconnect())
 
 


### PR DESCRIPTION
## Problem / Motivation

First-time WhatsApp pairing can never complete. **Settings → Channels → WhatsApp**
sits on *Waiting for a code…* forever: no QR is ever rendered, so the channel
cannot be linked at all. `GET /api/channels/whatsapp/qr/status` keeps answering
with a null `qr_data_url` because `WhatsAppClient.latest_qr` is never populated.

## Why it matters

The channel is unusable for every new user — pairing is the only way in, and
there is no workaround from the UI. It is silent rather than loud: the badge
reports a plausible waiting state and nothing is logged at WARNING or above, so
the failure looks like a slow network or a phone problem instead of a bug.

It hits hardest exactly where the product is normally run. The rotating code was
in fact being produced and written to the process's **stdout** as terminal escape
art, so a gateway launched from a terminal appears to work while a gateway
supervised by the desktop app (no reader on stdout) can never pair.

## What changed (motivation → approach → change)

**Symptom** — `latest_qr` stays empty for the channel's whole lifetime, so the
panel has no code to render.

**Root cause** — the QR handler was registered on the numbered event stream:

```python
@client.event(QREv)
async def _on_qr(_client: Any, event: Any) -> None: ...
```

neonize never dispatches QR there. `Event.execute()` only routes `INT_TO_EVENT`
codes into `list_func` — precisely what `client.event(...)` populates — and QR is
not one of those codes. The Go core delivers each rotating code by calling
`NewAClient.__onQr`, which invokes `client.event._qr(...)` directly, and
`Event.__init__` pre-seeds that slot with a default:

```python
# neonize/aioze/events.py
self._qr = self.__onqr
...
async def __onqr(self, _: NewAClient, data_qr: bytes):
    segno.make_qr(data_qr).terminal(compact=True)
```

So a handler placed on `client.event(QR)` can never fire, and every code went to
stdout via that default.

**Change** — register through `client.qr(...)`, the supported slot. It hands over
**one** rotating code as `bytes` per emission rather than a batch carrying
`.Codes`, so the handler decodes a single code and each emission supersedes the
last. `_render_qr`'s elapsed-time index — `min(elapsed // 20, len(codes) - 1)` —
is therefore always `0` and renders the live code, so the dashboard needs no
change. `QREv` is dropped from `_load_neonize`, since it is provably not
deliverable through that path.

A second, independent defect sat beside it: the first-boot pairing state was
gated on `session_exists()` evaluated *after* `NewAClient(self.db_path)`.
Constructing the client creates the sqlite store, so that probe is always true
and the branch never ran. The check is now snapshotted as `had_session` **before**
construction.

## Tests

Existing QR coverage passed over a channel that could not pair, so the fake was
fixed first. `_FakeNewAClient` implemented a generic `event()` accepting any
class, and the QR tests drove it with `SimpleNamespace(Codes=["c1", "c2"])` — a
shape real neonize never produces. It also never created the session store, which
hid the ordering defect. It now mirrors the real contract: a `qr()` registration
slot, and a constructor that writes the store the way neonize does.

Locked in by the updated/added tests:

- QR is registered on the callback slot and **not** as a numbered event
  (`qr_callback is not None`, and `QR` absent from the event handler set).
- A code arriving as `bytes` is decoded into `latest_qr`, sets the pairing state,
  and reaches the `on_qr` observer.
- A later emission replaces an earlier one, so the panel renders the live code.
- Pairing is still announced on first boot even though the constructor created
  the store (pins the `had_session` snapshot ordering).
- An existing session does not re-announce pairing.
- A failing `on_qr` observer is still swallowed rather than killing the loop.

`pytest test/test_whatsapp*.py` → 486 passed.

## Manual verification

Applied this change to a live install, restarted the gateway, and paired a real
WhatsApp account: the panel rendered the rotating code, the phone's *Link a
device* scan landed, and the badge flipped to **Connected**. Unit coverage alone
could not have shown this — the failure mode is that a real Go core emits codes
into a callback slot nobody registered, which only an end-to-end pairing proves.

Before the change, on the same install, the panel sat on *Waiting for a code…*
indefinitely across gateway restarts.

Reproduced and fixed against `neonize==0.4.3.post0`, the version pinned by the
`[whatsapp]` extra, on macOS arm64.

## Related Issues

None filed — found while pairing a fresh install.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a callback registered on a third-party API surface that never dispatches
it, kept invisible by a test double that implements the surface the code *assumed*
rather than the one the library actually offers. Two checks generalize: when
wrapping a library's event/callback API, confirm the registration path against
that library's own dispatch source (here `Event.execute` vs `__onQr`), and make
the double mirror the real contract — including side effects of construction,
such as a client constructor that creates its own store.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: `docs/whatsapp-integration.md` already describes this pairing flow correctly; it simply could not happen.
- [x] No secrets, credentials, or internal references in the diff
