### PR TITLE
fix(voice): read and write synthesized audio off the gateway event loop

### DIFF
--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -39,6 +39,37 @@ from kiro_crew.voice_reply import (
 logger = logging.getLogger(__name__)
 
 
+# Synthesized audio is read and written WHOLE, and its size scales with the
+# length of the reply being spoken — a Piper clip is uncompressed WAV, so a
+# minute of speech is megabytes. AUTOSDE `no-blocking-call-on-event-loop` names
+# "large synchronous file IO" as something that must not run on the gateway's
+# single loop, where it stalls every other session — and the heartbeat — for the
+# duration of the transfer. These two helpers hold the blocking halves; every
+# caller reaches them through `asyncio.to_thread`, the same seam this module
+# already uses for `resolve_polly_cli`.
+
+
+def _spill_chunk(mp3_bytes: bytes) -> str:
+    """Write one synthesized chunk to a temp file and return its path.
+
+    Blocking by design — call it through ``asyncio.to_thread``. ``os.close`` on
+    the ``mkstemp`` descriptor is in here for the same reason the write is: the
+    same AUTOSDE rule names it, and splitting the pair would leave a bare
+    descriptor owned by neither side.
+    """
+    fd, chunk_path = tempfile.mkstemp(suffix=".mp3")
+    os.close(fd)
+    with open(chunk_path, "wb") as f:
+        f.write(mp3_bytes)
+    return chunk_path
+
+
+def _read_audio(path: str) -> bytes:
+    """Read a synthesized clip whole. Blocking — call it through ``to_thread``."""
+    with open(path, "rb") as f:
+        return f.read()
+
+
 async def api_voice_config(request: web.Request) -> web.Response:
     """GET/PUT /api/voice/config — read or update voice settings."""
     if request.method == "GET":
@@ -186,11 +217,7 @@ async def api_voice_synthesize(request: web.Request) -> web.Response:
             region=_vc.region,
         ):
             # Save chunk for stitching
-
-            fd, chunk_path = tempfile.mkstemp(suffix=".mp3")
-            os.close(fd)
-            with open(chunk_path, "wb") as f:
-                f.write(mp3_bytes)
+            chunk_path = await asyncio.to_thread(_spill_chunk, mp3_bytes)
             chunk_paths.append(chunk_path)
 
             # Broadcast to dashboard for immediate playback
@@ -208,8 +235,7 @@ async def api_voice_synthesize(request: web.Request) -> web.Response:
         if chunk_paths:
             final_path = await stitch_mp3s(chunk_paths)
             if final_path:
-                with open(final_path, "rb") as f:
-                    final_bytes = f.read()
+                final_bytes = await asyncio.to_thread(_read_audio, final_path)
                 state.broadcast_ws(
                     "voice_complete",
                     {
@@ -264,8 +290,8 @@ async def _synthesize_nonstreaming(
             msg = "Piper TTS unavailable — check the piper binary and model path in Voice settings."
             state.broadcast_ws("voice_error", {"slot": slot_key, "error": msg})
             return web.json_response({"ok": False, "error": msg}, status=502)
-        with open(audio_path, "rb") as f:
-            audio_b64 = base64.b64encode(f.read()).decode()
+        audio_bytes = await asyncio.to_thread(_read_audio, audio_path)
+        audio_b64 = base64.b64encode(audio_bytes).decode()
         state.broadcast_ws(
             "voice_chunk",
             {

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import builtins
 import json
+import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -471,6 +473,127 @@ class TestVoiceSynthesize:
             assert data["ok"] is True
             assert data["chunks"] == 1
         state.broadcast_ws.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_the_piper_clip_is_read_off_the_event_loop(self, tmp_path, monkeypatch):
+        """AUTOSDE `no-blocking-call-on-event-loop`, Piper path.
+
+        Piper returns an UNCOMPRESSED wav whose size scales with the length of
+        the reply, and this handler reads it whole before base64-ing it. The
+        gateway runs every session on one loop, so a synchronous read here
+        stalls every other chat turn — and the liveness heartbeat — for as long
+        as the transfer takes.
+
+        The probe is the read itself: `open` is wrapped for this one path and
+        records the thread it was called on. Comparing that against the thread
+        running this coroutine is exact — no sleeping, no timing threshold.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            provider="piper", default_voice="Ruth", default_engine="generative",
+            default_rate="100%", default_pitch="0%", aws_profile="", region="",
+            piper_binary="", piper_model="~/m.onnx", piper_model_config="",
+            piper_length_scale=1.0,
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+
+        wav = tmp_path / "out.wav"
+        wav.write_bytes(b"RIFF....WAVEfake-audio-bytes")
+
+        async def _fake_synth(text, **kw):
+            return str(wav)
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.synthesize_speech", _fake_synth)
+
+        loop_thread = threading.get_ident()
+        read_threads: list[int] = []
+        real_open = builtins.open
+
+        def _watch_open(file, *args, **kwargs):
+            # Delegate everything; only the clip's own read is recorded, so
+            # nothing else in the request path is disturbed.
+            if str(file) == str(wav):
+                read_threads.append(threading.get_ident())
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", _watch_open)
+
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            resp = await client.post("/api/voice/synthesize", json={"text": "hello", "slot": "s1"})
+            assert resp.status == 200
+
+        assert read_threads, "the clip was never read — the probe did not fire"
+        assert loop_thread not in read_threads, (
+            "the synthesized clip was read on the gateway event loop "
+            f"(thread {loop_thread}); every other session blocks for the "
+            "length of that read"
+        )
+        # Positive control in the same test: the audio still reaches the client,
+        # so the assertion above is about WHERE the read happened, not about a
+        # read that silently stopped happening.
+        payloads = [c.args[1] for c in state.broadcast_ws.call_args_list]
+        assert any(p.get("audio") for p in payloads)
+
+    @pytest.mark.asyncio
+    async def test_the_polly_chunks_are_written_and_read_off_the_event_loop(
+        self, tmp_path, monkeypatch
+    ):
+        """Same rule, streaming path — and it is the worse of the two.
+
+        The chunk spill runs once per SENTENCE inside the streaming loop, so a
+        long reply blocks the loop repeatedly, and the stitched mp3 is then read
+        whole on top of that.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            provider="polly", default_voice="Joanna", default_engine="neural",
+            default_rate="100%", default_pitch="0%", aws_profile="", region="us-east-1",
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+
+        async def _mock_stream(*a, **kw):
+            yield 0, "Hello", b"\x00\x01\x02"
+            yield 1, "Again", b"\x03\x04\x05"
+
+        final = tmp_path / "final.mp3"
+        final.write_bytes(b"ID3stitched-audio")
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.streaming_voice_reply", _mock_stream)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_voice.stitch_mp3s", AsyncMock(return_value=str(final))
+        )
+
+        loop_thread = threading.get_ident()
+        audio_io_threads: list[int] = []
+        real_open = builtins.open
+
+        def _watch_open(file, *args, **kwargs):
+            # Both the per-sentence chunk spill and the stitched read are `.mp3`;
+            # the chunk path is chosen by mkstemp, so match on the suffix rather
+            # than on a path the test cannot know in advance.
+            if str(file).endswith(".mp3"):
+                audio_io_threads.append(threading.get_ident())
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", _watch_open)
+
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            resp = await client.post("/api/voice/synthesize", json={"text": "Hello. Again.", "slot": "s1"})
+            assert resp.status == 200
+            assert (await resp.json())["chunks"] == 2
+
+        # Two chunk writes plus the stitched read: the probe must have seen all
+        # three, otherwise "not on the loop" would be vacuously true.
+        assert len(audio_io_threads) == 3, (
+            f"expected 2 chunk writes + 1 stitched read, saw {len(audio_io_threads)}"
+        )
+        assert loop_thread not in audio_io_threads, (
+            "synthesized audio was written or read on the gateway event loop "
+            f"(thread {loop_thread})"
+        )
 
     @pytest.mark.asyncio
     async def test_synthesize_exception_returns_500_and_broadcasts_error(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/dashboard/chat_voice.py` moves whole synthesized audio payloads through
**synchronous** file IO inside `async` request handlers, so all of it runs on the gateway's
event loop:

```python
# api_voice_synthesize — once per SENTENCE, inside the streaming loop
fd, chunk_path = tempfile.mkstemp(suffix=".mp3")
os.close(fd)
with open(chunk_path, "wb") as f:
    f.write(mp3_bytes)
...
# the stitched result
with open(final_path, "rb") as f:
    final_bytes = f.read()

# _synthesize_nonstreaming — the Piper clip
with open(audio_path, "rb") as f:
    audio_b64 = base64.b64encode(f.read()).decode()
```

`AUTOSDE.yaml`'s `no-blocking-call-on-event-loop` (`blocking: true`, file-patterns
`src/kiro_crew/**/*.py`) names both of the primitives used here:

> Calls that block in the kernel and MUST NOT run on the loop: … `os.close()` on a file
> descriptor … large synchronous file IO or filesystem walks

and states the consequence directly: *"a single blocking call there freezes every task —
the user's chat turn AND the liveness heartbeat."*

## Why it matters

These are not incidental small reads; their size is a function of how much the assistant
just said.

- **Piper returns uncompressed WAV.** A minute of 16-bit mono speech is megabytes, and
  `_synthesize_nonstreaming` reads the whole clip in one call before encoding it. Longer
  reply → longer stall.
- **The chunk spill runs once per sentence**, inside the `async for` over
  `streaming_voice_reply`, so a long reply blocks the loop repeatedly rather than once —
  and then the stitched mp3 is read whole on top of that.
- Auto-speak makes this the default path rather than an occasional one, so the stall lands
  on ordinary use, not on an edge case.

Everything else the gateway is doing — every other session's chat turn, and the heartbeat
the watchdog reads — is stopped for the duration.

## What changed (motivation → approach → change)

Symptom: whole-payload audio IO on the event loop. Root cause: three call sites that were
written synchronously. Fix: move exactly those three behind the seam this module **already
uses**, one line above the code being changed:

```python
aws_bin = await asyncio.to_thread(resolve_polly_cli)   # existing, unchanged
```

Two small blocking helpers hold the file work, and every caller reaches them through
`asyncio.to_thread`:

```python
def _spill_chunk(mp3_bytes: bytes) -> str:
    fd, chunk_path = tempfile.mkstemp(suffix=".mp3")
    os.close(fd)
    with open(chunk_path, "wb") as f:
        f.write(mp3_bytes)
    return chunk_path


def _read_audio(path: str) -> bytes:
    with open(path, "rb") as f:
        return f.read()
```

`os.close` on the `mkstemp` descriptor moves **with** the write rather than being left
behind: the same rule names it, and splitting the pair would leave a bare descriptor owned
by neither side.

**Nothing else changes.** No new state, no config key, no route, no change to what is
broadcast, and no change to the response shape. The bodies of the moved blocks are the
original lines, so the diff is a relocation plus three `await`s.

**Scope boundary, stated rather than left for a reviewer to ask.** Two other synchronous
file operations in this module are deliberately **not** touched:

- **`os.unlink` in each `finally`.** Unlink is a metadata call whose cost does not scale
  with the payload, so it is not part of the condition this fixes. It is also the temp-file
  lifecycle, which is a separate and actively-worked surface; folding it in would mix a
  latency fix with a cleanup-semantics change.
- **The `api_voice_config` read/write of `config.json`.** A settings blob is bounded and
  small, so it does not meet the "large synchronous file IO" condition this PR is built on.
  Claiming it as the same defect would be claiming more than the evidence shows.

## Tests

Two regressions in `test/test_chat_voice.py`, one per handler, reusing the file's existing
`_make_voice_app` / `TestClient` harness.

The probe is the read itself: `open` is wrapped for the audio paths only — delegating
everything else untouched — and records `threading.get_ident()`. That is compared against
the thread running the coroutine. **Exact, not timed:** there is no sleep, no threshold, and
no wall-clock assertion, so it cannot flake on a loaded runner.

| Test | Locks in |
|---|---|
| `test_the_piper_clip_is_read_off_the_event_loop` | the uncompressed-WAV read must not run on the loop thread. Carries a positive control in the same test — the audio still reaches the client — so the assertion is about *where* the read happened, not about a read that quietly stopped happening |
| `test_the_polly_chunks_are_written_and_read_off_the_event_loop` | both per-sentence chunk writes **and** the stitched read. It first pins that the probe saw **exactly 3** IO events (2 spills + 1 read), so "not on the loop" cannot pass vacuously if a site is skipped or removed |

**Red-before**, with `chat_voice.py` restored to current `origin/main` (`7308a8b30`) and
nothing else changed — the failure message is the mechanism verbatim:

```
FAILED ...::test_the_piper_clip_is_read_off_the_event_loop
  AssertionError: the synthesized clip was read on the gateway event loop
  (thread 6724); every other session blocks for the length of that read
FAILED ...::test_the_polly_chunks_are_written_and_read_off_the_event_loop
  AssertionError: synthesized audio was written or read on the gateway event
  loop (thread 6724)
2 failed
```

**Green after**, with the directly relevant siblings (`test_chat_voice.py`,
`test_voice_reply.py`, `test_set_orch_cfg_voice.py`): **151 passed, 4 skipped**.

Gates on the touched files: `flake8` clean, `isort --check-only` clean, `git diff --check`
clean, `mypy src/kiro_crew/dashboard/chat_voice.py` — *Success: no issues found in 1 source
file* — and `scripts/check_black_formatting.py` **passed in scope** (2 files in scope,
nothing unformatted outside the baseline). No repository-wide suite was run; server CI owns
that.

## Manual verification

N/A — unit coverage sufficient: the property being fixed is *which thread* the IO runs on,
and the tests assert that directly through the real handlers rather than approximating it.

## Related Issues

None. Found by auditing `src/kiro_crew/dashboard` for blocking filesystem calls reached from
an `async def`, against the `no-blocking-call-on-event-loop` rule.

## Pattern harvest

Rule candidate: review-prompt
Pattern: an `async` handler that reads or writes a payload whose size is chosen by the
user's input — audio, an upload, a transcript — through plain `open()`.

The generalizable question is not "is there file IO in an async function" (there is, almost
everywhere, and most of it is bounded config). It is **"does this payload's size scale with
something the caller controls?"** A settings blob does not and is fine; a synthesized clip,
an attachment, or an exported transcript does, and belongs in `asyncio.to_thread`. That
distinction is why this PR moves three sites and deliberately leaves two others alone, and
it is the question a reviewer can ask without a scanner.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
