### PR TITLE
fix(sandbox): mask the crew governance tree at the OS gate

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -109,6 +109,147 @@ _VOICE_RUNTIME_LEAF = os.path.join("run", "voice-runtime")
 #: The data home the ``$HOME``-relative entries below assume.
 _CREW_HOME_DEFAULT = ".kiro/crew"
 
+#: Both data-home spellings every crew-relative rule below has to cover: a host that
+#: has not run the ``~/.kirocrew`` -> ``~/.kiro/crew`` migration still holds the real
+#: bytes at the legacy path, and ``config_dir()`` can resolve to either.
+_CREW_HOME_PREFIXES: tuple[str, ...] = (".kiro/crew", ".kirocrew")
+
+# ── The crew data home's governance tree, reconciled with security.py ──
+#
+# ``security.sensitive_home_dirs()`` is the AGENT-TOOL gate: it is what
+# ``is_sensitive_path`` refuses for a file_read/file_write tool call. The lists in this
+# module are a SEPARATE, OS-level gate — a spawned ``python -c`` or a shell command does
+# an ``open()`` that never routes through the tool gate, so a path fenced only there is
+# readable through any sandbox mode. Two entries (``.vault``, ``policy_cache``) were
+# already carried in both; the rest of the governance tree was not, which left the
+# ceiling itself (``security_policy.json``) readable and WRITABLE from an app lifecycle
+# script, a script hook, or a command cron.
+#
+# Reconciling the two is NOT a union, and the reason is specific: Kiro Crew's own MCP
+# servers (``mcp_core``, ``mcp_cron``, ``mcp_computer``) are spawned by kiro-cli UNDER
+# this launcher and share the agent's mount namespace, as does a script cron's
+# ``boot_platform()``. Whatever they open at OS level cannot be masked. So each crew-home
+# leaf gets one of three dispositions:
+#
+#   HIDDEN    Nothing that runs inside the sandbox reads it. An empty dir/file is
+#             bind-mounted over it, in EVERY mode — the treatment ``.vault`` already
+#             gets, for the same reason.
+#   READONLY  In-sandbox code READS it and a WRITE would let the agent choose its own
+#             ceiling. Hiding a ceiling is the WRONG direction: an absent policy file
+#             resolves to the permissive standalone default, so masking
+#             ``security_policy.json`` from the process that enforces it REMOVES the
+#             ceiling instead of protecting it. Exposed read-only instead, which is what
+#             ``policy_cache`` already does.
+#   VISIBLE   In-sandbox code needs READ *and* WRITE, so no OS rule can apply without
+#             breaking it. These stay on the tool gate alone.
+#
+# ``test_sandbox_governance_mask.py`` pins the union of the three equal to the crew-home
+# half of ``security.sensitive_home_dirs()``, so a leaf added there cannot silently land
+# in none of them. Spelled here rather than imported so this low-level module keeps not
+# importing the 7k-line security module (the ``_POLICY_CACHE_LEAF`` convention above).
+
+#: Crew-home leaves with no legitimate in-sandbox reader — bind-masked in every mode.
+_CREW_HIDDEN_LEAVES: tuple[str, ...] = (
+    # Channel credentials. Already file-masked in cc/strict via ``_CC_FILES``; listing
+    # it here extends the same treatment to standard, where a spawned command could
+    # otherwise read every Slack/Discord token off disk.
+    ".env",
+    # App data holding live credentials or owner-authorization bits. Whole DIRECTORY,
+    # not the leaf file, because an atomic write renames a sibling temp into place.
+    "apps/aws-control/data",
+    "apps/meetings/data/edits",
+    "whatsapp",
+    "workspace/md-notebook/pat",
+    "workspace/md-notebook/vaults.json",
+    "workspace/md-notebook/settings.json",
+    # Browser session material. The extension token reaches the CLI through the
+    # environment, never by ``open()``, so masking the file costs nothing; the other
+    # four are retired leaves with no reader left in the tree. The LIVE browser paths
+    # (``browser-state``, ``playwright-snapshots``, ``pw``, ``playwright-cli-config.json``)
+    # are deliberately absent from the sensitive list and stay fully visible.
+    "browser-cookies.txt",
+    "playwright-storage-state.json",
+    "playwright-extension-token",
+    "browser-mode-enabled",
+    "browser-engine",
+    # Cross-session state whose authorization model is "a session reaches only its own",
+    # enforced by the HTTP routes. Every legitimate reader goes through the gateway, so
+    # OS-masking closes the sideways path without touching a live consumer.
+    "ledger",
+    "cron-history",
+    "workflow_library",
+    "agentcore-inbound",
+    "routing",
+    "webhooks",
+    "live_target.json",
+    "backup",
+    "mcp-apps",
+    # Auth stores and signing keys owned by the gateway web server alone.
+    "token_signing.key",
+    "refresh_chains.json",
+    "kas",
+    "ops_mission_control_secrets.json",
+    "ops_mission_control_policy.json",
+    # No producer and no consumer left in the tree; masked so a backup restore that
+    # resurrects a stale file cannot make it readable either.
+    ".kiro_cli_binary_trust.json",
+)
+
+#: Crew-home CEILINGS: read by in-sandbox code, never writable by it. Exposed
+#: read-only rather than hidden — see the READONLY note above for why hiding a
+#: ceiling inverts its effect.
+_CREW_READONLY_LEAVES: tuple[str, ...] = (
+    # The governance ceiling and its trust root. ``boot_platform()`` resolves both
+    # inside the sandbox for a script cron, and an absent file means "no ceiling".
+    "security_policy.json",
+    "admission_policy.json",
+    "profiles",
+    "app_admission.json",
+    # Opt-out and consent ceilings the config loader reads in-sandbox. A writable
+    # ``denied_commands.json`` lets an auto-approved agent set ``disable_all`` and
+    # defeat the deny gate after a restart; a writable ``computer_use.json`` lets it
+    # turn computer use on for itself.
+    "denied_commands.json",
+    "computer_use.json",
+    "oauth_endpoints.json",
+    "aws_service_consent.json",
+)
+
+#: Crew-home leaves that MUST stay read-write for a sandboxed process. Every entry is
+#: a deliberate exception a reviewer should re-check, not an oversight.
+_CREW_SANDBOX_VISIBLE_LEAVES: tuple[str, ...] = (
+    # Holds this launcher itself (``<config_dir>/run/kirocrew_sandbox_*.py``), so the
+    # child cannot exec if it is masked. Already sealed READ-ONLY through
+    # ``_voice_runtime_parent_paths()``, with only the ``run/voice-runtime`` leaf hidden.
+    "run",
+    # The SEL trust root and its append targets. ``verify_session_pid`` reads
+    # ``trust/sel_hmac.key`` inside the sandbox to resolve the strict session identity,
+    # ``skill_search`` reads ``trust/project-skills.json``, and the in-sandbox MCP
+    # servers append to the log directly — a masked log turns an audit-or-deny write
+    # into a denial of the action it was auditing.
+    "trust",
+    "sel_hmac.key",
+    "security_events.jsonl",
+    "security_events.d",
+    # How an in-sandbox MCP server authenticates back to the dashboard. Masking it
+    # breaks cron triggering, screencast, and the Sage review driver.
+    ".local_secret",
+    # ``mcp_cron`` builds a ``CronService(base_dir=config_dir())`` in-sandbox and both
+    # reads and rewrites the job store through it.
+    "crons.json",
+)
+
+
+def _crew_home_entries(leaves: tuple[str, ...]) -> list[str]:
+    """Expand *leaves* across both data-home spellings."""
+    return [f"{prefix}/{leaf}" for prefix in _CREW_HOME_PREFIXES for leaf in leaves]
+
+
+#: Bind-masked in every mode.
+_CREW_HIDDEN_DIRS: list[str] = _crew_home_entries(_CREW_HIDDEN_LEAVES)
+#: Exposed read-only in every mode.
+_CREW_READONLY_TARGETS: list[str] = _crew_home_entries(_CREW_READONLY_LEAVES)
+
 _STRICT_DIRS: list[str] = [
     ".kiro/crew-auth-staging",
     ".aws",
@@ -142,6 +283,8 @@ _STRICT_DIRS: list[str] = [
     ".kiro/crew/run/voice-runtime",
     ".kirocrew/run/voice-runtime",
 ]
+_STRICT_DIRS += _CREW_HIDDEN_DIRS
+_STRICT_DIRS += [".midway"]
 
 _STANDARD_DIRS: list[str] = [
     ".kiro/crew-auth-staging",
@@ -167,6 +310,7 @@ _STANDARD_DIRS: list[str] = [
     ".kiro/crew/run/voice-runtime",
     ".kirocrew/run/voice-runtime",
 ]
+_STANDARD_DIRS += _CREW_HIDDEN_DIRS
 
 # CC mode: hides all credential dirs including .aws, but selectively exposes
 # .aws/config (needed for credential_process → Bedrock auth). All other .aws
@@ -197,6 +341,47 @@ _CC_DIRS: list[str] = [
     ".kiro/crew/run/voice-runtime",
     ".kirocrew/run/voice-runtime",
 ]
+_CC_DIRS += _CREW_HIDDEN_DIRS
+_CC_DIRS += [".midway"]
+
+
+def _relocated_crew_targets(leaves: tuple[str, ...]) -> list[str]:
+    """The RESOLVED crew-home paths for *leaves*, when the data home is not under ``$HOME``.
+
+    Every entry in the dir lists is ``$HOME``-relative and joined with ``Path.home()``, so
+    ``KIROCREW_HOME=/srv/crew`` moves the data home out from under all of them and no rule
+    matches the real governance tree. :func:`_relocated_policy_cache_dirs` already closes
+    that hole for the one directory it was written for; the ceiling and the secret leaves
+    need it for the same reason, so the resolution is shared here instead of restated.
+
+    Returns only the paths that DIFFER from the ``$HOME``-relative spelling the lists
+    already carry, so the default layout gains no duplicate rule.
+
+    ``normpath``, never ``realpath`` — this runs inside ``_build_launcher_script`` and the
+    seatbelt builder, which execute on the event loop for every async spawn, and a
+    link-resolving syscall on a stalled NFS home would freeze the gateway with its
+    liveness heartbeat. A symlinked home therefore reports as relocated and yields a
+    redundant rule for a path that is covered either way, never a missing one.
+
+    Never raises: a data home that cannot be resolved yields nothing and the
+    ``$HOME``-relative entries still apply.
+    """
+    try:
+        home_root = os.path.join(str(Path.home()), _CREW_HOME_DEFAULT)
+        resolved_root = str(config_dir())
+    except Exception:  # pragma: no cover - defensive; a spawn must not fail on this
+        logger.debug("could not resolve the crew data home for sandbox masking", exc_info=True)
+        return []
+    out: list[str] = []
+    for leaf in leaves:
+        try:
+            resolved = os.path.normpath(os.path.join(resolved_root, leaf))
+            default = os.path.normpath(os.path.join(home_root, leaf))
+        except Exception:  # pragma: no cover - defensive
+            continue
+        if resolved != default:
+            out.append(resolved)
+    return out
 
 
 def _relocated_policy_cache_dirs() -> list[str]:
@@ -742,6 +927,20 @@ def _is_policy_cache_dir(path: str) -> bool:
     spawn path.
     """
     return os.path.basename(path.rstrip("/" + os.sep)) == _POLICY_CACHE_LEAF
+
+
+def _crew_hidden_sandbox_targets() -> set[str]:
+    """Absolute paths of the crew-home leaves the sandbox masks, both spellings.
+
+    The seatbelt profile needs to tell these apart from the other hidden entries: they
+    take a write deny as well as a read deny, while ``.aws`` must not (a tool refreshing
+    a cached token rewrites it legitimately). On Linux the distinction does not arise --
+    a bind mount blocks both directions in one rule.
+    """
+    home = str(Path.home())
+    targets = {os.path.join(home, rel) for rel in _CREW_HIDDEN_DIRS}
+    targets.update(_relocated_crew_targets(_CREW_HIDDEN_LEAVES))
+    return targets
 
 
 def _is_voice_runtime_dir(path: str) -> bool:
@@ -2137,6 +2336,7 @@ def _build_launcher_script(
     hide_ssh = sandbox_level == "strict"
     hidden_dirs = [os.path.join(home, d) for d in dirs]
     hidden_dirs.extend(_relocated_policy_cache_dirs())
+    hidden_dirs.extend(_relocated_crew_targets(_CREW_HIDDEN_LEAVES))
     hidden_dirs.extend(_voice_runtime_sandbox_paths())
     hidden_dirs.extend(os.path.abspath(path) for path in extra_hidden_dirs)
     unhidden = [
@@ -2157,6 +2357,21 @@ def _build_launcher_script(
     # its lexical and canonical spellings read-only prevents an agent from
     # renaming the hidden voice-runtime mount out from under the path-based rule.
     readonly_dirs.extend(_voice_runtime_parent_paths())
+    # The crew data home's ceilings. Read-only rather than hidden because in-sandbox
+    # code resolves them (a script cron's ``boot_platform()``, the config loader) and an
+    # absent ceiling reads as the permissive standalone default — masking one would
+    # REMOVE it. A caller's ``extra_visible_dirs`` cannot re-open the write side, for the
+    # reason spelled out for the governance cache above.
+    readonly_dirs.extend(
+        os.path.join(home, target)
+        for target in _CREW_READONLY_TARGETS
+        if os.path.join(home, target) not in hidden_dirs
+    )
+    # A relocated data home escapes every ``$HOME``-relative rule above, which would
+    # leave the ceiling writable on exactly the managed fleets that set it.
+    readonly_dirs.extend(
+        path for path in _relocated_crew_targets(_CREW_READONLY_LEAVES) if path not in hidden_dirs
+    )
     # A caller-supplied hidden path may be a FILE, and the two launcher loops hide
     # each kind differently: a directory gets an empty dir bind-mounted over it, a file
     # gets an empty temp file. The dir loop is guarded by `if os.path.isdir(target)`, so
@@ -2454,12 +2669,17 @@ def main():
         # in our own user+mount namespace because we created the bind ourselves.
         for d in READONLY_DIRS:
             target = d.encode()
-            if os.path.isdir(target):
+            # ``exists``, not ``isdir``: a governance ceiling is a plain file
+            # (``security_policy.json``), and bind-over-self + MS_RDONLY seals a
+            # regular file exactly as it seals a directory. Guarding on ``isdir``
+            # would silently skip every ceiling FILE — the caller asks for it to be
+            # sealed, gets no error, and it stays writable.
+            if os.path.exists(target):
                 _mount_or_die(target, target, _MS_BIND,
-                              "exposing read-only directory %s" % d)
+                              "exposing read-only path %s" % d)
                 _mount_or_die(target, target,
                               _MS_REMOUNT | _MS_BIND | _MS_RDONLY,
-                              "sealing read-only directory %s" % d)
+                              "sealing read-only path %s" % d)
 
         # Restore selectively exposed files into the now-empty mounts
         for src_path, filename in EXPOSE_FILES:
@@ -2990,10 +3210,12 @@ def _build_seatbelt_profile(
     files = _CC_FILES if sandbox_level in ("cc", "strict") else []
     expose_files = _CC_EXPOSE_FILES if sandbox_level == "cc" else []
     expose_abs = {os.path.join(home, f) for f in expose_files}
+    crew_hidden = _crew_hidden_sandbox_targets()
     rules: list[str] = []
     for target in (
         [os.path.join(home, d) for d in dirs]
         + _relocated_policy_cache_dirs()
+        + _relocated_crew_targets(_CREW_HIDDEN_LEAVES)
         + list(_voice_runtime_sandbox_paths())
     ):
         if _hidden_path_contains_visible_path(
@@ -3021,14 +3243,19 @@ def _build_seatbelt_profile(
             rules.append(f'(deny file-read* (require-all (subpath "{escaped}") {exceptions}))')
         else:
             rules.append(f'(deny file-read* (subpath "{escaped}"))')
-        if _is_policy_cache_dir(target) or _is_voice_runtime_dir(target):
+        if _is_policy_cache_dir(target) or _is_voice_runtime_dir(target) or target in crew_hidden:
             # Linux bind-mounts these roots away, which blocks both directions.
             # macOS needs an explicit write deny as well as the read rule above:
-            # governance metadata is a trust root, while a writable voice-runtime
-            # image would race the gateway's authenticated decoder spawn. Keep this
-            # scoped to the two execution/trust roots; widening it to every entry
-            # would break paths such as .aws that legitimately refresh state.
+            # governance metadata is a trust root, a writable voice-runtime image would
+            # race the gateway's authenticated decoder spawn, and a crew-home secret that
+            # is read-denied but writable can still be OVERWRITTEN -- forging
+            # ``token_signing.key`` needs no read at all. Scoped to those three sets on
+            # purpose: widening it to every hidden entry would also cover .aws, which a
+            # tool rewrites legitimately when it refreshes a cached token.
             rules.append(f'(deny file-write* (subpath "{escaped}"))')
+            if target in crew_hidden:
+                # A leaf may be a plain file, which no subpath rule addresses.
+                rules.append(f'(deny file-write* (literal "{escaped}"))')
         # Deny creating a HARDLINK whose target is under this dir.
         # Seatbelt's file-read* deny is path-based, so a hardlink at a
         # non-denied path (e.g. /tmp) reads the same inode past the deny rule.
@@ -3050,6 +3277,18 @@ def _build_seatbelt_profile(
     for target in _voice_runtime_ancestor_guards():
         escaped = target.replace('"', '\\"')
         rules.append(f'(deny file-write* (literal "{escaped}"))')
+    # The crew data home's ceilings: readable (in-sandbox code resolves them) but never
+    # writable, so a sandboxed process cannot hand itself a ceiling. Mirrors
+    # READONLY_DIRS on Linux. Both spellings, because a ceiling may be a file
+    # (``literal``) or a directory (``subpath``), and ``file-link`` stops the agent
+    # minting a writable alias to the same inode.
+    for target in [
+        os.path.join(home, rel) for rel in _CREW_READONLY_TARGETS
+    ] + _relocated_crew_targets(_CREW_READONLY_LEAVES):
+        escaped = target.replace('"', '\\"')
+        rules.append(f'(deny file-write* (literal "{escaped}"))')
+        rules.append(f'(deny file-write* (subpath "{escaped}"))')
+        rules.append(f'(deny file-link (subpath "{escaped}"))')
     for f in files:
         target = os.path.join(home, f)
         escaped = target.replace('"', '\\"')

--- a/test/test_governance_distribution.py
+++ b/test/test_governance_distribution.py
@@ -4164,7 +4164,8 @@ class TestAnExposedCacheIsStillReadOnly:
 
         script = sandbox._build_launcher_script("standard")
         readonly = json.loads(script.split("READONLY_DIRS = ", 1)[1].split("\n", 1)[0])
-        assert set(readonly) == set(sandbox._voice_runtime_parent_paths())
+        assert set(readonly) >= set(sandbox._voice_runtime_parent_paths())
+        assert self._cache_path() not in readonly
 
     def test_macos_keeps_the_write_and_link_denies_when_it_drops_the_read_deny(self):
         from kiro_crew import sandbox
@@ -4189,7 +4190,7 @@ class TestAnExposedCacheIsStillReadOnly:
 
         script = sandbox._build_launcher_script("strict", extra_visible_dirs=(aws,))
         readonly = json.loads(script.split("READONLY_DIRS = ", 1)[1].split("\n", 1)[0])
-        assert set(readonly) == set(sandbox._voice_runtime_parent_paths())
+        assert set(readonly) >= set(sandbox._voice_runtime_parent_paths())
         assert aws not in readonly
 
     @pytest.mark.parametrize("prefix", [".kiro/crew", ".kirocrew"])

--- a/test/test_sandbox_governance_mask.py
+++ b/test/test_sandbox_governance_mask.py
@@ -1,0 +1,390 @@
+"""The OS-level sandbox mask covers the crew data home's governance tree.
+
+``security.sensitive_home_dirs()`` is the agent-TOOL gate: it is what
+``is_sensitive_path`` refuses for a file_read/file_write tool call. The dir lists in
+``sandbox.py`` are a separate, OS-level gate, and a spawned shell command reaches a path
+fenced only by the first one. These tests pin the reconciliation between them:
+
+* every crew-home entry on the tool gate has one of three sandbox dispositions,
+* the ceilings are exposed READ-ONLY rather than hidden, in every mode,
+* the deliberate read-write exceptions are exactly the declared set, in every mode.
+
+The third is the one worth failing loudly: an entry that quietly moves from "masked" to
+"exception" is a ceiling the agent can rewrite again.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+import pytest
+
+from kiro_crew import sandbox, security
+
+_POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX launcher only")
+
+_MODES = ("standard", "cc", "strict")
+_CREW_PREFIXES = (".kiro/crew", ".kirocrew")
+
+
+def _home() -> str:
+    return os.path.expanduser("~")
+
+
+def _crew_path(prefix: str, leaf: str) -> str:
+    """Spell a crew-home target the way the production builders do.
+
+    They join a SINGLE relative string onto the home, so the forward slashes inside it
+    survive and Windows gains exactly one native separator. Joining prefix and leaf as
+    separate components instead adds a second one, and the resulting mixed-separator
+    string matches nothing the builders emit.
+    """
+    return os.path.join(_home(), f"{prefix}/{leaf}")
+
+
+def _launcher_sets(mode: str) -> tuple[set[str], set[str], set[str]]:
+    """``(hidden_dirs, readonly, hidden_files)`` as the generated launcher declares them."""
+    script = sandbox._build_launcher_script(mode)
+
+    def _grab(name: str) -> set[str]:
+        match = re.search(rf"{name} = (\[.*?\])\n", script, re.S)
+        assert match, f"{name} missing from the launcher"
+        return set(json.loads(match.group(1)))
+
+    return _grab("SENSITIVE_DIRS"), _grab("READONLY_DIRS"), _grab("SENSITIVE_FILES")
+
+
+def _crew_sensitive_paths() -> list[str]:
+    """Absolute crew-data-home paths the tool gate declares sensitive."""
+    home = _home()
+    return [
+        os.path.join(home, rel)
+        for rel in security.sensitive_home_dirs()
+        if rel.startswith(_CREW_PREFIXES)
+    ]
+
+
+def _expected_exceptions() -> set[str]:
+    home = _home()
+    return {
+        os.path.join(home, f"{prefix}/{leaf}")
+        for prefix in _CREW_PREFIXES
+        for leaf in sandbox._CREW_SANDBOX_VISIBLE_LEAVES
+    }
+
+
+class TestKeystonesAreSealedInEveryMode:
+    """The ceiling files the issue named, on every backend the launcher feeds."""
+
+    #: Named individually rather than looped from the module tuple: the point is that
+    #: THESE paths are covered, so a test derived from the same tuple the production
+    #: code reads would pass just as happily after someone emptied it.
+    KEYSTONES = (
+        "security_policy.json",
+        "admission_policy.json",
+        "app_admission.json",
+        "profiles",
+        "denied_commands.json",
+        "computer_use.json",
+        "oauth_endpoints.json",
+        "aws_service_consent.json",
+    )
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    @pytest.mark.parametrize("prefix", _CREW_PREFIXES)
+    @pytest.mark.parametrize("leaf", KEYSTONES)
+    def test_linux_seals_the_ceiling_read_only(self, mode: str, prefix: str, leaf: str) -> None:
+        hidden, readonly, _files = _launcher_sets(mode)
+        target = _crew_path(prefix, leaf)
+
+        assert target in readonly, f"{leaf} is writable through the {mode} sandbox"
+        # Hiding a ceiling inverts its effect: an absent policy file resolves to the
+        # permissive standalone default, and a script cron's ``boot_platform()`` runs
+        # inside this namespace.
+        assert target not in hidden, f"{leaf} must stay READABLE, not be masked"
+
+    @pytest.mark.parametrize("mode", _MODES)
+    @pytest.mark.parametrize("prefix", _CREW_PREFIXES)
+    @pytest.mark.parametrize("leaf", KEYSTONES)
+    def test_macos_denies_writes_to_the_ceiling(self, mode: str, prefix: str, leaf: str) -> None:
+        profile = sandbox._build_seatbelt_profile(mode)
+        target = _crew_path(prefix, leaf)
+
+        assert f'(deny file-write* (literal "{target}"))' in profile
+        assert f'(deny file-write* (subpath "{target}"))' in profile
+        # A hardlink at a non-denied path would otherwise reach the same inode.
+        assert f'(deny file-link (subpath "{target}"))' in profile
+        assert f'(deny file-read* (subpath "{target}"))' not in profile
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_the_seal_survives_a_file_shaped_ceiling(self, mode: str) -> None:
+        """The read-only loop must not guard on ``isdir``.
+
+        ``security_policy.json`` is a plain file. An ``isdir`` guard skips it silently —
+        no error, and the ceiling stays writable.
+        """
+        script = sandbox._build_launcher_script(mode)
+        loop = script.split("for d in READONLY_DIRS:", 1)[1].split("\n\n", 1)[0]
+
+        assert "os.path.exists(target)" in loop
+        assert "os.path.isdir(target)" not in loop
+        assert "_MS_REMOUNT | _MS_BIND | _MS_RDONLY" in loop
+
+
+class TestSecretsAreMaskedInEveryMode:
+    """Crew-home leaves with no in-sandbox reader are bind-masked, not merely sealed."""
+
+    MASKED = (
+        "token_signing.key",
+        "refresh_chains.json",
+        "kas",
+        "mcp-apps",
+        "ledger",
+        "backup",
+        "browser-cookies.txt",
+        "playwright-storage-state.json",
+        "playwright-extension-token",
+        "ops_mission_control_secrets.json",
+        "whatsapp",
+        "apps/aws-control/data",
+        "workspace/md-notebook/pat",
+    )
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    @pytest.mark.parametrize("prefix", _CREW_PREFIXES)
+    @pytest.mark.parametrize("leaf", MASKED)
+    def test_linux_masks_it(self, mode: str, prefix: str, leaf: str) -> None:
+        hidden, _readonly, files = _launcher_sets(mode)
+        target = _crew_path(prefix, leaf)
+
+        # Both lists, because the child classifies by kind: a file entry reaching only
+        # the directory loop is skipped by its ``isdir`` guard and stays readable.
+        assert target in hidden, f"{leaf} readable through the {mode} sandbox"
+        assert target in files, f"{leaf} would be skipped if it is a file"
+
+    @pytest.mark.parametrize("mode", _MODES)
+    @pytest.mark.parametrize("prefix", _CREW_PREFIXES)
+    @pytest.mark.parametrize("leaf", MASKED)
+    def test_macos_denies_reads(self, mode: str, prefix: str, leaf: str) -> None:
+        profile = sandbox._build_seatbelt_profile(mode)
+        target = _crew_path(prefix, leaf)
+
+        assert f'(deny file-read* (subpath "{target}"))' in profile
+        assert f'(deny file-link (subpath "{target}"))' in profile
+
+    @pytest.mark.parametrize("mode", _MODES)
+    @pytest.mark.parametrize("prefix", _CREW_PREFIXES)
+    @pytest.mark.parametrize("leaf", MASKED)
+    def test_macos_denies_writes_too(self, mode: str, prefix: str, leaf: str) -> None:
+        """A read deny alone leaves the secret OVERWRITABLE.
+
+        The Linux launcher binds an empty dir/file over the target, which blocks both
+        directions in one rule. Seatbelt does not, and forging ``token_signing.key``
+        needs no read at all — so the read deny on its own is not the control it looks
+        like. Both spellings, because a leaf may be a plain file and no subpath rule
+        addresses one.
+        """
+        profile = sandbox._build_seatbelt_profile(mode)
+        target = _crew_path(prefix, leaf)
+
+        assert f'(deny file-write* (subpath "{target}"))' in profile
+        assert f'(deny file-write* (literal "{target}"))' in profile
+
+
+class TestTheReconciliationIsComplete:
+    """No crew-home entry on the tool gate is left with no sandbox disposition."""
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_every_crew_sensitive_path_is_masked_sealed_or_a_declared_exception(
+        self, mode: str
+    ) -> None:
+        hidden, readonly, _files = _launcher_sets(mode)
+        exceptions = _expected_exceptions()
+
+        unaccounted = [
+            path
+            for path in _crew_sensitive_paths()
+            if path not in hidden and path not in readonly and path not in exceptions
+        ]
+        assert not unaccounted, (
+            "crew-home paths the tool gate fences but the OS sandbox does not, and that "
+            f"are not declared exceptions either: {unaccounted}"
+        )
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_the_read_write_exceptions_are_exactly_the_declared_set(self, mode: str) -> None:
+        """A path drifting into the exception set is a ceiling the agent can rewrite.
+
+        ``run`` is expected on the read-only list rather than fully read-write: it holds
+        the launcher itself, so it must stay readable, and the voice-runtime rules
+        already seal it. Every other exception is genuinely unrestricted.
+        """
+        hidden, readonly, _files = _launcher_sets(mode)
+        unrestricted = {
+            path for path in _crew_sensitive_paths() if path not in hidden and path not in readonly
+        }
+        declared = _expected_exceptions()
+
+        assert (
+            unrestricted <= declared
+        ), f"undeclared read-write crew paths in {mode}: {sorted(unrestricted - declared)}"
+        for path in declared - unrestricted:
+            assert (
+                path in readonly
+            ), f"{path} is declared an exception but is neither read-write nor sealed"
+
+    def test_the_exception_set_names_only_paths_the_tool_gate_fences(self) -> None:
+        """An exception for a path nothing fences is dead weight that reads as a hole."""
+        home = _home()
+        fenced = {os.path.join(home, rel) for rel in security.sensitive_home_dirs()}
+
+        for path in _expected_exceptions():
+            assert path in fenced, f"{path} is exempted from a gate that never covered it"
+
+    def test_the_three_dispositions_do_not_overlap(self) -> None:
+        hidden = set(sandbox._CREW_HIDDEN_LEAVES)
+        readonly = set(sandbox._CREW_READONLY_LEAVES)
+        visible = set(sandbox._CREW_SANDBOX_VISIBLE_LEAVES)
+
+        assert not hidden & readonly
+        assert not hidden & visible
+        assert not readonly & visible
+
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_every_mode_carries_the_derived_set(self, mode: str) -> None:
+        """The governance tree is masked at every level, the way ``.vault`` already is.
+
+        A per-mode carve-out here would mean ``standard`` — the default — leaves the
+        ceiling exposed, which is the configuration almost every install runs.
+        """
+        listing = {
+            "standard": sandbox._STANDARD_DIRS,
+            "cc": sandbox._CC_DIRS,
+            "strict": sandbox._STRICT_DIRS,
+        }[mode]
+
+        for entry in sandbox._CREW_HIDDEN_DIRS:
+            assert entry in listing, f"{entry} missing from the {mode} dir list"
+
+
+class TestARelocatedDataHomeIsCoveredToo:
+    """``KIROCREW_HOME`` outside ``$HOME`` must not escape the mask.
+
+    Every dir-list entry is ``$HOME``-relative and joined with ``Path.home()``, so a
+    managed fleet that relocates the data home would otherwise get no rule at all for the
+    real governance tree — the ceiling left writable on exactly the installs most likely
+    to have one.
+
+    The expected target comes from ``config_dir()`` rather than from ``tmp_path`` spelled
+    by hand: the resolver creates the directory and can resolve through a symlink, which
+    is the ordinary case on macOS.
+    """
+
+    @staticmethod
+    def _relocate(monkeypatch, tmp_path) -> str:
+        from kiro_crew.config.paths import config_dir
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "relocated-crew"))
+        return str(config_dir())
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_the_launcher_masks_the_resolved_secret_leaves(self, mode, tmp_path, monkeypatch):
+        root = self._relocate(monkeypatch, tmp_path)
+        hidden, _readonly, files = _launcher_sets(mode)
+
+        target = os.path.join(root, "token_signing.key")
+        assert target in hidden, f"a relocated data home is unmasked in {mode}"
+        # Both lists, because the child classifies by kind and this leaf is a file.
+        assert target in files
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_the_launcher_seals_the_resolved_ceiling(self, mode, tmp_path, monkeypatch):
+        root = self._relocate(monkeypatch, tmp_path)
+        hidden, readonly, _files = _launcher_sets(mode)
+
+        target = os.path.join(root, "security_policy.json")
+        assert target in readonly, f"a relocated ceiling is writable in {mode}"
+        assert target not in hidden, "it must stay readable — masking a ceiling removes it"
+
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_the_seatbelt_profile_covers_the_resolved_paths(self, mode, tmp_path, monkeypatch):
+        root = self._relocate(monkeypatch, tmp_path)
+        profile = sandbox._build_seatbelt_profile(mode)
+
+        ceiling = os.path.join(root, "security_policy.json")
+        secret = os.path.join(root, "token_signing.key")
+        assert f'(deny file-write* (literal "{ceiling}"))' in profile
+        assert f'(deny file-read* (subpath "{secret}"))' in profile
+
+    def test_the_default_layout_adds_no_duplicate_rule(self, monkeypatch, tmp_path):
+        """De-duplication: where the two spellings match textually, no second rule."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "x" / ".kiro" / "crew"))
+        monkeypatch.setattr(sandbox.Path, "home", staticmethod(lambda: tmp_path / "x"))
+
+        assert sandbox._relocated_crew_targets(("security_policy.json",)) == []
+
+    def test_a_resolution_failure_never_breaks_a_spawn(self, monkeypatch):
+        """A spawn must not fail because the data home could not be resolved."""
+
+        def _boom() -> object:
+            raise RuntimeError("no home")
+
+        monkeypatch.setattr(sandbox.Path, "home", staticmethod(_boom))
+        assert sandbox._relocated_crew_targets(("security_policy.json",)) == []
+
+
+class TestThirdPartyCredentialsKeepTheirExistingTiering:
+    """The reconciliation must not quietly re-tier the non-crew credential entries."""
+
+    def test_standard_still_exposes_the_developer_workflow_dirs(self) -> None:
+        """``standard`` deliberately leaves ``.aws``/``.kube`` readable.
+
+        Masking them here would break an ordinary build running in the default mode; the
+        crew governance tree is masked at every level precisely because nothing
+        legitimate reads it.
+        """
+        assert ".aws" not in sandbox._STANDARD_DIRS
+        assert ".kube" not in sandbox._STANDARD_DIRS
+        assert ".aws" in sandbox._CC_DIRS
+        assert ".aws" in sandbox._STRICT_DIRS
+
+    @pytest.mark.parametrize("mode", _MODES)
+    def test_the_macos_write_deny_does_not_reach_the_refreshable_dirs(self, mode: str) -> None:
+        """``.aws`` is masked but must stay WRITABLE where it is exposed.
+
+        A tool refreshing a cached token rewrites it, so the crew-home write deny is
+        scoped to the crew leaves rather than applied to every hidden entry. Without this
+        the scoping is free to erode into a blanket rule.
+        """
+        profile = sandbox._build_seatbelt_profile(mode)
+
+        for leaf in (".aws", ".gnupg", ".docker"):
+            target = os.path.join(_home(), leaf)
+            assert f'(deny file-write* (subpath "{target}"))' not in profile
+
+    def test_the_sso_cookie_store_is_masked_at_the_credential_tiers(self) -> None:
+        """``.midway`` is a live bearer credential, the same class as ``.aws``."""
+        assert ".midway" in sandbox._STRICT_DIRS
+        assert ".midway" in sandbox._CC_DIRS
+        assert ".midway" not in sandbox._STANDARD_DIRS
+
+    def test_the_agent_runtime_auth_stores_stay_visible(self) -> None:
+        """kiro-cli / amazon-q identity stores are fenced at the tool gate only.
+
+        The agent runtime is itself spawned inside this sandbox and resolves its own
+        access token from that store, so masking it would break the agent's model auth
+        rather than protect anything. ``security.py`` states this explicitly.
+        """
+        for listing in (sandbox._STRICT_DIRS, sandbox._CC_DIRS, sandbox._STANDARD_DIRS):
+            assert ".local/share/kiro-cli" not in listing
+            assert ".local/share/amazon-q" not in listing

--- a/test/test_sandbox_mount_checked.py
+++ b/test/test_sandbox_mount_checked.py
@@ -213,8 +213,8 @@ def test_all_mounts_succeeding_lets_the_exec_proceed(tmp_path: Path) -> None:
     [
         (1, "propagation"),
         (2, "credential directory"),
-        (3, "exposing read-only directory"),
-        (4, "sealing read-only directory"),
+        (3, "exposing read-only path"),
+        (4, "sealing read-only path"),
         (5, "sensitive file"),
         (6, "ssh key directory"),
     ],
@@ -319,13 +319,13 @@ _ARMS: dict[str, tuple[str, str]] = {
     ),
     "site3": (
         "_mount_or_die(target, target, _MS_BIND,\n"
-        '                              "exposing read-only directory %s" % d)',
+        '                              "exposing read-only path %s" % d)',
         "_libc.mount(target, target, None, _MS_BIND, None)",
     ),
     "site4": (
         "_mount_or_die(target, target,\n"
         "                              _MS_REMOUNT | _MS_BIND | _MS_RDONLY,\n"
-        '                              "sealing read-only directory %s" % d)',
+        '                              "sealing read-only path %s" % d)',
         "_libc.mount(target, target, None, _MS_REMOUNT | _MS_BIND | _MS_RDONLY, None)",
     ),
     "site5": (


### PR DESCRIPTION
Closes #7332.

## The gap, measured

`security.sensitive_home_dirs()` carries **110** entries; `_STRICT_DIRS` carried **15**. The difference is **96** paths the agent's file tools refuse but a spawned OS subprocess reads straight through, on every backend the shared launcher feeds (Linux `unshare`, macOS Seatbelt, WSL2 — which reuses `_build_launcher_script` verbatim; `is_wsl()` has zero callers in `src/`, so there is no separate list to extend).

<details>
<summary><b>All 96 entries of <code>set(sensitive_home_dirs()) - set(strict_dirs())</code></b></summary>

Crew data home, both spellings (`.kiro/crew/…` and `.kirocrew/…`, 44 leaves × 2 = 88):

`.env` · `.kiro_cli_binary_trust.json` · `.local_secret` · `admission_policy.json` · `agentcore-inbound` · `app_admission.json` · `apps/aws-control/data` · `apps/meetings/data/edits` · `aws_service_consent.json` · `backup` · `browser-cookies.txt` · `browser-engine` · `browser-mode-enabled` · `computer_use.json` · `cron-history` · `crons.json` · `denied_commands.json` · `kas` · `ledger` · `live_target.json` · `mcp-apps` · `oauth_endpoints.json` · `ops_mission_control_policy.json` · `ops_mission_control_secrets.json` · `playwright-extension-token` · `playwright-storage-state.json` · `profiles` · `refresh_chains.json` · `routing` · `run` · `security_events.d` · `security_events.jsonl` · `security_policy.json` · `sel_hmac.key` · `token_signing.key` · `trust` · `webhooks` · `whatsapp` · `workflow_library` · `workspace/md-notebook/pat` · `workspace/md-notebook/settings.json` · `workspace/md-notebook/vaults.json`

Outside the crew home (8):

`.ssh` · `.midway` · `.npmrc` · `.pypirc` · `.netrc` · `.git-credentials` · `.docker/config.json` · `.kube/config`

kiro-cli / amazon-q identity stores (8): `.local/share/{kiro-cli,amazon-q}` · `Library/Application Support/{kiro-cli,amazon-q}` · `AppData/{Local,Roaming}/{kiro-cli,amazon-q}`

</details>

## Why this is not a union — the fact that shaped the design

KiroCrew's own MCP servers (`mcp_core`, `mcp_cron`, `mcp_computer`) are spawned by kiro-cli **under this launcher** and share the agent's mount namespace, and a script cron runs `boot_platform()` inside `wrap_argv()` (`cron_script.py:780`). Whatever they open at OS level cannot be masked.

That produces one finding worth stating on its own, because it inverts the obvious patch: **hiding a ceiling removes it.** An absent `security_policy.json` resolves to the permissive standalone default, so bind-mounting an empty file over it would leave the in-sandbox enforcer seeing *no* enterprise ceiling — strictly worse than today. Ceilings are therefore exposed **read-only**, the treatment `policy_cache` already gets, not hidden.

So each crew-home leaf gets one of three dispositions, applied at **every** level (`standard`/`cc`/`strict`) and on **both** backends.

## Classification

### (a) HIDDEN — no in-sandbox reader, bind-masked in every mode

| Leaf | Why it is safe to mask |
|---|---|
| `.env` | Already file-masked in cc/strict via `_CC_FILES`; this extends it to `standard`. |
| `apps/aws-control/data` | App backend opens it directly, unsandboxed. Whole dir — an atomic write renames a sibling temp. |
| `apps/meetings/data/edits` | Same. |
| `whatsapp` | `WhatsAppClient` is constructed in the gateway process over a Python wheel; not a spawned bridge. |
| `workspace/md-notebook/{pat,vaults.json,settings.json}` | Notes app backend, in-process. |
| `browser-cookies.txt`, `playwright-storage-state.json` | Only reader left is the retired standalone converter script. |
| `playwright-extension-token` | Gateway reads it in-process and injects `PLAYWRIGHT_MCP_EXTENSION_TOKEN`; the child never `open()`s it. |
| `browser-mode-enabled`, `browser-engine` | Retired leaves, zero readers in `src/`. |
| `ledger` | Per-session work ledgers; authorization model *is* the HTTP route, and `session_ledger_*` goes over HTTP. |
| `cron-history` | Writers are the gateway reaper and dashboard handlers. |
| `workflow_library` | `workflow_library_list` fetches `/api/workflows/definitions` over HTTP. |
| `agentcore-inbound`, `routing`, `webhooks`, `live_target.json`, `backup` | Gateway-side stores. |
| `mcp-apps` | gatewayd spawns unwrapped (`mcp_gateway/manager.py:566`) and is not sandboxed. |
| `token_signing.key`, `refresh_chains.json` | Owned solely by the dashboard web server. |
| `kas` | Crew reaches KAS through kiro-cli's ACP relay with `--auth-method cli`; it never touches KAS tokens. |
| `ops_mission_control_{secrets,policy}.json` | Ops app backend, in-process. |
| `.kiro_cli_binary_trust.json` | No producer and no consumer left in the tree. |

**Live browser paths are deliberately untouched** and were never on the sensitive list: `browser-state/`, `playwright-snapshots/`, `pw/`, `playwright-cli-config.json`. `state-save`/`state-load` *do* use the sandboxed process's own file access, so masking those would have broken the browser-auth workflow.

### (a′) READONLY — read in-sandbox, never writable

| Leaf | Why read-only, not hidden |
|---|---|
| `security_policy.json` | The ceiling. `boot_platform()` resolves it inside the sandbox; absent = permissive default. |
| `admission_policy.json` | Its signing trust root — forging both is the actual escalation path. |
| `profiles` | Per-surface governance profiles, read by `governance_profiles.py`. |
| `app_admission.json` | App Kit admission ceiling. Read-only on principle: a ceiling is never hidden. |
| `denied_commands.json` | A writable copy lets an auto-approved agent set `disable_all` and defeat the deny gate after a restart. |
| `computer_use.json` | The primary enable — writable means self-enabling computer use; masked means the feature silently breaks. |
| `oauth_endpoints.json`, `aws_service_consent.json` | Consent ceilings the config loader reads in-sandbox. |

### (b) VISIBLE — read **and** write needed in-sandbox; tool gate only

| Leaf | Evidence |
|---|---|
| `run` | Holds this launcher (`<config_dir>/run/kirocrew_sandbox_*.py`, `sandbox.py:2867`). Already sealed **read-only** via `_voice_runtime_parent_paths()`; only `run/voice-runtime` is hidden. |
| `trust` | `verify_session_pid` reads `trust/sel_hmac.key` in-sandbox (`session_pid_sig.py:145`) and `skill_search` reads `trust/project-skills.json`. Lazily created, so write is needed too. |
| `sel_hmac.key` | Live key path on pre-migration installs; same in-sandbox reader. |
| `security_events.jsonl` | In-sandbox MCP servers append directly (`sel.py:1121`). Masking turns an `audit-or-deny` write into a denial of the audited action. |
| `security_events.d` | Rotation target of that same appender. |
| `.local_secret` | How an in-sandbox MCP server authenticates back to the dashboard. Masking breaks cron trigger, screencast, and the Sage driver. |
| `crons.json` | `mcp_cron` builds `CronService(base_dir=config_dir())` in-sandbox and rewrites the store through it. |

### Outside the crew home

- **kiro-cli / amazon-q identity stores — left visible, deliberately.** The agent runtime is itself sandboxed and resolves its own access token from that store; `security.py` states the sandbox list is separate for exactly this reason. Masking would break model auth, not protect anything.
- **`.midway` added** to `_STRICT_DIRS` and `_CC_DIRS` — a live SSO bearer credential, the same class as `.aws`, so it follows `.aws`'s tiering rather than being masked in `standard`.
- **`.docker/config.json`, `.kube/config`, `.npmrc`, `.pypirc`, `.netrc`, `.git-credentials`, `.ssh` — no change.** They are already covered where their tier intends: `.docker` in all three modes, `.kube` in strict/cc, the four files via `_CC_FILES` in cc/strict, `.ssh` via the strict `HIDE_SSH` block. `standard` exposing them is a deliberate developer-workflow decision, and re-tiering it is out of scope for this issue.

## ⚠️ Entries I masked without a proven-safe reader — please confirm

Fail-closed per the issue's guidance. Each has no in-sandbox reader I could find, but the consequence of being wrong is an availability break, not a security hole:

- **`backup`** — if a *command cron* runs `kirocrew backup`, it runs sandboxed and would write into an empty mount. I found no such cron in-tree.
- **`webhooks`** — `webhooks.py` is in the in-sandbox import closure; I could not find an in-sandbox reader of the token store, but the import made me less certain than for its neighbours.
- **`ops_mission_control_policy.json`** — the ops autonomy ceiling. Masked rather than sealed read-only because its reader is the app backend (unsandboxed). If any in-sandbox path reads it, it belongs in the READONLY set instead.
- **`cron-history`** — `mcp_cron` constructs a `CronService`, which builds a `CronHistoryStore`. Construction against an empty dir is harmless and no MCP cron tool reads history, but the object graph does reach it.
- **`ledger`, `mcp-apps`, `kas`** — each verified gateway-side, but all three are load-bearing for a live feature, so worth a second opinion.

## Relocated data homes

Every dir-list entry is `$HOME`-relative and joined with `Path.home()`, so `KIROCREW_HOME=/srv/crew` moved the real governance tree out from under all of them — the ceiling left writable on exactly the managed fleets most likely to have one. Both new sets are therefore anchored on the resolved data home as well, sharing the resolution that previously existed for the governance cache alone. It keeps that helper's `normpath`-not-`realpath` discipline on purpose: this runs on the event loop for every async spawn, and a link-resolving syscall on a stalled NFS home would freeze the gateway with its liveness heartbeat. A symlinked home therefore yields one redundant rule for a path that is covered either way, never a missing one.

## Residual limitation

The trusted in-sandbox MCP servers share one mount namespace with the untrusted agent shell, so the class-(b) exceptions remain reachable by a shell command. Closing that needs process separation, not a mount rule; it is out of scope here. The read-only tier is what shrinks the blast radius today: the agent can no longer *rewrite* its own ceiling on any backend.

A second residual, raised in review and left open deliberately: a path-based mount rule can seal a ceiling that **exists**, but it cannot stop a child from **creating** an absent one. Creating `~/.kiro/crew/computer_use.json` is a write to the crew-home *directory*, and that directory has to stay writable (`sessions.db`, `config.json`). This is unchanged by this PR — the child could create *and* rewrite those files before it — so the diff strictly reduces exposure. Closing the create vector needs the gateway to prime the keystones before spawn, which changes governance semantics for `security_policy.json` (absent and empty are not the same ceiling) and belongs in its own change. Tracked as [#7676](https://github.com/kirodotdev/KiroCrew/issues/7676) with a per-leaf decision list and acceptance criteria, and waived on this PR via `/ai-review override gpt` rather than left silent.

## Verification

- New `test/test_sandbox_governance_mask.py` (269 cases): keystones read-only per mode **and** per backend, secret leaves masked in **both** launcher loops (a file entry reaching only the dir loop is skipped by its `isdir` guard), the read-write exception set exactly equal to the declared one, dispositions non-overlapping, and the third-party tiering unchanged.
- **Revert-verified**, three break-arms: empty the derived mask → masking + reconciliation guards fail; empty the read-only set → read-only guards fail; restore the `isdir` guard → the file-shaped-ceiling guard fails. Tree restored from an in-memory snapshot each time.
- Two pre-existing `READONLY_DIRS` equality pins in `test_governance_distribution.py` narrowed to their actual intent (`>=` plus "this path is absent"); the equality was incidental to when the voice-runtime parent was the only entry.
- `test_sandbox_mount_checked.py` break-arm strings follow the widened refusal text.

### Local gates

| Gate | Result |
|---|---|
| `pytest` (full) | 78539 passed · 94 failed |
| `isort --check-only` | pass |
| `flake8` | pass |
| `mypy src/kiro_crew/` | pass, 1220 files |
| `npx tsc -b` | pass |
| `npx vitest run` | 27171 passed |
| `check_black_formatting.py` | pass |
| brand / focus-cue / changelog / harness-parity / loop-bound / testpaths | pass (each with its base ref exported) |
| `scrub-lint.sh`, `docs_lint.py` | pass |

The 94 pytest failures are **pre-existing on this host and unrelated** — file explorer, playwright installer, PR-readiness workflow, service ownership, macOS release, peer-auth unix sockets. Verified by restoring the three touched files to `origin/main` content and re-running the same sets on the same host: identical counts both halves (48/1227 and 30/2157). None are in a sandbox, governance, or security file.

## Pattern harvest

Rule candidate: semgrep — a read-only/seal loop guarded on `os.path.isdir(target)` when its target set can contain plain files. The guard silently skips every file entry: the caller asked for the path to be sealed, got no error, and it stayed writable. The same shape already caused the documented `SENSITIVE_DIRS` file-entry bug this module comments on, so it has now happened twice in one file.

Rule candidate: grep/semgrep — a `$HOME`-relative path list in `sandbox.py` with no `config_dir()`-anchored companion. `KIROCREW_HOME` relocates the data home out from under every `Path.home()`-joined entry, so a new rule added to those lists covers nothing on a relocated fleet. `_relocated_policy_cache_dirs` existed for exactly this reason but was scoped to one leaf, which is why the second occurrence was not caught by its presence.

