### PR TITLE
fix(ci): respect the jsx-a11y preset's own 'off' entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1297,7 +1297,7 @@ jobs:
         # The ceiling must EQUAL the measured count, not sit above it: slack is
         # silent admission, and a warning that lands inside it never surfaces
         # again. Re-measure with `cd website && npx eslint src/` when burning down.
-        run: npx eslint src/ --max-warnings 659
+        run: npx eslint src/ --max-warnings 609
 
       - name: Copy/paste detection
         working-directory: website

--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -24,7 +24,21 @@ export default [
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
-      ...Object.fromEntries(Object.entries(jsxA11y.configs.recommended.rules || {}).map(([k, v]) => [k, 'warn'])),
+      // Downgrade jsx-a11y's recommended severities to 'warn' so they ride the
+      // --max-warnings ratchet instead of failing the build outright — but keep
+      // whatever the preset switched OFF off. A blanket rewrite to 'warn' also
+      // re-enables the rules the plugin deliberately disabled, which is how 44
+      // `label-has-for` warnings existed: the plugin marks that rule
+      // `deprecated: true, replacedBy: ['label-has-associated-control']` and
+      // ships it as 'off' in recommended, while the live replacement is already
+      // on. Those 44 were noise from a rule nobody chose, consuming ratchet
+      // headroom that a real a11y regression needs.
+      ...Object.fromEntries(
+        Object.entries(jsxA11y.configs.recommended.rules || {}).map(([k, v]) => [
+          k,
+          v === 'off' || v === 0 ? v : 'warn',
+        ]),
+      ),
       'jsx-a11y/no-autofocus': 'off',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',

--- a/website/src/apps/aws-control/DrivePage.tsx
+++ b/website/src/apps/aws-control/DrivePage.tsx
@@ -1706,7 +1706,6 @@ function ShareDialog({ account, section, fileKey, onClose }: { account: string; 
                 </button>
               ))}
             </div>
-            {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule can't see the htmlFor→id link to the custom Input control; label-has-associated-control is satisfied. */}
             <label htmlFor="aws-share-note" className="mb-1 block text-[12px] text-muted">{i18nT('apps.awsControl.console.share_note')}</label>
             <Input id="aws-share-note" value={note} onChange={(e) => setNote(e.target.value)} placeholder={i18nT('apps.awsControl.console.share_note_placeholder')} className="mb-3 w-full" data-testid="share-note" />
             <Btn primary onClick={() => shareMut.mutate()} disabled={shareMut.isPending} data-testid="share-create">

--- a/website/src/apps/crew-companion/PanelViews.tsx
+++ b/website/src/apps/crew-companion/PanelViews.tsx
@@ -209,7 +209,6 @@ const Toggle: React.FC<{
 }> = ({ on, onChange, label, hint }) => {
   const skin = useSkin()
   return (
-    // eslint-disable-next-line jsx-a11y/label-has-for -- input IS nested inside this label; nesting provides the association
     <label style={{
       display: 'flex', alignItems: 'flex-start', gap: 9, padding: '9px 10px',
       // No background/radius of its own: a Toggle may sit alone or grouped with

--- a/website/src/apps/issue-radar/components/CrewEditor.tsx
+++ b/website/src/apps/issue-radar/components/CrewEditor.tsx
@@ -216,7 +216,6 @@ function Field({
           caller passes either the custom `Input` or a `children` expression it
           cannot look inside. `label-has-associated-control`, the rule that
           replaced this deprecated one, is satisfied and stays on. */}
-      {/* eslint-disable-next-line jsx-a11y/label-has-for */}
       <label htmlFor={id} className="block">
         <span className="mb-1.5 block text-[13px] font-semibold text-text">{label}</span>
         {children}
@@ -665,7 +664,6 @@ export default function CrewEditor({ open, onClose, crew }: CrewEditorProps) {
               {/* The label wraps only the INPUT, not the Roll button beside it:
                   an interactive descendant of a label is a second thing to click
                   in one hit area. */}
-              {/* eslint-disable-next-line jsx-a11y/label-has-for -- nested + htmlFor→id both hold; the deprecated rule cannot see through the custom `Input`. */}
               <label htmlFor="crew-editor-name" className="min-w-0 flex-1">
                 <span className="mb-1.5 block text-[13px] font-semibold text-text">
                   {t('apps.issueRadar.views.crews.editor.name_label')}

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -3258,7 +3258,6 @@ function ChatInput({
               <div className="relative shrink-0" ref={plusWrapRef}>
                 {directFilePicker ? (
                   /* Association is intentionally absent while uploads disable the control. */
-                  // eslint-disable-next-line jsx-a11y/label-has-for
                   <label
                     htmlFor={uploading ? undefined : fileInputId}
                     aria-disabled={uploading || undefined}

--- a/website/src/components/FolderConfigModal.tsx
+++ b/website/src/components/FolderConfigModal.tsx
@@ -298,7 +298,6 @@ export default function FolderConfigModal({
           {/* Name. The folder's identity mark is a palette color, applied to
            *  the swatch row below — there is no per-folder icon to preview,
            *  so the name input owns the full width. */}
-          {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule can't see the htmlFor→id link to the custom Input control; label-has-associated-control is satisfied. */}
           <label htmlFor="folder-config-name-input" className="flex flex-col gap-1.5">
             <span className="text-[11.5px] font-semibold text-muted">{i18nT('components.folderConfigModal.name')}</span>
             <Input

--- a/website/src/components/RegistryManager.tsx
+++ b/website/src/components/RegistryManager.tsx
@@ -328,7 +328,6 @@ export default function RegistryManager({ bare = false }: { bare?: boolean } = {
         <div className="mt-4 border border-accent/30 rounded-lg p-4 bg-accent/5 animate-rise">
           <div className="grid grid-cols-[1fr_1fr_0.7fr] gap-3 mb-3 [&>div]:min-w-0">
             <div>
-              {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule can't see the htmlFor→id link to the custom Input control; label-has-associated-control is satisfied. */}
               <label htmlFor="registry-name" className="text-[12px] text-muted mb-1 block">{i18nT('components.registryManager.display_name')}</label>
               <Input
                 id="registry-name"
@@ -339,7 +338,6 @@ export default function RegistryManager({ bare = false }: { bare?: boolean } = {
               />
             </div>
             <div>
-              {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule can't see the htmlFor→id link to the custom Input control; label-has-associated-control is satisfied. */}
               <label htmlFor="registry-repo" className="text-[12px] text-muted mb-1 block">{i18nT('components.registryManager.repo')}</label>
               <Input
                 id="registry-repo"
@@ -357,7 +355,6 @@ export default function RegistryManager({ bare = false }: { bare?: boolean } = {
               />
             </div>
             <div>
-              {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule can't see the htmlFor→id link to the custom Input control; label-has-associated-control is satisfied. */}
               <label htmlFor="registry-branch" className="text-[12px] text-muted mb-1 block">{i18nT('components.registryManager.branch')}</label>
               <Input
                 id="registry-branch"

--- a/website/src/components/SkillForm.tsx
+++ b/website/src/components/SkillForm.tsx
@@ -874,12 +874,10 @@ export default function SkillForm({ data, onChange, hideIdentity, allowRaw = tru
         <div>
           {/* label-has-for can't resolve the control through the custom <Input>
               component; the runtime association via htmlFor + id + aria-label is correct. */}
-          {/* eslint-disable-next-line jsx-a11y/label-has-for */}
           <label htmlFor="skill-name" className="text-[13px] font-semibold text-text mb-1 block">{i18nT('components.skillForm.name')}</label>
           <Input id="skill-name" aria-label={i18nT('components.skillForm.name')} placeholder={i18nT('components.skillForm.e_g_my_tool')} value={data.name} onChange={e => set('name', e.target.value)} className="w-full" />
         </div>
         <div>
-          {/* eslint-disable-next-line jsx-a11y/label-has-for -- control resolved at runtime via htmlFor + id */}
           <label htmlFor="skill-category" className="text-[13px] font-semibold text-text mb-1 block">{i18nT('components.skillForm.category')} <span className="text-muted font-normal">{i18nT('components.skillForm.optional')}</span></label>
           <Input id="skill-category" aria-label={i18nT('components.skillForm.category')} placeholder={i18nT('components.skillForm.e_g_utils_code')} value={data.category} onChange={e => set('category', e.target.value)} className="w-full" />
           <div className="text-[11px] text-muted mt-1">{i18nT('components.skillForm.groups_the_skill_in_the_list_leave_empty_for_the')}</div>
@@ -894,13 +892,11 @@ export default function SkillForm({ data, onChange, hideIdentity, allowRaw = tru
       <div>
         {/* label-has-for can't resolve the control through the custom <Input>
             component; the runtime association via htmlFor + id + aria-label is correct. */}
-        {/* eslint-disable-next-line jsx-a11y/label-has-for */}
         <label htmlFor="skill-triggers" className="text-[13px] font-semibold text-text mb-1 block">{i18nT('components.skillForm.triggers')}</label>
         <Input id="skill-triggers" aria-label={i18nT('components.skillForm.triggers')} placeholder={i18nT('components.skillForm.keyword1_keyword2_keyword3')} value={data.triggers} onChange={e => set('triggers', e.target.value)} className="w-full" />
         <div className="text-[11px] text-muted mt-1">{i18nT('components.skillForm.comma_separated_keywords_that_activate_this_skil')}</div>
       </div>
       <div>
-        {/* eslint-disable-next-line jsx-a11y/label-has-for -- control resolved at runtime via htmlFor + id */}
         <label htmlFor="skill-tags" className="text-[13px] font-semibold text-text mb-1 block">{i18nT('components.skillForm.tags')} <span className="text-muted font-normal">{i18nT('components.skillForm.optional')}</span></label>
         <Input id="skill-tags" aria-label={i18nT('components.skillForm.tags')} placeholder={i18nT('components.skillForm.skill_tool_aws')} value={data.tags} onChange={e => set('tags', e.target.value)} className="w-full" />
         <div className="text-[11px] text-muted mt-1">{i18nT('components.skillForm.comma_separated_labels_for_categorization_metada')}</div>

--- a/website/src/components/themeEditor.tsx
+++ b/website/src/components/themeEditor.tsx
@@ -350,14 +350,12 @@ export function ThemeEditorPanel({ editor }: { editor: ReturnType<typeof useThem
               {/* Control is the custom <Input> (a forwardRef <input>) nested here
                   and linked via htmlFor+id; the deprecated label-has-for rule can't
                   see through the component wrapper, so scope-disable it. */}
-              {/* eslint-disable-next-line jsx-a11y/label-has-for */}
               <label htmlFor="theme-editor-name">
                 <span className="text-[12px] text-muted uppercase tracking-[.04em] mb-1 block">{i18nT('components.themeEditor.theme_name')}</span>
                 <Input id="theme-editor-name" value={themeName} onChange={e => setThemeName(e.target.value)} placeholder={i18nT('components.themeEditor.my_custom_theme')} />
               </label>
             </div>
             <div className="w-16 shrink-0">
-              {/* eslint-disable-next-line jsx-a11y/label-has-for */}
               <label htmlFor="theme-editor-emoji">
                 <span className="text-[12px] text-muted uppercase tracking-[.04em] mb-1 block">{i18nT('components.themeEditor.emoji')}</span>
                 <Input id="theme-editor-emoji" value={themeEmoji} onChange={e => setThemeEmoji(e.target.value)} placeholder="✨" className="text-center !flex-none w-full" />

--- a/website/src/pages/ChannelPage.tsx
+++ b/website/src/pages/ChannelPage.tsx
@@ -361,7 +361,6 @@ function NewChannelDialog({ onClose, onCreate, presets }: { onClose: () => void;
     // which predates this conversion and differs from the rendered title only in
     // case. The eslint disable below covers the label/Input association
     // (label-has-for cannot see through the custom <Input>).
-    /* eslint-disable jsx-a11y/label-has-for */
     <Modal
       open
       onClose={onClose}
@@ -394,7 +393,6 @@ function NewChannelDialog({ onClose, onCreate, presets }: { onClose: () => void;
         ))}
       </div>
     </Modal>
-    /* eslint-enable jsx-a11y/label-has-for */
   )
 }
 

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -2106,7 +2106,6 @@ export default function DevFleetPage() {
             <div style={{ marginBottom: 10 }}>
               <div style={{ fontSize: 10, letterSpacing: '0.08em', color: 'var(--muted)', textTransform: 'uppercase', borderBottom: '1px solid var(--border)', paddingBottom: 3, marginBottom: 4 }}>{i18nT('pages.devFleetPage.remove')}</div>
               {pruneDialog.candidates.filter((c) => c.code !== 'closed').map((c) => (
-                // eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule; the control is nested in the label and carries an aria-label, so it is properly associated.
                 <label key={c.name} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', cursor: 'pointer' }}>
                   <Checkbox checked={pruneSelected.has(c.name)} onChange={(e) => setPruneSelected((prev) => { const next = new Set(prev); if (e.target.checked) next.add(c.name); else next.delete(c.name); return next })} aria-label={i18nT('pages.devFleetPage.select', { name: c.name })} />
                   <span style={{ fontFamily: 'ui-monospace, SF Mono, Menlo, monospace', fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: '1 1 auto', minWidth: 0 }}>{c.name}</span>
@@ -2125,7 +2124,6 @@ export default function DevFleetPage() {
               <div style={{ fontSize: 10, letterSpacing: '0.08em', color: 'var(--warn)', textTransform: 'uppercase', borderBottom: '1px solid var(--border)', paddingBottom: 3, marginBottom: 4 }}>{i18nT('pages.devFleetPage.remove_closed_pr')}</div>
               <p style={{ fontSize: 11, color: 'var(--muted)', margin: '0 0 6px' }}>{i18nT('pages.devFleetPage.closed_pr_not_on_main_hint')}</p>
               {pruneDialog.candidates.filter((c) => c.code === 'closed').map((c) => (
-                // eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule; the control is nested in the label and carries an aria-label, so it is properly associated.
                 <label key={c.name} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', cursor: 'pointer' }}>
                   <Checkbox checked={pruneSelected.has(c.name)} onChange={(e) => setPruneSelected((prev) => { const next = new Set(prev); if (e.target.checked) next.add(c.name); else next.delete(c.name); return next })} aria-label={i18nT('pages.devFleetPage.select', { name: c.name })} />
                   <span style={{ fontFamily: 'ui-monospace, SF Mono, Menlo, monospace', fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: '1 1 auto', minWidth: 0 }}>{c.name}</span>
@@ -2159,7 +2157,6 @@ export default function DevFleetPage() {
                 const disabled = guarded || cannotForce
                 const checked = pruneForceSelected.has(k.name)
                 return (
-                  // eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule; the control is nested in the label and carries an aria-label, so it is properly associated.
                   <label key={k.name} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.6 : 1 }}>
                     {guarded
                       ? <span style={{ width: 13, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><ShieldAlert size={13} style={{ color: 'var(--muted)' }} /></span>

--- a/website/src/pages/KiroCrewAgentsPage.tsx
+++ b/website/src/pages/KiroCrewAgentsPage.tsx
@@ -154,7 +154,6 @@ function WorkspaceForm({
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-1">
               {/* Native input associated via htmlFor+id; label-has-for's nesting requirement is a false positive. */}
-              {/* eslint-disable-next-line jsx-a11y/label-has-for */}
               <label htmlFor="ws-name" className="text-[11px] text-muted uppercase tracking-wider font-medium">{i18nT('pages.kiroCrewAgentsPage.name')}</label>
               <InfoTip text={i18nT('pages.kiroCrewAgentsPage.a_unique_identifier_for_this_workspace_agents_re')} />
             </div>
@@ -163,7 +162,6 @@ function WorkspaceForm({
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-1">
               {/* Native input associated via htmlFor+id; label-has-for's nesting requirement is a false positive. */}
-              {/* eslint-disable-next-line jsx-a11y/label-has-for */}
               <label htmlFor="ws-dir" className="text-[11px] text-muted uppercase tracking-wider font-medium">{i18nT('pages.kiroCrewAgentsPage.directory')}</label>
               <InfoTip text={i18nT('pages.kiroCrewAgentsPage.subdirectory_inside_kiro_crew_where_this_workspa')} />
             </div>

--- a/website/src/pages/SchedulePage.tsx
+++ b/website/src/pages/SchedulePage.tsx
@@ -658,7 +658,6 @@ export default function SchedulePage() {
               <div className="flex items-center gap-2 mb-3 text-[13px] text-muted">
                 <Globe className="lucide-inline" />
                 {/* Control is correctly associated via htmlFor+id (the select can't be nested); label-has-for's nesting requirement is a false positive here. */}
-                {/* eslint-disable-next-line jsx-a11y/label-has-for */}
                 <label htmlFor="schedule-render-tz" className="mr-1">{i18nT('pages.schedulePage.render_in')}</label>
                 <TimezoneSelect id="schedule-render-tz" value={renderTz} onChange={setRenderTz} />
                 <InfoTip text={i18nT('pages.schedulePage.changes_only_how_the_calendar_grid_is_displayed')} />

--- a/website/src/pages/overview/KiroCrewCfgTab.tsx
+++ b/website/src/pages/overview/KiroCrewCfgTab.tsx
@@ -327,7 +327,6 @@ function SubagentSettings({ cfg, onSaved }: { cfg: KiroCrewCfg; onSaved: () => v
         {/* label-has-for flags a label whose only control is a <button>; the
             toggle button is self-labeling (its text is the value) and the label
             wrapper only extends the click target to the row text — intentional. */}
-        {/* eslint-disable-next-line jsx-a11y/label-has-for */}
         <label htmlFor="subagent-orchestrator-mode" className="flex justify-between items-center gap-3 py-1.5 border-b border-border text-sm">
           <span className="text-muted inline-flex items-center gap-1">{i18nT('pages.overview.kiroCrewCfgTab.orchestrator_mode')} <InfoTip text={i18nT('pages.overview.kiroCrewCfgTab.enable_conductor_skill_for_multi_agent_orchestra')} /></span>
           <button id="subagent-orchestrator-mode" aria-label={i18nT('pages.overview.kiroCrewCfgTab.orchestrator_mode')} onClick={() => setConductor(!conductor)}

--- a/website/src/pages/overview/SteeringTab.tsx
+++ b/website/src/pages/overview/SteeringTab.tsx
@@ -665,7 +665,6 @@ export default function SteeringTab() {
             form elements, so its nesting check false-positives on the trigger
             <button> SearchableSelect renders. Same disable as SchedulePage's
             render-timezone label, for the same component family. */}
-        {/* eslint-disable-next-line jsx-a11y/label-has-for */}
         <label className="flex flex-col gap-1" htmlFor="steering-new-scope">
           <span className="text-[13px] text-muted">{i18nT('pages.overview.steeringTab.scope')}</span>
           {/* SearchableSelect, not SimpleSelect: the workspace row is a REAL option

--- a/website/src/pages/overview/WorkflowLibraryTab.tsx
+++ b/website/src/pages/overview/WorkflowLibraryTab.tsx
@@ -483,7 +483,6 @@ export default function WorkflowLibraryTab() {
                 </Btn>
               </div>
               <div className="border-t border-border pt-3">
-                {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule cannot resolve the htmlFor/id link through the shared Input component. */}
                 <label
                   htmlFor="workflow-run-input"
                   className="block text-[12px] text-muted mb-2"
@@ -557,7 +556,6 @@ function WorkflowEditor({
   return (
     <div className="space-y-3">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule cannot resolve the htmlFor/id link through the shared Input component. */}
         <label htmlFor="workflow-name" className="text-[12px] text-muted">
           <span className="block mb-1">
             {i18nT('pages.overview.workflowLibrary.name')}
@@ -569,7 +567,6 @@ function WorkflowEditor({
             onChange={(event) => write('name', event.target.value)}
           />
         </label>
-        {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule cannot resolve the htmlFor/id link through the shared Input component. */}
         <label htmlFor="workflow-slug" className="text-[12px] text-muted">
           <span className="block mb-1">
             {i18nT('pages.overview.workflowLibrary.slug')}
@@ -582,7 +579,6 @@ function WorkflowEditor({
           />
         </label>
       </div>
-      {/* eslint-disable-next-line jsx-a11y/label-has-for -- deprecated rule cannot resolve the htmlFor/id link through the shared Input component. */}
       <label
         htmlFor="workflow-description"
         className="block text-[12px] text-muted"

--- a/website/src/pages/settings/NotificationsPanel.tsx
+++ b/website/src/pages/settings/NotificationsPanel.tsx
@@ -249,7 +249,6 @@ export function NotificationsPanel() {
           />
           <div className="flex flex-col gap-1.5 py-1.5" data-setting-label={i18nT('pages.settings.notificationsPanel.volume')}>
             {/* Slider is correctly associated via htmlFor+id (a range input can't be nested); label-has-for's nesting requirement is a false positive here. */}
-            {/* eslint-disable-next-line jsx-a11y/label-has-for */}
             <label htmlFor="mc-volume-slider" className="text-[13px] font-semibold text-text">{i18nT('pages.settings.notificationsPanel.volume')}</label>
             <div className="text-[12px] text-muted">{Math.round(settings.volume * 100)}%</div>
             <input

--- a/website/src/pages/settings/SecurityPanel.tsx
+++ b/website/src/pages/settings/SecurityPanel.tsx
@@ -1841,7 +1841,6 @@ function DeniedCommandsSection({ draft, onDraftChange, noteDraft, onNoteDraftCha
           <AlertTriangle size={18} className="text-warn shrink-0 mt-0.5" />
           <div className="text-[13px] text-text leading-relaxed">{confirmBody}</div>
         </div>
-        {/* eslint-disable-next-line jsx-a11y/label-has-for -- the Checkbox control is nested inside the label */}
         <label className="flex items-center gap-2.5 mt-4 cursor-pointer">
           <Checkbox checked={ack} onChange={e => setAck(e.target.checked)} />
           <span className="text-[13px] text-text">{i18nT('pages.settings.securityPanel.i_understand_this_weakens_kirocrew_s_protection')}</span>


### PR DESCRIPTION
## The bug

`website/eslint.config.js` spreads jsx-a11y's recommended preset and rewrites
**every** entry to `'warn'`:

```js
...Object.fromEntries(Object.entries(jsxA11y.configs.recommended.rules || {})
  .map(([k, v]) => [k, 'warn'])),
```

The intent is right — a11y findings should ride the `--max-warnings` ratchet
instead of failing the build outright. But the rewrite discards `v`, so it also
turns back **on** the rules the preset deliberately ships as `'off'`.

Two rules are `'off'` in the preset. One of them is `label-has-for`, which the
plugin itself marks:

```js
// node_modules/eslint-plugin-jsx-a11y/lib/rules/label-has-for.js
deprecated: true,
replacedBy: ['label-has-associated-control'],
```

The preset switched it off and enabled `label-has-associated-control` in its
place; our severity rewrite resurrected the deprecated one. That is where **44 of
the tree's 653 warnings** came from — a rule nobody in this repo chose, whose
live replacement is already running, holding 44 slots of ratchet headroom that a
real a11y regression needs. (The other `'off'` rule, `anchor-ambiguous-text`, has
0 violations, so respecting the preset costs nothing there.)

Nesting the control inside the `<label>` — what most of those 44 sites do — is
valid HTML and passes `label-has-associated-control`. The warnings were not
telling us about broken labels.

## The fix

```js
.map(([k, v]) => [k, v === 'off' || v === 0 ? v : 'warn'])
```

Preserve `'off'`, downgrade only what the preset actually enables. Nothing about
a11y coverage weakens: every rule the preset turns on stays on, at `'warn'` as
before.

Then the two consequences, both mechanical:

- **31 `eslint-disable` directives become dead** and are removed. They suppressed
  `label-has-for` at sites where it is no longer reported, so eslint flags each
  as `Unused eslint-disable directive` — which is itself a warning, and is why
  respecting the preset only nets 44 rather than 75. One block-scope
  `/* eslint-disable */` had a matching `/* eslint-enable */`; the pair is
  removed together. Each removal was identified by eslint's own
  `--format json` output, not by reading the source.
- **The ceiling drops 659 → 609**, because the workflow's own rule requires it:

  > The ceiling must EQUAL the measured count, not sit above it: slack is silent
  > admission, and a warning that lands inside it never surfaces again.

  Leaving 659 against a 609 tree would hand the next 50 warnings a free pass.

Deliberately kept: the `no-eval` directive in `crew-ghost-sprite.gen.mjs`. It is
"unused" only because `no-eval` is not enabled for `.mjs`, while the `eval()` it
annotates is real — deleting it would remove a true statement about the code and
let the warning return silently if the config ever covers `.mjs`.

<!-- no-visual-delta -->

**Why no screenshot:** every `website/src` edit deletes an `eslint-disable`
comment; no JSX, styles, or rendered output change, and `npx tsc -b` plus the
eslint count are the whole observable effect.

## Verification

Measured on pristine `origin/main` first, then on this branch:

| | main | this branch |
|---|---|---|
| `npx eslint src/` | 653 warnings, 0 errors | **609 warnings, 0 errors** |
| `--max-warnings <ceiling>` | 659, passes with 6 slack | **609, passes with 0 slack** |
| one tighter (`--max-warnings 608`) | — | fails, i.e. the ceiling equals the count |
| `npx tsc -b` | pass | pass |
| `npx jscpd .` | pass | pass (0 clones) |
| `npm run i18n:check` | pass | pass |

## Pattern harvest

Rule candidate: semgrep — flag a preset spread whose severity rewrite discards
the original value.

Pattern: `Object.entries(<plugin>.configs.<preset>.rules).map(([k, v]) => [k,
'<severity>'])` where `v` is bound but unused. A preset's `'off'` entries are
decisions ("this rule is deprecated / superseded"), not defaults awaiting a
house style, so a blanket rewrite silently adopts rules the plugin retired. The
defect is invisible by construction: the resurrected rule's output is
indistinguishable from any other warning inside a numeric budget, which is
exactly how 44 of them sat unnoticed until the ceiling was one over.

Not generalizable beyond that: the *deprecation* of `label-has-for` is a
one-off, but the config shape that resurrected it is not — the same three-line
idiom is the standard way to downgrade a preset, so any repo doing it has the
same latent bug.
