### PR TITLE
refactor(test): drop dead bindings flagged by no-unused-vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1323,7 +1323,7 @@ jobs:
         # The ceiling must EQUAL the measured count, not sit above it: slack is
         # silent admission, and a warning that lands inside it never surfaces
         # again. Re-measure with `cd website && npx eslint src/` when burning down.
-        run: npx eslint src/ --max-warnings 609
+        run: npx eslint src/ --max-warnings 584
 
       - name: Copy/paste detection
         working-directory: website

--- a/website/src/components/PrivacyChapter.cov80.test.tsx
+++ b/website/src/components/PrivacyChapter.cov80.test.tsx
@@ -1,7 +1,6 @@
 import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '../test/helpers'
 import PrivacyChapter from './PrivacyChapter'
-import { api } from '../api/client'
 
 vi.mock('../api/client', async importOriginal => {
   const mod = await importOriginal<typeof import('../api/client')>()

--- a/website/src/components/SendToInstanceSubmenu.cov80.test.tsx
+++ b/website/src/components/SendToInstanceSubmenu.cov80.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '../test/helpers'
 import SendToInstanceSubmenu from './SendToInstanceSubmenu'
 import { api } from '../api/client'

--- a/website/src/test/ChatPageMoreCoverage.test.tsx
+++ b/website/src/test/ChatPageMoreCoverage.test.tsx
@@ -538,7 +538,7 @@ describe('ChatPage window-event listeners', () => {
   })
 
   it('answers a run-in-terminal request exactly once, carrying its reqId back', async () => {
-    const { store } = await renderTurn()
+    await renderTurn()
     const results: { reqId?: string; ok?: boolean }[] = []
     const onResult = (e: Event) => { results.push((e as CustomEvent).detail) }
     window.addEventListener('mc:run-in-terminal-result', onResult)

--- a/website/src/test/CodeReviewSagePrSource.test.tsx
+++ b/website/src/test/CodeReviewSagePrSource.test.tsx
@@ -3,7 +3,6 @@
 // These are pure given a PullRequestSource, so they are tested directly; the tab
 // bar that hosts them (and the single shared query behind it) is covered in
 // CodeReviewSageShell.test.tsx.
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
@@ -14,14 +13,6 @@ import PrStatusChips from '../apps/code-review-sage/components/PrStatusChips'
 import type { PullRequestSource } from '../types'
 
 const URL_ = 'https://github.com/acme/widgets/pull/7'
-
-/** The comments tab posts replies, so it needs a query client for its mutations. */
-function renderComments(src: PullRequestSource) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(
-    <QueryClientProvider client={qc}><PartialNote src={src} /></QueryClientProvider>,
-  )
-}
 
 function source(over: Partial<PullRequestSource> = {}): PullRequestSource {
   return {

--- a/website/src/test/CrewCompanionBubbleLayout.test.ts
+++ b/website/src/test/CrewCompanionBubbleLayout.test.ts
@@ -439,11 +439,7 @@ describe('pickBubblePlacementWithinBounds', () => {
           }
 
           // Use a deterministic random that returns the fixed value
-          let callCount = 0
-          const fixedRandom = () => {
-            callCount++
-            return randomVal
-          }
+          const fixedRandom = () => randomVal
 
           const result = pickBubblePlacementWithinBounds(anchor, bw, bh, boundsRect, {
             random: fixedRandom,

--- a/website/src/test/CrewEditorSelect.test.tsx
+++ b/website/src/test/CrewEditorSelect.test.tsx
@@ -128,7 +128,6 @@ vi.mock('../components/SimpleSelect', () => ({
 
 
 import KiroCrewAgentsPage from '../pages/KiroCrewAgentsPage'
-import CrewAvatar from '../components/CrewAvatar'
 
 function createTestStore() {
   return configureStore({

--- a/website/src/test/DesignTweakHistoryCov80.test.tsx
+++ b/website/src/test/DesignTweakHistoryCov80.test.tsx
@@ -7,8 +7,7 @@
  * exercise the component's actual branching, not just bump statement counts.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { screen, waitFor, fireEvent, within, act } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import DesignTweak from '../apps/design-tweak/DesignTweakPage'
 import { renderWithProviders } from './helpers'
 import { i18nT } from '../i18n/t'

--- a/website/src/test/KnowledgeSettingsTab.test.tsx
+++ b/website/src/test/KnowledgeSettingsTab.test.tsx
@@ -47,11 +47,6 @@ function wrap() {
   )
 }
 
-async function settledInput(label: string): Promise<HTMLInputElement> {
-  const el = await screen.findByLabelText(label, {}, { timeout: 3000 })
-  return el as HTMLInputElement
-}
-
 function rejectOnce(mock: ReturnType<typeof vi.fn>) {
   mock.mockRejectedValueOnce(new Error('fail'))
 }

--- a/website/src/test/MarkdownRenderer.inlineCodeCopy.test.tsx
+++ b/website/src/test/MarkdownRenderer.inlineCodeCopy.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, fireEvent, act, waitFor, screen } from '@testing-library/react'
+import { render, fireEvent, act, screen } from '@testing-library/react'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import { copyToClipboard } from '../utils/clipboard'
 

--- a/website/src/test/OverlayDrawer.morph.test.tsx
+++ b/website/src/test/OverlayDrawer.morph.test.tsx
@@ -29,7 +29,7 @@ vi.mock('framer-motion', async () => {
   const React = await import('react')
   const make = (tag: string) =>
     React.forwardRef((props: any, ref: any) => {
-      const { children, initial, animate, exit, transition, ...rest } = props
+      const { children, initial, animate, exit, transition: _transition, ...rest } = props
       return React.createElement(tag, {
         ...rest,
         ref,

--- a/website/src/test/SessionFlyout.test.tsx
+++ b/website/src/test/SessionFlyout.test.tsx
@@ -18,7 +18,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent, within } from '@testing-library/react'
 import type { ChatSlot } from '../types'
-import SessionFlyout, { FLYOUT_MAX_ROWS, TOGGLE_RECT, toggleClip, FULL_CLIP } from '../pages/chat/SessionFlyout'
+import SessionFlyout, { FLYOUT_MAX_ROWS, toggleClip, FULL_CLIP } from '../pages/chat/SessionFlyout'
 
 // Render framer-motion elements as plain DOM (jsdom can't run projection).
 vi.mock('framer-motion', async () => {

--- a/website/src/test/SettingsRemoteCrewPanelCoverage.test.tsx
+++ b/website/src/test/SettingsRemoteCrewPanelCoverage.test.tsx
@@ -1048,7 +1048,7 @@ describe('RemoteCrewPanel — editing a crew', () => {
     })
     await u.click(screen.getByRole('button', { name: /Set up a new one/i }))
     await u.click(screen.getByRole('button', { name: /Your instances/i }))
-    const reopened = within(await screen.findByRole('group', { name: /Edit dev-box-1/i }))
+    await screen.findByRole('group', { name: /Edit dev-box-1/i })
 
     // The port moved externally, which is a machine coordinate, so the save is
     // withheld until the user adopts the current record. The point of the test

--- a/website/src/test/UpdateNudgeDot.test.tsx
+++ b/website/src/test/UpdateNudgeDot.test.tsx
@@ -1,6 +1,6 @@
 // Update nudge dots: the desktopUpdateAvailable flag, its mirroring from
 // Electron update-state events, and the dot rendering in SidePanelLayout tabs.
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'

--- a/website/src/test/UseVirtualChatCoverage.test.tsx
+++ b/website/src/test/UseVirtualChatCoverage.test.tsx
@@ -53,14 +53,6 @@ function makeScroller(initial: Geom, opts: { withScrollTo?: boolean } = {}) {
   return { el, state, writes }
 }
 
-/** Pin an element's rect so the header-offset derivation is deterministic. */
-function stubRectTop(node: HTMLElement, top: number) {
-  node.getBoundingClientRect = (() => ({
-    top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top,
-    toJSON: () => ({}),
-  })) as HTMLElement['getBoundingClientRect']
-}
-
 interface Item { id: string }
 const getKey = (it: Item) => it.id
 const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))

--- a/website/src/test/UseWebSocketCoverage.test.tsx
+++ b/website/src/test/UseWebSocketCoverage.test.tsx
@@ -27,7 +27,7 @@ import {
 } from '../hooks/useWebSocket'
 import { api } from '../api/client'
 import { store as globalStore } from '../store'
-import chatReducer, { setActiveSlot, clearMessages, sseChatMessage, sseActivityEvent, setQuestionCard, resolveQuestionCard, appendMessage } from '../store/chatSlice'
+import chatReducer, { setActiveSlot, clearMessages, sseChatMessage, sseActivityEvent, setQuestionCard, resolveQuestionCard } from '../store/chatSlice'
 import { sseSlots } from '../store/dashboardSlice'
 import { addNotification, removeNotificationByTs } from '../store/notificationsSlice'
 import type { ChatSlot } from '../types'

--- a/website/src/test/boardFolderCollapse.test.ts
+++ b/website/src/test/boardFolderCollapse.test.ts
@@ -5,7 +5,7 @@
  *  a programmatic expansion, so a failed-and-rolled-back server expand cannot
  *  surprise-collapse a column that was explicitly opened. */
 import { describe, it, expect, beforeEach } from 'vitest'
-import { boardCollapseKey, boardColumnFromDroppableId, loadBoardFolderCollapse, persistBoardOverride, persistClearFolderOverrides, clearFolderOverrides } from '../utils/boardFolderCollapse'
+import { boardColumnFromDroppableId, loadBoardFolderCollapse, persistBoardOverride, persistClearFolderOverrides, clearFolderOverrides } from '../utils/boardFolderCollapse'
 
 beforeEach(() => localStorage.clear())
 

--- a/website/src/test/extensionSeams.test.tsx
+++ b/website/src/test/extensionSeams.test.tsx
@@ -43,7 +43,6 @@ import {
   registerMobileConnectRenderer,
   getMobileConnectRenderers,
   canRenderMobileConnectKind,
-  BUILTIN_MOBILE_CONNECT_KINDS,
 } from '../components/mobileConnectRenderers'
 import { apiTransport } from '../api/apiTransport'
 // Importing the client installs the blessed transport (installApiTransport runs

--- a/website/src/test/issueRadarNarrowViewport.test.ts
+++ b/website/src/test/issueRadarNarrowViewport.test.ts
@@ -164,7 +164,7 @@ describe('Issue Radar at narrow widths', () => {
   })
 
   it('names the LIST in the Back control, not one item from it', async () => {
-    const s = await shell()
+    await shell()
     // `changeRequestTitle` is singular ("Pull Request") and reads as the item you
     // are looking at; Back returns to the list, which is the plural.
     // The PR pane owns its own Back control now, so the label lives there.

--- a/website/src/test/noPageZoom.test.ts
+++ b/website/src/test/noPageZoom.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { readFile, glob } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { installPageZoomSuppression } from '../utils/pageZoom'
 

--- a/website/src/test/tipsApi.test.ts
+++ b/website/src/test/tipsApi.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { checkSessionExpired, __resetAuthRecoveryStateForTests } from '../api/client'
+import { __resetAuthRecoveryStateForTests } from '../api/client'
 
 // We test that the tips API calls go through the shared response handler by
 // verifying the exported api.tipsNext / api.tipsStatus surface the proper
@@ -45,7 +45,7 @@ describe('tips API auth recovery (jNullable)', () => {
     fetchMock.mockResolvedValue(
       new Response('Internal Server Error', { status: 500, headers: { 'content-type': 'text/plain' } }),
     )
-    const { api, ApiError } = await import('../api/client')
+    const { api } = await import('../api/client')
     await expect(api.tipsStatus()).rejects.toThrow()
   })
 

--- a/website/src/test/useIsTouchDevice.test.ts
+++ b/website/src/test/useIsTouchDevice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useIsTouchDevice } from '../hooks/useIsTouchDevice'
 


### PR DESCRIPTION
Burns the `@typescript-eslint/no-unused-vars` bucket to zero — 24 warnings across
21 test files — and ratchets the CI eslint ceiling from **609 to 584**, the
measured count.

The ceiling equals the measured count in both directions:

```
$ npx eslint src/ --max-warnings 584   # exit 0
$ npx eslint src/ --max-warnings 583   # exit 1
```

### What the diff actually does

Nothing here changes what a test exercises. Three shapes:

- **Unused import specifiers** (`vi`, `waitFor`, `glob`, `within`, `act`,
  `userEvent`, `QueryClientProvider`, `boardCollapseKey`, `appendMessage`,
  `BUILTIN_MOBILE_CONNECT_KINDS`, `TOGGLE_RECT`, `CrewAvatar`, `api`, `render`,
  `checkSessionExpired`) — dropped from the import list.
- **Dead local helpers and counters** (`renderComments`, `settledInput`,
  `stubRectTop`, `callCount`) — zero call sites, verified per name with a
  file-wide grep before deletion.
- **Bindings whose initializer calls something** — the binding goes, the call
  stays. `const { store } = await renderTurn()` becomes `await renderTurn()`;
  deleting the statement would have removed the render the test then asserts
  against. Same for `const s = await shell()` and
  `const { api, ApiError } = await import('../api/client')`.

Two special cases worth a reviewer's eye:

- `OverlayDrawer.morph.test.tsx` destructures `transition` **alongside a rest
  element** in the framer-motion mock. Deleting it would leak `transition` into
  `...rest` and onto the DOM node, so it is renamed `_transition` — the eslint
  config's `varsIgnorePattern: '^_'` covers it and the exclusion stays real.
- `within(await screen.findByRole(...))` in `SettingsRemoteCrewPanelCoverage`
  discarded its result, so the `within` was pure and dead while the `await` was
  the load-bearing wait. The await stays, the wrapper goes.

### Verification

| Gate | Result |
|---|---|
| `npx eslint src/ --max-warnings 584` | exit 0 |
| `npx eslint src/ --max-warnings 583` | exit 1 (ceiling == count) |
| `npx tsc -b` | clean |
| `npx jscpd .` | 0 clones |
| `npm run i18n:check` | exit 0 |
| `npx vitest run` on the 22 affected files | 439 tests passed |

Every edit was also re-read by an independent adversarial pass whose only job was
to find a deleted call, a dropped `await`, a still-used identifier, or syntax
damage. It came back clean on all four batches.

<!-- no-visual-delta -->
**Why no screenshot:** test-only edits plus one CI ceiling number. No component,
style, string, or rendered markup is touched, so there is no visual delta to
capture.

## Pattern harvest

Rule candidate: an unused-variable fix must preserve the initializer's call. `const x = doThing()` with `x` unused is a dead *binding*, not a dead *statement* — `doThing()` may render, install a mock, or flush effects, and deleting the line silently shrinks what the test covers. The mechanical fix is to rewrite to a bare expression statement, never to delete.

Not generalizable: the `_transition` rename is specific to object destructuring that sits alongside a rest element, where the binding's only job is to *exclude* a key from `...rest`. There the variable is load-bearing precisely because it is unused, and an underscore prefix is the correct answer rather than a workaround.
