### PR TITLE
fix(dashboard): stop a stale agent-config snapshot resurrecting app MCP bridges

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -240,9 +240,61 @@ resurrected from a disabled or uninstalled app would have persisted indefinitely
 Lock order is unchanged (transaction → config → bridge-file); the widened hold is
 the innermost one.
 
+### 1a. The submission may not CREATE a name in the `<app>:<server>` region
+
+Every row above is about a name the submission **omits**. The mirror question is a
+name the submission **contains**, and until #7089 the answer was "persist it
+verbatim": an editor tab that loaded while an app was installed and running
+re-created that app's bridge on save after the app had been uninstalled or
+disabled. Same non-self-healing direction as above — reconciliation only revisits
+ENABLED apps — so the resurrected bridge stayed live and callable.
+
+`_drop_unbacked_app_entries` closes it with one rule: **a submitted name containing
+`:` that the installed spec does not hold is dropped**, because that region is
+reserved *from this endpoint* — the raw editor is not one of its writers. Two paths
+legitimately put a colon-containing key here: `_register_mcp_servers` (every app
+bridge, as `<app>:<server>`) and the MCP page's
+`handlers/mcp.py::_sync_mcp_to_agent_unlocked` (a global mcp.json server copied in
+under `mcp_server_alias`, which returns a slash-free name unchanged and so keeps a
+colon). A name either of them actually wrote is present on disk, and therefore
+untouched.
+
+| Submitted `mcpServers` entry | Verdict |
+| --- | --- |
+| plain name (no `:`), not on disk | **persisted** — this is how the user adds a server here |
+| `<app>:<server>` on disk | **persisted as submitted** — the snapshot still wins where the platform agrees the name exists |
+| `<app>:<server>` NOT on disk, app uninstalled | **dropped** — `_deregister_mcp_servers` removed it |
+| `<app>:<server>` NOT on disk, app installed but DISABLED | **dropped** — same, and reconciliation never revisits it |
+| `<app>:<server>` NOT on disk, app installed, ENABLED and DECLARING it | **dropped** — `_register_mcp_servers` skips an HTTP server with no live port and scrubs stale rows for it; a manifest's illustrative port is a dead URL that breaks every kiro session |
+| host-owned name containing `:` (an edition extra), not on disk | **persisted** — the host's key, not an app's; the host axis is unchanged |
+| any, spec readable but carrying no `mcpServers` key | **dropped** — a keyless spec holds no bridge, which is a definite answer; reading it as "unknown" lets the resurrection through |
+| any, spec unreadable, or `mcpServers` present but not an object | **persisted** — best-effort, so this endpoint stays the repair path for a corrupt spec, and nothing is deleted on evidence that cannot be read |
+
+The declared-name census is deliberately **not** consulted on this axis, and the
+last row above is why: it would rescue exactly the entry the registration path
+scrubbed on purpose. The two directions ask different questions — the absent axis
+must name an owner before KEEPING something the client asked to remove, while here
+every candidate is one the client is ADDING to a region it does not author, which
+the on-disk map answers alone. A consequence: this rule performs no manifest I/O
+and cannot raise `app_ownership_unreadable`, so it adds no new failure mode. Both
+rules read the spec **once**, through `_on_disk_mcp_servers`, so they cannot
+disagree about their baseline.
+
+The cost is that a name containing `:` can no longer be introduced through this raw
+editor; the MCP page is the path that adds a server, after which the name is on
+disk and this rule leaves it alone. Nothing becomes unremovable — an entry on disk
+stays deletable through the absent-axis rule.
+
+**Not closed here:** where the name is on disk and the submission carries a
+SUPERSEDED definition of it (an older port or command), the submitted row still
+wins and reverts a correction the registration path had made. Fixing that reverses
+the editor-snapshot-wins contract kept in #5899, and unlike resurrection it
+self-heals on the next gateway start, so it is left to a separate ruling.
+
 Writer: `apps/bridges.py::_apply_agent_mcp_policy`, `_mcp_json_path`,
 `_scrub_legacy_shared_mcp`;
-`dashboard/handlers/agents.py::_merge_unowned_servers` for the PUT side.
+`dashboard/handlers/agents.py::_merge_unowned_servers` and
+`_drop_unbacked_app_entries` for the PUT side.
 
 ## 2. Auto-approve is intersected with the governance ceiling
 

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -177,7 +177,157 @@ def _installed_agent_config() -> Path:
     return kiro_agents_dir_path() / AGENT_FILENAME
 
 
-def _merge_unowned_servers(config: dict[str, Any], installed_path: Path) -> tuple[str, ...]:
+def _on_disk_mcp_servers(installed_path: Path) -> dict[str, Any] | None:
+    """The installed spec's ``mcpServers`` map, or ``None`` when it cannot be read.
+
+    ONE read, TWO rules. ``_merge_unowned_servers`` (a name ABSENT from the
+    submission) and :func:`_drop_unbacked_app_entries` (a name PRESENT in a stale
+    submission) are two directions of one question -- what does on-disk state say
+    about this name -- so neither may read the file for itself. Two reads inside
+    one commit unit could only ever agree by luck, and a rule pair disagreeing
+    about its baseline is a defect that surfaces as a name both preserved and
+    dropped.
+
+    ``None`` AND ``{}`` ARE DIFFERENT ANSWERS and collapsing them is a defect --
+    in EITHER direction. ``{}`` means the spec was read and holds no bridge under
+    any name; ``None`` means it could not be interpreted at all. That distinction
+    only matters to the present-axis rule, and there it decides the verdict:
+    against ``{}`` every namespaced name the client submits is an addition the
+    platform never made, while against ``None`` nothing is known and nothing may be
+    decided. The absent-axis rule is indifferent -- it has nothing to preserve
+    either way -- which is why its own read conflated the two harmlessly for as long
+    as it was the only caller.
+
+    A MISSING ``mcpServers`` KEY IS ``{}``, NOT ``None``, and the difference is
+    load-bearing rather than cosmetic. A readable spec that simply carries no such
+    key holds no bridge, which is a definite answer; reading it as "unknown" hands
+    the stale-snapshot rule a reason to stand down and lets the resurrection
+    through. That state is reachable from this very handler: a PUT whose submission
+    omits ``mcpServers`` is persisted verbatim by ``_write_installed_config``, and
+    ``_deregister_mcp_servers`` pops its entries out of ``get("mcpServers", {})``
+    without ever adding the key back, so a spec can sit keyless while an old editor
+    tab still holds a bridge in its snapshot.
+
+    A ``mcpServers`` PRESENT BUT NOT AN OBJECT still answers ``None``, deliberately.
+    The file parsed, but that value cannot be interpreted, and the same
+    cannot-interpret state is what the submitted-side guard in
+    ``_merge_unowned_servers`` refuses to act on. Deleting the client's entries on
+    the strength of a value we cannot read is the guess this whole span exists to
+    avoid.
+
+    BEST-EFFORT ON AN UNREADABLE SPEC, deliberately. Missing (a first-ever write),
+    corrupt, or holding a non-object ``mcpServers`` all answer ``None``: there is
+    nothing authoritative to read, and this editor is the user's repair path for
+    exactly that state, so failing the PUT closed would leave a broken agent
+    unfixable from the dashboard. Neither rule then acts and the snapshot lands as
+    it did pre-fix; enabled apps re-register their servers on the next gateway
+    start (``reconcile_enabled_app_resources``), so the loss self-heals.
+
+    The CALLER holds bridges' flock across this read and the spec write, so no
+    in-gateway writer of this file can commit between them.
+    """
+    try:
+        on_disk = json.loads(installed_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(on_disk, dict):
+        return None
+    if "mcpServers" not in on_disk:
+        return {}  # read cleanly and holds no bridge: a definite answer
+    servers = on_disk["mcpServers"]
+    return servers if isinstance(servers, dict) else None
+
+
+def _drop_unbacked_app_entries(
+    config: dict[str, Any], existing: dict[str, Any] | None
+) -> tuple[str, ...]:
+    """Drop submitted ``<app>:<server>`` entries the installed spec does not hold (#7089).
+
+    THE STALE-SNAPSHOT AXIS, the mirror of ``_merge_unowned_servers``. That rule
+    decides what happens to a name the submission OMITS. This one decides one
+    narrow question about a name the submission CONTAINS: may the client CREATE a
+    name in the app-namespace region THROUGH THIS PUT? Not while the installed spec
+    is READABLE -- so a submitted namespaced name with no row on disk is dropped.
+    The readability qualifier is not a hedge: an unreadable spec answers nothing, so
+    the submission lands as it did pre-fix, and a rule stated without it would
+    contradict the best-effort path below.
+
+    THE REGION IS RESERVED FROM THIS ENDPOINT, not owned by a single writer, and
+    the distinction is worth stating because the weaker claim is false. Two paths
+    legitimately write a ``:``-containing key into this spec: ``_register_mcp_servers``
+    builds every app bridge as ``f"{app_name}:{server_name}"``, and the MCP page's
+    ``handlers/mcp.py::_sync_mcp_to_agent_unlocked`` copies a global mcp.json server
+    in under ``mcp_server_alias``, which returns a slash-free name UNCHANGED and so
+    preserves a colon (``npm:foo`` stays ``npm:foo``). What this rule withholds is
+    the ability to introduce such a name through the RAW EDITOR, where the client's
+    copy is indistinguishable from a resurrection; a name either of those writers
+    has actually placed on disk is present, and therefore untouched.
+
+    THE ROW-BY-ROW TABLE LIVES IN THE SPEC, ``docs/system-specs/modules/app-kit-platform.md``
+    section 1a, which is this axis's designated home; the absent axis keeps its
+    table in :func:`_app_declared_server_names` instead. Only what a reader of this
+    code has to know to not undo it is repeated here.
+
+    ABSENCE FROM DISK IS A VERDICT, not a gap, and it is reached three ways --
+    which is why the client's copy cannot be trusted over it:
+
+    * the app was UNINSTALLED (``_deregister_mcp_servers`` removed the bridge and
+      the app directory is gone);
+    * the app is installed but DISABLED (same deregistration; startup
+      reconciliation deliberately never revisits it);
+    * the app is installed and ENABLED but the entry was SKIPPED on purpose --
+      ``_register_mcp_servers`` refuses to write an HTTP server with no resolvable
+      live port, and scrubs any stale entry for it, because a manifest's
+      illustrative port is a reachable-LOOKING dead URL that kiro-cli dials on
+      every request and that breaks EVERY kiro session, not just that app's.
+
+    WHAT THIS DELIBERATELY DOES NOT DO: it never rewrites a submitted value. Where
+    the name is on disk AND in the submission, the submitted row still wins
+    untouched -- the editor-snapshot-wins contract kept in #5899 and re-affirmed
+    for #6664, pinned by ``test_app_owned_entry_present_in_the_snapshot_is_updated``.
+    Reversing it needs a maintainer ruling and is tracked separately.
+
+    THE DECLARED-NAME CENSUS IS DELIBERATELY NOT CONSULTED, and this is the one
+    part a later change is most likely to undo, so the reason is here rather than
+    only in the spec. The absent-axis rule must name an owner because it decides
+    whether to KEEP something the client asked to remove; every candidate here is
+    one the client is asking to ADD to a region it does not author, which the
+    on-disk map answers by itself. A census consulted here would RESCUE the third
+    case above and write back the dead URL the registration path scrubbed on
+    purpose. It also keeps this rule free of manifest I/O, so it cannot raise
+    :class:`AppOwnershipUnreadable` and adds no new way for a PUT to fail.
+
+    Host-owned names are excluded, including an edition extra whose key contains
+    ``:``: that key is the HOST's, and the host axis is unchanged here. Order
+    against the absent-axis rule is immaterial -- a name this rule drops is by
+    definition not on disk, so it cannot enter that rule's absent set.
+
+    Returns the names it dropped, for the caller to log.
+    """
+    submitted = config.get("mcpServers")
+    if not isinstance(submitted, dict) or not submitted:
+        # Absent, empty, or a shape kiro-cli rejects outright: nothing to decide,
+        # and the existing verbatim-persist behaviour is unchanged.
+        return ()
+    if existing is None:
+        # The spec could not be read, so nothing is authoritative. See
+        # :func:`_on_disk_mcp_servers` for why this is best-effort rather than a
+        # refusal.
+        return ()
+    host = emission_eligible_mcp_servers()
+    dropped = tuple(
+        sorted(
+            name for name in submitted if ":" in name and name not in existing and name not in host
+        )
+    )
+    for name in dropped:
+        del submitted[name]
+    return dropped
+
+
+def _merge_unowned_servers(
+    config: dict[str, Any], existing: dict[str, Any] | None
+) -> tuple[str, ...]:
     """Re-add ``mcpServers`` entries the submitting client does not own.
 
     MERGE-ON-WRITE (#6664). This PUT persists a whole-file snapshot the client
@@ -225,10 +375,13 @@ def _merge_unowned_servers(config: dict[str, Any], installed_path: Path) -> tupl
       explicit intent; the app lifecycle (disable/uninstall, which calls
       ``_deregister_mcp_servers``) is what removes it.
 
-    BEST-EFFORT ON AN UNREADABLE SPEC, deliberately. A corrupt installed spec has
-    no parseable entries to preserve, and this editor is the user's repair path
-    for exactly that state -- failing the PUT closed would leave a broken agent
-    with no way to fix it from the dashboard. So an unreadable spec preserves
+    BEST-EFFORT ON AN UNREADABLE SPEC, deliberately -- and the read itself now
+    lives in :func:`_on_disk_mcp_servers`, performed once on this rule's behalf and
+    on :func:`_drop_unbacked_app_entries`'s, so both directions decide from the
+    SAME bytes instead of from two reads that could disagree. A corrupt installed
+    spec has no parseable entries to preserve, and this editor is the user's repair
+    path for exactly that state -- failing the PUT closed would leave a broken
+    agent with no way to fix it from the dashboard. So an unreadable spec preserves
     nothing and the snapshot lands as it did pre-fix; enabled apps re-register
     their servers on the next gateway start
     (``reconcile_enabled_app_resources``), so the loss self-heals.
@@ -268,16 +421,11 @@ def _merge_unowned_servers(config: dict[str, Any], installed_path: Path) -> tupl
         )
         return ()
     submitted_servers: dict[str, Any] = submitted if isinstance(submitted, dict) else {}
-    try:
-        on_disk = json.loads(installed_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        # Missing (a first-ever write) or corrupt: nothing recoverable to
-        # preserve. See BEST-EFFORT above.
-        return ()
-    if not isinstance(on_disk, dict):
-        return ()
-    existing = on_disk.get("mcpServers")
-    if not isinstance(existing, dict) or not existing:
+    if not existing:
+        # Unreadable (``None``) or read and empty (``{}``): either way there is
+        # nothing recoverable to preserve, so the two answers are equivalent HERE
+        # and only here. See :func:`_on_disk_mcp_servers` for why they are not
+        # equivalent to the present-axis rule, and for the BEST-EFFORT reasoning.
         return ()
     absent = {name: spec for name, spec in existing.items() if name not in submitted_servers}
     if not absent:
@@ -637,7 +785,10 @@ def _commit_agent_config(
        the harmless end: it can raise :class:`AppOwnershipUnreadable` while
        having mutated only the in-memory *config*, so the caller's 500 is exact
        and all three targets are byte-identical (see
-       :func:`_app_or_host_owned` for why refusing beats guessing);
+       :func:`_app_or_host_owned` for why refusing beats guessing). The
+       stale-snapshot rule shares that step and adds NO prefix of its own: it
+       performs no I/O beyond the one read they share and cannot raise, so its
+       only effect is on the in-memory *config*;
     1. the ``config.json`` read raises :class:`ConfigReadError` — nothing
        durable, and the caller's 500 is exact;
     2. the ``config.json`` write fails — nothing durable;
@@ -747,14 +898,30 @@ def _commit_agent_config_locked(
     invariant documented on :func:`_commit_agent_config` applies here, and this
     is never called from anywhere else.
     """
-    # (0a) MERGE-ON-WRITE, immediately before the filter that governs the map it
-    # produces. Inside the unit for the same reason as (0) and (1): the on-disk
-    # read has to be adjacent to the write it feeds, or a bridge registration
-    # landing during the (unbounded, cross-process) flock wait is clobbered
-    # exactly as before the fix. BEFORE the filter, not after, so the entries it
-    # re-adds are governed too -- re-injecting them afterwards would hand an
-    # ``autoApprove`` on a preserved entry a path around step (0).
-    preserved = _merge_unowned_servers(config, installed_path)
+    # (0a) ON-DISK STATE DECIDES BOTH DIRECTIONS, immediately before the filter
+    # that governs the map they produce. Inside the unit for the same reason as
+    # (0) and (1): the on-disk read has to be adjacent to the write it feeds, or a
+    # bridge registration landing during the (unbounded, cross-process) flock wait
+    # is clobbered exactly as before the fix. BEFORE the filter, not after, so the
+    # entries the merge re-adds are governed too -- re-injecting them afterwards
+    # would hand an ``autoApprove`` on a preserved entry a path around step (0).
+    #
+    # ONE read for the two rules, so they cannot disagree about their baseline:
+    # #6664's merge decides names ABSENT from the submission, #7089's rule decides
+    # namespaced names PRESENT in a stale one. Their order is immaterial (see
+    # :func:`_drop_unbacked_app_entries`).
+    existing = _on_disk_mcp_servers(installed_path)
+    dropped = _drop_unbacked_app_entries(config, existing)
+    if dropped:
+        # WARNING, not info: the client submitted these and they are not being
+        # persisted, which is the one outcome here a user could be surprised by.
+        logger.warning(
+            "agent-config PUT: dropped %d app-namespaced mcpServers entry/entries the "
+            "installed spec does not hold, so a stale snapshot cannot resurrect them: %s",
+            len(dropped),
+            ", ".join(dropped),
+        )
+    preserved = _merge_unowned_servers(config, existing)
     if preserved:
         logger.info(
             "agent-config PUT: kept %d mcpServers entry/entries the client does not own: %s",

--- a/test/test_agent_config_merge_on_write.py
+++ b/test/test_agent_config_merge_on_write.py
@@ -1140,3 +1140,303 @@ async def test_preserved_entries_go_through_the_governance_filter(tmp_path, monk
         "a preserved entry kept a ceiling-denied autoApprove: the merge ran "
         "AFTER the governance filter, so what it re-added was never governed"
     )
+
+
+# ── (d) the stale-snapshot axis: entries PRESENT in the submission (#7089) ─────
+#
+# The mirror of section (b). There the submission OMITS a name and the question is
+# whether to KEEP it; here the submission CONTAINS a namespaced name absent from
+# disk and the question is whether the client may CREATE one. It may not: only
+# ``_register_mcp_servers`` writes the ``<app>:<server>`` region, so absence from
+# disk is a verdict the platform reached (uninstall, disable, or a deliberate
+# skip) rather than a gap for a snapshot to fill.
+#
+# Where the name is on disk AND submitted, the submitted row still wins untouched
+# -- see ``test_app_owned_entry_present_in_the_snapshot_is_updated`` in section
+# (c). This axis deletes; it never rewrites a submitted value.
+
+
+@pytest.mark.asyncio
+async def test_a_stale_snapshot_cannot_resurrect_an_uninstalled_apps_bridge(tmp_path):
+    """The headline case: the app went away, the editor tab did not.
+
+    The tab loaded while app ``demoapp`` was installed and running, so its
+    snapshot holds ``demoapp:tool``. The app was then uninstalled --
+    ``_deregister_mcp_servers`` removed the bridge and the app directory is gone,
+    so nothing on disk or under apps/ mentions it. Pre-fix the snapshot was
+    persisted verbatim and the bridge came back live, with nothing logged; and it
+    stayed back, because ``reconcile_enabled_app_resources`` only re-registers
+    ENABLED apps and there is no longer an app here at all.
+
+    The user's own plain entry in the same submission is untouched, which is what
+    makes this specifically the app-namespace axis rather than a blanket refusal.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"plainuser": {"url": "u"}}},
+        submitted={
+            "name": "kirocrew",
+            "mcpServers": {
+                "demoapp:tool": {"url": "http://127.0.0.1:9100/mcp"},
+                "plainuser": {"url": "u"},
+            },
+        },
+        apps={},  # nothing installed: the app was uninstalled
+    )
+
+    assert response.status == 200
+    assert "demoapp:tool" not in written["mcpServers"], (
+        "a stale editor snapshot resurrected app-owned server 'demoapp:tool' that "
+        "the installed spec does not hold: the PUT trusted the snapshot's copy of "
+        "a name in the app-namespace region instead of on-disk state"
+    )
+    assert written["mcpServers"]["plainuser"] == {"url": "u"}
+
+
+@pytest.mark.asyncio
+async def test_a_stale_snapshot_cannot_resurrect_a_disabled_apps_bridge(tmp_path):
+    """Installed but DISABLED, the case reconciliation provably never repairs.
+
+    Disable calls ``_deregister_mcp_servers``, so the bridge is off disk while the
+    app directory and its manifest remain. Resurrecting it keeps a disabled app's
+    code launchable through the retained bridge indefinitely -- startup
+    reconciliation skips disabled apps, so nothing ever removes it again.
+
+    ``scope_names`` declares the same name in the user's own mcp.json to pin that a
+    scope declaration does not rescue it, matching the absent-axis rule where
+    proven ownership -- not a declaration -- is what decides.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {}},
+        submitted={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        apps={"demo": ("notes",)},
+        enabled=False,
+        scope_names=frozenset({"demo:notes"}),
+    )
+
+    assert response.status == 200
+    assert "demo:notes" not in written["mcpServers"], (
+        "a stale snapshot resurrected the bridge of a DISABLED app: nothing "
+        "removes it again, because startup reconciliation only re-registers "
+        "enabled apps"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_stale_snapshot_cannot_rewrite_a_deliberately_skipped_http_bridge(tmp_path):
+    """ENABLED and DECLARED, yet absent from disk on purpose -- still dropped.
+
+    ``_register_mcp_servers`` refuses to write an HTTP server with no resolvable
+    live port and scrubs any stale entry for it, because a manifest's illustrative
+    port is a reachable-LOOKING dead URL that kiro-cli dials on every request:
+    a connect failure there breaks EVERY kiro session, not just this app's.
+
+    So this row also pins that the declared-name census is NOT consulted on this
+    axis. The app is installed, enabled, and declares ``notes`` -- every ingredient
+    the absent-axis ownership test needs -- and the entry is still dropped, because
+    the only question here is whether the platform PUT IT ON DISK, which it
+    deliberately did not.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {}},
+        submitted={
+            "name": "kirocrew",
+            # The manifest's illustrative port, which is what a snapshot taken
+            # before the scrub carries.
+            "mcpServers": {"demo:notes": {"url": "http://127.0.0.1:9100/mcp"}},
+        },
+        apps={"demo": ("notes",)},
+        enabled=True,
+    )
+
+    assert response.status == 200
+    assert "demo:notes" not in written["mcpServers"], (
+        "the PUT wrote back an HTTP bridge the registration path had scrubbed for "
+        "having no live backend: that dead URL breaks every kiro session, and the "
+        "declared-name census must not rescue an entry absent from disk"
+    )
+
+
+@pytest.mark.asyncio
+async def test_both_directions_decide_from_one_baseline_in_a_single_put(tmp_path):
+    """The two rules compose, and they read the same on-disk map to do it.
+
+    One realistic save carries both faults at once: the tab is old enough that its
+    snapshot still holds a bridge of an app that has since gone away
+    (``gone:tool``), and old enough that it predates a bridge that has since been
+    registered (``demo:notes``). The stale one must be dropped and the new one
+    preserved in the same PUT, off a single read -- two reads could only agree by
+    luck, and a rule pair disagreeing about its baseline would show up here as a
+    name both preserved and dropped.
+
+    ``apps`` installs only ``demo``, so ``gone`` has no owner to name while
+    ``demo:notes`` has one.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={
+            "name": "kirocrew",
+            "mcpServers": {"demo:notes": {"command": "notes-mcp"}, "plainuser": {"url": "u"}},
+        },
+        submitted={
+            "name": "kirocrew",
+            "mcpServers": {"gone:tool": {"command": "t"}, "plainuser": {"url": "u"}},
+        },
+        apps={"demo": ("notes",)},
+    )
+
+    assert response.status == 200
+    assert "gone:tool" not in written["mcpServers"], (
+        "the stale namespaced addition survived alongside a preserved bridge: the "
+        "two rules did not both act on the same baseline"
+    )
+    assert written["mcpServers"]["demo:notes"] == {"command": "notes-mcp"}, (
+        "the absent-axis merge stopped preserving an owned bridge once the "
+        "stale-snapshot rule ran ahead of it"
+    )
+    assert written["mcpServers"]["plainuser"] == {"url": "u"}
+
+
+@pytest.mark.asyncio
+async def test_a_plain_client_entry_the_client_adds_is_still_persisted(tmp_path):
+    """The rule is scoped to the namespace shape, and this is the guard on that.
+
+    A server the user types into this raw editor has no ``:`` in its name and is
+    absent from disk by definition on the PUT that creates it. Reading "absent
+    from disk" as a verdict for THAT entry would make the editor unable to add
+    anything at all -- the opposite failure, and a much louder one.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {}},
+        submitted={"name": "kirocrew", "mcpServers": {"myserver": {"command": "mine"}}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"]["myserver"] == {"command": "mine"}, (
+        "the client could not add its own server: the stale-snapshot rule reached "
+        "past the app-namespace region it is scoped to"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_namespaced_edition_extra_the_client_resubmits_is_left_alone(tmp_path):
+    """A ``:`` in the key does not always mean an app owns it.
+
+    An edition's ``_extra_mcp_servers`` may contribute a key containing ``:``, and
+    that key is the HOST's. The absent-axis rule already preserves such an entry by
+    host ownership; this axis must not delete the same entry when the client
+    resubmits it while the rebuild has yet to write it, so host-owned names are
+    excluded here and the host contract is left exactly as it was.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {}},
+        submitted={"name": "kirocrew", "mcpServers": {"edition:extra": {"command": "x"}}},
+        extra_managed={"edition:extra": {"command": "x"}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"]["edition:extra"] == {"command": "x"}, (
+        "a host-owned entry whose name happens to contain ':' was dropped as if an "
+        "app owned it: this axis must exclude host-owned names"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_readable_spec_with_no_servers_still_drops_a_namespaced_addition(tmp_path):
+    """``{}`` on disk is an ANSWER, and this is the row that makes it one.
+
+    A spec that reads cleanly and holds no ``mcpServers`` is definite: the platform
+    has written no bridge, so a namespaced name in the submission is an addition to
+    a region the client does not author. Collapsing this state with "could not
+    read" would silently reopen the whole axis for the commonest shape of all -- a
+    spec whose app bridges have just been deregistered.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {}},
+        submitted={"name": "kirocrew", "mcpServers": {"demoapp:tool": {"command": "t"}}},
+        apps={},
+    )
+
+    assert response.status == 200
+    assert "demoapp:tool" not in written["mcpServers"], (
+        "an empty-but-readable mcpServers map was treated as unreadable, so the "
+        "stale entry was persisted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_spec_with_no_mcpservers_key_still_drops_a_namespaced_addition(tmp_path):
+    """A KEYLESS spec is ``{}``, not "unknown" -- the GPT round-1 finding on #7465.
+
+    Reading a missing ``mcpServers`` key as unreadable hands this rule a reason to
+    stand down and lets the resurrection straight through. The state is reachable
+    from this handler: a PUT whose submission omits ``mcpServers`` is persisted
+    verbatim, and ``_deregister_mcp_servers`` pops entries out of
+    ``get("mcpServers", {})`` without ever adding the key back -- so the spec can sit
+    keyless while an old editor tab still holds the bridge.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew"},  # readable, and carries no mcpServers at all
+        submitted={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        apps={"demo": ("notes",)},
+        enabled=False,
+    )
+
+    assert response.status == 200
+    assert "demo:notes" not in written["mcpServers"], (
+        "a spec with no mcpServers key was treated as unreadable rather than as "
+        "holding no bridge, so the stale snapshot resurrected an executable bridge"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_mcpservers_value_on_disk_decides_nothing(tmp_path):
+    """Present but not an object stays ``None``: we do not delete on a value we cannot read.
+
+    The file parsed, but that value cannot be interpreted -- the same
+    cannot-interpret state the submitted-side guard in ``_merge_unowned_servers``
+    refuses to act on. Deleting the client's entries on the strength of it would be
+    the guess this span exists to avoid, so the submission lands as it did pre-fix.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": "not an object"},
+        submitted={"name": "kirocrew", "mcpServers": {"demoapp:tool": {"command": "t"}}},
+        apps={},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"]["demoapp:tool"] == {"command": "t"}, (
+        "an uninterpretable on-disk mcpServers value was read as an empty map, so "
+        "the client's submission was deleted on evidence we could not read"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_spec_still_persists_a_namespaced_entry(tmp_path):
+    """BEST-EFFORT holds on this axis too, for the same reason as the merge's.
+
+    A corrupt spec is precisely the state this editor exists to repair. Refusing
+    the PUT, or deleting what the user submitted, would leave a broken agent with
+    no way to fix it from the dashboard -- so an unreadable baseline decides
+    nothing and the snapshot lands as it did pre-fix. Enabled apps re-register on
+    the next gateway start, so the residue self-heals.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk="{ not json at all",
+        submitted={"name": "kirocrew", "mcpServers": {"demoapp:tool": {"command": "t"}}},
+        apps={},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"]["demoapp:tool"] == {"command": "t"}, (
+        "an unreadable spec deleted what the client submitted: this axis must be "
+        "best-effort so the raw editor stays the repair path for a corrupt spec"
+    )


### PR DESCRIPTION
## What is the problem?

`PUT /api/agent/config` persists a whole-file snapshot the dashboard's raw agent
editor read earlier. #6975 made on-disk state authoritative for a name the
submission **omits** -- an app bridge registered after the client's read is no
longer clobbered. The mirror case stayed open: a namespaced name the submission
still **contains** was written back verbatim.

So an editor tab that loaded while app `demo` was installed and running holds
`demo:notes` in its snapshot. Uninstall or disable the app -- `_deregister_mcp_servers`
removes the bridge -- then press Save in that old tab, and the entry comes back.

## Why this issue matters to the user

The resurrected entry is a live MCP server in the config kiro-cli reads, so the
removed app's code becomes launchable again through it. And it does not go away:
`reconcile_enabled_app_resources` only re-registers **enabled** apps, so startup
reconciliation never revisits the namespace of an app that was disabled or
uninstalled. Nothing logged, nothing to notice -- the entry simply persists until
someone hand-edits the file.

The same shape reaches a third, worse state. `_register_mcp_servers` deliberately
refuses to write an HTTP server with no resolvable live port, and scrubs any stale
row for it, because a manifest's illustrative port is a reachable-looking dead URL
that kiro-cli dials on **every** request: one connect failure there is retried and
then surfaced as a hard error, breaking every kiro session on the host rather than
just that app's tools. A stale snapshot wrote that scrubbed row straight back.

## How our fix solves it

The chain is: the PUT trusted the client's copy of a name in a region the client
does not author, and the platform's `<app>:<server>` region is written only by
`_register_mcp_servers`. So absence from disk is a **verdict**, not a gap:

- the app was uninstalled (bridge deregistered, app directory gone);
- the app is installed but disabled (same deregistration, never reconciled back);
- the app is installed and enabled but the row was skipped on purpose (the dead-URL
  case above).

`_drop_unbacked_app_entries` drops a submitted `mcpServers` name containing `:`
that the installed spec does not hold. Three consequences worth naming:

- **The declared-name census is not consulted.** The absent-axis rule must name an
  owner because it decides whether to *keep* something the client asked to remove;
  every candidate here is one the client is *adding*, which the on-disk map answers
  alone. Consulting the census would also rescue the third case, writing back
  exactly the URL the registration path scrubbed. It also means this rule does no
  manifest I/O and cannot raise `app_ownership_unreadable`, so it adds no new way
  for a PUT to fail.
- **Host-owned names are excluded**, including an edition extra whose key contains
  `:`. The host axis is unchanged.
- **Both directions read the spec once**, through the new `_on_disk_mcp_servers`,
  so they cannot disagree about their baseline. `None` (unreadable) and `{}` (read,
  no servers) are kept distinct, because only the new rule's verdict turns on the
  difference: against `{}` a namespaced submission is an addition, against `None`
  nothing is known and nothing is decided.

What this deliberately does **not** do: where the name is on disk *and* submitted,
the submitted row still wins untouched. That is the editor-snapshot-wins contract
kept in #5899 and re-affirmed for #6664, and reversing it is a separate ruling --
see the last section.

The cost, stated plainly: a name containing `:` can no longer be introduced through
this raw editor. The MCP page is the path that adds a server, after which the name
is on disk and this rule leaves it alone. Nothing becomes unremovable -- an entry
already on disk stays deletable through the absent-axis rule. The alternative was
to trust a colon-shaped key the client invented, which is indistinguishable from
the resurrection this exists to stop. Dropped names are logged at WARNING.

## What tests we did

New section (d) in `test/test_agent_config_merge_on_write.py`, all through the live
handler:

- `test_a_stale_snapshot_cannot_resurrect_an_uninstalled_apps_bridge` -- the
  headline case; the user's own plain entry in the same submission is untouched.
- `test_a_stale_snapshot_cannot_resurrect_a_disabled_apps_bridge` -- also declares
  the same name in the user's own mcp.json, pinning that a scope declaration does
  not rescue it.
- `test_a_stale_snapshot_cannot_rewrite_a_deliberately_skipped_http_bridge` --
  installed, enabled and declaring the server, still dropped; this is the row that
  pins the census out of this axis.
- `test_both_directions_decide_from_one_baseline_in_a_single_put` -- one PUT that
  drops a stale addition and preserves an absent owned bridge.
- `test_a_readable_spec_with_no_servers_still_drops_a_namespaced_addition` --
  `{}` is an answer.
- `test_an_unreadable_spec_still_persists_a_namespaced_entry` -- best-effort holds,
  so this endpoint stays the repair path for a corrupt spec.
- `test_a_plain_client_entry_the_client_adds_is_still_persisted` and
  `test_a_namespaced_edition_extra_the_client_resubmits_is_left_alone` -- scope
  guards.

Mutation-verified against base: the five assertions of new behaviour all fail on
`main` with the intended messages, and the three scope guards pass on base as they
must. Full file 44/44 green, and 110/110 across the three test files that exercise
this endpoint (`test_agent_config_merge_on_write.py`,
`test_api_agent_config_put_succeeds.py`, `test_json_object_body_guard.py`).
`test_app_owned_entry_present_in_the_snapshot_is_updated` is green and unmodified,
which is the mechanical proof that the kept contract was not reversed. flake8,
isort, black and mypy clean on the touched files.

`docs/system-specs/modules/app-kit-platform.md` gains section 1a with the
present-axis decision table, so the spec does not disagree with the code.

## Any other suggestions on the work?

- **The substitution half is still open, filed as #7470.** Where the name is on disk
  and the submission carries a *superseded* definition of it (an older port or
  command), the submitted row wins and reverts a correction the registration path
  had made. Closing that reverses the twice-kept editor-snapshot-wins contract, so
  it needs a maintainer ruling rather than a fix decided in review. It is also
  materially less severe: unlike resurrection it self-heals, because an enabled
  app's bridge is re-registered with its live port on the next gateway start.
- **Optimistic concurrency** (the issue's second candidate shape) would close both
  halves at once by version/etag-ing the snapshot and having the editor reload on a
  stale write. That is a new API contract plus a client reload path -- feature work,
  and not something to fold into a defect fix. Carried in #7470 alongside the
  substitution shape, so the two can be ruled on together.
- The dropped names go to the log only. Surfacing them in the PUT response so the
  editor can show "2 entries were not saved" would need `_commit_agent_config` to
  return more than its current `changed` flag, whose single-return shape is
  load-bearing in that function's documented contract; worth doing separately if
  the UX matters.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a whole-file PUT classifies the shared region in only ONE direction, so
the mirror direction persists a stale snapshot verbatim

This is the second defect in one span from the same root: a PUT that persists a
client snapshot over a file the gateway also writes. #6664 was the absent
direction, #7089 the present direction, and both were found by review rather than
by a gate. The mechanical form: for any endpoint accepting a whole-file snapshot
of a file with more than one writer, require the handler to classify every key of
the shared region in BOTH directions -- present in the submission and absent from
it -- and pin the classification as a table. The absent half alone reads as
complete and is not, which is exactly how this axis survived #6975's review.

A cheaper enforcement while that is unbuilt: a ratchet test asserting that the
region a non-client writer owns (here `mcpServers` keys containing `:`) is decided
by on-disk state on both axes, so adding a new owned region without a
present-axis rule fails the suite instead of shipping.

Closes #7089
