### PR TITLE
fix(config): connections_ui survives the masked config GET

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -7323,6 +7323,20 @@
       "defaultValue": true
     },
     {
+      "path": "connections_ui",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Connections UI",
+      "help": "Show the Connections gallery (held for a later release).",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
       "path": "timezone",
       "kind": "core",
       "type": "string",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -216,6 +216,7 @@ _KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
         "timezone",
         "auto_update",
         "registries",
+        "connections_ui",
     }
 )
 
@@ -7574,6 +7575,28 @@ class KiroCrewConfig:
         default=True,
         metadata=_meta("Auto Update", "Enable automatic update checks."),
     )
+    #: Opt-in for the Connections gallery, which is merged but held for a later
+    #: release. A real field rather than an unmodelled top-level key because the
+    #: browser is the consumer: the frontend reads this flag live off ``GET
+    #: /api/config/kirocrew`` (``useConnectionsUi.ts``), and that response drops
+    #: every key the core does not model — ``_masked_config_dict`` cannot tell
+    #: whether an unmodelled value is a secret, so it strips them all rather
+    #: than leak one. Being schema-known is therefore what makes the flag
+    #: reachable at all; it also stops ``validation`` reporting the operator's
+    #: own documented setting as an "unrecognized top-level key".
+    #:
+    #: Parsed through ``_safe_bool`` and defaulting False: a value Kiro Crew
+    #: cannot read must mean "keep the held surface hidden", never the reverse
+    #: (same posture as ``computer_use.cursor_motion``). The frontend predicate
+    #: is a strict ``=== true``, so coercing e.g. the string ``"true"`` would
+    #: only make the two ends disagree about what was configured.
+    connections_ui: bool = field(
+        default=False,
+        metadata=_meta(
+            "Connections UI",
+            "Show the Connections gallery (held for a later release).",
+        ),
+    )
     #: Top-level sections that were PRESENT on disk but not a JSON object, and
     #: were therefore coerced to defaults by :meth:`load`.
     #:
@@ -8820,6 +8843,7 @@ class KiroCrewConfig:
                 cursor_motion=_safe_bool(computer_use_data.get("cursor_motion", False), False),
             ),
             auto_update=data.get("auto_update", True),
+            connections_ui=_safe_bool(data.get("connections_ui", False), False),
             _degraded_sections=frozenset(_degraded | _OBSERVED_DEGRADED_SECTIONS),
             timezone=data.get("timezone", ""),
             snapshot_dir=data.get("snapshot_dir", ""),
@@ -9123,6 +9147,13 @@ class KiroCrewConfig:
             "snapshot_dir": self.snapshot_dir,
             "timezone": self.timezone,
             "auto_update": self.auto_update,
+            # Emitted unconditionally, like every other modelled top-level
+            # value: _KNOWN_CONFIG_SECTIONS must equal the key set to_dict()
+            # writes (test_known_sections_equals_emitted_sections), and a key
+            # listed there but not emitted would be excluded from
+            # _extra_sections capture AND dropped here — losing the operator's
+            # opt-in on the first save().
+            "connections_ui": self.connections_ui,
         }
         # External registries (always serialized so save() round-trips the field)
         d["registries"] = [asdict(r) for r in self.registries]

--- a/test/test_connections_ui_flag.py
+++ b/test/test_connections_ui_flag.py
@@ -1,0 +1,201 @@
+"""``connections_ui`` must survive load() -> masked GET -> frontend predicate.
+
+The Connections gallery is held for a later release and is reachable only when
+``connections_ui: true`` is set as a TOP-LEVEL key in the running instance's
+``config.json``. The frontend reads that flag live off ``GET
+/api/config/kirocrew`` (``website/src/hooks/useConnectionsUi.ts``:
+``connectionsUiEnabled`` requires the value to be exactly ``true``), so the
+whole feature turns on the key reaching the browser in that response body.
+
+Nothing but a real, schema-known config value gets there. An unmodelled
+top-level key is captured into ``KiroCrewConfig._extra_sections`` at load and
+then dropped wholesale by ``_masked_config_dict`` — a deliberate guard, because
+an edition-contributed section is absent from the schema and the sensitivity
+walk cannot know which of its values are secrets. These tests pin the flag on
+the modelled side of that line while keeping the guard itself intact: a
+genuinely unknown key must still never reach the browser.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.config import loader as L
+from kiro_crew.config.loader import KiroCrewConfig
+
+# The one spelling the frontend, the docs and existing user configs all use.
+FLAG = "connections_ui"
+
+
+def _point_loader_at(tmp_path, monkeypatch, data: dict) -> None:
+    """Write *data* as the instance config and aim the loader at it."""
+    cfgp = tmp_path / "config.json"
+    cfgp.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(L, "config_path", lambda: cfgp)
+    monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(L, "config_local_path", lambda: tmp_path / "config.local.json")
+
+
+def _masked(cfg: KiroCrewConfig) -> dict:
+    from kiro_crew.dashboard.handlers.core import _masked_config_dict
+
+    return _masked_config_dict(cfg)
+
+
+def _frontend_says_enabled(masked: dict) -> bool:
+    """Mirror of ``connectionsUiEnabled`` — strict ``=== true``, nothing else."""
+    return masked.get(FLAG) is True
+
+
+def test_flag_set_true_reaches_the_masked_get(tmp_path, monkeypatch):
+    """The launch blocker: ``true`` on disk must arrive in the browser's copy."""
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: True})
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.connections_ui is True
+    # Modelled, therefore NOT swept up as an unknown section...
+    assert FLAG not in cfg._extra_sections
+    # ...and therefore present in the browser-facing view.
+    assert _frontend_says_enabled(_masked(cfg))
+
+
+def test_flag_absent_leaves_the_gallery_off(tmp_path, monkeypatch):
+    """Default posture: a config that never mentions the flag stays closed."""
+    _point_loader_at(tmp_path, monkeypatch, {"agent": {"provider": "acp"}})
+    masked = _masked(KiroCrewConfig.load())
+
+    assert masked.get(FLAG) is False
+    assert not _frontend_says_enabled(masked)
+
+
+def test_flag_set_false_leaves_the_gallery_off(tmp_path, monkeypatch):
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: False})
+    masked = _masked(KiroCrewConfig.load())
+
+    assert masked.get(FLAG) is False
+    assert not _frontend_says_enabled(masked)
+
+
+def test_a_non_bool_value_fails_closed(tmp_path, monkeypatch):
+    """``"true"`` is not ``true``: an unparseable value must not open the gate.
+
+    Same posture as ``computer_use.cursor_motion`` — for a flag that reveals a
+    held-for-release surface, a value Kiro Crew cannot read means "off", never
+    the reverse. Coercing the string would also hand the frontend a value its
+    strict ``=== true`` check rejects anyway, so the two would disagree about
+    what the operator configured.
+    """
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: "true"})
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.connections_ui is False
+    assert not _frontend_says_enabled(_masked(cfg))
+
+
+def test_flag_survives_a_config_write(tmp_path, monkeypatch):
+    """load() -> save() must not destroy the operator's opt-in.
+
+    A key the core does not model would be re-emitted from
+    ``_extra_sections``; a key it models must be emitted from its own field.
+    Either way the operator's ``true`` has to still be on disk afterwards, and
+    still reach the browser on the next read.
+    """
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: True, "timezone": "UTC"})
+    KiroCrewConfig.load().save()
+
+    written = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert written[FLAG] is True
+
+    assert _frontend_says_enabled(_masked(KiroCrewConfig.load()))
+
+
+def test_flag_is_schema_known_so_load_does_not_warn_about_it():
+    """Registered in the schema, so validation stops calling it unrecognized.
+
+    ``validation.validate_config`` derives its known top-level keys from
+    ``SCHEMA_REGISTRY``, so an unmodelled flag makes every load of a
+    Connections-enabled config log "unrecognized top-level keys:
+    connections_ui" — the same missing-citizenship as the stripped GET.
+    """
+    from kiro_crew.config.schema import SCHEMA_REGISTRY
+
+    top_level = {e.path for e in SCHEMA_REGISTRY if "." not in e.path}
+    assert FLAG in top_level
+
+
+def test_flag_set_in_the_local_overlay_also_reaches_the_browser(tmp_path, monkeypatch):
+    """``config.local.json`` is the documented survives-upgrades place to set it.
+
+    The overlay is deep-merged at load, so the flag has to work from there too —
+    and ``save()`` must keep it overlay-owned rather than copying it into the
+    base file.
+    """
+    cfgp = tmp_path / "config.json"
+    cfgp.write_text(json.dumps({"agent": {"provider": "acp"}}), encoding="utf-8")
+    localp = tmp_path / "config.local.json"
+    localp.write_text(json.dumps({FLAG: True}), encoding="utf-8")
+    monkeypatch.setattr(L, "config_path", lambda: cfgp)
+    monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(L, "config_local_path", lambda: localp)
+
+    cfg = KiroCrewConfig.load()
+    assert _frontend_says_enabled(_masked(cfg))
+
+    cfg.save()
+    base = json.loads(cfgp.read_text(encoding="utf-8"))
+    assert FLAG not in base  # overlay-owned, not leaked into config.json
+    assert _frontend_says_enabled(_masked(KiroCrewConfig.load()))
+
+
+def test_the_unknown_extras_guard_is_not_weakened(tmp_path, monkeypatch):
+    """Making ONE key known must not open the browser view to unknown keys.
+
+    The strip exists because an unmodelled value can be a secret and the
+    schema-driven sensitivity walk cannot see it. That reasoning covers a
+    top-level scalar exactly as much as a section, so both must still be gone
+    from the masked response.
+    """
+    _point_loader_at(
+        tmp_path,
+        monkeypatch,
+        {
+            FLAG: True,
+            "amazon": {"api_token": "SECRET-section-value"},
+            "some_vendor_token": "SECRET-scalar-value",
+        },
+    )
+    cfg = KiroCrewConfig.load()
+    masked = _masked(cfg)
+
+    assert _frontend_says_enabled(masked)
+    assert "amazon" not in masked
+    assert "some_vendor_token" not in masked
+    body = json.dumps(masked)
+    assert "SECRET-section-value" not in body
+    assert "SECRET-scalar-value" not in body
+    # The save() path still carries them — only the browser-facing view drops them.
+    assert cfg.to_dict()["some_vendor_token"] == "SECRET-scalar-value"
+
+
+@pytest.mark.asyncio
+async def test_the_wire_response_carries_the_flag(tmp_path, monkeypatch):
+    """End to end over HTTP, because the wire is what the hook actually reads.
+
+    ``_masked_config_dict`` is one step of the GET; this drives the real route
+    so the assertion covers the whole path the frontend depends on.
+    """
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from kiro_crew.dashboard.handlers import core as core_mod
+
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: True})
+
+    app = web.Application()
+    app.router.add_route("*", "/api/config/kirocrew", core_mod.api_kirocrew_config)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/api/config/kirocrew")
+        assert resp.status == 200
+        assert _frontend_says_enabled(await resp.json())


### PR DESCRIPTION

## Problem / Motivation

Setting `connections_ui: true` in `config.json` — the documented opt-in for the Connections gallery — has never worked against a live gateway. The gallery stays hidden no matter what the operator writes.

The backend has zero references to the key, so `KiroCrewConfig.load()` files it under `_extra_sections` (unknown top-level key), and `_masked_config_dict` unconditionally pops every extras key from the `GET /api/config/kirocrew` response (a deliberate guard: the schema-driven sensitivity walk cannot tell which values in an unmodelled edition section are secrets). The frontend predicate (`useConnectionsUi.ts`) then reads `undefined === true` → `false`. The strip landed 2026-07-22; the flag landed 2026-08-03; every frontend test mocks the endpoint, so the real path was never exercised.

## Why it matters

The flag gates the entire Connections launch surface: the gallery page, the MCP tab's in-place Sign-in, and chat's card-owned OAuth banner suppression. Until it round-trips, the feature is unreachable on every real install, the manual launch re-test cannot even start (its step 0 detects exactly this), and — once the default-on flip lands — the `connections_ui: false` escape hatch would be silently inert, shipping a surface with no working opt-out.

## What changed (motivation → approach → change)

Symptom: the flag is set on disk, survives `save()` round-trips, and never reaches the browser. Root cause: the key is unknown to the config schema, so the browser-facing masked view strips it as a potential edition secret.

Approach: make the key **schema-known** rather than weakening the strip. The extras guard's reasoning is sound — an unmodelled top-level scalar could be a secret too — so the fix gives `connections_ui` real citizenship instead of carving an exception. `auto_update` is the exact precedent: `_KNOWN_CONFIG_SECTIONS` already holds top-level scalars, each with a dataclass field + `load()` parse + `to_dict()` emit.

Change (`src/kiro_crew/config/loader.py`, 4 sites, +31):
- `_KNOWN_CONFIG_SECTIONS` gains `connections_ui`, so `load()` no longer files it into `_extra_sections`.
- A `connections_ui: bool = False` dataclass field with schema metadata, so validation stops logging the operator's own documented setting as an unrecognized key.
- `load()` parses it through `_safe_bool(..., False)` — fail-closed: a value the config cannot read means "keep the held surface hidden", matching `computer_use.cursor_motion`'s posture. The frontend predicate is a strict `=== true`, so no string coercion.
- `to_dict()` emits it unconditionally — forced by `test_known_sections_equals_emitted_sections` (`_KNOWN_CONFIG_SECTIONS` must equal the emitted key set); a known-but-conditionally-emitted key would be excluded from extras capture and dropped on save. Consequence: the next `save()` stamps `"connections_ui": false` into configs that never set it, exactly as `auto_update` already does.

The masked GET's extras strip is untouched; genuinely unknown sections **and** unknown top-level scalars are still stripped (pinned by a test). Both `_masked_config_dict` call sites (GET and the PATCH response) are fixed by the same change. The write paths never destroyed the key (`update_config_locked` preserves unknown keys), so no write-side change was needed. `connections_ui` is deliberately **not** added to `_EDITABLE_CONFIG`: exposing an unreleased surface's flag as a dashboard toggle is a product decision, not part of this fix.

`config-baseline.json` is regenerated (+14: the one new schema entry) as `test_committed_snapshot_matches_generator` requires.

## Tests

`test/test_connections_ui_flag.py`, new, 9 tests, written red-first (8 failed on the parent commit, 8→9 pass after):

- `test_flag_set_true_reaches_the_masked_get` — the bug's direct assertion.
- `test_flag_absent_leaves_the_gallery_off` / `test_flag_set_false_leaves_the_gallery_off` — default and explicit-off behavior.
- `test_a_non_bool_value_fails_closed` — `_safe_bool` posture.
- `test_flag_survives_a_config_write` — load → save round-trip keeps the operator's value.
- `test_flag_is_schema_known_so_load_does_not_warn_about_it` — the unrecognized-key warning is gone.
- `test_flag_set_in_the_local_overlay_also_reaches_the_browser` — overlay path.
- `test_the_unknown_extras_guard_is_not_weakened` — an unknown section AND an unknown scalar are still stripped from the masked view while `to_dict()` carries them.
- `test_the_wire_response_carries_the_flag` — a real aiohttp route serving the masked body, not just the helper.

Full local gates green: black/subprocess-encoding/isort/flake8 clean, `mypy src/kiro_crew` clean (1220 files), scoped pytest 931 passed + 276 passed across the config and dashboard-core suites.

## Manual verification

N/A — unit coverage sufficient: the wire-level test exercises the exact GET body the browser reads, and the frontend consumer is unchanged.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only config plumbing; no pixel changes. The consuming surfaces (Connections gallery, MCP tab) render exactly as before — this change only makes the documented flag actually reach them.

## Pattern harvest

Rule candidate: contract test — every config key the frontend reads off `GET /api/config/kirocrew` must be schema-known. The defect class is a frontend-consumed key the backend never modeled: the masked GET strips unknown keys as potential edition secrets, and because every frontend test mocks that endpoint, the stripped key is invisible to the entire test suite. A cross-layer assertion (keys referenced by `kirocrewConfig` consumers in `website/src` ⊆ `_KNOWN_CONFIG_SECTIONS`), or a lint that flags a new frontend config-key read with no matching schema field, would catch the next instance at PR time instead of at launch-readiness verification.

## Related Issues

no linked issue: the defect was found during launch-readiness verification of the Connections feature (the manual re-test checklist's step 0 detects it); no tracking issue existed before this fix.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the field's docstring carries the rationale; no user-doc names the flag's internals
- [x] No secrets, credentials, or internal references in the diff

