### PR TITLE
fix(secrets): send dashboard:ui session key from SecretsPanel

### DIFF
--- a/website/src/pages/settings/SecretsPanel.test.tsx
+++ b/website/src/pages/settings/SecretsPanel.test.tsx
@@ -12,7 +12,7 @@ import { SecretsPanel } from './SecretsPanel'
  * add and delete paths must be asserted on the REQUEST they send, not just on
  * the re-render they cause.
  */
-type FetchCall = { url: string; method: string; body?: unknown }
+type FetchCall = { url: string; method: string; body?: unknown; headers?: Record<string, string> }
 
 let calls: FetchCall[] = []
 
@@ -26,10 +26,22 @@ function installFetch() {
   const impl = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input)
     const method = init?.method ?? 'GET'
+    // Normalise Headers object / plain object / undefined to a plain record so
+    // tests can do a simple property lookup regardless of how fetch was called.
+    let headers: Record<string, string> | undefined
+    if (init?.headers) {
+      if (init.headers instanceof Headers) {
+        headers = {}
+        init.headers.forEach((v, k) => { headers![k] = v })
+      } else {
+        headers = { ...(init.headers as Record<string, string>) }
+      }
+    }
     calls.push({
       url,
       method,
       body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      headers,
     })
 
     if (method === 'GET' && url === '/api/secrets') {
@@ -699,5 +711,41 @@ describe('SecretsPanel error feedback and in-flight guards', () => {
 
     await waitFor(() => expect(seen.length).toBeGreaterThan(0))
     expect(seen).toHaveLength(1)
+  })
+})
+
+describe('SecretsPanel session key', () => {
+  /**
+   * The panel sends the fixed `dashboard:ui` session key that the shared
+   * transport (`src/api/client.ts`) uses, on every request.  It previously read
+   * `localStorage['kiro_crew_token']` — a key nothing in the app ever writes —
+   * so that read always resolved to '' and was vestigial dead code.  This pins
+   * the panel to the same `dashboard:ui` identity every other panel sends, and
+   * guards against a regression back to a stored-token read.
+   */
+  it('sends the dashboard:ui session key on both the list GET and a mutating POST', async () => {
+    const user = userEvent.setup()
+
+    // Even with a stray token in localStorage, the panel must NOT read it —
+    // the header is the fixed dashboard:ui literal.
+    localStorage.setItem('kiro_crew_token', 'SHOULD-BE-IGNORED')
+    installFetch()
+
+    mount()
+    await screen.findByText('No secrets stored yet.')
+
+    const listGet = calls.find(c => c.method === 'GET' && c.url === '/api/secrets')
+    expect(listGet?.headers?.['X-Session-Key']).toBe('dashboard:ui')
+
+    await user.click(screen.getByRole('button', { name: 'Add secret' }))
+    await user.type(screen.getByLabelText('Secret name'), 'MY_KEY')
+    await user.type(screen.getByLabelText('Secret value'), 'sk-new')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      const post = calls.find(c => c.method === 'POST')
+      expect(post).toBeTruthy()
+      expect(post?.headers?.['X-Session-Key']).toBe('dashboard:ui')
+    })
   })
 })

--- a/website/src/pages/settings/SecretsPanel.tsx
+++ b/website/src/pages/settings/SecretsPanel.tsx
@@ -32,7 +32,14 @@ const j = async (r: Response) => {
   }
   return r.json()
 }
-const _sk = { 'X-Session-Key': localStorage.getItem('kiro_crew_token') || '' }
+// Send the same fixed `dashboard:ui` session key the shared transport uses
+// (`src/api/client.ts`). This panel previously read `localStorage['kiro_crew_token']`,
+// but nothing in the app ever writes that key — the browser's dashboard identity
+// is the `dashboard:ui` literal, and the backend treats a missing/empty
+// X-Session-Key as `dashboard:ui` anyway — so the read was vestigial dead code
+// that always resolved to ''. Use the literal directly so the header is explicit
+// and matches every other panel.
+const _sk = { 'X-Session-Key': 'dashboard:ui' }
 const get = (url: string) => fetch(url, { headers: { ..._sk } })
 const post = (url: string, body?: object) =>
   fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify(body) })


### PR DESCRIPTION
## Problem / Motivation

Fixes #7448.

`SecretsPanel` built its `X-Session-Key` request header from `localStorage`:

```ts
const _sk = { 'X-Session-Key': localStorage.getItem('kiro_crew_token') || '' }
```

But **nothing in the app ever writes `localStorage['kiro_crew_token']`** — a repo-wide search finds no writer. The browser's dashboard identity is the fixed `dashboard:ui` literal (`src/api/client.ts`, `ArtifactDeployPage.tsx`), and the backend (`token_auth.py`) treats a missing/empty `X-Session-Key` as `dashboard:ui`. So the `localStorage` read was **vestigial dead code that always resolved to `''`**.

> The PR was originally filed as a "header frozen at module load" bug. The fork Design + First-Principles reviewers correctly identified that the read is inert (nothing writes the key), so the framing was wrong. This revision fixes the real, smaller issue the dead read points at.

## Why it matters

`SecretsPanel` was the only settings panel not sending the same explicit `dashboard:ui` identity as every other panel — instead relying on the backend's empty-key fallback. Removing the dead `localStorage` read makes the header explicit and consistent with the shared transport, and eliminates a misleading read that implied a stored-token auth scheme that does not exist.

## What changed (motivation → approach → change)

Replace the `localStorage.getItem('kiro_crew_token')` read with the `dashboard:ui` literal the shared transport uses. `get`/`post`/`del` now send `{ 'X-Session-Key': 'dashboard:ui' }` directly — no behavior change on the happy path (the backend already resolved the old empty header to `dashboard:ui`), just an explicit, honest header and no dead code.

## Tests

- Reworked the panel's session-key test to assert both the list `GET` and a mutating `POST` carry `X-Session-Key: dashboard:ui`, and that a stray `localStorage['kiro_crew_token']` is **ignored** (guards against a regression back to a stored-token read).
- The test's `fetch` stub was extended (test-only) to capture request headers.
- `npx tsc -b` clean; `npx vitest run SecretsPanel.test.tsx` → 25/25 pass.

## Pattern harvest

Rule candidate: review-prompt — a browser client reading an auth token from `localStorage` under a key nothing in the app writes is dead code masquerading as auth; send the app's real fixed identity (`dashboard:ui`) instead. Pattern: vestigial credential read that always resolves empty and implies an auth scheme that does not exist.

<!-- no-visual-delta -->
**Why no screenshot:** This change only alters which `X-Session-Key` value the panel's `fetch` calls send. It touches no rendered markup, styling, layout, or copy in `SecretsPanel` — the panel looks and behaves identically. There is no visual delta to capture; behavior is covered by the vitest regression instead.
