### PR TITLE
fix(cron): guard against a duplicate folder id in create_cron_folder

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -6177,8 +6177,11 @@ class DashboardState:
     def create_cron_folder(self, name: str, folder_id: str) -> dict:
         """Create a new cron folder and persist.
 
-        Returns the created folder dict. Raises on persistence failure
-        (callers should surface a 500).
+        Returns the created folder dict. Raises ValueError if ``folder_id``
+        collides with an existing folder (``rename``/``delete`` act on the
+        first id match, so a duplicate would strand the shadowed folder as
+        un-renameable/un-deletable). Raises on persistence failure (callers
+        should surface a 500).
 
         The folder is persisted BEFORE it is exposed in ``_cron_folders``: a
         concurrent ``GET /api/cron-folders`` reads the live list, so appending
@@ -6188,6 +6191,8 @@ class DashboardState:
         it, and only then committing the reference means a reader sees either
         the pre-create list or the durably-saved one, never an intermediate.
         """
+        if any(f["id"] == folder_id for f in self._cron_folders):
+            raise ValueError("cron folder id collision")
         order = max((f["order"] for f in self._cron_folders), default=-1) + 1
         folder = {"id": folder_id, "name": name, "order": order}
         candidate = [*self._cron_folders, folder]

--- a/test/test_dashboard_cron_folders.py
+++ b/test/test_dashboard_cron_folders.py
@@ -349,6 +349,36 @@ class TestCronFolderDeleteStateMethod:
         assert result is False
 
 
+class TestCronFolderCreateStateMethod:
+    """DashboardState.create_cron_folder guards against a duplicate folder id."""
+
+    def test_create_rejects_duplicate_id(self, tmp_path, monkeypatch):
+        """A colliding folder_id is refused: rename/delete act on the first id
+        match, so a duplicate would strand the shadowed folder as
+        un-renameable/un-deletable. The guard keeps ids unique."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = [{"id": "dup", "name": "Ops", "order": 0}]
+        state.save_cron_folders()
+
+        with pytest.raises(ValueError, match="collision"):
+            state.create_cron_folder("Second", "dup")
+        # No shadow folder appended; the store is untouched
+        assert len(state._cron_folders) == 1
+        assert json.loads((tmp_path / state._CRON_FOLDERS_FILE).read_text()) == [
+            {"id": "dup", "name": "Ops", "order": 0}
+        ]
+
+    def test_create_appends_unique_id(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = [{"id": "f1", "name": "Ops", "order": 0}]
+
+        folder = state.create_cron_folder("Keep", "f2")
+        assert folder == {"id": "f2", "name": "Keep", "order": 1}
+        assert [f["id"] for f in state._cron_folders] == ["f1", "f2"]
+
+
 class TestCronFoldersAsyncPersistence:
     """Verify mutations go through asyncio.to_thread (event-loop non-blocking)."""
 


### PR DESCRIPTION
## Problem / Motivation

`create_cron_folder` appended a new folder to the store with no check that its id was unique. The id is an 8-hex-char (32-bit) truncation of a UUID, and `rename_cron_folder` / `delete_cron_folder` both act on the **first** id match. A duplicate id — however unlikely — would leave the shadowed folder permanently un-renameable and un-deletable.

## Why it matters

It is a latent correctness trap: a collision silently strands a folder in a state the UI cannot repair (rename/delete always hit the first match). The create path already runs under the cron-folders lock, so a uniqueness check is race-free and essentially free — cheap insurance against an un-fixable data state.

## What changed

Root cause: no uniqueness invariant was enforced at the one place ids enter the store. Fix: a guard at the top of `create_cron_folder` that raises `ValueError("cron folder id collision")` if the id already exists. The handler already wraps `create` in try/except and surfaces a 500, so a collision now fails loudly instead of corrupting state.

## Tests

Extended `test/test_dashboard_cron_folders.py`: a test asserts a duplicate `folder_id` raises `ValueError`, and a companion asserts a unique id still appends and returns the folder with the expected order. Proven red→green (raises-check fails with the guard absent).

## Manual verification

N/A — unit coverage sufficient; the guarded path is a pure in-memory invariant check.

## Pattern harvest

Rule candidate: review-prompt — "an id/key that mutators match by "first match" must be enforced unique at its single insertion point." Pattern: first-match lookup over a collection with no uniqueness guard on insert.

## Related Issues

Fixes #7484
