### PR TITLE
fix(secrets): return 404 when deleting a secret that does not exist

### DIFF
--- a/src/kiro_crew/dashboard/handlers/secrets.py
+++ b/src/kiro_crew/dashboard/handlers/secrets.py
@@ -157,6 +157,14 @@ async def api_secrets_delete(request: web.Request) -> web.Response:
         )
 
     vault = SecretVault(config_dir())
+    # `vault.delete` is a no-op when the name is absent, so an unconditional
+    # `{"ok": true}` would report success for a mistyped name that was never
+    # stored — the SecretsPanel then re-fetches and still shows the old entry,
+    # leaving the user to think a delete failed silently. Check membership first
+    # and return 404 so a missing name is an explicit, actionable error.
+    names = await asyncio.to_thread(vault.list_names)
+    if name not in names:
+        return web.json_response({"error": "Secret not found", "code": "not_found"}, status=404)
     await vault.delete(name)
     logger.info("Vault entry '%s' deleted via dashboard", _sanitize_for_log(name))
     return web.json_response({"ok": True, "name": name})

--- a/test/test_secrets_handler.py
+++ b/test/test_secrets_handler.py
@@ -155,15 +155,45 @@ class TestApiSecretsDelete:
                 assert vault.get("TEST_KEY") is None
 
     @pytest.mark.asyncio
-    async def test_delete_nonexistent(self, vault_dir: Path) -> None:
+    async def test_deletes_secret_removes_from_list(self, vault_dir: Path) -> None:
+        """A successful DELETE removes the name from the vault; a subsequent list
+        no longer includes it.  Proves the membership check does not block the
+        actual deletion path."""
         app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
         with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)):
             async with TestClient(TestServer(app)) as client:
-                resp = await client.delete("/api/secrets/MISSING")
-                assert resp.status == 200  # delete is idempotent
+                resp = await client.delete("/api/secrets/TEST_KEY")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["ok"] is True
+
+                list_resp = await client.get("/api/secrets")
+                assert list_resp.status == 200
+                names = (await list_resp.json())["names"]
+                assert "TEST_KEY" not in names
+                assert "DB_PASS" in names  # sibling entry untouched
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_returns_404(self, vault_dir: Path) -> None:
+        """DELETE of a name that was never stored returns 404 not_found.
+
+        Before the fix, vault.delete() was a silent no-op and the handler
+        returned 200 ok unconditionally, hiding mistyped names from the caller.
+        """
+        app = _app()
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.delete("/api/secrets/NONEXISTENT_NAME")
+                assert resp.status == 404
+                data = await resp.json()
+                assert data["code"] == "not_found"
+                assert "error" in data
 
 
 class TestApiSecretsOwnerAuthorization:
@@ -297,17 +327,29 @@ class TestApiSecretsLogInjection:
 
     @pytest.mark.asyncio
     async def test_crlf_in_delete_name_is_escaped_in_log(
-        self, vault_dir: Path, caplog: pytest.LogCaptureFixture
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
+        """A percent-encoded CR/LF in the path segment decodes to real control
+        characters in request.match_info["name"].  The handler must escape them
+        before logging so the emitted record cannot forge extra audit lines.
+
+        The name must actually exist in the vault so the handler reaches the
+        log statement (a non-existent name returns 404 before logging).
+        """
         app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
-        # A percent-encoded CR/LF in the path segment decodes to real control
-        # characters in request.match_info["name"].
-        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)):
+        # Seed a vault entry whose name contains a literal CRLF.
+        injected_name = "x\r\nWARNING-forged"
+        vault = SecretVault(tmp_path)
+        vault._set_sync(injected_name, "v")
+
+        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(tmp_path)):
             async with TestClient(TestServer(app)) as client:
                 with caplog.at_level(logging.INFO, logger="kiro_crew.dashboard.handlers.secrets"):
+                    # aiohttp URL-encodes the path when using client.delete(url)
+                    # with a plain string, so percent-encode manually.
                     resp = await client.delete("/api/secrets/x%0d%0aWARNING-forged")
                     assert resp.status == 200
 


### PR DESCRIPTION
## Problem / Motivation

Fixes #7452.

`DELETE /api/secrets/{name}` calls `vault.delete` (a documented no-op on a missing name) then unconditionally returns `200 {"ok": true}`, so deleting a name that was never stored reports success.

## Why it matters

The SecretsPanel re-fetches the list after a delete; a no-op delete of a mistyped name returns `ok:true` while the real entry stays in the list, reading as a silent failure to the user.

## What changed (motivation → approach → change)

`api_secrets_delete` now checks membership via `asyncio.to_thread(vault.list_names)` and returns `404 {"error":"Secret not found","code":"not_found"}` when the name is absent, before calling `vault.delete`. Self-contained in the handler — the vault's public no-op `delete` contract is untouched. The happy path still returns `200 ok` and removes the entry.

## Tests

- New `test_delete_nonexistent_returns_404` (missing name → 404 `not_found`) and `test_deletes_secret_removes_from_list` (seeded name deletes, subsequent list excludes it, sibling untouched). Removed the old `test_delete_nonexistent` that asserted the wrong `200`.
- Updated the CRLF log-injection test to seed the CRLF-bearing name first so the handler reaches the log line (it would otherwise now 404 before logging).
- Proven red→green: the 404 test fails on pre-fix (`assert 200 == 404`), passes with the check.
- Gates green: `pytest test/test_secrets_handler.py` 27 passed; isort / flake8 / mypy clean.



## Pattern harvest

Rule candidate: review-prompt — a handler wrapping a documented no-op mutation (delete/remove) must not return unconditional success; check existence and return 404 so a mistyped target is an explicit error. Pattern: no-op backend call reported as success hides caller mistakes.
