### PR TITLE
docs(skills): give the kirocrew-dev family one owner per concern

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -64,6 +64,12 @@ gates the PR; if this skill and CI disagree, CI wins. What this rule adds is
 the worktree-specific gotchas (parallelism, mypy CI-parity, dist ordering),
 not a replacement gate list.
 
+This rule covers **running** the gate and reading its verdict. **Writing** the tests
+it runs — isolation, the five determinism classes, cross-platform traps, residue
+diagnosis, suite speed — is the **writing-tests** skill. Load that one when a test is
+yours to fix; this one stays out of it rather than carrying a second, shorter copy
+that would drift.
+
 Run from the worktree root:
 
 ```bash
@@ -106,14 +112,16 @@ than fixed; if it only fails on your branch, it's yours. Never label a failure
 "known flaky" without that main-vs-branch comparison.
 
 **A confirmed flake is a bug with a root cause, not noise to retry.** Do NOT add a
-rerun, lengthen a `sleep`, or relax an assertion. Read
-`docs/system-specs/common/testing-conventions.md` § Determinism for the five classes
-and the one correct fix for each: seed nondeterministic input, poll instead of
-sleeping, `MagicMock` for sync methods, `await` after `cancel()`, and assert a
-complexity property structurally (identical invocation trace at `n` and `2n`) rather
-than by a timed duration or a tight timed ratio. To find what is
-actually flaky rather than guessing, mine CI instead of the local suite (a real flake
-often will not reproduce on macOS at all):
+rerun, lengthen a `sleep`, or relax an assertion. Once a failure is yours, FIXING it
+is the **writing-tests** skill's concern, not this one — it carries the decision order
+over `docs/system-specs/common/testing-conventions.md` § Determinism, and four of the
+five classes have a fix that looks like the obvious one and is not. Do not act on a
+one-line summary of that list, here or anywhere: pick the class from the symptom
+first.
+
+What this rule keeps is the step before that — deciding whether a red is yours at
+all. To find what is actually flaky rather than guessing, mine CI instead of the
+local suite (a real flake often will not reproduce on macOS at all):
 
 ```bash
 gh run list --workflow=ci.yml --limit 250 --json databaseId,conclusion \
@@ -128,16 +136,12 @@ a ratchet/contract test failing on feature branches is a TRUE POSITIVE, not a fl
 The Windows shards fail far more than Linux, so expect timer-granularity and
 process-semantics causes there.
 
-**Suite speed: profile, don't guess.** At ~56.5k tests, per-test setup cost dominates
-any single slow test. Time one file with `pytest test/test_x.py -n0 -q --no-cov
---durations=10` and compare a candidate fix **back to back** on the same machine
-(`git stash`, run, pop, run), because a loaded host makes an absolute number
-meaningless.
-The recurring wins are an autouse fixture requesting an unused `tmp_path`, a real
-`git` repo rebuilt per test instead of `copytree`d from a session template, and a
-production poll the test never asserts on. After any speedup, mutate the covered
-production code and confirm the test still fails. Full method and measured numbers:
-`docs/system-specs/common/testing-conventions.md` § Keeping the suite fast.
+**Suite speed is not this rule's concern.** If a gate run is slow enough to be the
+problem, the method — profile rather than guess, compare candidates back to back on
+the same host, which fixture shapes actually pay off, and the mutation check that
+proves a faster test still tests — is **writing-tests** § Keep the parallel suite
+fast, over `docs/system-specs/common/testing-conventions.md` § Keeping the suite
+fast. This rule only tells you to run the gate and how to read its verdict.
 
 **mypy must reproduce CI, not just "run".** CI installs `-e ".[voice]" --group
 dev` (mypy pinned in `pyproject.toml` `[dependency-groups] dev`) and does NOT

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -17,6 +17,24 @@ repo_scope: src/kiro_crew
 > the decision order — what to check first, and what the failure looks like when you
 > get it wrong.
 
+## Where this skill stops, and which sibling takes over
+
+This skill owns **authoring** a test: isolation, determinism, cross-platform
+behaviour, diagnosing a residue failure, and suite speed. Three siblings own the
+neighbouring steps, and none of them restates what is here:
+
+| You are doing | Skill |
+|---|---|
+| Writing, fixing, or speeding up a test | **this skill** |
+| Running the build gate in a worktree, and deciding whether a red is yours | **kirocrew-worktree-dev** |
+| Driving a branch to a review-ready PR and through CI | **prepare-pr** |
+| Polling that PR until it is green | **babysit** |
+
+The line that matters most in practice: **kirocrew-worktree-dev** tells you whether a
+failure is yours (re-run it on `origin/main`, mine CI for what is genuinely flaky);
+once it is yours, the fix is here. Do not fix a flake from a summary of the five
+determinism classes — pick the class from the symptom, in Rule 2.
+
 ## The two properties, and why they are one problem
 
 A test must be **hermetic** (no effect that outlives it, anywhere but its own tmp dir)


### PR DESCRIPTION
## Problem / Motivation

The four skills in `builtin_skills/kirocrew-dev/` are meant to own one step each:
`writing-tests` (author a test), `kirocrew-worktree-dev` (run the build gate in a
worktree), `prepare-pr` (drive a branch to a review-ready PR), `babysit` (poll it
until green). Two of those concerns were not actually separated.

`kirocrew-worktree-dev` Rule 2 carried two blocks whose subject is test AUTHORING,
which `writing-tests` owns:

1. The five determinism classes. Rule 2 restated the fixes inline as a one-line
   list ("seed nondeterministic input, poll instead of sleeping, `MagicMock` for
   sync methods, `await` after `cancel()`, and assert a complexity property
   structurally"). `writing-tests` Rule 2 deliberately does NOT restate them,
   because it warns that "four of the five have a fix that looks like the obvious
   one and is not" and sends the reader to the section matching their symptom.
2. Suite speed. Rule 2's "Suite speed: profile, don't guess" block repeated
   `writing-tests` Rule 5 item for item: per-test setup dominates, compare
   candidates back to back with `git stash`, the same three recurring wins (an
   autouse fixture requesting an unused `tmp_path`, a real `git` repo rebuilt per
   test instead of copied from a session template, a production poll the test
   never asserts on), and the mutate-after-speedup check.

Neither file named the other. `writing-tests` had no cross-reference to any sibling
in the family, and no sibling referenced it -- while `babysit`,
`kirocrew-worktree-dev` and `prepare-pr` already cross-reference each other by name.

## Why it matters

The duplication is not symmetric, so it is not merely untidy. An agent that loads
`kirocrew-worktree-dev` to run the gate hits the five-fix summary first and can act
on it without ever loading the skill that says four of those five fixes are traps.
That is the exact failure mode `writing-tests` was written to prevent, and it is
reachable from inside the same skill family.

It is also a drift surface with no ratchet: `docs/system-specs/common/testing-conventions.md`
is the canonical source both files defer to, so any change there now has to be
chased into two skill bodies, and the shorter copy is the one nobody re-reads.

## What changed (motivation -> approach -> change)

Motivation: one concern, one owner, cross-reference instead of copy.

Approach: the split follows what a reader is doing, not which document a fact came
from. Deciding whether a red belongs to your branch is gate-running work, so it
stays in `kirocrew-worktree-dev` (the main-vs-branch re-run, the CI flake-mining
recipe, the ratchet-is-a-true-positive rule, the Windows shard expectation). Fixing
a test once it is yours is authoring work, so it belongs to `writing-tests`. That
line lets both duplicated blocks collapse without losing anything a reader needs at
either location.

Change, in two skill bodies only:

- `kirocrew-worktree-dev` Rule 2 states the boundary once at its head, then replaces
  the inlined five-fix list and the suite-speed block with pointers at
  `writing-tests`. The "is this red mine" triage that was interleaved with the
  five-fix list is kept and now reads as its own step.
- `writing-tests` gains a short "Where this skill stops, and which sibling takes
  over" section: a four-row map of the family, plus the one line that matters in
  practice (worktree-dev tells you whether a failure is yours; the fix is here).
  This makes the cross-reference bidirectional, which is what stops the copy coming
  back.

Deliberately NOT changed: the `repo_scope` frontmatter. `writing-tests` and
`kirocrew-worktree-dev` declare `repo_scope: src/kiro_crew`; `prepare-pr` and
`babysit` do not, and that asymmetry is correct rather than an oversight. The two
scoped skills describe this repository's own conventions and are wrong elsewhere.
`prepare-pr` has a repo-independent core by design (most-specific-wins profile
resolution with a generic fallback, documented in `docs/ci/prepare-pr-portability.md`)
and `babysit` is about `monitor_start`, which is product surface. Adding `repo_scope`
to either would suppress a portable skill in exactly the non-Kiro-Crew sessions its
portability layer serves. Scoping is decided by "does this skill have a
repo-independent core", and by that test the family is already consistent.

## Tests

No new automated test. This is a prose reconciliation inside two skill bodies with
no code path, and the invariant it establishes ("no sibling restates what
`writing-tests` owns") has no mechanical expression in the repo today -- see Pattern
harvest for what would be needed to gate it.

Existing gates that cover this diff, all run locally and green:

- `scripts/check_builtin_skill_scope.py --test` (19 probes) and the real run:
  passed. This is the gate that governs what a shipped skill body may name, and
  `kirocrew-dev/` is exempt structurally as the family for developing this repo.
- `scripts/check_brand_name.py --test` and the diff-scoped real run against the
  merge base: passed, no misspelling of the product name on the added lines.
- `pytest test/test_builtin_skill_scope.py test/test_builtin_skill_packaging.py
  test/test_builtin_skill_sync_safety.py -x -q -n 4`: 100 passed. These are the
  tests that pin the builtin-skill tree's shape, packaging set, and sync safety.

## Manual verification

Read both edited files end to end at their new state to confirm the pointers land on
sections that exist and the surrounding prose still reads in order -- specifically
that Rule 2's flake-triage step and the CI-mining recipe that follows it still
connect after the five-fix list was removed from between them.

Verified the claim the new section makes ("none of them restates what is here") by
grepping the whole family for authoring-side vocabulary (flake, hermetic, xdist,
loadgroup, `tmp_path`, conftest, residue, isolation): after this change
`kirocrew-worktree-dev` retains only gate-running and triage uses, `babysit`'s three
hits are all about not writing a CI red off as flakiness, and `prepare-pr`'s are gate
lists. Also confirmed no test pins the body text of either edited file.

## Related Issues

No GitHub issue. This came out of an advisory first-principles review finding on an
earlier PR that was kept as design material rather than filed: the review read the
family as inconsistently scoped, that half was rebutted with evidence (see the
`repo_scope` note above), and this is the half that survived scrutiny -- a real
duplication with a real reader-facing consequence.

## Pattern harvest

Rule candidate: lint
Pattern: a skill body restates a section that a sibling skill in the same family
declares as its own concern, so the two copies drift and the shorter one wins

A mechanical form is plausible and is the reason this is filed as a candidate rather
than a rule: each `kirocrew-dev` skill's frontmatter already carries a `description`
naming its concern, and both duplicated blocks here pointed at the SAME canonical
document (`testing-conventions.md`) from two different skills. A gate that flags two
skills in one family citing the same canonical section, and asks which one owns it,
would have caught both blocks. It is not written here because the marker set needs an
argument of its own (a shared citation is legitimate when the two skills use it for
different purposes, which is true elsewhere in the tree), and inventing that
threshold inside a docs PR would ship an unratcheted guess.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A -- no code
      change; existing skill gates run and green, listed under Tests)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- this PR is the documentation change
- [x] No secrets, credentials, or internal references in the diff
