### PR TITLE
fix(feishu): log unsupported inbound message types

### DIFF
--- a/src/kiro_crew/feishu/client.py
+++ b/src/kiro_crew/feishu/client.py
@@ -259,8 +259,11 @@ class LarkClient:
         # message can be evicted from. Dedup lives in ``receive`` immediately
         # after authorization instead.
 
-        # Only handle plain-text messages for now.
-        if (message.message_type or "") != "text":
+        # Only handle plain-text messages for now. Record the platform type so
+        # an intentional drop is distinguishable from a broken WS connection.
+        message_type = message.message_type or "<missing>"
+        if message_type != "text":
+            logger.info("Feishu inbound ignored unsupported message type: %s", message_type)
             return
 
         sender = getattr(event, "sender", None)

--- a/test/test_feishu_client.py
+++ b/test/test_feishu_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import pathlib
 import sys
 import threading
@@ -622,7 +623,7 @@ class TestHandleReceiveV1:
         assert inbound.chat_id == "chat-99"
 
     @pytest.mark.asyncio
-    async def test_non_text_message_type_ignored(self) -> None:
+    async def test_non_text_message_type_ignored(self, caplog: pytest.LogCaptureFixture) -> None:
         from kiro_crew.feishu.client import LarkClient
 
         received: list[Any] = []
@@ -634,10 +635,12 @@ class TestHandleReceiveV1:
         client._loop = asyncio.get_running_loop()
 
         data = _make_event(message_id="img-1", message_type="image")
-        client._handle_receive_v1(data)
+        with caplog.at_level(logging.INFO, logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(data)
         await asyncio.sleep(0.05)
 
         assert len(received) == 0
+        assert caplog.messages == ["Feishu inbound ignored unsupported message type: image"]
 
     @pytest.mark.asyncio
     async def test_no_open_id_ignored(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

Feishu acknowledges unsupported inbound message types such as images, stickers, and files, but `LarkClient` silently returns before the dispatcher sees them. Operators therefore cannot distinguish an intentional type filter from a broken WebSocket connection or missing event subscription.

## Why it matters

Plain-text traffic continues to work while unsupported events disappear without any local trace. That makes a healthy channel look disconnected and turns a simple content-type diagnosis into investigation of credentials, permissions, and transport health.

## What changed (motivation → approach → change)

The existing text-only behavior remains unchanged. Before returning for a non-text frame, the client now logs one payload-free informational diagnostic containing only Feishu's message type. Message IDs, sender IDs, and content are not logged.

The existing non-text regression test now also pins the diagnostic while continuing to prove the event is not dispatched.

## Tests

- Deterministic red-before: the exact non-text test failed because the captured log list was empty.
- Focused green: the complete `TestHandleReceiveV1` class passed, 5/5.
- Touched-file Black, isort, and flake8 passed.
- Production-file mypy passed.
- `git diff --check` passed.

## Manual verification

N/A — the focused test passes a real normalized non-text event through the synchronous receive handler and verifies both the drop and emitted diagnostic without requiring external Feishu credentials.

## Related Issues

Fixes #7520

## Pattern harvest

Rule candidate: review-prompt
Pattern: intentional inbound filters should leave a payload-free reason diagnostic before dropping an acknowledged platform event.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no documented behavior changed
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
