### PR TITLE
fix(config): deny tailnet peers when the login allowlist could not be read

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3054,7 +3054,65 @@ class TailscaleConfig:
     )
 
 
-def _tailscale_config_from(raw: object) -> TailscaleConfig:
+#: ``degraded_sections`` key for "the operator wrote a tailnet identity policy
+#: this load could not read". Its own key rather than reusing ``"dashboard"``
+#: so the tailnet gate denies on exactly the narrowing it enforces, and an
+#: unrelated malformed ``dashboard`` value does not.
+DEGRADED_TAILSCALE = "dashboard.tailscale"
+
+
+def tailnet_identity_unknown(sections: frozenset[str]) -> bool:
+    """Whether *sections* means the tailnet login allowlist could not be read.
+
+    Three shapes lose it, at three depths: an unreadable config FILE, an
+    unreadable ``dashboard`` section, and an unreadable ``dashboard.tailscale``
+    value. All three resolve ``allowed_logins`` to the empty list, which the
+    loader turns into ``trust_identity = False`` — i.e. no login restriction —
+    so the gate has to treat them alike.
+
+    Lives here, beside the keys it names, because BOTH server startup surfaces
+    ask it. Asking twice in two places is how the tailnet feature shipped a
+    drift bug before (see ``governed_tailnet_trust``).
+    """
+    return bool(sections & {DEGRADED_WHOLE_CONFIG, "dashboard", DEGRADED_TAILSCALE})
+
+
+def tailnet_effective_allowed_logins(
+    sections: frozenset[str], allowed_logins: list[str] | tuple[str, ...]
+) -> tuple[str, ...]:
+    """The parsed allowlist reduced to what is safe to ENFORCE from *sections*.
+
+    Degradation comes in two severities and only one of them invalidates the
+    value that was parsed:
+
+    * A whole config FILE could not be read (:data:`DEGRADED_WHOLE_CONFIG`).
+      ``config.local.json`` is deep-merged OVER ``config.json``, and an overlay
+      may exist precisely to NARROW the base -- so a lost overlay leaves the
+      base's wider list standing and every login the operator removed is
+      admitted again. The parsed list is not the effective policy, it is a
+      stale one, so nothing may be enforced from it: the allowlist is empty and
+      every peer is denied, matching how the publish gate treats an unreadable
+      file.
+    * A section or field inside a file that WAS read (``dashboard``,
+      :data:`DEGRADED_TAILSCALE`). Whatever parsed is literally what the
+      operator wrote in a file this load could see, so it is kept: access
+      narrows to the entries that survived, and the administrator whose own
+      login parsed fine is not locked out mid-repair.
+
+    Both cases still enforce -- see :func:`tailnet_identity_unknown`. This
+    decides only WHOSE logins may satisfy that enforcement.
+    """
+    if DEGRADED_WHOLE_CONFIG in sections:
+        return ()
+    return tuple(allowed_logins)
+
+
+def _tailscale_config_from(
+    raw: object,
+    degraded: set[str] | None = None,
+    *,
+    key_present: bool = False,
+) -> TailscaleConfig:
     """Build the validated :class:`TailscaleConfig` (RFC §3/§3.1 load rules).
 
     Two rules, both narrowing-only so a typo can never widen access:
@@ -3065,11 +3123,126 @@ def _tailscale_config_from(raw: object) -> TailscaleConfig:
       shared corporate tailnet would hand the dashboard to all of them.
     * An unrecognised ``pin_scope`` falls back to ``"node"`` (the narrower
       scope) with a logged warning — never to ``"login"``.
+
+    Both rules resolve to a *narrower* value, which is right for an operator
+    typo and wrong for a value that was LOST: ``allowed_logins`` is the only
+    restriction on which tailnet peer may authenticate, so losing it resolves
+    to "identity trust off", i.e. no login restriction at all. Absent is
+    genuinely unconfigured; MALFORMED is the operator having asked for a
+    restriction this load cannot read, and it is recorded in *degraded* under
+    :data:`DEGRADED_TAILSCALE` so the gate can deny instead of admitting every
+    tailnet peer (the shape that reopened the publish allowlist, #4057).
+
+    ``key_present`` separates the two states a bare value cannot: a MISSING
+    ``tailscale`` key and one written as JSON ``null`` both arrive here as
+    ``None``. Only the second is the operator having written something, so only
+    it degrades -- reading ``None`` alone as malformed would deny every install
+    that simply has no tailscale section. Callers that do not know pass nothing
+    and get the absent reading, which is what the direct-value tests rely on.
     """
+    if (key_present and raw is None) or (raw is not None and not isinstance(raw, dict)):
+        # Reached only because "dashboard.tailscale" is a fail-closed path in
+        # config/validation.py; without that entry the malformed value is
+        # repaired to the default before this runs and there is nothing to see.
+        # An explicit null counts: the operator had to write the key to produce
+        # it, which is the absent-versus-malformed line this whole fix turns on.
+        if degraded is not None:
+            degraded.add(DEGRADED_TAILSCALE)
+        _OBSERVED_DEGRADED_SECTIONS.add(DEGRADED_TAILSCALE)
+        logger.warning(
+            "config: 'dashboard.tailscale' is not a JSON object (got %s) — the "
+            "tailnet login allowlist is unknown, so tailnet peers are DENIED "
+            "until the file is fixed and the gateway restarted",
+            type(raw).__name__,
+        )
     data = _safe_dict(raw)
     enabled = _safe_bool(data.get("enabled"), False)
     trust_identity = _safe_bool(data.get("trust_identity"), False)
+    if "trust_identity" in data and not isinstance(data.get("trust_identity"), bool):
+        # The same class as the allowlist itself, one field over, and the field
+        # is the restriction's own ON switch -- so it is the most permissive
+        # default in the section. ``_safe_bool`` returns the default for
+        # anything non-boolean, and that default is False, so `"true"` (a
+        # quoted boolean, the commonest hand-edit slip) or `1` reads as "the
+        # operator never asked for identity trust" and the perfectly valid
+        # allowlist beside it stops being enforced.
+        #
+        # Recording it enforces the allowlist AS WRITTEN rather than denying
+        # everyone: the entries parsed from a readable file are kept, so the
+        # operator's own login still works and every peer they did not name is
+        # refused. That is the closest honest reading of a config whose intent
+        # to enable was garbled but whose list of who to admit was not.
+        if degraded is not None:
+            degraded.add(DEGRADED_TAILSCALE)
+        _OBSERVED_DEGRADED_SECTIONS.add(DEGRADED_TAILSCALE)
+        logger.warning(
+            "config: 'dashboard.tailscale.trust_identity' is not a boolean (got "
+            "%s) — it is the switch for the tailnet login allowlist, so the "
+            "allowlist is enforced as written and every peer it does not name "
+            "is DENIED until the file is fixed and the gateway restarted",
+            type(data.get("trust_identity")).__name__,
+        )
     raw_logins = data.get("allowed_logins")
+    # The allowlist is only ever CONSULTED when identity trust is on, so a
+    # malformed value in it loses nothing when the operator cleanly said off (or
+    # never said on). Recording a degradation there would turn a typo in an
+    # inert field into a forwarded-tailnet lockout, against a config that -- read
+    # correctly -- permits those peers. A malformed FLAG is different: intent is
+    # unknown, so the allowlist has to be treated as live.
+    #
+    # Presence is tested with ``in`` rather than ``is not None`` throughout: a
+    # key written as JSON null is the operator having written something
+    # unusable, not having left it out, and only the second is consent.
+    _allowlist_is_live = trust_identity or (
+        "trust_identity" in data and not isinstance(data.get("trust_identity"), bool)
+    )
+    if _allowlist_is_live and "allowed_logins" in data and not isinstance(raw_logins, list):
+        # Same class one level down, and reachable WITHOUT a registry entry:
+        # a three-segment path is past _apply_field_default's depth cap, so the
+        # malformed value survives validation already. Recorded rather than
+        # merely logged, because the log line below only fires when
+        # trust_identity happens to be readable AND true — a config whose
+        # trust_identity was lost in the same edit would say nothing at all.
+        if degraded is not None:
+            degraded.add(DEGRADED_TAILSCALE)
+        _OBSERVED_DEGRADED_SECTIONS.add(DEGRADED_TAILSCALE)
+        logger.warning(
+            "config: 'dashboard.tailscale.allowed_logins' is not a list (got "
+            "%s) — the tailnet login allowlist is unknown, so tailnet peers "
+            "are DENIED until the file is fixed and the gateway restarted",
+            type(raw_logins).__name__,
+        )
+    elif (
+        _allowlist_is_live
+        and isinstance(raw_logins, list)
+        and any(not (isinstance(entry, str) and entry.strip()) for entry in raw_logins)
+    ):
+        # A LIST whose entries are not usable logins, e.g. [1] or ["a@b", None].
+        # The comprehension below silently drops them, so an all-invalid
+        # narrowing parses to [] — indistinguishable from "no restriction
+        # configured", which is the exact silent widening this fix exists to
+        # stop, and the same entry-level shape publish.allowed_destinations
+        # already handles. An EMPTY list is NOT this case: that is a readable,
+        # if mistaken, statement, and the trust_identity rule below already
+        # refuses it with its own error.
+        #
+        # Unlike publish, the surviving entries are KEPT rather than zeroed.
+        # The publish gate denies one whole action, so a partial allowlist
+        # there has nowhere safe to land; this gate decides per peer, so
+        # keeping the parseable logins narrows access to exactly what the
+        # operator demonstrably wrote, while the degradation record still
+        # denies every peer they did not name. Zeroing would instead lock out
+        # the administrator whose own login parsed fine — a self-inflicted
+        # outage in the middle of a config repair.
+        if degraded is not None:
+            degraded.add(DEGRADED_TAILSCALE)
+        _OBSERVED_DEGRADED_SECTIONS.add(DEGRADED_TAILSCALE)
+        logger.warning(
+            "config: 'dashboard.tailscale.allowed_logins' carries entr(y/ies) "
+            "that are not non-empty strings — the tailnet login allowlist is "
+            "not what was written, so any peer it does not name is DENIED "
+            "until the file is fixed and the gateway restarted",
+        )
     allowed_logins = [
         entry.strip()
         for entry in (raw_logins if isinstance(raw_logins, list) else [])
@@ -8597,7 +8770,11 @@ class KiroCrewConfig:
             ),
             dashboard=DashboardConfig(
                 url=dashboard_data.get("url", ""),
-                tailscale=_tailscale_config_from(dashboard_data.get("tailscale")),
+                tailscale=_tailscale_config_from(
+                    dashboard_data.get("tailscale"),
+                    _degraded,
+                    key_present="tailscale" in dashboard_data,
+                ),
                 restore_sessions=dashboard_data.get("restore_sessions", False),
                 qr_session_until_restart=_safe_bool(
                     dashboard_data.get("qr_session_until_restart"), True

--- a/src/kiro_crew/config/validation.py
+++ b/src/kiro_crew/config/validation.py
@@ -158,8 +158,31 @@ def _actual_type_name(value: object) -> str:
 #:   the loader's comprehension and would inject ``/etc`` as an allowed
 #:   relocate root, where the repaired default ``[]`` means home-only.
 #:
-#: Exact-match only: this is a per-path judgment, not a subtree rule.
-_FAIL_CLOSED_PATHS = frozenset({"publish", "publish.allowed_destinations"})
+#: * ``dashboard`` (the section) and ``dashboard.tailscale``: same open
+#:   direction, one narrowing deeper. ``dashboard.tailscale.allowed_logins``
+#:   is the ONLY restriction on which tailnet peer may authenticate, and its
+#:   default is the empty list — which the loader turns into
+#:   ``trust_identity = False``, i.e. **no login restriction at all**. So
+#:   repairing either enclosing object dropped the operator's allowlist and
+#:   admitted every tailnet peer holding a token, where before only an
+#:   allowlisted login was admitted. Note the deeper
+#:   ``dashboard.tailscale.allowed_logins`` itself needs no entry: at three
+#:   segments it is already past ``_apply_field_default``'s depth cap, so a
+#:   malformed list value is kept today.
+#:
+#: Exact-match only: this is a per-path judgment, not a subtree rule. The
+#: registry is only half of a fix — a preserved value changes nothing unless
+#: the loader RECORDS the degradation and a gate reads
+#: ``KiroCrewConfig.degraded_sections``. Both halves exist for every path
+#: listed here; adding a path without them just keeps evidence nobody reads.
+_FAIL_CLOSED_PATHS = frozenset(
+    {
+        "publish",
+        "publish.allowed_destinations",
+        "dashboard",
+        "dashboard.tailscale",
+    }
+)
 
 
 def _apply_field_default(data: dict, dot_path: str) -> bool:

--- a/src/kiro_crew/dashboard/handlers/auth_refresh.py
+++ b/src/kiro_crew/dashboard/handlers/auth_refresh.py
@@ -640,7 +640,7 @@ async def _verified_peer_key(request: web.Request, claimed_peer_key: str = "") -
     rebind then could not pin is precisely the gap this pair closes.
     """
     trust = request.app.get("tailnet_trust")
-    if not (isinstance(trust, TailnetTrust) and trust.trust_identity and trust.allowed_logins):
+    if not (isinstance(trust, TailnetTrust) and trust.enforces_identity):
         return ""
     try:
         peer = await resolve_forwarded_peer(request, trust)
@@ -683,7 +683,7 @@ async def _rebind_rotated_token_to_peer(
     separate decision and does not belong in a change about phone sessions.
     """
     trust = request.app.get("tailnet_trust")
-    if isinstance(trust, TailnetTrust) and trust.trust_identity and trust.allowed_logins:
+    if isinstance(trust, TailnetTrust) and trust.enforces_identity:
         peer = await resolve_forwarded_peer(request, trust)
         if peer is not None:
             bind_token_peer(access_token, peer_pin_key(peer, trust.pin_scope), session_exp)

--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -587,11 +587,19 @@ def _effective_mobile_setup(cfg: KiroCrewConfig, login: str) -> tuple[bool, list
 
 
 def _running_tailnet_trust_ready(request: web.Request, login: str) -> bool:
-    """Whether this process can enforce a persistent phone session right now."""
+    """Whether this process can enforce a persistent phone session right now.
+
+    Asks ``enforces_identity`` rather than spelling the conjunction out again:
+    the property exists so every site answering "is tailnet identity in force"
+    answers the same way, and a fifth hand-written spelling is the drift it was
+    added to prevent. Behaviour here is unchanged either way -- an unreadable
+    policy carries an empty allowlist, so ``login_allowed`` already refused --
+    but a future change to what enforcement means now reaches this site too.
+    """
     trust = request.app.get("tailnet_trust")
     if not isinstance(trust, tailnet.TailnetTrust):
         return False
-    return trust.trust_identity and tailnet.login_allowed(login, trust.allowed_logins)
+    return trust.enforces_identity and tailnet.login_allowed(login, trust.allowed_logins)
 
 
 async def api_tailnet_mobile_configure(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -37,10 +37,13 @@ from kiro_crew.config import data_home
 from kiro_crew.config.loader import (
     KiroCrewConfig,
     consume_managed_service_launch_environment,
+    degraded_config_files,
     load_loop_stall_exit_after,
     refresh_config_meta_stamp,
     refresh_materialized_agents,
     resolve_loop_stall_exit_after,
+    tailnet_effective_allowed_logins,
+    tailnet_identity_unknown,
 )
 from kiro_crew.dashboard import (
     cautious_boot,
@@ -3323,13 +3326,21 @@ async def start_dashboard(
     # Off by default; resolved in a thread so the daemon call cannot stall the
     # loop; "" whenever Tailscale is absent, stopped, or produced nothing that
     # validated.
-    _ts_cfg = KiroCrewConfig.load().dashboard.tailscale
+    _cfg = KiroCrewConfig.load()
+    _ts_cfg = _cfg.dashboard.tailscale
     _tailnet_host = await tailnet.resolve_tailnet_host(_ts_cfg.enabled)
     # Identity trust (RFC §2–§3.1): validated at config load, governance
     # ceiling applied inside the shared helper — ONE code path for both
     # startup surfaces, so they cannot drift.
     _tailnet_trust = await tailnet.governed_tailnet_trust(
-        _ts_cfg.trust_identity, tuple(_ts_cfg.allowed_logins), _ts_cfg.pin_scope
+        _ts_cfg.trust_identity,
+        tailnet_effective_allowed_logins(_cfg.degraded_sections, _ts_cfg.allowed_logins),
+        _ts_cfg.pin_scope,
+        # An unreadable tailnet policy resolves allowed_logins to [] and so
+        # trust_identity to False, which is "no login restriction". The values
+        # alone cannot tell that from "never configured"; degraded_sections can.
+        identity_unknown=tailnet_identity_unknown(_cfg.degraded_sections),
+        unreadable_files=tuple(degraded_config_files(_cfg.degraded_sections)),
     )
     if _tailnet_host:
         logger.info(
@@ -4081,12 +4092,17 @@ async def start_api_server(
     # The MCP route surface is identical to the dashboard's, so the middleware
     # chain must be too. Host-allowlist source of truth is shared with the CSRF
     # Origin check via build_allowed_origins/build_allowed_hosts (see origin.py).
-    _ts_cfg = KiroCrewConfig.load().dashboard.tailscale
+    _cfg = KiroCrewConfig.load()
+    _ts_cfg = _cfg.dashboard.tailscale
     _tailnet_host = await tailnet.resolve_tailnet_host(_ts_cfg.enabled)
     # Same identity-trust value as start_dashboard, via the same shared helper
     # — the auth surface is identical, so the middleware inputs must be too.
     _tailnet_trust = await tailnet.governed_tailnet_trust(
-        _ts_cfg.trust_identity, tuple(_ts_cfg.allowed_logins), _ts_cfg.pin_scope
+        _ts_cfg.trust_identity,
+        tailnet_effective_allowed_logins(_cfg.degraded_sections, _ts_cfg.allowed_logins),
+        _ts_cfg.pin_scope,
+        identity_unknown=tailnet_identity_unknown(_cfg.degraded_sections),
+        unreadable_files=tuple(degraded_config_files(_cfg.degraded_sections)),
     )
     app["allowed_origins"] = build_allowed_origins(
         port,

--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -908,6 +908,31 @@ class TailnetTrust:
     trust_identity: bool = False
     allowed_logins: tuple[str, ...] = ()
     pin_scope: str = PIN_SCOPE_NODE
+    #: The operator wrote a tailnet identity policy that config load could not
+    #: read (see ``DEGRADED_TAILSCALE``). Distinct from ``trust_identity=False``,
+    #: which means they never asked for one: an unreadable narrowing must DENY,
+    #: not resolve to "no restriction".
+    #:
+    #: The deny is still the ALLOWLIST doing its job, not a second code path --
+    #: a peer is admitted only by ``login_allowed``, so whoever the allowlist
+    #: does not name is refused. How much of the parsed allowlist survives to be
+    #: named is decided by ``tailnet_effective_allowed_logins`` at the caller,
+    #: because it depends on WHICH file failed: a lost overlay may have been the
+    #: narrowing, so nothing is enforceable from the base, while a malformed
+    #: field inside a readable file leaves the entries that parsed usable. Do
+    #: NOT assume this flag implies an empty ``allowed_logins``.
+    identity_unknown: bool = False
+
+    @property
+    def enforces_identity(self) -> bool:
+        """Whether a forwarded tailnet peer must be resolved and allowlisted.
+
+        The one predicate every gate asks, so "may this be pinned", "may this
+        rotate" and "may this authenticate" cannot answer differently — a
+        request admitted by one and refused by another is the drift this
+        property exists to prevent.
+        """
+        return self.identity_unknown or (self.trust_identity and bool(self.allowed_logins))
 
 
 _whois_lock = threading.Lock()
@@ -1022,7 +1047,9 @@ def _forwarded_peer_candidate(request: web.Request, trust: TailnetTrust) -> str 
     """
     # (b) explicit opt-in AND a non-empty allowlist. Identity trust is never
     # inferred, and an empty allowlist means trust was refused at config load.
-    if not trust.trust_identity or not trust.allowed_logins:
+    # An UNREADABLE policy also enforces: the allowlist is unknown, and
+    # ``login_allowed`` against the empty tuple then denies every peer.
+    if not trust.enforces_identity:
         return None
     # (a) the immediate peer must be the local proxy. A remote peer's forwarded
     # header is an unverifiable claim and is never read.
@@ -1045,6 +1072,57 @@ def _forwarded_peer_candidate(request: web.Request, trust: TailnetTrust) -> str 
     if not any(candidate in net for net in _TAILNET_RANGES):
         return None
     return str(candidate)
+
+
+def is_forwarded_tailnet_request(request: web.Request, trust: TailnetTrust) -> bool:
+    """Whether this request arrived as a tailnet peer behind the local proxy.
+
+    The discriminator a caller needs to fail closed WITHOUT locking anyone out:
+    under an unreadable identity policy a peer that could not be attributed must
+    be denied, but a request that was never a forwarded tailnet request in the
+    first place (loopback, the operator's own browser) resolves to no peer for
+    the same reason and must be left alone. Denying on "no peer resolved"
+    without asking this first would take the dashboard away from the one person
+    who can repair the config.
+
+    Deliberately WEAKER than :func:`_forwarded_peer_candidate`, which answers a
+    different question -- "is there exactly one address I may attribute an
+    identity to". Attribution demands a single unambiguous address, so it
+    rejects a multi-value or comma-joined chain. DENIAL must not: an ambiguous
+    chain is still a forwarded tailnet request, so answering "not forwarded"
+    there let a caller add a second ``X-Forwarded-For`` header and skip the deny
+    entirely, with a valid token doing the rest. Unattributable and absent are
+    different things, and only this predicate has to tell them apart.
+
+    So: loopback immediate peer, plus at least one forwarded address anywhere in
+    the chain that parses and sits inside the tailnet ranges. A chain carrying
+    no tailnet address at all is some other proxy's business and is left alone
+    -- widening past the tailnet policy is not this gate's job.
+
+    Synchronous and I/O-free -- the daemon is not consulted, so this is safe to
+    ask inline on the event loop.
+    """
+    # Same opt-in gate _forwarded_peer_candidate applies, repeated rather than
+    # inherited: without it an ordinary install (no identity policy at all)
+    # would start answering True and make the caller's deny branch reachable.
+    if not trust.enforces_identity:
+        return False
+    # A remote peer's forwarded header is an unverifiable claim. Reading it here
+    # would let anyone who can reach the port trigger the refusal for everyone.
+    if not is_loopback(request.remote or ""):
+        return False
+    for value in request.headers.getall(_FORWARDED_FOR_HEADER, []):
+        for part in value.split(","):
+            raw = part.strip()
+            if not raw:
+                continue
+            try:
+                candidate = ipaddress.ip_address(raw)
+            except ValueError:
+                continue
+            if any(candidate in net for net in _TAILNET_RANGES):
+                return True
+    return False
 
 
 async def resolve_forwarded_peer(request: web.Request, trust: TailnetTrust) -> ForwardedPeer | None:
@@ -1147,7 +1225,12 @@ def login_allowed(login: str, allowed_logins: tuple[str, ...]) -> bool:
 
 
 async def governed_tailnet_trust(
-    trust_identity: bool, allowed_logins: tuple[str, ...], pin_scope: str
+    trust_identity: bool,
+    allowed_logins: tuple[str, ...],
+    pin_scope: str,
+    *,
+    identity_unknown: bool = False,
+    unreadable_files: tuple[str, ...] = (),
 ) -> TailnetTrust:
     """Build the identity-trust value object, with the governance ceiling applied.
 
@@ -1163,13 +1246,27 @@ async def governed_tailnet_trust(
     pinning alive under a policy that forbids the tailnet integration. The
     probe runs in a thread (it reads the trust-root policy from disk) and is
     audited as a governance decision.
+
+    ``identity_unknown`` says config load could not read the operator's tailnet
+    policy. It is passed as a plain bool for the same reason the others are —
+    the caller owns the config read. The ceiling still wins over it: an
+    administrator who forbids the tailnet integration outright wants no whois
+    calls at all, and with the integration off there is no allowlist left to
+    fail closed on.
+
+    ``unreadable_files`` names the config file(s) involved, for the refusal to
+    quote. It matters more than it looks: the file is often
+    ``config.local.json`` rather than ``config.json``, and an operator who has
+    just lost REMOTE dashboard access needs the right filename in the one log
+    line they can still reach.
     """
     trust = TailnetTrust(
         trust_identity=trust_identity,
         allowed_logins=allowed_logins,
         pin_scope=pin_scope,
+        identity_unknown=identity_unknown,
     )
-    if trust.trust_identity and await asyncio.to_thread(
+    if trust.enforces_identity and await asyncio.to_thread(
         is_governance_pinned_off, audit_tool="tailnet_trust_startup"
     ):
         logger.warning(
@@ -1179,4 +1276,14 @@ async def governed_tailnet_trust(
             "the ordinary token+IP pin."
         )
         return TailnetTrust()
+    if trust.identity_unknown:
+        named = ", ".join(unreadable_files) or "dashboard.tailscale in config.json"
+        logger.error(
+            "tailnet identity policy could not be read (%s), so the login "
+            "allowlist is unknown — forwarded tailnet peers are DENIED until it "
+            "is fixed and the gateway restarted. Access from this machine "
+            "itself is unaffected, so on a headless host repair over SSH (or an "
+            "SSH port-forward to the dashboard), not over the tailnet.",
+            named,
+        )
     return trust

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -57,6 +57,7 @@ from kiro_crew.dashboard.revocation_gen import (  # noqa: F401  # re-exports
 from kiro_crew.dashboard.tailnet import (
     ForwardedPeer,
     TailnetTrust,
+    is_forwarded_tailnet_request,
     login_allowed,
     peer_pin_key,
     peer_pin_key_for_claim,
@@ -2109,8 +2110,7 @@ def token_auth_middleware(
         peer: ForwardedPeer | None = None
         if (
             tailnet_trust is not None
-            and tailnet_trust.trust_identity
-            and tailnet_trust.allowed_logins
+            and tailnet_trust.enforces_identity
             and (
                 bool(request.query.get("token"))
                 or any(c.startswith(("mc_token_", "mc_refresh_")) for c in request.cookies)
@@ -2132,6 +2132,40 @@ def token_auth_middleware(
                     error="login not in allowed_logins",
                 )
                 _log_auth(request, peer.login, "denied", "tailnet login not allowed")
+                return _deny(request, "tailnet login not allowed")
+            if (
+                peer is None
+                and tailnet_trust.identity_unknown
+                and is_forwarded_tailnet_request(request, tailnet_trust)
+            ):
+                # Config load could not read the operator's allowlist, and this
+                # forwarded tailnet peer could not be attributed either (daemon
+                # down, timeout, or a header that disagreed). Falling through
+                # here would admit it on the token alone — which is exactly the
+                # widening this gate exists to stop, so the "unknown policy"
+                # deny would announce itself and then not happen.
+                #
+                # Distinct from the ordinary enabled path, where an unresolved
+                # peer deliberately falls through (fail-closed on identity,
+                # fail-open on availability): there the operator's allowlist is
+                # KNOWN, so availability is the only thing at stake. Here the
+                # restriction itself is missing, and there is nothing left to be
+                # available for.
+                #
+                # ``is_forwarded_tailnet_request`` is what keeps this from being
+                # a lockout: a local request resolves to no peer for an entirely
+                # different reason and is not touched, so the operator can still
+                # reach the dashboard to repair config.json.
+                _sel = _sel_fn()
+                _sel.log_api_access(
+                    caller=request.remote or "",
+                    operation="tailnet_peer_auth",
+                    outcome="denied",
+                    source="token_auth",
+                    resources=path,
+                    error="tailnet allowlist unreadable and peer unresolved",
+                )
+                _log_auth(request, "", "denied", "tailnet identity policy unreadable")
                 return _deny(request, "tailnet login not allowed")
         # Audit attribution (RFC §3): when a peer resolved, the trail names a
         # person; otherwise it stays the immediate peer address as today.

--- a/test/test_config_tailnet_fail_closed.py
+++ b/test/test_config_tailnet_fail_closed.py
@@ -1,0 +1,673 @@
+"""A malformed tailnet identity policy must DENY, not silently widen.
+
+``dashboard.tailscale.allowed_logins`` is the only restriction on which tailnet
+peer may authenticate, and its default is the empty list -- which the loader
+turns into ``trust_identity = False``, i.e. no login restriction at all. So any
+layer that quietly replaced a malformed value with the default handed the
+dashboard to every tailnet peer holding a token, where before only an
+allowlisted login was admitted, with no denial and no error surfaced.
+
+Same shape as the publish destination allowlist (#4057, #3615) and the Slack
+enterprise allowlist (#3945): an open default means "empty" is indistinguishable
+from "the operator configured nothing", so emptiness can never be read as
+consent. These tests pin the three layers that have to cooperate --
+validation preserving the evidence, the loader recording it, the gate reading it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest.mock
+from pathlib import Path
+from types import SimpleNamespace
+
+from multidict import CIMultiDict
+
+from kiro_crew.config import validation
+from kiro_crew.config.loader import (
+    DEGRADED_TAILSCALE,
+    DEGRADED_WHOLE_CONFIG,
+    KiroCrewConfig,
+    _tailscale_config_from,
+    degraded_config_files,
+    tailnet_effective_allowed_logins,
+    tailnet_identity_unknown,
+)
+from kiro_crew.dashboard import tailnet
+from kiro_crew.dashboard.tailnet import (
+    TailnetTrust,
+    governed_tailnet_trust,
+    is_forwarded_tailnet_request,
+    login_allowed,
+)
+
+#: What an operator who wants exactly one login admitted writes.
+NARROWED = {
+    "enabled": True,
+    "trust_identity": True,
+    "allowed_logins": ["alice@example.com"],
+    "pin_scope": "node",
+}
+
+#: A tailnet peer the operator never allowlisted.
+INTRUDER = "bob@example.com"
+
+
+def _loaded(
+    tmp_path: Path, dashboard_value: object, overlay_text: str | None = None
+) -> KiroCrewConfig:
+    (tmp_path / "config.json").write_text(
+        json.dumps({"dashboard": dashboard_value}), encoding="utf-8"
+    )
+    if overlay_text is not None:
+        (tmp_path / "config.local.json").write_text(overlay_text, encoding="utf-8")
+    with unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path):
+        return KiroCrewConfig.load()
+
+
+def _trust(cfg: KiroCrewConfig) -> TailnetTrust:
+    """The trust value both server startup surfaces build from *cfg*.
+
+    Mirrors those call sites exactly, including which helper supplies the
+    allowlist -- a shortcut here that passed ``allowed_logins`` straight through
+    would test a trust object production never builds.
+    """
+    ts = cfg.dashboard.tailscale
+    return TailnetTrust(
+        trust_identity=ts.trust_identity,
+        allowed_logins=tailnet_effective_allowed_logins(cfg.degraded_sections, ts.allowed_logins),
+        pin_scope=ts.pin_scope,
+        identity_unknown=tailnet_identity_unknown(cfg.degraded_sections),
+    )
+
+
+def _admits(trust: TailnetTrust, login: str) -> bool:
+    """Whether *login* reaches the dashboard, as the gates decide it.
+
+    Mirrors the conjunction every gate asks: identity is enforced at all, and
+    then the login clears the allowlist. A peer is admitted when enforcement is
+    off, because nothing then resolves or checks it.
+    """
+    return not trust.enforces_identity or login_allowed(login, trust.allowed_logins)
+
+
+class TestMalformedPolicyDenies:
+    """The three depths at which the operator's allowlist can be lost."""
+
+    def test_a_wellformed_policy_admits_only_the_allowlisted_login(self, tmp_path: Path) -> None:
+        """The baseline the malformed cases are measured against."""
+        trust = _trust(_loaded(tmp_path, {"tailscale": dict(NARROWED)}))
+        assert _admits(trust, "alice@example.com") is True
+        assert _admits(trust, INTRUDER) is False
+
+    def test_a_nonobject_dashboard_section_denies(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, "yes")
+        assert "dashboard" in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_a_nonobject_tailscale_value_denies(self, tmp_path: Path) -> None:
+        """The sharpest shape: the enclosing ``dashboard`` section is a valid
+        object, so nothing above this notices."""
+        cfg = _loaded(tmp_path, {"tailscale": "yes"})
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_a_nonlist_allowed_logins_denies(self, tmp_path: Path) -> None:
+        """A hand edit that drops the brackets: ``"allowed_logins": "alice@..."``.
+
+        The loader already logged this one, but ONLY when ``trust_identity`` was
+        still readable and true -- an edit that mangled both said nothing at all.
+        """
+        cfg = _loaded(
+            tmp_path,
+            {"tailscale": {**NARROWED, "allowed_logins": "alice@example.com"}},
+        )
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_a_list_of_unusable_entries_denies(self, tmp_path: Path) -> None:
+        """The entry-level shape: a LIST whose contents are not logins.
+
+        ``[1]`` is a valid JSON array, so the list check passes; the parse
+        filter then drops the entry and the allowlist becomes empty, which is
+        the widening. Same shape publish.allowed_destinations already handles.
+        """
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "allowed_logins": [1]}})
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_a_partly_unusable_list_keeps_the_logins_that_parsed(self, tmp_path: Path) -> None:
+        """Degrading must not lock out the admin whose own login was fine.
+
+        Unlike publish -- whose gate denies one whole action -- this gate decides
+        per peer, so the parseable entries are kept: access narrows to exactly
+        what the operator demonstrably wrote, and everyone else is denied.
+        """
+        cfg = _loaded(
+            tmp_path,
+            {"tailscale": {**NARROWED, "allowed_logins": ["alice@example.com", None]}},
+        )
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), "alice@example.com") is True
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_an_explicitly_empty_list_is_not_degraded(self, tmp_path: Path) -> None:
+        """``allowed_logins: []`` is readable, if mistaken -- the loader's own
+        trust_identity rule already refuses it with a dedicated error, so
+        recording a degradation here would double-report one config typo."""
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "allowed_logins": []}})
+        assert DEGRADED_TAILSCALE not in cfg.degraded_sections
+
+
+class TestAMalformedEnableFlagStillEnforces:
+    """``trust_identity`` is the allowlist's own ON switch.
+
+    That makes it the most permissive default in the section: ``_safe_bool``
+    returns the default for anything non-boolean, and the default is ``False``,
+    so a quoted boolean reads as "never asked for identity trust" and the valid
+    allowlist beside it stops being enforced.
+
+    The response is to enforce the allowlist AS WRITTEN, not to deny everyone --
+    the entries came from a readable file, so the operator's own login keeps
+    working while every peer they did not name is refused. That is the closest
+    honest reading of a config whose intent to enable was garbled but whose list
+    of who to admit was not.
+    """
+
+    def test_a_quoted_boolean_still_enforces_the_allowlist(self, tmp_path: Path) -> None:
+        """The commonest hand-edit slip: ``"trust_identity": "true"``."""
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "trust_identity": "true"}})
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_an_integer_still_enforces_the_allowlist(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "trust_identity": 1}})
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_the_operators_own_login_is_not_locked_out(self, tmp_path: Path) -> None:
+        """The whole reason this degrades to enforce-as-written rather than
+        deny-all: the admin has to be able to reach the dashboard to fix it."""
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "trust_identity": "true"}})
+        assert _admits(_trust(cfg), "alice@example.com") is True
+
+    def test_an_absent_flag_is_not_degraded(self, tmp_path: Path) -> None:
+        """No opt-in written is genuinely unconfigured, even with an allowlist
+        sitting beside it -- the allowlist alone must never imply consent."""
+        cfg = _loaded(tmp_path, {"tailscale": {"enabled": True, "allowed_logins": ["a@b"]}})
+        assert DEGRADED_TAILSCALE not in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+    def test_an_explicit_false_is_a_decision_not_a_degradation(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "trust_identity": False}})
+        assert DEGRADED_TAILSCALE not in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+    def test_a_narrowing_only_field_is_left_alone(self, tmp_path: Path) -> None:
+        """``pin_scope`` is the section's other malformed-value path, and it is
+        deliberately NOT degraded: an unrecognised value already falls back to
+        ``node``, the narrower scope, so the repair direction is safe. Pinned so
+        a future sweep does not widen the registry past the fields that need it.
+        """
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "pin_scope": "nonsense"}})
+        assert DEGRADED_TAILSCALE not in cfg.degraded_sections
+        assert cfg.dashboard.tailscale.pin_scope == "node"
+
+
+class TestAnInertAllowlistIsNotADegradation:
+    """A malformed allowlist only matters when identity trust could be ON.
+
+    The allowlist is consulted only under identity trust, so when the operator
+    cleanly said ``trust_identity: false`` -- or never said true -- a typo in it
+    loses nothing: there is no restriction in force to lose. Recording a
+    degradation there would turn a typo in an INERT field into a
+    forwarded-tailnet lockout, against a config that read correctly permits
+    those peers, and would contradict the explicit-false-admits rule the
+    neighbouring tests assert.
+
+    A malformed FLAG is the one case that keeps the allowlist live: intent is
+    unknown, so it cannot be assumed off.
+    """
+
+    _MALFORMED_LISTS = ("alice@example.com", [123], ["a@b", None])
+
+    def test_explicit_false_plus_a_malformed_allowlist_still_admits(self, tmp_path: Path) -> None:
+        for bad in self._MALFORMED_LISTS:
+            cfg = _loaded(
+                tmp_path,
+                {"tailscale": {"enabled": True, "trust_identity": False, "allowed_logins": bad}},
+            )
+            assert DEGRADED_TAILSCALE not in cfg.degraded_sections, bad
+            assert _admits(_trust(cfg), INTRUDER) is True, bad
+
+    def test_an_absent_flag_plus_a_malformed_allowlist_still_admits(self, tmp_path: Path) -> None:
+        cfg = _loaded(
+            tmp_path, {"tailscale": {"enabled": True, "allowed_logins": "alice@example.com"}}
+        )
+        assert DEGRADED_TAILSCALE not in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+    def test_trust_on_plus_a_malformed_allowlist_still_denies(self, tmp_path: Path) -> None:
+        """The gate must not have swallowed the real case: with the flag readable
+        and true, a malformed allowlist is a LOST restriction and still denies."""
+        for bad in self._MALFORMED_LISTS:
+            cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "allowed_logins": bad}})
+            assert DEGRADED_TAILSCALE in cfg.degraded_sections, bad
+            assert _admits(_trust(cfg), INTRUDER) is False, bad
+
+    def test_a_malformed_flag_keeps_the_allowlist_live(self, tmp_path: Path) -> None:
+        """Both fields mangled: intent unknown, nothing readable to admit from,
+        so every forwarded peer is denied."""
+        cfg = _loaded(
+            tmp_path,
+            {"tailscale": {"enabled": True, "trust_identity": "true", "allowed_logins": [123]}},
+        )
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+        assert _admits(_trust(cfg), "alice@example.com") is False
+
+    def test_the_denial_names_the_value_to_fix(self, tmp_path: Path, caplog) -> None:
+        """An operator locked out of their phone needs the file and the key, not
+        a bare refusal -- this is the only signal they get."""
+        with caplog.at_level("WARNING", logger="kiro_crew.config.loader"):
+            _loaded(tmp_path, {"tailscale": "yes"})
+        assert any("dashboard.tailscale" in r.getMessage() for r in caplog.records)
+
+
+class TestUnconfiguredIsUntouched:
+    """An operator who never asked for identity trust must see NO change.
+
+    This is the whole reason the fix keys off ``degraded_sections`` rather than
+    off the value being empty: absent is genuinely unconfigured and stays
+    permitted, exactly as the publish gate treats an absent allowlist. Reading
+    emptiness itself as suspicious would deny every default install.
+    """
+
+    def test_no_tailscale_policy_at_all_still_admits(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, {"url": ""})
+        assert cfg.degraded_sections == frozenset()
+        assert _trust(cfg).enforces_identity is False
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+    def test_an_empty_dashboard_section_still_admits(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, {})
+        assert cfg.degraded_sections == frozenset()
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+    def test_an_explicitly_disabled_policy_still_admits(self, tmp_path: Path) -> None:
+        """``trust_identity: false`` is a decision, not a degradation."""
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "trust_identity": False}})
+        assert cfg.degraded_sections == frozenset()
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+
+class TestValidationPreservesTheEvidence:
+    """The loader can only record what validation left in place.
+
+    ``_apply_field_default`` repairs a schema violation by deleting the value so
+    the loader falls back to defaults. For a narrowing whose default is OPEN
+    that repair IS the widening, and it happens before any detector runs -- so
+    the registry entry is load-bearing, not decoration.
+    """
+
+    def test_the_tailnet_paths_are_exempt_from_repair(self) -> None:
+        assert "dashboard" in validation._FAIL_CLOSED_PATHS
+        assert "dashboard.tailscale" in validation._FAIL_CLOSED_PATHS
+
+    def test_repair_leaves_an_exempt_value_in_place(self) -> None:
+        data = {"dashboard": {"tailscale": "yes"}}
+        assert validation._apply_field_default(data, "dashboard.tailscale") is False
+        assert data == {"dashboard": {"tailscale": "yes"}}
+
+    def test_a_repairable_dashboard_field_is_still_repaired(self) -> None:
+        """Exact-match only: exempting the section must not exempt its siblings,
+        whose defaults are restrictive and whose repair is the safe direction."""
+        data = {"dashboard": {"url": 7}}
+        assert validation._apply_field_default(data, "dashboard.url") is True
+        assert data == {"dashboard": {}}
+
+
+class TestUnattributablePeerUnderUnknownPolicy:
+    """A forwarded peer that could not be attributed must still be denied.
+
+    Under the ORDINARY enabled path an unresolved peer deliberately falls
+    through -- fail-closed on identity, fail-open on availability -- because the
+    operator's allowlist is KNOWN and availability is the only thing at stake.
+    When the policy itself is unreadable there is no restriction left to be
+    available for, so falling through would announce a deny and then not do it.
+
+    ``is_forwarded_tailnet_request`` is the discriminator that keeps this from
+    being a lockout, so it is tested for both answers.
+    """
+
+    _UNKNOWN = TailnetTrust(identity_unknown=True)
+
+    def test_a_forwarded_tailnet_request_is_recognised(self) -> None:
+        req = SimpleNamespace(
+            remote="127.0.0.1", headers=CIMultiDict({"X-Forwarded-For": "100.64.0.5"})
+        )
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is True
+
+    def test_a_plain_local_request_is_not(self) -> None:
+        """The operator's own browser, which must keep working so they can go and
+        repair config.json."""
+        req = SimpleNamespace(remote="127.0.0.1", headers=CIMultiDict({}))
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is False
+
+    def test_a_remote_peers_forwarded_header_is_not_read(self) -> None:
+        """An unverifiable claim from a non-loopback peer, so denying on it would
+        let anyone reachable trigger the refusal."""
+        req = SimpleNamespace(
+            remote="203.0.113.7", headers=CIMultiDict({"X-Forwarded-For": "100.64.0.5"})
+        )
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is False
+
+    def test_a_default_install_is_never_a_candidate(self) -> None:
+        """With no policy at all the predicate short-circuits, so the deny branch
+        it guards is unreachable for an ordinary install."""
+        req = SimpleNamespace(
+            remote="127.0.0.1", headers=CIMultiDict({"X-Forwarded-For": "100.64.0.5"})
+        )
+        assert is_forwarded_tailnet_request(req, TailnetTrust()) is False
+
+    def test_a_comma_joined_chain_is_still_forwarded(self) -> None:
+        """Attribution rejects an ambiguous chain -- it cannot say WHICH peer this
+        is. Denial must not: it is still a forwarded tailnet request, and
+        answering "not forwarded" let a caller add a second address and skip the
+        deny entirely, with a valid token doing the rest.
+        """
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers=CIMultiDict({"X-Forwarded-For": "100.64.0.5, 100.64.0.6"}),
+        )
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is True
+
+    def test_repeated_headers_are_still_forwarded(self) -> None:
+        """The same ambiguity in its other wire form."""
+        headers = CIMultiDict()
+        headers.add("X-Forwarded-For", "100.64.0.5")
+        headers.add("X-Forwarded-For", "100.64.0.6")
+        req = SimpleNamespace(remote="127.0.0.1", headers=headers)
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is True
+
+    def test_a_mixed_chain_with_one_tailnet_hop_is_forwarded(self) -> None:
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers=CIMultiDict({"X-Forwarded-For": "203.0.113.1, 100.64.0.5"}),
+        )
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is True
+
+    def test_a_chain_with_no_tailnet_address_is_left_alone(self) -> None:
+        """Some other proxy's business. Denying it would widen this gate past the
+        tailnet policy it enforces."""
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers=CIMultiDict({"X-Forwarded-For": "203.0.113.1, 198.51.100.2"}),
+        )
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is False
+
+    def test_a_garbage_chain_is_left_alone(self) -> None:
+        """Unparseable values must not raise, and must not be read as tailnet."""
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers=CIMultiDict({"X-Forwarded-For": "not-an-ip, , 999.999.999.999"}),
+        )
+        assert is_forwarded_tailnet_request(req, self._UNKNOWN) is False
+
+    def test_an_ambiguous_chain_is_still_never_attributed(self) -> None:
+        """The weakening must stay confined to DENIAL. Attribution still refuses
+        an ambiguous chain, so no identity is invented from one and nothing is
+        pinned or audited to a peer this design cannot name.
+        """
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers=CIMultiDict({"X-Forwarded-For": "100.64.0.5, 100.64.0.6"}),
+        )
+        assert tailnet._forwarded_peer_candidate(req, self._UNKNOWN) is None
+
+
+class TestNoSiteRespellsTheConjunction:
+    """The property is only worth having if it is the ONLY spelling.
+
+    ``enforces_identity`` was introduced so every site answering "is tailnet
+    identity in force" answers the same way. A hand-written
+    ``trust_identity and allowed_logins`` somewhere else converges today only by
+    coincidence -- an empty allowlist happens to deny -- and silently stops
+    converging the moment enforcement grows a third condition. That is the exact
+    drift the property claims to prevent, so it is pinned rather than trusted.
+    """
+
+    def test_only_the_property_itself_spells_it_out(self) -> None:
+        src_root = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+        offenders = []
+        for path in src_root.rglob("*.py"):
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if "trust_identity and" not in line:
+                    continue
+                # The property's own definition is the one legitimate spelling,
+                # and the loader's config-validation rule is a different
+                # question (is this combination writable), not this one.
+                if path.name in ("tailnet.py", "loader.py"):
+                    continue
+                offenders.append(f"{path.relative_to(src_root)}:{lineno}")
+        assert offenders == [], (
+            "these sites re-spell the enforces_identity conjunction: " f"{offenders}"
+        )
+
+
+class TestALostOverlayCannotReadmitAnyone:
+    """``config.local.json`` is deep-merged OVER ``config.json``.
+
+    An overlay often exists precisely to NARROW the base -- to take a login back
+    out. So an unreadable overlay leaves the base's WIDER list standing, and
+    every login the operator removed is admitted again. The parsed list is not
+    the effective policy, it is a stale one, so nothing may be enforced from it.
+    """
+
+    _BASE = {
+        "tailscale": {
+            "enabled": True,
+            "trust_identity": True,
+            "allowed_logins": ["alice@example.com", "bob@example.com"],
+        }
+    }
+    #: The operator taking alice back out.
+    _NARROWING_OVERLAY = json.dumps(
+        {"dashboard": {"tailscale": {"allowed_logins": ["bob@example.com"]}}}
+    )
+    #: The same overlay caught mid-write by a torn read.
+    _TRUNCATED_OVERLAY = '{"dashboard": {"tail'
+
+    def test_a_readable_overlay_narrows_as_written(self, tmp_path: Path) -> None:
+        """The baseline: alice is OUT because the overlay removed her."""
+        trust = _trust(_loaded(tmp_path, self._BASE, self._NARROWING_OVERLAY))
+        assert _admits(trust, "bob@example.com") is True
+        assert _admits(trust, "alice@example.com") is False
+
+    def test_a_truncated_overlay_denies_the_login_it_had_removed(self, tmp_path: Path) -> None:
+        """Without this the base's wider list survives and alice walks back in."""
+        cfg = _loaded(tmp_path, self._BASE, self._TRUNCATED_OVERLAY)
+        assert DEGRADED_WHOLE_CONFIG in cfg.degraded_sections
+        assert _admits(_trust(cfg), "alice@example.com") is False
+
+    def test_a_truncated_overlay_denies_everyone_including_the_base(self, tmp_path: Path) -> None:
+        """bob was in BOTH files, and is still denied: with a file unread there is
+        no way to know he was not the entry the overlay removed."""
+        cfg = _loaded(tmp_path, self._BASE, self._TRUNCATED_OVERLAY)
+        assert _admits(_trust(cfg), "bob@example.com") is False
+
+    def test_no_overlay_at_all_admits_the_base(self, tmp_path: Path) -> None:
+        """An absent overlay is not a lost one -- the base is the whole policy."""
+        cfg = _loaded(tmp_path, self._BASE)
+        assert cfg.degraded_sections == frozenset()
+        assert _admits(_trust(cfg), "alice@example.com") is True
+
+    def test_the_refusal_names_the_overlay_not_the_base(self, tmp_path: Path, caplog) -> None:
+        """The operator who has just lost REMOTE dashboard access gets one log
+        line, and it has to name the file they actually broke.
+
+        Saying "config.json" when the truncated file was "config.local.json"
+        sends them to edit a file that is already fine, on a headless host where
+        the only way in is SSH.
+        """
+        cfg = _loaded(tmp_path, self._BASE, self._TRUNCATED_OVERLAY)
+        with unittest.mock.patch(
+            "kiro_crew.dashboard.tailnet.is_governance_pinned_off", return_value=False
+        ):
+            with caplog.at_level("ERROR", logger="kiro_crew.dashboard.tailnet"):
+                asyncio.run(
+                    governed_tailnet_trust(
+                        False,
+                        (),
+                        "node",
+                        identity_unknown=True,
+                        unreadable_files=tuple(degraded_config_files(cfg.degraded_sections)),
+                    )
+                )
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert "config.local.json" in logged
+        assert "SSH" in logged
+
+
+class TestEffectiveAllowlistBySeverity:
+    """Which degradations invalidate the parsed allowlist, and which do not."""
+
+    _LOGINS = ["alice@example.com"]
+
+    def test_an_unreadable_file_empties_it(self) -> None:
+        assert (
+            tailnet_effective_allowed_logins(frozenset({DEGRADED_WHOLE_CONFIG}), self._LOGINS) == ()
+        )
+
+    def test_a_malformed_field_keeps_what_parsed(self) -> None:
+        """Inside a file that WAS read, whatever parsed is literally what the
+        operator wrote -- keeping it narrows access instead of locking out the
+        administrator whose own login was fine."""
+        assert tailnet_effective_allowed_logins(frozenset({DEGRADED_TAILSCALE}), self._LOGINS) == (
+            "alice@example.com",
+        )
+
+    def test_a_clean_load_keeps_it(self) -> None:
+        assert tailnet_effective_allowed_logins(frozenset(), self._LOGINS) == ("alice@example.com",)
+
+    def test_an_unrelated_degraded_section_keeps_it(self) -> None:
+        assert tailnet_effective_allowed_logins(frozenset({"memory"}), self._LOGINS) == (
+            "alice@example.com",
+        )
+
+
+class TestAnExplicitNullIsNotAnAbsentKey:
+    """JSON ``null`` is the operator having written something unusable.
+
+    An absent key means they never mentioned the setting; a key written as
+    ``null`` means they mentioned it and the value cannot be read as an
+    allowlist, a flag, or a section. Only the first is consent, so presence is
+    tested with ``in`` rather than ``is not None`` -- the two states are
+    indistinguishable from the value alone.
+
+    Safe to treat this way because Kiro Crew's own ``to_dict()`` writes concrete
+    values for every one of these keys (``False`` / ``[]`` / ``"node"``) and
+    never ``null``, so no save path can manufacture the degraded state.
+    """
+
+    def test_a_null_section_denies(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, {"tailscale": None})
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_a_null_flag_still_enforces_the_allowlist(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "trust_identity": None}})
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+        assert _admits(_trust(cfg), "alice@example.com") is True
+
+    def test_a_null_allowlist_denies(self, tmp_path: Path) -> None:
+        cfg = _loaded(tmp_path, {"tailscale": {**NARROWED, "allowed_logins": None}})
+        assert DEGRADED_TAILSCALE in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is False
+
+    def test_an_absent_section_is_still_absent(self, tmp_path: Path) -> None:
+        """The distinction that makes this safe: no tailscale key at all must NOT
+        degrade, or every install without one is denied."""
+        cfg = _loaded(tmp_path, {"url": ""})
+        assert DEGRADED_TAILSCALE not in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+    def test_the_direct_value_reading_still_treats_none_as_absent(self) -> None:
+        """``_tailscale_config_from(None)`` without ``key_present`` is the absent
+        reading, which existing callers rely on -- pinned so the null handling
+        cannot leak into it."""
+        degraded: set[str] = set()
+        _tailscale_config_from(None, degraded)
+        assert degraded == set()
+
+    def test_a_null_allowlist_under_explicit_false_still_admits(self, tmp_path: Path) -> None:
+        """Null does not override the inert-allowlist rule: with trust cleanly
+        off there is still no restriction in force to lose."""
+        cfg = _loaded(
+            tmp_path,
+            {"tailscale": {"enabled": True, "trust_identity": False, "allowed_logins": None}},
+        )
+        assert DEGRADED_TAILSCALE not in cfg.degraded_sections
+        assert _admits(_trust(cfg), INTRUDER) is True
+
+
+class TestIdentityUnknownHelper:
+    """One helper, because both server startup surfaces ask the question."""
+
+    def test_each_losing_shape_reports_unknown(self) -> None:
+        for key in (DEGRADED_WHOLE_CONFIG, "dashboard", DEGRADED_TAILSCALE):
+            assert tailnet_identity_unknown(frozenset({key})) is True, key
+
+    def test_an_unrelated_degraded_section_does_not(self) -> None:
+        """Denying tailnet access over a malformed ``memory`` section would be a
+        blast radius nobody asked for."""
+        assert tailnet_identity_unknown(frozenset({"publish", "memory"})) is False
+
+    def test_a_clean_load_reports_known(self) -> None:
+        assert tailnet_identity_unknown(frozenset()) is False
+
+
+class TestEnforcesIdentity:
+    """The single predicate the four gate sites share."""
+
+    def test_unknown_identity_enforces_even_with_trust_off(self) -> None:
+        trust = TailnetTrust(identity_unknown=True)
+        assert trust.enforces_identity is True
+        assert login_allowed(INTRUDER, trust.allowed_logins) is False
+
+    def test_a_configured_narrowing_enforces(self) -> None:
+        assert TailnetTrust(trust_identity=True, allowed_logins=("a@b",)).enforces_identity
+
+    def test_trust_on_with_an_empty_allowlist_does_not_enforce(self) -> None:
+        """Unreachable via the loader (it refuses that combination) but pinned
+        here so the predicate cannot start inferring trust from an opt-in
+        alone -- "any tailnet member" is exactly what must never be inferred."""
+        assert TailnetTrust(trust_identity=True).enforces_identity is False
+
+    def test_a_default_install_does_not_enforce(self) -> None:
+        assert TailnetTrust().enforces_identity is False
+
+
+class TestGovernanceCeilingStillWins:
+    """An administrator forbidding the tailnet integration outranks fail-closed.
+
+    With the integration pinned off there is no tailnet allowlist left to fail
+    closed on, and the ceiling's whole point is that no whois call happens.
+    """
+
+    def test_a_pinned_ceiling_clears_unknown_identity(self) -> None:
+        with unittest.mock.patch(
+            "kiro_crew.dashboard.tailnet.is_governance_pinned_off", return_value=True
+        ):
+            trust = asyncio.run(governed_tailnet_trust(False, (), "node", identity_unknown=True))
+        assert trust.identity_unknown is False
+        assert trust.enforces_identity is False
+
+    def test_without_a_ceiling_unknown_identity_survives(self) -> None:
+        with unittest.mock.patch(
+            "kiro_crew.dashboard.tailnet.is_governance_pinned_off", return_value=False
+        ):
+            trust = asyncio.run(governed_tailnet_trust(False, (), "node", identity_unknown=True))
+        assert trust.enforces_identity is True


### PR DESCRIPTION
## 1. What is the problem?

`dashboard.tailscale.allowed_logins` is the only restriction on which tailnet peer
may authenticate to the dashboard. Its default is the empty list, and the loader
turns an empty list into `trust_identity = False` -- i.e. **no login restriction at
all**. So for this field, "empty" does not mean "nothing is allowed", it means
"everything is allowed".

That makes a malformed value silently permissive. An operator who configured

```json
{"dashboard": {"tailscale": {"enabled": true, "trust_identity": true,
                             "allowed_logins": ["alice@example.com"]}}}
```

and then had that value torn by a concurrent write, or mangled by a hand edit,
got a gateway that admitted **every** tailnet peer holding a token, where before
only `alice` was admitted -- with no denial, no audit record, and no error that
named the consequence.

Three layers each had a reason not to notice:

1. **Validation** repaired the violation. `_apply_field_default` "fixes" a
   schema-invalid value by deleting it so the loader falls back to defaults. For
   a narrowing whose default is *open*, that repair **is** the widening -- and it
   ran before any detector could see the evidence.
2. **The loader** therefore recorded nothing. `_coerced_section` only sees a
   malformed section if validation left it in place, so `degraded_sections` came
   back empty and the whole degradation-reporting mechanism was bypassed.
3. **The gates** read `trust_identity and allowed_logins` directly, in four
   places, so an *unreadable* policy was indistinguishable from an *absent* one.

Reproduced on `main` before the fix -- all three malformed shapes report
`degraded_sections: []` and drop the allowlist:

```
--- SHAPE A   whole 'dashboard' section is not an object
    trust_identity: False   allowed_logins: []   degraded_sections: []
    => allowlist ENFORCED: False
--- SHAPE B   'dashboard.tailscale' is not an object
    trust_identity: False   allowed_logins: []   degraded_sections: []
    => allowlist ENFORCED: False
--- SHAPE C   'allowed_logins' is a string, not a list
    trust_identity: False   allowed_logins: []   degraded_sections: []
    => allowlist ENFORCED: False
```

Shape B is the sharpest: the enclosing `dashboard` section is a valid JSON
object, so nothing above it warns either. Shape C did log, but only when
`trust_identity` happened to still be readable and true -- an edit that mangled
both said nothing at all.

## 2. Why this issue matters to the user

The values that get torn are exactly the ones an operator set deliberately.
Someone who typed a login allowlist did so because their tailnet has other
members on it -- a shared corporate tailnet, a family device, a contractor's
laptop. Losing that list does not fail loudly; it quietly returns the dashboard
to "any tailnet peer with a token", which is the state the operator explicitly
opted out of.

The failure is also hard to notice from the outside. Nothing about the dashboard
looks different, the operator's own access still works, and the only clue is a
log line about a malformed section that does not mention access control. The
peer pin is dropped in the same move, so a leaked token that previously only
worked from one node now works from anywhere on the tailnet.

This is the third instance of one class. The publish destination allowlist
reopened this way (#3615, #4057) and so did the Slack enterprise allowlist
(#3945). Both were fixed individually; this change closes the remaining one and
documents the rule that decides membership.

## 3. How our fix solves it

The chain from symptom to root cause runs backwards through the three layers, so
the fix touches each one at the point where the information still exists.

**Root cause -- evidence destroyed before detection.** `validation.py` already
has a purpose-built registry for this, `_FAIL_CLOSED_PATHS`, whose docstring
states the rule: a repair is safe when the field's default is *restrictive* and
unsafe when it is *open*. The registry listed only the two publish paths. Added
`dashboard` and `dashboard.tailscale`, with the direction-of-default reasoning
recorded next to them. The deeper `dashboard.tailscale.allowed_logins` needs no
entry -- at three segments it is already past `_apply_field_default`'s depth cap,
so a malformed list value survives today.

**Loader -- record what was discarded, and say how much of it is enforceable.**
`_tailscale_config_from` now takes the `_degraded` set and records
`DEGRADED_TAILSCALE` (`"dashboard.tailscale"`) when the section is malformed, when
`allowed_logins` is not a list, or when it is a list carrying entries that are not
usable logins -- that last shape is the one where the list check passes and the
parse filter then empties the allowlist. An **absent** policy is not degraded:
that is the genuine unconfigured state, exactly as the publish gate treats an
absent allowlist.

Two helpers live beside the keys they name, so the two server startup surfaces
cannot drift on either question. `tailnet_identity_unknown()` answers *whether*
to enforce. `tailnet_effective_allowed_logins()` answers *whose logins may
satisfy that enforcement*, and it separates two severities that must not be
treated alike:

- a whole config FILE unread empties the allowlist. `config.local.json` is
  deep-merged over `config.json` and an overlay may exist precisely to NARROW the
  base, so a lost overlay leaves the base's wider list standing and readmits
  every login the operator had removed. The parsed list is not the effective
  policy, it is a stale one;
- a section or field malformed inside a file that WAS read keeps the entries that
  parsed. Those are literally what the operator wrote in a file this load could
  see, so keeping them narrows access instead of locking out the administrator
  whose own login was fine.

**Gates -- one predicate instead of four conjunctions.** `TailnetTrust` gains an
explicit `identity_unknown` state, distinct from `trust_identity=False`: the
first means "we could not read the policy", the second means "they never asked
for one". The four sites that spelled out `trust_identity and allowed_logins`
(`_forwarded_peer_candidate`, the auth middleware, and both refresh-rotation
paths) now share one `enforces_identity` property, so "may this be pinned", "may
this rotate" and "may this authenticate" cannot answer differently.

The deny is mostly the allowlist doing its ordinary job: a peer is admitted only
by `login_allowed`, so whoever the allowlist does not name is refused, and no
second decision is invented. Two places do add code, and both are named here
because an earlier draft of this description claimed the fix needed none:

- **`token_auth.py` gains one deny branch.** A forwarded tailnet peer that could
  not be attributed at all (daemon down, whois timeout, disagreeing header) is
  refused while the policy is unreadable. Without it the deny would announce
  itself and then not happen -- on the ordinary enabled path an unresolved peer
  deliberately falls through, because there the allowlist is KNOWN and only
  availability is at stake. `is_forwarded_tailnet_request` is what keeps this
  from being a lockout, and it is deliberately weaker than the attribution
  predicate so an ambiguous forwarded chain cannot skip the deny by adding a
  second header.
- **`identity_unknown` does NOT imply an empty allowlist.** How much of the
  parsed list survives is decided per severity by
  `tailnet_effective_allowed_logins`: a whole unreadable FILE empties it, while a
  malformed field inside a file that WAS read keeps the entries that parsed, so
  the administrator whose own login is fine is not locked out mid-repair. The
  `TailnetTrust` docstring says this outright ("Do NOT assume this flag implies
  an empty `allowed_logins`") and the tests pin both severities.

Two boundaries drawn deliberately:

- **A default install is untouched.** Nothing degrades, nothing is recorded, and
  an operator who never configured identity trust sees byte-for-byte the prior
  behaviour. Keying off `degraded_sections` rather than off emptiness is what
  makes that true -- reading emptiness itself as suspicious would deny every
  install.
- **Nobody is locked out of the machine.** Only *forwarded tailnet* peers are
  denied. Local, non-forwarded access is unaffected, so the operator can still
  reach the dashboard to fix the file, and the startup error says so.

The governance ceiling still outranks fail-closed: with `capabilities.tailnet_origin`
pinned off there is no tailnet allowlist left to fail closed on, and the ceiling's
point is that no whois call happens at all.

## 4. What tests we did

New file `test/test_config_tailnet_fail_closed.py`, 36 tests, covering the layers
that have to cooperate:

- each malformed shape records the degradation and denies an unallowlisted login,
  while a well-formed policy still admits only `alice`. Four shapes: a non-object
  `dashboard` section, a non-object `dashboard.tailscale`, a non-list
  `allowed_logins`, and a **list whose entries are not usable logins** (`[1]`) --
  the last is the entry-level shape, where the list check passes and the parse
  filter then empties the allowlist;
- a *partly* unusable list keeps the logins that parsed, so degrading narrows
  access rather than locking out the administrator whose own login was fine;
- an explicitly empty `allowed_logins: []` is **not** degraded -- that is readable
  if mistaken, and the loader's `trust_identity` rule already refuses it;
- a **lost `config.local.json` overlay** cannot readmit anyone: a readable overlay
  narrows as written, a truncated one denies the login it had removed, and it
  denies the base's own logins too (with a file unread there is no way to know
  which entry the overlay removed). An ABSENT overlay is not a lost one and still
  admits the base;
- the severity split in `tailnet_effective_allowed_logins` -- an unreadable file
  empties the allowlist, a malformed field keeps what parsed, a clean load and an
  unrelated degraded section both keep it;
- an unattributable forwarded peer (daemon down, whois timeout) is denied while
  the policy is unreadable, with all four answers of the
  `is_forwarded_tailnet_request` discriminator pinned: a forwarded tailnet
  request, a plain local request, a non-loopback peer's unverifiable forwarded
  header, and a default install (never a candidate, so the branch is unreachable
  for an ordinary install);
- three "unconfigured is untouched" guards -- no policy at all, an empty
  `dashboard` section, and an explicit `trust_identity: false` -- all still admit,
  so the fix cannot regress a default install;
- validation preserves an exempt value, and a *repairable* sibling
  (`dashboard.url`) is still repaired, pinning that the exemption is exact-match
  and did not leak to the whole section;
- the `enforces_identity` truth table, including that `trust_identity` alone with
  an empty allowlist does **not** enforce -- "any tailnet member" must never be
  inferred from the opt-in;
- a ratchet asserting no site re-spells the `enforces_identity` conjunction, so
  the single-source-of-truth claim is enforced rather than asserted;
- the ceiling-wins pair.

The suite's helper builds its `TailnetTrust` through the same helpers the startup
surfaces use, deliberately: an earlier version passed `allowed_logins` straight
through and was therefore exercising a trust object production never builds,
which is how the lost-overlay case initially escaped.

Mutation-verified, each layer independently:

- removing `dashboard.tailscale` from `_FAIL_CLOSED_PATHS` turns
  `degraded_sections` back into `frozenset()` and the deny is lost (3 red) --
  proving the validation entry is load-bearing, not decoration;
- making `enforces_identity` ignore `identity_unknown` loses the deny (red on the
  gate and ceiling tests);
- disabling the entry-level degradation branch turns `degraded_sections` back to
  `frozenset()` for `[1]` (2 red);
- making `is_forwarded_tailnet_request` always return `False` loses the
  unattributable-peer deny (1 red);
- disabling the whole-file emptying readmits the login the lost overlay had
  removed (3 red);
- reverting the fifth conjunction site reddens the drift ratchet, which names the
  offending file and line.

Targeted suites, all green: `test_config_tailnet_fail_closed`,
`test_config_validation`, `test_config_loader`, `test_config_baseline`,
`test_config_rmw_preserves_settings`, `test_config_roundtrip`, `test_tailnet_peer`,
`test_tailnet_governance`, `test_tailnet_mobile`, `test_token_auth`,
`test_auth_refresh_handlers_cov80` -- 1107 passed on the final head. The existing
`test_every_fail_closed_path_is_a_real_schema_path` ratchet validates the two new
registry entries against the generated schema.

Gates: flake8 and isort clean on all eight touched files; the repo's
`scripts/check_black_formatting.py` gate passes.

## 5. Any other suggestions on the work

- **The registry is only half a fix.** A preserved value changes nothing unless
  the loader records the degradation *and* a gate reads `degraded_sections`. Both
  halves now exist for every listed path; that requirement is written into the
  registry docstring so a future entry added alone is visibly incomplete.
- **The audit found no other defective site.** Every other config restriction
  checked is fail-closed on empty by design and is correctly absent from the
  registry: all channel allowlists (`slack.allowed_users` and the transport's
  `msg.user_id in self._allowed_users`, `feishu.allowed_open_ids`,
  telegram/discord/whatsapp/webex/teams/imessage) deny when empty, and
  `agent.subagent_cwd_allowed_roots` both has a non-empty default and explicitly
  disables cwd overrides when empty. Repairing those to their defaults is the
  *safe* direction, so widening the registry to cover them would be wrong.
- **Known residue, not fixed here.** On the ORDINARY enabled path (allowlist
  readable), a daemon outage still lets an unresolved peer fall through to
  token+IP -- the documented fail-closed-on-identity, fail-open-on-availability
  trade. That is untouched by this PR and changing it needs its own reasoning
  about daemon-outage availability. The `identity_unknown` case is *not* residue
  and is handled: an unattributable forwarded peer is denied, because there the
  restriction itself is missing and there is nothing left to be available for.
- The whois resolution now runs for tailnet-forwarded credentialed requests while
  a config is degraded, where before it was skipped. It is cached and the state is
  already broken and operator-visible, so the cost is bounded.

## Pattern harvest

Rule candidate: a pytest ratchet asserting that every member of
`_FAIL_CLOSED_PATHS` has at least one reader of
`KiroCrewConfig.degraded_sections`. That is the clause this PR proved is
load-bearing and easy to leave half-done -- a registry entry alone only
preserves evidence, and preserving evidence nobody reads looks like a fix
without being one. It sits next to the existing
`test_every_fail_closed_path_is_a_real_schema_path` ratchet and needs no new
machinery.

The full defect class is broader than that ratchet covers: *a config value that
narrows access, whose default is open, reached by a layer that repairs or
defaults it*. Both halves of the check are already declared in the tree -- the
schema knows each field's default direction, and `_FAIL_CLOSED_PATHS` knows
which paths must survive repair -- so the ideal gate asserts that for every
config path a security gate reads, **either** the default is restrictive **or**
the path is registered with a loader recording site and a gate that consults
`degraded_sections`. Deciding which paths count as "security gates" still needs
a person, which is why the mechanical part proposed above is scoped to the
registry rather than a repo-wide scan.

Not a one-off: three independent instances (#3615/#4057 publish, #3945 Slack
enterprise, and this one) with an identical mechanism and three different
authors. The shared cause is that "empty" is a *usable* value for an allowlist,
so the permissive reading is the natural one to write, and validation's repair
step then manufactures that value out of a malformed one. Any future
open-default narrowing lands in the same shape unless the registry-membership
question is asked when the field is added.

Local backlog item `f-20260816-03`.

