### PR TITLE
fix(pins): enforce the create-time length caps when loading pins from disk

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -6311,6 +6311,16 @@ class DashboardState:
             self._chat_pins = []
             return
 
+        # Reuse the create-time ingress caps (source of truth: chat_pins.py) so a
+        # hand-edited chat_pins.json cannot smuggle an over-long mid/message_ts/
+        # preview past a loader that only checked type + non-emptiness. Imported
+        # here (not at module top) because chat_pins.py imports this module.
+        from kiro_crew.dashboard.chat_pins import (
+            _MAX_MESSAGE_TS_CHARS,
+            _MAX_MID_CHARS,
+            _MAX_PREVIEW_INPUT_CHARS,
+        )
+
         def _is_valid(pin: Any) -> bool:
             return (
                 isinstance(pin, dict)
@@ -6325,6 +6335,19 @@ class DashboardState:
                 and isinstance(pin.get("preview"), str)
                 and isinstance(pin.get("pinned_at"), str)
                 and bool(pin.get("pinned_at"))
+                # Enforce the create-time length caps at load, so an over-long
+                # record is partitioned into _unparsed rather than served. Guard
+                # each optional identity with isinstance before len(): a
+                # hand-edited record can carry a non-string mid/message_ts (e.g.
+                # a JSON number) while still being valid via the other identity,
+                # and len() on a non-string would crash the whole loader. preview
+                # is already isinstance-checked as a str above.
+                and (not isinstance(pin.get("mid"), str) or len(pin["mid"]) <= _MAX_MID_CHARS)
+                and (
+                    not isinstance(pin.get("message_ts"), str)
+                    or len(pin["message_ts"]) <= _MAX_MESSAGE_TS_CHARS
+                )
+                and len(pin.get("preview") or "") <= _MAX_PREVIEW_INPUT_CHARS
             )
 
         valid, unparsed = self._partition_preserving(

--- a/test/test_state_store_preservation.py
+++ b/test/test_state_store_preservation.py
@@ -118,6 +118,63 @@ class TestChatPinsPreservation:
         assert st._chat_pins == []
         assert st._unparsed_chat_pin_entries == [{"stale": "kept"}]
 
+    def test_oversized_records_are_dropped_and_preserved(self, cfg):
+        """A hand-edited pin exceeding the create-time length caps must not be
+        served: it is dropped from the active list and preserved verbatim in
+        ``_unparsed`` (mirrors api_chat_pins_create's ingress caps)."""
+        from kiro_crew.dashboard.chat_pins import (
+            _MAX_MESSAGE_TS_CHARS,
+            _MAX_MID_CHARS,
+            _MAX_PREVIEW_INPUT_CHARS,
+        )
+
+        big_preview = dict(self._valid_pin("bigprev"), preview="x" * (_MAX_PREVIEW_INPUT_CHARS + 1))
+        big_mid = dict(self._valid_pin("bigmid"), mid="m" * (_MAX_MID_CHARS + 1))
+        big_ts = {
+            "id": "bigts",
+            "slot_key": "slot1",
+            "message_ts": "t" * (_MAX_MESSAGE_TS_CHARS + 1),
+            "preview": "ok",
+            "pinned_at": "2026-01-01T00:00:00Z",
+        }
+        (cfg / "chat_pins.json").write_text(
+            json.dumps([self._valid_pin("good1"), big_preview, big_mid, big_ts]),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_chat_pins()
+        assert [p["id"] for p in st._chat_pins] == ["good1"]
+        assert big_preview in st._unparsed_chat_pin_entries
+        assert big_mid in st._unparsed_chat_pin_entries
+        assert big_ts in st._unparsed_chat_pin_entries
+
+    def test_non_string_identity_does_not_crash_the_loader(self, cfg):
+        """A hand-edited record with a non-string ``mid`` (e.g. a JSON number)
+        but a valid string ``message_ts`` must not crash the loader when the
+        length caps are applied: ``len()`` is only taken on string identities.
+        Before the isinstance guard, ``len(123)`` raised TypeError and took the
+        whole loader (and startup) down. The record remains valid via its
+        string ``message_ts`` identity; the point is that loading does not
+        raise."""
+        numeric_mid = {
+            "id": "nummid",
+            "slot_key": "slot1",
+            "mid": 123,  # non-string identity — must not reach len()
+            "message_ts": "2026-01-01T00:00:00Z",
+            "preview": "ok",
+            "pinned_at": "2026-01-01T00:00:00Z",
+        }
+        (cfg / "chat_pins.json").write_text(
+            json.dumps([self._valid_pin("good1"), numeric_mid]),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_chat_pins()  # must not raise TypeError
+        # good1 always loads; the numeric-mid record survives via its valid
+        # string message_ts identity. The regression is the crash, not the
+        # record's fate — assert the loader completed and good1 is present.
+        assert "good1" in [p["id"] for p in st._chat_pins]
+
 
 # --------------------------------------------------------------------------- #
 # tags — the boot-erasure case


### PR DESCRIPTION
## Problem / Motivation

`api_chat_pins_create` enforces length caps on ingress (`mid` ≤ 128, `message_ts` ≤ 256, `preview` ≤ 4096 chars), but `load_chat_pins._is_valid` only checked type and non-emptiness. A hand-edited or older `chat_pins.json` carrying an oversized `mid`/`message_ts`/`preview` therefore loaded intact and was served — the output redactor does not truncate — an ingress/load asymmetry.

## Why it matters

The load path was strictly more permissive than the create path, so a record that could never be created could still be loaded and returned (e.g. a multi-megabyte `preview`). The store is owner-only, which bounds exposure, but the asymmetry is a real robustness gap: validation on the way in should also hold on the way back from disk.

## What changed

Root cause: `_is_valid` did not mirror the create-time caps. Fix: added the three length-bound checks to `_is_valid`, referencing the same cap constants (imported function-locally to avoid an import cycle). Over-long records are now partitioned into `_unparsed_chat_pin_entries` — preserved verbatim for round-trip, not served — exactly as other malformed rows are handled.

## Tests

`test/test_state_store_preservation.py`: a new test writes a `chat_pins.json` with an oversized `preview`, `mid`, and `message_ts` plus one good record, loads it, and asserts only the good record is active while all three over-long records land in `_unparsed_chat_pin_entries`. Proven red→green (old code served all four; fixed code serves only the good one). 101 tests pass in the scoped run.

## Manual verification

N/A — unit coverage sufficient; the change is a validation predicate on a covered loader.

## Pattern harvest

Rule candidate: review-prompt — "ingress validation caps must also be enforced on the load-from-disk path, or a hand-edited/legacy store can bypass them." Pattern: loader more permissive than the writer for the same record shape.

## Related Issues

Fixes #7506
