### PR TITLE
fix(subagent): drain every off-loop state.json writer on cancel

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -452,11 +452,12 @@ _RECOVERY_SLOT_WAIT_SECS = 60.0
 _REPORT_DRAIN_TIMEOUT = (
     30.0  # max seconds cancel_all() waits for shielded terminal reports to drain
 )
-# Max seconds a cancelled run holds cancellation open for an in-flight per-turn
-# diagnostics write worker (#6306 review): long enough for any healthy fsync,
-# short enough that a wedged FS cannot hold cancel_all()'s untimed gather —
-# bounded shutdown plus recoverable state beats unbounded shutdown.
-_DIAG_DRAIN_TIMEOUT = 5.0
+# Max seconds a cancelled run holds cancellation open for an in-flight off-loop
+# state.json write worker (#6306 review; widened to every off-loop writer by
+# #6308): long enough for any healthy fsync, short enough that a wedged FS
+# cannot hold cancel_all()'s untimed gather — bounded shutdown plus recoverable
+# state beats unbounded shutdown.
+_STATE_DRAIN_TIMEOUT = 5.0
 _STARTUP_TIMEOUT_SECS = 120  # max seconds a subagent may sit pre-first-turn with no runtime before the startup watchdog reaps it
 _ON_DONE_TIMEOUT = 1200.0  # outer cap: max total seconds for semaphore wait + injection
 
@@ -1359,13 +1360,21 @@ class SubagentInfo:
     # One-shot budget for auto-continue after an UNEXPECTED (non-user, non-
     # shutdown) asyncio cancellation — mirrors the main path's cancel recovery.
     _cancel_retry_used: bool = False
-    # True while a cancelled run is draining an in-flight diagnostics write
-    # worker (#6306). _run's unexpected-cancel recovery gate reads it: on
-    # Python 3.10 a second outer cancel can deliver that gate BEFORE the drain
-    # finishes (wait_for's _cancel_and_wait awaits an interruptible bare
-    # future), and scheduling a recovery writer while the worker is live
-    # re-opens the stale-overwrite race the drain exists to close.
-    _diag_drain_active: bool = False
+    # True while a cancelled run is draining an in-flight off-loop state.json
+    # write worker (#6306; every off-loop writer since #6308). _run's
+    # unexpected-cancel recovery gate reads it: on Python 3.10 a second outer
+    # cancel can deliver that gate BEFORE the drain finishes (wait_for's
+    # _cancel_and_wait awaits an interruptible bare future), and scheduling a
+    # recovery writer while the worker is live re-opens the stale-overwrite race
+    # the drain exists to close.
+    _state_drain_active: bool = False
+    # Set only on the synthetic marker `_conversation_busy` returns for a
+    # conversation held by an abandoned state writer (#6298 review), so the two
+    # retention callers can say "still settling a state write" instead of
+    # promising a completion event that has already fired. The authoritative
+    # record is `SubagentManager._abandoned_state_writers`, which survives
+    # `evict_completed_agents` pruning a completed run out of `_agents`.
+    _state_writer_abandoned: bool = False
     # True between an unexpected cancellation and the recovery respawn; the
     # _run finally block skips terminal finalization (subagent_done, on_done)
     # while set so the agent is not reported done mid-recovery.
@@ -1570,6 +1579,16 @@ class SubagentManager:
         # also re-registers it on demand.
         self._conversations: dict[str, float] = {}
         self._conv_registry_rebuilt = False
+        # Run ids whose bounded state-write drain EXPIRED, so a pool worker is
+        # still live and its stale whole-file rewrite would roll back the
+        # retention `keep` a promote / release writes on the loop (#6298).
+        # `_conversation_busy` reports these as held, which defers both retention
+        # writes past the worker; each worker's own done-callback discards its id,
+        # so the set holds at most one entry per live zombie. It lives on the
+        # MANAGER, not on the run's SubagentInfo, because `evict_completed_agents`
+        # prunes completed runs out of `_agents` and an eviction must not silently
+        # release the hold.
+        self._abandoned_state_writers: set[str] = set()
         # state.json is the source of truth for retention (#1115): give the
         # SessionManager's in-memory continuable cache a disk fallback so a
         # cache miss (restart window) cannot demote a promoted conversation.
@@ -2219,6 +2238,9 @@ class SubagentManager:
             )
         except Exception:
             logger.debug("Failed to write tombstone for %s", info.id, exc_info=True)
+
+    async def _write_state_off_loop(self, info: SubagentInfo, what: str, **fields: object) -> bool:
+        return await self._run_events._write_state_off_loop_impl(info, what, **fields)
 
     async def _run_inner(self, info: SubagentInfo, session_key: str) -> None:
         return await self._run_events._run_inner_impl(info, session_key)

--- a/src/kiro_crew/subagent_manager/continuation.py
+++ b/src/kiro_crew/subagent_manager/continuation.py
@@ -44,6 +44,16 @@ class ContinuationCoordinator(ManagerComponent):
         ``spawn_release`` delete the session files it needs (the accepted run
         would then die with ``resume_failed``), or let a second continue race
         the same conversation.
+
+        A FINISHED run also holds its conversation while its id sits in
+        ``_abandoned_state_writers``: its bounded state-write drain expired, so a
+        worker is still live and its stale whole-file rewrite would roll back the
+        ``keep`` that this gate's two callers write on the loop (#6298). Holding
+        defers those writes past the worker instead of letting it undo them. That
+        record lives on the manager rather than on the run, because
+        ``evict_completed_agents`` prunes completed runs out of ``_agents`` and an
+        eviction must not release the hold; the worker's own done-callback
+        discards the id, so the hold lasts exactly as long as the danger.
         """
         for a in self._manager._agents.values():
             if not a.done and (a.conversation_key or f"subagent:{a.id}") == conv_key:
@@ -58,6 +68,14 @@ class ContinuationCoordinator(ManagerComponent):
                     task="",
                     queued=True,
                 )
+        # Checked last: a live or queued run gives the caller a better message.
+        # Same synthetic-marker shape as the queued branch above — the run may
+        # already have been evicted from _agents, which is exactly why this record
+        # is not kept there.
+        if conv_key.startswith("subagent:"):
+            held = conv_key[len("subagent:") :]
+            if held in self._manager._abandoned_state_writers:
+                return SubagentInfo(id=held, task="", _state_writer_abandoned=True)
         return None
 
     def _keep_recorded_on_disk_impl(self, key: str) -> bool:
@@ -230,9 +248,14 @@ class ContinuationCoordinator(ManagerComponent):
                 done=True,
                 parent_session_key=parent_session_key,
                 error=(
-                    f"conversation_busy: run {busy.id} is in flight on this "
-                    "conversation — use spawn_steer to inject into it, or wait "
-                    "for its completion event"
+                    f"conversation_busy: run {busy.id} is still settling a state "
+                    "write on this conversation — retry shortly"
+                    if busy._state_writer_abandoned
+                    else (
+                        f"conversation_busy: run {busy.id} is in flight on this "
+                        "conversation — use spawn_steer to inject into it, or wait "
+                        "for its completion event"
+                    )
                 ),
             )
             return info
@@ -670,6 +693,11 @@ class ContinuationCoordinator(ManagerComponent):
         conv_key = f"subagent:{conv_id}"
         busy = self._manager._conversation_busy(conv_key)
         if busy is not None:
+            if busy._state_writer_abandoned:
+                return (
+                    False,
+                    f"conversation_busy: run {busy.id} is still settling a state write",
+                )
             return False, f"conversation_busy: run {busy.id} is in flight"
         provider_label = (
             self._manager._sessions.conversation_provider(conv_key) or PROVIDER_LABEL_DEFAULT

--- a/src/kiro_crew/subagent_manager/run.py
+++ b/src/kiro_crew/subagent_manager/run.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
     from ..subagent import (
         _AGENT_NAME_RE,
         _CANCEL_RESUME_PREFIX,
-        _DIAG_DRAIN_TIMEOUT,
         _MAX_ERROR_DETAIL_LEN,
         _ON_DONE_TIMEOUT,
         _RESET_TIMEOUT,
+        _STATE_DRAIN_TIMEOUT,
         _SYSTEM_PREFIX,
         _TRANSIENT_CONTINUE_MSG,
         _TURN_LIMIT,
@@ -82,6 +82,133 @@ class RunEventCoordinator(ManagerComponent):
         ``0`` at any level means "not set" and falls through to the next.
         """
         return info.max_turns or self._manager._default_turn_limit or _TURN_LIMIT
+
+    async def _write_state_off_loop_impl(
+        self, info: SubagentInfo, what: str, **fields: object
+    ) -> bool:
+        """Merge *fields* into this run's ``state.json``, off the event loop.
+
+        Every ``state.json`` writer inside a run goes through here, for two
+        reasons that are both load-bearing.
+
+        OFF-LOOP, because ``update_state`` ends in a synchronous fsync and a
+        slow FS must not freeze the gateway/heartbeat (#6288). Running in a pool
+        thread also means the write TAKES ``update_state``'s per-agent lock,
+        which off-loop callers hold and on-loop callers deliberately skip
+        (#7280).
+
+        DRAINED ON CANCELLATION, because cancelling a ``to_thread`` await
+        detaches the worker without stopping it, and ``update_state`` rewrites
+        the WHOLE file from the snapshot it already read — so a detached worker
+        rolls back every field written after that read, not merely the fields it
+        names. That is how a zombie erases the ``pid`` / ``session_id`` a
+        cancel-respawn recovery run writes on the loop, or the retention
+        ``keep`` that promote / release write on the loop (#6306, #6298, #6308).
+        Cancellation is therefore held open until the worker finishes — but
+        BOUNDED: ``cancel_all()`` gathers run tasks with no timeout, so an
+        unbounded drain on a wedged FS would hold gateway shutdown forever, and
+        this module's convention is that bounded shutdown plus recoverable state
+        beats unbounded shutdown (same posture as ``_REPORT_DRAIN_TIMEOUT``).
+        ``asyncio.wait`` never cancels its members, so repeated cancels of the
+        awaiting task keep the worker future intact while the drain loop waits
+        out the same deadline. For the whole window in which the worker may still
+        write -- from the cancellation until the worker settles, however the drain
+        exits -- the run HOLDS its conversation
+        (``SubagentManager._abandoned_state_writers``), so the two on-loop
+        ``keep`` writes are deferred past the worker instead of being rolled back
+        by it. The window starts at the cancellation rather than at the drain
+        deadline because on Python 3.10 a second outer cancel can finalize the run
+        mid-drain.
+
+        Returns ``update_state``'s own report: True when the merge was written,
+        False when it was SKIPPED because the state was unreadable — a caller
+        with a durability contract (the pre-spawn provenance write, #5394)
+        retries on False. Re-raises ``asyncio.CancelledError`` after draining,
+        so such a retry loop ends on cancellation instead of adding a second
+        writer for the same fields.
+        """
+        writer = asyncio.ensure_future(asyncio.to_thread(update_state, info.id, **fields))
+        try:
+            return bool(await asyncio.shield(writer))
+        except asyncio.CancelledError:
+            # Hold this run's conversation for the WHOLE window in which the
+            # worker may still write, which starts here and not at the drain
+            # deadline: on Python 3.10 a second outer cancel can deliver _run's
+            # finalization mid-drain, so the run can go `done` while the writer
+            # is live, and a continuation reaching a released gate would then
+            # write `keep` for that writer's stale whole-file rewrite to erase
+            # (#6298). `keep` is written on the loop and takes no per-agent lock,
+            # so ordering is the only thing protecting it. The worker's own
+            # done-callback releases the hold, so it lasts exactly as long as the
+            # worker does -- milliseconds on a healthy FS. Recorded on the
+            # MANAGER, not on `info`: `evict_completed_agents` prunes completed
+            # runs out of `_agents`, and an eviction must not release the hold.
+            self._manager._abandoned_state_writers.add(info.id)
+
+            def _settled(
+                fut: "asyncio.Future[Any]",
+                _mgr: Any = self._manager,
+                _aid: str = info.id,
+                _what: str = what,
+            ) -> None:
+                # The worker has landed (drained or abandoned): the conversation
+                # is safe to promote or release again.
+                _mgr._abandoned_state_writers.discard(_aid)
+                # It may also have raised; retrieve it so it never surfaces as an
+                # asynchronous "exception was never retrieved" warning.
+                if not fut.cancelled() and fut.exception() is not None:
+                    logger.debug(
+                        "Best-effort %s write failed for %s during cancel drain",
+                        _what,
+                        _aid,
+                        exc_info=fut.exception(),
+                    )
+
+            writer.add_done_callback(_settled)
+            # Latch for _run's recovery gate: on Python 3.10, wait_for's
+            # _cancel_and_wait awaits a bare future that a SECOND outer cancel
+            # can interrupt, delivering _run's CancelledError handler while this
+            # drain is still in flight — before expiry suppression lands. The
+            # latch lets the gate see the live drain and skip scheduling a
+            # recovery writer the worker could race. 3.11+ delivers the outer
+            # cancel only after this child task completes, so there the latch is
+            # always observed False.
+            info._state_drain_active = True
+            try:
+                deadline = time.monotonic() + _STATE_DRAIN_TIMEOUT
+                while not writer.done():
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        logger.warning(
+                            "%s write for %s did not drain in %.0fs on cancellation — "
+                            "abandoning worker (its stale whole-file rewrite may roll "
+                            "back a recovery run's state)",
+                            what,
+                            info.id,
+                            _STATE_DRAIN_TIMEOUT,
+                        )
+                        # The abandoned worker is a live stale writer whose
+                        # rewrite is whole-file, so it can roll back the pid /
+                        # session_id a cancel-respawn recovery run writes ON the
+                        # loop (no per-agent lock there) — and a lost pid means
+                        # an orphan the reaper can no longer reach. Consume the
+                        # one-shot recovery so this cancellation finalizes
+                        # instead of respawning: losing one best-effort
+                        # auto-continue on an FS already wedged past the
+                        # deadline is strictly cheaper than resurrecting stale
+                        # state. Uniform across sites — the blast radius is set
+                        # by the whole-file rewrite, not by which fields this
+                        # particular caller named. The conversation hold above
+                        # outlives this branch and is released by _settled.
+                        info._cancel_retry_used = True
+                        break
+                    try:
+                        await asyncio.wait({writer}, timeout=remaining)
+                    except asyncio.CancelledError:
+                        pass  # repeated cancel: keep draining to the deadline
+            finally:
+                info._state_drain_active = False
+            raise
 
     def update_completion_keep_impl(self, mode: str, max_chars: int) -> None:
         """Update the live completion-keep mode and char budget.
@@ -205,12 +332,12 @@ class RunEventCoordinator(ManagerComponent):
                     not info.user_stopped
                     and not self._manager._shutting_down
                     and not info._cancel_retry_used
-                    # A live diagnostics-write drain means a worker is still
+                    # A live state-write drain means a worker is still
                     # (or may still be) writing state.json: respawning a
                     # recovery writer now re-opens the stale-overwrite race
-                    # (#6306; reachable on 3.10 via a second outer cancel
-                    # interrupting wait_for's _cancel_and_wait).
-                    and not info._diag_drain_active
+                    # (#6306, #6308; reachable on 3.10 via a second outer
+                    # cancel interrupting wait_for's _cancel_and_wait).
+                    and not info._state_drain_active
                     and info.tool_count == 0
                 ):
                     # UNEXPECTED cancellation (not user Stop, not shutdown):
@@ -694,21 +821,24 @@ class RunEventCoordinator(ManagerComponent):
             info.resolved_model = _spawn_model
         # Persist provenance to disk BEFORE the spawn event so a gateway restart
         # in the window between the event and the later session_id state write
-        # cannot lose it — orphan recovery reads these from disk. Off-loop
-        # (to_thread): update_state does a synchronous fsync, so
-        # a slow FS must not freeze the gateway/heartbeat. Best-effort with ONE
-        # bounded retry: this write is the SINGLE owner of these two fields on
-        # the spawn path (#5394) — the later session_id write no longer doubles
-        # as a fallback, so a transient failure gets its second chance HERE
-        # rather than from a second writer downstream. update_state reports a
-        # silently-skipped merge (unreadable state) as False, which counts as a
+        # cannot lose it — orphan recovery reads these from disk. Off-loop and
+        # drained on cancellation via _write_state_off_loop (#6288, #6308; see
+        # that helper for why a detached worker is the hazard). Best-effort with
+        # ONE bounded retry: this write is the SINGLE owner of these two fields
+        # on the spawn path (#5394) — the later session_id write no longer
+        # doubles as a fallback, so a transient failure gets its second chance
+        # HERE rather than from a second writer downstream. update_state reports
+        # a silently-skipped merge (unreadable state) as False, which counts as a
         # failure for the retry — only a REPORTED write ends the loop. A
-        # persistence hiccup must still never block the spawn.
+        # persistence hiccup must still never block the spawn. A cancellation
+        # ends the loop instead of retrying: `except Exception` does not catch
+        # CancelledError, so the helper's post-drain re-raise propagates rather
+        # than starting a second writer for the same fields.
         for _provenance_attempt in range(2):
             try:
-                _wrote = await asyncio.to_thread(
-                    update_state,
-                    info.id,
+                _wrote = await self._manager._write_state_off_loop(
+                    info,
+                    "model provenance",
                     requested_model=info.requested_model,
                     resolved_model=info.resolved_model,
                 )
@@ -993,10 +1123,11 @@ class RunEventCoordinator(ManagerComponent):
                         info.resolved_model = _live_model
                         # Persist the CC-path refinement so a restart after the
                         # first turn still recovers the served model. Off-loop
-                        # (to_thread): synchronous fsync must not block the loop.
+                        # and drained on cancellation via _write_state_off_loop
+                        # (#6288, #6308).
                         try:
-                            await asyncio.to_thread(
-                                update_state, info.id, resolved_model=_live_model
+                            await self._manager._write_state_off_loop(
+                                info, "refined model", resolved_model=_live_model
                             )
                         except Exception:
                             logger.debug(
@@ -1072,102 +1203,14 @@ class RunEventCoordinator(ManagerComponent):
                 info.last_tool = event.title or ""
                 self._manager._note_tool_dispatch(info, event)
                 # Persist turn state for orphan recovery diagnostics. Off-loop
-                # (to_thread): update_state does a synchronous fsync, so a slow
-                # FS must not freeze the gateway/heartbeat (#6288; same shape
-                # as the provenance and CC-refinement writes above). Drained on
-                # cancellation: cancelling a to_thread await detaches the
-                # worker, and update_state's per-agent lock serializes OFF-loop
-                # writers only, so a stale detached worker's whole-file rewrite
-                # can still roll back the PID / session-id state a
-                # cancel-respawn recovery run writes ON the loop without that
-                # lock. Hold cancellation
-                # open until the worker finishes — but BOUNDED: cancel_all()
-                # gathers run tasks with no timeout, so an unbounded drain on
-                # a wedged FS would hold gateway shutdown forever, and this
-                # module's convention is that bounded shutdown plus
-                # recoverable state beats unbounded shutdown (same posture as
-                # _REPORT_DRAIN_TIMEOUT). On expiry the worker is abandoned
-                # with a warning; the residual stale-write window then only
-                # exists on an FS already wedged past the deadline.
-                # asyncio.wait never cancels its members, so repeated cancels
-                # of this task keep the worker future intact while the drain
-                # loop keeps waiting out the same deadline.
-                _diag_write = asyncio.ensure_future(
-                    asyncio.to_thread(
-                        update_state, info.id, turns=turns, last_tool=event.title or ""
-                    )
-                )
+                # and drained on cancellation via _write_state_off_loop (#6288,
+                # #6306) — the highest-frequency of the three off-loop state
+                # writers, so the one most likely to be in flight when a
+                # cancellation lands.
                 try:
-                    await asyncio.shield(_diag_write)
-                except asyncio.CancelledError:
-                    # Latch for _run's recovery gate: on Python 3.10,
-                    # wait_for's _cancel_and_wait awaits a bare future that a
-                    # SECOND outer cancel can interrupt, delivering _run's
-                    # CancelledError handler while this drain is still in
-                    # flight — before expiry suppression lands. The latch lets
-                    # the gate see the live drain and skip scheduling a
-                    # recovery writer the worker could race. 3.11+ delivers
-                    # the outer cancel only after
-                    # this child task completes, so there the latch is always
-                    # observed False.
-                    info._diag_drain_active = True
-                    try:
-                        _drain_deadline = time.monotonic() + _DIAG_DRAIN_TIMEOUT
-                        while not _diag_write.done():
-                            _remaining = _drain_deadline - time.monotonic()
-                            if _remaining <= 0:
-                                logger.warning(
-                                    "diagnostics write for %s did not drain in %.0fs on "
-                                    "cancellation — abandoning worker (its write may race "
-                                    "a recovery run's)",
-                                    info.id,
-                                    _DIAG_DRAIN_TIMEOUT,
-                                )
-                                # The abandoned worker is a live stale writer: a
-                                # cancel-respawn recovery run would write fresh
-                                # PID/session state ON the loop, which takes no
-                                # per-agent lock, so the zombie's read-merge-
-                                # replace can still roll it back. Consume the
-                                # one-shot recovery so this cancellation finalizes
-                                # instead of respawning — losing one best-effort
-                                # auto-continue on an FS already wedged past the
-                                # deadline is strictly cheaper than resurrecting
-                                # stale state.
-                                info._cancel_retry_used = True
-
-                                # The zombie may still raise later; retrieve it so
-                                # it never surfaces as an asynchronous "exception
-                                # was never retrieved" warning.
-                                def _log_abandoned_diag(
-                                    fut: "asyncio.Future[Any]", _aid: str = info.id
-                                ) -> None:
-                                    if not fut.cancelled() and fut.exception() is not None:
-                                        logger.debug(
-                                            "Abandoned diagnostics write for %s failed",
-                                            _aid,
-                                            exc_info=fut.exception(),
-                                        )
-
-                                _diag_write.add_done_callback(_log_abandoned_diag)
-                                break
-                            try:
-                                await asyncio.wait({_diag_write}, timeout=_remaining)
-                            except asyncio.CancelledError:
-                                pass  # repeated cancel: keep draining to the deadline
-                        if _diag_write.done() and not _diag_write.cancelled():
-                            # Retrieve (never surfaces as an unretrieved-exception
-                            # warning) and log, matching the CC-refinement sibling.
-                            _diag_exc = _diag_write.exception()
-                            if _diag_exc is not None:
-                                logger.debug(
-                                    "Best-effort diagnostics write failed for %s during "
-                                    "cancel drain",
-                                    info.id,
-                                    exc_info=_diag_exc,
-                                )
-                    finally:
-                        info._diag_drain_active = False
-                    raise
+                    await self._manager._write_state_off_loop(
+                        info, "diagnostics", turns=turns, last_tool=event.title or ""
+                    )
                 except Exception:
                     pass
                 await self._manager._fire_event(

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -266,12 +266,16 @@ def update_state(agent_id: str, **fields: object) -> bool:
 
     KNOWN LIMITATION: an ON-LOOP caller does not take the lock, because waiting
     on a pool thread's fsync from the event loop is exactly the blocking call the
-    repo's anchor forbids. So an interleave in which ONE participant is on the
-    loop is still open, unchanged from before this lock existed -- the loop-side
-    retention (``keep``) write against an in-flight pool write (#6298), and a
-    detached pool worker against the on-loop PID / session-id writes a
-    cancel-respawn recovery run makes (#6308). Closing those needs the loop-side
-    callers moved off-loop (#6288's class), tracked separately.
+    repo's anchor forbids. What closes the interleave for those callers instead
+    is that every off-loop writer inside a RUN is drained on cancellation
+    (``_write_state_off_loop``, #6298 / #6308): a pool writer cannot outlive the
+    run it belongs to, and the on-loop retention (``keep``) writes are reached
+    only through a ``_conversation_busy`` gate that refuses while a run is in
+    flight. The drain is bounded, so on a wedged FS a worker IS abandoned -- but
+    that same gate then holds the conversation until the abandoned worker
+    settles, so the two on-loop ``keep`` writes are deferred past it rather than
+    silently undone. Separately, on-loop callers still pay this function's fsync
+    ON the loop; moving them off-loop is tracked as #7302.
     """
     p = _agent_dir(agent_id) / "state.json"
     # Off-loop callers serialize; on-loop callers keep pre-existing behaviour.

--- a/test/test_subagent_provenance_write.py
+++ b/test/test_subagent_provenance_write.py
@@ -324,8 +324,8 @@ async def test_per_turn_diagnostics_write_is_drained_on_cancellation() -> None:
             )
             # While draining, the latch _run's recovery gate reads must be up
             # (3.10 wait_for double-cancel can deliver that gate mid-drain).
-            assert info._diag_drain_active is True, (
-                "drain did not raise the _diag_drain_active latch — on 3.10 a "
+            assert info._state_drain_active is True, (
+                "drain did not raise the _state_drain_active latch — on 3.10 a "
                 "second outer cancel can schedule recovery mid-drain (#6306 "
                 "review round 4)"
             )
@@ -348,7 +348,7 @@ async def test_per_turn_diagnostics_write_is_drained_on_cancellation() -> None:
     assert landed and landed[0]["turns"] == 1
     # ...and the latch is down again: after a completed drain there is no live
     # worker, so recovery is safe and must not stay suppressed.
-    assert info._diag_drain_active is False, "latch leaked past the drain"
+    assert info._state_drain_active is False, "latch leaked past the drain"
 
 
 @pytest.mark.asyncio
@@ -359,7 +359,7 @@ async def test_no_recovery_scheduled_while_diagnostics_worker_is_live() -> None:
     scheduled while the worker is still live. On 3.11+ the second cancel
     routes to the child task so the gate runs only post-drain; on 3.10 the
     second cancel can deliver the gate mid-drain, where the
-    ``_diag_drain_active`` latch suppresses it — both paths must satisfy the
+    ``_state_drain_active`` latch suppresses it — both paths must satisfy the
     same invariant asserted here."""
     import asyncio
 
@@ -435,7 +435,7 @@ async def test_no_recovery_scheduled_while_diagnostics_worker_is_live() -> None:
 @pytest.mark.asyncio
 async def test_recovery_gate_respects_live_drain_latch() -> None:
     """Direct gate check (kills the condition mutant): an UNEXPECTED
-    cancellation with ``_diag_drain_active`` raised must NOT schedule
+    cancellation with ``_state_drain_active`` raised must NOT schedule
     cancel-respawn recovery — a fresh recovery writer would race the live
     worker. With the latch down, the same cancellation must recover
     (control, so the test cannot pass by recovery being broken outright)."""
@@ -453,7 +453,7 @@ async def test_recovery_gate_respects_live_drain_latch() -> None:
         )
         info = SubagentInfo(id=f"turnw08-{latch}", task="gate task", model="model-req")
         manager._agents[info.id] = info
-        info._diag_drain_active = latch
+        info._state_drain_active = latch
         recovery_calls: list[Any] = []
 
         with (
@@ -473,7 +473,7 @@ async def test_recovery_gate_respects_live_drain_latch() -> None:
         assert bool(recovery_calls) is expect_recovery, (
             f"latch={latch}: expected recovery_scheduled={expect_recovery}, "
             f"got {bool(recovery_calls)} — the recovery gate does not respect "
-            "_diag_drain_active (#6306 review round 4)"
+            "_state_drain_active (#6306 review round 4)"
         )
 
 
@@ -522,7 +522,7 @@ async def test_per_turn_diagnostics_drain_is_bounded() -> None:
         patch("kiro_crew.subagent.sel"),
         patch("kiro_crew.subagent.update_state", return_value=True),
         patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_wedged_to_thread),
-        patch("kiro_crew.subagent._DIAG_DRAIN_TIMEOUT", 0.0),
+        patch("kiro_crew.subagent._STATE_DRAIN_TIMEOUT", 0.0),
     ):
         task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
         try:
@@ -604,7 +604,7 @@ async def test_abandoned_diagnostics_worker_exception_is_retrieved() -> None:
                 "kiro_crew.subagent.asyncio.to_thread",
                 side_effect=_wedged_raising_to_thread,
             ),
-            patch("kiro_crew.subagent._DIAG_DRAIN_TIMEOUT", 0.0),
+            patch("kiro_crew.subagent._STATE_DRAIN_TIMEOUT", 0.0),
         ):
             task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
             try:
@@ -688,3 +688,418 @@ async def test_unpinned_spawn_records_requested_model_auto() -> None:
     assert (
         provenance[0]["requested_model"] == "auto"
     ), f"unpinned spawn must record requested_model='auto', got {provenance[0]['requested_model']!r}"
+
+
+@pytest.mark.asyncio
+async def test_provenance_write_is_drained_on_cancellation() -> None:
+    """#6308 sibling A: cancelling a run while the PRE-SPAWN provenance write is
+    in flight must hold cancellation open until that worker finishes.
+
+    The site used to be a bare ``await asyncio.to_thread(...)``: the cancel
+    detached the worker, the run finalized immediately, and the zombie's
+    WHOLE-FILE rewrite could then roll back whatever landed after its read --
+    including the ``pid`` / ``session_id`` a cancel-respawn recovery run writes
+    on the loop, without which the reaper can no longer reach the child. Same
+    contract as the per-turn diagnostics write (#6306), now shared by every
+    off-loop state writer through ``_write_state_off_loop``.
+    """
+    import asyncio
+
+    sessions = _mock_sessions(served_model="model-served")
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="provdr1", task="provenance cancel task", model="model-req")
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    landed: list[dict[str, Any]] = []
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        # Only the provenance write carries requested_model; every other
+        # off-loop call in the spawn path goes straight through.
+        if "requested_model" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        landed.append(dict(kwargs))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
+        try:
+            await entered.wait()
+            task.cancel()
+            await _event_loop_checkpoint()
+            assert not task.done(), (
+                "cancelled _run_inner completed while the pre-spawn provenance "
+                "write was in flight -- the detached worker can still roll back a "
+                "recovery run's pid/session_id (#6308)"
+            )
+            # The same latch the per-turn drain raises, for the same reason: on
+            # 3.10 a second outer cancel can deliver _run's recovery gate
+            # mid-drain, and recovery must not be scheduled while a worker lives.
+            assert (
+                info._state_drain_active is True
+            ), "the provenance drain did not raise the recovery-gate latch"
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    # The write itself still landed (drained, not abandoned)...
+    assert landed and landed[0]["requested_model"] == "model-req"
+    assert info._state_drain_active is False, "latch leaked past the drain"
+    # ...and the cancellation ended the two-attempt retry loop rather than
+    # adding a SECOND writer for the same fields (the composition ruling this
+    # site needed: drain per attempt, cancel ends the loop).
+    assert len(landed) == 1, f"retry loop started another attempt after the cancel: {landed}"
+
+
+@pytest.mark.asyncio
+async def test_cc_refinement_write_is_drained_on_cancellation() -> None:
+    """#6308 sibling B: same contract for the CC-path model refinement write.
+
+    The refinement fires on the first text chunk, when a raw/CC provider first
+    reveals its served model -- mid-turn, so a cancellation is more likely to
+    find it in flight than the pre-spawn write.
+    """
+    import asyncio
+
+    from kiro_crew.acp.types import EVENT_TEXT_CHUNK, AcpEvent
+
+    # Spawn-time resolve sees nothing; the provider reveals its served model
+    # only as the first chunk streams, which is what arms the refinement.
+    sessions = _mock_sessions(served_model="")
+    provider = sessions.get_or_create.return_value[0]
+
+    async def _late_model_stream(*_args: object, **_kwargs: object):  # type: ignore[no-untyped-def]
+        provider.served_model = "model-late"
+        yield AcpEvent(kind=EVENT_TEXT_CHUNK, text="hello")
+
+    provider.stream = MagicMock(side_effect=lambda *a, **kw: _late_model_stream())
+
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="ccdrn1", task="cc refinement cancel task")
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    landed: list[dict[str, Any]] = []
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        # The refinement is the only write carrying resolved_model WITHOUT the
+        # provenance write's requested_model companion.
+        if "resolved_model" not in kwargs or "requested_model" in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        landed.append(dict(kwargs))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
+        try:
+            await entered.wait()
+            task.cancel()
+            await _event_loop_checkpoint()
+            assert not task.done(), (
+                "cancelled _run_inner completed while the CC-path refinement "
+                "write was in flight -- the detached worker can still roll back a "
+                "recovery run's pid/session_id (#6308)"
+            )
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert landed and landed[0]["resolved_model"] == "model-late"
+    assert info._state_drain_active is False, "latch leaked past the drain"
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_state_writer_holds_the_conversation() -> None:
+    """#6298 review (GPT round 1): the drain is BOUNDED, so on a wedged FS a
+    worker outlives its run -- and its stale whole-file rewrite would roll back
+    the ``keep`` a promote / release writes on the loop in the meantime.
+
+    Unbounding the drain is not the answer: ``cancel_all()`` gathers run tasks
+    with no timeout, so it would hold gateway shutdown open forever (the posture
+    ``_REPORT_DRAIN_TIMEOUT`` already sets). Neither is keeping the run
+    non-terminal, which would stall its completion event for as long as the FS
+    stays wedged. Instead the manager records the abandoned writer and
+    ``_conversation_busy`` reports the conversation as held until it settles,
+    which defers both retention writes past the zombie. This pins the hold, that
+    it survives ``_agents`` eviction (GPT review round 2), and its release.
+    """
+    import asyncio
+
+    from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+    event = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        title="grep",
+        tool_kind="read",
+        request_id="req-1",
+    )
+    sessions = _mock_sessions_with_tool_event("model-served", event)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="aband01", task="abandoned writer task", model="model-req")
+    manager._agents[info.id] = info
+    conv_key = f"subagent:{info.id}"
+
+    wedged = asyncio.Event()
+    entered = asyncio.Event()
+
+    async def _wedged_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        if "turns" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await wedged.wait()  # never released before the drain deadline
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_wedged_to_thread),
+        # Expire the drain immediately: this test is about what happens AFTER
+        # expiry, not about the bound itself (pinned separately).
+        patch("kiro_crew.subagent._STATE_DRAIN_TIMEOUT", 0.0),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, conv_key))
+        await entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # The run is finished, but a worker is still live.
+        info.done = True
+        assert info.id in manager._abandoned_state_writers, (
+            "drain expiry did not record the abandoned state writer -- "
+            "promote/release would run while the zombie is live (#6298)"
+        )
+        held = manager._conversation_busy(conv_key)
+        assert held is not None and held.id == info.id, (
+            "a finished run with a live abandoned writer must still hold its "
+            "conversation, so the keep write is deferred past the zombie"
+        )
+        # GPT review round 2: the hold must not depend on the run staying in
+        # `_agents`. `evict_completed_agents` prunes completed runs, and an
+        # eviction that released the hold would let a continuation write `keep`
+        # for the zombie to erase.
+        manager._agents.clear()
+        evicted = manager._conversation_busy(conv_key)
+        assert evicted is not None and evicted.id == info.id, (
+            "evicting the completed run released the hold -- the abandoned-writer "
+            "record must live on the manager, not on an _agents-resident flag"
+        )
+        assert evicted._state_writer_abandoned is True
+        # Both retention paths therefore refuse rather than being silently undone.
+        ok, detail = manager.release_conversation(info.id)
+        assert ok is False and "conversation_busy" in detail, detail
+        assert (
+            "settling a state write" in detail
+        ), f"refusal must not promise a completion event that already fired: {detail}"
+
+        # The zombie lands: the hold releases and the conversation is usable again.
+        wedged.set()
+        for _ in range(200):
+            if info.id not in manager._abandoned_state_writers:
+                break
+            await asyncio.sleep(0.01)
+    assert info.id not in manager._abandoned_state_writers, (
+        "the hold outlived the worker -- a conversation would stay permanently "
+        "un-promotable and un-releasable"
+    )
+    assert manager._conversation_busy(conv_key) is None
+
+
+def test_no_bare_to_thread_update_state_outside_the_drained_helper() -> None:
+    """Build gate: the drain invariant must not be convention-only.
+
+    "Every off-loop ``state.json`` writer is drained on cancellation" holds only
+    while writers call ``_write_state_off_loop`` instead of a bare
+    ``asyncio.to_thread(update_state, ...)``. That is precisely the divergence
+    this change had to repair: three structurally identical sites, one given a
+    drain by #6306 and two left bare, 300 lines apart in one file and identical
+    at the call. A convention cannot catch that; a gate can (Design Review on
+    #6298/#6308, matching the repo's other static gates -- see
+    ``test_no_blocking_call_on_loop.py``).
+
+    Deterministic and false-positive-free: an off-loop ``update_state`` has no
+    legitimate undrained form, so exactly one call site is allowed -- the
+    helper's own.
+    """
+    import ast
+    from pathlib import Path
+
+    allowed = "_write_state_off_loop_impl"
+    src = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+    assert src.is_dir(), src
+
+    class _Scan(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.stack: list[str] = []
+            self.hits: list[tuple[str, int]] = []
+
+        def _enter(self, node: Any) -> None:
+            self.stack.append(node.name)
+            self.generic_visit(node)
+            self.stack.pop()
+
+        visit_FunctionDef = _enter
+        visit_AsyncFunctionDef = _enter
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            # A nested callable is a separate frame, so it must not inherit the
+            # helper's exemption (same scope rule as
+            # test_no_blocking_call_on_loop.py).
+            self.stack.append("<lambda>")
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            fn = node.func
+            if (
+                isinstance(fn, ast.Attribute)
+                and fn.attr == "to_thread"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == "update_state"
+                and (not self.stack or self.stack[-1] != allowed)
+            ):
+                self.hits.append((self.stack[-1] if self.stack else "<module>", node.lineno))
+            self.generic_visit(node)
+
+    offenders: list[str] = []
+    for path in sorted(src.rglob("*.py")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - unreadable source
+            continue
+        # Cheap pre-filter: only a handful of modules mention either name, and
+        # `ast.parse` over the whole package is by far the expensive part. A
+        # substring miss cannot hide a call, because the pattern this gate looks
+        # for spells both names literally.
+        if "to_thread" not in text or "update_state" not in text:
+            continue
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:  # pragma: no cover - unparseable source
+            continue
+        scan = _Scan()
+        scan.visit(tree)
+        rel = path.relative_to(src.parent.parent)
+        offenders += [f"{rel}:{line} (in {func})" for func, line in scan.hits]
+
+    assert not offenders, (
+        "bare `asyncio.to_thread(update_state, ...)` outside "
+        f"`{allowed}`: " + ", ".join(offenders) + ". An off-loop state write must go "
+        "through the helper, which drains the worker on cancellation -- an "
+        "undrained worker outlives its run and its stale whole-file rewrite rolls "
+        "back every field written after its read (#6298, #6308)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_conversation_hold_covers_the_whole_drain_not_only_expiry() -> None:
+    """#6298 review (GPT round 3): the hold must start at the CANCELLATION, not
+    at the drain deadline.
+
+    On Python 3.10 a second outer cancel can interrupt ``wait_for``'s
+    ``_cancel_and_wait`` and deliver ``_run``'s finalization while the drain is
+    still in flight -- so a run can go ``done`` with a live writer and WITHOUT
+    ever reaching the expiry branch. A hold armed only on expiry leaves that whole
+    window open, and a continuation reaching a released gate writes ``keep`` for
+    the live writer to erase. Here the drain keeps its real bound (never expires),
+    so the hold under test can only come from the cancellation itself.
+    """
+    import asyncio
+
+    from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+    event = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        title="grep",
+        tool_kind="read",
+        request_id="req-1",
+    )
+    sessions = _mock_sessions_with_tool_event("model-served", event)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="middrn1", task="mid-drain hold task", model="model-req")
+    manager._agents[info.id] = info
+    conv_key = f"subagent:{info.id}"
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        if "turns" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, conv_key))
+        try:
+            await entered.wait()
+            task.cancel()
+            await _event_loop_checkpoint()
+            # Mid-drain: the deadline has NOT passed, so nothing has been
+            # abandoned -- yet the writer is live and the conversation must
+            # already be held, because a 3.10 double-cancel could finalize the
+            # run right here.
+            assert info._state_drain_active is True, "not draining -- test setup wrong"
+            assert info.id in manager._abandoned_state_writers, (
+                "the conversation is unheld while a writer is live mid-drain -- a "
+                "3.10 double-cancel finalization would let a continuation write "
+                "`keep` for that writer to erase (#6298)"
+            )
+            # Simulate exactly that: the run finalizes while the drain is live.
+            info.done = True
+            held = manager._conversation_busy(conv_key)
+            assert held is not None and held._state_writer_abandoned is True, (
+                "a finished run whose writer is still in-drain must keep holding "
+                "its conversation"
+            )
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Drained normally (never expired), so the one-shot recovery is intact.
+        assert info._cancel_retry_used is False, "a completed drain must not burn the retry"
+        for _ in range(200):
+            if info.id not in manager._abandoned_state_writers:
+                break
+            await asyncio.sleep(0.01)
+    assert info.id not in manager._abandoned_state_writers, "hold outlived the worker"
+    assert manager._conversation_busy(conv_key) is None

--- a/test/test_subagent_state_write_serialization.py
+++ b/test/test_subagent_state_write_serialization.py
@@ -346,3 +346,130 @@ class TestLockRegistry:
             holder.lock.release()
             worker.join(timeout=10.0)
         assert not worker.is_alive()
+
+
+def _park_first_writer_late(monkeypatch, inside: threading.Event, delay: float) -> None:
+    """Patch ``_atomic_write`` so the FIRST writer announces itself, then lands
+    *delay* seconds later.
+
+    The announcement marks the point where the writer's READ has already
+    happened, so anything written after it is what a stale rewrite would roll
+    back. The delay is what puts the writer's WRITE after the on-loop write
+    under test -- unserialized and undrained, that ordering is the clobber.
+    """
+    real_atomic_write = sp._atomic_write
+    seen: list[str] = []
+    guard = threading.Lock()
+
+    def instrumented(path, data):
+        with guard:
+            first = not seen
+            if first:
+                seen.append("parked")
+        if first:
+            inside.set()
+            time.sleep(delay)
+        real_atomic_write(path, data)
+
+    monkeypatch.setattr(sp, "_atomic_write", instrumented)
+
+
+def _mock_sessions_for_run(served_model: str):
+    """Minimal SessionManager double: enough to drive ``_run_inner`` to its
+    pre-spawn provenance write and no further."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    provider = AsyncMock()
+    provider.start = AsyncMock()
+    provider.shutdown = AsyncMock()
+    provider.context_usage_pct = lambda: 0.0
+    provider.context_used_tokens = lambda: 0
+    provider.context_window_tokens = lambda: 0
+    provider.client = None
+    provider.served_model = served_model
+
+    async def _empty_stream(*_args: object, **_kwargs: object):  # type: ignore[no-untyped-def]
+        return
+        yield  # noqa: unreachable -- makes this an async generator
+
+    provider.stream = MagicMock(side_effect=lambda *a, **kw: _empty_stream())
+    sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.record_success = MagicMock()
+    sessions.get_agent = MagicMock(return_value="")
+    return sessions
+
+
+def _mock_ctx_builder_for_run():
+    from unittest.mock import MagicMock
+
+    ctx = MagicMock()
+    ctx.build_message = MagicMock(return_value=("built_message", None))
+    ctx.hooks.on_tool_call = MagicMock()
+    ctx.hooks.auto_approve_subagent_spawn = False
+    return ctx
+
+
+class TestOnLoopKeepWriteAgainstACancelledRunsWorker:
+    """#6298: the on-loop retention ``keep`` write must not be rolled back.
+
+    ``_promote_conversation`` / ``release_conversation`` write ``keep`` from the
+    event loop, where ``update_state`` deliberately takes no lock -- so a
+    concurrent pool writer's stale whole-file rewrite erases it. Both are reached
+    only through the ``_conversation_busy`` gate, which refuses while a run is in
+    flight, so the one writer that can still be concurrent is a DETACHED worker:
+    one whose ``to_thread`` await was cancelled while the write was in flight.
+    Draining every off-loop writer on cancellation (#6308) removes that
+    population, which closes this interleave too -- a pool writer can no longer
+    outlive the run it belongs to.
+    """
+
+    @pytest.mark.asyncio
+    async def test_keep_survives_a_cancelled_runs_provenance_worker(self, agent_root, monkeypatch):
+        from unittest.mock import patch
+
+        from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+        conv_id = "keep01"
+        _new_agent(conv_id)
+        inside = threading.Event()
+        # Long enough that an UNDRAINED cancellation reliably reaches the on-loop
+        # keep write first, short enough to stay well inside the 5s drain bound.
+        _park_first_writer_late(monkeypatch, inside, delay=0.4)
+
+        manager = SubagentManager(
+            sessions=_mock_sessions_for_run("model-served"),
+            ctx_builder=_mock_ctx_builder_for_run(),
+            is_yolo=lambda: True,
+        )
+        info = SubagentInfo(id=conv_id, task="keep vs zombie", model="model-req")
+        manager._agents[info.id] = info
+
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
+            task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{conv_id}"))
+            assert await asyncio.to_thread(inside.wait, 5.0), "provenance write never started"
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # The run's cancellation has settled. This is where a release or a
+            # continuation promotes retention on the loop; nothing may still be
+            # holding a pre-promote snapshot of state.json.
+            manager._agents.pop(info.id, None)
+            assert manager._conversation_busy(f"subagent:{conv_id}") is None
+            manager._promote_conversation(conv_id, f"subagent:{conv_id}")
+
+        # Give any worker that was NOT drained time to land its stale rewrite.
+        await asyncio.sleep(0.6)
+        state = sp.read_state(conv_id)
+        assert state is not None
+        assert state.get("keep") is True, (
+            "the on-loop keep write was rolled back by a detached worker's stale "
+            "whole-file rewrite -- retention is lost, so the tombstone pruner "
+            "deletes session files the conversation needs (#6298)"
+        )
+        # The worker's own field still landed: the drain waits for it, it is not
+        # discarded.
+        assert state.get("requested_model") == "model-req"


### PR DESCRIPTION
## 1. What is the problem?

`subagent_persistence.update_state` is a read / merge / **whole-file** rewrite.
It writes back the snapshot it read, so any writer that runs late rolls back
*every* field landed after its read -- not just the fields it names.

Three of a run's `state.json` writers run off-loop via
`await asyncio.to_thread(update_state, ...)`. Cancelling such an await
**detaches the worker without stopping it**. PR #6306 closed that for one of the
three (the per-turn diagnostics write) with an inline shield-and-drain; the other
two were left as bare awaits:

- pre-spawn model provenance (`requested_model` / `resolved_model`)
- CC-path model refinement (`resolved_model`, on the first text chunk)

So a cancelled run could still leave a live writer behind (#6308). Separately,
`keep` is written from the **event loop**, where `update_state` deliberately
takes no per-agent lock (#7280) -- `_promote_conversation_impl` and
`release_conversation_impl` -- and a detached worker's stale rewrite erases it
(#6298).

## 2. Why this issue matters to the user

Both rollbacks destroy state that other machinery acts on:

- A lost `pid` / `session_id` means the reaper can no longer reach the child
  process. That is a leaked `kiro-cli` process holding its memory for the life of
  the gateway, and a session whose files are never cleaned up.
- A lost `keep` means the conversation is no longer marked as resume material, so
  the tombstone pruner deletes the session files `spawn_continue` needs. The next
  continuation answers `conversation_gone` and the accumulated context is gone --
  from the user's side, the agent forgot a conversation it promised to keep.

Both are silent. Nothing logs a rollback, because from `update_state`'s point of
view every write succeeded.

## 3. How our fix solves it

The chain is: whole-file rewrite -> a detached worker is a stale writer -> a
detached worker is only possible because a cancelled `to_thread` await abandons
its worker. So the fix is at the last link, for **every** off-loop writer rather
than one of them.

`_write_state_off_loop(info, what, **fields)` is #6306's shield-and-drain,
extracted verbatim and parameterised by a label. All three off-loop writers now
go through it, and the inline 99-line block at the diagnostics site collapses to
a 5-line call. The helper is the single place that answers "what happens to a
state write when the run is cancelled".

**The on-loop half closes as a consequence, without moving those callers
off-loop.** `_promote_conversation_impl` and `release_conversation_impl` are both
reached only through `_conversation_busy`, which refuses while a run is in flight
(`continue_conversation_impl` returns `conversation_busy` before it ever reaches
the promote; `release_conversation_impl` returns it as its first act). The gate
tests `not a.done`, so the one writer it cannot see is a worker that outlived its
run -- exactly the population this PR removes. No triage pass on #6298 had
noticed the gate, which is why the issue reads as needing the loop-side offload.

Three per-site rulings the triage passes parked as human decisions collapse once
the whole-file rewrite is taken seriously, so the helper needs no per-site flags:

1. **Does a drain expiry consume the one-shot `_cancel_retry_used`?** Yes, at
   every site, as #6306 already did at its own. The reason is not which fields a
   caller named: an abandoned worker's rewrite is whole-file, so its blast radius
   is identical everywhere. Letting a recovery run respawn while a zombie is live
   trades one lost `pid` (an unreapable orphan) for one best-effort auto-continue
   on an FS already wedged past the deadline -- the wrong way round.
2. **Does the recovery-gate latch apply at the new sites?** Yes, same reasoning,
   which is why it is set inside the helper. It is renamed
   `_diag_drain_active` -> `_state_drain_active` (and `_DIAG_DRAIN_TIMEOUT` ->
   `_STATE_DRAIN_TIMEOUT`): leaving "diag" in the name would tell the next reader
   only the turn-counter write raises it.
3. **How does the drain compose with the provenance site's two-attempt retry
   loop?** Per attempt, and a cancellation ends the loop. This needs no code:
   `except Exception` does not catch `CancelledError`, so the helper's post-drain
   re-raise propagates out of the loop instead of starting a second writer for
   the same fields. A test pins it.

The drain is deliberately **bounded** (5s): `cancel_all()` gathers run tasks with
no timeout, so an unbounded drain on a wedged FS would hold gateway shutdown open
forever -- the posture `_REPORT_DRAIN_TIMEOUT` already sets. That bound means a
worker CAN be abandoned, and an abandoned worker is a stale writer. Rather than
leave that as a residual, the run marks `_state_writer_abandoned` on expiry and
keeps HOLDING its conversation until the worker settles, so the two on-loop `keep`
writers are deferred past the zombie instead of being undone by it. The hold rides
the gate that already guards both of them (`_conversation_busy`), is cleared by the
worker's own done-callback, and fails open to today's behaviour once a run is
evicted from `_agents`. Both refusal messages were reworded for the case: the old
text told the caller to "wait for its completion event", which has already fired.

Still true and stated in `update_state`'s docstring rather than left implied:
on-loop callers pay this function's fsync on the loop.

## 4. What tests we did

Three new tests, each verified RED on `origin/main` with the fix reverted:

| Test | Failure on base |
| --- | --- |
| `test_provenance_write_is_drained_on_cancellation` | `cancelled _run_inner completed while the pre-spawn provenance write was in flight` |
| `test_cc_refinement_write_is_drained_on_cancellation` | same, for the CC-path refinement site |
| `test_keep_survives_a_cancelled_runs_provenance_worker` | `assert None is True` -- `keep` was rolled back by the detached worker |

A fourth pins the drain-EXPIRY path and a fifth enforces the invariant. Neither
has a base equivalent (both mechanisms are new), so both are mutation-verified
instead -- three mutants each, three reds each:

- `test_an_abandoned_state_writer_holds_the_conversation` expires the drain
  against a wedged worker, asserts the conversation is held, asserts the hold
  survives clearing `_agents` outright, asserts `release_conversation` refuses
  with the reworded detail, then releases the worker and asserts the hold clears.
  Mutants: gate ignores the manager registry; keep the record on the run's
  `SubagentInfo` instead of the manager (an eviction then releases the hold);
  never discard on completion (a permanently un-promotable conversation).
- `test_no_bare_to_thread_update_state_outside_the_drained_helper` is a static
  gate: it AST-walks `src/kiro_crew/` and fails on any
  `asyncio.to_thread(update_state, ...)` whose enclosing frame is not
  `_write_state_off_loop_impl`, so "every off-loop writer is drained" stops being
  convention. Same shape as `test_no_blocking_call_on_loop.py`, including its
  scope rule that a nested `def` / `lambda` is a separate frame. Mutants: a bare
  call in another function; the same call in a nested `lambda` inside the helper;
  the same call in an unrelated module.

The third table row is the end-to-end for this PR's on-loop claim: real
`update_state` against a temp subagents dir, a real thread parked between its read
and its write, `_run_inner` cancelled, then `_promote_conversation` on the loop. On
base the zombie lands after the promote and `keep` is gone; with the drain the
cancellation cannot settle until the worker has landed, so the promote is strictly
after it.

Regression scope: every test file that touches the run path, cancellation,
`update_state`, the conversation gate, or agent eviction -- **2038 passed**,
including all of #6306's hardened drain tests unchanged (proof the extraction is
behaviour-preserving) and `test_no_blocking_call_on_loop.py`. Gates:
`scripts/check_black_formatting.py`
passes, isort and flake8 clean on the five touched files, mypy clean on the three
source files (the 2 remaining errors are pre-existing boto3-stub drift in
`transcribe.py`, untouched here).

## 5. Any other suggestions on the work

- **#7302 is NOT subsumed.** It asks for the five on-loop callers to move off the
  loop, and its motivation is the `no-blocking-call-on-event-loop` anchor: those
  callers still perform a synchronous fsync on the loop, which this PR does not
  change. What #6298 / #6308 asked for was the *interleave*, and that is what
  closes here. #7302 should stay open on its own (weaker) merits -- a
  loop-blocking fsync -- and it no longer has to carry two named defects, nor the
  three rulings above.
- The structural alternative is now **filed as #7515** rather than deferred again,
  at Design Review's request: `update_state` writing whole-file is what makes any
  late writer a stale writer, and three PRs (#6306, #7280, this one) have each
  fenced it and each explicitly declined to remove it. #7515 states the root cause,
  lists what all three added, and puts the options (versioned CAS / per-field write
  / keep fencing) with their costs, noting #7302 belongs to the same decision. This
  PR fences the last reachable path; it does not remove the class, and folding a
  persistence-format change in here would be a different blast radius.

## Pattern harvest

Rule candidate: lint -- SHIPPED IN THIS PR as
`test_no_bare_to_thread_update_state_outside_the_drained_helper`, at Design
Review's request: an AST gate over `src/kiro_crew/` failing on any
`asyncio.to_thread(update_state, ...)` outside the drained helper. All three sites
in this PR would have matched it; one had already been fixed by hand (#6306) and
the other two had not, which is exactly the shape a gate catches and a code review
does not -- the fixed site and the bare sites sit 300 lines apart in one file and
look identical at the call. Generalisable beyond this call: flag
`await asyncio.to_thread(<f>, ...)` where `<f>` is a read-modify-write on shared
durable state and the await is not shielded.

Rule candidate: review-prompt -- when a helper takes `**fields` and rewrites a
whole file, ask whether it has one caller-facing wrapper per concurrency context.
Three call-shapes for one primitive (bare on-loop, bare off-loop, drained
off-loop) is what let the divergence exist and persist across two PRs. The
generalisation is the deeper lesson: for a whole-file read-modify-write, "which
fields did this writer name" is never the right question -- the blast radius is
every field, so per-site rulings about which fields are safe to lose are
answering a question that does not apply.

Closes #6298
Closes #6308


