### PR TITLE
feat(source-providers): map Jira Fix Version onto the milestone slot

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -4069,6 +4069,43 @@ def _jira_linked_changes(fields: dict[str, Any], base_url: str) -> list[dict[str
     return changes
 
 
+def _jira_fix_versions(fields: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the fix versions that can populate the milestone slot.
+
+    A version is usable only when it is an object carrying a non-empty
+    ``name``: the Issue panel gates the milestone chip on the object being
+    truthy, so a nameless version would render an icon with no text.  A
+    malformed leading entry therefore does not hide a usable one behind it.
+    """
+    usable: list[dict[str, Any]] = []
+    for version in _as_list(fields.get("fixVersions")):
+        if not isinstance(version, dict):
+            continue
+        if str(version.get("name") or "").strip():
+            usable.append(version)
+    return usable
+
+
+def _jira_fix_version_milestone(version: dict[str, Any]) -> dict[str, str]:
+    """Map one Jira fix version onto the ``IssueMilestone`` contract.
+
+    Jira has no milestones; a fix version is the release a ticket is
+    scheduled for, which is the same thing the panel's milestone chip
+    communicates.  ``name`` becomes the title and ``releaseDate`` (ISO, unlike
+    the locale-formatted ``userReleaseDate``) becomes ``dueOn``.
+
+    ``state`` has only GitHub's two values to choose from.  A released version
+    is done, and an archived one no longer takes work, so both map to
+    ``closed`` and everything else stays ``open``.
+    """
+    released = bool(version.get("released")) or bool(version.get("archived"))
+    return {
+        "title": str(version.get("name") or "").strip(),
+        "state": "closed" if released else "open",
+        "dueOn": str(version.get("releaseDate") or ""),
+    }
+
+
 async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
     """Fetch a Jira issue via the REST API using configured credentials.
 
@@ -4103,7 +4140,7 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
         f"{base_url}/rest/api/{api_version}/issue/{issue_key}"
         f"?fields=summary,status,issuetype,assignee,description,labels,"
         f"comment,priority,reporter,created,updated,resolution,resolutiondate,"
-        f"issuelinks"
+        f"issuelinks,fixVersions"
     )
 
     # Build auth header
@@ -4258,6 +4295,14 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
             }
         )
 
+    # Fix versions -> the milestone slot. The contract holds exactly one, so a
+    # ticket scheduled for several releases surfaces the first and declares the
+    # rest partial rather than dropping them silently.
+    fix_versions = _jira_fix_versions(fields)
+    milestone = _jira_fix_version_milestone(fix_versions[0]) if fix_versions else None
+    if len(fix_versions) > 1:
+        _mark_partial(partial_sections, "fix versions")
+
     return {
         "provider": "jira",
         "url": ref.url,
@@ -4273,7 +4318,7 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
         "closedBy": "",  # Jira does not expose who resolved
         "labels": labels,
         "assignees": assignees,
-        "milestone": None,  # Jira uses Fix Version, not milestones
+        "milestone": milestone,  # Jira's Fix Version is its milestone equivalent
         "commentCount": total_comments,
         "locked": False,  # Jira has no issue locking concept
         "reactions": None,  # Jira has no reactions

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
 import pathlib
 import re
@@ -9626,6 +9627,201 @@ class TestJiraLinkedChanges:
         assert result[1]["issueKey"] == "B-2"
         assert result[1]["relation"] == "is duplicated by"
         assert result[1]["state"] == "closed"
+
+
+# --- Jira fix versions as the milestone equivalent (issue #2585) ---
+
+
+class TestJiraFixVersionMilestone:
+    """Tests for _jira_fix_versions and _jira_fix_version_milestone."""
+
+    def test_unreleased_version_maps_to_open_milestone(self) -> None:
+        """name -> title, releaseDate -> dueOn, unreleased -> open."""
+        fields = {
+            "fixVersions": [
+                {"name": "2.4.0", "releaseDate": "2026-09-30", "released": False},
+            ]
+        }
+        versions = source._jira_fix_versions(fields)
+        assert len(versions) == 1
+        assert source._jira_fix_version_milestone(versions[0]) == {
+            "title": "2.4.0",
+            "state": "open",
+            "dueOn": "2026-09-30",
+        }
+
+    def test_released_version_maps_to_closed(self) -> None:
+        """A shipped release is a closed milestone."""
+        version = {"name": "2.3.0", "releaseDate": "2026-06-30", "released": True}
+        assert source._jira_fix_version_milestone(version)["state"] == "closed"
+
+    def test_archived_version_maps_to_closed(self) -> None:
+        """An archived version no longer takes work, so it is not open."""
+        version = {"name": "1.0.0", "released": False, "archived": True}
+        assert source._jira_fix_version_milestone(version)["state"] == "closed"
+
+    def test_missing_release_date_keeps_the_name(self) -> None:
+        """A version with no release date still carries its target release."""
+        version = {"name": "Next", "released": False}
+        assert source._jira_fix_version_milestone(version) == {
+            "title": "Next",
+            "state": "open",
+            "dueOn": "",
+        }
+
+    def test_locale_formatted_release_date_is_not_used(self) -> None:
+        """userReleaseDate is locale-formatted, so only releaseDate feeds dueOn."""
+        version = {"name": "3.0", "releaseDate": "2026-12-01", "userReleaseDate": "01/Dec/26"}
+        assert source._jira_fix_version_milestone(version)["dueOn"] == "2026-12-01"
+
+    def test_first_usable_version_wins_over_malformed_head(self) -> None:
+        """A malformed or nameless leading entry does not hide a usable one."""
+        fields = {
+            "fixVersions": [
+                "not a dict",
+                None,
+                {"name": "   "},
+                {"name": "", "releaseDate": "2026-01-01"},
+                {"name": "4.1", "releaseDate": "2026-11-05"},
+            ]
+        }
+        versions = source._jira_fix_versions(fields)
+        assert len(versions) == 1
+        assert source._jira_fix_version_milestone(versions[0])["title"] == "4.1"
+
+    def test_name_is_trimmed(self) -> None:
+        """Surrounding whitespace in a version name is not rendered."""
+        version = {"name": "  2.5.0  "}
+        assert source._jira_fix_version_milestone(version)["title"] == "2.5.0"
+
+    def test_no_fix_versions_yields_nothing_usable(self) -> None:
+        """Missing, empty, and non-list fixVersions all yield no milestone."""
+        assert source._jira_fix_versions({}) == []
+        assert source._jira_fix_versions({"fixVersions": []}) == []
+        assert source._jira_fix_versions({"fixVersions": None}) == []
+        assert source._jira_fix_versions({"fixVersions": "1.0"}) == []
+
+    def test_multiple_versions_are_all_returned(self) -> None:
+        """The filter keeps every usable version so the caller can flag partial."""
+        fields = {
+            "fixVersions": [
+                {"name": "2.4.0"},
+                {"name": "2.5.0"},
+            ]
+        }
+        assert [v["name"] for v in source._jira_fix_versions(fields)] == ["2.4.0", "2.5.0"]
+
+    def test_milestone_keys_match_the_frontend_contract(self) -> None:
+        """The mapped shape is exactly IssueMilestone: title, state, dueOn."""
+        version = {"name": "2.4.0", "releaseDate": "2026-09-30"}
+        assert set(source._jira_fix_version_milestone(version)) == {"title", "state", "dueOn"}
+
+
+class _JiraFakeContent:
+    """Minimal ``StreamReader`` stand-in for the capped-response reader."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def iter_chunked(self, _n: int):
+        if self._body:
+            yield self._body
+
+
+class _JiraFakeResponse:
+    def __init__(self, body: bytes) -> None:
+        self.status = 200
+        self.content = _JiraFakeContent(body)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _JiraRecordingSession:
+    """Fake ``aiohttp.ClientSession`` that records the URL it was asked for."""
+
+    def __init__(self, body: bytes, seen: list[str]) -> None:
+        self._body = body
+        self._seen = seen
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def get(self, url, **_kwargs):
+        self._seen.append(url)
+        return _JiraFakeResponse(self._body)
+
+
+def _jira_recording_session(monkeypatch, fields: dict) -> list[str]:
+    """Arm a fake Jira endpoint serving *fields*; return the recorded URL list."""
+    body = json.dumps({"fields": fields}).encode("utf-8")
+    seen: list[str] = []
+    monkeypatch.setattr(
+        source.aiohttp, "ClientSession", lambda *a, **kw: _JiraRecordingSession(body, seen)
+    )
+    monkeypatch.setattr(source, "_get_jira_auth", lambda host: ("e@example.com", "tok"))
+    return seen
+
+
+async def _jira_fetch(monkeypatch, fields: dict) -> tuple[dict, list[str]]:
+    """Drive ``_fetch_jira_issue`` over a canned payload; return it and the URLs."""
+    seen = _jira_recording_session(monkeypatch, fields)
+    ref = source.parse_source_url("https://acme.atlassian.net/browse/PROJ-123")
+    return await source._fetch_jira_issue(ref), seen
+
+
+class TestJiraFixVersionInPayload:
+    """End-to-end pins: the field is requested and reaches the payload."""
+
+    @pytest.mark.asyncio
+    async def test_fix_versions_is_requested_from_the_rest_api(self, monkeypatch) -> None:
+        """An unrequested field is absent from the response, so it must be asked for."""
+        _issue, seen = await _jira_fetch(monkeypatch, {"summary": "x"})
+        assert len(seen) == 1
+        assert "fixVersions" in seen[0]
+
+    @pytest.mark.asyncio
+    async def test_milestone_carries_the_fix_version(self, monkeypatch) -> None:
+        """The Issues panel milestone chip is fed by the first fix version."""
+        issue, _seen = await _jira_fetch(
+            monkeypatch,
+            {
+                "summary": "Ship it",
+                "fixVersions": [{"name": "2.4.0", "releaseDate": "2026-09-30"}],
+            },
+        )
+        assert issue["milestone"] == {
+            "title": "2.4.0",
+            "state": "open",
+            "dueOn": "2026-09-30",
+        }
+        assert "fix versions" not in issue["partialSections"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_fix_versions_are_declared_partial(self, monkeypatch) -> None:
+        """Dropping the tail of a multi-release ticket is disclosed, not silent."""
+        issue, _seen = await _jira_fetch(
+            monkeypatch,
+            {
+                "summary": "Ship it twice",
+                "fixVersions": [{"name": "2.4.0"}, {"name": "2.5.0"}],
+            },
+        )
+        assert issue["milestone"]["title"] == "2.4.0"
+        assert "fix versions" in issue["partialSections"]
+
+    @pytest.mark.asyncio
+    async def test_no_fix_version_leaves_milestone_null(self, monkeypatch) -> None:
+        """A ticket with no fix version keeps the panel's 'no milestone' state."""
+        issue, _seen = await _jira_fetch(monkeypatch, {"summary": "Unscheduled"})
+        assert issue["milestone"] is None
+        assert "fix versions" not in issue["partialSections"]
 
 
 class _ReapProbe:


### PR DESCRIPTION
## Problem / Motivation

The Issues side panel shows which release a ticket is scheduled for, from the
issue's milestone. For a Jira ticket it never showed one: `_fetch_jira_issue`
returned a hardcoded literal.

```python
"milestone": None,  # Jira uses Fix Version, not milestones
```

The comment named the right concept and then stopped there. Jira has no
milestones, but it has the same idea under a different name: a **Fix Version**
is the release a ticket is scheduled for. Nothing asked the REST API for it
(`fixVersions` was absent from the `fields` parameter) and nothing mapped it,
so a Jira ticket with a perfectly good target release rendered as no milestone
at all.

A note on the issue's own framing: #2585 attributes the Jira fetch to PR #2380,
which was closed without merging. The scaffolding this PR builds on actually
landed in a different PR - `_fetch_jira_issue` was introduced by #3311
(`feat(issues): fetch and render Jira issue details in side panel`, commit
`2f47a3cac`). The function and the hardcoded literal are both on `main` today,
so the issue is actionable as written even though the PR it cites is not the
one that created the gap. An earlier automated attempt escalated this issue as
dependency-blocked on #2380; that block no longer applies.

## Why it matters

Release context is one of the few things a reader wants from a linked ticket
without leaving the panel: is this scheduled, and for when. Every Jira user got
a blank where every GitHub and GitLab user gets an answer, for a field Jira had
all along - so the panel silently looked less capable against Jira than it
actually is.

## What changed (motivation -> approach -> change)

The gap is a missing mapping, not a missing feature: the frontend milestone
chip already exists and already renders for the other two providers, so the
whole fix is backend and the panel lights up with no UI change.

Two things were missing, and both halves are needed - a mapping over a field
nobody requested would map `None` forever:

1. `fixVersions` is now in the REST `fields` parameter.
2. Two small pure helpers next to the existing `_jira_linked_changes` map it:
   `_jira_fix_versions` filters the array down to entries that can actually
   populate the slot, and `_jira_fix_version_milestone` maps one of them onto
   the `IssueMilestone` contract.

Three decisions worth naming, because each one differs from the obvious
reading:

- **The contract is `{title, state, dueOn}`, not `{title, dueOn, url}`.** The
  snippet in the issue proposes a `url` key; `IssueMilestone` in
  `website/src/types/index.ts` has no such field and does have a required
  `state`, which Issue Radar's detail panels render in parentheses. So `state`
  had to be derived rather than omitted: a `released` version is done and an
  `archived` one no longer takes work, so both map to `closed` and everything
  else stays `open` - the same two values GitHub's milestone state has.
- **`releaseDate`, never `userReleaseDate`.** Jira exposes both; the second is
  locale-formatted (`01/Dec/26`) and would put a rendered string where the
  contract wants a date.
- **First *usable* version, not first entry.** A version with no name would
  render a milestone icon with no text, because the panel gates the chip on the
  object being truthy rather than on its title. Filtering first means a
  malformed leading entry cannot hide a good one behind it, and no fix version
  at all still yields `None` and the existing "no milestone" state.

The contract holds exactly one milestone while a Jira ticket may carry several
fix versions. Rather than drop the tail silently, a multi-version ticket adds
`fix versions` to the existing `partialSections` list, which the panel already
renders as "provider results may be partial". Same mechanism as `comments`
above it, one line, and the simplification the issue calls reasonable becomes
visible to the user instead of invisible.

## Tests

Fourteen tests in `test/test_source_providers.py`, following the file's
existing `# --- Jira ... (issue #NNNN) ---` convention. Mutation-verified:
13 of the 14 fail against the base source with the tests in place (the
fourteenth is the `milestone is None` regression guard, which passes on base by
construction - that is the behavior it exists to keep).

`TestJiraFixVersionMilestone` (pure mapping):

- `name` -> `title`, `releaseDate` -> `dueOn`, unreleased -> `open`
- released -> `closed`; archived -> `closed`
- a version with no release date still surfaces its name
- `userReleaseDate` is not used for `dueOn`
- a malformed or nameless leading entry does not hide a usable one
- whitespace in a name is trimmed
- missing, empty, `null`, and non-list `fixVersions` all yield nothing usable
- multiple usable versions are all returned, so the caller can flag partial
- the mapped key set is exactly `{title, state, dueOn}`

`TestJiraFixVersionInPayload` (end to end through `_fetch_jira_issue` over a
recording fake session, so the request half is covered too):

- the request URL asks for `fixVersions` - an unrequested field is simply
  absent from the response, so this half is invisible to the pure helpers
- `milestone` carries the mapped fix version and nothing is marked partial
- two fix versions -> first one in `milestone`, `fix versions` in
  `partialSections`
- no fix version -> `milestone` stays `None`, nothing marked partial

Gates run locally: targeted `pytest -n 4` (60 passed across the Jira
selection), `flake8` clean on both files, `mypy` reports nothing in the touched
module, and the repo's baselined black gate passes in scope.

## Manual verification

N/A - no live Jira tenant is reachable from this environment. The end-to-end
tests drive the real `_fetch_jira_issue` over a canned payload built from the
documented Jira version shape, covering both the request and the mapping; the
frontend chip is unchanged and already exercised for the other providers.

## Related Issues

Closes #2585

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a hardcoded `None` whose own comment names the field that should fill
it. `"milestone": None,  # Jira uses Fix Version` documented the mapping and
shipped without it, and it survived because nothing distinguishes "this
provider has no such concept" from "this provider spells it differently and
nobody wired it up". A reviewer prompt over a provider-mapping diff can ask,
for each literal `None`/`""`/`[]` in a returned payload, whether the adjacent
comment names a real source field - if it does, the literal is an unfinished
mapping rather than a documented absence. Cheap to ask, and it generalizes to
the sibling entries in this same dict that are genuine absences
(`closedBy`, `locked`, `reactions`), which read the same way and would pass the
check by naming no field.
