### PR TITLE
refactor(pins): route pinsApi through the shared client error path

### DIFF
--- a/website/src/api/pins.ts
+++ b/website/src/api/pins.ts
@@ -1,9 +1,20 @@
 /**
  * Chat message pins API client.
- * Follows the same transport pattern as client.ts (same-origin fetch with X-Session-Key).
+ *
+ * Routes through the blessed shared transport (`apiTransport`) rather than raw
+ * `fetch`, so pin failures get the SAME pipeline every other dashboard API call
+ * already has: the `X-Session-Key` header, an `ApiError` carrying the HTTP
+ * status + raw backend body, the backend's machine-readable `code` parsed once
+ * at the chokepoint, and a recorded entry in the shared error journal. This
+ * replaces the module's own hand-rolled error-body parsing (which duplicated
+ * `ApiError` + `parseErrorCode` and never fed the journal) with the one
+ * established mechanism. Consumers read the backend `code` off the thrown
+ * `ApiError` via `parseErrorCode(err.body)` — see `pinErrorCode` in useChatPins.
  */
 
-const _sk = { 'X-Session-Key': 'dashboard:ui' }
+import { apiTransport } from './apiTransport'
+
+const { get, post, del, j } = apiTransport
 
 // Keep transport bounded while leaving ample look-ahead beyond the 200-character
 // stored preview for server-side credential and URL redaction.
@@ -27,48 +38,13 @@ export interface PinMessageBody {
   preview: string
 }
 
-/**
- * Structured error from the pins API: a plain `Error` carrying the
- * machine-readable `code` field the backend returns (e.g. `pin_limit_reached`,
- * `preview_too_large`, `persist_failed`) so callers can branch on the specific
- * failure rather than showing a single generic message.
- *
- * Deliberately a TYPE, not a class: consumers branch structurally on `code`
- * (see `pinErrorCode` in useChatPins), which stays correct across module-mock
- * boundaries in tests, where an `instanceof` against a re-exported class would
- * not — and a type adds no runtime export a partial mock could drop.
- */
-export type PinApiError = Error & { code?: string }
-
 export const pinsApi = {
   list: (slotKey: string): Promise<{ pins: ChatPin[] }> =>
-    fetch(`/api/chat/pins?slot=${encodeURIComponent(slotKey)}`, { headers: _sk })
-      .then(r => { if (!r.ok) throw new Error(`Pin list failed: ${r.status}`); return r.json() }),
+    get(`/api/chat/pins?slot=${encodeURIComponent(slotKey)}`).then(j) as Promise<{ pins: ChatPin[] }>,
 
-  create: async (body: PinMessageBody): Promise<ChatPin> => {
-    const r = await fetch('/api/chat/pins', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ..._sk },
-      body: JSON.stringify(body),
-    })
-    if (!r.ok) {
-      let code: string | undefined
-      try {
-        const data = await r.json() as Record<string, unknown>
-        if (typeof data.code === 'string') code = data.code
-      } catch {
-        // Body parse failure — fall through to the generic error below
-      }
-      const err: PinApiError = new Error(`Pin create failed: ${r.status}`)
-      err.code = code
-      throw err
-    }
-    return r.json() as Promise<ChatPin>
-  },
+  create: (body: PinMessageBody): Promise<ChatPin> =>
+    post('/api/chat/pins', body).then(j) as Promise<ChatPin>,
 
   remove: (id: string): Promise<{ ok: boolean }> =>
-    fetch(`/api/chat/pins/${encodeURIComponent(id)}`, {
-      method: 'DELETE',
-      headers: _sk,
-    }).then(r => { if (!r.ok) throw new Error(`Pin delete failed: ${r.status}`); return r.json() }),
+    del(`/api/chat/pins/${encodeURIComponent(id)}`).then(j) as Promise<{ ok: boolean }>,
 }

--- a/website/src/hooks/useChatPins.ts
+++ b/website/src/hooks/useChatPins.ts
@@ -1,18 +1,26 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
-import { PIN_PREVIEW_INPUT_MAX_CHARS, pinsApi, type ChatPin, type PinApiError, type PinMessageBody } from '../api/pins'
+import { PIN_PREVIEW_INPUT_MAX_CHARS, pinsApi, type ChatPin, type PinMessageBody } from '../api/pins'
+import { ApiError } from '../api/apiError'
+import { parseErrorCode } from '../utils/errorReport'
 import { secureRandomId } from '../utils/secureId'
 
 /**
  * The backend `code` from a pins API failure, or undefined for anything else.
- * Lives HERE rather than in api/pins so the hook keeps zero new runtime
- * imports from that module — several test files replace '../api/pins' with a
- * partial factory mock, and an imported helper those mocks omit would make
- * this hook's error handling throw inside onError.
+ *
+ * pinsApi now routes through the shared transport, so a failure is an
+ * `ApiError` carrying the raw backend body — the machine-readable `code` is
+ * read from that body with the same `parseErrorCode` the transport journals
+ * with, rather than off a bespoke `.code` property. The structural
+ * `'code' in err` fallback is kept so any error object that still carries a
+ * direct `code` (older callers, hand-built test errors) resolves too.
  */
 export function pinErrorCode(err: unknown): string | undefined {
+  if (err instanceof ApiError) {
+    return parseErrorCode(err.body)
+  }
   if (err instanceof Error && 'code' in err) {
-    const code = (err as PinApiError).code
+    const code = (err as { code?: unknown }).code
     return typeof code === 'string' ? code : undefined
   }
   return undefined

--- a/website/src/pages/settings/SecretsPanel.tsx
+++ b/website/src/pages/settings/SecretsPanel.tsx
@@ -14,8 +14,9 @@ import { i18nT } from '../../i18n/t'
  * 403/500 as a successful mutation: `onSuccess` fired and cleared the form,
  * silently discarding the secret the user had typed without ever storing it.
  * Throwing routes those statuses to `onError` instead, which leaves the form
- * populated so the value is not lost. Matches the `!r.ok` pattern used by
- * `src/api/pins.ts`.
+ * populated so the value is not lost. This is a local `!r.ok` guard rather than
+ * the shared `api/client.ts` transport because SecretsPanel authenticates with
+ * the raw stored token, not the transport's `dashboard:ui` session key.
  */
 const j = async (r: Response) => {
   if (!r.ok) {

--- a/website/src/test/Frontend5Api.cov80.test.ts
+++ b/website/src/test/Frontend5Api.cov80.test.ts
@@ -1,9 +1,11 @@
 /**
  * The two API-layer files whose behaviour is entirely in their error paths.
  *
- * `pins.ts` is three fetch calls that each turn a non-OK response into a thrown
- * Error — the request shape (URL encoding, method, the session-key header) and
- * that throw are the whole contract, and nothing else exercises either.
+ * `pins.ts` is three calls routed through the shared transport that each turn a
+ * non-OK response into a thrown `ApiError` — the request shape (URL encoding,
+ * method, the session-key header) and that throw are the whole contract, and
+ * nothing else exercises either. Importing `../api/client` for its install
+ * side-effect wires the blessed transport `pins.ts` now consumes.
  *
  * `apiTransport.ts` is the frozen downstream seam: every method is a wrapper
  * that resolves the installed helper at CALL time, plus a guard for the
@@ -13,7 +15,9 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+import '../api/client'
 import { pinsApi, PIN_PREVIEW_INPUT_MAX_CHARS, type PinMessageBody } from '../api/pins'
+import { ApiError } from '../api/apiError'
 
 /** One recorded fetch call. */
 interface Call {
@@ -23,7 +27,9 @@ interface Call {
 
 let calls: Call[] = []
 
-/** Queue one canned response per upcoming fetch. */
+/** Queue one canned response per upcoming fetch. The shared transport's `j`
+ *  reads `text()` on the error path and `json()` on success, so the stub
+ *  answers both from the same canned body. */
 function stubFetch(responses: Array<{ ok: boolean; status: number; body: unknown }>) {
   const queue = [...responses]
   calls = []
@@ -36,7 +42,10 @@ function stubFetch(responses: Array<{ ok: boolean; status: number; body: unknown
       return Promise.resolve({
         ok: next.ok,
         status: next.status,
+        url,
+        headers: { get: () => null },
         json: () => Promise.resolve(next.body),
+        text: () => Promise.resolve(next.body == null ? '' : JSON.stringify(next.body)),
       } as unknown as Response)
     }),
   )
@@ -66,9 +75,16 @@ describe('api/pins', () => {
     expect((calls[0].init?.headers as Record<string, string>)['X-Session-Key']).toBe('dashboard:ui')
   })
 
-  it('throws with the status when the list request fails', async () => {
-    stubFetch([{ ok: false, status: 503, body: null }])
-    await expect(pinsApi.list('zzslot')).rejects.toThrow(/503/)
+  it('throws an ApiError carrying the status and the backend body when the list request fails', async () => {
+    stubFetch([{ ok: false, status: 503, body: { code: 'pins_unavailable' } }])
+    const err = await pinsApi.list('zzslot').then(
+      () => { throw new Error('expected rejection') },
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(503)
+    // The raw body is retained so a consumer can parse the backend `code`.
+    expect((err as ApiError).body).toContain('pins_unavailable')
   })
 
   it('posts the pin body as JSON', async () => {
@@ -81,9 +97,15 @@ describe('api/pins', () => {
     expect(JSON.parse(String(calls[0].init?.body))).toEqual(body)
   })
 
-  it('throws with the status when the create request fails', async () => {
-    stubFetch([{ ok: false, status: 409, body: null }])
-    await expect(pinsApi.create(body)).rejects.toThrow(/409/)
+  it('throws an ApiError carrying the status and backend code when the create request fails', async () => {
+    stubFetch([{ ok: false, status: 409, body: { code: 'pin_limit_reached' } }])
+    const err = await pinsApi.create(body).then(
+      () => { throw new Error('expected rejection') },
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(409)
+    expect((err as ApiError).body).toContain('pin_limit_reached')
   })
 
   it('deletes by encoded id', async () => {
@@ -93,9 +115,14 @@ describe('api/pins', () => {
     expect(calls[0].init?.method).toBe('DELETE')
   })
 
-  it('throws with the status when the delete request fails', async () => {
-    stubFetch([{ ok: false, status: 404, body: null }])
-    await expect(pinsApi.remove('zzid')).rejects.toThrow(/404/)
+  it('throws an ApiError carrying the status when the delete request fails', async () => {
+    stubFetch([{ ok: false, status: 404, body: { code: 'pin_not_found' } }])
+    const err = await pinsApi.remove('zzid').then(
+      () => { throw new Error('expected rejection') },
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(404)
   })
 })
 

--- a/website/src/test/chatPins.test.tsx
+++ b/website/src/test/chatPins.test.tsx
@@ -5,14 +5,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createElement, type ReactNode } from 'react'
 import { useChatPins } from '../hooks/useChatPins'
 import { PinnedMessagesPanel } from '../pages/chat/PinnedMessagesPanel'
-import { PIN_PREVIEW_INPUT_MAX_CHARS, type ChatPin, type PinApiError } from '../api/pins'
+import { PIN_PREVIEW_INPUT_MAX_CHARS, type ChatPin } from '../api/pins'
+import { ApiError } from '../api/apiError'
 import { pinErrorCode } from '../hooks/useChatPins'
 
-/** Build the plain-Error-with-code shape pinsApi.create throws. */
-function pinError(message: string, code?: string): PinApiError {
-  const err: PinApiError = new Error(message)
-  err.code = code
-  return err
+/** Build the `ApiError` (with a code-bearing JSON body) that pinsApi now throws
+ *  via the shared transport, so `pinErrorCode` reads the code the real way. */
+function pinError(status: number, code?: string): ApiError {
+  const body = code ? JSON.stringify({ code }) : JSON.stringify({ error: 'boom' })
+  return new ApiError(status, `HTTP ${status}`, body)
 }
 
 // Mock the pins API. The hook branches structurally on the error's `code`
@@ -173,7 +174,7 @@ describe('useChatPins', () => {
     await waitFor(() => expect(result.current.pins).toHaveLength(1))
 
     ;(pinsApi.create as ReturnType<typeof vi.fn>).mockRejectedValue(
-      pinError('Pin create failed: 409', 'pin_limit_reached'),
+      pinError(409, 'pin_limit_reached'),
     )
 
     await act(async () => {
@@ -191,7 +192,7 @@ describe('useChatPins', () => {
     await waitFor(() => expect(result.current.pins).toHaveLength(1))
 
     ;(pinsApi.create as ReturnType<typeof vi.fn>).mockRejectedValue(
-      pinError('Pin create failed: 500', 'persist_failed'),
+      pinError(500, 'persist_failed'),
     )
 
     await act(async () => {
@@ -204,9 +205,14 @@ describe('useChatPins', () => {
     expect(result.current.error).toBe('pin')
   })
 
-  it('pinErrorCode extracts the backend code structurally', () => {
-    expect(pinErrorCode(pinError('Pin create failed: 409', 'pin_limit_reached'))).toBe('pin_limit_reached')
-    expect(pinErrorCode(pinError('Pin create failed: 500'))).toBeUndefined()
+  it('pinErrorCode extracts the backend code from the ApiError body', () => {
+    expect(pinErrorCode(pinError(409, 'pin_limit_reached'))).toBe('pin_limit_reached')
+    // ApiError whose body carries no `code` (only an `error` message) -> undefined.
+    expect(pinErrorCode(pinError(500))).toBeUndefined()
+    // Structural fallback: a plain Error still carrying a string `.code` resolves.
+    const legacy = new Error('x') as Error & { code?: unknown }
+    legacy.code = 'preview_too_large'
+    expect(pinErrorCode(legacy)).toBe('preview_too_large')
     expect(pinErrorCode(new Error('plain'))).toBeUndefined()
     expect(pinErrorCode('not an error')).toBeUndefined()
     expect(pinErrorCode(undefined)).toBeUndefined()


### PR DESCRIPTION
## Problem / Motivation

Follow-up from the review of the pin-error-codes fix (#5142). `api/pins.ts`
did its own error-body parsing to carry the backend `code`, and issued raw
`fetch` calls — while `api/client.ts` already ships the established mechanism
for exactly this: `ApiError` retaining the raw body, `parseErrorCode`, and
recording every failure in the shared error journal (the same pipeline the
settings/MCP surfaces use). Pin requests also bypassed that journal. Two
spellings of one mechanism had to be maintained.

## Why it matters

The duplicated error path is a maintenance and consistency hazard: the two
spellings can (and did) drift — pins never fed the error journal, so a pin
failure was invisible to the shared "ask the agent about this error" hand-off
that recovers full context (status, endpoint, backend `code`) from the message
alone. Every future change to the error contract had to be made twice, and only
one copy carried the `X-Session-Key` / auth-recovery / `ApiError` semantics the
rest of the dashboard relies on.

## What changed (motivation → approach → change)

- Root cause: `pins.ts` re-implemented, on raw `fetch`, what the blessed
  transport already does — so the mechanism existed twice and only one copy was
  journaled and auth-aware.
- Approach: route the three pins calls through the blessed **`apiTransport`**
  seam (`get`/`post`/`del` + `j`), which is the supported way for an API module
  to reuse the core helpers without forking `client.ts`. `j` is the single
  chokepoint that builds the `ApiError` (status + raw body), parses the backend
  `code`, and records the failure in the journal.
- Change:
  - `api/pins.ts`: `list`/`create`/`remove` now go through `apiTransport`; the
    local error-body parsing and the bespoke `PinApiError` type are deleted. It
    keeps `X-Session-Key`, gains `ApiError` + `parseErrorCode` + error-journal
    recording for free.
  - `hooks/useChatPins.ts`: `pinErrorCode` reads the backend `code` off the
    thrown `ApiError`'s raw `body` via the same `parseErrorCode` the transport
    journals with, and keeps a structural `'code' in err` fallback so any error
    still carrying a direct `code` resolves too.
  - `pages/settings/SecretsPanel.tsx`: refresh the now-stale comment that
    cross-referenced pins' old `!r.ok` pattern.

## Tests

- `test/Frontend5Api.cov80.test.ts` (pins unit test): installs the transport
  (imports `../api/client` for its install side-effect), and asserts each
  failure path now rejects with an `ApiError` carrying the HTTP `status` and the
  raw `body` (so a consumer can still parse the backend `code`). Request-shape
  assertions (URL encoding, method, `X-Session-Key`, JSON body) are unchanged.
- `test/chatPins.test.tsx`: the `pinError` helper now builds the real `ApiError`
  shape (a code-bearing JSON body) that `pinsApi` throws, and the `pinErrorCode`
  unit test covers both the `ApiError`-body extraction and the structural
  `'code' in err` fallback, plus the existing negative cases (non-Error,
  undefined, numeric `code`).

## Manual verification

N/A — unit coverage sufficient. This is an internal transport/error-path
refactor with no behavior change on the success path and identical
machine-readable `code` semantics on the failure path; the hook-level pin-limit
vs generic-error branching is covered by `chatPins.test.tsx`.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** internal API-layer refactor — no rendered UI changes; the
pin-limit vs generic error message the user sees is unchanged (same backend
`code`, same hook branching), only the plumbing that carries the code changed.

## Related Issues

Fixes #5169

## Pattern harvest

Not generalizable: a one-off consolidation of a single module that had grown a
second copy of the shared `ApiError`/`parseErrorCode` error path; there is no
broader class of "API module re-implementing the transport" to sweep for beyond
this instance.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
