### PR TITLE
fix(ci): re-measure the files.py log-site census after #7293

### DIFF
--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -234,7 +234,7 @@ _BASELINE_LOG_SITE_CENSUS: dict[str, int] = {
     "dashboard/chat_runner.py": 10,
     "dashboard/chat_title.py": 1,
     "dashboard/handlers/discover.py": 3,
-    "dashboard/handlers/files.py": 3,
+    "dashboard/handlers/files.py": 1,
     "dashboard/handlers/hooks.py": 1,
     "dashboard/handlers/messaging.py": 12,
     "dashboard/handlers/updates.py": 1,


### PR DESCRIPTION
## 1. What is the problem?

`main` is red. `test_security_posture.py::TestGateSideLogRedactorSpelling::test_the_census_holds_no_slack` fails:

```
AssertionError: `_BASELINE_LOG_SITE_CENSUS` is now looser than the code --
lower or drop these: dashboard/handlers/files.py: 1 sites, census says 3
```

The census is a two-way ratchet: one test forbids a module GROWING past its
recorded number, the sibling forbids the record staying ABOVE the code (dead
slots a future baseline line could slip into silently). The second one is
failing.

## 2. Why this issue matters to the user

It is not a flake and it does not clear on a retry, so every open PR on the
repository carries one permanently red `Backend Tests` shard and cannot reach a
green `PR Readiness`. Reproduced on pristine `origin/main` at `dd9e002bf`, not
only on a feature branch.

## 3. How our fix solves it

The number was measured on a tree that predated #7293, which consolidated
`dashboard/handlers/files.py`'s many `_sel().log_tool_invocation(...)` call sites
into one `_audit_file_send` helper. #7293 landed first; #7278 then merged with
the already-stale `3` in its census, and nothing re-measures the census at merge
time -- so main merged red rather than any single PR breaking it. No commit has
touched `files.py` since #7278 landed, which is what rules out a later
regression.

Lower the entry to the count the scanner reports, which is exactly what the
failing assertion prescribes ("lower or drop these"). One line, no source
change.

Why 1 and not 2, since the module still contains two `redact_credentials` /
`redact_exfiltration_urls` pairs: both feed `_audit_file_send(...)`, a local
helper, rather than a `logger.*` or `sel().log_*` call in the same function, so
the scanner's matcher does not count them. The security posture is unchanged
either way -- this PR moves a recorded number to match code that already exists.

## 4. What tests we did

`pytest test/test_security_posture.py::TestGateSideLogRedactorSpelling` -- 5
passed. Mutation-verified in BOTH ratchet directions, which is the point of a
two-way ratchet:

| Census value | Result |
| --- | --- |
| `3` (main today) | `test_the_census_holds_no_slack` FAILS -- the bug |
| `0` (over-lowered) | `test_no_new_gate_side_log_line_reads_the_baseline_redactor` FAILS: `files.py: 1 sites, census says 0` |
| `1` (this PR) | all 5 pass |

So the value is pinned from above and below, not merely made green.

## 5. Any other suggestions on the work

The real defect is structural and outlives this line: a scan-derived baseline
committed as a literal is measured at authoring time and consumed at merge time,
so any PR that lands in between silently invalidates it. The growth direction is
safe (a stale-high number only ever under-reports), but the slack direction turns
an unrelated merge into a red main. Options, cheapest first: have the census test
print a copy-pasteable corrected dict on failure; or generate the census into a
committed snapshot file with a `--update` flag; or drop the literal and assert
only the growth direction, accepting the dead slots the slack test exists to
prevent. Worth one maintainer decision rather than a re-measure PR each time.

## Pattern harvest

Rule candidate: review-prompt -- when a PR adds or edits a committed baseline
that was DERIVED by scanning the tree (a census, a count ratchet, a lint
allowlist with counts), ask whether it was re-measured against the merge base
rather than the authoring base. This class cannot be caught by reviewing the PR
in isolation, because the number is correct when written and wrong when merged.

Rule candidate: lint -- a CI job that recomputes such a baseline on `main` after
each merge and opens (or fails loudly with) the corrected value would have caught
this within one merge instead of leaving main red for every open PR to trip over.
