### PR TITLE
fix(ci): bring two drifted ratchet gates back in line with the code

### DIFF
--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -234,7 +234,7 @@ _BASELINE_LOG_SITE_CENSUS: dict[str, int] = {
     "dashboard/chat_runner.py": 10,
     "dashboard/chat_title.py": 1,
     "dashboard/handlers/discover.py": 3,
-    "dashboard/handlers/files.py": 3,
+    "dashboard/handlers/files.py": 1,
     "dashboard/handlers/hooks.py": 1,
     "dashboard/handlers/messaging.py": 12,
     "dashboard/handlers/updates.py": 1,

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1784,7 +1784,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
 
   // Persist the composer text against the slot it BELONGS to (composerSlotRef),
   // not the live activeSlot (see the composerSlotRef note above).
-  useEffect(() => { inputRef.current = input; const s = composerSlotRef.current; if (s) { setDraft(drafts.current, s, input); saveDraftsDebounced() } }, [input, saveDraftsDebounced]) // eslint-disable-line react-hooks/exhaustive-deps -- draft key is composerSlotRef; slot-change effect handles the transition
+  // The draft key is composerSlotRef, which a ref does not need to be a
+  // dependency of; the slot-change effect below handles the transition.
+  useEffect(() => { inputRef.current = input; const s = composerSlotRef.current; if (s) { setDraft(drafts.current, s, input); saveDraftsDebounced() } }, [input, saveDraftsDebounced])
   // Per-slot draft: save current → restore target (persisted to localStorage)
   useEffect(() => {
     // Re-hydrate from localStorage — only pull in keys we don't already have
@@ -1917,7 +1919,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     }
     // Draft key is composerSlotRef; the slot-change effect handles that
     // transition.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingFiles, saveDraftsDebounced])
   // Collapsed paste blocks backing the `[ Paste #N · M lines ]` tokens in
   // `input`. Persisted per-slot via chatPasteDrafts (localStorage, 30-day TTL)
@@ -1935,7 +1936,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       saveDraftsDebounced()
     }
     // draft key is composerSlotRef; slot-change effect handles that transition.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pasteBlocks, saveDraftsDebounced])
   // Session references staged by dragging a session from the list onto this
   // pane. Serialized as LINKS on send — never the referenced transcript.
@@ -1950,7 +1950,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       saveDraftsDebounced()
     }
     // draft key is composerSlotRef; slot-change effect handles that transition.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingSessions, saveDraftsDebounced])
   /** Stage a dropped session. Ignores duplicates and overflow (addSessionRef
    *  returns the same array, so this is a no-op re-render-free path). */
@@ -6369,7 +6368,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       // The tab is still created above -- it is revealed quietly instead.
       if (!search.isOpen && !isMobile) dispatch(openActivityPanel())
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- search re-identifies on every keystroke; only its isOpen flag is read
   }, [activeSlot, chatPins.length, dispatch, isMobile, isPinned, pinMessage, search.isOpen, unpinMessage])
   const handleUnpinById = useCallback((id: string) => {
     void unpinById(id).catch(() => {})

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -870,7 +870,6 @@ export default function DevFleetPage() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [detail, setDetail] = useState<Record<string, any>>({})
   const [detailLoading, setDetailLoading] = useState<Record<string, boolean>>({})
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [prov, setProv] = useState<Record<string, ProvRun | null>>({})
   const [provLogOpen, setProvLogOpen] = useState<Record<string, boolean>>({})
   const provDoneTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})

--- a/website/src/pages/settings/SecurityPanel.tsx
+++ b/website/src/pages/settings/SecurityPanel.tsx
@@ -2130,7 +2130,6 @@ function ThirdPartyAppsCard() {
           <AlertTriangle size={18} className="text-warn shrink-0 mt-0.5" />
           <div className="text-[13px] text-text leading-relaxed">{confirmBody}</div>
         </div>
-        {/* eslint-disable-next-line jsx-a11y/label-has-for -- the Checkbox control is nested inside the label */}
         {needsAck && (
           <label className="flex items-center gap-2.5 mt-4 cursor-pointer">
             <Checkbox checked={ack} onChange={e => setAck(e.target.checked)} />


### PR DESCRIPTION
## The problem

`main` is currently failing two of its own ratchet gates, and because a PR's CI
runs against **merge(branch, main)**, every open PR inherits both reds without
having touched anything related. Two examples at the time of writing: #7351 (a
backend-only change; its own head was `readiness: passed` an hour earlier) and
#7423.

Reproduced on pristine `origin/main` at `c28a2199`, no PR content involved:

```
$ cd website && npx eslint src/ --max-warnings 659
✖ 660 problems (0 errors, 660 warnings)
ESLint found too many warnings (maximum: 659).

$ pytest test/test_security_posture.py::TestGateSideLogRedactorSpelling -q
AssertionError: `_BASELINE_LOG_SITE_CENSUS` is now looser than the code
  — lower or drop these: dashboard/handlers/files.py: 1 sites, census says 3
```

Both gates are working exactly as designed. Each is a ratchet, and in both cases
the tree got **cleaner** and the counter was left behind:

- The eslint ceiling is one over, and 8 of the 660 warnings are `eslint-disable`
  directives that no longer suppress anything — dead notes left behind as the
  code they annotated was fixed. Removing a real violation costs a warning and
  gains one, so cleanups drift the count toward the ceiling.
- `dashboard/handlers/files.py` dropped from 3 gate-side baseline log sites to 1
  in #7293, which folded `file_send`'s two per-leg destination paths into one
  shared oracle. The census still claimed 3, which is precisely the slack
  `test_the_census_holds_no_slack` exists to refuse: 2 free slots a future
  baseline log line could appear in silently.

## The fix

Nothing about either gate's strictness changes. Both numbers are brought back
into line with the code, in the direction each gate demands.

- **`test/test_security_posture.py`**: census entry for
  `dashboard/handlers/files.py` lowered 3 → 1, the "converted site lowers its
  number" case the test's own docstring names. The module keeps its entry
  because 1 site is still there.
- **7 dead `eslint-disable` directives removed** (653 warnings, 6 under the
  ceiling). Each was verified dead by eslint itself, not by inspection — the
  `--format json` run reports them as `Unused eslint-disable directive`. They
  are dead for the obvious reason in every case: dependency arrays that are now
  complete, an `any` that is now typed, a label that now nests its control.
  Where a directive carried reasoning worth keeping (the draft-effect one in
  `ChatPage.tsx`), the prose is kept as an ordinary comment; a suppression that
  suppresses nothing is not the right home for a design note.

Deliberately **not** included: the 8th dead directive, the `no-eval` note in
`crew-ghost-sprite.gen.mjs`. `no-eval` is not enabled for that file today, so
eslint calls the directive unused — but the `eval(program)` under it is real, so
deleting the note would delete a true statement about the code and let the
warning return silently if the config ever covers `.mjs`. 7 removals are enough
to clear the ceiling with room to spare.

## Why nobody saw it on main

`main`'s own CI does not render a verdict on these lanes. At `c28a2199`: **379
cancelled, 193 success, 0 failure** — pushes land faster than a run completes,
so concurrency supersession cancels the runs before the gates report. The gates
therefore only ever fail on PRs, where they land on whoever pushed last. That
class of problem is not fixed here — changing the CI concurrency policy is a
bigger, opinionated change that deserves its own discussion — and is filed
separately as #7511.

## Verification

Pristine `origin/main` first (both fail), then this branch:

| gate | before | after |
|---|---|---|
| `npx eslint src/ --max-warnings 659` | 660 warnings, **fail** | 653 warnings, **pass** |
| `npx tsc -b` | pass | pass |
| `test/test_security_posture.py` | 1 failed, 46 passed | **47 passed** |
| `flake8` / `isort` / `check_black_formatting.py` | pass | pass |

The eslint count is stated as measured, not estimated: 660 → 653 is exactly the
7 directives removed, which also confirms none of the removals uncovered a
warning that the directive had been hiding.


<!-- no-visual-delta -->

**Why no screenshot:** the three `website/src` edits delete `eslint-disable`
comments and replace one with an ordinary comment — no JSX, no styles, and no
rendered output changes, so `npx tsc -b` and the eslint count are the whole
observable effect.

## Pattern harvest

Rule candidate: eslint config — set
`linterOptions.reportUnusedDisableDirectives: 'error'` for `website/src`.

The defect class is not "someone wrote a bad comment". It is that a dead
suppression is currently a *warning*, so it is indistinguishable from the 650
other warnings and it silently consumes ceiling headroom until an unrelated PR
trips over it. This is exactly the argument `eslint.config.js` already makes for
`no-restricted-syntax`:

> `'error'`, not `'warn'`, on purpose: the tree is at zero, so this is a
> hard-zero gate rather than a stored count, and it stays out of the
> `--max-warnings` budget where a real regression would be indistinguishable
> from an unrelated `no-explicit-any`.

After this PR that precondition holds — the app tree is at zero dead directives —
so the same reasoning applies, and the failure lands on the PR that orphans a
directive rather than on a bystander.

**Prerequisite, which is why this PR does not flip it:** the remaining directive
in `crew-ghost-sprite.gen.mjs` is "unused" only because `no-eval` is not enabled
for `.mjs`. A hard-zero gate would force deleting a note that guards a real
`eval()`. The right order is to enable `no-eval` for `.mjs` first — which makes
that suppression live and meaningful again — and only then flip the setting.
Doing both here would bundle a lint-policy change into a gate unbreaking, and the
unbreaking is time-sensitive for every open PR.

**Not a one-off:** 8 dead directives across 4 files accumulated before anyone
noticed, and the census half of this PR is the same shape on the Python side — a
cleanup that lowers a count, with nothing prompting the author to lower the
recorded number. #7511 covers the reason neither surfaced on `main`.
