### PR TITLE
fix(file_send): add the two missing auth rungs to the Slack leg

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1970,3 +1970,26 @@ window that broadcasts at a channel root. Restoring proper *threaded* delivery
 for warm-pool Slack sessions (by writing the HMAC sidecar at warm-pool claim
 time) is a delivery-quality follow-up, not an audience-safety gate — the
 disclosure hazard is closed by the refuse-on-unresolved rule above.
+
+#### Slack Upload Authorization Rungs (`file_send`)
+
+Both `file_send` legs resolve their destination through one oracle (`dashboard/upload_destination`), and both run the same two ceilings there before any destination work:
+
+| Rung | Predicate | Denial |
+|------|-----------|--------|
+| `channels`-scope governance | `upload_destination._slack_egress_permitted` → `vet_and_audit("channels", "slack", fail_closed=True)` | `403` `channels_governance_denied`, SEL governance decision recorded for grant AND denial |
+| Restricted-session ceiling | `upload_gate.uploads_restricted(channel_type="slack")` — the predicate the channel leg and the Telegram/Discord renderers' extraction path share | `403` `restricted_session`, SEL-audited by the shared predicate |
+
+On the Slack leg both are **direct calls**, not registry entries. Slack is deliberately absent from `channel_transports` (its dedicated client and streaming path are not registered), so it never reaches the shared send ladder that applies the governance vet for every other channel — the same situation `chat_compaction_notice._channel_egress_permitted` already resolves the same way. Registering Slack to reach the ladder would change what the registry means; a direct call to the audited seam does not.
+
+Why this leg needs them most: Slack is the broadest-audience surface (a tracked channel can be company-visible) and the only leg whose destination a REQUEST can name (`body["channel"]`, falling back to the session-map link then the owner DM), while the channel leg's destination comes exclusively from the caller's own session-map entry. Without these rungs an incognito/temporary session that refuses to write a transcript, read memory or save a title still uploaded local file bytes into a Slack channel or DM, and a profile denying the `channels` scope refused a Telegram upload while allowing a Slack one.
+
+**They precede destination resolution.** A denied caller never opens an owner DM and never reads the session map, so a refusal leaks nothing about where the file would have gone. (The shared admission gate — containment, MIME allowlist, content scans — still runs ahead of the oracle on both legs.)
+
+**The restricted rung restores the durable flags first.** For a channel-native key the ceiling reads `privacy_mode`'s process-local trackers, which only an INBOUND channel message populates. A turn no inbound message drove — a cron, a webhook-resumed session, a monitor/auto-nudge re-injection, an explicit `file_send` — would otherwise read empty trackers after a gateway restart and ship the bytes the user's `!incognito` forbids. `uploads_restricted` therefore calls `privacy_mode.hydrate` before consulting them, the same canonical restore `_is_restricted_session` uses, so the fix lands once for every caller of the shared predicate (both `file_send` legs and the renderers' extraction path) rather than per leg.
+
+**Sessionless callers are not muted.** The owner-DM fallback serves callers with no session of their own (a cron, the heartbeat, an out-of-band host action). An empty `X-Session-Key` is vetted under `HOST_SESSION_KEY` (`_host`), for the same reason `handlers.messaging` uses that sentinel on its channel legs: an empty key classifies as `unknown` and matches no profile at all, so vetting under it would make host-side governance inert here, while `_host` is the stable bind target operators attach it to. The restricted rung reads no slot and no channel privacy mode for such a key, so it answers permitted. Net effect on an ungoverned host: unchanged.
+
+**Identity asymmetry is inherited, not widened.** The Slack leg resolves its caller LENIENTLY (`_resolve_session_key()`, including the `/proc` ancestor walk) while the channel leg is handed the strict key. Both rungs read that same lenient key; neither introduces a new identity source.
+
+**Denials are refusals, not skips.** Both answer `403` with a machine-readable `code`, so the MCP tool surfaces "Slack upload failed" rather than reporting success for a file that never left. This differs deliberately from the channel leg, where "cannot deliver here" is the common case and a skip is correct.

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -637,11 +637,12 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
 
     Destination and authorization come from the shared oracle
     (:func:`kiro_crew.dashboard.upload_destination.resolve_slack`), which holds
-    this leg's ladder — request-named channel, session-map-linked thread,
-    owner-DM fallback, tracked-channel authorization — next to the non-Slack
-    leg's, so the two cannot drift apart rung by rung (issue #6060). What stays
-    here is what only this leg can answer: the Slack client, its upload verb,
-    and the response shapes.
+    this leg's ladder — the ``channels``-scope governance vet, the
+    restricted-session ceiling, then a request-named channel, a
+    session-map-linked thread, or the owner-DM fallback with its tracked-channel
+    authorization — next to the non-Slack leg's, so the two cannot drift apart
+    rung by rung (issue #6060). What stays here is what only this leg can
+    answer: the Slack client, its upload verb, and the response shapes.
 
     The client-presence check stays AHEAD of the body parse, where it shipped: a
     gateway with no Slack client answers ``skipped: no_slack`` even for a
@@ -667,9 +668,10 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
     if error_resp is not None:
         return error_resp
     assert resolved is not None and raw is not None  # narrowed by the gate
-    # ``is_tracked_channel`` is handed to the oracle rather than imported there:
-    # one binding site, and the module stays free of the Slack handler's config
-    # dependency (same contract as ``persisted_probe`` below).
+    # ``is_tracked_channel`` and the persisted-transcript probe are handed to the
+    # oracle rather than imported there: one binding site, and the module stays
+    # free of both the Slack handler's config dependency and the ``dashboard``
+    # package ``messaging.upload_gate`` may not import.
     destination = await upload_destination.resolve_slack(
         state,
         slack,
@@ -677,6 +679,7 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
         requested_channel=body.get("channel", ""),
         thread_ts=body.get("thread_ts"),
         tracked_probe=is_tracked_channel,
+        persisted_probe=_probe_persisted_session,
     )
     if isinstance(destination, upload_destination.Refusal):
         _audit_file_send(

--- a/src/kiro_crew/dashboard/upload_destination.py
+++ b/src/kiro_crew/dashboard/upload_destination.py
@@ -19,10 +19,12 @@ resolvers live here, share one refusal/skip vocabulary, and are audited through
 one shape (``_audit_file_send`` in the handlers module, which owns the
 test-patchable ``_sel``).
 
-Rung by rung, as shipped today -- the Slack column is what #6060 asks to
-converge, and the two NOT RUN rows are the parts that need the architecture
-decision in that issue's step 2 (does Slack join ``channel_transports``, or does
-the ladder grow a Slack adapter?), so they are named here, not silently changed:
+Rung by rung. Both legs now run the same two ceilings -- the ``channels``-scope
+governance vet and the restricted-session ceiling -- which is the convergence
+#6060 step 2 asked for and #7290 decided: the Slack leg calls them DIRECTLY
+(:func:`_slack_egress_permitted`) rather than joining ``channel_transports``,
+because its dedicated client genuinely cannot ride the shared ladder. The rows
+that still differ differ for a reason named in the row:
 
 ======================================  =============================  ===========================================
 rung                                    channel leg                    Slack leg
@@ -32,9 +34,9 @@ destination source                      session-map mirror link only    request-
 recipient authorization                 ``transport.may_send_to``       ``is_tracked_channel``; a session-map
                                         (fail-closed)                   channel passes on a ``D`` prefix OR
                                                                         tracking (both fail-closed)
-``channels``-scope governance           yes, inside                     NOT RUN (#6060 step 2)
-(``vet_and_audit``, fail-closed, SEL)   ``_resolve_channel_target``
-restricted-session ceiling              yes                             NOT RUN (#6060 step 2)
+``channels``-scope governance           yes, inside                     yes, direct call keyed on ``slack``
+(``vet_and_audit``, fail-closed, SEL)   ``_resolve_channel_target``     (``_slack_egress_permitted``)
+restricted-session ceiling              yes                             yes, same shared predicate
 (``upload_gate.uploads_restricted``)
 transport registration +                yes                             n/a -- Slack's dedicated client is
 ``supports_proactive_send``                                             deliberately absent from
@@ -42,9 +44,11 @@ transport registration +                yes                             n/a -- S
 caller identity on the wire             STRICT session key, pinned by   lenient ``_resolve_session_key()``; the
                                         the MCP tool                    tool's three-state classifier refuses an
                                                                         unresolved caller before the leg runs
-resolution off the event loop           yes (``asyncio.to_thread``)     no -- ``open_dm`` is a coroutine, so this
-                                                                        ladder stays on the loop with its config
-                                                                        and tracking reads inline, as before
+resolution off the event loop           yes (``asyncio.to_thread``)     partly -- ``open_dm`` is a coroutine, so
+                                                                        the ladder stays on the loop with its
+                                                                        config and tracking reads inline; the two
+                                                                        ceilings above are offloaded, since they
+                                                                        read the profile directory
 ======================================  =============================  ===========================================
 
 Ambient lookups are PARAMETERS, not imports (``tracked_probe``,
@@ -66,6 +70,8 @@ from typing import Any
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.messaging import upload_gate
 from kiro_crew.messaging.link import SLACK_NAMESPACE, is_channel_session_key
+from kiro_crew.platform.context import PlatformCompositionError
+from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY, vet_and_audit
 from kiro_crew.validation import FILE_SEND_SCHEMA, ValidationError, validate_tool_args
 
 logger = logging.getLogger(__name__)
@@ -134,6 +140,57 @@ class ChannelTarget:
     deliver: Callable[..., Any]
 
 
+def _slack_egress_permitted(session_key: str) -> bool:
+    """Vet a Slack file upload against the ``channels`` governance scope.
+
+    The channel leg inherits this from the shared send ladder. Slack is
+    deliberately absent from ``channel_transports`` and so never reaches that
+    ladder, which would leave the broadest-audience leg -- the only one whose
+    destination a REQUEST can name -- as the one unvetted, unaudited file egress.
+    Same shape as the other Slack egress that cannot reach the ladder
+    (``chat_compaction_notice._channel_egress_permitted``): a direct call to the
+    audited seam rather than a registry change, so the registry keeps meaning
+    "transports the shared ladder can drive".
+
+    An empty key is a caller with no session of its own -- a cron, the heartbeat,
+    an out-of-band host action -- reaching this leg through the owner-DM
+    fallback. It is vetted under ``HOST_SESSION_KEY`` for the same reason
+    ``handlers.messaging`` uses that sentinel on its channel legs: an empty key
+    classifies as ``unknown`` and matches no profile at all, so vetting under it
+    would make host-side governance inert here, while ``_host`` is the stable
+    bind target operators attach it to. A legitimate owner-DM send therefore
+    stays permitted on an ungoverned host, and is deniable by an explicit host
+    binding rather than by a fall-through.
+
+    Fail-closed: a degraded evaluation denies. ``PlatformCompositionError``
+    propagates -- an unusable governance ceiling is a host misconfiguration, not
+    a routine authorization answer, and must not be reported as one.
+
+    Synchronous by design -- the caller runs it through ``asyncio.to_thread``
+    because the gate reads the profile directory.
+    """
+    try:
+        decision = vet_and_audit(
+            "channels",
+            SLACK_NAMESPACE,
+            session_key=session_key or HOST_SESSION_KEY,
+            tool_name="file_send",
+            fail_closed=True,
+        )
+    except PlatformCompositionError:
+        raise
+    except Exception:
+        logger.debug(
+            "slack upload: governance check failed for %s; denying (fail-closed)",
+            session_key,
+            exc_info=True,
+        )
+        return False
+    # Default False: a Decision without ``permitted`` is an unusable answer from
+    # a gate and must not read as permission.
+    return bool(getattr(decision, "permitted", False))
+
+
 async def resolve_slack(
     state: Any,
     slack: Any,
@@ -142,6 +199,7 @@ async def resolve_slack(
     requested_channel: str,
     thread_ts: str | None,
     tracked_probe: TrackedProbe,
+    persisted_probe: upload_gate.PersistedProbe,
 ) -> SlackTarget | Refusal | Skip:
     """Resolve the Slack leg's destination and authorize the caller for it.
 
@@ -159,7 +217,40 @@ async def resolve_slack(
     a thread ts belongs to one channel, so pairing it with a different one would
     post into an unrelated conversation. ``state.sessions`` is read after the
     linkable test, so a key that names no session never touches it.
+
+    Both ceilings run BEFORE any of that: a caller who may not egress here never
+    opens an owner DM and never reads the session map, so a denial leaks nothing
+    about where the file would have gone.
     """
+    # Off-loop: the gate reads the profile directory and writes a SEL record
+    # either way (no-blocking-call-on-event-loop).
+    if not await asyncio.to_thread(_slack_egress_permitted, session_key):
+        return Refusal(
+            error="slack egress denied by the active governance profile",
+            code="channels_governance_denied",
+            status=403,
+            audit_error="channels_governance_denied",
+            downstream=SLACK_NAMESPACE,
+        )
+    # The ceiling the channel leg and the renderers' extraction path already
+    # enforce, on the same shared predicate (which SEL-audits its own denial): a
+    # session the user expected to leave no trace ships no local file bytes to a
+    # chat surface, and Slack -- where a tracked channel can be company-visible
+    # -- must not be the one exception. A Refusal, not a Skip: the caller asked
+    # for this send, so it must learn the file did not leave.
+    if await upload_gate.uploads_restricted(
+        state,
+        session_key,
+        channel_type=SLACK_NAMESPACE,
+        persisted_probe=persisted_probe,
+    ):
+        return Refusal(
+            error="restricted session: local file bytes may not leave it",
+            code="restricted_session",
+            status=403,
+            audit_error="restricted_session",
+            downstream=SLACK_NAMESPACE,
+        )
     target_channel = requested_channel
     channel_from_session_map = False
     # A dashboard session carries its Slack link in the session map; a

--- a/src/kiro_crew/messaging/upload_gate.py
+++ b/src/kiro_crew/messaging/upload_gate.py
@@ -113,7 +113,14 @@ async def uploads_restricted(
       a transcript, read memory or save a title would still ship local file bytes
       into a DM or a supergroup-readable Topic. It is not a blanket fail-closed
       either — an unrestricted conversation is allowed, which is the common case,
-      and a channel with no modes at all reads ``False`` exactly as before.
+      and a channel with no modes at all reads ``False`` exactly as before. The
+      DURABLE flags are restored first, because that predicate reads process-local
+      trackers that only an INBOUND channel message populates: a turn no inbound
+      message drove — a cron, a webhook-resumed session, a monitor/auto-nudge
+      re-injection, an explicit ``file_send`` — would otherwise read empty
+      trackers after a gateway restart and ship the bytes the user's
+      ``!incognito`` forbids. Same canonical restore, for the same reason, as
+      ``dashboard.handlers._shared._is_restricted_session``.
     * A LIVE slot answers directly, off the same ``slot.is_restricted`` signal as
       the artifact gate, so the two cannot drift.
     * No live slot, but a ``dashboard:`` binding still resolved. This is a real
@@ -133,6 +140,12 @@ async def uploads_restricted(
     transport audits its authorization denials.
     """
     if not session_key.startswith(_DASHBOARD_PREFIX):
+        # Restore the durable flags before reading the process-local trackers (see
+        # the docstring). Idempotent, allocation-free for an unflagged key, and an
+        # in-memory ``SessionMap`` read rather than disk, so it is safe to run on
+        # the loop at every decision point. A state with no session manager is a
+        # no-op inside ``hydrate``.
+        privacy_mode.hydrate(getattr(dashboard_state, "sessions", None), session_key)
         # The channel's own mode, on the same predicate its transcript, memory and
         # title writes use, so one conversation cannot be private for three of them
         # and public for the fourth.

--- a/test/test_file_send_channel.py
+++ b/test/test_file_send_channel.py
@@ -314,9 +314,17 @@ class TestFileUploadSlotThreading:
     """Behaviour: file_send resolves thread_ts from session_map when not explicitly provided."""
 
     def _make_state_with_link(self, slack, thread_ts=None, channel=None):
-        """Create state with a sessions mock that returns slack link data."""
+        """Create state with a sessions mock that returns slack link data.
+
+        The slot is explicitly UNRESTRICTED. These are all ordinary
+        (non-incognito) dashboard sessions, and the leg's restricted-session
+        ceiling reads the live slot for a ``dashboard:`` key — an auto-attribute
+        mock answers that with a truthy stand-in and would deny the upload for a
+        reason none of these cases is about.
+        """
         state = MagicMock()
         state.slack_client = slack
+        state.get_slot.return_value.is_restricted = False
         sessions = MagicMock()
         sessions.get_slack_link = MagicMock(
             return_value=(thread_ts, channel)
@@ -1000,6 +1008,278 @@ class TestChannelUploadEndpoint:
         assert body["error"] == "channel delivery failed"
 
 
+class TestSlackUploadAuthorizationRungs:
+    """The two ceilings the Slack leg shares with the channel leg (issue #7290).
+
+    Slack is deliberately absent from ``channel_transports``, so it reaches
+    neither the send ladder's ``channels`` governance vet nor the ceiling the
+    ladder's caller applies. Both are direct calls in the oracle. Pinned here:
+    that they are reached, that a denial is a REFUSAL the caller sees rather than
+    a silent skip, that they run before any destination work, and that a caller
+    with no session of its own is not muted by them.
+    """
+
+    @staticmethod
+    def _state(slack, *, restricted=False):
+        state = MagicMock()
+        state.slack_client = slack
+        state.get_slot.return_value.is_restricted = restricted
+        return state
+
+    @staticmethod
+    def _decision(permitted):
+        return MagicMock(permitted=permitted, rule="", layer="", reason="")
+
+    async def _post(self, app, payload, *, headers=None):
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/slack/upload-file", json=payload, headers=headers)
+            return resp, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_a_restricted_session_is_denied_the_slack_upload(
+        self, tmp_path, outbox_file
+    ):
+        # An incognito/temporary session refuses to write a transcript, read
+        # memory or save a title; shipping its local file bytes into a Slack
+        # channel or DM is the same disclosure with a different destination.
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path, state=self._state(slack, restricted=True))
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel", return_value=True
+        ):
+            resp, body = await self._post(
+                app,
+                {
+                    "file_path": str(outbox_file),
+                    "filename": "report.txt",
+                    "channel": "C0TRACKED123",
+                },
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 403
+        assert body["code"] == "restricted_session"
+        slack.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_governance_denied_channels_scope_denies_the_slack_leg(
+        self, tmp_path, outbox_file
+    ):
+        # The vet the channel leg inherits from its send ladder. A profile that
+        # denies the ``channels`` scope refused a Telegram upload and allowed a
+        # Slack one; one denial now answers for both.
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path, state=self._state(slack))
+        sel = MagicMock()
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel", return_value=True
+        ), patch(
+            "kiro_crew.dashboard.handlers.files._sel", return_value=sel
+        ), patch(
+            "kiro_crew.dashboard.upload_destination.vet_and_audit",
+            return_value=self._decision(False),
+        ):
+            resp, body = await self._post(
+                app,
+                {
+                    "file_path": str(outbox_file),
+                    "filename": "report.txt",
+                    "channel": "C0TRACKED123",
+                },
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 403
+        assert body["code"] == "channels_governance_denied"
+        slack.upload_file.assert_not_called()
+        # The audit lane an operator greps for refused sends, same shape as every
+        # other refusal on this leg.
+        denied = [
+            r for r in (c.kwargs for c in sel.log_tool_invocation.call_args_list)
+            if r.get("outcome") == "denied"
+        ]
+        assert [r["error"] for r in denied] == ["channels_governance_denied"]
+        assert denied[0]["downstream_service"] == "slack"
+
+    @pytest.mark.asyncio
+    async def test_the_vet_names_the_slack_transport_and_the_channels_scope(
+        self, tmp_path, outbox_file
+    ):
+        # The scope/item pair is the authorization content of the rung: vetting
+        # anything but the transport the file actually leaves over would evaluate
+        # one channel's rule against another's egress.
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path, state=self._state(slack))
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel", return_value=True
+        ), patch(
+            "kiro_crew.dashboard.upload_destination.vet_and_audit",
+            return_value=self._decision(True),
+        ) as vet:
+            resp, _ = await self._post(
+                app,
+                {
+                    "file_path": str(outbox_file),
+                    "filename": "report.txt",
+                    "thread_ts": "999.888",
+                    "channel": "C0TRACKED123",
+                },
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 200
+        assert vet.call_args[0] == ("channels", "slack")
+        assert vet.call_args[1]["session_key"] == "dashboard:chat-1"
+        # Fail-closed: a degraded evaluation on an egress chokepoint must deny.
+        assert vet.call_args[1]["fail_closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_degraded_governance_evaluation_denies(self, tmp_path, outbox_file):
+        # Fail-closed at the point the error is caught: an unusable gate answer
+        # must not read as permission on the broadest-audience leg.
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        app = _make_app(slack, tmp_path, state=self._state(slack))
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.handlers.files.is_tracked_channel", return_value=True
+        ), patch(
+            "kiro_crew.dashboard.upload_destination.vet_and_audit",
+            side_effect=RuntimeError("profile store unreadable"),
+        ):
+            resp, body = await self._post(
+                app,
+                {
+                    "file_path": str(outbox_file),
+                    "filename": "report.txt",
+                    "channel": "C0TRACKED123",
+                },
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 403
+        assert body["code"] == "channels_governance_denied"
+        slack.upload_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_sessionless_owner_dm_caller_is_not_muted(self, tmp_path, outbox_file):
+        # The owner-DM fallback serves callers with no session of their own (a
+        # cron, the heartbeat, an out-of-band host action). Neither ceiling may
+        # mute them on an ungoverned host: governance runs for real here, and the
+        # ceiling has no slot and no channel privacy mode to read.
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        app = _make_app(slack, tmp_path, state=self._state(slack))
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load"
+        ) as mock_cfg:
+            mock_cfg.return_value.load_credentials.return_value = {
+                "KIROCREW_OWNER_ID": "U_OWNER"
+            }
+            resp, body = await self._post(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+            )
+
+        assert resp.status == 200
+        assert body.get("ok") is True
+        assert slack.upload_file.call_args[0][0] == "D_OWNER_DM"
+
+    @pytest.mark.asyncio
+    async def test_a_sessionless_caller_is_vetted_under_the_host_sentinel(
+        self, tmp_path, outbox_file
+    ):
+        # An EMPTY key classifies as ``unknown`` and matches no profile at all, so
+        # vetting under it would make host-side governance inert on this leg.
+        # ``_host`` is the bind target operators actually attach it to.
+        from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
+
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        app = _make_app(slack, tmp_path, state=self._state(slack))
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load"
+        ) as mock_cfg, patch(
+            "kiro_crew.dashboard.upload_destination.vet_and_audit",
+            return_value=self._decision(True),
+        ) as vet:
+            mock_cfg.return_value.load_credentials.return_value = {
+                "KIROCREW_OWNER_ID": "U_OWNER"
+            }
+            resp, _ = await self._post(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+            )
+
+        assert resp.status == 200
+        assert vet.call_args[1]["session_key"] == HOST_SESSION_KEY
+
+    @pytest.mark.asyncio
+    async def test_both_ceilings_precede_any_destination_work(self, tmp_path, outbox_file):
+        # A caller that may not egress here never opens an owner DM and never
+        # reads the session map, so a denial leaks nothing about where the file
+        # would have gone — the same ordering rule the admission gate follows.
+        slack = MagicMock()
+        slack.upload_file = AsyncMock()
+        slack.open_dm = AsyncMock(return_value="D_OWNER_DM")
+        state = self._state(slack)
+        state.sessions = MagicMock()
+        state.sessions.get_slack_link = MagicMock(return_value=("111.222", "D0SLOTDM01"))
+        app = _make_app(slack, tmp_path, state=state)
+
+        with patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ), patch(
+            "kiro_crew.dashboard.upload_destination.vet_and_audit",
+            return_value=self._decision(False),
+        ):
+            resp, _ = await self._post(
+                app,
+                {"file_path": str(outbox_file), "filename": "report.txt", "channel": ""},
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+
+        assert resp.status == 403
+        state.sessions.get_slack_link.assert_not_called()
+        slack.open_dm.assert_not_called()
+
+
 class TestDestinationOracleEquivalence:
     """The rungs the destination oracle must keep answering exactly as the two
     inline ladders did (issue #6060).
@@ -1016,6 +1296,10 @@ class TestDestinationOracleEquivalence:
     def _state(slack, *, thread_ts=None, channel=None):
         state = MagicMock()
         state.slack_client = slack
+        # Unrestricted slot: these cases are about destination resolution, and an
+        # auto-attribute mock reads as a restricted session, which the ceiling
+        # ahead of resolution would answer first.
+        state.get_slot.return_value.is_restricted = False
         sessions = MagicMock()
         sessions.get_slack_link = MagicMock(return_value=(thread_ts, channel))
         state.sessions = sessions
@@ -1290,6 +1574,13 @@ class TestDestinationOracleEquivalence:
         ), patch(
             "kiro_crew.config.loader.KiroCrewConfig.load",
             side_effect=RuntimeError("credential store unreadable"),
+        ), patch(
+            # An unreadable config also breaks the governance evaluation this leg
+            # runs first, and THAT rung is fail-closed — so without pinning it
+            # permitted, its 403 would answer before the owner-DM fallback this
+            # case is about ever ran.
+            "kiro_crew.dashboard.upload_destination.vet_and_audit",
+            return_value=MagicMock(permitted=True, rule="", layer="", reason=""),
         ):
             resp, body = await self._post_slack(
                 app,

--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -1411,6 +1411,64 @@ class TestUploadGate:
         dispatcher, _, _ = _dispatcher({1})
         assert await dispatcher._uploads_restricted("telegram:kirocrew:direct:1") is False
 
+    @pytest.mark.asyncio
+    async def test_a_persisted_mode_survives_an_empty_tracker(self, tmp_path) -> None:
+        # The restart case. The privacy trackers are process-local and only an
+        # INBOUND channel message populates them, so a turn no inbound message
+        # drove — a cron, a webhook resume, a monitor/auto-nudge re-injection, an
+        # explicit file_send — reaches this gate with empty trackers even though
+        # the user's !incognito is on disk. Without the durable restore the gate
+        # reads "unrestricted" and the bytes leave the session that forbade them.
+        from kiro_crew.messaging import privacy_mode
+        from kiro_crew.messaging.upload_gate import uploads_restricted
+        from kiro_crew.session_map import SessionMap
+
+        key = "telegram:kirocrew:direct:1"
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            sm = SessionMap()
+        # ``set_flag`` -> ``_save`` schedules a debounced ``_flush_async`` task on
+        # THIS test's loop, so the retirement has to be in a ``finally``: loop
+        # teardown would otherwise destroy it mid-write ("Task was destroyed but
+        # it is pending"), leaking a failure into whichever test runs next.
+        try:
+            sm.set_flag(key, privacy_mode.MODE_INCOGNITO, True)
+            privacy_mode.reset()  # the empty process-local view a restart leaves
+            state = SimpleNamespace(sessions=SimpleNamespace(_session_map=sm))
+
+            assert (
+                await uploads_restricted(
+                    state,
+                    key,
+                    channel_type="telegram",
+                    persisted_probe=lambda _slot: (False, None),
+                )
+                is True
+            )
+        finally:
+            await sm.aclose()
+
+    @pytest.mark.asyncio
+    async def test_an_unflagged_channel_key_stays_allowed_after_the_restore(self, tmp_path) -> None:
+        # The restore must not turn the common case into a refusal: a conversation
+        # with no durable flag is still permitted.
+        from kiro_crew.messaging import privacy_mode
+        from kiro_crew.messaging.upload_gate import uploads_restricted
+        from kiro_crew.session_map import SessionMap
+
+        privacy_mode.reset()
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            state = SimpleNamespace(sessions=SimpleNamespace(_session_map=SessionMap()))
+
+        assert (
+            await uploads_restricted(
+                state,
+                "telegram:kirocrew:direct:1",
+                channel_type="telegram",
+                persisted_probe=lambda _slot: (False, None),
+            )
+            is False
+        )
+
     @pytest.mark.parametrize("restricted", [True, False])
     @pytest.mark.asyncio
     async def test_a_live_dashboard_slot_decides(self, restricted: bool) -> None:
@@ -3350,7 +3408,13 @@ class TestPrivacyModeEnforcement:
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(privacy_mode, "hydrate", lambda s, k: seen.append(k))
             await d.handle_message(_dm("hello"))
-        assert seen == [d._session_key(("direct", "7"))]
+        # Asserted as a SET: what matters is which key is restored and that the
+        # pre-rotation one never is. The restore is idempotent and every gate that
+        # reads the process-local trackers runs it, so pinning a call count here
+        # would fail on a second gate joining the turn rather than on the key
+        # being wrong.
+        assert seen, "the inbound path must restore the durable flags"
+        assert set(seen) == {d._session_key(("direct", "7"))}
 
 
 class TestPollingLoopAck:


### PR DESCRIPTION
Closes #7290.

`file_send`'s Slack leg ran neither of the two authorization rungs the channel leg runs on every send. So an incognito/temporary session that refuses to write a transcript still uploaded local file bytes into a Slack channel or DM, and a profile denying the `channels` scope refused a Telegram upload while allowing a Slack one — on the leg with the broadest audience and the only leg whose destination a **request** can name.

This is an authorization change, not a refactor: a send that succeeds today can now be denied.

Rebased onto `main` after #7293 landed, so both rungs sit in the destination oracle (`dashboard/upload_destination.resolve_slack`) — the landing site #7290 names — instead of inline in the handler.

## Rung shape: the direct-vet precedent

Rung 1 is a **direct `vet_and_audit("channels", SLACK_NAMESPACE, fail_closed=True)` call** (`upload_destination._slack_egress_permitted`), not a `channel_transports` registry entry. This follows the shipped precedent `dashboard/chat_compaction_notice._channel_egress_permitted`, whose docstring names this exact case ("Slack is deliberately absent from `channel_transports` and so never reaches that ladder"). The registry keeps meaning "transports the shared ladder can drive"; no registry change.

Rung 2 is the existing shared predicate `upload_gate.uploads_restricted(channel_type="slack")` — the same one `resolve_channel` and the Telegram/Discord renderers' extraction path use. Its `persisted_probe` is passed in from the handler, matching the module's existing parameter-not-import contract for ambient lookups.

Both run **ahead of any destination work**, so a denied caller never opens an owner DM and never reads the session map — a refusal leaks nothing about where the file would have gone. Both are `Refusal`s, not `Skip`s: `403` with a machine-readable `code` (`channels_governance_denied` / `restricted_session`) plus the leg's usual SEL denial record, so the caller is told the file did not leave rather than reading success. That is deliberately unlike the channel leg, where "cannot deliver here" is the common case and a skip is correct.

The oracle's rung table is updated: the two `NOT RUN (#6060 step 2)` rows now read as run on both legs, and the off-the-event-loop row records that these two ceilings are offloaded even though `open_dm` keeps the rest of the ladder on the loop.

## Blast radius honored

- **Sessionless owner-DM callers are not muted.** An empty `X-Session-Key` (cron, heartbeat, out-of-band host action reaching the owner-DM fallback) is vetted under `HOST_SESSION_KEY` (`_host`), the same sentinel `handlers.messaging` uses on its channel legs: an empty key classifies as `unknown` and matches no profile at all, so vetting under it would make host-side governance inert here, while `_host` is the stable bind target operators attach it to. On an ungoverned host the outcome is unchanged, and the restricted rung reads no slot and no channel privacy mode for such a key.
- **The lenient/strict identity asymmetry is inherited, not widened.** This leg resolves its caller leniently (`_resolve_session_key()`, including the `/proc` ancestor walk) while the channel leg gets the strict key. Both rungs read that same key; neither adds an identity source.
- **Fail-closed.** A degraded governance evaluation denies; `PlatformCompositionError` propagates rather than being reported as a routine authorization answer.

## Tests

New `TestSlackUploadAuthorizationRungs` (7 tests). Revert-verified by removing only the two rung blocks while keeping the signature: six fail, and the seventh is the regression guard that must pass on both sides.

- a restricted session is denied the Slack upload
- a governance-denied `channels` scope denies the leg, and writes exactly one denied SEL record with `downstream_service=slack`
- the vet names `("channels", "slack")` with `fail_closed=True` under the caller's key
- a degraded governance evaluation denies
- a sessionless owner-DM caller is **not** muted
- a sessionless caller is vetted under `HOST_SESSION_KEY`
- both ceilings precede any destination work (no `open_dm`, no `get_slack_link`)

## Pinned outcomes changed

No shipped Slack **outcome** changed. Three test setups did, because the new restricted rung reads a dashboard slot that an auto-attribute `MagicMock` answers as truthy (i.e. restricted) for sessions none of those cases is about:

- `TestFileUploadSlotThreading._make_state_with_link` — sets `state.get_slot.return_value.is_restricted = False`, with a comment saying why. Covers its six `dashboard:`-keyed tests.
- `TestDestinationOracleEquivalence._state` — same, for the destination-resolution cases.
- `TestDestinationOracleEquivalence.test_an_unreadable_credential_store_is_a_skip_not_a_500` — additionally pins `vet_and_audit` permitted. Its `KiroCrewConfig.load` patch raises for *every* reader, including the lazy platform-context build behind the governance vet, so the fail-closed rung would answer `403` before the owner-DM fallback this case is about ever ran.

## Gates

`pytest` (touched surface 116 passed; full suite's 117 reds reproduce identically on a clean `origin/main` in this environment — 118 in the same file set — and none are in `file_send` / `upload_destination` / Slack-upload tests), `isort`, `flake8`, `mypy`, `tsc -b`, `vitest`, plus the four diff-scoped gates (brand, changelog-history, focus-cue, harness-parity) run with their base refs exported.


## Pattern harvest

Rule candidate: parity test (the repo's existing guard shape), not semgrep — the defect is an ABSENCE on one branch, which a pattern matcher cannot see.

Pattern: a feature with two sibling egress legs where an authorization rung is applied on the leg that reaches a shared ladder and silently skipped on the leg that is deliberately absent from that ladder's registry. Here `channel_transports` is the registry, `_resolve_mirror_target` is the ladder, and Slack's non-membership is what made both ceilings vanish from its leg while reading as intentional.

Generalizable guard: for each egress leg in `upload_destination`, assert the resolver reaches both the `channels`-scope vet and `uploads_restricted`. That test would have failed on `main` before this change and now passes on both legs, so it is a real ratchet rather than a restatement. The broader lesson for reviewers: "not in the registry" is a routing fact, never an authorization exemption — every registry-absent transport needs its rungs restated by direct call, which is exactly the precedent `chat_compaction_notice._channel_egress_permitted` set and this change follows.


## Round 2 — GPT finding fixed at the shared predicate

GPT flagged (correctly) that the restricted-session ceiling can be bypassed after a gateway restart: for a channel-native key it reads `privacy_mode`'s process-local trackers, which only an INBOUND channel message populates, so a turn no inbound message drove — a cron, a webhook resume, a monitor/auto-nudge re-injection, an explicit `file_send` — reads empty trackers and ships bytes the user's `!incognito` forbade.

Real, and pre-existing in the shared predicate rather than introduced here: `dashboard/handlers/_shared._is_restricted_session` already documents this exact restart gap and calls `privacy_mode.hydrate` to close it.

Fixed in `messaging/upload_gate.uploads_restricted` — the shared predicate — not in `resolve_slack` as the finding suggested. A leg-local hydrate would have fixed the Slack leg and left the channel leg and the renderers' extraction path exposed, re-creating the exact asymmetry this PR exists to remove. `hydrate` is idempotent, allocation-free for an unflagged key, and an in-memory `SessionMap` read rather than disk, so it is safe on the loop at every decision point.

Tests, in `test/test_telegram_parity.py::TestUploadGate`:

- a durable incognito flag with empty trackers is DENIED (the restart case) — revert-verified load-bearing: removing only the `hydrate` call fails this and nothing else
- an unflagged channel key stays ALLOWED — the guard that the restore does not turn the common case into a refusal, passing on both sides

One existing assertion changed: `test_hydration_uses_the_post_rotation_key` compared the hydrate-call list by equality, which pinned an incidental CALL COUNT rather than the key it names. It is now a set comparison, so it still proves the post-rotation key is restored and the pre-rotation one never is, without failing because a second gate on the same turn also runs the idempotent restore.


## Round 3 — rebased onto main, GPT's test-side-effect finding fixed

Rebased onto `origin/main 7eb5d8f94` (33 commits). Clean — no conflicts. Two of those commits touch files this PR also edits (`#7705` rewrote a chunk of `docs/system-specs/modules/security.md`, `#7678` edited `dashboard/handlers/files.py`), and neither collided with these hunks. `test_security_posture.py` (47 tests) passes on the rebased head, so `#7705`'s spec-census changes and this PR's `security.md` addition coexist.

GPT flagged `test/test_telegram_parity.py:1429` under `no-test-side-effects`: `sm.set_flag(...)` leaves a `SessionMap` flush task pending across loop teardown. **Real, and confirmed empirically rather than from the finding text** — `set_flag` → `_save()`, and `_save` on a thread with a running loop takes the `loop.create_task(self._flush_async())` branch, so the async test schedules a debounced flush on its own loop. Running the test alone printed:

```
Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<SessionMap._flush_async() running at src/kiro_crew/session_map.py:568> ...>
```

Fixed with `await sm.aclose()` in a `finally` — `aclose` is `SessionMap`'s documented retirement path, cancelling the registered task and landing any owed snapshot. The leak count on that test is now 0.

Scoped to the one test that mutates: the sibling `test_an_unflagged_channel_key_stays_allowed_after_the_restore` constructs a `SessionMap` but never writes, so `_save` is never reached and there is no task to retire — verified at 0 leaks without a change. Adding `aclose` there too would have been cargo cult.

Worth noting for anyone reading the earlier CI: the leak did **not** reproduce when the whole `TestUploadGate` class ran, only when that test ran alone — the warning fires at GC time, so scheduling decides whether it surfaces. That is an argument for fixing it rather than waiting for it to fail, since the destroyed task lands on whichever test happens to run next.


## Round 4 — the three CI reds were main-side, fixed by rebase

Rebased onto `origin/main 9580a8b98` (27 commits). Clean, payload unchanged at 506 insertions across the same 6 files.

Three FAILUREs on the prior head, none in a file this PR touches:

| Check | Test | Verdict |
|---|---|---|
| Backend Tests (Windows) (3) | `test_session_control.py::test_the_created_agent_name_is_sanitized_before_storage` | main-side, fixed by #7840 |
| Backend Tests (Windows) (3) | `test_session_control.py::test_the_audit_write_does_not_run_on_the_event_loop` | main-side, fixed by #7840 |
| Backend Tests (3.10, 2) | `test_external_logout_detection.py::TestStoreRelocation::test_a_leftover_default_store_is_not_read_when_relocated` | flake, SEL chain-lock contention |

`Coverage Gate` was a cascade of the two backend reds, not an independent failure.

**The two `test_session_control` reds were bisected rather than assumed.** `test/test_session_control.py` run ALONE, with no xdist and no sharding, reproduced both failures on this PR's head — which ruled out shard-membership reshuffling as the cause. The same file then passed on current `origin/main` and failed on `7eb5d8f94`, this PR's own base, with this PR's commit absent. That isolates the cause to the base commit, not to this change.

The mechanism: `dashboard/create_rate_limit.py` holds a process-global `_buckets` dict with a budget of `MAX_SESSION_CREATES_PER_WINDOW = 20`, and `session_control.py:821` refuses the 21st create with `create_rate_limited`. The module ships a `reset_for_tests()` for exactly this, and `test_session_control.py` already resets its OTHER piece of process-wide state (`stop_retry.reset_for_tests()` in an autouse fixture) — but nothing reset the rate limiter, so session-creating tests accumulated across the file until the budget ran out. `77db85951` (#7840, "test: isolate the creation rate limiter's module-level buckets between tests") wires it. Verified: the two files go from 2 failed / 225 passed to 227 passed on the rebased head.

The `test_external_logout_detection` red is a genuine flake, not a main-side fix: no commit in the range touches that test, `kiro_prerequisite`, `hooks`, or `sel`, and the test passes 3/3 in isolation here. Its CI failure carried `OSError: SEL chain lock is held by another writer; refusing to wait for it on the event-loop thread`, so `identity_fingerprint` returned `""` and the assertion read `assert '' != ''` — lock contention between parallel xdist workers, which a rerun clears. Flagging rather than patching, since the contention is in the SEL audit chain and not in this PR's surface.

Local gates on the rebased head: 530 passed on the touched surface, `check_black_formatting` / isort / flake8 clean, mypy clean on 1264 files, and all four diff-scoped gates PASS with `BASE_REF` exported.


## Round 5 — rebased onto main to pick up the fast-uri dependency fix

Rebased onto `origin/main ca55e411a` (22 commits). Clean, still one commit, payload unchanged at 506 insertions across the same 6 files.

`Dependency Audit / Audit Production Dependencies` was the only real FAILURE on the prior head — the other reds were CANCELLED runs from the superseded head. It failed on four high-severity `fast-uri` advisories in `website/electron/package-lock.json`:

```
ERROR: unexcepted high/critical production vulnerabilities:
  website/electron/package-lock.json: fast-uri GHSA-5jgf-p345-68v8 (high) - host confusion via skipped IDN canonicalization on scheme-relative references
  website/electron/package-lock.json: fast-uri GHSA-f65p-4m7j-42xc (high) - SSRF via malformed IPv6 normalization
  website/electron/package-lock.json: fast-uri GHSA-fph4-wmhf-6fwf (high) - SSRF via repeated hostname percent-decoding
  website/electron/package-lock.json: fast-uri GHSA-jqff-g426-hqxp (high) - host confusion via percent-encoded scheme normalization
```

Main-side, not introduced here: this PR touches no dependency manifest at all — its six files are Python, tests, and one spec doc. `0545b668e` (#7936, "fix(deps): unpin fast-uri so the patched 3.1.7 can resolve") landed on main after this branch's base, and is now an ancestor of this head with `fast-uri` resolving to `3.1.7`.

The rebase also carries `51198168b` (#7780, Python floor to 3.12 / 3.10 CI lane dropped), so the `Backend Tests (3.10, ...)` lane that reported the `test_external_logout_detection` SEL chain-lock flake in Round 4 no longer runs.

Local gates on the rebased head: 763 passed across the touched surface plus the two files that were red in Round 4 (`test_session_control.py`, `test_external_logout_detection.py`), isort / flake8 clean, mypy clean on 1264 files, and all five scripted gates PASS (`check_black_formatting`, `check_brand_name`, `check_changelog_history`, `check_focus_cue`, `check_harness_parity`) with `BASE_REF` exported.
