### PR TITLE
fix(spawn): give the unknown-agent refusal a machine-readable code

### DIFF
--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -624,6 +624,41 @@ Request: `{"task": "..."}`
 Response: `{"id": "abc123", "task": "...", "status": "spawned"}`
 Errors: 400 (missing task), 429 (capacity reached), 503 (subagents not available)
 
+**Typed rejections.** A rejection raised INSIDE `spawn()` answers 400 with a
+machine-readable `code` beside the advisory `error` prose (plus `counted: true` —
+see Wave liveness above): `agent_not_found` for a named-but-unknown agent,
+`spawn_rejected` for every other kind (empty task, low memory, cwd refusal,
+governance). `code` is the contract and `error` is advisory (RFC 9457 3.1.3),
+which is what lets the refusal sentence be reworded without breaking a client.
+The identifier is minted AT the decision — `subagent.AGENT_NOT_FOUND_CODE`,
+returned by `_validate_agent` — carried on `SubagentInfo.error_code`, and
+forwarded by the handler without being respelled there, so the value has exactly
+one spelling in the tree.
+
+`spawn_run` switches on that code for the wave short-circuit (#4842): once the
+gateway has refused an agent name, the remaining members of a wave sharing it are
+not re-posted. Fail-soft in both version directions — an old client still
+text-matches the unchanged prose, and a new client against a gateway that sends
+no `code` loses only the short-circuit (every member is dispatched and refused
+individually) and never refuses a name the gateway would have accepted. That
+asymmetry is why a missing code is safe here, and why a code is never used to
+REJECT a spawn.
+
+The request-validation errors (bad JSON, missing task, bad `approval_mode` /
+`batch_id`), the 429 capacity answer and the 503 are prose-only today; converting
+them is Track B work tracked by `error-code-baseline.json`.
+
+Not yet true of the sibling endpoints: `POST /api/spawn/{id}/continue` and
+`.../release` DO answer with a `code`, but they derive it by prefix-matching the
+manager's prose (`info.error.startswith("conversation_busy")`), because
+`continue_conversation` mints those two decisions as sentences rather than
+returning an identifier. `SubagentInfo.error_code` is the carrier that would let
+them be minted at the decision the way the unknown-agent refusal now is; until
+that migration, treat `conversation_busy` / `conversation_gone` as inferred, not
+minted. Two more consumers reconstruct the same two decisions from prose
+internally (`crew_chat`'s queue hold, `continuation`'s busy retry), so the
+migration has to move them together.
+
 ### Handler keywords (instant, no LLM)
 
 User-typed `spawn <task>`, `bg <task>`, `spawn list`, `spawn status` are intercepted by the handler for instant execution.

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1213,
+    "missing_code": 1212,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1437,
+  "_compliant": 1443,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -113,7 +113,7 @@
     },
     "dashboard/handlers/messaging.py": {
       "dynamic_status": 6,
-      "missing_code": 87
+      "missing_code": 86
     },
     "dashboard/handlers/onboarding_import.py": {
       "missing_code": 7

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -162,6 +162,13 @@ def _sel():
 
 # ── Subagents ──
 
+#: Generic ``code`` for a spawn rejection that mints no identifier of its own.
+#: Spelled once for the two handlers that answer with it (``api_spawn`` and
+#: ``api_spawn_continue``), so the pair cannot drift apart. A rejection a client
+#: acts on differently gets its OWN code at the decision instead -- see
+#: ``subagent.AGENT_NOT_FOUND_CODE``.
+_SPAWN_REJECTED_CODE = "spawn_rejected"
+
 
 async def api_spawn(request: web.Request) -> web.Response:
     """POST /api/spawn — spawn a subagent.
@@ -269,7 +276,21 @@ async def api_spawn(request: web.Request) -> web.Response:
         # batch members) announced through the completion consumer
         # (_announce_rejection). "counted" tells spawn_run's client-side
         # reconcile to skip this member.
-        return web.json_response({"error": info.error, "counted": True}, status=400)
+        #
+        # ``code`` is what the client switches on; ``error`` is advisory prose
+        # (RFC 9457 3.1.3). Only the unknown-agent refusal mints its own
+        # identifier today, because it is the only rejection a client treats
+        # differently — spawn_run stops re-posting a name already refused. Every
+        # other rejection reports the generic code, matching the sibling
+        # /continue handler below.
+        return web.json_response(
+            {
+                "error": info.error,
+                "code": info.error_code or _SPAWN_REJECTED_CODE,
+                "counted": True,
+            },
+            status=400,
+        )
     resp: dict[str, object] = {"id": info.id, "task": task, "status": "spawned"}
     # Server-side effort verdict: only this side knows the model the factory's
     # effort gate will see (explicit per-call value, else the subagent role
@@ -359,7 +380,7 @@ async def api_spawn_continue(request: web.Request) -> web.Response:
             return web.json_response({"error": info.error, "code": "conversation_busy"}, status=409)
         if info.error.startswith("conversation_gone"):
             return web.json_response({"error": info.error, "code": "conversation_gone"}, status=404)
-        return web.json_response({"error": info.error, "code": "spawn_rejected"}, status=400)
+        return web.json_response({"error": info.error, "code": _SPAWN_REJECTED_CODE}, status=400)
     return web.json_response({"id": info.id, "conversation": conv_id, "status": "spawned"})
 
 

--- a/src/kiro_crew/mcp_tools/spawn.py
+++ b/src/kiro_crew/mcp_tools/spawn.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 import os
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 from urllib.parse import urlencode
 
@@ -30,7 +30,11 @@ from kiro_crew.context_management import COMPLETION_KEEP_DEFAULT_CHARS
 from kiro_crew.mcp_shared import ToolCancelled, is_tool_cancelled
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-from kiro_crew.subagent import resolve_max_subagents, visible_agent_names
+from kiro_crew.subagent import (
+    AGENT_NOT_FOUND_CODE,
+    resolve_max_subagents,
+    visible_agent_names,
+)
 from kiro_crew.subagent_persistence import agent_dir_for_display
 from kiro_crew.validation import (
     MAX_MEDIUM_STRING,
@@ -467,20 +471,27 @@ def schemas() -> list[dict[str, Any]]:
     ]
 
 
-def _is_unknown_agent_refusal(err: str, agent: str) -> bool:
-    """True when *err* is the gateway refusing *agent* as a name it cannot load.
+def _is_unknown_agent_refusal(resp: Mapping[str, Any], agent: str) -> bool:
+    """True when *resp* is the gateway refusing *agent* as a name it cannot load.
 
-    Matched on the message text because the refusal has no wire code of its own,
-    and the two sides are pinned together by a test that feeds
-    ``subagent._validate_agent``'s real output through this predicate -- so the
-    wording cannot drift out from under it silently.
+    Reads the response's machine-readable ``code`` (``AGENT_NOT_FOUND_CODE``,
+    spelled once in ``subagent`` and imported by both sides), not its prose. The
+    refusal text is advisory and free to be reworded; before this it WAS the
+    contract, so any rewording silently disabled the wave short-circuit until a
+    test caught it.
 
-    Fail-soft by construction: a miss reproduces today's behavior (every member
-    is dispatched and refused individually), never a refusal of a name the
-    gateway would have accepted. That asymmetry is why matching text is safe
-    here, while matching text to REJECT a spawn would not be.
+    The response answers the POST that named *agent*, so no name re-check is
+    needed -- pairing is what the old text match had to reconstruct from the
+    message. ``agent`` is still required, because an unnamed request means "use
+    the default" and can never produce this refusal.
+
+    Fail-soft by construction: a miss reproduces today's behavior (every member is
+    dispatched and refused individually), never a refusal of a name the gateway
+    would have accepted. That asymmetry is what makes a missing code safe -- a
+    client newer than the gateway simply loses the short-circuit -- while using it
+    to REJECT a spawn would not be.
     """
-    return bool(agent) and err.startswith(f"agent {agent!r} not found")
+    return bool(agent) and resp.get("code") == AGENT_NOT_FOUND_CODE
 
 
 def _collapse_effort_verdicts(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
@@ -633,7 +644,7 @@ def spawn_run(name: str, args: dict[str, Any]) -> str:
                 transport_errors.append(error_line)
                 continue
             errors.append(error_line)
-            if a and _is_unknown_agent_refusal(str(d["error"]), a):
+            if a and _is_unknown_agent_refusal(d, a):
                 refused_agents[a] = str(d["error"])
             # Wave-liveness reconcile: every sibling's batch_total counts
             # THIS member,

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -172,6 +172,17 @@ _MAX_CONCURRENT = 3
 #: the pair and it cannot drift when a third reserved name appears.
 UNADVERTISED_AGENTS = frozenset({"kirocrew", "kirocrew-conductor"})
 
+#: Wire code for the unknown-agent refusal ``_validate_agent`` returns. It rides
+#: ``SubagentInfo.error_code`` to ``POST /api/spawn``, which forwards the FIELD as
+#: the response's ``code`` without naming the value -- so the gateway handler never
+#: spells this identifier and stays agnostic about which code it is carrying. The
+#: refusal's PROSE is advisory and free to be reworded (RFC 9457 3.1.3); this is
+#: the contract ``spawn_run`` switches on, and here is the only place the literal
+#: appears: ``mcp_tools.spawn`` imports it, under the same single-definition rule
+#: as the reserved pair above, because a respelled literal is exactly the drift a
+#: code exists to remove.
+AGENT_NOT_FOUND_CODE = "agent_not_found"
+
 
 def visible_agent_names(
     names: Iterable[str],
@@ -251,7 +262,7 @@ def _available_agents_hint(available: list[str]) -> str:
     return hint
 
 
-def _validate_agent(requested: str, project_dir: str = "") -> tuple[str, str]:
+def _validate_agent(requested: str, project_dir: str = "") -> tuple[str, str, str]:
     """Validate that an agent name is one kiro-cli can actually load.
 
     Runs ON the event loop (``spawn`` is synchronous), so it must not add
@@ -271,16 +282,20 @@ def _validate_agent(requested: str, project_dir: str = "") -> tuple[str, str]:
     *project_dir* must be the cwd the subagent will actually run in, because that
     is what kiro-cli resolves ``--agent`` against.
 
-    Returns (agent_name, error). If agent found, error is empty.
-    If not found, agent_name is empty and error explains what happened.
+    Returns (agent_name, error, code). If the agent is found, error and code are
+    both empty. If not, agent_name is empty, error explains what happened in prose
+    and code is the machine-readable identifier for that decision. The code is
+    returned rather than inferred by the caller so that a SECOND refusal kind
+    added here has to choose its own identifier instead of silently inheriting
+    this one.
     """
     if not requested:
-        return "", ""
+        return "", "", ""
     known = {a.name for a in list_agents()}
     if project_dir:
         known |= set(cached_project_agent_names(project_dir) or frozenset())
     if requested in known:
-        return requested, ""
+        return requested, "", ""
     available = sorted(known - UNADVERTISED_AGENTS)
     # REFUSE a named-but-unknown agent rather than silently falling back to the
     # host default: that fallback runs the full default agent (frequently at
@@ -291,7 +306,11 @@ def _validate_agent(requested: str, project_dir: str = "") -> tuple[str, str]:
     logger.warning("Agent %r not found; refusing spawn. Available: %s", requested, available)
     # The roster travels WITH the refusal, not only to the log: the caller acts on
     # the returned string, and a bare "not found" gives it nothing to correct to.
-    return "", f"agent {requested!r} not found{_available_agents_hint(available)}"
+    return (
+        "",
+        f"agent {requested!r} not found{_available_agents_hint(available)}",
+        AGENT_NOT_FOUND_CODE,
+    )
 
 
 def _vet_spawn_governance(parent_session_key: str, agent: str, app: str = "") -> str | None:
@@ -1147,6 +1166,17 @@ class SubagentInfo:
     result_path: str = ""
     result_truncated: bool = False  # completion-event copy dropped content → summary+path
     error: str = ""
+    # Machine-readable identifier for ``error``, forwarded by ``POST /api/spawn``
+    # as the response's ``code`` so a client can switch on the decision instead of
+    # parsing the prose. Set today only by the unknown-agent refusal
+    # (``AGENT_NOT_FOUND_CODE``), which is the one rejection a client acts on
+    # differently: ``spawn_run`` stops re-posting a name the gateway already
+    # refused. The other kinds that DO carry an error (bad task, low memory, a cwd
+    # refusal, governance) stay un-coded and the handler answers them under a
+    # generic code — a code with no consumer would be contract surface bought for
+    # nothing. A capacity refusal never reaches this field at all: it returns no
+    # record, and the handler answers 429 from that absence.
+    error_code: str = ""
     parent_session_key: str = ""
     agent: str = ""
     # The app that spawned this child (empty for a non-app spawn). Persisted so

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -413,7 +413,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             effective_cwd = resolved_cwd or str(
                 getattr(self._manager._sessions, "_pool_cwd", "") or ""
             )
-            agent, err = _validate_agent(agent, effective_cwd)
+            agent, err, err_code = _validate_agent(agent, effective_cwd)
             if err:
                 info = SubagentInfo(
                     id=agent_id,
@@ -422,6 +422,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     parent_session_key=parent_session_key,
                     done=True,
                     error=err,
+                    error_code=err_code,
                     batch_id=batch_id,
                     batch_total=max(0, int(batch_total)),
                 )

--- a/test/test_agent_roster_shared.py
+++ b/test/test_agent_roster_shared.py
@@ -121,7 +121,7 @@ class TestNoSurfaceReimplementsThePipeline:
 
         with patch.object(sa, "visible_agent_names", _stub):
             with patch.object(sa, "list_agents", return_value=_agents("scout")):
-                _, refusal = sa._validate_agent("nope")
+                _, refusal, _ = sa._validate_agent("nope")
         assert marker in refusal
 
         with patch.object(spawn_tools, "visible_agent_names", _stub):
@@ -142,20 +142,20 @@ class TestRenderedStringsAreUnchanged:
 
     def test_the_refusal_reads_the_same(self) -> None:
         with patch.object(sa, "list_agents", return_value=_agents("kirocrew", "scout", "probe")):
-            name, err = sa._validate_agent("explore")
+            name, err, _ = sa._validate_agent("explore")
         assert name == ""
         assert err == "agent 'explore' not found; available: probe, scout"
 
     def test_the_truncated_refusal_reads_the_same(self) -> None:
         many = [f"agent-{i:02d}" for i in range(sa._MAX_AVAILABLE_IN_ERROR + 3)]
         with patch.object(sa, "list_agents", return_value=_agents(*many)):
-            _, err = sa._validate_agent("nope")
+            _, err, _ = sa._validate_agent("nope")
         expected = ", ".join(many[: sa._MAX_AVAILABLE_IN_ERROR])
         assert err == f"agent 'nope' not found; available: {expected} (+3 more, call spawn_list)"
 
     def test_the_empty_refusal_reads_the_same(self) -> None:
         with patch.object(sa, "list_agents", return_value=_agents("kirocrew")):
-            _, err = sa._validate_agent("explore")
+            _, err, _ = sa._validate_agent("explore")
         assert err == (
             "agent 'explore' not found; no other agents are installed - "
             "omit 'agent' to use the default"
@@ -218,7 +218,7 @@ class TestOrderingConverged:
 
     def test_the_refusal_orders_the_same_way(self) -> None:
         with patch.object(sa, "list_agents", return_value=_agents(CREDENTIAL_SHAPED, "beacon")):
-            _, err = sa._validate_agent("nope")
+            _, err, _ = sa._validate_agent("nope")
         assert err == f"agent 'nope' not found; available: beacon, {REDACTED}"
 
 

--- a/test/test_app_spawn_capability.py
+++ b/test/test_app_spawn_capability.py
@@ -366,13 +366,14 @@ class TestManagerRefusesUnknownAgent:
             ],
         )
         # Empty request still means "use the default" — no error.
-        assert subagent._validate_agent("") == ("", "")
+        assert subagent._validate_agent("") == ("", "", "")
         # A known agent passes through unchanged.
-        assert subagent._validate_agent("mochi--mochi-bg") == ("mochi--mochi-bg", "")
+        assert subagent._validate_agent("mochi--mochi-bg") == ("mochi--mochi-bg", "", "")
         # A named-but-unknown agent is REFUSED (error), not silently defaulted.
-        name, err = subagent._validate_agent("does-not-exist")
+        name, err, code = subagent._validate_agent("does-not-exist")
         assert name == ""
         assert err and "not found" in err
+        assert code == subagent.AGENT_NOT_FOUND_CODE
 
     def test_project_scope_is_read_from_cache_not_the_filesystem(self, monkeypatch):
         """``spawn`` is synchronous and runs on the event loop, so validation must not
@@ -402,7 +403,7 @@ class TestManagerRefusesUnknownAgent:
             "project_agent_files",
             lambda p, include_legacy=False: pytest.fail("globbed on the event loop"),
         )
-        assert subagent._validate_agent("repobot", "/some/project") == ("repobot", "")
+        assert subagent._validate_agent("repobot", "/some/project") == ("repobot", "", "")
 
     def test_cold_project_cache_refuses_rather_than_scanning(self, monkeypatch):
         """Fail closed on a cold cache — refusing an unknown name is this function's
@@ -415,7 +416,7 @@ class TestManagerRefusesUnknownAgent:
             lambda project_dir=None: [types.SimpleNamespace(name="kirocrew")],
         )
         monkeypatch.setattr(subagent, "cached_project_agent_names", lambda p: None)
-        name, err = subagent._validate_agent("repobot", "/some/project")
+        name, err, _code = subagent._validate_agent("repobot", "/some/project")
         assert name == ""
         assert "repobot" in err
 

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -28,6 +28,7 @@ from aiohttp import web
 
 import kiro_crew.config.loader as loader
 import kiro_crew.dashboard.handlers.messaging as mod
+from kiro_crew.subagent import AGENT_NOT_FOUND_CODE
 
 
 class _Req:
@@ -100,6 +101,7 @@ def _info(**kw: Any) -> Any:
         "task": "do it",
         "done": False,
         "error": "",
+        "error_code": "",
         "result": "",
         "result_path": "",
         "started": 1_700_000_000.0,
@@ -185,7 +187,30 @@ class TestApiSpawn:
         mgr.spawn.return_value = _info(done=True, error="cwd not allowed")
         resp = _run(mod.api_spawn, _Req(_state(subagents=mgr), {"task": "x"}))
         assert resp.status == 400
-        assert _payload(resp) == {"error": "cwd not allowed", "counted": True}
+        # An un-coded rejection kind reports the generic identifier, so the body
+        # is machine-readable even where the manager mints nothing.
+        assert _payload(resp) == {
+            "error": "cwd not allowed",
+            "code": "spawn_rejected",
+            "counted": True,
+        }
+
+    def test_unknown_agent_rejection_carries_its_own_code(self) -> None:
+        """The one rejection a client acts on differently keeps its own identifier:
+        ``spawn_run`` stops re-posting a name the gateway already refused, and it
+        must not have to parse the prose to know which refusal this was."""
+        mgr = _mgr()
+        mgr.spawn.return_value = _info(
+            done=True,
+            error="agent 'ghost' not found; available: scout",
+            error_code=AGENT_NOT_FOUND_CODE,
+        )
+        resp = _run(mod.api_spawn, _Req(_state(subagents=mgr), {"task": "x", "agent": "ghost"}))
+        assert resp.status == 400
+        body = _payload(resp)
+        assert body["code"] == AGENT_NOT_FOUND_CODE
+        # Prose still travels for the model to read and self-correct from.
+        assert "available: scout" in body["error"]
 
     def test_success_coerces_string_flags_and_bounds_batch_total(self) -> None:
         mgr = _mgr()

--- a/test/test_spawn_agent_roster.py
+++ b/test/test_spawn_agent_roster.py
@@ -10,6 +10,10 @@ invented names.
    agent name, instead of re-posting the same doomed name per task.
 3. The roster must be reachable from ``spawn_run``'s own parameter description,
    because a caller that never called ``spawn_list`` has never seen it.
+
+Seam 2 recognized the refusal by its SENTENCE, which made an advisory message
+part of the wire contract. It now travels as ``code`` (``AGENT_NOT_FOUND_CODE``),
+so the prose is free to change and the short-circuit is not.
 """
 
 from __future__ import annotations
@@ -29,23 +33,25 @@ def _agents(*names: str) -> list[types.SimpleNamespace]:
 class TestRefusalCarriesTheRoster:
     def test_available_names_are_in_the_returned_error(self) -> None:
         with patch.object(sa, "list_agents", return_value=_agents("kirocrew", "scout", "probe")):
-            name, err = sa._validate_agent("explore")
+            name, err, code = sa._validate_agent("explore")
         assert name == ""
         # The names the log line already had.
         assert "scout" in err and "probe" in err
         # The host default is not advertised: it is reached by omitting `agent`.
         assert "kirocrew" not in err
+        # ...and the decision travels as data next to the prose.
+        assert code == sa.AGENT_NOT_FOUND_CODE
 
     def test_empty_roster_says_to_omit_the_parameter(self) -> None:
         """With nothing to correct TO, the only valid move is to stop naming one."""
         with patch.object(sa, "list_agents", return_value=_agents("kirocrew")):
-            _, err = sa._validate_agent("explore")
+            _, err, _ = sa._validate_agent("explore")
         assert "omit" in err
 
     def test_roster_is_bounded_and_reports_the_remainder(self) -> None:
         many = [f"agent-{i:02d}" for i in range(sa._MAX_AVAILABLE_IN_ERROR + 5)]
         with patch.object(sa, "list_agents", return_value=_agents(*many)):
-            _, err = sa._validate_agent("nope")
+            _, err, _ = sa._validate_agent("nope")
         assert f"agent-{sa._MAX_AVAILABLE_IN_ERROR - 1:02d}" in err
         assert f"agent-{sa._MAX_AVAILABLE_IN_ERROR:02d}" not in err
         assert "+5 more" in err
@@ -58,7 +64,7 @@ class TestRefusalCarriesTheRoster:
         with patch.object(
             sa, "list_agents", return_value=_agents("scout", hostile, "\u4ee3\u7406")
         ):
-            _, err = sa._validate_agent("nope")
+            _, err, _ = sa._validate_agent("nope")
         assert "; available: scout" in err
         assert "IGNORE" not in err and "\n" not in err
         assert "\u4ee3\u7406" not in err
@@ -71,29 +77,68 @@ class TestRefusalCarriesTheRoster:
             patch.object(sa, "list_agents", return_value=_agents("kirocrew")),
             patch.object(sa, "cached_project_agent_names", return_value=frozenset({"repobot"})),
         ):
-            _, err = sa._validate_agent("nope", "/some/project")
+            _, err, _ = sa._validate_agent("nope", "/some/project")
         assert "; available: repobot" in err
 
 
-class TestPredicateTracksTheRealRefusal:
-    """Both sides of the seam, pinned: ``spawn_run`` matches the refusal text that
-    ``_validate_agent`` actually produces, so a reworded message fails HERE rather
-    than silently disabling the wave short-circuit in production."""
+class TestPredicateReadsTheWireCode:
+    """Both sides of the seam, pinned on the CODE: ``spawn_run`` recognizes the
+    refusal by the identifier ``_validate_agent`` mints, so the message text is free
+    to be reworded without silently disabling the wave short-circuit."""
+
+    def _refusal(self, agent: str = "explore") -> tuple[str, str]:
+        with patch.object(sa, "list_agents", return_value=_agents("kirocrew", "scout")):
+            _, err, code = sa._validate_agent(agent)
+        return err, code
 
     def test_real_refusal_is_recognized(self) -> None:
-        with patch.object(sa, "list_agents", return_value=_agents("kirocrew", "scout")):
-            _, err = sa._validate_agent("explore")
-        assert spawn_tools._is_unknown_agent_refusal(err, "explore") is True
+        err, code = self._refusal()
+        assert code == sa.AGENT_NOT_FOUND_CODE
+        assert spawn_tools._is_unknown_agent_refusal({"error": err, "code": code}, "explore")
+
+    def test_reworded_prose_is_still_recognized(self) -> None:
+        """The point of the migration: the wording is advisory (RFC 9457 3.1.3).
+        Before this, a rewrite of the sentence disabled the short-circuit."""
+        _, code = self._refusal()
+        reworded = {"error": "no agent named 'explore' is installed", "code": code}
+        assert spawn_tools._is_unknown_agent_refusal(reworded, "explore")
 
     def test_other_refusals_are_not_swallowed(self) -> None:
         # A policy denial is a different decision and must keep its own path.
         assert not spawn_tools._is_unknown_agent_refusal(
-            "agent 'explore' not permitted by spawn policy", "explore"
+            {"error": "agent 'explore' not permitted by spawn policy", "code": "spawn_rejected"},
+            "explore",
         )
-        # Another member's name must not short-circuit this one.
-        assert not spawn_tools._is_unknown_agent_refusal("agent 'other' not found", "explore")
-        assert not spawn_tools._is_unknown_agent_refusal("capacity reached (3)", "explore")
-        assert not spawn_tools._is_unknown_agent_refusal("agent '' not found", "")
+        assert not spawn_tools._is_unknown_agent_refusal(
+            {"error": "capacity reached (3)", "counted": True}, "explore"
+        )
+        # An unnamed request means "use the default", which cannot be refused as
+        # unknown -- so no response may short-circuit on it.
+        assert not spawn_tools._is_unknown_agent_refusal(
+            {"error": "x", "code": sa.AGENT_NOT_FOUND_CODE}, ""
+        )
+
+    def test_a_gateway_without_the_code_fails_soft(self) -> None:
+        """A client newer than the gateway sees no ``code`` and loses only the
+        short-circuit: every member is dispatched and refused individually, which is
+        the pre-#4842 behavior -- never a refusal of a name the gateway would take."""
+        assert not spawn_tools._is_unknown_agent_refusal(
+            {"error": "agent 'explore' not found; available: scout", "counted": True}, "explore"
+        )
+
+    def test_the_code_has_one_definition(self) -> None:
+        """A respelled literal on the client is exactly the drift a code removes, so
+        the identifier is imported, not retyped. Source ratchet: a behavioral test
+        cannot see a re-duplication because both spellings compare equal."""
+        import pathlib
+
+        assert spawn_tools.AGENT_NOT_FOUND_CODE is sa.AGENT_NOT_FOUND_CODE
+        for module, expected in ((sa, 1), (spawn_tools, 0)):
+            src = pathlib.Path(module.__file__).read_text(encoding="utf-8")
+            assert src.count('"agent_not_found"') == expected, (
+                f"{module.__name__} respells the refusal code; import "
+                "subagent.AGENT_NOT_FOUND_CODE instead"
+            )
 
 
 class TestWaveStopsAfterTheFirstRefusal:
@@ -103,7 +148,7 @@ class TestWaveStopsAfterTheFirstRefusal:
         def _post(path: str, body: dict) -> dict:
             posts.append((path, body))
             if path == "/api/spawn":
-                return {"error": error, "counted": True}
+                return {"error": error, "code": sa.AGENT_NOT_FOUND_CODE, "counted": True}
             return {}
 
         with (
@@ -137,7 +182,11 @@ class TestWaveStopsAfterTheFirstRefusal:
                 return {}
             posts.append(body)
             if body["agent"] == "ghost":
-                return {"error": "agent 'ghost' not found; available: scout", "counted": True}
+                return {
+                    "error": "agent 'ghost' not found; available: scout",
+                    "code": sa.AGENT_NOT_FOUND_CODE,
+                    "counted": True,
+                }
             return {"id": f"id{len(posts)}"}
 
         with (
@@ -159,7 +208,11 @@ class TestWaveStopsAfterTheFirstRefusal:
             if path != "/api/spawn":
                 return {}
             posts.append(body)
-            return {"error": "agent 'scout' not found", "transport_error": True}
+            return {
+                "error": "agent 'scout' not found",
+                "code": sa.AGENT_NOT_FOUND_CODE,
+                "transport_error": True,
+            }
 
         with (
             patch.object(spawn_tools.mcp_core, "_post", side_effect=_post),

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -86,32 +86,33 @@ class TestSafeFire:
 
 class TestValidateAgent:
     def test_empty_request_is_the_default(self) -> None:
-        assert sa._validate_agent("") == ("", "")
+        assert sa._validate_agent("") == ("", "", "")
 
     def test_known_user_agent_accepted(self) -> None:
         with patch.object(sa, "list_agents", return_value=[SimpleNamespace(name="scout")]):
-            assert sa._validate_agent("scout") == ("scout", "")
+            assert sa._validate_agent("scout") == ("scout", "", "")
 
     def test_unknown_agent_refused_not_defaulted(self) -> None:
         with patch.object(sa, "list_agents", return_value=[SimpleNamespace(name="scout")]):
-            name, err = sa._validate_agent("typo")
+            name, err, code = sa._validate_agent("typo")
         assert name == ""
         assert "not found" in err
+        assert code == sa.AGENT_NOT_FOUND_CODE
 
     def test_project_scope_widens_known_set(self, tmp_path: Path) -> None:
         with (
             patch.object(sa, "list_agents", return_value=[]),
             patch.object(sa, "cached_project_agent_names", return_value=frozenset({"local"})),
         ):
-            assert sa._validate_agent("local", str(tmp_path)) == ("local", "")
+            assert sa._validate_agent("local", str(tmp_path)) == ("local", "", "")
 
     def test_project_scope_cold_cache_refuses(self, tmp_path: Path) -> None:
         with (
             patch.object(sa, "list_agents", return_value=[]),
             patch.object(sa, "cached_project_agent_names", return_value=None),
         ):
-            name, err = sa._validate_agent("local", str(tmp_path))
-        assert (name, "not found" in err) == ("", True)
+            name, err, code = sa._validate_agent("local", str(tmp_path))
+        assert (name, "not found" in err, code) == ("", True, sa.AGENT_NOT_FOUND_CODE)
 
 
 # ── _vet_spawn_governance ─────────────────────────────────────────────────


### PR DESCRIPTION
## What is the problem?

`POST /api/spawn`'s pre-spawn rejection returned prose only:

```python
return web.json_response({"error": info.error, "counted": True}, status=400)
```

So the client had nothing to switch on, and `spawn_run` recognized the
unknown-agent refusal by reading the sentence:

```python
return bool(agent) and err.startswith(f"agent {agent!r} not found")
```

That promoted an advisory message to wire contract. The only thing keeping the
two sides in step was a test that fed `_validate_agent`'s real output through the
predicate -- so the wording could not be changed at all without a test
round-trip, and any rewording that slipped past it would disable the wave
short-circuit in production with no error anywhere.

No user-visible defect: a missed match falls soft to today's dispatch-everything
behavior. The cost is maintenance coupling.

## Why this issue matters to the user

The short-circuit this predicate guards is what stops a wave of doomed
dispatches on one invented agent name (#4842): a caller that names `general` for
8 tasks POSTs once, not 8 times. If the refusal text is ever reworded -- the kind
of edit that reads as harmless copy polish -- the predicate silently stops
matching and that wave is back to 8 refusals, 8 tombstones and 8 lines of
identical error in the caller's context.

It also blocks the repo's own i18n direction. `test_error_code_contract.py`
requires an error body to carry a machine-readable `code` because the dashboard
renders `res.error` verbatim into a localized UI; this handler was on the debt
list, and the client parsing that prose is why the debt could not simply be paid.

## How our fix solves it

Chain from the symptom back to the cause:

1. **Symptom** -- `spawn_run` reads the refusal's sentence.
2. **Because** the refusal had no identifier of its own on the wire.
3. **Because** `_validate_agent` returned prose only, and nothing carried a code
   from the manager to the HTTP boundary.

So the code is minted at the decision and carried to the client:

- `subagent.AGENT_NOT_FOUND_CODE = "agent_not_found"` -- spelled **once**, next
  to `UNADVERTISED_AGENTS`, and imported by both sides. A respelled literal on
  the client is exactly the drift a code exists to remove, so a source ratchet
  test asserts the literal appears in `subagent.py` and nowhere in
  `mcp_tools/spawn.py`.
- `_validate_agent` returns `(agent, error, code)`. The code is **returned, not
  inferred by the caller**, so a second refusal kind added there has to pick its
  own identifier instead of silently inheriting this one.
- `SubagentInfo.error_code` carries it from the manager to the handler.
- `api_spawn` emits `{"error": ..., "code": info.error_code or "spawn_rejected",
  "counted": true}`. Prose still travels -- the model reads the roster out of it
  to self-correct -- it is just advisory now (RFC 9457 3.1.3).
- `_is_unknown_agent_refusal(resp, agent)` switches on the code. The response
  answers the POST that named `agent`, so the name re-check the text match had to
  reconstruct from the message is no longer needed; `agent` is still required
  because an unnamed request means "use the default" and can never be refused as
  unknown.

**Scope, deliberately:** only this one rejection gets its own code. The other six
un-coded error bodies in `api_spawn` (capacity, bad task, memory, governance)
keep reporting the generic `spawn_rejected`, because the contract gate's own rule
is that codes move *with their consumers* -- and this is the only rejection a
client acts on differently. Minting five more identifiers nothing switches on
would be contract surface bought for nothing. The same restraint covers the
sibling decisions one endpoint over: `conversation_busy` / `conversation_gone` are
still *inferred* by prefix-matching prose at five sites (`messaging.py:379,381`
and `:455`, `crew_chat.py:1668`, `continuation.py:599`) rather than minted. The
`error_code` field added here is exactly the carrier that migration needs, but it
spans three modules plus a client consumer, so it is deferred as Track B rather
than folded in -- called out in the spec section too, so the next reader is not
misled by the "minted at the decision" sentence, and recorded locally as
`f-20260901-01`.

**Behavior is unchanged.** The same waves short-circuit. A response with no
`code` -- a client newer than the gateway -- fails soft to per-member dispatch,
which is precisely what a missed text match already did, and never refuses a name
the gateway would have accepted. That asymmetry is what makes a missing code safe
here, while using one to *reject* a spawn would not be.

`error-code-baseline.json` is regenerated for the one converted site
(`messaging.py` `missing_code` 87 -> 86), and the module spec moves in the same
commit: `docs/system-specs/modules/subagent.md`'s `POST /api/spawn` section now
records the typed rejection contract (`code` beside advisory `error`,
`agent_not_found` vs `spawn_rejected`, where the identifier is minted) and the
short-circuit seam, including which bodies are still prose-only so it does not
overclaim.

## What tests we did

Targeted files only (never the full suite):

- `test_spawn_agent_roster.py` -- migrated the seam class to the code and added
  the two cases the old design could not express: a **reworded** refusal is still
  recognized, and a **code-less** response fails soft. Plus the one-definition
  source ratchet.
- `test_handlers_messaging_coverage.py` -- new `TestApiSpawn` case asserting the
  handler propagates `agent_not_found`, and the existing exact-body case updated
  to expect `spawn_rejected`.
- Mutation-verified both, since a test that cannot fail proves nothing:
  - reverting the predicate to text matching kills
    `test_reworded_prose_is_still_recognized` (`assert False`) and
    `test_a_gateway_without_the_code_fails_soft` (`assert not True`);
  - making the handler emit a constant `spawn_rejected` kills
    `test_unknown_agent_rejection_carries_its_own_code`
    (`assert 'spawn_rejected' == 'agent_not_found'`).
- Green, in the files touched by the return-shape change and everything adjacent
  to the spawn path: `test_spawn_agent_roster` + `test_subagent_coverage` (267),
  `test_handlers_messaging_coverage` + `test_app_spawn_capability` (253),
  `test_subagent` + `test_spawn_reasoning_effort` + `test_native_subagent_spawn`
  (288), `test_api_server` + `test_subagent_persistence` + `test_spawn_followup` +
  `test_subagent_context_group_boundary` (152), `test_mcp_core_coverage` +
  `test_mcp_core_wait` + `test_mcp_tool_registry` (249),
  `test_error_code_contract` (6).
- Gates: flake8 clean, isort clean, `scripts/check_black_formatting.py` passed
  (9 files in scope), mypy reports no error in the four changed source files (the
  two it prints are in `transcribe.py`, which fails identically on base).
- Checked that inserting a dataclass field is safe: every `SubagentInfo(...)`
  construction in `src/` and `test/` is keyword-only, so nothing was shifted
  positionally.

`_compliant` in the baseline moves 1437 -> 1443 rather than 1437 -> 1438. That is
not this change: the recorded value had drifted, because the ratchet asserts
per-file bucket counts and never asserts `_compliant`. Measured with the gate's
own scanner over this branch's base -- `messaging.py` is the only changed file
that contains a `json_response` site at all -- the base tree has 1442 compliant
sites and this branch has 1443: `+1` compliant, `-1` missing_code, as expected.

- Rebased onto current `main` twice (the only conflicts were
  `error-code-baseline.json`, resolved by taking main's file and regenerating --
  never by hand-editing a count -- and, on the second rebase,
  `subagent.py` / `mcp_tools/spawn.py` where main had landed the shared
  `visible_agent_names()` roster helper. Both sides kept: the helper is main's,
  the code constant is this PR's, and `spawn.py` now imports both). All of the
  above re-run green on the rebased head, including the one-definition ratchet,
  which still holds after main moved the roster pipeline out of `spawn.py`.
- Review round 1: two comment-accuracy findings fixed (the constant's docstring
  claimed the gateway handler *imports* it -- it forwards the field and never
  spells the value; and the field's comment listed capacity among the kinds
  answered under the generic code -- capacity returns no record at all and is
  answered 429 from that absence). Both verified against the code before editing.
  541 tests re-run green afterwards; the baseline is byte-identical, because
  hoisting a literal into a module constant leaves the site compliant either way.

## Any other suggestions on the work

- **The same defect class has named siblings, deferred deliberately.**
  `continue_conversation` mints `conversation_busy:` / `conversation_gone:` as
  *prose* (`subagent_manager/continuation.py:233,270`) and three places match it
  back into a code by prefix: `handlers/messaging.py:379,381` and `:449`, plus
  client-side `crew_chat.py:1668` (and internally `continuation.py:599`). The
  `error_code` field this PR adds is the general fix and would delete those
  matches -- but that is a second, larger change across three modules with its own
  client, so it is accepted-and-deferred rather than folded in here. Recorded
  locally as `f-20260901-01`.
- The remaining un-coded `api_spawn` bodies (bad task, low memory, cwd,
  governance, and the 429 capacity answer) are a clean Track B unit for a
  follow-up that moves them with an actual consumer.
- `spawn_rejected` now has one spelling for both handlers that answer with it
  (`_SPAWN_REJECTED_CODE`), so this PR does not leave a duplicated literal behind.
- `api_spawn_continue` reads `info.error` for its own decisions. If
  `continue_conversation` ever grows agent validation, it should read
  `info.error_code` the way `api_spawn` now does -- it does not validate an agent
  today, so wiring it now would be dead code.

## Pattern harvest

Rule candidate: semgrep (or a sibling static gate) -- flag a client-side
predicate that decides control flow by matching a server's error *prose*.

That is a defect class, not a style issue: the message is advisory by every
error-contract authority the repo already cites in
`test_error_code_contract.py`. The existing gate ratchets the *producer* (an
error body must carry a `code`) but nothing ratchets the *consumer*. The check
would flag, in `mcp_tools/` and the app SDK, any `.startswith(` / `in` / `==`
test against a value read out of an error/message field of an HTTP response
dict, and require it to read `code` instead. That is what would have caught this
seam when it was introduced, and it composes with the existing ratchet instead
of duplicating it.

Not a one-off: the same shape lives in
`apps/builtins/ops_mission_control/backend/ledger_sync.py:711`
(`"not found" in detail.lower()`), which matches a git CLI's stderr rather than
an internal API and so needs a different remedy -- evidence that the class
recurs wherever a typed signal is missing.

Closes local backlog `f-20260821-04` (deferred design finding from #4855).
