### PR TITLE
refactor(security): one home for the credential spellings the log redactor shares

### DIFF
--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
@@ -77,6 +77,7 @@ from kiro_crew.apps.builtins.pptx_maker.backend import (
 )
 from kiro_crew.apps.manager import is_app_enabled
 from kiro_crew.atomic_write import atomic_write
+from kiro_crew.credential_patterns import AWS_KEY_ID
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.hooks import FileTooLargeError
 from kiro_crew.messaging.raster import SNIFF_BYTES, sniff_raster_mime
@@ -202,9 +203,9 @@ _BITMAP_FTYP_MAGIC = b"ftyp"
 # body (see `_BITMAP_URI_TERMINATORS`), which covers every separator rather than an
 # enumerated few.
 #
-# Case-sensitive on purpose: `[A-Z0-9]{16}` over a lowercased body would match ordinary
-# mixed-case base64 constantly.
-_ENCODED_CREDENTIAL_RE = re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}")
+# Case-sensitive on purpose: the shared spelling's uppercase-only body over a
+# lowercased body would match ordinary mixed-case base64 constantly.
+_ENCODED_CREDENTIAL_RE = re.compile(AWS_KEY_ID)
 
 
 # Characters that legitimately END a `data:` URI in the artifact formats the engine

--- a/src/kiro_crew/credential_patterns.py
+++ b/src/kiro_crew/credential_patterns.py
@@ -1,0 +1,86 @@
+"""Credential regex spellings shared by the log-redaction leaf and the scrubber.
+
+``log_redaction`` installs at CLI bootstrap, before heavy modules load, so it
+cannot import ``security``. The two AWS-key-ID and JWT spellings were therefore
+written out twice -- once in each home -- and parity was held only by tests that
+read ``security.py`` as SOURCE TEXT and grepped it for a literal. That guard
+fires on a rename, not on a divergence in meaning, and it costs a test per
+duplicated pattern.
+
+This module is the single home for those spellings. Both consumers import from
+here, so there is nothing left to keep in sync.
+
+Why fragments rather than compiled patterns
+-------------------------------------------
+Everything below is pattern SOURCE. ``security.py`` embeds the AWS spelling in
+five differently shaped patterns -- three plain alternation branches, one
+``X-Amz-Credential=`` presigned-URL matcher and one fully anchored ``^...$``
+parameter validator -- and each needs its own anchors, continuations and compile
+flags. A compiled pattern could not be reused at four of those five sites.
+
+Why this module imports NOTHING
+-------------------------------
+Not even ``re``, and not even ``from __future__ import annotations`` -- there is
+nothing here to annotate. ``log_redaction`` is a deliberate import leaf -- it is
+installed before the heavy modules load -- so anything it imports is on the
+bootstrap path. Exporting plain strings keeps this module's import cost at zero
+and makes it impossible for a future edit here to drag a dependency into that
+path. ``test_credential_patterns.py`` pins the import-free shape.
+
+The two AWS spellings deliberately DIVERGE
+------------------------------------------
+The redaction floor matches two prefixes the scrubber does not. Over-matching is
+the fail-closed direction for redaction: a false positive costs one masked log
+line, while a miss writes a live key to disk. The scrubber's narrower spelling is
+load-bearing in the other direction -- it gates request-blocking decisions and a
+cheap literal pre-filter whose anchors must stay a superset of every branch (see
+``_CREDENTIAL_PATTERNS`` in ``security.py``), so widening it is a security
+behaviour change and not a refactor.
+
+That asymmetry is preserved and made explicit here: ``AWS_KEY_ID_REDACTION`` is
+BUILT from the same prefix and body fragments as ``AWS_KEY_ID`` plus named extra
+prefixes. The superset relation now holds by construction, so no test has to
+compare two hand-written strings to discover whether it still does.
+"""
+
+#: AWS access key-ID prefixes both consumers match: long-term (``AKIA``) and
+#: temporary/STS (``ASIA``) ids.
+AWS_KEY_ID_PREFIXES = "AKIA|ASIA"
+
+#: Prefixes matched by the REDACTION floor only -- ``ABIA`` (bearer tokens) and
+#: ``ACCA`` (context-specific credentials). Kept out of ``AWS_KEY_ID`` because
+#: adding them to the scrubber widens what a security surface blocks and needs
+#: matching pre-filter anchors; see the module docstring.
+AWS_KEY_ID_REDACTION_ONLY_PREFIXES = "ABIA|ACCA"
+
+#: The id body: exactly 16 uppercase alphanumerics after the 4-letter prefix.
+#: Precise enough for near-zero false positives, and the id is the searchable
+#: half of a leaked AWS credential pair.
+AWS_KEY_ID_BODY = "[A-Z0-9]{16}"
+
+#: AWS access key ID as the credential scrubber matches it.
+AWS_KEY_ID = f"(?:{AWS_KEY_ID_PREFIXES}){AWS_KEY_ID_BODY}"
+
+#: AWS access key ID as the log-redaction floor matches it: a strict superset of
+#: :data:`AWS_KEY_ID`, by construction.
+#:
+#: No word-boundary assertions here or in :data:`AWS_KEY_ID`: a key rendered
+#: adjacent to word characters (``aws_AKIA...``, ``key=AKIA...x``) has no ``\b``
+#: between ``_`` and ``A`` and would slip past a bounded pattern. Over-matching
+#: inside a longer token is the fail-closed direction for a redaction floor.
+AWS_KEY_ID_REDACTION = (
+    f"(?:{AWS_KEY_ID_PREFIXES}|{AWS_KEY_ID_REDACTION_ONLY_PREFIXES}){AWS_KEY_ID_BODY}"
+)
+
+#: Multi-segment JWT: an ``eyJ`` header plus 2-4 further dot-separated base64url
+#: segments, covering 3-segment JWS AND 4-5-segment JWE (``dir``/ECDH-ES).
+#: Catches tokens carried OUTSIDE a ``Bearer `` scheme -- JSON-embedded, bare, or
+#: assignment-style.
+#:
+#: The segment class cannot cross the literal ``.`` separators, so it does not
+#: over-capture into surrounding text. ``security.py`` carries a SECOND,
+#: deliberately different two-segment link-token pattern whose ``{96,}`` floor is
+#: tuned against false positives such as ``eyJ2IjoxfQ.json``; that one is a
+#: distinct pattern for a distinct job, not another spelling of this one, and it
+#: stays where it is used.
+JWT_MULTI_SEGMENT = r"eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*){2,4}"

--- a/src/kiro_crew/log_redaction.py
+++ b/src/kiro_crew/log_redaction.py
@@ -35,6 +35,8 @@ import logging
 import re
 from typing import Callable, Optional
 
+from kiro_crew.credential_patterns import AWS_KEY_ID_REDACTION, JWT_MULTI_SEGMENT
+
 logger = logging.getLogger(__name__)
 
 # Bearer tokens: RFC 6750 token68 charset (case-insensitive to catch
@@ -45,28 +47,22 @@ _BEARER_RE = re.compile(r"Bearer [A-Za-z0-9._~+/=-]{8,}", re.IGNORECASE)
 # alphanumerics. Precise enough for near-zero false positives, and the ID is
 # the searchable half of a leaked AWS credential pair.
 #
-# These live LOCALLY rather than importing ``security.py``'s scrubbing
-# helpers: this module is a deliberate import leaf (it installs at CLI
-# bootstrap before heavy modules load, and ``test_zero_vault_imports`` pins
-# its dependency-free shape). The JWT spelling below is identical to
-# ``security.py``'s; this AWS spelling is a DELIBERATE SUPERSET of
-# ``security.py``'s ``(?:AKIA|ASIA)[A-Z0-9]{16}`` (adds the ``ABIA``/``ACCA``
-# prefixes — wider matching is fail-closed for redaction).
-# ``test_log_redaction.py`` pins BOTH relationships so the homes cannot
-# silently drift.
-# No word-boundary assertions: a key rendered adjacent to word characters
-# (``aws_AKIA…``, ``key=AKIA…x``) has no ``\b`` between ``_`` and ``A`` and
-# would slip past a bounded pattern. Over-matching inside a longer token is
-# the fail-closed direction for a redaction floor.
-_AWS_KEY_ID_RE = re.compile(r"(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}")
+# The spellings come from ``credential_patterns``, the single home this module
+# and ``security.py``'s scrubber both import. That module imports nothing at
+# all, so it does not compromise this module's import-leaf shape (it installs
+# at CLI bootstrap, before heavy modules load, and cannot import
+# ``security.py``). The redaction spelling is a DELIBERATE SUPERSET of the
+# scrubber's -- it adds the ``ABIA``/``ACCA`` prefixes, because wider matching
+# is fail-closed for redaction -- and it is BUILT from the scrubber spelling's
+# own fragments, so that relationship holds by construction rather than by a
+# test comparing two hand-written strings.
+_AWS_KEY_ID_RE = re.compile(AWS_KEY_ID_REDACTION)
 
-# Standalone JWTs: same derived spelling as ``security.py``'s scrubber —
-# ``eyJ`` header plus 2-4 further dot-separated base64url segments, covering
-# 3-segment JWS AND 4-5-segment JWE (dir/ECDH-ES). Catches tokens logged
-# OUTSIDE a ``Bearer `` scheme — JSON-embedded, bare, or assignment-style.
-# ``test_log_redaction.py`` pins parity with ``security.py``'s spelling so the
-# two homes cannot silently drift.
-_JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*){2,4}")
+# Standalone JWTs: the shared ``eyJ`` header plus 2-4 further dot-separated
+# base64url segments, covering 3-segment JWS AND 4-5-segment JWE (dir/ECDH-ES).
+# Catches tokens logged OUTSIDE a ``Bearer `` scheme -- JSON-embedded, bare, or
+# assignment-style. Same string object as the scrubber's JWS/JWE branch.
+_JWT_RE = re.compile(JWT_MULTI_SEGMENT)
 
 
 class SecretRedactionFilter:

--- a/src/kiro_crew/metrics/schema.py
+++ b/src/kiro_crew/metrics/schema.py
@@ -22,6 +22,7 @@ import math
 import re
 from typing import Dict, Optional, Union
 
+from kiro_crew.credential_patterns import AWS_KEY_ID
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 # ---------------------------------------------------------------------------
@@ -68,7 +69,7 @@ RESOURCE_ATTR_PROCESS_START_TIME = "kirocrew.process.start_time"
 # Patterns that indicate high-entropy / credential-shaped values.
 _HIGH_ENTROPY_PATTERNS: list[re.Pattern[str]] = [
     # AWS access key ID (AKIA) + STS temporary security credentials (ASIA)
-    re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{16}"),
+    re.compile(AWS_KEY_ID),
     # AWS SecretAccessKey= pattern
     re.compile(r"SecretAccessKey\s*=", re.IGNORECASE),
     # Private key headers

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 from urllib.parse import parse_qs, unquote, unquote_plus, urlparse
 
+from kiro_crew.credential_patterns import AWS_KEY_ID, JWT_MULTI_SEGMENT
 from kiro_crew.executors import maintenance_executor
 from kiro_crew.identity_stores import fenced_home_dirs
 from kiro_crew.sel import SecurityEvent, SecurityEventLog
@@ -9088,7 +9089,7 @@ _EXFIL_PATTERNS = re.compile(
     r"(?:"
     r"[A-Za-z0-9+/=]{40,}"  # base64-like blob (40+ chars)
     r"|%[0-9A-Fa-f]{2}(?:%[0-9A-Fa-f]{2}){20,}"  # heavy URL-encoding (20+ encoded chars)
-    r"|(?:AKIA|ASIA)[A-Z0-9]{16}"  # AWS access key ID
+    f"|{AWS_KEY_ID}"  # AWS access key ID (shared spelling: credential_patterns)
     r"|(?:ssh-rsa|ssh-ed25519)[\s+%]"  # SSH public key
     r"|BEGIN[\s+%](?:RSA|DSA|EC|OPENSSH)[\s+%]PRIVATE[\s+%]KEY"  # private key header
     r"|xox[bpas]-[0-9a-zA-Z-]+"  # Slack token
@@ -9415,7 +9416,8 @@ def _approved_oauth_authorization_endpoint(host: str, path: str) -> bool:
 # amazonaws.com domain.  Values are validated to prevent spoofing.
 _S3_PRESIGNED_RE = re.compile(
     r"X-Amz-Algorithm=AWS4-HMAC-SHA256"
-    r".*X-Amz-Credential=(?:AKIA|ASIA)[A-Z0-9]{16}(?:%2F|/)"
+    f".*X-Amz-Credential={AWS_KEY_ID}"  # shared spelling: credential_patterns
+    r"(?:%2F|/)"
     r".*X-Amz-Expires=\d{1,6}"
     r".*X-Amz-Signature=[0-9a-f]{64}",
     re.IGNORECASE,
@@ -9441,7 +9443,8 @@ _S3_PRESIGNED_PARAMS = frozenset(
 # than exempted, so attacker-controlled data cannot be smuggled through.
 _STS_TOKEN_RE = re.compile(r"^(?:FwoGZX|IQoJb3JpZ2lu)[A-Za-z0-9+/=%]{1,2000}$")
 _CREDENTIAL_RE = re.compile(
-    r"^(?:AKIA|ASIA)[A-Z0-9]{16}(?:%2F|/)[0-9]{8}"
+    f"^{AWS_KEY_ID}"  # shared spelling: credential_patterns
+    r"(?:%2F|/)[0-9]{8}"
     r"(?:%2F|/)[a-z0-9-]+(?:%2F|/)s3(?:%2F|/)aws4_request$"
 )
 _SIGNATURE_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -9485,7 +9488,7 @@ def _is_safe_presigned(domain: str, query: str) -> bool:
 # hashes — are benign).
 _HARD_CREDENTIAL_RE = re.compile(
     r"(?:"
-    r"(?:AKIA|ASIA)[A-Z0-9]{16}"  # AWS access key ID
+    f"{AWS_KEY_ID}"  # AWS access key ID (shared spelling: credential_patterns)
     r'|(?:SecretAccessKey|aws_secret_access_key)["\']?\s*[:=]\s*["\']?[^\s"\',}]+'
     r'|(?:SessionToken|aws_session_token)["\']?\s*[:=]\s*["\']?[^\s"\',}]+'
     r'|(?:AccessKeyId|aws_access_key_id)["\']?\s*[:=]\s*["\']?[^\s"\',}]+'
@@ -9900,7 +9903,7 @@ def redact_exfiltration_urls(text: str) -> tuple[str, list[str]]:
 _CREDENTIAL_PATTERNS = re.compile(
     r"(?:"
     # ── AWS ──
-    r"(?:AKIA|ASIA)[A-Z0-9]{16}"  # AWS access key ID
+    f"{AWS_KEY_ID}"  # AWS access key ID (shared spelling: credential_patterns)
     # key-value forms: tolerate an optional closing quote after the key name and an
     # optional opening quote before the value so JSON (`"aws_secret_access_key": "v"`)
     # is redacted, not just bare `key=v` / `key: v`. Without the `["']?` the closing
@@ -10096,7 +10099,7 @@ _CREDENTIAL_PATTERNS = re.compile(
     # 6750 `b64token`) stops at whitespace/quotes, so neither over-captures. A
     # Bearer header carrying a JWT redacts as one match (the Bearer class subsumes
     # the JWT); a bare JWT is still caught independently (defense in depth).
-    r"|eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*){2,4}"  # JWS (3-seg) / JWE (5-seg incl. dir/ECDH-ES)
+    f"|{JWT_MULTI_SEGMENT}"  # JWS (3-seg) / JWE (5-seg incl. dir/ECDH-ES), shared spelling
     r"|(?<![A-Za-z0-9_.-])eyJ[A-Za-z0-9_-]{96,}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])"  # 2-seg link token
     r"|(?i:Authorization)[\"\']?\s*[:=]\s*[\"\']?(?i:Bearer)\s+[A-Za-z0-9._~+/-]+=*"  # HTTP/JSON bearer
     r")",

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -54,6 +54,7 @@ from typing import IO, Literal, NamedTuple, overload
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
+from kiro_crew.credential_patterns import AWS_KEY_ID_PREFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -404,7 +405,11 @@ def _redact_deep(obj: object, redactor: Callable[[str], str]) -> object:
 # alphanumeric run (where extra chars change the case-restore candidates)
 # stays out of scope.
 _AWS_KEY_ANYCASE_RE = re.compile(
-    r"(?<![A-Za-z0-9])(?:AKIA|ASIA)[A-Za-z0-9]{16}(?![A-Za-z0-9])",
+    # Prefixes come from the shared home; the BODY deliberately does not. This net
+    # is mixed-case and boundary-bounded, so it is a different pattern from the
+    # scrubber's uppercase-only one rather than another spelling of it.
+    f"(?<![A-Za-z0-9])(?:{AWS_KEY_ID_PREFIXES})"
+    r"[A-Za-z0-9]{16}(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 

--- a/test/test_credential_patterns.py
+++ b/test/test_credential_patterns.py
@@ -1,0 +1,158 @@
+"""Tests for the shared home of the credential-pattern spellings.
+
+These replace two source-grep pins that used to read ``security.py`` as TEXT and
+assert a literal appeared in it. With one home there is no drift left to pin, so
+what remains here guards the three properties the consolidation actually rests
+on: the home stays import-free, both consumers really do read from it, and the
+one deliberate divergence stays exactly as wide as intended and no wider.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import credential_patterns as cp
+
+
+class TestImportFreeShape:
+    """The home is on the CLI bootstrap path, so it must import nothing."""
+
+    def test_module_has_no_import_node(self) -> None:
+        """Parsed as an AST: not one ``import`` node, ``re`` and futures included.
+
+        ``log_redaction`` installs before the heavy modules load. A ``sys.modules``
+        delta cannot see a stdlib module some earlier test already imported, and a
+        text scan trips over the docstring, so the AST is the exact check.
+        """
+        tree = ast.parse(open(cp.__file__, encoding="utf-8").read())
+        offenders = [
+            ast.unparse(node)
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        ]
+        assert offenders == [], f"credential_patterns must import nothing; found: {offenders}"
+
+    def test_fresh_import_pulls_in_no_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A fresh import adds only the module itself to ``sys.modules``."""
+        import kiro_crew
+
+        mod_name = "kiro_crew.credential_patterns"
+        monkeypatch.setattr(kiro_crew, "credential_patterns", sys.modules[mod_name])
+        monkeypatch.delitem(sys.modules, mod_name)
+
+        before = set(sys.modules)
+        importlib.import_module(mod_name)
+        new = set(sys.modules) - before
+        assert new == {mod_name}, f"importing the home pulled in: {sorted(new - {mod_name})}"
+
+
+class TestSharedSpellings:
+    """Both consumers compile the shared strings, not their own copies."""
+
+    def test_scrubber_branches_carry_the_shared_spellings(self) -> None:
+        """``security.py``'s compiled patterns contain the shared fragments.
+
+        Asserted against the COMPILED pattern, not the source file: a rename or a
+        reflow of the concatenation cannot make this pass vacuously, and a
+        hand-written copy reintroduced at one of the five AWS sites fails here.
+        """
+        from kiro_crew import security
+
+        for name in (
+            "_EXFIL_PATTERNS",
+            "_S3_PRESIGNED_RE",
+            "_CREDENTIAL_RE",
+            "_HARD_CREDENTIAL_RE",
+            "_CREDENTIAL_PATTERNS",
+        ):
+            pattern = getattr(security, name).pattern
+            assert cp.AWS_KEY_ID in pattern, f"{name} no longer carries the shared AWS spelling"
+
+        assert cp.JWT_MULTI_SEGMENT in security._CREDENTIAL_PATTERNS.pattern
+
+    def test_redaction_floor_compiles_the_shared_spellings(self) -> None:
+        """``log_redaction``'s patterns are exactly the shared strings."""
+        from kiro_crew.log_redaction import _AWS_KEY_ID_RE, _JWT_RE
+
+        assert _AWS_KEY_ID_RE.pattern == cp.AWS_KEY_ID_REDACTION
+        assert _JWT_RE.pattern == cp.JWT_MULTI_SEGMENT
+
+    def test_no_module_spells_the_prefix_group_by_hand(self) -> None:
+        """No module under ``src/kiro_crew`` writes the prefix group as a literal.
+
+        The point of the consolidation, enforced across the WHOLE tree rather than
+        the two original homes: five sites in ``security.py``, the redaction floor,
+        the pptx-maker data-URI scan, the metrics privacy scrub and the SEL
+        any-case audit net all read their prefixes from here, so a sixth copy
+        pasted anywhere reds here instead of becoming a new drift pair.
+
+        Matched on the regex-literal form ``(?:AKIA`` so prose that merely mentions
+        an ``AKIA...`` key, and ``AWS_KEY_ID_PREFIXES`` itself, do not trip it.
+        """
+        src_root = Path(cp.__file__).parent
+        offenders = [
+            str(path.relative_to(src_root))
+            for path in sorted(src_root.rglob("*.py"))
+            if "_vendor" not in path.parts
+            and "(?:AKIA" in path.read_text(encoding="utf-8", errors="replace")
+        ]
+        assert offenders == [], (
+            "these modules spell the AWS key-ID prefix group out again -- import "
+            f"AWS_KEY_ID / AWS_KEY_ID_PREFIXES from credential_patterns instead: {offenders}"
+        )
+
+    def test_siblings_read_their_spelling_from_the_home(self) -> None:
+        """The three sites outside the two original homes compile the shared strings."""
+        from kiro_crew import sel
+        from kiro_crew.apps.builtins.pptx_maker.backend import routes as pptx_routes
+        from kiro_crew.metrics import schema as metrics_schema
+
+        assert pptx_routes._ENCODED_CREDENTIAL_RE.pattern == cp.AWS_KEY_ID
+        assert metrics_schema._HIGH_ENTROPY_PATTERNS[0].pattern == cp.AWS_KEY_ID
+        # SEL shares only the PREFIXES: its body is mixed-case and boundary-bounded,
+        # a different pattern rather than another spelling of the same one.
+        assert f"(?:{cp.AWS_KEY_ID_PREFIXES})" in sel._AWS_KEY_ANYCASE_RE.pattern
+        assert cp.AWS_KEY_ID not in sel._AWS_KEY_ANYCASE_RE.pattern
+
+
+class TestDeliberateDivergence:
+    """The redaction floor is wider than the scrubber, by construction."""
+
+    def test_redaction_spelling_is_a_strict_superset(self) -> None:
+        """Every id the scrubber matches, the redaction floor matches too."""
+        narrow, wide = re.compile(cp.AWS_KEY_ID), re.compile(cp.AWS_KEY_ID_REDACTION)
+        body = "0123456789ABCDEF"
+        for prefix in ("AKIA", "ASIA"):
+            assert narrow.search(prefix + body)
+            assert wide.search(prefix + body)
+        for prefix in ("ABIA", "ACCA"):
+            assert not narrow.search(
+                prefix + body
+            ), "scrubber widened -- that is a behaviour change"
+            assert wide.search(prefix + body)
+
+    def test_divergence_is_only_the_named_extra_prefixes(self) -> None:
+        """The two spellings differ in nothing but the redaction-only prefixes.
+
+        Pins the shape the superset relation is derived from. Swapping the body
+        class or the prefix group on one side only -- the exact drift the deleted
+        grep pins were watching for -- fails here.
+        """
+        assert cp.AWS_KEY_ID == f"(?:{cp.AWS_KEY_ID_PREFIXES}){cp.AWS_KEY_ID_BODY}"
+        assert cp.AWS_KEY_ID_REDACTION == (
+            f"(?:{cp.AWS_KEY_ID_PREFIXES}|{cp.AWS_KEY_ID_REDACTION_ONLY_PREFIXES})"
+            f"{cp.AWS_KEY_ID_BODY}"
+        )
+
+    def test_both_spellings_reject_a_short_or_lowercase_body(self) -> None:
+        """The body stays 16 UPPERCASE alphanumerics on both sides."""
+        for spelling in (cp.AWS_KEY_ID, cp.AWS_KEY_ID_REDACTION):
+            compiled = re.compile(spelling)
+            assert not compiled.search("AKIA" + "0123456789ABCDE")  # 15 chars
+            assert not compiled.search("AKIA" + "abcdefghijklmnop")  # lowercase

--- a/test/test_log_redaction.py
+++ b/test/test_log_redaction.py
@@ -104,43 +104,6 @@ class TestSecretRedactionFilter:
         result = filt.redact(f"token: {jwe}")
         assert "eyJhbGciOiJkaXIifQ" not in result
 
-    def test_jwt_spelling_matches_security_scrubber(self) -> None:
-        """The local JWT spelling stays in parity with ``security.py``'s.
-
-        ``log_redaction`` is a bootstrap import leaf and cannot import
-        ``security.py``; this TEST can, and pins the two spellings together so
-        the duplicated pattern homes cannot silently drift.
-        """
-        import kiro_crew.security as security_mod
-
-        source = open(security_mod.__file__, encoding="utf-8").read()
-        assert r"eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*){2,4}" in source, (
-            "security.py's derived JWS/JWE spelling changed — update "
-            "log_redaction._JWT_RE to match and keep this pin in sync."
-        )
-
-    def test_aws_spelling_is_superset_of_security_scrubber(self) -> None:
-        """The local AWS pattern stays a superset of ``security.py``'s.
-
-        The local spelling deliberately adds the ``ABIA``/``ACCA`` prefixes
-        (wider matching is fail-closed for redaction). This pin fails when
-        ``security.py`` changes its base spelling — the local superset must
-        then be re-derived — or if the local pattern ever stops covering the
-        base prefixes.
-        """
-        import kiro_crew.security as security_mod
-
-        source = open(security_mod.__file__, encoding="utf-8").read()
-        assert r"(?:AKIA|ASIA)[A-Z0-9]{16}" in source, (
-            "security.py's AWS key-ID spelling changed — re-derive "
-            "log_redaction._AWS_KEY_ID_RE's superset and update this pin."
-        )
-        # The local pattern must cover everything the base spelling covers.
-        from kiro_crew.log_redaction import _AWS_KEY_ID_RE
-
-        for prefix in ("AKIA", "ASIA"):
-            assert _AWS_KEY_ID_RE.search(prefix + "0123456789ABCDEF")
-
 
 def _make_record(msg: str, exc_info: object = None) -> logging.LogRecord:
     """Create a record through the LIVE factory — how ``logging`` itself does it."""


### PR DESCRIPTION
## Problem / Motivation

The AWS access key-ID spelling is written out by hand in eight places across five
modules, and the JWT spelling in two. The two that matter most cannot see each other:
`log_redaction.py` installs at CLI bootstrap, before the heavy modules load, so it cannot
import `security.py` -- and `security.py`'s scrubber needs the same two spellings. The
only thing holding those two together was a pair of tests that opened `security.py`, read
it as SOURCE TEXT, and grepped it for a literal:

```python
source = open(security_mod.__file__, encoding="utf-8").read()
assert r"(?:AKIA|ASIA)[A-Z0-9]{16}" in source, (...)
```

That guard fires when someone renames the literal, not when the two spellings stop
meaning the same thing, and it costs one test per duplicated pattern. The other six sites
had no guard at all.

## Why it matters

These are the patterns that decide whether an AWS key or a JWT reaches a log file, a
Slack message, a metrics attribute, an audit record, or an outbound URL. Eight homes for
one spelling means a fix applied to one site can silently miss seven, and a source-grep
pin cannot tell the difference between "still in parity" and "the literal still appears
somewhere in a 12,000-line file". The next person to widen the pattern has to know, from
nothing in the code, where the other copies are.

## What changed (motivation -> approach -> change)

The import-leaf constraint forbids `log_redaction -> security`, not the reverse, so a
shared home was always reachable. Both review lanes on #6815 said so.

Approach: a new `src/kiro_crew/credential_patterns.py` that **imports nothing at all** --
not `re`, not `from __future__`. Rather than have `security.py` import the logging leaf,
every consumer imports from a home that owns only strings, so nothing new lands on the
bootstrap path and the layering reads correctly in every direction.

It exports pattern SOURCE FRAGMENTS, not compiled patterns, because the sites do not
share a shape:

| site | shape | shares |
| --- | --- | --- |
| `security._EXFIL_PATTERNS` | alternation branch, `re.IGNORECASE` | full spelling |
| `security._S3_PRESIGNED_RE` | inside `X-Amz-Credential=` with a `(?:%2F\|/)` continuation | full spelling |
| `security._CREDENTIAL_RE` | fully anchored `^...$` presigned-param validator | full spelling |
| `security._HARD_CREDENTIAL_RE` | alternation branch, `re.IGNORECASE` | full spelling |
| `security._CREDENTIAL_PATTERNS` | alternation branch, no flags (inline `(?i:...)`) | full spelling + JWT |
| `log_redaction._AWS_KEY_ID_RE` | standalone, deliberately wider | fragments (see below) |
| `pptx_maker/backend/routes._ENCODED_CREDENTIAL_RE` | standalone data-URI body scan | full spelling |
| `metrics/schema._HIGH_ENTROPY_PATTERNS[0]` | list member, privacy scrub | full spelling |
| `sel._AWS_KEY_ANYCASE_RE` | boundary-bounded, mixed-case, `re.IGNORECASE` | prefixes only |

Each site keeps its own anchors, continuations and compile flags and interpolates the
fragment via an f-string that participates in the existing implicit string concatenation.
The compiled result is byte-identical, which is what lets
`test_credential_prefilter.py` -- which splits `_CREDENTIAL_PATTERNS.pattern` into
branches and requires every branch to have a superset pre-filter anchor -- keep passing
untouched.

`sel._AWS_KEY_ANYCASE_RE` takes only the prefixes on purpose. Its body is `[A-Za-z0-9]`
under `re.IGNORECASE` because a lowercased audit query is trivially reversible; it is a
different pattern from the scrubber's uppercase-only one, not another spelling of it, and
it is documented as such at the site.

**The redactor's and the scrubber's AWS spellings deliberately diverge, and that is
preserved.** The redaction floor matches `ABIA`/`ACCA`; the scrubber does not.
Over-matching is fail-closed for redaction (a false positive costs one masked log line, a
miss writes a live key to disk), while widening the scrubber changes what a
request-blocking surface matches and would need new `_CREDENTIAL_PATTERNS` pre-filter
anchors -- a security behaviour decision, not a refactor. So this PR does **not** unify
them. Instead the wide spelling is BUILT from the narrow one's own fragments plus named
extra prefixes:

```python
AWS_KEY_ID           = f"(?:{AWS_KEY_ID_PREFIXES}){AWS_KEY_ID_BODY}"
AWS_KEY_ID_REDACTION = f"(?:{AWS_KEY_ID_PREFIXES}|{AWS_KEY_ID_REDACTION_ONLY_PREFIXES}){AWS_KEY_ID_BODY}"
```

The superset relation now holds by construction, and no module under `src/kiro_crew`
spells the prefix group out by hand any more.

Two `eyJ`-prefixed patterns in `security.py` are deliberately left alone because they are
different patterns, not other spellings of the shared one: the two-segment link-token
branch whose `{96,}` floor is tuned against false positives like `eyJ2IjoxfQ.json`, and
`_PARTIAL_JWT_TAIL_RE`, whose `{0,4}` bound exists to match a truncated tail. Both are
documented in the new module.

## Tests

Both source-grep pins are deleted. What replaces them asserts against compiled objects
and module structure instead of file text, in `test/test_credential_patterns.py`:

- `test_module_has_no_import_node` -- parses the home's AST and requires zero
  `Import`/`ImportFrom` nodes. A text scan trips over the docstring and a `sys.modules`
  delta cannot see a stdlib module an earlier test already imported, so the AST is the
  only exact check.
- `test_fresh_import_pulls_in_no_module` -- a fresh import adds only the module itself.
- `test_scrubber_branches_carry_the_shared_spellings` -- all five `security.py` patterns
  and the JWS/JWE branch contain the shared fragment, checked on `.pattern`.
- `test_redaction_floor_compiles_the_shared_spellings` -- the leaf's patterns *are* the
  shared strings.
- `test_siblings_read_their_spelling_from_the_home` -- pptx-maker and metrics compile
  `AWS_KEY_ID` exactly; SEL carries the prefixes but explicitly NOT the full spelling.
- `test_no_module_spells_the_prefix_group_by_hand` -- walks every `.py` under
  `src/kiro_crew` (excluding `_vendor`) and fails if any file contains the regex-literal
  `(?:AKIA`. This is the guard the old two-file grep could not be: a ninth copy pasted
  anywhere in the tree reds here. Costs 0.13s.
- `test_redaction_spelling_is_a_strict_superset` -- and, notably, asserts the scrubber
  still does NOT match `ABIA`/`ACCA`, so an accidental widening reds here.
- `test_divergence_is_only_the_named_extra_prefixes` -- pins the derivation shape.

Each was mutation-verified: adding an import to the home, pasting the AWS spelling back
into `security.py`, widening `AWS_KEY_ID_PREFIXES` to include `ABIA`, drifting one
`security.py` site off the shared fragment, and changing the body class on one side only
each turn the corresponding test RED, and the tree restores clean afterwards.

## Manual verification

Behaviour preservation was proven mechanically rather than by inspection, since the whole
claim of the PR is "no matching behaviour changed":

- Dumped `.pattern` and `.flags` for all nine touched regexes, on the base commit and
  again after the change. Seven are **byte-identical**, flags included.
- The two textual deltas are both the same character-class reorder: the bodies in
  `log_redaction` and `metrics/schema` were spelled `[0-9A-Z]` and are now the shared
  `[A-Z0-9]`. Proven equivalent by enumerating all 69,632 codepoints below `0x11000` and
  asserting `[0-9A-Z]` and `[A-Z0-9]` accept exactly the same set -- 0 mismatches -- plus
  accept/reject probes that are unchanged before vs after: 42 cases over the leaf, and
  882 cases over the three sibling sites (every prefix, including `ABIA`/`akia`/`AkIa`,
  crossed with seven body shapes and seven surrounding contexts, which is what pins
  SEL's boundary and case behaviour).
- Targeted suites, all green: `test_credential_patterns.py`, `test_log_redaction.py`,
  `test_credential_prefilter.py`, `test_security.py`, `test_denied_commands_security.py`,
  `test_sel.py` -- 2220 passed, 1 skipped; `test_pptx_maker_routes.py` and
  `test/metrics/` -- 674 passed; `test_redaction_mirror_parity.py`, `test_acp_client.py`,
  `test_action_interactions.py`, `test_workflows_app.py`, `test_snapshot_redaction.py`,
  `test_redact_meta_snapshot.py` green.
- flake8, isort, the repo's baseline-aware black gate, and `woke -c .woke.yml` over the
  added lines (checksum-verified v0.19.0, the version CI pins): all clean.

## Related Issues

Closes #7135
Refs #6815, #6814

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: a constant duplicated across an import boundary, kept in parity by a test that
greps the *other* file's source text for a literal. The grep passes as long as the string
appears anywhere in the file, so it survives the duplication diverging in meaning and
only reds on a rename. Two follow-on rules generalize from this one:

1. When an import-leaf constraint forces a second copy, ask which direction the
   constraint actually forbids. Here it forbade only `log_redaction -> security`, so a
   dependency-free shared home was available the whole time.
2. A parity guard should be a whole-tree negative grep, not a two-file one. The original
   pins watched the two homes that knew about each other and were blind to the six sites
   that did not -- and a two-file guard would have stayed blind to a ninth copy. The
   replacement walks all of `src/kiro_crew`.

Where two copies must genuinely differ, derive the wider one from the narrower one's
fragments so the relationship is structural instead of asserted.

Still open after this PR: two source-text greps in `test_redaction_mirror_parity.py`
(`:166`, `:181`) pin the frontend redaction mirror. Same anti-pattern, but it crosses a
language boundary rather than an import one, so the fix is a generated shared constant
rather than an import -- worth its own change.
