### PR TITLE
refactor(auto-research): fold watchdog settle loop onto _settle_before_cancellation

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -15,6 +15,7 @@ import threading
 import time
 import uuid
 import weakref
+from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -954,7 +955,11 @@ def _campaign_transition_lock(campaign_id: str) -> asyncio.Lock:
     return lock
 
 
-async def _settle_before_cancellation(task: "asyncio.Task[Any]") -> Any:
+async def _settle_before_cancellation(
+    task: "asyncio.Task[Any]",
+    *,
+    on_settled: "Callable[[asyncio.Task[Any]], None] | None" = None,
+) -> Any:
     """Await *task* and guarantee it SETTLES before cancellation propagates
     out of this coroutine.
 
@@ -964,6 +969,12 @@ async def _settle_before_cancellation(task: "asyncio.Task[Any]") -> Any:
     DELETE interleave and have its directory resurrected by the worker's
     ``mkdir``. Mirrors the shield-and-settle discipline of the terminal
     settlement in the watchdog path.
+
+    When *on_settled* is provided, it is invoked with the now-settled *task*
+    on the cancellation path only — after the settle loop and before the
+    original cancellation is re-raised — so a caller can retrieve and report
+    the worker outcome without letting it replace the shutdown cancellation.
+    When it is None the helper just re-raises the cancellation as before.
     """
     try:
         return await asyncio.shield(task)
@@ -978,6 +989,8 @@ async def _settle_before_cancellation(task: "asyncio.Task[Any]") -> Any:
             except Exception:
                 # The worker failed; the cancellation below still wins.
                 break
+        if on_settled is not None:
+            on_settled(task)
         raise cancelled
 
 
@@ -1479,26 +1492,11 @@ async def _settle_campaign_from_watchdog(
             await _remove_terminating_loop()
             _emit_sse({"type": status.value, "campaign_id": campaign_id})
 
-    settlement = asyncio.create_task(_settle())
-    try:
-        await asyncio.shield(settlement)
-    except asyncio.CancelledError as cancelled:
-        # Status persistence and loop removal are one terminal transition. A
-        # shutdown cancellation after SQLite commits must not leave an active
-        # persisted loop that start() can re-arm for a terminal campaign.
-        while not settlement.done():
-            try:
-                await asyncio.shield(settlement)
-            except asyncio.CancelledError:
-                # Repeated shutdown cancellation must not cancel the cleanup
-                # task or let the watchdog resume its polling loop.
-                continue
-            except Exception:
-                # Retrieve and report the worker failure below without letting
-                # it replace the watchdog's shutdown cancellation.
-                break
+    def _report_terminal_settlement(settled: "asyncio.Task[Any]") -> None:
+        # Retrieve and report the worker failure without letting it replace the
+        # watchdog's shutdown cancellation.
         try:
-            settlement.result()
+            settled.result()
         except asyncio.CancelledError:
             logger.error("auto_research terminal settlement was cancelled")
         except Exception:
@@ -1506,7 +1504,13 @@ async def _settle_campaign_from_watchdog(
             # campaign remains non-terminal and its active loop can retry after
             # restart instead of leaving shutdown stuck in the watchdog loop.
             logger.exception("auto_research terminal settlement failed during shutdown")
-        raise cancelled
+
+    # Status persistence and loop removal are one terminal transition. A
+    # shutdown cancellation after SQLite commits must not leave an active
+    # persisted loop that start() can re-arm for a terminal campaign, so settle
+    # the cleanup task before the cancellation propagates.
+    settlement = asyncio.create_task(_settle())
+    await _settle_before_cancellation(settlement, on_settled=_report_terminal_settlement)
 
 
 async def _watchdog_loop(app: web.Application | None = None) -> None:


### PR DESCRIPTION
## Summary

Folds the watchdog's inline shield-and-settle loop onto the shared `_settle_before_cancellation` helper in `src/kiro_crew/apps/builtins/auto_research/handlers.py`, eliminating the duplication flagged by the Design Review and First Principles Review lanes on #5996. One settle discipline instead of two.

Resolves #7261.

## Changes

- Extended `_settle_before_cancellation(task)` with an optional keyword-only `on_settled: Callable[[asyncio.Task[Any]], None] | None = None`, invoked with the settled task **on the cancellation path only** (after the settle loop, before `raise cancelled`). When `None`, behavior is byte-for-byte identical to before.
- Replaced the inline `while not settlement.done()` re-shield loop and the post-loop `settlement.result()` failure-logging in `_settle_campaign_from_watchdog` with a nested `_report_terminal_settlement` callback passed via `on_settled=`. The two log strings (`logger.error("auto_research terminal settlement was cancelled")`, `logger.exception("auto_research terminal settlement failed during shutdown")`) and comments are preserved verbatim. The shutdown `CancelledError` still always propagates; a worker failure is logged but never replaces the cancellation.
- Added `from collections.abc import Callable`. The pre-existing third call site (`_write_and_persist_cycles`) is unaffected because the new param is keyword-only with a `None` default.

Net: 1 file, +25/-21.

## Testing

Network mode for this session was `INTEGRATIONS_ONLY` (Repository access only), so the full pytest suite could not run in-sandbox (aiohttp/numpy/cryptography and the wider `kiro_crew` package are not installable offline, blocking import/collection of the auto_research test modules).

Host-based verification performed:
- `py_compile` clean on the modified `handlers.py`.
- Static checks: the inline `while not settlement.done` loop is gone; `_settle_before_cancellation` is now called at the watchdog site.
- A standalone harness (copying only the refactored helper with a stub logger) passed all three behaviors: settle-before-cancel; worker failure logged via `logger.exception` yet CancelledError still wins; success-under-cancel logs nothing and still propagates CancelledError.

**Before merge, run the authoritative gate in a network-enabled environment:**
```
pytest test/test_auto_research_onloop_fs.py::TestCancellationSettlesWorker test/test_auto_research.py -k 'settlement or cancellation'
```
`TestCancellationSettlesWorker` covers the None-callback default path; `test_cancellation_propagates_after_status_write_failure` covers the callback failure-logging + cancel-wins branch.