### PR TITLE
refactor(agent_sdk): give the acp_backend axis one claude comparison

### DIFF
--- a/src/kiro_crew/agent_sdk/backend_identity.py
+++ b/src/kiro_crew/agent_sdk/backend_identity.py
@@ -1,0 +1,85 @@
+"""Which ACP backend a live session is talking to.
+
+This is the ``agent.acp_backend`` axis, and it is NOT the axis
+:mod:`kiro_crew.agent_sdk.provider_identity` owns. The two are independent and a
+reader who conflates them will draw the wrong conclusion from either:
+
+* ``agent.provider`` -- ``"acp"`` or ``"claude_code"``. Which *seam* serves the
+  session. Answered by ``provider_identity.is_claude_code``.
+* ``agent.acp_backend`` -- ``""`` (kiro-cli), ``"kas"``, or ``"claude"``. Which
+  *harness* the ACP seam spawned. Answered here.
+
+Both can say "claude" about the same session and neither implies the other: the
+public build admits only ``provider == "acp"`` while still refusing
+``acp_backend == "claude"``, so the pair is genuinely two-dimensional.
+
+Why this module takes the backend NAME and not the provider
+-----------------------------------------------------------
+Every caller already has to reach the backend string through whatever shape its
+provider happens to be in, and those shapes differ for reasons that are not this
+module's business -- an ``AcpProvider`` holds it at ``client.backend``, a
+runtime-backed ``AcpSessionProvider`` holds it at ``backend``, and the two
+existing predicates gate on ``isinstance`` before reading either. Accepting the
+provider here would mean either importing ``kiro_crew.providers`` (a forbidden
+root, which would put this module on the wrong side of the boundary it exists to
+serve) or dropping the ``isinstance`` gate and reading the attribute blind.
+
+Reading it blind is the trap. ``ACP_BACKEND_KIRO`` is the empty string, so a
+``getattr(provider, "backend", "")`` that misses -- wrong shape, unstarted
+provider, plain mock -- returns the *kiro backend's own value* and the miss is
+indistinguishable from a real answer. Comparing to ``ACP_BACKEND_CLAUDE`` is
+safe under that failure; comparing to kiro is not. So the lookup stays at the
+call site that knows the shape, and only the comparison is centralized.
+
+That also preserves the string-vs-property property the codebase depends on. See
+``providers.acp.provider_label``: a ``MagicMock(spec=...)`` constrains attribute
+names but not their values, so a spec'd provider's ``is_claude_backend``
+*property* reads truthy while its ``client.backend`` *string* does not match any
+real backend. Call sites that read the string are mock-safe and call sites that
+read the property are not, and that difference is deliberate at each one. This
+module changes neither.
+
+``AcpClient._is_claude`` is deliberately not routed here
+-------------------------------------------------------
+``acp.client.AcpClient`` runs its own ``backend == ACP_BACKEND_CLAUDE`` check and
+keeps it. ``agent_sdk`` sits ABOVE ``kiro_crew.acp``, so having the client import
+this module would invert that layering and pull the SDK package -- and the
+backend-install registry its ``__init__`` builds -- into every client import.
+A one-line comparison against a constant both modules already read from
+``acp_backends`` is the cheaper duplicate.
+
+Only ``claude`` is here
+-----------------------
+``providers.acp`` also exposes ``is_kas_backend`` and ``is_kiro_backend``, and
+they are deliberately not consolidated: both have zero readers outside
+``providers/acp.py``, so there is no second place for them to drift from. And a
+bare ``is_kiro_backend_name`` helper would be an attractive nuisance for the
+empty-string reason above -- it would answer True for every failed lookup. Add
+either one when a real second reader appears, not before.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.acp_backends import ACP_BACKEND_CLAUDE
+
+__all__ = ["ACP_BACKEND_CLAUDE", "is_claude_backend_name"]
+
+
+def is_claude_backend_name(backend: str | None) -> bool:
+    """Whether *backend* names the claude-agent-acp harness.
+
+    Takes the ``acp_backend`` string a caller already resolved from its own
+    provider shape -- deliberately the same calling convention as
+    ``provider_identity.is_claude_code``, so both provider axes are asked the
+    same way.
+
+    Named ``..._name`` rather than ``is_claude_backend`` because
+    ``providers.acp`` already exports an ``is_claude_backend`` that takes a
+    *provider*. Two functions with one name and different argument types, one
+    ``isinstance``-gated and one not, is how a call site ends up passing the
+    wrong thing to the wrong one.
+
+    A missing or empty value is NOT the claude backend: empty is the kiro
+    backend's own spelling, so this answers False rather than guessing.
+    """
+    return backend == ACP_BACKEND_CLAUDE

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -23,7 +23,6 @@ from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeError
 from kiro_crew.acp.session_handle import AcpSessionHandle
 from kiro_crew.acp.session_provider import AcpSessionProvider
 from kiro_crew.acp.types import (
-    ACP_BACKEND_CLAUDE,
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
     ACP_BACKENDS_ACP_RUNTIME,
@@ -37,6 +36,7 @@ from kiro_crew.acp.types import (
     STOP_REASON_CANCELLED,
     STOP_REASON_END_TURN,
 )
+from kiro_crew.agent_sdk.backend_identity import is_claude_backend_name
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.constants import COMPACT_WAIT_TIMEOUT_SECS
@@ -445,8 +445,14 @@ class AcpProvider(LLMProvider):
 
     @property
     def is_claude_backend(self) -> bool:
-        """True when this ACP provider talks to claude-agent-acp (vs kiro-cli)."""
-        return self._client.backend == ACP_BACKEND_CLAUDE
+        """True when this ACP provider talks to claude-agent-acp (vs kiro-cli).
+
+        The comparison lives in ``agent_sdk.backend_identity`` so this property,
+        ``session._is_claude_backend`` and ``provider_label`` cannot drift about
+        what "the claude backend" means. Reading ``self._client.backend`` stays
+        here because only this class knows where its own backend string lives.
+        """
+        return is_claude_backend_name(self._client.backend)
 
     @property
     def is_kas_backend(self) -> bool:
@@ -1523,7 +1529,7 @@ def provider_label(provider: Any) -> str:
         backend = getattr(getattr(provider, "client", None), "backend", "")
     else:
         return PROVIDER_LABEL_DEFAULT
-    if backend == ACP_BACKEND_CLAUDE:
+    if is_claude_backend_name(backend):
         return PROVIDER_LABEL_CLAUDE
     if backend == ACP_BACKEND_KAS:
         return PROVIDER_LABEL_KAS

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -93,7 +93,6 @@ if TYPE_CHECKING:
 from kiro_crew import model_registry, platform_compat, shutdown_event
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
 from kiro_crew.acp.types import (
-    ACP_BACKEND_CLAUDE,
     ACP_BACKEND_KIRO,
     ACP_BACKENDS_ACP_RUNTIME,
     PROVIDER_LABEL_CLAUDE,
@@ -102,6 +101,7 @@ from kiro_crew.acp.types import (
 from kiro_crew.acp_backends import selectable_backends
 from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.agent_discovery import _read_agent_spec, spec_model
+from kiro_crew.agent_sdk.backend_identity import is_claude_backend_name
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     CONTEXT_WARN_MARGIN_PCT,
@@ -209,13 +209,19 @@ def _is_claude_backend(provider: Any) -> bool:
     which the public build offers: ``BASELINE_SELECTABLE_BACKENDS`` includes it, so
     the factory selects it whenever an operator has chosen it and the adapter is
     installed.
+
+    The ``isinstance`` gate and the backend-string read stay here -- they are
+    what makes this predicate mock-safe, and the shape they read is the
+    provider's own business. Only the comparison is delegated to
+    ``agent_sdk.backend_identity``, so this and ``AcpProvider.is_claude_backend``
+    cannot disagree about which string counts as the claude backend.
     """
     from kiro_crew.providers.acp import AcpProvider  # circular import: providers -> session
 
     if not isinstance(provider, AcpProvider):
         return False
     backend = getattr(provider.client, "backend", "")
-    return backend == ACP_BACKEND_CLAUDE
+    return is_claude_backend_name(backend)
 
 
 def _provider_label(provider: Any) -> str:

--- a/test/test_agent_sdk_backend_identity.py
+++ b/test/test_agent_sdk_backend_identity.py
@@ -1,0 +1,264 @@
+"""The ``agent.acp_backend`` axis has one comparison, and it lives in agent_sdk.
+
+Four places used to spell ``backend == ACP_BACKEND_CLAUDE`` independently:
+``AcpProvider.is_claude_backend``, ``providers.acp.provider_label``,
+``session._is_claude_backend``, and ``AcpClient._is_claude``. Nothing asserted
+they agreed. Three now delegate to
+:func:`kiro_crew.agent_sdk.backend_identity.is_claude_backend_name`; the client
+keeps its own for a layering reason this module pins so the exception stays
+deliberate.
+
+These tests also pin the two properties that make the delegation safe: the
+helper takes the backend NAME (not a provider), and reading the backend STRING
+keeps the predicates mock-safe in a way reading the ``is_claude_backend``
+property is not.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.acp_backends import ACP_BACKEND_CLAUDE, ACP_BACKEND_KAS, ACP_BACKEND_KIRO
+from kiro_crew.agent_sdk.backend_identity import is_claude_backend_name
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+#: Sites that must ask the helper rather than compare the constant themselves.
+DELEGATING = (
+    "providers/acp.py",
+    "session.py",
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("claude", True),
+        ("kas", False),
+        ("", False),
+        (None, False),
+        ("Claude", False),
+        ("claude ", False),
+        ("claude_code", False),
+    ],
+)
+def test_truth_table(value: str | None, expected: bool) -> None:
+    """Only the exact backend id is the claude harness.
+
+    ``"claude_code"`` is False on purpose: that is the ``agent.provider`` value
+    on the OTHER axis, and a caller that passes it here has confused the two.
+    """
+    assert is_claude_backend_name(value) is expected
+
+
+def test_a_failed_lookup_reads_as_not_claude() -> None:
+    """The empty string must answer False, because empty IS the kiro backend.
+
+    This is the whole reason the helper takes a name and the lookup stays at the
+    call site. ``getattr(provider, "backend", "")`` returns ``""`` on a miss, and
+    ``ACP_BACKEND_KIRO`` is also ``""`` -- so a missed lookup is indistinguishable
+    from a real kiro answer. Comparing to claude is safe under that failure mode;
+    a kiro helper would not be, which is why none is offered.
+    """
+    assert ACP_BACKEND_KIRO == ""
+    assert is_claude_backend_name(ACP_BACKEND_KIRO) is False
+    assert is_claude_backend_name(getattr(object(), "backend", "")) is False
+
+
+def test_module_reaches_only_the_leaf_constants() -> None:
+    """The helper may import ``acp_backends`` and nothing else from the package.
+
+    ``acp_backends`` is a documented leaf. An import of ``kiro_crew.acp`` or
+    ``kiro_crew.providers`` here would put the consolidation point inside the
+    very roots the boundary gate forbids, so every consumer that routed through
+    it would gain a forbidden edge instead of losing one.
+    """
+    tree = ast.parse((SRC / "agent_sdk" / "backend_identity.py").read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+        elif isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+    assert [m for m in imported if m.startswith("kiro_crew")] == ["kiro_crew.acp_backends"]
+
+
+def test_importing_this_module_does_not_load_acp_or_providers() -> None:
+    """Neither forbidden root may load when the helper is imported.
+
+    The static gate cannot catch a regression: a new eager edge added inside the
+    exempt ``agent_sdk/`` tree keeps the gate green while every SDK consumer
+    starts paying the ACP package -- or worse, closes a providers/session cycle.
+
+    Runs in a subprocess because ``sys.modules`` is process-wide and the suite
+    has already imported most of the package by now.
+    """
+    probe = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(SRC.parent)!r})\n"
+        "from kiro_crew.agent_sdk.backend_identity import is_claude_backend_name\n"
+        "assert is_claude_backend_name('claude') is True\n"
+        "loaded = {\n"
+        "    'acp': 'kiro_crew.acp' in sys.modules,\n"
+        "    'providers': 'kiro_crew.providers' in sys.modules,\n"
+        "    'acp_backends': 'kiro_crew.acp_backends' in sys.modules,\n"
+        "}\n"
+        "print(repr(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        cwd=str(SRC.parent.parent),
+        **UTF8_TEXT,
+    )
+    assert result.returncode == 0, f"probe failed: {result.stderr[-2000:]}"
+    loaded = ast.literal_eval(result.stdout.strip().splitlines()[-1])
+
+    assert loaded["acp"] is False, "importing the helper loaded kiro_crew.acp"
+    assert loaded["providers"] is False, "importing the helper loaded kiro_crew.providers"
+    # Asserted, not tolerated: the helper reads its constant from here.
+    assert loaded["acp_backends"] is True
+
+
+def _constant_comparisons(path: Path) -> list[int]:
+    """Lines comparing something against the claude backend constant by name."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not all(isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops):
+            continue
+        for operand in [node.left, *node.comparators]:
+            if isinstance(operand, ast.Name) and operand.id == "ACP_BACKEND_CLAUDE":
+                hits.append(node.lineno)
+                break
+            if isinstance(operand, ast.Constant) and operand.value == ACP_BACKEND_CLAUDE:
+                hits.append(node.lineno)
+                break
+    return hits
+
+
+@pytest.mark.parametrize("rel", DELEGATING)
+def test_delegating_files_do_not_compare_the_constant(rel: str) -> None:
+    """Ratchet: these files must not re-grow their own comparison."""
+    hits = _constant_comparisons(SRC / rel)
+    assert hits == [], (
+        f"{rel} compares the claude backend constant directly at line(s) {hits}; "
+        f"call is_claude_backend_name() so the four predicates cannot drift"
+    )
+
+
+@pytest.mark.parametrize("rel", DELEGATING)
+def test_delegating_files_ask_the_helper(rel: str) -> None:
+    """Non-vacuity guard: deleting the call would satisfy the ratchet above.
+
+    Counts CALLS from the AST rather than mentions in the text. A substring
+    check passes on the surviving ``import`` line alone, which a mutation run
+    confirmed -- so it would have stayed green with every call site rewritten to
+    read the property instead.
+    """
+    tree = ast.parse((SRC / rel).read_text(encoding="utf-8"))
+    calls = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "is_claude_backend_name"
+    ]
+    assert calls, f"{rel} imports the helper but never calls it"
+
+
+def test_acp_client_keeps_its_own_comparison() -> None:
+    """``AcpClient._is_claude`` is the documented exception, not an oversight.
+
+    ``agent_sdk`` sits above ``kiro_crew.acp``, so routing the client through the
+    helper would invert the layering and drag the SDK package -- and the
+    backend-install registry its ``__init__`` builds -- into every client import.
+
+    Pinned so a future sweep that "finishes the job" has to read this reason
+    first. If the layering ever changes, delete this test deliberately.
+    """
+    body = (SRC / "acp" / "client.py").read_text(encoding="utf-8")
+    assert "is_claude_backend_name" not in body, (
+        "acp/client.py now imports the agent_sdk helper; that inverts the "
+        "acp -> agent_sdk layering. If this is intended, remove this test."
+    )
+    assert _constant_comparisons(SRC / "acp" / "client.py"), (
+        "acp/client.py no longer compares the constant itself; if its check "
+        "moved, this test is stale"
+    )
+
+
+class _FakeClient:
+    """Minimal stand-in for the object an ``AcpProvider`` holds as ``client``."""
+
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+
+
+def _provider_with_backend(backend: str):
+    """An ``AcpProvider`` carrying *backend*, without running its ``__init__``.
+
+    ``__init__`` spawns a real ``AcpClient``; the two predicates under test read
+    only ``client.backend``, so bypassing construction keeps this a unit test.
+    """
+    from kiro_crew.providers.acp import AcpProvider
+
+    provider = object.__new__(AcpProvider)
+    provider._client = _FakeClient(backend)  # type: ignore[attr-defined]
+    return provider
+
+
+@pytest.mark.parametrize(
+    "backend,expected",
+    [(ACP_BACKEND_CLAUDE, True), (ACP_BACKEND_KAS, False), (ACP_BACKEND_KIRO, False)],
+)
+def test_the_property_and_the_session_predicate_agree(backend: str, expected: bool) -> None:
+    """Both surviving predicates must answer the same for the same backend.
+
+    They are kept as separate implementations on purpose -- the session one gates
+    on ``isinstance`` and defers its import across the providers/session cycle --
+    so nothing but a test can hold them equal.
+    """
+    from kiro_crew.providers.acp import is_claude_backend
+    from kiro_crew.session import _is_claude_backend
+
+    provider = _provider_with_backend(backend)
+    assert provider.is_claude_backend is expected
+    assert is_claude_backend(provider) is expected
+    assert _is_claude_backend(provider) is expected
+
+
+def test_a_spec_mock_is_not_every_backend_at_once() -> None:
+    """The string read must stay mock-safe; this is why it is not a property read.
+
+    A ``MagicMock(spec=...)`` constrains attribute NAMES but not their values, so
+    a spec'd provider's ``is_claude_backend`` property reads truthy. The session
+    predicate reads ``client.backend`` instead and is therefore unfooled. If it
+    is ever "simplified" to read the property, this test fails and explains why
+    the simplification is wrong.
+    """
+    from kiro_crew.providers.acp import AcpProvider
+    from kiro_crew.session import _is_claude_backend
+
+    spec_mock = MagicMock(spec=AcpProvider)
+    assert bool(spec_mock.is_claude_backend) is True, "premise changed: spec mock is not truthy"
+    assert _is_claude_backend(spec_mock) is False
+
+
+def test_non_acp_objects_are_not_the_claude_backend() -> None:
+    """A provider this axis knows nothing about answers False, not an error."""
+    from kiro_crew.providers.acp import is_claude_backend
+    from kiro_crew.session import _is_claude_backend
+
+    assert is_claude_backend(object()) is False
+    assert _is_claude_backend(object()) is False
+    assert _is_claude_backend(None) is False


### PR DESCRIPTION
## Problem / Motivation

Four modules each independently decided what "this is the Claude Code backend" means, by spelling the comparison themselves:

- `AcpProvider.is_claude_backend` — `self._client.backend == ACP_BACKEND_CLAUDE`
- `providers.acp.provider_label` — `backend == ACP_BACKEND_CLAUDE`
- `session._is_claude_backend` — `backend == ACP_BACKEND_CLAUDE`
- `AcpClient._is_claude` — `self.backend == ACP_BACKEND_CLAUDE`

Nothing asserted the four agreed. This is the `agent.acp_backend` axis, and it is the one provider axis that had no single owner: the sibling `agent.provider` axis was consolidated into `agent_sdk/provider_identity.py` by #7303, but that PR did not touch this one.

## Why it matters

A silent divergence between these four is a wrong-harness decision, not a cosmetic drift. They gate MCP server injection, session-map labelling, resume compatibility, and session-file cleanup routing. Two of them disagreeing means a session is persisted under one harness's label and resumed under another's rules — and because each comparison is a separate literal against the same constant, a future edit to one is invisible to the other three.

## What changed (motivation → approach → change)

**Goal:** one place owns the judgment, so the four cannot drift.

**Approach, and why this shape.** The obvious move — a helper that takes the *provider* and answers the question outright — is wrong here for two reasons, so the helper takes the backend **name** instead:

1. Reaching the backend off a provider needs an `isinstance(provider, AcpProvider)` gate. `agent_sdk` cannot import `kiro_crew.providers`: it is a `FORBIDDEN_ROOT` for the boundary gate, so a helper that imported it would put the consolidation point on the wrong side of the boundary it exists to serve, and every consumer routing through it would *gain* a forbidden edge rather than lose one.
2. Reading the attribute blind instead is a trap. `ACP_BACKEND_KIRO` is the **empty string**, so a `getattr(provider, "backend", "")` that misses — wrong shape, unstarted provider, plain mock — returns the kiro backend's own value, and the miss is indistinguishable from a real answer.

So the **lookup stays at the call site that knows its own shape, and only the comparison is centralized.** This also preserves a property the codebase already depends on: a `MagicMock(spec=...)` constrains attribute names but not their values, so a spec'd provider's `is_claude_backend` *property* reads truthy while its `client.backend` *string* matches no real backend. Sites that read the string are mock-safe and sites that read the property are not; that difference is deliberate at each one, and this PR changes neither.

**What was built.** `src/kiro_crew/agent_sdk/backend_identity.py`, holding `is_claude_backend_name(backend: str | None) -> bool` — deliberately the same calling convention as `provider_identity.is_claude_code`, so both provider axes are asked the same way. Three of the four sites now delegate to it. Its only `kiro_crew` import is the leaf `acp_backends`.

**Named `..._name`, not `is_claude_backend`,** because `providers.acp` already exports an `is_claude_backend` that takes a *provider*. Two functions with one name and different argument types — one `isinstance`-gated, one not — is how a call site ends up passing the wrong thing to the wrong one.

**`AcpClient._is_claude` deliberately keeps its own copy.** `agent_sdk` sits *above* `kiro_crew.acp`, so having the client import this helper would invert that layering and drag the SDK package — and the backend-install registry its `__init__` builds — into every client import. A one-line comparison against a constant both modules already read from `acp_backends` is the cheaper duplicate. A test pins this so a future sweep that "finishes the job" has to read the reason first.

**Two things this PR deliberately does not do:**

- `is_kas_backend` / `is_kiro_backend` are not consolidated. Both have **zero** readers outside `providers/acp.py`, so there is no second place for them to drift from — and a bare `is_kiro_backend_name` helper would be an attractive nuisance for the empty-string reason above, answering True for every failed lookup.
- **The boundary baseline does not shrink** (108 edges, unchanged). `chat_runner.py` and `subagent.py` import `providers.acp` for the `isinstance`-gated free function, and removing those edges needs `is_claude_backend` declared on the `LLMProvider` ABC so consumers can read it with no import and no `isinstance`. That is a real change with a real trade-off — an ABC property reinherits the mock hazard above — so it belongs in its own PR, not quietly here.

## Tests

`test/test_agent_sdk_backend_identity.py`, 20 tests:

- **Truth table** for `is_claude_backend_name`, including `"claude_code"` → False: that is the *other* axis's value, and a caller passing it here has confused the two.
- **`test_a_failed_lookup_reads_as_not_claude`** — pins that `""` answers False and asserts `ACP_BACKEND_KIRO == ""`, recording *why* the helper takes a name rather than a provider.
- **`test_module_reaches_only_the_leaf_constants`** — the helper's `kiro_crew` imports must be exactly `["kiro_crew.acp_backends"]`, so it can never drift onto the forbidden side of the boundary.
- **`test_importing_this_module_does_not_load_acp_or_providers`** — subprocess probe. The static gate is blind to this: a new eager edge added inside the exempt `agent_sdk/` tree keeps the gate green while every SDK consumer starts paying the ACP package.
- **Ratchet + non-vacuity pair** over `providers/acp.py` and `session.py`: no direct comparison against the constant, and the helper is actually **called**. The non-vacuity half counts AST `Call` nodes, not substring mentions — a mutation run proved a substring check passes on the surviving `import` line alone, so it would have stayed green with every call site rewritten to read the property.
- **`test_the_property_and_the_session_predicate_agree`** — the two surviving predicates answer identically for claude/kas/kiro. They are separate implementations on purpose (the session one gates on `isinstance` and defers its import across the providers/session cycle), so nothing but a test can hold them equal.
- **`test_a_spec_mock_is_not_every_backend_at_once`** — pins the mock-safety property directly. Mutation-verified: rewriting `session._is_claude_backend` to read the property makes exactly this test fail.
- **`test_acp_client_keeps_its_own_comparison`** — pins the documented layering exception in both directions, so it stays deliberate.

## Manual verification

N/A — pure refactor of a boolean comparison with no user-visible surface; behavioural equivalence at each delegating site is asserted directly by the tests above rather than observed by hand.

Gate status on this head: `agent-sdk-boundary` (108 edges, unchanged), `harness-parity`, black, isort, flake8, mypy, `subprocess-encoding`, `sync-io-in-async`, brand, changelog, `focus-cue`, `testpaths-coverage`, `docs-lint`, `vendor-manifest`, `scrub-lint` all green. Focused suite 1238 passed / 15 skipped; the three `agent_sdk` test files 71 passed. The full backend suite was not completed locally — it was killed after decelerating under host contention (load average 99 on 16 cores) — so CI is the authority on it.

## Related Issues

no linked issue: this is the second step of the in-flight `agent_sdk` boundary consolidation, tracked by the RFC landed in #6939 rather than by a discrete issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
