### PR TITLE
fix(sandbox): actionable voice-runtime workspace errors + project pre-flight

### DIFF
--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -22,6 +22,7 @@ from kiro_crew.dashboard.token_auth import caller_names_a_missing_slot, derive_c
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.loop_lock import LoopBoundLock
+from kiro_crew.sandbox import voice_runtime_workspace_conflict
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
@@ -329,6 +330,34 @@ def _validate_project_dir(raw: str) -> tuple[str, str | None]:
     return resolved, None
 
 
+def _folder_project_overlap_denied(resolved: str) -> str | None:
+    """Pre-flight the voice-runtime workspace guard for a folder's project_dir.
+
+    #7392 review round 3: a folder's linked project lands on slots verbatim, so
+    without this check "link a folder to ~" is refused only at agent spawn.
+    Same shared scan and message as the project endpoint and set_project — the
+    user-driven moments of choice agree. Returns the refusal message or None.
+
+    Synchronous on purpose (realpath/mkdir priming on first use — round 4):
+    callers on the event loop MUST run it via ``asyncio.to_thread``, exactly
+    like the project endpoint does. It is deliberately NOT part of
+    ``_validate_project_dir``: that validator also re-checks STORED values on
+    the slot-create read path, where re-priming per read would be loop-blocking
+    and where the spawn guard remains the authority.
+    """
+    conflict = voice_runtime_workspace_conflict(resolved)
+    if conflict is None:
+        return None
+    sel().log_api_access(
+        caller="dashboard",
+        operation="chat.folder_project_dir",
+        outcome="denied",
+        resources=resolved,
+        error="voice runtime overlap",
+    )
+    return conflict
+
+
 def _resolve_folder_project_dir(
     folders: list[dict[str, Any]], folder_id: str
 ) -> tuple[str, str | None]:
@@ -506,6 +535,13 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
     project_dir, err = _validate_project_dir(project_dir)
     if err:
         return web.json_response({"error": err}, status=400)
+    if project_dir:
+        # Off-loop: the shared scan primes runtime paths on first use (round 4).
+        conflict = await asyncio.to_thread(_folder_project_overlap_denied, project_dir)
+        if conflict is not None:
+            return web.json_response(
+                {"error": conflict, "code": "workspace_overlaps_data_home"}, status=400
+            )
     default_agent = str(body.get("default_agent") or "").strip()
     color = str(body.get("color") or "").strip().lower()
     if color and not _is_valid_folder_color(color):
@@ -710,6 +746,13 @@ async def api_chat_folder_update(request: web.Request) -> web.Response:
         pd, err = _validate_project_dir(str(body["project_dir"] or "").strip())
         if err:
             return web.json_response({"error": err}, status=400)
+        if pd:
+            # Off-loop: the shared scan primes runtime paths on first use (round 4).
+            conflict = await asyncio.to_thread(_folder_project_overlap_denied, pd)
+            if conflict is not None:
+                return web.json_response(
+                    {"error": conflict, "code": "workspace_overlaps_data_home"}, status=400
+                )
         changes["project_dir"] = pd
     if "color" in body:
         # Palette color for the folder glyph. None or empty string clears back

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -108,6 +108,7 @@ from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.providers.acp import AcpProvider
 from kiro_crew.providers.base import LLMProvider
 from kiro_crew.safety_override import safety_override
+from kiro_crew.sandbox import voice_runtime_workspace_conflict
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
@@ -2269,10 +2270,18 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
             cfg_proj = cfg.dashboard.default_project if cfg else ""
             if isinstance(cfg_proj, str) and cfg_proj:
                 resolved = os.path.realpath(os.path.expanduser(cfg_proj))
-                if os.path.isdir(resolved) and not is_sensitive_path(resolved):
-                    cfg_proj = resolved
-                else:
-                    cfg_proj = ""
+                eligible = os.path.isdir(resolved) and not is_sensitive_path(resolved)
+                if eligible:
+                    # #7392 round 3: a configured default that overlaps the
+                    # data home would be refused at spawn anyway — skip it
+                    # here like a sensitive path, falling back to the
+                    # workspace default instead of wedging every new slot.
+                    # Off-loop (round 4): the shared scan primes runtime
+                    # paths (realpath/mkdir) on first use.
+                    eligible = (
+                        await asyncio.to_thread(voice_runtime_workspace_conflict, resolved)
+                    ) is None
+                cfg_proj = resolved if eligible else ""
             else:
                 cfg_proj = ""
             slot.project = cfg_proj or default_project_dir(workspace)
@@ -5330,6 +5339,25 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
                 error="sensitive path",
             )
             return web.json_response({"error": "Access denied"}, status=403)
+        # Pre-flight the voice-runtime workspace guard (issue #7392): a
+        # workspace that contains (or sits inside) the Kiro Crew data home is
+        # refused at agent spawn anyway, but only after the session exists and
+        # with a spawn-time stack trace. Reject it here, at the moment of
+        # choice, with the same actionable message. Off-loop: the check primes
+        # the runtime path cache (mkdir/realpath) on first use.
+        conflict = await asyncio.to_thread(voice_runtime_workspace_conflict, project)
+        if conflict is not None:
+            sel().log_api_access(
+                caller=request.get("user", "dashboard"),
+                operation="chat_slot_project",
+                outcome="denied",
+                resources=f"slot={name} project={project}",
+                error="voice runtime overlap",
+            )
+            return web.json_response(
+                {"error": conflict, "code": "workspace_overlaps_data_home"},
+                status=400,
+            )
     old_project = slot.project
     slot.project = project
     logger.info("Slot %s project set to %r", name, project)

--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -426,6 +426,7 @@ async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> 
 
 async def _set_project(state: Any, slot: Any, args: dict[str, Any]) -> str:
     from kiro_crew.dashboard.chat_utils import effective_session_key
+    from kiro_crew.sandbox import voice_runtime_workspace_conflict
     from kiro_crew.security import is_sensitive_path
 
     clear = bool(args.get("clear"))
@@ -463,6 +464,15 @@ async def _set_project(state: Any, slot: Any, args: dict[str, Any]) -> str:
         raise _DirectiveDenied("Error: access denied (sensitive path).")
     if not is_dir:
         return f"Error: not a directory: {rp}"
+    # #7392 pre-flight, mirrored from the HTTP project endpoint: this directive
+    # is the OTHER user/agent-driven moment of choice that sets slot.project
+    # (set_project MCP routes here in-process, never through the endpoint), so
+    # without this check the overlap refusal would still land at spawn time,
+    # after the bad folder was committed. Same helper, same message; off the
+    # loop because it stats the runtime paths.
+    overlap = await asyncio.to_thread(voice_runtime_workspace_conflict, rp)
+    if overlap is not None:
+        return f"Error: {overlap}"
     slot.project = rp
     if rp != old_project:
         slot._pending_reset_history_key = effective_session_key(slot)

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -573,6 +573,87 @@ def _voice_runtime_guard_message(
     )
 
 
+def _lexical_runtime_overlap(
+    workspace_paths: tuple[str, ...], runtime_paths: tuple[str, ...]
+) -> tuple[str, str, _VoiceGuardRelationship] | None:
+    """First lexical containment hit between workspace and runtime spellings.
+
+    THE shared containment scan: :func:`voice_runtime_workspace_conflict` (the
+    non-raising pre-flight) and :func:`assert_voice_runtime_outside_agent_workspace`
+    (the fail-closed spawn guard) both call this, so the pre-flight cannot
+    silently drift from the guard it mirrors (Design/FP review round 2 — the
+    two previously carried independent copies of this loop).
+
+    Returns ``(workspace_path_to_name, runtime_path, relationship)`` for the
+    first hit, or ``None``. Naming convention is the guard's: refusals always
+    name the workspace as the caller spelled it (``workspace_paths[0]``); a
+    hit found only on a non-original spelling (the realpath of a symlinked
+    workspace) is an ``"alias"`` relationship — formatting the resolved path
+    instead would print the runtime path twice and omit the path the user
+    actually configured.
+    """
+    original = workspace_paths[0]
+    for workspace_path in workspace_paths:
+        for runtime_path in runtime_paths:
+            try:
+                common = os.path.commonpath((workspace_path, runtime_path))
+            except ValueError:
+                continue
+            if common not in (workspace_path, runtime_path):
+                continue
+            if workspace_path != original:
+                return (original, runtime_path, "alias")
+            return (
+                original,
+                runtime_path,
+                "inside" if common == runtime_path else "contains",
+            )
+    return None
+
+
+def voice_runtime_workspace_conflict(workspace: str | os.PathLike[str]) -> str | None:
+    """Pre-flight: describe why *workspace* would be rejected, or ``None``.
+
+    A non-raising lexical version of
+    :func:`assert_voice_runtime_outside_agent_workspace` for validation
+    surfaces (the project endpoint, pickers) that want to warn BEFORE a
+    session exists. Lexical containment only — the descriptor/identity walks
+    stay in the spawn-time guards, which remain authoritative; a ``None`` here
+    is a pre-flight pass, not a security verdict. Darwin-gated to MATCH the
+    guards it pre-flights: every spawn-time guard early-returns off macOS, so
+    a workspace that overlaps the data home spawns fine on Linux/Windows
+    today — refusing it here would remove a working configuration to prevent
+    a macOS-only harm (and with macOS-worded copy).
+
+    Messages come from :func:`_voice_runtime_guard_message` (#7407) and the
+    containment scan is shared with the spawn-time guard
+    (:func:`_lexical_runtime_overlap`), so the pre-flight warning and the
+    spawn-time refusal read identically and cannot drift apart.
+    """
+    if sys.platform != "darwin":
+        return None
+    workspace_paths = tuple(
+        dict.fromkeys(
+            (
+                os.path.abspath(os.fspath(workspace)),
+                os.path.realpath(os.fspath(workspace)),
+            )
+        )
+    )
+    try:
+        runtime_paths = tuple(
+            dict.fromkeys(os.path.abspath(path) for path in _voice_runtime_sandbox_paths())
+        )
+    except OSError:
+        # Pre-flight only: if the runtime paths cannot be resolved here, let
+        # the spawn-time guard (which fails closed) produce the verdict.
+        return None
+    hit = _lexical_runtime_overlap(workspace_paths, runtime_paths)
+    if hit is not None:
+        return _voice_runtime_guard_message(*hit)
+    return None
+
+
 def assert_voice_runtime_outside_agent_workspace(workspace: str | os.PathLike[str]) -> None:
     """Fail closed when a macOS agent workspace can reach decoder snapshots.
 
@@ -612,26 +693,13 @@ def assert_voice_runtime_outside_agent_workspace(workspace: str | os.PathLike[st
     # only on the canonical (realpath) spelling of a symlinked workspace is an
     # alias relationship from the caller's own spelling -- formatting the
     # resolved path instead would print the runtime path twice and omit the
-    # path the user actually configured.
+    # path the user actually configured. The scan itself is shared with the
+    # non-raising pre-flight (_lexical_runtime_overlap), so the two surfaces
+    # cannot drift apart.
     original_workspace_path = raw_workspace_paths[0]
-    for workspace_path in raw_workspace_paths:
-        for runtime_path in raw_runtime_paths:
-            try:
-                common = os.path.commonpath((workspace_path, runtime_path))
-            except ValueError:
-                continue
-            if common in (workspace_path, runtime_path):
-                if workspace_path != original_workspace_path:
-                    raise RuntimeError(
-                        _voice_runtime_guard_message(original_workspace_path, runtime_path, "alias")
-                    )
-                raise RuntimeError(
-                    _voice_runtime_guard_message(
-                        workspace_path,
-                        runtime_path,
-                        "inside" if common == runtime_path else "contains",
-                    )
-                )
+    lexical_hit = _lexical_runtime_overlap(raw_workspace_paths, raw_runtime_paths)
+    if lexical_hit is not None:
+        raise RuntimeError(_voice_runtime_guard_message(*lexical_hit))
 
     # Path spelling is only a fast reject. Compare filesystem identities too,
     # walking both ancestor directions so case, normalization, symlink, and

--- a/test/test_chat_slot_project.py
+++ b/test/test_chat_slot_project.py
@@ -87,6 +87,40 @@ class TestChatSlotProject:
                 assert resp.status == 403
 
     @pytest.mark.asyncio
+    async def test_data_home_overlap_returns_actionable_400(self, tmp_path, monkeypatch):
+        """#7392 pre-flight: a workspace containing the voice runtime is refused
+        at the endpoint with the actionable message, before any session spawn."""
+        import kiro_crew.sandbox as sandbox_mod
+
+        # The pre-flight is darwin-gated to match the spawn-time guards it
+        # mirrors (review round 1), so pin the platform for the refusal path.
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        runtime.mkdir(parents=True)
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+        slot = _ChatSlot("test")
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/project",
+                json={"project": str(tmp_path)},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["code"] == "workspace_overlaps_data_home"
+            assert "protected voice runtime" in data["error"]
+            # The guard message embeds paths with !r (#7407), so on Windows the
+            # backslashes are repr-escaped — assert the repr form, which is the
+            # exact token the formatter emits on every platform.
+            assert repr(str(runtime)) in data["error"]
+            assert "Pick a project subdirectory" in data["error"]
+            assert slot.project != str(tmp_path)
+
+    @pytest.mark.asyncio
     async def test_can_change_mid_session(self, tmp_path):
         """Unlike workspace, project can be changed after messages are sent."""
         slot = _ChatSlot("test")
@@ -145,3 +179,44 @@ class TestChatSlotProject:
                 assert resp.status == 200
         state.sessions.reset.assert_not_awaited()
         assert slot._pending_reset_history_key is None
+
+
+class TestFolderProjectDirOverlapPreflight:
+    """#7392 review round 3: the folder ``project_dir`` write path is the third
+    user-driven project chokepoint — it must refuse a data-home overlap at the
+    moment of choice with the SAME message as the endpoint and set_project.
+    Round 4: the check lives in ``_folder_project_overlap_denied`` (run off-loop
+    by the create/update handlers), NOT in ``_validate_project_dir``, which the
+    slot-create read path re-runs against stored values."""
+
+    def _pin_runtime(self, tmp_path, monkeypatch):
+        import kiro_crew.sandbox as sandbox_mod
+
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        runtime.mkdir(parents=True)
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+        return runtime
+
+    def test_folder_overlap_denied_with_guard_message(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_folders import _folder_project_overlap_denied
+
+        runtime = self._pin_runtime(tmp_path, monkeypatch)
+        err = _folder_project_overlap_denied(str(tmp_path))
+        assert err is not None
+        # Byte-identical family: same formatter as endpoint + spawn guard (#7407).
+        assert "protected voice runtime" in err
+        assert repr(str(runtime)) in err
+        assert "Pick a project subdirectory" in err
+
+    def test_folder_overlap_check_accepts_non_overlapping_dir(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_folders import _folder_project_overlap_denied
+
+        self._pin_runtime(tmp_path, monkeypatch)
+        clean = tmp_path / "clean"
+        clean.mkdir()
+        assert _folder_project_overlap_denied(str(clean)) is None

--- a/test/test_mcp_core_set_project.py
+++ b/test/test_mcp_core_set_project.py
@@ -300,6 +300,32 @@ class TestSetProjectApplier:
         assert slot.project == "/existing/project"
 
     @pytest.mark.asyncio
+    async def test_data_home_overlap_refused_without_mutating_slot(self, tmp_path, monkeypatch):
+        """#7392 pre-flight on the directive path: set_project routes here
+        in-process (never through the HTTP endpoint), so the overlap check
+        must also live here or the refusal regresses to spawn time on every
+        channel surface (FP review round 1). Patched on the source module —
+        _set_project imports it lazily from kiro_crew.sandbox."""
+        slot = _FakeSlot(project="/existing/project")
+        state = _FakeState()
+        monkeypatch.setattr(
+            "kiro_crew.sandbox.voice_runtime_workspace_conflict",
+            lambda *a, **k: "macOS agent workspace overlaps the protected voice runtime",
+        )
+        result = await apply_session_directive(
+            state,
+            slot,
+            slot.key,
+            "set_project",
+            {"project": str(tmp_path), "clear": False},
+            producer_is_user_facing=True,
+        )
+        assert result.startswith("Error:")
+        assert "voice runtime" in result
+        # Load-bearing: the slot was NOT repointed to the overlapping path.
+        assert slot.project == "/existing/project"
+
+    @pytest.mark.asyncio
     async def test_clear_empties_project(self, tmp_path):
         slot = _FakeSlot(project=str(tmp_path))
         state = _FakeState()

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -317,6 +317,79 @@ class TestBuildSeatbeltProfile:
 
         sandbox_mod.assert_voice_runtime_outside_agent_workspace(sibling)
 
+    def test_voice_runtime_workspace_conflict_preflight(self, monkeypatch, tmp_path):
+        """#7392: the non-raising pre-flight mirrors the lexical guard and
+        names both paths, the data home, and the remedy."""
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        sibling = tmp_path / "workspace"
+        runtime.mkdir(parents=True)
+        sibling.mkdir()
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+
+        contains = sandbox_mod.voice_runtime_workspace_conflict(tmp_path)
+        assert contains is not None and "contains" in contains
+        assert "protected voice runtime" in contains
+        assert str(tmp_path) in contains
+        assert str(runtime) in contains
+        # Same remedy sentence as the spawn-time refusal (#7407's shared formatter).
+        assert "Pick a project subdirectory" in contains
+
+        inside = sandbox_mod.voice_runtime_workspace_conflict(runtime / "nested")
+        assert inside is not None and "inside it" in inside
+
+        assert sandbox_mod.voice_runtime_workspace_conflict(sibling) is None
+
+    def test_voice_runtime_workspace_conflict_passes_off_darwin(self, monkeypatch, tmp_path):
+        """The pre-flight matches the guards it mirrors: every spawn-time
+        guard early-returns off macOS, so an overlapping workspace spawns
+        fine on Linux/Windows today — the pre-flight must not 400 a working
+        configuration there (Design/FP review round 1)."""
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "linux")
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        runtime.mkdir(parents=True)
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+        assert sandbox_mod.voice_runtime_workspace_conflict(tmp_path) is None
+
+    def test_preflight_and_spawn_guard_refuse_with_the_same_message(self, monkeypatch, tmp_path):
+        """Drift pin (Design/FP review round 2): the pre-flight and the
+        spawn-time guard share ONE containment scan and ONE formatter, so the
+        same overlapping workspace must produce byte-identical refusal text on
+        both surfaces. If either ever grows its own copy again, this fails."""
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        runtime.mkdir(parents=True)
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+        preflight = sandbox_mod.voice_runtime_workspace_conflict(tmp_path)
+        assert preflight is not None
+        with pytest.raises(RuntimeError) as exc:
+            sandbox_mod.assert_voice_runtime_outside_agent_workspace(tmp_path)
+        assert str(exc.value) == preflight
+
+    def test_voice_runtime_workspace_conflict_fails_open_on_prime_error(
+        self, monkeypatch, tmp_path
+    ):
+        """Pre-flight passes when runtime paths cannot resolve; the spawn-time
+        guard (fail-closed) stays authoritative."""
+
+        def _boom() -> tuple[str, ...]:
+            raise OSError("no data home")
+
+        monkeypatch.setattr(sandbox_mod, "_voice_runtime_sandbox_paths", _boom)
+        assert sandbox_mod.voice_runtime_workspace_conflict(tmp_path) is None
+
     def test_delegated_macos_agent_workspace_checks_canonical_alias(self, monkeypatch, tmp_path):
         runtime = tmp_path / "real-data" / "run" / "voice-runtime"
         alias = tmp_path / "linked-runtime"


### PR DESCRIPTION
<!-- no-visual-delta -->

> **Rescoped 2026-09-01:** the raise-site error-message half of #7392 is now shipping in maintainer PR #7407, so this PR was cut down to the **pre-flight half only** — the duplicate message formatter and raise-site edits were dropped, making the two PRs order-independent (the `sandbox.py` changes are the new pre-flight helper plus factoring the spawn guard's containment loop into the shared `_lexical_runtime_overlap` — behavior-preserving, drift-pinned by test). #7407 has since merged and this diff now reuses its `_voice_runtime_guard_message` directly, so both surfaces read identically (no follow-up pending).

## Problem / Motivation

On macOS, choosing a workspace that is — or contains — the Kiro Crew data home fails at agent spawn: the session is created, the spawn is attempted, and only then does the voice-runtime guard's `RuntimeError` surface. With the default data home at `~/.kiro/crew`, every ancestor is unusable as a workspace — `~`, `~/.kiro`, `~/.kiro/crew` — and "open my home folder" is one of the most natural choices a new user makes. The refusal arrives late and (before #7407) with no actionable detail.

## Why it matters

First-session UX: the user's most likely wrong choice (their home directory) fails *after* they have already committed to the directory. The refusal should land at the moment of choice, in the picker flow, with the remedy attached.

## What changed (motivation → approach → change)

Goal: keep the spawn-time guard's fail-closed semantics exactly as they are, and add validation *at the moment of directory choice*.

- **Pre-flight helper** (`voice_runtime_workspace_conflict` in `src/kiro_crew/sandbox.py`, a non-raising lexical version of the guard's containment check, returning an actionable description (both concrete paths, the recognisable data home, the remedy) or `None`. It shares ONE containment scan (`_lexical_runtime_overlap`) and ONE message formatter with the spawn-time guard, with a drift-pin test asserting both surfaces refuse with byte-identical text (review round 2). The descriptor/identity walks stay in the spawn-time guards, which remain authoritative; the pre-flight fails *open* if runtime paths cannot resolve, because the spawn-time guard fails *closed*. Darwin-gated to match the guards it mirrors (review round 1): every spawn-time guard early-returns off macOS, so refusing an overlapping workspace on Linux/Windows would remove a configuration that works there today.
- **Endpoint wiring** (`POST /api/chat/slots/{slot}/project` in `chat_handlers.py` — the dashboard picker's chokepoint; the `set_project` MCP tool applies in-process via the session-directive path, which now runs the same pre-flight (review round 1)): an overlapping workspace is now rejected with a 400 carrying the actionable message before any session spawn, with a SEL audit entry.
- **Folder chokepoint** (review round 3): creating or updating a chat folder with an overlapping `project_dir` is refused with the same 400 + message (`_folder_project_overlap_denied` in `chat_folders.py`, run off-loop by both handlers). A folder's linked project lands on slots verbatim, so this was the third user-driven moment of choice.
- **Configured default skipped** (review round 3; behavior change): a `dashboard.default_project` that overlaps the data home is now skipped at slot create — like a sensitive path — falling back to the workspace default instead of wedging every new slot at spawn. Known deferral: a pre-existing folder's STORED project applied at slot create is not re-pre-flighted (read path; the spawn guard remains authoritative).
- No frontend change needed: picker failures already surface the server's message through the shared agent-switch notice (`agentSwitchFailureMessage` prefers the API layer's message).

Alternatives considered (on the issue): auto-substituting a safe subdirectory (rejected — silently changing the user's chosen scope is worse than refusing clearly) and relaxing the guard for `~` (rejected — the security rationale is sound).

## Tests

- `test_voice_runtime_workspace_conflict_preflight` — the pre-flight reports `contains` for an ancestor (message carries both paths, the data home, and the remedy), `is inside` for a descendant, and `None` for a sibling.
- `test_voice_runtime_workspace_conflict_fails_open_on_prime_error` — pre-flight passes when runtime paths cannot resolve (spawn-time guard stays authoritative).
- `test_data_home_overlap_returns_actionable_400` — the project endpoint refuses an overlapping workspace with a 400 carrying the actionable message, and the slot's project is not changed.
- All existing guard-refusal tests in `test/test_sandbox_argv.py` pass unchanged (the raise sites are untouched by this PR), as do all 9 existing project-endpoint tests.

## Manual verification

N/A — unit coverage sufficient: the endpoint test exercises the full HTTP path with the real handler, and the pre-flight tests cover ancestor/descendant/sibling geometry plus the fail-open path.

## Screenshots / video

**Why no screenshot:** no visual delta — backend-only diff; the user-visible copy is delivered through the existing error-notice surface.

## Related Issues

Fixes #7392 (pre-flight half; the raise-site message half ships in #7407)

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a fail-closed guard that fires at spawn time hides the refusal from the moment of choice — when a validation chokepoint exists upstream (endpoint, picker), pre-flight the same containment check there with a non-raising, fail-open variant"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->



