### PR TITLE
ci: annotate a red pytest job with the tests that failed, not a warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,20 @@ jobs:
           REDUCED: ${{ steps.scope.outputs.reduced }}
           TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
         run: |
+          # Take the `python` problem matcher registered by actions/setup-python
+          # out of scope before pytest writes a line. Its pattern is a traceback
+          # frame followed by `raise SomeError('msg')`, matched anywhere in the
+          # log -- including inside pytest's warnings summary. MEASURED on the six
+          # jobs in #7296: it matched a warning traceback every time and a pytest
+          # failure not once, so every red was annotated `Event loop is closed`
+          # at asyncio/base_events.py's line 545 while the tests that actually
+          # failed were named in no annotation at all, and four unrelated PRs
+          # were misdiagnosed as an event-loop teardown flake. conftest.py's
+          # `pytest_terminal_summary` now emits the annotations from pytest's own
+          # report objects; this keeps a louder wrong answer off the check run.
+          # Not `add-problem-matchers: false`: that input does not exist on this
+          # action pin, and passing it only adds an "Unexpected input(s)" warning.
+          echo "::remove-matcher owner=python::"
           # Reduced scope (frontend-only diff): run just the cross-surface
           # files, still sharded, with coverage off -- a subset's coverage is
           # not comparable to the repo floor, so Coverage Combine/Gate skip the
@@ -785,6 +799,10 @@ jobs:
         # uninterpretable one at the 40-minute cap.
         shell: bash
         run: |
+          # Same as backend-test (#7296): the `python` matcher annotates any
+          # traceback in the log, including one printed inside a warning, and
+          # never matches a pytest failure.
+          echo "::remove-matcher owner=python::"
           pytest -q -n auto --timeout=180 --no-cov --max-worker-restart=0 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }}
         # Nothing is deselected here either, and the same guards carry it: Windows has no
@@ -846,6 +864,10 @@ jobs:
       - name: Assert the macOS peer-identity canary runs (not skipped)
         run: |
           set -o pipefail
+          # Same as backend-test (#7296): the `python` matcher annotates any
+          # traceback in the log, including one printed inside a warning, and
+          # never matches a pytest failure.
+          echo "::remove-matcher owner=python::"
           pytest -v -n0 --no-cov --timeout=120 \
             "test/test_socketsec.py::test_macos_check_matches_a_socket_we_connected_to_ourselves" \
             | tee canary.log
@@ -928,6 +950,10 @@ jobs:
         # `coverage-combine` taught to consume it, which couples the coverage gate to a
         # job it does not depend on today. Separate change; the omit carries the pointer.
         run: |
+          # Same as backend-test (#7296): the `python` matcher annotates any
+          # traceback in the log, including one printed inside a warning, and
+          # never matches a pytest failure.
+          echo "::remove-matcher owner=python::"
           pytest -q --timeout=180 --no-cov \
             test/test_script_hooks.py \
             test/test_cron_script.py \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,11 @@ jobs:
           # deselect list any more: if the sysctl is reverted, those tests skip
           # themselves on `skipif(not userns_available())` and the rest of the suite
           # still runs -- which is what ci.yml's sharded matrix relies on too.
+          # Same as ci.yml's pytest jobs (#7296): the `python` problem matcher
+          # actions/setup-python registers annotates any traceback in the log,
+          # including one printed inside a pytest warning, and never matches a
+          # pytest failure. conftest.py emits the real annotations instead.
+          echo "::remove-matcher owner=python::"
           pytest -q -n auto --timeout=120 --no-cov
 
   resolve-promotion:

--- a/.github/workflows/test-durations.yml
+++ b/.github/workflows/test-durations.yml
@@ -58,6 +58,11 @@ jobs:
         # durations now; the tests inside them that need a namespace sandbox skip here
         # (this runner has none) and a skip is measured as the near-zero it is.
         run: |
+          # Same as ci.yml's pytest jobs (#7296): the `python` problem matcher
+          # actions/setup-python registers annotates any traceback in the log,
+          # including one printed inside a pytest warning, and never matches a
+          # pytest failure. conftest.py emits the real annotations instead.
+          echo "::remove-matcher owner=python::"
           pytest -q -n auto --timeout=120 --no-cov --store-durations || true
           test -f .test_durations || { echo "::error::no .test_durations produced"; exit 1; }
 

--- a/conftest.py
+++ b/conftest.py
@@ -2526,3 +2526,151 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         "cwd=<a directory under tmp_path> to the spawn, and scope any assertion "
         "about the file to where that child actually ran."
     )
+
+
+# ── Check-run annotations that name the failing test (issue #7296) ──────────
+#
+# A red shard is read from its check run's ANNOTATIONS, not from the log: that
+# is what the PR page shows, what a fork contributor sees, and all that survives
+# in a triage report. Nothing in this repo wrote one, so the annotations came
+# from the `python` problem matcher that `actions/setup-python` registers by
+# default, whose pattern is a traceback frame (`File "...", line N, in f`)
+# followed by `raise SomeError('msg')`.
+#
+# MEASURED on the six Backend Tests jobs cited in #7296: that pattern matched
+# pytest's WARNINGS SUMMARY every time and a pytest failure not once. All six
+# reds were annotated only `Event loop is closed` at line 545 -- which is
+# `asyncio/base_events.py:545` inside `_check_closed`, reached from a
+# `PytestUnraisableExceptionWarning` about a garbage-collected coroutine, i.e. a
+# WARNING. The reds themselves were ordinary named failures (a `git add`
+# timeout, a missing diag.jsonl, sandbox-dependent project tests) and appeared
+# in no annotation at all. Four unrelated PRs were triaged as an event-loop
+# teardown flake on the strength of that, and the class had been "fixed" four
+# times before.
+#
+# Replacing the matcher with a better matcher is not the fix. `--color=yes` is
+# in the addopts, so the summary line a matcher would have to scrape reads
+# `\x1b[31mFAILED\x1b[0m test/x.py::\x1b[1mtest_y\x1b[0m - AssertionError: ...`
+# with escape sequences INSIDE the node id. The report objects already carry the
+# path, the line and the node id as data, so the annotation is emitted from them
+# here and nothing is parsed back out of rendered output.
+
+#: Failures that get their own annotation before the rest are only counted.
+#: GitHub keeps a bounded number per check run and drops the excess with no
+#: notice, so past this point the annotation list stops being something anyone
+#: reads and the short test summary in the log is the better artifact.
+_MAX_ANNOTATED_FAILURES = 10
+
+#: Annotation messages are cut to this many characters. A full assertion diff is
+#: a page long, does not fit the check-run UI, and is already in the log.
+_MAX_ANNOTATION_CHARS = 400
+
+
+def _gha_escape(value: str, *, is_property: bool) -> str:
+    """Escape *value* for a GitHub Actions workflow command.
+
+    The runner splits a command on ``,`` and on ``::``, and every pytest node id
+    contains ``::`` -- unescaped, the annotation is truncated at the first one
+    and names the FILE instead of the test, which is most of the defect this
+    exists to fix. Property values need the two structural characters escaped on
+    top of the data set, per the workflow-commands spec.
+    """
+    escaped = value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if is_property:
+        escaped = escaped.replace(":", "%3A").replace(",", "%2C")
+    return escaped
+
+
+def _report_location(report: object) -> tuple[str, int | None]:
+    """Repository-relative path and 1-based line for *report*, best effort.
+
+    ``report.location`` is a ``(path, lineno, domain)`` triple whose line is
+    0-BASED, while an annotation line is 1-based. A collection error carries no
+    line at all, and a guessed one points the reader at the wrong statement, so
+    ``None`` means "omit ``line=``" rather than "line 1".
+    """
+    location = getattr(report, "location", None) or ()
+    path = location[0] if len(location) >= 1 and isinstance(location[0], str) else ""
+    if not path:
+        path = str(getattr(report, "fspath", "") or "")
+    raw_line = location[1] if len(location) >= 2 else None
+    line = raw_line + 1 if isinstance(raw_line, int) and raw_line >= 0 else None
+    return path, line
+
+
+def _cut(reason: str) -> str:
+    """*reason* trimmed to :data:`_MAX_ANNOTATION_CHARS`."""
+    reason = reason.strip()
+    if len(reason) > _MAX_ANNOTATION_CHARS:
+        return reason[: _MAX_ANNOTATION_CHARS - 3] + "..."
+    return reason
+
+
+def _failure_reason(report: object) -> str:
+    """One-line reason for *report*, cut to :data:`_MAX_ANNOTATION_CHARS`.
+
+    Prefers the line pytest marks with ``E`` in the first column, which is the
+    error itself. ``longrepr.reprcrash.message`` looks like the obvious source
+    and is right for an assertion, but for a FIXTURE error it is the preamble --
+    MEASURED, an annotation built from it reads ``file <path>, line 5`` and
+    spends its whole width saying nothing, while the ``E`` line two rows down
+    says ``fixture 'x' not found``. Source lines in the same block are indented,
+    so anchoring at column 0 does not mistake a statement for the verdict.
+
+    ``reprcrash`` is the fallback, then the first rendered line; a report with
+    none of the three still gets an annotation, because the node id was the part
+    that was missing.
+    """
+    rendered = str(getattr(report, "longreprtext", "") or "")
+    for raw in rendered.splitlines():
+        if raw.startswith("E ") and raw[1:].strip():
+            return _cut(raw[1:])
+    crash = getattr(getattr(report, "longrepr", None), "reprcrash", None)
+    reason = str(getattr(crash, "message", "") or "")
+    if not reason.strip():
+        reason = rendered
+    lines = [line for line in reason.strip().splitlines() if line.strip()]
+    if not lines:
+        return "no failure detail in the report"
+    return _cut(lines[0])
+
+
+def pytest_terminal_summary(
+    terminalreporter: object, exitstatus: int, config: pytest.Config
+) -> None:
+    """Emit one ``::error`` annotation per failing test. See the note above.
+
+    Controller-only: under xdist a worker's reports are sent back and counted
+    here, so annotating from the worker too would double every line. Gated on
+    ``GITHUB_ACTIONS`` because outside Actions these lines are noise nothing
+    interprets, and a green run writes nothing at all.
+    """
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return
+    if hasattr(config, "workerinput"):  # pragma: no cover - xdist worker
+        return
+    stats = getattr(terminalreporter, "stats", None) or {}
+    reports = [report for key in ("failed", "error") for report in stats.get(key, [])]
+    if not reports:
+        return
+    write = getattr(terminalreporter, "write_line", None)
+    if write is None:  # pragma: no cover - no terminal reporter (e.g. -p no:terminal)
+        return
+    for report in reports[:_MAX_ANNOTATED_FAILURES]:
+        nodeid = str(getattr(report, "nodeid", "") or "") or "<unknown test>"
+        path, line = _report_location(report)
+        properties = []
+        if path:
+            properties.append(f"file={_gha_escape(path, is_property=True)}")
+        if line is not None:
+            properties.append(f"line={line}")
+        properties.append(f"title={_gha_escape(nodeid, is_property=True)}")
+        message = _gha_escape(f"{nodeid} - {_failure_reason(report)}", is_property=False)
+        write(f"::error {','.join(properties)}::{message}")
+    hidden = len(reports) - _MAX_ANNOTATED_FAILURES
+    if hidden > 0:
+        write(
+            f"::notice::{len(reports)} tests failed or errored on this job; the first "
+            f"{_MAX_ANNOTATED_FAILURES} are annotated. The remaining {hidden} are in "
+            "this job's short test summary."
+        )

--- a/test/test_ci_failure_annotations.py
+++ b/test/test_ci_failure_annotations.py
@@ -1,0 +1,406 @@
+"""A red pytest job must annotate the TESTS that failed (issue #7296).
+
+Annotations are what a check run shows: the PR page renders them, a fork
+contributor who cannot re-run a job has nothing else, and a triage report copies
+them. Nothing in this repository wrote one, so they came from the ``python``
+problem matcher ``actions/setup-python`` registers by default -- a two-line
+pattern (a traceback frame, then ``raise SomeError('msg')``) applied to the whole
+log, including the part where pytest prints its WARNINGS summary.
+
+MEASURED on the six Backend Tests jobs cited in #7296: that pattern matched a
+warning traceback every time and a pytest failure not once. All six reds carried
+only ``Event loop is closed`` at line 545 -- ``asyncio/base_events.py`` inside
+``_check_closed``, reached from a ``PytestUnraisableExceptionWarning`` about a
+garbage-collected coroutine -- while the tests that actually failed (a ``git
+add`` timeout, a missing diag.jsonl, sandbox-dependent project tests) were named
+nowhere. Four unrelated PRs were filed and triaged as an event-loop teardown
+flake on that evidence.
+
+So these tests pin the two halves of the answer: the rootdir conftest turns each
+failing report into an annotation that names the test, and every workflow job
+that runs pytest has the matcher that used to lie turned off.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_ROOT_CONFTEST = _REPO_ROOT / "conftest.py"
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+
+
+def _load_root_conftest():
+    """Import the rootdir conftest under its own module name.
+
+    ``from conftest import ...`` inside ``test/`` binds to ``test/conftest.py``
+    (prepend import mode puts this directory on ``sys.path`` first), so the
+    rootdir file has to be loaded by path. Same idiom as
+    ``test_host_isolation_floor.py``; the fixtures it defines are inert here
+    because nothing in this namespace collects them.
+    """
+    spec = importlib.util.spec_from_file_location("_kirocrew_annotations_conftest", _ROOT_CONFTEST)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_root = _load_root_conftest()
+
+
+class _Reporter:
+    """Minimal stand-in for pytest's terminal reporter."""
+
+    def __init__(self, stats: dict[str, list[object]]) -> None:
+        self.stats = stats
+        self.lines: list[str] = []
+
+    def write_line(self, line: str) -> None:
+        self.lines.append(line)
+
+
+def _report(
+    nodeid: str,
+    *,
+    path: str = "test/test_thing.py",
+    lineno: int | None = 41,
+    message: str = "AssertionError: assert False",
+) -> SimpleNamespace:
+    """A stand-in carrying the attributes the emitter reads off a real report."""
+    location = (path, lineno, nodeid) if path else ()
+    return SimpleNamespace(
+        nodeid=nodeid,
+        location=location,
+        longrepr=SimpleNamespace(reprcrash=SimpleNamespace(message=message)),
+        longreprtext=message,
+    )
+
+
+def _emit(stats: dict[str, list[object]], monkeypatch: pytest.MonkeyPatch) -> _Reporter:
+    """Run the hook as GitHub Actions would and return what it wrote."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    reporter = _Reporter(stats)
+    _root.pytest_terminal_summary(reporter, 1, SimpleNamespace())
+    return reporter
+
+
+class TestTheAnnotationNamesTheFailingTest:
+    """The whole point: a reader of the check run learns which test failed."""
+
+    def test_a_failure_is_annotated_with_its_node_id_file_and_line(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """File and line come from ``report.location``, which is 0-based."""
+        nodeid = "test/test_md_notebook.py::test_sync_refuses_rather_than_pushing_a_subset"
+        reporter = _emit(
+            {"failed": [_report(nodeid, path="test/test_md_notebook.py", lineno=41)]},
+            monkeypatch,
+        )
+
+        assert len(reporter.lines) == 1, reporter.lines
+        line = reporter.lines[0]
+        assert line.startswith("::error "), line
+        assert "file=test/test_md_notebook.py" in line
+        # 41 is 0-based in the report; the annotation is 1-based.
+        assert "line=42" in line
+        assert "test_sync_refuses_rather_than_pushing_a_subset" in line
+        assert line.endswith("AssertionError: assert False")
+
+    def test_setup_and_teardown_errors_are_annotated_too(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``error`` is a separate stats bucket, and it reds the job the same way."""
+        reporter = _emit(
+            {"error": [_report("test/test_x.py::test_y", message="ImportError: no module")]},
+            monkeypatch,
+        )
+
+        assert len(reporter.lines) == 1, reporter.lines
+        assert "test_y" in reporter.lines[0]
+        assert reporter.lines[0].endswith("ImportError: no module")
+
+    def test_a_collection_error_without_a_line_omits_the_line_property(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A guessed line points the reader at an unrelated statement."""
+        reporter = _emit(
+            {"error": [_report("test/test_x.py", path="test/test_x.py", lineno=None)]},
+            monkeypatch,
+        )
+
+        assert "line=" not in reporter.lines[0], reporter.lines[0]
+        assert "file=test/test_x.py" in reporter.lines[0]
+
+    def test_a_report_with_no_failure_detail_still_names_the_test(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Losing the reason is survivable; losing the test id is the defect."""
+        report = _report("test/test_x.py::test_y", message="")
+        report.longreprtext = ""
+        reporter = _emit({"failed": [report]}, monkeypatch)
+
+        assert "test/test_x.py::test_y" in reporter.lines[0].replace("%3A", ":")
+        assert "no failure detail" in reporter.lines[0]
+
+    def test_a_fixture_error_reports_the_error_not_the_preamble(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``reprcrash`` is the preamble for this shape, MEASURED on a real run.
+
+        An annotation built from it reads ``file <path>, line 5`` and spends its
+        whole width saying nothing. The verdict is the ``E`` line below it.
+        """
+        report = _report("test/test_x.py::test_y", message="file /repo/test/test_x.py, line 5")
+        report.longreprtext = (
+            "file /repo/test/test_x.py, line 5\n"
+            "      def test_y(nonexistent_fixture):\n"
+            "E       fixture 'nonexistent_fixture' not found\n"
+            ">       available fixtures: anyio_backend, cache\n"
+        )
+        reporter = _emit({"failed": [report]}, monkeypatch)
+
+        assert reporter.lines[0].endswith("fixture 'nonexistent_fixture' not found")
+
+    def test_an_indented_source_line_is_not_mistaken_for_the_verdict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pytest puts its marker in column 0; a statement is indented."""
+        report = _report("test/test_x.py::test_y", message="AssertionError: boom")
+        report.longreprtext = "      E = compute()\nE       AssertionError: boom\n"
+        reporter = _emit({"failed": [report]}, monkeypatch)
+
+        assert reporter.lines[0].endswith("AssertionError: boom")
+
+
+class TestTheAnnotationSurvivesTheRunnersParser:
+    """The runner splits a workflow command on ``,`` and ``::``.
+
+    Every pytest node id contains ``::``, so an unescaped one truncates the
+    annotation at the first colon pair -- which would name the file and drop the
+    test, most of the defect this exists to fix.
+    """
+
+    def test_the_node_id_colons_are_escaped_in_the_title(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        reporter = _emit({"failed": [_report("test/test_x.py::TestC::test_y")]}, monkeypatch)
+        line = reporter.lines[0]
+
+        title = line.split("title=", 1)[1].split("::", 1)[0]
+        assert title == "test/test_x.py%3A%3ATestC%3A%3Atest_y", title
+
+    def test_a_parametrized_id_with_a_comma_is_escaped_in_the_title(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real id from the #7296 logs carried spaces, quotes and separators."""
+        nodeid = 'test/test_data_home_not_relocatable.py::test_alias[cd ~; mv "a,b" /tmp/x]'
+        reporter = _emit({"failed": [_report(nodeid)]}, monkeypatch)
+        # The command's own leading "::" is not a separator, so drop the prefix
+        # before splitting the property list off the message.
+        properties = reporter.lines[0][len("::error ") :].split("::", 1)[0]
+
+        assert "%2C" in properties, properties
+        # The property list must not gain a bare comma, which would read as the
+        # start of another property name.
+        assert properties.count(",") == 2, properties
+
+    def test_percent_signs_in_the_message_are_escaped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``%`` is the escape introducer, so it has to go first or it eats the rest."""
+        report = _report("test/test_x.py::test_y", message="")
+        report.longrepr = None
+        report.longreprtext = "AssertionError: 50% off"
+        reporter = _emit({"failed": [report]}, monkeypatch)
+
+        assert "%25" in reporter.lines[0]
+        assert "50% off" not in reporter.lines[0]
+
+    def test_line_breaks_are_escaped_rather_than_ending_the_command(self) -> None:
+        """A raw newline terminates the workflow command and drops the rest.
+
+        Exercised on the escaper directly: the emitter only ever passes it one
+        line, so a regression that stopped escaping breaks would be invisible
+        end-to-end until some report shape carried an embedded break.
+        """
+        escaped = _root._gha_escape("first\r\nsecond", is_property=False)
+
+        assert escaped == "first%0D%0Asecond"
+
+    def test_a_very_long_reason_is_truncated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A full assertion diff does not fit the check-run UI and is in the log."""
+        reporter = _emit(
+            {"failed": [_report("test/test_x.py::test_y", message="E" * 5000)]},
+            monkeypatch,
+        )
+
+        assert len(reporter.lines[0]) < 1000, len(reporter.lines[0])
+        assert reporter.lines[0].endswith("...")
+
+
+class TestTheAnnotationsStayBounded:
+    """GitHub keeps a bounded number per check run and drops the excess silently."""
+
+    def test_past_the_cap_the_rest_are_counted_not_annotated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cap = _root._MAX_ANNOTATED_FAILURES
+        reports = [_report(f"test/test_x.py::test_{i}") for i in range(cap + 7)]
+        reporter = _emit({"failed": reports}, monkeypatch)
+
+        errors = [line for line in reporter.lines if line.startswith("::error ")]
+        notices = [line for line in reporter.lines if line.startswith("::notice::")]
+        assert len(errors) == cap, len(errors)
+        assert len(notices) == 1, reporter.lines
+        assert f"{cap + 7} tests failed" in notices[0]
+        assert "remaining 7" in notices[0]
+
+    def test_exactly_the_cap_gets_no_notice(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An off-by-one here claims failures the job does not have."""
+        cap = _root._MAX_ANNOTATED_FAILURES
+        reports = [_report(f"test/test_x.py::test_{i}") for i in range(cap)]
+        reporter = _emit({"failed": reports}, monkeypatch)
+
+        assert all(line.startswith("::error ") for line in reporter.lines), reporter.lines
+
+
+class TestNothingIsWrittenWhenThereIsNothingToSay:
+    """These lines are noise anywhere they are not interpreted."""
+
+    def test_a_green_run_writes_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        reporter = _emit({"passed": [_report("test/test_x.py::test_y")]}, monkeypatch)
+
+        assert reporter.lines == []
+
+    def test_outside_github_actions_writes_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A developer's local red must not grow workflow-command lines."""
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        reporter = _Reporter({"failed": [_report("test/test_x.py::test_y")]})
+        _root.pytest_terminal_summary(reporter, 1, SimpleNamespace())
+
+        assert reporter.lines == []
+
+    def test_an_xdist_worker_writes_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The worker's reports are counted again on the controller.
+
+        Annotating from both would double every line, once per worker that saw the
+        test -- which is how a 2-failure shard reports 20 annotations.
+        """
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        reporter = _Reporter({"failed": [_report("test/test_x.py::test_y")]})
+        _root.pytest_terminal_summary(reporter, 1, SimpleNamespace(workerinput={}))
+
+        assert reporter.lines == []
+
+
+class TestTheMatcherThatLiedIsOffWhereverPytestRuns:
+    """The other half: nothing else may write a pytest job's annotations.
+
+    Asserted from the workflow SOURCE across EVERY workflow, keyed to whether the
+    job runs pytest, so a new pytest job cannot inherit the default matcher
+    unnoticed -- in ci.yml or anywhere else. Scoping this to ci.yml was the first
+    version and it left `release.yml` and `test-durations.yml` matched, which is
+    exactly the gap the guard exists to close (found in review).
+    """
+
+    _DIRECTIVE = "::remove-matcher owner=python::"
+
+    @staticmethod
+    def _runs_pytest(step: dict) -> bool:
+        return re.search(r"(?m)^\s*pytest\s", str(step.get("run", ""))) is not None
+
+    @classmethod
+    def _pytest_jobs(cls) -> dict[str, list[dict]]:
+        """``<workflow>:<job>`` -> its steps, for every job that runs pytest."""
+        found: dict[str, list[dict]] = {}
+        for path in sorted(_WORKFLOWS.glob("*.yml")):
+            document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            for name, job in (document.get("jobs") or {}).items():
+                steps = job.get("steps") or []
+                if any(cls._runs_pytest(step) for step in steps):
+                    found[f"{path.name}:{name}"] = steps
+        return found
+
+    def test_the_pytest_jobs_are_the_ones_this_covers(self) -> None:
+        """A guard whose subject list silently empties protects nothing."""
+        assert set(self._pytest_jobs()) >= {
+            "ci.yml:backend-test",
+            "ci.yml:backend-test-windows",
+            "ci.yml:backend-test-macos",
+            "ci.yml:backend-test-sandbox",
+            "release.yml:release-candidate-tests",
+            "test-durations.yml:refresh",
+        }, set(self._pytest_jobs())
+
+    def test_every_pytest_job_removes_the_python_matcher_before_pytest_runs(self) -> None:
+        """Its pattern matches a traceback, and a warning can print one (#7296).
+
+        Ordering matters and is asserted, not assumed: ``::remove-matcher`` takes
+        effect for the rest of the job from the point it is echoed, so a
+        directive placed after the pytest step would leave the run it was meant
+        to protect fully matched.
+        """
+        offenders = []
+        for name, steps in self._pytest_jobs().items():
+            first_pytest = next(i for i, step in enumerate(steps) if self._runs_pytest(step))
+            removed_at = [
+                i for i, step in enumerate(steps) if self._DIRECTIVE in str(step.get("run", ""))
+            ]
+            if not removed_at or min(removed_at) > first_pytest:
+                offenders.append(name)
+
+        assert not offenders, (
+            f"{offenders} run pytest with setup-python's `python` problem matcher still in "
+            "scope. It annotates any `File ...` + `raise X('msg')` pair in the log, "
+            "including one printed inside pytest's warnings summary, and it never matches "
+            f"a pytest failure -- so the check run names a warning and hides the red. Echo "
+            f"`{self._DIRECTIVE}` at or before the first step that runs pytest."
+        )
+
+    def test_no_workflow_passes_the_input_that_does_not_exist(self) -> None:
+        """``add-problem-matchers`` is not an input on this action pin.
+
+        It was the obvious first attempt and it is a trap: the action ignores it
+        and the runner answers with an ``Unexpected input(s)`` warning, which
+        becomes one more annotation saying nothing about the tests. MEASURED on
+        this PR's own first run, against ``actions/setup-python`` v7.0.0.
+
+        Checked against the PARSED step inputs, not the file text, so prose that
+        names the trap (this docstring's counterpart in ci.yml) does not trip it.
+        """
+        offenders = []
+        for path in sorted(_WORKFLOWS.glob("*.yml")):
+            document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            for name, job in (document.get("jobs") or {}).items():
+                for step in job.get("steps") or []:
+                    if "add-problem-matchers" in (step.get("with") or {}):
+                        offenders.append(f"{path.name}:{name}")
+
+        assert not offenders, (
+            f"{offenders} pass `add-problem-matchers` to an action that has no such input; "
+            "the runner warns and the matcher stays on. Echo "
+            f"`{self._DIRECTIVE}` in the job instead."
+        )
+
+    def test_the_emitter_lives_in_the_rootdir_conftest(self) -> None:
+        """``test/conftest.py`` is not loaded for the in-package app suites.
+
+        Those testpaths red the same jobs, so an emitter registered there would
+        leave exactly the runs that fail hardest with no annotation at all.
+        """
+        root = _ROOT_CONFTEST.read_text(encoding="utf-8")
+        suite = (_REPO_ROOT / "test" / "conftest.py").read_text(encoding="utf-8")
+        hook = "def pytest_terminal_summary"
+
+        assert hook in root, "the annotation emitter must be registered from the rootdir"
+        assert hook not in suite, (
+            "a second definition in test/conftest.py would shadow nothing but would "
+            "annotate twice for `test/` and not at all for the in-package suites"
+        )


### PR DESCRIPTION
## Problem / Motivation

A red pytest job is read from its check run's ANNOTATIONS -- that is what the PR
page renders, what a fork contributor who cannot re-run a job has, and what a
triage report copies. Nothing in this repository wrote one, so the annotations
came from the `python` problem matcher that `actions/setup-python` registers by
default (`add-problem-matchers` defaults to true). Its pattern is a traceback
frame (`File "...", line N, in f`) followed by `raise SomeError('msg')`, applied
to the whole log -- including the part where pytest prints its warnings summary.

Measured on the six Backend Tests jobs cited in #7296, that pattern matched a
warning traceback every time and a pytest failure not once:

| job | annotations | what actually failed |
| --- | --- | --- |
| 98966209341 Windows (3) | 1x `Event loop is closed` | `test_mcp_gatewayd_coverage.py::TestZombieDiagnostic::test_dead_accept_loop_is_dumped_and_stops_the_daemon` (missing diag.jsonl) |
| 98986152965 Windows (3) | 1x `Event loop is closed` | `test_md_notebook.py::test_sync_refuses_rather_than_pushing_a_subset` (`git add` timed out after 120s) |
| 99498254362 Windows (3) | 2x `Event loop is closed` | 17 failed, `test_project_bundle_git` / `test_project_capabilities` |
| 99498254412 (3.10, 3) | 4x `Event loop is closed` | 7 failed, same family |
| 99498254667 (3.12, 3) | 4x `Event loop is closed` | 7 failed, same family |
| 99525858843 Windows (2) | 10x `Event loop is closed` | `test_data_home_not_relocatable.py`, 2 alias cases |

The annotated line number is the same on every platform because it is not a line
in this repository: 545 is `asyncio/base_events.py`, inside `_check_closed`,
reached from a `PytestUnraisableExceptionWarning` about a garbage-collected
coroutine. So the reported symptom is real and its stated cause is not -- in all
six jobs `Event loop is closed` was a WARNING, the shard exit code came from
ordinary named failures, and not one of those tests was named in an annotation.

## Why it matters

Four unrelated PRs were filed and triaged as an event-loop teardown flake on that
evidence, and the class had already been "fixed" four times (#4764, #4784, #5491,
#5856) before this recurrence. The cost the issue describes -- "the red carries no
actionable test identity", "there is no test name to bisect from" -- is produced
by the annotation pipeline, not by asyncio. Until the annotations name the real
test, every future red of any cause gets read as this flake again, and on a fork
PR the CI red also skips all five `fork-*-review` lanes, so a misread costs the
review round as well as the CI round.

## What changed (motivation -> approach -> change)

Symptom: the check run names a warning and hides the red. Root cause: the only
thing writing annotations is a text matcher that cannot tell a warning traceback
from a failure and has no pattern for a pytest failure at all.

A better matcher cannot be the fix. `--color=yes` is in `addopts`, so the summary
line a matcher would have to scrape reads
`\x1b[31mFAILED\x1b[0m test/x.py::\x1b[1mtest_y\x1b[0m - AssertionError: ...`,
with escape sequences inside the node id. The report objects already carry the
same facts as data, so:

- `conftest.py` gains `pytest_terminal_summary`, which emits one `::error`
  annotation per failed/errored report: `file` and 1-based `line` from
  `report.location`, `title` from the node id, message from the `E`-marked line
  (`reprcrash` is the preamble for a fixture error and would spend the whole
  annotation saying `file <path>, line 5`). Controller-only, so an xdist worker's
  reports are not annotated twice; gated on `GITHUB_ACTIONS`, so a local red is
  unchanged; capped at 10 with a `::notice::` counting the rest, because GitHub
  drops the excess silently.
- It lives in the ROOTDIR conftest, not `test/conftest.py`: the in-package app
  suites never load the latter and they red the same jobs.
- The four jobs that run pytest (`backend-test`, `backend-test-windows`,
  `backend-test-macos`, `backend-test-sandbox`) echo
  `::remove-matcher owner=python::` from inside the step that runs pytest, so the
  matcher that lied cannot put a louder wrong answer next to the right one, and
  the directive cannot be separated from the run it protects by a later
  reordering. `add-problem-matchers: false` was tried first and is a trap: that
  input does not exist on `actions/setup-python` v7.0.0 at this pin, so the
  action ignored it and the runner answered with an `Unexpected input(s)`
  warning -- one more annotation saying nothing about the tests. Caught by this
  PR's own first CI run and now pinned by a test.

Deliberately NOT changed: the `Event loop is closed` unraisables themselves. They
are real leaked coroutines (`turn_dispatch.py:385 _bounded_turn` and
`gatewayd.py:3291 _drain_inbox_to_stub`, both GC-finalized after their loop
closed) but they are warnings, they failed nothing here, and silencing them is a
per-site product change that would also have hidden this diagnosis. Widening
`_drain_windows_proactor_finalizers` past its win32/`sessionfinish` scope was
considered and rejected for the same reason: it suppresses the evidence.

## Tests

`test/test_ci_failure_annotations.py`, 20 cases. Mutation-verified: 18 of the 20
fail with both production files reverted to `origin/main` (the 2 that pass are the
subject-list guard and the not-an-input guard, neither of which depends on the fix).

- the annotation carries node id, file, and the 1-based line (report line 41 ->
  `line=42`); setup/teardown errors are annotated too; a collection error with no
  line omits `line=` rather than guessing 1
- a fixture error reports `fixture 'x' not found`, not the `file <path>, line 5`
  preamble; an indented `E = compute()` source line is not mistaken for the verdict
- node-id `::` and a comma inside a parametrized id are escaped (`%3A%3A`, `%2C`)
  so the runner does not truncate the annotation at the first separator; `%` and
  carriage-return and newline escaped; a 5000-char reason truncated
- 10-annotation cap emits exactly 10 plus one `::notice::`; exactly 10 emits no notice
- nothing written for a green run, outside GitHub Actions, or on an xdist worker
- ci.yml source: the four pytest jobs are found by scanning for a step that runs
  pytest (so a NEW pytest job is covered without editing a list); each must remove
  the matcher at or before its FIRST pytest step (ordering asserted, not assumed --
  a directive placed after the run leaves it fully matched); no workflow may pass
  `add-problem-matchers` to a step at all; the hook must be in the rootdir conftest
  and not in `test/conftest.py`

Gates on the touched files: black, isort, flake8 clean; `check_black_formatting`,
`check_testpaths_coverage`, `check_sync_io_in_async`, `check_loop_bound_locks`,
`check_brand_name`, `check_focus_cue`, `check_changelog_history` all pass.

## Manual verification

Live proof on this PR's own CI. The first run's `Backend Tests (Windows) (3)` and
`(3.10, 3)` went red on a main-owned ratchet drift, and the check-run annotation
now reads:

```
test/test_security_posture.py:1046
  title: test/test_security_posture.py::TestGateSideLogRedactorSpelling::test_the_census_holds_no_slack
  message: ... - AssertionError: `_BASELINE_LOG_SITE_CENSUS` is now looser than the code
```

Exact file, exact line, node id as the title -- against the `Event loop is closed`
at `.github:515` that the old matcher put on the same job. That same run is what
exposed the `add-problem-matchers` mistake, which is fixed in this revision.

Before that, ran a local pytest invocation with two deliberately broken tests and
`GITHUB_ACTIONS=true` against the real rootdir conftest. Emitted:

| annotation field | first probe test | second probe test |
| --- | --- | --- |
| `file` | test/test_zz_annotation_probe.py | test/test_zz_annotation_probe.py |
| `line` | 1 | 5 |
| `title` | ...probe.py%3A%3Atest_probe_fails | ...probe.py%3A%3Atest_probe_errors |
| message | ...::test_probe_fails - assert 1 == 2 | ...::test_probe_errors - fixture 'nonexistent_fixture' not found |

(Rendered as a table on purpose. A raw `::error ...` line pasted at the start of a
line is a LIVE workflow command to any job that prints this description into its
log -- the first revision of this section made the GPT review job emit a bogus
`test/test_zz_annotation_probe.py:1` annotation for a file that does not exist in
the repository. Same defect class this PR is about, so it is not repeated here.)

The probe file was removed afterwards; the tree is clean.

Known remaining case, stated rather than fixed: the rootdir `pytest_sessionfinish`
residue guard can turn a green run red AFTER `pytest_terminal_summary` has run, so
a residue-only red still carries no annotation. It prints its own explicit
`repository root residue` section, and folding an annotation into that path needs
its own test setup, so it is left for a follow-up rather than claimed here.

## Related Issues

Closes #7296

## Pattern harvest

Rule candidate: review-prompt. Pattern: "a CI diagnosis taken from check-run
annotations when no step in the repository writes them" -- if annotations are
produced by a generic text matcher rather than by the tool that knows what
failed, the annotation is a guess and the shard's own summary is the evidence.
Concretely reusable check: any job that runs a test framework should either emit
its own annotations or leave `add-problem-matchers` off; a job doing neither will
eventually annotate a warning as its failure. The four predecessors of this issue
are what that class costs when it is not caught.


