### PR TITLE
fix(cron): return a snapshot from the cron-folders GET so a concurrent rename cannot tear the read

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -1433,8 +1433,13 @@ def _get_cron_folders_lock() -> LoopBoundLock:
 async def api_cron_folders(request: web.Request) -> web.Response:
     """GET /api/cron-folders — list all cron folders."""
     state: DashboardState = request.app["state"]
-    # Bare list, matching the chat-folders precedent (api_chat_folders).
-    return web.json_response(state._cron_folders)
+    # Serialize a shallow snapshot, not the live list: rename_cron_folder
+    # mutates a folder dict's "name" in place, so encoding state._cron_folders
+    # by reference could interleave with a concurrent rename and surface a torn
+    # or stale name. Copying each dict gives the encoder a stable read. This
+    # mirrors the chat-folders GET (api_chat_folders), which likewise does not
+    # return the live list — it builds a fresh list off-thread.
+    return web.json_response([dict(f) for f in state._cron_folders])
 
 
 async def api_cron_folders_create(request: web.Request) -> web.Response:

--- a/test/test_dashboard_cron_folders.py
+++ b/test/test_dashboard_cron_folders.py
@@ -80,6 +80,36 @@ class TestCronFoldersList:
         assert len(body) == 1
         assert body[0]["name"] == "Ops"
 
+    @pytest.mark.asyncio
+    async def test_list_serializes_a_snapshot_not_the_live_dicts(self, tmp_path):
+        """The GET must hand the encoder a copy, so a concurrent rename that
+        mutates a folder dict's name in place cannot tear the read."""
+        state = _make_state(tmp_path)
+        live = {"id": "a1", "name": "Ops", "order": 0}
+        state._cron_folders = [live]
+        request = _request(state)
+
+        captured = {}
+
+        def _capture(payload, **kw):
+            captured["payload"] = payload
+            return MagicMock(status=200)
+
+        with patch("kiro_crew.dashboard.handlers.cron.web.json_response", side_effect=_capture):
+            await api_cron_folders(request)
+
+        payload = captured["payload"]
+        # The response list is a fresh object, not the live list...
+        assert payload is not state._cron_folders
+        # ...and each entry is a copy, not the live dict a rename mutates.
+        assert payload[0] is not live
+        assert payload[0] == {"id": "a1", "name": "Ops", "order": 0}
+        # Mutating the returned snapshot must not touch server state.
+        payload[0]["name"] = "Renamed"
+        payload.append({"id": "b2", "name": "Injected", "order": 1})
+        assert live["name"] == "Ops"
+        assert state._cron_folders == [live]
+
 
 class TestCronFoldersCreate:
     """POST /api/cron-folders creates a new folder."""


### PR DESCRIPTION
## Problem / Motivation

The `GET /api/cron-folders` handler returned the live in-memory `_cron_folders` list by reference. `create`/`delete` swap that reference atomically (safe), but `rename_cron_folder` mutates a folder dict **in place** on the very objects the GET response is serializing. A rename interleaving the JSON encode can surface a torn or stale folder name to the client.

## Why it matters

It is a rare-but-real read/write consistency window: a concurrent rename during a folder-list fetch can return an inconsistent name. The handler's `# matching the chat-folders precedent` comment also overstated the parallel — the chat-folders GET builds a fresh list off-thread, so it does not return the live list either.

## What changed

Root cause: the reader shared object identity with the in-place mutator. Fix (single hunk): serialize a shallow snapshot — `return web.json_response([dict(f) for f in state._cron_folders])` — so the encoder never touches a dict a rename may be mutating, and corrected the misleading comment to describe the copy as a consistency snapshot.

## Tests

New `test_list_serializes_a_snapshot_not_the_live_dicts` in `test/test_dashboard_cron_folders.py`: patches `web.json_response`, captures the payload, and asserts it is a distinct list of distinct dicts from `state._cron_folders` and that mutating the returned value leaves server state untouched. Proven red→green (fails on the bare-reference return).

## Manual verification

N/A — unit coverage sufficient; the change is a serialization-boundary copy with no user-visible behavior change on the happy path.

## Pattern harvest

Rule candidate: review-prompt — "a GET that returns an in-memory collection by reference races any in-place mutator of that collection; serialize a snapshot." Pattern: handler returns live mutable state by reference.

## Related Issues

Fixes #7486
