### PR TITLE
fix(pins): scope the per-slot pin quota per origin_app to match list/idempotency

### DIFF
--- a/src/kiro_crew/dashboard/chat_pins.py
+++ b/src/kiro_crew/dashboard/chat_pins.py
@@ -211,7 +211,15 @@ async def api_chat_pins_create(request: web.Request) -> web.Response:
             # disk may hold an unredacted credential from an older version.
             return web.json_response(_redacted_pin(existing), status=200)
 
-        slot_pin_count = sum(1 for p in state._chat_pins if p["slot_key"] == slot_key)
+        # Scope the quota to the caller's own records so one origin_app filling
+        # the slot to the cap cannot block a different origin_app from pinning
+        # in the same slot -- matching the (slot_key, mid, origin_app) scope
+        # used by the idempotency lookup above and api_chat_pins_list.
+        slot_pin_count = sum(
+            1
+            for p in state._chat_pins
+            if p["slot_key"] == slot_key and p.get("origin_app", "") == request_app
+        )
         if slot_pin_count >= _MAX_PINS_PER_SLOT:
             return web.json_response(
                 {

--- a/test/test_dashboard_chat_pins.py
+++ b/test/test_dashboard_chat_pins.py
@@ -254,6 +254,48 @@ async def test_create_pin_enforces_per_slot_limit_without_mutation(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_create_pin_quota_is_scoped_per_origin_app(tmp_path, monkeypatch):
+    """One origin's pins filling a slot to the cap must not block another origin.
+
+    The quota is scoped by (slot_key, origin_app) to match the idempotency
+    lookup and api_chat_pins_list. An app-owned slot pre-filled to the cap with
+    foreign-origin records (e.g. legacy pins carrying no origin_app) must still
+    let the app create its own pin -- otherwise it gets a 409 for records it can
+    neither see nor unpin.
+    """
+    monkeypatch.setattr(chat_pins_module, "_MAX_PINS_PER_SLOT", 2)
+    state = _make_state(tmp_path)
+    state.get_or_create_slot("slot-shared", app="app-a")
+    # Slot already at the cap, but every record belongs to a DIFFERENT origin
+    # (legacy blank origin_app here) that the caller cannot see or manage.
+    state._chat_pins = [
+        _pin(f"pin-legacy-{idx}", "slot-shared", f"ts-{idx}", origin_app="") for idx in range(2)
+    ]
+
+    async with _client(tmp_path, state=state, app_name="app-a") as client:
+        resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-shared",
+                "mid": "m-app-a-first-1",
+                "message_ts": "ts-app-a",
+                "role": "assistant",
+                "preview": "app-a pin",
+            },
+        )
+        # Before the fix the global slot count (2) hits the cap and returns 409;
+        # after the fix app-a has zero pins of its own so the pin is created.
+        assert resp.status == 201, await resp.json()
+        created = await resp.json()
+        assert created["origin_app"] == "app-a"
+        assert {p["id"] for p in state._chat_pins} == {
+            "pin-legacy-0",
+            "pin-legacy-1",
+            created["id"],
+        }
+
+
+@pytest.mark.asyncio
 async def test_create_pin_missing_slot_key(tmp_path):
     async with _client(tmp_path) as client:
         resp = await client.post(
@@ -1871,11 +1913,17 @@ async def test_idempotent_create_same_caller_returns_existing(tmp_path):
 
 @pytest.mark.asyncio
 async def test_slot_reuse_same_mid_respects_pin_limit(tmp_path):
-    """Even when a foreign record occupies (slot, mid), the new caller-owned
-    record still counts against the slot-wide pin limit."""
+    """The per-slot pin limit counts only the CALLER's own records.
+
+    A foreign record occupying (slot, mid) does not satisfy idempotency for a
+    different caller, and foreign records do not count against this caller's
+    quota (they are invisible to it via list/delete). The limit still fires
+    once the caller's OWN pins reach the cap.
+    """
     state = _make_state(tmp_path)
     state.get_or_create_slot("slot-limit", app="app-new")
-    # Fill slot to capacity with foreign pins (app-old)
+    # Fill slot to capacity with FOREIGN pins (app-old). These are invisible to
+    # app-new and must NOT count against app-new's quota.
     for i in range(_MAX_PINS_PER_SLOT):
         state._chat_pins.append(
             {
@@ -1891,8 +1939,9 @@ async def test_slot_reuse_same_mid_respects_pin_limit(tmp_path):
         )
 
     async with _client(tmp_path, state=state, app_name="app-new") as client:
-        # Target the same mid as filler-0000 — foreign record exists but
-        # slot is at capacity, so creation should be rejected.
+        # Target the same mid as filler-0000 — a foreign record exists but is
+        # not app-new's, so this is a fresh creation, not idempotent, and the
+        # foreign records do not exhaust app-new's quota.
         resp = await client.post(
             "/api/chat/pins",
             json={
@@ -1903,9 +1952,39 @@ async def test_slot_reuse_same_mid_respects_pin_limit(tmp_path):
                 "preview": "new caller preview",
             },
         )
+        assert resp.status == 201, await resp.json()
+        assert (await resp.json())["origin_app"] == "app-new"
+
+
+@pytest.mark.asyncio
+async def test_slot_pin_limit_counts_only_callers_own_records(tmp_path, monkeypatch):
+    """Once the CALLER's own pins reach the cap, further pins are rejected —
+    foreign-origin records in the same slot neither help nor hurt the count."""
+    monkeypatch.setattr(chat_pins_module, "_MAX_PINS_PER_SLOT", 2)
+    state = _make_state(tmp_path)
+    state.get_or_create_slot("slot-limit", app="app-new")
+    # Foreign filler (does not count) + app-new at its own cap (does count).
+    state._chat_pins.extend(
+        [
+            _pin("foreign-0", "slot-limit", "ts-f0", origin_app="app-old"),
+            _pin("mine-0", "slot-limit", "ts-m0", origin_app="app-new"),
+            _pin("mine-1", "slot-limit", "ts-m1", origin_app="app-new"),
+        ]
+    )
+
+    async with _client(tmp_path, state=state, app_name="app-new") as client:
+        resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-limit",
+                "mid": "m-over-cap-app",
+                "message_ts": "ts-over",
+                "role": "user",
+                "preview": "over cap",
+            },
+        )
         assert resp.status == 409
-        data = await resp.json()
-        assert data["code"] == "pin_limit_reached"
+        assert (await resp.json())["code"] == "pin_limit_reached"
 
 
 # ── Finding 2 (GPT 5.6): Transient I/O error must NOT replace valid in-memory state ──


### PR DESCRIPTION
## Problem / Motivation

In `api_chat_pins_create`, the per-slot pin quota counted **every** pin in the slot regardless of `origin_app`, while the idempotency lookup and `api_chat_pins_list` both scope by `origin_app`. So one app (or the dashboard) filling a co-owned slot to the cap blocked a **different** app from creating any pin in that slot — and that app could neither see nor unpin the records causing its 409.

## Why it matters

The quota namespace was inconsistent with the visibility namespace: a caller could be blocked by records it has no way to observe or remove, an opaque and unfixable failure from that caller's perspective. Scoping the count to the caller makes the quota, idempotency, and listing all agree on the same `(slot_key, origin_app)` namespace.

## What changed

Root cause: the quota `sum(...)` omitted the `origin_app` predicate that idempotency/list use. Fix: scope the count to the caller — `... and p.get("origin_app", "") == request_app` — so one origin at the cap no longer blocks a different origin. A same-origin caller still hits the cap exactly as before.

## Tests

`test/test_dashboard_chat_pins.py`: added a cross-origin test (an app-owned slot filled to the cap with foreign-origin records still lets the caller pin) and one proving the cap still fires on the caller's own records. An existing test that encoded the old cross-origin-blocking contract in its own docstring was **updated** to the corrected per-origin contract (not weakened — the finding changes this contract). Proven red→green (regression test returns `pin_limit_reached` on pre-fix code). 87 tests pass.

## Manual verification

N/A — unit coverage sufficient; the change is a scoping predicate on a covered handler.

## Pattern harvest

Rule candidate: review-prompt — "a quota/limit count must share the same scoping namespace as the reads and idempotency checks that govern the same records." Pattern: limit counted over a wider namespace than the records the caller can see/mutate.

## Related Issues

Fixes #7502
