### PR TITLE
fix(secrets): fail closed on a non-object vault envelope

### DIFF
--- a/src/kiro_crew/secrets/vault.py
+++ b/src/kiro_crew/secrets/vault.py
@@ -368,6 +368,16 @@ class SecretVault:
         raw = self._store_path.read_text(encoding="utf-8")
         envelope = json.loads(raw)
 
+        # A corrupt / hand-edited store can carry a non-object top-level value
+        # (a list, a string, null, a number). Guard before ``.get`` so it fails
+        # closed with a descriptive ValueError rather than a raw AttributeError,
+        # matching the ``entries`` guard below. No store content is echoed.
+        if not isinstance(envelope, dict):
+            raise ValueError(
+                f"Vault store corrupt: top-level value must be an object, "
+                f"got {type(envelope).__name__}."
+            )
+
         if envelope.get("backend") != self._BACKEND:
             raise ValueError(
                 f"Vault backend mismatch: expected {self._BACKEND!r}, "

--- a/test/test_secrets_vault.py
+++ b/test/test_secrets_vault.py
@@ -456,3 +456,93 @@ def test_corrupt_entry_raises_from_get_many(tmp_path) -> None:
     vault = SecretVault(tmp_path)
     with pytest.raises(ValueError, match="Vault store corrupt: an entry is malformed"):
         vault.get_many(["A"])
+
+
+# ── Non-dict top-level envelope guard (F5) ──
+
+
+def _write_raw_store(tmp_path: Path, raw_json: str) -> None:
+    """Write raw JSON bytes directly to the store path, bypassing the envelope builder."""
+    (tmp_path / ".vault").mkdir(exist_ok=True)
+    (tmp_path / ".vault" / "secrets.enc").write_text(raw_json, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "[]",  # JSON array
+        '["a","b"]',  # JSON array with content
+        '"x"',  # JSON string
+        "42",  # JSON number
+        "true",  # JSON boolean
+        "null",  # JSON null
+    ],
+)
+def test_non_dict_top_level_envelope_raises_value_error(tmp_path, raw) -> None:
+    """A store whose top-level JSON value is not an object fails closed with ValueError.
+
+    On origin/main (without the isinstance guard) this raised a raw AttributeError
+    from envelope.get().  The fix raises a descriptive ValueError that mirrors the
+    existing 'entries' guard, so callers see a consistent module-level error rather
+    than an internal implementation detail.
+    """
+    _seed_key(tmp_path)
+    _write_raw_store(tmp_path, raw)
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="corrupt"):
+        vault._load_entries()
+
+
+def test_non_dict_envelope_error_contains_type_name(tmp_path) -> None:
+    """The ValueError message names the unexpected type, not the store content."""
+    _seed_key(tmp_path)
+    _write_raw_store(tmp_path, "[]")
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError) as exc:
+        vault._load_entries()
+    msg = str(exc.value)
+    # Message must mention "object" (expected) and the actual type.
+    assert "object" in msg
+    assert "list" in msg
+
+
+def test_non_dict_envelope_error_does_not_echo_store_content(tmp_path) -> None:
+    """The corrupt-envelope error carries no store content in the message."""
+    _seed_key(tmp_path)
+    store_payload = '"sensitive-payload-12345"'
+    _write_raw_store(tmp_path, store_payload)
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError) as exc:
+        vault._load_entries()
+    assert "sensitive-payload-12345" not in str(exc.value)
+
+
+def test_non_dict_envelope_raises_from_list_names(tmp_path) -> None:
+    """The public list_names() path surfaces the ValueError for a non-dict envelope."""
+    _seed_key(tmp_path)
+    _write_raw_store(tmp_path, "[]")
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="corrupt"):
+        vault.list_names()
+
+
+def test_valid_store_still_loads_after_guard(tmp_path) -> None:
+    """A well-formed store is unaffected by the isinstance guard."""
+    vault = SecretVault(tmp_path)
+    vault._set_sync("k", "v")
+    # Must not raise — guard is only a speed-bump for non-dict values.
+    entries = vault._load_entries()
+    assert "k" in entries
+
+
+def test_corrupt_entries_guard_still_works_with_envelope_guard(tmp_path) -> None:
+    """The existing 'entries' guard (non-dict entries value) still fires correctly.
+
+    Ensures the new top-level guard does not mask or accidentally break the
+    entries-level guard that was already present.
+    """
+    _seed_key(tmp_path)
+    _write_store(tmp_path, ["not", "a", "dict"])
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="Vault store corrupt: 'entries' must be an object"):
+        vault._load_entries()


### PR DESCRIPTION
## Problem / Motivation

Fixes #7456.

`SecretVault._load_entries` fails closed with a descriptive `ValueError` when the `entries` value is a non-dict, but the outer envelope has no such guard: `envelope.get("backend")` runs directly on `json.loads(raw)`, so a hand-corrupted store whose top-level JSON is an array / string / number / null raises a raw `AttributeError`.

## Why it matters

It is the asymmetric gap of an existing guard: the module already fails closed with a clear `ValueError` for a bad `entries` shape, but a bad top-level shape leaks a raw `AttributeError` into an unrelated caller. Marginal (only a hand-edited store reaches it) but trivially correct.

## What changed (motivation → approach → change)

Add one `isinstance(envelope, dict)` check right after `json.loads`, raising the same style of descriptive `ValueError` (naming the unexpected type, echoing no store content) that the `entries` guard already uses.

## Tests

- New parametrized `test_non_dict_top_level_envelope_raises_value_error` (`[]`, `["a","b"]`, `"x"`, `42`, `true`, `null` → `ValueError` matching `corrupt`), plus asserts that the message names the type but not the store content, that `list_names()` surfaces it, that a valid store still loads, and that the existing `entries` guard still fires.
- Proven red→green: the 9 new asserts fail on pre-fix (`AttributeError`), all pass with the guard.
- Gates green: `pytest test/test_secrets_vault.py` 40 passed; isort / flake8 / mypy / black clean.



## Pattern harvest

Rule candidate: review-prompt — when one shape of parsed input is guarded (fail-closed ValueError), guard the enclosing shape too; `json.loads(...).get(...)` on an unvalidated top-level value raises a raw AttributeError. Pattern: inner guard present, outer container unguarded.
