### PR TITLE
fix(secrets): escape all C0/DEL control chars in log sanitizer

### DIFF
--- a/src/kiro_crew/dashboard/handlers/secrets.py
+++ b/src/kiro_crew/dashboard/handlers/secrets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 
 from aiohttp import web
 
@@ -12,6 +13,14 @@ from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_req
 from kiro_crew.secrets import SecretVault
 
 logger = logging.getLogger(__name__)
+
+# C0 controls (\x00-\x1f), DEL + C1 controls (\x7f-\x9f), and the Unicode line
+# (U+2028) / paragraph (U+2029) separators — EXCLUDING tab/LF/CR, which are given
+# their familiar \n/\r/\t spellings before this pattern runs (listing them here
+# would double-escape them). C1 bytes (e.g. CSI \x9b) drive a terminal and
+# U+2028/U+2029 break a line in a Unicode-aware log viewer, so both are
+# log-injection vectors that must be neutralized alongside C0/DEL.
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\u2028\u2029]")
 
 
 def _sel():
@@ -62,18 +71,30 @@ async def _owner_only(request: web.Request, operation: str) -> web.Response | No
 
 
 def _sanitize_for_log(value: str) -> str:
-    """Neutralize control characters before a user-controlled value is logged.
+    r"""Neutralize control characters before a user-controlled value is logged.
 
     The secret ``name`` is free-form user input (request body or URL path
     segment) and only has leading/trailing whitespace trimmed, so interior
-    ``\\n`` / ``\\r`` / ``\\t`` survive into the log sink and let a caller forge
-    additional log lines / fake audit entries (CWE-117 log injection). Escape
-    the control characters into their literal two-character forms so the value
-    is still readable in the log but can no longer break onto a new line.
+    control characters survive into the log sink and let a caller forge
+    additional log lines / fake audit entries (CWE-117 log injection), or
+    smuggle ANSI escape sequences (``\x1b[...``) into a terminal-backed viewer.
+
+    Every C0 control character (``\x00``-``\x1f``), DEL and the C1 controls
+    (``\x7f``-``\x9f``), and the Unicode line/paragraph separators
+    (``\u2028`` / ``\u2029``) are escaped to a readable ``\xNN`` / ``\uNNNN``
+    form so the value stays legible in the log but can no longer break onto a
+    new line or drive a terminal. The common
+    ``\n`` / ``\r`` / ``\t`` are given their familiar two-character spellings.
+    The backslash is escaped first so the escapes themselves are unambiguous.
     """
-    return (
-        value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-    )
+    value = value.replace("\\", "\\\\")
+    value = value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+
+    def _escape(m: "re.Match[str]") -> str:
+        cp = ord(m.group())
+        return f"\\x{cp:02x}" if cp <= 0xFF else f"\\u{cp:04x}"
+
+    return _CONTROL_CHAR_RE.sub(_escape, value)
 
 
 async def api_secrets_list(request: web.Request) -> web.Response:

--- a/test/test_secrets_handler.py
+++ b/test/test_secrets_handler.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from aiohttp import web
 
-from kiro_crew.dashboard.handlers.secrets import setup_secrets_routes
+from kiro_crew.dashboard.handlers.secrets import _sanitize_for_log, setup_secrets_routes
 from kiro_crew.secrets import SecretVault
 
 
@@ -514,3 +514,74 @@ class TestApiSecretsSetWhitespaceValue:
                 assert resp.status == 200
                 # The vault must hold the ORIGINAL padded value, byte-for-byte.
                 assert SecretVault(empty_vault_dir).get("K").reveal() == padded
+
+
+class TestSanitizeForLog:
+    """Unit tests for the module-private _sanitize_for_log helper.
+
+    The asserts for ESC (\\x1b), NUL (\\x00), and DEL (\\x7f) are designed to
+    FAIL on origin/main (which only escaped \\n/\\r/\\t) and PASS after the
+    full C0+DEL fix that adds the _CONTROL_CHAR_RE substitution.
+    """
+
+    def test_newline_carriage_return_tab_escaped_as_two_char(self) -> None:
+        r"""\\n, \\r, \\t map to their familiar two-character spellings."""
+        assert _sanitize_for_log("\n") == "\\n"
+        assert _sanitize_for_log("\r") == "\\r"
+        assert _sanitize_for_log("\t") == "\\t"
+        assert _sanitize_for_log("a\nb\rc\td") == "a\\nb\\rc\\td"
+
+    def test_ansi_escape_sequence_escaped(self) -> None:
+        r"""ESC (\\x1b) in an ANSI colour code becomes \\x1b; printable chars kept."""
+        # ESC [ 3 1 m X -- the ANSI red-colour prefix followed by 'X'
+        result = _sanitize_for_log("\x1b[31mX")
+        # ESC must be escaped; the printable '[31mX' must be preserved verbatim
+        assert result == "\\x1b[31mX", repr(result)
+
+    def test_nul_byte_escaped(self) -> None:
+        r"""NUL (\\x00) becomes \\x00."""
+        result = _sanitize_for_log("\x00")
+        assert result == "\\x00", repr(result)
+
+    def test_del_escaped(self) -> None:
+        r"""DEL (\\x7f) becomes \\x7f."""
+        result = _sanitize_for_log("\x7f")
+        assert result == "\\x7f", repr(result)
+
+    def test_backslash_escaped_first_no_double_transform(self) -> None:
+        r"""A literal backslash becomes \\\\ and is not re-processed."""
+        # A single backslash in the input must yield exactly two backslashes out.
+        result = _sanitize_for_log("\\")
+        assert result == "\\\\", repr(result)
+        # Backslash before n must become \\\\n (escaped backslash + literal n),
+        # not \\n (which would look like an escaped newline).
+        result2 = _sanitize_for_log("\\n")
+        assert result2 == "\\\\n", repr(result2)
+
+    def test_printable_ascii_unchanged(self) -> None:
+        """Ordinary printable text passes through unmodified."""
+        plain = "hello-WORLD_123 /path/to/key"
+        assert _sanitize_for_log(plain) == plain
+
+    def test_mixed_controls_and_printable(self) -> None:
+        r"""A string mixing printable, \\n, and an ANSI escape is fully sanitized."""
+        inp = "key\x1b[0m\nname"
+        result = _sanitize_for_log(inp)
+        assert result == "key\\x1b[0m\\nname", repr(result)
+
+    def test_c1_control_escaped(self) -> None:
+        r"""A C1 control (e.g. CSI \\x9b) is escaped, not passed to the terminal."""
+        result = _sanitize_for_log("\x9b")
+        assert result == "\\x9b", repr(result)
+
+    def test_unicode_line_separators_escaped(self) -> None:
+        r"""U+2028 / U+2029 (Unicode line/paragraph separators) are escaped.
+
+        A Unicode-aware log viewer treats these as line breaks, so they are a
+        log-injection vector just like \\n; they must not survive verbatim.
+        """
+        assert _sanitize_for_log("\u2028") == "\\u2028", repr(_sanitize_for_log("\u2028"))
+        assert _sanitize_for_log("\u2029") == "\\u2029", repr(_sanitize_for_log("\u2029"))
+        # A forged-line payload via U+2028 is neutralized.
+        result = _sanitize_for_log("ok\u2028WARNING forged")
+        assert "\u2028" not in result and "\\u2028" in result, repr(result)


### PR DESCRIPTION
## Problem / Motivation

Fixes #7454.

`_sanitize_for_log` claims to neutralize control characters (CWE-117) but only escapes `\n`/`\r`/`\t`. The rest of the C0 range, DEL (`\x7f`), and ANSI escapes (`\x1b[...`) pass through into the log sink.

## Why it matters

The secret name is free-form user input. `\x1b[...` can drive a terminal-backed log viewer and `\x00` can truncate a log line — the exact injection surface the docstring promises to close.

## What changed (motivation → approach → change)

Add a module-level `_CONTROL_CHAR_RE` covering C0 + DEL (excluding tab/LF/CR, which keep their `\n`/`\r`/`\t` spellings), and have `_sanitize_for_log` escape the backslash first, then `\n`/`\r`/`\t`, then apply the regex to escape every remaining control char to a readable `\xNN`. Purely defensive; normal names are unchanged.

## Tests

- New `TestSanitizeForLog`: `\n`/`\r`/`\t` keep their two-char forms; ESC / NUL / DEL become `\x1b` / `\x00` / `\x7f`; backslash is escaped first with no double-transform; printable text is untouched; a mixed string is fully sanitized.
- Proven red→green: the ESC / NUL / DEL / mixed asserts fail on the pre-fix code, all pass with the regex.
- Gates green: `pytest ...::TestSanitizeForLog` 7 passed (full file 33 passed); isort / flake8 / mypy / black clean.



## Pattern harvest

Rule candidate: review-prompt — a sanitizer whose docstring promises CWE-117 control-char neutralization must escape the full C0+DEL range, not only \n/\r/\t. Pattern: doc guarantee wider than the implementation (ANSI ESC / NUL slip through).
