### PR TITLE
fix(usage): read a turn's billing through a declared provider seam

### DIFF
--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -370,6 +370,17 @@ class AcpSessionProvider(LLMProvider):
         """Return tokens used in the current context."""
         return self._handle.last_prompt_stats.context_used_tokens
 
+    def billing_stats(self) -> object | None:
+        """Live per-turn billing stats (public — see LLMProvider).
+
+        The same object ``last_prompt_stats`` exposes and the context accessors
+        above read; declaring it here is what makes the accounting path's read a
+        stated capability instead of a search for that attribute name. The handle
+        installs a fresh object as each turn begins, which is the identity the
+        accounting path compares against.
+        """
+        return self._handle.last_prompt_stats
+
     @property
     def session_id(self) -> str:
         """The ACP session ID."""

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -30,6 +30,7 @@ from kiro_crew.providers.base import (
     EVENT_TOOL_CALL,
     LLMEvent,
     LLMProvider,
+    resolve_billing_stats,
 )
 from kiro_crew.security import (
     is_denied,
@@ -1109,14 +1110,28 @@ def _billing_stats(provider: Any) -> Any:
     Returned as the object rather than a value so callers can compare identity:
     the runner installs a FRESH stats object as it begins a turn, which is what
     tells a completed turn apart from one that never started.
+
+    Each holder is read through :func:`resolve_billing_stats`, the one spelling
+    the wrappers use too: a provider's declared
+    :meth:`LLMProvider.billing_stats` wins, and the ``last_prompt_stats``
+    fallback keeps every holder that was found before the capability existed --
+    the raw ``AcpClient``, and the doubles that stand in for a runner. One
+    holder's broken read is skipped rather than abandoning the walk, so a faulty
+    wrapper cannot lose a turn whose billing a later node still carries.
     """
     try:
-        for node in _billing_stat_holders(provider):
-            stats = getattr(node, "last_prompt_stats", None)
-            if stats is not None:
-                return stats
+        holders = _billing_stat_holders(provider)
     except Exception:
-        logger.debug("billing stats lookup failed", exc_info=True)
+        logger.debug("billing stats holder walk failed", exc_info=True)
+        return None
+    for node in holders:
+        try:
+            stats = resolve_billing_stats(node)
+        except Exception:
+            logger.debug("billing stats read failed for one holder", exc_info=True)
+            continue
+        if stats is not None:
+            return stats
     return None
 
 
@@ -1257,13 +1272,18 @@ def provider_last_turn_usage(provider: Any, *, since: Any = _NO_PRIOR_STATS) -> 
 def _billing_stat_holders(provider: Any) -> "list[Any]":
     """Objects that may carry ``last_prompt_stats``, nearest wrapper first.
 
-    The turn-runner sits behind a different attribute per seam: the acp provider
-    keeps it on ``_client``, the session provider on ``_handle``, and the shared
-    background session hands non-kiro callers a thin adapter whose only link to
-    the runner is ``_sess.provider``. Walking all of them keeps a background turn
-    on the claude_code / bedrock seam from reporting 0 credits for a turn that
-    was billed. Bounded and identity-deduped so a self-referential wrapper chain
-    cannot loop.
+    The compatibility path behind :func:`_billing_stats`, and the lookup
+    :func:`_provider_label` still needs: the turn-runner sits behind a different
+    attribute per seam: the acp provider keeps it on ``_client``, the session
+    provider on ``_handle``, and the shared background session hands non-kiro
+    callers a thin adapter whose only link to the runner is ``_sess.provider``.
+    Walking all of them keeps a background turn on the claude_code / bedrock seam
+    from reporting 0 credits for a turn that was billed. Bounded and
+    identity-deduped so a self-referential wrapper chain cannot loop.
+
+    A name absent from this tuple is exactly how a new seam's spend went
+    unreported, which is why the billing read now prefers the provider's declared
+    :meth:`LLMProvider.billing_stats` and only falls back here.
     """
     out: list[Any] = []
     seen: set[int] = set()

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -51,6 +51,7 @@ from kiro_crew.providers.base import (
     CancelOutcome,
     LLMEvent,
     LLMProvider,
+    resolve_billing_stats,
 )
 from kiro_crew.providers.cleanup import _is_safe_path
 
@@ -1284,6 +1285,21 @@ class AcpProvider(LLMProvider):
 
     def context_used_tokens(self) -> int:
         return self._client.last_prompt_stats.context_used_tokens
+
+    def billing_stats(self) -> object | None:
+        """Live per-turn billing stats (public — see LLMProvider).
+
+        Forwards the inner client's own DECLARATION rather than reading an
+        attribute off it: this provider wraps whichever client the backend
+        installs (a raw ``AcpClient`` for claude / pre-startup, an
+        ``AcpSessionProvider`` after kiro startup replaces the placeholder), and
+        forwarding the capability is what keeps the wrapper from re-introducing
+        the attribute-name dependency the accounting path just shed. Resolved
+        through the shared helper so this forward cannot diverge from the reader
+        it feeds, and per call because the placeholder client is replaced at
+        runtime startup.
+        """
+        return resolve_billing_stats(getattr(self, "_client", None))
 
     async def compact(self, context: str = "") -> None:
         """Trigger native /compact with optional context-preserving prompt."""

--- a/src/kiro_crew/providers/base.py
+++ b/src/kiro_crew/providers/base.py
@@ -33,6 +33,31 @@ from kiro_crew.constants import COMPACT_WAIT_TIMEOUT_SECS
 CancelOutcome = Literal["acked", "timeout", "no_turn", "error"]
 
 
+def resolve_billing_stats(holder: object | None) -> object | None:
+    """The billing stats *holder* declares, else the ``last_prompt_stats`` it carries.
+
+    The single spelling of "read a turn's billing off this object", shared by the
+    accounting path and by every wrapper that forwards it, so a wrapper cannot
+    resolve the capability differently from the reader it feeds.
+
+    The declaration is resolved off the TYPE, not the instance: a class that
+    defines :meth:`LLMProvider.billing_stats` is stating the capability, whereas
+    an object that merely answers an attribute of that name may be a mock whose
+    auto-created child would masquerade as a stats object and shadow the real
+    billing. A holder that declares nothing -- or leaves the ABC default, which
+    answers ``None`` -- falls back to the ``last_prompt_stats`` the ACP runner
+    carries, so a holder found before the capability existed is still read.
+    """
+    if holder is None:
+        return None
+    seam = getattr(type(holder), "billing_stats", None)
+    if callable(seam):
+        declared = seam(holder)
+        if declared is not None:
+            return declared
+    return getattr(holder, "last_prompt_stats", None)
+
+
 class LLMProvider(ABC):
     """Abstract LLM backend."""
 
@@ -205,6 +230,36 @@ class LLMProvider(ABC):
         real values. Base returns (None, None) which disables abort push.
         """
         return (None, None)
+
+    def billing_stats(self) -> object | None:
+        """The live per-turn billing stats object, or None when unmetered.
+
+        Declared here so what a turn COST is a stated provider capability, like
+        the context accessors above, instead of an attribute name the accounting
+        path has to guess. Surfaces that dispatch without an ``EVENT_COMPLETE``
+        in hand -- cron, heartbeat, autonudge, workflows, the task runner --
+        recover the turn's spend through ``llm_helpers.provider_last_turn_usage``,
+        which otherwise finds it only by walking the private attributes
+        ``_client`` / ``_handle`` / ``_sess`` / ``provider`` for a
+        ``last_prompt_stats``. A provider that links to its turn-runner under any
+        other name is not found by that walk: the read yields empty usage, the
+        ``usage_has_billing`` gate reads that as "nothing to record", and the
+        spend never reaches the usage store -- absent from the dashboard while
+        the account balance moves, with no error raised anywhere.
+
+        Return the stats OBJECT, not a value. The accounting path compares
+        identity to tell a turn that ran from one whose dispatch failed while a
+        previous, already-recorded turn's stats were still installed, so a
+        provider must install a fresh object as each turn begins (as the ACP
+        runner does) for that comparison to hold.
+
+        The object need only carry the billing: ``to_turn_usage()`` is preferred
+        when it offers one -- that is the single source of truth for every
+        dimension a seam bills on -- and a ``credits`` attribute is read
+        otherwise. Default None means "this backend reports no per-turn
+        billing", so an unmetered provider needs no override.
+        """
+        return None
 
     # ── Turn-control and capability surface (harness-parity H14) ──
     # The session, shutdown-drain, steer, and dashboard layers read these off a

--- a/test/test_background_turn_accounting.py
+++ b/test/test_background_turn_accounting.py
@@ -11,11 +11,13 @@ even under cancellation.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from kiro_crew.llm_helpers import background_turn, provider_last_turn_usage
+from kiro_crew.providers.base import LLMProvider
 
 _USAGE_TARGET = "kiro_crew.dashboard.handlers.usage.persist_token_record_async"
 
@@ -234,6 +236,242 @@ class TestBillingStatsReachThroughTheAdapter(unittest.TestCase):
         self.assertEqual(provider_last_turn_usage(runner, since=prior).credits, 0.0)
         runner.last_prompt_stats = _Stats(7.0)
         self.assertEqual(provider_last_turn_usage(runner, since=prior).credits, 7.0)
+
+
+class TestBillingIsReadThroughTheDeclaredSeam(unittest.TestCase):
+    """A provider's billing is a declared capability, not a guessed attribute."""
+
+    def test_a_runner_the_walk_cannot_name_is_still_billed(self):
+        """The failure this seam removes: a provider that links to its turn-runner
+        under a name the private walk does not know reported empty usage, which
+        the ``usage_has_billing`` gate reads as "nothing to record" -- the spend
+        never reaching the usage store, with no error raised."""
+        from kiro_crew.llm_helpers import usage_has_billing
+
+        class _Runner:
+            def __init__(self) -> None:
+                self.last_prompt_stats = _Stats(9.5)
+
+        class _FutureSeamProvider:
+            """Same billing as the acp seam, linked under its own name."""
+
+            def __init__(self) -> None:
+                self._runner = _Runner()
+
+            def billing_stats(self) -> object | None:
+                return self._runner.last_prompt_stats
+
+        usage = provider_last_turn_usage(_FutureSeamProvider())
+        self.assertEqual(usage.credits, 9.5)
+        self.assertTrue(usage_has_billing(usage))
+
+    def test_a_provider_declaring_nothing_is_still_found_by_the_walk(self):
+        """The walk stays the compatibility path: a holder that predates the seam
+        (the raw AcpClient, the doubles standing in for a runner) must keep
+        billing exactly as before."""
+
+        class _Runner:
+            def __init__(self) -> None:
+                self.last_prompt_stats = _Stats(4.0)
+
+        class _KnownSeamProvider:
+            def __init__(self) -> None:
+                self._client = _Runner()
+
+        self.assertEqual(provider_last_turn_usage(_KnownSeamProvider()).credits, 4.0)
+
+    def test_the_abc_default_does_not_count_as_a_declaration(self):
+        """A provider that inherits the ABC default has declared nothing, so the
+        read must fall back to what it carries rather than report "no billing"."""
+        from kiro_crew.providers.base import resolve_billing_stats
+
+        class _Inheriting(LLMProvider):
+            """Implements ONLY the abstract surface; billing is the ABC default."""
+
+            def __init__(self) -> None:
+                self.last_prompt_stats = _Stats(6.0)
+
+            async def start(self) -> None:
+                return None
+
+            async def shutdown(self) -> None:
+                return None
+
+            async def stream(self, message: str):
+                yield SimpleNamespace(kind="complete")
+
+            async def approve_tool(self, request_id, *, always: bool = False) -> None:
+                return None
+
+            async def reject_tool(self, request_id) -> None:
+                return None
+
+            def context_usage_pct(self) -> float:
+                return 0.0
+
+        provider = _Inheriting()
+        self.assertIsNone(provider.billing_stats())
+        self.assertIs(resolve_billing_stats(provider), provider.last_prompt_stats)
+        self.assertEqual(provider_last_turn_usage(provider).credits, 6.0)
+
+    def test_an_attribute_of_that_name_on_a_double_does_not_shadow_the_billing(self):
+        """The seam is read off the TYPE: a mock answers every attribute with an
+        auto-created child, and consuming one as a stats object would zero a turn
+        that really billed."""
+        double = MagicMock()
+        double.last_prompt_stats = _Stats(2.0)
+
+        self.assertTrue(callable(double.billing_stats))
+        self.assertIsNone(getattr(type(double), "billing_stats", None))
+        self.assertEqual(provider_last_turn_usage(double).credits, 2.0)
+
+    def test_a_raising_seam_falls_back_instead_of_losing_the_turn(self):
+        class _Broken:
+            def __init__(self) -> None:
+                self._client = SimpleNamespace(last_prompt_stats=_Stats(1.25))
+
+            def billing_stats(self) -> object | None:
+                raise RuntimeError("seam is broken")
+
+        self.assertEqual(provider_last_turn_usage(_Broken()).credits, 1.25)
+
+    def test_the_seam_hands_back_the_object_so_identity_still_guards(self):
+        """Reported by identity, not by value: a dispatch that failed before the
+        runner installed fresh stats must bill nothing, even though the previous
+        turn's credits are still readable."""
+
+        class _Provider:
+            def __init__(self) -> None:
+                self._runner = SimpleNamespace(last_prompt_stats=_Stats(7.0))
+
+            def billing_stats(self) -> object | None:
+                return self._runner.last_prompt_stats
+
+        provider = _Provider()
+        prior = provider.billing_stats()
+        self.assertEqual(provider_last_turn_usage(provider, since=prior).credits, 0.0)
+        provider._runner.last_prompt_stats = _Stats(7.0)
+        self.assertEqual(provider_last_turn_usage(provider, since=prior).credits, 7.0)
+
+
+class TestEveryProviderDeclaresItsBilling(unittest.TestCase):
+    """Ratchet: the seam only removes the defect if providers actually declare it.
+
+    A new provider that forgets billing is the whole failure class -- its spend is
+    absent from the usage page with nothing raised -- so it fails here instead. A
+    genuinely unmetered backend satisfies this by overriding the method to return
+    None, which documents the choice on the provider rather than in this test.
+    """
+
+    @staticmethod
+    def _product_subclasses(root: type) -> list[type]:
+        """Every subclass defined in the product tree, transitively.
+
+        Filtered to ``kiro_crew.*`` so a test module's own double (this file's
+        included) is not held to the product contract.
+        """
+        out: list[type] = []
+        for cls in root.__subclasses__():
+            if cls.__module__.startswith("kiro_crew."):
+                out.append(cls)
+            out.extend(TestEveryProviderDeclaresItsBilling._product_subclasses(cls))
+        return out
+
+    def test_concrete_providers_override_billing_stats(self):
+        import kiro_crew.acp.session_provider  # noqa: F401
+        import kiro_crew.providers.acp  # noqa: F401
+
+        found = self._product_subclasses(LLMProvider)
+        # Guards the ratchet itself: an import that stopped registering the
+        # providers would make the assertion below vacuously true.
+        self.assertGreaterEqual(len(found), 2, f"provider classes not registered: {found}")
+
+        missing = sorted(
+            f"{cls.__module__}.{cls.__name__}"
+            for cls in found
+            if not inspect.isabstract(cls) and cls.billing_stats is LLMProvider.billing_stats
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "these providers do not declare billing_stats(), so a turn they serve "
+            "bills invisibly -- override it to return the live per-turn stats "
+            f"object, or None if the backend is genuinely unmetered: {missing}",
+        )
+
+    def test_the_shared_background_adapter_path_reads_the_inner_declaration(self):
+        """Background callers hold the adapter, whose only link to the runner is
+        ``_sess.provider``. The adapter itself declares nothing -- it is
+        application code that must not import the provider layer (the
+        agent-SDK boundary gate) -- so the walk reaching that node and resolving
+        ITS declaration is what keeps a background turn's spend visible."""
+        from kiro_crew.session_background import _ProviderBgSession
+
+        stats = _Stats(5.5)
+
+        class _Inner:
+            def billing_stats(self) -> object | None:
+                return stats
+
+        adapter = _ProviderBgSession(SimpleNamespace(provider=_Inner()))  # type: ignore[arg-type]
+
+        self.assertFalse(hasattr(adapter, "billing_stats"))
+        self.assertEqual(provider_last_turn_usage(adapter).credits, 5.5)
+
+    def test_the_acp_provider_answers_from_either_client_shape(self):
+        """``_client`` is a raw AcpClient until kiro startup replaces it with an
+        AcpSessionProvider, and both shapes must report the same turn. Asserted
+        through the seam itself: the walk would find these stats anyway, so only
+        an identity check on ``billing_stats()`` pins the declaration."""
+        from kiro_crew.acp.session_provider import AcpSessionProvider
+        from kiro_crew.providers.acp import AcpProvider
+
+        raw_stats = _Stats(1.5)
+        raw = object.__new__(AcpProvider)
+        raw._client = SimpleNamespace(last_prompt_stats=raw_stats)  # type: ignore[attr-defined]
+        self.assertIs(raw.billing_stats(), raw_stats)
+        self.assertEqual(provider_last_turn_usage(raw).credits, 1.5)
+
+        shared_stats = _Stats(2.5)
+        session_provider = object.__new__(AcpSessionProvider)
+        session_provider._handle = SimpleNamespace(  # type: ignore[attr-defined]
+            last_prompt_stats=shared_stats
+        )
+        self.assertIs(session_provider.billing_stats(), shared_stats)
+        shared = object.__new__(AcpProvider)
+        shared._client = session_provider  # type: ignore[attr-defined]
+        self.assertIs(shared.billing_stats(), shared_stats)
+        self.assertEqual(provider_last_turn_usage(shared).credits, 2.5)
+
+    def test_a_wrapper_forwards_the_inner_declaration_not_the_attribute_name(self):
+        """``AcpProvider`` holds whichever client the backend installs, so it
+        forwards the CAPABILITY. Reading ``last_prompt_stats`` off the inner
+        object instead would re-introduce the same name dependency one level
+        down: an inner provider that keeps its runner elsewhere has no such
+        attribute, and its billed turn would report nothing."""
+        from kiro_crew.providers.acp import AcpProvider
+        from kiro_crew.session_background import _ProviderBgSession
+
+        stats = _Stats(8.25)
+
+        class _FutureSeamProvider:
+            """Declares billing; carries no ``last_prompt_stats`` of its own."""
+
+            def billing_stats(self) -> object | None:
+                return stats
+
+        inner = _FutureSeamProvider()
+        self.assertFalse(hasattr(inner, "last_prompt_stats"))
+
+        wrapper = object.__new__(AcpProvider)
+        wrapper._client = inner  # type: ignore[attr-defined]
+        self.assertIs(wrapper.billing_stats(), stats)
+        self.assertEqual(provider_last_turn_usage(wrapper).credits, 8.25)
+
+        # The background adapter declares nothing and needs to: the walk reaches
+        # its ``_sess.provider`` and resolves the declaration on that node.
+        adapter = _ProviderBgSession(SimpleNamespace(provider=inner))  # type: ignore[arg-type]
+        self.assertEqual(provider_last_turn_usage(adapter).credits, 8.25)
 
 
 class TestBilledAttemptsSurviveARetry(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## What is the problem?

The accounting path that recovers a completed turn's billing found it by
*searching* for it. `llm_helpers._billing_stats` walked the private attributes
`_client` / `_handle` / `_sess` / `provider`, up to eight nodes deep, looking for
an object with a `last_prompt_stats`. Nothing in the `LLMProvider` interface said
a word about billing, so the real contract a new provider had to satisfy was
"name your turn-runner one of these four private strings".

A provider that links to its turn-runner under any other name is simply not
found. Reproduced on `main` with two providers carrying identical billing, one
linked under a known name and one under `_runner`:

```
known-name seam  credits=9.5 has_billing=True
future-name seam credits=0.0 has_billing=False
```

The zero is not an error. It flows into `usage_has_billing(usage)`, which reads
it as "nothing to record", so `persist_token_record_async` is never called.

## Why this issue matters to the user

Every surface that dispatches without an `EVENT_COMPLETE` in hand -- cron,
heartbeat, autonudge, workflows, the task runner -- recovers its spend through
this read. When it returns empty, the turn's cost is absent from the Usage page
while the account balance moves, and nothing is logged: the exact
invisible-spend symptom the background-accounting work exists to remove,
reappearing once per new provider seam. The failure is silent and permanent for
that seam, and it looks identical to a genuinely free turn.

To be exact about the timing of the harm: **no shipped provider mis-bills today.**
Both in-tree providers keep their runner under a name the walk happens to know,
which is why the reproduction has to use a synthetic provider. What this fixes is
the condition under which the next one bills invisibly, and the ratchet is what
makes that stick -- a provider added without the declaration fails a test instead
of quietly reporting zero. Read it as a preventive fix with a mechanical
enforcement, not as a live accounting bug.

## How our fix solves it

Chain from symptom to cause:

1. Spend is missing from the Usage page because no row was written.
2. No row was written because the `usage_has_billing` gate saw empty usage.
3. Usage was empty because the stats object was not found.
4. It was not found because discovery was a search over private attribute
   names, and the provider's name was not in the list.
5. The name was not in the list because billing was never a declared
   capability -- so there was no place for a provider to state it and no way to
   notice one had not.

So step 5 is what the fix changes. `LLMProvider.billing_stats()` is declared on
the ABC next to the context accessors that already read the very same stats
object, with a safe `None` default (meaning "this backend reports no per-turn
billing"). Both concrete ACP providers answer it.

One helper, `resolve_billing_stats()` in `providers/base.py`, is the single
spelling of "read a turn's billing off this object". It has two consumers: the
accounting walk resolves EVERY holder through it, and `AcpProvider` forwards its
inner client through it -- so a wrapper cannot resolve the capability differently
from the reader it feeds. Because the walk resolves per holder, the shared
background adapter needs no forward of its own: the walk reaches `_sess.provider`
and honours the declaration on that node. That also keeps `session_background.py`
out of the diff, which matters -- it is application code, and the agent-SDK
boundary gate (`rfc-crew-agent-sdk-boundary` Phase 1) forbids growing its
dependence on `kiro_crew.providers*`, lazily or otherwise.

Three details that make it hold:

- **The `last_prompt_stats` fallback stays**, per holder. Every holder that was
  found before the capability existed -- the raw `AcpClient` the Slack gateway
  passes bare, and the doubles standing in for a runner -- keeps billing exactly
  as before. There is no separate preference layer: `_billing_stats` is one loop
  that resolves each holder, and a broken read on one holder is skipped rather
  than abandoning the walk.
- **The wrapper forwards the DECLARATION, not the attribute.** `AcpProvider`
  wraps whichever client the backend installs and asks it for its capability.
  Reading `last_prompt_stats` off it instead would re-introduce the same name
  dependency one level down.
- **The declaration is resolved off the TYPE, not the instance.** A class that
  defines `billing_stats` is declaring the capability; an object that merely
  answers an attribute of that name may be a mock, whose auto-created child would
  masquerade as a stats object and zero a turn that really billed.

The value returned is still the stats *object*, because the accounting path
compares identity to tell a turn that ran from one whose dispatch failed while a
previous, already-recorded turn's stats were still installed.

Not in scope, and stated so it is not mistaken for part of this change: the
second half of the original finding -- "only `credits` is read, so a token-billed
backend reports nothing" -- was already fixed on `main`. `_attempt_usage` prefers
the stats object's own `to_turn_usage()` (tokens, cache fields, `cost_usd`) and
`usage_has_billing` is the single shared predicate. `_provider_label` still walks
the same chain for the row's provider dimension; that is a label lookup, not the
billing read, and is left alone -- accepted and deferred to its own change.

## What tests we did

Targeted only (34 in the file, 629 in the neighbouring modules), plus lint:

- **Mechanism reproduced first**, before any fix: a provider whose runner sits
  under an unknown name reports `credits=0.0, has_billing=False` while its
  known-name twin reports `9.5`.
- **Red on base.** With only the test file applied to `main`, 5 of the 9 new
  tests fail, including the headline one at `AssertionError: 0.0 != 9.5`.
- **Mutation probes on the shared resolver**, each reddening broadly and for the
  right reason: downgrading the type-level resolution to instance-level reddens 7
  tests (including the mock-shadowing one at `1.0 != 2.0`), and dropping the
  `last_prompt_stats` fallback reddens 20 -- so both halves of the helper are
  load-bearing. Earlier probes on the pre-review shape reddened the adapter
  forward (`AttributeError`) and the wrapper forward (`None is not <_Stats>`).
- A mutation probe is also what caught a **dead branch in my own first draft**:
  `AcpProvider.billing_stats` special-cased `AcpSessionProvider` via `isinstance`,
  and the probe did not redden anything because that class already exposes
  `last_prompt_stats` as a public property. That branch is gone.
- **Ratchet**: every concrete `LLMProvider` subclass in `kiro_crew.*` must declare
  `billing_stats()`. A genuinely unmetered backend satisfies it by overriding the
  method to return `None`, which documents the choice on the provider; the
  assertion message names that recourse. A guard assertion checks the provider
  classes registered at all, so an import regression cannot make the sweep
  vacuously true.
- Regression guards, green on base and after: a non-declaring holder is still
  found; a provider left on the ABC default falls back to what it carries rather
  than reporting "no billing"; a raising seam falls back instead of losing the
  turn; the identity guard still reports nothing for a dispatch that never
  started.
- **Boundary gate.** An earlier round routed the background adapter's forward
  through a call-time `providers.base` import; the agent-SDK boundary gate caught
  it (`ACP-layer imports grew from 2 to 3`) and the forward was deleted rather
  than worked around, since the walk already covers that path. The gate now
  passes locally in `--test` mode and against the branch, and this PR adds zero
  ACP-layer import edges.
- The background path is covered by the mechanism that carries it:
  `test_the_shared_background_adapter_path_reads_the_inner_declaration` asserts
  the adapter declares nothing and that a turn behind it still bills.
- Neighbours: `test_providers_base_cov80`, `test_session_provider_liveness`,
  `test_acp_session_provider`, `test_acp_session_provider_shutdown`,
  `test_llm_helpers`, `test_run_bg_oneliner`, `test_turn_usage`,
  `test_acp_usage_cost`, `test_usage`, `test_session_usage`,
  `test_kiro_usage_api`, `test_background_approval_routing` -- all pass.
- flake8, isort, mypy clean on the touched files. `providers/acp.py` is in
  `.github/black-baseline.txt` and its reformat is pre-existing on base; black
  touches none of the added lines.

## Any other suggestions on the work

- `_provider_label` still resolves the backend label by walking the same private
  chain. Same class of fragility, different field, and worth the same treatment
  in its own change.
- The ratchet covers providers, not wrappers. `AcpProvider`'s forward is pinned by
  a named test rather than by the class sweep, and the background adapter relies
  on the walk reaching its inner provider. A future wrapper would need its own
  test; a shared wrapper base class would be the structural fix, but it cannot
  live in `providers/` while application-layer wrappers are forbidden from
  importing it -- that belongs to the agent-SDK boundary RFC, not here.
- The seam reports what a turn cost but not what it cost in, and the consumer
  infers that from the stats object's shape. If a third billing model appears,
  making the unit explicit would be better than duck-typing `to_turn_usage`.

## Pattern harvest

Rule candidate: when a cross-cutting concern is collected from implementations by
SEARCHING for an attribute name, a missing name silently reads as the absence of
the thing itself. Declare it as a capability on the interface and ratchet that
every implementation answers it -- a forgotten implementation is then a red test
instead of a zero.

Mechanically catchable, and this PR adds the check for the billing case rather
than only proposing it: `test_concrete_providers_override_billing_stats` sweeps
`LLMProvider.__subclasses__()` and fails any concrete `kiro_crew.*` provider that
has not overridden `billing_stats`.

Generalizable beyond billing: the same sweep applies to any ABC method whose
default is a *silent* zero/empty/False rather than an error. `context_usage_pct`
is abstract, so the interpreter enforces it; `billing_stats`,
`context_window_tokens`, and `runtime_info` cannot be abstract without breaking
providers that lack the capability, and those are exactly the ones where a
forgotten override is invisible. A future generic test could assert that every
non-abstract ABC method returning a falsy default is either overridden or listed
as exempt.

Not a one-off: this is the second appearance of the shape on this surface. The
private walk itself was added because one seam's spend was already going
unreported, which is how `_sess` / `provider` came to be in the tuple. Adding a
fifth name would have been the third.


