### PR TITLE
refactor(channels): delete the two dead outbound-upload surfaces

### DIFF
--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -17,14 +17,12 @@ new thread; turns never run directly in a normal guild channel.
 
 from __future__ import annotations
 
-import logging
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
 from kiro_crew.discord.client import (
     DISCORD_CHUNK_LIMIT,
-    DISCORD_MAX_FILES_PER_MESSAGE,
     DiscordClient,
     DiscordInbound,
 )
@@ -38,8 +36,6 @@ from kiro_crew.messaging.transport import (
     TransportCapabilities,
 )
 from kiro_crew.sel import sel
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -157,38 +153,6 @@ class DiscordTransport(MessagingTransport):
         mid = await self._client.send_message(conversation_id, content)
         return str(mid or "")
 
-    async def send_message_with_files(
-        self,
-        conversation_id: str,
-        content: str,
-        files: Sequence[OutboundFile],
-        thread_id: str | None = None,
-    ) -> str:
-        """Send ``content`` with ``files`` attached. Returns the message id.
-
-        The transport-level upload verb: :meth:`send_message` plus attachments,
-        same return contract, so a caller holding a transport does not reach past
-        it into the client. ``files`` carry the validated bytes from
-        ``messaging/outbound_files.py``; this path uploads exactly those and never
-        re-opens ``OutboundFile.path``.
-
-        Discord's ceilings are budgets the CALLER feeds to extraction, because a
-        file refused before it is read keeps its markdown in the text -- refusing
-        here would drop it after the reference was already cut out. Anything still
-        over the count cap is a caller bug, dropped with a warning rather than
-        failing the whole send.
-        """
-        if len(files) > DISCORD_MAX_FILES_PER_MESSAGE:
-            logger.warning(
-                "discord: %d attachments exceeds the %d-per-message cap; sending the first %d",
-                len(files),
-                DISCORD_MAX_FILES_PER_MESSAGE,
-                DISCORD_MAX_FILES_PER_MESSAGE,
-            )
-            files = list(files)[:DISCORD_MAX_FILES_PER_MESSAGE]
-        mid = await self._client.send_message_with_files(conversation_id, content, files)
-        return str(mid or "")
-
     async def send_document(
         self,
         conversation_id: str,
@@ -199,8 +163,9 @@ class DiscordTransport(MessagingTransport):
     ) -> str:
         """Send one validated file, keeping its admitted name. Returns the message id.
 
-        The name-preserving counterpart of :meth:`send_message_with_files`, whose
-        sanitizer is aimed at LLM-authored reference paths and would deliver
+        The transport-level upload verb, and the name-preserving counterpart of the
+        renderer's extraction upload (``DiscordClient.send_message_with_files``),
+        whose sanitizer is aimed at LLM-authored reference paths and would deliver
         ``report.pdf`` as ``report.bin``. A caller here has already gated the name
         (``file_send``), so the real basename is pinned onto the multipart part.
         ``file`` carries validated bytes (the ``OutboundFile`` contract — the path

--- a/src/kiro_crew/messaging/split.py
+++ b/src/kiro_crew/messaging/split.py
@@ -73,7 +73,6 @@ __all__ = [
     "chunk_utf8_bytes",
     "iter_fence_spans",
     "iter_fence_lines",
-    "open_fence_at_end",
     "truncate_utf8",
     "FENCE_OUTSIDE",
     "FENCE_OPEN",
@@ -476,14 +475,6 @@ def _advance(fence: _Fence | None, line: str) -> _Fence | None:
     if m:
         return _Fence(char=m.group(1)[0], length=len(m.group(1)), opener=body)
     return None
-
-
-def open_fence_at_end(text: str) -> tuple[str, int, str] | None:
-    """Return ``(character, length, opener)`` for the fence open at text's end."""
-    fence: _Fence | None = None
-    for line, _full, _terminated in _lines(text):
-        fence = _advance(fence, line)
-    return (fence.char, fence.length, fence.opener) if fence else None
 
 
 def iter_fence_spans(text: str) -> Iterator[tuple[int, int]]:

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -248,7 +248,7 @@ class TelegramTransport(MessagingTransport):
     ) -> str:
         """Send one validated file into this conversation. Returns the message id.
 
-        The transport-level upload verb, Discord's ``send_message_with_files``
+        The transport-level upload verb, Discord's ``send_document``
         counterpart: a caller holding a transport does not reach past it into
         the client. ``file`` carries validated bytes (the ``OutboundFile``
         contract — the path is provenance, never re-opened).

--- a/test/test_discord_outbound_files.py
+++ b/test/test_discord_outbound_files.py
@@ -521,18 +521,6 @@ class TestDocumentVerb:
         assert asyncio.run(transport.send_document("c1", _doc())) == ""
 
 
-class TestTransportVerb:
-    def test_send_message_with_files_returns_the_message_id(self) -> None:
-        transport = DiscordTransport(cli := FakeClient(), allowed_user_ids=["u1"])  # type: ignore[arg-type]
-        file = _file()
-        assert asyncio.run(transport.send_message_with_files("c1", "hi", [file])).isdigit() and cli.uploaded_files == [file]
-
-    def test_over_cap_attachments_are_dropped_not_failed(self) -> None:
-        transport = DiscordTransport(cli := FakeClient(), allowed_user_ids=["u1"])  # type: ignore[arg-type]
-        files = [_file(f"/tmp/{i}.png") for i in range(DISCORD_MAX_FILES_PER_MESSAGE + 3)]
-        assert asyncio.run(transport.send_message_with_files("c1", "hi", files)).isdigit() and len(cli.uploaded_files) == DISCORD_MAX_FILES_PER_MESSAGE
-
-
 async def _done(value: Any) -> Any:
     return value
 

--- a/test/test_file_send_channel.py
+++ b/test/test_file_send_channel.py
@@ -798,11 +798,12 @@ class TestChannelUploadEndpoint:
         # was the extraction one, whose sanitizer maps any non-raster mime to
         # `.bin` (report.pdf would arrive as report.bin). It now has the same
         # purpose-built name-preserving verb Telegram uses, so it delivers.
+        # `spec_set` names that verb alone: reaching for any other upload verb
+        # raises here instead of being caught by an after-the-fact assertion.
         from unittest.mock import AsyncMock
 
-        transport = MagicMock(spec_set=["send_document", "send_message_with_files"])
+        transport = MagicMock(spec_set=["send_document"])
         transport.send_document = AsyncMock(return_value="900")
-        transport.send_message_with_files = AsyncMock(return_value="901")
         app = self._app()
         with patch(
             "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
@@ -826,9 +827,6 @@ class TestChannelUploadEndpoint:
         assert resp.status == 200
         assert body == {"ok": True, "delivered": True, "channel_type": "discord"}
         transport.send_document.assert_awaited_once()
-        # The extraction verb stays out of this path: it is the one whose
-        # sanitizer would rename the attachment.
-        transport.send_message_with_files.assert_not_called()
         args, kwargs = transport.send_document.call_args
         assert args[0] == "555"
         outbound = args[1]
@@ -879,13 +877,10 @@ class TestChannelUploadEndpoint:
 
     @pytest.mark.asyncio
     async def test_a_discord_transport_without_the_verb_is_still_a_skip(self, tmp_path, outbox_file):
-        # The channel list is not the authority — the verb is. A transport that
-        # predates it keeps the dashboard-link fallback rather than being routed
-        # into the extraction upload whose sanitizer renames the attachment.
-        from unittest.mock import AsyncMock
-
-        transport = MagicMock(spec_set=["send_message_with_files"])
-        transport.send_message_with_files = AsyncMock(return_value="900")
+        # The channel list is not the authority — the verb is. A Discord
+        # transport that predates `send_document` keeps the dashboard-link
+        # fallback rather than failing the request on a missing attribute.
+        transport = MagicMock(spec_set=["send_message"])
         app = self._app()
         with patch(
             "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
@@ -901,7 +896,7 @@ class TestChannelUploadEndpoint:
         assert resp.status == 200
         assert body["delivered"] is False
         assert body["skipped"] == "channel_upload_unsupported:discord"
-        transport.send_message_with_files.assert_not_called()
+        transport.send_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_a_channel_without_an_upload_verb_is_a_skip(self, tmp_path, outbox_file):


### PR DESCRIPTION
## Problem / Motivation

Two outbound-upload surfaces shipped in #4832 as the seams the O3 Telegram / O4b Slack transports were expected to consume. Neither gained a consumer, and both are dead on `main` today:

- `messaging/split.py::open_fence_at_end` -- zero callers anywhere, and zero tests. Its only other appearance is its own `__all__` entry.
- `DiscordTransport.send_message_with_files` -- zero production callers. The renderer uploads through the client verb (`renderer.py::_land_sealed` -> `DiscordClient.send_message_with_files`), and the `file_send` path resolves `send_document` by name (`dashboard/upload_destination.py:284`), never the extraction verb. The transport verb's only callers were its own two tests.

## Why it matters

Dead code that looks like a designed extension point is worse than dead code that looks dead. A reader arriving at `DiscordTransport.send_message_with_files` finds a documented "transport-level upload verb" with a ceiling policy and a warning branch, and reasonably concludes the upload path goes through it -- it does not. The same goes for a public `open_fence_at_end` in a module whose spec enumerates its exports: it advertises a fence-state accessor no caller has ever needed, and its two tests (for the transport verb) buy confidence in a path no user reaches.

It also costs maintenance directly. The transport verb carried an over-cap drop branch whose reasoning had to be kept true against the client's real ceilings, and it kept a module logger alive for one warning that never fires in production.

## What changed (motivation -> approach -> change)

Task 1 and task 2 of #4919 both asked "give it a consumer or delete it". No consumer landed, and both surfaces stay reachable in git history if a future one wants them back, so deletion is the answer. Pure subtraction -- no replacement code, no behaviour change on any live path:

- `messaging/split.py`: the function and its `__all__` entry. Its `_advance` / `_lines` helpers stay, because `iter_fence_spans` and `iter_fence_lines` drive them.
- `discord/transport.py`: the verb and its over-cap drop branch, plus the three imports that branch was the last user of (`Sequence`, `DISCORD_MAX_FILES_PER_MESSAGE`, `logging`) and the now-unused module logger. `send_document` -- the verb `file_send` actually calls -- is untouched.
- Two docstring cross-references would have dangled, so they now name live symbols: Discord's `send_document` points at the client verb it is the name-preserving counterpart of, and Telegram's `send_document` points at Discord's `send_document` rather than at the deleted one.

`MessagingTransport` declares no upload verb, so nothing is left abstract by the removal.

Task 3 of #4919 (have `split_markdown_safe` declare its context-degrading tier so the Discord renderer can drop its synthetic `![x](/tmp/x.png)` probe) is NOT a deletion and does not belong in this PR. It is carried forward as #7540, which also records that the third half of that task -- hoisting the restricted-session upload gate into a channel-neutral helper -- has already landed as `messaging/upload_gate.py::uploads_restricted`.

## Tests

No new tests: a deletion's proof is that nothing needed the thing.

- Removed `test_discord_outbound_files.py::TestTransportVerb` (2 tests) -- the deleted verb's only callers.
- Two mock transports in `test_file_send_channel.py` no longer declare a verb the real class cannot have. In the delivering case `spec_set=["send_document"]` now IS the guard the removed `assert_not_called` used to be, and a stricter one: an upload path reaching for any other verb raises on the mock instead of being audited after the fact. The verb-less-Discord-transport case is modelled with `send_message`, which keeps its actual pin (a `discord` link whose transport lacks `send_document` is a skip, not a crash -- distinct from the neighbouring `teams` case, which never reaches the verb lookup at all).

Targeted runs, all green: `test_messaging_split.py`, `test_discord_outbound_files.py`, `test_file_send_channel.py` (252 passed), and the adjacent transport consumers `test_discord.py`, `test_capability_ledger.py`, `test_channel_registry.py`, `test_channel_transport_outbound_authz.py` (320 passed). flake8 / isort / black clean on all five touched files; `scripts/check_black_formatting.py` passes in scope.

## Manual verification

N/A -- unit coverage sufficient. Nothing on a live path changes: the two deleted symbols have no production callers, verified by grep across `src/`, `test/` and `docs/` for both names, with every surviving hit belonging to the client verb of the same name.

## Related Issues

Closes #4919
Refs #7540

## Pattern harvest

Rule candidate: `lint`
Pattern: a module-level `def` exported in `__all__` with no reference anywhere in `src/` or `test/`. `open_fence_at_end` survived a year because `__all__` membership reads as intent and no gate distinguishes "public API" from "public and unused" -- a vulture-style unused-symbol pass over `src/kiro_crew/**`, behind a shrinking baseline like the black and per-file-coverage gates, would have flagged it the day its consumer failed to land. The Discord half is weaker as a rule candidate (the method is reachable in principle through duck-typed transport dispatch, so a naive callers-count check would false-positive across the channel layer) and its real tell was different: a verb whose only callers are its own tests. That one is a review-prompt line rather than a lint.
