### PR TITLE
test(auto-research): pin the settle discipline folded in #7420 (#7261)

### DIFF
--- a/test/test_auto_research.py
+++ b/test/test_auto_research.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import threading
 import time
 from pathlib import Path
@@ -2395,6 +2396,68 @@ class TestWatchdogStopTombstone:
         # A non-terminal campaign keeps its loop so restart can retry settling.
         assert svc.get_by_slot(f"research-{cid}") is loop
         svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_settlement_failure_is_logged_without_replacing_cancellation(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The watchdog reports a settlement failure it swallowed during shutdown.
+
+        The shield-and-settle discipline deliberately lets the ORIGINAL
+        cancellation win over a worker failure; the failure's only remaining
+        trace is the watchdog's log record. Pin that record so folding the
+        inline settlement loop onto ``_settle_before_cancellation`` (or any
+        later refactor of it) cannot silently drop the reporting path.
+        """
+        from kiro_crew.apps.builtins.auto_research import handlers as h
+        from kiro_crew.autonudge import AutoNudgeService
+
+        cid = "a1b2c3d4"
+        svc = AutoNudgeService(base_dir=tmp_path)
+        await svc.start()
+        await svc.add(slot_key=f"research-{cid}", message="watch", idle_secs=60)
+        monkeypatch.setattr(h, "_autonudge_instance", lambda: svc)
+        monkeypatch.setattr(
+            h,
+            "_stalled_campaign_verdict",
+            lambda _cid, _files, *, stopped_reason="": (CampaignStatus.STOPPED, None),
+        )
+
+        status_write_started = threading.Event()
+        release_status_write = threading.Event()
+
+        def _persist(_cid, _status, **_kwargs):
+            status_write_started.set()
+            assert release_status_write.wait(timeout=5)
+            raise OSError("status store unavailable")
+
+        monkeypatch.setattr(h, "update_campaign_status", _persist)
+        monkeypatch.setattr(h, "_campaign_run_is_current", lambda _cid, _started: True)
+        task = asyncio.create_task(
+            h._settle_campaign_from_watchdog(
+                cid, [], {}, {}, observed_started_at=1.0
+            )
+        )
+        assert await asyncio.to_thread(status_write_started.wait, 5)
+
+        try:
+            task.cancel()
+            release_status_write.set()
+            with caplog.at_level(logging.ERROR, logger=h.__name__):
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=5)
+
+            failure_records = [
+                r
+                for r in caplog.records
+                if "terminal settlement failed during shutdown" in r.getMessage()
+            ]
+            assert failure_records, "the swallowed settlement failure must be logged"
+            assert failure_records[0].exc_info is not None, (
+                "the log record must carry the worker failure's traceback"
+            )
+        finally:
+            svc.stop()
 
     @pytest.mark.asyncio
     async def test_partial_terminal_persistence_still_removes_durable_loop(

--- a/test/test_auto_research_onloop_fs.py
+++ b/test/test_auto_research_onloop_fs.py
@@ -34,7 +34,7 @@ import inspect
 import json
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -355,3 +355,44 @@ class TestCancellationSettlesWorker:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert finished, "the worker ran to completion before cancellation propagated"
+
+    @pytest.mark.asyncio
+    async def test_on_settled_runs_after_settlement_only_when_cancelled(self):
+        """``on_settled`` is the seam the watchdog's failure logging rides on:
+        it must observe a SETTLED task (so ``task.result()`` cannot raise
+        ``InvalidStateError``), fire exactly once on the cancellation path,
+        and stay silent on the normal path. A REPEAT cancellation while the
+        helper is re-shielding must neither cancel the inner task nor abort
+        the settling loop (the ``continue`` branch).
+        """
+        release = threading.Event()
+        observed: list[bool] = []
+
+        def worker() -> NoReturn:
+            release.wait(timeout=10)
+            raise OSError("worker failed")
+
+        inner = asyncio.create_task(asyncio.to_thread(worker))
+        task = asyncio.create_task(
+            h._settle_before_cancellation(inner, on_settled=lambda t: observed.append(t.done()))
+        )
+        await asyncio.sleep(0.05)  # let the worker thread start
+        task.cancel()
+        await asyncio.sleep(0.05)  # first cancellation lands; helper re-shields
+        task.cancel()
+        await asyncio.sleep(0.05)  # repeat cancellation hits the continue branch
+        assert not task.done(), "a repeat cancellation must not abort the settling loop"
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not inner.cancelled(), "no cancellation may reach the settling task"
+        assert observed == [True], "on_settled fires once, after the task settled"
+
+        # Normal path: the callback must not run when nothing was cancelled.
+        observed.clear()
+        result = await h._settle_before_cancellation(
+            asyncio.create_task(asyncio.to_thread(lambda: 42)),
+            on_settled=lambda t: observed.append(t.done()),
+        )
+        assert result == 42
+        assert observed == [], "on_settled must not fire on the uncancelled path"


### PR DESCRIPTION
## Problem / Motivation

[#7420](https://github.com/kirodotdev/KiroCrew/pull/7420) merged the production
fold of the watchdog's inline shield-and-settle loop onto
`_settle_before_cancellation` (issue #7261) — but it shipped from a sandbox
that could not run pytest, and its body explicitly defers the authoritative
test gate:

> **Before merge, run the authoritative gate in a network-enabled environment**

No test on main covers the two behaviors that fold had to preserve: the
watchdog's failure logging under shutdown cancellation, and the
repeat-cancellation `continue` branch of the re-shield loop (previously
covered by no test in either copy of the loop).

This PR was opened 2 minutes before #7420 merged, carrying an equivalent
production change plus these tests; the production half is superseded, so it
is now the test gate #7420 deferred. (History: this operator's pipeline ran
two concurrent sessions on #7261; #7420 won the race.)

## Why it matters

Both mutation holes are LIVE on current main — verified by mutating main's
merged implementation and running the new tests:

- Dropping `on_settled=_report_terminal_settlement` at the watchdog call site
  (the exact regression a future "simplify the call" edit would make) keeps
  the whole suite green today; the new caplog test fails it.
- Flipping the re-shield `continue` to `break` — reintroducing the "repeat
  shutdown cancellation cancels the settlement task" bug — keeps the whole
  suite green today; the new helper-contract test fails it.

## What changed (motivation → approach → change)

Test-only; `git diff main -- src/` is empty.

- `test/test_auto_research.py`
  `TestWatchdogStopTombstone::test_settlement_failure_is_logged_without_replacing_cancellation`
  — end-to-end through `_settle_campaign_from_watchdog`: a status-write
  failure under shutdown cancellation must emit the
  `logger.exception("auto_research terminal settlement failed during shutdown")`
  record with traceback (`exc_info`) while the ORIGINAL `CancelledError` still
  propagates. `try/finally` guarantees service cleanup on assertion failure.
- `test/test_auto_research_onloop_fs.py`
  `TestCancellationSettlesWorker::test_on_settled_runs_after_settlement_only_when_cancelled`
  — helper contract: `on_settled` observes a SETTLED task (no
  `InvalidStateError` window), fires exactly once on the cancellation path,
  never on the normal path; a REPEAT cancellation neither cancels the settling
  task (`inner.cancelled() is False`) nor aborts the settling loop.

Provenance: the tests were written against this branch's original (now
superseded) implementation, reviewed pre-push by two model-pinned reviewers
(GPT 5.6 PASS zero findings; Opus PASS zero blocking, advisories adopted —
including the repeat-cancellation coverage), and re-validated 22/22 against
main's merged implementation.

## Tests

The diff IS the tests. Validation performed:
- 22/22 pass on `test_auto_research_onloop_fs.py` +
  `TestWatchdogStopTombstone` against current main tip.
- Mutation-verified against MAIN's implementation (both mutations above fail
  exactly one new test each; suite green with mutations absent).
- Gates: isort / flake8 / black + subprocess-encoding ratchets green.

## Manual verification

N/A — the change is deterministic asyncio unit tests; the mutation runs above
are the verification that they bite.

## Related Issues

Refs #7261 (closed by #7420); delivers the test verification #7420's body
deferred.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only
- [x] No secrets, credentials, or internal references in the diff
