### PR TITLE
docs(cron): note _persist_cron_folders is the shared persist path for all folder mutations

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -6154,7 +6154,11 @@ class DashboardState:
 
         Takes the list to persist explicitly so a caller can save a candidate
         list before committing it to ``_cron_folders`` (see ``create_cron_folder``),
-        keeping in-memory state and disk from diverging mid-operation. Any
+        keeping in-memory state and disk from diverging mid-operation. This is the
+        single persist chokepoint for all folder mutations: ``create_cron_folder``
+        passes a candidate list here before committing it, while ``save_cron_folders``
+        (used by ``rename_cron_folder`` and ``delete_cron_folder``) passes the
+        already-mutated ``_cron_folders`` to commit an in-place edit. Any
         malformed entries preserved at load time (``_unparsed_cron_folder_entries``)
         are appended, so a save cannot erase bytes a hand-edit left in a shape
         the loader could not validate.


### PR DESCRIPTION
## Problem / Motivation

The `_persist_cron_folders` docstring described only the candidate-list use ("so a caller can save a candidate list before committing it to `_cron_folders`, see `create_cron_folder`"). It did not mention that `save_cron_folders` — used by both `rename_cron_folder` and `delete_cron_folder` — also routes through it. A reader would miss that this method is the single persist chokepoint for all three folder mutations.

## Why it matters

The surrounding code is heavily commented on the persist/unparsed-entry contract, so this silence is a real doc gap: a maintainer could wrongly assume the candidate-list pattern is the method's only caller and refactor it unsafely. Documenting the chokepoint protects the invariant.

## What changed

Docstring-only. Added a sentence noting that `create_cron_folder` passes a candidate list here before committing, while `save_cron_folders` (rename/delete) passes the already-mutated `_cron_folders` to commit an in-place edit — i.e. it is the shared persist path for every folder mutation. No signature or behavior change.

## Tests

N/A — comment-only change; no docstring-shape (`__doc__`) test asserts on this method, so there is nothing to lock in with a test. Lint/type gates confirm the file still parses cleanly.

## Manual verification

N/A — documentation-only.

## Pattern harvest

Not generalizable: a one-off docstring accuracy fix; no defect class.

## Related Issues

Fixes #7487
