### PR TITLE
fix(ci): burn one eslint warning down to the ratchet ceiling

### DIFF
--- a/website/src/test/useQueuedMessageActions.test.tsx
+++ b/website/src/test/useQueuedMessageActions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { StrictMode, type ReactNode } from 'react'
+import { StrictMode } from 'react'
 import { render, act, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'


### PR DESCRIPTION
## Problem / Motivation

The Frontend Lint gate runs `npx eslint src/ --max-warnings 659`. Main currently
measures **660 warnings, 0 errors**, so the lane fails on every PR whose changed
surface reaches it -- for reasons that have nothing to do with that PR's diff.

Measured on `dd9e002bf` (main tip at the time of writing):

```
$ npx eslint src/
660 problems (0 errors, 660 warnings)
```

The same count appears in CI. Observed today: [#7462](https://github.com/kirodotdev/KiroCrew/pull/7462)
passed this lane at 03:41Z, and PRs whose surface reached it after that failed
with exactly this 660-vs-659 signature.

## Why it matters

It is a false red on unrelated work, and a costly one to diagnose: the failing
PR's author has to prove the warnings are not theirs before they can ignore it
(CI lints the merge with main, so the linted frontend tree is main's even for a
backend-only diff). Meanwhile the readiness gate counts the lane as a failure,
so the PR cannot go green, and `/ai-review override` does not apply because this
is a CI lane rather than a review bot.

Most PRs skip the lane, which is why the drift went unnoticed -- it only bites
the occasional PR whose changed surface pulls the frontend in.

## What changed (motivation -> approach -> change)

The ceiling is documented as something to burn DOWN, not raise: "The ceiling must
EQUAL the measured count, not sit above it: slack is silent admission ... do not
raise it." So the fix is to remove one real warning, not to touch the gate.

Removed an unused `type ReactNode` import from
`website/src/test/useQueuedMessageActions.test.tsx`. It is the smallest true
warning available: a test file, no product code, no behaviour, and the symbol is
referenced nowhere else in the file (`grep ReactNode` returns only the import).

Deliberately ONE warning, not a batch: it restores the gate with the smallest
reviewable diff, and it leaves the remaining 659 for a burn-down that can be
judged on its own merits. `eslint` reports 8 of them as `--fix`-able if someone
wants to take a bite.

## Tests

`npx vitest run src/test/useQueuedMessageActions.test.tsx` -- 17 tests pass,
unchanged.

Gate verification, the exact CI command:

```
$ npx eslint src/
659 problems (0 errors, 659 warnings)
$ npx eslint src/ --max-warnings 659 && echo ok
ok
```

## Manual verification

N/A -- a removed unused type import has no runtime surface. The measurement above
is the verification.

## Related Issues

None filed; found while diagnosing a red Frontend Lint lane on an unrelated
backend PR ([#7435](https://github.com/kirodotdev/KiroCrew/pull/7435)), which
carries the full evidence trail.

## Pattern harvest

Rule candidate: `ci`.
Pattern: "a ratchet whose gate is SKIPPED for most diffs stops being a ratchet --
it becomes a landmine for whoever's changed surface happens to reach it."

The count can only drift upward while the lane is skipped, and the drift is then
charged to an unrelated PR, which is the expensive part: the failing author must
first prove the warnings are not theirs. Two mechanical options, both cheap:

- Run the measurement (not the whole lane) on every push to main and fail there,
  so the commit that adds warning 660 is the one that gets the red.
- Or have the gate report the delta it attributes to the PR's own changed files,
  so a backend-only diff reads "0 added by this PR" instead of a bare `660 > 659`.

Either turns this class from "diagnose it on someone else's PR" into "the author
who added it sees it".
