### PR TITLE
fix(companion): diagnose malformed lottie imports

### DIFF
--- a/website/src/apps/crew-companion/LottieRenderer.test.tsx
+++ b/website/src/apps/crew-companion/LottieRenderer.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render } from '@testing-library/react'
+import React from 'react'
+import lottie from 'lottie-web/build/player/lottie_light'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { LottieRenderer } from './LottieRenderer'
+
+const loadAnimation = vi.mocked(lottie.loadAnimation)
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  loadAnimation.mockClear()
+})
+
+it('leaves a diagnostic when an imported animation is malformed', () => {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  render(<LottieRenderer animationData="{not json" width={64} height={64} />)
+
+  expect(loadAnimation).not.toHaveBeenCalled()
+  expect(errorSpy).toHaveBeenCalledWith(
+    '[crew-companion] lottie JSON parse failed',
+    expect.objectContaining({ bytes: 9 }),
+  )
+})

--- a/website/src/apps/crew-companion/LottieRenderer.tsx
+++ b/website/src/apps/crew-companion/LottieRenderer.tsx
@@ -47,7 +47,12 @@ const LottieRendererInner: React.FC<LottieRendererProps> = ({
     try {
       parsed = JSON.parse(animationData)
     } catch {
-      // Invalid JSON — skip loading
+      // A malformed imported clip renders as an empty slot, so leave enough
+      // context to distinguish bad pack data from a renderer failure.
+      // eslint-disable-next-line no-console
+      console.error('[crew-companion] lottie JSON parse failed', {
+        bytes: animationData.length,
+      })
       return
     }
 


### PR DESCRIPTION
## Problem / Motivation

Crew Companion accepts Lottie JSON from imported appearance packs. When that JSON is malformed, `LottieRenderer` catches the parse exception and returns without loading anything or leaving a diagnostic. The affected avatar or gallery slot is blank, with no way to distinguish bad pack data from a renderer failure.

## Why it matters

Imported packs are third-party data. A silent blank makes a corrupt pack unnecessarily difficult to diagnose and sends maintainers toward the rendering and window plumbing even though parsing failed before `lottie-web` ran.

## What changed (motivation → approach → change)

The renderer should keep its fail-soft behavior—one bad clip must not crash Crew Companion—but the parse failure should be observable. The catch branch now emits a bounded console diagnostic containing only the animation byte count, then returns exactly as before. It does not log the imported JSON payload, the parse exception (which can echo payload fragments), or change the rendered UI.

A focused component test passes malformed JSON through the real renderer, proves `loadAnimation` is not called, and pins the diagnostic.

## Tests

- Red-before: the new focused test failed because `console.error` had zero calls.
- Green: focused renderer test plus the direct Gallery and Pet consumers, 126/126 tests passed.
- Touched-file ESLint passed.
- `npx tsc -b` passed.
- `git diff --check` passed.

## Manual verification

N/A — unit coverage exercises the exact parse-failure branch and its observable console output; the rendered blank-slot behavior is intentionally unchanged.

<!-- no-visual-delta -->
**Why no screenshot:** This change only adds a bounded console diagnostic for malformed Lottie JSON; rendered behavior is intentionally unchanged.

## Related Issues

No linked issue. This closes the Crew Companion diagnostic residual identified during review of #7385.

## Pattern harvest

Rule candidate: review-prompt
Pattern: fail-soft rendering of imported third-party media must leave a bounded diagnostic when parsing fails, without logging the payload.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no documented behavior changed
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
