### PR TITLE
fix(platform): gate installed_context() callers instead of trusting prose

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -102,11 +102,22 @@ Core code reads adapters directly when it has the context, or via
 
 `installed_context()` returns the INSTALLED context or `None` as a bare
 attribute read — it never resolves, never raises, and does no I/O. Use it ONLY
-where the answer for "no context" is already the conservative one (the
-exempt-host lookup below is the one such caller), because it skips the config
-load and entry-point discovery that `current_context()` performs on every call
-while unbooted. A caller that must honour a companion's policy has to go through
-`current_context()` and take the fail-closed `PlatformCompositionError`.
+where the answer for "no context" is already the conservative one, because it
+skips the config load and entry-point discovery that `current_context()`
+performs on every call while unbooted. A caller that must honour a companion's
+policy has to go through `current_context()` and take the fail-closed
+`PlatformCompositionError`.
+
+Whether the no-context answer is conservative is a property of the CALLER, so
+the accessor cannot check it and this paragraph cannot enforce it — while it was
+the only guard, the caller set grew from one to three and the sentence here still
+said "the one such caller". Every call site is therefore declared in
+`context.PEEK_CALLERS` with that reason, and `test_platform_cpp_seam_coverage.py`
+fails the build on an undeclared peek AND on an entry whose call site is gone.
+Today's three: the exempt-host lookup (below), `redact_log_via_context` (above),
+and `governance.active_policy_distribution`. The gate is a review forcing
+function, not a proof — it cannot verify that a written justification is true,
+only that one was written where a reviewer will read it.
 
 ## Boot sequence
 

--- a/src/kiro_crew/platform/context.py
+++ b/src/kiro_crew/platform/context.py
@@ -417,6 +417,67 @@ def set_context(ctx: PlatformContext) -> None:
     _install(ctx)
 
 
+# ── Declared no-I/O peek callers ──
+#
+# ``installed_context()`` is the one context accessor that does NOT take the
+# fail-closed path: where ``current_context()`` refuses to compose open-source
+# defaults on a non-standalone host, the peek simply answers ``None``.  That is
+# safe only where the no-context answer is already the conservative one — and
+# that is a property of the CALLER, not of this function, so the function cannot
+# check it.
+#
+# For a while nothing did.  The contract lived in the docstring below and in
+# ``docs/system-specs/modules/platform-context.md``, and the caller set grew from
+# one to three with nothing objecting — the spec sentence naming "the one such
+# caller" was still describing a set of three.
+#
+# So the caller set is declared HERE and gated by
+# ``test_platform_cpp_seam_coverage.py``, the same declared-map-plus-AST-scan
+# shape :data:`RESERVED_SLOTS` uses, rot-proof in both directions:
+#
+#   1. Every call site of ``installed_context()`` in the package must appear in
+#      this map.  A new peek fails the build until its author writes down why ITS
+#      no-context answer is conservative — the review question the docstring
+#      could only ask politely.
+#   2. Every entry must still have a real call site.  A caller that is deleted or
+#      renamed takes its entry with it, so the map cannot decay into a list of
+#      permissions nobody exercises.
+#
+# The gate is a forcing function, not a proof: it cannot verify that a written
+# justification is TRUE.  What it removes is the silent path — adding a peek now
+# costs a diff to the very file whose fail-closed contract is being bypassed, and
+# every justification lands in front of a reviewer.
+#
+# Keys are ``"<path under src/kiro_crew>::<enclosing function>"``.  Each value
+# must contain the phrase ``no-context answer`` so the justification is greppable
+# and cannot dodge the question it exists to answer.
+PEEK_CALLERS: "dict[str, str]" = {
+    "security.py::_exempt_exact_hosts": (
+        "no-context answer is the empty exempt-host set, which means MORE "
+        "redaction: every host runs the base64-blob / query-length heuristics. "
+        "The lookup can only ever RELAX those heuristics, never the hard-"
+        "credential floor, so an absent context cannot be the reason a "
+        "credential survives — it is stricter than any companion-supplied "
+        "exemption list could be."
+    ),
+    "platform/context.py::redact_log_via_context": (
+        "no-context answer is the full OSS baseline redaction pass, which is "
+        "byte-for-byte what each of these log sites did before adopting the "
+        "helper. Nothing in that state evidences a companion whose policy is "
+        "being skipped; the genuine downgrade case — a context IS installed and "
+        "its policy failed to compose — is handled separately by withholding "
+        "the line's text (LOG_WITHHELD_PLACEHOLDER)."
+    ),
+    "platform/governance.py::active_policy_distribution": (
+        "no-context answer is an unconfigured PolicyDistribution, i.e. no "
+        "central fetch. It is reached only when boot never installed a context, "
+        "and then this process holds no ceiling to refresh and runs no refresher "
+        "against one; it is also exactly what this function's own except-branch "
+        "returns, so the peek cannot produce an answer its error path would not."
+    ),
+}
+
+
 def installed_context() -> Optional[PlatformContext]:
     """The INSTALLED context, or ``None``. Never resolves, never raises, no I/O.
 
@@ -431,6 +492,11 @@ def installed_context() -> Optional[PlatformContext]:
     Use this ONLY where the no-context answer is already the conservative one.
     A caller that must honour a companion's policy has to go through
     ``current_context()`` and take the fail-closed error.
+
+    Every call site must be declared in :data:`PEEK_CALLERS` with the reason its
+    no-context answer is conservative; ``test_platform_cpp_seam_coverage.py``
+    fails the build on an undeclared peek, and on a declaration whose call site
+    is gone.
     """
     return _ACTIVE
 

--- a/test/test_platform_cpp_seam_coverage.py
+++ b/test/test_platform_cpp_seam_coverage.py
@@ -28,6 +28,14 @@ individual methods on fields that are otherwise live (today: the unread
 Consumption sites are discovered by **static analysis of the real source tree**
 (``ast``), not from a hand-maintained list — a list would itself rot. See
 :func:`_find_seam_reads`.
+
+The same shape guards the one accessor that opts OUT of the fail-closed contract.
+``context.installed_context()`` answers ``None`` instead of refusing to compose,
+which is safe only where the caller's no-context answer is already the
+conservative one — a property of the CALLER, so the function cannot check it.
+Every call site must appear in ``context.PEEK_CALLERS`` with that reason
+(:class:`TestInstalledContextPeeks`), and an entry whose call site is gone fails
+too, so the map cannot outlive the callers it permits.
 """
 
 from __future__ import annotations
@@ -36,7 +44,7 @@ import ast
 import dataclasses
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 import pytest
 
@@ -53,6 +61,7 @@ from kiro_crew.platform import (
 from kiro_crew.platform.context import (
     _RESERVED_DEFAULT_ADAPTERS,
     _RESERVED_WARNED,
+    PEEK_CALLERS,
     PlatformContext,
     _reserved_slot_is_default,
 )
@@ -197,6 +206,100 @@ def _find_method_reads(field_names: Set[str]) -> Dict[str, List[str]]:
                     f"{_rel(path)}:{node.lineno}"
                 )
     return method_reads
+
+
+# ── installed_context() peek discovery ──
+#
+# The peek scan differs from the seam scan above in one deliberate way: it does
+# NOT exclude ``platform/``. A seam READ inside the platform package is plumbing,
+# but a peek inside it is a real bypass of the module's own fail-closed contract
+# (``redact_log_via_context`` and ``governance.active_policy_distribution`` are
+# both in there), so excluding the directory would hide two of today's three
+# callers and make the gate pass while permitting exactly what it forbids.
+_PEEK_FUNC = "installed_context"
+
+
+def _peek_scanned_files() -> List[Path]:
+    """Every ``.py`` under ``src/kiro_crew`` except vendored third-party source."""
+    return [
+        path
+        for path in sorted(_SRC_ROOT.rglob("*.py"))
+        if "_vendor" not in path.relative_to(_SRC_ROOT).parts
+    ]
+
+
+def _module_key(path: Path) -> str:
+    """``src/kiro_crew/platform/context.py`` → ``platform/context.py``."""
+    return path.relative_to(_SRC_ROOT).as_posix()
+
+
+def _calls_with_scope(tree: ast.AST) -> Iterator[Tuple[str, ast.Call]]:
+    """Yield ``(enclosing-scope-qualname, Call)`` for every call in *tree*.
+
+    The scope is the dotted chain of enclosing ``def``/``class`` names, so a peek
+    is attributed to the function a reader would name it by. Manual descent rather
+    than ``ast.walk`` because ``walk`` discards the nesting the attribution needs.
+    """
+
+    def _descend(node: ast.AST, scope: Tuple[str, ...]) -> Iterator[Tuple[str, ast.Call]]:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                yield from _descend(child, scope + (child.name,))
+                continue
+            if isinstance(child, ast.Call):
+                yield ".".join(scope), child
+            yield from _descend(child, scope)
+
+    yield from _descend(tree, ())
+
+
+def _is_peek_call(node: ast.Call) -> bool:
+    """True for ``installed_context()`` and ``<module>.installed_context()``."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == _PEEK_FUNC
+    if isinstance(func, ast.Attribute):
+        return func.attr == _PEEK_FUNC
+    return False
+
+
+def _peeks_in_source(source: str, module: str) -> Dict[str, List[str]]:
+    """Map ``"<module>::<function>"`` → ``["<module>:LINE", ...]`` for one file.
+
+    Split out from :func:`_find_installed_context_peeks` so the scanner can be
+    exercised against a synthetic source string — the coherence guard that keeps
+    the gate from passing because it silently found nothing.
+    """
+    peeks: Dict[str, List[str]] = {}
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+        return peeks
+    for scope, node in _calls_with_scope(tree):
+        if not _is_peek_call(node):
+            continue
+        peeks.setdefault(f"{module}::{scope or '<module>'}", []).append(f"{module}:{node.lineno}")
+    return peeks
+
+
+def _find_installed_context_peeks() -> Dict[str, List[str]]:
+    """Every ``installed_context()`` call site in the package, keyed by caller."""
+    peeks: Dict[str, List[str]] = {}
+    for path in _peek_scanned_files():
+        try:
+            source = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:  # pragma: no cover - defensive
+            continue
+        if _PEEK_FUNC not in source:  # cheap pre-filter before the parse
+            continue
+        for key, sites in _peeks_in_source(source, _module_key(path)).items():
+            peeks.setdefault(key, []).extend(sites)
+    return peeks
+
+
+@pytest.fixture(scope="module")
+def peek_sites() -> Dict[str, List[str]]:
+    return _find_installed_context_peeks()
 
 
 @pytest.fixture(scope="module")
@@ -414,6 +517,94 @@ class TestReservedMethodCoverage:
                 assert "no core call site" in reason, (
                     f"RESERVED_METHODS[{field!r}][{method!r}] must state " "'no core call site'"
                 )
+
+
+# ── The peek gate: installed_context() callers are declared, or the build fails ──
+
+
+class TestInstalledContextPeeks:
+    """``installed_context()`` opts out of the fail-closed contract; its callers
+    must say why that is safe for them, in a map a reviewer sees."""
+
+    def test_scanner_detects_a_synthetic_peek(self) -> None:
+        """Guard against a vacuous gate.
+
+        Both arms below pass trivially if the scanner finds nothing, so pin the
+        two call shapes and the scope attribution against source we control.
+        """
+        found = _peeks_in_source(
+            "\n".join(
+                (
+                    "from kiro_crew.platform.context import installed_context",
+                    "def outer():",
+                    "    return installed_context()",
+                    "class C:",
+                    "    def m(self):",
+                    "        return pc.installed_context()",
+                    "def unrelated():",
+                    "    return current_context()",
+                )
+            ),
+            "synthetic.py",
+        )
+        assert set(found) == {"synthetic.py::outer", "synthetic.py::C.m"}, found
+
+    def test_scanner_finds_the_real_call_sites(self, peek_sites) -> None:
+        """The scan must see the live tree, not an empty one."""
+        assert peek_sites, "peek scanner found no installed_context() call site at all"
+        assert "security.py::_exempt_exact_hosts" in peek_sites, sorted(peek_sites)
+
+    def test_scanner_does_not_count_the_definition(self, peek_sites) -> None:
+        """``def installed_context()`` is not a call — the accessor is not its own
+        caller, and counting it would let the map self-justify."""
+        assert f"platform/context.py::{_PEEK_FUNC}" not in peek_sites
+
+    def test_every_peek_is_declared(self, peek_sites) -> None:
+        """An undeclared peek fails HERE.
+
+        Adding a caller now costs a ``PEEK_CALLERS`` entry stating why ITS
+        no-context answer is the conservative one — the question that decides
+        whether skipping the fail-closed path is safe, and the one a docstring
+        could only ask politely.
+        """
+        undeclared = {key: sites for key, sites in peek_sites.items() if key not in PEEK_CALLERS}
+        assert not undeclared, (
+            f"undeclared installed_context() caller(s): {undeclared}. This accessor "
+            "answers None instead of refusing to compose, so it is safe ONLY where "
+            "the no-context answer is already the conservative one. Add an entry to "
+            "kiro_crew.platform.context.PEEK_CALLERS stating why that holds for this "
+            "caller, or use current_context() and take the fail-closed error."
+        )
+
+    def test_declared_peeks_still_have_a_call_site(self, peek_sites) -> None:
+        """A permission must not outlive the caller it was written for.
+
+        Without this arm a deleted or renamed caller leaves behind an entry that
+        reads as a reviewed decision, and the next author points at it as
+        precedent for a call site nobody examined.
+        """
+        stale = sorted(key for key in PEEK_CALLERS if key not in peek_sites)
+        assert not stale, (
+            f"PEEK_CALLERS entries with no matching call site: {stale}. The caller was "
+            "removed or renamed — delete the entry (or re-key it) so the map keeps "
+            f"describing the real callers. Live sites: {sorted(peek_sites)}"
+        )
+
+    def test_peek_justifications_answer_the_question(self) -> None:
+        """Each reason must actually address the no-context answer, greppably."""
+        for key, reason in PEEK_CALLERS.items():
+            assert "no-context answer" in reason, (
+                f"PEEK_CALLERS[{key!r}] must state what the 'no-context answer' is, "
+                "so the justification addresses the contract it bypasses"
+            )
+            assert len(reason) > 60, f"PEEK_CALLERS[{key!r}] reason is too terse"
+
+    def test_peek_keys_name_real_modules(self) -> None:
+        """A key that names no file could never match a site, in either arm."""
+        missing = sorted(
+            key for key in PEEK_CALLERS if not (_SRC_ROOT / key.split("::", 1)[0]).is_file()
+        )
+        assert not missing, f"PEEK_CALLERS keys naming non-existent module(s): {missing}"
 
 
 # ── The runtime signal: composing into a reserved slot is loud ──


### PR DESCRIPTION
## Problem / Motivation

`platform/context.py` exposes two accessors with opposite safety contracts.
`current_context()` is fail-closed: on a non-standalone host that never composed
its companion it raises `PlatformCompositionError` rather than hand the caller
open-source defaults. `installed_context()` is the deliberate exception -- a bare
attribute read that answers `None` instead of raising, so a hot path whose
no-context answer is already the conservative one does not re-pay a config load
and entry-point discovery per call.

That exception is safe only where the caller's no-context answer really is the
conservative one, and that is a property of the CALLER, not of the accessor. The
accessor cannot check it. Nothing else did either: the rule lived in the
accessor's docstring and in `docs/system-specs/modules/platform-context.md`, with
no test behind it.

Under that guard the caller set silently tripled:

- 2026-08-20 (PR #4563 design review) -- one caller,
  `security._exempt_exact_hosts`, and the spec said so.
- 2026-08-28, PR #6264 -- `governance.active_policy_distribution` added.
- 2026-08-31, PR #7151 -- `context.redact_log_via_context` added.

Neither addition met any friction, and the spec sentence naming "the one such
caller" was still on main describing a set of three.

## Why it matters

Every current caller is in fact conservative -- I checked all three, and this PR
changes no behavior. The defect is the missing gate, and its cost is the next
caller: a peek whose no-context answer is NOT conservative would silently take
open-source defaults on a host whose companion policy failed to compose, which is
precisely the fail-open that `current_context()`'s raise exists to prevent. A
reviewer would have to know the unwritten rule and notice a one-line function call
to catch it. The stale spec sentence shows the prose guard already failing: it
told a reader there was one caller while three existed, so the next author had no
accurate picture of what they were joining.

## What changed (motivation -> approach -> change)

Symptom: two callers joined a contract-bypassing accessor with nothing objecting.
Root cause: the constraint is a caller property, so it can only be enforced where
callers are enumerated -- and they were not enumerated anywhere.

This module already solves that exact shape once, for `RESERVED_SLOTS`: a
declared map next to the thing it describes, gated by AST analysis of the real
source tree (a hand list would rot), with two arms so the map cannot go stale in
either direction. This change reuses it rather than inventing a second idiom.

- `context.PEEK_CALLERS` maps `"<path under src/kiro_crew>::<function>"` to the
  reason that caller's no-context answer is conservative. All three of today's
  callers are declared, with the reason written out for each -- including the two
  that were never reviewed against this contract.
- `test_platform_cpp_seam_coverage.py` gains `TestInstalledContextPeeks`. Arm one:
  every `installed_context()` call site in the package must appear in the map, so a
  new peek fails the build until its author writes down why it is safe. Arm two:
  every entry must still have a live call site, so a deleted or renamed caller
  cannot leave behind a permission that reads as a reviewed decision.
- The peek scan deliberately does NOT exclude `platform/`, unlike the existing
  seam scan. A seam read inside the platform package is plumbing, but a peek there
  is a real bypass -- two of the three callers live in it, so excluding the
  directory would have hidden them and made the gate pass while permitting exactly
  what it forbids.
- The spec paragraph is corrected (it claimed one caller) and now names the map
  and the gate instead of asking politely.

The gate is a review forcing function, not a proof: it cannot verify that a
written justification is true. What it removes is the silent path. Adding a peek
now costs a diff to the very file whose fail-closed contract is being bypassed,
and the justification lands in front of a reviewer.

## Tests

`test/test_platform_cpp_seam_coverage.py::TestInstalledContextPeeks` (7 tests):

- `test_every_peek_is_declared` -- arm one. Mutation-verified: adding a new
  module that calls `installed_context()` reds it with
  `undeclared installed_context() caller(s): {'_peek_probe.py::probe_drift': [...]}`,
  1 failed / 6 passed. This is the regression PR #6264 and PR #7151 would have hit.
- `test_declared_peeks_still_have_a_call_site` -- arm two. Mutation-verified: a
  declared entry for a caller that does not exist reds it and lists the three real
  sites, 1 failed / 6 passed in isolation.
- `test_scanner_detects_a_synthetic_peek` -- anti-vacuity guard. Both arms pass
  trivially if the scanner finds nothing, so the two call shapes
  (`installed_context()` and `pc.installed_context()`) and the scope attribution
  are pinned against source the test controls.
- `test_scanner_finds_the_real_call_sites`, `test_scanner_does_not_count_the_definition`,
  `test_peek_justifications_answer_the_question` (each reason must contain the
  phrase `no-context answer`, so a justification cannot dodge the question),
  `test_peek_keys_name_real_modules`.

Targeted runs: `test_platform_cpp_seam_coverage.py` 57 passed;
`test_platform_context.py` + `test_platform_cpp_seam_coverage.py` +
`test_harness_parity.py` 112 passed. flake8, black and isort clean on the touched
files.

## Manual verification

N/A -- unit coverage sufficient. The change adds a build-time gate plus a
declaration; there is no runtime path and no user-visible surface.

## Related Issues

No GitHub issue. The finding came from the design review on PR #4563, which
recorded it as unreachable-today with the risk being "a future second consumer
whose no-context answer is NOT conservative". Two such consumers have since
landed, which is what this PR gates.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a documented-only caller restriction on a contract-bypassing accessor --
where the safety condition is a property of the CALLER, so the callee cannot
enforce it. `installed_context()` is one instance; the general shape is any
"use this only when X" accessor whose X the function itself cannot check. The
generalizable rule: such an accessor needs an enumerated caller set gated from
both sides, not a docstring. The two arms matter equally -- an allowlist with no
staleness arm becomes a list of permissions nobody re-examines, which the next
author cites as precedent.
