### PR TITLE
fix(build): own electron dep install; sync dev extra pins (#7226)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,11 +72,9 @@ kirocrew gateway             # start server (dashboard + messaging channels)
 The dashboard is at `http://localhost:5476`.
 
 On Windows, `.\make.ps1 build` does steps 2 and 3 in one command (the venv lands
-in `.venv\Scripts\`, and `Activate.ps1` replaces `source .venv/bin/activate`),
-except the `website/electron` sub-package — run
-`npm ci --prefix website/electron` separately before `npm test`. Read the
-[Windows guide](docs/guides/windows-install.md) first — a few features need an
-explicit opt-in there.
+in `.venv\Scripts\`, and `Activate.ps1` replaces `source .venv/bin/activate`).
+Read the [Windows guide](docs/guides/windows-install.md) first — a few features
+need an explicit opt-in there.
 
 **Messaging channels are optional**: the default `kirocrew setup` configures
 none, and the dashboard + CLI work without any channel credentials. Connect

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ frontend:
 	# `cat` exits 1. With `&&` chaining that non-zero exit aborts the whole
 	# recipe line, so the target fails before npm is ever reached. An absent
 	# marker must degrade to "use whatever node is on PATH", not stop the build.
+	# website/electron is its own npm package (website/package.json declares no
+	# `workspaces`), so the website/ install in this recipe never reaches it --
+	# and `npm test` / `npm run check` in website/ then die with MODULE_NOT_FOUND
+	# on its missing deps. Install it in the same shell, so it reuses the
+	# node-bin-dir PATH handling, and AFTER `npm run build`, so the desktop-only
+	# dependency tree cannot block building the dashboard itself (#7226).
 	cd website && \
 	  NBD="$$(cat "$${KIROCREW_HOME:-$$HOME/.kiro/crew}/node-bin-dir" 2>/dev/null || true)"; \
 	  { [ -z "$$NBD" ] || export PATH="$$NBD:$$PATH"; }; \
@@ -34,7 +40,9 @@ frontend:
 	    exit 1; \
 	  fi; \
 	  if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi && \
-	  npm run build
+	  npm run build && \
+	  ( cd electron && \
+	    if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi )
 	rm -rf src/kiro_crew/static/dist
 	mkdir -p src/kiro_crew/static
 	cp -R website/dist src/kiro_crew/static/dist

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -202,7 +202,9 @@ venv puts its executables in `.venv\Scripts\`, and the macOS-only
 
 1. **`frontend`**: `npm ci` (or `npm install`) + `npm run build` in `website/`,
    then copies `website/dist` into `src/kiro_crew/static/dist` so the backend
-   serves the SPA.
+   serves the SPA, and installs `website/electron`'s own deps last — it is a
+   separate npm package the `website/` install never reaches, and `npm test`
+   in `website/` needs it.
 2. **`backend`**: creates `.venv` and runs an editable install with the `dev`
    extra (`pip install -e ".[dev]"`).
 
@@ -362,7 +364,7 @@ Linux, `.\make.ps1 <target>` on Windows.
 | Target | What it does |
 |--------|--------------|
 | `make build` | Frontend (npm/Vite) + backend into `.venv` |
-| `make frontend` | Dashboard only: npm build, staged into `src/kiro_crew/static/dist` |
+| `make frontend` | Frontend only: npm build staged into `src/kiro_crew/static/dist`, plus `website/electron` deps |
 | `make backend` | Backend only: `.venv` + editable install with the `dev` extra |
 | `make wheel` | Self-contained pip wheel with the dashboard bundled, into `dist/` |
 | `make backend-bin` | Frozen standalone backend binary (host arch only) |

--- a/make.ps1
+++ b/make.ps1
@@ -285,6 +285,22 @@ function Invoke-Frontend {
             Invoke-Step $npm @("install", "--no-audit", "--no-fund") "npm install"
         }
         Invoke-Step $npm @("run", "build") "npm run build"
+        # website/electron is its own npm package (website/package.json declares
+        # no `workspaces`), so the install above never reaches it -- and
+        # `npm test` / `npm run check` in website/ then die with MODULE_NOT_FOUND
+        # on its missing deps. Install it here, AFTER the build, so the
+        # desktop-only dependency tree cannot block building the dashboard
+        # itself (#7226).
+        Push-Location "electron"
+        try {
+            if (Test-Path "package-lock.json") {
+                Invoke-Step $npm @("ci", "--no-audit", "--no-fund") "npm ci (electron)"
+            } else {
+                Invoke-Step $npm @("install", "--no-audit", "--no-fund") "npm install (electron)"
+            }
+        } finally {
+            Pop-Location
+        }
     } finally {
         Pop-Location
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -175,6 +175,12 @@ dev =
     isort==6.0.0
     flake8==7.1.0
     mypy==1.14.1
+    # Not a dev TOOL -- see the [dependency-groups] dev rationale in
+    # pyproject.toml: kiro_crew.config.validation imports jsonschema behind a
+    # try/except, so a `.[dev]` install without it silently SKIPS the 11
+    # config-validation guard tests (pytest scores a skip as a pass). Keep the
+    # pin identical to the group's.
+    jsonschema==4.26.0
     PyJWT[crypto]==2.13.0
 
 [options.packages.find]

--- a/test/test_build_target_parity.py
+++ b/test/test_build_target_parity.py
@@ -101,6 +101,59 @@ def test_documented_target_table_covers_every_target() -> None:
     ), f"targets missing from docs/guides/install.md's target table: {undocumented}"
 
 
+def _makefile_recipe(target: str) -> str:
+    """The recipe body of one Makefile target, with comment lines stripped.
+
+    Same reasoning as ``_powershell_code``: the guards asserted below are named
+    in nearby rationale comments, so matching raw text would keep passing after
+    the recipe line itself was deleted.
+    """
+    text = (_REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(target)}:\n((?:\t.*\n)+)", text, re.MULTILINE)
+    assert match, f"Makefile has no recipe for target {target!r}"
+    return "\n".join(
+        line for line in match.group(1).splitlines() if not line.strip().startswith("#")
+    )
+
+
+def test_frontend_target_installs_the_electron_subpackage() -> None:
+    """Both build drivers must install website/electron's own dependencies.
+
+    ``website/electron`` is a separate npm package (``website/package.json``
+    declares no ``workspaces``), so the website/ install step never reaches it.
+    A scripted build that skips it leaves ``npm test`` / ``npm run check`` in
+    website/ dying with MODULE_NOT_FOUND on electron's missing deps -- the gap
+    that made CONTRIBUTING.md grow a manual work-around note, since dropped
+    because the build owns the install (#7226).
+    """
+    recipe = _makefile_recipe("frontend")
+    assert "cd electron" in recipe, (
+        "the Makefile frontend recipe no longer enters website/electron; its "
+        "deps then go uninstalled and `npm test` in website/ breaks"
+    )
+    # Bound the window to the electron subshell: matching the rest of the
+    # recipe would let unrelated npm lines satisfy the assertion after the
+    # electron block itself lost the branch.
+    electron_part = recipe.split("cd electron", 1)[1].split(")", 1)[0]
+    assert "npm ci" in electron_part and "npm install" in electron_part, (
+        "the Makefile frontend recipe must run the ci-vs-install branch inside "
+        "website/electron, mirroring the website/ install step"
+    )
+
+    code = _powershell_code()
+    assert 'Push-Location "electron"' in code, (
+        "make.ps1's Invoke-Frontend no longer enters website/electron; its "
+        "deps then go uninstalled and `npm test` in website/ breaks on Windows"
+    )
+    # Same bound: the rest of make.ps1 has pip `"install"` invocations that
+    # would keep the assertion green after the electron block lost the branch.
+    ps_electron_part = code.split('Push-Location "electron"', 1)[1].split("Pop-Location", 1)[0]
+    assert '"ci"' in ps_electron_part and '"install"' in ps_electron_part, (
+        "make.ps1's Invoke-Frontend must run the ci-vs-install branch inside "
+        "website/electron, mirroring the website/ install step"
+    )
+
+
 def test_powershell_driver_declares_no_posix_only_step() -> None:
     """make.ps1 must not invoke the macOS-only resign step.
 

--- a/test/test_pip_deps_consistency.py
+++ b/test/test_pip_deps_consistency.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import ast
 import configparser
 import pathlib
+import re
 import sys
 
 # --- Dist name -> importable root package mapping ---
@@ -244,6 +245,88 @@ def test_dev_extra_covers_test_imports():
             "test/conftest.py imports it at module scope, so the whole suite "
             f"fails to collect without it. Declared: {declared}"
         )
+
+
+def _dependency_group_requirements(group: str) -> list[str]:
+    """Requirement strings from a pyproject ``[dependency-groups]`` list.
+
+    Text-level, like every other pyproject read in this module: the 3.10 shard
+    has no ``tomllib`` and this gate must run there too. The list items are
+    plain double-quoted strings, so collecting quoted spans between the group's
+    opening ``[`` and its closing ``]`` reads exactly what pip's
+    ``--group`` resolver sees.
+    """
+    lines = _pyproject_text().splitlines()
+    requirements: list[str] = []
+    in_groups = in_list = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_groups = stripped.startswith("[dependency-groups]")
+            continue
+        if in_groups and not in_list:
+            if re.match(rf"{re.escape(group)}\s*=\s*\[", stripped):
+                in_list = True
+            continue
+        if in_list:
+            if stripped.startswith("]"):
+                break
+            match = re.match(r'"([^"]+)"', stripped)
+            if match:
+                requirements.append(match.group(1))
+    return requirements
+
+
+def _pinned_versions(requirements: list[str]) -> dict[str, str]:
+    """Map of normalized dist name -> exact ``==`` pin, ignoring unpinned specs."""
+    pins: dict[str, str] = {}
+    for spec in requirements:
+        if "==" not in spec:
+            continue
+        name, version = spec.split("==", 1)
+        name = name.split("[")[0].strip().lower().replace("_", "-")
+        pins[name] = version.split(";")[0].strip()
+    return pins
+
+
+def test_dev_extra_pins_agree_with_the_dev_dependency_group():
+    """Deps in BOTH the ``dev`` extra and the CI dev group must pin identically,
+    and the import-or-skip test enablers must be in the extra at all.
+
+    The group is what CI installs (``--group dev``); the extra is what
+    CONTRIBUTING.md tells a contributor to install (``.[dev]``). jsonschema and
+    PyJWT are not dev tools -- they are what makes guarded test modules RUN:
+    ``kiro_crew.config.validation`` imports jsonschema behind a try/except, so
+    an install without it silently skips the 11 config-validation guard tests
+    (pytest scores a skip as a pass), and ``test_teams_client.py``'s
+    ``importorskip`` does the same for the Teams token gate. A missing entry
+    means a locally green pytest that never ran those guards; a version skew is
+    quieter still -- both sides run, against different behavior.
+    """
+    group_pins = _pinned_versions(_dependency_group_requirements("dev"))
+    extra_pins = _pinned_versions(_extra_requirements("dev"))
+
+    assert group_pins, "pyproject.toml [dependency-groups] dev declares no == pins"
+
+    # The enablers must be present in the extra, not merely consistent-if-present.
+    for enabler in ("jsonschema", "pyjwt"):
+        assert enabler in extra_pins, (
+            f"setup.cfg [options.extras_require] dev must pin {enabler!r} in sync "
+            "with pyproject's [dependency-groups] dev -- without it a `.[dev]` "
+            "install silently skips the guard tests that import it. "
+            f"Extra pins: {sorted(extra_pins)}"
+        )
+
+    skewed = {
+        name: (extra_pins[name], group_pins[name])
+        for name in extra_pins.keys() & group_pins.keys()
+        if extra_pins[name] != group_pins[name]
+    }
+    assert not skewed, (
+        "setup.cfg dev extra pins disagree with pyproject [dependency-groups] dev "
+        f"(extra, group): {skewed}. The extra's header comment mandates keeping "
+        "them in sync -- bump both in lockstep."
+    )
 
 
 def test_python_requires_agrees_between_pyproject_and_setup_cfg():


### PR DESCRIPTION
## Problem / Motivation

Two setup-ecosystem gaps, both verified on `main`, filed as deliberate follow-ups from the docs-only #7225 (issue #7209):

1. The scripted build never installs `website/electron`'s deps. The Makefile `frontend` target and `make.ps1`'s `Invoke-Frontend` run `npm ci`/`npm install` + `npm run build` in `website/` only. `website/electron` is a separate npm package (`website/package.json` has no `workspaces` key), so after a scripted build, `npm test` / `npm run check` in `website/` fail with `MODULE_NOT_FOUND` on electron's missing deps.
2. The setup.cfg `dev` extra skews from pyproject.toml's `[dependency-groups]` dev group: the group pins `jsonschema==4.26.0` (so the config-validation guard tests actually run), but the extra omits it — a contributor installing `.[dev]` per CONTRIBUTING.md gets a locally green pytest that silently skips the 11 config-validation guard tests.

## Why it matters

Every contributor who follows the documented scripted-build path hits the `MODULE_NOT_FOUND` wall on `npm test`, and every `.[dev]` contributor runs a test suite that quietly proves less than CI does — a skew that hides regressions in the config-validation guards until CI catches them a round later. The extra's own header comment mandates staying in sync with the group.

## What changed (motivation → approach → change)

- **Build owns the electron install.** The Makefile `frontend` recipe now runs the same ci-vs-install branch inside `website/electron`, in the same shell (so it reuses the node-bin-dir `PATH` handling), and `make.ps1`'s `Invoke-Frontend` mirrors it through the existing `Invoke-Step` helper and lockfile branch. In both drivers the electron install runs **after** `npm run build`, so the desktop-only dependency tree cannot block building the dashboard itself.
- **Dev extra re-synced.** `setup.cfg`'s `dev` extra gains `jsonschema==4.26.0`, matching the group's pin exactly and following the `PyJWT[crypto]` precedent (the repo's settled resolution pattern for import-or-skip test enablers).
- **Stopgap doc note dropped.** The CONTRIBUTING.md Windows note added by #7225 (run `npm ci --prefix website/electron` manually) is removed now that the build owns the install — per the issue's own "then the doc note can be dropped again". The manual (non-make) setup steps keep their electron line, since they never go through the build drivers.
- **Docs of record updated.** `docs/guides/install.md`'s `frontend`-step description and target table now match the recipe they document.

## Tests

- `test/test_build_target_parity.py::test_frontend_target_installs_the_electron_subpackage` — both build drivers must enter `website/electron` and run the ci-vs-install branch; assertion windows are bounded to the electron block so unrelated `install` text elsewhere in either driver cannot vacuously satisfy the check. Red on pre-fix code (verified by stash-revert).
- `test/test_pip_deps_consistency.py::test_dev_extra_pins_agree_with_the_dev_dependency_group` — every dist pinned `==` in both the `dev` extra and the `[dependency-groups]` dev group must pin identically, and the import-or-skip enablers (jsonschema, PyJWT) must be present in the extra at all. Text-level pyproject parse so it runs on the 3.10 shard (no tomllib). Red on pre-fix code (verified by stash-revert).

## Manual verification

- `make frontend` run end-to-end on Linux: exits 0, `website/electron/node_modules` present, dashboard staged into `src/kiro_crew/static/dist`.
- `npm run test:electron` in `website/`: 1474 pass / 0 fail resolving electron deps (26 `cancelledByParent` cancellations in `gateway-stop.test.js` are host-env — identical on pristine `main`).
- `make -n frontend` recipe piped through `bash -n`: syntax clean. `make.ps1` not executed locally (no pwsh on this host); the change reuses the file's existing `Invoke-Step`/`Push-Location` shape and CI's Windows shards exercise it.
- Fresh `.[dev]` install brings in `jsonschema 4.26.0`.

## Related Issues

Closes #7226

## Pattern harvest

Rule candidate: review-prompt
Pattern: a build driver that installs a parent npm package but not its non-workspace sub-package leaves test commands broken; any dependency declared in only one of two parallel dependency lists (extra vs group) silently weakens the weaker install path.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
