### PR TITLE
fix(knowledge): make the sync_status column the single source of truth

### DIFF
--- a/.github/sync-io-in-async-baseline.txt
+++ b/.github/sync-io-in-async-baseline.txt
@@ -18,5 +18,4 @@
 #   python3 scripts/check_sync_io_in_async.py --report
 63 src/kiro_crew/dashboard/handlers/knowledge.py
 15 src/kiro_crew/knowledge/ingestion.py
-1 src/kiro_crew/knowledge/sync.py
-6 src/kiro_crew/knowledge/watcher.py
+2 src/kiro_crew/knowledge/watcher.py

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -1215,7 +1215,6 @@ async def confirm_source(request: web.Request) -> web.Response:
         _sel_log("source.confirm_denied", source_id=source_id, reason="sensitive_path")
         return web.json_response({"error": "Path is restricted for security reasons"}, status=403)
     props = json.loads(row["properties"]) if isinstance(row["properties"], str) else (row["properties"] or {})
-    props["sync_status"] = "active"
     props.pop("scan_paused", None)
     store.update_source(source_id, properties=props, sync_status="active")
     _sel_log("source.confirm", source_id=source_id)
@@ -1242,12 +1241,9 @@ async def pause_source(request: web.Request) -> web.Response:
         return web.json_response({"error": "not found"}, status=404)
     props = json.loads(row["properties"]) if isinstance(row["properties"], str) else (row["properties"] or {})
     props["scan_paused"] = True
-    # Keep the JSON copy in sync with the column: the watcher's pre-scan skip
-    # reads properties["sync_status"] (it selects `properties`, not the column),
-    # so leaving this stale meant a paused folder was still fully walked and
-    # delete-reconciled every sweep -- only the deeper scan_paused gate in
-    # folder_watcher stopped the ingestion. confirm/resume already do this.
-    props["sync_status"] = "paused"
+    # The watcher's pre-scan skip reads the sync_status COLUMN, so this write is
+    # what stops the sweep from walking and delete-reconciling the whole folder;
+    # the deeper scan_paused gate in folder_watcher stops the ingestion itself.
     store.update_source(source_id, properties=props, sync_status="paused")
     _sel_log("source.pause", source_id=source_id)
     return web.json_response({"status": "paused"})
@@ -1267,7 +1263,6 @@ async def resume_source(request: web.Request) -> web.Response:
         return web.json_response({"error": "Path is restricted for security reasons"}, status=403)
     props = json.loads(row["properties"]) if isinstance(row["properties"], str) else (row["properties"] or {})
     props.pop("scan_paused", None)
-    props["sync_status"] = "active"
     store.update_source(source_id, properties=props, sync_status="active")
     _sel_log("source.resume", source_id=source_id)
     # Trigger scan to pick up remaining files

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -84,6 +84,45 @@ def _validated_aliases(value: object) -> str:
     return text
 
 
+def _without_sync_status(properties):
+    """*properties* with any ``sync_status`` key removed.
+
+    The ``sources.sync_status`` COLUMN is the single source of truth for a
+    source's sync state: the dashboard list, the watcher's pre-scan skip and
+    ``SyncScheduler.sync_all`` all read it. A ``sync_status`` key inside the
+    properties JSON is a SECOND store that only the writer touching it observes
+    -- the divergence that let a paused folder go on being walked every sweep
+    and a vanished file go on rendering 'synced'.
+
+    Callers may still STATE a status in properties at INSERT time (that is the
+    channel ``_initial_sync_status`` reads, under an allowlist); it is dropped
+    from what gets persisted, so no row carries two answers. After insert the
+    column is written explicitly or not at all: a status found in a properties
+    write is discarded rather than applied, because a blob read off a legacy row
+    carries a value that is stale by definition, and honouring it would let the
+    watcher stamp 'missing' back onto a file it had just re-ingested.
+
+    The input is never mutated. A value that is not a JSON object (legacy
+    imports hold arrays), an unparsable blob, and a blob without the key all
+    pass through unchanged.
+    """
+    if isinstance(properties, str):
+        try:
+            parsed = json.loads(properties)
+        except (ValueError, TypeError, RecursionError):
+            # RecursionError is a RuntimeError, so it needs naming: json.loads
+            # recurses per nesting level, and this helper sits on every insert
+            # and update path. A pathologically nested blob is left exactly as
+            # it was rather than failing the write.
+            return properties
+        if not isinstance(parsed, dict) or "sync_status" not in parsed:
+            return properties
+        return json.dumps(_without_sync_status(parsed))
+    if not isinstance(properties, dict) or "sync_status" not in properties:
+        return properties
+    return {k: v for k, v in properties.items() if k != "sync_status"}
+
+
 class _NodeView:
     """Minimal node-attribute view supporting get, subscript, iteration, and len."""
 
@@ -513,41 +552,81 @@ class KnowledgeStore:
         src_cols = {r[1] for r in self.db.execute("PRAGMA table_info(sources)").fetchall()}
         if "sync_status" not in src_cols:
             self.db.execute("ALTER TABLE sources ADD COLUMN sync_status TEXT DEFAULT 'pending'")
-        # Repair rows whose column still holds the un-written 'pending' default
-        # while the properties JSON carries the intended state (rows inserted
-        # before the column was written on INSERT). The dashboard picks the
-        # row's control from the column, so a divergent row renders Pause
-        # instead of Confirm and the source cannot be started. Only 'pending'
-        # rows are candidates: any row a handler transitioned already had its
-        # column written, so a repaired value never overwrites a live state.
-        divergent = self.db.execute(
-            "SELECT id, properties FROM sources WHERE sync_status = 'pending'").fetchall()
-        for row in divergent:
+        # ONE pass over the rows that still carry a blob copy of the status:
+        # repair the column where it was never written, then retire the copy.
+        # After this pass no row has a copy at all, so on a store that has
+        # already opened once the scan matches nothing.
+        #
+        # An INITIAL state is repaired onto a column still at its un-written
+        # 'pending' default (rows inserted before the column was written on
+        # INSERT). The dashboard picks the row's control from the column, so a
+        # divergent row renders Pause instead of Confirm and the source cannot be
+        # started. Only 'pending' rows are candidates: any row a handler has
+        # transitioned already had its column written, so a repair never
+        # overwrites a live state.
+        #
+        # A LIFECYCLE value in the blob is deliberately NOT promoted, not even
+        # 'error'. It cannot be ordered against the column: a pre-column
+        # ``_record_failure`` wrote 'error' to the blob alone, and a later
+        # successful re-ingest wrote 'synced' to the column alone, so the two
+        # copies carry no evidence of which happened last. Promoting would mark a
+        # recovered source errored and, since the copy is retired in the same
+        # pass, nothing would correct it. Not promoting costs at most ONE sync
+        # attempt: ``_record_failure`` reads ``consecutive_failures`` from the
+        # blob, which such a row already has at or above its threshold, so the
+        # first attempt that fails writes the column and quiesces the source for
+        # good -- while an attempt that SUCCEEDS is the right outcome for a source
+        # that had recovered. The column is authoritative; a value that cannot be
+        # ordered against it does not get to overrule it.
+        #
+        # The copy is then RETIRED. This runs on EVERY open, so leaving the key in
+        # place would make the repair above a standing reader of a value that goes
+        # stale the moment a column-only writer moves the row. Retiring makes it a
+        # one-time repair instead.
+        #
+        # The repair is compare-and-set on the row as READ -- the blob AND the
+        # column -- so a concurrent writer wins and the row is converged by the
+        # next open instead. The retirement predicates on the blob ALONE, which
+        # is the only field it writes: a column-only transition is what every
+        # live writer does, and requiring the column to be unmoved would abandon
+        # the copy for exactly the transitions that are expected to happen.
+        # No SQL prefilter on the blob text. A raw substring match cannot decide
+        # membership here: JSON escapes are legal inside a KEY, so a blob stored
+        # as {"sync_\u0073tatus": "paused"} parses to the very key this pass
+        # converges while `properties LIKE '%sync_status%'` never matches it. The
+        # key only exists once decoded, so the decision has to be made on the
+        # PARSED value. `sources` holds one row per knowledge source, so parsing
+        # each one is bounded and cheap -- and after this pass no row carries a
+        # copy at all, so later opens parse and skip.
+        #
+        # Nothing in-tree can write that escaped form any more (`json.dumps`
+        # never escapes ASCII, and `_without_sync_status` re-serializes on every
+        # insert and update), but `import_bundle` used to store a bundle's
+        # properties text verbatim, so a row imported before this change can
+        # still hold one.
+        blob_copies = self.db.execute(
+            "SELECT id, properties, sync_status FROM sources").fetchall()
+        for row in blob_copies:
             try:
                 props = json.loads(row["properties"] or "{}")
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, RecursionError):
+                # RecursionError (a RuntimeError, so not covered by ValueError):
+                # json.loads recurses per nesting level, and this runs on EVERY
+                # open, so one pathologically nested legacy blob would otherwise
+                # abort every store construction -- a gateway that cannot start.
                 continue
-            if not isinstance(props, dict):
+            if not isinstance(props, dict) or "sync_status" not in props:
                 continue
-            json_status = props.get("sync_status")
-            if (isinstance(json_status, str) and json_status != "pending"
-                    and json_status in self._INITIAL_SYNC_STATUSES):
-                # Re-check BOTH copies in the UPDATE itself: a concurrent
-                # handler may have transitioned the row between the SELECT
-                # and this write, and its live state must win over the
-                # snapshot taken above. The column alone is not enough --
-                # ``SyncScheduler._record_failure`` writes the properties copy
-                # without the column, so a failure landing in that window
-                # would leave the JSON reading 'error' under a repaired
-                # 'pending_confirmation' column and the dashboard would offer
-                # Confirm for a source the scheduler has given up on. Binding
-                # the properties blob as read makes this a compare-and-set on
-                # both; a row that moved is skipped and repaired by the next
-                # open, since this runs on every one.
+            copied = props["sync_status"]
+            if (row["sync_status"] == "pending" and isinstance(copied, str)
+                    and copied != "pending" and copied in self._INITIAL_SYNC_STATUSES):
                 self.db.execute(
                     "UPDATE sources SET sync_status = ? "
                     "WHERE id = ? AND sync_status = 'pending' AND properties = ?",
-                    (json_status, row["id"], row["properties"]))
+                    (copied, row["id"], row["properties"]))
+            self.db.execute(
+                "UPDATE sources SET properties = ? WHERE id = ? AND properties = ?",
+                (_without_sync_status(row["properties"]), row["id"], row["properties"]))
         if "summary_topic" not in src_cols:
             self.db.execute("ALTER TABLE sources ADD COLUMN summary_topic TEXT")
         if "summary_themes" not in src_cols:
@@ -1046,10 +1125,11 @@ class KnowledgeStore:
                     return None, False
             sid = str(uuid4())
             now = datetime.now().isoformat()
+            stored = _without_sync_status(properties)
             self.db.execute(
                 "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
                 "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (sid, name, source_type, uri, json.dumps(properties),
+                (sid, name, source_type, uri, json.dumps(stored),
                  self._initial_sync_status(properties), now, now),
             )
             self.db.execute("COMMIT")
@@ -1305,12 +1385,13 @@ class KnowledgeStore:
             (item_id, entity_id, context, now))
         self.db.commit()
 
-    # States a sources row may legitimately START in. Lifecycle states
-    # (syncing/synced/error/paused/missing) are written by handlers as
-    # transitions and are never valid at insert: persisting a caller-supplied
-    # 'syncing' would make the sync endpoint report a conflict forever for a
-    # source whose sync never started.
-    _INITIAL_SYNC_STATUSES = frozenset({"pending", "pending_confirmation", "active"})
+    # States a sources row may legitimately START in: the DURABLE ones, which a
+    # caller (or a restored bundle) can assert about a source before any work has
+    # run. The transient and outcome states -- syncing/synced/error/missing --
+    # are claims about work, so only the operation that did the work may write
+    # them: persisting a caller-supplied 'syncing' would make the sync endpoint
+    # report a conflict forever for a source whose sync never started.
+    _INITIAL_SYNC_STATUSES = frozenset({"pending", "pending_confirmation", "active", "paused"})
 
     @staticmethod
     def _initial_sync_status(properties) -> str:
@@ -1325,19 +1406,30 @@ class KnowledgeStore:
         Values outside the initial-state allowlist fall back to 'pending'.
         """
         if isinstance(properties, dict):
-            status = properties.get("sync_status")
-            if isinstance(status, str) and status in KnowledgeStore._INITIAL_SYNC_STATUSES:
-                return status
+            return KnowledgeStore._initial_status_or_default(properties.get("sync_status"))
+        return "pending"
+
+    @staticmethod
+    def _initial_status_or_default(status) -> str:
+        """*status* if a row may legitimately start there, else 'pending'.
+
+        The allowlist itself, shared by every insert path so a status arriving
+        through the properties blob and one restored from a bundle's column are
+        held to the same rule.
+        """
+        if isinstance(status, str) and status in KnowledgeStore._INITIAL_SYNC_STATUSES:
+            return status
         return "pending"
 
     def add_source(self, name, source_type, uri, **kwargs) -> str:
         sid = str(uuid4())
         now = datetime.now().isoformat()
         properties = kwargs.get("properties", {})
+        stored = _without_sync_status(properties)
         self.db.execute(
             "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
             "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (sid, name, source_type, uri, json.dumps(properties),
+            (sid, name, source_type, uri, json.dumps(stored),
              self._initial_sync_status(properties), now, now))
         self.db.commit()
         return sid
@@ -1349,15 +1441,42 @@ class KnowledgeStore:
     _SOURCE_COLUMNS = {"name", "source_type", "uri", "properties", "last_synced", "sync_status", "updated_at"}
 
     def update_source(self, source_id, **fields):
+        """Write *fields* to a sources row.
+
+        ``if_sync_status`` makes the write a compare-and-set on the status
+        column: the row is written only while it still reads that value. A caller
+        deriving a status from a SNAPSHOT it took earlier must pass it, because
+        the row can move in between -- a sweep that observed 'missing' and then
+        writes 'synced' would otherwise overwrite the 'error' a manual sync
+        recorded in the meantime. A caller writing the outcome of something that
+        just happened has current information and does not need it.
+        """
+        expected = fields.pop("if_sync_status", None)
         if not fields:
             return
+        if "properties" in fields:
+            # The blob is not a place a status can live. Dropping it here means a
+            # legacy row's second copy disappears the first time anything writes
+            # its properties, and no caller can mint a new one. It is DROPPED,
+            # not applied to the column: a blob read off a legacy row carries a
+            # stale value, so honouring it would let the watcher stamp 'missing'
+            # back onto a file it had just re-ingested. A transition passes
+            # sync_status= explicitly.
+            fields["properties"] = _without_sync_status(fields["properties"])
         fields["updated_at"] = datetime.now().isoformat()
         safe = {k: v for k, v in fields.items() if k in self._SOURCE_COLUMNS}
         if not safe:
             return
         cols = ", ".join(f"{k} = ?" for k in safe)
         vals = [json.dumps(v) if isinstance(v, (list, dict)) else v for v in safe.values()]
-        self.db.execute(f"UPDATE sources SET {cols} WHERE id = ?", (*vals, source_id))  # noqa: S608
+        sql = f"UPDATE sources SET {cols} WHERE id = ?"  # noqa: S608
+        params: list = [*vals, source_id]
+        if expected is not None:
+            # IS, not =, so a NULL column compares as a value rather than
+            # silently matching nothing.
+            sql += " AND sync_status IS ?"
+            params.append(expected)
+        self.db.execute(sql, params)
         self.db.commit()
 
     def add_source_location(self, item_id, source_id, chunk_range=None, section_title=None, anchor=None):
@@ -1559,11 +1678,33 @@ class KnowledgeStore:
         self.db.execute("BEGIN")
         try:
             for src in bundle.get("sources", []):
+                # Restore the status from the COLUMN, which ``export_all`` ships
+                # (it serializes SELECT * FROM sources). Reading the blob copy
+                # instead would land every bundle exported from a fixed store at
+                # the 'pending' default -- there is no copy there any more -- and
+                # silently resume a folder the user had paused. A bundle written
+                # before this change has the blob copy and no column, so fall
+                # back to it. Both go through the same allowlist as the other
+                # insert paths: a bundle is untrusted input, and a restored
+                # 'syncing' would report a conflict forever for a sync that
+                # never started.
+                #
+                # The blob is then stripped like every other insert path: after
+                # an insert the column is the only place a status lives, and a
+                # value the allowlist just refused has no business surviving
+                # inside the row it was refused from. The migration would retire
+                # such a key on the next open without ever promoting it, so this
+                # is the boundary holding, not a second line of defence.
+                props_text = _validated_properties(src.get("properties"))
+                restored = src.get("sync_status")
+                if not isinstance(restored, str) or not restored:
+                    restored = json.loads(props_text or "{}").get("sync_status")
                 self.db.execute(
-                    "INSERT OR IGNORE INTO sources (id, name, source_type, uri, properties, created_at, updated_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT OR IGNORE INTO sources (id, name, source_type, uri, properties, "
+                    "sync_status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     (src["id"], src["name"], src["source_type"], src["uri"],
-                     _validated_properties(src.get("properties")),
+                     _without_sync_status(props_text),
+                     self._initial_status_or_default(restored),
                      src.get("created_at", now), now))
             for item in bundle.get("items", []):
                 raw_emb = item.get("embedding")

--- a/src/kiro_crew/knowledge/sync.py
+++ b/src/kiro_crew/knowledge/sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime
@@ -70,24 +71,30 @@ class SyncScheduler:
         props["consecutive_failures"] = failures
         updates = {"properties": props}
         if failures >= MAX_FAILURES:
-            props["sync_status"] = "error"
-            # Write the column too, so the reader below (and the dashboard, which
-            # reads the column) observes the error regardless of which store it checks.
+            # The column is the single source of truth: the dashboard, the
+            # watcher's pre-scan skip and sync_all below all read it.
             updates["sync_status"] = "error"
             logger.warning("Source %s reached %d failures, marking as error", source_id, failures)
         self.store.update_source(source_id, **updates)
 
     async def sync_all(self) -> list[dict]:
-        rows = self.store.db.execute(
-            "SELECT id, properties, sync_status FROM sources").fetchall()
+        # Off the loop: this is a background coroutine and a contended sqlite
+        # read holds it for as long as busy_timeout.
+        rows = await asyncio.to_thread(
+            lambda: self.store.db.execute("SELECT id, sync_status FROM sources").fetchall())
         results = []
         for row in rows:
-            # sync_status lives in two stores: KnowledgeIngestion writes the COLUMN,
-            # while _record_failure historically wrote only the properties JSON. Treat
-            # an 'error' value in EITHER store as errored so both writers are observed
-            # and legacy JSON-only rows are still skipped.
-            props = json.loads(row["properties"] or "{}")
-            if row["sync_status"] == "error" or props.get("sync_status") == "error":
+            # An errored source stays quiesced instead of being retried every
+            # sweep. A row errored before the column existed carries the state in
+            # its properties blob only, which cannot be ordered against the
+            # column, so it is not promoted: such a row is polled like any other
+            # source until an attempt actually FAILS, and that first failure has
+            # _record_failure -- whose failure count the row already carries --
+            # write the column, after which it quiesces here like the rest. A
+            # poll that finds nothing to fetch costs what every healthy source's
+            # poll costs; promoting the blob value instead would let a state no
+            # writer has touched since overrule the column.
+            if row["sync_status"] == "error":
                 continue
             results.append(await self.sync_source(row["id"]))
         return results

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -179,6 +179,19 @@ class KnowledgeWatcher:
             else:
                 logger.debug("Knowledge project-docs discovery still failing: %s", sig)
 
+    async def _store_rows(self, sql: str, params: tuple = ()) -> list:
+        """Run a sweep query off the event loop.
+
+        The sweep is a background coroutine on the gateway's loop, and sqlite
+        reads are synchronous: a contended database can hold one for as long as
+        ``busy_timeout``, stalling every other task on the loop. ``KnowledgeStore``
+        keeps a connection per THREAD, so a worker thread gets its own rather
+        than sharing the loop's -- the same reason the sweep's writes hop out
+        too. Rows come back detached, so the caller uses them normally.
+        """
+        return await asyncio.to_thread(
+            lambda: self.store.db.execute(sql, params).fetchall())
+
     async def _scan(self):
         """Check all watched sources for changes."""
         # Pick up a newly-created workspace drop folder before scanning, so a
@@ -192,12 +205,13 @@ class KnowledgeWatcher:
         sweep_chunks_used = 0
 
         # Folder sources (local_folder, obsidian_vault)
-        folder_rows = self.store.db.execute(
-            "SELECT id, uri, source_type, properties FROM sources WHERE source_type IN ({})".format(
+        folder_rows = await self._store_rows(
+            "SELECT id, uri, source_type, properties, sync_status FROM sources "
+            "WHERE source_type IN ({})".format(
                 ",".join("?" for _ in FOLDER_SOURCE_TYPES)
             ),
             tuple(FOLDER_SOURCE_TYPES),
-        ).fetchall()
+        )
         ws_base: str | None = None
         chunk_budget: int | None = None
         for row in folder_rows:
@@ -211,7 +225,12 @@ class KnowledgeWatcher:
             try:
                 source = dict(row)
                 props = self._parse_props(source.get("properties"))
-                if props.get("sync_status") in ("paused", "pending_confirmation"):
+                # Read from the sync_status COLUMN, the single source of truth
+                # the dashboard and SyncScheduler also read. This used to read a
+                # copy inside the properties JSON, so a pause recorded only in
+                # the column still walked and delete-reconciled the whole folder
+                # every sweep.
+                if source.get("sync_status") in ("paused", "pending_confirmation"):
                     continue
                 budget: int | None = None
                 if props.get(AUTO_ADDED_PROP):
@@ -279,9 +298,10 @@ class KnowledgeWatcher:
                 logger.exception("Error scanning folder source %s", row["uri"])
 
         # Single-file sources (local_file)
-        rows = self.store.db.execute(
-            "SELECT id, uri, properties FROM sources WHERE source_type = 'local_file'"
-        ).fetchall()
+        rows = await self._store_rows(
+            "SELECT id, uri, properties, sync_status FROM sources "
+            "WHERE source_type = 'local_file'"
+        )
 
         for row in rows:
             try:
@@ -292,18 +312,29 @@ class KnowledgeWatcher:
                     logger.warning("Skipping sensitive path: %s", uri)
                     continue
                 if not Path(uri).exists():
-                    # Mark missing
-                    props = self._parse_props(row["properties"])
-                    if props.get("sync_status") != "missing":
-                        props["sync_status"] = "missing"
-                        self.store.update_source(row["id"], properties=json.dumps(props))
+                    # Mark missing in the COLUMN. Writing it into the properties
+                    # JSON instead left the row's visible state stale -- the
+                    # Library renders the column, so a file that had vanished
+                    # went on showing 'synced'. ``if_sync_status`` because the
+                    # value under test came from the snapshot at the top of the
+                    # sweep: a row a manual sync has moved since is left alone
+                    # and re-examined next sweep.
+                    if row["sync_status"] != "missing":
+                        await asyncio.to_thread(
+                            self.store.update_source, row["id"],
+                            sync_status="missing", if_sync_status=row["sync_status"])
                     continue
 
                 mtime = os.stat(uri).st_mtime
                 props = self._parse_props(row["properties"])
                 stored_mtime = props.get("mtime", 0)
-
-                if mtime > stored_mtime:
+                # A row that reads 'missing' has been away, and the mtime gate
+                # cannot speak for it: a restore preserving the archived mtime
+                # (cp -p, rsync -t, tar -x) puts different content on disk under
+                # an mtime that never advanced, so the gate reports 'unchanged'
+                # about a file it has not read. Deletion is exactly the event
+                # that breaks the mtime heuristic, so read the content instead.
+                if mtime > stored_mtime or row["sync_status"] == "missing":
                     # Check content hash to avoid re-ingesting touched-but-unchanged files
                     content_hash = await asyncio.get_running_loop().run_in_executor(
                         None, self._hash_file, Path(uri)
@@ -322,20 +353,42 @@ class KnowledgeWatcher:
                             # persisting mtime/hash so the file is re-evaluated on
                             # the next scan -- raising knowledge.max_ingest_file_mb
                             # (config is read live) then recovers it automatically.
-                            self.store.db.execute(
-                                "UPDATE sources SET sync_status = 'error' WHERE id = ?",
-                                (row["id"],))
-                            self.store.db.commit()
+                            await asyncio.to_thread(
+                                self.store.update_source, row["id"], sync_status="error")
                             continue
                         # Re-read props after ingest (ingest may update them)
-                        source = self.store.get_source_by_uri(uri)
+                        source = await asyncio.to_thread(
+                            self.store.get_source_by_uri, uri)
                         if source:
                             props = self._parse_props(source.get("properties"))
                     props["mtime"] = mtime
                     props["content_hash"] = content_hash
-                    self.store.update_source(row["id"], properties=json.dumps(props))
+                    await asyncio.to_thread(
+                        self.store.update_source, row["id"], properties=json.dumps(props))
+                if row["sync_status"] == "missing":
+                    # The file is back, so the marker has to come off, and the
+                    # CAS on 'missing' is what decides whether this write is the
+                    # one to do it. An ingestion that ran has already written the
+                    # column -- 'synced' when it stored the document, 'error' on
+                    # a partial write -- and moves the row off 'missing', so this
+                    # no-ops. It fires for the outcome that writes NO status: the
+                    # duplicate gate, which refuses the write because a holder
+                    # already holds this exact document (verified under its write
+                    # lock) and deletes this source's superseded items. Without
+                    # this the marker would sit on a file that is present and
+                    # accounted for. Deliberately LAST, after the read: claiming
+                    # 'synced' before reading the file would leave that claim
+                    # standing if the read then failed -- a failed ingest raises,
+                    # so control never reaches here.
+                    await asyncio.to_thread(
+                        self.store.update_source, row["id"],
+                        sync_status="synced", if_sync_status="missing")
             except Exception:
-                logger.exception("Error checking source %s", row.get("uri", row["id"]))
+                # sqlite3.Row has no .get(): the previous spelling raised
+                # AttributeError from inside the handler, which replaced the real
+                # error with a confusing one AND escaped the loop, abandoning
+                # every source after this one for the rest of the sweep.
+                logger.exception("Error checking source %s", row["uri"] or row["id"])
 
         # After file-level reconciliation, self-heal vectors left stale by an
         # embedding-setup change (model/budget) -- the file gates above never fire

--- a/test/test_folder_watch_handlers.py
+++ b/test/test_folder_watch_handlers.py
@@ -145,19 +145,20 @@ class TestPauseSource:
         assert row["sync_status"] == "paused"
 
     @pytest.mark.asyncio
-    async def test_pause_syncs_sync_status_into_properties(self, store, tmp_path):
-        """The watcher's pre-scan skip reads properties["sync_status"], not the
-        column, so a paused folder was still walked every sweep when the JSON
-        copy stayed "active"."""
+    async def test_pause_records_the_status_in_one_place(self, store, tmp_path):
+        """The pause lands in the COLUMN the watcher's pre-scan skip reads, and
+        nowhere else: a second copy in the properties JSON is what let a paused
+        folder go on being walked every sweep while one store said "active"."""
         sid = store.add_source(
             "test", "local_folder", str(tmp_path), properties={"sync_status": "active"},
         )
         async with TestClient(TestServer(_make_app(store))) as client:
             resp = await client.post(f"/api/knowledge/sources/{sid}/pause")
             assert resp.status == 200
-        row = store.db.execute("SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()
-        props = json.loads(row["properties"])
-        assert props["sync_status"] == "paused"
+        row = store.db.execute(
+            "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "paused"
+        assert "sync_status" not in json.loads(row["properties"])
 
 
 class TestDeleteSourceDismissal:

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -116,6 +116,221 @@ class TestKnowledgeStore:
         assert stats["items"] == 2
         assert stats["entities"] == 1
 
+    def test_export_import_restores_a_paused_source(self, store_factory):
+        """A restored bundle keeps each source's state, from the column.
+
+        ``export_all`` serializes SELECT * FROM sources, so the state travels in
+        the column; the blob carries no copy. Seeding the restored column from
+        the blob would land every source at the 'pending' default and silently
+        resume walking a folder the user had paused.
+        """
+        s1 = store_factory("export-status.db")
+        paused = s1.add_source("vault", "local_folder", "/tmp/rt-paused",
+                               properties={"sync_status": "paused"})
+        unconfirmed = s1.add_source("docs", "local_folder", "/tmp/rt-unconfirmed",
+                                    properties={"sync_status": "pending_confirmation"})
+        # An outcome state a completed operation wrote: a bundle is untrusted
+        # input, so restoring it as-is would assert work that never ran here.
+        errored = s1.add_source("dead", "local_folder", "/tmp/rt-errored")
+        s1.update_source(errored, sync_status="error")
+        bundle = s1.export_all()
+        assert {s["sync_status"] for s in bundle["sources"]} == {
+            "paused", "pending_confirmation", "error"}
+
+        s2 = store_factory("import-status.db")
+        s2.import_bundle(bundle)
+        restored = {r["id"]: r["sync_status"] for r in s2.db.execute(
+            "SELECT id, sync_status FROM sources").fetchall()}
+        assert restored[paused] == "paused"
+        assert restored[unconfirmed] == "pending_confirmation"
+        assert restored[errored] == "pending"
+
+    def test_export_import_restores_a_legacy_bundle_from_the_blob(self, store_factory):
+        """A bundle written before the column travelled still restores."""
+        s2 = store_factory("import-legacy.db")
+        s2.import_bundle({"sources": [{
+            "id": "legacy-1", "name": "vault", "source_type": "local_folder",
+            "uri": "/tmp/rt-legacy",
+            "properties": json.dumps({"sync_status": "paused"}),
+        }]})
+        row = s2.db.execute(
+            "SELECT sync_status, properties FROM sources WHERE id = ?",
+            ("legacy-1",)).fetchone()
+        assert row["sync_status"] == "paused"
+        assert "sync_status" not in json.loads(row["properties"])
+
+    def test_import_does_not_leave_a_refused_status_for_the_migration(self, tmp_path):
+        """A refused bundle status cannot come back at the next store open.
+
+        A bundle is untrusted input, so an outcome state in it is refused and the
+        row lands 'pending'. Storing the blob verbatim would leave that refused
+        value inside the row for the every-open error-lift to read, applying it
+        one reopen later and quiescing a source the allowlist had just protected.
+        """
+        db = str(tmp_path / "import-refused.db")
+        s1 = KnowledgeStore(db)
+        try:
+            s1.import_bundle({"sources": [{
+                "id": "refused-1", "name": "vault", "source_type": "local_folder",
+                "uri": "/tmp/rt-refused",
+                "properties": json.dumps({"sync_status": "error"}),
+            }]})
+            row = s1.db.execute(
+                "SELECT sync_status FROM sources WHERE id = ?", ("refused-1",)).fetchone()
+            assert row["sync_status"] == "pending"
+        finally:
+            s1.close()
+
+        s2 = KnowledgeStore(db)
+        try:
+            row = s2.db.execute(
+                "SELECT sync_status FROM sources WHERE id = ?", ("refused-1",)).fetchone()
+            assert row["sync_status"] == "pending"
+        finally:
+            s2.close()
+
+    def test_update_source_compare_and_set_refuses_a_moved_row(self, store):
+        """``if_sync_status`` makes a snapshot-derived write lose a race.
+
+        A caller that decided what to write from a status it read earlier must
+        not overwrite a transition that landed in between -- a sweep that saw
+        'missing' and writes 'synced' would otherwise bury the 'error' a manual
+        sync recorded while it ran.
+        """
+        sid = store.add_source("f", "local_file", "/tmp/cas.md")
+        store.update_source(sid, sync_status="error")
+
+        store.update_source(sid, sync_status="synced", if_sync_status="missing")
+        assert store.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?",
+            (sid,)).fetchone()["sync_status"] == "error"
+
+        store.update_source(sid, sync_status="synced", if_sync_status="error")
+        assert store.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?",
+            (sid,)).fetchone()["sync_status"] == "synced"
+
+    def test_migration_lift_loses_to_a_concurrent_column_write(self, store, tmp_path):
+        """The repair binds the COLUMN it read, not just the blob.
+
+        Every live writer transitions the column WITHOUT touching properties, so
+        a blob-only precondition would still match and would stamp the blob's
+        initial state over a transition that had just landed.
+        """
+        import sqlite3
+
+        db_path = str(tmp_path / "test.db")
+        sid = str(uuid4())
+        now = datetime.now().isoformat()
+        store.db.execute(
+            "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (sid, "s", "local_folder", "/tmp/repair-race",
+             json.dumps({"sync_status": "pending_confirmation"}), "pending", now, now))
+        store.db.commit()
+        store.close()
+
+        real_loads = json.loads
+        fired: list[bool] = []
+
+        def confirm_lands_mid_scan(raw):
+            parsed = real_loads(raw)
+            if (not fired and isinstance(parsed, dict)
+                    and parsed.get("sync_status") == "pending_confirmation"):
+                fired.append(True)
+                # The user confirms the source while the pass is mid-row: a
+                # COLUMN-only transition, leaving properties untouched.
+                conn = sqlite3.connect(db_path, timeout=30)
+                try:
+                    conn.execute(
+                        "UPDATE sources SET sync_status = 'active' WHERE id = ?", (sid,))
+                    conn.commit()
+                finally:
+                    conn.close()
+            return parsed
+
+        with patch("kiro_crew.knowledge.store.json.loads", confirm_lands_mid_scan):
+            reopened = KnowledgeStore(db_path)
+        try:
+            assert fired, "the mid-scan write never landed; the test proves nothing"
+            assert reopened.db.execute(
+                "SELECT sync_status FROM sources WHERE id = ?",
+                (sid,)).fetchone()["sync_status"] == "active"
+        finally:
+            reopened.close()
+
+    def test_migration_survives_a_pathologically_nested_blob(self, store, tmp_path):
+        """One unparsable legacy row must not stop the gateway from starting.
+
+        ``json.loads`` recurses per nesting level and raises RecursionError --
+        a RuntimeError, so not covered by the ValueError/TypeError guard. This
+        migration runs on EVERY store open, so an uncaught one would abort every
+        construction rather than skipping the row.
+        """
+        deep = '{"sync_status": "active"}'
+        for _ in range(60000):
+            deep = '{"a": ' + deep + '}'
+        with pytest.raises(RecursionError):
+            json.loads(deep)
+
+        ok = str(uuid4())
+        bad = str(uuid4())
+        now = datetime.now().isoformat()
+        for sid, props_json, uri in (
+            (bad, deep, "/tmp/deep"),
+            (ok, json.dumps({"sync_status": "active"}), "/tmp/ok"),
+        ):
+            store.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sid, "s", "local_folder", uri, props_json, "pending", now, now))
+        store.db.commit()
+        store.close()
+
+        reopened = KnowledgeStore(str(tmp_path / "test.db"))
+        try:
+            rows = {r["id"]: r["sync_status"] for r in reopened.db.execute(
+                "SELECT id, sync_status FROM sources").fetchall()}
+            # The row that could be read is still repaired; the other is skipped.
+            assert rows[ok] == "active"
+            assert rows[bad] == "pending"
+        finally:
+            reopened.close()
+
+    def test_migration_converges_a_json_escaped_status_key(self, store, tmp_path):
+        """A JSON-escaped key is still the key, so it still converges.
+
+        JSON permits escapes inside a KEY, so a blob stored as
+        {"sync_\\u0073tatus": "paused"} parses to `sync_status` while never
+        containing that substring literally. Deciding membership by raw text
+        would skip the row: the column would stay at its 'pending' default and
+        the watcher, which now reads the column, would walk a folder the user had
+        paused. `import_bundle` used to store a bundle's properties verbatim, so
+        such a row can exist.
+        """
+        escaped = str(uuid4())
+        now = datetime.now().isoformat()
+        raw = '{"sync_\\u0073tatus": "paused"}'
+        assert "sync_status" not in raw, "the point of the fixture is the escape"
+        assert json.loads(raw) == {"sync_status": "paused"}
+        store.db.execute(
+            "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (escaped, "s", "local_folder", "/tmp/escaped", raw, "pending", now, now))
+        store.db.commit()
+        store.close()
+
+        reopened = KnowledgeStore(str(tmp_path / "test.db"))
+        try:
+            row = reopened.db.execute(
+                "SELECT sync_status, properties FROM sources WHERE id = ?",
+                (escaped,)).fetchone()
+            assert row["sync_status"] == "paused"
+            # Retired too, and re-serialized, so the escape cannot come back.
+            assert json.loads(row["properties"]) == {}
+        finally:
+            reopened.close()
+
     # ---- import_bundle JSON-column well-formedness (issue #5559) -----------
     # The invariant "sources.properties / entities.aliases is JSON text every
     # reader json.loads()s back" is enforced at the writer, so every store
@@ -181,13 +396,13 @@ class TestKnowledgeStore:
 
     def test_import_bundle_accepts_valid_json_columns(self, store):
         bundle = {
-            "sources": [self._source(properties='{"sync_status": "synced"}')],
+            "sources": [self._source(properties='{"namespace": "docs"}')],
             "entities": [self._entity(aliases='["svc", "the-svc"]')],
         }
         result = store.import_bundle(bundle)
         assert result["entities_created"] == 1
         props = store.db.execute("SELECT properties FROM sources").fetchone()["properties"]
-        assert json.loads(props) == {"sync_status": "synced"}
+        assert json.loads(props) == {"namespace": "docs"}
         # The committed alias row is readable by the alias-scanning reader.
         assert store.find_entity("THE-SVC")["id"] == "e1"
 
@@ -853,12 +1068,14 @@ class TestKnowledgeStoreExtended:
         assert store.get_source_by_uri("/tmp/nope") is None
 
     def test_add_source_persists_sync_status_column(self, store):
-        """The sync_status column and the properties JSON must agree on insert.
+        """Insert seeds the COLUMN and stores no second copy in the blob.
 
         The dashboard reads the COLUMN to pick the row's control (the Confirm
         button renders only for 'pending_confirmation'), so a column stuck at
         the 'pending' default while properties carries 'pending_confirmation'
-        makes a folder source unstartable.
+        makes a folder source unstartable. Callers still STATE the initial
+        status in properties; it is lifted onto the column and dropped from the
+        blob so the row cannot hold two answers.
         """
         sid = store.add_source(
             "vault", "local_folder", "/tmp/vault",
@@ -866,7 +1083,13 @@ class TestKnowledgeStoreExtended:
         row = store.db.execute(
             "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
         assert row["sync_status"] == "pending_confirmation"
-        assert json.loads(row["properties"])["sync_status"] == "pending_confirmation"
+        assert "sync_status" not in json.loads(row["properties"])
+
+    def test_add_source_does_not_mutate_the_callers_properties(self, store):
+        """Lifting the status out is not allowed to edit the caller's dict."""
+        props = {"sync_status": "active", "namespace": "docs"}
+        store.add_source("vault", "local_folder", "/tmp/vault-nomut", properties=props)
+        assert props == {"sync_status": "active", "namespace": "docs"}
 
     def test_add_source_sync_status_defaults_to_pending(self, store):
         """A caller that states no sync_status keeps the column's default."""
@@ -876,27 +1099,41 @@ class TestKnowledgeStoreExtended:
         assert row["sync_status"] == "pending"
 
     def test_add_source_rejects_non_initial_sync_status(self, store):
-        """A lifecycle state in properties never seeds the column.
+        """A transient or outcome state in properties never seeds the column.
 
         The create endpoint passes request-body properties through, so a
         caller-supplied 'syncing' would otherwise persist and make the sync
         endpoint report a conflict forever for a source whose sync never
-        started. Only genuine initial states pass; the rest fall back to
-        'pending'.
+        started. Only durable states pass; a claim about work that never ran
+        falls back to 'pending', and the forged value survives in neither store.
         """
-        for forged in ("syncing", "synced", "error", "paused", "missing", "garbage"):
+        for forged in ("syncing", "synced", "error", "missing", "garbage"):
             sid = store.add_source(
                 "f", "local_file", f"/tmp/forged-{forged}.md",
                 properties={"sync_status": forged})
             row = store.db.execute(
-                "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+                "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
             assert row["sync_status"] == "pending", forged
+            assert "sync_status" not in json.loads(row["properties"]), forged
+
+    def test_add_source_accepts_paused_as_an_initial_state(self, store):
+        """A source may START paused: it is a durable decision, not a claim.
+
+        A bundle import restores a source the user had paused, and the column is
+        now the only place that state can live -- dropping it would silently
+        resume scanning a folder the user stopped.
+        """
+        sid = store.add_source("vault", "local_folder", "/tmp/vault-paused",
+                               properties={"sync_status": "paused"})
+        row = store.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "paused"
 
     def test_auto_source_persists_sync_status_column(self, store):
-        """The auto-source insert path keeps the same column/JSON invariant.
+        """The auto-source insert path keeps the same single-store invariant.
 
         Drop-folder and project-docs auto sources seed sync_status='active' in
-        properties; the column must match or the dashboard renders the stale
+        properties; the column must carry it or the dashboard renders the stale
         'pending' control for a source the watcher is actively scanning.
         """
         sid, created = store.create_auto_source_unless_dismissed(
@@ -904,8 +1141,10 @@ class TestKnowledgeStoreExtended:
             {"sync_status": "active", "auto_added": True})
         assert created and sid is not None
         row = store.db.execute(
-            "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+            "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
         assert row["sync_status"] == "active"
+        assert "sync_status" not in json.loads(row["properties"])
+        assert json.loads(row["properties"])["auto_added"] is True
 
     def test_migration_repairs_divergent_sync_status_rows(self, store, tmp_path):
         """Reopening a store repairs rows whose column diverged from the JSON.
@@ -953,14 +1192,16 @@ class TestKnowledgeStoreExtended:
             reopened.close()
 
     def test_migration_skips_a_row_whose_properties_moved_mid_repair(self, store, tmp_path):
-        """A properties-only write landing mid-repair wins over the snapshot.
+        """A properties-only write landing mid-pass wins over the snapshot.
 
-        The repair reads both copies, then writes. ``SyncScheduler._record_failure``
-        moves the properties copy WITHOUT the column, so comparing only the column
-        would let the repair stamp 'pending_confirmation' onto a row whose JSON now
-        reads 'error' -- the dashboard would offer Confirm for a source the
-        scheduler has given up on. Comparing the properties blob as read skips that
-        row instead; the next store open repairs it.
+        The pass reads both copies, then writes. A pre-column
+        ``SyncScheduler._record_failure`` moved the properties copy WITHOUT the
+        column, so comparing only the column would let the repair stamp
+        'pending_confirmation' onto a row whose blob now reads 'error' -- the
+        dashboard would offer Confirm for a source the scheduler has given up on.
+        Binding the blob as read refuses every write for that row, including the
+        retire, so nothing is lost; the next open sees the settled state and
+        converges it.
         """
         import sqlite3
 
@@ -980,7 +1221,7 @@ class TestKnowledgeStoreExtended:
 
         def failure_lands_mid_scan(raw):
             parsed = real_loads(raw)
-            # Fire once, only for the row under test: the repair parses each
+            # Fire once, only for the row under test: the pass parses each
             # candidate row between its SELECT and its UPDATE.
             if (not fired and isinstance(parsed, dict)
                     and parsed.get("sync_status") == "pending_confirmation"):
@@ -1001,10 +1242,196 @@ class TestKnowledgeStoreExtended:
             assert fired, "the mid-scan write never landed; the test proves nothing"
             row = reopened.db.execute(
                 "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
+            # Never the stale snapshot: the row the scheduler gave up on must not
+            # come back offering Confirm.
             assert row["sync_status"] == "pending"
+            # The refused retire left the copy intact, so nothing was dropped.
             assert json.loads(row["properties"])["sync_status"] == "error"
         finally:
             reopened.close()
+
+        # The next open sees a row nobody is racing and retires the copy. The
+        # blob's 'error' is a lifecycle value, so it is dropped rather than
+        # promoted: it cannot be ordered against the column, and the scheduler's
+        # own failure count re-marks the source on its next failed attempt.
+        settled = KnowledgeStore(db_path)
+        try:
+            row = settled.db.execute(
+                "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
+            assert row["sync_status"] == "pending"
+            assert "sync_status" not in json.loads(row["properties"])
+            assert json.loads(row["properties"])["consecutive_failures"] == 3
+        finally:
+            settled.close()
+
+    def test_migration_lifts_a_legacy_json_only_error_onto_the_column(self, store, tmp_path):
+        """The copy is retired, and a LIFECYCLE value in it is never promoted.
+
+        Only an INITIAL state is repaired, and only onto a column still at its
+        un-written default. A blob 'error' is left where it is: it cannot be
+        ordered against the column, so promoting it would mark a recovered source
+        errored with no copy left to correct it.
+        """
+        divergent = str(uuid4())
+        legacy_error = str(uuid4())
+        healthy = str(uuid4())
+        recovered = str(uuid4())
+        listprops = str(uuid4())
+        now = datetime.now().isoformat()
+        for sid, column, props_json, uri in (
+            (divergent, "pending",
+             json.dumps({"sync_status": "pending_confirmation"}), "/tmp/divergent"),
+            (legacy_error, "pending", json.dumps({"sync_status": "error",
+                                                  "consecutive_failures": 3}), "/tmp/legacy"),
+            (healthy, "synced", json.dumps({"mtime": 1}), "/tmp/healthy"),
+            # A pre-column failure recorded in the blob, then a successful
+            # re-ingest that wrote the COLUMN only. The column is the newer
+            # answer and must survive untouched.
+            (recovered, "synced", json.dumps({"sync_status": "error"}), "/tmp/recovered"),
+            (listprops, "pending", "[]", "/tmp/listprops"),
+        ):
+            # local_folder: the reopen also runs the orphan cleanup, which
+            # deletes item-less sources of every other type.
+            store.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sid, "s", "local_folder", uri, props_json, column, now, now))
+        store.db.commit()
+        store.close()
+
+        reopened = KnowledgeStore(str(tmp_path / "test.db"))
+        try:
+            rows = {r["id"]: dict(r) for r in reopened.db.execute(
+                "SELECT id, sync_status, properties FROM sources").fetchall()}
+            # An initial state IS repaired onto an un-written column.
+            assert rows[divergent]["sync_status"] == "pending_confirmation"
+            # A lifecycle value is NOT promoted, whatever the column reads.
+            assert rows[legacy_error]["sync_status"] == "pending"
+            assert rows[recovered]["sync_status"] == "synced"
+            assert rows[healthy]["sync_status"] == "synced"
+            assert rows[listprops]["sync_status"] == "pending"
+            # The second store is RETIRED, not left for the next open to re-read.
+            for sid, r in rows.items():
+                parsed = json.loads(r["properties"] or "{}")
+                if isinstance(parsed, dict):
+                    assert "sync_status" not in parsed, sid
+            # The rest of the blob survives the strip.
+            assert json.loads(rows[legacy_error]["properties"])["consecutive_failures"] == 3
+        finally:
+            reopened.close()
+
+    def test_migration_does_not_re_error_a_source_that_has_since_synced(self, store, tmp_path):
+        """A recovered source survives the upgrade, whenever it recovered.
+
+        Ingestion's success writers are column-only -- they never touch
+        properties -- so a legacy blob-'error' row that syncs keeps its blob copy.
+        Both orderings must leave the healthy column alone: a recovery that landed
+        BEFORE the first open under this change (the copy is still present when
+        the migration first runs) and one that lands after it.
+        """
+        before = str(uuid4())
+        after = str(uuid4())
+        now = datetime.now().isoformat()
+        for sid, column, uri in ((before, "synced", "/tmp/before"),
+                                 (after, "pending", "/tmp/after")):
+            store.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sid, "s", "local_folder", uri,
+                 json.dumps({"sync_status": "error", "consecutive_failures": 3}),
+                 column, now, now))
+        store.db.commit()
+        store.close()
+
+        first = KnowledgeStore(str(tmp_path / "test.db"))
+        try:
+            rows = {r["id"]: r["sync_status"] for r in first.db.execute(
+                "SELECT id, sync_status FROM sources").fetchall()}
+            # Recovered before the upgrade: never overwritten.
+            assert rows[before] == "synced"
+            assert rows[after] == "pending"
+            # A successful re-sync, written the way ingestion writes it: column
+            # only, properties untouched.
+            first.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (after,))
+            first.db.commit()
+        finally:
+            first.close()
+
+        second = KnowledgeStore(str(tmp_path / "test.db"))
+        try:
+            rows = {r["id"]: r["sync_status"] for r in second.db.execute(
+                "SELECT id, sync_status FROM sources").fetchall()}
+            assert rows[before] == "synced"
+            assert rows[after] == "synced"
+        finally:
+            second.close()
+
+    def test_update_source_drops_a_properties_borne_status(self, store):
+        """A status written through properties is dropped, not stored.
+
+        This is the seam that makes the column the only store: a legacy row's
+        second copy disappears the first time anything writes its properties,
+        and no caller can create a new one.
+        """
+        sid = store.add_source("f", "local_file", "/tmp/lift.md")
+        store.update_source(sid, properties={"sync_status": "missing", "mtime": 7})
+        row = store.db.execute(
+            "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        props = json.loads(row["properties"])
+        assert "sync_status" not in props
+        assert props["mtime"] == 7
+        # Dropped, NOT applied: see the next test for why that matters.
+        assert row["sync_status"] == "pending"
+
+    def test_update_source_does_not_let_a_stale_blob_move_the_column(self, store):
+        """An unrelated properties write must not resurrect a legacy status.
+
+        A row written by the pre-column watcher carries 'missing' in its blob.
+        The watcher re-reads that blob to persist mtime/content_hash after
+        re-ingesting the file, so a seam that APPLIED the blob's status would
+        stamp 'missing' back onto a source that had just been re-ingested.
+        """
+        sid = store.add_source("f", "local_file", "/tmp/stale.md")
+        store.db.execute(
+            "UPDATE sources SET properties = ?, sync_status = 'synced' WHERE id = ?",
+            (json.dumps({"sync_status": "missing", "mtime": 1}), sid))
+        store.db.commit()
+
+        legacy_blob = json.loads(store.db.execute(
+            "SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()["properties"])
+        legacy_blob["mtime"] = 2
+        store.update_source(sid, properties=json.dumps(legacy_blob))
+
+        row = store.db.execute(
+            "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "synced"
+        assert json.loads(row["properties"]) == {"mtime": 2}
+
+    def test_update_source_drops_a_status_out_of_a_serialized_blob(self, store):
+        """Callers that hand over pre-serialized JSON get the same treatment."""
+        sid = store.add_source("f", "local_file", "/tmp/lift-str.md")
+        store.update_source(sid, properties=json.dumps({"sync_status": "error", "mtime": 3}))
+        row = store.db.execute(
+            "SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert json.loads(row["properties"]) == {"mtime": 3}
+
+    def test_update_source_writes_an_explicit_status(self, store):
+        """The kwarg is the only channel a transition may use."""
+        sid = store.add_source("f", "local_file", "/tmp/lift-both.md")
+        store.update_source(
+            sid, properties={"sync_status": "missing"}, sync_status="active")
+        row = store.db.execute(
+            "SELECT sync_status, properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "active"
+        assert "sync_status" not in json.loads(row["properties"])
+
+    def test_update_source_leaves_a_non_object_blob_alone(self, store):
+        """A blob that is not a JSON object is stored as given, not rewritten."""
+        sid = store.add_source("f", "local_file", "/tmp/lift-list.md")
+        store.update_source(sid, properties="[]")
+        row = store.db.execute(
+            "SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["properties"] == "[]"
 
     def test_update_source(self, store):
         sid = store.add_source("f", "local_file", "/tmp/f.md")
@@ -2281,11 +2708,14 @@ class TestEntityExtractorNonceDelimiters:
 
 @pytest.mark.asyncio
 class TestSyncAllSkipsErroredSources:
-    """sync_all must skip a source marked errored by EITHER writer.
+    """sync_all must skip an errored source, whichever writer marked it.
 
-    KnowledgeIngestion marks failure in the sync_status COLUMN, while
-    SyncScheduler._record_failure historically wrote only the properties JSON.
-    sync_all must observe both so an errored source is never re-synced forever.
+    KnowledgeIngestion and SyncScheduler both mark failure in the sync_status
+    COLUMN, which is the only store sync_all reads. Rows errored before the
+    column existed carry the state in their properties JSON, which cannot be
+    ordered against the column and so is never promoted onto it; such a row is
+    polled until an attempt of its own fails, and that failure writes the column
+    (issue #3946).
     """
 
     def _scheduler(self, store):
@@ -2317,15 +2747,50 @@ class TestSyncAllSkipsErroredSources:
         assert err_id not in attempted, "column-only errored source must be skipped"
         assert ok_id in attempted, "healthy source must still be synced"
 
-    async def test_legacy_json_only_error_is_still_skipped(self, store):
-        # A source errored the old way: sync_status lives only in the
-        # properties JSON, column falls back to its 'pending' default.
-        err_id = store.add_source("LegacyDead", "local_file", "/tmp/legacy",
-                                  properties={"sync_status": "error"})
-        col = store.db.execute("SELECT sync_status FROM sources WHERE id = ?", (err_id,)).fetchone()
-        assert col["sync_status"] != "error", "column should be pending for the legacy case"
+    async def test_legacy_json_only_error_is_quiesced_by_its_first_failure(self, store, tmp_path):
+        """A pre-column errored row is polled until an attempt of its own fails.
 
-        scheduler, attempted = self._scheduler(store)
-        await scheduler.sync_all()
+        Its state lives in the properties blob only, which cannot be ordered
+        against the column, so the store does not promote it -- promoting would
+        mark a source errored that had in fact recovered. It is therefore polled
+        like any healthy source, and the first attempt that FAILS is what quiesces
+        it: ``_record_failure`` reads ``consecutive_failures`` from the blob, which
+        such a row already carries at or above MAX_FAILURES, so that one failure
+        writes the column and the source is skipped from then on.
+        """
+        err_id = str(uuid4())
+        ok_id = str(uuid4())
+        now = datetime.now().isoformat()
+        for sid, uri, props_json in (
+            (err_id, "/tmp/legacy",
+             json.dumps({"sync_status": "error", "consecutive_failures": 3})),
+            (ok_id, "/tmp/legacy-ok", json.dumps({})),
+        ):
+            # local_folder: the reopen also runs the orphan cleanup, which
+            # deletes item-less sources of every other type.
+            store.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, sync_status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sid, "LegacyDead", "local_folder", uri, props_json, "pending", now, now))
+        store.db.commit()
+        store.close()
 
-        assert err_id not in attempted, "legacy JSON-only errored source must still be skipped"
+        reopened = KnowledgeStore(str(tmp_path / "test.db"))
+        try:
+            scheduler, attempted = self._scheduler(reopened)
+            await scheduler.sync_all()
+            assert attempted == [err_id, ok_id] or set(attempted) == {err_id, ok_id}, (
+                "both legacy rows are polled, the blob-errored one included")
+
+            # An attempt that FAILS is what writes the column.
+            scheduler._record_failure(err_id)
+            assert reopened.db.execute(
+                "SELECT sync_status FROM sources WHERE id = ?",
+                (err_id,)).fetchone()["sync_status"] == "error"
+
+            attempted.clear()
+            await scheduler.sync_all()
+            assert err_id not in attempted, "an errored column must never be retried"
+            assert ok_id in attempted, "healthy source must still be synced"
+        finally:
+            reopened.close()

--- a/test/test_knowledge_project_docs.py
+++ b/test/test_knowledge_project_docs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -99,11 +98,11 @@ class TestRegistration:
         sid, created = ensure_project_doc_source(store, str(root))
         assert created and sid
         row = store.db.execute(
-            "SELECT source_type, uri, properties FROM sources WHERE id = ?", (sid,)
+            "SELECT source_type, uri, sync_status FROM sources WHERE id = ?", (sid,)
         ).fetchone()
         assert row["source_type"] == "local_folder"
         assert row["uri"] == str(root)
-        assert json.loads(row["properties"])["sync_status"] == "active"
+        assert row["sync_status"] == "active"
 
     def test_second_call_reuses_the_row(self, store, tmp_path):
         root = _repo(tmp_path)
@@ -117,10 +116,10 @@ class TestRegistration:
                                   uri=str(root), properties={"sync_status": "paused"})
         sid, created = ensure_project_doc_source(store, str(root))
         assert sid == manual and created is False
-        # Their explicit choice survives: properties are not overwritten.
-        props = json.loads(store.db.execute(
-            "SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()["properties"])
-        assert props["sync_status"] == "paused"
+        # Their explicit choice survives: the row's state is not overwritten.
+        row = store.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["sync_status"] == "paused"
 
     def test_dismissed_root_is_not_re_registered(self, store, tmp_path):
         root = _repo(tmp_path)

--- a/test/test_knowledge_sync_status_column.py
+++ b/test/test_knowledge_sync_status_column.py
@@ -1,0 +1,327 @@
+"""The sources.sync_status COLUMN is the single source of truth.
+
+A source's sync state used to live in two places: the ``sources.sync_status``
+column and a ``sync_status`` key inside the ``properties`` JSON blob. Writers
+were split across the two -- most transitions wrote the column only, while the
+watcher's 'missing' marker went into the blob only -- and readers were split the
+same way, so each side saw a state the other had not written.
+
+These tests pin the converged contract on the watcher paths that read and write
+it: the pre-scan skip reads the column, and the missing marker is written to the
+column and can be left again.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.knowledge.store import KnowledgeStore
+from kiro_crew.knowledge.watcher import KnowledgeWatcher
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    yield s
+    s.close()
+
+
+def _watcher(store) -> KnowledgeWatcher:
+    pipeline = MagicMock()
+    # No embedder configured -> _scan skips the self-heal re-embed branch.
+    pipeline.embedder = None
+    watcher = KnowledgeWatcher(store=store, pipeline=pipeline)
+    # Discovery registers workspace folders from live config; irrelevant here
+    # and it would put rows in the table the assertions do not expect.
+    watcher._discover_drop_folder = AsyncMock()  # type: ignore[method-assign]
+    watcher._discover_project_docs = AsyncMock()  # type: ignore[method-assign]
+    watcher._maybe_reembed_stale = AsyncMock()  # type: ignore[method-assign]
+    return watcher
+
+
+def _status(store, sid: str) -> str:
+    return store.db.execute("SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()[
+        "sync_status"
+    ]
+
+
+def _props(store, sid: str) -> dict:
+    raw = store.db.execute("SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()[
+        "properties"
+    ]
+    return json.loads(raw or "{}")
+
+
+def _hash(path) -> str:
+    """The digest the watcher itself would compute for this file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class TestFolderPreScanSkip:
+    @pytest.mark.asyncio
+    async def test_a_paused_folder_is_not_walked(self, store, tmp_path):
+        """A pause recorded in the column stops the sweep.
+
+        The skip used to read the properties copy, so a pause the column knew
+        about still walked and delete-reconciled the whole folder every sweep.
+        """
+        folder = tmp_path / "vault"
+        folder.mkdir()
+        sid = store.add_source("vault", "local_folder", str(folder))
+        store.db.execute("UPDATE sources SET sync_status = 'paused' WHERE id = ?", (sid,))
+        store.db.commit()
+        assert "sync_status" not in _props(store, sid), "the JSON copy must not exist"
+
+        watcher = _watcher(store)
+        scan = AsyncMock(return_value={})
+        watcher._folder_watcher.scan_source = scan  # type: ignore[method-assign]
+        await watcher._scan()
+
+        scan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_unconfirmed_folder_is_not_walked(self, store, tmp_path):
+        folder = tmp_path / "vault"
+        folder.mkdir()
+        sid = store.add_source(
+            "vault", "local_folder", str(folder), properties={"sync_status": "pending_confirmation"}
+        )
+        assert _status(store, sid) == "pending_confirmation"
+
+        watcher = _watcher(store)
+        scan = AsyncMock(return_value={})
+        watcher._folder_watcher.scan_source = scan  # type: ignore[method-assign]
+        await watcher._scan()
+
+        scan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_active_folder_is_still_walked(self, store, tmp_path):
+        """The guard rejects only the two states, so 'active' still scans."""
+        folder = tmp_path / "vault"
+        folder.mkdir()
+        store.add_source("vault", "local_folder", str(folder), properties={"sync_status": "active"})
+
+        watcher = _watcher(store)
+        scan = AsyncMock(return_value={})
+        watcher._folder_watcher.scan_source = scan  # type: ignore[method-assign]
+        await watcher._scan()
+
+        scan.assert_called_once()
+
+
+class TestSingleFileMissingMarker:
+    @pytest.mark.asyncio
+    async def test_a_vanished_file_marks_the_column_missing(self, store, tmp_path):
+        """The Library renders the column, so that is where 'missing' belongs.
+
+        Marking it in the properties JSON instead left the visible state stale:
+        a file that was gone went on reading 'synced'.
+        """
+        gone = tmp_path / "gone.md"
+        gone.write_text("# gone")
+        sid = store.add_source("gone.md", "local_file", str(gone))
+        store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (sid,))
+        store.db.commit()
+        gone.unlink()
+
+        await _watcher(store)._scan()
+
+        assert _status(store, sid) == "missing"
+        assert "sync_status" not in _props(store, sid), "no second copy is written"
+
+    @pytest.mark.asyncio
+    async def test_a_returning_file_leaves_missing(self, store, tmp_path):
+        """'missing' must be a state a source can leave.
+
+        An unchanged file is not re-ingested, so nothing else moves the column
+        back and the source would read missing for as long as it existed.
+        """
+        back = tmp_path / "back.md"
+        back.write_text("# back")
+        # A stored mtime in the future keeps the re-ingest out of it: the file's
+        # content hash matches, so the returning-file read finds it unchanged.
+        sid = store.add_source(
+            "back.md",
+            "local_file",
+            str(back),
+            properties={"mtime": 1 << 40, "content_hash": _hash(back)},
+        )
+        store.db.execute("UPDATE sources SET sync_status = 'missing' WHERE id = ?", (sid,))
+        store.db.commit()
+
+        await _watcher(store)._scan()
+
+        assert _status(store, sid) == "synced"
+
+    @pytest.mark.asyncio
+    async def test_a_restore_under_an_unadvanced_mtime_is_not_called_synced(self, store, tmp_path):
+        """A returning file is read, not assumed, whatever its mtime says.
+
+        A restore that preserves the archived mtime (cp -p, rsync -t, tar -x) can
+        put DIFFERENT content on disk under an mtime that never advanced. Trusting
+        the mtime gate there would stamp 'synced' over content the store does not
+        hold, and the stale copy would keep answering searches.
+        """
+        back = tmp_path / "restored.md"
+        back.write_text("# restored from an older backup")
+        sid = store.add_source(
+            "restored.md",
+            "local_file",
+            str(back),
+            # mtime far ahead of the file's, so `mtime > stored_mtime` is False.
+            properties={"mtime": 1 << 40, "content_hash": _hash(back) + "-before-the-restore"},
+        )
+        store.db.execute("UPDATE sources SET sync_status = 'missing' WHERE id = ?", (sid,))
+        store.db.commit()
+
+        watcher = _watcher(store)
+        # Raising is what proves the claim is withheld: the file was read, the
+        # read failed, and nothing was stamped 'synced' on its behalf.
+        watcher.pipeline.ingest_file = AsyncMock(side_effect=RuntimeError("read failed"))
+        await watcher._scan()
+
+        watcher.pipeline.ingest_file.assert_awaited_once()
+        assert _status(store, sid) == "missing"
+
+    @pytest.mark.asyncio
+    async def test_a_present_file_keeps_its_status(self, store, tmp_path):
+        """The recovery write fires only for a row that reads 'missing'."""
+        here = tmp_path / "here.md"
+        here.write_text("# here")
+        sid = store.add_source(
+            "here.md", "local_file", str(here), properties={"mtime": 1 << 40, "content_hash": "abc"}
+        )
+        store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (sid,))
+        store.db.commit()
+
+        await _watcher(store)._scan()
+
+        assert _status(store, sid) == "error"
+
+    @pytest.mark.asyncio
+    async def test_recovery_does_not_overwrite_a_status_that_moved(self, store, tmp_path):
+        """The recovery write loses to a transition that landed mid-sweep.
+
+        'missing' comes from the snapshot taken at the top of the sweep. A manual
+        sync that fails while the sweep runs writes 'error', and stamping
+        'synced' over it would report content the store does not have.
+        """
+        back = tmp_path / "raced.md"
+        back.write_text("# raced")
+        sid = store.add_source(
+            "raced.md",
+            "local_file",
+            str(back),
+            # Hash matching the file: the returning-file read finds it unchanged,
+            # so the recovery write is what runs and what the CAS has to lose.
+            properties={"mtime": 1 << 40, "content_hash": _hash(back)},
+        )
+        store.db.execute("UPDATE sources SET sync_status = 'missing' WHERE id = ?", (sid,))
+        store.db.commit()
+
+        real_update = store.update_source
+
+        def a_manual_sync_fails_first(source_id, **fields):
+            if fields.get("sync_status") == "synced":
+                store.db.execute(
+                    "UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,)
+                )
+                store.db.commit()
+            return real_update(source_id, **fields)
+
+        store.update_source = a_manual_sync_fails_first  # type: ignore[method-assign]
+        await _watcher(store)._scan()
+
+        assert _status(store, sid) == "error"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_reingest_is_not_recorded_as_synced(self, store, tmp_path):
+        """'synced' is a claim about content, so it waits for the re-ingest.
+
+        A returning file whose content CHANGED is re-ingested, and the pipeline
+        writes the column itself. Clearing 'missing' to 'synced' before that read
+        would leave the claim standing when the read fails -- the source would
+        report holding content it never ingested.
+        """
+        back = tmp_path / "changed.md"
+        back.write_text("# changed")
+        sid = store.add_source(
+            "changed.md", "local_file", str(back), properties={"mtime": 1, "content_hash": "stale"}
+        )
+        store.db.execute("UPDATE sources SET sync_status = 'missing' WHERE id = ?", (sid,))
+        store.db.commit()
+
+        watcher = _watcher(store)
+        watcher.pipeline.ingest_file = AsyncMock(side_effect=RuntimeError("read failed"))
+        await watcher._scan()
+
+        watcher.pipeline.ingest_file.assert_awaited_once()
+        assert _status(store, sid) == "missing"
+
+    @pytest.mark.asyncio
+    async def test_an_ingest_that_writes_no_status_still_clears_missing(self, store, tmp_path):
+        """The marker comes off a file the duplicate gate accounted for.
+
+        A returning file whose content changed to something already in the Library
+        is refused by the pre-ingest duplicate gate, which writes no status at all
+        -- it records a terminal job and deletes this source's superseded items.
+        Nothing else clears the marker, so a present, accounted-for file would go
+        on reading 'missing'.
+        """
+        back = tmp_path / "dupe.md"
+        back.write_text("# already in the library under another source")
+        sid = store.add_source(
+            "dupe.md",
+            "local_file",
+            str(back),
+            properties={"mtime": 1, "content_hash": "stale"},
+        )
+        store.db.execute("UPDATE sources SET sync_status = 'missing' WHERE id = ?", (sid,))
+        store.db.commit()
+
+        watcher = _watcher(store)
+        # The duplicate gate's shape: returns a terminal job id, writes no status.
+        watcher.pipeline.ingest_file = AsyncMock(return_value="dupe-job-id")
+        await watcher._scan()
+
+        watcher.pipeline.ingest_file.assert_awaited_once()
+        assert _status(store, sid) == "synced"
+        # The restored file's own mtime and hash are recorded, so a later edit is
+        # detected even when the restore LOWERED the mtime this row had stored.
+        assert _props(store, sid)["content_hash"] == _hash(back)
+
+    @pytest.mark.asyncio
+    async def test_the_clear_loses_to_a_status_the_ingest_wrote(self, store, tmp_path):
+        """An ingestion that DID write the column keeps its own verdict.
+
+        The clear runs after every non-raising ingest, so the CAS on 'missing' is
+        the only thing keeping it off a row the pipeline just marked 'error' for a
+        partial write.
+        """
+        back = tmp_path / "partial.md"
+        back.write_text("# partially written")
+        sid = store.add_source(
+            "partial.md",
+            "local_file",
+            str(back),
+            properties={"mtime": 1, "content_hash": "stale"},
+        )
+        store.db.execute("UPDATE sources SET sync_status = 'missing' WHERE id = ?", (sid,))
+        store.db.commit()
+
+        watcher = _watcher(store)
+
+        async def a_partial_write(*_args, **_kwargs):
+            store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (sid,))
+            store.db.commit()
+            return "job-id"
+
+        watcher.pipeline.ingest_file = AsyncMock(side_effect=a_partial_write)
+        await watcher._scan()
+
+        assert _status(store, sid) == "error"

--- a/test/test_knowledge_workspace_autosource.py
+++ b/test/test_knowledge_workspace_autosource.py
@@ -152,9 +152,12 @@ class TestEnsureDropSource:
 
     def test_seeded_active_so_the_watcher_scans_it(self, store, tmp_path):
         ensure_drop_source(store, str(tmp_path))
-        status = _props(store, str(tmp_path))["sync_status"]
+        # The COLUMN is the single source of truth the watcher's pre-scan skip
+        # reads, so that is where the seeded state has to land.
+        status = store.get_source_by_uri(str(tmp_path))["sync_status"]
         assert status == "active"
         assert status not in ("paused", "pending_confirmation")
+        assert "sync_status" not in _props(store, str(tmp_path))
 
     def test_marks_source_auto_added(self, store, tmp_path):
         ensure_drop_source(store, str(tmp_path))
@@ -595,8 +598,10 @@ class TestPauseSurvivesRestart:
             row = s2.get_source_by_uri(str(drop))
             assert row is not None, "paused empty folder source was orphan-deleted"
             assert row["id"] == sid
-            props = json.loads(row["properties"])
-            assert props["sync_status"] == "paused"
+            # The COLUMN is the single source of truth, so that is where the
+            # pause has to still be readable after a restart.
+            assert row["sync_status"] == "paused"
+            assert json.loads(row["properties"])["scan_paused"] is True
         finally:
             s2.close()
 


### PR DESCRIPTION
## Problem / Motivation

A knowledge source's sync state is stored twice: the `sources.sync_status`
COLUMN and a `sync_status` key inside the `properties` JSON blob. Writers and
readers are split across the two stores, so each side can act on a state the
other never wrote.

Two symptoms a user can see today:

- A local file that has been deleted keeps rendering its old badge in the
  Library ("synced"). The watcher marks it missing in the properties blob only,
  and the Library renders the column. The blob key is also never cleared when
  the file comes back, so the two stores stay divergent for the life of the row.
- The watcher's folder pre-scan skip reads the blob copy, so any pause recorded
  in the column alone still walks and delete-reconciles the whole folder every
  sweep. Today that is avoided only because three handlers remember to write
  both stores by hand; the next transition that forgets re-opens the bug.

Restoring a bundle also landed every source at the `pending` default, because
`import_bundle` -- the third insert path -- never wrote the column at all.

## Why it matters

Sync state is what the Library shows and what the sweep obeys, so a divergence
is both a wrong badge and wrong work: a paused folder that is still walked
spends the scan budget the user paused to stop, and an errored source that only
one reader can see is retried forever. It has already been patched twice
(seeding the column on insert, then reading either store in `sync_all`), each
time by teaching one more site about both copies. That is the pattern that keeps
the defect alive: every new transition has to remember a rule nothing enforces.

## What changed (motivation -> approach -> change)

Symptom: state read from one store, written to the other. Root cause: two
stores, with no seam that makes one of them authoritative. Fix: converge on the
column, and put the convergence at the store's own write seam rather than in a
convention writers must remember.

The blob keeps exactly one role -- the INSERT-time channel a caller uses to
STATE an initial status, held to an allowlist. It is no longer persisted next to
the column, and no row keeps a second answer once the store has opened. After
insert the column is written explicitly or not at all: a status found in a
properties write is DROPPED, not applied. That direction is deliberate -- a blob
read off a legacy row is stale by definition, and applying it would let the
watcher stamp `missing` back onto a file it had just re-ingested (pinned by a
test).

- `store.py`: `_without_sync_status` strips the key on all three insert paths and
  on every `update_source`, so no caller can mint a second copy.
- `store.py`: ONE migration pass over the rows that still carry a copy does all
  the convergence -- it absorbs the pre-existing initial-state repair, repairs the
  column where it was never written, and then RETIRES the copy. Every candidate is
  a row whose blob holds a status. Membership is decided on the PARSED blob
  rather than a substring of its text: JSON escapes are legal inside a key, so a
  blob stored as `{"sync_\u0073tatus": "paused"}` holds the key this pass
  converges without ever containing it literally, and a raw-text filter would
  skip the row -- leaving the column at its default and the watcher walking a
  folder the user had paused. `import_bundle` used to store a bundle's properties
  verbatim, so such a row can exist. The retirement is what keeps the repair
  honest: the migration runs on every open, so leaving the key would make it a
  standing reader of a value that goes stale the moment a column-only writer moves
  the row.
- `store.py`: a LIFECYCLE value in the blob is deliberately NOT promoted, not even
  `'error'`. It cannot be ordered against the column -- a pre-column
  `_record_failure` wrote `'error'` to the blob alone, and a later successful
  re-ingest wrote `'synced'` to the column alone, so neither copy carries evidence
  of which happened last. Promoting would mark a RECOVERED source errored, with
  the copy retired in the same pass so nothing could correct it. Not promoting
  costs at most ONE sync attempt: `_record_failure` reads `consecutive_failures`
  from the blob, which such a row already carries at or above its threshold, so the
  first attempt that fails writes the column and quiesces the source for good --
  while an attempt that SUCCEEDS is the right outcome for a source that had
  recovered. The column is authoritative; a value that cannot be ordered against
  it does not get to overrule it.
- `store.py`: `import_bundle` restores each source's status from the COLUMN that
  `export_all` ships, falling back to a legacy bundle's blob copy, so a restored
  pause is not silently resumed -- then strips the blob like every other insert
  path, so a status the allowlist REFUSED cannot be read back by the migration
  one reopen later. `'paused'` joins the durable initial states, which every
  insert path now reads through one shared allowlist; a bundle is untrusted
  input, so an outcome state like `error` or `syncing` still cannot be asserted
  about work that never ran.
- `store.py`: `update_source` gains `if_sync_status`, a compare-and-set on the
  status column, and the migration's repair binds the column it read as well as
  the blob. Every live writer transitions the column WITHOUT touching properties, so
  a blob-only precondition still matched: the repair could stamp the blob's initial
  state over a transition that had just landed, and the sweep could stamp
  `'synced'` over an `'error'` a manual sync recorded while it ran. A caller that derives a
  status from a snapshot passes the value it saw; a caller writing the outcome of
  something that just happened has current information and does not.
- `store.py`: the migration's JSON parses also catch `RecursionError` -- a
  `RuntimeError`, so the `ValueError`/`TypeError` guard missed it. `json.loads`
  recurses per nesting level and this runs on EVERY open, so one pathologically
  nested legacy blob would abort every store construction rather than skipping
  one row.
- `watcher.py`: the folder pre-scan skip reads the column; a vanished
  `local_file` is marked `missing` in the column, and can LEAVE that state when
  the file returns. A returning file's content is READ, not assumed: deletion is
  the event that breaks the mtime heuristic, because a restore preserving the
  archived mtime (`cp -p`, `rsync -t`, `tar -x`) can put different content on disk
  under an mtime that never advanced, so the change gate now also fires for a row
  that reads `missing`. The clear runs LAST, after the read, and its
  compare-and-set on `missing` is what decides whether it is the write that takes
  the marker off: an ingestion that ran has already written the column (`synced`
  when it stored the document, `error` on a partial write) and this no-ops, while
  the one outcome that writes NO status -- the pre-ingest duplicate gate, which
  refuses the write because a holder already holds this exact document -- is the
  one it clears. A failed ingest raises, so the clear is never reached with the
  file unread. Both writes derive from the sweep's snapshot, so both are
  compare-and-set. Status writes go through `update_source`
  (one spelling in the file, including the one that was already there).
- `watcher.py`: every store call in the sweep's own body -- the two source
  queries, the post-ingest re-read, and all four writes -- now runs off the event
  loop. The sweep is a background coroutine and sqlite reads are synchronous, so
  a contended database could hold one for as long as `busy_timeout` and stall
  every other task; `KnowledgeStore` keeps a connection per thread, so a worker
  gets its own. Scope boundary, stated rather than implied: the re-embed job the
  sweep delegates to at the end still makes synchronous store calls. Those are
  pre-existing, belong to the embedding-job machinery rather than to source
  state, and are untouched here. `.github/sync-io-in-async-baseline.txt` records
  the shrink the repo's own gate asks for: `knowledge/sync.py` 1 -> 0 and
  `knowledge/watcher.py` 6 -> 2.
- `watcher.py`: the sweep's own error handler called `.get()` on a `sqlite3.Row`,
  which has no such method -- so any failure in the single-file loop raised
  `AttributeError` from inside the handler, replacing the real error and
  abandoning every remaining source for that sweep. Found by the test for the
  failed-re-ingest case above.
- `sync.py`: `_record_failure` writes the column only; `sync_all` reads it only,
  off the event loop.
- `handlers/knowledge.py`: confirm / pause / resume stop double-writing the blob.

No frontend change: the Library already reads the top-level `sync_status` field,
which is the column.

## Tests

New `test/test_knowledge_sync_status_column.py` -- the watcher contract:

- a paused folder is not walked, with the state in the column and no blob copy
- an unconfirmed folder is not walked; an active one still is
- a vanished `local_file` is marked `missing` in the column, and writes no
  second copy
- a returning file leaves `missing`; a present file at another status is
  untouched; a returning file whose re-ingest FAILS stays `missing` rather than
  reporting content it never ingested; and the recovery write loses to a status
  that moved mid-sweep
- a file restored under an UNADVANCED mtime is READ rather than assumed -- the
  case where the mtime gate alone would have reported freshness about a file it
  never opened
- an ingestion that writes no status (the duplicate gate) still gets the marker
  cleared, so a present, accounted-for file does not go on reading `missing`;
  and the clear loses to a status the ingestion itself wrote

`test/test_knowledge.py` -- the store contract, including a JSON-escaped status
key that converges and is retired: insert stores no second copy and
does not mutate the caller's dict; an outcome state in properties still never
seeds the column, while `paused` is accepted; `update_source` drops a blob-borne
status and honours `if_sync_status`; a stale blob cannot move the column; the
migration retires the copy without promoting a lifecycle value, does not
re-error a source that has since synced (whether it recovered before or after the
first open), loses its repair to a concurrent column write, and survives a blob
too deeply nested to parse; an export/import round trip restores
`paused` and `pending_confirmation` while refusing `error`; a legacy blob-only
bundle still restores; and a refused bundle status does not come back at the next
open.

Rewritten rather than deleted, so the behaviour they guarded is still guarded:
the `sync_all` legacy-error test now builds a real pre-column row and reopens the
store, so it proves the honest contract: the row is attempted once, and the first
failure writes the column and quiesces it for good; the
mid-pass race test still proves a concurrent properties write beats the snapshot,
and now also pins the self-heal -- every write for the raced row is refused, so
nothing is lost, and the next open converges it; the
pause / project-docs / autosource assertions read the column; the bundle
JSON-well-formedness test keeps its subject on a non-status key.

Every new or changed case was checked RED against the code it fixes -- 11 of 15
against unmodified `src/` in round 1, and every round-2 and round-3 case against
the revision it corrects. 558 tests pass across the affected files; flake8 and
isort clean on every touched file.

## Manual verification

N/A -- unit coverage sufficient. Both symptoms are store/watcher state
transitions with no UI of their own, and each is now driven end to end through
the real `KnowledgeWatcher._scan()` and a real reopened `KnowledgeStore`,
including the concurrent-writer windows.

## Related Issues

No GitHub issue: this comes from the local review backlog as `f-20260815-02`
(recorded 2026-08-15, held for a ruling on which store should win; the ruling is
the column, which is what both prior patches had been converging on anyway).

## Pattern harvest

Rule candidate: `review-prompt` / `agents-md`.
Pattern: "one fact persisted in two places, converged by asking every writer to
update both". The tell is a comment that explains why a write is duplicated
("keep the JSON copy in sync with the column") or a read that ORs two stores
("errored in EITHER store") -- both appeared here, added by earlier fixes to
this same defect. Each such patch narrows the window instead of closing it,
because correctness then rests on every future writer remembering. The
generalizable move is the one taken here: pick the authoritative store, and
enforce it at the single write seam so the other copy cannot be created, rather
than teaching one more site to write both.

Three narrower rules this PR earned the hard way, all worth a review prompt:

- When a change EMPTIES a storage channel, every READER of that channel has to
  move in the same commit. Revision 1 stripped the blob but left `import_bundle`
  reading it, which would have resumed a paused folder on every restore.
  Mechanical check: after removing a key from a persisted structure, grep for
  remaining readers of that key.
- A retirement migration that RUNS ON EVERY OPEN and leaves the retired copy in
  place is not a migration, it is a permanent second reader. Revision 2 had a
  lift that would re-apply a stale `error` over a fresh `synced` at every start.
  Mechanical check: a repair pass that reads a field it does not also clear will
  re-apply it forever.
- A compare-and-set must bind every field a competing writer can move, not just
  the one the reader happened to look at. Revision 2's lift bound the blob only
  -- and after this change every live writer moves the COLUMN and leaves the blob
  alone, so the precondition matched exactly when it should not have. Mechanical
  check: when converging on one field, audit each CAS whose precondition names a
  different field from the one being written.






**Revision note (`c48c2c1e4`).** An earlier revision of this PR DID promote a blob
`'error'` onto the column. Opus showed that a source which recovered before the
first upgrade open would be re-marked errored and then have its copy retired, so
nothing could correct it -- the third finding against that one mechanism across
three rounds. Adding a fourth guard was the wrong answer: the promotion is not
load-bearing, because the scheduler's own failure count re-quiesces a still-failing
row on its first failed attempt. It is gone, and the pattern harvest below records
that.



