### PR TITLE
docs(log-redaction): split run-on paragraph in module docstring

### DIFF
--- a/src/kiro_crew/log_redaction.py
+++ b/src/kiro_crew/log_redaction.py
@@ -17,7 +17,9 @@ the string the scan inspects. Any opaque object arg disqualifies preservation
 — its attributes can carry credentials a structured handler would serialize
 but no text scan can bound. ``exc_info`` is ALWAYS rendered, redacted into
 ``exc_text``, and cleared: a live traceback is an object graph whose frames
-carry locals no text scan can bound. The trade this makes explicit: redaction inspects the RENDERED
+carry locals no text scan can bound.
+
+The trade this makes explicit: redaction inspects the RENDERED
 text, never the internals of the ``args`` objects themselves, so a structured
 handler that serializes arg objects directly (attribute dumps, JSON) can emit
 content the text scan never saw. That limitation existed before too — the scan


### PR DESCRIPTION
## Problem / Motivation

Fixes #7458.

The `log_redaction.py` module docstring runs two conceptual paragraphs together — the `exc_info` explanation flows directly into the trade-off discussion on the same line — where the rest of the docstring uses blank lines to separate paragraphs.

## Why it matters

Documentation clarity only. The docstring is load-bearing (it explains the redaction trade-off) and the run-on obscures where that explanation starts. No code impact.

## What changed (motivation → approach → change)

Insert one blank line at the sentence boundary so the trade-off explanation begins its own paragraph, matching the docstring's existing blank-line-separated style. Docstring whitespace only.

## Tests

No test — this is a docstring whitespace change with no runtime behavior. Verified `flake8` (repo config) and `black --check` clean on the file.
