### PR TITLE
fix(ci): repair two cross-merge breakages reding main's own tip

### DIFF
--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -234,7 +234,7 @@ _BASELINE_LOG_SITE_CENSUS: dict[str, int] = {
     "dashboard/chat_runner.py": 10,
     "dashboard/chat_title.py": 1,
     "dashboard/handlers/discover.py": 3,
-    "dashboard/handlers/files.py": 3,
+    "dashboard/handlers/files.py": 1,
     "dashboard/handlers/hooks.py": 1,
     "dashboard/handlers/messaging.py": 12,
     "dashboard/handlers/updates.py": 1,

--- a/website/src/pages/settings/SecurityPanel.tsx
+++ b/website/src/pages/settings/SecurityPanel.tsx
@@ -2130,7 +2130,6 @@ function ThirdPartyAppsCard() {
           <AlertTriangle size={18} className="text-warn shrink-0 mt-0.5" />
           <div className="text-[13px] text-text leading-relaxed">{confirmBody}</div>
         </div>
-        {/* eslint-disable-next-line jsx-a11y/label-has-for -- the Checkbox control is nested inside the label */}
         {needsAck && (
           <label className="flex items-center gap-2.5 mt-4 cursor-pointer">
             <Checkbox checked={ack} onChange={e => setAck(e.target.checked)} />


### PR DESCRIPTION
## Problem / Motivation

Two checks fail on main's current tip for **every open PR**, regardless of the PR's own diff:

1. `CI / Frontend Lint & Type Check`: `npx eslint src/ --max-warnings 659` measures **660** warnings on a clean `origin/main` checkout. The extra warning is `Unused eslint-disable directive (no problems were reported from 'jsx-a11y/label-has-for')` at `website/src/pages/settings/SecurityPanel.tsx:2133` — the directive no longer suppresses anything, and eslint counts a stale directive as a warning.
2. `Backend Tests` shard 3: `test_security_posture.py::TestGateSideLogRedactorSpelling::test_the_census_holds_no_slack` fails on a clean `origin/main` checkout — `_BASELINE_LOG_SITE_CENSUS` says `dashboard/handlers/files.py` has 3 log sites, the code now has 1 (log sites were removed without ratcheting the census down).

## Why it matters

Repo-wide CI break: every PR based on current main reds both gates through no fault of its own (first observed on PR #7346, whose diff adds zero eslint warnings and touches neither file). Until this lands, no PR can go green.

## What changed (motivation → approach → change)

Symptom: main's own tip fails two of its ratchet-style gates. Root cause: cross-merge drift — in each case one merged PR tightened a ratchet (lowered the eslint budget / the census counts a file's sites) while another independently made the tightened bound wrong (made a disable directive redundant / removed log sites), and neither failed alone because CI runs each PR against the merge ref it was created with. Change: two one-line ratchet repairs — delete the unused eslint-disable directive (a clean checkout then measures exactly 659 and the gate passes) and lower the census entry for `dashboard/handlers/files.py` from 3 to 1 (census ratchets downward by design; the test itself demands this repair in its failure message).

## Tests

The two failing gates are themselves the regression tests: at this commit `npx eslint src/ --max-warnings 659` exits 0 (exactly 659) and `test/test_security_posture.py` passes 47/47; at the parent both fail.

## Manual verification

Ran locally at this commit: eslint budget check → exit 0; `npx tsc -b` → exit 0; full `test_security_posture.py` → 47 passed; flake8/black/isort clean on the changed test file. At the parent commit both repaired gates fail with the exact CI errors.

<!-- no-visual-delta -->
**Why no screenshot:** comment-only edit in a .tsx file plus a backend test baseline constant; no rendered output changes.

## Related Issues

no linked issue: repo-wide CI breakage found while babysitting PR #7346; no tracking issue exists.

## Pattern harvest

Rule candidate: lint
Pattern: cross-merge ratchet drift — one green PR tightens a budget/census while another independently invalidates the bound; main's tip breaks without either PR failing. A post-merge run of the ratchet gates on main's tip would catch it at the source.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

_Opened by Ember, helenars's AI agent, to unbreak CI for all open PRs._
