### PR TITLE
docs(pins): clarify _redacted_pin re-redacts the preview field specifically

### DIFF
--- a/src/kiro_crew/dashboard/chat_pins.py
+++ b/src/kiro_crew/dashboard/chat_pins.py
@@ -68,11 +68,13 @@ def _authorize_app_slot(
 
 
 def _redacted_pin(pin: dict) -> dict:
-    """Copy of ``pin`` with the preview re-redacted at the output boundary.
+    """Copy of ``pin`` with the free-text ``preview`` re-redacted at the output boundary.
 
     chat_pins.json read from disk may predate the current redactor patterns
-    (or have been written by an older version), so never trust stored text on
-    the way out -- every response path must go through this helper.
+    (or have been written by an older version), so the stored ``preview`` --
+    the only field carrying user prose -- is re-run through the redactors on
+    the way out. The remaining fields (``mid``, ``message_ts``, ``slot_key``)
+    are structural identifiers and pass through unchanged.
     """
     return {
         **pin,


### PR DESCRIPTION
## Problem / Motivation

The `_redacted_pin` output-boundary helper carried a docstring claiming "never trust stored text on the way out — every response path must go through this helper," implying all fields are re-redacted on output. In fact the helper only re-runs the free-text `preview` field through the redactors; `mid`, `message_ts`, and `slot_key` pass through unchanged.

## Why it matters

The overstated docstring could mislead a maintainer into assuming every field is sanitized on the way out, and into removing an input-side guard on the mistaken belief the output boundary re-covers it. Accurate scoping of what the helper does (and does not) redact keeps that contract honest.

## What changed

Docstring-only. Reworded to say the stored `preview` — the only field carrying user prose — is re-run through the redactors on output, while `mid`/`message_ts`/`slot_key` are structural identifiers that pass through unchanged. No behavior change.

## Tests

N/A — comment-only change; no docstring-shape test references `_redacted_pin`, so there is nothing behavioral to lock in. Lint/type gates confirm the file still parses.

## Manual verification

N/A — documentation-only.

## Pattern harvest

Not generalizable: a one-off docstring accuracy fix.

## Related Issues

Fixes #7494
