### PR TITLE
fix(ci): stop the screenshot gate blaming the PR body for a failed API read

### DIFF
--- a/.github/workflows/screenshot-evidence.yml
+++ b/.github/workflows/screenshot-evidence.yml
@@ -54,7 +54,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -uo pipefail
-          changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- \
+          # A diff this step could not COMPUTE is not a diff that touched
+          # nothing visual. `2>/dev/null || true` collapsed a failed `git diff`
+          # (a base or head object absent after a force-push race, a pruned
+          # base branch) onto the same empty string as "no visual surface
+          # changed", and the gate then skipped its own evidence step -- a
+          # required check reporting green having examined nothing. That
+          # polarity is worse than a false red, so an uncomputable diff fails
+          # loudly and is re-runnable instead.
+          if ! changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- \
             'website/src/components/**' \
             'website/src/pages/**' \
             'website/src/apps/**' \
@@ -63,8 +71,10 @@ jobs:
             ':(exclude)website/src/**/*.test.ts' \
             ':(exclude)website/src/**/*.test.tsx' \
             ':(exclude)website/src/test/**' \
-            ':(exclude)website/src/**/*.d.ts' \
-            2>/dev/null || true)"
+            ':(exclude)website/src/**/*.d.ts')"; then
+            echo "::error::Could not compute the diff between the base and head commits, so this check cannot tell whether a user-visible surface changed. This is a diff failure, not an absence of visual changes -- re-run this job."
+            exit 1
+          fi
           if [ -n "$changed" ]; then
             echo "visual=true" >> "$GITHUB_OUTPUT"
             echo "Visual surfaces touched:"
@@ -93,7 +103,43 @@ jobs:
             exit 0
           fi
 
-          body="$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""' 2>/dev/null || true)"
+          # A body this step could not READ is not a body without evidence.
+          # `2>/dev/null || true` discarded both the error text and the exit
+          # status, so a transient API failure left `body` empty and every
+          # check below missed -- and the step then blamed the description,
+          # telling an author to attach evidence their PR already carried.
+          # The common case is transient, so absorb it here rather than
+          # spending the author's re-run on it: up to three attempts with a
+          # short backoff. A read that never succeeds fails closed (this gate
+          # is required, so an unreadable body must never pass silently) while
+          # naming the read as the cause. A description that is genuinely empty
+          # reads successfully on the first attempt and falls through to the
+          # no-evidence branch, which is correct.
+          body=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if body="$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""')"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR description failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's description from the API after 3 attempts, so the check cannot judge whether it carries evidence. This is a read failure, not missing evidence -- re-run this job."
+            {
+              echo "### Could not read the PR description"
+              echo
+              echo "The API read for this PR's description failed on every attempt, so the"
+              echo "check could not tell whether visual evidence is present. On this"
+              echo "evidence alone there is nothing wrong with the description -- re-run"
+              echo "this job. The failing \`gh api\` output is above this summary in the"
+              echo "step log."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
           # Accept any form that actually renders as an image/video for a
           # reviewer: markdown image, HTML img/video, a committed

--- a/test/test_pr_quality_gates.py
+++ b/test/test_pr_quality_gates.py
@@ -130,7 +130,14 @@ class TestScreenshotEvidenceBodyLogic:
     fixture body, so the waiver semantics are locked by behavior.
     """
 
-    def _run_step(self, tmp_path: Path, body: str, exempt: str = "false"):
+    def _run_step(
+        self,
+        tmp_path: Path,
+        body: str,
+        exempt: str = "false",
+        gh_status: int = 0,
+        fail_first: int = 0,
+    ):
         wf = yaml.safe_load(_read("screenshot-evidence.yml"))
         steps = wf["jobs"]["screenshot-evidence"]["steps"]
         step = next(
@@ -142,14 +149,33 @@ class TestScreenshotEvidenceBodyLogic:
         body_file.write_text(body, encoding="utf-8")
         # `gh api ... --jq '.body // ""'` prints the raw body: stub it with cat.
         # The sentinel proves the stub (not a real gh on PATH) served the call.
+        # `cat` is the last command, so a failed read is the stub's own exit
+        # status -- which the step now reports as a read failure instead of
+        # silently treating the empty body as a description carrying no
+        # evidence. That distinction is what keeps a broken harness from
+        # reporting itself as the gate's verdict.
         sentinel = tmp_path / "gh-stub-invoked"
         gh = tmp_path / "gh"
-        gh.write_text(
-            f'#!/bin/sh\ntouch "{sentinel}"\ncat "{body_file}"\n',
-            encoding="utf-8",
-            newline="\n",
-        )
+        attempts = tmp_path / "gh-attempts"
+        stub = f'#!/bin/sh\ntouch "{sentinel}"\nprintf x >> "{attempts}"\n'
+        if gh_status:
+            # Stand in for an API failure on every attempt (5xx, rate limit).
+            stub += f'echo "gh: could not reach the API" >&2\nexit {gh_status}\n'
+        elif fail_first:
+            # Transient: fail the first N attempts, then serve the body. The
+            # attempt tape doubles as the counter.
+            stub += (
+                f'if [ "$(wc -c < "{attempts}")" -le {fail_first} ]; then\n'
+                '  echo "gh: temporarily unavailable" >&2\n'
+                "  exit 1\n"
+                "fi\n"
+                f'cat "{body_file}"\n'
+            )
+        else:
+            stub += f'cat "{body_file}"\n'
+        gh.write_text(stub, encoding="utf-8", newline="\n")
         gh.chmod(0o755)
+        self._attempts_file = attempts
         summary = tmp_path / "summary.md"
         summary.touch()
         # HERMETIC env, not `**os.environ`. The step's outcome is decided entirely
@@ -219,6 +245,10 @@ class TestScreenshotEvidenceBodyLogic:
         body = "<!-- no-visual-delta -->\n**Why no screenshot:**\n"
         result = self._run_step(tmp_path, body)
         assert result.returncode == 1, result.stdout + result.stderr
+        # Naming the branch is what makes this test mean anything. Exit 1 alone
+        # is also what a body that never arrived produces, so the bare returncode
+        # assertion held whether or not the marker was ever seen and rejected.
+        assert "marker without a justification" in result.stdout, result.stdout
 
     def test_emphasis_opening_justification_waives(self, tmp_path):
         # A reason that opens with markdown emphasis is still a reason.
@@ -238,7 +268,36 @@ class TestScreenshotEvidenceBodyLogic:
     def test_no_marker_no_image_still_fails(self, tmp_path):
         result = self._run_step(tmp_path, "A visual change with no evidence.\n")
         assert result.returncode == 1, result.stdout + result.stderr
-        assert "::error::" in result.stdout
+        # Assert the sentence, not just `::error::`: the step has three error
+        # branches (unreadable body, marker without justification, no evidence)
+        # and only the last one is the verdict under test.
+        assert "carries no screenshot or recording" in result.stdout, result.stdout
+
+    def test_unreadable_body_is_not_reported_as_missing_evidence(self, tmp_path):
+        # A failed API read is not an absent screenshot. The step used to
+        # discard both gh's status and its stderr, so a transient failure left
+        # the body empty and the run told the author their description carried
+        # no evidence -- sending them to fix a description that was already
+        # correct. It must still fail closed (this gate is required) while
+        # naming the read as the cause.
+        body = "![shot](https://example.test/x.png)\n"
+        result = self._run_step(tmp_path, body, gh_status=1)
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Could not read this PR's description" in result.stdout, result.stdout
+        assert "carries no screenshot or recording" not in result.stdout, result.stdout
+        # Pin the retry budget: a read that never succeeds is attempted three
+        # times and then gives up, rather than once or forever.
+        assert self._attempts_file.read_bytes() == b"xxx", self._attempts_file.read_bytes()
+
+    def test_transient_read_failure_is_absorbed_by_the_retry(self, tmp_path):
+        # The failure class this gate trips on is transient, so a first-attempt
+        # 5xx must not cost the author a manual re-run: the retry reads the
+        # body on a later attempt and the gate judges the real description.
+        body = "![shot](https://example.test/x.png)\n"
+        result = self._run_step(tmp_path, body, fail_first=1)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Visual evidence found" in result.stdout, result.stdout
+        assert self._attempts_file.read_bytes() == b"xx", self._attempts_file.read_bytes()
 
     def test_image_in_body_still_passes(self, tmp_path):
         result = self._run_step(tmp_path, "![shot](https://example.test/x.png)\n")
@@ -260,6 +319,79 @@ class TestScreenshotEvidenceBodyLogic:
         result = self._run_step(tmp_path, "no evidence at all", exempt="true")
         assert result.returncode == 0, result.stdout + result.stderr
         assert "'no-screenshots' label present" in result.stdout
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="the detection step runs under bash on ubuntu-latest",
+)
+class TestScreenshotEvidenceSurfaceDetection:
+    """Execute the real surface-detection step with ``git`` stubbed.
+
+    This step decides whether the evidence step runs at all, so a wrong
+    ``visual=false`` is a silent bypass of a required gate rather than a
+    visible failure. The cases below pin which of the two empty results --
+    "nothing visual changed" and "the diff could not be computed" -- produced
+    the answer.
+    """
+
+    def _run_detect(self, tmp_path: Path, git_stdout: str = "", git_status: int = 0):
+        wf = yaml.safe_load(_read("screenshot-evidence.yml"))
+        steps = wf["jobs"]["screenshot-evidence"]["steps"]
+        step = next(
+            (s for s in steps if s.get("name") == "Detect user-visible frontend changes"),
+            None,
+        )
+        assert step is not None, "step 'Detect user-visible frontend changes' not found"
+        git = tmp_path / "git"
+        if git_status:
+            body = f'echo "fatal: bad object" >&2\nexit {git_status}\n'
+        else:
+            body = f'printf %s "{git_stdout}"\n'
+        git.write_text(f"#!/bin/sh\n{body}", encoding="utf-8", newline="\n")
+        git.chmod(0o755)
+        outputs = tmp_path / "outputs.txt"
+        outputs.touch()
+        env = {
+            # tmp_path first so the `git` stub wins the lookup.
+            "PATH": f"{tmp_path}{os.pathsep}/usr/local/bin{os.pathsep}/usr/bin{os.pathsep}/bin",
+            "LC_ALL": "C",
+            "BASE_SHA": "1111111111111111111111111111111111111111",
+            "HEAD_SHA": "2222222222222222222222222222222222222222",
+            "GITHUB_OUTPUT": str(outputs),
+            "TMPDIR": str(tmp_path),
+        }
+        result = subprocess.run(
+            ["bash", "-c", step["run"]],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        return result, outputs.read_text(encoding="utf-8")
+
+    def test_visual_path_sets_visual_true(self, tmp_path):
+        result, outputs = self._run_detect(tmp_path, git_stdout="website/src/components/Foo.tsx\n")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "visual=true" in outputs, outputs
+
+    def test_no_visual_path_sets_visual_false(self, tmp_path):
+        result, outputs = self._run_detect(tmp_path, git_stdout="")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "visual=false" in outputs, outputs
+
+    def test_uncomputable_diff_fails_instead_of_skipping_the_gate(self, tmp_path):
+        # The failure this pins: a failed `git diff` used to be swallowed into
+        # the same empty string as "nothing visual changed", so the step wrote
+        # visual=false, the evidence step's `if:` went false, and a REQUIRED
+        # check reported green having examined nothing. Failing open on a gate
+        # is worse than a false red, so the diff failure must surface.
+        result, outputs = self._run_detect(tmp_path, git_status=128)
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Could not compute the diff" in result.stdout, result.stdout
+        assert "visual=false" not in outputs, outputs
 
 
 class TestCrossPlatform:


### PR DESCRIPTION
## Problem / Motivation

Both steps of the Screenshot Evidence gate read something fallible and discard
the failure:

```
changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- ... 2>/dev/null || true)"
body="$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""' 2>/dev/null || true)"
```

`2>/dev/null || true` collapses "the read failed" and "the read is legitimately
empty" into one value before anything examines it, so each step reports the
wrong one of the two -- in opposite directions, both wrong.

**The body read blames the author.** A transient API failure leaves `body`
empty, all three pattern checks miss, and the step reports:

    ::error::This PR changes a user-visible frontend surface but its
    description carries no screenshot or recording.

The description was never read, so that is not a finding about it. The remedy
it implies (edit the description) is wrong; the one that works (re-run) is not
mentioned.

**The surface detection fails open.** A failed `git diff` -- a base or head
object absent after a force-push race, a pruned base branch -- collapses onto
the same empty string as "no visual surface changed". The step writes
`visual=false`, the evidence step's `if:` goes false, and this **required**
check reports green having examined nothing. On a gate that polarity is worse
than a false red.

The same conflation reached the tests. `TestScreenshotEvidenceBodyLogic` runs
the real step with `gh` stubbed; when a fixture body failed to arrive, every
case collapsed onto the no-evidence branch, so two cases held whether or not
the branch under test ever ran:

| test | assertion | an unread body also produces it |
| --- | --- | --- |
| `test_empty_justification_does_not_waive` | `returncode == 1` | yes |
| `test_no_marker_no_image_still_fails` | `"::error::" in stdout` | yes |

The cases expecting exit 0 do fail on an unread body, but with `result.stdout`
as the message -- so the failure reads as a gate verdict about the fixture
rather than as a broken stub. That is how this surfaced: an intermittent red on
`test_marker_with_justification_passes_with_warning` whose message pointed at
gate logic that was not the cause.

## Why it matters

For a contributor the body-read error is a false instruction on a required
gate: edit a description that was already correct, and the fix that works is
the one thing the message does not suggest. A blocked PR plus a wasted round
trip.

The detection failure is the more serious direction. It cannot be noticed --
there is no red to investigate, just a green check on a PR whose visual change
was never examined. A gate that fails open is worse than no gate, because it is
trusted.

For this repo's own CI, two of the waiver-semantics cases were not pinning
their branches. The marker waiver is a self-service bypass of a required gate;
`test_empty_justification_does_not_waive` is what stops a bare
`**Why no screenshot:**` from waiving it, and it would have stayed green if
that check regressed, as long as the step exited 1 for any reason.

## What changed (motivation -> approach -> change)

Symptom: a red gate naming the description, and a green gate that examined
nothing. Root cause in both: a fallible read whose failure is erased into the
same value as a legitimate empty result. So the change restores that
distinction at each read, and the tests stop accepting a verdict that could
have come from either.

Body read (`gh api`): retried up to three times with a short backoff, because
the failure class this gate trips on is transient and absorbing it is cheaper
than spending the author's re-run. A read that never succeeds exits 1 naming
the read, and gh's stderr now reaches the step log. It still fails closed --
this gate is required, so an unreadable body must never pass. A description
that reads successfully and is genuinely empty is untouched and still reaches
the no-evidence branch, which is the correct verdict for it.

Surface detection (`git diff`): an uncomputable diff exits 1 naming the diff
rather than writing `visual=false`. Re-runnable, and it can no longer skip the
gate it guards.

Tests: both weak cases now assert the message of the branch they are about.
`_run_step` grew `gh_status` (fail every attempt) and `fail_first` (fail N then
serve), so the retry budget and the transient-absorbed path are both pinned by
behaviour rather than by reading the loop. A new
`TestScreenshotEvidenceSurfaceDetection` class executes the detection step with
`git` stubbed, pinning which of the two empty results produced its answer. No
new `grep` enters the evidence step, so the here-string ratchet's "exactly
three body checks" still holds.

## Tests

`pytest test/test_pr_quality_gates.py -k ScreenshotEvidence -n 4` -> 22 passed
(17 before). Whole file: 57 passed. flake8 / black / isort clean on the touched
test file; the workflow parses as YAML.

- `test_uncomputable_diff_fails_instead_of_skipping_the_gate` (new) -- `git`
  exits 128: the step exits 1, names the diff, and writes no `visual=false`.
- `test_visual_path_sets_visual_true` / `test_no_visual_path_sets_visual_false`
  (new) -- the two success paths still resolve as before, so the change above
  is a new branch and not a rewritten verdict.
- `test_unreadable_body_is_not_reported_as_missing_evidence` (new) -- every
  attempt fails: exit 1, the error names the read, the missing-evidence
  sentence is absent, and the attempt tape reads exactly three.
- `test_transient_read_failure_is_absorbed_by_the_retry` (new) -- first attempt
  fails, second serves the body: exit 0 on the real description, two attempts.
- `test_empty_justification_does_not_waive` -- now also asserts
  `marker without a justification`, so it fails unless the marker was seen and
  its empty justification rejected.
- `test_no_marker_no_image_still_fails` -- now asserts the no-evidence
  sentence, so it cannot be satisfied by either of the other two error
  branches.

Mutation verification, all three new behaviours run against the pre-fix
workflow (`da28c697f`): 3 failed / 19 passed, each failing with the bug's own
text -- the two body-read cases with
`::error::This PR changes a user-visible frontend surface...` and the detection
case with `No user-visible frontend surface touched.` Separately, mutating the
harness to serve an empty body reds `test_empty_justification_does_not_waive`,
which passed under its previous `returncode == 1` assertion.

## Manual verification

Ran the extracted evidence step under stub variants against the pre-fix and
fixed workflow to confirm which branch each one reaches:

| stub | pre-fix | fixed |
| --- | --- | --- |
| serves marker + justification | exit 0, waiver warning | unchanged |
| serves marker, empty justification | exit 1, `marker without a justification` | unchanged |
| serves prose, no evidence | exit 1, `carries no screenshot or recording` | unchanged |
| succeeds, empty output | exit 1, `carries no screenshot or recording` | unchanged (correct: an empty description has no evidence) |
| fails every attempt | exit 1, `carries no screenshot or recording` | exit 1, `Could not read this PR's description` |

Only the last row changes. The `EXEMPT=true` label path exits before the read
and is unaffected (`test_label_waiver_unchanged`).

## Related Issues

No GitHub issue: carried as local backlog finding `f-20260818-16`
("`test_marker_with_justification_passes_with_warning` fails intermittently in
CI while passing locally"). The intermittency itself was the
`printf | grep -q` SIGPIPE misreport fixed in #5857 (0952dd115); what remained
was the misdiagnosis that made it unreadable, which is what this removes.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a fallible read whose failure is swallowed into the same value as a
legitimate empty result, so downstream logic confidently reports the wrong one
of two causes. `x="$(cmd ... 2>/dev/null || true)"` in a gate script is the
shell shape. Both instances in this file had it and they failed in opposite
directions, which is the point: the polarity depends on what the empty value
happens to mean downstream, so it cannot be reasoned about from the read site
alone. The question worth asking of any gate is what it reports when its input
could not be obtained, and whether a green there means "checked and fine" or
"never checked".

The paired test smell travels with it: when one branch is what a degraded input
falls through to, a test for a *different* branch that asserts only an exit
status or a shared prefix (`::error::`) passes without ever reaching its branch.

Scope note: `2>/dev/null || true` appears 57 times under `.github/workflows/`.
Both instances in this file are fixed here. The remaining verdict-feeding ones
that First Principles counted -- `first-principles-review.yml:160`,
`fork-first-principles-review.yml:312`,
`disposition-deferral-check.yml:64-65` -- are left alone deliberately: each
needs its own judgement about what failing closed means for that gate, and
folding three unrelated workflows into this PR would make it unreviewable.
