### PR TITLE
feat: rename sidebar sessions on double-click

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1402,7 +1402,7 @@ interface SessionRowProps {
   boost: PaletteBoost
   boostFor: (hex: string) => PaletteBoost
   renameInputRef: React.MutableRefObject<HTMLTextAreaElement | null>
-  onRenameStart: (key: string, scope: string, title: string) => void
+  onRenameStart: (key: string, scope: string, title: string, fromMenu: boolean) => void
   onRenameChange: (value: string) => void
   onRenameCommit: (key: string, value: string) => void
   onRenameCancel: () => void
@@ -1768,7 +1768,7 @@ const SessionRow = memo(function SessionRow({
     const rowMenuProps = {
       slotKey: s.key,
       mode,
-      onRename: () => onRenameStart(s.key, scope, s.title && s.title !== s.key ? s.title : ''),
+      onRename: () => onRenameStart(s.key, scope, s.title && s.title !== s.key ? s.title : '', true),
       onOpenInNewTab: onOpenSlotInNewTab ? () => onOpenSlotInNewTab(s.key) : undefined,
     }
     return (
@@ -1851,6 +1851,10 @@ const SessionRow = memo(function SessionRow({
             onOpenSlotInNewTab(s.key, { background: true })
           }) : undefined}
           onClick={e => {
+            // A browser emits two click events before dblclick. Let the first
+            // select an inactive session, but do not fetch it a second time
+            // before the title's double-click handler opens rename.
+            if (e.detail > 1 && (e.target as HTMLElement).closest?.('[data-session-title]')) return
             if ((e.target as HTMLElement).closest?.('[data-fork]')) { onDuplicate(s.key); return }
             if ((e.target as HTMLElement).closest?.('[data-close]')) { onCloseSession(s.key); return }
             // When the gateway is offline, switching sessions silently fails
@@ -1876,6 +1880,13 @@ const SessionRow = memo(function SessionRow({
             }
             dispatch(switchSlot(s.key))
             onSelectSlot?.(s.key)
+          }}
+          onDoubleClick={e => {
+            if (!(e.target as HTMLElement).closest?.('[data-session-title]')) return
+            if (renamingHere) return
+            e.preventDefault()
+            e.stopPropagation()
+            onRenameStart(s.key, scope, s.title && s.title !== s.key ? s.title : '', false)
           }}>
           {/* Held-modifier digit badge: while the chat-jump modifier is down,
            *  the first nine sessions in shortcut order show the digit that
@@ -2076,7 +2087,11 @@ const SessionRow = memo(function SessionRow({
                 made the list read as ragged. The full string stays reachable
                 through the `title` attribute, and the rename box below is the one
                 place it is shown in full. */}
-            <div className={`${ROW_TITLE_CLS} font-semibold text-text ${renamingHere ? '' : 'truncate'}`} title={s.title && s.title !== s.key ? s.title : s.key}>
+            <div
+              data-session-title
+              className={`${ROW_TITLE_CLS} font-semibold text-text ${renamingHere ? '' : 'truncate'}`}
+              title={s.title && s.title !== s.key ? s.title : s.key}
+            >
               {/* No separate fork glyph: forked titles already carry the
                   persisted "↳ " marker (chat_fork.py _FORK_TITLE_MARKER). Keeping
                   the arrow in the title text — rather than as a UI-only glyph —
@@ -2480,8 +2495,8 @@ function ChatSidebar({
   // draft VALUE from the row as an argument rather than closing over
   // `renameValue` — a closure over it would mint a new handler per keystroke
   // and re-render every row on each key.
-  const onRenameStart = useCallback((key: string, scope: string, title: string) => {
-    suppressMenuRestoreRef.current = true
+  const onRenameStart = useCallback((key: string, scope: string, title: string, fromMenu: boolean) => {
+    if (fromMenu) suppressMenuRestoreRef.current = true
     setRenamingSlot(key)
     setRenameScope(scope)
     setRenameValue(title)

--- a/website/src/test/ChatSidebar.renameDraggable.test.tsx
+++ b/website/src/test/ChatSidebar.renameDraggable.test.tsx
@@ -11,8 +11,7 @@
  * while its rename input is open, and "true" otherwise.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { fireEvent, render, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
@@ -71,10 +70,10 @@ import ChatSidebar from '../pages/ChatSidebar'
 const SLOT_KEY = 'chat-rename-1'
 const slot = { key: SLOT_KEY, title: 'My Session Title', running: false, tags: [], created: '', last_ts: '' }
 
-function renderSidebar() {
+function renderSidebar(connected = false, onSelectSlot?: (key: string) => void) {
   const store = createTestStore({
     dashboard: {
-      status: {}, connected: false, slots: [slot], approvalMode: 'normal',
+      status: {}, connected, slots: [slot], approvalMode: 'normal',
       channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
       subagentRunning: {}, subagentDetails: {}, subagentText: {},
       sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
@@ -93,6 +92,7 @@ function renderSidebar() {
             <ChatSidebar
               slots={[slot]} activeSlot={null} unreadSlots={[]}
               history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+              onSelectSlot={onSelectSlot}
             />
           </MemoryRouter>
         </ThemeProvider>
@@ -122,26 +122,26 @@ describe('session row drag is disabled during inline rename', () => {
     expect(rowFor(container).getAttribute('data-draggable')).toBe('true')
   })
 
-  // Radix ContextMenu/DropdownMenu requires PointerEvent support that jsdom
-  // lacks. The rename+drag invariant is visually verified. Skipped until we
-  // add a jsdom PointerEvent polyfill or migrate to Playwright component tests.
-  it.skip('row becomes non-draggable once the rename input is open', async () => {
-    const user = userEvent.setup({ pointerEventsCheck: 0 })
-    const { container } = renderSidebar()
+  it('double-clicking the title selects once, opens rename, and disables dragging', () => {
+    const onSelectSlot = vi.fn()
+    const { container } = renderSidebar(true, onSelectSlot)
     const row = rowFor(container)
     expect(row.getAttribute('data-draggable')).toBe('true')
 
-    await user.click(within(row).getByLabelText('More options'))
-    const menu = document.querySelector('[role="menu"]') as HTMLElement
-    expect(menu).toBeTruthy()
-    await user.click(within(menu).getByText('Rename'))
+    const title = within(row).getByTitle('My Session Title')
+    fireEvent.click(title, { detail: 1 })
+    fireEvent.click(title, { detail: 2 })
+    fireEvent.doubleClick(title, { detail: 2 })
 
-    // Same row node, now rendering the input; drag must be off so the browser
-    // gives the input native click-to-place-caret.
+    expect(onSelectSlot).toHaveBeenCalledTimes(1)
+    expect(onSelectSlot).toHaveBeenCalledWith(SLOT_KEY)
+    // Same row node, now rendering the existing inline editor; drag must be off
+    // so the browser gives the textarea native click-to-place-caret behavior.
     expect(rowFor(container).getAttribute('data-draggable')).toBe('false')
+    const input = within(rowFor(container)).getByRole('textbox') as HTMLTextAreaElement
+    expect(input.value).toBe('My Session Title')
     // select-text overrides the row's inherited select-none so click-drag
     // selection works in the field — the other half of the fix.
-    const input = within(rowFor(container)).getByRole('textbox')
     expect(input.className).toContain('select-text')
   })
 })


### PR DESCRIPTION
## Problem / Motivation

Renaming a session from the Sessions sidebar currently requires opening the row action menu and choosing **Rename**. Folders in the same sidebar already support double-click-to-rename, but session titles do not.

## Why it matters

People managing many active sessions rename them frequently. Requiring the overflow menu for every edit adds friction and makes sibling objects in the sidebar behave inconsistently. Double-click is an optional desktop shortcut; the existing menu remains the discoverable and accessible path.

## What changed (motivation → approach → change)

The change reuses the existing scope-bound inline rename editor rather than adding a second editing path:

- marks only the rendered session-title region as the double-click target;
- handles `dblclick` on the existing keyboard-accessible session row;
- allows the first click to select an inactive session, while suppressing the browser's second title click so it does not trigger a duplicate session switch/detail request;
- distinguishes menu-triggered rename from direct rename so Radix focus restoration is suppressed only when a menu is closing;
- preserves the existing editor's focus, Enter/Escape/blur, title prefill, and drag-disabled behavior.

Related implementation history:

- [PR #458](https://github.com/kirodotdev/KiroCrew/pull/458) introduced in-place session-title editing.
- [PR #1226](https://github.com/kirodotdev/KiroCrew/pull/1226) improved the full-title sidebar editor.
- [PR #3991](https://github.com/kirodotdev/KiroCrew/pull/3991) hardened rename targeting across session changes.
- [PR #6703](https://github.com/kirodotdev/KiroCrew/pull/6703) established the current memoized session-row structure and folder double-click convention.

## Tests

- Replaced the skipped menu-only drag assertion with a deterministic regression that emits the browser's `click(detail=1)`, `click(detail=2)`, and `dblclick` sequence.
- Verifies an inactive session is selected exactly once.
- Verifies the existing inline textarea opens with the current title.
- Verifies the row becomes non-draggable while editing.
- 43 focused tests passed across six sidebar suites.
- TypeScript compilation and the production frontend build passed.
- Focused ESLint reported zero errors and only the file's nine pre-existing warnings.
- Exact-patch GPT and Opus local reviews found no issues.

## Manual verification

Rendered the real built SPA with the repository's deterministic dashboard API fixture and drove it with sandboxed Firefox. A real browser double-click produced exactly one session-detail request, opened the correctly prefilled inline editor, and changed the row to `data-draggable="false"`.

## Screenshots / video

### Session title at rest

![Session title at rest](https://github.com/Pearcekieser/KiroCrew/blob/1bebbf8a6af2886b75009bebf3e94bf46e03ebd0/gh-pr-images/pr-7462/01-sidebar-at-rest.png?raw=true)

### Inline editor after double-click

![Inline editor after double-click](https://github.com/Pearcekieser/KiroCrew/blob/1bebbf8a6af2886b75009bebf3e94bf46e03ebd0/gh-pr-images/pr-7462/02-sidebar-inline-rename.png?raw=true)

The screenshots are uploaded as GitHub-hosted PR assets and are intentionally not part of the feature branch diff.

## Related Issues

Fixes #7400

Related folder-rename correctness context: [#2636](https://github.com/kirodotdev/KiroCrew/issues/2636).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no public API or documented configuration changed)
- [x] No secrets, credentials, or internal references in the diff


