### PR TITLE
fix(security): gate traversals that reach a fence without find

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -8613,6 +8613,11 @@ def is_sensitive_bash_command(
     if native_result:
         return native_result
 
+    # ── Pass 4: alternate traversal tools rooted above a fenced path ──
+    alt_result = _check_alt_traversal_reaches_fence(command)
+    if alt_result:
+        return alt_result
+
     # IMDS access via any IP encoding (decimal, hex, octal, IPv6-mapped)
     imds_result = _check_imds_access(command, enabled_ids=enabled_ids)
     if imds_result:
@@ -14706,6 +14711,1837 @@ _IMDS_IP = "169.254.169.254"
 # because canonicalize_ip returns native IPv6 unchanged; mirrors embeddings.py's
 # SSRF gate which also blocks it (CWE-918 dual-stack parity).
 _IMDS_IPV6 = "fd00:ec2::254"
+
+
+# ── Alternate traversal tools that reach a fenced path ──
+#
+# ``find`` is not the only program that factors a fenced path into a root plus a
+# name and then hands the result to a reader, and each tool spells the same shape
+# with its own grammar::
+#
+#     fd '^\.env$' ~/.kiro/crew -x cat        positional regex, exec is -x/-X
+#     fd -e key . ~/.kiro/crew -X cat         extension filter, batched exec
+#     grep -r secret ~/.kiro/crew             the reader IS the traversal
+#     rg --files ~/.kiro/crew | xargs cat     --files makes ripgrep a lister
+#     du -a ~/.kiro/crew | xargs cat          size lister used as a path producer
+#
+# The question this pass asks is the reverse-direction one
+# :func:`path_contains_sensitive` already answers for bulk operations -- does the
+# root HOLD a fenced path -- so a recursive read rooted above a credential store
+# is refused whatever name it goes looking for. A recursive read delivers every
+# file under its root, so narrowing by the pattern cannot make the store
+# unreachable: ``grep -r`` opens ``.env`` regardless of which lines it prints.
+#
+# This is NOT a producer allow-list and must not become one. Enumerating the
+# programs that are SAFE fails OPEN, because every tool nobody thought of reads as
+# covered. Each grammar below only ever ADDS a denial, so a traversal tool this
+# pass does not know is exactly as gated as it was before, and the shapes still
+# open are named in the residuals rather than half-closed:
+#
+#   * ``locate``/``plocate`` have NO root operand -- the database supplies the
+#     path -- so the root-containment clause every rule here rests on has nothing
+#     to test. Its pattern alone would have to carry the signal, and a pattern
+#     test recognising only the leaf names the fence DECLARES would still miss
+#     ``locate id_rsa | xargs cat`` (``.ssh`` is fenced as a whole directory, so
+#     no leaf name is declared for it) while reading as covered. Naming it here is
+#     the honest half of that trade.
+#   * A name list delivered through a command substitution (``cat $(fd …)``) or a
+#     ``while read`` loop instead of ``xargs``.
+#   * A whole-directory COPIER rooted at the fence: ``tar -cf out.tar
+#     ~/.kiro/crew``, ``cp -r ~/.kiro/crew /tmp``, ``zip -r``, or a direct
+#     ``rsync -r`` (as opposed to the lister-pipe spelling, which IS covered
+#     because ``rsync`` reads as a sink there). These reach the same bytes without
+#     searching for them, so they are the same delivery with a different verb --
+#     but treating copiers as traversals is a new program class with its own false
+#     positives (``cp -r ./src /tmp`` must stay allowed, and a copier names its
+#     DESTINATION as an operand too), which is a separate change rather than one
+#     more entry here. Named so this list does not read as complete.
+#   * A traversal that names no root at all AFTER a ``cd`` into the fence
+#     (``cd ~/.kiro/crew; rg secret``). A root spelled relative to a ``cd`` IS
+#     covered -- the bases that ``cd`` moves to are collected and relative roots are
+#     joined onto them -- but with no operand at all there is nothing to join, and
+#     the working directory this pass can see is the gateway's rather than the
+#     shell's. The explicit-root spelling of the same read is denied here, and the
+#     no-root one is denied by the cd-taint pass.
+#   * A traversal that names NO root at all, reached through a word this pass does
+#     not recognise as something-that-runs-a-program (``busybox rg secret``,
+#     ``stdbuf -o L rg secret``). The traversal itself is still FOUND -- it is
+#     matched by its own name wherever it sits -- but a reading that was not in the
+#     program position is not allowed to assume the working directory, because a
+#     bare mention of a program name is ordinary text (``which rg``,
+#     ``sudo cp rg /usr/bin/``) and assuming it would refuse those outright
+#     whenever the gateway runs from a directory that holds the crew home. Every
+#     spelling that NAMES its root is covered whatever precedes it.
+#
+# Cost, stated plainly: a recursive content read rooted at the crew data-home or
+# its workspace root is refused, because both hold declared credential leaves
+# (``.env``, ``token_signing.key``, the Notes vault's PAT). Scoping the read to a
+# subdirectory that holds none of them is allowed and is the intended spelling.
+
+#: ``fd`` and the Debian/Ubuntu name for the same binary.
+_FD_PROGRAM_NAMES: frozenset[str] = frozenset({"fd", "fdfind"})
+
+#: ``fd``'s ``find -exec`` equivalents. Presence of any of these makes the
+#: traversal deliver file CONTENT rather than a name list, so no separate sink is
+#: needed for the read to happen.
+_FD_EXEC_FLAGS: frozenset[str] = frozenset({"-x", "-X", "--exec", "--exec-batch"})
+
+#: GNU grep and its aliases. ``rgrep`` is recursive without a flag.
+#: ``ugrep`` is GNU-compatible: it takes a pattern and needs ``-r``/``--recursive``
+#: to walk, so it shares grep's grammar and grep's recursion test rather than
+#: needing a rule of its own.
+_GREP_PROGRAM_NAMES: frozenset[str] = frozenset(
+    {"grep", "egrep", "fgrep", "ugrep"}
+)
+
+#: Greppers that recurse with NO flag at all, so naming the root is the whole
+#: command. ``ag`` (the_silver_searcher) and ``ack`` belong here for the same reason
+#: ``rgrep`` does, and leaving them out made the fix one renamed binary wide: this
+#: module already names both in :data:`_DATA_CONSUMER_PROGRAMS`, so they were known
+#: tools sitting outside the only set that would have caught them.
+_ALWAYS_RECURSIVE_GREP_NAMES: frozenset[str] = frozenset(
+    {"rgrep", "ag", "ack", "ack-grep"}
+)
+
+#: The long spellings that turn grep into a traversal. The short forms are
+#: recognised by scanning cluster letters (``-rn`` is ``-r -n``), which a set of
+#: whole tokens cannot see.
+_GREP_RECURSIVE_LONG_FLAGS: frozenset[str] = frozenset(
+    {"--recursive", "--dereference-recursive"}
+)
+
+#: GNU grep's OTHER recursive switch: ``-d recurse`` / ``--directories=recurse``
+#: sets the directory ACTION rather than passing a recursion flag, and it
+#: traverses exactly as ``-r`` does. Its argument is what carries the meaning, so
+#: the value is matched rather than the flag.
+_GREP_DIRECTORIES_FLAGS: frozenset[str] = frozenset({"-d", "--directories"})
+_GREP_RECURSE_ACTION = "recurse"
+
+#: ripgrep, which is recursive with no flag at all.
+_RIPGREP_PROGRAM_NAMES: frozenset[str] = frozenset({"rg"})
+
+#: ripgrep's pure-lister mode: ``--files`` prints paths without opening them, so
+#: it needs a sink before anything is disclosed. ``-l``/``--files-with-matches``
+#: is NOT here -- it still opens every file to decide whether to print it.
+_RIPGREP_LISTER_FLAGS: frozenset[str] = frozenset({"--files"})
+
+#: Flags that supply the search pattern, so the first positional is a ROOT rather
+#: than the pattern. Getting this wrong in the other direction is what matters:
+#: with one of these present, nothing is exempted from the root test.
+_PATTERN_SUPPLYING_FLAGS: frozenset[str] = frozenset(
+    {"-e", "--regexp", "-f", "--file", "--files", "--type-list"}
+)
+
+#: The subset of the above whose pattern arrives as a VALUE. ``--files`` and
+#: ``--type-list`` are modes that take no argument, so consuming the next word
+#: after them would swallow a root.
+_PATTERN_VALUE_FLAGS: frozenset[str] = frozenset(
+    {"-e", "--regexp", "-f", "--file"}
+)
+
+#: Flags whose value IS a traversal root. Their value is always tested, never
+#: exempted as the pattern: ``fd --search-path ~/.kiro/crew '^\.env$' -x cat``
+#: puts the root in the first positional slot, so a pattern exemption that only
+#: counted positionals skipped the root itself.
+_ROOT_SUPPLYING_FLAGS: frozenset[str] = frozenset(
+    {"--search-path", "--base-directory"}
+)
+
+#: Programs whose whole job is to emit paths under a root. Harmless alone; they
+#: matter when a sink turns the list into content.
+_PATH_LISTER_PROGRAMS: frozenset[str] = frozenset({"du"})
+
+#: Programs that take the name list on stdin and run a command per name, which is
+#: what converts a lister into a read.
+_NAME_LIST_EXEC_PROGRAMS: frozenset[str] = frozenset({"xargs", "parallel"})
+
+#: Anything that opens a file it is handed. Union of the two sets the module
+#: already maintains so a verb added to either reaches this pass with no second
+#: edit.
+#: Readers the two module sets above do not carry, because those sets answer a
+#: different question -- which VERB names a read in a path-shaped command -- while
+#: this one asks which program, handed a file NAME, emits its bytes. Omission here
+#: is fail-OPEN: a lister piped into an unlisted reader reads as emitting names
+#: only. So the boundary is drawn generously, and includes the compressors and
+#: digest tools, whose output is a faithful copy of a file for anyone who can read
+#: it back.
+_ALT_EXTRA_READER_PROGRAMS: frozenset[str] = frozenset(
+    {
+        # `git hash-object -w` writes each file's CONTENT into a readable repository
+        # object and `git cat-file` prints it back; `rsync --files-from=-` copies the
+        # named files wholesale. Measured before adding: of fifteen reader spellings
+        # probed, twelve already denied, so these are the holes in a near-complete
+        # set rather than the start of an open-ended table.
+        "git",
+        "rsync",
+        "dd",
+        "install",
+        "shred",
+        "split",
+        "csplit",
+        "iconv",
+        "expand",
+        "unexpand",
+        "rev",
+        "pr",
+        "fmt",
+        "base32",
+        "basenc",
+        "cksum",
+        "sum",
+        "b2sum",
+        "shasum",
+        "sha1sum",
+        "sha224sum",
+        "sha384sum",
+        "sha512sum",
+        "openssl",
+        "gzip",
+        "gunzip",
+        "zcat",
+        "bzip2",
+        "bunzip2",
+        "bzcat",
+        "xz",
+        "unxz",
+        "xzcat",
+        "zstd",
+        "zstdcat",
+        "lz4",
+        "tar",
+        "cpio",
+        "cmp",
+        "vimdiff",
+        "hexdump",
+        "bat",
+        "batcat",
+    }
+)
+
+#: Anything that opens a file it is handed.
+_ALT_CONTENT_READER_PROGRAMS: frozenset[str] = (
+    _NORMALIZER_READ_VERBS | _DATA_CONSUMER_PROGRAMS | _ALT_EXTRA_READER_PROGRAMS
+)
+
+#: ``env``'s directory flag. Its value is a directory the command is run FROM, so
+#: it is a traversal base rather than an operand to skip past.
+_ENV_CHDIR_FLAGS: frozenset[str] = frozenset({"-C", "--chdir"})
+
+#: ``env``'s command-string flag. Its value is a whole command rather than an
+#: operand, so the payload is re-tokenized as its own stages.
+_ENV_COMMAND_STRING_FLAGS: frozenset[str] = frozenset({"-S", "--split-string"})
+
+#: Words that mean "run the thing that follows". Peeling them is what keeps
+#: ``command grep -r . ~/.kiro/crew`` from being read as a stage that runs
+#: ``command``, which no rule here matches. The same three the ``cd`` walk
+#: unwraps, plus ``exec``, which replaces the shell with the traversal.
+_ALT_EXEC_WRAPPER_PROGRAMS: frozenset[str] = frozenset(
+    {"builtin", "command", "exec", "&"}
+)
+
+#: ``exec -a NAME prog`` takes a value, so the name must be skipped with the flag
+#: or it is read as the program.
+_ALT_WRAPPER_VALUE_FLAGS: frozenset[str] = frozenset({"-a"})
+
+#: Programs that run the argv that FOLLOWS them, adjusting only how it runs.
+#: ``nice grep -r . ~/.kiro/crew`` is the same read as the bare ``grep``, and
+#: reading the first word as the program saw ``nice`` and matched no rule.
+#: Unlike :data:`_ALT_EXEC_WRAPPER_PROGRAMS` these are ordinary programs rather
+#: than shell builtins, but for this pass they play one role: whatever follows is
+#: the traversal.
+_ALT_ARGV_FORWARDING_PROGRAMS: frozenset[str] = frozenset(
+    {
+        "nice",
+        "nohup",
+        "stdbuf",
+        "setsid",
+        "ionice",
+        "chrt",
+        "taskset",
+        "time",
+        "timeout",
+        "sudo",
+        "doas",
+    }
+)
+
+#: A wrapper's own POSITIONAL argument, which is not the program: ``timeout``'s
+#: duration (``5``, ``1.5m``), ``taskset``'s CPU mask (``0x3``), ``chrt``'s
+#: priority. Matched by SHAPE rather than by a per-wrapper table, because a table
+#: entry omitted is a wrapper whose duration gets read as the program word.
+_ALT_WRAPPER_OPERAND_RE = re.compile(
+    r"\A(?:[0-9]+(?:\.[0-9]+)?[smhd]?|0[xX][0-9a-fA-F]+)\Z"
+)
+
+#: Executable suffixes Windows appends to a program name. ``_program_basename``
+#: deliberately leaves them on -- the checks that care spell them in their own
+#: pattern (``_SELF_PROGRAM_RE``, ``_PYTHON_PROGRAM_RE``) -- so this pass strips
+#: them itself, otherwise ``grep.exe -r . ~/.kiro/crew`` matched no rule.
+_ALT_WINDOWS_EXE_SUFFIXES: tuple[str, ...] = (".exe", ".com", ".bat", ".cmd")
+
+#: ``env``'s own options, split by whether the value is a separate word. Skipping
+#: them is what keeps ``env -i grep -r . ~/.kiro/crew`` from reading ``-i`` as the
+#: program; a spelling missing from the value set costs one skipped operand, never
+#: a missed program, because the scan stops at the first non-flag word either way.
+_ENV_VALUE_FLAGS: frozenset[str] = frozenset(
+    {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+)
+
+#: Every program name this pass treats as a traversal. A stage is scanned for one
+#: of these ANYWHERE in it rather than only in the program position, because
+#: everything that can sit in front of a program -- a wrapper, an applet
+#: dispatcher, a wrapper option's value -- is an unbounded set, and enumerating it
+#: put the miss one unlisted spelling away (``stdbuf -o L grep -r``,
+#: ``busybox grep -r``, ``timeout -s KILL 5 rg``).
+_ALT_TRAVERSAL_PROGRAMS: frozenset[str] = (
+    _FD_PROGRAM_NAMES
+    | _GREP_PROGRAM_NAMES
+    | _ALWAYS_RECURSIVE_GREP_NAMES
+    | _RIPGREP_PROGRAM_NAMES
+    | _PATH_LISTER_PROGRAMS
+)
+
+#: Every name this pass ROUTES a decision on -- the traversals, the name-list
+#: executors that turn a lister into a read, the shells and verbs that carry a
+#: command string, and ``env``. A word in any of these roles can arrive through a
+#: variable, so resolution has to cover the whole set and not just the traversals:
+#: an unresolved ``$X`` in the executor slot hid a sink, and an unresolved ``$S`` in
+#: the shell slot hid a payload.
+_ALT_ROUTED_PROGRAMS: frozenset[str] = (
+    _ALT_TRAVERSAL_PROGRAMS
+    | _NAME_LIST_EXEC_PROGRAMS
+    | _NESTED_SHELL_PROGRAMS
+    | _NESTED_SHELL_VERBS
+    | _ENV_SPLIT_PROGRAMS
+)
+
+#: How many operands one unit of construction budget pays for. Building a reading
+#: copies the operand tail, so the cost is proportional to its length rather than
+#: flat: charging one unit per token left 3,000 tokens building 3,000 slices of
+#: 3,000 entries, which is the O(N^2) MEMORY half of the wedge. Sized so an ordinary
+#: command -- a handful of operands -- still charges a single unit.
+_ALT_OPERANDS_PER_UNIT = 64
+
+#: How short an abbreviation of a GNU long option is honoured. getopt_long accepts
+#: any UNAMBIGUOUS prefix, so ``--rec`` and ``--recurs`` are ``--recursive`` and a
+#: set of whole tokens saw neither. Ambiguity is judged against the flags this pass
+#: knows rather than against the tool's full option table, which over-matches in
+#: the denial direction only; the floor keeps ``--r`` from standing for anything.
+_ALT_MIN_LONG_FLAG_PREFIX = 3
+
+#: How deep a nested command-string payload is followed. A shell inside a shell is
+#: a real spelling and stacking them is the obvious way to bury a traversal, so the
+#: limit is generous; :data:`_ALT_MAX_STAGES` is what actually bounds the work, so
+#: depth does not have to be tight to keep an attacker-shaped string cheap.
+_ALT_NESTED_DEPTH_LIMIT = 12
+
+#: Ceiling on the stages collected from one command. Payload extraction branches,
+#: so depth alone bounds the walk's height and not its width.
+_ALT_MAX_STAGES = 512
+
+#: Ceiling on how many variable RESOLUTIONS one command may cost. Every operand is
+#: tried against every value every name it mentions was ever assigned, which is a
+#: product -- and a single stage can carry thousands of prefix assignments without
+#: tripping :data:`_ALT_MAX_STAGES`, because it is still one stage. Measured before
+#: this bound existed: k=200 cost 1.1s, k=600 cost 11s, k=1500 cost 62s of
+#: SYNCHRONOUS CPU. This gate runs on the gateway's single asyncio loop, so that is
+#: not slowness, it is a wedge -- the shape the module's own pass-1b comment records
+#: as a prior production hang. The budget is far above any real command (a handful
+#: of variables against a handful of roots) and exhausting it REFUSES.
+_ALT_MAX_RESOLUTIONS = 4096
+
+
+class _AltWorkBudget:
+    """One command's budget for the alt-traversal walk, charged from every axis.
+
+    The first version of this budget counted only variable resolutions, and it was
+    decremented inside the assignment-HISTORY loop -- which never runs for a command
+    that assigns nothing. That left the readings x operands product unbounded, so a
+    single stage of repeated traversal words (``rg rg … rg /tmp``) spent 21 seconds
+    of synchronous CPU on the event loop for a 1.8 KB string while every declared
+    budget read as untouched.
+
+    So the budget is per COMMAND rather than per call, and it is charged wherever
+    the walk does real work: each operand examined, each expansion reading tried,
+    each candidate handed to :func:`path_contains_sensitive`. Whichever dimension an
+    attacker grows, the same counter runs out.
+
+    Two ways to spend, because the walk has two kinds of caller -- but only ONE
+    meaning for running out:
+
+    * :meth:`spend` raises, for code inside the main loop's ``try``;
+    * :meth:`charge` reports, for callers that run OUTSIDE that ``try`` and must not
+      raise past it.
+
+    Both record :attr:`exhausted`, and :func:`_check_alt_traversal_reaches_fence`
+    refuses whenever it is set. That single flag is the whole point of this class's
+    third revision. The previous version let :meth:`drain` return False and had each
+    caller "stop enumerating and return what they have", which reads as prudent and
+    is a FAIL-OPEN: a 5,000-token padding stage spent the budget, the traversal
+    token-scan that is the only catcher of an applet-dispatched grep was silently
+    dropped, and ``busybox grep -r secret ~/.kiro/crew`` was allowed. That was the
+    third limit in this PR whose exhaustion path failed open (the round-5 stage
+    budget and the round-12 brace cap were the other two, each introduced while
+    fixing the previous one), so the fix is the CLASS: running out of budget can no
+    longer be expressed as a smaller answer, only as a refusal.
+
+    :func:`_alt_pipeline_stages_bounded` already had this shape for stage
+    truncation; this makes the two agree.
+    """
+
+    __slots__ = ("remaining", "exhausted")
+
+    def __init__(self, total: int) -> None:
+        self.remaining = total
+        self.exhausted = False
+
+    def spend(self, reason: str = "work") -> None:
+        """Charge one unit, raising :class:`_AltResolutionBudget` when overdrawn."""
+        self.remaining -= 1
+        if self.remaining < 0:
+            self.exhausted = True
+            raise _AltResolutionBudget(reason)
+
+    def charge(self, units: int = 1) -> bool:
+        """Charge *units*; False once overdrawn. Never raises, always RECORDS.
+
+        Takes an amount because some work is proportional rather than flat: building
+        one reading copies an operand tail, so a stage with a huge tail must pay for
+        it or the memory grows quadratically while a per-item counter reads as
+        barely touched.
+
+        A False return means the caller must stop, and it also means the command can
+        no longer be judged -- which is why it sets :attr:`exhausted` rather than
+        leaving the caller to decide what a partial answer means.
+        """
+        if self.remaining <= 0:
+            self.exhausted = True
+            return False
+        self.remaining -= max(1, units)
+        if self.remaining <= 0:
+            self.exhausted = True
+        return True
+
+
+class _AltResolutionBudget(Exception):
+    """Raised when a command's variable resolution exceeds its budget.
+
+    Carried as an exception rather than a sentinel return so the refusal cannot be
+    mistaken for "no fenced root found" by any caller in the chain.
+    """
+
+
+def _alt_pipeline_stages(command: str, depth: int = 0) -> list[list[str]]:
+    """Split *command* into per-stage token lists.
+
+    Segments come from :func:`_split_shell_segments` (quote-aware, and it declines
+    to split inside a substitution), then each segment is split again on an
+    unquoted ``|`` because a pipeline's stages are separate programs and this pass
+    identifies a program by its own first token.
+
+    A command STRING carried as a flag value -- ``sh -c '…'``, ``env -S '…'`` -- is
+    re-tokenized and its stages appended, bounded by
+    :data:`_ALT_NESTED_DEPTH_LIMIT`. Without that, wrapping the traversal in a
+    shell hid it completely: the outer stage's program is ``sh`` and the real
+    command was just one quoted operand.
+
+    Stages are returned FLAT, with no record of which pipeline they belonged to.
+    That is deliberate: the sink test below asks whether the command contains a
+    reader anywhere, and over-approximating across a ``&&`` boundary can only add
+    a denial. Pairing each lister with only its own downstream stages would be the
+    narrower answer and is not worth the grammar.
+    """
+    stages, _truncated = _alt_pipeline_stages_bounded(command, depth)
+    return stages
+
+
+def _alt_pipeline_stages_bounded(
+    command: str, depth: int = 0, assignments: dict[str, str] | None = None
+) -> tuple[list[list[str]], bool]:
+    """*command*'s stages, plus whether the stage budget cut the walk short.
+
+    The budget exists so an attacker-shaped string cannot make this pass expensive,
+    but dropping the stages past it silently made the budget itself the bypass:
+    600 copies of ``echo x`` in front of ``rg . ~/.kiro/crew`` pushed the traversal
+    past the cap, so it was never inspected. The caller is told, so exhaustion
+    becomes a REFUSAL rather than a gap -- a command with this many stages is not a
+    shape anyone types, so denying it costs nothing real.
+    """
+    stages: list[list[str]] = []
+    _alt_collect_stages(command, depth, stages, assignments)
+    return stages, len(stages) >= _ALT_MAX_STAGES
+
+
+def _alt_collect_stages(
+    command: str,
+    depth: int,
+    stages: list[list[str]],
+    assignments: dict[str, str] | None = None,
+) -> None:
+    """Append *command*'s stages, and its payloads' stages, to *stages*.
+
+    Recursion is bounded by BOTH the depth limit and the running length of
+    *stages*, which is why the accumulator is threaded through rather than each
+    level returning its own list: payload extraction branches, so a per-level
+    depth cap bounds only the height of the walk.
+    """
+    for segment in _split_shell_segments(command):
+        for piece in _split_unquoted_pipes(segment):
+            if not piece.strip():
+                continue
+            if len(stages) >= _ALT_MAX_STAGES:
+                return
+            try:
+                tokens = normalize_shell_command(piece)
+            except Exception:
+                continue
+            if not tokens:
+                continue
+            stages.append(tokens)
+            if depth < _ALT_NESTED_DEPTH_LIMIT:
+                for payload in _alt_command_string_payloads(tokens, assignments):
+                    _alt_collect_stages(payload, depth + 1, stages, assignments)
+
+
+def _alt_command_string_payloads(
+    tokens: list[str], assignments: dict[str, str] | None = None
+) -> list[str]:
+    """The command STRINGS these tokens carry as a flag value.
+
+    ``sh -c 'cat "$@"'`` and ``env -S 'grep -r . ~/.kiro/crew'`` both hold a whole
+    command where an operand would normally sit, so the text has to be read as a
+    command rather than as data.
+
+    The scan looks for the SHELL (or ``env``) token itself and then reads that
+    program's own grammar, rather than treating a bare ``-c`` as a command-string
+    flag wherever it appears. Two reasons, and both matter: ``-c`` means something
+    else entirely on other programs (``head -c 100``, ``wc -c``), and a shell's
+    ``-c`` clusters with its other short options -- ``bash -lc 'rg . ~/.kiro/crew'``
+    is the spelling a tool actually emits, and matching the whole token missed it.
+
+    :func:`_nested_shell_payloads` -- the extractor the self-protection floor
+    already uses -- is unioned in rather than replaced by the scan above, because
+    the two cover different spellings and a payload missed is a traversal never
+    looked at. It adds a shell reached through a variable (``$SHELL -c``), a
+    herestring (``bash <<< '…'``), a payload after ``-c --``, an array expansion run
+    as a command line, GNU ``sed``'s ``s///e`` replacement, and a multiword alias.
+    The scan above adds the one it declines: a payload GLUED to a short cluster
+    (``sh -c'rg . …'``), whose token holds characters its flag pattern rejects.
+    Extracting text that turns out not to be a command costs nothing here -- it
+    re-tokenizes to stages that match no traversal rule. The result is de-duplicated
+    because the two extractors agree on most spellings, and re-staging one payload
+    twice doubles the walk below it for no new reading.
+    """
+    payloads: list[str] = list(_nested_shell_payloads(tokens))
+    for index, token in enumerate(tokens):
+        # Resolved, not literal: `S=sh; "$S" -c '…'` carries a payload and the
+        # literal `$S` named no shell.
+        program = _alt_resolved_program_word(token, assignments or {})
+        if program in _NESTED_SHELL_PROGRAMS:
+            payloads.extend(_alt_shell_c_payloads(tokens[index + 1 :]))
+        elif program in _ENV_SPLIT_PROGRAMS:
+            payloads.extend(_alt_env_s_payloads(tokens[index + 1 :]))
+        elif program in _NESTED_SHELL_VERBS:
+            # `eval` and `source`/`.` take the command as ORDINARY operands rather
+            # than as a flag value, and bash joins them with a space before
+            # executing. Quoting the whole thing (`eval 'rg . ~/.kiro/crew'`) is
+            # the spelling that hid the traversal completely: the stage's own
+            # tokens are `eval` and one opaque word.
+            operands = [word for word in tokens[index + 1 :] if not word.startswith("-")]
+            if operands:
+                payloads.append(" ".join(operands))
+    deduped: list[str] = []
+    for payload in payloads:
+        if payload not in deduped:
+            deduped.append(payload)
+    return deduped
+
+
+def _alt_shell_c_payloads(argv: list[str]) -> list[str]:
+    """The command strings a shell's ``-c`` carries, in every spelling of it.
+
+    ``-c`` takes a value, so it ends a short-option cluster: the command is either
+    glued onto the cluster (``-c'cmd'``) or the next word (``-c 'cmd'``,
+    ``-lc 'cmd'``).
+    """
+    payloads: list[str] = []
+    for index, token in enumerate(argv):
+        if token.startswith("--"):
+            continue
+        if not token.startswith("-") or len(token) < 2:
+            continue
+        cluster = token[1:]
+        position = cluster.find("c")
+        if position == -1:
+            continue
+        glued = cluster[position + 1 :]
+        if glued:
+            payloads.append(glued)
+            bound = _alt_positional_bound_payload(glued, argv[index + 1 :])
+            if bound:
+                payloads.append(bound)
+        elif index + 1 < len(argv):
+            payloads.append(argv[index + 1])
+            # The words AFTER the command string are its positional parameters.
+            bound = _alt_positional_bound_payload(
+                argv[index + 1], argv[index + 2 :]
+            )
+            if bound:
+                payloads.append(bound)
+    return payloads
+
+
+def _alt_env_s_payloads(argv: list[str]) -> list[str]:
+    """The command strings ``env``'s ``--split-string`` carries."""
+    payloads: list[str] = []
+    for index, token in enumerate(argv):
+        flag, sep, glued = token.partition("=")
+        if sep and flag in _ENV_COMMAND_STRING_FLAGS:
+            if glued:
+                payloads.append(glued)
+            continue
+        if token in _ENV_COMMAND_STRING_FLAGS:
+            if index + 1 < len(argv):
+                payloads.append(argv[index + 1])
+            continue
+        if token.startswith("-S") and len(token) > 2:
+            payloads.append(token[2:])
+    return payloads
+
+
+def _split_unquoted_pipes(segment: str) -> list[str]:
+    """Split on ``|`` outside quotes, leaving ``||`` alone.
+
+    ``_split_shell_segments`` consumes ``||`` as a separator before this runs, so
+    a doubled bar does not normally arrive here. It is still handled, so the
+    helper is correct on any fragment rather than only on that caller's output.
+
+    ``|&`` is bash's pipe-with-stderr and is ONE operator: consuming only the bar
+    left ``&`` as the next stage's first word, so the reader after it was never
+    looked at (``rg --files ~/.kiro/crew |& xargs cat``).
+
+    A BARE ``&`` backgrounds what precedes it and starts a new command, so it is a
+    separator too. ``_split_shell_segments`` breaks on ``&&`` but not on one ``&``,
+    which left ``echo start & grep -r secret ~/.kiro/crew`` as a single stage whose
+    program read as ``echo`` -- anything placed before the ``&`` hid the traversal
+    after it. An ``&`` belonging to a redirection (``2>&1``, ``>&2``) is NOT a
+    separator, so a preceding ``>`` or ``<`` keeps it joined.
+    """
+    pieces: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(segment)
+    while i < n:
+        ch = segment[i]
+        if quote is not None:
+            buf.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < n:
+                buf.append(segment[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < n:
+            buf.append(ch)
+            buf.append(segment[i + 1])
+            i += 2
+            continue
+        if ch == "|":
+            pieces.append("".join(buf))
+            buf = []
+            # `||` and `|&` are both two-character operators; step over the second
+            # character so it does not become the next stage's program word.
+            i += 2 if i + 1 < n and segment[i + 1] in ("|", "&") else 1
+            continue
+        if ch == "&":
+            # `&&` is already a segment separator upstream, and an `&` that belongs
+            # to a redirection is data, not a separator.
+            previous = "".join(buf).rstrip()
+            if (i + 1 < n and segment[i + 1] == "&") or previous.endswith((">", "<")):
+                buf.append(ch)
+                i += 1
+                continue
+            pieces.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    pieces.append("".join(buf))
+    return pieces
+
+
+def _alt_program_word(token: str) -> str:
+    """The program *token* names, lowercased, with a Windows suffix removed.
+
+    ``_program_basename`` keeps ``.exe`` on purpose, so every comparison in this
+    pass would miss the Windows spelling of the same program.
+    """
+    program = _program_basename(token).lower()
+    for suffix in _ALT_WINDOWS_EXE_SUFFIXES:
+        if program.endswith(suffix):
+            return program[: -len(suffix)]
+    return program
+
+
+_ALT_GLOB_METACHARS = "*?["
+_ALT_MAX_BRACE_ALTERNATIVES = 16
+
+
+def _alt_brace_expansions(candidate: str) -> list[str]:
+    """*candidate* with its FIRST brace group expanded into alternatives.
+
+    One level is deliberate. Nested braces multiply, and this is a fail-closed
+    check: each alternative is tested on its own, so a nested group that stays
+    unexpanded still leaves a wildcard or a literal for the caller to answer.
+    """
+    open_at = candidate.find("{")
+    if open_at == -1:
+        return [candidate]
+    close_at = candidate.find("}", open_at)
+    if close_at == -1:
+        return [candidate]
+    body = candidate[open_at + 1 : close_at]
+    if not body or "," not in body:
+        return [candidate]
+    prefix, suffix = candidate[:open_at], candidate[close_at + 1 :]
+    alternatives = body.split(",")
+    expansions = [
+        f"{prefix}{alternative}{suffix}"
+        for alternative in alternatives[:_ALT_MAX_BRACE_ALTERNATIVES]
+    ]
+    if len(alternatives) > _ALT_MAX_BRACE_ALTERNATIVES:
+        # Dropping the overflow silently made the cap the bypass: padding a brace
+        # with 16 harmless alternatives pushed the fenced one out of range and the
+        # gate answered no while bash expanded it anyway. Every other overflow in
+        # this pass fails CLOSED, so this one does too -- by emitting the group's
+        # own parent, which is the same containment answer the wildcard branch
+        # gives, rather than by raising the cap to the next number an attacker
+        # would exceed.
+        parent = os.path.dirname(prefix)
+        if parent:
+            expansions.append(parent)
+    return expansions
+
+
+def _alt_glob_root_readings(candidate: str) -> list[str]:
+    """The paths a GLOB or BRACE root could expand to, as far as text can say.
+
+    The shell expands ``rg . ~/.kiro/cr*`` before this gate is ever asked, so the
+    literal candidate holds no fence and answered no while ripgrep walked the crew
+    home. Two expansions, each a concrete path the shell will really try:
+
+    * brace alternatives are enumerated, because ``~/.kiro/{crew,other}`` names the
+      crew home outright in one of them;
+    * a wildcard is answered by the directory that CONTAINS it. Which entries
+      ``cr*`` matches depends on the filesystem at run time, so the honest question
+      is whether the directory being globbed holds a fenced path -- exactly the
+      question this pass asks of every other root.
+
+    That second rule is fail-closed by construction: a glob whose parent holds the
+    fence is refused even when the pattern would not have matched the fenced entry
+    (``*`` skips dotfiles, so ``~/*`` misses ``.kiro``). Scoping the read to a
+    subdirectory is the same spelling this pass already asks for elsewhere, and the
+    alternative -- expanding globs against the real filesystem inside a security
+    gate -- makes the answer depend on directory contents at check time.
+
+    A candidate with no metacharacter returns nothing, so an ordinary path costs one
+    scan of its own characters.
+    """
+    if not candidate or not any(ch in candidate for ch in "*?[{"):
+        return []
+    readings: list[str] = []
+    for expanded in _alt_brace_expansions(candidate):
+        cuts = [expanded.index(ch) for ch in _ALT_GLOB_METACHARS if ch in expanded]
+        if not cuts:
+            if expanded not in readings:
+                readings.append(expanded)
+            continue
+        parent = os.path.dirname(expanded[: min(cuts)])
+        if parent and parent not in readings:
+            readings.append(parent)
+    return readings
+
+
+def _alt_positional_bound_payload(payload: str, argv: list[str]) -> str | None:
+    """*payload* with the shell's POSITIONAL parameters substituted.
+
+    ``bash -c 'rg . "$1"' _ ~/.kiro/crew`` hands the root in as ``$1``, so
+    re-staging the payload text alone left ``$1`` unresolved and the traversal named
+    no root at all. The words after a command string are exactly what the shell
+    binds: the first is ``$0``, the rest are ``$1`` onward, and ``$@``/``$*`` stand
+    for all of them.
+
+    Returns None when the payload references no positional, so the ordinary case
+    adds no second reading to re-stage.
+    """
+    if not argv or "$" not in payload:
+        return None
+    positional = argv[1:]
+    if not positional:
+        return None
+    bound = payload
+    joined = " ".join(positional)
+    for marker in ('"$@"', "'$@'", "$@", '"$*"', "'$*'", "$*"):
+        bound = bound.replace(marker, joined)
+    # Descending, so `${1}` is spent before `$1` can match its opening two bytes.
+    for index in range(min(len(positional), 9), 0, -1):
+        value = positional[index - 1]
+        bound = bound.replace("${" + str(index) + "}", value)
+        bound = bound.replace(f"${index}", value)
+    return bound if bound != payload else None
+
+
+def _alt_long_flag_matches(flag: str, candidates: frozenset[str]) -> bool:
+    """Does *flag* spell one of *candidates*, allowing GNU prefix abbreviation?
+
+    ``getopt_long`` accepts any unambiguous prefix of a long option, so
+    ``grep --rec`` and ``grep --recurs`` recurse exactly as ``--recursive`` does
+    and ``--direct=recurse`` sets the directory action exactly as
+    ``--directories=recurse`` does. Comparing whole tokens saw only the fully
+    spelled form, which made every abbreviation a bypass.
+
+    Short flags are answered exactly: they cluster, so they are read letter by
+    letter by the callers that care, and a one-letter prefix means nothing.
+
+    Only flags whose presence ADDS a denial are matched this way. The exemptions --
+    the pattern-supplying flags, ``rg --files`` -- stay exact on purpose, so an
+    abbreviation there fails towards blocking rather than towards allowing.
+    """
+    if flag in candidates:
+        return True
+    if not flag.startswith("--"):
+        return False
+    if len(flag) - 2 < _ALT_MIN_LONG_FLAG_PREFIX:
+        return False
+    return any(candidate.startswith(flag) for candidate in candidates)
+
+
+def _alt_resolved_program_word(token: str, assignments: dict[str, str]) -> str:
+    """The program *token* names, resolved through the command's own assignments.
+
+    ``R=rg; "$R" --hidden . ~/.kiro/crew`` runs ripgrep, and reading the token
+    literally saw ``$R`` and matched no rule -- the same indirection the ROOT
+    operands already resolve through :func:`_expansion_readings`, applied to the
+    program slot as well.
+
+    Every reading is tried and the first that names a word this pass ROUTES ON wins,
+    so a braced or operator spelling (``"${R}"``) resolves too. When none does, the
+    literal reading is returned unchanged, so a token that is simply not a variable
+    costs one dictionary lookup.
+
+    Resolving only the traversal names left the pass's other lookups reading ``$X``:
+    ``X=xargs; rg --files ~/.kiro/crew | "$X" cat`` hid the SINK and
+    ``S=sh; "$S" -c 'rg . ~/.kiro/crew'`` hid the payload CARRIER, so both ran while
+    the gate matched nothing. Every role this pass keys a decision on is resolved.
+    """
+    program = _alt_program_word(token)
+    if program in _ALT_ROUTED_PROGRAMS or not assignments:
+        return program
+    for reading in _expansion_readings(token, assignments):
+        candidate = _alt_program_word(reading)
+        if candidate in _ALT_ROUTED_PROGRAMS:
+            return candidate
+        # An unquoted expansion that resolves to SEVERAL words is argv, not one
+        # word: `G='grep -r'; $G secret ~/.kiro/crew` runs grep recursively, and
+        # reading the whole string as the program named no tool.
+        head = _alt_expansion_argv(reading)
+        if head and _alt_program_word(head[0]) in _ALT_ROUTED_PROGRAMS:
+            return _alt_program_word(head[0])
+    return program
+
+
+def _alt_program_readings(
+    token: str,
+    assignments: dict[str, str],
+    history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> list[str]:
+    """Every program *token* could name, across each value its variable ever held.
+
+    :func:`_alt_resolved_program_word` resolves through last-wins assignments, which
+    is what the shell finally leaves the name set to -- but not what an EARLIER
+    stage already ran. ``R=rg; "$R" . ~/.kiro/crew; R=echo`` reassigns after the
+    read, so the last-wins reading was ``echo``, matched no traversal, and ripgrep
+    walked the crew home. The roots have resolved against assignment history since
+    round eight; the program slot is the same indirection and now shares it.
+
+    Charged through :meth:`_AltWorkBudget.charge`, not ``spend``: this runs outside
+    the main loop's ``try``, so an exhausted budget stops the enumeration instead of
+    raising past it. The root check that follows is charged from the same counter,
+    so an exhausted command still refuses.
+    """
+    programs: list[str] = []
+    # One walk, shared with every other slot: `_alt_token_readings` owns the history
+    # expansion, so this no longer keeps a second copy of it.
+    for reading in _alt_token_readings(token, assignments, history, budget):
+        candidate = _alt_resolved_program_word(reading, assignments)
+        if candidate and candidate not in programs:
+            programs.append(candidate)
+    if not programs:
+        programs.append(_alt_program_word(token))
+    return programs
+
+
+def _alt_expansion_argv(reading: str) -> list[str]:
+    """*reading* split into argv words, when it carries more than one.
+
+    Word splitting is what the shell does to an UNQUOTED expansion, so a variable
+    holding ``grep -r`` contributes two words to the command line. Returns an empty
+    list for the ordinary single-word case so callers can skip cheaply.
+    """
+    if not reading or (" " not in reading and "\t" not in reading):
+        return []
+    try:
+        words = reading.split()
+    except Exception:  # pragma: no cover - split does not raise on str
+        return []
+    return words if len(words) > 1 else []
+
+
+def _alt_stage_readings(
+    tokens: list[str],
+    assignments: dict[str, str],
+    history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> list[tuple[str, list[str], bool]]:
+    """Every ``(program, operands, may_assume_cwd)`` this stage could be running.
+
+    Two readings, and the second is what closes the wrapper class:
+
+    * the stage HEAD, with everything that can sit in front of a program peeled
+      (:func:`_alt_stage_head`). This is the reading that may fall back to the
+      working directory when the traversal names no root at all, because a word in
+      the program position with no root operand really is ``rg secret`` walking
+      ``.``;
+    * EVERY other token that names a traversal program. Enumerating what may
+      precede a program is unbounded -- ``command``, ``nice``, ``sudo``,
+      ``busybox``, ``stdbuf -o L``, ``timeout -s KILL 5``, and the next wrapper
+      nobody listed -- so the traversal is found by its own name wherever it sits
+      instead of by its position. These readings require an EXPLICIT root that
+      reaches the fence: a bare mention of a program name is ordinary text
+      (``which rg``, ``sudo cp rg /usr/bin/``), and letting it assume the working
+      directory would refuse those outright whenever the gateway runs from a
+      directory that holds the crew home.
+
+    The head reading is usually one of the scanned ones as well. The duplicate is
+    harmless -- both readings ask the same question of the same operands -- and
+    keeping them independent is what lets the cwd fallback belong to exactly one.
+    """
+    readings: list[tuple[str, list[str], bool]] = []
+    # Hashed rather than scanned: the `not in readings` test this replaces was O(N)
+    # per reading, which made CONSTRUCTION quadratic on a stage of N traversal words
+    # -- before the root check's budget was ever consulted.
+    seen: set[tuple[str, tuple[str, ...], bool]] = set()
+    head, head_operands = _alt_stage_head(tokens, assignments)
+    if head:
+        readings.append((head, head_operands, True))
+        seen.add((head, tuple(head_operands), True))
+    for index, token in enumerate(tokens):
+        # Charged BEFORE resolution: examining a token costs a history scan even
+        # when it names no variable, so the per-token cost must be paid whether or
+        # not it turns out to route anywhere.
+        if budget is not None and not budget.charge():
+            return readings
+        for program in _alt_program_readings(token, assignments, history, budget):
+            if program not in _ALT_TRAVERSAL_PROGRAMS:
+                continue
+            # Building a reading is real work -- it copies the operand tail -- so it
+            # is charged in PROPORTION to that tail rather than one flat unit, which
+            # is what bounds the memory as well as the CPU. `charge` rather than
+            # `spend`: this runs OUTSIDE the main loop's try, so exhaustion stops
+            # enumerating instead of raising past it, and the root check that
+            # follows refuses on the same spent counter.
+            if budget is not None:
+                units = 1 + (len(tokens) - index - 1) // _ALT_OPERANDS_PER_UNIT
+                if not budget.charge(units):
+                    return readings
+            operands = tokens[index + 1 :]
+            # When the token was a MULTIWORD expansion, the words after its program
+            # are operands too (`G='grep -r'` carries the `-r` that makes it
+            # recurse), so they lead the operand list rather than being dropped.
+            for candidate in _expansion_readings(token, assignments or {}):
+                words = _alt_expansion_argv(candidate)
+                if words and _alt_program_word(words[0]) == program:
+                    operands = words[1:] + operands
+                    break
+            key = (program, tuple(operands), False)
+            if key not in seen:
+                seen.add(key)
+                readings.append((program, operands, False))
+    return readings
+
+
+def _alt_stage_head(
+    tokens: list[str], assignments: dict[str, str] | None = None
+) -> tuple[str, list[str]]:
+    """The stage's program basename and the operands that follow it.
+
+    Everything that can sit in FRONT of the real program word is peeled: a
+    ``NAME=value`` prefix, a declaration keyword (:data:`_DECLARATION_BUILTINS`),
+    a shell execution wrapper (:data:`_ALT_EXEC_WRAPPER_PROGRAMS`), an
+    argv-forwarding program (:data:`_ALT_ARGV_FORWARDING_PROGRAMS`), and ``env`` --
+    each with its OWN options, because those options occupy exactly the slot the
+    program word would::
+
+        env -i grep -r . ~/.kiro/crew        `-i` read as the program
+        command grep -r . ~/.kiro/crew       `command` read as the program
+        exec -a x grep -r . ~/.kiro/crew     `-a`'s value read as the program
+        nice grep -r . ~/.kiro/crew          `nice` read as the program
+        timeout 5 grep -r . ~/.kiro/crew     the duration read as the program
+
+    A wrapper's own positional argument is recognised by SHAPE
+    (:data:`_ALT_WRAPPER_OPERAND_RE`) rather than by a per-wrapper table, so a
+    wrapper whose argument nobody enumerated does not read as the program.
+
+    Peeling repeats, so a stacked spelling (``command env -i grep``,
+    ``nohup nice rg``) resolves too. :func:`_alt_program_word` resolves a quoted,
+    path-qualified or ``.exe`` spelling to the same name.
+    """
+    index = 0
+    value_flags: frozenset[str] = frozenset()
+    peeling_options = False
+    while index < len(tokens):
+        token = tokens[index]
+        if _SHELL_ASSIGN_RE.match(token):
+            index += 1
+            continue
+        program = _alt_resolved_program_word(token, assignments or {})
+        if (
+            program in _DECLARATION_BUILTINS
+            or program in _ALT_EXEC_WRAPPER_PROGRAMS
+            or program in _ALT_ARGV_FORWARDING_PROGRAMS
+        ):
+            peeling_options = True
+            value_flags = _ALT_WRAPPER_VALUE_FLAGS
+            index += 1
+            continue
+        if program in _ENV_SPLIT_PROGRAMS:
+            peeling_options = True
+            value_flags = _ENV_VALUE_FLAGS
+            index += 1
+            continue
+        if peeling_options and token.startswith("-") and token != "-":
+            flag = token.partition("=")[0]
+            # A separate-word value would otherwise be read as the program.
+            if "=" not in token and flag in value_flags:
+                index += 1
+            index += 1
+            continue
+        if peeling_options and _ALT_WRAPPER_OPERAND_RE.match(token):
+            index += 1
+            continue
+        return program, tokens[index + 1 :]
+    return "", []
+
+
+def _alt_assignments(stages: list[list[str]]) -> dict[str, str]:
+    """Every ``NAME=value`` the command itself sets, across all stages.
+
+    A traversal root is routinely held in a variable the same line assigns
+    (``D=$HOME/.kiro/crew; rg . "$D"``). Each stage is tokenized on its own, so
+    without this the ``$D`` operand stayed literal and the fence was never
+    consulted. ``$HOME`` is already expanded by ``normalize_shell_command``, so the
+    recorded value is an absolute path.
+
+    ``+=`` appends, matching bash, so a root assembled in two steps resolves too.
+
+    A declaration keyword assigns just as a bare ``NAME=value`` segment does, so
+    the scan looks past it and its options -- ``export D=$HOME/.kiro/crew`` recorded
+    nothing while bash set ``D``, which put the root back out of reach. Read from
+    :data:`_DECLARATION_BUILTINS`, the same table the segment walk uses.
+    """
+    assignments: dict[str, str] = {}
+    for tokens in stages:
+        declaring = False
+        for token in tokens:
+            program = _alt_program_word(token)
+            if program in _DECLARATION_BUILTINS:
+                declaring = True
+                continue
+            if (
+                program in _ALT_EXEC_WRAPPER_PROGRAMS
+                or program in _ALT_ARGV_FORWARDING_PROGRAMS
+                or program in _ENV_SPLIT_PROGRAMS
+            ):
+                continue
+            if declaring and token.startswith("-") and token != "-":
+                continue
+            match = _SHELL_ASSIGN_RE.match(token)
+            if not match:
+                break
+            name, append, value = match.group(1), match.group(2), match.group(3)
+            assignments[name] = (assignments.get(name, "") + value) if append else value
+    return assignments
+
+
+def _alt_root_operands(
+    program: str, operands: list[str], assignments: dict[str, str] | None = None
+) -> list[str]:
+    """The operands that could name a traversal ROOT.
+
+    Every operand is tested rather than the ones a per-tool grammar would classify
+    as a root: tracking which flags take a value needs a table per tool, and each
+    omission from such a table is a MISS, while testing a flag's value as if it
+    were a root only adds a denial -- and a flag value naming a credential store
+    (``--search-path ~/.kiro/crew``) is security-relevant wherever it sits.
+
+    ONE operand is exempted: the search PATTERN of ``fd``/``grep``/``rg``, which is
+    text to look for and not a place to look in. Without the exemption, searching
+    source for a reference to the crew home was refused::
+
+        grep -r "$HOME/.kiro" ./src      the pattern normalizes to a fenced parent
+        rg '~/.kiro/crew' src/
+
+    The exemption is the FIRST positional and only when no flag supplied the
+    pattern. Two things keep it from hiding a root. A value that arrives through a
+    root-supplying flag (:data:`_ROOT_SUPPLYING_FLAGS`) is pulled out first and
+    always tested, because that value occupies the positional slot the pattern
+    would otherwise hold. And when a flag supplied the pattern -- see
+    :func:`_alt_pattern_is_flag_supplied`, which reads glued and clustered
+    spellings too -- or ``rg --files`` takes no pattern at all, every positional is
+    a root and nothing is exempted.
+
+    ``du`` is the one program here that names ONLY roots, so it is the only one
+    exempt from the exemption. ``rgrep`` takes a pattern exactly as ``grep`` does,
+    so it shares the rule rather than routing through the all-operands branch.
+
+    When a flag DID supply the pattern, that flag's value is dropped and every
+    positional stays a root. Returning the operands untouched tested the value as
+    a root, so ``grep -re "$HOME/.kiro" ./src`` was refused while the equivalent
+    positional spelling was allowed -- the same false positive the exemption
+    exists to prevent, reached through the other spelling.
+    """
+    if program in _PATH_LISTER_PROGRAMS:
+        return operands
+    if _alt_pattern_is_flag_supplied(operands, assignments):
+        return _alt_without_pattern_flag_values(operands, assignments)
+    forced: list[str] = []
+    rest: list[str] = []
+    expect_root_value = False
+    for token in operands:
+        if expect_root_value:
+            forced.append(token)
+            expect_root_value = False
+            continue
+        flag, sep, glued = token.partition("=")
+        if _alt_long_flag_matches(flag, _ROOT_SUPPLYING_FLAGS):
+            if sep:
+                forced.append(glued)
+            else:
+                expect_root_value = True
+            continue
+        rest.append(token)
+    remaining: list[str] = list(forced)
+    skipped = False
+    past_end_of_flags = False
+    for token in rest:
+        # `--` ends option parsing, so the word after it is the PATTERN even when
+        # it is dash-prefixed. Requiring a non-dash token skipped that pattern and
+        # exempted the ROOT instead: `grep -r -- -foo ~/.kiro/crew` read clean.
+        if not skipped and token == "--":
+            past_end_of_flags = True
+            remaining.append(token)
+            continue
+        if not skipped and (past_end_of_flags or not token.startswith("-")):
+            skipped = True
+            continue
+        remaining.append(token)
+    return remaining
+
+
+def _alt_pattern_flag_supplies_a_value(flag: str) -> bool:
+    """Does *flag* name a pattern flag whose value is a SEPARATE word?
+
+    Abbreviation makes this two questions rather than one. ``--reg`` can only be
+    ``--regexp``, which takes a value, so the next word is the pattern. ``--fil``
+    prefixes both ``--file`` (takes a value) and ``--files`` (a mode that takes
+    none), and consuming the next word on that reading would swallow the ROOT -- so
+    an abbreviation shared with a no-value flag consumes nothing. Real tools reject
+    an ambiguous abbreviation outright; here the ambiguous reading simply keeps
+    every positional a root, which is the fail-closed answer.
+    """
+    if not _alt_long_flag_matches(flag, _PATTERN_VALUE_FLAGS):
+        return False
+    if flag in _PATTERN_VALUE_FLAGS:
+        return True
+    return not _alt_long_flag_matches(
+        flag, _PATTERN_SUPPLYING_FLAGS - _PATTERN_VALUE_FLAGS
+    )
+
+
+def _alt_without_pattern_flag_values(
+    operands: list[str], assignments: dict[str, str] | None = None
+) -> list[str]:
+    """*operands* minus the value each pattern-supplying flag carries.
+
+    The value is the text being searched FOR, so testing it as a root refuses an
+    ordinary source search whose pattern happens to spell a fenced path. Both
+    spellings are dropped: a separate word (``-e PAT``, ``--regexp PAT``) and a
+    ``=``-glued one (``--regexp=PAT``). A value glued to a short cluster
+    (``-ePAT``) stays in the list -- the token keeps its ``-e`` prefix, so it does
+    not resolve to a directory and answers no on its own.
+    """
+    kept: list[str] = []
+    expect_value = False
+    for token in operands:
+        if expect_value:
+            expect_value = False
+            continue
+        if token == "--" or "--" in _alt_token_readings(token, assignments or {}):
+            kept.append(token)
+            continue
+        flag, sep, _glued = token.partition("=")
+        if _alt_long_flag_matches(flag, _PATTERN_SUPPLYING_FLAGS):
+            # `rg --files` supplies no pattern and takes no value.
+            if not sep and _alt_pattern_flag_supplies_a_value(token):
+                expect_value = True
+            continue
+        if token.startswith("--") or not token.startswith("-") or len(token) < 2:
+            kept.append(token)
+            continue
+        # A short pattern flag inside a CLUSTER. A value-taking letter ends the
+        # cluster, so `-re PAT` carries its value in the next word while `-rePAT`
+        # glues it on. Matching whole tokens saw neither, so `grep -re "$HOME/.kiro"
+        # ./src` still tested the pattern as a root.
+        cluster = token[1:]
+        position = next(
+            (i for i, letter in enumerate(cluster) if letter in ("e", "f")), None
+        )
+        if position is None:
+            kept.append(token)
+            continue
+        if position == len(cluster) - 1:
+            expect_value = True
+        continue
+    return kept
+
+
+def _alt_pattern_is_flag_supplied(
+    operands: list[str], assignments: dict[str, str] | None = None
+) -> bool:
+    """Did a FLAG supply the search pattern, leaving every positional a root?
+
+    Short pattern flags take a value, so they end a cluster and the value may be
+    glued onto it: ``-e secret``, ``-esecret`` and ``-refoo`` all supply the
+    pattern. Matching whole tokens saw only the first, so the exemption below
+    fired on ``grep -r -esecret ~/.kiro/crew`` and dropped the credential-store
+    root -- a false NEGATIVE, which is the direction that actually costs
+    something. The cluster scan is case-sensitive on purpose: lowercase ``-e``/
+    ``-f`` name the pattern, while uppercase ``-E``/``-F`` only choose a regex
+    dialect.
+    """
+    for token in operands:
+        # `--` can arrive through a variable (`E=--; grep -r "$E" -e …`), and missing
+        # it left `-e` reading as a pattern flag that swallowed the ROOT as its value.
+        if token == "--" or "--" in _alt_token_readings(token, assignments or {}):
+            return False
+        # Matched by unique prefix, because a pattern flag NOBODY recognised is a
+        # pattern flag not seen -- which exempts the first positional as the
+        # pattern, and in `grep -r --reg=secret ~/.kiro/crew` that positional is the
+        # ROOT. Missing a pattern flag drops a root; seeing one too eagerly only
+        # keeps every positional a root, so the two directions are not symmetric.
+        if _alt_long_flag_matches(token.partition("=")[0], _PATTERN_SUPPLYING_FLAGS):
+            return True
+        if token.startswith("--"):
+            continue
+        if token.startswith("-") and len(token) > 1:
+            if any(letter in ("e", "f") for letter in token[1:]):
+                return True
+    return False
+
+
+#: A command substitution opening in an assignment's value. Either spelling means
+#: the value is computed at run time, so the gate cannot know what the variable holds.
+_ALT_UNRESOLVED_SUBST_RE = re.compile(r"\$\(|`")
+
+
+def _alt_substitution_assignment_fences(stages: list[list[str]]) -> dict[str, str]:
+    """Assigned names whose value is COMPUTED, mapped to a fence their stage names.
+
+    ``D=$(printf %s "$HOME/.kiro/crew"); rg . "$D"`` reaches the store, and nothing
+    in the recorded value says so: the tokenizer splits the substitution across
+    words, so the value is the truncated ``$(printf`` while the fenced path sits in
+    a separate token of the same stage. Reading the substitution body off the value
+    therefore cannot see it, and evaluating the substitution is not on offer.
+
+    What is reliable is the pair of facts this returns: the value opens a
+    substitution, so the gate CANNOT know what the variable holds; and the stage
+    computing it names the fenced directory in plain text. A traversal rooted at
+    such a variable then fails closed.
+
+    Requiring the stage to name a fence is what keeps the honest spellings working:
+    ``D=$(pwd)`` and ``D=$(printf %s "./src")`` name none, so they resolve normally.
+    """
+    fences: dict[str, str] = {}
+    for tokens in stages:
+        computed: list[str] = []
+        for token in tokens:
+            match = _SHELL_ASSIGN_RE.match(token)
+            if match and _ALT_UNRESOLVED_SUBST_RE.search(match.group(3)):
+                computed.append(match.group(1))
+        if not computed:
+            continue
+        for token in tokens:
+            # The closing `)` of the substitution rides on the last word.
+            for cand in _path_candidates(token.rstrip(")`\"'")):
+                if cand and not cand.startswith("-") and path_contains_sensitive(cand):
+                    for name in computed:
+                        fences.setdefault(name, cand)
+                    break
+    return fences
+
+
+def _alt_assignment_history(stages: list[list[str]]) -> dict[str, list[str]]:
+    """Every value each name is assigned, in order, not just the last one.
+
+    :func:`_alt_assignments` is last-wins, which matches what the shell finally
+    holds but not what an EARLIER stage read: in
+    ``D=$HOME/.kiro/crew; rg . "$D"; D=/tmp`` the traversal ran against the crew
+    home and the recorded value was ``/tmp``, so a trailing reassignment hid the
+    root. Every value a name ever takes is a value some stage could have used, so
+    each one is tested and the fenced reading wins.
+
+    ``+=`` appends to whatever the name held at that point, matching bash, so the
+    accumulated form is what is recorded for that step.
+    """
+    history: dict[str, list[str]] = {}
+    current: dict[str, str] = {}
+    for tokens in stages:
+        for token in tokens:
+            match = _SHELL_ASSIGN_RE.match(token)
+            if not match:
+                continue
+            name, append, value = match.group(1), match.group(2), match.group(3)
+            current[name] = (current.get(name, "") + value) if append else value
+            versions = history.setdefault(name, [])
+            if current[name] not in versions:
+                versions.append(current[name])
+    return history
+
+
+def _alt_cd_bases(
+    stages: list[list[str]],
+    assignments: dict[str, str],
+    history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> list[str]:
+    """Directories a ``cd`` on this command line moves to.
+
+    A traversal root is routinely spelled RELATIVE to a directory the same line
+    entered (``cd ~/.kiro && rg . crew``), and resolving it against the gateway's
+    own directory answered no while the shell walked the crew home. The normalizer
+    pass tracks the same bases for its own operand checks; this is the one question
+    that pass cannot answer, because it asks whether a path IS fenced while this
+    pass asks whether a directory HOLDS a fenced path -- and the crew home holds
+    without being.
+
+    ``cd`` takes ONE operand, so the scan stops at the first non-flag word. Bounded
+    by the same cap the normalizer's base list uses.
+    """
+    bases: list[str] = []
+
+    def _remember(raw: str) -> None:
+        for reading in _alt_token_readings(raw, assignments, history, budget):
+            for cand in _path_candidates(reading):
+                if cand and cand not in bases:
+                    bases.append(cand)
+
+    for tokens in stages:
+        # `env --chdir DIR prog …` enters DIR before running prog, so that value is
+        # a traversal base exactly as `cd DIR` is. It was being skipped as one of
+        # env's own option values, which let `env --chdir "$HOME/.kiro/crew" grep -r
+        # secret .` resolve its `.` against the gateway's directory instead.
+        expect_chdir = False
+        for token in tokens:
+            if expect_chdir:
+                _remember(token)
+                expect_chdir = False
+                continue
+            flag, sep, glued = token.partition("=")
+            # Prefix-matched, not exact: `env --chd DIR` enters DIR exactly as
+            # `--chdir DIR` does, and comparing whole tokens made every GNU
+            # abbreviation a bypass. `-C` is short, so it still answers exactly.
+            if _alt_long_flag_matches(flag, _ENV_CHDIR_FLAGS):
+                if sep:
+                    _remember(glued)
+                else:
+                    expect_chdir = True
+
+        program, operands = _alt_stage_head(tokens, assignments)
+        # Membership in the set this module already owns rather than the literal
+        # `"cd"`: five of its six verbs were uncovered, so `pushd ~/.kiro && rg .
+        # crew` walked the fence while the `cd` spelling denied. A verb added to
+        # `_CHDIR_VERBS` now reaches this pass with no second edit.
+        if program.lower() not in _CHDIR_VERBS_LOWER:
+            continue
+        for token in operands:
+            if token.startswith("-"):
+                continue
+            _remember(token)
+            break
+    return bases[:_MAX_TRACKED_BASES]
+
+
+def _alt_root_reaching_fence(
+    operands: list[str],
+    assignments: dict[str, str],
+    cd_bases: list[str] | None = None,
+    subst_fences: dict[str, str] | None = None,
+    assignment_history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> str | None:
+    """Which operand names a directory that HOLDS a fenced path, if any.
+
+    ``key=value`` and glued-redirect spellings come from :func:`_path_candidates`,
+    the same extraction the operand checks in the normalizer pass use, and
+    :func:`_expansion_readings` supplies every value an operand carrying an
+    expansion could take -- so a root held in a variable is judged on its value,
+    not on the literal ``$D``.
+
+    Three readings of one operand, because a root reaches the fence three ways:
+
+    * the operand as written;
+    * the BODY of any command substitution written inside the operand itself;
+    * the operand JOINED onto each ``cd`` base, for a root spelled relative to a
+      directory the same line entered.
+
+    A root held in a variable the command COMPUTED is handled separately, by
+    :func:`_alt_substitution_assignment_fences` -- see there for why the value
+    itself cannot carry the answer.
+
+    A non-path operand costs nothing: a pattern like ``secret`` resolves under the
+    gateway's directory and holds no fence, so it answers no.
+    """
+    bases = cd_bases or []
+    history = assignment_history or {}
+    # Markers built ONCE per name instead of once per (operand, name), and one
+    # scratch dict mutated in place instead of a fresh O(names) copy per value.
+    markers = {name: (f"${name}", "${" + name + "}") for name in history}
+    scratch = dict(assignments) if history else {}
+    # Per COMMAND, not per call: this function runs once per reading, and it was the
+    # readings x operands product -- not the variable history -- that wedged the
+    # gate for tens of seconds on a command that assigns nothing at all.
+    work = budget if budget is not None else _AltWorkBudget(_ALT_MAX_RESOLUTIONS)
+    for token in operands:
+        work.spend("operand")
+        # A root the command COMPUTED cannot be resolved from the text, so a
+        # variable whose assignment stage named a fence answers with that fence.
+        for name, fenced in (subst_fences or {}).items():
+            if f"${name}" in token or f"${{{name}}}" in token:
+                return fenced
+        # Each name is tried against EVERY value it is ever assigned, because a
+        # later reassignment does not unwind what an earlier stage already read.
+        readings = list(_expansion_readings(token, assignments))
+        for name, versions in history.items():
+            plain, braced = markers[name]
+            if plain not in token and braced not in token:
+                continue
+            restore = scratch.get(name)
+            for value in versions:
+                work.spend(name)
+                scratch[name] = value
+                for extra in _expansion_readings(token, scratch):
+                    if extra not in readings:
+                        readings.append(extra)
+            if restore is None:
+                scratch.pop(name, None)
+            else:
+                scratch[name] = restore
+        for reading in readings:
+            candidates = list(_path_candidates(reading))
+            for body in _substitution_bodies(reading):
+                candidates.extend(_path_candidates(body))
+            for cand in candidates:
+                if not cand or cand == "-" or cand.startswith("--"):
+                    continue
+                work.spend("candidate")
+                if path_contains_sensitive(cand):
+                    return cand
+                # A glob is expanded by the shell before this gate sees a path, so
+                # the literal candidate holds no fence while the expansion does.
+                for expanded in _alt_glob_root_readings(cand):
+                    work.spend("glob")
+                    if path_contains_sensitive(expanded):
+                        return expanded
+                # A relative root resolves against the `cd`, not against us.
+                if bases and not os.path.isabs(cand) and not cand.startswith("~"):
+                    for base in bases:
+                        joined = os.path.join(base, cand)
+                        if path_contains_sensitive(joined):
+                            return joined
+    return None
+
+
+def _alt_implicit_cwd_root() -> str | None:
+    """The fenced-holding answer for a traversal given no root at all.
+
+    ``fd .env -x cat`` walks the working directory, so the root is real even
+    though no operand names it.
+    """
+    return "." if path_contains_sensitive(".") else None
+
+
+def _alt_names_an_explicit_root(operands: list[str]) -> bool:
+    """Did the traversal name a directory to walk?
+
+    Only a traversal that named NONE falls back to the working directory. Testing
+    the fallback unconditionally meant a gateway launched from the home directory
+    refused every recursive read, including one explicitly rooted at a clean tree
+    (``grep -r TODO ./src``), because the home directory holds the crew data-home.
+    The explicit root is what the command actually walks, so once one is named the
+    working directory is not consulted.
+    """
+    for token in operands:
+        if token.startswith("-") or token == "--":
+            continue
+        for cand in _path_candidates(token):
+            if not cand or cand == "-":
+                continue
+            if _is_path_like(cand):
+                return True
+            try:
+                if os.path.isdir(cand):
+                    return True
+            except (OSError, ValueError):
+                continue
+    return False
+
+
+def _alt_token_readings(
+    token: str,
+    assignments: dict[str, str],
+    history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> list[str]:
+    """Every spelling *token* could have once the command's assignments apply.
+
+    A FLAG and a SINK program are as reachable through a variable as a root is
+    (``R=-r; grep "$R" secret ~/.kiro/crew``, ``C=cat; rg --files … | xargs "$C"``),
+    and comparing the literal token saw ``$R`` and matched nothing. The literal
+    reading is kept alongside the resolved ones, so a token that is not an
+    expansion answers exactly as before.
+
+    When *history* is supplied, EVERY value a name ever held is tried, not just the
+    one the command finally leaves set. A later reassignment does not unwind what an
+    earlier stage already read, so ``R=-r; grep "$R" secret ~/.kiro/crew; R=-n``
+    really does recurse. That rule reached only the ROOT slot until round fourteen --
+    the recursion flag, the sink program and the chdir base each resolved through
+    this function with the last-wins view alone, so the same trailing-reassignment
+    trick worked on all three while the root spelling denied. It lives HERE rather
+    than at those three call sites so a slot added later inherits it instead of
+    needing a fourth copy.
+
+    The scratch dict is built LAZILY, only once a name's marker actually appears in
+    the token: copying it per token charged nothing and cost O(assignments) on every
+    token that mentioned no variable at all.
+    """
+    if not assignments or "$" not in token:
+        return [token]
+    readings = [token]
+    for reading in _expansion_readings(token, assignments):
+        if reading not in readings:
+            readings.append(reading)
+    if not history:
+        return readings
+    scratch: dict[str, str] | None = None
+    for name, versions in history.items():
+        if f"${name}" not in token and "${" + name + "}" not in token:
+            continue
+        if scratch is None:
+            scratch = dict(assignments)
+        restore = scratch.get(name)
+        for value in versions:
+            if budget is not None and not budget.charge():
+                break
+            scratch[name] = value
+            for extra in _expansion_readings(token, scratch):
+                if extra not in readings:
+                    readings.append(extra)
+        if restore is None:
+            scratch.pop(name, None)
+        else:
+            scratch[name] = restore
+    return readings
+
+
+def _grep_is_recursive(
+    operands: list[str],
+    assignments: dict[str, str] | None = None,
+    history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> bool:
+    """Does this grep invocation traverse directories?
+
+    Short flags cluster, so the LETTERS of every single-dash token are scanned
+    rather than the token compared whole: ``-rn`` is ``-r -n``, and it is the
+    spelling a person actually types. Everything after ``--`` is an operand.
+
+    ``-d recurse`` / ``--directories=recurse`` is grep's other recursive mode and
+    traverses identically, so the directory ACTION is read as well as the flags --
+    the value carries the meaning, in either the glued or the separate-word form.
+
+    Every operand is judged on all of its readings (:func:`_alt_token_readings`),
+    because the flag itself can arrive through a variable: ``R=-r; grep "$R" secret
+    ~/.kiro/crew`` recurses, and the literal ``$R`` matched no rule. The scan stays
+    indexed by OPERAND so the ``-d`` lookahead still reads the next operand rather
+    than the next reading of the same one.
+    """
+    resolved = assignments or {}
+    readings = [
+        _alt_token_readings(token, resolved, history, budget) for token in operands
+    ]
+
+    def _next_operand_is_recurse(index: int) -> bool:
+        return index + 1 < len(readings) and any(
+            reading == _GREP_RECURSE_ACTION for reading in readings[index + 1]
+        )
+
+    for index, group in enumerate(readings):
+        # `--` ends option parsing, and only its literal spelling does: a variable
+        # whose VALUE is `--` still arrives as one word to this pass either way.
+        if operands[index] == "--":
+            break
+        for token in group:
+            if _alt_long_flag_matches(token, _GREP_RECURSIVE_LONG_FLAGS):
+                return True
+            flag, sep, glued = token.partition("=")
+            if _alt_long_flag_matches(flag, _GREP_DIRECTORIES_FLAGS):
+                # The action is either glued on (`--directories=recurse`) or the
+                # next word (`--directories recurse`, `-d recurse`).
+                if sep:
+                    if glued == _GREP_RECURSE_ACTION:
+                        return True
+                elif _next_operand_is_recurse(index):
+                    return True
+                continue
+            if token.startswith("--"):
+                continue
+            if token.startswith("-") and len(token) > 1:
+                cluster = token[1:]
+                if any(letter in ("r", "R") for letter in cluster):
+                    return True
+                # `-d` takes a value, so it ends the cluster: the argument is
+                # either glued onto it (`-drecurse`, `-ndrecurse`) or the next word
+                # (`-d recurse`, `-nd recurse`). Scanning the whole cluster is what
+                # catches the clustered spellings a person actually types.
+                position = cluster.find("d")
+                if position != -1:
+                    glued_action = cluster[position + 1 :]
+                    if glued_action:
+                        if glued_action == _GREP_RECURSE_ACTION:
+                            return True
+                    elif _next_operand_is_recurse(index):
+                        return True
+    return False
+
+
+def _alt_sink_program_names(
+    operands: list[str],
+    assignments: dict[str, str] | None = None,
+    history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> list[str]:
+    """Every program name a name-list executor could actually run.
+
+    The direct payload, plus -- when that payload is a shell -- the programs
+    inside its ``-c`` command string. ``xargs sh -c 'cat "$@"' sh`` runs ``cat``,
+    and reading only the direct payload saw ``sh`` and called it clean.
+
+    The payload word is resolved through the command's own assignments for the same
+    reason the traversal's program word is: ``C=cat; rg --files … | xargs "$C"``
+    runs a reader, and the literal ``$C`` named none.
+    """
+    resolved = assignments or {}
+    names: list[str] = []
+    for token in operands:
+        if token.startswith("-"):
+            continue
+        for reading in _alt_token_readings(token, resolved, history, budget):
+            names.append(_alt_program_word(reading))
+            # A QUOTED template is a whole command in one token, so the word above
+            # was the entire string and matched no reader: `parallel 'cat {}'` read
+            # as a program literally named `cat {}`. Splitting it makes the quoted
+            # spelling agree with the unquoted payload it is equivalent to, which
+            # already denied.
+            for word in _alt_expansion_argv(reading):
+                names.append(_alt_program_word(word))
+    for payload in _alt_command_string_payloads(operands, resolved):
+        for tokens in _alt_pipeline_stages(payload, _ALT_NESTED_DEPTH_LIMIT - 1):
+            program, _rest = _alt_stage_head(tokens, resolved)
+            if program:
+                names.append(program)
+    return names
+
+
+def _alt_has_reader_sink(
+    stages: list[list[str]],
+    assignments: dict[str, str] | None = None,
+    history: dict[str, list[str]] | None = None,
+    budget: "_AltWorkBudget | None" = None,
+) -> bool:
+    """Does any stage turn a name list into file content?
+
+    ``xargs``/``parallel`` run their payload once per name, so the payload's
+    program is what decides. A bare ``| cat`` is NOT a sink: it prints the name
+    list on stdin, it does not open the files those names point to.
+
+    EVERY operand is examined rather than only the first non-flag one, because
+    several of ``xargs``'s own flags take a value (``-n 1``, ``-P 4``, ``-I {}``)
+    and that value sits exactly where the payload would -- so the first non-flag
+    token can be ``1`` rather than ``cat``. Scanning on can only add a denial, and
+    a non-payload operand that happens to share a reader's name is not a shape
+    worth a per-flag table.
+    """
+    resolved = assignments or {}
+    for tokens in stages:
+        program, operands = _alt_stage_head(tokens, resolved)
+        if program not in _NAME_LIST_EXEC_PROGRAMS:
+            continue
+        for name in _alt_sink_program_names(operands, resolved, history, budget):
+            if name in _ALT_CONTENT_READER_PROGRAMS:
+                return True
+    return False
+
+
+def _check_alt_traversal_reaches_fence(command: str) -> str | None:
+    """Is a non-``find`` traversal rooted at a directory that holds a fenced path?
+
+    Three shapes, each with its own delivery question:
+
+    * ``grep -r``/``rg`` in matching mode open every file under the root, so the
+      traversal IS the read and no sink is needed.
+    * ``fd`` with ``-x``/``-X`` runs a reader per hit, which is the same delivery
+      ``find -exec`` performs.
+    * ``fd`` without an exec flag, ``rg --files`` and ``du -a`` emit names only, so
+      they are refused only when the command also contains a sink that opens them.
+
+    Returns a denial reason, or None when clean.
+    """
+    stages, truncated = _alt_pipeline_stages_bounded(command)
+    if not stages:
+        return None
+    assignments = _alt_assignments(stages)
+    if assignments:
+        # Staging runs before the assignments are known -- they are derived FROM the
+        # stages -- so a payload carried by a variable-named shell (`S=sh; "$S" -c
+        # '…'`) had nothing to resolve against on the first pass. Re-stage with them
+        # and union: the second pass only ever adds stages, under the same budget.
+        second, also_truncated = _alt_pipeline_stages_bounded(
+            command, assignments=assignments
+        )
+        truncated = truncated or also_truncated
+        for tokens in second:
+            if tokens not in stages:
+                stages.append(tokens)
+    if truncated:
+        # The budget stopped the walk, so any stage past it was never read. Refusing
+        # is the only honest answer: allowing would make the cap the bypass.
+        return (
+            "Blocked: command has more pipeline stages than this gate inspects "
+            f"({_ALT_MAX_STAGES}), so a traversal in it cannot be ruled out"
+        )
+    assignment_history = _alt_assignment_history(stages)
+    # ONE budget for the whole command, created BEFORE the slots that resolve
+    # history so none of them is uncharged. Threading `history` into these three in
+    # round 14 without the budget is what reopened the wedge: they resolved every
+    # operand against every historical value with nothing counting.
+    work = _AltWorkBudget(_ALT_MAX_RESOLUTIONS)
+    sink = _alt_has_reader_sink(stages, assignments, assignment_history, work)
+    cd_bases = _alt_cd_bases(stages, assignments, assignment_history, work)
+    subst_fences = _alt_substitution_assignment_fences(stages)
+    for tokens in stages:
+        for program, operands, may_assume_cwd in _alt_stage_readings(
+            tokens, assignments, assignment_history, work
+        ):
+            delivers: bool
+            # A flag can arrive through a variable just as a root can, so each
+            # operand is matched on all of its readings.
+            operand_readings = [
+                reading
+                for token in operands
+                for reading in _alt_token_readings(
+                    token, assignments, assignment_history, work
+                )
+            ]
+            if program in _FD_PROGRAM_NAMES:
+                delivers = sink or any(
+                    _alt_long_flag_matches(token.partition("=")[0], _FD_EXEC_FLAGS)
+                    for token in operand_readings
+                )
+            elif program in _ALWAYS_RECURSIVE_GREP_NAMES:
+                delivers = True
+            elif program in _GREP_PROGRAM_NAMES:
+                if not _grep_is_recursive(
+                    operands, assignments, assignment_history, work
+                ):
+                    continue
+                delivers = True
+            elif program in _RIPGREP_PROGRAM_NAMES:
+                # The lister flag stays EXACT: an abbreviation nobody recognised
+                # leaves ripgrep in matching mode here, which needs no sink and so
+                # denies rather than allows.
+                lister = any(
+                    token.partition("=")[0] in _RIPGREP_LISTER_FLAGS
+                    for token in operand_readings
+                )
+                delivers = sink if lister else True
+            elif program in _PATH_LISTER_PROGRAMS:
+                delivers = sink
+            else:
+                continue
+            if not delivers:
+                continue
+            roots = _alt_root_operands(program, operands, assignments)
+            try:
+                root = _alt_root_reaching_fence(
+                    roots,
+                    assignments,
+                    cd_bases,
+                    subst_fences,
+                    assignment_history,
+                    work,
+                )
+            except _AltResolutionBudget:
+                # The command costs more variable resolution than this gate spends,
+                # so it cannot be judged. Refusing is the only honest answer, and it
+                # is also what stops the cost from being the attack.
+                return (
+                    "Blocked: command requires more traversal analysis than this "
+                    f"gate performs ({_ALT_MAX_RESOLUTIONS} units), so a traversal "
+                    "in it cannot be ruled out"
+                )
+            if (
+                root is None
+                and may_assume_cwd
+                and not _alt_names_an_explicit_root(roots)
+            ):
+                root = _alt_implicit_cwd_root()
+            if root is not None:
+                return (
+                    "Blocked: recursive traversal rooted at a directory that holds "
+                    f"a sensitive credential path ({program}: {root[:80]})"
+                )
+    if work.exhausted:
+        # ONE place decides what running out means, and it means refuse. Any helper
+        # that stopped early returned a PARTIAL answer, so "no fenced root found" is
+        # not something this walk is entitled to conclude -- a padding stage that
+        # spends the budget would otherwise delete the very reading that catches an
+        # applet-dispatched traversal.
+        return (
+            "Blocked: command requires more traversal analysis than this gate "
+            f"performs ({_ALT_MAX_RESOLUTIONS} units), so a traversal in it cannot "
+            "be ruled out"
+        )
+    return None
 
 
 def _check_imds_access(

--- a/test/test_security_alt_traversal.py
+++ b/test/test_security_alt_traversal.py
@@ -1,0 +1,1839 @@
+"""Tests for the alternate-traversal pass in ``security.py``.
+
+``find`` is not the only program that factors a fenced path into a root plus a
+name and hands the result to a reader. These tests pin the shapes ``fd``,
+``grep -r``, ``rg`` and ``du`` can spell, the legitimate forms of each that must
+keep working, and the residuals that are deliberately left open.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from kiro_crew import security
+from kiro_crew.security import is_sensitive_bash_command
+
+#: A crew-home directory that HOLDS fenced leaves (``.env``,
+#: ``token_signing.key``) without being fenced itself -- the root every blocked
+#: case below traverses.
+CREW = "~/.kiro/crew"
+
+#: The legacy data-home prefix, fenced by the same leaf list.
+CREW_LEGACY = "~/.kirocrew"
+
+
+def _denied(command: str) -> bool:
+    return is_sensitive_bash_command(command) is not None
+
+
+def _clean_dir_candidates() -> tuple[str, ...]:
+    """Absolute directories worth testing for cleanliness on THIS platform.
+
+    The POSIX system roots do not exist on Windows, where every one of them
+    fails ``isdir`` -- so that platform's own roots have to be named too, or the
+    search comes up empty there and finds nothing to assert against.
+    """
+    candidates = ["/usr/share", "/usr/lib", "/etc", "/opt", "/tmp"]
+    for variable in ("SystemRoot", "ProgramFiles", "ProgramData"):
+        value = os.environ.get(variable)
+        if value:
+            candidates.append(value)
+    candidates.append(tempfile.gettempdir())
+    return tuple(candidates)
+
+
+def _first_clean_dir() -> str | None:
+    """An absolute directory this environment agrees holds no fenced path.
+
+    A must-stay-ALLOW case needs a target that is clean HERE, not one that happens
+    to be clean on the author's host: ``/tmp`` is unfenced on a dev box but IS
+    fenced on the CI runner, where the crew home lives under it, so hard-coding it
+    made the assertion an environment fact rather than a code fact.
+
+    Returns ``None`` when the environment offers none, so the single case that
+    needs one SKIPS. Raising instead would raise during import, and pytest splits
+    tests only after collecting them, so every xdist shard imports every module:
+    an import-time raise errors the whole run in all shards rather than dropping
+    the one case it concerns.
+    """
+    for candidate in _clean_dir_candidates():
+        if os.path.isdir(candidate) and not security.path_contains_sensitive(candidate):
+            return candidate
+    return None
+
+
+#: Resolved once: a directory that is clean in THIS environment, or ``None``.
+_CLEAN_ELSEWHERE = _first_clean_dir()
+
+#: Marks the one case whose target must be an unfenced directory.
+_needs_clean_dir = pytest.mark.skipif(
+    _CLEAN_ELSEWHERE is None,
+    reason="no unfenced directory here, so the allow-side assertion would be vacuous",
+)
+
+
+# ── fd: a positional regex, a root, and find's -exec under another name ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The issue's headline shapes.
+        f"fd '^\\.env$' {CREW} -x cat",
+        f"fd -e key . {CREW} -X cat",
+        # The Debian/Ubuntu binary name for the same tool.
+        f"fdfind '^\\.env$' {CREW} -x cat",
+        # Long spellings of both exec forms.
+        f"fd . {CREW} --exec cat",
+        f"fd . {CREW} --exec-batch cat",
+        # The reader does not have to be `cat`.
+        f"fd . {CREW} -x base64",
+        f"fd . {CREW} -x head -c 100",
+        # A path-qualified program word.
+        f"/usr/bin/fd . {CREW} -x cat",
+        # A quoted root, which shlex unwraps.
+        f"fd . '{CREW}' -x cat",
+        # $HOME instead of a tilde.
+        "fd . $HOME/.kiro/crew -x cat",
+        # The legacy data-home carries the same leaves.
+        f"fd . {CREW_LEGACY} -x cat",
+        # The root arrives through a flag rather than as a positional.
+        f"fd --search-path {CREW} '^\\.env$' -x cat",
+        f"fd --search-path={CREW} nothing --exec-batch cat",
+        # No exec flag, but the name list is piped into a reader.
+        f"fd . {CREW} | xargs cat",
+        f"fd . {CREW} | xargs -0 head -c 100",
+        f"fd . {CREW} | parallel cat",
+        # xargs flags that take a VALUE put it where the payload would sit, so
+        # the payload cannot be found by stopping at the first non-flag token.
+        f"fd . {CREW} | xargs -n 1 cat",
+        f"fd . {CREW} | xargs -P 4 cat",
+        f"fd . {CREW} | xargs -I {{}} cat {{}}",
+        # An `env` wrapper hides the program word from a naive first-token read.
+        f"env fd . {CREW} -x cat",
+        f"env FOO=1 fd . {CREW} -x cat",
+        f"env grep -r secret {CREW}",
+        # `env`'s own options sit where the program word would, so they have to be
+        # skipped as well -- otherwise `-i` is read as the program.
+        f"env -i grep -r . {CREW}",
+        f"env -i -u FOO grep -r . {CREW}",
+        f"env -u FOO grep -r . {CREW}",
+        f"env --unset=FOO grep -r . {CREW}",
+        # `|&` is ONE operator; consuming only the bar left `&` as the next
+        # stage's program and the reader after it was never looked at.
+        f"rg --files {CREW} |& xargs cat",
+        f"fd . {CREW} |& xargs cat",
+        # The workspace root holds the Notes vault's PAT.
+        f"grep -r secret {CREW}/workspace",
+    ],
+)
+def test_fd_traversal_into_crew_home_is_denied(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A listing is not a read: names are not the secret.
+        f"fd . {CREW}",
+        f"fd '^\\.env$' {CREW}",
+        # `cat` on the PIPE prints the name list on stdin; it does not open the
+        # files those names point to, so it is not a sink.
+        f"fd . {CREW} | cat",
+        f"fd . {CREW} | wc -l",
+        # An ordinary project tree holds no fenced leaf.
+        "fd '^main.py$' ./src -x cat",
+        "fd -e py . src",
+        "fd -e ts . website/src -x npx prettier --check",
+        "fd . ~/Documents",
+        "fd . ~/projects/app -x cat",
+        # A crew subdirectory that holds no fenced leaf stays readable.
+        f"fd . {CREW}/workspace/memory -x cat",
+    ],
+)
+def test_fd_without_delivery_or_fence_is_allowed(command: str) -> None:
+    assert not _denied(command), command
+
+
+# ── grep -r / rg: the reader IS the traversal, so there is no sink to find ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f"grep -r secret {CREW}",
+        f"grep -R secret {CREW}",
+        # Clustered short flags -- the spelling a person actually types.
+        f"grep -rn secret {CREW}",
+        f"grep -rl secret {CREW}",
+        f"grep -irn secret {CREW}",
+        # Long spellings.
+        f"grep --recursive secret {CREW}",
+        f"grep --dereference-recursive secret {CREW}",
+        # grep's aliases, including the one that is recursive with no flag.
+        f"egrep -r secret {CREW}",
+        f"fgrep -r secret {CREW}",
+        f"rgrep secret {CREW}",
+        # ripgrep recurses with no flag at all.
+        f"rg secret {CREW}",
+        # `-l` still opens every file to decide whether to print its name.
+        f"rg -l secret {CREW}",
+        f"rg --files-with-matches secret {CREW}",
+        # `--files` is a pure lister, so it needs a sink -- and here it has one.
+        f"rg --files {CREW} | xargs cat",
+        f"rg --files {CREW} | parallel cat",
+        # Reached through a sequencer rather than as the whole line.
+        f"true && grep -r secret {CREW}",
+        f"cd /tmp; grep -r secret {CREW}",
+        f"grep -r secret {CREW_LEGACY}",
+    ],
+)
+def test_recursive_read_rooted_above_fence_is_denied(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Not recursive: a single named file is the normalizer pass's business,
+        # and this one is not fenced.
+        "grep -n secret ~/projects/notes.txt",
+        "grep secret ./src/main.py",
+        # Recursive, but rooted where no fenced leaf lives.
+        "grep -r TODO ./src",
+        "grep -r secret ~/projects/app",
+        "grep -r secret /tmp/scratch",
+        f"grep -r TODO {CREW}/workspace/memory",
+        "rg secret ./website/src",
+        # A pure lister with no sink discloses nothing.
+        f"rg --files {CREW}",
+        f"rg --files {CREW} | wc -l",
+        "rg --files ./src | xargs cat",
+        # The words appear as data, not as a program.
+        "echo grep -r",
+        f"echo 'grep -r secret {CREW}'",
+    ],
+)
+def test_non_recursive_or_unfenced_reads_are_allowed(command: str) -> None:
+    assert not _denied(command), command
+
+
+# ── A root held in a variable the command itself assigns ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Each stage is tokenized on its own, so without assignment tracking the
+        # `$D` operand stayed literal and the fence was never consulted.
+        'D=$HOME/.kiro/crew; rg . "$D"',
+        'D=$HOME/.kiro/crew; grep -r secret "$D"',
+        'D=$HOME/.kiro/crew; fd . "$D" -x cat',
+        # `+=` appends, so a root assembled in two steps resolves too.
+        'P=$HOME/.kiro; P+=/crew; rg . "$P"',
+        # A declaration keyword assigns just as a bare `NAME=value` does, so the
+        # scan has to look past it -- and past its options.
+        'export D=$HOME/.kiro/crew; rg . "$D"',
+        'readonly D=$HOME/.kiro/crew; rg . "$D"',
+        'declare D=$HOME/.kiro/crew; rg . "$D"',
+        'declare -x D=$HOME/.kiro/crew; rg . "$D"',
+        'typeset D=$HOME/.kiro/crew; rg . "$D"',
+        'local D=$HOME/.kiro/crew; grep -r x "$D"',
+    ],
+)
+def test_variable_expanded_root_is_denied(command: str) -> None:
+    assert _denied(command), command
+
+
+def test_variable_expanded_root_outside_the_fence_is_allowed() -> None:
+    assert not _denied('D=$HOME/projects; rg . "$D"')
+    assert not _denied('export D=$HOME/projects; rg . "$D"')
+
+
+# ── grep's other recursive switch: the directory ACTION ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f"grep -d recurse . {CREW}",
+        f"grep --directories=recurse . {CREW}",
+        f"grep --directories recurse . {CREW}",
+        f"grep -drecurse . {CREW}",
+        # The action flag ends a short-flag cluster, in both spellings.
+        f"grep -nd recurse . {CREW}",
+        f"grep -ndrecurse . {CREW}",
+    ],
+)
+def test_directory_recurse_action_is_denied(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `-d skip` and `-d read` are the non-recursive actions.
+        f"grep -d skip . {CREW}",
+        f"grep --directories=skip . {CREW}",
+        "grep --directories skip . ./src",
+        # Recursive, but rooted where no fenced leaf lives.
+        "grep -n -d recurse pattern ./src",
+    ],
+)
+def test_non_recursive_directory_action_is_allowed(command: str) -> None:
+    assert not _denied(command), command
+
+
+# ── A reader wrapped in a shell ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The xargs payload is `sh`, and reading only the direct payload called
+        # that clean while the `-c` string runs `cat`.
+        f"rg --files {CREW} | xargs sh -c 'cat \"$@\"' sh",
+        f"fd . {CREW} | xargs bash -c 'cat \"$@\"' bash",
+        # The traversal itself inside a shell command string.
+        f"sh -c 'grep -r secret {CREW}'",
+        f"bash -c 'rg secret {CREW}'",
+        # `env -S` carries a whole command the same way `sh -c` does.
+        f"env -S 'grep -r secret {CREW}'",
+        # `-c` takes a value, so it ends a short-option cluster: `-lc` is the
+        # spelling a tool actually emits, and matching the whole token missed it.
+        f"bash -lc 'rg . {CREW}'",
+        f"sh -lc 'grep -r . {CREW}'",
+        f"bash -c'rg . {CREW}'",
+        f"rg --files {CREW} | xargs bash -lc 'cat \"$@\"' bash",
+        f"rg --files {CREW} | xargs sh -c 'exec cat \"$@\"' sh",
+    ],
+)
+def test_shell_wrapped_traversal_and_sink_are_denied(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A word meaning "run the thing that follows" sits where the program word
+        # would, so the traversal stage matched no rule at all.
+        f"command grep -r . {CREW}",
+        f"command rg . {CREW}",
+        f"command fd . {CREW} -x cat",
+        f"command du -a {CREW} | xargs cat",
+        f"builtin grep -r . {CREW}",
+        f"exec grep -r . {CREW}",
+        # `exec -a NAME` takes a value, which would otherwise be read as the
+        # program.
+        f"exec -a x grep -r . {CREW}",
+        # Peeling repeats, so a stacked spelling resolves too.
+        f"command env -i grep -r . {CREW}",
+    ],
+)
+def test_execution_wrappers_do_not_hide_the_traversal(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "command grep -r TODO ./src",
+        "exec grep -r TODO ./src",
+        "bash -lc 'rg TODO ./src'",
+        # `-c` means something else entirely on other programs.
+        "head -c 100 ./src/main.py",
+        "wc -c ./src/main.py",
+    ],
+)
+def test_wrapped_forms_outside_the_fence_are_allowed(command: str) -> None:
+    assert not _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sh -c 'grep -r TODO ./src'",
+        "rg --files ./src | xargs sh -c 'cat \"$@\"' sh",
+        # A shell payload that opens nothing is not a sink.
+        f"fd . {CREW} | xargs sh -c 'rm \"$@\"' sh",
+    ],
+)
+def test_shell_wrapped_forms_outside_the_fence_are_allowed(command: str) -> None:
+    assert not _denied(command), command
+
+
+# ── The search PATTERN is text to look for, not a place to look in ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Searching source for a reference to the crew home is a legitimate read
+        # of an ordinary tree; the pattern merely spells a fenced parent.
+        'grep -r "$HOME/.kiro" ./src',
+        f"grep -r {CREW} ./src",
+        f"rg '{CREW}' src/",
+        # Pattern only, so the root is the working directory.
+        f"rg {CREW}",
+    ],
+)
+def test_a_pattern_naming_a_fenced_parent_is_not_a_root(command: str) -> None:
+    assert not _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # With the pattern supplied by a flag, every positional is a root again.
+        f"grep -r -e secret {CREW}",
+        f"rg -e secret {CREW}",
+        # A root arriving through a root-supplying flag occupies the slot the
+        # pattern would hold, so it must not be exempted with it.
+        f"fd --search-path {CREW} '^\\.env$' -x cat",
+        f"fd --search-path={CREW} nothing --exec-batch cat",
+        # A short pattern flag takes a value, so it ends a cluster and the value
+        # may be glued on. Matching whole tokens saw only `-e secret`, so these
+        # spellings fired the exemption and dropped the credential-store root --
+        # a false NEGATIVE, which is the direction that actually costs something.
+        f"grep -r -esecret {CREW}",
+        f"grep -refoo {CREW}",
+        f"grep -r -fpatterns.txt {CREW}",
+        f"rg -esecret {CREW}",
+        # `rgrep` takes a pattern exactly as `grep` does, so it shares the rule --
+        # and the root after that pattern is still tested.
+        f"rgrep secret {CREW}",
+    ],
+)
+def test_the_pattern_exemption_never_hides_a_root(command: str) -> None:
+    assert _denied(command), command
+
+
+def test_rgrep_shares_the_pattern_exemption() -> None:
+    """`rgrep` is recursive with no flag, but its first positional is the pattern."""
+    assert not _denied(f"rgrep '{CREW}' ./src")
+
+
+# ── Wrappers that only change HOW the traversal runs ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # An argv-forwarding program runs the traversal that follows it, so
+        # reading the first word as the program matched no rule at all.
+        f"nice grep -r . {CREW}",
+        f"nohup grep -r . {CREW}",
+        f"setsid rg . {CREW}",
+        f"ionice rg . {CREW}",
+        f"stdbuf -o0 grep -r . {CREW}",
+        f"sudo grep -r . {CREW}",
+        f"doas grep -r . {CREW}",
+        # A wrapper's own positional argument is not the program.
+        f"timeout 5 rg . {CREW}",
+        f"timeout 1.5m rg . {CREW}",
+        f"taskset 0x3 rg . {CREW}",
+        f"chrt 10 rg . {CREW}",
+        f"nice -n 10 grep -r . {CREW}",
+        # Stacked, and mixed with the shell wrappers.
+        f"nohup nice rg . {CREW}",
+        f"command nice grep -r . {CREW}",
+        f"nice env -i grep -r . {CREW}",
+        # The delivery rules still apply through a wrapper.
+        f"nice fd . {CREW} -x cat",
+        f"nice du -a {CREW} | xargs cat",
+    ],
+)
+def test_argv_forwarding_wrappers_do_not_hide_the_traversal(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "nice grep -r TODO ./src",
+        "timeout 5 rg TODO ./src",
+        "nohup nice rg TODO ./website/src",
+    ],
+)
+def test_wrapped_traversals_outside_the_fence_are_allowed(command: str) -> None:
+    assert not _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `_program_basename` keeps a Windows suffix on purpose, so this pass has
+        # to strip it or every Windows spelling matches no rule.
+        f"grep.exe -r . {CREW}",
+        f"rg.EXE . {CREW}",
+        f"rg.cmd . {CREW}",
+        f"fd.exe . {CREW} -x cat",
+    ],
+)
+def test_windows_executable_suffix_is_stripped(command: str) -> None:
+    assert _denied(command), command
+
+
+def test_program_word_strips_only_a_windows_suffix() -> None:
+    assert security._alt_program_word("grep.exe") == "grep"
+    assert security._alt_program_word("/usr/bin/RG.EXE") == "rg"
+    assert security._alt_program_word("rg.cmd") == "rg"
+    # A dot that is not an executable suffix is part of the name.
+    assert security._alt_program_word("python3.12") == "python3.12"
+
+
+# ── `--` ends option parsing, so the word after it is the pattern ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Requiring a non-dash token to be the pattern skipped `-foo` and exempted
+        # the ROOT instead, so the recursive read of the crew home read clean.
+        f"grep -r -- -foo {CREW}",
+        f"rg -- -foo {CREW}",
+        f"grep -r -- --foo {CREW}",
+        # The ordinary spelling still works.
+        f"grep -r -- foo {CREW}",
+    ],
+)
+def test_a_dash_prefixed_pattern_after_end_of_flags_does_not_hide_the_root(
+    command: str,
+) -> None:
+    assert _denied(command), command
+
+
+# ── A flag-supplied pattern is text to search for, not a place to search ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The value carries the pattern, so testing it as a root refused an
+        # ordinary source search -- the same false positive the positional
+        # exemption exists to prevent, reached through the flag spelling.
+        'grep -r -e "$HOME/.kiro" ./src',
+        'grep -re "$HOME/.kiro" ./src',
+        "grep -r --regexp=$HOME/.kiro ./src",
+        'grep -r --regexp "$HOME/.kiro" ./src',
+        'rg -e "$HOME/.kiro" ./src',
+        "grep -r -f $HOME/.kiro ./src",
+    ],
+)
+def test_a_pattern_supplied_by_a_flag_is_not_a_root(command: str) -> None:
+    assert not _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Dropping the VALUE must not drop the root that follows it.
+        f"grep -r -e secret {CREW}",
+        f"grep -re secret {CREW}",
+        f"grep -r --regexp=secret {CREW}",
+        f"grep -r --regexp secret {CREW}",
+        f"grep -r -f pats.txt {CREW}",
+        f"rg -e secret {CREW}",
+    ],
+)
+def test_dropping_the_pattern_value_keeps_the_root(command: str) -> None:
+    assert _denied(command), command
+
+
+def test_pattern_flag_value_removal_reads_both_spellings() -> None:
+    strip = security._alt_without_pattern_flag_values
+    assert strip(["-r", "-e", "PAT", "/root"]) == ["-r", "/root"]
+    assert strip(["-re", "PAT", "/root"]) == ["/root"]
+    assert strip(["-r", "--regexp=PAT", "/root"]) == ["-r", "/root"]
+    # `--files` is a MODE with no value, so the next word stays a root.
+    assert strip(["--files", "/root"]) == ["/root"]
+    # `--` is an operand marker, not a pattern flag.
+    assert strip(["-r", "--", "/root"]) == ["-r", "--", "/root"]
+
+
+# ── The working directory is a fallback for a ROOTLESS traversal only ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Consulting the cwd unconditionally refused every recursive read on a
+        # gateway launched from the home directory, including one rooted at a
+        # clean tree.
+        "grep -r TODO ./src",
+        "rg TODO ./website/src",
+        "grep -r secret /tmp/scratch",
+    ],
+)
+def test_an_explicit_clean_root_is_not_overridden_by_the_working_directory(
+    command: str,
+) -> None:
+    assert not _denied(command), command
+
+
+def test_explicit_root_detection_reads_path_shaped_operands() -> None:
+    names = security._alt_names_an_explicit_root
+    assert names(["./src"])
+    assert names(["/tmp/scratch"])
+    assert names(["~/projects"])
+    # A reader payload and flags are not roots.
+    assert not names(["-x", "cat"])
+    assert not names(["-r"])
+
+
+# ── du: a size lister used as a path producer ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f"du -a {CREW} | xargs cat",
+        # An intervening stage does not hide the sink.
+        f"du -a {CREW} | awk '{{print $2}}' | xargs cat",
+    ],
+)
+def test_size_lister_with_reader_sink_is_denied(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f"du -a {CREW}",
+        f"du -sh {CREW}",
+        "du -a ~/projects | xargs cat",
+    ],
+)
+def test_size_lister_without_sink_or_fence_is_allowed(command: str) -> None:
+    assert not _denied(command), command
+
+
+# ── Residuals: named here so a later change cannot quietly assume coverage ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `locate` has NO root operand -- the database supplies the path -- so the
+        # root-containment clause every rule above rests on has nothing to test.
+        # Recognising only the leaf names the fence DECLARES would still miss
+        # `id_rsa` (`.ssh` is fenced as a whole directory, so no leaf name is
+        # declared for it) while reading as covered, so it is left open and named
+        # rather than half-closed.
+        "locate id_rsa | xargs cat",
+        "plocate id_rsa | xargs cat",
+        # A name list delivered through a command substitution rather than xargs.
+        f"cat $(fd '^\\.env$' {CREW})",
+        # A traversal with NO root operand, after the same line moved into the
+        # fenced directory. The root is the shell's working directory, which this
+        # pass resolves against the gateway's rather than the shell's. The
+        # explicit-root spelling of the same read IS denied, by the cd-taint pass.
+        f"cd {CREW}; rg secret",
+        # A whole-directory COPIER rooted at the fence reaches the same bytes
+        # without searching for them. Treating copiers as traversals is a new
+        # program class with its own false positives, so it is named rather than
+        # half-closed. The lister-pipe spelling (`rg --files … | xargs rsync
+        # --files-from=-`) IS denied, because rsync reads as a sink there.
+        f"tar -cf out.tar {CREW}",
+        f"cp -r {CREW} /tmp",
+        f"zip -r out.zip {CREW}",
+        f"rsync -r {CREW} /tmp",
+    ],
+)
+def test_documented_residuals_are_not_yet_covered(command: str) -> None:
+    """Pins the residuals the module's block comment names.
+
+    A failure here is GOOD news -- it means a later change closed the shape. Move
+    the case up to the denied set and delete it from the block comment's residual
+    list; do not relax the pass to keep this test passing.
+    """
+    assert not _denied(command), command
+
+
+# ── Unit-level behaviour of the pass's own helpers ──
+
+
+def test_reader_sink_requires_the_payload_to_be_a_reader() -> None:
+    stages = security._alt_pipeline_stages("fd . x | xargs cat")
+    assert security._alt_has_reader_sink(stages)
+    stages = security._alt_pipeline_stages("fd . x | xargs rm")
+    assert not security._alt_has_reader_sink(stages)
+
+
+def test_reader_sink_survives_an_xargs_flag_that_takes_a_value() -> None:
+    """`-n 1` puts its value where the payload would sit."""
+    stages = security._alt_pipeline_stages("fd . x | xargs -n 1 cat")
+    assert security._alt_has_reader_sink(stages)
+
+
+def test_stage_head_skips_assignments_and_an_env_wrapper() -> None:
+    program, operands = security._alt_stage_head(["env", "FOO=1", "fd", ".", "/tmp"])
+    assert program == "fd"
+    assert operands == [".", "/tmp"]
+    program, operands = security._alt_stage_head(["FOO=1", "grep", "-r", "x"])
+    assert program == "grep"
+    assert operands == ["-r", "x"]
+
+
+def test_bare_pipe_to_a_reader_is_not_a_sink() -> None:
+    """`| cat` prints the NAME list, it does not open the named files."""
+    stages = security._alt_pipeline_stages("fd . x | cat")
+    assert not security._alt_has_reader_sink(stages)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A bare `&` backgrounds what precedes it and starts a new command.
+        # `_split_shell_segments` breaks on `&&` but not on one `&`, so anything
+        # placed before it made the stage read as that first program and the
+        # traversal after it was never examined.
+        f"echo start & grep -r secret {CREW}",
+        f"true & rg secret {CREW}",
+        f"echo start & fd . {CREW} -x cat",
+        f"rg --files {CREW} & xargs cat",
+        # Trailing `&` keeps the traversal in its own stage.
+        f"grep -r secret {CREW} &",
+        f"grep -r secret {CREW} & echo done",
+    ],
+)
+def test_a_bare_ampersand_separates_stages(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # An `&` belonging to a redirection is data, not a separator, so the stage
+        # it sits in must stay intact.
+        f"grep -r secret {CREW} 2>&1",
+        f"rg secret {CREW} >&2",
+    ],
+)
+def test_a_redirection_ampersand_does_not_split_the_stage(command: str) -> None:
+    assert _denied(command), command
+
+
+def test_redirect_ampersand_keeps_one_stage() -> None:
+    stages = security._alt_pipeline_stages("grep -r x ./src 2>&1")
+    programs = [security._alt_stage_head(s)[0] for s in stages]
+    assert programs == ["grep"]
+
+
+def test_bare_ampersand_yields_two_stages() -> None:
+    stages = security._alt_pipeline_stages("echo start & grep -r x ./src")
+    programs = [security._alt_stage_head(s)[0] for s in stages]
+    assert "echo" in programs and "grep" in programs
+
+
+def test_pipe_with_stderr_is_one_operator() -> None:
+    """`|&` must not leave `&` as the next stage's program word."""
+    stages = security._alt_pipeline_stages("rg --files x |& xargs cat")
+    programs = [security._alt_stage_head(s)[0] for s in stages]
+    assert "xargs" in programs
+    assert "&" not in programs
+
+
+def test_command_string_payloads_become_their_own_stages() -> None:
+    stages = security._alt_pipeline_stages("sh -c 'grep -r x ./src'")
+    programs = [security._alt_stage_head(s)[0] for s in stages]
+    assert "sh" in programs and "grep" in programs
+
+
+def test_nested_shell_recursion_is_depth_bounded() -> None:
+    """A shell inside a shell resolves; an unbounded walk is not on offer."""
+    nested = "sh -c 'sh -c 'sh -c ''cat x''''"
+    assert security._alt_pipeline_stages(nested) is not None
+
+
+def test_assignments_are_collected_across_stages() -> None:
+    stages = security._alt_pipeline_stages("D=/a/b; P=/c; P+=/d; rg . $D")
+    assignments = security._alt_assignments(stages)
+    assert assignments["D"] == "/a/b"
+    assert assignments["P"] == "/c/d"
+
+
+def test_env_options_are_skipped_before_the_program_word() -> None:
+    program, operands = security._alt_stage_head(["env", "-i", "grep", "-r", "."])
+    assert program == "grep"
+    assert operands == ["-r", "."]
+    program, _rest = security._alt_stage_head(["env", "-u", "FOO", "grep", "-r"])
+    assert program == "grep"
+
+
+def test_execution_wrappers_are_peeled_before_the_program_word() -> None:
+    for wrapper in ("command", "builtin", "exec"):
+        program, operands = security._alt_stage_head([wrapper, "grep", "-r", "."])
+        assert program == "grep", wrapper
+        assert operands == ["-r", "."], wrapper
+    # `exec -a NAME` takes a value.
+    program, _rest = security._alt_stage_head(["exec", "-a", "x", "grep", "-r"])
+    assert program == "grep"
+    # Peeling repeats across stacked wrappers.
+    program, _rest = security._alt_stage_head(["command", "env", "-i", "grep", "-r"])
+    assert program == "grep"
+
+
+def test_shell_c_payload_is_read_from_a_cluster() -> None:
+    # Exactly once: both extractors see this spelling, and re-staging one payload
+    # twice doubles the walk below it for no new reading.
+    assert security._alt_command_string_payloads(["bash", "-lc", "cat x"]) == ["cat x"]
+    assert security._alt_command_string_payloads(["sh", "-c", "cat x"]) == ["cat x"]
+    assert security._alt_command_string_payloads(["bash", "-c cat x"]) == [" cat x"]
+    # `-c` on a non-shell program is not a command string.
+    assert security._alt_command_string_payloads(["head", "-c", "100"]) == []
+
+
+def test_env_split_string_payload_is_read() -> None:
+    assert security._alt_command_string_payloads(["env", "-S", "cat x"]) == ["cat x"]
+
+
+def test_payload_extraction_does_not_repeat_a_shared_spelling() -> None:
+    """Both extractors find `sh -c '…'`; the union must not stage it twice."""
+    payloads = security._alt_command_string_payloads(["sh", "-c", "grep -r x ./src"])
+    assert payloads == ["grep -r x ./src"]
+    assert security._alt_command_string_payloads(["env", "--split-string=cat x"]) == ["cat x"]
+
+
+def test_pattern_supplying_detection_reads_glued_and_clustered_flags() -> None:
+    assert security._alt_pattern_is_flag_supplied(["-e", "secret"])
+    assert security._alt_pattern_is_flag_supplied(["-esecret"])
+    assert security._alt_pattern_is_flag_supplied(["-refoo"])
+    assert security._alt_pattern_is_flag_supplied(["-fpatterns.txt"])
+    assert security._alt_pattern_is_flag_supplied(["--regexp=secret"])
+    # Uppercase only chooses a regex dialect; it supplies no pattern.
+    assert not security._alt_pattern_is_flag_supplied(["-F", "-E", "secret"])
+    assert not security._alt_pattern_is_flag_supplied(["-rn", "secret"])
+    # Everything after `--` is an operand.
+    assert not security._alt_pattern_is_flag_supplied(["--", "-e"])
+
+
+def test_root_operands_exempt_the_pattern_but_not_a_root_flag_value() -> None:
+    # Exactly one operand is dropped -- the pattern. Flags stay, because a flag's
+    # value can itself be a root and testing a flag only ever answers "no".
+    assert security._alt_root_operands("grep", ["-r", "PAT", "/root"]) == [
+        "-r",
+        "/root",
+    ]
+    # `du` names only roots, so nothing is exempted there.
+    assert security._alt_root_operands("du", ["-a", "/root"]) == ["-a", "/root"]
+    # A pattern-supplying flag means nothing is exempted.
+    assert "/root" in security._alt_root_operands("grep", ["-r", "-e", "PAT", "/root"])
+    # A root-supplying flag's value survives the exemption.
+    assert "/root" in security._alt_root_operands(
+        "fd", ["--search-path", "/root", "PAT", "-x", "cat"]
+    )
+
+
+def test_pipeline_split_respects_quoting() -> None:
+    stages = security._alt_pipeline_stages("grep -r 'a|b' ./src")
+    assert len(stages) == 1
+    assert security._alt_stage_head(stages[0]) == ("grep", ["-r", "a|b", "./src"])
+
+
+def test_grep_recursion_is_read_off_clustered_short_flags() -> None:
+    assert security._grep_is_recursive(["-rn", "secret", "."])
+    assert security._grep_is_recursive(["--recursive", "secret", "."])
+    assert not security._grep_is_recursive(["-n", "secret", "."])
+    # Everything after `--` is an operand, not a flag.
+    assert not security._grep_is_recursive(["--", "-r", "."])
+
+
+def test_root_check_accepts_a_flag_value_as_a_candidate_root() -> None:
+    """A root can arrive as a flag's value, so every operand is tested.
+
+    Tracking which flags take a value would need a table per tool, and each
+    omission from such a table would be a MISS.
+    """
+    home = os.path.expanduser("~")
+    assert security._alt_root_reaching_fence([f"--search-path={home}/.kiro/crew"], {})
+    assert security._alt_root_reaching_fence([f"{home}/.kiro/crew"], {})
+    assert not security._alt_root_reaching_fence(["--max-depth", "2", "secret"], {})
+
+
+def test_root_check_resolves_a_root_held_in_an_assignment() -> None:
+    home = os.path.expanduser("~")
+    assignments = {"D": f"{home}/.kiro/crew"}
+    assert security._alt_root_reaching_fence(["$D"], assignments)
+    assert not security._alt_root_reaching_fence(["$D"], {"D": f"{home}/projects"})
+
+
+def test_pass_is_reachable_from_the_public_gate() -> None:
+    """The pass must be wired into ``is_sensitive_bash_command``, not just defined."""
+    reason = is_sensitive_bash_command(f"grep -r secret {CREW}")
+    assert reason is not None
+    assert "recursive traversal" in reason
+
+
+# ── Program identification: the traversal is found by NAME, not by position ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `eval` takes the command as ordinary operands, so quoting the whole
+        # thing left the stage holding one opaque word.
+        f"eval 'rg --hidden . {CREW}'",
+        f'eval "grep -r secret {CREW}"',
+        f"eval grep -r secret {CREW}",
+        # Stacked shells: one payload per level, deeper than a shell-in-a-shell.
+        f'sh -c "sh -c \\"sh -c \\\\\\"rg . {CREW}\\\\\\"\\""',
+        # A dispatcher that takes the real program as its first operand.
+        f"busybox grep -r . {CREW}",
+        f"busybox rg . {CREW}",
+        # A wrapper whose own option takes a NON-numeric value, which sat exactly
+        # where the program word does.
+        f"stdbuf -o L grep -r . {CREW}",
+        f"timeout -s KILL 5 rg . {CREW}",
+        f"timeout --signal=KILL 5 rg . {CREW}",
+        f"ionice -c 3 grep -r secret {CREW}",
+    ],
+)
+def test_a_word_in_front_of_the_program_cannot_hide_it(command: str) -> None:
+    """Whatever precedes the traversal, the traversal is still found.
+
+    Enumerating what may sit in front of a program is unbounded -- a builtin, a
+    wrapper, an applet dispatcher, a wrapper option's value -- so the program is
+    matched by its own name wherever it appears in the stage.
+    """
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f'R=rg; "$R" --hidden . {CREW}',
+        f'G=grep; "$G" -r secret {CREW}',
+        f'R=rg; "${{R}}" . {CREW}',
+        f"export R=rg; $R . {CREW}",
+        f'F=fd; "$F" . {CREW} -x cat',
+    ],
+)
+def test_a_program_held_in_a_variable_is_resolved(command: str) -> None:
+    """The program slot resolves through the command's own assignments.
+
+    The same indirection the ROOT operands already resolve through, applied to the
+    program word -- reading it literally saw ``$R`` and matched no rule.
+    """
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # getopt_long accepts any unambiguous prefix, so each of these recurses.
+        f"grep --recurs . {CREW}",
+        f"grep --recursi . {CREW}",
+        f"grep --rec . {CREW}",
+        f"grep --der . {CREW}",
+        f"grep --direct=recurse . {CREW}",
+        f"grep --dir recurse . {CREW}",
+        # fd's exec flags and its root-supplying flag abbreviate the same way.
+        f"fd . {CREW} --exe cat",
+        f"fd --sear {CREW} . -x cat",
+    ],
+)
+def test_an_abbreviated_long_option_means_what_it_abbreviates(command: str) -> None:
+    """A GNU long option matches by unique prefix, not as a whole token."""
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A traversal program's NAME as ordinary text. Scanning every token for a
+        # program name must not turn any of these into a traversal.
+        "which rg",
+        "which fd",
+        "type du",
+        "command -v rg",
+        "man grep",
+        "cat ~/bin/rg",
+        "ls -la ~/.local/bin/fd",
+        "sudo cp rg /usr/local/bin/",
+        "chmod +x ./bin/rg",
+        "cargo install ripgrep fd-find",
+        "echo rg",
+        # The search PATTERN happening to be a program name.
+        "grep -r rg ./src",
+        "rg du ./src",
+        "grep -rn fd ./test",
+    ],
+)
+def test_mentioning_a_traversal_program_is_not_running_one(command: str) -> None:
+    """A name-scan reading needs an EXPLICIT root that reaches the fence.
+
+    Without that, every command that merely names ``rg`` would be refused whenever
+    the gateway happens to run from a directory holding the crew home -- the
+    working-directory fallback belongs to the program POSITION alone.
+    """
+    assert not _denied(command), command
+
+
+def test_long_flag_matching_accepts_a_prefix_but_not_an_ambiguous_one() -> None:
+    candidates = frozenset({"--recursive", "--dereference-recursive"})
+    assert security._alt_long_flag_matches("--recursive", candidates)
+    assert security._alt_long_flag_matches("--recurs", candidates)
+    assert security._alt_long_flag_matches("--rec", candidates)
+    # Below the floor: `--r` stands for nothing.
+    assert not security._alt_long_flag_matches("--re", candidates)
+    assert not security._alt_long_flag_matches("--r", candidates)
+    # A short flag is answered exactly -- clusters are read letter by letter.
+    assert not security._alt_long_flag_matches("-r", candidates)
+    # Longer than the candidate is not a prefix OF it.
+    assert not security._alt_long_flag_matches("--recursively", candidates)
+    assert not security._alt_long_flag_matches("--directories", candidates)
+
+
+def test_program_word_resolves_through_an_assignment() -> None:
+    assert security._alt_resolved_program_word("$R", {"R": "rg"}) == "rg"
+    assert security._alt_resolved_program_word("${R}", {"R": "/usr/bin/rg"}) == "rg"
+    # No assignment reaches a traversal name, so the literal reading is returned --
+    # which is what `_program_basename` makes of the token, `$` and all.
+    assert security._alt_resolved_program_word("$R", {"R": "cat"}) == "r"
+    assert security._alt_resolved_program_word("cat", {}) == "cat"
+
+
+def test_stage_readings_give_the_cwd_fallback_to_the_program_position_only() -> None:
+    """The head reading may assume the working directory; a name-scan one may not."""
+    head = security._alt_stage_readings(["nice", "rg", "secret"], {})
+    assert ("rg", ["secret"], True) in head
+    scanned = security._alt_stage_readings(["busybox", "rg", "secret"], {})
+    assert ("rg", ["secret"], False) in scanned
+    assert not any(program == "rg" and cwd for program, _ops, cwd in scanned)
+
+
+def test_stage_collection_is_bounded_by_the_stage_budget() -> None:
+    """Payload extraction branches, so depth alone does not bound the walk."""
+    wide = " | ".join(["echo x"] * (security._ALT_MAX_STAGES + 200))
+    assert len(security._alt_pipeline_stages(wide)) <= security._ALT_MAX_STAGES
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Reached by unioning in `_nested_shell_payloads`, the extractor the
+        # self-protection floor already uses. Each is a payload spelling the pass's
+        # own scan declines to see.
+        f"bash <<< 'rg . {CREW}'",
+        f"bash <<<'grep -r secret {CREW}'",
+        f"$SHELL -c 'rg . {CREW}'",
+        f"bash -c -- 'rg . {CREW}'",
+        f"alias x='grep -r secret {CREW}'; x",
+    ],
+)
+def test_payloads_the_shared_extractor_finds_are_read_as_commands(command: str) -> None:
+    """The reused extractor's spellings reach this pass too.
+
+    Re-implementing payload extraction here meant the two disagreed about which
+    spellings carry a command, and every spelling only one of them knew was a
+    traversal never looked at.
+    """
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A payload GLUED to a short cluster: the token holds characters the shared
+        # extractor's flag pattern rejects, so this pass's own scan is what sees it.
+        f"sh -c'rg . {CREW}'",
+        f"bash -lc 'rg . {CREW}'",
+        f"env -S 'grep -r secret {CREW}'",
+    ],
+)
+def test_the_local_scan_still_finds_what_the_shared_extractor_declines(
+    command: str,
+) -> None:
+    """Both extractors are needed: the union is not a replacement of either."""
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `-c` means something else on a program that is not a shell, so unioning in
+        # a second extractor must not turn these into payload carriers.
+        "head -c 100 ./README.md",
+        "wc -c ./README.md",
+        "bash <<< 'rg TODO ./src'",
+        "alias x='grep -r TODO ./src'; x",
+    ],
+)
+def test_payload_extraction_stays_scoped_to_shells(command: str) -> None:
+    assert not _denied(command), command
+
+
+def test_exhausting_the_stage_budget_is_a_refusal_not_a_gap() -> None:
+    """Padding a command past the budget must not hide the traversal after it.
+
+    The cap keeps an attacker-shaped string cheap; dropping the stages past it
+    silently made the cap ITSELF the bypass.
+    """
+    padded = "; ".join(["echo x"] * (security._ALT_MAX_STAGES + 100))
+    assert _denied(f"{padded}; rg . {CREW}")
+    # The same padding with no traversal is refused too -- the pass cannot see far
+    # enough to say otherwise, and this many stages is not a shape anyone types.
+    reason = is_sensitive_bash_command(padded)
+    assert reason is not None and "pipeline stages" in reason
+
+
+def test_an_ordinary_pipeline_is_nowhere_near_the_budget() -> None:
+    """The refusal above must not reach a command a person would actually write."""
+    stages, truncated = security._alt_pipeline_stages_bounded(
+        "rg --files ./src | xargs grep -l TODO | sort | uniq -c | head -20"
+    )
+    assert not truncated
+    assert len(stages) < security._ALT_MAX_STAGES
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # An abbreviated long PATTERN flag. Missing it exempted the first positional
+        # as the pattern -- and here that positional is the ROOT.
+        f"grep -r --reg=secret {CREW}",
+        f"grep -r --regex=secret {CREW}",
+        f"grep -r --reg secret {CREW}",
+    ],
+)
+def test_an_abbreviated_pattern_flag_does_not_exempt_the_root(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The flag that makes grep recursive, held in a variable.
+        f'R=-r; grep "$R" secret {CREW}',
+        f'R=-rn; grep "$R" secret {CREW}',
+        f'D=recurse; grep -d "$D" secret {CREW}',
+        # The sink program, held in a variable.
+        f'C=cat; rg --files {CREW} | xargs "$C"',
+        f'C=cat; fd . {CREW} | xargs "$C"',
+    ],
+)
+def test_a_flag_or_sink_held_in_a_variable_is_resolved(command: str) -> None:
+    """Assignments already resolved the ROOT and the program word; now the rest."""
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `dd` and its family copy a file's bytes, so a lister piped into one
+        # delivers content exactly as `xargs cat` does.
+        f"rg --files {CREW} | xargs -I{{}} dd if={{}}",
+        f"fd . {CREW} | xargs -I{{}} gzip -c {{}}",
+        f"du -a {CREW} | xargs -I{{}} sha512sum {{}}",
+        f"fd . {CREW} | xargs -I{{}} hexdump {{}}",
+    ],
+)
+def test_a_copying_reader_is_a_sink(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # An abbreviated pattern flag whose VALUE names the fence is still a
+        # pattern, so the clean root stands.
+        'grep -r --reg="$HOME/.kiro" ./src',
+        'grep -r --regexp="$HOME/.kiro/crew" ./src',
+        'grep -r --reg "$HOME/.kiro" ./src',
+        # A variable holding a flag that does NOT make grep recursive.
+        'R=-n; grep "$R" secret ./src',
+        # A variable holding a sink that opens nothing.
+        'C=echo; rg --files ./src | xargs "$C"',
+        # An ordinary lister into a copying reader, rooted in a clean tree.
+        "fd . ./src | xargs -I{} gzip -c {}",
+    ],
+)
+def test_the_round_five_fixes_do_not_refuse_ordinary_commands(command: str) -> None:
+    assert not _denied(command), command
+
+
+def test_pattern_flag_value_arity_resolves_an_ambiguous_abbreviation() -> None:
+    """An abbreviation shared with a no-value flag must not consume the next word.
+
+    `--fil` prefixes both `--file` (takes a value) and `--files` (takes none), so
+    consuming the next word on that reading would swallow the root.
+    """
+    assert security._alt_pattern_flag_supplies_a_value("-e")
+    assert security._alt_pattern_flag_supplies_a_value("--regexp")
+    assert security._alt_pattern_flag_supplies_a_value("--reg")
+    assert security._alt_pattern_flag_supplies_a_value("--file")
+    # Ambiguous across a value-taking and a no-value flag.
+    assert not security._alt_pattern_flag_supplies_a_value("--fil")
+    # A mode that takes no value at all.
+    assert not security._alt_pattern_flag_supplies_a_value("--files")
+    assert not security._alt_pattern_flag_supplies_a_value("--recursive")
+
+
+def test_token_readings_keep_the_literal_alongside_the_resolved() -> None:
+    assert security._alt_token_readings("-r", {}) == ["-r"]
+    assert security._alt_token_readings("-r", {"R": "-r"}) == ["-r"]
+    readings = security._alt_token_readings("$R", {"R": "-r"})
+    assert "$R" in readings and "-r" in readings
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A root spelled RELATIVE to a `cd` the same line performs. Resolved against
+        # the gateway's own directory this answered no while the shell walked the
+        # crew home. The `cd`-into-the-fence spelling was already denied by the
+        # cd-taint pass; this is the parent-then-subdirectory one.
+        "cd ~/.kiro && rg . crew",
+        "cd ~/.kiro; grep -r secret crew",
+        "cd ~ && rg . .kiro/crew",
+        f"cd {CREW}/.. && rg . crew",
+    ],
+)
+def test_a_root_relative_to_a_cd_resolves_against_it(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A root whose value the command COMPUTES. The tokenizer splits the
+        # substitution across words, so the recorded value is truncated and the
+        # fenced path sits in a separate token of the same stage -- the value itself
+        # can never carry the answer.
+        'D=$(printf %s "$HOME/.kiro/crew"); rg . "$D"',
+        'D=$(echo $HOME/.kiro/crew); rg . "$D"',
+        'D=`echo $HOME/.kiro/crew`; rg . "$D"',
+        'D=$(printf %s "$HOME/.kiro/crew"); grep -r secret "$D"',
+    ],
+)
+def test_a_root_computed_by_a_substitution_fails_closed(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Every ROLE this pass keys a decision on, reached through a variable.
+        f'X=xargs; rg --files {CREW} | "$X" cat',
+        f"S=sh; \"$S\" -c 'rg . {CREW}'",
+        f'E=--; grep -r "$E" -e {CREW}',
+        # A later reassignment does not unwind what the earlier stage already read.
+        'D=$HOME/.kiro/crew; rg . "$D"; D=/tmp',
+        'D=$HOME/.kiro/crew; grep -r secret "$D"; D=/tmp; D=/var',
+    ],
+)
+def test_a_routed_word_held_in_a_variable_is_resolved(command: str) -> None:
+    """Resolving only the traversal name left the sink, the payload carrier and the
+    option terminator reading their literal ``$X``."""
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A `cd` to a clean tree must not make its relative reads suspicious.
+        "cd ./src && grep -r TODO .",
+        "cd ./src; rg TODO lib",
+        "cd ~/Documents && rg . notes",
+        # A computed value that names no fence resolves normally -- this is what
+        # keeps the fail-closed rule from swallowing every `$(pwd)`.
+        'D=$(pwd); rg . "$D"',
+        'D=$(printf %s "./src"); rg . "$D"',
+        # A variable holding a word in a routed slot, pointed at a clean tree.
+        'X=xargs; rg --files ./src | "$X" cat',
+        "S=sh; \"$S\" -c 'rg . ./src'",
+        'E=--; grep -r "$E" -e ./src',
+        pytest.param(
+            f'D=./src; rg . "$D"; D={_CLEAN_ELSEWHERE or "/usr/share"}',
+            marks=_needs_clean_dir,
+        ),
+    ],
+)
+def test_the_round_seven_fixes_do_not_refuse_ordinary_commands(command: str) -> None:
+    assert not _denied(command), command
+
+
+def test_assignment_history_keeps_every_value_a_name_took() -> None:
+    stages = security._alt_pipeline_stages("D=/a; rg . $D; D=/b; D+=/c")
+    history = security._alt_assignment_history(stages)
+    assert history["D"] == ["/a", "/b", "/b/c"]
+    # The last-wins view is unchanged, so callers that want it still get it.
+    assert security._alt_assignments(stages)["D"] == "/b/c"
+
+
+def test_cd_bases_are_collected_from_the_command_itself() -> None:
+    stages = security._alt_pipeline_stages("cd /a/b && rg . c")
+    bases = security._alt_cd_bases(stages, {})
+    assert "/a/b" in bases
+    # `cd` takes ONE operand, so a following word is not a base.
+    stages = security._alt_pipeline_stages("cd /a/b /c/d")
+    assert "/c/d" not in security._alt_cd_bases(stages, {})
+
+
+def test_a_computed_assignment_is_only_fenced_when_its_stage_names_one() -> None:
+    home = os.path.expanduser("~")
+    fenced = security._alt_pipeline_stages(f'D=$(printf %s "{home}/.kiro/crew"); rg . "$D"')
+    assert "D" in security._alt_substitution_assignment_fences(fenced)
+    clean = security._alt_pipeline_stages('D=$(pwd); rg . "$D"')
+    assert not security._alt_substitution_assignment_fences(clean)
+
+
+def test_a_wrapper_hidden_traversal_with_no_root_is_a_documented_residual() -> None:
+    """Pins the residual the block comment names, without needing a fenced cwd.
+
+    The traversal IS found -- that is the point of the name scan -- but the reading
+    is not in the program position, so it may not assume the working directory. A
+    failure here means the fallback was widened; re-read why it is narrow before
+    relaxing this.
+    """
+    readings = security._alt_stage_readings(["busybox", "rg", "secret"], {})
+    rg_readings = [r for r in readings if r[0] == "rg"]
+    assert rg_readings, "the traversal must still be found"
+    assert not any(may_assume_cwd for _p, _o, may_assume_cwd in rg_readings)
+
+
+# ── round ten: program history, positionals, globs, env abbreviation, cost ──
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A trailing reassignment does not unwind what the earlier stage read, so
+        # the PROGRAM slot is judged on every value its name ever held -- the same
+        # rule the roots have followed since round seven.
+        f'R=rg; "$R" . {CREW}; R=echo',
+        f'G=grep; "$G" -r secret {CREW}; G=true',
+        f'R=rg; "${{R}}" . {CREW}; R=echo',
+        f'R=rg; "$R" . {CREW_LEGACY}; R=:',
+    ],
+)
+def test_a_routed_program_is_judged_on_every_value_its_name_held(command: str) -> None:
+    assert _denied(command), command
+
+
+def _survives_tokenization(candidate: str) -> bool:
+    """Does *candidate* reach the gate's own tokenizer unchanged?
+
+    The gate tokenizes with POSIX rules, where a backslash is an ESCAPE. A Windows
+    absolute root therefore arrives as ``C:Usersrunner…`` -- every separator eaten --
+    and names nothing fenced. Asked through the real tokenizer rather than a
+    hand-written rule, so the two cannot disagree.
+    """
+    stages = security._alt_pipeline_stages(f"rg . {candidate}")
+    return any(candidate in tokens for tokens in stages)
+
+
+def _fenced_root() -> str | None:
+    """A root that is fenced HERE and survives POSIX tokenization, or None.
+
+    Two independent requirements, each learned from a shard failure:
+
+    * fenced in THIS environment, because the suite pins ``KIROCREW_HOME`` per test,
+      so ``~/.kiro/crew`` is not where the fence lives while the tests run -- and the
+      tokenizer expands ``~`` before this pass sees it, so on Windows that expansion
+      mixes separators and stops matching;
+    * unchanged by tokenization, because pointing the cases at the pinned home in
+      round twelve substituted a BACKSLASH path into a POSIX command string and the
+      escapes ate it.
+
+    Resolved at CALL time: a module-level constant would capture whatever was set
+    before the per-test fixture ran. Returns None when the platform offers no usable
+    spelling, so the cases SKIP rather than assert an environment fact -- which is
+    the honest answer for a platform where a POSIX command cannot name the root.
+    """
+    home = os.environ.get("KIROCREW_HOME")
+    candidates = []
+    if home:
+        # Forward slashes first: Windows accepts them and they survive tokenization.
+        candidates.extend([home.replace("\\", "/"), home])
+    candidates.append(CREW)
+    for candidate in candidates:
+        if not candidate or not security.path_contains_sensitive(candidate):
+            continue
+        if _survives_tokenization(candidate):
+            return candidate
+    return None
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        # `sh -c 'script' name arg…` binds arg… as $1 onward, so the payload's
+        # positional root is a real root and not an unresolvable token.
+        "bash -c 'rg . \"$1\"' _ {root}",
+        "sh -c 'grep -r secret \"$1\"' _ {root}",
+        "sh -c 'rg . \"$@\"' _ {root}",
+        "sh -c 'rg . $1' _ {root}",
+        "bash -c 'rg . \"${{1}}\"' _ {root}",
+        # Glued to the cluster, which is the other spelling of the same flag.
+        "sh -c'rg . \"$1\"' _ {root}",
+    ],
+)
+def test_a_positional_root_passed_to_a_shell_payload_is_resolved(template: str) -> None:
+    root = _fenced_root()
+    if root is None:
+        pytest.skip("no fenced root here survives POSIX tokenization")
+    command = template.format(root=root)
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The shell expands these before the gate is asked, so the literal token
+        # holds no fence while what runs does.
+        "rg . ~/.kiro/cr*",
+        "grep -r secret ~/.kiro/cr*/",
+        "rg . ~/.kiro/cre?",
+        "rg . ~/.kiro/[cd]rew",
+        # A brace alternative names the crew home outright.
+        "rg . ~/.kiro/{crew,other}",
+        f"rg . {CREW}/../cr*",
+    ],
+)
+def test_a_glob_or_brace_root_is_answered_by_what_it_can_expand_to(
+    command: str,
+) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `getopt_long` accepts any unambiguous prefix, so every abbreviation of
+        # env's own chdir flag enters the fenced directory too.
+        f"env --chd {CREW} rg secret .",
+        f"env --chdi {CREW} rg secret .",
+        f"env --chdir {CREW} rg secret .",
+        f"env --chd={CREW} rg secret .",
+        f"env -C {CREW} rg secret .",
+    ],
+)
+def test_every_spelling_of_env_chdir_supplies_a_traversal_base(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Each round-ten fix could have been "fixed" by refusing more broadly.
+        # These are the commands that would have cost.
+        'R=rg; "$R" . ./src; R=echo',
+        "bash -c 'rg . \"$1\"' _ ./src",
+        "sh -c 'rg . \"$@\"' _ ./src",
+        "rg . ./sr*",
+        "rg . /usr/sha*",
+        "grep -r 'cr*' ./src",
+        "rg . ./src/{lib,bin}",
+        "env --chd ./src rg secret .",
+        "env --chdir ./src grep -r TODO .",
+    ],
+)
+def test_the_round_ten_fixes_do_not_refuse_ordinary_commands(command: str) -> None:
+    assert not _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A renamed grepper is the same traversal. `ag`/`ack` recurse with no flag.
+        f"ag secret {CREW}",
+        f"ack secret {CREW}",
+        f"ack-grep secret {CREW}",
+        # `ugrep` is GNU-compatible, so it needs -r and then walks like grep.
+        f"ugrep -r secret {CREW}",
+        f"ugrep --recursive secret {CREW}",
+        # The same wrapper/variable spellings the other traversals are found through.
+        f"busybox ag secret {CREW}",
+        f'A=ag; "$A" secret {CREW}',
+        f"env --chd {CREW} ag secret .",
+    ],
+)
+def test_a_renamed_grepper_is_the_same_traversal(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The pattern exemption applies to them too, so searching source FOR the
+        # crew path stays allowed -- the false positive the exemption exists for.
+        f"ag '{CREW}' ./src",
+        'ag "$HOME/.kiro" ./src',
+        "ag secret ./src",
+        "ack secret ./src",
+        # ugrep without a recursion flag is not a traversal.
+        f"ugrep secret {CREW}/config.json",
+        "ugrep -r secret ./src",
+    ],
+)
+def test_the_renamed_greppers_keep_their_ordinary_forms(command: str) -> None:
+    assert not _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "count",
+    [
+        security._ALT_MAX_BRACE_ALTERNATIVES,
+        security._ALT_MAX_BRACE_ALTERNATIVES + 1,
+        200,
+    ],
+)
+def test_a_brace_cap_overflow_fails_closed(count: int) -> None:
+    """Padding a brace past the cap must not drop the fenced alternative.
+
+    The cap used to truncate, so alternative 17 was discarded silently while bash
+    expanded it regardless. A failure here means the overflow went back to failing
+    open, which is worse than the cap being low.
+    """
+    padded = ",".join(["a"] * count)
+    assert _denied(f"rg secret ~/.kiro/{{{padded},crew}}")
+
+
+def test_a_brace_overflow_still_allows_a_clean_tree() -> None:
+    """Failing closed on overflow must not refuse an ordinary over-long brace."""
+    padded = ",".join(["a"] * 40)
+    assert not _denied(f"rg secret ./src/{{{padded},lib}}")
+
+
+def test_the_brace_overflow_reading_is_the_containing_directory() -> None:
+    over = "~/.kiro/{" + ",".join(["a"] * 40) + ",crew}"
+    assert "~/.kiro" in security._alt_glob_root_readings(over)
+    # Within the cap there is nothing to contain, so no parent is added.
+    assert security._alt_glob_root_readings("~/.kiro/{a,crew}") == [
+        "~/.kiro/a",
+        "~/.kiro/crew",
+    ]
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        # A quoted command template is argv, so its reader is a real sink.
+        "rg --files {root} | parallel 'cat {{}}'",
+        'rg --files {root} | parallel "cat {{}}"',
+        "rg --files {root} | parallel -I{{}} 'cat {{}}'",
+        "rg --files {root} | parallel 'head -c 200 {{}}'",
+        "fd . {root} | parallel 'cat {{}}'",
+        "rg --files {root} | xargs -I{{}} 'cat {{}}'",
+        # `sh -c` inside the template still resolves through the payload extractor.
+        "rg --files {root} | parallel 'sh -c \"cat {{}}\"'",
+    ],
+)
+def test_a_quoted_sink_template_is_still_a_sink(template: str) -> None:
+    root = _fenced_root()
+    if root is None:
+        pytest.skip("no fenced root here survives POSIX tokenization")
+    command = template.format(root=root)
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["cat", "echo", "wc -l", "head -c 200", "printf %s"],
+)
+def test_a_quoted_template_agrees_with_its_unquoted_payload(payload: str) -> None:
+    """The quoted spelling must not have its own policy.
+
+    Whatever `xargs <payload>` decides, `parallel '<payload> {}'` decides too. This
+    is the guard against "fixing" the quoted form by inventing a narrower reader
+    set for it, which would leave the two spellings disagreeing.
+    """
+    root = _fenced_root()
+    if root is None:
+        pytest.skip("no fenced root here survives POSIX tokenization")
+    unquoted = _denied(f"rg --files {root} | xargs {payload}")
+    quoted = _denied(f"rg --files {root} | parallel '{payload} {{}}'")
+    assert unquoted == quoted, f"{payload}: unquoted={unquoted} quoted={quoted}"
+
+
+def test_a_template_that_opens_nothing_is_not_a_sink() -> None:
+    root = _fenced_root()
+    if root is None:
+        pytest.skip("no fenced root here survives POSIX tokenization")
+    assert not _denied(f"rg --files {root} | parallel 'true'")
+    # And a clean tree is never a sink question in the first place.
+    assert not _denied("rg --files ./src | parallel 'cat {}'")
+
+
+def test_reading_construction_is_charged_to_the_budget() -> None:
+    """Pins Opus's round-13 finding: CONSTRUCTION was the uncharged axis.
+
+    `_alt_stage_readings` built one reading per traversal token before the root
+    check's budget was consulted, so a stage of N repeated traversal words cost
+    O(N^2) with every declared budget reading as untouched.
+    """
+    tokens = ["rg"] * 400 + ["/x"]
+    budget = security._AltWorkBudget(10)
+    readings = security._alt_stage_readings(tokens, {}, None, budget)
+    # Enumeration stops once the budget is spent, so it cannot build 400 readings.
+    assert len(readings) <= 12, len(readings)
+    assert budget.remaining <= 0
+    # With a budget that is not exhausted, every traversal token is still read.
+    roomy = security._AltWorkBudget(10_000)
+    assert len(security._alt_stage_readings(tokens, {}, None, roomy)) >= 2
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A later reassignment does not unwind what an earlier stage already read,
+        # and that rule now reaches EVERY control slot rather than only the root.
+        f'R=-r; grep "$R" secret {CREW}; R=-n',
+        f'R=--recursive; grep "$R" secret {CREW}; R=--count',
+        f'C=cat; rg --files {CREW} | xargs "$C"; C=true',
+        f'D={CREW}; cd "$D" && rg . .; D=/usr/share',
+        # The root slot, covered since round eight, must stay covered.
+        f'D={CREW}; rg . "$D"; D=/usr/share',
+    ],
+)
+def test_assignment_history_reaches_every_control_slot(command: str) -> None:
+    """Pins round 14's GPT finding: history was root-only.
+
+    The recursion flag, the sink program and the chdir base each resolved through
+    the shared primitive with the LAST-WINS view alone, so the same
+    trailing-reassignment trick worked on all three while the root spelling denied.
+    """
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # These copy file CONTENT, so they are sinks like `cat`.
+        f"rg --files {CREW} | xargs git hash-object -w",
+        f"rg --files {CREW} | xargs git cat-file --batch",
+        f"rg --files {CREW} | xargs rsync -a --files-from=-",
+        f"fd . {CREW} | xargs git hash-object -w",
+    ],
+)
+def test_content_copying_sinks_are_readers(command: str) -> None:
+    assert _denied(command), command
+
+
+@pytest.mark.parametrize(
+    "verb",
+    ["cd", "pushd", "chdir", "sl", "set-location", "push-location"],
+)
+def test_every_chdir_verb_supplies_a_traversal_base(verb: str) -> None:
+    """The literal `"cd"` covered one of the six verbs the module already owns.
+
+    `pushd ~/.kiro && rg . crew` walked the fence while the `cd` spelling denied.
+    Sourced from `_CHDIR_VERBS` now, so a verb added there needs no second edit.
+    """
+    assert _denied(f"{verb} ~/.kiro && rg . crew"), verb
+
+
+def test_the_chdir_verbs_come_from_the_shared_set() -> None:
+    """Guards the subtraction: a second, narrower spelling must not come back."""
+    stages = security._alt_pipeline_stages("pushd /a/b && rg . c")
+    assert "/a/b" in security._alt_cd_bases(stages, {})
+    # Every verb the shared set declares is honoured, so the two cannot diverge.
+    for verb in security._CHDIR_VERBS:
+        stages = security._alt_pipeline_stages(f"{verb} /a/b && rg . c")
+        assert "/a/b" in security._alt_cd_bases(stages, {}), verb
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Each round-14 fix could have been "fixed" by refusing more broadly.
+        'R=-r; grep "$R" secret ./src; R=-n',
+        'C=cat; rg --files ./src | xargs "$C"; C=true',
+        "pushd ./src && rg . lib",
+        "rg --files ./src | xargs git hash-object -w",
+        "rg --files ./src | xargs rsync -a --files-from=-",
+        "git status",
+        "cp -r ./src /tmp",
+    ],
+)
+def test_the_round_fourteen_fixes_do_not_refuse_ordinary_commands(
+    command: str,
+) -> None:
+    assert not _denied(command), command
+
+
+def test_the_history_walk_lives_in_one_place() -> None:
+    """The primitive every slot shares owns the history expansion.
+
+    Round 14 replaced four call-site patches with one mechanism, so a slot added
+    later inherits history instead of needing a fifth copy. A failure here means the
+    walk was re-inlined somewhere.
+    """
+    history = {"R": ["-r", "-n"]}
+    readings = security._alt_token_readings("$R", {"R": "-n"}, history)
+    assert "-r" in readings and "-n" in readings
+    # Without history, only the last-wins value resolves.
+    assert "-r" not in security._alt_token_readings("$R", {"R": "-n"})
+    # A token naming no variable never builds the scratch copy at all.
+    assert security._alt_token_readings("plain", {"R": "-n"}, history) == ["plain"]
+
+
+@pytest.mark.parametrize(
+    "traversal",
+    [
+        # The applet-dispatched spelling is the one the padding attack deleted: it
+        # is caught ONLY by the traversal token-scan, which is what stopped being
+        # produced once the budget was spent.
+        f"busybox grep -r secret {CREW}",
+        f"grep -r secret {CREW}",
+        f"rg . {CREW}",
+        f"stdbuf -o L grep -r secret {CREW}",
+        f"env grep -r secret {CREW}",
+    ],
+)
+def test_padding_out_the_budget_cannot_unblock_a_traversal(
+    traversal: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pins round 15's fail-open: exhaustion must refuse, not answer with less.
+
+    A padding stage spends the shared budget, so any helper that stopped early
+    returned a PARTIAL reading set -- and the walk then concluded "no fenced root
+    found", which it was not entitled to conclude. Every spelling is checked because
+    the reported one was only the cheapest to find.
+
+    The budget is shrunk rather than the command grown: driving the real 4,096-unit
+    budget needs ~5,000 tokens, and the normalizer's cost on a string that long is
+    57s per case. Same code path, same assertion, milliseconds instead.
+    """
+    monkeypatch.setattr(security, "_ALT_MAX_RESOLUTIONS", 4)
+    padding = " ".join(["x=1"] * 12)
+    assert _denied(f"{padding}; {traversal}"), traversal
+    # And the same traversal is still denied without the padding, so the test cannot
+    # pass merely because padded commands are refused wholesale.
+    assert _denied(traversal), traversal
+
+
+def test_budget_exhaustion_is_always_a_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invariant, stated directly: exhausted budget => refusal.
+
+    Asserted on the flag rather than on one command, because this PR shipped a
+    fail-open limit three times and each round's test pinned only the single
+    spelling that had been reported.
+    """
+    monkeypatch.setattr(security, "_ALT_MAX_RESOLUTIONS", 4)
+    padding = " ".join(["x=1"] * 12)
+    reason = security._check_alt_traversal_reaches_fence(f"{padding}; echo hello")
+    assert reason is not None
+    assert "more traversal analysis" in reason
+    # The message is built from `_ALT_MAX_RESOLUTIONS` at call time, so seeing the
+    # PATCHED value proves the refusal path reads the live production constant
+    # rather than a hard-coded number -- the same thing an end-to-end run against
+    # the real 4,096-unit budget would show, without its 40 seconds.
+    assert "(4 units)" in reason
+
+
+def test_history_resolution_is_charged_in_every_slot() -> None:
+    """No slot may resolve assignment history without charging the budget.
+
+    Round 14 threaded `history` into the recursion-flag, sink and chdir-base helpers
+    WITHOUT the budget, which reopened a 62-second wedge. Each helper is called here
+    with a nearly-spent budget and must stop rather than walk the whole history.
+    """
+    history = {"V": [f"/{i}" for i in range(500)]}
+    assignments = {"V": "/0"}
+    operands = ['"$V"'] * 500
+
+    spent = security._AltWorkBudget(5)
+    security._grep_is_recursive(operands, assignments, history, spent)
+    assert spent.exhausted is True
+
+    spent = security._AltWorkBudget(5)
+    stages = [["cd", '"$V"'], ["rg", ".", "."]]
+    security._alt_cd_bases(stages, assignments, history, spent)
+    assert spent.exhausted is True
+
+    spent = security._AltWorkBudget(5)
+    security._alt_sink_program_names(operands, assignments, history, spent)
+    assert spent.exhausted is True
+
+
+def test_the_budget_has_no_silently_truncating_spend_path() -> None:
+    """Guards the class fix: a caller must not be able to proceed with less.
+
+    `drain` was removed rather than kept as an alias, because its contract -- "stop
+    enumerating and return what you have" -- is the fail-open itself. A future
+    reintroduction should fail here.
+    """
+    assert not hasattr(security._AltWorkBudget, "drain")
+    assert hasattr(security._AltWorkBudget, "charge")
+    assert hasattr(security._AltWorkBudget, "spend")
+
+
+def test_a_glob_root_reads_as_the_directory_it_globs() -> None:
+    """The wildcard's own parent is the question, because the match set is runtime.
+
+    Expanding a glob against the real filesystem inside a security gate would make
+    the verdict depend on directory contents at check time, so the parent directory
+    is asked the same question every other root is asked.
+    """
+    assert security._alt_glob_root_readings("~/.kiro/cr*") == ["~/.kiro"]
+    assert security._alt_glob_root_readings("/a/b/c?") == ["/a/b"]
+    # A brace group enumerates concrete paths rather than a parent.
+    assert security._alt_glob_root_readings("/a/{b,c}") == ["/a/b", "/a/c"]
+    # No metacharacter, no extra reading -- an ordinary path costs nothing.
+    assert security._alt_glob_root_readings("/a/b") == []
+    # A bare pattern has no parent to name, so it contributes nothing.
+    assert security._alt_glob_root_readings("cr*") == []
+
+
+def test_positional_binding_follows_the_shell_argument_order() -> None:
+    """``sh -c script name a b`` makes ``name`` $0 and ``a``/``b`` $1/$2."""
+    bound = security._alt_positional_bound_payload('rg . "$1"', ["_", "/x"])
+    assert bound == 'rg . "/x"'
+    assert security._alt_positional_bound_payload('rg . "$2"', ["_", "/x", "/y"]) == ('rg . "/y"')
+    # `$@` stands for the whole positional list, not including $0.
+    assert security._alt_positional_bound_payload("rg . $@", ["_", "/x", "/y"]) == ("rg . /x /y")
+    # No positional referenced, so no second reading is manufactured.
+    assert security._alt_positional_bound_payload("rg . /x", ["_", "/y"]) is None
+    # $0 alone supplies no arguments to bind.
+    assert security._alt_positional_bound_payload('rg . "$1"', ["_"]) is None
+
+
+def test_the_work_budget_is_charged_from_every_axis_not_only_variables() -> None:
+    """Pins Opus's round-ten finding: the unbounded axis had no assignments at all.
+
+    A single stage of repeated traversal words spends readings x operands work, and
+    the earlier budget only decremented inside the assignment-history loop, which
+    never runs for a command that assigns nothing. A failure here means the budget
+    stopped covering that axis.
+    """
+    budget = security._AltWorkBudget(3)
+    budget.spend()
+    budget.spend()
+    budget.spend()
+    with pytest.raises(security._AltResolutionBudget):
+        budget.spend()
+    # `charge` reports instead of raising, for the callers outside the main try --
+    # and RECORDS exhaustion, so running out can never be expressed as a smaller
+    # answer. That flag is what `_check_alt_traversal_reaches_fence` refuses on.
+    soft = security._AltWorkBudget(1)
+    assert soft.charge() is True
+    assert soft.exhausted is True, "hitting zero must be recorded, not just returned"
+    assert soft.charge() is False
+    assert soft.exhausted is True
+    # A budget that was never overdrawn must not claim exhaustion.
+    roomy = security._AltWorkBudget(10)
+    assert roomy.charge() is True
+    assert roomy.exhausted is False
+
+
+@_needs_clean_dir
+def test_a_repeated_program_command_refuses_rather_than_wedging() -> None:
+    """The wedge shape itself: one stage, no assignments, N traversal words.
+
+    The root has to be a directory that is clean HERE. The test suite relocates the
+    crew home under the temporary directory, so a hard-coded ``/tmp`` root is fenced
+    while the tests run and the command is refused for reaching a fence -- never
+    reaching the budget this test exists to pin.
+    """
+    command = " ".join(["rg"] * 600) + f" {_CLEAN_ELSEWHERE}"
+    reason = is_sensitive_bash_command(command)
+    assert reason is not None
+    assert "more traversal analysis" in reason


### PR DESCRIPTION
Closes #7309.

## Problem

`find` is not the only program that factors a fenced path into a root plus a name and then hands the result to a reader. Each tool spells that shape with its own grammar, so none of them were seen by the gate:

| command | why it was allowed |
|---|---|
| `fd '^\.env$' ~/.kiro/crew -x cat` | program word is `fd`/`fdfind`, pattern is a positional regex, exec is `-x`/`-X` |
| `fd -e key . ~/.kiro/crew -X cat` | extension filter, batched exec |
| `grep -r secret ~/.kiro/crew` | needs no second command — the reader IS the traversal |
| `rg --files ~/.kiro/crew \| xargs cat` | `--files` makes ripgrep a lister |
| `du -a ~/.kiro/crew \| xargs cat` | size lister used as a path producer |

Verified on `origin/main` before the change: `security.py` had zero coverage for `fd`/`fdfind`/`locate`/`plocate` as traversal tools, and every row above returned clean from `is_sensitive_bash_command`. Each reaches the permanent secrets the keystone fence exists to hold back (`.env`, `token_signing.key`, `.local_secret`, `security_policy.json`), deterministically and with no timing.

## Approach

The new pass asks the reverse-direction question `path_contains_sensitive` already answers for bulk operations — **does the traversal's root HOLD a fenced path** — rather than reasoning about the pattern. For a recursive read that is the whole answer: `grep -r` opens every file under its root, so narrowing the pattern cannot make the store unreachable.

**Delivery** is what separates the rules:

- `grep -r`/`-R`/`--recursive`/`-d recurse`, `rgrep`, and `rg` in matching mode ARE the read, so no sink is needed.
- `fd` with `-x`/`-X`/`--exec`/`--exec-batch` runs a reader per hit — the same delivery `find -exec` performs.
- `fd` without an exec flag, `rg --files` and `du -a` emit names only, so they are refused only when the command also carries a sink that opens them (`xargs`/`parallel` with a reader payload). A bare `| cat` is **not** a sink: it prints the name list on stdin, it does not open the files those names point to.

### A traversal is found by its NAME, not by its position

Rounds 1-4 of review produced the same class of finding every time, never against
the fence logic: something was put in FRONT of the traversal so the program word
read as that instead. `command`, `exec -a x`, `nice`, `env -i`, `timeout 5`,
`stdbuf -o L`, `timeout -s KILL 5`, `busybox`, `$R` where `R=rg`. Each round added
a table entry and the next round found the entry nobody wrote, so this revision
stops enumerating what may precede a program.

Every stage now yields two kinds of reading:

- the stage **head**, with the known prefixes peeled. This reading may fall back
  to the working directory when the traversal names no root at all, because a word
  in the program position with no root operand really is `rg secret` walking `.`;
- **every other token that names a traversal program**, wherever it sits. These
  require an EXPLICIT root that reaches the fence, which is what keeps `which rg`,
  `sudo cp rg /usr/local/bin/` and `grep -r rg ./src` allowed.

The prefix tables still exist, but their completeness is no longer what decides
whether a traversal is seen — an unlisted wrapper now costs only the
working-directory reading, not the detection. GNU long options match by unique
prefix rather than as whole tokens, so `--rec`, `--recurs` and `--direct=recurse`
are not new spellings to enumerate either.

**Deliberately NOT a producer allow-list.** Enumerating the programs that are *safe* fails open, because every tool nobody thought of reads as covered — the exact failure mode #7034 called out. Each grammar here only ever ADDS a denial, so a traversal tool this pass does not know is exactly as gated as it was before.

### The search PATTERN is not a root

Testing every operand as a candidate root also treated the search pattern as one, so `grep -r "$HOME/.kiro" ./src` — searching an ordinary tree for a reference to the crew home — was refused. Exactly **one** operand is now exempted: the first positional, and only when no flag supplied the pattern. Two things keep that from hiding a root, both of which are load-bearing and tested:

- A value arriving through a root-supplying flag (`--search-path`, `--base-directory`) is pulled out first and always tested, because it occupies the positional slot the pattern would hold.
- Pattern-supplying flags are detected in **glued and clustered** spellings (`-e secret`, `-esecret`, `-refoo`, `-fpatterns.txt`), not just as whole tokens.

## Review rounds

The first revision was refused by both AI lanes, and every finding was a real spelling that still reached the store. All are fixed in this revision, each with a regression test:

| finding | spelling that got through | fix |
|---|---|---|
| GPT | `export D=$HOME/.kiro/crew; rg . "$D"` | assignment scan looks past a declaration keyword (`_DECLARATION_BUILTINS`) and its options |
| GPT | `grep --directories recurse . ~/.kiro/crew` | the separate-word long form of the directory action, alongside `=recurse` |
| GPT | `bash -lc 'rg . ~/.kiro/crew'`, `xargs bash -lc 'cat "$@"'` | `-c` ends a short-option cluster; payload extraction reads the cluster and is scoped to shells, so `head -c 100` is untouched |
| GPT | `command grep -r . ~/.kiro/crew`, `exec -a x grep …` | execution wrappers (`command`/`builtin`/`exec`/`&`) and their options are peeled before the program word, repeatedly |
| Opus | `grep -r -esecret ~/.kiro/crew` | glued/clustered short pattern flags now suppress the positional exemption — this one was a **false negative introduced by the exemption itself** |
| Opus | `rgrep '~/.kiro/crew' ./src` refused | `rgrep` shares the pattern exemption instead of routing through the all-operands branch |

Also closed while fixing the above, same class: the traversal itself inside `sh -c` / `env -S`, and `env`'s own options (`env -i grep -r . …`).

A later round produced four more BLOCKING findings, all of them the same class
again, which is what prompted the restructure above rather than a fifth round of
table entries. Each is verified as a live bypass before the change and blocked
after, and each has a regression test:

| finding | spelling that got through | fix |
|---|---|---|
| GPT | `eval 'rg --hidden . ~/.kiro/crew'`, `eval "grep -r secret …"` | `eval`/`source` take the command as ordinary operands, so the payload is read as a command rather than as one opaque word |
| GPT | four-deep nested `sh -c`, `source <(echo rg . …)` | payload recursion is bounded by a stage BUDGET rather than by a depth of 3, so stacking shells is not an escape |
| GPT | `R=rg; "$R" --hidden . ~/.kiro/crew`, `"${R}"` | the program word resolves through the command's own assignments — the same indirection the roots already resolved through |
| GPT | `grep --rec`, `--recurs`, `--recursi`, `--direct=recurse` | GNU long options match by unique prefix; `getopt_long` accepts any unambiguous abbreviation |
| GPT | `stdbuf -o L grep -r …`, `timeout -s KILL 5 rg . …` | a wrapper option's non-numeric value sat exactly where the program word does; the name scan no longer cares what precedes the traversal |
| Opus | `busybox grep -r . ~/.kiro/crew` | an applet dispatcher takes the real program as its first operand; same name scan |

The reviewer's suggested fix for the payload finding was to reuse
`_nested_shell_payloads`, the extractor the self-protection floor already uses, and
that is adopted: it is unioned in rather than replacing this pass's own scan,
because the two cover different spellings and a payload missed is a traversal never
looked at. Doing so closed five more shapes that were live bypasses and that no
review round had named — `bash <<< 'rg . ~/.kiro/crew'` and its glued spelling,
`$SHELL -c '…'`, `bash -c -- '…'`, and a multiword `alias` — while this pass's own
scan keeps the one the shared extractor declines, a payload glued to a short
cluster (`sh -c'rg . …'`), whose token holds characters its flag pattern rejects.
The union is de-duplicated, so the spellings both find are staged once. This also
answers the first-principles reviewer's observation that the two extractors
partially re-implemented each other.

Abbreviation matching is applied per flag by asking which DIRECTION an unseen
abbreviation fails in, and an earlier revision of this PR got that backwards for
one group. Missing a recursion flag under-denies, so those match by prefix. Missing
a **pattern-supplying** flag also under-denies -- not over-denies as this section
previously claimed -- because an unrecognised `--reg=secret` leaves the first
positional exempted as the pattern, and in `grep -r --reg=secret ~/.kiro/crew` that
positional is the ROOT. Those match by prefix too, with an ambiguity guard: `--fil`
prefixes both `--file` (takes a value) and `--files` (takes none), so that reading
consumes no following word and every positional stays a root. `rg --files` is the
one flag left EXACT, and that genuinely does fail towards blocking -- an
unrecognised abbreviation leaves ripgrep in matching mode, which needs no sink.

A further round produced four more blocking findings, all verified as live
bypasses before the fix and blocked after, each with a regression test. Two of them
are defects this PR introduced in the round above, which is the honest reading of
them:

| finding | spelling that got through | fix |
|---|---|---|
| GPT | 600 benign stages, then `rg . ~/.kiro/crew` | the stage BUDGET added last round failed open — padding pushed the traversal past the cap and it was never inspected. Exhaustion is now a refusal, so the cap cannot be the bypass |
| GPT | `grep -r --reg=secret ~/.kiro/crew` | an abbreviated pattern flag went unrecognised, which exempted the ROOT as the pattern. Pattern flags now match by prefix, with the ambiguity guard described above |
| GPT | `R=-r; grep "$R" secret …`, `C=cat; rg --files … \| xargs "$C"` | a FLAG and a SINK program are as reachable through a variable as a root is; both now resolve through the command's own assignments, as the roots and the program word already did |
| GPT | `rg --files ~/.kiro/crew \| xargs -I{} dd if={}` | the reader set was the union of two module sets that answer a different question, and omission there is fail-open. A pass-local set adds `dd` and its family — the copying tools, compressors and digest tools, whose output is a faithful copy of a file |

A further round closed the last of this class, plus one unrelated CI red that
turned out to be main-side:

| finding | spelling that got through | fix |
|---|---|---|
| GPT | `cd ~/.kiro && rg . crew` | a root spelled RELATIVE to a `cd` the same line performs resolved against the gateway's directory. The bases a `cd` moves to are now collected and relative roots are joined onto them |
| GPT | `D=$(printf %s "$HOME/.kiro/crew"); rg . "$D"` | a root whose value the command COMPUTES. The tokenizer splits the substitution across words, so the recorded value is the truncated `$(printf` and the path sits in a separate token — reading the body off the value cannot see it. Such a name now fails closed, and only when its own stage names a fenced directory, which keeps `D=$(pwd)` working |
| own audit | `X=xargs; … \| "$X" cat`, `S=sh; "$S" -c '…'`, `E=--; grep -r "$E" -e …` | only the TRAVERSAL slot resolved through assignments, so the sink, the payload carrier and the option terminator each read their literal `$X`. Every role this pass keys a decision on is resolved now |
| own audit | `D=$HOME/.kiro/crew; rg . "$D"; D=/tmp` | assignment collection was last-wins, so a trailing reassignment hid what the earlier stage actually read. Every value a name takes is now tested |

The last two rows were found by my own probe rather than by a reviewer, and are
recorded here because they are the same class and were live.

A ninth round closed two more spellings and bounded the pass's own cost:

| finding | spelling that got through | fix |
|---|---|---|
| GPT | `env --chdir "$HOME/.kiro/crew" grep -r secret .` | `env`'s own `-C`/`--chdir` value is a traversal BASE, and it was being discarded as a mere option value. The chdir flags now feed the same base collection a `cd` feeds, in the three spellings `-C x`, `--chdir x` and `--chdir=x`. **Round ten corrected this row:** it originally claimed GNU abbreviations were covered too, and they were not — the flag was compared by exact membership, so `--chd` walked straight through until round ten routed it through `_alt_long_flag_matches` |
| GPT | `G='grep -r'; $G secret ~/.kiro/crew` | a command-position expansion resolving to MULTIPLE words stayed one token, so the program word was the whole string and matched nothing. Multiword readings are split: first word as the program, the rest as leading operands, so the flags they carry are still seen |
| Opus | 1,500 prefix assignments in one stage | a hard resolution budget. The round-seven history loop rebuilt its marker strings per (token, name) and copied the assignment map per value, so operands x names x values was unbounded. Markers are hoisted, one scratch dict is mutated in place, and exhaustion REFUSES — the same fail-closed answer the stage budget already gives |

On that last finding I argued the attribution was wrong, on the grounds that the
multi-second latency was pre-existing on `main`. **Round ten showed that answer was
incomplete, and the correction matters more than the original point.** What I
measured was true of the axis I measured — under `cProfile` at 600 *assignments*, of
12.13s total, 9.24s was 610 `re.Pattern.search` calls in an existing module pattern
and this pass accounted for 0.88s — but I generalised from one axis to the whole
pass. A second axis owed nothing to the normalizer: with **no assignments at all**,
`rg rg … rg /tmp` spent readings x operands work that no budget touched, because the
only budget decremented inside the assignment-history loop, which such a command
never enters. Measured at 21.3s for a 1.8 KB string. Opus was right that this pass
had an unbounded synchronous dimension; I answered about the wrong one.

Round ten replaces the per-call resolution counter with a per-COMMAND work budget
charged on every operand, reading and candidate, so the bound no longer depends on
which axis grows. After it, the pass is measurably **cheaper than not having it**,
because it refuses early instead of falling through to the expensive normalizer:

| input, k=3000 words | reaches this pass | never reaches this pass |
|---|---|---|
| `rg rg … rg /tmp` | **10.7s** | — |
| `echo echo … echo /tmp` | — | 23.0s |

The pre-existing normalizer cost on long strings is real and still there; it is now
demonstrably the whole of the residual rather than, as I claimed, the whole of the
problem. It belongs in its own change against those regexes.

### Two unrelated CI reds, both resolved on main rather than here

`Backend Tests (Windows) (3)` failed on `test_session_control.py` with `too many
sessions created recently`. That was **not** this PR: the file and
`create_rate_limit.py` were byte-identical to `main`, the same two tests failed on
`origin/main`'s tree with this PR's files removed, and the file exceeds its own
20-create budget on its own. Which tests land past the budget depends on collection
order and xdist shard membership, which is why adding tests anywhere surfaced it. I
had carried a one-fixture fix for it here; `main` has since landed the same fix in
**#7898**, so **my hunk was dropped** and this PR no longer touches that file. The
diff is now exactly two files.

`Dependency Audit` was red on a `fast-uri` advisory reached through the lockfile,
also not this diff. Cleared by rebasing onto a `main` that carries the bumped
lockfile; nothing in this branch pins it.

A tenth round closed four more spellings, the cost axis above, and one class a
design reviewer named:

| finding | spelling that got through | fix |
|---|---|---|
| Opus | `rg rg … rg /tmp` (no assignments) | the per-command work budget described above. This is the finding round nine answered incorrectly |
| GPT | `R=rg; "$R" . ~/.kiro/crew; R=echo` | the PROGRAM word resolved only through last-wins assignments, so a trailing reassignment hid the traversal. Roots have resolved against assignment HISTORY since round eight; the program slot is the same indirection and now shares it |
| GPT | `bash -c 'rg . "$1"' _ ~/.kiro/crew` | a payload was re-staged with its POSITIONAL parameters unbound, so the traversal named no root. The words after a command string are exactly what the shell binds — `$0`, then `$1` onward, with `$@`/`$*` the whole list — so a bound reading is added alongside the literal one |
| GPT | `rg . ~/.kiro/cr*` | a GLOB root holds no fence as literal text while the shell expands it into one. Brace alternatives are enumerated, and a wildcard is answered by the directory that CONTAINS it — the same question this pass asks of every other root |
| GPT | `env --chd ~/.kiro/crew rg secret .` | `_ENV_CHDIR_FLAGS` was compared by exact membership, so every GNU abbreviation walked through. Now matched by `_alt_long_flag_matches` like the other deny-adding long flags |
| Design Review | `ag secret ~/.kiro/crew`, `ack`, `ugrep -r` | a renamed grepper was the same traversal with none of the coverage. `ag`/`ack`/`ack-grep` recurse with no flag, so they join `rgrep`; `ugrep` is GNU-compatible, so it shares grep's grammar and grep's recursion test. Both sets inherit the pattern exemption, so `ag '~/.kiro/crew' ./src` stays allowed |

The glob rule is fail-closed by construction and worth stating plainly: a glob whose
parent holds the fence is refused even where the pattern could not have matched the
fenced entry (`*` skips dotfiles, so `~/*` misses `.kiro`). The alternative is
expanding globs against the real filesystem inside a security gate, which makes the
verdict depend on directory contents at check time. Scoping the read to a
subdirectory is the same spelling this PR already asks for.

### The Windows reds: two hard-coded POSIX roots in the new test file

`Backend Tests (Windows)` failed in **all four shards** with the same
`AssertionError: no unfenced directory available`. Both halves were this file's
own defects, not the pass's:

1. `_first_clean_dir()` raised at **module import** when no candidate matched, and
   its candidate list was five POSIX roots (`/usr/share`, `/usr/lib`, `/etc`,
   `/opt`, `/tmp`) that all fail `isdir` on Windows. An import-time raise is a
   *collection* error, and xdist splits tests only after collecting them, so every
   worker imports every module -- which is why one file's problem errored all four
   shards instead of one. It now names Windows' own roots (`SystemRoot`,
   `ProgramFiles`, `ProgramData`, `tempfile.gettempdir()`) and returns `None`
   rather than raising, so a future gap skips the one case that needs a clean
   directory instead of failing the run.
2. `test_a_repeated_program_command_refuses_rather_than_wedging` rooted its wedge
   command at a hard-coded `/tmp`. The suite relocates the crew home under the
   temporary directory, so that root is *fenced while the tests run*: the command
   was refused for reaching a fence and never reached the budget the test exists
   to pin. It now uses the same resolved clean directory. This one reproduced
   locally on macOS as well.

Rounds eleven and twelve closed one fail-open and two environment-dependent tests:

| finding | what got through | fix |
|---|---|---|
| Opus | `rg secret ~/.kiro/{a,…x16,crew}` | the brace-alternative cap **failed open**: `body.split(",")[:16]` dropped the fenced 17th alternative and the gate answered no while bash expanded it anyway. On overflow the brace group's parent is now emitted as a reading, giving the same containment answer the wildcard branch gives. The cap was deliberately NOT raised — a bigger number is the next one an attacker exceeds, so the fix is the failure direction |
| own audit (Windows shard) | `sh -c 'rg . $1' _ ~/.kiro/crew` | the tokenizer expands `~` before this pass sees the token, so a positional argument arrives as an ambient-home path. On Windows that expansion mixes separators and stops matching the fence, so the two cases whose substitution yields an *unquoted* path were asserting where the crew home lives rather than the resolution they pin. The root is now resolved at call time from the `KIROCREW_HOME` the suite pins per test |
| own audit (Windows shard) | `_first_clean_dir` raising at import | the helper raised when no unfenced directory existed, and pytest imports every module in every xdist shard before splitting, so an import-time raise errored whole shards instead of skipping the one case. It returns `None` now and the single case that needs one skips; Windows roots were added to the candidate list, which had only POSIX ones |

Two of those three are the same defect class — **a test asserting an environment
fact rather than a code fact** — and it has now appeared three times in this file
(`/tmp` twice, `~` once). That is why the clean-directory and fenced-root helpers are
shared and resolved at call time rather than written inline per case.

A thirteenth round closed a sink bypass, both halves of the cost finding, and the
Windows regression round twelve introduced:

| finding | what got through | fix |
|---|---|---|
| GPT | `rg --files ~/.kiro/crew \| parallel 'cat {}'` | a QUOTED command template is one operand token, so the program word was the literal string `cat {}` and matched no reader. The template is argv, so it is split and every word is tested. Checked against the unquoted spelling FIRST: `xargs cat`/`echo`/`wc -l`/`head -c 200`/`printf %s` all already denied, so the quoted forms now agree rather than the quoted spelling getting a narrower policy of its own |
| Opus | `rg rg … rg /tmp` (no assignments) | reading CONSTRUCTION was uncharged — one reading per traversal token, each an O(N) operand slice plus an O(N) `not in readings` scan, all before the root check's budget was consulted. Construction now charges that budget and the linear scan is a hashed seen-set |
| Opus, second half | the same input at N=3000 | the first fix charged one FLAT unit per token, so a 4,096 budget never bit and 3,001 readings still held ~3,000-entry slices each — the O(N²) *memory* half. The charge is now proportional to the operand tail, so the same input builds 89 readings instead of 3,001 |
| own audit (Windows shard) | `sh -c 'rg . $1' _ <pinned home>` | round twelve pointed these cases at the pinned `KIROCREW_HOME`, which on Windows is a BACKSLASH path. The gate tokenizes with POSIX rules where a backslash is an escape, so `C:\Users\…` arrived as `C:Users…` and named nothing — turning 2 shard failures into 6. The helper now requires the root to survive the real tokenizer round-trip, prefers forward slashes, and skips when the platform offers neither |

The memory half is worth calling out as a process point: charging the budget made the
*timing* look fixed while the quadratic allocation was untouched, and only the
readings count in the probe output showed it. Measured on the pass alone rather than
through the whole gate, `_check_alt_traversal_reaches_fence` is now flat in N —
0.075s / 0.024s / 0.041s at N=600 / 1500 / 3000 — while the full gate's residual on a
9 KB command is the pre-existing normalizer (a same-length command that never reaches
this pass takes 22.9s against this pass's 0.041s share).

A fourteenth round closed the last blocking pair, and both fixes are
CONSOLIDATIONS rather than patches, because that is what the recurring findings kept
pointing at:

| finding | what got through | fix |
|---|---|---|
| GPT | `R=-r; grep "$R" secret ~/.kiro/crew; R=-n` | assignment HISTORY reached only the ROOT slot. The recursion-flag, sink and chdir-base slots each resolved with the last-wins view alone, so the same trailing-reassignment trick worked on all three while the root spelling denied. The walk moved INTO the shared primitive (`_alt_token_readings`) that all four slots already use, and the round-10 duplicate walk was deleted — so a slot added later inherits history instead of needing a fifth copy |
| GPT | `rg --files ~/.kiro/crew \| xargs git hash-object -w` | `git hash-object` writes file CONTENT into readable repo objects; `git cat-file` prints it back; `rsync --files-from=-` copies the files. Measured before adding: of 15 reader spellings probed, **12 already denied**, so these are three holes in a near-complete set rather than an open-ended table |
| First Principles | `pushd ~/.kiro && rg . crew` | `_alt_cd_bases` compared the literal `"cd"` while the module already owned `_CHDIR_VERBS` — **5 of its 6 verbs walked the fence**. Replaced by membership in the existing set, deleting the narrower spelling |
| Opus (advisory) | `A1=x … AN=x cmd o1 … oN` | `_alt_program_readings` copied `dict(assignments)` and scanned the whole history per token, charging nothing when the token named no variable. The shared primitive builds that scratch lazily and the per-token charge is paid before resolution |

**The pattern behind fourteen rounds, stated plainly.** Nearly every recurring finding
has had one shape: this pass owning a *second, narrower copy* of a set or mechanism
`security.py` already has — a literal `"cd"` beside `_CHDIR_VERBS`, history taught to
one slot of four, a private payload extractor beside the shared one. Each copy has to
be taught every rule separately, and each gap between copies has been a live bypass.
That is why round 14's fixes delete copies instead of adding cases, and why the
consolidation is now tracked in **#8196** rather than in this description.

## Answers to the advisory reviews

**Design Review — uncovered sibling tools.** Fixed, as the row above records.
`ag`/`ack`/`ack-grep`/`ugrep` are in the traversal set with tests on both sides.

**Design Review — two traversal engines once #7298 lands.** Accepted as real. #7298
is still open, so its helpers do not exist on `main` and could not be reused; the
consolidation direction I would take is that this pass's stage/assignment/cd-base
resolver is the more general of the two (it answers *does this root HOLD a fence*,
which subsumes the `find` question), so `find` coverage should become a program-set
membership in this pass rather than a second engine. That is a change to #7298's
shape, not to this PR, and it needs whoever owns #7298 — naming it here rather than
pre-empting it.

**First Principles — the glued `-c'payload'` blind spot remains for
`_nested_shell_payloads`' three other consumers**, including the self-protection
floor. Confirmed, and deliberately not fixed here: this PR closes the gap for its
own pass, and folding the handling into the shared extractor changes the behaviour
of the self-protection floor and two other call sites, which is a different blast
radius that deserves its own review rather than riding along inside a 3.1k-line
security-gate PR. It is a pre-existing gap this PR neither introduces nor widens.
Flagged for a follow-up issue; if the maintainer would rather it land here, say so
and I will widen the diff.

**First Principles — `ls -R … | xargs cat` and `tree -fi … | xargs cat` siblings.**
Correct that they belong on the residual list rather than being silently absent;
added to it below.

**First Principles — five spellings of assignment collection.** Accepted as
duplication worth removing, and not removable from inside this PR: pass 2's
collector respects subshell scoping and this pass's does not, so unifying them
changes pass 2's verdicts. Same follow-up as the extractor.

## Residual: `locate` is documented, not covered

`locate`/`plocate` have **no root operand** — the database supplies the path — so the root-containment clause every rule here rests on has nothing to test. Its pattern alone would have to carry the signal, and a pattern test recognising only the leaf names the fence DECLARES would still miss `locate id_rsa | xargs cat` (`.ssh` is fenced as a whole directory, so no leaf name is declared for it) while reading as covered. Per the issue's own guidance it is named in the pass's block comment rather than half-closed, and `test_documented_residuals_are_not_yet_covered` pins it so a later change cannot quietly assume coverage.

The name-lister class gates `du` plus `fd`/`rg --files`, so `ls -R … | xargs cat`
and `tree -fi … | xargs cat` are same-cause siblings that this pass does not yet
reach. They are named here rather than left absent; the pass's fail-toward-refusal
shape makes them deferred rather than wrong, and closing them is a membership edit
in the lister set once someone confirms `ls -R`'s output is a usable name list for
every sink form.

Two smaller residuals are named the same way: a name list delivered through a command substitution (`cat $(fd …)`) or a `while read` loop instead of `xargs`; and a traversal that names **no root at all** reached through a word this pass does not recognise as something-that-runs-a-program (`busybox rg secret`). A root spelled relative to a `cd` **is** now covered, so it has been removed from the residual list and from the block comment; only the no-root-after-`cd` spelling remains, and the cd-taint pass denies that one. In that last case the traversal IS still found — it is matched by its own name — but a reading that was not in the program position is not allowed to assume the working directory, because a bare mention of a program name is ordinary text and assuming it would refuse `which rg` outright whenever the gateway runs from a directory that holds the crew home. Every spelling that NAMES its root is covered whatever precedes it. `test_a_wrapper_hidden_traversal_with_no_root_is_a_documented_residual` pins the trade rather than leaving it implied.

## Relationship to #7298

#7298 (the `find` pass) is still **open**, so `_find_traversal_reaches_fence` and `_find_store_holds_match` do not exist on `main` and could not be reused as the issue anticipated. Rather than duplicate that 675-line framework, this pass reuses `path_contains_sensitive`, `_path_candidates`, `_split_shell_segments`, `_expansion_readings`, `_DECLARATION_BUILTINS` and `normalize_shell_command`, all already on `main`. The two changes are independent: this one adds a separate pass and does not touch the region #7298 introduces, so `find` coverage still lands with #7298.

A fifteenth round fixed two defects **round 14 introduced**, which share one root
cause, plus the class behind them:

| finding | what got through | fix |
|---|---|---|
| Opus | 5,000 padding assignments then `busybox grep -r secret ~/.kiro/crew` | **fail-open.** The padding spent the shared budget, `drain()` returned a PARTIAL reading set, and the traversal token-scan — the only reading that catches an applet-dispatched grep — was silently dropped, so the walk answered "no fenced root found". Verified: allowed padded, blocked unpadded |
| Opus | `V=/1 … V=/2000 grep -r "$V" "$V" … "$V"` | **61.9s in the pass alone.** Round 14 threaded `history` into `_grep_is_recursive`, `_alt_cd_bases` and `_alt_sink_program_names` without threading the budget, so those three resolved every operand against every historical value with nothing counting |

Fixed structurally, because this was the **third** limit in this PR whose exhaustion
path failed open — the round-5 stage budget, the round-12 brace cap, and now `drain` —
and each was introduced while fixing the previous one. `drain` is **removed** rather
than aliased (its contract, "stop enumerating and return what you have", *is* the
fail-open); `charge` records exhaustion; and `_check_alt_traversal_reaches_fence`
refuses on that flag in one place, however the budget ran out — the shape
`_alt_pipeline_stages_bounded` already used for stage truncation. The budget is now
created before the three slot helpers and threaded into all of them, so no history
resolution anywhere is uncharged. Wedge: **61.9s → 0.28s**, near-flat in N.

## Scope freeze

Stated on the record because the review history makes it necessary. Across the
previous 17 findings this PR's disposition rate was **17 fixed, 0 rebutted** — the
review contract has two outcomes and only one was ever used, which is the mechanism
behind a diff that kept growing. Issue #7309 names six concrete commands; those were
closed around round 4, and the rounds since have been progressively more exotic
spellings of the same six shapes, each of which presupposes the agent is *already*
executing attacker-chosen shell — the threat the OS sandbox and keystone fence exist
for.

From here the pass is treated as **feature-complete for #7309**. Further findings that
require a new program class, a new table entry, or a more exotic spelling will be
**rebutted as disproportional, or deferred to #8196**, not fixed. Two exceptions stay
in-PR: a **fail-open**, and a **defect this PR introduced**. Both of round 15's
findings were both of those, which is why they were fixed rather than deferred.

## What this closes, and what it does not

This is a **bar-raise, not a closed class.** The real ceiling stays the OS sandbox and
the keystone fence; this pass removes the cheap, obvious spellings of reading the crew
credential stores through a non-`find` traversal. The residual list below is the
honest measure of what is left, and round 14 made it *longer* by naming the
copy/archive sibling class (`tar -cf`, `cp -r`, `zip -r`, direct `rsync -r`, all
verified open) — which looks like the wrong direction for a score and is the right
direction for a claim.

## Cost, stated plainly

A recursive content read rooted at the crew data-home or its workspace root is refused, because both hold declared credential leaves (`.env`, `token_signing.key`, the Notes vault's PAT). Scoping the read to a subdirectory that holds none of them is allowed and is the intended spelling — `grep -r TODO ~/.kiro/crew/workspace/memory` still works.

## Tests

`test/test_security_alt_traversal.py`, 364 cases:

- every blocked form above, plus long/short/clustered/glued flag spellings, `fdfind`, `rgrep`, `egrep`/`fgrep`, a path-qualified program word, a quoted root, `$HOME` in place of `~`, the legacy `.kirocrew` data-home, a root arriving via `--search-path`/`--search-path=`, sequencer-reached forms, `env`/`command`/`builtin`/`exec` wrappers, declaration keywords, and `xargs` value-flags before the payload;
- the legitimate forms that must keep passing: listers without a sink, `| cat` and `| wc -l` on a name list, non-recursive reads, recursive reads rooted in an ordinary project tree, `head -c`/`wc -c`, `-d skip`, a shell payload that opens nothing, and the crew subdirectory that holds no fenced leaf;
- the residuals, pinned so closing one is a visible test change;
- the program-identification set: `eval`/`source` payloads, stacked shells, a program held in a variable, every abbreviated long option, wrapper option values, applet dispatch — and, in the other direction, the commands that merely NAME a traversal program (`which rg`, `sudo cp rg /usr/local/bin/`, `cat ~/bin/rg`, `grep -r rg ./src`) which must stay allowed;
- the payload set from both extractors: herestrings, `$SHELL -c`, `-c --`, a multiword alias, a payload glued to a short cluster — and the scoping that keeps `head -c 100` and `wc -c` from reading as payload carriers;
- the round-five set: budget exhaustion refusing rather than truncating (and an ordinary pipeline staying nowhere near the cap), abbreviated pattern flags, a recursion flag and a sink program held in a variable, and the copying readers — plus the ordinary commands each of those must not refuse (`grep -r --reg="$HOME/.kiro" ./src`, `R=-n`, `C=echo`, a clean-rooted lister into `gzip -c`);
- the round-seven set: a root relative to a `cd`, a root computed by a substitution, each routed role held in a variable, a trailing reassignment — plus the ordinary commands each must not refuse (`cd ./src && grep -r TODO .`, `D=$(pwd)`, `X=xargs` pointed at a clean tree);
- unit coverage for the sink test, the pipeline split's quote-awareness and `|&` handling, command-string payload extraction, wrapper peeling, assignment collection, the clustered-flag scans, the long-flag prefix matcher's floor and its refusal of an over-long token, the program-word resolution through an assignment, which reading owns the working-directory fallback, the stage budget, and that the pass is actually wired into `is_sensitive_bash_command` rather than merely defined.

## Manual verification

N/A — this is a pure decision function over command strings, and the unit suite exercises it directly with the real fence.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff; the pass has no rendered surface.

## Pattern harvest

Rule candidate: semgrep

Pattern 1 — **an argv-parsing security gate that identifies the program by POSITION.** Reading `tokens[0]` (or the first token after a table of known prefixes) as "the program this stage runs" is the root cause of every BLOCKING finding across four review rounds of this PR, and the fix each round was one more table entry. What sits in front of a program is unbounded: shell builtins (`command`, `builtin`, `exec`), argv forwarders (`nice`, `nohup`, `sudo`, `timeout`, `stdbuf`, `ionice`, `chrt`, `taskset`), their own option VALUES (`stdbuf -o L`, `timeout -s KILL 5`, `exec -a name`), applet dispatchers (`busybox`), `env` and its options, declaration keywords, and a variable holding the name. A gate that must not miss the program should scan the stage for the names it cares about and treat position as a refinement, not as the lookup. Detectable shape: a comparison of a single computed "head" token against a set of security-relevant program names, in the same function as a table of wrapper names.

Pattern 2 — **a long option compared as a whole token in a gate.** `token == "--recursive"` / `token in FLAGS` misses every abbreviation `getopt_long` accepts (`--recurs`, `--rec`, `--direct=recurse`), so the gate's own flag table becomes a list of spellings to avoid.

Pattern 3 — **a short option compared as a whole token** (the original harvest, still valid): `-esecret`, `-refoo`, `-lc`, `-nd recurse`, `-drecurse`. A short flag that takes a value ends a cluster and its value may be glued on, so whole-token comparison misses the spelling tools actually emit.

All three share one shape worth a rule: **a security gate whose correctness depends on a table of the ways an attacker may SPELL something.** The safe direction is to key on the thing being protected (here: does the root HOLD a fenced path) and let the spelling table only refine, never decide.

## Local gates

| gate | result |
|---|---|
| `pytest` (full, 16 workers) | 84,202 passed, 117 failed against an `origin/main` baseline of 116 — the single extra is `test_public_repo_chip_status.py::test_force_public_to_private_transition_queues_hide_update`, which passes in isolation and which appeared in one earlier full run and was **absent from a second run of byte-identical code**. Earlier measurement, kept because it is the evidence for that claim: a failure set **identical** to the `origin/main` baseline (taken in its own worktree with `PYTHONPATH` shadowing so it genuinely loads main's `security.py`), with **zero failures in `test_security_alt_traversal.py`**. Earlier rounds saw 2 extras which were proven order-dependent rather than caused by this diff: they passed in isolation on **both** trees, and a second full run of byte-identical code produced a **completely disjoint** extra set (7 different tests, zero overlap) from the same two files, `test_app_backend.py` and `test_public_repo_chip_status.py`. Shard splitting here is count-based (#4227), so a test-adding diff reshuffles which pre-existing order-dependent tests land in which shard. The rest of the reds are environmental (`AF_UNIX path too long`, home-ownership, missing optional binaries). |
| `isort --check-only` | pass |
| `flake8` | pass |
| `mypy src/kiro_crew/` | pass, 1280 files |
| `scripts/check_black_formatting.py` | pass on the real diff |
| `npx tsc -b` | pass |
| `npx vitest run` | **could not run on this host** — Node 20.20.2 rejects `--no-experimental-webstorage`, which vitest 4.1.10 emits; reproduces on an unrelated worktree, so it is a local toolchain mismatch. The diff touches zero frontend files and CI's `changes` job skips frontend tests for a backend-only diff. |







