### PR TITLE
fix(irq): give a coalescing entry its own floor instead of the window's age

### DIFF
--- a/docs/system-specs/features/agent-interrupt-controller.md
+++ b/docs/system-specs/features/agent-interrupt-controller.md
@@ -84,9 +84,11 @@ When a nonempty `Tick.epoch` changes, `irq.run` removes epoch-scoped alerts and
 open-window entries, then retains epoch-independent alerts and open-window
 entries. Check-derived observations must not survive a head change, or an old
 head can be reported as current. Conversation-derived observations must survive,
-or a head change replays already-reported discussion. The carried window receives
-a fresh start stamp: this preserves the pending delivery while ensuring a fresh
-head receives its full settling floor. These invariants are pinned by
+or a head change replays already-reported discussion. Each carried entry's own
+open time is dropped, so its clock restarts on the new epoch: this preserves the
+pending delivery while ensuring a fresh head receives its full settling floor,
+and because the entry itself is carried, the restart is a delay and never a loss.
+These invariants are pinned by
 `test_an_open_epoch_scoped_window_is_dropped_by_an_epoch_change`,
 `test_a_sticky_key_survives_an_epoch_change`,
 `test_a_fresh_epoch_anomaly_still_gets_a_full_settling_floor`, and
@@ -103,20 +105,46 @@ the only reporting value. See `irq.run`,
 
 ## Coalescing
 
-A non-NMI `WAKE` observation opens a persisted window. The window fires all
-entries when the convergence floor has passed and `Tick.pending` is zero, or
-when the hard cap has passed; the hard cap is independent of the floor. The
-floor prevents a newly changed subject from reporting a transient empty rollup
-as convergence. The cap prevents a permanently pending subject from losing an
-otherwise actionable wake. These properties are pinned by
+A non-NMI `WAKE` observation opens a persisted window, and each entry records its
+own open time. An entry triggers delivery when its own age has passed the
+convergence floor and `Tick.pending` is zero, or, for an epoch-independent entry,
+when its own age has passed the floor alone. Separately, when the oldest entry's
+age passes the hard cap the whole window flushes; the hard cap is independent of
+the floor and remains window level. The floor prevents a newly changed subject
+from reporting a transient empty rollup as convergence. The cap prevents a
+permanently pending subject from losing an otherwise actionable wake, and stays a
+window-level flush because withholding an unconverged entry from a cap wake would
+turn one flush into one wake per entry.
+The floor is per entry because one window holds signals of different ages: a
+partial fire leaves entries that have already waited, and a later tick can add one
+that has not. A shared window age let such an entry trigger a wake with no
+settling window of its own, so signals arriving one at a time each produced a
+wake. Once an entry triggers, the wake carries every entry the population gate
+admits, aged or not; riding along cannot add a wake, while withholding an admitted
+entry produces another one later. These properties are pinned by
 `test_floor_blocks_a_premature_converged_wake`,
-`test_hard_cap_fires_when_pending_never_drains`, and
-`test_hard_cap_outranks_a_floor_set_above_it`.
+`test_hard_cap_fires_when_pending_never_drains`,
+`test_hard_cap_outranks_a_floor_set_above_it`,
+`test_the_hard_cap_flushes_the_WHOLE_window_not_only_the_capped_entry`,
+`test_an_entry_joining_after_a_partial_fire_serves_its_own_floor`, and
+`test_coalescing_folds_staggered_reds_into_one_wake`.
+
+`coalesce_started_at` is never written. It survives as a read in `load_state`
+only, to seed entries persisted before they carried their own open time, so an
+upgrade does not restart an in-flight window; see
+`test_a_window_written_before_per_entry_ages_keeps_the_age_it_had`. Because it is
+not stored, the legacy field falls off at the first write after the upgrade.
+
+The window age the cap reads is the oldest SURVIVING entry's age, so a partial
+fire that delivers the entry which opened the window moves the cap clock onto the
+survivor. That is a bound rather than a reset: an entry is flushed no later than
+the cap measured from its own arrival. See
+`test_an_entry_left_by_a_partial_fire_still_reaches_the_cap`.
 
 While pending work remains after the floor, epoch-independent entries fire and
-epoch-scoped entries remain in the window. The partial fire retains the original
-window start time for the remaining entries, so repeated discussion cannot keep
-postponing a check-derived observation. See
+epoch-scoped entries remain in the window. The remaining entries keep their own
+open times, so repeated discussion cannot keep postponing a check-derived
+observation. See
 `test_a_sticky_wake_fires_at_the_floor_while_checks_are_still_pending` and
 `test_the_sticky_half_fires_while_the_epoch_scoped_half_keeps_waiting`.
 

--- a/src/kiro_crew/irq.py
+++ b/src/kiro_crew/irq.py
@@ -107,10 +107,13 @@ DEFAULT_MAX_CONSECUTIVE_ERRORS = 6
 #: a converged state that never happened.
 DEFAULT_COALESCE_SECS = 240.0
 
-#: Hard wall-clock bound on a coalescing window, measured from the FIRST anomaly.
-#: Reached only when ``pending`` never drains (a check wedged in queued, or a
-#: phantom pending row). Independent of ``pending`` on purpose: it is what
-#: guarantees a delayed wake rather than a lost one.
+#: Hard wall-clock bound on a coalescing window, measured from the OLDEST entry
+#: still in it. Reached only when ``pending`` never drains (a check wedged in
+#: queued, or a phantom pending row). Independent of ``pending`` on purpose: it
+#: is what guarantees a delayed wake rather than a lost one, and reading the
+#: oldest entry keeps that guarantee per entry -- ``oldest`` is never below any
+#: single entry's age, so nothing outlives this bound counted from its own
+#: arrival.
 DEFAULT_COALESCE_MAX_SECS = 1800.0
 
 #: Cap on how many observation labels a coalesced wake spells out.
@@ -399,15 +402,32 @@ def load_state(path: Path) -> dict:
     errors = data.get("errors")
     if isinstance(errors, int) and not isinstance(errors, bool) and errors >= 0:
         state["errors"] = errors
+    # Read, never stored: the local value below seeds legacy window rows with the
+    # age they were persisted with, and nothing reads the key back out of state.
+    # Not storing it is what lets the legacy field fall off at the first
+    # post-upgrade write instead of riding along until the window closes.
     started = _coerce_ts(data.get("coalesce_started_at"))
-    if started is not None:
-        state["coalesce_started_at"] = started
     window_rows = data.get("coalescing")
     if isinstance(window_rows, dict):
-        pending_wakes: dict[str, str] = {}
-        for key, brief in window_rows.items():
-            if isinstance(key, str) and isinstance(brief, str):
-                pending_wakes[_migrate_key(key)] = brief
+        pending_wakes: dict[str, dict] = {}
+        for key, row in window_rows.items():
+            if not isinstance(key, str):
+                continue
+            if isinstance(row, str):
+                # Written before an entry carried its own open time: the whole
+                # window shared one stamp, so seed every entry from it. Reading
+                # the old shape as unstamped instead would restart the clock of
+                # a window already open on disk, and an in-flight watch would
+                # serve a second floor across the version change.
+                brief, opened = row, started
+            elif isinstance(row, dict) and isinstance(row.get("brief"), str):
+                brief, opened = row["brief"], _coerce_ts(row.get("opened_at"))
+            else:
+                continue
+            entry: dict = {"brief": brief}
+            if opened is not None:
+                entry["opened_at"] = opened
+            pending_wakes[_migrate_key(key)] = entry
         state["coalescing"] = pending_wakes
     return state
 
@@ -432,6 +452,24 @@ _PERSIST_WARNING = (
     "deduplication is degraded (repeats possible). Fix permissions on the "
     "watch directory under the data home."
 )
+
+
+def _install_window(state: dict, window: dict[str, dict]) -> None:
+    """Store the open coalescing window, or close it when nothing is left.
+
+    Every entry carries its OWN ``opened_at``, because one window legitimately
+    holds signals of different ages: a partial fire leaves entries that have
+    already waited, and the next tick can add one that has not waited at all.
+    That per-entry stamp is the only age this module stores.
+
+    There is deliberately no window-level stamp to write or clear:
+    ``coalesce_started_at`` is read once in :func:`load_state`, to seed entries
+    persisted before they carried their own, and never stored again.
+    """
+    if window:
+        state["coalescing"] = window
+        return
+    state.pop("coalescing", None)
 
 
 def _coalesced_brief(briefs: list[str]) -> str:
@@ -501,9 +539,22 @@ def run(
     with an unrelated structural move; here the timing change IS the change.
 
     Coalescing semantics -- a window opens on the first non-exempt anomaly of the
-    current epoch and fires when::
+    current epoch and every entry carries its own open time. An entry TRIGGERS a
+    wake when::
 
-        elapsed >= coalesce_secs and (pending == 0 or elapsed >= coalesce_max_secs)
+        age >= coalesce_secs and (pending == 0 or the entry is epoch-independent)
+
+    and the wake then carries every entry the same population gate admits, aged
+    or not. ``pending`` gates epoch-scoped entries only, because it counts CHECKS
+    and a comment is complete the moment it is posted. Separately, when the OLDEST
+    entry's age passes ``coalesce_max_secs`` the whole window flushes: that cap is
+    an absolute wall and is not gated behind the floor.
+
+    The trigger is per ENTRY because one window holds signals of different ages --
+    a partial fire leaves entries that have already waited, and the next tick can
+    add one that has not waited at all, which must not wake the agent on its own.
+    The payload stays generous for the opposite reason: riding along never adds a
+    wake, while holding an admitted entry back guarantees another one later.
 
     ``coalesce_secs`` is a FLOOR rather than a timeout, which is the difference
     that matters: a subject that just changed epoch may report ``pending ==
@@ -671,31 +722,36 @@ def run(
         # back. Epoch-scoped window entries ARE dropped -- they describe checks
         # on a commit that is no longer under review.
         #
-        # The start stamp is deliberately NOT carried. One scalar cannot serve
-        # both populations the new window holds: the carried sticky entries have
-        # already been waiting, while an epoch-scoped anomaly observed on the
-        # fresh head has not waited at all and MUST get a full settling floor --
-        # a freshly pushed commit briefly shows an almost-empty rollup, so
-        # ``pending == 0`` can be true while nothing has run, which is the entire
-        # reason DEFAULT_COALESCE_SECS is a floor. Re-installing the old stamp
-        # left that floor already satisfied, so a ``ready`` observation on the new
-        # head fired at once and announced "all checks green" before its checks
-        # existed.
+        # The carried entry's own stamp is deliberately NOT kept, so its clock
+        # restarts on the new epoch. A freshly pushed commit briefly shows an
+        # almost-empty rollup, so ``pending == 0`` can be true while nothing has
+        # run, which is the entire reason DEFAULT_COALESCE_SECS is a floor;
+        # re-installing an aged stamp left that floor already satisfied, so a
+        # ``ready`` observation on the new head fired at once and announced
+        # "all checks green" before its checks existed. Per-entry ages now keep
+        # the two apart on their own -- the fresh ``ready`` gets its own floor
+        # regardless -- so keeping the carried stamp is a one-line change. It is
+        # left out of this change on purpose: it is a shift in WAKE TIMING on a
+        # different trigger (a push cadence faster than the floor re-delaying a
+        # carried comment), and this module's rule is that a timing change ships
+        # as its own attributable step rather than riding along with a
+        # structural one.
         #
         # Restarting costs the carried entry one more floor of latency after a
         # force-push. That is a DELAY, and the invariant that matters is that it
-        # is not a LOSS: the entry itself is carried, so it still fires. A push
-        # cadence faster than the floor could keep re-delaying it -- the narrow
-        # residue of having only one stamp, which per-entry ages would remove.
+        # is not a LOSS: the entry itself is carried, so it still fires.
         carried = {
             key: value
             for key, value in (state.get("alerted") or {}).items()
             if isinstance(key, str) and key.startswith(_STICKY_SENTINEL)
         }
         carried_window = {
-            key: brief
-            for key, brief in (state.get("coalescing") or {}).items()
-            if isinstance(key, str) and isinstance(brief, str) and key.startswith(_STICKY_SENTINEL)
+            key: {"brief": row["brief"]}
+            for key, row in (state.get("coalescing") or {}).items()
+            if isinstance(key, str)
+            and key.startswith(_STICKY_SENTINEL)
+            and isinstance(row, dict)
+            and isinstance(row.get("brief"), str)
         }
         state = {"epoch": tick.epoch, "alerted": carried, "errors": 0}
         if carried_window:
@@ -784,16 +840,33 @@ def run(
     # the woken agent reads live state regardless, which is strictly better than
     # never being told a human had blocked the PR.
     observed_wakes = {_dedupe_key(o) for o in tick.observations if o.severity is Severity.WAKE}
-    window: dict[str, str] = {
-        key: brief
-        for key, brief in (state.get("coalescing") or {}).items()
+    window: dict[str, dict] = {
+        key: row
+        for key, row in (state.get("coalescing") or {}).items()
         if key in observed_wakes or key.startswith(_STICKY_SENTINEL)
     }
-    window.update(fresh_wakes)
+    # A fresh signal joins with its OWN open time. Re-observing an entry already
+    # in the window refreshes its BRIEF and never its stamp: a probe reports an
+    # unresolved anomaly on every tick until it clears, so restamping here would
+    # reset its clock each time and the window would never reach its floor.
+    for key, brief in fresh_wakes.items():
+        row = window.get(key)
+        if row is None:
+            window[key] = {"brief": brief, "opened_at": now}
+        else:
+            row["brief"] = brief
     if window:
-        state["coalescing"] = window
-        if not _coerce_ts(state.get("coalesce_started_at")):
-            state["coalesce_started_at"] = now
+        # A row with no usable stamp opens its clock now. Two producers reach
+        # here: a sticky entry carried across an epoch reset, which restarts by
+        # design (see above), and persisted state whose window stamp was itself
+        # unusable. A stamp in the FUTURE is a clock rollback, and treating it as
+        # opening now is what keeps it from firing at once or never. Both cost a
+        # delay, never a loss.
+        for row in window.values():
+            opened = _coerce_ts(row.get("opened_at"))
+            if opened is None or opened > now:
+                row["opened_at"] = now
+        _install_window(state, window)
         # Persist BEFORE evaluating the fire condition, so ``persist_ok`` below
         # reflects this tick's write rather than a stale initial value: whether
         # the window can be remembered is exactly what decides if delaying it is
@@ -803,46 +876,79 @@ def run(
         # Everything in flight cleared. Close the window rather than leaving a
         # start stamp behind, or the NEXT anomaly would inherit this window's
         # age and could fire without any settling time of its own.
-        state.pop("coalescing", None)
-        state.pop("coalesce_started_at", None)
+        _install_window(state, window)
         persist()
         raise Skip(tick.detail or f"{tick.pending} pending")
 
-    started = _coerce_ts(state.get("coalesce_started_at"))
-    if started is None or started > now:
-        # No start stamp, or one in the future (clock rollback): treat the
-        # window as starting now rather than firing immediately or never.
-        started = now
-        state["coalesce_started_at"] = now
-    elapsed = now - started
     converged = tick.pending == 0
-    # The cap is an ABSOLUTE wall, so it must not be gated behind the floor.
-    # Written as `elapsed >= floor and (converged or elapsed >= cap)` it was:
-    # a caller passing a floor above the cap (legal, both finite and positive)
-    # plus a pending count that never drains meant the cap could never be
-    # reached first, and the guarantee it exists to make -- a delayed wake
-    # rather than a dropped one -- was quietly void for those values.
-    if elapsed >= coalesce_max_secs:
-        fire = dict(window)
-    elif elapsed >= coalesce_secs and converged:
-        fire = dict(window)
-    elif elapsed >= coalesce_secs:
-        # The floor is reached but checks are still draining. ``pending`` counts
-        # CHECKS, which makes it the right gate for an epoch-scoped anomaly -- a
-        # draining check is exactly what can still resolve one. It is the wrong
-        # gate for a STICKY signal: a comment is complete the moment it is posted
-        # and does not become truer when a check finishes, so gating it on that
-        # count buys nothing and costs up to ``coalesce_max_secs``. Measured on a
-        # real pull request with 18 checks in flight, a fresh review comment was
-        # held the full 30 minutes for no observation it could have gained.
-        #
-        # So each population fires on its OWN readiness. Firing the whole window
-        # here instead would announce an epoch-scoped `ready` before the new
-        # head's checks existed -- the convergence-that-never-happened the floor
-        # was added to prevent.
-        fire = {k: v for k, v in window.items() if k.startswith(_STICKY_SENTINEL)}
+    ages = {key: now - float(row["opened_at"]) for key, row in window.items()}
+    oldest = max(ages.values(), default=0.0)
+    # The cap is an ABSOLUTE wall, and it stays a WINDOW-level one that flushes
+    # everything. It must not be gated behind the floor -- written as
+    # `age >= floor and (converged or age >= cap)` it was, a caller passing a
+    # floor above the cap (legal, both finite and positive) plus a pending count
+    # that never drains meant the cap could never be reached first, and the
+    # guarantee it exists to make -- a delayed wake rather than a dropped one --
+    # was quietly void for those values.
+    #
+    # Making the cap per entry too was tried and reverted: withholding an
+    # unconverged neighbour from a cap wake turns ONE flush into one wake per
+    # entry for a subject whose ``pending`` never drains, which is the per-wake
+    # cost this window exists to remove and the opposite of what the payload rule
+    # below is for. So the cap's PAYLOAD is what it always was: everything.
+    #
+    # Its CLOCK does move, and the one scenario is worth naming. Base measured
+    # the cap from a window stamp deliberately retained across a partial fire;
+    # this reads the oldest SURVIVING entry, so a partial fire that delivers the
+    # entry which opened the window defers the cap wake by that entry's head
+    # start. Keeping the delivered entry's stamp alive just to preserve the old
+    # instant would rebuild the very conflation this change removes -- a later
+    # joiner would then flush on a clock it never spent. What the cap actually
+    # promises is a bound, and the bound survives per entry: ``oldest`` is never
+    # below any single entry's age, so no entry outlives the cap measured from
+    # its own arrival. The shift is therefore always toward a LATER wake, never
+    # an earlier one and never a lost one.
+    if oldest >= coalesce_max_secs:
+        fire = {key: row["brief"] for key, row in window.items()}
+        triggered = True
     else:
+        # Two separate questions, and keeping them separate is the whole change.
+        #
+        # (1) May an entry TRIGGER a wake? Only once it has served a floor of its
+        #     OWN. One window-level age could not answer that, because one window
+        #     holds signals of different ages: a partial fire leaves entries that
+        #     have already waited, and the next tick can add one that has not
+        #     waited at all. The joining entry inherited an age it never spent and
+        #     woke the agent on the very next tick, so a burst arriving one at a
+        #     time cost one wake each.
+        #
+        # (2) Given that a wake IS going out, which entries ride along? Every
+        #     entry this tick's population gate admits, aged or not, which is
+        #     unchanged. Riding along never ADDS a wake, and holding an admitted
+        #     entry back would guarantee another one later, so the answer here has
+        #     to stay generous or coalescing stops coalescing.
+        #
+        # The population gate: past the floor, an epoch-scoped entry additionally
+        # waits for ``pending`` to drain and a STICKY one does not. ``pending``
+        # counts CHECKS, which makes it the right gate for an epoch-scoped anomaly
+        # -- a draining check is exactly what can still resolve one -- and the
+        # wrong gate for a comment, which is complete the moment it is posted and
+        # does not become truer when a check finishes. Measured on a real pull
+        # request with 18 checks in flight, a fresh review comment was held the
+        # full 30 minutes for no observation it could have gained. Admitting the
+        # epoch-scoped half on a sticky signal's readiness instead would announce
+        # a `ready` before the new head's checks existed -- the
+        # convergence-that-never-happened the floor was added to prevent.
         fire = {}
+        triggered = False
+        for key, row in window.items():
+            if not (converged or key.startswith(_STICKY_SENTINEL)):
+                continue
+            fire[key] = row["brief"]
+            if ages[key] >= coalesce_secs:
+                triggered = True
+        if not triggered:
+            fire = {}
     # `persist_ok` gates the partial fire, and the reason is the fallback below.
     # Withholding the epoch-scoped half is only a DELAY while the window can be
     # remembered; with an unwritable state directory the next tick reloads an
@@ -853,32 +959,27 @@ def run(
         for key in fire:
             alerted[key] = now
         remaining = {k: v for k, v in window.items() if k not in fire}
-        if remaining:
-            # Keep the START STAMP, not merely the entries: those have been
-            # waiting since it, and restarting the clock on every partial fire
-            # would push them out by a fresh floor each time a sticky signal
-            # arrives -- turning a talkative pull request into an indefinite
-            # delay for the check anomaly sitting beside it.
-            state["coalescing"] = remaining
-        else:
-            state.pop("coalescing", None)
-            state.pop("coalesce_started_at", None)
+        # The remainder keeps its OWN stamps, so a partial fire never pushes it
+        # out: those entries have been waiting since they opened, and restarting
+        # their clock each time a sticky signal arrives would turn a talkative
+        # pull request into an indefinite delay for the check anomaly beside it.
+        _install_window(state, remaining)
         persist()
         raise Report(with_warning(body(list(fire.values()))))
 
     if not persist_ok:
         # A window needs to REMEMBER when it opened, so an unwritable state
         # directory does not merely degrade coalescing -- it destroys it. Every
-        # cron subprocess reloads an empty window, `elapsed` is always zero, and
+        # cron subprocess reloads an empty window, every age is always zero, and
         # the fire condition can never be reached: the wake is not delayed, it
         # is lost. Deliver now instead, with the warning that says why the
         # operator is about to see repeats. Without coalescing this hazard did
         # not exist (an unwritable directory only caused duplicate wakes), so it
         # arrived with the window and is guarded where the window is.
-        raise Report(with_warning(body(list(window.values()))))
+        raise Report(with_warning(body([row["brief"] for row in window.values()])))
 
     persist()
     raise Skip(
-        f"coalescing window open {int(elapsed)}s/{int(coalesce_secs)}s, "
+        f"coalescing window open {int(oldest)}s/{int(coalesce_secs)}s, "
         f"{len(window)} anomaly(ies) coalescing, {tick.pending} pending"
     )

--- a/test/test_irq.py
+++ b/test/test_irq.py
@@ -337,14 +337,79 @@ def test_hard_cap_outranks_a_floor_set_above_it():
     assert isinstance(verdict, Report), "the cap must fire even below the floor"
 
 
+def test_the_hard_cap_flushes_the_WHOLE_window_not_only_the_capped_entry():
+    """The cap stays a WINDOW-level wall even though the floor is per entry.
+
+    Making the cap per entry as well was tried and reverted here: for a subject
+    whose `pending` never drains, withholding an unconverged neighbour from a cap
+    wake turns ONE flush into one wake per entry, spaced by their arrival
+    spacing. That is the per-wake cost the window exists to remove, and it is the
+    opposite of the payload rule -- riding along cannot add a wake, withholding
+    guarantees one. The floor is what a joining entry must serve; the cap is the
+    promise that a wedged queue costs a delay and not a wake per signal.
+    """
+    first = _wake("red:a", "first red")
+    probe = ScriptedProbe(
+        [
+            Tick(epoch="e1", observations=[first], pending=5),
+            # A second red arrives long after the first opened, so on a per-entry
+            # cap it would be nowhere near its own wall.
+            Tick(epoch="e1", observations=[first, _wake("red:b", "second red")], pending=5),
+        ]
+    )
+    assert isinstance(_verdict(probe, coalesce_secs=999, coalesce_max_secs=9999), Skip)
+    _settle()
+    verdict = _verdict(probe, coalesce_secs=999, coalesce_max_secs=_COALESCE)
+    assert isinstance(verdict, Report)
+    body = str(verdict)
+    assert "first red" in body
+    assert "second red" in body, "the cap flushes the window, not just what aged out"
+
+
+def test_an_entry_left_by_a_partial_fire_still_reaches_the_cap():
+    """The cap's promise is a bounded delay, and a partial fire must not extend it.
+
+    The window's age is now the oldest SURVIVING entry's age, so a partial fire
+    that delivers the entry which opened the window moves the cap clock onto the
+    survivor. That is a bound, not a reset: an entry is flushed no later than the
+    cap measured from its own arrival, which is what "delayed, never dropped"
+    means per entry. Seeded from disk rather than slept for, so the bound is
+    asserted rather than raced.
+    """
+    path = state_path("test-kind", "sub-1", "job-1")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = dedupe_key(_wake("red:a"))
+    path.write_text(
+        json.dumps(
+            {
+                "epoch": "e1",
+                # What a partial fire leaves: the sticky half already delivered,
+                # one epoch-scoped survivor carrying the age it earned.
+                "coalescing": {key: {"brief": "a red", "opened_at": time.time() - 600}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    probe = ScriptedProbe([Tick(epoch="e1", observations=[_wake("red:a", "a red")], pending=4)])
+    # The floor is unreachable, so only the cap can produce this wake.
+    verdict = _verdict(probe, coalesce_secs=9999, coalesce_max_secs=300)
+    assert isinstance(verdict, Report), "the survivor's own cap must still fire"
+    assert "a red" in str(verdict)
+
+
 def test_window_state_survives_across_ticks():
     probe = ScriptedProbe([Tick(epoch="e1", observations=[_wake("red:a")], pending=3)])
     _verdict(probe, coalesce_secs=999)
     state = load_state(state_path("test-kind", "sub-1", "job-1"))
     # Asserted through the kernel's own key helper rather than a literal: the
     # test's subject is that the window PERSISTED, not how a key is spelled.
-    assert list(state["coalescing"]) == [dedupe_key(_wake("red:a"))]
-    assert state["coalesce_started_at"] > 0
+    key = dedupe_key(_wake("red:a"))
+    assert list(state["coalescing"]) == [key]
+    # The age lives on the ENTRY. There is no window-level stamp to assert: one
+    # scalar could not serve entries admitted at different times, which is the
+    # defect `test_an_entry_joining_after_a_partial_fire_serves_its_own_floor`
+    # pins.
+    assert state["coalescing"][key]["opened_at"] > 0
 
 
 def test_window_cleared_after_it_fires():
@@ -460,8 +525,14 @@ def test_cleared_anomaly_is_pruned_from_an_open_window():
             Tick(epoch="e1", observations=[_wake("red:a", "A failed")], pending=3),
             # red:a reran green; only red:b is still observed this tick
             Tick(epoch="e1", observations=[_wake("red:b", "B failed")], pending=0),
+            Tick(epoch="e1", observations=[_wake("red:b", "B failed")], pending=0),
         ]
     )
+    assert isinstance(_verdict(probe, coalesce_secs=_COALESCE), Skip)
+    _settle()
+    # red:b joined on this tick, so it serves a floor of its OWN rather than
+    # inheriting the age of the window red:a opened. It is the wake below that
+    # must not carry red:a, and the extra tick is what red:b's own floor costs.
     assert isinstance(_verdict(probe, coalesce_secs=_COALESCE), Skip)
     _settle()
     verdict = _verdict(probe, coalesce_secs=_COALESCE)
@@ -1000,3 +1071,103 @@ def test_a_partial_fire_defers_to_the_unwritable_state_fallback():
     assert "said" in body, "the sticky half must still be delivered"
     assert "green" in body, "the withheld half must NOT be held back into a lost window"
     assert "unwritable" in body, "the operator has to be told why repeats are coming"
+
+
+# ------------------------------------------- one window, entries of different ages
+
+
+def test_an_entry_joining_after_a_partial_fire_serves_its_own_floor():
+    """A partial fire leaves the window open, and the next tick can add a signal
+    that has not waited at all. One window-level start stamp handed that signal
+    an age it never spent, so it was delivered on the very next tick with no
+    settling window of its own -- and the signal arriving seconds behind it then
+    needed a wake of its own too, which is the per-wake cost coalescing exists to
+    remove.
+
+    Both halves are pinned here: the joining entry does not ride out early, and
+    it is DELAYED rather than dropped -- it arrives once its own floor closes, in
+    ONE wake together with the signal that joined behind it.
+    """
+    conversation = _sticky("comment:1", "said")
+    checks = _wake("red:a", "a red")
+    probe = ScriptedProbe(
+        [
+            # A comment lands while checks run, so the window opens and cannot
+            # converge.
+            Tick(epoch="e1", observations=[conversation, checks], pending=4),
+            # Past the floor: the sticky half fires and the check entry stays, so
+            # the window -- and its one start stamp -- survives the partial fire.
+            Tick(epoch="e1", observations=[conversation, checks], pending=4),
+            # A second comment joins the aged window having waited nothing.
+            Tick(epoch="e1", observations=[checks, _sticky("comment:2", "two")], pending=4),
+            # And a third joins behind it, inside the second one's floor.
+            Tick(
+                epoch="e1",
+                observations=[
+                    checks,
+                    _sticky("comment:2", "two"),
+                    _sticky("comment:3", "three"),
+                ],
+                pending=4,
+            ),
+            Tick(
+                epoch="e1",
+                observations=[
+                    checks,
+                    _sticky("comment:2", "two"),
+                    _sticky("comment:3", "three"),
+                ],
+                pending=4,
+            ),
+        ]
+    )
+    assert isinstance(_verdict(probe, coalesce_secs=_COALESCE), Skip)
+    _settle()
+
+    partial = _verdict(probe, coalesce_secs=_COALESCE)
+    assert isinstance(partial, Report)
+    assert "said" in str(partial)
+
+    # No _settle() on purpose: comment:2 has waited nothing.
+    joined = _verdict(probe, coalesce_secs=_COALESCE)
+    assert isinstance(joined, Skip), "a joining entry must not inherit the window's age"
+
+    # Still no _settle(): comment:3 lands inside comment:2's floor, which is what
+    # gives the two something to coalesce INTO.
+    behind = _verdict(probe, coalesce_secs=_COALESCE)
+    assert isinstance(behind, Skip)
+
+    _settle()
+    late = _verdict(probe, coalesce_secs=_COALESCE)
+    assert isinstance(late, Report), "a held entry must be delayed, never dropped"
+    body = str(late)
+    assert "two" in body and "three" in body, "both joiners belong in ONE wake"
+
+
+def test_a_window_written_before_per_entry_ages_keeps_the_age_it_had():
+    """An upgrade must not restart the clock of a window already open on disk.
+
+    State written before entries carried their own open time has one window-level
+    stamp and bare brief strings. Reading that shape has to seed every entry from
+    the old stamp, or an in-flight watch silently serves a second floor across the
+    version change -- a delay the operator cannot see the reason for.
+    """
+    path = state_path("test-kind", "sub-1", "job-1")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = dedupe_key(_sticky("comment:1"))
+    path.write_text(
+        json.dumps(
+            {
+                "epoch": "e1",
+                "coalescing": {key: "said"},
+                "coalesce_started_at": time.time() - 600,
+            }
+        ),
+        encoding="utf-8",
+    )
+    probe = ScriptedProbe(
+        [Tick(epoch="e1", observations=[_sticky("comment:1", "said")], pending=4)]
+    )
+    verdict = _verdict(probe, coalesce_secs=_COALESCE)
+    assert isinstance(verdict, Report), "the entry had already waited ten minutes"
+    assert "said" in str(verdict)


### PR DESCRIPTION
## What is the problem?

The interrupt controller's coalescing window kept ONE start stamp
(`coalesce_started_at`) for every entry it held. That is fine while a window
opens, ages and fires as a unit -- and it stops being fine the moment a window
holds entries of different ages, which the shipped code deliberately creates:

* a PARTIAL fire delivers the epoch-independent half and leaves the epoch-scoped
  half in the window, keeping the window (and its one stamp) open;
* the next tick can add a brand-new signal to that already-aged window.

The joining signal inherited an age it never spent. `elapsed` was already past
`coalesce_secs`, so the entry satisfied the floor on arrival and woke the agent
on the very next tick with no settling window of its own.

## Why this issue matters to the user

The floor exists so a burst of signals becomes ONE wake instead of one wake
each. Past a partial fire that guarantee was off: comments landing on a talkative
pull request, or checks going red one at a time, each triggered their own wake --
exactly the per-wake cost this feature was built to remove, and the cost is paid
in the user's tokens, once per wake.

Two independent reproductions exist in the test suite. The new
`test_an_entry_joining_after_a_partial_fire_serves_its_own_floor` fails on the
base commit at `a joining entry must not inherit the window's age`. And
`test_cleared_anomaly_is_pruned_from_an_open_window` was ALREADY passing only
because of this defect: every entry that opened the window had been pruned, yet
the survivor still fired immediately on the dead window's stamp.

## How our fix solves it

Symptom: a signal joining an open window wakes the agent without waiting.
Cause: `elapsed` is a property of the WINDOW, and the window's age says nothing
about how long any individual entry has been in it.
Fix: each entry carries its own `opened_at`, and the fire decision is split into
the two questions the single stamp had conflated.

1. **May an entry TRIGGER a wake?** Only once it has served a floor of its own.
   This is the fix -- a joiner can no longer wake anyone on arrival.
2. **Given a wake is going out, which entries ride along?** Every entry the
   population gate admits, aged or not. Unchanged, and keeping it generous is
   load-bearing: riding along can never ADD a wake, while withholding an
   admitted entry guarantees a second wake later.

Re-observing an entry refreshes its brief and never its stamp (a probe reports an
unresolved anomaly every tick, so restamping would reset its own clock and no
window would ever fire).

The change also touches the hard cap, and the boundary is worth stating exactly
rather than as "unchanged", because two review rounds went into finding where that
word was wrong:

* **The cap's PAYLOAD is unchanged: it still flushes the whole window.** An
  earlier revision of this PR made the cap per entry too. Both review lanes caught
  it independently and they were right: for a subject whose `pending` never
  drains, withholding an unconverged neighbour from a cap wake turns one flush
  into one wake per entry -- the exact cost this window exists to remove, and the
  opposite of rule 2 above. Reverted, and now pinned by
  `test_the_hard_cap_flushes_the_WHOLE_window_not_only_the_capped_entry`, which
  reddens if a per-entry cap is reintroduced.
* **The cap's CLOCK does move, in exactly one scenario.** Base measured it from a
  window stamp deliberately retained across a partial fire; this reads the oldest
  SURVIVING entry. So a partial fire that delivers the entry which opened the
  window defers the cap wake by that entry's head start -- always LATER, never
  earlier, never lost. Keeping the delivered entry's stamp alive to preserve the
  old instant would rebuild the conflation this PR removes: a later joiner would
  then flush on a clock it never spent. What the cap promises is a bound, and the
  bound survives per entry because `oldest` is never below any single entry's age,
  so no entry outlives the cap counted from its own arrival.
  `test_an_entry_left_by_a_partial_fire_still_reaches_the_cap` seeds that state
  with an unreachable floor, so only the cap can produce the wake, and asserts it
  does. Called out by GPT in round 2 and by First Principles in round 3 -- both
  times because the description called the cap "unchanged" without this
  qualification.

One behaviour is deliberately left as it shipped, because it is a wake-timing
change on a different trigger and this module's rule is that a timing change
ships as its own attributable step, and one field was subtracted outright:

* **The epoch reset still restarts a carried entry's clock.** Per-entry ages make
  keeping the carried stamp a one-line follow-up, but the trigger is different (a
  push cadence faster than the floor re-delaying a carried comment).
* **`coalesce_started_at` is never written.** The first revision wrote it as a
  derived value and the docstring claimed the `Skip` detail read it back; First
  Principles verified that claim was false (the `Skip` line computes the age
  live), and in round 2 found the remaining `load_state` write had no reader
  either. Both are gone, along with the pop that only existed to clean up the
  write. The field survives as a READ in `load_state` alone, to seed entries
  persisted before they carried their own stamp -- an in-flight watch must not
  serve a second floor across the version change -- and the legacy value falls off
  at the first write after the upgrade.

## What tests we did

* `test_an_entry_joining_after_a_partial_fire_serves_its_own_floor` (new) pins
  all three halves: the joiner does not ride out early, it is DELAYED rather than
  dropped, and it lands in ONE wake with the signal that joined behind it.
  Mutation-verified: fails on the base commit.
* `test_the_hard_cap_flushes_the_WHOLE_window_not_only_the_capped_entry` (new)
  closes the gap Design Review named ("no test pins the multi-entry cap scenario
  either way"). Mutation-verified: filtering the cap flush to capped entries
  reddens it at `the cap flushes the window, not just what aged out`.
* `test_an_entry_left_by_a_partial_fire_still_reaches_the_cap` (new) pins the cap
  bound GPT round 2 questioned: the post-partial-fire state is seeded from disk
  with an unreachable floor, so only the cap can produce the wake.
  Mutation-verified: restamping a re-observed entry reddens it at `the survivor's
  own cap must still fire`.
* `test_a_window_written_before_per_entry_ages_keeps_the_age_it_had` (new) pins
  the migration. It passes on base by construction (base has no other shape), so
  it was mutation-verified against the fix instead: dropping the legacy stamp
  seed reddens it at `the entry had already waited ten minutes`.
* `test_cleared_anomaly_is_pruned_from_an_open_window` (amended) now serves the
  surviving anomaly its own floor. Not a loosening -- the amended test also fails
  on base, so it pins the same defect a second time from a different direction,
  and its original assertion (a cleared anomaly must not ride along) is untouched.
* `test_window_state_survives_across_ticks` (amended) asserts the entry's own
  `opened_at` instead of a window-level stamp that no longer exists.
* Targeted suites green: `test_irq.py` (61), `test_babysit_pr_watch.py` plus
  `test_ai_pr_watchers_coverage.py` (220), `test_cron_script.py` plus
  `test_spawn_audit.py` (136), `test_black_gate_contract.py` (11).
* black, isort, flake8 clean on both touched Python files; mypy on `irq.py`
  reports only the two pre-existing `transcribe.py` errors also present on base.
* The spec moved with the code: the coalescing and epoch sections of
  `docs/system-specs/features/agent-interrupt-controller.md` described the single
  window stamp verbatim.

## Any other suggestions on the work

* The epoch-reset restart is now a one-line change and worth its own step: a push
  cadence faster than the floor can keep re-delaying a carried comment.
* `pending` is a scalar count for a set of checks whose members are also of
  different ages -- the same shape of assumption this change removes from the
  window. Worth a look before another signal population is added.

## Pattern harvest

Rule candidate: a collection whose members are admitted at different times must
not be aged by a single timestamp stored beside it.

Pattern: a scalar `*_at` / `*_started_at` field living in the same state record as
a dict or list that is mutated incrementally -- here `coalesce_started_at` beside
`coalescing`. That co-occurrence is mechanically detectable, and the question to
ask on a hit is "can an element join after this stamp is set?" If yes, the age
belongs on the element.

Not a one-off: the same defect class already surfaced twice in this module's
history and was patched both times by deciding what the ONE stamp should do at a
transition (keep it across a partial fire; drop it across an epoch reset) rather
than by removing the conflation -- which is why the residue survived to this
change. When a second transition needs a different answer from one scalar, that is
the signal to move the value onto the elements instead of adding a third rule.

The review round on this PR harvests a second, narrower rule: when a change makes
one dimension per-element, check every OTHER decision that read the old scalar
before making it per-element too. Here the cap read the same stamp, and making it
per-entry looked consistent while inverting the feature's purpose.


