### PR TITLE
fix: name both paths and the remedy in voice-runtime guard refusals

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -39,7 +39,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
@@ -338,6 +338,56 @@ def _voice_runtime_ancestor_guards() -> tuple[str, ...]:
     return _voice_runtime_paths_cache[4]
 
 
+_VOICE_GUARD_REMEDY = "Pick a project subdirectory that does not contain the Kiro Crew data home."
+
+_VoiceGuardRelationship = Literal["contains", "inside", "alias", "cannot-verify"]
+
+
+def _voice_runtime_guard_message(
+    workspace_path: str,
+    runtime_path: str,
+    relationship: _VoiceGuardRelationship,
+    failed_path: str | None = None,
+    failure_reason: str | None = None,
+) -> str:
+    """Build every variant of the voice-runtime workspace refusal.
+
+    Each variant leads with the two concrete absolute paths, keeps its own
+    distinguishing detail, and ends with the same remedy sentence, so a user
+    who picked ``~`` (an ancestor of the default ``~/.kiro/crew`` data home)
+    sees exactly which two paths collide and what to choose instead. The
+    message is operator-facing and may reach logs: it carries only the two
+    paths the caller already knows (plus, on the cannot-verify variant, the
+    path whose filesystem check failed).
+    """
+    if relationship == "contains":
+        return (
+            f"macOS agent workspace {workspace_path!r} overlaps Kiro Crew's "
+            f"protected voice runtime {runtime_path!r}: the workspace contains "
+            f"the voice runtime / data home. {_VOICE_GUARD_REMEDY}"
+        )
+    if relationship == "inside":
+        return (
+            f"macOS agent workspace {workspace_path!r} overlaps Kiro Crew's "
+            f"protected voice runtime {runtime_path!r}: the workspace is the "
+            f"voice runtime / data home or lives inside it. {_VOICE_GUARD_REMEDY}"
+        )
+    if relationship == "alias":
+        return (
+            f"macOS agent workspace {workspace_path!r} aliases Kiro Crew's "
+            f"protected voice runtime {runtime_path!r}: by filesystem identity "
+            "(a case, normalization, symlink, or firmlink alias) one of these "
+            f"paths is the other or an ancestor of the other. {_VOICE_GUARD_REMEDY}"
+        )
+    return (
+        f"cannot verify that macOS agent workspace {workspace_path!r} is "
+        f"separate from Kiro Crew's protected voice runtime {runtime_path!r}: "
+        f"a filesystem check failed on {failed_path!r} ({failure_reason}), "
+        "so the guard cannot prove the paths are disjoint and fails closed "
+        f"rather than start an agent it cannot isolate. {_VOICE_GUARD_REMEDY}"
+    )
+
+
 def assert_voice_runtime_outside_agent_workspace(workspace: str | os.PathLike[str]) -> None:
     """Fail closed when a macOS agent workspace can reach decoder snapshots.
 
@@ -373,6 +423,12 @@ def assert_voice_runtime_outside_agent_workspace(workspace: str | os.PathLike[st
     raw_runtime_paths = tuple(
         dict.fromkeys(os.path.abspath(path) for path in _voice_runtime_sandbox_paths())
     )
+    # Refusals always name the workspace as the caller spelled it. A hit found
+    # only on the canonical (realpath) spelling of a symlinked workspace is an
+    # alias relationship from the caller's own spelling -- formatting the
+    # resolved path instead would print the runtime path twice and omit the
+    # path the user actually configured.
+    original_workspace_path = raw_workspace_paths[0]
     for workspace_path in raw_workspace_paths:
         for runtime_path in raw_runtime_paths:
             try:
@@ -380,9 +436,16 @@ def assert_voice_runtime_outside_agent_workspace(workspace: str | os.PathLike[st
             except ValueError:
                 continue
             if common in (workspace_path, runtime_path):
+                if workspace_path != original_workspace_path:
+                    raise RuntimeError(
+                        _voice_runtime_guard_message(original_workspace_path, runtime_path, "alias")
+                    )
                 raise RuntimeError(
-                    "macOS agent workspace overlaps Kiro Crew's protected voice "
-                    "runtime; keep the workspace and Kiro Crew data home disjoint"
+                    _voice_runtime_guard_message(
+                        workspace_path,
+                        runtime_path,
+                        "inside" if common == runtime_path else "contains",
+                    )
                 )
 
     # Path spelling is only a fast reject. Compare filesystem identities too,
@@ -395,23 +458,27 @@ def assert_voice_runtime_outside_agent_workspace(workspace: str | os.PathLike[st
         runtime_identities = tuple(
             (info.st_dev, info.st_ino) for info in (os.stat(path) for path in raw_runtime_paths)
         )
-        if any(
-            _identity_in_ancestor_chain(identity, runtime_path)
-            for identity in workspace_identities
-            for runtime_path in raw_runtime_paths
-        ) or any(
-            _identity_in_ancestor_chain(identity, workspace_path)
-            for identity in runtime_identities
-            for workspace_path in raw_workspace_paths
-        ):
-            raise RuntimeError(
-                "macOS agent workspace aliases Kiro Crew's protected voice "
-                "runtime; keep the workspace and Kiro Crew data home disjoint"
-            )
+        for workspace_identity in workspace_identities:
+            for runtime_path in raw_runtime_paths:
+                if _identity_in_ancestor_chain(workspace_identity, runtime_path):
+                    raise RuntimeError(
+                        _voice_runtime_guard_message(original_workspace_path, runtime_path, "alias")
+                    )
+        for runtime_path, runtime_identity in zip(raw_runtime_paths, runtime_identities):
+            for workspace_path in raw_workspace_paths:
+                if _identity_in_ancestor_chain(runtime_identity, workspace_path):
+                    raise RuntimeError(
+                        _voice_runtime_guard_message(original_workspace_path, runtime_path, "alias")
+                    )
     except OSError as exc:
         raise RuntimeError(
-            "cannot verify that the macOS agent workspace is separate from "
-            "Kiro Crew's protected voice runtime"
+            _voice_runtime_guard_message(
+                raw_workspace_paths[0],
+                raw_runtime_paths[0] if raw_runtime_paths else "<unknown>",
+                "cannot-verify",
+                failed_path=getattr(exc, "filename", None) or "<unknown path>",
+                failure_reason=getattr(exc, "strerror", None) or str(exc),
+            )
         ) from exc
 
 
@@ -474,13 +541,20 @@ def bind_voice_safe_agent_workspace(
 
     workspace_fd = -1
     runtime_fds: list[int] = []
+    runtime_paths: tuple[str, ...] = ()
     try:
+        # Resolve the runtime paths before opening the workspace: a workspace
+        # open() failure lands in the OSError handler below, which names the
+        # colliding runtime path in its refusal -- resolving after the open
+        # would print "<unknown>" for exactly the failure a user hits first.
+        runtime_paths = _voice_runtime_sandbox_paths()
+
         workspace_fd = _open_directory_descriptor(workspace_path)
         workspace_identity = os.fstat(workspace_fd)
         workspace_id = (workspace_identity.st_dev, workspace_identity.st_ino)
         workspace_ancestors = set(_directory_ancestor_identities(workspace_fd))
 
-        for runtime_path in _voice_runtime_sandbox_paths():
+        for runtime_path in runtime_paths:
             runtime_fd = _open_directory_descriptor(runtime_path)
             runtime_fds.append(runtime_fd)
             runtime_identity = os.fstat(runtime_fd)
@@ -488,8 +562,11 @@ def bind_voice_safe_agent_workspace(
             runtime_ancestors = set(_directory_ancestor_identities(runtime_fd))
             if workspace_id in runtime_ancestors or runtime_id in workspace_ancestors:
                 raise RuntimeError(
-                    "macOS agent workspace overlaps Kiro Crew's protected voice "
-                    "runtime; keep the workspace and Kiro Crew data home disjoint"
+                    _voice_runtime_guard_message(
+                        os.path.abspath(workspace_path),
+                        os.path.abspath(runtime_path),
+                        "inside" if runtime_id in workspace_ancestors else "contains",
+                    )
                 )
 
         return workspace_path, workspace_fd
@@ -497,8 +574,13 @@ def bind_voice_safe_agent_workspace(
         if workspace_fd >= 0:
             os.close(workspace_fd)
         raise RuntimeError(
-            "cannot bind a macOS agent workspace separately from Kiro Crew's "
-            "protected voice runtime"
+            _voice_runtime_guard_message(
+                os.path.abspath(workspace_path),
+                os.path.abspath(runtime_paths[0]) if runtime_paths else "<unknown>",
+                "cannot-verify",
+                failed_path=getattr(exc, "filename", None) or "<unknown path>",
+                failure_reason=getattr(exc, "strerror", None) or str(exc),
+            )
         ) from exc
     except BaseException:
         if workspace_fd >= 0:

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -333,8 +333,16 @@ class TestBuildSeatbeltProfile:
             lambda path: str(runtime) if os.fspath(path) == str(alias) else realpath(path),
         )
 
-        with pytest.raises(RuntimeError, match="protected voice runtime"):
+        with pytest.raises(RuntimeError, match="protected voice runtime") as excinfo:
             sandbox_mod.assert_voice_runtime_outside_agent_workspace(alias)
+
+        # The refusal names the workspace as the caller spelled it (the
+        # symlink), not its canonical resolution, and classifies a hit found
+        # only on the canonical spelling as an alias relationship.
+        message = str(excinfo.value)
+        assert os.path.abspath(str(alias)) in message
+        assert "aliases" in message
+        assert str(runtime) in message
 
     @pytest.mark.parametrize(
         ("runtime_leaf", "workspace_leaf"),
@@ -386,6 +394,162 @@ class TestBuildSeatbeltProfile:
 
         with pytest.raises(RuntimeError, match="protected voice runtime"):
             sandbox_mod.assert_voice_runtime_outside_agent_workspace(workspace)
+
+    def test_voice_guard_refusal_names_both_paths_when_workspace_contains_runtime(
+        self, monkeypatch, tmp_path
+    ):
+        """Lexical 'contains' variant: both absolute paths plus the remedy."""
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        runtime.mkdir(parents=True)
+        workspace = tmp_path
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            sandbox_mod.assert_voice_runtime_outside_agent_workspace(workspace)
+
+        message = str(excinfo.value)
+        assert str(workspace) in message
+        assert str(runtime) in message
+        assert "contains" in message
+        assert (
+            "Pick a project subdirectory that does not contain the Kiro Crew data home."
+            in message
+        )
+
+    def test_voice_guard_refusal_names_both_paths_when_workspace_is_inside_runtime(
+        self, monkeypatch, tmp_path
+    ):
+        """Lexical 'inside' variant: both absolute paths plus the remedy."""
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        workspace = runtime / "nested"
+        workspace.mkdir(parents=True)
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            sandbox_mod.assert_voice_runtime_outside_agent_workspace(workspace)
+
+        message = str(excinfo.value)
+        assert str(workspace) in message
+        assert str(runtime) in message
+        assert "lives inside it" in message
+        assert (
+            "Pick a project subdirectory that does not contain the Kiro Crew data home."
+            in message
+        )
+
+    def test_voice_guard_alias_refusal_names_both_paths(self, monkeypatch, tmp_path):
+        """Filesystem-identity variant: both absolute paths plus the remedy."""
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        workspace = tmp_path / "workspace"
+        runtime.mkdir(parents=True)
+        workspace.mkdir()
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+        real_stat = sandbox_mod.os.stat
+        runtime_info = real_stat(runtime)
+
+        def alias_stat(path, *args, **kwargs):
+            if os.path.abspath(os.fspath(path)) == os.path.abspath(str(workspace)):
+                return runtime_info
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(sandbox_mod.os, "stat", alias_stat)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            sandbox_mod.assert_voice_runtime_outside_agent_workspace(workspace)
+
+        message = str(excinfo.value)
+        assert str(workspace) in message
+        assert str(runtime) in message
+        assert "aliases" in message
+        assert (
+            "Pick a project subdirectory that does not contain the Kiro Crew data home."
+            in message
+        )
+
+    def test_voice_guard_cannot_verify_refusal_names_the_failed_stat(
+        self, monkeypatch, tmp_path
+    ):
+        """OSError variant: workspace, runtime, the failed path, and the remedy."""
+        runtime = tmp_path / "data" / "run" / "voice-runtime"
+        workspace = tmp_path / "workspace"
+        runtime.mkdir(parents=True)
+        workspace.mkdir()
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (str(runtime),),
+        )
+        real_stat = sandbox_mod.os.stat
+
+        def failing_stat(path, *args, **kwargs):
+            if os.path.abspath(os.fspath(path)) == os.path.abspath(str(workspace)):
+                raise PermissionError(13, "Permission denied", os.fspath(path))
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(sandbox_mod.os, "stat", failing_stat)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            sandbox_mod.assert_voice_runtime_outside_agent_workspace(workspace)
+
+        message = str(excinfo.value)
+        assert "cannot verify" in message
+        assert str(workspace) in message
+        assert str(runtime) in message
+        assert "a filesystem check failed on" in message
+        assert "Permission denied" in message
+        assert "fails closed" in message
+        assert (
+            "Pick a project subdirectory that does not contain the Kiro Crew data home."
+            in message
+        )
+        assert isinstance(excinfo.value.__cause__, OSError)
+
+    def test_voice_guard_bind_cannot_verify_refusal_names_the_failed_open(
+        self, monkeypatch
+    ):
+        """Bind-path OSError variant: workspace, failed path, and the remedy."""
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: ("/protected/voice-runtime",),
+        )
+
+        def failing_open(path, **_kwargs):
+            raise PermissionError(13, "Permission denied", os.fspath(path))
+
+        monkeypatch.setattr(sandbox_mod, "_open_directory_descriptor", failing_open)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            sandbox_mod.bind_voice_safe_agent_workspace("/mutable/workspace")
+
+        message = str(excinfo.value)
+        assert "cannot verify" in message
+        assert "/mutable/workspace" in message
+        assert "/protected/voice-runtime" in message
+        assert "a filesystem check failed on" in message
+        assert "Permission denied" in message
+        assert (
+            "Pick a project subdirectory that does not contain the Kiro Crew data home."
+            in message
+        )
+        assert isinstance(excinfo.value.__cause__, OSError)
 
     def test_macos_workspace_binding_uses_opened_ancestor_identities(self, monkeypatch):
         monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
@@ -541,9 +705,16 @@ class TestBuildSeatbeltProfile:
         closed: list[int] = []
         monkeypatch.setattr(sandbox_mod.os, "close", closed.append)
 
-        with pytest.raises(RuntimeError, match="protected voice runtime"):
+        with pytest.raises(RuntimeError, match="protected voice runtime") as excinfo:
             sandbox_mod.bind_voice_safe_agent_workspace("/mutable/workspace")
 
+        message = str(excinfo.value)
+        assert "/mutable/workspace" in message
+        assert "/protected/voice-runtime" in message
+        assert (
+            "Pick a project subdirectory that does not contain the Kiro Crew data home."
+            in message
+        )
         assert closed == [51, 52]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

On macOS, the voice-runtime workspace guard (`assert_voice_runtime_outside_agent_workspace` and `bind_voice_safe_agent_workspace` in `src/kiro_crew/sandbox.py`) correctly refuses an agent workspace that is, contains, or aliases Kiro Crew's protected voice runtime / data home — but the raise sites say only "macOS agent workspace overlaps Kiro Crew's protected voice runtime; keep the workspace and Kiro Crew data home disjoint" (or the `aliases` / "cannot verify" / "cannot bind" variants). None of them names the workspace path, the colliding runtime path, or what to do instead.

Because the default data home is `~/.kiro/crew`, every ancestor of it (`~`, `~/.kiro`, `~/.kiro/crew`) is an invalid workspace, and picking `~` is a common first move for a new user — who then hits an opaque refusal with no visible cause.

## Why it matters

A new macOS user whose first workspace choice is their home directory gets a hard startup failure with a message that names neither path involved nor the remedy. The remedy is always the same and cheap to state: choose a project subdirectory that does not contain the data home. Without it, the guard reads as a bug rather than a protection.

## What changed (motivation → approach → change)

Symptom: opaque refusal. Root cause: raise sites each hand-spell a pathless message. Change: one private formatter, `_voice_runtime_guard_message`, now builds every variant of this refusal from structured inputs — the workspace path, the colliding runtime/data-home path, and the relationship (workspace contains runtime / workspace is inside runtime / filesystem-identity alias / could not stat). Every variant leads with the two concrete absolute paths, keeps its distinguishing detail sentence, and ends with the same remedy: pick a project subdirectory that does not contain the Kiro Crew data home. The "cannot verify" (`OSError`) variants say a filesystem check failed on the named path and why that blocks startup (the guard fails closed).

All five raise sites route through it: the lexical `overlaps`, identity `aliases`, and `OSError` raises in `assert_voice_runtime_outside_agent_workspace`, plus the duplicated `overlaps` raise and the `OSError` "cannot bind" raise in `bind_voice_safe_agent_workspace` (the fifth was flagged by First Principles review as an unfixed sibling of the same root cause). Exactly one place now spells this guidance.

Behaviour is unchanged: same conditions, same `RuntimeError` type, same fail-closed semantics, same `from exc` chaining on both `OSError` paths. The alias `any()`-chains become equivalent explicit loops (identical evaluation order and `stat` sequence) only so the raise can name the offending pair; the bind path resolves its runtime-paths tuple (a pure cache read) before opening the workspace, so a workspace-open failure still names the concrete runtime path in its refusal instead of a placeholder. No auto-substitution of a "safe" subdirectory is added — the issue and triage both reject that, and the guard is deliberately not relaxed or widened.

The message carries only the two paths already known to the caller (plus, on the cannot-verify variants, the failing path from the `OSError`): no environment dumps, tokens, or unrelated paths, since it is operator-facing and may reach logs.

Local pre-push review (two model-pinned reviewer subagents mirroring the GPT and Opus CI lanes) converged on one advisory finding — the alias variant's original wording claimed the two names resolve to the *same* identity, which is wrong when the identity hit is containment through a case/normalization/symlink/firmlink alias. Reworded to "one of these paths is the other or an ancestor of the other", which is symmetric and accurate for both alias loops. Per First Principles review, the "keep the workspace and Kiro Crew data home disjoint" clause was dropped from the overlap/alias variants — the remedy sentence that follows restates it.

Three review findings on the new messages are folded in: the cannot-verify label is "a filesystem check failed" rather than "stat failed" (the bind path's chained `OSError` can come from `open()`/`fstat()`, not only `stat()`); the bind path resolves the runtime paths before opening the workspace so a workspace-open refusal names the runtime path; and every refusal names the workspace as the caller spelled it — a hit found only on the canonical (realpath) spelling of a symlinked workspace is reported as an alias of the caller's own spelling rather than printing the resolved runtime path twice.

## Tests

Extended `test/test_sandbox_argv.py` (all red on base, green on this branch):

- `test_voice_guard_refusal_names_both_paths_when_workspace_contains_runtime` — lexical "contains" variant carries both absolute paths + the remedy sentence.
- `test_voice_guard_refusal_names_both_paths_when_workspace_is_inside_runtime` — lexical "inside" variant, both paths + remedy.
- `test_voice_guard_alias_refusal_names_both_paths` — filesystem-identity variant, both paths + "aliases" + remedy.
- `test_delegated_macos_agent_workspace_checks_canonical_alias` (extended) — a symlinked workspace's refusal names the caller's own spelling and classifies the canonical-spelling hit as an alias.
- `test_voice_guard_cannot_verify_refusal_names_the_failed_stat` — OSError variant names the failed path and reason under the "a filesystem check failed" label, states the fail-closed consequence, keeps `__cause__` chaining.
- `test_voice_guard_bind_cannot_verify_refusal_names_the_failed_open` — bind-path OSError variant names the workspace, the runtime path, the failed open, and the remedy, keeps `__cause__` chaining.
- `test_macos_workspace_binding_rejects_opened_runtime_ancestor` (extended) — the descriptor-based bind refusal also carries both paths + remedy.

All existing guard-refusal tests (contains/inside/ancestor, canonical alias, APFS spelling aliases, identity alias, descriptor ancestry) pass unchanged — the guard still refuses every previously rejected shape. Platform flipping follows the file's existing pattern (`monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")` — module-local, not global).

## Manual verification

N/A — unit coverage sufficient: the change is message construction only; every variant and all raise paths are asserted directly, and the full backend suite shows a failure set identical to pristine `main` (25 environmental failures, zero new).

## Related Issues

Refs #7392 — this PR deliberately addresses only the error-message half of the issue. The project-picker / `set_project` pre-flight warning half needs a UI decision and stays open on the issue (being pursued in #7402), so no closing keyword is used.

## Pattern harvest

Rule candidate: review-prompt
Pattern: fail-closed guard refusals that omit the concrete inputs (paths/ids) and the remedy — a guard message that names neither operand reads as a bug, not a protection.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour change
- [x] No secrets, credentials, or internal references in the diff

