### PR TITLE
perf(history): stop the session metadata cache thrashing at scale

### DIFF
--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -1261,7 +1261,13 @@ async def api_session_detail(request: web.Request) -> web.Response:
     key = request.match_info["key"]
     if not state.conversation_log:
         return web.json_response([])
-    return web.json_response(state.conversation_log.read_messages(key))
+    # read_messages() opens and parses the transcript on a cache miss, which for
+    # the multi-MB sessions a long-lived store accumulates is 100-300 ms of
+    # blocking file IO — on the event loop, stalling every other request. Off the
+    # loop, like every other conversation_log read in this module (list_sessions,
+    # get_metadata, session_mtime, search_sessions, delete_session).
+    messages = await asyncio.to_thread(state.conversation_log.read_messages, key)
+    return web.json_response(messages)
 
 
 async def api_session_delete(request: web.Request) -> web.Response:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -32,6 +32,7 @@ from kiro_crew.frontmatter import (  # noqa: F401 - facade re-exports
     frontmatter_value,
 )
 from kiro_crew.history_cache import (
+    _METADATA_CACHE_MAX,
     _TRANSCRIPT_CACHE_MAX,
     HistoryCacheCoordinator,
     _FileChangeCacheEntry,
@@ -1139,7 +1140,15 @@ class ConversationLog:
         #: invalidation generation and a warm hit requires both fields to
         #: match, so a preserved-mtime metadata edit through another
         #: instance (whose pops cannot reach this cache) still unhits.
-        self._meta_cache: _LRUCache[tuple[float, int, dict]] = _LRUCache(cache_max)
+        #:
+        #: Sized by ``_METADATA_CACHE_MAX``, NOT ``cache_max``: this memo holds one
+        #: parsed first line per session rather than a transcript window, and
+        #: ``list_sessions`` reads it in a whole-directory cyclic scan that an LRU
+        #: smaller than the corpus cannot hit. Same reasoning the search budgets
+        #: already use to decline that knob. Deliberately not overridable: a test
+        #: that needs a small bound assigns ``_meta_cache`` directly rather than
+        #: adding a constructor parameter no product caller uses.
+        self._meta_cache: _LRUCache[tuple[float, int, dict]] = _LRUCache(_METADATA_CACHE_MAX)
         #: Bounded, mtime-keyed LRU of formatted ``recent()`` windows keyed by
         #: (key, max_messages, roles). The tail-read fast path intentionally
         #: never warms ``_msg_cache`` (it returns a partial view), so a session

--- a/src/kiro_crew/history_cache.py
+++ b/src/kiro_crew/history_cache.py
@@ -20,10 +20,33 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Default upper bound on the number of distinct session keys held in the
-#: in-memory transcript / metadata caches. Unbounded ``dict`` caches grow one
-#: entry per session key touched and never evict; a bounded LRU keeps hot
-#: sessions resident while giving the working set a deterministic ceiling.
+#: in-memory transcript caches. Unbounded ``dict`` caches grow one entry per
+#: session key touched and never evict; a bounded LRU keeps hot sessions
+#: resident while giving the working set a deterministic ceiling.
+#:
+#: This bound no longer covers the METADATA cache, which is sized separately by
+#: ``_METADATA_CACHE_MAX`` below for the reasons documented there.
 _TRANSCRIPT_CACHE_MAX = 256
+
+#: Upper bound for ``ConversationLog._meta_cache`` specifically, kept separate
+#: from ``_TRANSCRIPT_CACHE_MAX`` above.
+#:
+#: That bound is sized for the PARSED MESSAGE caches, whose entries are whole
+#: transcript windows. A metadata entry is one parsed first line — title, agent,
+#: created_at, tab_id, folder_id — measured in hundreds of bytes, so 256 buys
+#: almost nothing in RAM terms and costs a great deal in I/O: ``list_sessions``
+#: scans the WHOLE session directory in one cyclic pass, so an LRU smaller than
+#: the corpus is evicted in exactly the order it will next be read and its hit
+#: rate collapses to ~0. Measured on an 810-session store: a warm
+#: ``list_sessions`` re-opened and re-parsed ~554 first lines on every call
+#: (57.9 ms); with the cache able to hold the corpus the same call costs 24.5 ms,
+#: all of it the unavoidable ``glob`` + one ``stat`` per file.
+#:
+#: This is the same failure mode ``_SearchTextCache`` already documents and
+#: fixes — an LRU collapsing to a zero hit rate against the cyclic scan order —
+#: applied to the memo every sidebar page fetch depends on. Still bounded, so a
+#: gateway touching an unbounded number of sessions cannot grow without limit.
+_METADATA_CACHE_MAX = 8192
 
 _V = TypeVar("_V")
 

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -15,6 +15,7 @@ from windows_sim import builtin_open_sharing_violation
 from kiro_crew import history
 from kiro_crew.history import (
     _CONSOLIDATION_THRESHOLD,
+    _METADATA_CACHE_MAX,
     _SESSION_KEEP_LINES,
     _SESSION_MAX_BYTES,
     ConversationLog,
@@ -3983,12 +3984,35 @@ class TestConversationLogCacheBounded:
         assert len(log._msg_cache) <= 4
 
     def test_meta_cache_evicts_beyond_bound(self, tmp_path):
-        log = ConversationLog(base_dir=tmp_path, cache_max=3)
+        # Bounds the metadata cache by assigning it directly rather than through a
+        # constructor parameter: the production default deliberately does not follow
+        # ``cache_max`` down, and a kwarg only tests pass is production API surface
+        # with no product consumer. The eviction invariant under test is unchanged.
+        from kiro_crew.history import _LRUCache
+
+        log = ConversationLog(base_dir=tmp_path)
+        log._meta_cache = _LRUCache(3)
         for i in range(10):
             key = f"sess{i}"
             log.append(key, "user", f"hi {i}")
             log.get_metadata(key)  # populate meta cache
         assert len(log._meta_cache) <= 3
+
+    def test_a_small_cache_max_cannot_shrink_the_metadata_cache(self, tmp_path):
+        """``cache_max`` must not drag the metadata cache down with it.
+
+        ``list_sessions`` reads ``_meta_cache`` in one cyclic pass over the whole
+        session directory, so a bound below the corpus size is evicted in exactly
+        the order it will next be read and the hit rate collapses to ~0 — every
+        call re-opens and re-parses the first line of most of the store. The
+        transcript cache still honors the knob.
+        """
+        log = ConversationLog(base_dir=tmp_path, cache_max=8)
+        assert log._msg_cache._maxsize == 8, "the transcript cache still honors cache_max"
+        assert log._meta_cache._maxsize == _METADATA_CACHE_MAX, (
+            "the metadata cache followed cache_max down; list_sessions will thrash "
+            "on any store larger than that knob"
+        )
 
     def test_cache_hit_returns_same_object(self, tmp_path):
         log = ConversationLog(base_dir=tmp_path, cache_max=8)


### PR DESCRIPTION
## Problem / Motivation

Opening a session in the dashboard is slow on a large session store. Measured on an
810-session store (644 MB, largest session 33.6 MB): a warm `list_sessions()` call
costs 57.9 ms and re-opens and re-parses roughly 554 session first lines every time.

Two independent causes:

1. `ConversationLog._meta_cache` is sized by `cache_max`, which defaults to
   `_TRANSCRIPT_CACHE_MAX = 256`. `list_sessions()` scans the whole session directory
   in one cyclic pass. An LRU smaller than the corpus is evicted in exactly the order
   it will next be read, so its hit rate collapses to about zero.
2. `api_session_detail` calls `read_messages()` directly on the event loop. On a
   multi-MB session that is 100-300 ms of blocking file IO, and it stalls every other
   request while it runs.

## Why it matters

The metadata cache stops working at the point it starts to matter. Under 256 sessions
it hits. Over 256 sessions it never hits, so every sidebar page fetch re-parses the
first line of most of the store.

The event-loop read compounds this. On the affected store the gateway log shows
`event-loop heartbeat: lag 6.1s (loop was blocked)`.

Enumeration itself is not the problem and is not changed here: the `glob` costs 1.8 ms
and stat-ing all 810 files costs 5.0 ms.

## What changed (motivation → approach → change)

Symptom: warm `list_sessions()` re-reads most of the store.
Root cause: one bound serves two caches with different entry sizes and different access
patterns.
Change: give the metadata cache its own bound.

`_METADATA_CACHE_MAX = 8192` is added in `history_cache.py` beside `_TRANSCRIPT_CACHE_MAX`,
and `_meta_cache` is sized by it. A metadata entry is one parsed first line (title, agent,
created_at, tab_id, folder_id), measured in hundreds of bytes. A transcript entry is a
whole message window. Sizing both from one constant forces the cheap cache to inherit a
bound chosen for the expensive one.

This is the failure mode `_SearchTextCache` already documents and fixes in this file, an
LRU collapsing to a zero hit rate against a cyclic scan order, applied to the memo every
sidebar fetch depends on.

Rejected: raise `cache_max` instead. That enlarges the transcript caches too, where entries
are whole windows, so the memory cost is orders of magnitude higher for no added benefit.
Revisit if transcript entries ever shrink to metadata scale.

Rejected: make `_meta_cache` unbounded. A gateway that touches an unbounded number of
sessions would then grow without limit. Revisit if a session-count ceiling is enforced
elsewhere.

Rejected: adopt `_SearchTextCache`'s admission control instead of raising the count bound.
That is the cause-level fix. Its own docstring says a budget "reintroduces the cliff, so
eviction is replaced by admission control", and a count bound of 8192 does reintroduce it:
a store with more than 8192 sessions re-enters the same ~0% hit rate this PR removes.
Adopting it means changing the bound from an entry count to a byte budget and replacing
eviction with admission, in a memo whose entries are hundreds of bytes rather than whole
transcripts. That is a larger change with its own reasoning, so it is deliberately not
folded into this one. Revisit when a store is expected to exceed 8192 sessions, or if RSS
attributable to `_meta_cache` becomes measurable.

No new constructor surface. An earlier revision added a `meta_cache_max` kwarg so
`test_meta_cache_evicts_beyond_bound` could still assert eviction after the metadata cache
stopped following `cache_max`. That was wrong: it is production API surface with no product
consumer. The test now assigns `log._meta_cache = _LRUCache(3)` directly, which keeps the
eviction invariant and leaves the constructor unchanged.

Separately, `api_session_detail` now reads through `asyncio.to_thread`. This matches the five
other `conversation_log` reads in the same module, which are already offloaded
(`list_sessions`, `get_metadata`, `session_mtime`, `search_sessions`, `delete_session`).

## Tests

- `test/test_history.py`: 309 pass.
- `test_meta_cache_evicts_beyond_bound` now bounds the cache by assigning
  `log._meta_cache = _LRUCache(3)` directly, with no production kwarg. The eviction
  invariant it locks in is unchanged.
- `test_a_small_cache_max_cannot_shrink_the_metadata_cache` is new. It asserts
  `_msg_cache._maxsize == 8` while `_meta_cache._maxsize == _METADATA_CACHE_MAX`, so a future
  change that re-couples the two bounds fails here.
- `test/test_open_slots_persistence.py`: 62 pass. This file covers `api_session_detail`.
- flake8 7.1.0 (repo-pinned): clean on all four files.

## Manual verification

Measured against a real 810-session, 644 MB store, not a fixture:

- warm `list_sessions()`: 57.9 ms before, 24.5 ms after (2.33x).
- Output compared before and after: identical session count, ordering, keys and titles.
- The residual 24.5 ms is the `glob` plus one `stat` per file, which this change does not
  attempt to remove.

## Related Issues

no linked issue: neither defect had a tracked issue when this was written. I searched open
pull requests and issues and found none covering the metadata-cache bound or the event-loop
read, so this PR closes nothing and the omission is deliberate rather than a forgotten
trailer.

Follow-up work identified during review is tracked separately in issue #7408 (the remaining
non-offloaded transcript reads, all six sites). This PR does not complete that work, so it
carries no closing keyword for it.

## Pattern harvest

Rule candidate: review-prompt
Pattern: an LRU cache bounded below the working set of a cyclic full-scan, which drives its
hit rate to zero rather than degrading it. The tell is one size constant shared by caches
whose entries differ in size by orders of magnitude.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff




