### PR TITLE
perf(cron): skip disk write when a folder rename is a no-op

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -6208,9 +6208,14 @@ class DashboardState:
         Returns the updated folder dict, or None if folder_id not found.
         Raises on persistence failure (callers should surface a 500);
         original name is restored on failure.
+
+        A same-name rename is a no-op: it neither mutates memory nor writes
+        to disk, so a redundant PATCH cannot cost an atomic file write.
         """
         for folder in self._cron_folders:
             if folder["id"] == folder_id:
+                if folder["name"] == name:
+                    return folder
                 old_name = folder["name"]
                 folder["name"] = name
                 try:

--- a/test/test_dashboard_cron_folders.py
+++ b/test/test_dashboard_cron_folders.py
@@ -230,6 +230,33 @@ class TestCronFoldersUpdate:
         assert body["code"] == "folder_save_failed"
 
 
+class TestCronFoldersRenameState:
+    """State-level rename_cron_folder behavior against a real DashboardState."""
+
+    def test_rename_persists_on_actual_change(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = [{"id": "f1", "name": "Old", "order": 0}]
+        with patch.object(state, "save_cron_folders") as save:
+            result = state.rename_cron_folder("f1", "New")
+        assert result["name"] == "New"
+        assert state._cron_folders[0]["name"] == "New"
+        save.assert_called_once()
+
+    def test_same_name_rename_is_a_noop_and_skips_disk_write(self, tmp_path, monkeypatch):
+        """A rename to the folder's current name must not touch disk: the
+        atomic save_cron_folders() write is skipped and the folder is
+        returned unchanged."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = [{"id": "f1", "name": "Ops", "order": 0}]
+        with patch.object(state, "save_cron_folders") as save:
+            result = state.rename_cron_folder("f1", "Ops")
+        save.assert_not_called()
+        assert result == {"id": "f1", "name": "Ops", "order": 0}
+        assert state._cron_folders[0]["name"] == "Ops"
+
+
 class TestCronFoldersDelete:
     """DELETE /api/cron-folders/{folder_id} removes folder and clears assignments."""
 


### PR DESCRIPTION
## Problem / Motivation

`rename_cron_folder` in the dashboard cron-folder store always wrote the folder file to disk — via a full atomic write — even when the submitted name was identical to the current one. A redundant rename PATCH (re-submitting the same name, or a blur without an edit) therefore cost an unnecessary atomic file round-trip.

## Why it matters

Cron-folder renames are a UI action that can fire with an unchanged value (form blur, re-submit). Each no-op still forced a serialized disk write, wasted I/O on the shared config file, and briefly held the folders lock for nothing. `create`/`delete` are inherently state-changing; only `rename` can be a genuine no-op, so it is the one path worth short-circuiting.

## What changed

Root cause: `rename_cron_folder` had no equality check before mutating and persisting. Fix: an early `if folder["name"] == name: return folder` guard, placed before the in-place mutation and `save_cron_folders()` call, so a same-name rename returns the folder unchanged and performs zero disk I/O. Behavior for a real rename is unchanged.

## Tests

Extended `test/test_dashboard_cron_folders.py` with `TestCronFoldersRenameState`: one test asserts a real rename triggers exactly one persist, and one asserts a same-name rename does **not** call `save_cron_folders` and returns the folder unchanged. Proven red→green (the no-op test fails with the guard reverted).

## Manual verification

N/A — unit coverage sufficient; behavior-preserving optimization on a covered store method.

## Pattern harvest

Not generalizable: a targeted no-op guard on one mutator; the sibling mutations (`create`/`delete`) are inherently state-changing and have no equivalent no-op.

## Related Issues

Fixes #7482
