### PR TITLE
fix: offload remaining transcript reads off the gateway loop

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5874,7 +5874,13 @@ async def _run_chat(
                 history_key = slot_history_key(slot)
                 disk_count = 0
                 if state.conversation_log:
-                    disk_count = len(state.conversation_log.read_messages(history_key))
+                    # The disk read is 100-300ms of blocking IO on a large store; keep
+                    # it off the loop so it cannot stall the prompt-submit path. Only the
+                    # read crosses; the count and prefix build stay loop-affine.
+                    disk_messages = await asyncio.to_thread(
+                        state.conversation_log.read_messages, history_key
+                    )
+                    disk_count = len(disk_messages)
                 mem_count = sum(1 for m in slot.messages if m.get("role") in ("user", "assistant"))
                 if mem_count > disk_count:
                     history = _build_history_prefix(slot)

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -41,7 +41,7 @@ from kiro_crew.dashboard.channel_folders import (
     ensure_channel_folder,
     stored_folder_name,
 )
-from kiro_crew.dashboard.chat_persistence import _rehydrate_slot_from_history
+from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
 from kiro_crew.dashboard.chat_utils import (
     CRON_NOTIFICATION_KIND,
     _remove_queued_by_id,
@@ -2075,7 +2075,7 @@ async def api_send_message(request: web.Request) -> web.Response:
         # "Origin reachable" = one of:
         #   - Hot: slot in state._slots (user has the tab open) → fast path
         #   - Cold: slot not loaded but JSONL exists without closed=true →
-        #     _rehydrate_slot_from_history restores it from disk, tab reappears
+        #     rehydrate_slot_from_history_async restores it from disk, tab reappears
         #
         # "Origin unreachable" = any of:
         #   - User clicked ✕ on the tab (closed=true in JSONL metadata) —
@@ -2124,15 +2124,16 @@ async def api_send_message(request: web.Request) -> web.Response:
             slot_key, job_name = _resolve_session_target(state, target_session, caller_session)
             if slot_key:
                 # Resolve the origin slot. get_slot is the hot path (fast,
-                # O(1) dict lookup). On miss, _rehydrate_slot_from_history
-                # restores from disk if the session exists and isn't closed.
+                # O(1) dict lookup). On miss, rehydrate_slot_from_history_async
+                # restores from disk off the loop if the session exists and
+                # isn't closed.
                 # Truly-gone sessions (never persisted, deleted, or closed)
                 # return None and delivery falls through to the Slack DM
                 # path below — no phantom empty tab is ever created.
                 slot = state.get_slot(slot_key)
                 was_loaded = slot is not None
                 if slot is None:
-                    slot = _rehydrate_slot_from_history(state, slot_key)
+                    slot = await rehydrate_slot_from_history_async(state, slot_key)
                 logger.info(
                     "send_message session=origin resolved slot_key=%s job=%s was_loaded=%s rehydrated=%s",
                     slot_key,

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -115,7 +115,6 @@ from kiro_crew.dashboard.cron_inject import (
 )
 from kiro_crew.dashboard.handlers import MAX_PROMPT_BYTES
 from kiro_crew.dashboard.handlers.autonudge import compose_nudge_body
-from kiro_crew.dashboard.handlers.messaging import _rehydrate_slot_from_history
 from kiro_crew.dashboard.handlers.updates import remediation_command as _remediation_command
 from kiro_crew.dashboard.handlers.usage import (
     persist_token_record_async,
@@ -3236,7 +3235,9 @@ class GatewayOrchestrator:
                     slot_key = job.session_key.removeprefix("dashboard:")
                     slot = self.dashboard_state.get_slot(slot_key)
                     if slot is None:
-                        slot = _rehydrate_slot_from_history(self.dashboard_state, slot_key)
+                        slot = await rehydrate_slot_from_history_async(
+                            self.dashboard_state, slot_key
+                        )
                     label = redact(job.name)
                     if slot:
                         wrapped = f'[Cron notification: "{label}"]\n{message}\n[/Cron notification]'
@@ -4578,10 +4579,21 @@ class GatewayOrchestrator:
                             and not job.hide_in_chat
                             and self.dashboard_state.has_slot(f"cron-{job.id}")
                         ):
+                            # Prefetch the transcript off the loop so the inject's
+                            # linked-session read cannot block, matching the creator path.
+                            history = (
+                                await asyncio.to_thread(
+                                    self.dashboard_state.conversation_log.read_messages,
+                                    f"cron:{job.id}",
+                                )
+                                if self.dashboard_state.conversation_log
+                                else []
+                            )
                             inject_cron_result_to_dashboard(
                                 self.dashboard_state,
                                 job,
                                 result_text,
+                                history=history,
                                 context_reading=_ctx_reading,
                             )
                         return result_text
@@ -4602,10 +4614,21 @@ class GatewayOrchestrator:
                         and not job.hide_in_chat
                         and self.dashboard_state.has_slot(f"cron-{job.id}")
                     ):
+                        # Prefetch the transcript off the loop so the inject's
+                        # linked-session read cannot block, matching the creator path.
+                        history = (
+                            await asyncio.to_thread(
+                                self.dashboard_state.conversation_log.read_messages,
+                                f"cron:{job.id}",
+                            )
+                            if self.dashboard_state.conversation_log
+                            else []
+                        )
                         inject_cron_result_to_dashboard(
                             self.dashboard_state,
                             job,
                             result_text,
+                            history=history,
                             context_reading=_ctx_reading,
                         )
                     return result_text

--- a/test/test_cron_origin_injection.py
+++ b/test/test_cron_origin_injection.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import sys
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -149,7 +149,9 @@ async def test_resolved_key_with_no_live_slot_falls_back_to_bell(mock_sel):
     it posts a notification."""
     state = _state_with_job(slot=None)
     with patch(
-        "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history", return_value=None
+        "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+        new_callable=AsyncMock,
+        return_value=None,
     ):
         async with TestClient(TestServer(_make_app(state))) as c:
             resp = await c.post(

--- a/test/test_dashboard_file_io.py
+++ b/test/test_dashboard_file_io.py
@@ -607,11 +607,13 @@ class TestSendMessage:
         mock_job.session_key = "dashboard:chat-1-1712793600"
         state.crons.list_jobs = MagicMock(return_value=[mock_job])
         app = _make_send_app(state)
-        with patch(
-            "kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock
-        ) as mock_run, patch(
-            "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history"
-        ) as mock_rehydrate:
+        with (
+            patch("kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock) as mock_run,
+            patch(
+                "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+                new_callable=AsyncMock,
+            ) as mock_rehydrate,
+        ):
             async with TestClient(TestServer(app)) as client:
                 resp = await client.post(
                     "/api/send-message",
@@ -655,7 +657,8 @@ class TestSendMessage:
         state.crons.list_jobs = MagicMock(return_value=[mock_job])
         app = _make_send_app(state)
         with patch(
-            "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history"
+            "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+            new_callable=AsyncMock,
         ) as mock_rehydrate:
             async with TestClient(TestServer(app)) as client:
                 resp = await client.post(
@@ -714,12 +717,14 @@ class TestSendMessage:
         mock_job.session_key = "dashboard:chat-1-1712793600"
         state.crons.list_jobs = MagicMock(return_value=[mock_job])
         app = _make_send_app(state)
-        with patch(
-            "kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock
-        ) as mock_run, patch(
-            "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history",
-            return_value=mock_slot,
-        ) as mock_rehydrate:
+        with (
+            patch("kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock) as mock_run,
+            patch(
+                "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+                new_callable=AsyncMock,
+                return_value=mock_slot,
+            ) as mock_rehydrate,
+        ):
             async with TestClient(TestServer(app)) as client:
                 resp = await client.post(
                     "/api/send-message",
@@ -757,7 +762,9 @@ class TestSendMessage:
         state.crons.list_jobs = MagicMock(return_value=[mock_job])
         app = _make_send_app(state)
         with patch(
-            "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history", return_value=None
+            "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+            new_callable=AsyncMock,
+            return_value=None,
         ) as mock_rehydrate:
             async with TestClient(TestServer(app)) as client:
                 resp = await client.post(
@@ -810,9 +817,13 @@ class TestSendMessage:
         mock_job.session_key = "dashboard:chat-1-1712793600"
         state.crons.list_jobs = MagicMock(return_value=[mock_job])
         app = _make_send_app(state)
-        with patch(
-            "kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock
-        ) as mock_run, patch("kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history"):
+        with (
+            patch("kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock) as mock_run,
+            patch(
+                "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+                new_callable=AsyncMock,
+            ),
+        ):
             async with TestClient(TestServer(app)) as client:
                 resp = await client.post(
                     "/api/send-message",
@@ -835,7 +846,8 @@ class TestSendMessage:
         state.get_slot = MagicMock()
         app = _make_send_app(state)
         with patch(
-            "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history"
+            "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+            new_callable=AsyncMock,
         ) as mock_rehydrate:
             async with TestClient(TestServer(app)) as client:
                 resp = await client.post(
@@ -873,7 +885,8 @@ class TestSendMessage:
         state.crons.list_jobs = MagicMock(return_value=[mock_job])
         app = _make_send_app(state)
         with patch(
-            "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history"
+            "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+            new_callable=AsyncMock,
         ) as mock_rehydrate:
             async with TestClient(TestServer(app)) as client:
                 resp = await client.post(

--- a/test/test_send_message_targeted.py
+++ b/test/test_send_message_targeted.py
@@ -1420,7 +1420,8 @@ class TestChannelTextIsNotTheNotificationText:
         with (
             _governance(True),
             patch(
-                "kiro_crew.dashboard.handlers.messaging._rehydrate_slot_from_history",
+                "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+                new_callable=AsyncMock,
                 return_value=None,
             ),
         ):

--- a/test/test_transcript_reads_off_loop.py
+++ b/test/test_transcript_reads_off_loop.py
@@ -1,0 +1,321 @@
+"""Transcript reads that survived earlier offload passes must not run on the loop.
+
+``ConversationLog.read_messages`` / ``read_messages_chained`` parse a whole
+transcript from disk — 100-300 ms of blocking IO on a large store. On the gateway
+event loop that stalls every other request; the liveness heartbeat is itself a
+coroutine, so a stalled loop cannot pet its watchdog and the process exits.
+
+Three call paths were still reading on the loop after the dashboard-wide sweep:
+
+  * ``chat_runner._run_chat`` read the transcript inline to decide whether the
+    in-memory history needed re-injecting. It is wrapped in ``asyncio.to_thread``
+    now, so only the read crosses to a worker; the count and the prefix build
+    stay loop-affine.
+  * ``api_send_message``'s cron→origin path rebuilt a missing slot with the
+    synchronous ``_rehydrate_slot_from_history``. It routes through the existing
+    ``rehydrate_slot_from_history_async`` now, which reads off the loop and keeps
+    the loop-affine slot construction on the loop.
+  * the gateway's cron dedup-suppress and silent-suppress paths let
+    ``inject_cron_result_to_dashboard`` do its linked-session read on the loop
+    (they passed no ``history``). They prefetch it off the loop and pass
+    ``history=`` now, matching the creator path — which makes the inject perform
+    no on-loop read. The invariant the prefetch depends on is verified directly
+    against ``inject_cron_result_to_dashboard``.
+
+Each test records the thread each read actually runs on (a recorder wrapping the
+real read) and asserts the loop thread's ident never appears, plus at least one
+behaviour-preservation assertion per site. Modeled on
+``test_completion_result_read_off_loop.py``.
+
+NOTE: this suite cannot execute in the offline sandbox (aiohttp / pytest-asyncio
+are not installed and PyPI is blocked). It is authored to the repo's off_loop
+pattern and its execution is deferred to CI.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard.chat_runner import _run_chat
+
+
+class _ReadRecorder:
+    """Wrap a ``ConversationLog`` read and remember which thread ran each call.
+
+    The wrapper delegates to the real method, so the recorded ident is the
+    thread that genuinely opened and parsed the transcript — not merely a thread
+    that reached a call site.
+    """
+
+    def __init__(self, conversation_log, method_name):
+        self._real = getattr(conversation_log, method_name)
+        self.threads: list[int] = []
+        self.keys: list[str] = []
+
+    def __call__(self, key, *args, **kwargs):
+        self.threads.append(threading.get_ident())
+        self.keys.append(key)
+        return self._real(key, *args, **kwargs)
+
+
+def _stream_empty(client: MagicMock) -> None:
+    async def _empty(msg):
+        return
+        yield  # pragma: no cover - generator shape only
+
+    client.stream = _empty
+    client.stream_command = _empty
+
+
+def _run_chat_state(tmp_path, name="offload-run-chat"):
+    """A ``_run_chat`` harness whose session ``get_or_create`` reports is_new.
+
+    The transcript read under test only runs on a NEW session with in-memory
+    messages that have not been flushed (the stop-mid-turn re-injection guard),
+    so the fixture pins ``is_new=True`` and seeds the slot with a user turn.
+    """
+    state = _make_state(tmp_path)
+    client = MagicMock()
+    client.shutdown = AsyncMock()
+    state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+    state.sessions.release = MagicMock()
+    state.sessions.reset = AsyncMock()
+    state.sessions.set_approval_policy = MagicMock()
+    state.sessions.check_context_usage = MagicMock()
+    state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+    state.sessions.record_failure = AsyncMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.is_yolo_active = MagicMock(return_value=False)
+    state._background_tasks = set()
+    slot = state.get_or_create_slot(name)
+    slot.append("user", "hello", "msg msg-u")
+    _stream_empty(client)
+    return state, slot
+
+
+# ── chat_runner._run_chat ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_chat_history_read_runs_off_the_loop_thread(tmp_path):
+    """_run_chat's re-injection disk read executes on a non-loop thread."""
+    state, slot = _run_chat_state(tmp_path)
+    recorder = _ReadRecorder(state.conversation_log, "read_messages")
+
+    with patch.object(state.conversation_log, "read_messages", recorder):
+        await _run_chat(state, slot, "next message")
+
+    assert recorder.threads, (
+        "the _run_chat re-injection read never ran -- this test no longer "
+        "exercises the on-loop read and would pass vacuously"
+    )
+    assert threading.get_ident() not in recorder.threads, (
+        "the _run_chat history read ran on the event-loop thread; it must be "
+        "handed to asyncio.to_thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_chat_reinjects_when_memory_leads_disk(tmp_path):
+    """Preservation: mem_count > disk_count still triggers history re-injection.
+
+    The slot carries a user turn that was never flushed to disk (the empty
+    transcript reads back zero rows), so the loop must still prepend the
+    in-memory prefix to the outgoing prompt exactly as before the offload.
+    """
+    state, slot = _run_chat_state(tmp_path)
+    sent: list[str] = []
+
+    async def _capture(msg):
+        sent.append(msg)
+        return
+        yield  # pragma: no cover - generator shape only
+
+    state.sessions.get_or_create.return_value[0].stream = _capture
+    state.sessions.get_or_create.return_value[0].stream_command = _capture
+
+    with patch(
+        "kiro_crew.dashboard.chat_runner._build_history_prefix",
+        return_value="[history prefix]\n",
+    ) as prefix:
+        await _run_chat(state, slot, "next message")
+
+    # disk read returned 0 rows while the slot holds a user message, so the
+    # mem>disk branch fires and the prefix is applied to the sent prompt.
+    prefix.assert_called_once_with(slot)
+    assert sent, "the turn never reached the provider stream"
+    assert sent[0].startswith("[history prefix]\n")
+
+
+# ── inject_cron_result_to_dashboard (the invariant the gateway prefetch uses) ──
+
+
+def _cron_job(job_id="cronjob1"):
+    job = MagicMock()
+    job.id = job_id
+    job.name = "nightly"
+    job.agent_id = ""
+    return job
+
+
+@pytest.mark.asyncio
+async def test_cron_inject_performs_no_read_when_history_is_supplied(tmp_path):
+    """Passing history= skips inject_cron_result_to_dashboard's on-loop read.
+
+    The two gateway suppress paths prefetch the transcript off the loop and pass
+    it in; this pins the contract they rely on — a supplied history means the
+    inject never touches ``conversation_log`` on the loop.
+    """
+    from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard
+
+    state = _make_state(tmp_path)
+    state.push_slots_update = MagicMock()
+    job = _cron_job()
+    recorder = _ReadRecorder(state.conversation_log, "read_messages")
+
+    with patch.object(state.conversation_log, "read_messages", recorder):
+        inject_cron_result_to_dashboard(state, job, "cron output", history=[])
+
+    assert recorder.threads == [], (
+        "inject_cron_result_to_dashboard read the transcript even though the "
+        "caller supplied history=; the gateway suppress paths depend on this "
+        "read being skipped so their off-loop prefetch is the only read"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cron_inject_reads_inline_only_without_history(tmp_path):
+    """Preservation: with no history the defensive inline read still runs.
+
+    The inline read is the fallback for a purely-synchronous caller; removing it
+    would silently drop the linked-session hydration. This is the on-loop read
+    the gateway callers avoid by prefetching — kept here as the documented
+    fallback, and shown to fire only when history is omitted.
+    """
+    from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard
+
+    state = _make_state(tmp_path)
+    state.push_slots_update = MagicMock()
+    job = _cron_job("cronjob2")
+    recorder = _ReadRecorder(state.conversation_log, "read_messages")
+
+    with patch.object(state.conversation_log, "read_messages", recorder):
+        inject_cron_result_to_dashboard(state, job, "cron output")
+
+    assert recorder.keys == [
+        "cron:cronjob2"
+    ], "the no-history fallback did not read the linked cron transcript"
+
+
+# ── api_send_message cron→origin rehydrate routing ─────────────────────────
+
+
+def _send_app(state):
+    from aiohttp import web
+
+    from kiro_crew.dashboard.handlers import api_send_message
+
+    app = web.Application()
+    app.router.add_post("/api/send-message", api_send_message)
+    app["state"] = state
+    return app
+
+
+def _send_state_missing_slot(job_id="sendjob1"):
+    """A send-message state whose origin slot is absent, forcing rehydrate."""
+    state = MagicMock()
+    state.slack_client = None
+    state.owner_id = ""
+    job = MagicMock()
+    job.id = job_id
+    job.name = "nightly"
+    job.session_key = "dashboard:chat-1-origin"
+    state.crons.list_jobs.return_value = [job]
+    state.get_slot.return_value = None
+    return state
+
+
+@pytest.mark.asyncio
+async def test_send_message_origin_routes_through_async_rehydrate():
+    """The cron→origin cold path awaits rehydrate_slot_from_history_async.
+
+    Routing through the async entry keeps the transcript read off the loop while
+    the loop-affine slot build stays on it. The synchronous _rehydrate helper
+    must not be called on this path.
+    """
+    state = _send_state_missing_slot()
+    revived = MagicMock()
+    revived.running = False
+    revived._in_stage_execution = False
+    revived.task = None
+    revived.key = "chat-1-origin"
+    state._background_tasks = set()
+    state.push_slots_update = MagicMock()
+
+    with (
+        patch(
+            "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+            new_callable=AsyncMock,
+            return_value=revived,
+        ) as async_rehydrate,
+        patch(
+            "kiro_crew.dashboard.chat_persistence._rehydrate_slot_from_history"
+        ) as sync_rehydrate,
+        patch("kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock),
+    ):
+        app = _send_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/send-message",
+                json={
+                    "text": "update",
+                    "session": "origin",
+                    "caller_session": "cron:sendjob1",
+                },
+                headers={"X-Session-Key": "cron:sendjob1"},
+            )
+            assert resp.status == 200
+
+    async_rehydrate.assert_awaited_once_with(state, "chat-1-origin")
+    sync_rehydrate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_message_origin_none_rehydrate_falls_back_to_notify():
+    """Preservation: async rehydrate returning None still degrades to the bell.
+
+    The async entry has the same contract as the sync form — None for a
+    closed/gone session — and the handler must keep treating that as
+    origin-unreachable rather than creating a phantom slot.
+    """
+    state = _send_state_missing_slot("sendjob2")
+    state.get_slot.return_value = None
+
+    with patch(
+        "kiro_crew.dashboard.handlers.messaging.rehydrate_slot_from_history_async",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as async_rehydrate:
+        app = _send_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/send-message",
+                json={
+                    "text": "update",
+                    "session": "origin",
+                    "caller_session": "cron:sendjob2",
+                },
+                headers={"X-Session-Key": "cron:sendjob2"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+
+    async_rehydrate.assert_awaited_once_with(state, "chat-1-origin")
+    assert data["session"] is False
+    state.notify.assert_called_once()


### PR DESCRIPTION
## Summary

Closes the remaining blocking `ConversationLog` reads that ran on the gateway event loop (issue #7408). The re-triage comment's correction was confirmed: after auditing **both** `asyncio.to_thread` and `loop.run_in_executor` spellings, the real work list was **3 sites, not 6** — three of the six named sites were already offloaded and are left unchanged.

The signature-change judgment the issue flagged was answered by **routing to the pre-existing `rehydrate_slot_from_history_async`** rather than mutating the sync helper's signature, so its sync callers are untouched.

## Per-site analysis (why each is correct)

| # | site (dashboard-relative) | enclosing | reached from loop? | prior offload state | action taken |
|---|---|---|---|---|---|
| 1 | `chat_runner.py:5877` | `async def _run_chat` | **YES** (bare on-loop read in the prompt-submit re-injection guard) | none | Wrapped in `await asyncio.to_thread(read_messages, history_key)`. `history_key` is an immutable local snapshot; only the disk read + JSON parse cross the hop. `len()`, the `mem_count` scan, and `_build_history_prefix` stay loop-affine. The `if state.conversation_log:` guard is preserved. |
| 2 | `session_transfer.py:173` | sync `_read_chained_history` | no | **already offloaded** via `asyncio.to_thread(_read_and_assemble)` | **unchanged** |
| 3 | `chat_persistence.py:1009` | sync `_rehydrate_slot_from_history` | **YES** at two async callers (`slack/gateway.py:3239` `_deliver_script_result`, `handlers/messaging.py:2135` `api_send_message`) | none at those sites (async entry existed) | Routed both callers to `await rehydrate_slot_from_history_async(...)` (same None-for-closed/gone contract; loop-affine slot build stays on the loop). Sync signature **unchanged**. Gateway's now-unused sync import removed; messaging's import swapped (no F401). |
| 4 | `channel_slots.py:751` | sync nested `_load_messages` | no | **already offloaded** via `loop.run_in_executor(None, _load_messages)` | **unchanged**. A `to_thread`-only audit misses this (~447 `run_in_executor` vs ~2321 `to_thread` on main) — exactly the re-triage's point. |
| 5 | `handlers/artifacts.py:755` | sync `_collect_session_docs` | no | **already offloaded** via `_run_off_loop` through both callers | **unchanged** |
| 6 | `cron_inject.py:98` | sync `inject_cron_result_to_dashboard` | **YES** at the two gateway suppress callers only (dedup-suppress, silent-suppress; passed no `history`) | none at those two; other two callers already prefetch | Both suppress callers now prefetch `history = await asyncio.to_thread(read_messages, "cron:{job.id}") if conversation_log else []` and pass `history=`, so `history is None` is False and the inline read is skipped. `cron_inject.py` is **unchanged** and keeps its inline read as the fallback for a synchronous caller. Signature **unchanged**. |

## Changed files

Production: `dashboard/chat_runner.py`, `dashboard/handlers/messaging.py`, `slack/gateway.py`.
Tests: `test/test_transcript_reads_off_loop.py` (new) plus mechanical renamed-symbol updates to `test_dashboard_file_io.py`, `test_cron_origin_injection.py`, `test_send_message_targeted.py`.
Confirmed **not** in the diff: `session_transfer.py`, `channel_slots.py`, `handlers/artifacts.py`, `cron_inject.py`. No docs/CHANGELOG touched.

## Testing

New `test/test_transcript_reads_off_loop.py` uses a thread recorder that wraps the real reads and asserts the loop thread's ident never appears, plus a behavior-preservation assertion per site (would fail if any offload were reverted).

**Not runnable in this sandbox** (network mode `INTEGRATIONS_ONLY`: PyPI blocked, `aiohttp`/`pytest`/`pytest-asyncio` not installed). Achievable gate passed on the pyenv 3.11.15 interpreter: `py_compile` exit 0 on all 7 changed files; ruff clean on the new test file and all changed regions; `black --check` clean on the new test file and changed production files. **The new test and the 3 updated tests must run in CI before merge.**

## Reviewer note (non-blocking)

`_run_chat` has a benign post-hop staleness window: `disk_count` is a pre-`await` snapshot while `mem_count` is read after the hop. Worst case on a brand-new session's first turn is a redundant or skipped history prefix, never corruption.

## Follow-up (not in this PR)

`read_messages_chained` full-reads a transcript then keeps only `messages[-500:]` (~254 ms on a 33.6 MB session, ~99% discarded). A tail-read would fix it but must recompute `_disk_older_count`, which drives the frozen-prefix save model, so it carries data-loss risk and needs its own tests. Tracked separately, intentionally out of scope here.

This PR references #7408 but does not close it via keyword, so the issue stays open for the follow-up.

## Pattern harvest

Rule candidate: repo gate (AST walker under `scripts/`, in the shape of `check_harness_parity.py` / `check_subprocess_encoding.py`) — "a blocking `ConversationLog` read reached directly from an `async def`".

Pattern to flag: a call to `ConversationLog.read_messages`, `read_messages_chained`, or `get_metadata` (each a whole-file open plus a JSON parse per line — 100–300 ms on a large store) whose nearest enclosing function is an `async def`, and which does not sit in the callable-argument position of `asyncio.to_thread(...)` / `loop.run_in_executor(...)`. That is a purely syntactic test — no dataflow needed, because the offload idiom is itself syntactic — and it is exactly what the manual audit behind this PR was doing by hand.

Why the class is real rather than a one-off: the three sites fixed here match that shape, and so do two more that a reviewer found afterwards by grepping `\.read_messages(_chained)?\(` and reading each enclosing scope — `dashboard/handlers/sessions.py` (`api_session_detail`, whose own file-neighbours `api_sessions_search` and `api_session_delete` both offload) and `sync_bridge.py` (`handoff_to_slack`, plus a bare `get_metadata` two lines later). Five instances, and a careful hand audit still missed two. Nothing in CI notices: the code type-checks, every test passes, and the only symptom is a latency spike plus — because the loop-stall watchdog is itself a coroutine — a process exit under load. A defect class that is invisible to every existing gate and invisible in review regrows on the next handler someone writes, which is why this one wants a gate rather than another audit. The two sites named above are the gate's first two hits and are listed in this PR's follow-up.

Secondary, review-prompt line: "when you hoist IO across an `await` to get it off the loop, check both what consumes it and what catches it." The first version of this fix prefetched the cron transcript unconditionally at both suppress sites, although `inject_cron_result_to_dashboard` reads `history` only under `if not slot.linked_session_key` — so it paid, on every suppressed run, the exact cost the offload exists to remove. Worse, the whole of `_cron_callback` is inside one broad `except Exception` that ends at `record_failure()`: hoisting the read up into that scope meant a transcript `OSError` on a run that had already produced its result would be counted as a cron failure, marching a healthy job toward auto-pause. Generalized as a review question with two halves: "on which branch does the callee actually consume this argument?", and "which handler now catches this exception, and what does it conclude from it?"
