### PR TITLE
fix: gate reset-conversation on the semaphore, atomically with the pop (#5635)

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -475,9 +475,16 @@ Three properties the route holds, each of which fails silently if broken:
   turn on the session with no dashboard task behind it (an inbound channel
   message, which `slot.running` cannot see), a turn mid-write, a plan between
   stages, and children still running after their parent's turn ended.
-  `has_active_turn` inherits the reload route's edge: a turn holding the
-  per-session semaphore before its prompt is in flight is not seen. Matching the
-  sibling is deliberate — two notions of "busy" for one teardown drift apart.
+  The four probes above are best-effort fast paths; the authoritative guard is
+  the fifth, `discard_conversation(..., skip_if_busy=True)`, which probes the
+  per-session SEMAPHORE atomically with the session pop and refuses with the
+  same `turn_in_flight` 409. It closes the edge the fast paths share: a turn
+  holding the semaphore before its prompt is in flight is invisible to
+  `has_active_turn`. This is the same contract the sibling reload route rests
+  on, so the two teardowns keep one notion of "busy". Of the route's refusal
+  paths, only the atomic one emits a SEL `denied` record — it is the sole
+  refusal that occurs after the route has committed to the teardown; the
+  fast-path 409s are pre-checks and stay unlogged, as they are on the sibling.
 
 Authorization is `_app_cancel_denied`, not a slot-ownership check, and that
 distinction is load-bearing: `get_or_create_slot` resolves `linked_session_key`

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3592,11 +3592,17 @@ async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response
     mid-write, a plan between stages, and children still running after their
     parent's turn ended.
 
-    ``has_active_turn`` is the probe the reload route uses for this same teardown,
-    and it inherits that probe's edge: a turn holding the per-session semaphore
-    but not yet having a prompt in flight is not seen. Matching the sibling is
-    deliberate — a second, subtly different notion of "busy" for one teardown is
-    how the two drift apart.
+    The ``has_active_turn()`` check is a best-effort fast path; the
+    authoritative guard is the discard's ``skip_if_busy``, which probes the
+    per-session SEMAPHORE atomically with the session pop (see
+    :meth:`SessionManager.discard_conversation`). The fast path has a known
+    edge — a turn holding the semaphore but not yet having a prompt in flight
+    is invisible to it — and the atomic guard is what closes it, the same
+    contract the sibling reload route rests on, so the two teardowns keep one
+    notion of "busy". Of the refusal paths, only the atomic guard's decline is
+    SEL-recorded (``outcome="denied"``): it is the one refusal that happens
+    after the route has committed to the teardown, while the fast-path 409s
+    are pre-checks and stay unlogged, as they are on the sibling.
 
     The transcript is deliberately left in place, which means the tab still shows
     the earlier messages while the model no longer remembers them. That is the
@@ -3681,9 +3687,28 @@ async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response
     if attached is not None:
         return attached
 
-    await state.sessions.discard_conversation(key, replay=replay)
+    # ``skip_if_busy``: the fast paths above cannot see a turn that holds the
+    # per-session semaphore but has not yet put a prompt in flight (an inbound
+    # channel message between the lease and its first stream event). The discard
+    # probes the semaphore atomically with the session pop, so a turn admitted
+    # after the guards above answered False is refused here instead of being
+    # torn down mid-lease.
+    discarded = await state.sessions.discard_conversation(key, replay=replay, skip_if_busy=True)
+    if not discarded:
+        sel().log_api_access(
+            caller=request.get("app", "") or "dashboard",
+            operation="slot_reset_conversation",
+            outcome="denied",
+            resources=f"slot={name} replay={replay}",
+        )
+        return web.json_response(
+            {"error": "a turn is in flight", "code": "turn_in_flight", "slot": name},
+            status=409,
+        )
     # The fresh conversation will advertise its own model list, so the previous
-    # one's withhold verdict no longer describes this slot.
+    # one's withhold verdict no longer describes this slot. Only on a performed
+    # discard: a refusal above leaves the old conversation (and its verdict) in
+    # place.
     slot.record_model_withheld(None)
     sel().log_api_access(
         caller=request.get("app", "") or "dashboard",

--- a/test/test_chat_slot_reset_conversation.py
+++ b/test/test_chat_slot_reset_conversation.py
@@ -28,7 +28,8 @@ its own state.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -125,7 +126,7 @@ class TestTheReplayParameter:
         assert resp.status == 200
         assert body["replay"] is False
         state.sessions.discard_conversation.assert_awaited_once_with(
-            "dashboard:chat-1-foo", replay=False
+            "dashboard:chat-1-foo", replay=False, skip_if_busy=True
         )
 
     @pytest.mark.asyncio
@@ -180,7 +181,7 @@ class TestItClearsTheRightThing:
         assert status == 200
         assert body["reset"] is True
         state.sessions.discard_conversation.assert_awaited_once_with(
-            "dashboard:chat-1-foo", replay=True
+            "dashboard:chat-1-foo", replay=True, skip_if_busy=True
         )
 
     @pytest.mark.asyncio
@@ -197,7 +198,9 @@ class TestItClearsTheRightThing:
         status, _ = await _post(_make_app(state), "slack_123.456")
 
         assert status == 200
-        state.sessions.discard_conversation.assert_awaited_once_with("slack:123.456", replay=True)
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "slack:123.456", replay=True, skip_if_busy=True
+        )
 
     @pytest.mark.asyncio
     async def test_it_keeps_the_entry_rather_than_deleting_it(self):
@@ -263,7 +266,7 @@ class TestItRefusesWhenItCannotBeSafe:
 
         assert status == 200
         state.sessions.discard_conversation.assert_awaited_once_with(
-            "dashboard:chat-1-foo", replay=True
+            "dashboard:chat-1-foo", replay=True, skip_if_busy=True
         )
 
     @pytest.mark.asyncio
@@ -305,8 +308,66 @@ class TestItRefusesWhenItCannotBeSafe:
 
         assert status == 200
         state.sessions.discard_conversation.assert_awaited_once_with(
-            "dashboard:chat-1-foo", replay=True
+            "dashboard:chat-1-foo", replay=True, skip_if_busy=True
         )
+
+    @pytest.mark.asyncio
+    async def test_a_semaphore_held_turn_with_no_prompt_in_flight_is_refused(self):
+        """The edge every fast path above misses, closed by the atomic guard.
+
+        The channel-message shape: an inbound message on a linked session has
+        acquired the per-session semaphore but not yet put a prompt in flight,
+        so ``has_active_turn()`` answers False and ``slot.running`` is False by
+        construction (no dashboard task exists). Only ``discard_conversation``'s
+        ``skip_if_busy`` — the semaphore probed atomically with the session
+        pop — sees it, and its False return must surface as the same
+        ``turn_in_flight`` 409 the fast paths give, not as a success.
+        """
+        state = _state(_slot("slack_123.456", linked="slack:123.456"), active_turn=False)
+        # Behave like the real primitive against a busy session: refuse when
+        # asked to skip, tear down (losing the leased turn's work) when not.
+        # A mutation dropping ``skip_if_busy=True`` then fails on the 409
+        # itself, not merely on the call signature.
+        state.sessions.discard_conversation = AsyncMock(
+            side_effect=lambda key, *, replay=True, skip_if_busy=False: not skip_if_busy
+        )
+        sel_events: list[dict] = []
+
+        with patch(
+            "kiro_crew.dashboard.chat_handlers.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: sel_events.append(kw)),
+        ):
+            status, body = await _post(_make_app(state), "slack_123.456")
+
+        assert status == 409
+        assert body["code"] == "turn_in_flight"
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "slack:123.456", replay=True, skip_if_busy=True
+        )
+        # The refusal is a decline, not a completed teardown: logging
+        # ``completed`` here would record a reset that never happened.
+        assert [e["outcome"] for e in sel_events] == ["denied"]
+
+    @pytest.mark.asyncio
+    async def test_an_idle_session_still_tears_down(self):
+        """The negative half of the atomic guard: an idle session (semaphore
+        free) is discarded and the route reports the reset it performed."""
+        state = _state(_slot("chat-1-foo"), active_turn=False)
+        state.sessions.discard_conversation.return_value = True
+        sel_events: list[dict] = []
+
+        with patch(
+            "kiro_crew.dashboard.chat_handlers.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: sel_events.append(kw)),
+        ):
+            status, body = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 200
+        assert body["reset"] is True
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:chat-1-foo", replay=True, skip_if_busy=True
+        )
+        assert [e["outcome"] for e in sel_events] == ["completed"]
 
 
 class TestAppScope:
@@ -318,7 +379,7 @@ class TestAppScope:
 
         assert status == 200
         state.sessions.discard_conversation.assert_awaited_once_with(
-            "dashboard:acme-obj-1", replay=True
+            "dashboard:acme-obj-1", replay=True, skip_if_busy=True
         )
 
     @pytest.mark.asyncio
@@ -371,5 +432,5 @@ class TestAppScope:
 
         assert status == 200
         state.sessions.discard_conversation.assert_awaited_once_with(
-            "dashboard:acme-obj-1", replay=True
+            "dashboard:acme-obj-1", replay=True, skip_if_busy=True
         )


### PR DESCRIPTION
## Problem / Motivation

`POST /api/chat/slots/{slot}/reset-conversation` can tear down a session whose turn holds the per-session lease but has not started streaming yet. The route's busy story is `provider.has_active_turn()` plus `slot.running` / `slot._in_stage_execution`, and none of those can see a turn that has acquired the session's `BoundedSemaphore(1)` but not yet put a prompt in flight. The reachable trigger is an inbound channel message on a linked session: it runs with no dashboard task behind it, so `slot.running` is False by construction, and a reset landing between the lease and the first stream event destroys the provider under the leased turn, losing its work.

## Why it matters

Anyone resetting a conversation on a channel-linked slot while a channel message is arriving can silently kill that reply. The sibling reload route already closed this exact edge by moving to the semaphore-authoritative guard; reset-conversation is the one teardown left on the old contract, and its docstring justified that by a parity argument that became factually stale the moment the sibling moved.

## What changed (motivation → approach → change)

Symptom: a teardown gated only on `has_active_turn()` races the lease-to-first-stream window. Root cause: the route never adopted `discard_conversation`'s existing `skip_if_busy` parameter, which probes the semaphore atomically with the session pop (the probe a caller-side pre-check cannot close). Change, one route adopting an existing parameter:

- `api_chat_slot_reset_conversation` now calls `discard_conversation(key, replay=replay, skip_if_busy=True)` and answers a `False` return with the route's existing `turn_in_flight` 409 — no new error code or response shape. The `has_active_turn()` / `running` / `_in_stage_execution` checks stay as cheap fast paths, mirroring the reload route.
- The SEL audit call no longer logs `outcome="completed"` unconditionally: the refusal branch logs `outcome="denied"` (the file's established refusal spelling) instead.
- The route docstring paragraph that described matching the sibling's old `has_active_turn` probe as deliberate is rewritten: the authoritative guard is the semaphore, evaluated atomically with the pop, and `has_active_turn()` is a best-effort fast path — the same wording the reload route uses. The twin paragraph in `docs/system-specs/modules/session.md` is corrected in the same commit (AGENTS.md same-commit spec mandate), including the guard list gaining the atomic refusal as the authoritative fifth entry.
- Out of scope, deliberately: no signature re-plumbing, no polarity change, and the three channel recovery call sites plus the chat_runner escalation are untouched — all four are already correct under the default-off polarity.

Pre-push review: a GPT-charter reviewer (mirroring codex-review.yml) returned no findings; an Opus-charter reviewer (claude-review.yml + AUTOSDE.yaml) returned 0 blocking and 2 advisory findings — the stale spec twin paragraph and the SEL asymmetry across the route's refusal paths — both addressed in this commit (spec corrected; the asymmetry documented in the docstring: only the atomic refusal is post-commitment, the fast-path 409s are pre-checks and stay unlogged, as on the sibling).

## Tests

Extended `test/test_chat_slot_reset_conversation.py`:

- `test_a_semaphore_held_turn_with_no_prompt_in_flight_is_refused` — the channel-message shape: `has_active_turn()` False, `slot.running` False, semaphore held. The busy mock models the real primitive (`side_effect=lambda ...: not skip_if_busy`), so the route must both pass the flag and honor the refusal to get the 409; it also asserts the SEL outcome is `denied`, not `completed`.
- `test_an_idle_session_still_tears_down` — idle session returns 200 `{"reset": true}` and logs `completed`.
- The seven existing call-signature assertions updated for the new kwarg.

Mutation verification: removing `skip_if_busy=True` from the route makes the new test fail semantically (`assert 200 == 409` — the mutated route tears down the leased turn and reports success), then the guard was restored and the suite returned to green (20/20 in the file). The primitive's own semaphore-vs-`has_active_turn` behavior is already locked in by `test/test_session.py::…discard_conversation…` (skip_if_busy True/False matrix), which this PR does not duplicate.

Gates: isort, flake8, mypy clean; diff-scoped suites green. The full suite's pre-existing failures on the dev host (userns EPERM / AF_UNIX path length) reproduce identically on a clean tree at the same base and are unrelated to this diff.

## Manual verification

N/A — unit coverage sufficient: the route contract (guard pass-through, 409 shape, SEL outcomes) and the primitive's atomicity are both unit-locked, and the race window itself is only closable at the primitive, which is unchanged.

## Related Issues

Fixes #5635

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a docstring justifies a weaker guard by parity with a sibling that has since moved to a stronger one — check the cited sibling's current code, not the claim"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
