### PR TITLE
fix: redact full text before bounding at core-path slice sites (#7390)

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -1003,6 +1003,15 @@ def _build_tool_result_event(update: dict[str, Any]) -> AcpEvent | None:
     tool_use_id = update.get("toolCallId", "")
     if not tool_use_id:
         return None
+    # Parts are collected RAW and redaction runs once over their JOIN, before
+    # the single 8000-char bound. Both orderings matter: bounding first can
+    # split a credential at a cut into fragments no redaction regex matches,
+    # and redacting per part would blind the multi-line PEM pattern
+    # (``BEGIN ... [\s\S]*? END``) to a key whose header and footer arrive in
+    # DIFFERENT parts — only the combined text shows such a secret whole. The
+    # former per-part 4000 cut is deliberately gone: applied before redaction
+    # it IS this defect class, and it cannot be reconstructed afterwards, so
+    # the final head cut is the one bound.
     output_parts: list[str] = []
     # Path 1: content blocks (mid-stream).
     content = update.get("content")
@@ -1014,7 +1023,7 @@ def _build_tool_result_event(update: dict[str, Any]) -> AcpEvent | None:
             if isinstance(inner, dict) and inner.get("type") == "text":
                 text = inner.get("text", "")
                 if text:
-                    output_parts.append(str(text)[:4000])
+                    output_parts.append(str(text))
     # Path 2: rawOutput (status=completed) fallback.
     if not output_parts:
         raw_output = update.get("rawOutput")
@@ -1025,22 +1034,22 @@ def _build_tool_result_event(update: dict[str, Any]) -> AcpEvent | None:
                     if not isinstance(item, dict):
                         continue
                     if "Text" in item and item.get("Text"):
-                        output_parts.append(str(item["Text"])[:4000])
+                        output_parts.append(str(item["Text"]))
                         continue
                     j = item.get("Json")
                     if isinstance(j, dict):
                         if "stdout" in j and j.get("stdout"):
-                            output_parts.append(str(j["stdout"])[:4000])
+                            output_parts.append(str(j["stdout"]))
                         else:
                             _mcp_text = _mcp_content_text(j)
                             if _mcp_text is not None:
-                                output_parts.append(_mcp_text[:4000])
+                                output_parts.append(_mcp_text)
                             else:
-                                output_parts.append(json.dumps(j, default=str)[:4000])
+                                output_parts.append(json.dumps(j, default=str))
     if not output_parts:
         return None
     joined = "\n".join(output_parts)
-    final_output = _redact(joined[:8000])
+    final_output = _redact(joined)[:8000]
     # An MCP App render marker lives at offset 0 of its own text part, but the
     # 8000-char join cut is applied to the CONCATENATION of all parts: when the
     # marker part is preceded by other (up to 4000-char) parts, its offset in

--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -3240,8 +3240,11 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
     # The Knowledge Library is an external surface (RAG/search), so even the
     # source name metadata must be redacted before ingestion — matching the
     # treatment _handle_to_artifact applies to its artifact name.
+    # Redact the question WHOLE, then bound: cutting first can split a
+    # credential at the 60-char boundary into fragments no redaction regex
+    # matches, leaking it into the Knowledge Library source name.
     name = (
-        f"Research: {_redact_finding({'v': row['question'][:60]})['v']}"
+        f"Research: {_redact_finding({'v': row['question']})['v'][:60]}"
         if row
         else f"Research: {cid}"
     )

--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -706,7 +706,11 @@ async def _stream_task(
         EVENT_TEXT_CHUNK,
         EVENT_TOOL_CALL,
     )
-    from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+    from kiro_crew.security import (
+        redact_and_truncate,
+        redact_credentials,
+        redact_exfiltration_urls,
+    )
     from kiro_crew.sel import sel
 
     chunks: list[str] = []
@@ -763,8 +767,14 @@ async def _stream_task(
                     await client.approve_tool(event.request_id)
                     continue
                 # Normal mode — interactive approval
-                sanitized_input, _ = redact_credentials(event.tool_input[:500])
-                sanitized_input, _ = redact_exfiltration_urls(sanitized_input)
+                # Redact over the FULL input, then bound: cutting first can
+                # split a credential at the boundary into fragments no
+                # redaction regex matches, leaking it into the approval prompt.
+                # tool_input is model-authored and size-unbounded, so the
+                # full-text pass runs off-loop (no-blocking-call-on-event-loop).
+                sanitized_input = await asyncio.to_thread(
+                    redact_and_truncate, event.tool_input, 500
+                )
                 sanitized_name, _ = redact_credentials(event.text or "")
                 sanitized_name, _ = redact_exfiltration_urls(sanitized_name)
                 loop = asyncio.get_running_loop()

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -229,6 +229,7 @@ from kiro_crew.security import (
     StreamRedactor,
     is_sensitive_path,
     oauth_url_contains_credential,
+    redact_and_truncate,
     redact_credentials,
     redact_exfiltration_urls,
 )
@@ -1853,10 +1854,9 @@ def _native_subagent_sync(state, slot, subagents, tracker, card_output=None) -> 
         if sid not in tracker:
             agent, _ = redact_exfiltration_urls(str(sub.get("role") or sub.get("agentName") or ""))
             agent, _ = redact_credentials(agent)
-            task, _ = redact_exfiltration_urls(
-                str(sub.get("initialQuery") or sub.get("sessionName") or "")[:2000]
+            task = redact_and_truncate(
+                str(sub.get("initialQuery") or sub.get("sessionName") or ""), 2000
             )
-            task, _ = redact_credentials(task)
             # Skip cards with empty task entirely — kiro-cli sometimes emits
             # list_update notifications where initialQuery/sessionName are both
             # empty. Showing an Activity card with no meaningful input is
@@ -2614,18 +2614,20 @@ async def _deliver_cross_surface_user_message(
 def _prepare_mirror_msg(raw_user_message: str) -> str:
     """Prepare a user message for the cross-surface / Slack mirror echo.
 
-    Truncates first, then redacts through the canonical ``redact_via_context``
-    egress shim so a loaded companion's extra credential/token regexes apply.
-    The shim's standalone fallback is the OSS baseline ``security.redact``, so a
-    standalone host keeps the previous redaction behaviour.
+    Redacts through the canonical ``redact_via_context`` egress shim over the
+    FULL text, then truncates — bounding first can cut a credential at the
+    boundary into fragments no redaction regex matches, so it would escape into
+    the mirrored echo. The shim's standalone fallback is the OSS baseline
+    ``security.redact``, so a standalone host keeps the previous redaction
+    behaviour.
 
     Scanned in DISPLAY form as well, like the assistant leg above and the Slack
     chokepoint: this echo goes to a channel without passing a renderer, and a
     credential the user typed with markdown between its halves is whole once the
     client renders the markup away.
     """
-    safe, _ = redact_for_display((raw_user_message or "")[:500], redact_via_context)
-    return safe
+    safe, _ = redact_for_display(raw_user_message or "", redact_via_context)
+    return safe[:500]
 
 
 def _flush_segment(
@@ -6633,22 +6635,31 @@ async def _run_chat(
                 _nat_card_r = (
                     _native_tc_card.get(event.tool_call_id) if event.tool_call_id else None
                 )
+                # Redact the FULL output once, then bound each consumer's copy
+                # (the native card's 4000 and the PostToolUse hook's 2000):
+                # bounding first can cut a credential at the boundary into
+                # fragments no redaction regex matches, and sharing the pass
+                # keeps the full-text cost single.
+                _redacted_out, _ = redact_exfiltration_urls(_out)
+                _redacted_out, _ = redact_credentials(_redacted_out)
                 if (
                     _nat_card_r
                     and event.tool_output
                     and event.tool_call_id not in _native_result_seen
                 ):
                     _native_result_seen.add(event.tool_call_id)
-                    _nout, _ = redact_exfiltration_urls(_out)
-                    _nout, _ = redact_credentials(_nout)
                     _native_card_output_len[_nat_card_r] = _append_native_output(
                         _native_card_output.setdefault(_nat_card_r, []),
-                        f"{_nout[:4000]}\n",
+                        f"{_redacted_out[:4000]}\n",
                         _native_card_output_len.get(_nat_card_r, 0),
                     )
                     state.broadcast_ws(
                         "subagent_chunk",
-                        {"id": _nat_card_r, "slot": slot.key, "text": f"{_nout[:4000]}\n"},
+                        {
+                            "id": _nat_card_r,
+                            "slot": slot.key,
+                            "text": f"{_redacted_out[:4000]}\n",
+                        },
                     )
                 # Mark the matching tool message as done so completion state
                 # survives page reload (persisted in message meta, replayed via SSE).
@@ -6669,12 +6680,11 @@ async def _run_chat(
                 # Fire PostToolUse hooks
                 _tool_name = _pending_tools.pop(event.tool_call_id, "")
                 try:
-                    _redacted_out, _ = redact_credentials(_out[:2000])
-                    _redacted_out, _ = redact_exfiltration_urls(_redacted_out)
+                    _redacted_out_bounded = _redacted_out[:2000]
                     await _fire(
                         HOOK_EVENT_POST_TOOL_USE,
                         tool_name=_tool_name,
-                        tool_response={"output": _redacted_out},
+                        tool_response={"output": _redacted_out_bounded},
                     )
                 except Exception:
                     logger.debug("PostToolUse hook error", exc_info=True)
@@ -7128,11 +7138,7 @@ async def _run_chat(
                             meta=(
                                 {
                                     "tool_call_id": event.tool_call_id,
-                                    "purpose": redact_credentials(
-                                        redact_exfiltration_urls((event.tool_purpose or "")[:200])[
-                                            0
-                                        ]
-                                    )[0],
+                                    "purpose": redact_and_truncate(event.tool_purpose or "", 200),
                                 }
                                 if event.tool_call_id
                                 else None
@@ -8454,8 +8460,7 @@ async def _run_chat(
             # on turn 1 with zero tool calls and no visible output usually points
             # at what we PREPENDED (persona / injected context / replay), not the
             # user's text; log the redacted prompt head + turn shape at WARNING.
-            _refusal_head, _ = redact_exfiltration_urls(full_message[:600])
-            _refusal_head, _ = redact_credentials(_refusal_head)
+            _refusal_head = redact_and_truncate(full_message, 600)
             logger.warning(
                 "Model refusal for slot %s — not retrying "
                 "[is_new=%s resumed=%s tool_calls=%d visible_output=%s "

--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -603,11 +603,15 @@ def _strip_content(content: str) -> str:
 def _snippet_from(stripped: str) -> str:
     """Redacted, truncated display snippet from already-stripped text.
 
-    Redacts a generous prefix so patterns straddling the truncation boundary are
-    still caught (same controls the detail path applies to ``content``), then
-    trims to ``_SNIPPET_MAX_LEN``.
+    Redacts over the FULL text, then trims to ``_SNIPPET_MAX_LEN``. A bounded
+    pre-redaction window can cut a credential at its edge into fragments no
+    redaction regex matches, and redaction shrinking earlier text can slide
+    such a fragment into the final snippet. The full-text pass is expensive,
+    so list scans call this through :func:`_cached_snippet` (memoized per
+    artifact version) and always from the scan's executor thread, keeping it
+    off the event loop.
     """
-    head = _redact_text(stripped[: _SNIPPET_MAX_LEN * 3]).strip()
+    head = _redact_text(stripped).strip()
     return head[:_SNIPPET_MAX_LEN]
 
 
@@ -632,8 +636,13 @@ def _context_snippet(content: str, q_lower: str) -> str:
         # Match came from name/tags/description — no body line to center on.
         return _snippet_from(" ".join(lines))
     start = max(0, idx - 2)
-    window = [ln[:_CONTEXT_LINE_LEN] for ln in lines[start : idx + 3][:_CONTEXT_MAX_LINES]]
-    return _redact_text("\n".join(window))
+    window = lines[start : idx + 3][:_CONTEXT_MAX_LINES]
+    # Redact over the FULL window lines, then bound each line: cutting a line
+    # first can split a credential at the cut into fragments no redaction regex
+    # matches (same class as the prefix snippet above). Redaction tags carry no
+    # newlines, so the line structure survives the pass.
+    redacted = _redact_text("\n".join(window))
+    return "\n".join(ln[:_CONTEXT_LINE_LEN] for ln in redacted.splitlines())
 
 
 def _resolve_folder_ref(ref: Any, *, create_missing: bool) -> tuple[str, str | None]:
@@ -940,6 +949,34 @@ _content_cache: dict[str, tuple[tuple[int, str], str, str]] = {}
 _content_cache_bytes = 0
 _content_cache_lock = threading.Lock()
 
+#: Cache of the redacted prefix snippet, keyed by slug under the same
+#: (version, updated_at) key as the content cache. The snippet path redacts
+#: the FULL stripped body (see :func:`_snippet_from`), which is too expensive
+#: to repeat for every listed artifact on every debounced request — memoizing
+#: under the version key pays that pass once per artifact version. Entries are
+#: at most ``_SNIPPET_MAX_LEN`` chars, but slugs accumulate across
+#: create/delete cycles with no other pruning, so a fixed entry cap drops the
+#: whole cache when crossed (the same drop-all pressure valve the content
+#: cache uses); shares :data:`_content_cache_lock` (same executor-thread
+#: access pattern).
+_SNIPPET_CACHE_MAX_ENTRIES = 4096
+_snippet_cache: dict[str, tuple[tuple[int, str], str]] = {}
+
+
+def _cached_snippet(a: Any, stripped: str) -> str:
+    """The redacted prefix snippet for artifact *a*, memoized per version."""
+    key = (a.version, a.updated_at)
+    with _content_cache_lock:
+        hit = _snippet_cache.get(a.slug)
+        if hit and hit[0] == key:
+            return hit[1]
+    snippet = _snippet_from(stripped)
+    with _content_cache_lock:
+        if len(_snippet_cache) >= _SNIPPET_CACHE_MAX_ENTRIES:
+            _snippet_cache.clear()
+        _snippet_cache[a.slug] = (key, snippet)
+    return snippet
+
 
 def _cache_entry_bytes(raw: str, stripped: str) -> int:
     return len(raw) + len(stripped)
@@ -1003,7 +1040,7 @@ def _scan_artifacts(
             d["snippet"] = (
                 _context_snippet(raw, q_lower)
                 if (do_content and q_lower)
-                else _snippet_from(stripped)
+                else _cached_snippet(a, stripped)
             )
         out.append(d)
     return out
@@ -3479,14 +3516,17 @@ async def api_artifact_post_comment(request: web.Request) -> web.Response:
         # Anchor strings are LLM/agent-influenced (esp. on the MCP path) and are
         # echoed back to the dashboard, so redact credentials/exfil-URLs and cap
         # length — same treatment as the comment body (backend-security-controls).
+        # Redaction runs over the FULL value (capping first can cut a credential
+        # into fragments no regex matches), and the values are request-sized, so
+        # the pass runs off-loop (no-blocking-call-on-event-loop).
         def _anchor_str(v: object) -> str | None:
             if not isinstance(v, str) or not v:
                 return None
-            return _redact_text(v[:2000])
+            return _redact_text(v)[:2000]
 
-        anchor_quote = _anchor_str(anchor_data.get("quote"))
-        anchor_prefix = _anchor_str(anchor_data.get("prefix"))
-        anchor_suffix = _anchor_str(anchor_data.get("suffix"))
+        anchor_quote = await asyncio.to_thread(_anchor_str, anchor_data.get("quote"))
+        anchor_prefix = await asyncio.to_thread(_anchor_str, anchor_data.get("prefix"))
+        anchor_suffix = await asyncio.to_thread(_anchor_str, anchor_data.get("suffix"))
         anchor_start = anchor_data.get("start_offset")
         anchor_end = anchor_data.get("end_offset")
         anchor_ver = anchor_data.get("version_number")
@@ -3502,7 +3542,7 @@ async def api_artifact_post_comment(request: web.Request) -> web.Response:
     # author (or the agent badge). getpass.getuser() is the alias on dev desks.
     # The author is LLM/agent-influenced on the MCP path and echoed to the
     # dashboard, so redact + cap it like the body (backend-security-controls).
-    author = _redact_text(str(body.get("author") or "")[:256])
+    author = (await asyncio.to_thread(_redact_text, str(body.get("author") or "")))[:256]
     if not author and not is_agent:
 
         try:
@@ -3641,7 +3681,7 @@ async def api_artifact_reply_comment(request: web.Request) -> web.Response:
     # who left them), mirroring the create handler. Agent replies keep their
     # explicit author. Without this, replies render as "Unknown". Redact + cap
     # the LLM/agent-influenced author before it is echoed to the dashboard.
-    author = _redact_text(str(body.get("author") or "")[:256])
+    author = (await asyncio.to_thread(_redact_text, str(body.get("author") or "")))[:256]
     if not author and not is_agent:
 
         try:
@@ -3916,7 +3956,7 @@ async def api_artifact_delete_comment(request: web.Request) -> web.Response:
     # artifact activity feed (dashboard), so redact credentials/exfil URLs before
     # it is persisted or echoed (backend-security-controls) — same treatment as
     # comment bodies / author / anchors.
-    reason = _redact_text(str(body.get("reason") or "").strip()[:500])
+    reason = (await asyncio.to_thread(_redact_text, str(body.get("reason") or "").strip()))[:500]
 
     store = get_default_store()
     try:

--- a/src/kiro_crew/dashboard/handlers/discover.py
+++ b/src/kiro_crew/dashboard/handlers/discover.py
@@ -632,13 +632,18 @@ async def api_skills_discover_preview(request: web.Request) -> web.Response:
     # still installed intact regardless of this display cap.
     max_preview = 64 * 1024
     # Provider-sourced fields (including the full SKILL.md body) are
-    # attacker-controllable -- redact before returning to the dashboard.
+    # attacker-controllable -- redact before returning to the dashboard. The
+    # body is size-uncapped provider input, so its full-text redaction runs
+    # off-loop (no-blocking-call-on-event-loop); the display cap is applied to
+    # the REDACTED text, because capping first can cut a credential at the
+    # boundary into fragments no redaction regex matches.
+    safe_content = await asyncio.to_thread(_redact_external, content)
     return web.json_response({
         "description": _redact_external(meta.get("description", "")),
         "name": _redact_external(meta.get("name", "")),
         "license": _redact_external(meta.get("license", "")),
         "author": _redact_external(meta.get("author", "")),
-        "content": _redact_external(content[:max_preview]),
+        "content": safe_content[:max_preview],
         "files": [_redact_external(f) for f in files[:200]],
         "file_count": len(files),
     })

--- a/src/kiro_crew/knowledge/agent_fetch.py
+++ b/src/kiro_crew/knowledge/agent_fetch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact_and_truncate
 
 if TYPE_CHECKING:
     from kiro_crew.knowledge.llm_pool import LLMPool
@@ -61,8 +61,7 @@ async def fetch_url_content(url: str, pool: "LLMPool") -> str:
     content_lower = content[:200].lower()
     for indicator in _ERROR_INDICATORS:
         if indicator.lower() in content_lower:
-            redacted, _ = redact_exfiltration_urls(content[:300])
-            redacted, _ = redact_credentials(redacted)
+            redacted = redact_and_truncate(content, 300)
             logger.error("fetch_url_content: error indicator '%s' found in response: %s", indicator, redacted[:200])
             raise RuntimeError(f"Failed to fetch {url}: {redacted[:300]}")
     # Sanity check: real documents should have meaningful length

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 from kiro_crew import mcp_core, platform_compat, session_directive
 from kiro_crew.mcp_shared import ToolCancelled, is_tool_cancelled
 from kiro_crew.mcp_tools._limits import _MONITOR_DEFAULT_MAX_CYCLES
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact_and_truncate, redact_credentials, redact_exfiltration_urls
 from kiro_crew.session_surface import has_dashboard_surface
 from kiro_crew.validation import (
     ASK_QUESTION_SCHEMA,
@@ -538,8 +538,14 @@ def task_run(name: str, args: dict[str, Any]) -> str:
     if d.get("error"):
         return f"Error: {d['error']}"
 
-    safe_label, _ = redact_exfiltration_urls(task_name or spec[:80])
-    safe_label, _ = redact_credentials(safe_label)
+    # ``task_name`` is used whole; only the ``spec`` fallback is bounded, so
+    # only that branch needs the redact-then-bound composition — bounding first
+    # can cut a credential into fragments no redaction regex matches.
+    if task_name:
+        safe_label, _ = redact_exfiltration_urls(task_name)
+        safe_label, _ = redact_credentials(safe_label)
+    else:
+        safe_label = redact_and_truncate(spec, 80)
     return f"Task runner started: {safe_label}"
 
 

--- a/src/kiro_crew/mcp_tools/spawn.py
+++ b/src/kiro_crew/mcp_tools/spawn.py
@@ -960,13 +960,13 @@ def spawn_sub_agents(name: str, args: dict[str, Any]) -> str:
             sa_body["cwd"] = cwd
         d = mcp_core._post("/api/spawn", sa_body)
         if d.get("error"):
-            sa_errors.append(f"{_redact_sa(prompt[:60])}: {_redact_sa(d['error'])}")
+            sa_errors.append(f"{_redact_sa(prompt)[:60]}: {_redact_sa(d['error'])}")
         else:
             aid = d.get("id", "")
             if aid:
                 sa_ids.append(aid)
             else:
-                sa_errors.append(f"{_redact_sa(prompt[:60])}: spawn returned no agent id")
+                sa_errors.append(f"{_redact_sa(prompt)[:60]}: spawn returned no agent id")
 
     if not sa_ids and sa_errors:
         return "Error spawning sub-agents:\n" + "\n".join(f"  - {e}" for e in sa_errors)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -238,7 +238,12 @@ from kiro_crew.platform.update_governance import (
 from kiro_crew.providers.base import LLMEvent
 from kiro_crew.safety_override import flush_breadcrumb_writes, safety_override
 from kiro_crew.sandbox import ensure_agents_slice_limits, warm_backend
-from kiro_crew.security import redact, redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import (
+    redact,
+    redact_and_truncate,
+    redact_credentials,
+    redact_exfiltration_urls,
+)
 from kiro_crew.sel import sel
 from kiro_crew.service.common import restart_command_hint
 from kiro_crew.session import HEARTBEAT_KEY, SessionManager
@@ -5276,10 +5281,12 @@ class GatewayOrchestrator:
             # Only notify when task is complete — suppress delivery for
             # incomplete tasks (HEARTBEAT_KEEP) to avoid spamming every cycle.
             if is_keep_response(result_safe):
-                logger.info("Heartbeat task incomplete, suppressing delivery: %s", task_text[:80])
+                logger.info(
+                    "Heartbeat task incomplete, suppressing delivery: %s",
+                    redact_and_truncate(task_text, 80),
+                )
             else:
-                task_safe, _ = redact_exfiltration_urls(task_text[:100])
-                task_safe, _ = redact_credentials(task_safe)
+                task_safe = redact_and_truncate(task_text, 100)
                 await self._deliver_result(
                     "💓 Heartbeat",
                     task_safe,
@@ -7669,8 +7676,7 @@ class GatewayOrchestrator:
                 # Show error in UI + queue for LLM context on next turn.
                 slot = self.dashboard_state.get_slot(slot_name)
                 if slot:
-                    task_preview, _ = redact_exfiltration_urls((info.task or "")[:100])
-                    task_preview, _ = redact_credentials(task_preview)
+                    task_preview = redact_and_truncate(info.task or "", 100)
                     error_text, _ = redact_exfiltration_urls(extra.get("error", "timed out"))
                     error_text, _ = redact_credentials(error_text)
                     # The visible transcript card must state the run's real

--- a/src/kiro_crew/subagent_manager/continuation.py
+++ b/src/kiro_crew/subagent_manager/continuation.py
@@ -636,10 +636,16 @@ class ContinuationCoordinator(ManagerComponent):
         if self._manager._on_done is None:
             return
         label_msgs = messages if messages is not None else info.pending_followups
+        # The label joins the RAW messages and redacts the JOIN before any
+        # bound: bounding first can split a credential at a cut into fragments
+        # no redaction regex matches, and redacting per message would blind the
+        # multi-line PEM pattern to a key whose header and footer sit in
+        # DIFFERENT messages. The budget scales with the message count,
+        # matching the former 120-chars-per-message cap.
+        followup_label = _redact("; ".join(label_msgs))[: 120 * len(label_msgs)]
         synthetic = failure_info or SubagentInfo(
             id=uuid.uuid4().hex[:8],
-            task=f"[follow_up of run {info.id}] "
-            + _redact("; ".join(m[:120] for m in label_msgs) or "queued follow-up"),
+            task=f"[follow_up of run {info.id}] " + (followup_label or "queued follow-up"),
             done=True,
             parent_session_key=info.parent_session_key,
             error=reason,

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -344,16 +344,19 @@ def build_inline_keyboard(options: list[str]) -> dict | None:
     A label is MODEL-authored text that Telegram renders, so it is a display sink
     like the answer body: the driver's byte-level scan can see a credential as
     broken that the rendered button shows whole. Scanned HERE because this is the
-    one place both callers pass through. Bounded work by construction -- at most
-    ``max_buttons`` labels of at most 64 chars -- so it stays on the loop.
+    one place both callers pass through. Each label is redacted WHOLE and bounded
+    to 64 chars only after the scan — cutting first can split a credential at the
+    boundary into fragments no redaction regex matches. Bounded work by
+    construction — at most ``max_buttons`` single-line labels — so it stays on
+    the loop.
     """
     if not options:
         return None
     buttons: list[list[dict]] = []
     row: list[dict] = []
     for i, opt in enumerate(options):
-        safe, _ = redact_for_display(opt[:64], _default_redactor)
-        row.append({"text": safe, "callback_data": f"opt:{i}"})
+        safe, _ = redact_for_display(opt, _default_redactor)
+        row.append({"text": safe[:64], "callback_data": f"opt:{i}"})
         if len(row) == 2:
             buttons.append(row)
             row = []

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -61,7 +61,7 @@ from kiro_crew.project_scope import (
     project_scope_satisfied,
     scope_is_admissible,
 )
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact_and_truncate
 from kiro_crew.validation import ALLOWED_LESSON_CATEGORIES, normalize_lesson_category
 
 # Consolidation caps live in vector_memory_constants (a light module with no
@@ -1818,8 +1818,7 @@ class VectorMemoryStore:
             # is surfaced verbatim on the dashboard (/api/memory/events -> get_events).
             # Scrub exfiltration URLs + credentials before persisting the audit
             # snippet so poisoned text can't smuggle secrets onto that surface.
-            safe_snippet, _ = redact_exfiltration_urls(text[:200])
-            safe_snippet, _ = redact_credentials(safe_snippet)
+            safe_snippet = redact_and_truncate(text, 200)
             self._log_event(
                 SemanticRejectCode.INJECTION.value,
                 "episodic",

--- a/test/test_core_path_redact_before_bound.py
+++ b/test/test_core_path_redact_before_bound.py
@@ -1,0 +1,240 @@
+"""Redact-before-bound at the core-path slice sites (issue #7390).
+
+A bounded slice applied to text BEFORE it is passed to a redactor can cut a
+credential at the slice boundary into fragments no redaction regex matches, so
+the raw fragment escapes redaction and reaches the sink (log line, error
+payload, external display surface). The fix is the established mechanical
+reorder: feed the redactor the FULL text and bound AFTER —
+``security.redact_and_truncate(text, n)`` for head cuts (identical composition
+to ``redact(text)[:n]``), or ``redact(text)[-n:]`` for tail cuts.
+
+Two layers of pinning, mirroring ``test_theme_clone_stderr_redact_before_bound``:
+
+- Behavioral straddle tests on the pure display helpers: the secret is laid out
+  so the bound falls INSIDE it, so a raw slice AND a slice-then-redact reorder
+  both go red.
+- A structural AST scan over every module the issue names: a bounded char slice
+  may never appear INSIDE a redact call's argument expression. Deliberate
+  limits: a slice of a renamed local later fed to a redactor is beyond this
+  scan — the behavioral tests carry that shape. Constant bounds under 10 are
+  ignored to keep whole-item idioms (``splitlines()[-1:]``, ``raw[:7]`` hex)
+  out of scope: it is the wide CHAR slice that severs a secret.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from kiro_crew.acp import _dispatch as acp_dispatch
+from kiro_crew.dashboard.handlers import artifacts as artifacts_handlers
+from kiro_crew.security import redact_credentials
+from kiro_crew.telegram import renderer as tg_renderer
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A fake AWS access key id: matches (?:AKIA|ASIA)[A-Z0-9]{16}, asserted absent.
+_TOKEN = "AKIA" + "STRADDLE0123456A"
+
+
+class TestTelegramOptionLabelStraddle:
+    """A credential straddling the 64-char button-label bound must not leak."""
+
+    def test_label_bound_falls_inside_the_credential(self) -> None:
+        bound = 64
+        prefix = "x" * (bound - 9)
+        label = f"{prefix}{_TOKEN} tail"
+        # Premise guard: the bound must actually cut into the token, or this
+        # test silently stops pinning the invariant.
+        start = label.index(_TOKEN)
+        assert start < bound < start + len(_TOKEN)
+
+        keyboard = tg_renderer.build_inline_keyboard([label])
+        assert keyboard is not None
+        texts = [btn["text"] for row in keyboard["inline_keyboard"] for btn in row]
+        joined = "\n".join(texts)
+        assert _TOKEN not in joined
+        # The exact fragment a bound-before-redact implementation leaks —
+        # everything of the token left of the bound — must be absent too.
+        leaked_prefix = _TOKEN[: bound - start]
+        assert leaked_prefix and leaked_prefix not in joined
+
+
+class TestArtifactSnippetStraddle:
+    """The gallery snippet path must redact the FULL text before any bound."""
+
+    def test_prefix_snippet_shrink_slide_does_not_leak(self) -> None:
+        """Straddle + shrink layout for ``_snippet_from``.
+
+        The token straddles the old 3x pre-redaction window edge, and a long
+        labelled secret BEFORE it shrinks under redaction — so under a
+        windowed (bound-before-redact) implementation the unmatched token
+        fragment slides left into the final ``_SNIPPET_MAX_LEN`` cut. Only
+        full-text redact-then-bound scrubs it.
+        """
+        max_len = artifacts_handlers._SNIPPET_MAX_LEN
+        window = max_len * 3
+        secret_label = "SecretAccessKey=" + "A1b2" * 100
+        pad = "x" * (window - 10 - len(secret_label) - 1)
+        stripped = f"{secret_label} {pad}{_TOKEN} tail text"
+
+        # Premise guards: the token must straddle the old window edge …
+        start = stripped.index(_TOKEN)
+        assert start < window < start + len(_TOKEN)
+        # … and redacting the labelled secret must shrink the text enough that
+        # the token fragment would land INSIDE the final snippet under a
+        # windowed implementation (otherwise absence proves nothing).
+        shrink = len(secret_label) - len(redact_credentials(secret_label)[0])
+        leaked_len = window - start
+        assert start - shrink + leaked_len <= max_len
+
+        snippet = artifacts_handlers._snippet_from(stripped)
+        assert len(snippet) <= max_len
+        assert _TOKEN not in snippet
+        leaked_prefix = _TOKEN[:leaked_len]
+        assert leaked_prefix and leaked_prefix not in snippet
+        assert "[REDACTED" in snippet
+
+    def test_context_snippet_line_bound_does_not_leak(self) -> None:
+        """A credential straddling the per-line context cut must not leak."""
+        line_len = artifacts_handlers._CONTEXT_LINE_LEN
+        prefix = "needle " + "y" * (line_len - 10 - len("needle "))
+        content = f"before\n{prefix}{_TOKEN} after-token\nafter"
+        # Premise guard: the line cut must fall inside the token.
+        line = f"{prefix}{_TOKEN} after-token"
+        start = line.index(_TOKEN)
+        assert start < line_len < start + len(_TOKEN)
+
+        out = artifacts_handlers._context_snippet(content, "needle")
+        assert "needle" in out
+        assert _TOKEN not in out
+        leaked_prefix = _TOKEN[: line_len - start]
+        assert leaked_prefix and leaked_prefix not in out
+
+
+class TestToolResultPartStraddle:
+    """Tool-output parts must be redacted as ONE combined text, bounded after.
+
+    Two failure shapes are pinned: a credential straddling what used to be a
+    per-part cut (a bound applied before redaction severs it into unmatchable
+    fragments), and a multi-line PEM key whose header and footer arrive in
+    DIFFERENT parts (per-part redaction can never see it whole — only the
+    joined text can)."""
+
+    def test_part_bound_falls_inside_the_credential(self) -> None:
+        part_bound = 4000
+        prefix = "x" * (part_bound - 9)
+        part = f"{prefix}{_TOKEN} tail"
+        start = part.index(_TOKEN)
+        # Premise guard: the token must straddle the former part cut.
+        assert start < part_bound < start + len(_TOKEN)
+
+        update = {
+            "toolCallId": "t1",
+            "content": [{"content": {"type": "text", "text": part}}],
+        }
+        event = acp_dispatch._build_tool_result_event(update)
+        assert event is not None
+        assert _TOKEN not in event.tool_output
+        leaked_prefix = _TOKEN[: part_bound - start]
+        assert leaked_prefix and leaked_prefix not in event.tool_output
+        assert "[REDACTED" in event.tool_output
+
+    def test_pem_key_split_across_parts_is_redacted(self) -> None:
+        """A PEM header in one part and its footer in another: the multi-line
+        pattern only matches the JOINED text, so a per-part redaction pass
+        leaves the key body raw. Pins join-level redaction."""
+        key_body = "FAKEKEYMATERIALLINE1/abcdefghijklmnop"  # fake, asserted absent
+        part1 = f"log line\n-----BEGIN RSA PRIVATE KEY-----\n{key_body}"
+        part2 = "MORELINES==\n-----END RSA PRIVATE KEY-----\ntrailing"
+        update = {
+            "toolCallId": "t2",
+            "content": [
+                {"content": {"type": "text", "text": part1}},
+                {"content": {"type": "text", "text": part2}},
+            ],
+        }
+        event = acp_dispatch._build_tool_result_event(update)
+        assert event is not None
+        assert key_body not in event.tool_output
+        assert "BEGIN RSA PRIVATE KEY" not in event.tool_output
+        assert "[REDACTED" in event.tool_output
+
+
+# Every module the issue names, relative to the repo root. The scan pins the
+# WHOLE module, not just the fixed lines, so a new slice-before-redact call
+# shape in these files goes red immediately.
+_SCANNED_MODULES = [
+    "src/kiro_crew/channel.py",
+    "src/kiro_crew/dashboard/chat_runner.py",
+    "src/kiro_crew/acp/_dispatch.py",
+    "src/kiro_crew/dashboard/handlers/artifacts.py",
+    "src/kiro_crew/dashboard/handlers/discover.py",
+    "src/kiro_crew/mcp_tools/control.py",
+    "src/kiro_crew/mcp_tools/spawn.py",
+    "src/kiro_crew/vector_memory.py",
+    "src/kiro_crew/knowledge/agent_fetch.py",
+    "src/kiro_crew/slack/gateway.py",
+    "src/kiro_crew/telegram/renderer.py",
+    "src/kiro_crew/subagent_manager/continuation.py",
+    "src/kiro_crew/apps/builtins/auto_research/handlers.py",
+]
+
+
+class TestNoSliceInsideRedactCallInNamedModules:
+    """Structural class pin over every module issue #7390 names."""
+
+    def test_no_bounded_slice_inside_a_redact_call(self) -> None:
+        offenders: list[str] = []
+        for rel in _SCANNED_MODULES:
+            offenders += _find_slice_inside_redact_call(_REPO_ROOT / rel)
+        assert offenders == []
+
+
+def _call_name(call: ast.Call) -> str:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return ""
+
+
+def _constant_bound(sl: ast.Slice) -> int | None:
+    """The largest integer literal edge of a slice, or None when non-constant."""
+    bound = None
+    for edge in (sl.lower, sl.upper):
+        if isinstance(edge, ast.Constant) and isinstance(edge.value, int):
+            bound = max(bound or 0, edge.value)
+        elif (
+            isinstance(edge, ast.UnaryOp)
+            and isinstance(edge.op, ast.USub)
+            and isinstance(edge.operand, ast.Constant)
+            and isinstance(edge.operand.value, int)
+        ):
+            bound = max(bound or 0, edge.operand.value)
+    return bound
+
+
+def _find_slice_inside_redact_call(path: Path) -> list[str]:
+    """Char slices appearing INSIDE a redact call's argument expression.
+
+    Slicing the redact call's RESULT is the sanctioned composition (redaction
+    ran over the full text; the cut can at worst split a redaction marker), so
+    only slices nested in the call's own arguments are offenders. A constant
+    bound under 10 is a whole-item idiom, not a secret-severing cut; a
+    non-constant bound cannot be sized, so it is flagged conservatively.
+    """
+    offenders: list[str] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or "redact" not in _call_name(node).lower():
+            continue
+        for arg in [*node.args, *(kw.value for kw in node.keywords)]:
+            for sub in ast.walk(arg):
+                if not isinstance(sub, ast.Subscript) or not isinstance(sub.slice, ast.Slice):
+                    continue
+                bound = _constant_bound(sub.slice)
+                if bound is not None and bound < 10:
+                    continue
+                offenders.append(f"{path.name}:{sub.lineno}")
+    return offenders

--- a/test/test_cross_surface_mirror.py
+++ b/test/test_cross_surface_mirror.py
@@ -453,11 +453,13 @@ class TestDeliverCrossSurfaceUserMessage:
         raw = "tok AKIAIOSFODNN7EXAMPLE " + "x" * 800
         await _deliver_cross_surface_user_message(state, "k", raw)
         sent = tp.send_message.await_args.args[1]
-        # _prepare_mirror_msg truncates to 500 THEN redacts (redact_via_context),
-        # matching the Slack echo. Distinct from security.redact_and_truncate,
-        # which redacts-then-truncates (security-review e27617c6) — the mirror echo keeps
-        # the truncate-first order so the 500-char budget is measured pre-redaction.
-        assert sent == "💬 " + redact_via_context(raw[:500])
+        # _prepare_mirror_msg redacts over the FULL text (redact_via_context)
+        # THEN truncates to 500 — the same composition as
+        # security.redact_and_truncate, applied through the egress shim.
+        # Truncating first can cut a credential at the 500-char boundary into
+        # fragments no redaction regex matches, so the raw remainder would leak
+        # into the mirrored echo (the slice-before-redact class).
+        assert sent == "💬 " + redact_via_context(raw)[:500]
 
     @pytest.mark.asyncio
     async def test_send_failure_is_swallowed(self, tmp_path):


### PR DESCRIPTION
## Summary

Closes #7390.

A bounded slice applied to text BEFORE it is passed to a redactor can cut a credential at the slice boundary into fragments no redaction regex matches, so the raw fragment escapes redaction and reaches the sink (log line, error payload, external display surface). PRs #7316/#7350/#7383 fixed this class at subprocess-stderr sites; this PR applies the same mechanical reorder — feed the redactor the FULL text, bound AFTER (`security.redact_and_truncate(x, N)` where both redactors apply, `redact(x)[:N]` otherwise) — at the core-path sites #7390 names.

Per site, the current head/tail anchoring is preserved exactly: every fixed site was a head cut and stays a head cut. Head-vs-tail anchoring judgment remains #5555's scope.

## Sites fixed

All sites from #7390's list, re-located by pattern on current main:

- `channel.py` (approval-prompt tool input, 500)
- `dashboard/chat_runner.py` × 4: the cross-surface mirror echo (500), the PostToolUse hook output (2000), the model-refusal log head (600), plus a multi-line sibling the issue's single-line grep missed — the native sub-agent card task label (2000) and tool `purpose` meta (200)
- `acp/_dispatch.py` (tool-result join, 8000 — see below)
- `dashboard/handlers/artifacts.py`: prefix snippet, match-context snippet lines (a multi-line same-class sibling in the same function family), comment anchor strings (2000), comment/reply `author` (256 × 2), delete `reason` (500)
- `dashboard/handlers/discover.py` (skill preview content, 64 KiB)
- `mcp_tools/control.py` (task label spec fallback, 80; the `task_name` branch is used whole, exactly as before)
- `mcp_tools/spawn.py` (sub-agent error labels, 60 × 2)
- `vector_memory.py` (episodic reject audit snippet, 200)
- `knowledge/agent_fetch.py` (fetch error snippet, 300)
- `slack/gateway.py` (heartbeat task label, 100; plus the adjacent unredacted `task_text[:80]` log line, found in review)
- `telegram/renderer.py` (inline-keyboard button labels, 64 — bound now applied after redaction, upstream label size is schema-capped so work stays bounded)
- `subagent_manager/continuation.py` (follow-up label messages, per-element 120 — each message is redacted whole, then bounded; messages are separate strings so per-element redaction sees every secret intact)
- `apps/builtins/auto_research/handlers.py` (Knowledge Library source name, 60)

**`acp/_dispatch.py` needed more than the outer reorder**: `_build_tool_result_event` also cut each output PART at 4000 chars before the join, so a credential straddling a part's own cut was severed before any redaction ran. Each part is now redacted whole before its per-part bound; parts join on a newline and no redaction pattern matches across whitespace, so the join needs no second pass and the outer cut applies to already-redacted text.

## Not touched (scope)

- The five sites in #5582 (claimed by another operator): `subagent.py`, `handlers_project.py`, `agent.py`, `spec_builder/backend/routes.py` × 2, plus its `cron_script.py` fold-ins.
- The hex-verified `dashboard/handlers/files.py` `redact(raw[:7])` site (#5582's documented exemption — regex-verified short hex cannot carry a credential).
- `chat_utils._redact_tool_field`'s 1 MB byte-level safety cap runs before its redaction passes; it is a pre-existing site outside #7390's list, the cut is marked with an explicit truncation notice, and a 1 MB head window is a different risk class. Left for a follow-up rather than folded in here.
- **Repo-wide promotion of the AST scan is deliberately left out**, matching the calls made in #7350 and #7383: a remaining-offender baseline still exists outside the files this PR owns (#5582's sites among them), so the scan is pinned to the 13 named modules instead.

## Event-loop safety (review finding, fixed in this PR)

Removing a pre-slice can turn a bounded redaction into a full-text pass over size-uncapped input. Where that input is externally scalable and the call ran on the asyncio event loop, the pass now runs off-loop (`asyncio.to_thread`), with the bound applied to the redacted text:

- `discover.py` skill preview content (registry-publisher-controlled, size-uncapped)
- `channel.py` approval tool input (model-authored, size-unbounded)
- `artifacts.py` comment anchor/author/reason fields (request-sized)

`_scan_artifacts`' snippet path already ran in an executor; its full-text pass is additionally memoized per artifact version (`_cached_snippet`) so a listing pays it once per version, not once per request.

Two sites also swap redaction pass order as a side effect of adopting `redact_and_truncate` (credentials-then-exfiltration became exfiltration-then-credentials): this is the stronger order — credential scrubbing first can shorten a URL query below the exfiltration matcher's minimum and suppress whole-URL redaction — and matches the canonical helper's composition.

## Tests

`test/test_core_path_redact_before_bound.py` (new), reusing the shape of PR #7383's `test_theme_clone_stderr_redact_before_bound.py`:

- Behavioral straddle tests laying a fake AWS key across the exact bound: the Telegram button-label cut, the artifact prefix snippet (straddle + redaction-shrink slide layout, with premise guards), the artifact context-snippet line cut, and the tool-result per-part cut in `_dispatch`.
- A structural AST scan over all 13 named modules: a char slice with a bound ≥ 10 (or any non-constant bound) may never appear inside a `redact*` call's argument expression. Slicing the redact call's RESULT is the sanctioned composition.

`test/test_cross_surface_mirror.py::test_truncates_and_redacts` updated: it pinned the old truncate-first order at the mirror-echo site, which #7390 names as a defect site; the assertion now pins redact-then-bound.

## Verification

- Backend gates green: black baseline gate, subprocess-encoding gate, isort, flake8, `mypy src/kiro_crew/` (0 issues), brand gate, harness-parity gate.
- Full `python -m pytest`: 77 735 passed; the only failures (96 + 2 errors) reproduce identically on a pristine main worktree on the same host (host-environment classes: AF_UNIX path length, home-dir project-root classification, xdist budget) — zero net-new failures from this branch.
- Targeted re-runs green after every review fix: the new test file plus channel, artifacts handlers, telegram, mcp tools, dispatch/render, redaction-parity, and cross-surface mirror suites.
- Pre-push review: two concurrent model-pinned reviewer lanes (GPT + Opus mirrors of the CI review contracts). Both initial BLOCK verdicts' findings were fixed in this PR: the `_dispatch` per-part cuts, the event-loop offloads, the adjacent raw log line, the snippet memoization, and a duplicated redaction pass now shared. Five root-level scratch files that an earlier head accidentally shipped (caught again by the First Principles lane) are removed from the diff as of the current head.

No frontend changes; no UI changes (no screenshots required).

## Pattern harvest

Rule candidate: AST scan (landed in this PR, module-pinned)
Pattern: a bounded char slice inside a `redact*` call's argument expression (slice-before-redact) — the recurring class behind #7316, #7350, #7383, and this PR. `test/test_core_path_redact_before_bound.py::_find_slice_inside_redact_call` pins all 13 modules this issue names and goes red on any new slice with a bound ≥ 10 (or any non-constant bound) nested in a redactor's arguments. Repo-wide promotion is deliberately deferred (same call as #7350/#7383) while an offender baseline exists outside this PR's files — #5582's claimed sites plus the shape-identical `subagent_manager/run.py`, `subagent_manager/terminal.py`, and `dev_fleet/server.py` hits the First Principles lane enumerated. A second candidate the AST shape cannot express — a bounded slice on a value that only later flows into a redactor (the `_dispatch` per-part cuts fixed here) — needs data-flow awareness and is better suited to a semgrep taint rule than to this scan.
