### PR TITLE
fix(ci): give the coverage matrix arm its own job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,7 +578,13 @@ jobs:
     name: Backend Tests
     needs: [changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Per arm, not per job: only 3.12 runs under coverage (see the "Run tests"
+    # step), and tracing costs about 2x wall time. Measured on this matrix, the
+    # --no-cov arm finishes in 7.7 to 13.9 minutes while the coverage arm takes
+    # 18.3 to 30.3, so one cap sized for the cheap arm cancels the expensive one
+    # at the wall while its sibling sits under half the budget. Same reasoning
+    # as the Windows job's 40, which is already higher for a smaller gap.
+    timeout-minutes: ${{ matrix.python-version == '3.12' && 45 || 30 }}
     strategy:
       # Don't cancel sibling shards when one fails -- we want the full failure
       # picture across the suite, not just the first shard to break.

--- a/test/test_backend_test_timeout_contract.py
+++ b/test/test_backend_test_timeout_contract.py
@@ -1,0 +1,164 @@
+"""The coverage-bearing matrix arm needs its own job cap, not the cheap arm's.
+
+`backend-test` runs the same four shards twice: once on 3.10 with `--no-cov`
+and once on 3.12 with `--cov`. Tracing roughly doubles wall time, so the two
+arms do measurably different amounts of work while `timeout-minutes` is a
+job-level key shared by every matrix cell.
+
+Measured from `completed_at - started_at` on three heads:
+
+    head        3.10 (--no-cov)      3.12 (+cov)              ratio
+    d94950d39   7.68 - 13.87 min     27.33 - 30.25 CANCELLED  2.18x
+    760124a75   10.00 - 13.60 min    22.22 - 30.27 CANCELLED  2.23x
+    92c3b5fff   12.02 - 13.83 min    18.32 - 27.13 min        1.96x
+
+The cheap arm used at most 46% of a 30-minute budget; the coverage arm reached
+101% and was cancelled. It is not confined to fork PRs either: of seven
+consecutive pushes to main sampled on 2026-09-01, three had a 3.12 shard
+cancelled at the wall and the rest finished at 28.3 to 28.9 minutes, which is
+94 to 96% of the cap. A `cancelled` shard fails `Coverage Gate` closed, so a
+green diff goes red for a reason no diff can account for.
+
+The same file already accepts this principle: `backend-test-windows` carries
+`timeout-minutes: 40` because "windows-latest runners run the same shards
+measurably slower". That job's slowest observed shard was 18.03 minutes, 45% of
+its cap. The coverage arm is further from its budget than Windows is from its,
+and still shares 30 minutes.
+
+Deliberately one-directional. It does not pin the cheap arm's number, does not
+forbid raising both, and does not care which expression shape encodes the split.
+It asserts only that the two arms are not capped identically and that the
+coverage arm is given at least as much room as Windows already has, because the
+alternative reading of the measurements ("the coverage arm is fine at 30") is
+the one the cancellations disprove.
+
+This guards a workflow, so it cannot be exercised by running the code it
+describes. What it can do is fail when the differentiation is deleted, which is
+the regression that matters: the value looks like a tidy-up candidate, and
+collapsing it back to one scalar restores a red that surfaces days later on an
+unrelated PR.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+# The Windows arm's cap is the in-repo precedent for "this arm is slower, give
+# it its own budget". It is a floor, not a target: the coverage arm's measured
+# maximum already exceeds the Windows arm's, so anything below this is known to
+# be too small before CI runs.
+WINDOWS_PRECEDENT_MINUTES = 40
+
+# ${{ <ctx>.<key> == '<value>' && <then> || <else> }}
+_TERNARY = re.compile(
+    r"^\$\{\{\s*matrix\.(?P<key>[\w-]+)\s*==\s*'(?P<value>[^']+)'"
+    r"\s*&&\s*(?P<then>.+?)\s*\|\|\s*(?P<else_>.+?)\s*\}\}$"
+)
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(CI.read_text(encoding="utf-8"))
+
+
+def _coverage_arm() -> tuple[str, str, str]:
+    """Locate the job whose pytest coverage flag is chosen by a matrix value.
+
+    Returns (job id, matrix key, the value of that key that gets coverage).
+    Derived rather than hardcoded: the job name, the matrix axis and the Python
+    version have all changed before, and a hardcoded triple would keep passing
+    against a job that no longer exists.
+    """
+    for job_id, job in _workflow()["jobs"].items():
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            run = str(step.get("run", ""))
+            if "pytest" not in run:
+                continue
+            for expr in re.findall(r"\$\{\{[^}]+\}\}", run):
+                parsed = _TERNARY.match(expr.strip())
+                if not parsed:
+                    continue
+                then, else_ = parsed["then"], parsed["else_"]
+                # One branch turns tracing on, the other explicitly off. That
+                # pairing is what makes the two arms unequal work.
+                if "--cov" in then and "--no-cov" in else_:
+                    return job_id, parsed["key"], parsed["value"]
+    raise AssertionError(
+        "no job in ci.yml selects its pytest coverage flag from a matrix value. "
+        "If coverage moved to its own job the arms no longer share a cap and "
+        "this file should be deleted; if the expression shape changed, teach "
+        "_coverage_arm the new shape rather than deleting the guard."
+    )
+
+
+def _cap_for(job: dict, key: str, value: str) -> int:
+    """Resolve `timeout-minutes` for one matrix cell.
+
+    A plain scalar resolves to itself for every cell, which is exactly the
+    unfixed state, so this must not special-case it away.
+    """
+    raw = job.get("timeout-minutes")
+    assert raw is not None, "the job declares no timeout-minutes at all"
+    if isinstance(raw, int):
+        return raw
+    parsed = _TERNARY.match(str(raw).strip())
+    assert parsed, (
+        f"timeout-minutes is {raw!r}, which this test cannot resolve per arm. "
+        f"Extend _TERNARY to cover the new shape; do not weaken the assertions "
+        f"below, because an unresolvable value hides whether the arms differ."
+    )
+    assert parsed["key"] == key, (
+        f"timeout-minutes keys off matrix.{parsed['key']} while the coverage "
+        f"flag keys off matrix.{key}. Two different axes cannot be relied on to "
+        f"agree about which cell is the expensive one."
+    )
+    branch = parsed["then"] if parsed["value"] == value else parsed["else_"]
+    return int(branch)
+
+
+def test_ci_still_has_a_coverage_conditional_backend_matrix() -> None:
+    # Anti-vacuity. Every assertion below reads this triple, so a rename or a
+    # move of coverage into its own job must fail loudly here rather than
+    # quietly turning the rest of the file into a no-op.
+    job_id, key, value = _coverage_arm()
+    assert job_id and key and value
+
+
+def test_the_coverage_arm_is_not_capped_like_the_cheap_arm() -> None:
+    job_id, key, value = _coverage_arm()
+    job = _workflow()["jobs"][job_id]
+    other = [v for v in job["strategy"]["matrix"][key] if str(v) != value]
+    assert other, f"matrix.{key} has no arm other than {value!r} to compare against"
+    cov = _cap_for(job, key, value)
+    for arm in other:
+        cheap = _cap_for(job, key, str(arm))
+        assert cov > cheap, (
+            f"{job_id} caps matrix.{key}={value} (runs --cov) at {cov} minutes "
+            f"and matrix.{key}={arm} (runs --no-cov) at {cheap}. Coverage costs "
+            f"about 2x wall time here, so a shared cap cancels the coverage arm "
+            f"at the wall while the cheap arm finishes under half the budget, "
+            f"and a cancelled shard fails Coverage Gate closed."
+        )
+
+
+def test_the_coverage_arm_gets_at_least_the_windows_arms_budget() -> None:
+    # The Windows job's 40 minutes covers a slowest-observed 18.03-minute shard.
+    # The coverage arm's slowest observed shard was censored at the 30-minute
+    # wall, so it is at least 30.3, already past what Windows needs. A cap below
+    # the Windows precedent is therefore known to be short in advance.
+    job_id, key, value = _coverage_arm()
+    job = _workflow()["jobs"][job_id]
+    cov = _cap_for(job, key, value)
+    assert cov >= WINDOWS_PRECEDENT_MINUTES, (
+        f"{job_id} gives the coverage arm {cov} minutes, under the "
+        f"{WINDOWS_PRECEDENT_MINUTES} the Windows arm already gets for a "
+        f"smaller measured gap (18.03 minutes used of 40, against at least "
+        f"30.3 of 30 here)."
+    )


### PR DESCRIPTION
## Problem / Motivation

`backend-test` runs the same four shards twice, on 3.10 with `--no-cov` and on 3.12 with `--cov`, and `timeout-minutes` is a job level key shared by all eight matrix cells. Coverage roughly doubles wall time, so the 30 minute cap that the cheap arm uses less than half of is the cap the coverage arm hits. A shard cancelled at the wall makes `Coverage Gate` fail closed with `backend-test=cancelled -- failing closed.`

Measured as `completed_at - started_at` from `/commits/<sha>/check-runs`:

| head | 3.10 (`--no-cov`) | 3.12 (`+cov`) | max ratio |
|---|---|---|---|
| `d94950d39` | 7.68 to 13.87 min | 27.33 to **30.25 CANCELLED** | 2.18x |
| `760124a75` | 10.00 to 13.60 min | 22.22 to **30.27 CANCELLED** | 2.23x |
| `92c3b5fff` | 12.02 to 13.83 min | 18.32 to 27.13 min | 1.96x |

## Why it matters

It is red on `main`, not only on pull requests. Seven consecutive pushes to `main` sampled on 2026-09-01:

| main head | 3.12 shard times | cancelled |
|---|---|---|
| `dd9e002bf` | 21.7, 30.3, 30.3, 21.3 | 2 |
| `bb01943c1` | 15.1, 28.9, 28.2, 26.5 | 0 |
| `fd38eff08` | 27.6, 28.3, 27.1, 27.2 | 0 |
| `15b062558` | 27.9, 30.3, 27.7, 28.0 | 1 |
| `da28c697f` | 26.9, 28.3, 26.5, 24.4 | 0 |
| `7eea2bea1` | 26.2, 28.3, 27.9, 27.8 | 0 |
| `78cc85a83` | 15.3, 27.4, 28.4, 18.4 | 0 |

Three of seven lost a shard at the wall. The runs that survived finished at 94 to 96% of the cap, so ordinary variance is enough to flip the rest. Every red costs a maintainer a re-run and teaches contributors to read a real `Coverage Gate` failure as noise.

## What changed (motivation → approach → change)

Symptom: a lone 3.12 shard reports `cancelled` while every sibling passes, and `Coverage Gate` fails closed on it.

Root cause: `timeout-minutes` is one scalar for a matrix whose two arms do measurably different amounts of work. Coverage is enabled on 3.12 only, and tracing costs about 2x wall time here, so a cap sized for the `--no-cov` arm is 46% occupied on that arm and 101% occupied on the other.

Change: resolve the cap per arm.

```yaml
timeout-minutes: ${{ matrix.python-version == '3.12' && 45 || 30 }}
```

Two things I checked rather than assumed, because guessing at CI semantics is the same class of error as the defect:

* `jobs.<job_id>.timeout-minutes` accepts the `matrix` context. GitHub's own context availability table lists `github, needs, strategy, matrix, vars, inputs` for that key. This is the first expression valued `timeout-minutes` in this repository, so it is worth a maintainer's eye on the shape even though the syntax is documented.
* 45 comes from the measurement, not from taste. The slowest uncancelled coverage shard was 28.93 minutes, which is 64% of 45. The cancelled shards are censored at the 30 minute wall, so their real length is unknown, which is why I did not try to derive a tighter number from them. For comparison `backend-test-windows` already carries 40 minutes for its slowest observed shard of 18.03, so this leaves the coverage arm proportionally tighter than the Windows arm, not looser.

Deliberately not in this PR:

* The other half of the fix is the shard split itself. Without a committed `.test_durations` file pytest-split falls back to an even split by test count, so which shard carries the heavy tests is arbitrary and a raised cap does not make it deterministic. That file exists on `chore/update-test-durations` (`ab0eb7c71`) and has never been opened as a PR. Landing it is a maintainer action and #4227 already routed it as a CI policy decision, so it is asked for in #7516 rather than done here.
* No change to the coverage floor, the shard count, `Coverage Gate` itself, `test-durations.yml`, or the 3.10 arm's cap.

## Tests

`test/test_backend_test_timeout_contract.py`, modelled on the existing `test/test_xdist_worker_restart_contract.py` workflow contract test.

* `test_ci_still_has_a_coverage_conditional_backend_matrix` is the anti-vacuity guard. Every other assertion reads the job, matrix key and coverage-bearing value discovered here, so a job rename or a move of coverage into its own job fails loudly instead of turning the file into a no-op.
* `test_the_coverage_arm_is_not_capped_like_the_cheap_arm` resolves `timeout-minutes` for each matrix arm and asserts the coverage arm gets strictly more. A plain scalar resolves to itself for every arm, which is exactly the unfixed state, so this fails on unfixed `ci.yml`.
* `test_the_coverage_arm_gets_at_least_the_windows_arms_budget` pins the floor at the Windows arm's 40, since the coverage arm's measured maximum already exceeds the Windows arm's.

It is deliberately one directional. It does not pin the cheap arm's number, does not forbid raising both, and does not care which expression shape encodes the split, so a future change that gives the coverage arm even more room stays green.

Load bearing, verified by reverting the workflow with `git show HEAD~1:.github/workflows/ci.yml`:

```
2 failed, 1 passed     (unfixed ci.yml)
3 passed               (with the fix)
```

## Manual verification

N/A for the runtime behaviour, since this changes a workflow and not code that a test can execute. What was run locally on the pushed head:

* every test file in the repository that reads `.github/workflows/ci.yml`, 24 files, 1899 passed
* `python3 scripts/check_black_formatting.py`, `isort --check-only src/kiro_crew test conftest.py xdist_budget.py`, `flake8 src/kiro_crew test conftest.py xdist_budget.py`, `mypy src/kiro_crew/`, all clean
* `./scripts/scrub-lint.sh --no-history`, all checks passed

## Screenshots / video

N/A, no user-visible UI change. This edits `.github/workflows/ci.yml` and adds a test that parses it, so there is no rendered surface to show.

## Related Issues

Fixes #7516

Two independent PRs are sitting red on this today, #7414 and #7376, and neither diff can account for a 28 minute shard. Prior art on the split half is #4227, closed on its fail fast half by #5043 and #5267 with the durations question left open.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a job level resource budget shared by matrix arms that do measurably different amounts of work. `timeout-minutes` sits above `strategy.matrix`, so a cap written when every cell was equivalent silently becomes wrong the moment one arm gains work that the others do not have. Worth asking on any PR that adds a per arm conditional flag to a matrix step: does the cheap arm's budget still fit the arm you just made expensive?

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text -- it will be added here once Legal provides it. -->
