### PR TITLE
fix(system): bind the two sibling trash removals to descriptors

### DIFF
--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -605,6 +605,106 @@ would put a link where the session's data belongs — leaving a dangling pointer
 the batch is emptied. Only a link resolving *within* the batch reaches this check;
 `_staged_path` already refuses one that escapes.
 
+### All three removal paths are descriptor-bound, and one module owns the mechanism
+
+Emptying is the largest of the three removals but not the only one. Discarding a
+fully-restored batch and cleaning up a batch no session was staged into also remove a
+whole directory, and both did it with `shutil.rmtree(path)` - which re-resolves every
+ancestor, so a directory above the trash swapped to a link after the caller's own by-path
+read is followed and the removal lands outside the trash. Both now go through
+`pinned_fs.remove_tree_pinned`: parent chain pinned one `openat` per component, batch
+opened through it `O_NOFOLLOW`, one scan, and every removal inside addressed by a
+descriptor whose inode that scan recorded.
+
+Pinning is the weaker half of that, and the spec says so because the code does.
+`Path.resolve()` FOLLOWS an ancestor that is already a link, so a swap landing before the
+resolve produces a faithful pinned walk to the wrong tree. What closes that is an IDENTITY:
+each caller records the batch's `(st_dev, st_ino)` before ANY read of the batch's contents - at
+`target.mkdir(...)` under the mutation lock on the staging path, and at the TOP of
+`_restore_locked`, before its first manifest read, on the restore path - and the approval hook
+compares the pinned root's `fstat` against it as its first question. An unreadable identity
+refuses rather than proceeding.
+
+The restore's capture point is load-bearing and is why `_discard_restored_batch` takes the
+identity rather than sampling one. That cleanup is reached only after the manifest has been read
+and every listed file moved out, so an identity taken there would already be a substitute's if an
+ancestor had been swapped during any of that, and every later check would then agree with itself
+about the wrong directory. Anchored at the top instead, the same comparison refuses a swap that
+landed at any point inside the operation. A swap already in place BEFORE the restore begins is
+still followed - `pin_parent` resolves the parent path too, so an ancestor that is already a link
+cannot be told from a real path - but reaching that requires the victim tree to have served as
+the restore's own source, which means content was already injected into the live session stores;
+the removal of the emptied directory afterwards is not the damage.
+
+The content checks come second and are not what carries this. The approval also re-asks,
+from ONE inode-verified read of ONE file, that the manifest's header claims this batch's own
+directory name, and that NOTHING but the manifest remains - not "nothing unlisted", nothing
+at all. Both callers arrive with the batch already empty of files: the restore path has moved
+every listed file back out, and the staging path has a manifest with no entries. So a file at
+a listed path is not the listed file; it arrived at that name afterwards and may be the only
+copy of whatever it is, and consulting the listing would authorise deleting exactly that on
+the strength of a name the manifest happens to mention. The header check establishes that
+emptying the batch is *correct*, not that it *is* the batch: an actor who can write into the
+tree a swapped link points at can plant a header naming the selected batch, and every content
+question then answers yes about the wrong directory. An inode cannot be forged by writing
+files. A withheld approval removes nothing and keeps the batch, which stays listed and
+restorable; reporting a success that did not happen is what `ignore_errors=True` did.
+
+"Nothing but the manifest" includes LINKS, which these two paths refuse rather than remove even
+though the delete path removes scanned ones. A link holds no data of its own, but it is the only
+entry a removal can take by NAME: `_unlink_verified` compares the scanned inode and then unlinks,
+and POSIX has no atomic "unlink if this inode", so admitting a link admits that two-syscall
+window - plant one, let the approval pass it, put a file at that name in between, and the removal
+deletes the file. Neither of these removals was asked for, so they refuse; `empty_trash` still
+clears such a batch on the user's own say-so, through an approval that does remove links.
+
+Where the platform has no `openat`/`O_NOFOLLOW`, these two paths remove the batch through
+`rename-verify-remove` instead: `_stage_batch_by_name` renames it aside inside the trash root,
+verifies `(st_dev, st_ino)` on the RENAMED directory against the identity the caller captured,
+and only the staged name is removed; a mismatch or an unreadable identity puts the directory
+back under the name the user saw, and so does a tree that will not go. Refusing outright was an
+earlier answer here and it was wrong: this branch is the whole of Windows, so refusing left a
+batch behind after every restore and every rolled-back move, still listing sessions it no longer
+held - five pre-existing tests read that as a failure, and so would a user. What the rename buys
+is that the approved name no longer exists once it has happened, so nothing can be substituted
+at it, and the identity is checked on the directory that was actually moved. What it does not
+buy: the removal still resolves the staging path, so an actor who can OBSERVE that name inside
+the window can redirect it through an ancestor swapped afterwards. That residual is accepted on
+this platform for all three callers - the explicit empty and the two cleanups - through one
+owner rather than three spellings.
+
+Because the cleanup can now DECLINE, a fully restored batch can outlive it - and every entry
+in its manifest describes a file the restore already moved back OUT, so that batch shows a
+user sessions that are not in it and offers to restore them. That stale listing is an ACCEPTED
+RESIDUAL, not an oversight: clearing it needs a write to the batch path, and there is nowhere
+safe to put one. After the cleanup the descriptor is closed and every refusal is itself
+evidence the path may be redirected, so writing then answers a swap by writing through it.
+Before the cleanup, the full-restore branch has no write at all today, so adding one hands
+`atomic_write` - which REPLACES its destination - a path that a batch swapped to a link points
+wherever an actor chose, including another batch's manifest, whose staged sessions would
+become unlistable. A stale listing is visible and reversible; that is not. So neither cleanup
+path writes to the batch, the full-restore branch of `_restore_locked` does not either, and
+`empty_trash` clears the batch on the user's own say-so (verified in
+`test_a_full_restore_never_writes_to_the_batch_it_is_leaving`). The partial-restore branch
+keeps its pre-existing rewrite: it has to record what is still staged, and it is not reached
+through a refusal.
+
+`rename-verify-remove` - move a name to `.<name>.removing-<random>` in the same parent,
+re-check the identity there through the parent's descriptor, remove only that name, and
+rename BACK only when the identity matched - was spelled inline three times: the interior
+directories, the batch directory, and the coarse path. It is now
+`pinned_fs.remove_dir_verified`, with the pinned scan and the identity-verified chain-open
+beside it, and `session_storage` keeps only the policy: which map authorises the removal,
+what a refusal means to the user, and how it is worded. That split is deliberate rather than
+tidy-up: per-call-site respelling of this mechanism is what `pinned_fs` was created to end
+after #2446 and #2447, and a fourth copy would have repeated it. The descriptor-less platform
+has its own owner, `_stage_batch_by_name`, because `pinned_fs` cannot serve it -
+`remove_dir_verified` addresses a parent descriptor and that is precisely what this platform
+lacks - and all three callers there (the explicit empty and the two cleanups) go through it
+rather than respelling the rename. Which mechanism a call site gets is an explicit branch at
+the call site rather than a fallback inside the primitive: `pinned_fs` refuses by design rather
+than silently substituting a weaker one.
+
 ### The origin is derived, not trusted
 
 A manifest record's `origin` is not information restore needs: the staged path
@@ -953,6 +1053,12 @@ user's "empty this batch" is consent for nothing while destroying something. Suc
 batch is skipped and logged rather than deleted, so `freed_bytes` under-reports
 instead of the trash over-deleting. `TestEmptyTrash` and
 `test_restore_never_deletes_a_file_the_manifest_omits` cover both directions.
+
+All three now also re-establish the answer through the descriptor they remove by, not only
+by path. The by-path read is a pre-screen that produces the user-facing count; the pinned
+re-read is what the removal is bound to, because a file arriving after the pre-screen - or
+an ancestor swapped after it - makes the by-path answer describe a directory the removal is
+no longer addressing.
 
 ## Constants
 

--- a/src/kiro_crew/pinned_fs.py
+++ b/src/kiro_crew/pinned_fs.py
@@ -40,26 +40,45 @@ import errno
 import os
 import shutil
 import stat as _stat
+from collections.abc import Iterable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Callable
 
 __all__ = [
+    "PUT_BACK_FAILED",
+    "PUT_BACK_NAME_TAKEN",
     "PinnedPathRefusal",
+    "PinnedTree",
+    "REMOVAL_FAILED",
+    "REMOVAL_IDENTITY_CHANGED",
+    "REMOVAL_STAGE_FAILED",
+    "REMOVAL_UNVERIFIABLE",
     "SKIP_NOT_REGULAR",
     "SKIP_SYMLINK",
     "SKIP_VANISHED",
     "SkipReporter",
+    "StagedRemoval",
+    "TreeRemoval",
+    "close_all",
     "copy_file_pinned",
     "create_and_open_dir_pinned",
     "dir_flags",
+    "drain_verified_chain",
     "fatal_skip_reporter",
     "is_reparse_point",
     "is_regular_at",
     "stat_at",
     "open_dir_pinned",
     "open_in_pinned_parent",
+    "open_verified_chain",
     "pin_parent",
+    "put_back_no_clobber",
     "refuse_hardlink_alias",
+    "remove_dir_verified",
+    "remove_tree_pinned",
+    "scan_tree_pinned",
     "stage_tree_pinned",
     "supports_pinned_tree_walk",
     "supports_pinned_walk",
@@ -923,3 +942,809 @@ def _open_child_dir(parent_fd: int, entry: str, by_name: str, on_skip: SkipRepor
             on_skip(SKIP_SYMLINK, by_name)
             return None
         raise
+
+
+# ---------------------------------------------------------------------------
+# Verified removal
+#
+# Everything below owns ONE mechanism: removing something reached through a pinned
+# descriptor, where the removal itself must not address a name that could have been
+# swapped since it was checked. It lives here rather than at its call sites because it
+# was previously spelled once per site -- the interior directories of a trash batch, the
+# batch directory, and the coarse fallback -- and a fourth consumer is what finally shows
+# which parts are consumer-agnostic. That per-site respelling is the failure this module's
+# own docstring names, from #2446 and #2447.
+#
+# The policy stays with the caller. Nothing here logs, and nothing here decides whether a
+# refusal aborts or is reported and skipped: each function returns what happened and the
+# caller words it. That is the same split the walk above already uses.
+# ---------------------------------------------------------------------------
+
+#: Reason codes returned by :func:`remove_dir_verified` and :func:`remove_tree_pinned`.
+#: The caller words the message; these only classify.
+#:
+#: Named for the REMOVAL rather than borrowing the ``SKIP_`` prefix its first consumer
+#: uses. That consumer has its own ``SKIP_UNREADABLE``/``SKIP_IDENTITY_CHANGED`` for the
+#: batch it is skipping, and both families end up in the same log line -- one pair of names
+#: meaning two things, with one of them a DIFFERENT string, is how a later reader matching
+#: on the value gets it wrong.
+REMOVAL_IDENTITY_CHANGED = "removal_identity_changed"
+REMOVAL_UNVERIFIABLE = "removal_unverifiable"
+REMOVAL_FAILED = "removal_failed"
+REMOVAL_STAGE_FAILED = "removal_stage_failed"
+
+
+def close_all(fds: Iterable[int]) -> None:
+    """Close every descriptor in *fds*, tolerating one that is already closed.
+
+    A close that raises must not abandon the rest: a leaked directory descriptor pins its
+    inode for the life of the process, and a tree removal opens one per directory.
+
+    Public for the same reason :func:`dir_flags` is -- a second module walking trees the
+    same way needs it, and reaching for a private is how the divergence starts.
+    """
+    for fd in fds:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+@dataclass(frozen=True)
+class PinnedTree:
+    """What one pinned traversal saw, keyed by components relative to the scan root.
+
+    Three maps rather than one because the removal treats them differently: a directory is
+    removed with ``rmdir`` after its children, a link is unlinked without ever being
+    followed, and a file is unlinked. The values are inodes, which is the part that matters
+    -- see :func:`scan_tree_pinned`.
+    """
+
+    dirs: dict[tuple[str, ...], int]
+    files: dict[tuple[str, ...], int]
+    links: dict[tuple[str, ...], int]
+
+
+@dataclass(frozen=True)
+class StagedRemoval:
+    """The outcome of one identity-verified directory removal.
+
+    ``staged_name`` is set only when the entry was LEFT under the staging name, which is
+    the case a human has to be told about: the object there is not the one that was
+    approved, so the name it came from is not this code's to write to either. A removal
+    that failed but WAS renamed back therefore reports no staging name -- that is the same
+    fact, and a second field carrying it would be a second place for it to be wrong.
+    """
+
+    removed: bool
+    reason: str | None = None
+    staged_name: str | None = None
+    error: OSError | None = None
+
+
+@dataclass(frozen=True)
+class TreeRemoval:
+    """The outcome of :func:`remove_tree_pinned`.
+
+    ``survivors`` counts entries still present in the closing scan. It is reported rather
+    than raised on so a caller can keep a partly-emptied directory listed instead of
+    claiming success.
+
+    No ``error`` field, unlike :class:`StagedRemoval`: that one carries the exception
+    because its caller RE-RAISES it, and a whole-tree caller does not. It reports the
+    reason code and keeps the directory, so an exception object here would be surface
+    nothing reads.
+    """
+
+    removed: bool
+    survivors: int = 0
+    reason: str | None = None
+    staged_name: str | None = None
+
+
+def scan_tree_pinned(dir_fd: int, *, device: int) -> PinnedTree:
+    """One pinned traversal of the tree under *dir_fd*: its directories, files and links.
+
+    Records the inode of every entry, keyed by components relative to the scan root, plus
+    every LINK's key separately. Children are opened relative to the descriptor with
+    ``O_NOFOLLOW``, so no path is resolved and a directory that is really a link is not
+    descended into. The inodes come from the directory block itself
+    (``os.DirEntry.inode``), so recording them costs no extra syscall.
+
+    The inodes are the point. ``O_NOFOLLOW`` refuses a LINK, but a real directory RENAMED
+    into a scanned name is not a link and satisfies ``O_DIRECTORY`` -- so moving a live
+    directory onto a scanned directory's name redirects later unlinks at live files that
+    happen to share a name, and pinning the ROOT does not cover that, because the root's
+    own inode is unchanged by a rename inside it. Every directory a removal later opens
+    must be the inode this scan recorded. A map read at removal time cannot serve: it
+    reports the impostor.
+
+    Refuses an entry on another ``device``, which is how a mount arriving underneath is
+    caught: it is not a link either.
+
+    ITERATIVE, with an explicit stack, because a recursive walk of a deeply nested tree
+    raises ``RecursionError`` -- which is not ``OSError``, so it escapes callers that turn
+    a failed read into a refusal.
+
+    What it costs in descriptors, stated accurately because the obvious guess is wrong: a
+    directory's child directories are ALL opened before any of them is visited, so what is
+    held at once is the queued frontier, not the current path. A wide tree can therefore
+    exhaust descriptors as easily as a deep one. Both surface as ``EMFILE`` -- an ``OSError``
+    every caller here already treats as "cannot read this, keep it" -- so the failure is
+    contained either way; only the arithmetic differs. Files and links cost nothing, which is
+    what makes this bearable in practice: the trees this walks are wide in FILES and narrow
+    in directories.
+
+    Opening children eagerly is deliberate rather than incidental. Each child's inode is
+    taken from the directory block and cross-checked against the ``fstat`` of the descriptor
+    opened a moment later, and that pair is what catches a directory renamed into a scanned
+    name between the listing and the open. Deferring the open until the child is visited
+    would put every sibling's processing inside that window, trading a documented containment
+    property for a descriptor bound. The bound is the thing worth giving up.
+
+    Raises rather than returning a short list: this feeds decisions about deleting the only
+    copy of something, so an incomplete answer must not read as "nothing unaccounted for".
+    """
+    dirs: dict[tuple[str, ...], int] = {}
+    files: dict[tuple[str, ...], int] = {}
+    links: dict[tuple[str, ...], int] = {}
+    # (key prefix, descriptor, whether this function opened it and must close it)
+    stack: list[tuple[tuple[str, ...], int, bool]] = [((), dir_fd, False)]
+    try:
+        while stack:
+            here, fd, owned = stack.pop()
+            try:
+                with os.scandir(fd) as entries:
+                    listing = list(entries)
+                for entry in listing:
+                    key = here + (entry.name,)
+                    if entry.is_symlink():
+                        links[key] = entry.inode()
+                        continue
+                    if not entry.is_dir(follow_symlinks=False):
+                        files[key] = entry.inode()
+                        continue
+                    child = os.open(entry.name, dir_flags(), dir_fd=fd)
+                    try:
+                        info = os.fstat(child)
+                        if info.st_dev != device:
+                            raise OSError(
+                                f"refusing a scanned directory on another device: {entry.name!r}"
+                            )
+                        # The name was listed by `scandir` and opened a moment later, which
+                        # is a check-to-use window like any other -- and this one produces
+                        # the map every later verification is made of. A rename in between
+                        # means the inode recorded here belongs to the replacement, so the
+                        # map blesses it. `entry.inode()` is what the listing saw; the
+                        # descriptor is what was opened. They have to agree.
+                        if info.st_ino != entry.inode():
+                            raise OSError(
+                                "refusing a scanned directory that changed between the "
+                                f"listing and the open: {entry.name!r}"
+                            )
+                    except OSError:
+                        close_all((child,))
+                        raise
+                    dirs[key] = info.st_ino
+                    stack.append((key, child, True))
+            finally:
+                if owned:
+                    close_all((fd,))
+    finally:
+        # Whatever is still queued when an error unwinds this: the loop closes each
+        # descriptor as it finishes with it, so only the unvisited remainder is left.
+        close_all(fd for _key, fd, owned in stack if owned)
+    return PinnedTree(dirs=dirs, files=files, links=links)
+
+
+def open_verified_chain(
+    root_fd: int,
+    parts: tuple[str, ...],
+    *,
+    cache: dict[tuple[str, ...], int],
+    dirs: Mapping[tuple[str, ...], int],
+    device: int,
+) -> int:
+    """Open the directory named by *parts* under *root_fd*, or raise ``OSError``.
+
+    Every component is opened with ``O_NOFOLLOW`` relative to the previous one, so a
+    component that is (or becomes) a link fails the open instead of being followed, and
+    each one is admitted only as the inode *dirs* recorded for that name on *device*. A
+    rename landing after the scan is therefore refused rather than followed -- which
+    ``O_NOFOLLOW`` alone cannot do, since a renamed real directory is not a link.
+
+    Descriptors are cached because one tree has a handful of directories and can have tens
+    of thousands of files inside them, so each directory is verified once and then
+    addressed by the descriptor that was checked. The cache is the CALLER's, because
+    dropping it between phases is what forces a re-check -- see
+    :func:`drain_verified_chain`.
+    """
+    fd = root_fd
+    key: tuple[str, ...] = ()
+    for part in parts:
+        key = key + (part,)
+        cached = cache.get(key)
+        if cached is not None:
+            fd = cached
+            continue
+        expected = dirs.get(key)
+        if expected is None:
+            raise OSError(f"refusing a scanned directory the tree scan did not see: {part!r}")
+        child = os.open(part, dir_flags(), dir_fd=fd)
+        try:
+            info = os.fstat(child)
+        except OSError:
+            close_all((child,))
+            raise
+        if (info.st_dev, info.st_ino) != (device, expected):
+            close_all((child,))
+            raise OSError(f"refusing a scanned directory that changed identity: {part!r}")
+        cache[key] = child
+        fd = child
+    return fd
+
+
+def drain_verified_chain(cache: dict[tuple[str, ...], int]) -> None:
+    """Close and forget every descriptor in *cache*.
+
+    Emptied as it goes rather than closed in a loop and cleared afterwards: a failure
+    part-way would otherwise leave already-closed descriptors in the cache for a later
+    cleanup to close a SECOND time, and a reused number makes that second close land on an
+    unrelated file.
+    """
+    while cache:
+        _key, fd = cache.popitem()
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def _name_is_free(parent_fd: int, name: str) -> bool:
+    """Whether *name* holds nothing under *parent_fd*, as far as one ``stat`` can say.
+
+    Deliberately conservative in both directions: only a definite "nothing is there" answers
+    True, so a name that cannot be read is treated as occupied rather than free. See
+    :func:`remove_dir_verified` for what this check does and does not buy.
+    """
+    try:
+        os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return False
+
+
+def remove_dir_verified(
+    parent_fd: int,
+    name: str,
+    *,
+    expect: tuple[int, int],
+) -> StagedRemoval:
+    """Remove the directory at *name* under *parent_fd*, only if it is *expect*.
+
+    *expect* is ``(st_dev, st_ino)``. This is the single owner of rename-verify-remove.
+    ``rmdir`` addresses a NAME and so does any check above it, so an actor with write
+    access to the parent can swap the name between the two and have an unapproved
+    directory removed on another one's approval. So:
+
+    1. the name is renamed to ``.<name>.removing-<random>`` in the SAME parent, which is
+       atomic and moves whatever holds the name somewhere only this call knows;
+    2. the identity is re-checked THERE, through the parent descriptor, against *expect*;
+    3. only that staging name is removed.
+
+    The suffix is random because ``os.rename`` replaces an existing destination silently on
+    POSIX: a predictable name is one that can be squatted.
+
+    The rename BACK is the part that is easy to get wrong, so both halves are stated.
+
+    On a MISMATCH it never happens: the object under the staging name is not the one that
+    was approved, which means the name it came from is not this code's to write to either --
+    and rename replaces its destination, so putting the impostor back would destroy whatever
+    now answers to the original name.
+
+    On a failed ``rmdir`` it happens only if the original name is FREE. It has to be put back
+    where it can be found: this directory could not be removed because something is inside
+    it, and that something is unaccounted-for content nobody listed -- leaving it under an
+    unguessable name means nothing can point at it again. But POSIX rename REPLACES a
+    directory destination when that destination is an empty directory, so renaming back
+    blindly can silently remove one a concurrent writer created at the name. Checking the
+    name is free first is a check-to-use pair, and this module says elsewhere that those are
+    the mistake it exists to remove -- so what it does and does not buy is worth being exact
+    about. There is no no-replace rename for directories in the stdlib (``renameat2``'s
+    ``RENAME_NOREPLACE`` is Linux-only and unexposed), so the choice is between this and one
+    of two unconditional losses. What the check removes is the DETERMINISTIC case, where
+    something already holds the name by the time the removal fails; what is left is a race
+    inside two adjacent syscalls whose worst outcome is an empty directory removed, which
+    holds no data and is trivially remade. A name found occupied leaves the directory staged
+    and reported.
+
+    Never raises for these outcomes and never logs: the caller decides between
+    log-and-continue and raise, and words the message. ``error`` carries the underlying
+    ``OSError`` for a caller that re-raises.
+    """
+    try:
+        staging = f".{name}.removing-{os.urandom(4).hex()}"
+        os.rename(name, staging, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+    except OSError as exc:
+        return StagedRemoval(removed=False, reason=REMOVAL_STAGE_FAILED, error=exc)
+    try:
+        moved = os.stat(staging, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as exc:
+        # NOT restored. What is under the staging name is unknown, so putting it back means
+        # renaming an unknown object onto the original name -- and POSIX rename REPLACES
+        # its destination, which would destroy whatever is there now.
+        return StagedRemoval(
+            removed=False, reason=REMOVAL_UNVERIFIABLE, staged_name=staging, error=exc
+        )
+    if not _stat.S_ISDIR(moved.st_mode) or (moved.st_dev, moved.st_ino) != expect:
+        # Also NOT restored, and this is the case that matters: an actor who swapped the
+        # directory and then placed something at the original name would have had the
+        # rename-back destroy it.
+        return StagedRemoval(removed=False, reason=REMOVAL_IDENTITY_CHANGED, staged_name=staging)
+    try:
+        os.rmdir(staging, dir_fd=parent_fd)
+    except OSError as exc:
+        # The identity matched, so this IS the approved directory and the original name is
+        # where it belongs -- but only while nothing else has taken that name. A rename-back
+        # that itself fails leaves the staging name, and that -- not a second flag saying the
+        # same thing -- is what the caller reports.
+        left: str | None = staging
+        if _name_is_free(parent_fd, name):
+            try:
+                os.rename(staging, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            except OSError:
+                pass
+            else:
+                left = None
+        return StagedRemoval(
+            removed=False,
+            reason=REMOVAL_FAILED,
+            staged_name=left,
+            error=exc,
+        )
+    return StagedRemoval(removed=True)
+
+
+def _unlink_verified(holder_fd: int, name: str, expect: tuple[int, int]) -> bool:
+    """Unlink *name* under *holder_fd*, only if it is still ``(st_dev, st_ino)`` *expect*.
+
+    The residual is irreducible and better stated than implied: POSIX has no
+    unlink-by-inode, so the stat and the unlink are two syscalls addressing the same NAME.
+    What CAN be done is refuse when the name no longer holds what the scan saw, which is
+    what turns "delete whatever answers to this name" into "delete this object, or nothing".
+    The remaining window needs a swap landing between two adjacent syscalls, and the
+    directory holding the name was itself reached only through verified descriptors.
+    """
+    try:
+        info = os.stat(name, dir_fd=holder_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    if (info.st_dev, info.st_ino) != expect:
+        return False
+    try:
+        os.unlink(name, dir_fd=holder_fd)
+    except OSError:
+        return False
+    return True
+
+
+#: Outcomes of :func:`put_back_no_clobber`. ``None`` means the name is back.
+PUT_BACK_NAME_TAKEN = "name_taken"
+PUT_BACK_FAILED = "failed"
+
+
+def put_back_no_clobber(
+    src_parent_fd: int,
+    dst_dir_fd: int,
+    src_name: str,
+    dst_name: str,
+    *,
+    expect_ino: int,
+) -> str | None:
+    """Recreate *dst_name* inside *dst_dir_fd* from *src_name*, refusing to replace anything.
+
+    The undo half of "move an entry aside, remove the tree, put it back if the tree would
+    not go". It has to be no-clobber: something may have arrived at *dst_name* while the
+    entry was out, and that something is a file this code has never read.
+
+    *src_name* is treated as UNTRUSTED, which is the part that is easy to skip. It is a name
+    in a directory an actor may be able to write to, and the whole reason this function runs
+    is that an earlier step already failed -- so time has passed. The name is opened
+    ``O_NOFOLLOW`` and its inode checked against *expect_ino* before anything is read from
+    it, and the copy reads that DESCRIPTOR rather than re-opening the name. Without that, a
+    name swapped for a symbolic link is followed and whatever it points at -- a credential,
+    say -- is linked or copied into the destination under a name the caller will treat as its
+    own.
+
+    First choice is ``os.link``, which cannot clobber, and it is called with
+    ``follow_symlinks=False`` so a swap landing after the verification links the link itself
+    rather than its target. What LANDED is then checked by inode too, because that link is
+    still addressed by name.
+
+    Where hard links are unsupported there is no second no-clobber RENAME in the stdlib --
+    ``renameat2``'s ``RENAME_NOREPLACE`` is Linux-only and unexposed -- and the two obvious
+    substitutes are each a documented loss:
+
+    * ``rename`` after checking the name is free puts a check-to-use window between the look
+      and the act, so a file arriving in between is replaced. That is the same
+      trusted-a-name mistake this module exists to remove.
+    * giving up leaves the tree holding data with nothing that lists it: unreachable and
+      unrecoverable.
+
+    ``O_CREAT | O_EXCL`` is the third option and has neither flaw. The create either wins or
+    fails with ``EEXIST``, decided inside one syscall, so nothing can arrive in a window;
+    and it needs no hard-link support, so it strands nothing. The cost is a copy rather than
+    a link, paid only on a filesystem without links and only when a removal already failed.
+
+    Note WHY the copy path cannot be skipped by probing first: ``os.link in
+    os.supports_dir_fd`` tests whether the OS accepts ``dir_fd``, not what the MOUNT
+    supports, so a filesystem without hard links passes that probe and then refuses the
+    call. A guard built on the probe is a guard that fails exactly where it matters.
+
+    Returns ``None`` when the name is back, :data:`PUT_BACK_NAME_TAKEN` when something else
+    holds it (nothing was overwritten), or :data:`PUT_BACK_FAILED`.
+    """
+    try:
+        src = os.open(src_name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=src_parent_fd)
+    except OSError:
+        return PUT_BACK_FAILED
+    try:
+        if os.fstat(src).st_ino != expect_ino:
+            # The name no longer holds what was moved aside, so there is nothing here this
+            # function may put anywhere. Refusing leaves the caller to report the name.
+            return PUT_BACK_FAILED
+        linked = False
+        try:
+            os.link(
+                src_name,
+                dst_name,
+                src_dir_fd=src_parent_fd,
+                dst_dir_fd=dst_dir_fd,
+                follow_symlinks=False,
+            )
+        except FileExistsError:
+            return PUT_BACK_NAME_TAKEN
+        except (OSError, NotImplementedError):
+            pass
+        else:
+            linked = True
+        if linked:
+            # The link was addressed by NAME on both ends, so what landed is checked before
+            # the caller is told the entry is back.
+            try:
+                if os.stat(dst_name, dir_fd=dst_dir_fd, follow_symlinks=False).st_ino == expect_ino:
+                    return None
+            except OSError:
+                return PUT_BACK_FAILED
+            # NOT unlinked. The name holds something that is not what this call linked, so
+            # it is a replacement that arrived in between -- and it may be the only copy of
+            # whatever it is. The link this call made is no longer reachable through that
+            # name, so there is nothing of ours left to clean up either; reporting the
+            # failure is the whole remedy.
+            return PUT_BACK_FAILED
+        try:
+            dst = os.open(
+                dst_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=dst_dir_fd,
+            )
+        except FileExistsError:
+            return PUT_BACK_NAME_TAKEN
+        except OSError:
+            return PUT_BACK_FAILED
+        try:
+            created = os.fstat(dst)
+        except OSError:
+            os.close(dst)
+            return PUT_BACK_FAILED
+        try:
+            # From the VERIFIED descriptor, not from the name again.
+            os.lseek(src, 0, os.SEEK_SET)
+            while True:
+                chunk = os.read(src, 1 << 20)
+                if not chunk:
+                    break
+                while chunk:
+                    chunk = chunk[os.write(dst, chunk) :]
+        except OSError:
+            # A half-written file is worse than none: it would carry SOME of the content and
+            # silently drop the rest, which reads as a smaller batch rather than as a failure.
+            #
+            # Emptied FIRST, through the descriptor this call is still holding. That part
+            # cannot touch anything else: `dst` is the file this call created, so even if the
+            # name now leads elsewhere the truncate lands on our own inode. It means the
+            # partial content is gone whether or not the unlink below happens.
+            #
+            # Then the name is removed, but only while it still holds that same file. The
+            # check narrows a two-syscall window rather than closing it - POSIX has no
+            # "unlink if this inode" - and the truncate above is what makes the residual
+            # bounded: the worst case is a file that arrived at a private name this call
+            # created moments earlier, inside a recovery path reached only after a removal
+            # already failed. Leaving the name in place instead would satisfy the window
+            # completely and leave a zero-length manifest at it, which a later read cannot
+            # tell from a corrupted one and a later retry cannot overwrite.
+            with suppress(OSError):
+                os.ftruncate(dst, 0)
+            _unlink_verified(dst_dir_fd, dst_name, (created.st_dev, created.st_ino))
+            return PUT_BACK_FAILED
+        finally:
+            os.close(dst)
+    finally:
+        os.close(src)
+    return None
+
+
+def remove_tree_pinned(
+    resolved_path: str,
+    *,
+    what: str,
+    approve: Callable[[int, PinnedTree], str | None],
+    refusal: type[Exception] = PinnedPathRefusal,
+    keep_until_empty: str | None = None,
+) -> TreeRemoval:
+    """Remove the directory *resolved_path* and everything in it, by descriptor throughout.
+
+    The whole-tree counterpart of the pieces above, for callers whose answer to "what may
+    be deleted here" is "all of it" -- a directory they have already established holds
+    nothing worth keeping. What it replaces at those call sites is
+    ``shutil.rmtree(path)``, which re-resolves the path: every ancestor is walked again by
+    the kernel, so one of them swapped to a link after the caller's own checks is followed
+    and the removal lands outside the tree entirely.
+
+    The sequence: pin the parent chain one ``openat`` per component, open the target
+    through it with ``O_NOFOLLOW``, scan it once, let *approve* look at what was found,
+    remove links and files against the scanned inodes, remove directories deepest-first
+    through :func:`remove_dir_verified`, re-scan to decide whether it is actually empty,
+    and only then remove the target itself -- verified against the descriptor the whole
+    operation was pinned to.
+
+    *approve* is where a caller re-establishes, THROUGH THE PINNED DESCRIPTOR, whatever it
+    believes about this directory. It is called once with ``(root_fd, tree)`` before
+    anything is removed, and returning a reason string refuses the whole removal having
+    touched nothing. It is REQUIRED, and not nullable. Resolving the parent does NOT by
+    itself prove the opened directory is the caller's, because ``Path.resolve()`` follows an
+    ancestor that is ALREADY a link -- so a swap landing before the resolve produces a
+    perfectly pinned walk to the wrong tree, and pinning alone would then delete it. What
+    defeats that is the caller asking a question only its own directory can answer, and
+    asking it of the descriptor rather than of the path. A removal that asks nothing is the
+    weaker mode, and there is no caller that wants it: leaving the parameter optional would
+    only make the weak mode available to a future caller by omission.
+
+    *keep_until_empty* names a top-level FILE to remove LAST, and it exists because the
+    order is load-bearing rather than tidy. Some trees are only DISCOVERABLE through one
+    entry -- an index, a manifest -- and removing that first means a later failure leaves
+    the rest of the tree on disk with nothing that lists it: data neither visible nor
+    recoverable, while the removal reported a partial success. So the named entry is skipped
+    by the file pass, the closing scan must find nothing but it, and only then is it moved
+    aside and the tree removed. If the tree still will not go, the entry goes back through
+    :func:`put_back_no_clobber`, which cannot overwrite whatever arrived at that name and
+    needs no hard-link support to succeed.
+
+    Raises *refusal* on a platform that cannot pin (see
+    :func:`supports_pinned_tree_walk`) rather than falling back to a by-name removal. That
+    is this module's standing rule: the caller is told and decides. It also raises
+    *refusal* when the target cannot be opened at all, which is precisely the ancestor swap
+    the pinned walk exists to catch.
+
+    Returns rather than raises for a tree that would not go: ``removed`` is False and
+    ``survivors`` says how much is left, so a caller can keep the directory visible instead
+    of reporting a success that did not happen.
+
+    *resolved_path* must already be RESOLVED -- see :func:`pin_parent` for why demanding
+    that is safe rather than brittle.
+    """
+    if not supports_pinned_tree_walk():
+        raise refusal(
+            f"refusing to remove the {what} by name: this platform cannot open relative to "
+            "a directory descriptor, so the removal would re-resolve every ancestor"
+        )
+    target = Path(resolved_path)
+    if target.parent == target:
+        raise refusal(f"refusing to remove the {what}: {resolved_path!r} has no parent")
+    parent_fd = pin_parent(str(target.parent), what=what, refusal=refusal)
+    try:
+        try:
+            root_fd = os.open(target.name, dir_flags(), dir_fd=parent_fd)
+        except OSError as exc:
+            raise refusal(f"refusing to remove the {what}: {exc}") from exc
+        try:
+            pinned = os.fstat(root_fd)
+            device = pinned.st_dev
+            cache: dict[tuple[str, ...], int] = {}
+            deferred_key: tuple[str, ...] | None = None
+            deferred_ino: int | None = None
+            try:
+                tree = scan_tree_pinned(root_fd, device=device)
+                withheld = approve(root_fd, tree)
+                if withheld is not None:
+                    # Before ANY removal, so a refusal costs nothing: the directory is
+                    # exactly as it was found.
+                    return TreeRemoval(
+                        removed=False,
+                        survivors=len(tree.dirs) + len(tree.files) + len(tree.links),
+                        reason=withheld,
+                    )
+                # Resolved against the SCAN, not by asking the directory again: the entry
+                # held back has to be the one this pass saw, so the identity re-checked
+                # after the removal has something honest to compare with. Named but absent
+                # means there is nothing to defer, which is not an error - a tree with no
+                # index entry is simply one where the order does not matter.
+                if keep_until_empty is not None and (keep_until_empty,) in tree.files:
+                    deferred_key = (keep_until_empty,)
+                    deferred_ino = tree.files[deferred_key]
+                # Links first and never followed: a link is unlinked, so what it points at
+                # is irrelevant -- but only if it is STILL the link the scan saw, because
+                # the name could now hold a real file that is somebody's only copy.
+                for key, ino in tree.links.items():
+                    try:
+                        holder = open_verified_chain(
+                            root_fd, key[:-1], cache=cache, dirs=tree.dirs, device=device
+                        )
+                    except OSError:
+                        continue
+                    _unlink_verified(holder, key[-1], (device, ino))
+                for key, ino in tree.files.items():
+                    if key == deferred_key:
+                        # Held back on purpose - see `keep_until_empty`. Removing it now and
+                        # then failing to remove the tree would leave data on disk that
+                        # nothing lists.
+                        continue
+                    try:
+                        holder = open_verified_chain(
+                            root_fd, key[:-1], cache=cache, dirs=tree.dirs, device=device
+                        )
+                    except OSError:
+                        continue
+                    _unlink_verified(holder, key[-1], (device, ino))
+                # Dropped FIRST, so the directory phase re-opens every directory and
+                # re-checks its inode. Reusing a descriptor cached during the file phase
+                # would satisfy the check with the identity the directory had THEN, and
+                # `rmdir` addresses a name.
+                drain_verified_chain(cache)
+                staged: str | None = None
+                for key in sorted(tree.dirs, key=len, reverse=True):
+                    try:
+                        # The FULL key, so the directory about to go is itself checked
+                        # against the scanned inode -- not merely the chain leading to it.
+                        open_verified_chain(
+                            root_fd, key, cache=cache, dirs=tree.dirs, device=device
+                        )
+                        holder = open_verified_chain(
+                            root_fd, key[:-1], cache=cache, dirs=tree.dirs, device=device
+                        )
+                    except OSError:
+                        continue
+                    outcome = remove_dir_verified(
+                        holder,
+                        key[-1],
+                        expect=(device, tree.dirs[key]),
+                    )
+                    if outcome.staged_name is not None:
+                        staged = outcome.staged_name
+                drain_verified_chain(cache)
+                # The post-condition is a FRESH pinned scan, for the same reason the
+                # removal is driven by the first one: asking "is it empty" of the same walk
+                # that decided what to delete lets one answer stand in for the other.
+                try:
+                    left = scan_tree_pinned(root_fd, device=device)
+                except OSError:
+                    # Cannot confirm it is empty, so it is not treated as empty: removing
+                    # the directory now would be doing it on an answer that was never read.
+                    return TreeRemoval(
+                        removed=False,
+                        reason=REMOVAL_UNVERIFIABLE,
+                        staged_name=staged,
+                    )
+                remaining = dict(left.files)
+                if deferred_key is not None:
+                    # By INODE, not by name. Everything after this treats the survivor as
+                    # the entry that was deliberately kept: it is moved aside and, once the
+                    # tree is gone, unlinked. A file substituted at that name after the
+                    # first scan would otherwise be accepted here and then destroyed.
+                    if remaining.pop(deferred_key, None) != deferred_ino:
+                        return TreeRemoval(
+                            removed=False,
+                            survivors=len(left.dirs) + len(left.files) + len(left.links),
+                            reason=REMOVAL_IDENTITY_CHANGED,
+                            staged_name=staged,
+                        )
+                survivors = len(left.dirs) + len(remaining) + len(left.links)
+                if survivors:
+                    return TreeRemoval(
+                        removed=False,
+                        survivors=survivors,
+                        reason=REMOVAL_FAILED,
+                        staged_name=staged,
+                    )
+            finally:
+                drain_verified_chain(cache)
+            if deferred_key is None or deferred_ino is None:
+                outcome = remove_dir_verified(
+                    parent_fd,
+                    target.name,
+                    expect=(pinned.st_dev, pinned.st_ino),
+                )
+                return TreeRemoval(
+                    removed=outcome.removed,
+                    reason=outcome.reason,
+                    staged_name=outcome.staged_name,
+                )
+            return _remove_with_deferred_entry(
+                parent_fd,
+                root_fd,
+                target.name,
+                deferred_key[0],
+                deferred_ino,
+                (pinned.st_dev, pinned.st_ino),
+            )
+        finally:
+            close_all((root_fd,))
+    finally:
+        close_all((parent_fd,))
+
+
+def _remove_with_deferred_entry(
+    parent_fd: int,
+    root_fd: int,
+    name: str,
+    entry: str,
+    entry_ino: int,
+    expect: tuple[int, int],
+) -> TreeRemoval:
+    """Move the deferred entry out, remove the now-empty tree, then delete the entry.
+
+    The entry and the directory have to go TOGETHER, and ``rmdir`` cannot run while the
+    entry is still in there. Unlinking it first leaves a window that a file created after
+    the closing scan turns into silent loss: the ``rmdir`` then fails on a non-empty
+    directory, and the tree - now without the entry that made it discoverable - is data on
+    disk that nothing lists.
+
+    So the entry is MOVED to the parent under an unguessable debris name instead of deleted.
+    From there the tree can be removed, and if that fails the entry goes straight back,
+    leaving it discoverable exactly as it was. A crash between the two renames leaves one
+    small file rather than an unreadable tree.
+
+    The way back is :func:`put_back_no_clobber`, never ``rename``: POSIX rename REPLACES its
+    destination silently, which is the property the debris name is chosen to be safe
+    against, and this direction needs the opposite - a file that arrived at the entry's name
+    in the interval must not be clobbered. The debris is unlinked only once the entry is
+    back, so no window has neither.
+    """
+    debris = f".{name}.{entry}.removing-{os.urandom(4).hex()}"
+    try:
+        os.rename(entry, debris, src_dir_fd=root_fd, dst_dir_fd=parent_fd)
+    except OSError:
+        return TreeRemoval(removed=False, reason=REMOVAL_STAGE_FAILED)
+    landed: int | None = None
+    try:
+        landed = os.stat(debris, dir_fd=parent_fd, follow_symlinks=False).st_ino
+    except OSError:
+        pass
+    if landed != entry_ino:
+        # The rename moved something that is not the verified entry, so the unlink at the
+        # end of this would destroy it. Left as debris, named for a human.
+        return TreeRemoval(removed=False, reason=REMOVAL_IDENTITY_CHANGED, staged_name=debris)
+    outcome = remove_dir_verified(parent_fd, name, expect=expect)
+    if not outcome.removed:
+        put_back_no_clobber(parent_fd, root_fd, debris, entry, expect_ino=landed)
+        # The debris is KEPT here, and that is the whole point of this branch. The tree
+        # survived, so the entry is what makes it discoverable, and the check available
+        # before an unlink can only confirm that DEBRIS is still the file that was staged -
+        # never that the name it was put back to still holds a good copy. A file replaced at
+        # the entry's name after the put-back would leave the debris as the last readable
+        # copy, and unlinking it would turn a batch that is merely stuck into one nothing
+        # lists and nothing can restore, which is exactly the loss the deferral exists to
+        # prevent. The cost is one small named file per stuck cleanup, reported below.
+        return TreeRemoval(
+            removed=False,
+            reason=outcome.reason,
+            # The directory's staging name first when there is one: the whole tree sits
+            # under it, so it is the more urgent thing to name. Otherwise the debris, so no
+            # retained copy is left unmentioned.
+            staged_name=outcome.staged_name or debris,
+        )
+    _unlink_verified(parent_fd, debris, (expect[0], landed))
+    return TreeRemoval(removed=True)

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -74,7 +74,7 @@ import stat
 import threading
 import time
 import uuid
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -1354,19 +1354,49 @@ def _unlisted_files(batch: Path) -> list[Path]:
     return unlisted
 
 
-def _discard_restored_batch(batch: Path, header: dict[str, Any]) -> None:
+def _identity_of(path: Path) -> tuple[int, int] | None:
+    """``(st_dev, st_ino)`` for *path*, or None if it cannot be read.
+
+    Links are not followed: the question is what this NAME holds, never what it points at.
+    Taken so a later removal can be bound to the directory the caller was actually looking
+    at - see :func:`_remove_emptied_batch` for why a pinned walk alone does not establish
+    that.
+    """
+    try:
+        info = os.stat(path, follow_symlinks=False)
+    except OSError:
+        return None
+    return (info.st_dev, info.st_ino)
+
+
+def _discard_restored_batch(batch: Path, expect: tuple[int, int] | None) -> None:
     """Remove a fully-restored batch, unless it holds files nothing listed.
 
     Deleting the directory wholesale would destroy an interrupted move's staged
     files — on the one path that exists to be safe. Those keep the batch alive
     instead, so a user can still see it and decide.
+
+    *expect* is the batch's identity as the CALLER recorded it, before the restore read
+    anything inside it. It is not re-taken here on purpose: this function is reached only
+    after the restore has read the manifest and moved every listed file out, so an identity
+    sampled at this point would already be a substitute's if an ancestor had been swapped
+    during any of that. Taken at the top of the operation instead, the same comparison
+    refuses a swap that landed at ANY point in it. ``None`` means the caller could not read
+    it, which refuses.
+
+    NOTHING here writes, and a batch this declines to remove stays exactly as it was found -
+    including its manifest, whose entries all describe files the restore has already moved
+    back OUT. That stale listing is a decided residual, not an oversight: clearing it would
+    mean writing to a path that a refusal has just given evidence about - a swapped ancestor,
+    an identity that could not be read - and ``atomic_write`` REPLACES its destination, so the
+    tidying would land wherever the path now leads. See the caller for why the write is not
+    hoisted above this call either. `empty_trash` clears the batch on the user's own say-so.
     """
     try:
         leftovers = _unlisted_files(batch)
     except SessionStorageError as exc:
         # Not knowing is treated exactly like finding leftovers: keep the batch.
         logger.warning("keeping trash batch %r: %s", batch.name, exc)
-        _rewrite_manifest(batch, header, [])
         return
     if leftovers:
         logger.warning(
@@ -1375,9 +1405,262 @@ def _discard_restored_batch(batch: Path, header: dict[str, Any]) -> None:
             batch.name,
             len(leftovers),
         )
-        _rewrite_manifest(batch, header, [])
         return
-    shutil.rmtree(batch, ignore_errors=True)
+    _remove_emptied_batch(batch, "the restored batch", expect=expect)
+
+
+def _approve_emptied_batch(
+    batch: Path,
+    root_fd: int,
+    tree: pinned_fs.PinnedTree,
+) -> str | None:
+    """Re-ask "is this the batch, and does it hold anything unlisted" of a DESCRIPTOR.
+
+    The trash-specific half of :func:`_remove_emptied_batch`, passed to ``pinned_fs`` as its
+    approval hook. Both questions were already answered by path before the removal was
+    reached - which is exactly the answer that cannot be relied on, because resolving the
+    batch's parent FOLLOWS an ancestor that is already a symbolic link. Pinning the walk
+    then reaches the link's target faithfully, and the removal would empty that.
+
+    So the two questions are asked again here, of the descriptor the removal will actually
+    address, from ONE read of ONE file:
+
+    * the pinned root must BE the directory the caller was looking at, compared by
+      ``(st_dev, st_ino)`` against an identity the caller captured before its own by-path
+      read - at the batch's creation on one path, before the leftover scan on the other.
+      This is the check that makes the rest sound. Without it the only thing standing
+      between a swapped ancestor and a deletion is whether the directory the link points at
+      can produce a convincing manifest, and a tree an actor can write to can: they plant a
+      header naming this batch and a listing covering its contents, and every other question
+      here answers yes about the wrong directory. An inode cannot be forged by writing files.
+    * the manifest is opened through ``root_fd``, its inode is checked on the OPEN handle
+      against the one the scan recorded, and its header must claim THIS batch's
+      directory name. The header is the link back to the caller's own selection: a directory
+      substituted for the batch brings its own contents, and a directory that is not a
+      trash batch at all brings none - neither can produce a header naming this name.
+      :func:`_header_names_this_batch` is the same check the approval on the delete path
+      makes, for the same reason.
+    * NOTHING but the manifest may remain. Not "nothing unlisted" - nothing at all. Both
+      callers reach here only when the batch should already be empty of files: the restore
+      path has MOVED every listed file back out, and the staging path has a manifest with no
+      entries at all. So a file at a listed path is not the listed file; it is something that
+      arrived at that name afterwards, and it may be the only copy of whatever it is.
+      Consulting the listing here would authorise deleting exactly that, on the strength of a
+      name the manifest happens to mention. The stricter rule also needs no listing, which is
+      why the entries this read produced are discarded.
+
+    ONE read, not two, and that is the load-bearing part rather than an efficiency note.
+    Asking :func:`_summarize_manifest` for the header and :func:`_manifest_rels` for a listing
+    opens the file TWICE, and a manifest replaced in between passes the header check on the
+    first file while the second answers for another. The header now comes from one handle
+    whose inode was verified on that same handle, so there is no interval for a replacement to
+    land in.
+
+    Returns None to allow the removal, or a reason code to withhold it. The identity
+    comparison against the caller's recorded inode happens BEFORE this, in
+    :func:`_remove_emptied_batch`'s own hook -- it owns that answer because the caller also
+    needs to know whether the path was verified, and a reason code cannot carry that.
+
+    Links are refused too, not exempted. A symbolic link holds no data of its own, which is
+    why the delete path removes scanned ones - but it is also the only entry a removal can
+    take by NAME, with a scanned-inode check and an unlink that are two separate syscalls.
+    Admitting one is admitting that window, so a batch holding a link is kept and left for
+    `empty_trash`, which removes links through its own approval when a user asks for the
+    empty.
+    """
+    scanned_ino = tree.files.get((MANIFEST_NAME,))
+    if scanned_ino is None:
+        # Nothing here vouches for this being the selected batch, and `list_trash` would not
+        # offer a batch with no manifest either.
+        logger.warning("keeping trash batch %r: it has no manifest to identify it", batch.name)
+        return SKIP_UNREADABLE
+    try:
+        parsed = _read_manifest(batch, dir_fd=root_fd, expect_ino=scanned_ino)
+    except UnicodeDecodeError:
+        # `_read_manifest` reports an unreadable manifest as None, but it DECODES strictly,
+        # so bytes that are not UTF-8 raise instead - and a ValueError, which neither its own
+        # `except OSError` nor anything between here and the caller catches. Reached when the
+        # file is corrupted after the by-path pre-screen read it, which is the very race this
+        # pinned re-read exists for. A manifest that cannot be decoded cannot identify the
+        # batch, so it withholds the removal like any other unreadable one instead of
+        # aborting a restore that has already moved the user's files back.
+        logger.warning("keeping trash batch %r: its manifest is not valid UTF-8", batch.name)
+        return SKIP_UNREADABLE
+    if parsed is None:
+        logger.warning(
+            "keeping trash batch %r: its manifest is not readable as the file that was scanned",
+            batch.name,
+        )
+        return SKIP_UNREADABLE
+    header, _entries = parsed
+    # `_header_names_this_batch` takes a `_summarize_manifest` triple; it consults only the
+    # header, and handing it the one this read already produced is what keeps this to one
+    # open.
+    if not _header_names_this_batch((header, 0, 0), batch.name):
+        return SKIP_IDENTITY_CHANGED
+    for key in tree.files:
+        if key == (MANIFEST_NAME,):
+            continue
+        logger.warning(
+            "keeping trash batch %r: it still holds %r, which nothing here may remove",
+            batch.name,
+            "/".join(key),
+        )
+        return SKIP_UNLISTED_FILES
+    if tree.links:
+        # A link is the ONE entry the removal takes by name: `_unlink_verified` compares the
+        # scanned inode and then unlinks, and POSIX offers no "unlink if this inode", so those
+        # are two syscalls. Admitting a link therefore hands an actor a lever - plant one, let
+        # this approval pass it, then put a file at that name in the window and the removal
+        # deletes the file instead of the link. A file is refused above for the same reason and
+        # a link is not different enough to treat differently here.
+        #
+        # It costs nothing that matters: neither of these two removals was asked for, and a
+        # batch kept for this reason is still cleared by `empty_trash` on the user's own
+        # say-so, which removes scanned links through its own approval.
+        logger.warning(
+            "keeping trash batch %r: it holds %d link(s), which the removal could only take "
+            "by name",
+            batch.name,
+            len(tree.links),
+        )
+        return SKIP_UNLISTED_FILES
+    return None
+
+
+def _remove_emptied_batch(batch: Path, what: str, *, expect: tuple[int, int] | None) -> bool:
+    """Remove a batch that holds nothing worth keeping, by descriptor rather than by name.
+
+    Both callers reach this having already established that the batch holds no file the
+    manifest does not list - a fully restored batch, and one no session was staged into.
+    What is left is the removal, and it used to be ``shutil.rmtree(batch)``: a PATH, which
+    the kernel re-resolves component by component. The trash root and the directories above
+    it are writable by the same user, which in this product includes an agent, so one of
+    them swapped to a symbolic link after the caller's own read is followed and the removal
+    lands wherever the link points. Neither caller holds the mutation lock across that
+    window, and the checks above them are all by path, so nothing else closed it.
+
+    :func:`kiro_crew.pinned_fs.remove_tree_pinned` is the same mechanism the delete path
+    uses, reached through the same module rather than respelled here: the parent chain is
+    pinned one ``openat`` per component, the batch is opened through it with
+    ``O_NOFOLLOW``, and every removal inside addresses a descriptor whose inode a scan
+    already recorded.
+
+    Pinning is only half of it, and the weaker half. It closes the window after the path is
+    resolved; the swap that lands BEFORE the resolve is followed by ``Path.resolve()``
+    itself, and the pinned walk then reaches the wrong tree correctly - faithfully pinned to
+    a directory that is not this batch. What closes that is
+    :func:`_approve_emptied_batch`, which compares the pinned root against *expect* - an
+    identity the CALLER captured before its own by-path read - and then re-asks through the
+    same descriptor the two questions the callers asked by path.
+
+    *expect* being None means the caller could not read the batch's identity, and the removal
+    is refused: with nothing to bind to, every remaining question would be answered about an
+    unknown directory.
+
+    A refusal LEAVES THE BATCH, and that is the safe direction on both paths: the batch is
+    still listed, so a user can still see it and act. Reporting a success that did not
+    happen is what a bare ``ignore_errors=True`` did. Nothing here writes to the batch on
+    the way out either: every refusal below is evidence about the path, and answering it
+    with a by-path write would be writing through the very redirection it just caught.
+
+    Returns whether the batch is gone.
+    """
+    if not _FD_SAFE_DELETE:
+        # No ``openat``/``O_NOFOLLOW``, so there is no descriptor to bind the removal to.
+        # It goes through the same rename-verify-remove the explicit empty uses on this
+        # platform, from the same owner: the batch is renamed aside inside the trash root,
+        # its identity is checked THERE, and only the staged name is removed.
+        #
+        # Refusing outright was the earlier answer here, on the reasoning that nobody asked
+        # for these two removals so the safer half of the trade came free. It does not: this
+        # branch is the whole of Windows, so refusing leaves a batch behind after EVERY
+        # restore and every rolled-back move, still listing the sessions it no longer holds.
+        # Five pre-existing tests read that as a failure and so would a user. The residual
+        # accepted instead is the one `empty_trash` already accepts here and documents - an
+        # actor who can observe the staging name inside the window can redirect the removal
+        # through an ancestor swapped afterwards - and it is bounded by an identity check
+        # that a same-named impostor cannot pass.
+        if expect is None:
+            # Nothing to bind to, so the verify half would be answered about an unknown
+            # directory and the rename would only move the batch out of sight.
+            logger.warning("keeping trash batch %r: its identity was never established", batch.name)
+            return False
+        staged, skip = _stage_batch_by_name(batch, expect=expect)
+        if staged is None:
+            logger.warning(
+                "keeping trash batch %r: %s was not removed (%s)", batch.name, what, skip
+            )
+            return False
+        try:
+            shutil.rmtree(staged)
+        except OSError as exc:
+            # Back under the name the user saw: a batch left under a staging name is one
+            # `list_trash` does not offer, so it would be neither visible nor restorable.
+            logger.warning(
+                "keeping trash batch %r: %s could not be removed: %s", batch.name, what, exc
+            )
+            _rename_back(staged, batch)
+            return False
+        return True
+    try:
+        # Only the PARENT is resolved, and the name is re-joined onto it. `Path.resolve()`
+        # follows the FINAL component too, so a batch directory replaced by a symlink would
+        # resolve to its target and every removal below would run there - deleting from
+        # outside the trash on the strength of a name inside it. Re-joining the name leaves
+        # the last component for the pinned ``O_NOFOLLOW`` open to refuse. This is the same
+        # rule :func:`_approve_batch` follows, for the same reason.
+        resolved = batch.parent.resolve() / batch.name
+    except OSError as exc:
+        logger.warning(
+            "keeping trash batch %r: its location could not be read: %s", batch.name, exc
+        )
+        return False
+
+    def _approve(root_fd: int, tree: pinned_fs.PinnedTree) -> str | None:
+        if expect is None:
+            # Nothing to bind to, so every remaining question would be answered about an
+            # unknown directory.
+            logger.warning("keeping trash batch %r: its identity was never established", batch.name)
+            return SKIP_UNREADABLE
+        opened = os.fstat(root_fd)
+        if (opened.st_dev, opened.st_ino) != expect:
+            logger.warning(
+                "keeping trash batch %r: it is not the directory that was selected", batch.name
+            )
+            return SKIP_IDENTITY_CHANGED
+        return _approve_emptied_batch(batch, root_fd, tree)
+
+    try:
+        outcome = pinned_fs.remove_tree_pinned(
+            str(resolved),
+            what=what,
+            refusal=OSError,
+            approve=_approve,
+            # The manifest goes LAST, and comes back if the batch itself will not go.
+            # `list_trash` omits a batch with no readable manifest, so removing it first and
+            # then failing on the directory would leave a batch holding data that is neither
+            # visible nor restorable - the same reason the delete path moves it aside rather
+            # than unlinking it.
+            keep_until_empty=MANIFEST_NAME,
+        )
+    except OSError as exc:
+        # Includes the ancestor swap the pinned walk exists to catch. Warned rather than
+        # raised: on both paths the caller has already finished the work the user asked for,
+        # and a leftover batch is visible and restorable.
+        logger.warning(
+            "keeping trash batch %r: it could not be removed safely: %s", batch.name, exc
+        )
+        return False
+    if not outcome.removed:
+        logger.warning(
+            "keeping trash batch %r: %s left %d entr(y/ies) behind%s",
+            batch.name,
+            outcome.reason or "the removal",
+            outcome.survivors,
+            f"; part of it is now {outcome.staged_name!r}" if outcome.staged_name else "",
+        )
+    return outcome.removed
 
 
 def _write_header(handle: IO[str], batch_id: str, created_at: float, reason: str) -> None:
@@ -1504,7 +1787,7 @@ def _manifest_records(handle: IO[str], batch: Path) -> Iterator[dict[str, Any]]:
 
 
 def _read_manifest(
-    batch: Path, *, dir_fd: int | None = None
+    batch: Path, *, dir_fd: int | None = None, expect_ino: int | None = None
 ) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
     """Parse a batch manifest into its header and session entries.
 
@@ -1515,11 +1798,20 @@ def _read_manifest(
     mid-append) is skipped rather than failing the whole batch — every complete
     line before it describes real moved files that must stay restorable (see
     :func:`_manifest_records`).
+
+    *expect_ino* refuses a manifest that is not the file the caller already identified,
+    checked by ``fstat`` on the OPEN handle rather than by a stat of the name - so there is
+    no interval between the check and the read for a replacement to land in. A caller that
+    needs both the header and the listing to describe ONE file passes it and makes a single
+    call: two calls are two opens, and a manifest rewritten between them lets the header
+    check pass on one file while the listing that authorises a deletion comes from another.
     """
     header: dict[str, Any] | None = None
     entries: list[dict[str, Any]] = []
     try:
         with _open_manifest(batch, dir_fd) as handle:
+            if expect_ino is not None and os.fstat(handle.fileno()).st_ino != expect_ino:
+                return None
             for record in _manifest_records(handle, batch):
                 if header is None:
                     header = record
@@ -1790,6 +2082,13 @@ def _move_to_trash_locked(
     batch_id = f"{stamp}-{uuid.uuid4().hex[:8]}"
     target = _batch_dir(batch_id)
     target.mkdir(parents=True, exist_ok=False)
+    # Recorded HERE, at creation and under the mutation lock, because it is the strongest
+    # anchor this path will ever have: the directory was made by this call, so nothing has
+    # had a window to substitute anything for it yet. The cleanup below removes this batch
+    # by descriptor and compares that descriptor against these numbers, so a swapped
+    # ancestor reaching a different directory - however convincingly it is dressed up - is
+    # refused rather than emptied.
+    created_identity = _identity_of(target)
     archives = _archive_index()
 
     moved_bytes = 0
@@ -1933,7 +2232,7 @@ def _move_to_trash_locked(
             raise SessionStorageError(
                 "no sessions were staged, and some files could not be put back; " f"see {target}"
             )
-        shutil.rmtree(target, ignore_errors=True)
+        _remove_emptied_batch(target, "the empty batch", expect=created_identity)
         if revived:
             # A distinct message from "not found": every selected session is still
             # exactly where the caller left it, and it is still resumable. Saying
@@ -2043,6 +2342,14 @@ def _restore_locked(batch_id: str, uids: list[str] | None = None) -> int:
     blocked file leaves the whole session staged.
     """
     batch = _batch_dir(batch_id)
+    # BEFORE the first read of anything inside the batch, which is the point. This identity is
+    # what the cleanup at the bottom binds its removal to, and every check between here and
+    # there is by path: an ancestor swapped at ANY point during the restore is caught, because
+    # the pinned root the cleanup opens will not be the inode recorded here. Captured later -
+    # after the manifest read, or after the files have moved - the swap that landed in between
+    # would be recorded as though it were the batch, and the cleanup would then verify
+    # consistently against a directory the caller was never looking at.
+    identity = _identity_of(batch)
     parsed = _read_manifest(batch)
     if parsed is None:
         raise SessionStorageError(f"no restorable batch {batch_id!r}")
@@ -2130,7 +2437,18 @@ def _restore_locked(batch_id: str, uids: list[str] | None = None) -> int:
     if remaining:
         _rewrite_manifest(batch, header, remaining)
     else:
-        _discard_restored_batch(batch, header)
+        # NO write on this branch, and that is a decided residual rather than an oversight.
+        # Every entry below the header describes a file this restore moved back OUT, so a
+        # batch the cleanup then declines to remove still lists sessions that are not in it.
+        # Clearing them needs a write to `batch`, and there is nowhere safe to put one:
+        # AFTER the cleanup the descriptor is closed and every refusal is itself evidence
+        # the path may be redirected, and BEFORE it this branch has no write at all today,
+        # so adding one hands `atomic_write` - which REPLACES its destination - a path that
+        # a batch swapped to a link points wherever an actor chose, including another
+        # batch's manifest, whose sessions would become unlistable. A stale listing is
+        # visible and reversible; that is not. `empty_trash` clears the batch on the user's
+        # own say-so.
+        _discard_restored_batch(batch, identity)
     return restored
 
 
@@ -2263,158 +2581,21 @@ _FD_SAFE_DELETE = (
 _dir_open_flags = pinned_fs.dir_flags
 
 
-def _close_all(fds: Iterable[int]) -> None:
-    """Close every descriptor in *fds*, tolerating one that is already closed.
+#: Descriptor bookkeeping for the pinned walks below, from the same source as the walk
+#: itself. Aliases rather than second copies: a leaked descriptor pins its inode for the
+#: life of the process, and the drain's "pop as you go" rule exists so a failure part-way
+#: cannot leave an already-closed number for a later cleanup to close again.
+_close_all = pinned_fs.close_all
+_drain = pinned_fs.drain_verified_chain
 
-    A close that raises must not abandon the rest: a leaked directory descriptor pins
-    its inode for the life of the process, and this path opens one per staged directory.
-    """
-    for fd in fds:
-        with suppress(OSError):
-            os.close(fd)
-
-
-def _drain(cache: dict[tuple[str, ...], int]) -> None:
-    """Close and forget every descriptor in *cache*.
-
-    Emptied as it goes rather than closed in a loop and cleared afterwards: a failure
-    part-way would otherwise leave already-closed descriptors in the cache for the
-    cleanup below to close a SECOND time, and a reused number makes that second close
-    land on an unrelated file.
-    """
-    while cache:
-        _key, fd = cache.popitem()
-        with suppress(OSError):
-            os.close(fd)
-
-
-def _scan_batch(
-    dir_fd: int,
-    device: int,
-    prefix: tuple[str, ...],
-    dirs: dict[tuple[str, ...], int],
-    files: dict[tuple[str, ...], int],
-    links: dict[tuple[str, ...], int],
-) -> None:
-    """One pinned traversal of a batch: its directories, its files, and its links.
-
-    Records the inode of each directory AND of each non-directory entry, keyed by
-    batch-relative components, plus every LINK's key. Children are opened relative to the
-    descriptor with ``O_NOFOLLOW``, so no path is resolved and a directory that is really a
-    link is not descended into. The inodes come from the directory block itself
-    (``os.DirEntry.inode``), so recording them costs no extra syscall.
-
-    The inodes are the point. ``O_NOFOLLOW`` refuses a LINK, but a real directory RENAMED
-    into a staged name is not a link and satisfies ``O_DIRECTORY`` - so moving a live
-    directory onto a staged directory's name redirected the unlinks at live files that
-    happen to share a staged name, and pinning the batch does not cover that, because the
-    batch's own inode is unchanged by a rename INSIDE it. Every directory the delete later
-    opens must be the inode :func:`staged_targets` recorded while the mutation lock was
-    held. A map read at delete time cannot serve: it reports the impostor.
-
-    ITERATIVE, with an explicit stack, because a recursive walk of a deeply nested tree
-    raises ``RecursionError`` - which is not ``OSError``, so it escaped the callers that
-    turn a failed read into a refusal and reached the dashboard as a snapshot failure. One
-    descriptor is held per level of the CURRENT path, so a tree deep enough still fails,
-    but it fails with ``EMFILE`` - an ``OSError``, which every caller here already treats
-    as "cannot read this batch, keep it".
-
-    Raises rather than returning a short list, for the same reason
-    :func:`_unlisted_files` does: this feeds a decision about deleting the only copy of
-    something, so an incomplete answer must not read as "nothing unaccounted for".
-    """
-    # (key prefix, descriptor, whether this function opened it and must close it)
-    stack: list[tuple[tuple[str, ...], int, bool]] = [(prefix, dir_fd, False)]
-    try:
-        while stack:
-            here, fd, owned = stack.pop()
-            try:
-                with os.scandir(fd) as entries:
-                    listing = list(entries)
-                for entry in listing:
-                    key = here + (entry.name,)
-                    if entry.is_symlink():
-                        links[key] = entry.inode()
-                        continue
-                    if not entry.is_dir(follow_symlinks=False):
-                        files[key] = entry.inode()
-                        continue
-                    child = os.open(entry.name, _dir_open_flags(), dir_fd=fd)
-                    try:
-                        info = os.fstat(child)
-                        if info.st_dev != device:
-                            raise OSError(
-                                f"refusing a staged directory on another device: {entry.name!r}"
-                            )
-                        # The name was listed by `scandir` and opened a moment later, which is
-                        # a check-to-use window like any other - and this one produces the map
-                        # the APPROVAL is made of. A rename in between means the inode recorded
-                        # here belongs to the replacement, so the approval blesses it and the
-                        # delete, validating against that map, removes it. `entry.inode()` is
-                        # what the listing saw; the descriptor is what was opened. They have to
-                        # agree.
-                        if info.st_ino != entry.inode():
-                            raise OSError(
-                                "refusing a staged directory that changed between the listing "
-                                f"and the open: {entry.name!r}"
-                            )
-                    except OSError:
-                        _close_all((child,))
-                        raise
-                    dirs[key] = info.st_ino
-                    stack.append((key, child, True))
-            finally:
-                if owned:
-                    _close_all((fd,))
-    finally:
-        # Whatever is still queued when an error unwinds this: the loop closes each
-        # descriptor as it finishes with it, so only the unvisited remainder is left.
-        _close_all(fd for _key, fd, owned in stack if owned)
-
-
-def _open_chain(
-    batch_fd: int,
-    parts: tuple[str, ...],
-    cache: dict[tuple[str, ...], int],
-    dirs: dict[tuple[str, ...], int],
-    device: int,
-) -> int:
-    """Open the directory named by *parts* under a pinned batch, or raise.
-
-    Every component is opened with ``O_NOFOLLOW`` relative to the previous one, so a
-    component that is (or becomes) a link fails the open instead of being followed, and
-    each one is admitted only as the inode :func:`_scan_batch` recorded for that name on
-    the batch's own device. A rename landing after that scan is therefore refused rather
-    than followed - which ``O_NOFOLLOW`` alone cannot do, since a renamed real directory
-    is not a link.
-
-    Descriptors are cached because one batch has a handful of directories and tens of
-    thousands of files inside them, so each directory is verified once and then addressed
-    by the descriptor that was checked.
-    """
-    fd = batch_fd
-    key: tuple[str, ...] = ()
-    for part in parts:
-        key = key + (part,)
-        cached = cache.get(key)
-        if cached is not None:
-            fd = cached
-            continue
-        expected = dirs.get(key)
-        if expected is None:
-            raise OSError(f"refusing a staged directory the batch scan did not see: {part!r}")
-        child = os.open(part, _dir_open_flags(), dir_fd=fd)
-        try:
-            info = os.fstat(child)
-        except OSError:
-            _close_all((child,))
-            raise
-        if (info.st_dev, info.st_ino) != (device, expected):
-            _close_all((child,))
-            raise OSError(f"refusing a staged directory that changed identity: {part!r}")
-        cache[key] = child
-        fd = child
-    return fd
+#: The pinned traversal and the verified chain-open used to be spelled here. They are
+#: consumer-agnostic - "walk a tree without ever re-resolving a name" and "open a
+#: component only as the inode a scan recorded" say nothing about batches, manifests or
+#: approval - so they now live in :mod:`kiro_crew.pinned_fs` with the rest of the
+#: mechanism, and what stays in this module is the trash-specific part: which map
+#: authorises the delete, and what a refusal means to the user.
+_scan_tree = pinned_fs.scan_tree_pinned
+_open_chain = pinned_fs.open_verified_chain
 
 
 def _plain_parts(rel: str) -> tuple[str, ...] | None:
@@ -2552,11 +2733,11 @@ def _remove_scanned_dirs(
     The removal itself goes through a rename to an unguessable name, because ``rmdir``
     addresses a NAME and so does the check above it: an actor with write access to the
     parent could swap the name between the two and have an unapproved directory removed on
-    another one's approval. Renaming first moves whatever holds the name to somewhere only
-    this call knows, and the identity is re-checked THERE before anything is removed - so a
-    swap that beats the rename gets the intruder's directory moved within its own parent
-    rather than deleted, and is then refused. This is the same technique the manifest and
-    the batch directory already use, for the same reason.
+    another one's approval. That mechanism is
+    :func:`kiro_crew.pinned_fs.remove_dir_verified`, which is where the batch directory and
+    the whole-tree removal get it too - one owner rather than a copy per site. What stays
+    here is the policy: this path logs and CONTINUES, because the post-condition scan below
+    is what decides whether the batch is incomplete.
     """
     for key in sorted(dirs, key=len, reverse=True):
         try:
@@ -2565,108 +2746,69 @@ def _remove_scanned_dirs(
             # directory's parent IS the batch, so verifying only the parent verified
             # nothing about it, and `rmdir` addresses a NAME: an empty directory swapped
             # into that name would have been removed on the approval of another one.
-            _open_chain(batch_fd, key, cache, dirs, device)
-            parent = _open_chain(batch_fd, key[:-1], cache, dirs, device)
+            _open_chain(batch_fd, key, cache=cache, dirs=dirs, device=device)
+            parent = _open_chain(batch_fd, key[:-1], cache=cache, dirs=dirs, device=device)
         except OSError as exc:
             logger.warning("could not reach staged directory %r: %s", key[-1], exc)
             continue
-        # Random, like every other staging name here: `os.rename` replaces an existing
-        # destination silently on POSIX, so a predictable name is one that can be squatted.
-        staging = f".{key[-1]}.removing-{uuid.uuid4().hex[:8]}"
-        try:
-            os.rename(key[-1], staging, src_dir_fd=parent, dst_dir_fd=parent)
-        except OSError as exc:
-            logger.warning("could not stage staged directory %r for removal: %s", key[-1], exc)
+        outcome = pinned_fs.remove_dir_verified(
+            parent,
+            key[-1],
+            expect=(device, dirs[key]),
+        )
+        if outcome.removed:
             continue
-        try:
-            moved = os.stat(staging, dir_fd=parent, follow_symlinks=False)
-        except OSError as exc:
-            # NOT restored. What is under the staging name is unknown, so putting it back
-            # means renaming an unknown object onto the listed name - and POSIX rename
-            # REPLACES its destination, which would destroy whatever is there now.
-            logger.warning(
-                "could not re-check staged directory %r; leaving it as %r: %s",
-                key[-1],
-                staging,
-                exc,
-            )
-            continue
-        if not stat.S_ISDIR(moved.st_mode) or (moved.st_dev, moved.st_ino) != (device, dirs[key]):
-            # Also NOT restored, and this is the case that matters: the object under the
-            # staging name is NOT the approved directory, so the listed name is not ours to
-            # write to either. An actor who swapped the directory and then placed something
-            # at the listed name would have had this rename destroy it. It stays under the
-            # unguessable name, logged, and the post-condition reports the batch incomplete.
+        if outcome.reason == pinned_fs.REMOVAL_IDENTITY_CHANGED:
+            # The object under the staging name is NOT the approved directory, so the listed
+            # name is not ours to write to either. An actor who swapped the directory and
+            # then placed something at the listed name would have had a rename-back destroy
+            # it. It stays under the unguessable name, logged, and the post-condition
+            # reports the batch incomplete.
             logger.error(
                 "refusing a staged directory that is not the one that was approved; it is "
                 "now %r and is left there rather than renamed back",
-                staging,
+                outcome.staged_name,
             )
-            continue
-        try:
-            os.rmdir(staging, dir_fd=parent)
-        except OSError as exc:
-            # Restored, and ONLY here: the identity matched, so this IS the approved
-            # directory and the listed name is the one it came from.
-            logger.warning("could not remove staged directory %r: %s", key[-1], exc)
-            _restore_staged_dir(parent, staging, key[-1])
+        elif outcome.reason == pinned_fs.REMOVAL_UNVERIFIABLE:
+            # Also not put back: what is under the staging name is unknown, so renaming it
+            # onto the listed name would replace whatever is there now.
+            logger.warning(
+                "could not re-check staged directory %r; leaving it as %r: %s",
+                key[-1],
+                outcome.staged_name,
+                outcome.error,
+            )
+        elif outcome.reason == pinned_fs.REMOVAL_STAGE_FAILED:
+            logger.warning(
+                "could not stage staged directory %r for removal: %s", key[-1], outcome.error
+            )
+        else:
+            logger.warning("could not remove staged directory %r: %s", key[-1], outcome.error)
+            if outcome.staged_name is not None:
+                # The identity matched, so this IS the approved directory - but it could not
+                # be put back, and a directory under a staging name is one nothing
+                # recognises.
+                logger.error(
+                    "staged directory %r is now %r and could not be put back",
+                    key[-1],
+                    outcome.staged_name,
+                )
 
 
-def _copy_back_exclusive(parent_fd: int, batch_fd: int, debris: str, name: str) -> bool:
-    """Recreate *name* inside *batch_fd* from *debris*, refusing to replace anything.
+def _unlink_debris(parent_fd: int, debris: str, expect_ino: int | None) -> None:
+    """Unlink the moved-aside manifest, only while that name still holds it.
 
-    The recovery's first choice is `os.link`, which cannot clobber. Where hard links are
-    unsupported there is no second no-clobber RENAME in the stdlib -- `renameat2`'s
-    `RENAME_NOREPLACE` is Linux-only and unexposed -- and the two obvious substitutes are
-    each a documented loss:
-
-    * `rename` after checking the name is free puts a check-to-use window between the look
-      and the act, so a file arriving in between is replaced. That is the same
-      trusted-a-name mistake this whole path exists to remove.
-    * giving up leaves the batch holding data with no manifest, which `list_trash()` omits:
-      unlistable and unrestorable.
-
-    `O_CREAT | O_EXCL` is the third option and has neither flaw. The create either wins or
-    fails with EEXIST, decided inside one syscall, so nothing can arrive in a window; and it
-    needs no hard-link support, so it strands nothing. The cost is a copy rather than a link,
-    paid only on a filesystem without links and only when a batch already failed to empty.
-
-    Returns True when the manifest is back.
+    The debris name lives in the trash root, and by the time this runs the batch removal has
+    either succeeded or failed - so time has passed in a directory an actor may be able to
+    write to. Unlinking by name alone would destroy whatever answers to it by then, which is
+    the same trusted-a-name mistake every other removal on this path was rewritten to avoid.
+    Best effort: a name that no longer holds the manifest is left alone, not chased.
     """
-    try:
-        src = os.open(debris, os.O_RDONLY, dir_fd=parent_fd)
-    except OSError:
-        return False
-    try:
-        try:
-            dst = os.open(
-                name,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                0o600,
-                dir_fd=batch_fd,
-            )
-        except OSError:
-            # EEXIST is the case worth naming: something holds the name, so the batch is
-            # listable through it and nothing here may overwrite it.
-            return False
-        try:
-            while True:
-                chunk = os.read(src, 1 << 20)
-                if not chunk:
-                    break
-                while chunk:
-                    chunk = chunk[os.write(dst, chunk) :]
-        except OSError:
-            # A half-written manifest is worse than none: it would list SOME sessions and
-            # silently drop the rest. Remove it and report the failure instead.
-            with suppress(OSError):
-                os.unlink(name, dir_fd=batch_fd)
-            return False
-        finally:
-            os.close(dst)
-    finally:
-        os.close(src)
-    return True
+    if expect_ino is None:
+        return
+    with suppress(OSError):
+        if os.stat(debris, dir_fd=parent_fd, follow_symlinks=False).st_ino == expect_ino:
+            os.unlink(debris, dir_fd=parent_fd)
 
 
 def _inode_of(name: str, dir_fd: int) -> int | None:
@@ -2691,22 +2833,26 @@ def _remove_pinned_batch(parent_fd: int, batch_fd: int, name: str) -> None:
     left holding data with nothing to list it, while the caller reported success.
 
     So the name is moved to one nothing can predict, its identity is checked against the
-    descriptor the whole operation was pinned to, and only that name is removed. Raising
-    rather than reporting lets the caller's existing recovery run unchanged: it renames the
-    manifest back through ``batch_fd``, so it lands in the REAL batch and the batch stays
-    listed and restorable.
+    descriptor the whole operation was pinned to, and only that name is removed - by
+    :func:`kiro_crew.pinned_fs.remove_dir_verified`, the same primitive the interior
+    directories use. Raising rather than reporting lets the caller's existing recovery run
+    unchanged: it renames the manifest back through ``batch_fd``, so it lands in the REAL
+    batch and the batch stays listed and restorable.
     """
     expected = os.fstat(batch_fd)
-    staging = f".{name}.removing-{uuid.uuid4().hex[:8]}"
-    os.rename(name, staging, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
-    moved = None
-    with suppress(OSError):
-        moved = os.stat(staging, dir_fd=parent_fd, follow_symlinks=False)
-    if (
-        moved is None
-        or not stat.S_ISDIR(moved.st_mode)
-        or (moved.st_dev, moved.st_ino) != (expected.st_dev, expected.st_ino)
-    ):
+    outcome = pinned_fs.remove_dir_verified(
+        parent_fd,
+        name,
+        expect=(expected.st_dev, expected.st_ino),
+    )
+    if outcome.removed:
+        return
+    if outcome.reason == pinned_fs.REMOVAL_STAGE_FAILED:
+        # Nothing was moved, so there is nothing to report about a staging name. Raised as
+        # the OSError the rename itself produced, which is what this function's callers
+        # already handle.
+        raise outcome.error or OSError(f"could not stage the batch for removal: {name!r}")
+    if outcome.reason in (pinned_fs.REMOVAL_IDENTITY_CHANGED, pinned_fs.REMOVAL_UNVERIFIABLE):
         # NOT renamed back. Whatever is under the staging name is not the pinned batch, so
         # the batch's name is not ours to write to either - and POSIX rename REPLACES its
         # destination, so putting this back would destroy whatever now answers to that name.
@@ -2714,31 +2860,61 @@ def _remove_pinned_batch(parent_fd: int, batch_fd: int, name: str) -> None:
         logger.error(
             "the batch name no longer denotes the pinned batch; what was there is now %r "
             "in the trash root and is left there rather than renamed back",
-            staging,
+            outcome.staged_name,
         )
         raise OSError(f"the batch name no longer denotes the pinned batch: {name!r}")
-    try:
-        os.rmdir(staging, dir_fd=parent_fd)
-    except OSError:
-        # Renamed back, and only here: the identity matched, so this IS the pinned batch and
-        # the name it came from is its own.
-        _restore_staged_dir(parent_fd, staging, name)
-        raise
+    if outcome.staged_name is not None:
+        # The identity matched, so this IS the pinned batch - but the rmdir failed AND it
+        # could not be renamed back, so it is now under a name `list_trash` does not offer.
+        logger.error(
+            "staged directory %r is now %r and could not be put back", name, outcome.staged_name
+        )
+    raise outcome.error or OSError(f"could not remove the batch directory: {name!r}")
 
 
-def _restore_staged_dir(parent: int, staging: str, name: str) -> None:
-    """Put a directory staged for removal back under the name the batch listed.
+def _stage_batch_by_name(batch: Path, *, expect: tuple[int, int]) -> tuple[Path | None, str | None]:
+    """Rename *batch* aside inside the trash root and verify its identity THERE.
 
-    Without this a refusal would leave the directory under a name nothing recognises,
-    which is worse than the swap it refused: the post-condition scan reports the batch
-    incomplete either way, but only one of the two leaves the user something they can
-    identify.
+    The half of rename-verify-remove that works on a platform with no ``openat``: there is
+    no descriptor to bind a removal to, and checking the path and then handing that same
+    path to a remover re-resolves it, so a swap in between is followed and an unapproved
+    replacement destroyed. The rename is what makes the check meaningful rather than
+    decorative. After it the approved name no longer exists, so nothing can be substituted
+    at it; the identity is verified on the RENAMED directory, so a swap that landed before
+    the rename is caught and the impostor is put back rather than removed; and the name a
+    caller finally removes existed for microseconds and carries random characters.
+
+    NOT airtight, and better said than implied: the caller's removal still resolves the
+    staging path, so an actor who can OBSERVE that name inside the window can redirect it
+    through an ancestor swapped afterwards. That residual is accepted on this platform
+    because the alternative is worse in both directions - refusing the empty a user
+    explicitly asked for, or leaving a batch behind after every restore, which no test and
+    no user would read as success.
+
+    Returns ``(staged path, None)`` when the caller may remove it, or ``(None, skip code)``
+    with the batch already back under the name the user saw. One owner for three callers:
+    the explicit empty, and the two cleanups that follow work which already succeeded.
     """
+    staging = batch.parent / f".{batch.name}.removing-{uuid.uuid4().hex[:8]}"
     try:
-        os.rename(staging, name, src_dir_fd=parent, dst_dir_fd=parent)
-    except OSError:
-        # Logged loudly with the staging name, which is what a human needs to undo it.
-        logger.error("staged directory %r is now %r and could not be put back", name, staging)
+        os.rename(batch, staging)
+    except OSError as exc:
+        logger.warning("refusing to remove trash batch %r: %s", batch.name, exc)
+        return None, SKIP_UNREADABLE
+    try:
+        current = os.stat(staging, follow_symlinks=False)
+    except OSError as exc:
+        logger.warning("refusing to remove trash batch %r: %s", batch.name, exc)
+        _rename_back(staging, batch)
+        return None, SKIP_UNREADABLE
+    if (current.st_dev, current.st_ino) != expect:
+        logger.warning(
+            "refusing to remove trash batch %r: it is not the directory that was selected",
+            batch.name,
+        )
+        _rename_back(staging, batch)
+        return None, SKIP_IDENTITY_CHANGED
+    return staging, None
 
 
 def _rename_back(staging: Path, batch: Path) -> None:
@@ -2869,41 +3045,15 @@ def _delete_listed_files(
     if not _FD_SAFE_DELETE:
         if expect_identity is None:
             return _coarse_remove(batch, rels, on_progress, base_bytes)
-        # Checking the path and then handing the same path to `rmtree` re-resolves it, so a
-        # swap in between is followed and an unapproved replacement destroyed. There is no
-        # descriptor to bind to here, so the batch is RENAMED first - atomic within the
-        # trash root - and everything after that addresses the new name.
-        #
-        # The rename is what makes the check meaningful rather than decorative. After it,
-        # the approved name no longer exists, so nothing can be substituted at it; the
-        # identity is verified on the renamed directory, so a swap that happened BEFORE the
-        # rename is caught and the impostor is put back rather than deleted; and the name
-        # finally removed is one that existed for microseconds and carries random
-        # characters, so re-targeting it means guessing it.
-        #
-        # NOT airtight, and better said than implied: `rmtree` still resolves the staging
-        # path, so a caller that can guess the name inside that window can still redirect
-        # it. Failing closed instead would refuse every empty on this platform, which is a
-        # worse answer than a window an attacker has to guess their way into.
-        staging = batch.parent / f".{batch.name}.removing-{uuid.uuid4().hex[:8]}"
-        try:
-            os.rename(batch, staging)
-        except OSError as exc:
-            logger.warning("refusing to empty %r: %s", batch.name, exc)
-            return 0, SKIP_UNREADABLE
-        try:
-            current = os.stat(staging, follow_symlinks=False)
-        except OSError as exc:
-            logger.warning("refusing to empty %r: %s", batch.name, exc)
-            _rename_back(staging, batch)
-            return 0, SKIP_UNREADABLE
-        if (current.st_dev, current.st_ino) != (expect_identity.dev, expect_identity.ino):
-            logger.warning(
-                "refusing to empty %r: it is not the directory that was selected",
-                batch.name,
-            )
-            _rename_back(staging, batch)
-            return 0, SKIP_IDENTITY_CHANGED
+        # Rename aside inside the trash root, verify the identity THERE, remove only the
+        # staged name - see :func:`_stage_batch_by_name` for why the rename is what makes
+        # the check meaningful, and for the residual this platform accepts. Shared with the
+        # two cleanup paths rather than respelled here.
+        staging, skip = _stage_batch_by_name(
+            batch, expect=(expect_identity.dev, expect_identity.ino)
+        )
+        if staging is None:
+            return 0, skip
         freed, skip = _coarse_remove(staging, rels, on_progress, base_bytes)
         if skip is not None:
             # A tree that would not go must not be left under a staging name: `list_trash`
@@ -2962,10 +3112,11 @@ def _delete_listed_files(
             present: dict[tuple[str, ...], int] = {}
             links: dict[tuple[str, ...], int] = {}
             try:
-                _scan_batch(batch_fd, device, (), dirs, present, links)
+                scanned = _scan_tree(batch_fd, device=device)
             except OSError as exc:
                 logger.warning("refusing to empty %r: %s", batch.name, exc)
                 return 0, SKIP_UNREADABLE
+            dirs, present, links = scanned.dirs, scanned.files, scanned.links
             # The interior has to match the APPROVAL, not merely be self-consistent. A map
             # built here records whatever is present by now - a directory swapped in during
             # the handoff included - so it cannot be the thing that authorises the delete.
@@ -3052,7 +3203,9 @@ def _delete_listed_files(
                     logger.warning("refusing a staged entry that names the manifest")
                     continue
                 try:
-                    holder = _open_chain(batch_fd, parts[:-1], cache, verify, device)
+                    holder = _open_chain(
+                        batch_fd, parts[:-1], cache=cache, dirs=verify, device=device
+                    )
                     info = os.stat(parts[-1], dir_fd=holder, follow_symlinks=False)
                 # ValueError as well as OSError, and it matters more here than anywhere: an
                 # exception escaping this loop stops an IRREVERSIBLE operation partway, with
@@ -3097,7 +3250,9 @@ def _delete_listed_files(
             # that was recorded.
             for key, seen_ino in links.items():
                 try:
-                    holder = _open_chain(batch_fd, key[:-1], cache, verify, device)
+                    holder = _open_chain(
+                        batch_fd, key[:-1], cache=cache, dirs=verify, device=device
+                    )
                     info = os.stat(key[-1], dir_fd=holder, follow_symlinks=False)
                 except (OSError, ValueError):
                     continue
@@ -3140,11 +3295,12 @@ def _delete_listed_files(
             left_files: dict[tuple[str, ...], int] = {}
             left_links: dict[tuple[str, ...], int] = {}
             try:
-                _scan_batch(batch_fd, device, (), left_dirs, left_files, left_links)
+                left = _scan_tree(batch_fd, device=device)
             except OSError as exc:
                 logger.warning("emptying %r: could not confirm it is empty: %s", batch.name, exc)
                 cleared = False
             else:
+                left_dirs, left_files, left_links = left.dirs, left.files, left.links
                 # By INODE, not by name. Everything after this point treats the survivor as
                 # the batch's own manifest: it is renamed aside and, once the batch is gone,
                 # the debris is unlinked. So a file substituted at that name after the first
@@ -3219,27 +3375,40 @@ def _delete_listed_files(
                         logger.warning("emptying %r did not remove it: %s", batch.name, exc)
                         cleared = False
                         restored = False
-                        try:
-                            # `link`, not `rename`: POSIX rename REPLACES its destination
-                            # silently, which is the property the debris name above is
-                            # chosen to be safe against - and this direction needs the
-                            # opposite guarantee. If anything has created a
-                            # `manifest.jsonl` in the batch since ours was moved aside,
-                            # renaming over it would destroy the only copy of a file this
-                            # code has never read. `link` fails with EEXIST instead, and
-                            # the debris is unlinked only once the batch has its manifest
-                            # back, so no window has neither.
-                            os.link(
+                        # `landed` equalled this inode above, which is what let this branch be
+                        # reached at all. Bound to a local, and the recovery skipped outright
+                        # if it is unknown: without an identity to check, the debris name is
+                        # just a name in a directory an actor may be able to write to.
+                        debris_ino = present.get((MANIFEST_NAME,))
+                        # Never `rename`: POSIX rename REPLACES its destination silently,
+                        # which is the property the debris name above is chosen to be safe
+                        # against - and this direction needs the opposite guarantee. If
+                        # anything has created a `manifest.jsonl` in the batch since ours
+                        # was moved aside, renaming over it would destroy the only copy of a
+                        # file this code has never read.
+                        #
+                        # `pinned_fs.put_back_no_clobber` owns that: the debris name is opened
+                        # `O_NOFOLLOW` and checked against `debris_ino` before anything is read
+                        # from it, `os.link` first because it cannot clobber, and an
+                        # `O_CREAT | O_EXCL` create-and-copy where the MOUNT has no hard links
+                        # - which the `os.supports_dir_fd` probe cannot see, since it tests
+                        # what the OS accepts and not what the filesystem does. The debris is
+                        # unlinked only once the batch has its manifest back, so no window has
+                        # neither.
+                        back: str | None = pinned_fs.PUT_BACK_FAILED
+                        if debris_ino is not None:
+                            back = pinned_fs.put_back_no_clobber(
+                                parent_fd,
+                                batch_fd,
                                 debris,
                                 MANIFEST_NAME,
-                                src_dir_fd=parent_fd,
-                                dst_dir_fd=batch_fd,
+                                expect_ino=debris_ino,
                             )
-                            restored = True
-                        except FileExistsError:
+                        restored = back is None
+                        if back == pinned_fs.PUT_BACK_NAME_TAKEN:
                             # Something arrived at the name. NOT overwritten - that is the
-                            # whole reason this is a link - and the batch is still listable,
-                            # because whatever arrived is a manifest by name and
+                            # whole reason this is not a rename - and the batch is still
+                            # listable, because whatever arrived is a manifest by name and
                             # `list_trash()` can read it. The debris stays for a human.
                             logger.error(
                                 "emptying %r could not restore its manifest because another "
@@ -3248,36 +3417,17 @@ def _delete_listed_files(
                                 batch.name,
                                 debris,
                             )
-                        except OSError as exc:
-                            # `link` is not universally available: a filesystem without hard
-                            # links refuses it, and the capability probe cannot see that -
-                            # it tests whether the OS accepts `dir_fd`, not what the MOUNT
-                            # supports. Giving up here would strand the batch with no
-                            # manifest while its data survived, which is the exact loss this
-                            # recovery exists to prevent.
-                            #
-                            # The fallback is an EXCLUSIVE create and a copy, not a rename
-                            # after checking the name is free: that check-to-use pair leaves
-                            # a window an arriving file loses in, which is the mistake this
-                            # module spent every other guard removing. `O_CREAT | O_EXCL`
-                            # decides in one syscall, so there is no window to lose.
-                            restored = _copy_back_exclusive(
-                                parent_fd, batch_fd, debris, MANIFEST_NAME
+                        elif not restored:
+                            logger.error(
+                                "emptying %r removed neither the batch nor its manifest; "
+                                "the manifest is now %r in the trash root",
+                                batch.name,
+                                debris,
                             )
-                            if not restored:
-                                logger.error(
-                                    "emptying %r removed neither the batch nor its manifest; "
-                                    "the manifest is now %r in the trash root: %s",
-                                    batch.name,
-                                    debris,
-                                    exc,
-                                )
                         if restored:
-                            with suppress(OSError):
-                                os.unlink(debris, dir_fd=parent_fd)
+                            _unlink_debris(parent_fd, debris, debris_ino)
                     else:
-                        with suppress(OSError):
-                            os.unlink(debris, dir_fd=parent_fd)
+                        _unlink_debris(parent_fd, debris, present.get((MANIFEST_NAME,)))
                         freed += manifest_bytes
         finally:
             _drain(cache)
@@ -3402,10 +3552,8 @@ def _approve_batch(path: Path) -> tuple[BatchIdentity, int] | None:
         # it first also fails closed: a rewrite after this point leaves the digest
         # describing the old listing, so the delete refuses.
         digest = _rels_digest(_manifest_rels(path, dir_fd=batch_fd))
-        dirs: dict[tuple[str, ...], int] = {}
-        files: dict[tuple[str, ...], int] = {}
-        links: dict[tuple[str, ...], int] = {}
-        _scan_batch(batch_fd, info.st_dev, (), dirs, files, links)
+        scanned = _scan_tree(batch_fd, device=info.st_dev)
+        dirs, files, links = scanned.dirs, scanned.files, scanned.links
         summary = _summarize_manifest(path, dir_fd=batch_fd)
     except OSError:
         return None

--- a/test/test_pinned_staging.py
+++ b/test/test_pinned_staging.py
@@ -1416,6 +1416,20 @@ def test_no_name_based_filesystem_question_where_a_descriptor_is_held() -> None:
                 # Reading a descriptor's own metadata is by definition not name-based.
                 if isinstance(fn.value, ast.Name) and fn.value.id.endswith("_fd"):
                     continue
+                # An `os.DirEntry` yielded by `os.scandir(<fd>)` is also not a name-based
+                # question, and this is the second naming convention the ratchet reads
+                # (`_fd` is the first): a receiver called `entry`, or ending `_entry`, must
+                # be one. CPython keeps the iterator's DESCRIPTOR on each entry and stats
+                # through it -- `entry.path` is the bare name and the stat still answers
+                # from a working directory the name does not exist in, which
+                # `test_a_direntry_from_a_descriptor_scan_stats_through_it` pins rather
+                # than leaving as a comment. The alternative form the ratchet would accept,
+                # `os.stat(entry.name, dir_fd=fd)`, asks the kernel the same question and
+                # costs one extra syscall per entry on trees with six figures of them.
+                if isinstance(fn.value, ast.Name) and (
+                    fn.value.id == "entry" or fn.value.id.endswith("_entry")
+                ):
+                    continue
                 offenders.append(f"{module}:{node.lineno} -> .{fn.attr}()")
 
     assert not offenders, (

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -496,6 +496,49 @@ class TestRestoreIsAllOrNothing:
         assert seg.read_bytes() == b"a" * 16
         assert session_storage.list_trash() == []
 
+    def test_a_full_restore_never_writes_to_the_batch_it_is_leaving(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The full-restore branch writes NOTHING to the batch, and keeps its listing stale.
+
+        Both are one decision. Every entry below the header describes a file this restore
+        moved back out, so a batch the cleanup declines to remove still lists sessions that
+        are not in it. Clearing them needs a write to the batch PATH, and `atomic_write`
+        replaces its destination: a batch swapped to a link would send that write to another
+        batch's manifest and make ITS staged sessions unlistable. A stale listing is visible
+        and reversible; that is not. So the listing stays and `empty_trash` is the way out.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        def _no_writes_here(*args: object, **kwargs: object) -> None:
+            raise AssertionError(f"the full-restore path wrote by name: {args!r}")
+
+        monkeypatch.setattr(session_storage, "atomic_write", _no_writes_here)
+        # A cleanup that DECLINES, which is what makes the stale listing reachable: the
+        # batch stays instead of going away with its manifest.
+        monkeypatch.setattr(session_storage, "_remove_emptied_batch", lambda *a, **k: False)
+
+        assert session_storage.restore(batch.batch_id) == 1
+
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").read_bytes() == b"c" * 8
+        kept = session_storage.list_trash()
+        assert [b.batch_id for b in kept] == [batch.batch_id], "kept, not removed"
+        # The accepted residual, pinned so that clearing it later is a deliberate change.
+        assert kept[0].sessions == 1, "the listing goes stale rather than being rewritten"
+
+        # And the user is not stuck with it: the explicit empty still takes the batch.
+        monkeypatch.undo()
+        session_storage.empty_trash()
+        assert session_storage.list_trash() == []
+
     def test_an_occupied_half_leaves_the_whole_session_staged(
         self, stores: tuple[Path, Path]
     ) -> None:
@@ -1321,15 +1364,15 @@ class TestUntrustedNamesAreLogSafeOutsideListTrash:
         ``_unlisted_files`` seam — no hostile directory has to exist on disk.
         """
         forged = session_storage.trash_root() / self._FORGED_NAME
-        # Neither branch may write: the point under test is the log line.
-        monkeypatch.setattr(session_storage, "_rewrite_manifest", lambda *a, **k: None)
+        # No write to patch out any more: the caller clears the manifest before this is
+        # reached, so neither branch below writes at all.
 
         def _refuse(batch: Path) -> list[Path]:
             raise SessionStorageError(f"could not read all of {batch.name!r}")
 
         monkeypatch.setattr(session_storage, "_unlisted_files", _refuse)
         with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
-            session_storage._discard_restored_batch(forged, {})
+            session_storage._discard_restored_batch(forged, None)
         self._assert_escaped(
             self._carrying(caplog, "keeping trash batch"), self._FORGED_NAME, "unreadable-scan"
         )
@@ -1339,7 +1382,7 @@ class TestUntrustedNamesAreLogSafeOutsideListTrash:
             session_storage, "_unlisted_files", lambda batch: [forged / "orphan.jsonl"]
         )
         with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
-            session_storage._discard_restored_batch(forged, {})
+            session_storage._discard_restored_batch(forged, None)
         self._assert_escaped(
             self._carrying(caplog, "keeping trash batch"), self._FORGED_NAME, "leftover-files"
         )
@@ -3096,11 +3139,11 @@ class TestEmptyTrash:
         planted = holder / "dangling"
         planted.symlink_to(kiro_home / "nowhere")
 
-        real_scan = session_storage._scan_batch
+        real_scan = session_storage._scan_tree
         swapped: list[bool] = []
 
-        def scan_then_swap(batch_fd, device, here, dirs, files, links):  # type: ignore[no-untyped-def]
-            out = real_scan(batch_fd, device, here, dirs, files, links)
+        def scan_then_swap(dir_fd, *, device):  # type: ignore[no-untyped-def]
+            out = real_scan(dir_fd, device=device)
             # After the scan has recorded the link and before the pass unlinks it: the
             # name now holds a file that nothing staged and nothing lists.
             if not swapped:
@@ -3110,7 +3153,7 @@ class TestEmptyTrash:
             return out
 
         with pytest.MonkeyPatch.context() as patched:
-            patched.setattr(session_storage, "_scan_batch", scan_then_swap)
+            patched.setattr(session_storage, "_scan_tree", scan_then_swap)
             session_storage.empty_trash([batch.batch_id], on_skip=lambda _reason: None)
 
         assert swapped == [True], "the swap must land inside the window under test"
@@ -3462,11 +3505,11 @@ class TestEmptyTrash:
         root = session_storage.trash_root()
         staged = root / batch.batch_id
         manifest = staged / session_storage.MANIFEST_NAME
-        real_scan = session_storage._scan_batch
+        real_scan = session_storage._scan_tree
         calls: list[int] = []
 
-        def scan_then_swap(batch_fd, device, here, dirs, files, links):  # type: ignore[no-untyped-def]
-            out = real_scan(batch_fd, device, here, dirs, files, links)
+        def scan_then_swap(dir_fd, *, device):  # type: ignore[no-untyped-def]
+            out = real_scan(dir_fd, device=device)
             calls.append(1)
             # The SECOND scan is the post-condition. Swapping right after it lands between
             # the inode it verified and the rename that addresses the name.
@@ -3480,7 +3523,7 @@ class TestEmptyTrash:
 
         skips: list[str] = []
         with pytest.MonkeyPatch.context() as patched:
-            patched.setattr(session_storage, "_scan_batch", scan_then_swap)
+            patched.setattr(session_storage, "_scan_tree", scan_then_swap)
             session_storage.empty_trash([batch.batch_id], on_skip=skips.append)
 
         assert len(calls) >= 2, "the swap must land after the post-condition scan"
@@ -3738,11 +3781,11 @@ class TestEmptyTrash:
         bystander.write_bytes(b"ONLY COPY")
         original = manifest.read_bytes()
 
-        real_scan = session_storage._scan_batch
+        real_scan = session_storage._scan_tree
         rewritten: list[bool] = []
 
-        def scan_then_rewrite(batch_fd, device, here, dirs, files, links):  # type: ignore[no-untyped-def]
-            out = real_scan(batch_fd, device, here, dirs, files, links)
+        def scan_then_rewrite(dir_fd, *, device):  # type: ignore[no-untyped-def]
+            out = real_scan(dir_fd, device=device)
             # In place, so the manifest's own inode never changes.
             if not rewritten:
                 rewritten.append(True)
@@ -3756,7 +3799,7 @@ class TestEmptyTrash:
             return out
 
         with pytest.MonkeyPatch.context() as patched:
-            patched.setattr(session_storage, "_scan_batch", scan_then_rewrite)
+            patched.setattr(session_storage, "_scan_tree", scan_then_rewrite)
             ids, _total, identities = session_storage.staged_targets([batch.batch_id])
 
         assert rewritten == [True], "the rewrite must land inside the approval"
@@ -4578,12 +4621,11 @@ class TestEmptyTrash:
         parent_fd, batch_fd = session_storage._open_absolute_nofollow(staged)
         try:
             device = os.fstat(batch_fd).st_dev
-            dirs: dict[tuple[str, ...], int] = {}
-            present: dict[tuple[str, ...], int] = {}
-            session_storage._scan_batch(batch_fd, device, (), dirs, present, {})
+            scanned = session_storage._scan_tree(batch_fd, device=device)
+            dirs = scanned.dirs
 
             # The real staged directory opens against the scan that saw it.
-            session_storage._open_chain(batch_fd, (holder,), {}, dirs, device)
+            session_storage._open_chain(batch_fd, (holder,), cache={}, dirs=dirs, device=device)
 
             # A different REAL directory renamed into that name does not - and it is not
             # a symlink, so O_NOFOLLOW alone would have opened it. Checked against the
@@ -4595,7 +4637,7 @@ class TestEmptyTrash:
             (staged / holder).rename(staged / "moved-aside")
             impostor.rename(staged / holder)
             with pytest.raises(OSError):
-                session_storage._open_chain(batch_fd, (holder,), {}, dirs, device)
+                session_storage._open_chain(batch_fd, (holder,), cache={}, dirs=dirs, device=device)
         finally:
             os.close(batch_fd)
             os.close(parent_fd)
@@ -4627,17 +4669,23 @@ class TestEmptyTrash:
         impostor.mkdir()
         for rel in listed:
             (impostor / PurePosixPath(rel).name).write_bytes(b"LIVE DATA")
-        real_scan = session_storage._scan_batch
+        real_scan = session_storage._scan_tree
+        swapped: list[bool] = []
 
-        def scan_then_swap(dir_fd, device, prefix, dirs, files, links):  # type: ignore[no-untyped-def]
-            real_scan(dir_fd, device, prefix, dirs, files, links)
-            if prefix == () and holder.is_dir():
+        def scan_then_swap(dir_fd, *, device):  # type: ignore[no-untyped-def]
+            tree = real_scan(dir_fd, device=device)
+            # Once, right after the scan the approval is compared against, and before the
+            # removal reads it. A latch rather than a scan-depth test: the scan is one call
+            # per pass, so the pass number is the only thing that distinguishes them.
+            if not swapped and holder.is_dir():
+                swapped.append(True)
                 holder.rename(staged / "moved-aside")
                 impostor.rename(holder)
+            return tree
 
         skips: list[str] = []
         with pytest.MonkeyPatch.context() as patched:
-            patched.setattr(session_storage, "_scan_batch", scan_then_swap)
+            patched.setattr(session_storage, "_scan_tree", scan_then_swap)
             session_storage.empty_trash([batch.batch_id], on_skip=skips.append)
 
         assert skips == [session_storage.SKIP_INCOMPLETE]
@@ -4961,7 +5009,7 @@ class TestEmptyTrash:
         swapped: list[bool] = []
 
         def chain_then_swap(batch_fd, parts, cache, dirs, device):  # type: ignore[no-untyped-def]
-            fd = real_chain(batch_fd, parts, cache, dirs, device)
+            fd = real_chain(batch_fd, parts, cache=cache, dirs=dirs, device=device)
             # ONLY during the removal pass. A file's parent chain names the same key, so
             # hooking every call would swap during the FILE phase instead and end up
             # re-testing the sibling case above, which a different check already covers.
@@ -5056,20 +5104,25 @@ class TestEmptyTrash:
         listed = session_storage._manifest_rels(staged)
         assert listed
         victim = staged / PurePosixPath(listed[0])
-        real_scan = session_storage._scan_batch
+        real_scan = session_storage._scan_tree
+        swapped: list[bool] = []
 
-        def scan_then_swap(dir_fd, device, prefix, dirs, files, links):  # type: ignore[no-untyped-def]
-            real_scan(dir_fd, device, prefix, dirs, files, links)
-            if prefix == () and victim.is_file():
+        def scan_then_swap(dir_fd, *, device):  # type: ignore[no-untyped-def]
+            tree = real_scan(dir_fd, device=device)
+            # Once, right after the scan the approval is compared against. A latch rather
+            # than a scan-depth test: the scan is one call per pass.
+            if not swapped and victim.is_file():
+                swapped.append(True)
                 # A different file takes the staged file's name, on the same filesystem.
                 replacement = kiro_home / "not-approved.jsonl"
                 replacement.write_bytes(b"LIVE DATA")
                 victim.unlink()
                 replacement.rename(victim)
+            return tree
 
         skips: list[str] = []
         with pytest.MonkeyPatch.context() as patched:
-            patched.setattr(session_storage, "_scan_batch", scan_then_swap)
+            patched.setattr(session_storage, "_scan_tree", scan_then_swap)
             session_storage.empty_trash([batch.batch_id], on_skip=skips.append)
 
         assert skips == [session_storage.SKIP_INCOMPLETE]

--- a/test/test_trash_pinned_sibling_removal.py
+++ b/test/test_trash_pinned_sibling_removal.py
@@ -1,0 +1,1055 @@
+"""The two sibling trash-removal paths, and the primitive they now share.
+
+Both paths reach a point where the batch holds nothing worth keeping and has to go.
+Removing it by PATH re-resolves every ancestor, so a directory above the trash swapped
+to a symbolic link -- by anything running as this user, which in this product includes
+an agent -- is followed and the removal lands outside the trash entirely.
+
+The swap is set up on disk rather than simulated, and the victim carries a file, so a
+test that passes says the file survived rather than that a code path was taken.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import pinned_fs, session_storage
+
+_NOW = 1_700_000_000.0
+_BATCH = "20231114-batch"
+
+pytestmark = pytest.mark.skipif(
+    not pinned_fs.supports_pinned_tree_walk(),
+    reason="the pinned removal needs openat/O_NOFOLLOW; the coarse branch is tested elsewhere",
+)
+
+
+def _batch_with_manifest(root: Path, name: str, *, entries: list[dict[str, object]]) -> Path:
+    """A trash batch whose header claims its own directory name."""
+    batch = root / name
+    batch.mkdir(parents=True)
+    lines = [
+        json.dumps(
+            {
+                "schema": session_storage.MANIFEST_SCHEMA,
+                "batch_id": name,
+                "created_at": _NOW,
+                "reason": "manual",
+            }
+        )
+    ]
+    lines += [json.dumps(entry) for entry in entries]
+    (batch / session_storage.MANIFEST_NAME).write_text("\n".join(lines) + "\n")
+    return batch
+
+
+def _approve_anything(_root_fd: int, _tree: pinned_fs.PinnedTree) -> str | None:
+    """The approval a test passes when the thing under test is the removal, not the check.
+
+    ``remove_tree_pinned`` requires the hook rather than accepting None, so a test
+    exercising the mechanism itself has to STATE that it approves everything instead of
+    inheriting the weaker ask-nothing mode by omission.
+    """
+    return None
+
+
+def _identity(path: Path) -> tuple[int, int]:
+    """What the caller captures before its own by-path read, and binds the removal to."""
+    info = os.stat(path, follow_symlinks=False)
+    return (info.st_dev, info.st_ino)
+
+
+def _swap_parent_for_a_link(parent: Path, victim: Path) -> None:
+    """Replace *parent* with a symbolic link to *victim*, keeping the real one aside.
+
+    This is the ancestor swap, done exactly as an attacker would: the batch's own path
+    is untouched and still spelled the same, but every component above it now resolves
+    somewhere else.
+    """
+    parent.rename(parent.with_name(parent.name + ".real"))
+    parent.symlink_to(victim, target_is_directory=True)
+
+
+class TestAncestorSwapContainment:
+    """Neither sibling path may delete through a swapped ancestor."""
+
+    def test_discarding_a_restored_batch_refuses_a_swapped_ancestor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The swap lands AFTER the by-path pre-screen, which is the real window.
+
+        ``_discard_restored_batch`` reads the batch by path to decide whether it holds
+        anything unlisted, and then removes it. A swap BEFORE that read is caught by the
+        read itself -- it walks into the victim and finds files no manifest names. The
+        window the removal has to survive on its own is the one that opens after the read
+        returns, so the swap is performed at that seam.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        # What the swap points at: a directory holding a batch of the SAME name, with a
+        # file in it. Nothing here is a trash batch -- there is no manifest -- which is
+        # what the pinned approval asks and what a name cannot answer.
+        victim = tmp_path / "victim"
+        (victim / _BATCH).mkdir(parents=True)
+        precious = victim / _BATCH / "precious.txt"
+        precious.write_text("the only copy")
+
+        real_unlisted = session_storage._unlisted_files
+
+        def _screen_then_swap(target: Path) -> list[Path]:
+            found = real_unlisted(target)
+            _swap_parent_for_a_link(root, victim)
+            return found
+
+        monkeypatch.setattr(session_storage, "_unlisted_files", _screen_then_swap)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            # The identity comes from the caller, recorded before the restore read anything -
+            # here, before the swap the scan performs below.
+            session_storage._discard_restored_batch(batch, _identity(batch))
+
+        assert precious.read_text() == "the only copy"
+        assert (victim / _BATCH).is_dir()
+        assert "keeping trash batch" in caplog.text
+        # The real batch is untouched too: a refusal removes nothing at all.
+        assert (root.with_name("trash.real") / _BATCH).is_dir()
+
+    def test_the_empty_batch_cleanup_refuses_a_swapped_ancestor(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The same swap at the other site, reached through its own entry point.
+
+        ``move_to_trash``'s cleanup runs when no session was staged, so it is exercised
+        through :func:`_remove_emptied_batch` with that site's own wording -- the branch
+        above it is a different function's control flow, not this removal's.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        # Captured BEFORE the swap, which is what the caller does: `move_to_trash` records
+        # it at the moment it creates the batch, under the mutation lock.
+        identity = _identity(batch)
+        victim = tmp_path / "victim"
+        (victim / _BATCH).mkdir(parents=True)
+        precious = victim / _BATCH / "staged.jsonl"
+        precious.write_text("staged, unlisted, the only copy")
+
+        _swap_parent_for_a_link(root, victim)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            session_storage._remove_emptied_batch(batch, "the empty batch", expect=identity)
+
+        assert precious.read_text() == "staged, unlisted, the only copy"
+        assert (victim / _BATCH).is_dir()
+
+    def test_a_victim_holding_a_forged_matching_manifest_is_still_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """A swap target that IS a batch, with a manifest forged to name the selected one.
+
+        This is the case the content checks alone cannot carry, and it is why an identity is
+        captured at all. An actor who can write into the tree the link points at can plant a
+        header naming this batch and a listing covering its contents, and every
+        content-based question then answers yes about the wrong directory. An inode cannot be
+        forged by writing files, so the caller records one before its own by-path read and
+        the approval compares the pinned root against it.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        # Captured BEFORE the swap, which is what both callers do.
+        identity = _identity(batch)
+        victim = tmp_path / "victim"
+        # A genuine batch directory whose manifest header names the SELECTED batch, so the
+        # header check passes on it, and whose only file the manifest lists, so the
+        # unlisted-file check passes too.
+        forged = _batch_with_manifest(
+            victim,
+            _BATCH,
+            entries=[{"uid": "aaaa1111", "files": [{"rel": "session.jsonl", "bytes": 4}]}],
+        )
+        (forged / "session.jsonl").write_text("data")
+
+        _swap_parent_for_a_link(root, victim)
+
+        session_storage._remove_emptied_batch(batch, "the restored batch", expect=identity)
+
+        assert forged.is_dir()
+        assert (forged / "session.jsonl").read_text() == "data"
+        assert (forged / session_storage.MANIFEST_NAME).is_file()
+
+    def test_a_swap_during_the_restore_is_refused_by_the_callers_identity(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The anchor is taken at the TOP of the restore, so a swap anywhere inside it is caught.
+
+        The cleanup is reached only after the restore has read the manifest and moved every
+        listed file out. An identity sampled there would already be the substitute's if an
+        ancestor had been swapped during any of that, and every later check would then agree
+        with itself about the wrong directory. Recording it before the first read makes the
+        pinned comparison refuse instead. Driven through `restore()` so the capture point under
+        test is the real one.
+        """
+        home = tmp_path / "home"
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        monkeypatch.setenv("KIRO_HOME", str(home / "kiro"))
+        (home / "sessions").mkdir(parents=True)
+        (home / "kiro" / "sessions" / "cli").mkdir(parents=True)
+        session_storage.invalidate_scan_cache()
+        live = home / "kiro" / "sessions" / "cli" / "aaaa1111.jsonl"
+        live.write_text("live")
+        # Old enough to be reclaimable: staging refuses a session touched recently.
+        os.utime(live, (_NOW - 40 * 86400, _NOW - 40 * 86400))
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=session_storage.SessionIndex(stem_to_sid={}, active_sids=frozenset()),
+            now=_NOW,
+        )
+        root = session_storage.trash_root()
+        victim = tmp_path / "victim"
+        (victim / batch.batch_id).mkdir(parents=True)
+        precious = victim / batch.batch_id / "staged.jsonl"
+        precious.write_text("the only copy")
+        # A manifest that would satisfy every CONTENT question about the victim.
+        (victim / batch.batch_id / session_storage.MANIFEST_NAME).write_text(
+            json.dumps(
+                {
+                    "schema": session_storage.MANIFEST_SCHEMA,
+                    "batch_id": batch.batch_id,
+                    "created_at": _NOW,
+                    "reason": "manual",
+                }
+            )
+            + "\n"
+        )
+        real_unlisted = session_storage._unlisted_files
+
+        def _screen_then_swap(target: Path) -> list[Path]:
+            found = real_unlisted(target)
+            _swap_parent_for_a_link(root, victim)
+            return found
+
+        monkeypatch.setattr(session_storage, "_unlisted_files", _screen_then_swap)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.restore(batch.batch_id) == 1
+
+        assert precious.read_text() == "the only copy", "the victim's file must survive"
+        assert (victim / batch.batch_id / session_storage.MANIFEST_NAME).is_file()
+        assert "not the directory that was selected" in caplog.text
+
+    def test_an_unestablished_identity_refuses_rather_than_proceeds(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No identity means nothing to bind to, so the removal is refused, not attempted.
+
+        Proceeding would answer every remaining question about a directory reached by name
+        alone, which is the state this whole path exists to get out of.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            session_storage._remove_emptied_batch(batch, "the empty batch", expect=None)
+
+        assert batch.is_dir()
+        assert (batch / session_storage.MANIFEST_NAME).is_file()
+        assert "identity was never established" in caplog.text
+
+
+class TestUnswappedRemovalStillHappens:
+    """The containment must not turn either path into a no-op."""
+
+    def test_a_clean_restored_batch_is_removed(self, tmp_path: Path) -> None:
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        # Interior directories left behind by a restore: emptied of files, still present.
+        (batch / "cli").mkdir()
+        (batch / "cli" / "nested").mkdir()
+
+        session_storage._discard_restored_batch(batch, _identity(batch))
+
+        assert not batch.exists()
+        assert root.is_dir()
+
+    def test_a_refused_removal_writes_nothing_at_all(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cleanup must not write to a path whose removal it just refused.
+
+        A refusal is evidence about the PATH -- a swapped ancestor, an identity that could
+        not be read, a platform with no descriptor to bind to. ``atomic_write`` REPLACES its
+        destination, so tidying the manifest afterwards would land wherever the path now
+        leads: answering evidence of a swap by writing through it. The entries are cleared
+        by the caller BEFORE any of this, so there is nothing left for this path to write.
+        """
+        root = tmp_path / "trash"
+        entries = [{"uid": "aaaa1111", "files": [{"rel": "cli/aaaa1111.jsonl", "bytes": 4}]}]
+        batch = _batch_with_manifest(root, _BATCH, entries=entries)
+        before = (batch / session_storage.MANIFEST_NAME).read_text()
+        real_remove = pinned_fs.remove_dir_verified
+
+        def _refuse_the_batch(
+            parent_fd: int, name: str, *, expect: tuple[int, int]
+        ) -> pinned_fs.StagedRemoval:
+            if name == _BATCH:
+                return pinned_fs.StagedRemoval(
+                    removed=False, reason=pinned_fs.REMOVAL_FAILED, error=OSError("held open")
+                )
+            return real_remove(parent_fd, name, expect=expect)
+
+        def _no_writes_here(*args: object, **kwargs: object) -> None:
+            raise AssertionError(f"the cleanup wrote by path: {args!r}")
+
+        monkeypatch.setattr(session_storage, "atomic_write", _no_writes_here)
+        # The refusal that reaches furthest: the batch directory itself will not go, so a
+        # descriptor confirmed the path first and a tidying write would look safest here.
+        monkeypatch.setattr(pinned_fs, "remove_dir_verified", _refuse_the_batch)
+        session_storage._discard_restored_batch(batch, _identity(batch))
+
+        assert (batch / session_storage.MANIFEST_NAME).read_text() == before
+
+    def test_a_batch_holding_an_unlisted_file_is_kept(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The pinned approval enforces the same rule the by-path pre-screen does.
+
+        Reached by calling the removal directly, which is what a caller whose by-path
+        walk raced the arrival of the file would do.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        (batch / "orphan.jsonl").write_text("staged but never recorded")
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            session_storage._remove_emptied_batch(batch, "the empty batch", expect=_identity(batch))
+
+        assert (batch / "orphan.jsonl").read_text() == "staged but never recorded"
+        assert "which nothing here may remove" in caplog.text
+
+    def test_a_batch_holding_a_link_is_kept_rather_than_unlinked_by_name(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A link is the one entry a removal can only take by NAME, so it withholds too.
+
+        `_unlink_verified` compares the scanned inode and then unlinks, which is two syscalls
+        with no atomic "unlink if this inode" between them. Admitting a link admits that
+        window: plant one, let the approval pass it, put a file at the name in between, and the
+        removal deletes the file. `empty_trash` still clears such a batch when a user asks.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        (batch / "planted").symlink_to(tmp_path / "nowhere")
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            removed = session_storage._remove_emptied_batch(
+                batch, "the restored batch", expect=_identity(batch)
+            )
+
+        assert removed is False
+        assert (batch / "planted").is_symlink(), "nothing may be removed by name here"
+        assert "link(s), which the removal could only take by name" in caplog.text
+
+    def test_a_file_at_a_listed_path_is_kept_not_deleted(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The manifest naming a path does NOT authorise removing whatever sits there.
+
+        Both callers arrive with the batch already empty of files -- the restore path has
+        moved every listed file back out, and the staging path has a manifest with no entries
+        at all. So a file at a listed path is not the listed file; it arrived at that name
+        afterwards and may be the only copy of whatever it is. An earlier version of this
+        test asserted the opposite, which was the hole: it let a name the manifest happens to
+        mention authorise a deletion.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(
+            root,
+            _BATCH,
+            entries=[{"uid": "aaaa1111", "files": [{"rel": "cli/aaaa1111.jsonl", "bytes": 4}]}],
+        )
+        (batch / "cli").mkdir()
+        replanted = batch / "cli" / "aaaa1111.jsonl"
+        replanted.write_text("arrived after the restore moved the real one out")
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            session_storage._remove_emptied_batch(
+                batch, "the restored batch", expect=_identity(batch)
+            )
+
+        assert replanted.read_text() == "arrived after the restore moved the real one out"
+        assert "which nothing here may remove" in caplog.text
+
+
+class TestTheManifestGoesLast:
+    """A tree that will not empty must stay LISTED, which means keeping its manifest.
+
+    `list_trash()` omits a batch with no readable manifest. So a removal that unlinks the
+    manifest and then fails to remove the directory leaves data on disk that is neither
+    visible nor restorable - worse than not having tried, and reported as a partial success.
+    """
+
+    def test_a_staged_file_that_will_not_go_leaves_the_manifest_in_place(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(
+            root,
+            _BATCH,
+            entries=[{"uid": "aaaa1111", "files": [{"rel": "cli/aaaa1111.jsonl", "bytes": 4}]}],
+        )
+        (batch / "cli").mkdir()
+        (batch / "cli" / "aaaa1111.jsonl").write_text("data")
+
+        real_unlink = os.unlink
+
+        def _refuse(path: object, **kwargs: object) -> None:
+            if path == "aaaa1111.jsonl":
+                raise OSError("held open")
+            real_unlink(path, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "unlink", _refuse)
+        session_storage._remove_emptied_batch(batch, "the restored batch", expect=_identity(batch))
+
+        assert (batch / "cli" / "aaaa1111.jsonl").read_text() == "data"
+        assert (batch / session_storage.MANIFEST_NAME).is_file(), "the batch must stay listable"
+
+    def test_a_batch_directory_that_will_not_go_gets_its_manifest_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The manifest is moved aside BEFORE the final rmdir, so that failing must undo it.
+
+        Put back with ``os.link``, and the debris copy RETAINED: no check available before an
+        unlink can prove the name it went back to still holds a good copy, so removing the
+        redundant copy is a chance to turn a stuck batch into an unlistable one. The retained
+        name is reported rather than left silent.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        original = (batch / session_storage.MANIFEST_NAME).read_text()
+        real_remove = pinned_fs.remove_dir_verified
+
+        def _refuse_the_batch(
+            parent_fd: int, name: str, *, expect: tuple[int, int]
+        ) -> pinned_fs.StagedRemoval:
+            if name == _BATCH:
+                return pinned_fs.StagedRemoval(
+                    removed=False,
+                    reason=pinned_fs.REMOVAL_FAILED,
+                    error=OSError("held open"),
+                )
+            return real_remove(parent_fd, name, expect=expect)
+
+        monkeypatch.setattr(pinned_fs, "remove_dir_verified", _refuse_the_batch)
+        session_storage._remove_emptied_batch(batch, "the empty batch", expect=_identity(batch))
+
+        assert (batch / session_storage.MANIFEST_NAME).read_text() == original
+        debris = [p.name for p in root.iterdir() if p.name != _BATCH]
+        assert len(debris) == 1, f"the redundant copy is kept, not unlinked: {debris!r}"
+        assert (root / debris[0]).read_text() == original
+
+    def test_the_primitive_keeps_its_deferred_entry_when_the_tree_survives(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "tree"
+        root.mkdir()
+        (root / "index").write_text("listing")
+        (root / "stuck").write_text("x")
+
+        real_unlink = os.unlink
+
+        def _refuse(path: object, **kwargs: object) -> None:
+            if path == "stuck":
+                raise OSError("held open")
+            real_unlink(path, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "unlink", _refuse)
+        outcome = pinned_fs.remove_tree_pinned(
+            str(root), what="the tree", approve=_approve_anything, keep_until_empty="index"
+        )
+
+        assert outcome.removed is False
+        assert outcome.survivors == 1
+        assert (root / "index").read_text() == "listing"
+        assert (root / "stuck").read_text() == "x"
+
+    def test_the_deferred_entry_is_removed_with_the_tree_when_it_goes(self, tmp_path: Path) -> None:
+        root = tmp_path / "tree"
+        (root / "a").mkdir(parents=True)
+        (root / "a" / "leaf").write_text("x")
+        (root / "index").write_text("listing")
+
+        outcome = pinned_fs.remove_tree_pinned(
+            str(root), what="the tree", approve=_approve_anything, keep_until_empty="index"
+        )
+
+        assert outcome.removed is True
+        assert not root.exists()
+        assert sorted(p.name for p in tmp_path.iterdir()) == [], "no debris left behind"
+
+
+class TestTheApprovalReadsOneFile:
+    """The header and the listing must describe ONE manifest, bound to the scanned inode.
+
+    Two reads is the defect: a manifest replaced in between passes the header check on the
+    first file while the listing that decides which staged files may be deleted comes from
+    the second, so a forged listing can name an unlisted staged file and have it destroyed.
+    """
+
+    def test_a_manifest_that_is_not_the_scanned_file_is_refused(self, tmp_path: Path) -> None:
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+
+        fd = os.open(str(batch), pinned_fs.dir_flags())
+        try:
+            seen = pinned_fs.scan_tree_pinned(fd, device=os.fstat(fd).st_dev)
+            # Same name, an inode the scan did not record - which is what a manifest
+            # replaced between the scan and the read looks like from here.
+            forged = pinned_fs.PinnedTree(
+                dirs={},
+                files={
+                    (session_storage.MANIFEST_NAME,): seen.files[(session_storage.MANIFEST_NAME,)]
+                    + 1
+                },
+                links={},
+            )
+            assert (
+                session_storage._approve_emptied_batch(batch, fd, forged)
+                == session_storage.SKIP_UNREADABLE
+            )
+            # The real one still passes, so the check is binding rather than always-refusing.
+            assert session_storage._approve_emptied_batch(batch, fd, seen) is None
+        finally:
+            os.close(fd)
+
+    def test_a_manifest_that_is_not_valid_utf8_is_refused_not_raised(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Undecodable bytes withhold the removal instead of escaping as an exception.
+
+        The pinned read exists to catch a manifest replaced after the by-path pre-screen, so
+        it is the one read that meets content the pre-screen never saw. ``UnicodeDecodeError``
+        is a ``ValueError``, so the ``except OSError`` that turns an unreadable manifest into
+        a refusal does not cover it, and on the restore path an escape would abort AFTER the
+        user's files were already moved back.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        (batch / session_storage.MANIFEST_NAME).write_bytes(b'{"schema": "\xff\xfe not utf8"}\n')
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            removed = session_storage._remove_emptied_batch(
+                batch, "the restored batch", expect=_identity(batch)
+            )
+
+        assert removed is False
+        assert batch.is_dir(), "the batch stays, so a user can still see and act on it"
+        assert "not valid UTF-8" in caplog.text
+
+    def test_a_batch_with_no_manifest_is_refused(self, tmp_path: Path) -> None:
+        batch = tmp_path / "trash" / _BATCH
+        batch.mkdir(parents=True)
+
+        fd = os.open(str(batch), pinned_fs.dir_flags())
+        try:
+            seen = pinned_fs.scan_tree_pinned(fd, device=os.fstat(fd).st_dev)
+            assert (
+                session_storage._approve_emptied_batch(batch, fd, seen)
+                == session_storage.SKIP_UNREADABLE
+            )
+        finally:
+            os.close(fd)
+
+
+class TestPutBackNoClobber:
+    """The undo half of "move it aside, remove the tree, put it back"."""
+
+    def test_it_falls_back_to_a_copy_where_the_filesystem_has_no_links(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``os.link in os.supports_dir_fd`` cannot answer this, which is the whole point.
+
+        That probe tests whether the OS accepts ``dir_fd``, not whether the MOUNT supports
+        hard links - so a filesystem without them passes the probe and then refuses the call.
+        A guard built on the probe fails exactly where it matters, so the recovery carries an
+        ``O_CREAT | O_EXCL`` copy instead of trusting it.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        original = (batch / session_storage.MANIFEST_NAME).read_text()
+
+        def _no_links(*_args: object, **_kwargs: object) -> None:
+            raise OSError(errno.EOPNOTSUPP, "the filesystem has no hard links")
+
+        real_remove = pinned_fs.remove_dir_verified
+
+        def _refuse_the_batch(
+            parent_fd: int, name: str, *, expect: tuple[int, int]
+        ) -> pinned_fs.StagedRemoval:
+            if name == _BATCH:
+                return pinned_fs.StagedRemoval(
+                    removed=False, reason=pinned_fs.REMOVAL_FAILED, error=OSError("held open")
+                )
+            return real_remove(parent_fd, name, expect=expect)
+
+        monkeypatch.setattr(os, "link", _no_links)
+        monkeypatch.setattr(pinned_fs, "remove_dir_verified", _refuse_the_batch)
+        session_storage._remove_emptied_batch(batch, "the empty batch", expect=_identity(batch))
+
+        assert (batch / session_storage.MANIFEST_NAME).read_text() == original
+        debris = [p.name for p in root.iterdir() if p.name != _BATCH]
+        assert len(debris) == 1, f"the copy is kept, not unlinked: {debris!r}"
+        assert (root / debris[0]).read_text() == original
+
+    def test_a_file_that_took_the_name_is_not_overwritten(self, tmp_path: Path) -> None:
+        (tmp_path / "aside").mkdir()
+        (tmp_path / "aside" / "debris").write_text("the moved copy")
+        (tmp_path / "tree").mkdir()
+        (tmp_path / "tree" / "index").write_text("arrived while it was out")
+
+        src = os.open(str(tmp_path / "aside"), pinned_fs.dir_flags())
+        dst = os.open(str(tmp_path / "tree"), pinned_fs.dir_flags())
+        try:
+            ino = os.stat("debris", dir_fd=src, follow_symlinks=False).st_ino
+            assert (
+                pinned_fs.put_back_no_clobber(src, dst, "debris", "index", expect_ino=ino)
+                == pinned_fs.PUT_BACK_NAME_TAKEN
+            )
+        finally:
+            pinned_fs.close_all((src, dst))
+
+        assert (tmp_path / "tree" / "index").read_text() == "arrived while it was out"
+        assert (tmp_path / "aside" / "debris").read_text() == "the moved copy"
+
+    def test_a_partial_copy_is_removed_but_only_if_it_is_still_ours(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A half-written file must go -- and only while the name still holds the one we made.
+
+        Half a file is worse than none: it carries some of the content and silently drops the
+        rest. But the cleanup addresses a NAME, so a replacement that arrived at it in between
+        is not ours to delete, and unlinking by name alone would destroy someone's only copy.
+        The write is made to fail here, once with nothing else touching the name and once with
+        the name swapped in the same instant, so both halves are exercised.
+        """
+        (tmp_path / "aside").mkdir()
+        (tmp_path / "aside" / "debris").write_text("the moved copy")
+        (tmp_path / "tree").mkdir()
+
+        def _no_links(*_args: object, **_kwargs: object) -> None:
+            raise OSError(errno.EOPNOTSUPP, "the filesystem has no hard links")
+
+        real_write = os.write
+        swap: list[bool] = []
+
+        def _fail_the_write(fd: int, data: bytes) -> int:
+            if swap:
+                # The race, made deterministic: something else takes the name in the same
+                # instant the write fails.
+                other = tmp_path / "arrived"
+                other.write_text("someone else's only copy")
+                os.replace(other, tmp_path / "tree" / "index")
+            raise OSError(errno.EIO, "the write failed")
+
+        src = os.open(str(tmp_path / "aside"), pinned_fs.dir_flags())
+        dst = os.open(str(tmp_path / "tree"), pinned_fs.dir_flags())
+        try:
+            ino = os.stat("debris", dir_fd=src, follow_symlinks=False).st_ino
+            monkeypatch.setattr(os, "link", _no_links)
+            monkeypatch.setattr(os, "write", _fail_the_write)
+
+            assert (
+                pinned_fs.put_back_no_clobber(src, dst, "debris", "index", expect_ino=ino)
+                == pinned_fs.PUT_BACK_FAILED
+            )
+            monkeypatch.setattr(os, "write", real_write)
+            assert not (tmp_path / "tree" / "index").exists(), "our own partial file goes"
+
+            swap.append(True)
+            monkeypatch.setattr(os, "write", _fail_the_write)
+            assert (
+                pinned_fs.put_back_no_clobber(src, dst, "debris", "index", expect_ino=ino)
+                == pinned_fs.PUT_BACK_FAILED
+            )
+        finally:
+            monkeypatch.setattr(os, "write", real_write)
+            pinned_fs.close_all((src, dst))
+
+        assert (
+            tmp_path / "tree" / "index"
+        ).read_text() == "someone else's only copy", "a replacement is not ours to delete"
+
+    def test_a_partial_copy_that_cannot_be_unlinked_is_left_empty_not_partial(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The content is dropped through the DESCRIPTOR, before any name is addressed.
+
+        The unlink that follows can only ever narrow a two-syscall window - POSIX has no
+        "unlink if this inode" - so the guarantee that no partial content survives cannot rest
+        on it. Here the unlink is refused outright, which is what a leftover would look like:
+        the file at the name must still be empty rather than carrying half a manifest, because
+        half a manifest lists some sessions and silently drops the rest.
+        """
+        (tmp_path / "aside").mkdir()
+        (tmp_path / "aside" / "debris").write_text("entry-one\nentry-two\nentry-three\n")
+        (tmp_path / "tree").mkdir()
+
+        def _no_links(*_args: object, **_kwargs: object) -> None:
+            raise OSError(errno.EOPNOTSUPP, "the filesystem has no hard links")
+
+        real_write = os.write
+
+        def _write_then_fail(fd: int, data: bytes) -> int:
+            real_write(fd, data[: len(data) // 2])
+            raise OSError(errno.ENOSPC, "no space left on device")
+
+        def _refuse_unlink(*_args: object, **_kwargs: object) -> None:
+            raise OSError(errno.EPERM, "not permitted")
+
+        src = os.open(str(tmp_path / "aside"), pinned_fs.dir_flags())
+        dst = os.open(str(tmp_path / "tree"), pinned_fs.dir_flags())
+        try:
+            ino = os.stat("debris", dir_fd=src, follow_symlinks=False).st_ino
+            monkeypatch.setattr(os, "link", _no_links)
+            monkeypatch.setattr(os, "write", _write_then_fail)
+            monkeypatch.setattr(os, "unlink", _refuse_unlink)
+
+            assert (
+                pinned_fs.put_back_no_clobber(src, dst, "debris", "index", expect_ino=ino)
+                == pinned_fs.PUT_BACK_FAILED
+            )
+        finally:
+            pinned_fs.close_all((src, dst))
+
+        left = tmp_path / "tree" / "index"
+        assert left.exists(), "the refused unlink is the point of this case"
+        assert left.read_bytes() == b"", f"partial content survived: {left.read_bytes()!r}"
+
+    def test_a_swapped_source_name_is_refused_rather_than_followed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The moved-aside name is UNTRUSTED by the time the recovery runs.
+
+        It is a name in a directory an actor may be able to write to, and this path only runs
+        because something already failed -- so time has passed. Without an inode check and
+        ``O_NOFOLLOW``, a name swapped for a symbolic link is followed and whatever it points
+        at gets copied into the destination under a name the caller treats as its own. A
+        credential is the obvious thing to point it at.
+
+        Hard links are disabled so the COPY path runs, which is where the source-side guard
+        is load-bearing: the link path has its own defences (``follow_symlinks=False`` plus a
+        check of what landed), so with links available this swap is caught there instead and
+        the source check is never reached.
+        """
+        (tmp_path / "aside").mkdir()
+        (tmp_path / "aside" / "debris").write_text("the moved copy")
+        (tmp_path / "tree").mkdir()
+        secret = tmp_path / "secret.txt"
+        secret.write_text("a credential this code has never read")
+
+        def _no_links(*_args: object, **_kwargs: object) -> None:
+            raise OSError(errno.EOPNOTSUPP, "the filesystem has no hard links")
+
+        src = os.open(str(tmp_path / "aside"), pinned_fs.dir_flags())
+        dst = os.open(str(tmp_path / "tree"), pinned_fs.dir_flags())
+        try:
+            ino = os.stat("debris", dir_fd=src, follow_symlinks=False).st_ino
+            # The swap: same name, now a link pointing outside.
+            os.unlink("debris", dir_fd=src)
+            os.symlink(str(secret), "debris", dir_fd=src)
+            monkeypatch.setattr(os, "link", _no_links)
+            assert (
+                pinned_fs.put_back_no_clobber(src, dst, "debris", "index", expect_ino=ino)
+                == pinned_fs.PUT_BACK_FAILED
+            )
+        finally:
+            pinned_fs.close_all((src, dst))
+
+        assert not (tmp_path / "tree" / "index").exists(), "nothing may be placed from a swap"
+        assert secret.read_text() == "a credential this code has never read"
+
+
+class TestTheCoarsePlatform:
+    """Where there is no descriptor to bind to, these two paths still remove the batch.
+
+    They go through the rename-verify-remove the explicit empty already uses on this
+    platform: the batch is renamed aside inside the trash root, its identity is checked
+    THERE, and only the staged name is removed. Refusing outright was an earlier answer and
+    it was wrong, because this branch is the whole of Windows: it left a batch behind after
+    every restore and every rolled-back move, still listing sessions it no longer held.
+    The residual the rename accepts is the one this platform already accepts for an empty.
+    """
+
+    def test_the_batch_is_removed_through_a_verified_staged_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        identity = _identity(batch)
+        (batch / "cli").mkdir()
+
+        monkeypatch.setattr(session_storage, "_FD_SAFE_DELETE", False)
+        assert session_storage._remove_emptied_batch(batch, "the empty batch", expect=identity)
+
+        assert not batch.exists(), "the cleanup must finish on this platform, not refuse"
+        assert root.is_dir()
+        assert list(root.iterdir()) == [], "no staging name may be left behind"
+
+    def test_a_batch_that_is_not_the_selected_one_is_put_back_not_removed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The identity check is what the rename buys, so it is checked on its own.
+
+        A directory answering to the batch's name that is NOT the one the caller recorded
+        goes back under that name with its contents intact -- it may be somebody's only copy.
+        """
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        stale_identity = (_identity(batch)[0], _identity(batch)[1] + 1)
+        (batch / "keep.me").write_text("not the selected batch")
+
+        monkeypatch.setattr(session_storage, "_FD_SAFE_DELETE", False)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            removed = session_storage._remove_emptied_batch(
+                batch, "the empty batch", expect=stale_identity
+            )
+
+        assert removed is False
+        assert (batch / "keep.me").read_text() == "not the selected batch"
+        assert list(root.iterdir()) == [batch], "put back under the name the user saw"
+        assert "not the directory that was selected" in caplog.text
+
+    def test_no_victim_is_reachable_without_descriptors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The swap the identity check exists to catch, confirmed to reach nothing."""
+        root = tmp_path / "trash"
+        batch = _batch_with_manifest(root, _BATCH, entries=[])
+        identity = _identity(batch)
+        victim = tmp_path / "victim"
+        (victim / _BATCH).mkdir(parents=True)
+        precious = victim / _BATCH / "staged.jsonl"
+        precious.write_text("the only copy")
+
+        _swap_parent_for_a_link(root, victim)
+        monkeypatch.setattr(session_storage, "_FD_SAFE_DELETE", False)
+        session_storage._remove_emptied_batch(batch, "the restored batch", expect=identity)
+
+        assert precious.read_text() == "the only copy"
+        assert (victim / _BATCH).is_dir()
+        assert not any(p.name.startswith(".") for p in victim.iterdir())
+
+
+class TestScanTreePinned:
+    """The traversal, and the claim the by-name ratchet's exemption rests on."""
+
+    def test_a_direntry_from_a_descriptor_scan_stats_through_it(self, tmp_path: Path) -> None:
+        """``os.scandir(<fd>)`` entries answer through the descriptor, not by path.
+
+        The scan asks ``entry.is_symlink()`` and ``entry.is_dir(follow_symlinks=False)``
+        rather than ``os.stat(name, dir_fd=fd)``, which the pinned-module ratchet would
+        otherwise read as a name-based question. This is why that reading is wrong, pinned
+        as behaviour: a symbolic link forces a real stat (the directory block reports only
+        that it is a link), ``entry.path`` is the bare name, and the working directory is
+        one where that name does not exist -- so an answer at all proves the stat went
+        through the iterator's descriptor.
+        """
+        real = tmp_path / "elsewhere"
+        real.mkdir()
+        holder = tmp_path / "holder"
+        holder.mkdir()
+        (holder / "link").symlink_to(real, target_is_directory=True)
+
+        fd = os.open(str(holder), pinned_fs.dir_flags())
+        try:
+            entry = next(iter(os.scandir(fd)))
+            assert entry.path == "link"
+            assert not Path.cwd().joinpath("link").exists()
+            assert entry.is_symlink() is True
+            assert entry.is_dir() is True
+        finally:
+            os.close(fd)
+
+    def test_it_records_dirs_files_and_links_separately(self, tmp_path: Path) -> None:
+        root = tmp_path / "tree"
+        (root / "a").mkdir(parents=True)
+        (root / "a" / "leaf").write_text("x")
+        (root / "top").write_text("y")
+        (root / "dangling").symlink_to(tmp_path / "nowhere")
+
+        fd = os.open(str(root), pinned_fs.dir_flags())
+        try:
+            tree = pinned_fs.scan_tree_pinned(fd, device=os.fstat(fd).st_dev)
+        finally:
+            os.close(fd)
+
+        assert set(tree.dirs) == {("a",)}
+        assert set(tree.files) == {("top",), ("a", "leaf")}
+        assert set(tree.links) == {("dangling",)}
+
+    def test_a_directory_on_another_device_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mount arriving underneath is not a link, so only the device catches it."""
+        root = tmp_path / "tree"
+        (root / "elsewhere").mkdir(parents=True)
+
+        fd = os.open(str(root), pinned_fs.dir_flags())
+        try:
+            with pytest.raises(OSError, match="another device"):
+                pinned_fs.scan_tree_pinned(fd, device=os.fstat(fd).st_dev + 1)
+        finally:
+            os.close(fd)
+
+
+class TestRemoveDirVerified:
+    """The primitive the three former inline spellings now share."""
+
+    def test_it_removes_the_directory_it_was_given(self, tmp_path: Path) -> None:
+        (tmp_path / "gone").mkdir()
+        parent_fd = os.open(str(tmp_path), pinned_fs.dir_flags())
+        try:
+            info = os.stat(str(tmp_path / "gone"), follow_symlinks=False)
+            outcome = pinned_fs.remove_dir_verified(
+                parent_fd, "gone", expect=(info.st_dev, info.st_ino)
+            )
+        finally:
+            os.close(parent_fd)
+
+        assert outcome.removed is True
+        assert outcome.staged_name is None
+        assert not (tmp_path / "gone").exists()
+
+    def test_a_swapped_name_is_refused_and_left_under_the_staging_name(
+        self, tmp_path: Path
+    ) -> None:
+        """The swap this primitive exists for, and the rename-back that must NOT happen.
+
+        Putting the impostor back would write to a name the refusal just proved is not
+        ours -- and POSIX rename replaces its destination, so it would destroy whatever
+        now answers to it. So a bystander is placed at the original name and has to
+        survive.
+        """
+        (tmp_path / "approved").mkdir()
+        approved = os.stat(str(tmp_path / "approved"), follow_symlinks=False)
+        (tmp_path / "approved").rename(tmp_path / "moved-away")
+        (tmp_path / "approved").mkdir()
+
+        parent_fd = os.open(str(tmp_path), pinned_fs.dir_flags())
+        try:
+            outcome = pinned_fs.remove_dir_verified(
+                parent_fd,
+                "approved",
+                expect=(approved.st_dev, approved.st_ino),
+            )
+        finally:
+            os.close(parent_fd)
+
+        assert outcome.removed is False
+        assert outcome.reason == pinned_fs.REMOVAL_IDENTITY_CHANGED
+        assert outcome.staged_name is not None
+        # The impostor is under the unguessable name, and nothing was deleted.
+        assert (tmp_path / outcome.staged_name).is_dir()
+        assert (tmp_path / "moved-away").is_dir()
+
+    def test_a_non_empty_directory_is_put_back(self, tmp_path: Path) -> None:
+        """``rmdir`` failing is the one case the rename-back is correct for."""
+        (tmp_path / "full").mkdir()
+        (tmp_path / "full" / "child").write_text("x")
+        info = os.stat(str(tmp_path / "full"), follow_symlinks=False)
+
+        parent_fd = os.open(str(tmp_path), pinned_fs.dir_flags())
+        try:
+            outcome = pinned_fs.remove_dir_verified(
+                parent_fd, "full", expect=(info.st_dev, info.st_ino)
+            )
+        finally:
+            os.close(parent_fd)
+
+        assert outcome.removed is False
+        assert outcome.reason == pinned_fs.REMOVAL_FAILED
+        # Put back, which is exactly what "no staging name to report" means.
+        assert outcome.staged_name is None
+        assert (tmp_path / "full" / "child").read_text() == "x"
+
+
+class TestRemoveTreePinned:
+    """The composition, including its two refusals."""
+
+    def test_it_removes_a_whole_tree(self, tmp_path: Path) -> None:
+        root = tmp_path / "tree"
+        (root / "a" / "b").mkdir(parents=True)
+        (root / "a" / "b" / "leaf").write_text("x")
+        (root / "top").write_text("y")
+        (root / "link").symlink_to(tmp_path / "elsewhere")
+
+        outcome = pinned_fs.remove_tree_pinned(
+            str(root), what="the tree", approve=_approve_anything
+        )
+
+        assert outcome.removed is True
+        assert not root.exists()
+
+    def test_a_withheld_approval_removes_nothing(self, tmp_path: Path) -> None:
+        root = tmp_path / "tree"
+        (root / "a").mkdir(parents=True)
+        (root / "a" / "leaf").write_text("x")
+        seen: list[int] = []
+
+        def _withhold(root_fd: int, tree: pinned_fs.PinnedTree) -> str:
+            seen.append(len(tree.files))
+            return "not-mine"
+
+        outcome = pinned_fs.remove_tree_pinned(str(root), what="the tree", approve=_withhold)
+
+        assert outcome.removed is False
+        assert outcome.reason == "not-mine"
+        assert seen == [1]
+        assert (root / "a" / "leaf").read_text() == "x"
+
+    def test_a_target_that_is_a_link_is_refused(self, tmp_path: Path) -> None:
+        """``O_NOFOLLOW`` on the final component, which is what a re-joined name buys."""
+        (tmp_path / "real").mkdir()
+        (tmp_path / "real" / "keep").write_text("x")
+        (tmp_path / "as-link").symlink_to(tmp_path / "real", target_is_directory=True)
+
+        with pytest.raises(pinned_fs.PinnedPathRefusal):
+            pinned_fs.remove_tree_pinned(
+                str(tmp_path / "as-link"), what="the tree", approve=_approve_anything
+            )
+
+        assert (tmp_path / "real" / "keep").read_text() == "x"
+
+    def test_a_survivor_is_reported_rather_than_claimed_gone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A tree that would not go must not report success.
+
+        The unlink is made to fail so the closing scan finds the file still there. Left
+        as a report rather than an exception because a caller keeps such a directory
+        listed instead of claiming it was emptied.
+        """
+        root = tmp_path / "tree"
+        root.mkdir()
+        (root / "stuck").write_text("x")
+
+        real_unlink = os.unlink
+
+        def _refuse(path: object, **kwargs: object) -> None:
+            if path == "stuck":
+                raise OSError("held open")
+            real_unlink(path, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "unlink", _refuse)
+        outcome = pinned_fs.remove_tree_pinned(
+            str(root), what="the tree", approve=_approve_anything
+        )
+
+        assert outcome.removed is False
+        assert outcome.survivors == 1
+        assert outcome.reason == pinned_fs.REMOVAL_FAILED
+        assert (root / "stuck").read_text() == "x"


### PR DESCRIPTION
## What is the problem?

#7011 bound the trash DELETE path to descriptors and named two sibling paths it left open.
Both were still removing a batch by re-resolved path:

- `_discard_restored_batch`, after a restore has moved every listed file back out
- `move_to_trash`'s cleanup, when a staging attempt ends with nothing recorded

Both spelled it `shutil.rmtree(batch, ignore_errors=True)`. A path is re-resolved component by
component by the kernel, so a directory above the trash swapped to a symbolic link after the
caller's own checks is followed, and the removal lands wherever the link points. Neither caller
holds the mutation lock across that window, every check above them is by path, and
`ignore_errors=True` means the deletion that lands outside the trash is also silent.

## Why this issue matters to the user

The trash holds the only copy of a session's replay log, transcript and archive segments
between staging and an explicit empty. These two paths run on ordinary operations - every
restore, and every move that rolls back - so the exposure is not a rare corner.

Everything here runs as one uid, which in this product includes an agent acting on the user's
behalf. That is the actor the pinning defends against: not a remote attacker, but a process
that can write in the directories above the trash while the user's own restore is in flight.

## How our fix solves it

**Both siblings now remove by descriptor.** They call
`pinned_fs.remove_tree_pinned`, which pins the parent chain one `openat` per component, opens
the batch through it with `O_NOFOLLOW`, scans it once, unlinks links and files against the
inodes that scan recorded, removes directories deepest-first through `remove_dir_verified`,
re-scans to decide whether the tree is actually empty, and only then removes the batch itself,
verified against the descriptor the whole operation was pinned to.

**Pinning is the weaker half, so an identity carries the fix.** `Path.resolve()` follows an
ancestor that is ALREADY a link, so a swap landing before the resolve produces a faithful
pinned walk to the wrong tree. Each caller therefore records the batch's `(st_dev, st_ino)`
before its own by-path read - at `target.mkdir(...)` under the mutation lock on the staging
path, and before the leftover scan on the restore path - and the approval hook compares the
pinned root's `fstat` against it as its first question. An unreadable identity refuses.

**The content checks come second and cannot carry it.** From ONE inode-verified read of ONE
file, the approval re-asks that the manifest's header claims this batch's own directory name,
and that NOTHING but the manifest remains - not "nothing unlisted", nothing at all. Both
callers arrive with the batch empty of files, so a file at a listed path is not the listed
file; it arrived afterwards and may be the only copy of whatever it is. An actor who can write
into the tree a swapped link points at can plant a matching header; an inode cannot be forged
by writing files.

**The manifest goes last.** `list_trash()` omits a batch with no readable manifest, so removing
it first and then failing on the directory would leave data on disk that nothing lists.
`keep_until_empty` names it: skipped by the file pass, required to be the only survivor of the
closing scan and verified there by inode, then moved aside under an unguessable debris name and
put back through `put_back_no_clobber` if the tree still will not go - link first, then an
`O_CREAT | O_EXCL` copy, because `os.link in os.supports_dir_fd` tests what the OS accepts and
not what the mount supports. The debris copy is RETAINED whenever the removal failed: no check
available before an unlink can prove the name it went back to still holds a good copy, so
removing the redundant one is a chance to turn a stuck batch into an unlistable one. The
retained name is reported through `staged_name`.

**On a platform with no `openat`, the removal is bound to a verified name instead.**
`_stage_batch_by_name` renames the batch aside inside the trash root, verifies `(st_dev,
st_ino)` on the RENAMED directory against the caller's identity, and removes only the staged
name; a mismatch, an unreadable identity, or a tree that will not go puts the directory back
under the name the user saw. It is one owner for three callers - the explicit empty, which
already worked this way, and the two cleanups. Refusing outright instead is not available:
that branch is the whole of Windows, so refusing leaves a batch after every restore and every
rolled-back move, still listing sessions it no longer holds, which five pre-existing tests
read as a failure. The residual is stated rather than implied and tracked in #7566.

**A refused cleanup writes nothing.** The batch stays exactly as found, including a manifest
whose entries describe files the restore already moved out. That stale listing is a decided
residual: clearing it needs a write to the batch path, and there is nowhere safe to put one.
After the cleanup, every refusal is itself evidence the path may be redirected, and
`atomic_write` REPLACES its destination. Before it, the full-restore branch has no write at
all today, so adding one hands that primitive a path a batch swapped to a link points wherever
an actor chose, including another batch's manifest, whose sessions would become unlistable. A
stale listing is visible and reversible; that is not, and `empty_trash` clears the batch on the
user's own say-so.

**One owner per mechanism.** `rename-verify-remove` was spelled inline three times - the
interior directories, the batch directory, and the coarse path - and is now
`pinned_fs.remove_dir_verified`, with `scan_tree_pinned`, `open_verified_chain`,
`drain_verified_chain`, `remove_tree_pinned` and `put_back_no_clobber` beside it.
`session_storage` keeps the policy: which map authorises a removal, what a refusal means to
the user, and how it is worded. Per-call-site respelling of this mechanism is what `pinned_fs`
was created to end after #2446 and #2447.

**Riders, same root cause.** The delete path's manifest recovery trusted a mutable name: it
opened the debris without `O_NOFOLLOW`, linked with the default `follow_symlinks=True`, and
unlinked unconditionally, on a name in a directory an actor may be able to write to, reached
only after something already failed. Its source is now opened `O_NOFOLLOW` and inode-checked
before anything is read, the copy reads that descriptor rather than re-opening the name, the
link passes `follow_symlinks=False` and checks what landed, and both debris unlinks are
identity-checked. Leaving this out would have shipped a shared put-back owner whose delete-path
caller kept the unguarded spelling of the same hole.

`_read_manifest` gains `expect_ino`, checked with `fstat` on the open handle, so a caller that
needs the header and the listing to describe ONE file makes a single call - two calls are two
opens, and a manifest rewritten between them lets the header check pass on one file while the
listing comes from another. The approval also refuses a manifest that is not valid UTF-8:
`UnicodeDecodeError` is a `ValueError`, so the `except OSError` that turns an unreadable
manifest into a refusal does not cover it, and an escape would abort a restore that had already
moved the user's files back.

## What tests we did

`test/test_trash_pinned_sibling_removal.py` is new and covers both siblings end to end. The
ancestor swap is set up ON DISK rather than simulated, and the victim carries a file, so a
passing test says the file survived rather than that a branch was taken:

- a swapped ancestor is refused on both paths, and the victim's file is intact
- a victim holding a manifest FORGED to name the selected batch is still refused, because the
  identity was captured before the swap
- an identity that could never be established refuses rather than proceeding
- a clean batch is still removed, and a batch holding an unlisted file is kept
- a file at a listed path is kept, not deleted
- the manifest survives a tree that will not go, and comes back when the batch directory will
  not go, with the redundant copy retained and reported
- the put-back falls back to a copy where the filesystem has no hard links, refuses a swapped
  source name, and removes a partial copy only while it is still the file this call created
- a manifest that is not valid UTF-8 refuses instead of raising
- on the descriptor-less platform the batch is removed through a verified staged name, a
  directory that is not the selected one is put back with its contents intact, and a swapped
  ancestor reaches no victim

Every security assertion is mutation-verified: reverting the guard reddens the test, each on a
victim file that no longer exists or a credential that was copied.

The descriptor-less branch is unreachable on Linux, so it was run locally against a forced
coarse platform in both directions - the five pre-existing Windows tests pass with the staged
removal and fail with a refusal - and then confirmed on the Windows shards in CI.

Gates: `black`, `flake8`, `isort`, `mypy` clean on touched files; `docs_lint` passes; the spec
in `docs/system-specs/modules/session-storage.md` moves with the code in the same commit.

## Any other suggestions on the work?

**Accepted residuals, each named rather than implied.** The descriptor-less platform still
resolves the staging path, so an actor who can observe that name inside the window can redirect
the removal through an ancestor swapped afterwards, and `_identity_of` is itself a by-path
`stat` that a swap already in place can fool. Both are tracked in #7566, which describes the
handle-based deletion that would close them. Neither is a regression: on mainline these paths
are a bare `shutil.rmtree(batch, ignore_errors=True)` with no identity check at any point, and
`_identity_of` does not exist there at all.

**Deferred, with a reason.** `_delete_listed_files` still drives its own move-aside-remove
choreography rather than calling the primitive. Converging it means carrying freed-byte
accounting, the `cleared` flag behind `SKIP_INCOMPLETE`, and a progress callback into a module
that holds no policy by design, on a path that only just converged in #7011.

`remove_tree_pinned` has one consumer today, serving both fixed sites. The alternative is to
inline the whole pinned walk back into `session_storage`, which is the respelling `pinned_fs`
exists to end.

## Pattern harvest

Rule candidate: extend the AST ratchet in `test_pinned_staging.py` to `session_storage.py`,
banning `shutil.rmtree` and by-name `os.rmdir`/`os.unlink` inside any function that holds a
directory descriptor.

The defect class is "a filesystem mutation that addresses a PATH inside a function that already
holds, or could hold, a descriptor for the object". `test_pinned_staging.py` already ratchets
exactly this for `pinned_fs.py` by walking the AST - and it is the reason this PR's own moved
code was caught rather than shipped. `session_storage.py` is not covered, which is why these
two `rmtree(path)` calls survived #7011: nothing mechanical would have named them.

It cannot be done here as a clean gate: `session_storage.py` has legitimate by-name sites - the
coarse branch and the by-path pre-screens - and separating them needs the per-line marker
convention that the existing ratchet's own docstring identifies as the blocker for widening to
`snapshot.py`. That is one change serving three modules rather than three narrow ones.

Not a one-off: this is the third time this exact class has been closed in this module (#2446,
#2447, #7011), and each round found it at a site the previous round's review had not looked at.

Closes #7113
