### PR TITLE
fix(session-map): route prune removals through the audited _remove_entry chokepoint

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -61,6 +61,7 @@ from kiro_crew.messaging.link import (
     UNBIND_REASON_DASHBOARD_UNLINK,
     UNBIND_REASON_ENTRY_DELETED,
     UNBIND_REASON_ORIGIN_REBIND,
+    UNBIND_REASON_PRUNED_STALE,
     UNBIND_REASON_SESSION_DESTROYED,
     UNBIND_REASON_UNSPECIFIED,
     UNBIND_REASON_USER_UNLINK,
@@ -2086,6 +2087,7 @@ _INBOUND_UNBIND_WHY: dict[str, str] = {
     UNBIND_REASON_ORIGIN_REBIND: "this conversation was relinked to a new session",
     UNBIND_REASON_SESSION_DESTROYED: "that session was deleted",
     UNBIND_REASON_ENTRY_DELETED: "that session's record was removed",
+    UNBIND_REASON_PRUNED_STALE: "that session's record was no longer on disk",
     UNBIND_REASON_UNSPECIFIED: "the link was cleared",
 }
 _INBOUND_UNBIND_WHY_DEFAULT = "the link was cleared"

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -258,6 +258,13 @@ UNBIND_REASON_SESSION_DESTROYED = "session_destroyed"
 # rather than its cause.
 UNBIND_REASON_ENTRY_DELETED = "entry_deleted"
 
+# ``SessionMap.prune`` collected the entry as stale: its native session file is
+# gone and the entry held nothing that had to outlive it. Distinct from
+# ``entry_deleted`` because nobody asked for this one — it is the map's own
+# garbage collection, so a binding appearing under this reason says the STALE
+# predicate let a live conversation through rather than that a caller removed it.
+UNBIND_REASON_PRUNED_STALE = "pruned_stale"
+
 #: The closed vocabulary. A reason outside this set is normalized to
 #: ``unspecified`` at the map's choke point, so it can neither fragment the audit
 #: trail nor reach the channel notice's phrasing map as a miss.
@@ -269,6 +276,7 @@ UNBIND_REASONS: frozenset[str] = frozenset(
         UNBIND_REASON_ORIGIN_REBIND,
         UNBIND_REASON_SESSION_DESTROYED,
         UNBIND_REASON_ENTRY_DELETED,
+        UNBIND_REASON_PRUNED_STALE,
     }
 )
 

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -24,6 +24,7 @@ from kiro_crew.config.paths import config_dir, kiro_sessions_dir
 from kiro_crew.messaging.link import (
     SLACK_NAMESPACE,
     UNBIND_REASON_ENTRY_DELETED,
+    UNBIND_REASON_PRUNED_STALE,
     UNBIND_REASON_UNSPECIFIED,
     UNBIND_REASONS,
     ChannelLink,
@@ -1019,6 +1020,17 @@ class SessionMap:
 
         Returns the number of entries removed; a ``sid``-only reset is a repair,
         not a removal, so it is not counted.
+
+        Collection goes through :meth:`_remove_entry` rather than deleting out of
+        ``_data``, so it inherits the audit and the announcement every other
+        removal path gets. Today that is unreachable — :func:`_survives_prune`
+        holds every bound entry back — and reaching the choke point anyway is the
+        point: a future loosening of that predicate then lands on an audited path
+        instead of silently collecting a live binding. On prune's only production
+        path (``start_pool``, on the startup loop) the per-entry saves coalesce
+        through ``_save``'s debounced deferred flush into one worker-thread
+        write; off the loop each save writes inline, which no production caller
+        does.
         """
         sessions_dir = _kiro_sessions_dir()
         stale: list[str] = []
@@ -1038,10 +1050,20 @@ class SessionMap:
                     stale.append(key)
             elif not sid and not survives:
                 stale.append(key)
-        for k in stale:
-            del self._data[k]
         if stale:
+            for k in stale:
+                self._remove_entry(k, reason=UNBIND_REASON_PRUNED_STALE)
+            # Still a FULL rebuild, not the per-key index drop
+            # ``_remove_entry`` already did: two entries can claim one
+            # thread, and only a rebuild re-resolves the thread to the
+            # survivor instead of leaving it ownerless.
             self._rebuild_thread_index()
+            # One more dirty-mark after the rebuild. ``_save`` is loop-aware:
+            # on prune's only production path (``start_pool`` on the startup
+            # loop) the saves coalesce into one deferred flush whose disk
+            # write runs on a worker thread (#2405) — the loop still pays the
+            # serialize, never the write. A ``batched_save`` here would write
+            # inline at batch exit on that same loop.
             self._save()
             logger.info("Pruned %d stale session map entries", len(stale))
         elif repaired:

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from kiro_crew.messaging.link import (
+    UNBIND_REASON_PRUNED_STALE,
     UNBIND_REASON_UNSPECIFIED,
     ChannelLink,
     legacy_dashboard_mirror_key,
@@ -1020,6 +1021,109 @@ class TestInboundUnbindIsLoud:
         assert session_map.get_mirror_link("dashboard:chat-1") == INBOUND_LINK
         assert session_map.mirror_accepts_inbound("dashboard:chat-1") is True
         assert unbind_calls == []
+
+
+class TestPruneRemovesThroughTheChokePoint:
+    """Prune's deletions are audited like every other entry removal.
+
+    ``_survives_prune`` keeps every bound entry out of prune's delete branch, so
+    today prune cannot reach a binding at all — which is precisely why this needs
+    pinning rather than leaving to inspection. Prune used to delete straight out
+    of ``_data``, so the audit and the announcement were not skipped by policy,
+    they were simply unreachable: any future loosening of that predicate would
+    have reopened a silent binding-removal path and nothing in the trail would
+    have named prune as the remover.
+    """
+
+    def test_a_pruned_binding_is_audited_and_announced(
+        self, session_map, unbind_calls, sel_events, monkeypatch
+    ):
+        """The latent path, made reachable: the removal still has to be loud."""
+        key = "dashboard:chat-1"
+        session_map.set(key, "sid-that-no-longer-exists")
+        session_map.set_mirror_link(key, INBOUND_LINK, accepts_inbound=True)
+        # Stand in for a future edit to the predicate: the entry becomes
+        # collectable while still holding the binding prune would take with it.
+        monkeypatch.setattr("kiro_crew.session_map._survives_prune", lambda entry: False)
+
+        assert session_map.prune() == 1
+        assert key not in session_map._data
+
+        audits = _inbound_audits(sel_events)
+        assert len(audits) == 1
+        assert key in audits[0]["resources"]
+        assert "discord:chan-1" in audits[0]["resources"]
+        assert UNBIND_REASON_PRUNED_STALE in audits[0]["resources"]
+        assert unbind_calls == [(key, INBOUND_LINK, UNBIND_REASON_PRUNED_STALE)]
+
+    def test_collecting_an_unbound_row_stays_silent(
+        self, session_map, unbind_calls, sel_events
+    ):
+        """The reachable case is unchanged: garbage strands nobody, so no event.
+
+        Routing prune through the choke point must not start narrating ordinary
+        collection — the audit exists for a lost binding, and a bare stale row
+        holds none.
+        """
+        session_map.set("dashboard:chat-1", "sid-that-no-longer-exists")
+
+        assert session_map.prune() == 1
+        assert "dashboard:chat-1" not in session_map._data
+        assert unbind_calls == []
+        assert _inbound_audits(sel_events) == []
+
+    @pytest.mark.asyncio
+    async def test_startup_collection_defers_the_write_off_loop(self, session_map):
+        """Prune on a running loop pays no inline whole-map write.
+
+        ``_save`` defers the disk write to a worker thread precisely so the
+        loop never blocks on serialization (its docstring cites #2405), and
+        prune's sole caller is ``start_pool`` on the startup loop. Routing
+        removals through the choke point must keep that property: per-key
+        audits, zero loop-thread writes, one coalesced flush afterwards.
+        """
+        import kiro_crew.session_map as mod
+
+        loop_thread = threading.current_thread()
+        replace_threads: list[threading.Thread] = []
+        real_replace = mod.os.replace
+
+        def _recording_replace(src, dst, **kw):
+            replace_threads.append(threading.current_thread())
+            return real_replace(src, dst, **kw)
+
+        # NOTE: mod.os IS the os module, so this patch is process-global, not
+        # module-local. Harmless under xdist process isolation; do not widen.
+        with patch.object(mod.os, "replace", side_effect=_recording_replace):
+            for n in range(5):
+                session_map.set(f"dashboard:chat-{n}", f"sid-gone-{n}")
+
+            assert session_map.prune() == 5
+            assert [t for t in replace_threads if t is loop_thread] == []
+            while True:
+                task = session_map._flush_task
+                if task is None:
+                    break
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                if task is session_map._flush_task:
+                    break
+            assert len(replace_threads) == 1
+            assert replace_threads[0] is not loop_thread
+
+    def test_a_collected_thread_binding_leaves_the_index(
+        self, session_map, monkeypatch
+    ):
+        """The reverse index cannot outlive the entry that owned the thread."""
+        key = "dashboard:chat-1"
+        session_map.set_slack_link(key, "1700000000.000100", "C123")
+        assert session_map.get_session_for_thread("1700000000.000100") == key
+        monkeypatch.setattr("kiro_crew.session_map._survives_prune", lambda entry: False)
+
+        assert session_map.prune() == 1
+        assert session_map.get_session_for_thread("1700000000.000100") is None
 
 
 class TestOutboundOnlyStaysQuiet:


### PR DESCRIPTION
## Problem / Motivation

`SessionMap.prune` removed stale entries with a raw `del self._data[k]`, bypassing `_remove_entry` — the one chokepoint through which every other whole-entry removal leaves the map. `_remove_entry` is where a removal that takes an inbound binding with it emits its security-event-log record and its unbind notice; prune emitted neither. Found while attributing the 2026-08-30 Discord option-press incident: prune was the only binding-removal path with no SEL event, i.e. the one way a DM→session binding could disappear without a trace.

## Why it matters

Today the gap is latent: `_survives_prune` holds every bound entry out of prune's delete branch, so prune cannot reach a binding. But that is one predicate edit away from reopening — and if it ever does, a live conversation's binding would be silently collected with nothing in the audit trail naming prune as the remover. Incident attribution then starts from a false premise (as ours did). Closing the gap now means any future loosening of the predicate lands on an audited path by construction.

## What changed (motivation → approach → change)

Symptom: prune deletes entries invisibly. Root cause: it deletes straight out of `_data` instead of routing through the audited chokepoint. Change: prune now calls `_remove_entry(k, reason=UNBIND_REASON_PRUNED_STALE)` per stale key — a new reason in the closed `UNBIND_REASONS` vocabulary with its own `_INBOUND_UNBIND_WHY` phrasing (required by the every-reason-has-a-phrase ratchet) — keeps the full `_rebuild_thread_index()` (two entries can contest one thread; only a rebuild re-resolves it to the survivor), and ends with one trailing loop-aware `_save()`. The per-key saves coalesce through `_save`'s debounced deferred flush, so prune's only production caller (`start_pool`, on the startup event loop) still pays no inline whole-map disk write — an earlier draft wrapped the loop in `batched_save()`, whose batch-exit inline write on the startup loop was blocked by both pre-push review lanes and replaced with this shape. What gets deleted is unchanged; `_survives_prune` is untouched.

## Tests

`test/test_session_map_mirror.py`, new `TestPruneRemovesThroughTheChokePoint` (4 tests):
- a pruned binding is audited and announced with the `pruned_stale` reason (red-first: 0 SEL events before the fix) — reachability stood in by stubbing `_survives_prune`, exactly the future edit the fix guards against;
- collecting an unbound row stays silent (the audit is for binding loss, not routine collection);
- prune on a running loop performs zero loop-thread `os.replace` calls and exactly one coalesced off-loop flush (red-first against the `batched_save` draft, which wrote inline on the loop);
- a collected thread binding leaves the reverse index.

Suite: all `test_session_map_*` files + `test_messaging_link` + `test_inbound_unbind_notice` + `test_session_pool` — 344 passed. flake8/isort/black clean.

## Manual verification

N/A — unit coverage sufficient: the changed behavior (audit emission, write deferral, index rebuild) is fully pinned by the four tests above plus the pre-existing suites.

## Issue link

no linked issue: the gap was found during an incident post-mortem, not filed as an issue; this PR is the direct hardening.

## Pattern harvest

Rule candidate: semgrep
Pattern: direct `del` on an audited collection (`self._data`) outside its designated removal chokepoint (`_remove_entry`) — any store whose removals must emit an audit record should have exactly one deleting method, and every other `del`/`pop` on that container is a finding.
