### PR TITLE
fix(agent): ceiling-filter allowedTools in build_agent_config (#7401)

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2125,6 +2125,11 @@ def build_agent_config(*, gated_off: "frozenset[str] | None" = None) -> dict:
     ``kiro_hooks`` from ``~/.kiro/crew/config.json`` are then additively merged;
     bundled hooks always run first and cannot be removed.
 
+    The assembled ``allowedTools`` list is ceiling-filtered before return (see
+    :func:`_apply_allowed_tools_ceiling`), so every spec derived from this
+    template starts governed — an installer no longer has to remember the
+    filter to avoid shipping a blanket auto-approve for a floor-gated builtin.
+
     Args:
         gated_off: Managed servers whose ``spec_gate`` is closed. Pass the
             caller's snapshot so one rebuild's emit path and its withhold audit
@@ -2212,6 +2217,18 @@ def build_agent_config(*, gated_off: "frozenset[str] | None" = None) -> dict:
     # a kiro-spec key — kiro-cli rejects unknown fields and would drop the whole
     # spec. build_agent_config stays pure (no disk writes) so its many
     # read-only callers don't mutate managed-state as a side effect.
+
+    # Governance ceiling over the assembled ``allowedTools`` — HERE, at the one
+    # constructor every derived-spec installer starts from, so the invariant is
+    # held by the predicate rather than by each installer's author remembering
+    # it (#7401). ``rebuild_agent_config`` keeps its own final pass because its
+    # ``_load_existing_config`` path takes entries from an on-disk spec that
+    # never comes through here; for that caller this filter is idempotent (the
+    # predicate is pure, so filtering twice equals filtering once). A caller
+    # that replaces ``allowedTools`` wholesale (``_install_conductor_agent``)
+    # is unaffected. The SEL audit inside is best-effort and never raises, so
+    # the purity note above still holds for config/managed-state.
+    _apply_allowed_tools_ceiling(config, source="build_agent_config")
     return config
 
 
@@ -3279,6 +3296,53 @@ def _may_auto_approve(ref: str) -> bool:
     tests without reaching into another module's namespace.
     """
     return may_skip_gate_now(ref)
+
+
+def _apply_allowed_tools_ceiling(config: dict, *, source: str) -> None:
+    """Filter ``config["allowedTools"]`` through the governance ceiling, in place.
+
+    ``allowedTools`` is the ONE path that never reaches the PreToolUse gate, so
+    every entry on it must be approved by :func:`_may_auto_approve`. This runs
+    inside :func:`build_agent_config` so every installer that derives a spec
+    from the template inherits the filter — ``_install_research_agent`` shipped
+    the template's ``fs_read``/``code``/``glob``/``grep`` grants verbatim
+    because the filter lived only in ``rebuild_agent_config``'s final pass,
+    which writes only ``kirocrew.json`` (#7401).
+
+    A withheld ref stays MOUNTED (``tools`` is untouched — mounting a tool is
+    not auto-approving it); its calls go through the gate, where the
+    per-argument rule applies. Non-string entries (a hand-edited config) are
+    dropped: they are not valid tool refs and would crash the predicate.
+
+    Withholding a grant is a permission DECISION, so it leaves the same
+    ``mcp_auto_approve_withheld`` SEL record every other ``allowedTools``
+    writer emits — best-effort, never raising, so an audit failure cannot
+    break a build or an install.
+    """
+    allowed = config.get("allowedTools")
+    if not isinstance(allowed, list):
+        return
+    kept: list[str] = []
+    withheld: list[str] = []
+    for ref in allowed:
+        if not isinstance(ref, str):
+            continue
+        (kept if _may_auto_approve(ref) else withheld).append(ref)
+    config["allowedTools"] = kept
+    if withheld:
+        try:
+            sel().log_api_access(
+                caller="system",
+                operation="mcp_auto_approve_withheld",
+                outcome="ok",
+                source=source,
+                resources=(
+                    f"{', '.join(withheld)} mounted without auto-approve "
+                    "(governance ceiling); calls go through the approval gate"
+                ),
+            )
+        except Exception:  # noqa: BLE001 — the audit must not break the build
+            logger.debug("SEL audit unavailable for withheld auto-approve", exc_info=True)
 
 
 def _ceiling_filtered_spec(ref: str, spec: dict[str, Any]) -> dict[str, Any]:

--- a/test/test_app_mcp_scoping.py
+++ b/test/test_app_mcp_scoping.py
@@ -906,6 +906,95 @@ class TestBuiltinAutoApprovalsGoThroughTheFinalPass:
         assert config["allowedTools"] == ["fs_write", "@ok"], "the silent ones are kept"
 
 
+class TestTemplateGrantsAreCeilingFilteredAtBuild:
+    """The template's ``allowedTools`` is ceiling-filtered inside
+    ``build_agent_config`` itself, so every derived spec inherits the filter.
+
+    ``rebuild_agent_config``'s final pass covers only ``kirocrew.json``. A
+    sibling installer that derives from ``build_agent_config`` and writes its
+    own file (``_install_research_agent``) shipped the template's floor-gated
+    builtins (``fs_read``, ``code``, …) on a blanket auto-approve list —
+    ``code`` auto-approved means unrestricted edits that never reach the
+    PreToolUse gate (#7401). Filtering at the constructor holds the invariant
+    by the predicate rather than by each installer's author remembering it.
+    """
+
+    @staticmethod
+    def _floor_builtins() -> set[str]:
+        from kiro_crew.platform.governance import _FLOOR_GATE_SCOPES, BUILTIN_TOOL_SCOPES
+
+        return {
+            name
+            for name, scopes in BUILTIN_TOOL_SCOPES.items()
+            if _FLOOR_GATE_SCOPES.intersection(scopes)
+        }
+
+    def test_build_output_carries_no_floor_scoped_builtin_grant(self) -> None:
+        from kiro_crew import agent
+
+        config = agent.build_agent_config()
+        leaked = self._floor_builtins().intersection(config.get("allowedTools", []))
+        assert not leaked, f"template floor builtins survived the build filter: {leaked}"
+        # Mount, not auto-approve: the tools list is untouched by the filter.
+        shipped = set(agent.get_shipped_tools()["tools"])
+        assert self._floor_builtins() & shipped <= set(config.get("tools", []))
+
+    def test_the_filter_is_idempotent_so_rebuilds_are_unchanged(self) -> None:
+        """No-op proof for the primary spec: ``rebuild_agent_config``'s own
+        final pass re-filters this same list through the same pure predicate,
+        so a fresh rebuild's ``kirocrew.json`` is byte-for-byte what it was
+        before the filter moved into the constructor."""
+        from kiro_crew import agent
+
+        config = agent.build_agent_config()
+        allowed = config.get("allowedTools", [])
+        assert [ref for ref in allowed if agent._may_auto_approve(ref)] == allowed
+
+    def test_the_build_filter_is_pinned_in_source(self) -> None:
+        """The anchor the writer-parity rule below leans on: deriving from
+        ``build_agent_config`` IS inheriting the ceiling filter."""
+        import inspect
+
+        from kiro_crew import agent
+
+        src = inspect.getsource(agent.build_agent_config)
+        assert "_apply_allowed_tools_ceiling(" in src
+
+    def test_every_crew_spec_writer_filters_or_inherits(self) -> None:
+        """Writer parity: the NEXT installer cannot reintroduce the gap.
+
+        Every Crew-authored agent-spec writer in ``agent.py`` must either
+        derive from ``build_agent_config`` (which filters), filter what it
+        writes through ``_may_auto_approve``, or not write an ``allowedTools``
+        key at all. ``_install_research_agent`` failed this before the fix:
+        it derived from a then-unfiltered constructor.
+        """
+        import inspect
+
+        from kiro_crew import agent
+
+        writers = [
+            fn
+            for name, fn in vars(agent).items()
+            if callable(fn)
+            and getattr(fn, "__module__", "") == agent.__name__
+            and (name.startswith("_install_") and name.endswith("_agent"))
+        ]
+        writers.append(agent.rebuild_agent_config)
+        assert len(writers) >= 5, "installer inventory shrank; update this parity test"
+        for fn in writers:
+            src = inspect.getsource(fn)
+            covered = (
+                "build_agent_config(" in src
+                or "_may_auto_approve(" in src
+                or "allowedTools" not in src
+            )
+            assert covered, (
+                f"{fn.__name__} writes an agent spec without inheriting or applying "
+                "the governance ceiling over allowedTools (see #7401)"
+            )
+
+
 class TestTheCodeToolIsGovernedForWrites:
     """`code` edits files and runs formatters, so a write/commands/tools ceiling
     must withhold its blanket auto-approve.

--- a/test/test_auto_research.py
+++ b/test/test_auto_research.py
@@ -2189,6 +2189,91 @@ class TestResearchAgentInstall:
         assert data["name"] == "kirocrew-research"
         assert "research" in data["prompt"].lower()
 
+    @staticmethod
+    def _floor_builtins() -> set[str]:
+        """The builtins whose always-on gate floor forbids a blanket grant.
+
+        Derived from the governance maps rather than hardcoding the four names,
+        so the assertion keeps holding if the template (or the map) changes.
+        """
+        from kiro_crew.platform.governance import _FLOOR_GATE_SCOPES, BUILTIN_TOOL_SCOPES
+
+        return {
+            name
+            for name, scopes in BUILTIN_TOOL_SCOPES.items()
+            if _FLOOR_GATE_SCOPES.intersection(scopes)
+        }
+
+    def _install_real(self, monkeypatch, tmp_path) -> dict:
+        """Install with the REAL build_agent_config — the fix under test lives
+        inside it, so stubbing it (as the identity test above does) would
+        bypass exactly the path #7401 is about."""
+        from kiro_crew import agent
+
+        monkeypatch.setattr(agent, "KIRO_AGENTS_DIR", tmp_path)
+        agent._install_research_agent()
+        return json.loads((tmp_path / "kirocrew-research.json").read_text(encoding="utf-8"))
+
+    def test_no_floor_scoped_builtin_is_blanket_approved(self, monkeypatch, tmp_path):
+        """The installed research spec must not auto-approve a floor builtin.
+
+        The shipped template's ``allowedTools`` starts with floor-gated
+        builtins (``fs_read``, ``code``, …). ``code`` is the consequential one:
+        auto-approved, its calls never reach ``hooks.on_tool_call``, so the
+        sensitive-path check, the write-protected-config check, the governance
+        ceiling and the SEL deny record are all skipped — for the least
+        supervised agent in the product (#7401).
+        """
+        data = self._install_real(monkeypatch, tmp_path)
+        leaked = self._floor_builtins().intersection(data.get("allowedTools", []))
+        assert not leaked, f"floor-gated builtins on the blanket auto-approve list: {leaked}"
+
+    def test_floor_builtins_stay_mounted(self, monkeypatch, tmp_path):
+        """The regression guard proving capability was not removed.
+
+        The withhold removes the BLANKET grant only: the tool stays in
+        ``tools`` (mounted), and read-only file tools still auto-approve via
+        hooks AFTER the floor runs — so a stock install gains no new prompt
+        and the unattended research loop is not handed a stall.
+        """
+        from kiro_crew import agent
+
+        data = self._install_real(monkeypatch, tmp_path)
+        shipped_tools = set(agent.get_shipped_tools()["tools"])
+        expected_mounted = self._floor_builtins().intersection(shipped_tools)
+        assert expected_mounted, "template stopped mounting floor builtins; test needs updating"
+        missing = expected_mounted - set(data.get("tools", []))
+        assert not missing, f"filter must not unmount tools, only ungrant them: {missing}"
+
+    def test_withhold_leaves_the_standard_sel_record(self, monkeypatch, tmp_path):
+        """Withholding is a permission DECISION — same event, same feed as the
+        other ``allowedTools`` writers (``mcp_auto_approve_withheld``)."""
+        from kiro_crew import agent
+
+        events: list[dict] = []
+        monkeypatch.setattr(
+            agent,
+            "sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        self._install_real(monkeypatch, tmp_path)
+        withheld = [e for e in events if e.get("operation") == "mcp_auto_approve_withheld"]
+        assert withheld, "the floor withhold must leave a SEL record"
+        # The record names what lost its grant, so an operator can explain a prompt.
+        assert any("code" in e.get("resources", "") for e in withheld)
+
+    def test_audit_failure_never_fails_the_install(self, monkeypatch, tmp_path):
+        """Best-effort audit: SEL being unavailable must not break the install."""
+        from kiro_crew import agent
+
+        def _broken_sel():
+            raise RuntimeError("SEL unavailable")
+
+        monkeypatch.setattr(agent, "sel", _broken_sel)
+        data = self._install_real(monkeypatch, tmp_path)
+        assert data["name"] == "kirocrew-research"
+        assert not self._floor_builtins().intersection(data.get("allowedTools", []))
+
 
 # --- Watchdog unresponsive grace ---
 

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -186,6 +186,37 @@ class TestConductorInstaller:
         # the four the test above withholds.
         assert "@kirocrew-dashboard" not in granted
 
+    def test_template_grants_never_leak_into_the_conductor_list(self, tmp_path, monkeypatch):
+        """No-op proof for #7401: the conductor replaces ``allowedTools``
+        wholesale with its own filtered ``granted`` list, so the ceiling filter
+        moving into ``build_agent_config`` changes nothing here — and template
+        grants (filtered or not) can never leak through.
+        """
+        monkeypatch.setattr(agent, "kiro_agents_dir_path", lambda: tmp_path)
+        monkeypatch.setattr(
+            agent,
+            "build_agent_config",
+            lambda: {
+                "name": "kirocrew",
+                "prompt": "file://x",
+                "mcpServers": {
+                    "kirocrew-core": {"command": "/resolved/kirocrew", "args": ["mcp-core"]}
+                },
+                "tools": ["fs_read", "@kirocrew-core"],
+                # A template list carrying floor builtins — as if the build-time
+                # filter did not exist. None of it may survive the replacement.
+                "allowedTools": ["fs_read", "code", "glob", "grep", "@kirocrew-core"],
+            },
+        )
+        monkeypatch.setattr(
+            agent, "_kirocrew_mcp_invocation", lambda sub: ("/resolved/kirocrew", [sub])
+        )
+        monkeypatch.setattr(agent, "_may_auto_approve", lambda ref: True)
+        agent._install_conductor_agent()
+        data = json.loads((tmp_path / CONDUCTOR_AGENT_FILENAME).read_text(encoding="utf-8"))
+        for template_grant in ("fs_read", "code", "glob", "grep"):
+            assert template_grant not in data["allowedTools"], template_grant
+
     def test_mounts_no_tool_the_charter_never_names(self, tmp_path, monkeypatch):
         """An unused grant is surface the charter cannot account for.
 


### PR DESCRIPTION
## Summary

Closes #7401.

`_install_research_agent` derived the `kirocrew-research` spec from `build_agent_config()` and wrote it with no `allowedTools` filtering, so the shipped template's floor-gated builtins (`fs_read`, `code`, `glob`, `grep`) reached `~/.kiro/agents/kirocrew-research.json` on a blanket auto-approve list. `code` is the consequential one: its scope tuple is `("commands", "tools", "filesystem.write")`, so auto-approved `code` calls never reach `hooks.on_tool_call` — the sensitive-path check, the write-protected-config check, the governance ceiling, and the SEL deny record are all skipped for the least-supervised agent in the product (the Research Lab autonudge loop worker). `may_skip_gate` would have refused all four: the `_FLOOR_GATE_SCOPES` check runs before the `ceiling is None` early return, so this holds on governed and ungoverned hosts alike.

## Shape chosen (and why)

**The ceiling filter is folded into `build_agent_config()` itself** (new helper `_apply_allowed_tools_ceiling`, applied to the assembled list before return), so every caller inherits it and the invariant is held by the predicate rather than by each installer's author remembering it. All call sites were checked before choosing this over the narrower per-installer filter:

- `rebuild_agent_config` (fresh build) — the filter is idempotent; the predicate is pure, so filtering twice equals filtering once. **Its own final pass is kept**, because the `_load_existing_config` path takes entries from an on-disk spec that never comes through `build_agent_config()`.
- `_load_existing_config` corrupt/refresh-failure fallbacks — return into `rebuild_agent_config`, covered as above.
- `_install_research_agent` — the fixed gap: it now inherits the filter.
- `_install_conductor_agent` — replaces `allowedTools` wholesale with an already-filtered `granted` list; no-op.

No caller needed the raw template, so the fallback shape was not required.

## No behaviour change on a stock install

The floor withhold removes the **blanket grant only**: the four tools stay mounted in `tools`, and read-only file tools still auto-approve via hooks after the floor runs, so no new prompt appears and the unattended research loop is not handed a stall. This is proven by tests rather than asserted:

- the installed research spec carries no floor-scoped builtin in `allowedTools` (derived from `_FLOOR_GATE_SCOPES` × `BUILTIN_TOOL_SCOPES`, not hardcoded names);
- those tools remain **mounted** in `tools` (the capability-not-removed regression guard);
- the filter is idempotent, so a fresh rebuild's `kirocrew.json` is what it was before (its final pass re-filters the same list through the same pure predicate);
- the conductor's wholesale replacement is pinned immune to template grants.

## SEL audit

A withhold on the research path now leaves the same `mcp_auto_approve_withheld` record every other `allowedTools` writer emits (source `build_agent_config`), best-effort and never fatal — an unavailable SEL cannot fail a build or an install (tested).

## Writer parity (the class fix)

A source-scan parity test walks every Crew-authored spec writer in `agent.py` (`_install_*_agent` + `rebuild_agent_config`) and requires each to derive from `build_agent_config()`, filter through `_may_auto_approve`, or write no `allowedTools` at all — so the next installer cannot silently reintroduce the gap.

## Out of scope (deliberately untouched)

- The ceiling predicate, `_FLOOR_GATE_SCOPES`, `BUILTIN_TOOL_SCOPES`, and the shipped template's `allowedTools` in `config/defaults.json` — the predicate is correct; this is a call-site coverage fix.
- #7339 (PreToolUse hooks fail open) and #6938 (gate misses canonical MCP identity) are the same family but cover gate **execution**, not spec **generation** — not folded in.

## Pattern harvest

Rule candidate: when a security invariant over a generated list is enforced by ONE writer's final pass, every sibling writer that derives the same list is a latent bypass — enforce at the shared constructor and add a writer-parity test over all current and future writers. Pattern: derived-spec installer ships an unfiltered template because the filter lives only in the primary writer (`rebuild_agent_config` filtered, `_install_research_agent` did not).

## Testing

- `isort` / `flake8` / `mypy` / black-baseline gate: clean.
- Full backend suite: 78413 passed; the 13 failures are host-environment (STT optional deps absent, host-CPU xdist budget, one serial-pass async flake) and reproduce identically on clean `main` in the same environment.
- New tests: `test_auto_research.py::TestResearchAgentInstall` (5 governance tests), `test_app_mcp_scoping.py::TestTemplateGrantsAreCeilingFilteredAtBuild` (4 incl. writer parity), `test_conductor_agent.py` (template-leak no-op proof).
