### PR TITLE
fix(agent): fold auto-approve floor pass into build_agent_config (#7401)

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2207,6 +2207,69 @@ def build_agent_config(*, gated_off: "frozenset[str] | None" = None) -> dict:
     for name, spec in _extra_mcp_servers().items():
         mcp.setdefault(name, dict(spec))
 
+    # FINAL governance pass over the auto-approve LIST itself, folded in HERE so
+    # the returned config is already floor-safe before ANY caller writes it. The
+    # writers above (managed/shared MCP) apply the ceiling to entries THEY add,
+    # but a builtin auto-approve (fs_read, code, glob, grep, …) arrives straight
+    # from the shipped TEMPLATE into `allowedTools` and no per-entry writer ever
+    # re-touches it. `allowedTools` is kiro-cli's blanket auto-approve list — the
+    # ONE path that never reaches the PreToolUse gate — so a floor-scoped builtin
+    # left on it is approved WITHOUT the deny floor, sensitive-path check, or
+    # governance ceiling ever running. `may_skip_gate_now` (via _may_auto_approve)
+    # returns False for any builtin whose scope intersects the floor gate scopes
+    # ({filesystem.read, filesystem.write, commands}) even on an ungoverned host,
+    # so `code` (commands, tools, filesystem.write) and fs_read/glob/grep
+    # (filesystem.read) lose their blanket grant here, while web_fetch/web_search/
+    # introspect/session/report and any silent-ceiling `@server` are kept.
+    #
+    # Historically only rebuild_agent_config ran this pass, so kirocrew.json
+    # shipped floor-safe but _install_research_agent — which writes this returned
+    # config UNTOUCHED — shipped kirocrew-research.json with fs_read/code/glob/grep
+    # still auto-approved, in the LEAST supervised context (the Research Lab
+    # autonudge worker). Folding the pass in here closes that writer-coverage gap
+    # for every current and future caller instead of relying on each installer to
+    # remember to filter. The pass is pure and idempotent, so rebuild_agent_config
+    # re-running it is a no-op and _install_conductor_agent (which hand-filters) is
+    # unaffected. `tools` (the mount list) is deliberately left intact — mounting a
+    # tool is not auto-approving it, and read-only file tools still auto-approve via
+    # hooks after the floor runs, so this adds NO read prompt on a stock install.
+    allowed = config.get("allowedTools")
+    if isinstance(allowed, list):
+        kept: list[str] = []
+        withheld: list[str] = []
+        for ref in allowed:
+            if not isinstance(ref, str):
+                # A malformed non-string entry (e.g. a hand-edited override with
+                # `allowedTools: [1]`) would crash may_skip_gate's ref.startswith()
+                # and fault the whole build. It is not a valid tool ref, so drop it
+                # entirely rather than keep or audit it — matching the identical
+                # handling in rebuild_agent_config's final pass.
+                continue
+            (kept if _may_auto_approve(ref) else withheld).append(ref)
+        config["allowedTools"] = kept
+        if withheld:
+            # Withholding a grant is a permission DECISION, and folded in here this
+            # is the FIRST place a builtin that arrived straight from the shipped
+            # template (fs_read, code, …) loses its blanket auto-approve. Emit the
+            # SAME SEL event the other writers emit (identical operation name so it
+            # lands in one feed), tagged source=build_agent_config so an operator
+            # can tell the build-time floor pass from rebuild_agent_config's. A
+            # silent drop would leave no record of why a template tool now prompts.
+            # Auditing must never fail the build.
+            try:
+                sel().log_api_access(
+                    caller="system",
+                    operation="mcp_auto_approve_withheld",
+                    outcome="ok",
+                    source="build_agent_config",
+                    resources=(
+                        f"{', '.join(withheld)} mounted without auto-approve "
+                        "(governance floor/ceiling); calls go through the approval gate"
+                    ),
+                )
+            except Exception:  # noqa: BLE001 — the audit must not break a build
+                logger.debug("SEL audit unavailable for withheld auto-approve", exc_info=True)
+
     # Default-model tracking ("managed" vs frozen) is recorded in the
     # agent_state sidecar by the install path (rebuild_agent_config), never as
     # a kiro-spec key — kiro-cli rejects unknown fields and would drop the whole

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -5332,3 +5332,161 @@ class TestSelHookRejectedRedaction:
         _sel_hook_rejected("preToolUse", "c" * 250, "denied")
         assert len(events) == 1
         assert events[0].resources == f"event=preToolUse command={'c' * 200}"
+
+
+# The floor-scoped builtins: their governance scope intersects
+# _FLOOR_GATE_SCOPES ({filesystem.read, filesystem.write, commands}), so
+# may_skip_gate_now declines them for blanket auto-approve even on an ungoverned
+# host. `code` (commands, tools, filesystem.write) is the sharpest of these: it
+# writes files and can shell out, so it must never ship on an auto-approve list.
+_FLOOR_BUILTINS = {"fs_read", "code", "glob", "grep"}
+# Non-floor grants the shipped template lists: these auto-approve fine even
+# ungoverned, so the floor pass must KEEP them.
+_NON_FLOOR_BUILTINS = {"web_fetch", "web_search", "introspect", "session", "report"}
+
+
+class TestBuildAgentConfigFloorPass:
+    """#: the final auto-approve floor pass is folded into ``build_agent_config``.
+
+    ``allowedTools`` is kiro-cli's blanket auto-approve list — the one path that
+    never reaches the PreToolUse gate — and the floor builtins (fs_read, code,
+    glob, grep) arrive on it straight from the shipped template. Previously only
+    ``rebuild_agent_config`` filtered that list, so ``_install_research_agent`` —
+    which writes ``build_agent_config()``'s output untouched — shipped
+    ``kirocrew-research.json`` with ``code`` still auto-approved in the least
+    supervised context (the Research Lab autonudge worker). Folding the pass into
+    ``build_agent_config`` closes that gap for every caller. These tests assert the
+    floor builtins are ABSENT from the produced ``allowedTools``, so they FAIL if
+    the fold-in is reverted.
+    """
+
+    def test_build_agent_config_drops_floor_builtins_from_allowed_tools(self) -> None:
+        from kiro_crew.agent import build_agent_config
+
+        cfg = build_agent_config()
+        allowed = cfg["allowedTools"]
+        assert isinstance(allowed, list)
+
+        # No floor builtin is auto-approved (the regression the fold-in fixes).
+        assert not (_FLOOR_BUILTINS & set(allowed)), (
+            f"floor builtins still on the blanket auto-approve list: "
+            f"{_FLOOR_BUILTINS & set(allowed)}"
+        )
+        # `code` specifically — it writes files and can shell out.
+        assert "code" not in allowed
+
+        # The non-floor grants are retained (the floor pass must not over-filter).
+        assert _NON_FLOOR_BUILTINS.issubset(set(allowed)), (
+            f"non-floor grants dropped: {_NON_FLOOR_BUILTINS - set(allowed)}"
+        )
+        # The managed-server grants survive too.
+        assert any(str(r).startswith("@kirocrew-cron") for r in allowed)
+        assert "@kirocrew-core" in allowed
+
+    def test_build_agent_config_allowed_tools_all_satisfy_predicate(self) -> None:
+        """Every surviving ref passes the one predicate all writers consult."""
+        from kiro_crew.agent import build_agent_config
+        from kiro_crew.platform.governance import may_skip_gate_now
+
+        cfg = build_agent_config()
+        for ref in cfg["allowedTools"]:
+            assert may_skip_gate_now(ref), f"{ref!r} should not be auto-approved"
+
+    def test_build_agent_config_leaves_tools_mount_intact(self) -> None:
+        """Only ``allowedTools`` is filtered; the ``tools`` mount list is untouched.
+
+        Mounting a tool is not auto-approving it — read-only file tools still
+        auto-approve via hooks after the floor runs — so the floor builtins must
+        stay MOUNTED (no read prompt added on a stock install), just not on the
+        blanket auto-approve list.
+        """
+        from kiro_crew.agent import build_agent_config
+
+        cfg = build_agent_config()
+        tools = set(cfg.get("tools", []))
+        assert _FLOOR_BUILTINS & tools, (
+            "the floor builtins were stripped from the tools mount list; only "
+            "allowedTools should be filtered"
+        )
+
+    def test_build_agent_config_drops_non_string_allowed_tools_entries(
+        self, monkeypatch
+    ) -> None:
+        """A malformed non-string entry is dropped silently, not kept or crashed on.
+
+        Mirrors ``rebuild_agent_config``'s handling: a hand-edited override with
+        ``allowedTools: [1]`` must not fault the whole build.
+        """
+        import kiro_crew.agent as agent_mod
+
+        real = agent_mod._load_json
+
+        def _inject(path):  # noqa: ANN001
+            data = real(path)
+            if isinstance(data, dict) and isinstance(data.get("allowedTools"), list):
+                data = dict(data)
+                data["allowedTools"] = [*data["allowedTools"], 123, None]
+            return data
+
+        monkeypatch.setattr(agent_mod, "_load_json", _inject)
+        cfg = agent_mod.build_agent_config()
+        assert all(isinstance(r, str) for r in cfg["allowedTools"])
+        assert 123 not in cfg["allowedTools"]
+
+
+class TestInstallResearchAgentFloorSafe:
+    """``_install_research_agent`` inherits the floor pass via ``build_agent_config``.
+
+    It derives from the kirocrew agent and writes the config straight to disk, so
+    before the fold-in it shipped the template's floor builtins on the blanket
+    auto-approve list. Driving it into a tmp agents dir and reading the written
+    JSON pins that ``code`` (and every floor builtin) is now absent from
+    ``allowedTools`` while the tools stay mounted.
+    """
+
+    def _write_research(self, tmp_path: Path, monkeypatch) -> dict:
+        import kiro_crew.agent as agent_mod
+
+        agents_dir = tmp_path / "kiro_agents"
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents_dir)
+        agent_mod._install_research_agent()
+        written = agents_dir / agent_mod._RESEARCH_AGENT_FILENAME
+        return json.loads(written.read_text())
+
+    def test_research_spec_has_no_floor_builtin_auto_approved(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        data = self._write_research(tmp_path, monkeypatch)
+        assert data["name"] == "kirocrew-research"
+        allowed = data["allowedTools"]
+        assert "code" not in allowed, (
+            "kirocrew-research shipped `code` on the blanket auto-approve list"
+        )
+        assert not (_FLOOR_BUILTINS & set(allowed)), (
+            f"floor builtins auto-approved in research spec: "
+            f"{_FLOOR_BUILTINS & set(allowed)}"
+        )
+
+    def test_research_spec_every_allowed_ref_satisfies_predicate(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Regression: the research spec agrees with the floor invariant.
+
+        Every ref on the research spec's auto-approve list must satisfy the same
+        predicate ``kirocrew.json`` is held to, so the two Crew-authored specs do
+        not drift apart on the floor.
+        """
+        from kiro_crew.platform.governance import may_skip_gate_now
+
+        data = self._write_research(tmp_path, monkeypatch)
+        for ref in data["allowedTools"]:
+            assert may_skip_gate_now(ref), f"{ref!r} should not be auto-approved"
+
+    def test_research_spec_keeps_tools_mounted(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The floor builtins stay MOUNTED on the research spec (only auto-approve filtered)."""
+        data = self._write_research(tmp_path, monkeypatch)
+        assert _FLOOR_BUILTINS & set(data.get("tools", [])), (
+            "the research spec lost its tools mount; only allowedTools should be filtered"
+        )


### PR DESCRIPTION
Closes #7401.

## Problem

`allowedTools` is kiro-cli's blanket auto-approve list, the one grant path that never reaches the PreToolUse gate (no deny floor, no sensitive-path check, no governance ceiling). The final floor pass that filters this list lived **only** inside `rebuild_agent_config` (which writes `kirocrew.json`). `_install_research_agent` writes `build_agent_config()`'s output straight to disk untouched, so `kirocrew-research.json` shipped `fs_read, code, glob, grep` on its auto-approve list.

`code` is the one that matters: its scope tuple is `(commands, tools, filesystem.write)` (writes files and can shell out), so it was auto-approved without ever reaching `hooks.on_tool_call` in the least-supervised context in the product, the Research Lab autonudge loop worker. This is a writer-coverage gap, not a policy decision: the pass already existed and the predicate was already correct; one writer just did not call it.

## Fix (favored shape 1 from the issue)

Folded the final `allowedTools` floor/ceiling pass into `build_agent_config()` (right before `return config`) so **every** caller inherits a floor-safe list. The pass filters each entry through `_may_auto_approve` / `may_skip_gate_now`, drops non-string entries, and emits the standard `mcp_auto_approve_withheld` SEL event tagged `source=build_agent_config`.

- `may_skip_gate` runs its floor check (`{filesystem.read, filesystem.write, commands}`) before the `if ceiling is None` early return, so `code`/`fs_read`/`glob`/`grep` lose their blanket grant on a stock ungoverned host too, while `web_fetch`/`web_search`/`introspect`/`session`/`report` and silent-ceiling `@server` entries are kept.
- `rebuild_agent_config` keeps its own pass because it also covers the `_load_existing_config` path (entries from an on-disk spec, not the template). The pass is pure and idempotent, so re-running it is a no-op; `_install_conductor_agent` (which hand-filters) is unaffected.
- `config/defaults.json` is untouched and the `tools` mount list is unchanged, so read-only file tools still auto-approve via hooks after the floor runs. **No read prompt is added on a stock install** — the fix aligns the research spec with the primary spec rather than changing product behavior, so the unattended autonudge loop is not handed a new stall.

## Files changed

- `src/kiro_crew/agent.py` (+63): the fold-in.
- `test/test_agent.py` (+158): `TestBuildAgentConfigFloorPass` (4 tests) and `TestInstallResearchAgentFloorSafe` (3 tests).

## Testing

The sandbox runs in a repository-access-only network mode, so PyPI is unreachable and the pytest suite cannot collect (`test/conftest.py` imports `hypothesis`). Validated instead by direct import + standalone assertions:

- `build_agent_config().allowedTools` now excludes all floor builtins, retains `web_fetch/web_search/introspect/session/report` + `@kirocrew-cron/*`/`@kirocrew-core`, and every ref satisfies `may_skip_gate_now`; `tools` still mounts the builtins.
- `_install_research_agent` into a tmp dir writes `kirocrew-research.json` with `code` and all floor builtins absent from `allowedTools`, matching `kirocrew.json`.
- Revert-guard: on `main`, `build_agent_config()` returns `['fs_read','code','glob','grep',...]` (bug present), confirming the added tests would fail if the fold-in were reverted.

The added pytest tests should be run in CI where the full test toolchain is available.