### PR TITLE
fix(secrets): reject a whitespace-only secret value

### DIFF
--- a/src/kiro_crew/dashboard/handlers/secrets.py
+++ b/src/kiro_crew/dashboard/handlers/secrets.py
@@ -134,7 +134,11 @@ async def api_secrets_set(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "Secret name is required", "code": "missing_name"}, status=400
         )
-    if not value:
+    # Reject a value that is empty or whitespace-only, but store the ORIGINAL
+    # value unchanged: a credential can legitimately contain leading/trailing
+    # whitespace, and trimming it before storage would corrupt the secret and
+    # break downstream authentication. Only the emptiness *check* strips.
+    if not value.strip():
         return web.json_response(
             {"error": "Secret value is required", "code": "missing_value"}, status=400
         )

--- a/test/test_secrets_handler.py
+++ b/test/test_secrets_handler.py
@@ -379,3 +379,96 @@ class TestApiSecretsSetInputValidation:
                 # Name is still trimmed, as before.
                 assert data["name"] == "PADDED"
                 assert SecretVault(empty_vault_dir).list_names() == ["PADDED"]
+
+
+class TestApiSecretsSetWhitespaceValue:
+    """POST /api/secrets rejects a value that is whitespace-only (F2 regression).
+
+    Before the fix, ``name`` was stripped before its empty-check but ``value``
+    was not — so a body like ``{"name":"K","value":"   "}`` bypassed the
+    ``if not value:`` guard (a non-empty string of spaces is truthy) and wrote
+    a blank secret to the vault.  After the fix, ``value = value.strip()`` is
+    applied before the empty-check, so the three-space value collapses to ``""``
+    and correctly hits the existing ``missing_value`` 400 path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_value_is_rejected(self, empty_vault_dir: Path) -> None:
+        """``{"name":"K","value":"   "}`` must return 400 missing_value."""
+        app = _app()
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch(
+            "kiro_crew.dashboard.handlers.secrets.config_dir",
+            return_value=str(empty_vault_dir),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/api/secrets", json={"name": "K", "value": "   "})
+                assert resp.status == 400
+                data = await resp.json()
+                assert data["code"] == "missing_value"
+                # The vault must not have stored K.
+                assert SecretVault(empty_vault_dir).list_names() == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ws_value", ["   ", "\t", "\n", " \t \n "])
+    async def test_various_whitespace_variants_are_rejected(
+        self, empty_vault_dir: Path, ws_value: str
+    ) -> None:
+        """Tabs, newlines, and mixed whitespace all reduce to empty after strip."""
+        app = _app()
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch(
+            "kiro_crew.dashboard.handlers.secrets.config_dir",
+            return_value=str(empty_vault_dir),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/api/secrets", json={"name": "K", "value": ws_value})
+                assert resp.status == 400
+                data = await resp.json()
+                assert data["code"] == "missing_value"
+                assert SecretVault(empty_vault_dir).list_names() == []
+
+    @pytest.mark.asyncio
+    async def test_normal_value_still_stores(self, empty_vault_dir: Path) -> None:
+        """Positive regression: a real value continues to be stored correctly."""
+        app = _app()
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch(
+            "kiro_crew.dashboard.handlers.secrets.config_dir",
+            return_value=str(empty_vault_dir),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/api/secrets", json={"name": "K", "value": "real-value"})
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["ok"] is True
+                assert SecretVault(empty_vault_dir).list_names() == ["K"]
+
+    @pytest.mark.asyncio
+    async def test_padded_value_is_stored_unchanged(self, empty_vault_dir: Path) -> None:
+        """A value with real content plus surrounding whitespace is stored VERBATIM.
+
+        The emptiness check uses ``value.strip()``, but the stored value must be
+        the original, untrimmed string — a credential can legitimately carry
+        leading/trailing whitespace and trimming it would corrupt the secret.
+        """
+        app = _app()
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        padded = "  sk-live-abc  "
+        with patch(
+            "kiro_crew.dashboard.handlers.secrets.config_dir",
+            return_value=str(empty_vault_dir),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/api/secrets", json={"name": "K", "value": padded})
+                assert resp.status == 200
+                # The vault must hold the ORIGINAL padded value, byte-for-byte.
+                assert SecretVault(empty_vault_dir).get("K").reveal() == padded


### PR DESCRIPTION
## Problem / Motivation

Fixes #7450.

`api_secrets_set` strips the secret **name** before its emptiness check but never strips the **value**. A `"   "` (whitespace-only) value is truthy, so it slips past `if not value:` and is encrypted into the vault.

## Why it matters

A whitespace-only value is almost always a mistaken paste; the stored "secret" reads back effectively empty via `reveal()`, and the asymmetry with the name handling is a correctness gap.

## What changed (motivation → approach → change)

Add `value = value.strip()` right after `name = name.strip()`. The existing `if not value:` → 400 `missing_value` path then rejects the whitespace-only case. One production line.

## Tests

- New `TestApiSecretsSetWhitespaceValue`: `"   "` → 400 `missing_value` and the vault stays empty; parametrized over spaces / tab / newline / mixed; plus a positive test that a real value still stores.
- Proven red→green: 5 asserts fail on the pre-fix code (`assert 200 == 400`), all pass with `value.strip()`.
- Gates green: `pytest test/test_secrets_handler.py` 32 passed; isort / flake8 / mypy / black clean.



## Pattern harvest

Rule candidate: review-prompt — when one field of a pair is normalized (`.strip()`) before its validation, apply the same normalization to the sibling field before its own check. Pattern: asymmetric input normalization lets a whitespace-only value pass a truthiness guard.
