### PR TITLE
fix(hooks): fail closed when a PreToolUse hook delivers no verdict

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1571,7 +1571,9 @@ The Agents page context window section shows per-session info:
 When `_run_chat` refuses a tool call for a **recoverable, system-side** reason —
 a host-gate policy deny (`hooks.on_tool_call` → `TOOL_DENY`), the read-only
 bash safety gate (`is_read_only_bash` / `unsafe_bash_reason`), or a PreToolUse
-script hook block (`exit 2` → `BLOCKED:<hook>:<stderr>`) — kiro-cli ends the
+script hook block (`exit 2` → `BLOCKED:<hook>:<stderr>`, or any other nonzero
+exit → `BLOCKED:<hook>:<error>`, since only 0 and 2 are verdicts a gate can
+deliver) — kiro-cli ends the
 turn early by emitting the attribution-free marker `Tool uses were interrupted,
 waiting for the next user prompt`. Without recovery, the reason reaches only the
 dashboard pill and SEL audit log, so the model cannot adapt.

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4708,9 +4708,48 @@ async def _run_chat(
                             "text": f"Hook {r.hook_name} BLOCKED: {r.stderr[:100] if r.stderr else 'denied'}",
                         },
                     )
-                elif r.exit_code not in (0, 2) and r.stderr:
-                    # Non-zero, non-block: show warning
-                    logger.warning("Hook %s warning: %s", r.hook_name, r.stderr[:200])
+                elif r.exit_code not in (0, 2):
+                    detail = (r.error or r.stderr or f"exited with code {r.exit_code}")[:200]
+                    if event == HOOK_EVENT_PRE_TOOL_USE:
+                        # Fail closed. A PreToolUse hook has a two-valued
+                        # contract — exit 0 is a delivered allow, exit 2 a
+                        # delivered deny — so every other code means the gate
+                        # did not decide, and for a gate that resolves to deny.
+                        # Treating it as a pass would mean breaking, slowing, or
+                        # deleting the deny hook silently disables the policy it
+                        # enforces. Same shape as the hook-store and
+                        # fire()-raised denials on this path.
+                        #
+                        # This deliberately covers more than the undelivered
+                        # shapes (timeout and crash → -1, unexecutable → 126/127):
+                        # a hook that runs to completion and exits 1 also blocks
+                        # here, where it previously only warned. A hook's own
+                        # uncaught error surfaces as exit 1 too and is
+                        # indistinguishable from a deliberate one, and the exit
+                        # code a failed exec produces is shell- and
+                        # platform-specific (cmd /c yields 9009 or 1 where
+                        # /bin/sh yields 127), so an allowlist of "real" failure
+                        # codes would fail open on Windows for exactly this
+                        # class. The hook store already calls every nonzero
+                        # non-2 exit an error (``last_status = "error"``); this
+                        # branch gives the gate the matching direction.
+                        injected.append(f"BLOCKED:{r.hook_name}:{detail}")
+                        logger.error(
+                            "Hook %s could not deliver a verdict (%s) - blocking tool",
+                            r.hook_name,
+                            detail,
+                        )
+                        state.broadcast_ws(
+                            "activity_event",
+                            {
+                                "slot": slot.key,
+                                "kind": "hook",
+                                "text": f"Hook {r.hook_name} BLOCKED (no verdict): {detail[:100]}",
+                            },
+                        )
+                    elif r.stderr:
+                        # Non-zero, non-block on a non-gating event: warn only.
+                        logger.warning("Hook %s warning: %s", r.hook_name, r.stderr[:200])
         except Exception as exc:
             if event == HOOK_EVENT_PRE_TOOL_USE:
                 logger.warning("Hook fire error during blocking event %s: %s", event, exc)

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -530,6 +530,81 @@ class TestApprovalModes:
         ), msgs
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "label,result_kwargs",
+        [
+            # asyncio.TimeoutError branch of run_script_hook: no exit_code is set,
+            # so the dataclass default (-1) stands and `error` carries the reason.
+            (
+                "timeout",
+                {"exit_code": -1, "error": "Timed out after 3s", "stderr": "", "stdout": ""},
+            ),
+            # Generic exception branch: same shape, exception text on `error`.
+            (
+                "crash",
+                {"exit_code": -1, "error": "boom", "stderr": "", "stdout": ""},
+            ),
+            # /bin/sh could not exec the hook command at all.
+            (
+                "missing binary",
+                {"exit_code": 127, "error": "", "stderr": "", "stdout": ""},
+            ),
+        ],
+    )
+    async def test_auto_approve_blocked_when_pretooluse_hook_delivers_no_verdict(
+        self, tmp_path, label, result_kwargs
+    ):
+        """A PreToolUse hook that cannot render a verdict must fail CLOSED.
+
+        Timeout, crash, and missing-binary all leave an exit code that is neither
+        0 nor 2. Treating those as "no opinion" means slowing, breaking, or
+        deleting a deny hook silently disables the policy it enforces, so the
+        auto-approve path must reject the tool instead of proceeding.
+        """
+        cb = _context_builder(ToolHookResult.auto_approve())
+        hook_store = _make_hook_store()
+        hook_store.fire = AsyncMock(
+            return_value=[MagicMock(hook_name="policy-gate", **result_kwargs)]
+        )
+        state, client = _make_state(tmp_path, context_builder=cb, hook_store=hook_store)
+        slot = _make_slot()
+        _set_stream(client, [_permission_event(), _complete_event()])
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+
+        client.reject_tool.assert_called_once()
+        client.approve_tool.assert_not_called()
+        msgs = _tool_messages(slot)
+        assert any(
+            "hook blocked" in m.get("content", "").lower() for m in msgs
+        ), (label, msgs)
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_allowed_when_pretooluse_hook_exits_zero(self, tmp_path):
+        """Exit 0 is a delivered "allow" verdict and must still approve.
+
+        Pins the fail-closed branch to non-0/2 exits only, so a healthy hook that
+        approves silently is not caught by it.
+        """
+        cb = _context_builder(ToolHookResult.auto_approve())
+        hook_store = _make_hook_store()
+        hook_store.fire = AsyncMock(
+            return_value=[
+                MagicMock(exit_code=0, stdout="", stderr="", error="", hook_name="policy-gate")
+            ]
+        )
+        state, client = _make_state(tmp_path, context_builder=cb, hook_store=hook_store)
+        slot = _make_slot()
+        _set_stream(client, [_permission_event(), _complete_event()])
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+
+        client.approve_tool.assert_called_once()
+        client.reject_tool.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_auto_approve_deny_by_default_on_unexpected_hook_output(self, tmp_path):
         """Non-list/None hook return must reject the tool (deny-by-default)."""
         cb = _context_builder(ToolHookResult.auto_approve())


### PR DESCRIPTION
## Problem / Motivation

A PreToolUse script hook is the policy gate on the dashboard auto-approve path, but every failure mode of the hook *itself* resolved to allow. A hook that exits 2 inside its window blocks correctly; the same hook made slow, killed, or removed stops blocking anything, with no refusal and nothing beyond a log warning.

`run_script_hook`'s `asyncio.TimeoutError` and generic-exception branches return a `ScriptHookResult` with no `exit_code`, so it keeps the dataclass default `-1`; a hook binary the shell cannot exec comes back as `127`. `_fire` converted only exit `0` (inject stdout) and exit `2` (emit a `BLOCKED:` marker) into results — every other code fell into a log-only branch and contributed nothing, so `_pre_tool_hooks_should_block([])` hit the documented empty-list pass-through and the tool proceeded.

## Why it matters

Slowing, breaking, or deleting the deny hook silently disabled the policy it enforces, at the moment enforcement mattered. The reporter hit this wiring an external approval tool behind a preToolUse hook: any decision slower than the hook window — a human reading the command before approving it — was converted into an approval.

Two neighbouring paths on the same branch already fail closed (an uninitialized hook store emits `BLOCKED:system:hook store not initialized`; an exception out of `fire()` rejects via `_reject_hook_error`), so the intent existed — the timeout and crash cases just never reached either one.

## What changed (motivation → approach → change)

Symptom: a timed-out or crashed deny hook approves the tool. Root cause: `_fire` treats "no verdict" and "allow" as the same thing, because both produce an empty results list. Change: for `HOOK_EVENT_PRE_TOOL_USE`, any hook result whose exit code is neither 0 nor 2 now emits a `BLOCKED:<hook>:<detail>` marker, logs at error level, and broadcasts the block to the activity feed — the same shape as the two neighbouring fail-closed paths.

A policy gate has a two-valued contract: exit 0 is a delivered allow, exit 2 is a delivered deny. Any third value means the gate did not decide, and for a gate that must resolve to deny. Exit 0 still approves, so a healthy silent-allow hook is untouched.

The detail string prefers `result.error` (already redacted inside `run_script_hook`) over `stderr`, falling back to the exit code when both are empty — a missing binary produces neither. Non-gating events (`postToolUse`, `userPromptSubmit`, `stop`) keep the previous warn-only behaviour, so nothing outside the gate changes.

This deliberately covers more than the undelivered shapes: a hook that runs to completion and exits 1 now blocks where it previously warned. That breadth is stated in the comment, because it is a behaviour change for an existing warn-style preToolUse hook. It is the right direction — a hook's own uncaught error surfaces as exit 1 and is indistinguishable from a deliberate one, and the exit code a failed exec produces is shell- and platform-specific (`cmd /c` yields 9009 or 1 where `/bin/sh` yields 127), so an allowlist of "real" failure codes would fail open on Windows for exactly this class. The hook store already calls every nonzero non-2 exit an error (`last_status = "error"`); this branch gives the gate the matching direction.

The spec moved with the code: `docs/system-specs/modules/learn-cron-dashboard.md`'s Tool-Refusal Recovery section described only `exit 2` → `BLOCKED:<hook>:<stderr>` and now also names any other nonzero exit. No `CHANGELOG.md` entry — that file holds shipped releases only, so the behaviour change is one for the release editor to pick up rather than something this PR can add.

Scope held deliberately narrow: the subagent / task-runner path (`fire_tool_hooks`) is informational-only by design — the tool is already running when hooks fire and results are discarded — so a preToolUse hook cannot deny there at any exit code or speed. Closing that means moving the hook ahead of execution on the autonomous paths, which is a control-flow change to the autonomous runtime rather than a classification fix. It is tracked on its own in #7547, so merging this and closing #7339 does not lose the tracker for the remaining fail-open path. #7547 also carries the per-hook direction switch the issue names as the escape hatch, and the point at which the verdict predicate is worth hoisting out of `_fire` — with the second caller in hand, the shape of the shared predicate is finally known.

## Tests

- `test_auto_approve_blocked_when_pretooluse_hook_delivers_no_verdict` — parametrized over the three failure shapes from the issue's repro (timeout `exit_code=-1` + `error`, crash `exit_code=-1` + `error`, missing binary `exit_code=127`). Drives the full `_run_chat` auto-approve path and locks in that `reject_tool` is called and the user-facing pill reports the hook blocked.
- `test_auto_approve_allowed_when_pretooluse_hook_exits_zero` — pins the new branch to non-0/2 exits, so a delivered allow is not caught by it.
- Revert-verified: with the `chat_runner.py` change stashed, all three failure-shape cases fail (`reject_tool` called 0 times) and the exit-0 case still passes.

## Manual verification

N/A — unit coverage is sufficient: the tests drive the real `_run_chat` auto-approve path end to end rather than the helper in isolation, and the issue's repro is reproduced as the parametrized failure shapes.

## Related Issues

Fixes #7339

Related: #7547 — the autonomous-path (`fire_tool_hooks`) half, deliberately not closed by this PR.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a security verdict derived from an equality test against a permissive-defaulting field, so an error path that never sets the field reads as "allow" (`exit_code: int = -1` with `blocked = exit_code == 2`, and a `[]` results list meaning both "no hooks" and "the hook died").

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
