### PR TITLE
fix(oauth): default a scheme-less callback paste to http

### DIFF
--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 
 _MAX_RETURN_ADDRESS_BYTES = 8192
 _MAX_REQUEST_TARGET_BYTES = 6144
+# RFC 3986 scheme followed by "://". Deliberately requires the "//": a bare
+# "host:port/..." (which urlsplit would misread as scheme + opaque path) must
+# NOT count as having a scheme, so it gets the http:// default (#7406).
+_URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
 _SERVER_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _ALLOWED_CALLBACK_QUERY_KEYS = {
     "authuser",
@@ -51,12 +55,24 @@ def _validated_loopback_return_address(value: object) -> _LoopbackCallback | Non
     The user controls only an unprivileged loopback port and an ASCII HTTP
     request-target containing a single OAuth code.  The network host is selected
     later from fixed literals, so request data can never choose a remote host.
+
+    A paste with no scheme is normalized to ``http://`` first (#7406): mobile
+    browsers — iOS Safari in particular — copy address-bar URLs without the
+    scheme, so the documented paste-back flow otherwise fails on exactly the
+    text the browser gave the user. Prepending a scheme is safe here because
+    every containment constraint below (loopback host literals, port floor,
+    query allowlist) applies to the normalized value; a scheme cannot turn a
+    non-loopback host into a loopback one. The regex also catches the
+    ``urlsplit`` gotcha where ``localhost:8976/...`` parses ``localhost`` as
+    the scheme rather than the host.
     """
     if not isinstance(value, str):
         return None
     candidate = value.strip()
     if not candidate or len(candidate.encode("utf-8")) > _MAX_RETURN_ADDRESS_BYTES:
         return None
+    if not _URL_SCHEME_RE.match(candidate):
+        candidate = f"http://{candidate}"
     try:
         parsed = urlsplit(candidate)
         port = parsed.port

--- a/test/test_connections_oauth_relay.py
+++ b/test/test_connections_oauth_relay.py
@@ -43,6 +43,33 @@ def test_return_address_validation_accepts_runtime_callback_shape(host):
     assert callback.request_target == "/callback?code=one-time&state=opaque"
 
 
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "[::1]"])
+def test_return_address_validation_defaults_missing_scheme_to_http(host):
+    """#7406: iOS Safari copies address-bar URLs without the scheme; the
+    scheme-less paste must validate as if it carried http://."""
+    value = f"{host}:43123/callback?code=one-time&state=opaque"
+    callback = connections._validated_loopback_return_address(value)
+    assert callback is not None
+    assert callback.port == 43123
+    assert callback.request_target == "/callback?code=one-time&state=opaque"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # The http:// default must not admit anything the strict form refuses.
+        "10.0.0.5:43123/?code=x",
+        "evil.example:43123/?code=x",
+        "127.0.0.1:80/?code=x",
+        "127.0.0.1/?code=x",
+        # An explicit non-http scheme stays rejected — no rewrite to http.
+        "ftp://127.0.0.1:43123/?code=x",
+    ],
+)
+def test_scheme_default_does_not_widen_containment(value):
+    assert connections._validated_loopback_return_address(value) is None
+
+
 @pytest.mark.asyncio
 async def test_relay_delivers_to_loopback_without_following_redirects(monkeypatch):
     received: list[dict[str, str]] = []

--- a/website/src/components/OAuthRelayAffordance.tsx
+++ b/website/src/components/OAuthRelayAffordance.tsx
@@ -5,7 +5,7 @@ import { api, ApiError } from '../api/client'
 import { queryClient } from '../api/queryClient'
 import type { McpServer } from '../types'
 import { parseErrorCode } from '../utils/errorReport'
-import { isValidLoopbackReturnAddress } from '../utils/loopbackReturnAddress'
+import { isValidLoopbackReturnAddress, normalizeLoopbackReturnAddress } from '../utils/loopbackReturnAddress'
 import { i18nT } from '../i18n/t'
 import { useImeGuard } from '../hooks/useImeGuard'
 
@@ -166,11 +166,14 @@ export default function OAuthRelayAffordance({
   }
 
   const runRelay = async () => {
-    const value = returnAddress.trim()
+    // Normalize a scheme-less mobile paste to http:// first (#7406), then run
+    // the same client-side pre-check the Connections card runs: a malformed
+    // paste fails locally with the specific shared message instead of a
+    // round-trip collapsing into the generic delivery-failure copy. The
+    // NORMALIZED value is what gets submitted, so older gateways without the
+    // backend normalization accept it too.
+    const value = normalizeLoopbackReturnAddress(returnAddress)
     if (!value || busy) return
-    // Same client-side pre-check the Connections card runs: a malformed paste
-    // fails locally with the specific shared message instead of a round-trip
-    // collapsing into the generic delivery-failure copy.
     if (!isValidLoopbackReturnAddress(value)) {
       setError(i18nT('pages.connectionsPage.invalid_return_address'))
       return

--- a/website/src/pages/connections/ConnectionsPage.tsx
+++ b/website/src/pages/connections/ConnectionsPage.tsx
@@ -83,7 +83,7 @@ function safeApprovalUrl(value: string): string {
 
 // The loopback pre-check lives in `utils/loopbackReturnAddress` (shared with
 // the chat banner's relay affordance).
-import { isValidLoopbackReturnAddress } from '../../utils/loopbackReturnAddress'
+import { isValidLoopbackReturnAddress, normalizeLoopbackReturnAddress } from '../../utils/loopbackReturnAddress'
 import { useImeGuard } from '../../hooks/useImeGuard'
 
 export interface PendingConnect {
@@ -414,12 +414,15 @@ function ConnectionCard({
   }
   const meta = stateMeta[state]
   const runRelay = async () => {
-    if (!isValidLoopbackReturnAddress(returnAddress)) {
+    // Normalize a scheme-less mobile paste (#7406) and submit the normalized
+    // form, mirroring the chat banner's relay affordance.
+    const normalized = normalizeLoopbackReturnAddress(returnAddress)
+    if (!isValidLoopbackReturnAddress(normalized)) {
       setInvalidReturnAddress(true)
       return
     }
     setInvalidReturnAddress(false)
-    const delivered = await onRelay(returnAddress.trim())
+    const delivered = await onRelay(normalized)
     if (delivered) setReturnAddress('')
   }
 

--- a/website/src/test/ConnectionsPage.test.tsx
+++ b/website/src/test/ConnectionsPage.test.tsx
@@ -1,4 +1,4 @@
-import { isValidLoopbackReturnAddress } from '../utils/loopbackReturnAddress'
+import { isValidLoopbackReturnAddress, normalizeLoopbackReturnAddress } from '../utils/loopbackReturnAddress'
 import { describe, expect, it } from 'vitest'
 import type { ChatMessage, McpServer } from '../types'
 import {
@@ -349,6 +349,33 @@ describe('loopback OAuth return-address validation', () => {
     'http://127.0.0.1:43123/?code=x#fragment',
   ])('rejects unsafe or incomplete return address %s', value => {
     expect(isValidLoopbackReturnAddress(value)).toBe(false)
+  })
+
+  // #7406: iOS Safari copies address-bar URLs without the scheme; the
+  // scheme-less paste must normalize to http:// and validate.
+  it.each([
+    '127.0.0.1:43123/?code=one-time&state=s',
+    'localhost:43123/callback?code=one-time',
+    '[::1]:43123/?code=one-time',
+  ])('accepts a scheme-less loopback paste %s via the http default', value => {
+    expect(normalizeLoopbackReturnAddress(value)).toBe(`http://${value}`)
+    expect(isValidLoopbackReturnAddress(value)).toBe(true)
+  })
+
+  it.each([
+    // The http default must not widen containment beyond the strict form.
+    '10.0.0.5:43123/?code=x',
+    'evil.example:43123/?code=x',
+    '127.0.0.1/?code=x',
+    // An explicit non-http scheme stays rejected — no rewrite to http.
+    'ftp://127.0.0.1:43123/?code=x',
+  ])('scheme default still rejects %s', value => {
+    expect(isValidLoopbackReturnAddress(value)).toBe(false)
+  })
+
+  it('leaves an already-schemed value untouched', () => {
+    expect(normalizeLoopbackReturnAddress(' http://127.0.0.1:43123/?code=x '))
+      .toBe('http://127.0.0.1:43123/?code=x')
   })
 })
 

--- a/website/src/utils/loopbackReturnAddress.ts
+++ b/website/src/utils/loopbackReturnAddress.ts
@@ -9,9 +9,31 @@
  * Shared by the Connections card and the chat banner's relay affordance so the
  * two surfaces cannot drift apart again (PR #4796 Design review).
  */
+
+/** RFC 3986 scheme followed by `://`. Requires the `//` on purpose: a bare
+ * `host:port/...` must not count as having a scheme, so it gets the default. */
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i
+
+/** Default a scheme-less paste to `http://` (#7406).
+ *
+ * Mobile browsers — iOS Safari in particular — copy address-bar URLs without
+ * the scheme, so the paste-back flow otherwise rejects exactly the text the
+ * browser gave the user. The loopback callback listener is always plain HTTP,
+ * and every containment check in `isValidLoopbackReturnAddress` (loopback
+ * host, port floor, single code) applies to the normalized value, so the
+ * default cannot admit anything the strict form would refuse. Callers must
+ * validate AND submit this normalized value, mirroring the backend's own
+ * normalization in `_validated_loopback_return_address`.
+ */
+export function normalizeLoopbackReturnAddress(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed || SCHEME_RE.test(trimmed)) return trimmed
+  return `http://${trimmed}`
+}
+
 export function isValidLoopbackReturnAddress(value: string): boolean {
   try {
-    const url = new URL(value.trim())
+    const url = new URL(normalizeLoopbackReturnAddress(value))
     const loopback =
       url.hostname === '127.0.0.1'
       || url.hostname === '[::1]'


### PR DESCRIPTION
<!-- no-visual-delta -->

## Problem / Motivation

In the remote-gateway MCP OAuth flow, the provider redirects the browser to a loopback callback that only exists on the gateway host, so the user copies the failed URL and pastes it into the relay affordance. iOS Safari (and other mobile browsers) copy address-bar URLs **without the scheme** — the clipboard carries `127.0.0.1:8976/callback?code=...`. Both validation layers rejected that paste: the frontend's `new URL(value)` throws on a scheme-less string, and the backend's `_validated_loopback_return_address` requires `parsed.scheme == "http"` (a scheme-less paste parses with an empty scheme — or a bogus one: `urlsplit("localhost:8976/cb")` reads `localhost` as the scheme). The user gets "invalid return address" for exactly the text their browser gave them.

## Why it matters

The paste-back relay exists precisely for the remote/mobile case — the user is on a device where the loopback redirect cannot land. That is the population most likely to be pasting from a mobile browser, so the flow failed for its own primary audience with no hint that a missing `http://` was the cause.

## What changed (motivation → approach → change)

Goal: accept the paste the browser actually produces, without widening what the validators admit.

- **Shared frontend util** (`website/src/utils/loopbackReturnAddress.ts`): new `normalizeLoopbackReturnAddress` prepends `http://` when the trimmed value lacks an RFC 3986 `scheme://` prefix (the `//` is required on purpose, so `host:port/...` counts as scheme-less). `isValidLoopbackReturnAddress` validates the normalized form. Both callers — the Connections card and the chat banner's relay affordance — validate **and submit** the normalized value, so older gateways without the backend change accept it too.
- **Backend validator** (`_validated_loopback_return_address` in `src/kiro_crew/dashboard/handlers/connections.py`): the same normalization before `urlsplit`, as defense in depth for direct API callers. The same regex also fixes the `urlsplit` scheme-gotcha for `localhost:port/...` pastes.
- **Containment unchanged**: every constraint (loopback host literal allowlist, port ≥ 1024, no userinfo/fragment, single `code`, query-key allowlist) applies **after** normalization — prepending a scheme cannot turn a non-loopback host into a loopback one, and an explicit non-http scheme (`ftp://`, `https://`) is still rejected, never rewritten.

## Tests

- Backend (`test/test_connections_oauth_relay.py`): scheme-less pastes for all three loopback hosts validate to the same callback shape as their `http://` forms; a second parametrized set proves the default does **not** widen containment (non-loopback hosts, privileged port, missing port, explicit `ftp://` all still rejected). 40/40 file tests pass.
- Frontend (`website/src/test/ConnectionsPage.test.tsx`): scheme-less loopback pastes normalize to `http://<paste>` and validate; non-loopback and explicit-non-http values still rejected; an already-schemed value is left untouched (trim only). 56/56 file tests pass; the two banner relay test files (25 tests) also pass.
- Full floor: `tsc -b` rc=0, eslint clean on touched files, black/isort/flake8/mypy clean on the backend files.

## Manual verification

N/A — unit coverage sufficient: the normalization is a pure string transform exercised end-to-end by the endpoint tests (the relay delivery tests run the real handler), and the component tests drive the real paste field.

## Screenshots / video

**Why no screenshot:** no visual delta — the change alters paste validation logic only; every surface renders identically, the accepted-input set just grows to include what mobile browsers actually copy.

## Related Issues

Fixes #7406

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a URL validator that hard-requires a scheme rejects mobile-browser clipboard output — when input arrives via user paste, normalize the schemeless form before validating instead of assuming address-bar fidelity"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
