### PR TITLE
feat(jira): convert ADF rich text to markdown instead of plain text

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -3016,58 +3016,899 @@ def _jira_is_cloud(host: str) -> bool:
     return host.lower().endswith(".atlassian.net")
 
 
-def _adf_to_plain_text(node: Any, *, _depth: int = 0) -> str:
-    """Recursively extract plain text from an Atlassian Document Format tree.
+_ADF_MAX_DEPTH = 64
 
-    ADF is the JSON document model used by Jira Cloud v3. This performs a
-    depth-limited traversal (max 64 levels) to prevent stack exhaustion from
-    malformed or maliciously deep documents.
-    """
-    _MAX_DEPTH = 64
-    if _depth > _MAX_DEPTH:
-        return ""
-    if not isinstance(node, dict):
-        return ""
-    node_type = node.get("type")
-    # Text leaf node
-    if node_type == "text":
-        return str(node.get("text") or "")
-    # Inline card (link)
-    if node_type == "inlineCard":
-        attrs = _as_dict(node.get("attrs"))
-        return str(attrs.get("url") or "")
-    # Mention (user/team @-mention) — extract the visible name
-    if node_type == "mention":
-        attrs = _as_dict(node.get("attrs"))
-        return str(attrs.get("text") or attrs.get("id") or "")
-    # Emoji — extract the shortName or fallback text
-    if node_type == "emoji":
-        attrs = _as_dict(node.get("attrs"))
-        return str(attrs.get("text") or attrs.get("shortName") or "")
-    # Hard break — render as newline
-    if node_type == "hardBreak":
-        return "\n"
-    parts: list[str] = []
-    for child in _as_list(node.get("content")):
-        parts.append(_adf_to_plain_text(child, _depth=_depth + 1))
-    text = "".join(parts)
-    # Block-level nodes get a trailing newline for readability.
-    block_types = {
+# ADF node types that occupy a line of their own. Everything else is treated as
+# an inline run, so an unknown node still contributes its text rather than
+# vanishing.
+_ADF_BLOCK_TYPES = frozenset(
+    {
+        "doc",
         "paragraph",
         "heading",
+        "codeBlock",
+        "blockquote",
+        "panel",
+        "rule",
         "bulletList",
         "orderedList",
-        "listItem",
-        "blockquote",
-        "codeBlock",
-        "rule",
+        "taskList",
         "table",
-        "tableRow",
-        "tableCell",
+        "expand",
+        "nestedExpand",
+        "layoutSection",
+        "layoutColumn",
+        "bodiedExtension",
+        "decisionList",
+        "mediaSingle",
+        "mediaGroup",
+        "blockCard",
+        "embedCard",
     }
-    if node_type in block_types and text and not text.endswith("\n"):
-        text += "\n"
-    return text
+)
+
+# Containers that only GROUP other blocks. Markdown has no columns, so the
+# grouping flattens to its children in document order -- but the children must
+# still render as BLOCKS. Reaching the inline path instead concatenates them:
+# a two-column layout of a paragraph and a heading rendered as `firstsecond`,
+# with the separator and the `##` both gone. Measured on each type below.
+_ADF_BLOCK_CONTAINER_TYPES = frozenset(
+    {
+        "layoutSection",
+        "layoutColumn",
+        "bodiedExtension",
+        "decisionList",
+        "mediaSingle",
+        "mediaGroup",
+    }
+)
+
+# Block-level cards carry their URL in an attribute and have no content, so the
+# inline container fallthrough rendered them as the empty string -- the URL was
+# lost outright, which is the same unrecoverable loss this change exists to fix.
+_ADF_BLOCK_CARD_TYPES = frozenset({"blockCard", "embedCard"})
+
+# List types, which follow their sibling block without a blank line so the
+# nested list stays part of the same (tight) list item.
+_ADF_LIST_TYPES = frozenset({"bulletList", "orderedList", "taskList"})
+
+# Inline markdown/HTML syntax openers. The panel renders a source's
+# ``description`` and every comment ``body`` through MarkdownRenderer
+# (react-markdown + remark-gfm + rehypeRaw), so ADF *text* that merely looks
+# like markup would otherwise be re-parsed as markup: a literal ``**`` in a
+# Jira description would turn bold, a literal ``<b>`` would be eaten by the
+# HTML sanitizer, and a literal ``&copy;`` would be decoded to a copyright sign.
+# ``!`` earns its place for a different reason: this converter emits real ``[``
+# for a link, a mention card and a media node, so a literal ``!`` landing
+# immediately before one would splice into image syntax and the panel would
+# auto-fetch a provider-controlled URL -- the beacon the media-as-link form
+# exists to avoid. `$` is there because the same renderer runs remark-math, so a
+# literal `$$x$$` in a Jira description would render as KaTeX rather than as the
+# characters someone typed. Backslash-escaping these keeps ADF text literal,
+# leaving the marks and block types below as the only things that become real
+# markdown. Every character here is ASCII punctuation, which CommonMark says may
+# always be backslash-escaped.
+_MD_INLINE_ESCAPE = str.maketrans({ch: "\\" + ch for ch in "\\`*_[]<>|~&!$"})
+
+# A text run that OPENS a line can also start a *block* construct the inline set
+# above does not cover (``# heading``, ``- item``, ``1. item``, and a line of
+# ``=`` or ``-`` that makes the line ABOVE it a setext heading). Only paragraph
+# and list-item text is passed through this: a heading's own ``#`` prefix
+# already claims its line, and list markers are added by the list renderer after
+# its items are rendered.
+_MD_BLOCK_LEAD_RE = re.compile(r"^([ \t]*)(?:([-+#=])|(\d{1,9})([.)]))", re.MULTILINE)
+
+# The characters `_URL_RE` will not cross that can nonetheless appear INSIDE a
+# URL. Its path/query class is `[^\s)\"'>]*`, so any of these ends the match and
+# puts the rest of the URL -- including its whole query -- outside every
+# exfiltration check that follows.
+#
+# Whitespace is deliberately NOT here even though the class excludes it. A space
+# genuinely ends a URL: the renderer's own autolinker stops there too, so text
+# after it is prose rather than part of a fetchable address. Encoding it treated
+# the two as one URL and destroyed benign content -- `see <url>?id=7 <40-char
+# sha> for detail` collapsed to `see%20[REDACTED: suspicious URL ...]`, losing
+# every word after the URL.
+#
+# This table is a SHADOW of that scanner's terminator set and exists only while
+# the scanner carries the bug. Retire it when #7611 lands rather than keeping
+# both: two copies of one set drift, and the copy that matters is the scanner's.
+_URL_SCAN_ESCAPES = str.maketrans(
+    {
+        '"': "%22",
+        "'": "%27",
+        "(": "%28",
+        ")": "%29",
+        ">": "%3E",
+    }
+)
+
+# A URL as any consumer delimits one: it runs to the first whitespace. Terminator
+# encoding is applied only INSIDE these spans so surrounding prose keeps its own
+# punctuation.
+_URL_SPAN_RE = re.compile(r"https?://\S*", re.IGNORECASE)
+
+# The largest ordered-list start CommonMark accepts. Ten digits is not a list
+# marker, so a longer number renders as a literal paragraph.
+_MD_MAX_LIST_START = 999999999
+
+# One highlighter token, and nothing that could leave the fence's own line. The
+# anchors are deliberately absent: `$` also matches just before a TRAILING
+# newline, so `re.match` accepted `"python\n"` and the fence emitted a blank
+# first line inside the block. `fullmatch` is the check that means what this
+# comment says.
+_MD_CODE_LANGUAGE_RE = re.compile(r"[A-Za-z0-9+#._-]{1,32}")
+
+
+def _md_redact_untruncated(text: str, *, single_url: bool = False) -> str:
+    """Redact *text* with the URL scan able to see whole URLs.
+
+    `_redact_provider_data` inherits `_URL_RE`, whose path/query class stops at
+    whitespace, ``)``, ``"``, ``'`` or ``>``. A URL carrying any of them is
+    scanned only as far as that character, so its query -- the part that would
+    carry exfiltrated data -- is never inspected, and `_exfil_url_warning`
+    returns clean on a truncated match with no ``?`` left in it. Scanning a form
+    with those characters percent-encoded is what lets the checks see all of it.
+
+    Every place this converter emits provider text goes through here, because
+    the gap is per-CALL-SITE, not per-node-type: when only the link destination
+    was covered, an expand title, a mention label, an inline card and a media URL
+    each still leaked a high-entropy query, measured one by one.
+
+    The rule is to scan the form that will actually be EMITTED, which is why
+    whitespace is handled differently per site rather than uniformly:
+
+    * ``single_url`` -- a link DESTINATION is one address, and the angle-bracket
+      form emits it with whitespace percent-encoded, so a space does NOT end it.
+      The scan encodes whitespace too, or it would stop where the emitted URL
+      does not.
+    * otherwise -- in prose a space really does end the URL. Verified against the
+      renderer: for `https://host/a?data= <blob>` the emitted anchor's href is
+      `https://host/a?data=`, so following text cannot ride along in a fetchable
+      address. Encoding whitespace here treated a URL and the next word as one
+      address: a URL followed by a commit SHA scanned as a query carrying the SHA,
+      the entropy heuristic fired, and the WHOLE paragraph was replaced.
+
+    When nothing is found the ORIGINAL text comes back, so no encoding is ever
+    visible in the ordinary case. When something IS found the redacted encoded
+    form is returned: the marker replaces the URL wholesale, and a stray percent
+    escape beside a redaction marker is a better outcome than emitting a URL that
+    was only scanned up to its first parenthesis.
+    """
+    if single_url:
+        scanned = re.sub(r"\s+", "%20", text).translate(_URL_SCAN_ESCAPES)
+    else:
+        scanned = _URL_SPAN_RE.sub(lambda m: m.group(0).translate(_URL_SCAN_ESCAPES), text)
+    redacted = str(_redact_provider_data(scanned))
+    return text if redacted == scanned else redacted
+
+
+def _md_escape_inline(text: str) -> str:
+    """Backslash-escape the markdown syntax characters in literal ADF text."""
+    return text.translate(_MD_INLINE_ESCAPE)
+
+
+def _adf_attr_label(value: Any) -> str:
+    """Prepare an ADF *attribute* string for emission as an inline label.
+
+    Redact, collapse whitespace, then escape -- in that order, and all three for
+    the same reason.
+
+    An attribute is a label, not prose. Where a text node's own newline is
+    content, a newline inside an attribute would end the construct the attribute
+    sits in and let the remainder become document structure, so whitespace is
+    collapsed first. Escaping then keeps the rest literal -- and because escaping
+    inserts a backslash, it would hide a credential from the payload-level
+    ``_redact_provider_data`` pass that runs afterwards, so redaction has to
+    happen here, before the backslash lands.
+
+    Doing it here rather than in a pre-pass over the whole tree is what keeps the
+    work bounded: this runs inside the converter's own depth-capped traversal,
+    while ``_redact_provider_data`` recurses without a cap and raises
+    ``RecursionError`` on a document a few hundred levels deep.
+    """
+    collapsed = re.sub(r"\s+", " ", _md_redact_untruncated(str(value or ""))).strip()
+    return _md_escape_inline(collapsed)
+
+
+def _md_code_language(value: Any) -> str:
+    """The fence info string for an ADF code block's ``language`` attribute.
+
+    A fence's info string runs to the end of its line, so a newline-bearing (or
+    merely space-bearing) attribute would close the fence early and turn
+    provider-controlled text into real document structure. Only a single
+    highlighter token is admitted: letters, digits, and the punctuation real
+    language names carry (``c++``, ``c#``, ``objective-c``, ``asp.net``,
+    ``shell_session``). Anything else drops to a bare fence, which costs syntax
+    highlighting and nothing else.
+    """
+    language = str(value or "")
+    return language if _MD_CODE_LANGUAGE_RE.fullmatch(language) else ""
+
+
+def _md_escape_block_leads(text: str) -> str:
+    """Escape a line-leading ``-``/``+``/``#``/``1.`` so it stays literal text.
+
+    The backslash goes before the punctuation, never before the digit: ``\\1`` is
+    not a valid CommonMark escape and would render as a visible backslash.
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        if match.group(2):
+            return f"{match.group(1)}\\{match.group(2)}"
+        return f"{match.group(1)}{match.group(3)}\\{match.group(4)}"
+
+    return _MD_BLOCK_LEAD_RE.sub(_sub, text)
+
+
+def _md_backtick_fence(text: str, minimum: int) -> str:
+    """A backtick fence long enough to survive the backticks inside *text*."""
+    longest = max((len(run) for run in re.findall(r"`+", text)), default=0)
+    return "`" * max(minimum, longest + 1)
+
+
+def _md_inline_code(text: str) -> str:
+    """Wrap *text* in an inline code span, unescaped (code spans are literal).
+
+    CommonMark cannot open a span whose content starts or ends with a backtick,
+    and it strips one leading and one trailing character from a span whose
+    content both begins and ends with a space or newline (unless the content is
+    nothing but whitespace, which is left alone). One space of padding -- which
+    that same rule then removes -- is what keeps such content intact.
+    """
+    fence = _md_backtick_fence(text, 1)
+    first, last = text[:1], text[-1:]
+    edge_stripped = first in (" ", "\n") and last in (" ", "\n") and text.strip() != ""
+    pad = " " if text.startswith("`") or text.endswith("`") or edge_stripped else ""
+    return f"{fence}{pad}{text}{pad}{fence}"
+
+
+def _md_link_target(url: str) -> str | None:
+    """Render *url* as a markdown link destination, or None to omit the link.
+
+    The bare form covers the common case; the angle-bracket form takes over when
+    the URL carries whitespace or parentheses, which would otherwise end the
+    destination early and spill the rest of the URL into the document.
+
+    None means this URL must not become a destination at all. The old plain-text
+    walker dropped every href, so a provider-controlled destination reaching the
+    payload is new here, and the payload-level scan cannot be relied on to clean
+    one up afterwards: ``_URL_RE``'s path group excludes ``)``, so a URL with a
+    ``)`` in its path is matched only up to that point. Everything past it --
+    including the whole query -- is then outside every check that follows, and
+    ``_exfil_url_warning`` returns clean on a truncated match with no ``?`` left
+    in it. Measured: a high-entropy query blob is redacted without the paren and
+    NOT redacted with it, and no credential-pattern pass covers a bare blob.
+
+    So the scan here is run against a form with every character that terminates
+    that match percent-encoded -- not just the parenthesis, which was the one
+    member of the class this gate originally covered. The encoded form is only
+    ever used to DECIDE: a URL that passes is emitted exactly as it arrived.
+    Encoding a handful of characters cannot trip the heavy-encoding rule, which
+    needs 20 consecutive octets, and a URL pathological enough to reach that is
+    dropped rather than leaked. A link that fails is dropped rather than emitted
+    partly redacted; the label still carries the text, so nothing silently
+    vanishes.
+
+    This shields the hrefs THIS converter emits. The truncation itself is in the
+    shared scanner and every other caller still has it, so it is filed as #7611
+    rather than left recorded only here; fixing a shared security regex is a
+    different blast radius than a Jira rendering change.
+    """
+    if not url:
+        return None
+    if _md_redact_untruncated(url, single_url=True) != url:
+        return None
+    if not re.search(r"[\s()<>]", url):
+        return url
+    inner = re.sub(r"\s+", "%20", url).replace("<", "%3C").replace(">", "%3E")
+    return f"<{inner}>"
+
+
+def _md_one_line(text: str) -> str:
+    """Fold *text* onto a single line, collapsing ONLY line breaks.
+
+    A heading and a GFM table cell each occupy exactly one line, but the repeated
+    spaces and tabs inside one are content, not layout: a code span's whitespace
+    is literal by definition, and the padding that protects its boundary spaces
+    would be eaten by a blanket whitespace collapse. Only a newline has to go,
+    and a code span's own padding sits inside its backticks where no newline can
+    reach it.
+    """
+    return re.sub(r"\s*\n\s*", " ", text).strip()
+
+
+def _md_guard_line_expansion(text: str, per_line: int) -> None:
+    """Refuse a per-line expansion that would blow the payload ceiling.
+
+    Marking or indenting adds *per_line* characters to EVERY line, and a provider
+    controls both numbers. Newlines embedded in a single text node cost about
+    three bytes of payload each, while sixty levels of nesting adds a hundred and
+    twenty characters to every one of them, so a document well inside the 8MiB
+    fetch cap can project past three hundred MiB of output. The payload gate runs
+    only AFTER conversion, so without this check the allocation happens first:
+    measured before it, a 2.3MiB payload rendered 93MiB of markdown with a 224MiB
+    peak, and the 8MiB cap extrapolates to roughly 780MiB.
+
+    Raising here matches how an oversized response is already refused, and it
+    lives inside the two expanders rather than at their call sites so no new
+    caller can forget it.
+    """
+    if len(text) + per_line * (text.count("\n") + 1) > _MAX_PAYLOAD_BYTES:
+        raise SourceProviderError("Jira issue content is too large to render.")
+
+
+def _md_prefix_lines(text: str, prefix: str) -> str:
+    """Prefix every line of *text*, keeping blank lines inside the same block."""
+    _md_guard_line_expansion(text, len(prefix))
+    stripped = prefix.rstrip()
+    return "\n".join(prefix + line if line else stripped for line in text.split("\n"))
+
+
+def _md_hang_indent(body: str, marker: str) -> str:
+    """Put *marker* on the first line and align continuation lines under it."""
+    if not body:
+        return ""
+    _md_guard_line_expansion(body, len(marker))
+    pad = " " * len(marker)
+    head, *rest = body.split("\n")
+    lines = [marker + head]
+    lines.extend(pad + line if line else "" for line in rest)
+    return "\n".join(lines)
+
+
+def _adf_to_markdown(node: Any, *, _depth: int = 0) -> str:
+    """Convert an Atlassian Document Format tree to markdown.
+
+    ADF is the JSON document model Jira Cloud v3 returns for rich-text fields
+    (descriptions and comment bodies). The panel renders those fields through
+    MarkdownRenderer, and every other provider puts real markdown in the same
+    payload field (a GitHub issue ``body``, a GitLab ``description``), so
+    emitting markdown here restores headings, lists, link URLs, code fences and
+    tables that a plain-text walk would drop.
+
+    Traversal is depth-limited (max 64 levels) to prevent stack exhaustion from a
+    malformed or maliciously deep document, and literal text is escaped so a
+    description cannot smuggle markup into the panel.
+
+    Best-effort by design: ADF tables may carry merged cells and nested blocks
+    that GFM cannot express (rendered as a flat approximation), and a ``media``
+    node without a public ``url`` attribute has no fetchable address, so it
+    contributes nothing.
+    """
+    if _depth > _ADF_MAX_DEPTH or not isinstance(node, dict):
+        return ""
+    if str(node.get("type") or "") in _ADF_BLOCK_TYPES:
+        return _adf_block_to_markdown(node, _depth=_depth)
+    return _adf_inline_to_markdown(node, _depth=_depth)
+
+
+def _adf_block_to_markdown(node: dict[str, Any], *, _depth: int) -> str:
+    """Render one ADF block node. Only called for a type in _ADF_BLOCK_TYPES."""
+    node_type = str(node.get("type") or "")
+    attrs = _as_dict(node.get("attrs"))
+    if node_type == "doc":
+        return _adf_join_blocks(node, _depth=_depth)
+    if node_type in _ADF_BLOCK_CONTAINER_TYPES:
+        return _adf_join_blocks(node, _depth=_depth)
+    if node_type in _ADF_BLOCK_CARD_TYPES:
+        return _adf_url_link(str(attrs.get("url") or ""))
+    if node_type == "paragraph":
+        return _md_escape_block_leads(_adf_inline_run(node, _depth=_depth))
+    if node_type == "heading":
+        level = min(max(_int_or_zero(attrs.get("level")) or 1, 1), 6)
+        # A heading occupies one line, and only its first line carries the `#`
+        # prefix. A hardBreak inside it would push the rest onto a second line
+        # where a leading `-` or `#` is neither inline- nor block-lead-escaped and
+        # would render as a spurious list or heading.
+        text = _md_one_line(_adf_inline_run(node, _depth=_depth))
+        return f"{'#' * level} {text}" if text else ""
+    if node_type == "codeBlock":
+        body = _adf_plain_text(node, _depth=_depth)
+        fence = _md_backtick_fence(body, 3)
+        language = _md_code_language(attrs.get("language"))
+        # The newline before the closing fence SEPARATES the body from it, so a
+        # body that already ends with one does not need another: adding it
+        # unconditionally turned a source ending in `\n` into content ending in
+        # `\n\n`, and an empty body into a block holding one blank line.
+        if not body:
+            return f"{fence}{language}\n{fence}"
+        separator = "" if body.endswith("\n") else "\n"
+        return f"{fence}{language}\n{body}{separator}{fence}"
+    if node_type in ("blockquote", "panel"):
+        # An ADF panel (info/note/warning) has no markdown equivalent; a
+        # blockquote keeps it visually set apart from the surrounding prose.
+        #
+        # A chain of single-child quotes is collapsed and prefixed ONCE. Marking
+        # at every level re-copies text the level below already marked, which is
+        # quadratic in the nesting depth for the number of lines it carries: on a
+        # 6.7MB document nested 60 deep that measured 2.57s of blocking work
+        # against 0.47s for the same content unnested. Each collapsed level still
+        # consumes depth, so the traversal cap applies exactly as before.
+        marks = 1
+        inner_node = node
+        while True:
+            only = _as_list(inner_node.get("content"))
+            if len(only) == 1 and str(only[0].get("type") or "") in ("blockquote", "panel"):
+                inner_node = only[0]
+                marks += 1
+                _depth += 1
+            else:
+                break
+        inner = _adf_join_blocks(inner_node, _depth=_depth)
+        return _md_prefix_lines(inner, "> " * marks) if inner else ""
+    if node_type == "rule":
+        return "---"
+    if node_type in ("bulletList", "orderedList"):
+        return _adf_list_to_markdown(node, _depth=_depth, ordered=node_type == "orderedList")
+    if node_type == "taskList":
+        return _adf_task_list_to_markdown(node, _depth=_depth)
+    if node_type == "table":
+        return _adf_table_to_markdown(node, _depth=_depth)
+    # expand / nestedExpand: a collapsed section, whose title is the only part
+    # markdown cannot express as a container.
+    title = _adf_attr_label(attrs.get("title"))
+    inner = _adf_join_blocks(node, _depth=_depth)
+    return "\n\n".join(part for part in (f"**{title}**" if title else "", inner) if part)
+
+
+def _adf_inline_to_markdown(node: Any, *, _depth: int, _scanned: bool = False) -> str:
+    """Render one ADF inline node, recursing into an unrecognised container."""
+    if _depth > _ADF_MAX_DEPTH or not isinstance(node, dict):
+        return ""
+    node_type = str(node.get("type") or "")
+    attrs = _as_dict(node.get("attrs"))
+    if node_type == "text":
+        return _adf_apply_marks(str(node.get("text") or ""), _as_list(node.get("marks")))
+    if node_type == "hardBreak":
+        # Two trailing spaces: the panel renders with CommonMark soft-break
+        # collapse, so a bare newline would become a space.
+        return "  \n"
+    if node_type == "mention":
+        name = _adf_attr_label(attrs.get("text") or attrs.get("id"))
+        if not name:
+            return ""
+        return name if name.startswith("@") else f"@{name}"
+    if node_type == "emoji":
+        return _adf_attr_label(attrs.get("text") or attrs.get("shortName"))
+    if node_type == "inlineCard":
+        return _adf_url_link(str(attrs.get("url") or ""))
+    if node_type == "media":
+        # A link, not an image: the URL stays recoverable (the loss this fix is
+        # about) without the panel auto-fetching a provider-controlled address
+        # the moment someone opens the issue.
+        return _adf_url_link(str(attrs.get("url") or ""), _adf_attr_label(attrs.get("alt")))
+    # An unrecognised inline container contributes only its children, so it gets
+    # the same span treatment they would get at the top level -- otherwise two
+    # equally marked text nodes one level down still emit `**a****b**`. The
+    # ancestor's scan already covered this subtree, so it is not repeated.
+    return _adf_inline_sequence(_as_list(node.get("content")), _depth=_depth + 1, _scanned=_scanned)
+
+
+_ADF_EMPHASIS_MARKS = frozenset({"strong", "em"})
+
+
+def _adf_emphasis_item(node: dict[str, Any], *, _depth: int) -> tuple[str, frozenset[str]]:
+    """Split one inline node into (text, marks that can be factored).
+
+    Only ``strong`` and ``em`` are factorable, because they are the only two
+    marks that share a delimiter CHARACTER and so the only two whose delimiter
+    runs can merge with a neighbour's. A node carrying anything else -- a code
+    mark, strike, a link -- is rendered whole and treated as opaque: its own
+    backtick, tilde or bracket sits at the boundary and keeps the asterisks
+    apart, which was verified per pair rather than assumed.
+    """
+    text = str(node.get("text") or "")
+    kinds = {str(mark.get("type") or "") for mark in _as_list(node.get("marks"))}
+    if str(node.get("type") or "") != "text" or not text or not kinds <= _ADF_EMPHASIS_MARKS:
+        return _adf_inline_to_markdown(node, _depth=_depth, _scanned=True), frozenset()
+    return _md_escape_inline(text), frozenset(kinds)
+
+
+def _md_wrap_emphasis(mark: str, inner: str, before: str, after: str) -> str:
+    """Wrap *inner* for one emphasis mark with a delimiter that survives.
+
+    ``before`` and ``after`` are the single characters on either side, not the
+    surrounding text: only the adjacent character decides either rule, and
+    passing the accumulated output instead made the emitter quadratic.
+
+    ``strong`` has only ``**``, and an asterisk on the INSIDE of it is fine: a
+    closing ``***`` resolves correctly. ``em`` needs both of its spellings,
+    because neither works everywhere -- ``*`` is re-lexed when it touches
+    another asterisk run, and ``_`` will not open or close INTRAWORD. When
+    neither is safe at both ends the mark is dropped and the text kept: that
+    loses an italic, where emitting the delimiter anyway would show it as
+    content and lose the italic as well.
+    """
+    if not inner:
+        return ""
+    if mark == "strong":
+        return f"**{inner}**"
+    if before != "*" and after != "*":
+        return f"*{inner}*"
+    if not before.isalnum() and not after.isalnum():
+        return f"_{inner}_"
+    return inner
+
+
+def _md_emit_emphasis(items: list[tuple[str, frozenset[str]]], *, before: str = "") -> str:
+    """Emit a run of (text, marks) items, factoring a shared mark out ONCE.
+
+    Wrapping each node independently is what corrupts overlapping marks. A
+    strong node, then strong+em, then em emitted ``**a*****b****c*``, which a
+    CommonMark parser reads as strong(a), a LITERAL ``***b***``, then em(c): the
+    delimiters become visible text and the middle node loses both its marks.
+    Emitting a mark shared by neighbours ONCE, around all of them, is what keeps
+    the runs unambiguous -- ``**a*b***_c_`` parses as intended.
+
+    The scan is greedy from the left, taking the mark that spans the longest run
+    at each position. A different factorisation can occasionally keep a mark this
+    one drops; greedy is chosen because its fallback is lossy, never wrong.
+
+    ``before`` is the one character preceding this run. Recursion is bounded by
+    the number of factorable marks -- each level removes one, so it is at most
+    two deep and needs no depth guard of its own.
+    """
+    out: list[str] = []
+    last = before
+    index = 0
+    while index < len(items):
+        text, marks = items[index]
+        if not marks:
+            out.append(text)
+            last = text[-1:] or last
+            index += 1
+            continue
+        best_mark, best_end = "", index
+        for mark in ("strong", "em"):
+            if mark not in marks:
+                continue
+            end = index
+            while end < len(items) and mark in items[end][1]:
+                end += 1
+            if end > best_end:
+                best_mark, best_end = mark, end
+        inner = _md_emit_emphasis(
+            [(t, ms - {best_mark}) for t, ms in items[index:best_end]], before=last
+        )
+        if best_end < len(items):
+            next_text, next_marks = items[best_end]
+            # A marked neighbour opens with a delimiter, which is punctuation for
+            # the underscore rule and an asterisk for the run-merging one.
+            following = "*" if next_marks else next_text[:1]
+        else:
+            following = ""
+        piece = _md_wrap_emphasis(best_mark, inner, last, following)
+        out.append(piece)
+        last = piece[-1:] or last
+        index = best_end
+    return "".join(out)
+
+
+def _adf_apply_marks(text: str, marks: list[dict[str, Any]]) -> str:
+    """Wrap literal *text* in the markdown for each ADF mark, innermost first.
+
+    A ``code`` mark is exclusive: a code span is literal by definition, so the
+    emphasis marks are not applied inside one and the text is not escaped.
+    Empty text takes no mark wrapping at all, since a bare ``****`` or ``` `` ```
+    would render as those literal characters rather than as nothing.
+    """
+    kinds = {str(mark.get("type") or "") for mark in marks}
+    if not text:
+        out = ""
+    elif "code" in kinds:
+        out = _md_inline_code(text)
+    else:
+        out = _md_escape_inline(text)
+        if "strong" in kinds:
+            out = f"**{out}**"
+        if "em" in kinds:
+            # Asterisk, not underscore: CommonMark refuses to open or close an
+            # underscore emphasis INTRAWORD, so an italic node between two plain
+            # ones would render as `a_b_c` with the underscores visible and the
+            # italic lost. Asterisk has no such restriction, and `***x***` still
+            # nests correctly when a strong mark wraps the same text.
+            out = f"*{out}*"
+        if "strike" in kinds:
+            out = f"~~{out}~~"
+    for mark in marks:
+        if str(mark.get("type") or "") != "link":
+            continue
+        href = str(_as_dict(mark.get("attrs")).get("href") or "")
+        if href:
+            target = _md_link_target(href)
+            if target:
+                out = f"[{out or _md_escape_inline(href)}]({target})"
+            else:
+                # No destination, but keep the text: the label is what the reader
+                # was shown, and the href is the part that failed the scan.
+                out = out or _adf_attr_label(href)
+        break
+    return out
+
+
+def _adf_inline_run(node: dict[str, Any], *, _depth: int) -> str:
+    """Concatenate a block's inline children into one line of markdown."""
+    return _adf_inline_sequence(_as_list(node.get("content")), _depth=_depth + 1).strip()
+
+
+def _adf_inline_sequence(
+    children: list[dict[str, Any]], *, _depth: int, _scanned: bool = False
+) -> str:
+    """Render a run of inline nodes.
+
+    Redaction is checked ONCE, over the whole run, against the plain-text
+    rendition a seamless walk would produce -- every node's own text in order,
+    with no markup between any of it. That string is exactly what the
+    payload-level ``_redact_provider_data`` pass used to see, so checking it is
+    what preserves a catch this converter would otherwise break: escaping puts a
+    backslash inside ``ghp_``, and marks put delimiters between the halves of a
+    secret split across siblings, so a credential contiguous in the old output is
+    not contiguous in this one.
+
+    Checking the WHOLE run rather than some span of it is deliberate. Any
+    narrower boundary has to answer "which nodes contribute text seamlessly", and
+    that question kept having a wider answer than the last one -- a bold sibling,
+    then an unrecognised container, then a mention or emoji label, each of which
+    contributes text with no delimiter of its own. The run has no such boundary
+    to get wrong.
+
+    When the check fires the run is emitted as that redacted string: it loses its
+    formatting, but no node's text is lost with it.
+
+    ``_scanned`` says an ancestor already scanned this subtree and found it clean.
+    That scan covered every descendant's text, since ``_adf_plain_text`` recurses,
+    so re-scanning inside a nested container is provably redundant -- and it is
+    not free: rescanning at each level is depth-times-text work, which measured
+    7.0s for 1MiB under 60 unrecognised containers and 27.8s for 4MiB.
+    """
+    if not _scanned:
+        plain = "".join(_adf_plain_text(child, _depth=_depth) for child in children)
+        redacted = _md_redact_untruncated(plain)
+        if redacted != plain:
+            return _md_escape_inline(redacted)
+    return _md_emit_emphasis(
+        [_adf_emphasis_item(node, _depth=_depth) for node in _adf_merge_marked_text(children)]
+    )
+
+
+def _adf_mark_key(node: dict[str, Any]) -> list[tuple[str, str]]:
+    """An order-insensitive signature for a text node's marks."""
+    return sorted(
+        (str(mark.get("type") or ""), json.dumps(_as_dict(mark.get("attrs")), sort_keys=True))
+        for mark in _as_list(node.get("marks"))
+    )
+
+
+def _adf_merge_marked_text(span: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge neighbouring text nodes whose marks are identical.
+
+    A hardBreak between two text nodes stops the merge, since the break has to
+    survive between them.
+
+    Each run's text is collected in a list and joined ONCE at the end. Rebuilding
+    the accumulator as ``previous + current`` per node is superlinear -- measured
+    at 0.26s for 100k adjacent nodes, 0.75s for 200k and 1.48s for 300k, and 300k
+    single-character text nodes fit inside the 8MiB fetch cap -- so a provider
+    could buy seconds of synchronous work on the event loop. Only the traversal
+    DEPTH is capped; nothing bounds a node's breadth.
+    """
+    merged: list[dict[str, Any]] = []
+    runs: list[list[str]] = []
+    previous_key: list[tuple[str, str]] | None = None
+    for node in span:
+        is_text = str(node.get("type") or "") == "text"
+        key = _adf_mark_key(node) if is_text else None
+        if merged and is_text and previous_key is not None and key == previous_key:
+            runs[-1].append(str(node.get("text") or ""))
+            continue
+        merged.append(node)
+        runs.append([str(node.get("text") or "")] if is_text else [])
+        previous_key = key
+    return [{**node, "text": "".join(run)} if run else node for node, run in zip(merged, runs)]
+
+
+def _adf_plain_text(node: Any, *, _depth: int) -> str:
+    """The plain text a node contributes, with no markup of any kind.
+
+    This is the rendition the old plain-text walk produced, and it serves two
+    callers for the same reason -- both want the characters, not the markup: a
+    code block's literal body, and the redaction gate in
+    ``_adf_inline_sequence``, which has to see what the payload-level redactor
+    used to see.
+
+    A label-bearing node contributes its label WITHOUT the markup this converter
+    would wrap it in -- a mention's bare name, not ``@name``; a card's URL, not
+    ``[url](url)``. That is deliberate: the gate must never see less contiguity
+    than the rendered output has, and dropping the prefix can only make it see
+    more, which errs toward redacting.
+    """
+    if _depth > _ADF_MAX_DEPTH or not isinstance(node, dict):
+        return ""
+    node_type = str(node.get("type") or "")
+    attrs = _as_dict(node.get("attrs"))
+    if node_type == "text":
+        return str(node.get("text") or "")
+    if node_type == "hardBreak":
+        return "\n"
+    if node_type == "mention":
+        return str(attrs.get("text") or attrs.get("id") or "")
+    if node_type == "emoji":
+        return str(attrs.get("text") or attrs.get("shortName") or "")
+    if node_type == "media":
+        # The ALT before the URL, because the alt is what the reader is shown and
+        # what can JOIN a neighbour's text. When the URL fails the destination
+        # scan the link is dropped and the alt is emitted with no brackets around
+        # it, so a credential split across a text node and an alt becomes one
+        # contiguous token -- measured, with the backslash from escaping `ghp_`
+        # then defeating the payload pass. Returning the URL here made the gate
+        # blind to exactly that. The URL is the fallback for a media node with no
+        # alt, which is still emitted as the label.
+        return str(attrs.get("alt") or attrs.get("url") or "")
+    if node_type == "inlineCard":
+        # A card has no alt: its label IS the redacted URL, so the URL is what
+        # the gate must see.
+        return str(attrs.get("url") or "")
+    return "".join(
+        _adf_plain_text(child, _depth=_depth + 1) for child in _as_list(node.get("content"))
+    )
+
+
+def _adf_url_link(url: str, label: str = "") -> str:
+    """Render a provider URL as a link, or as its label alone if the URL fails.
+
+    The single place a provider URL becomes a markdown destination, so the scan
+    in `_md_link_target` cannot be skipped by adding another node type that
+    carries a URL. `_adf_attr_label` is the matching chokepoint for attribute
+    text; between them, no provider attribute reaches the document unscanned.
+    """
+    if not url:
+        return ""
+    text = label or _adf_attr_label(url)
+    target = _md_link_target(url)
+    return f"[{text}]({target})" if target else text
+
+
+def _adf_join_blocks(node: dict[str, Any], *, _depth: int) -> str:
+    """Render a container's children as markdown blocks, blank-line separated."""
+    rendered = (
+        _adf_to_markdown(child, _depth=_depth + 1) for child in _as_list(node.get("content"))
+    )
+    return "\n\n".join(block for block in rendered if block)
+
+
+def _adf_item_body(item: dict[str, Any], *, _depth: int) -> str:
+    """Render one list item, which may mix inline text with nested blocks."""
+    blocks: list[tuple[str, bool]] = []
+    run: list[dict[str, Any]] = []
+
+    def flush() -> None:
+        # Through _adf_inline_sequence, so an item's own inline children get the
+        # same split-credential guarantee a paragraph's do.
+        text = _adf_inline_sequence(list(run), _depth=_depth + 1).strip()
+        run.clear()
+        if text:
+            blocks.append((_md_escape_block_leads(text), False))
+
+    for child in _as_list(item.get("content")):
+        child_type = str(child.get("type") or "")
+        if child_type in _ADF_BLOCK_TYPES:
+            flush()
+            # Through _adf_to_markdown, never straight to the block renderer: a
+            # nested list would otherwise re-enter its own renderer past the
+            # depth cap and exhaust the stack on a deeply nested document.
+            rendered = _adf_to_markdown(child, _depth=_depth + 1)
+            if rendered:
+                blocks.append((rendered, child_type in _ADF_LIST_TYPES))
+        else:
+            run.append(child)
+    flush()
+
+    if not blocks:
+        return ""
+    parts = [blocks[0][0]]
+    for text, is_list in blocks[1:]:
+        parts.append("\n" if is_list else "\n\n")
+        parts.append(text)
+    return "".join(parts)
+
+
+def _adf_list_to_markdown(node: dict[str, Any], *, _depth: int, ordered: bool) -> str:
+    """Render a bullet or ordered list, honouring an explicit start number."""
+    items = _as_list(node.get("content"))
+    raw_order = _as_dict(node.get("attrs")).get("order")
+    # `or 1` collapsed an explicit `order: 0`, which ADF allows and CommonMark
+    # honours as `<ol start="0">`. Only an absent, non-integer or negative value
+    # falls back to 1. `bool` is excluded because it is an `int` in Python and
+    # `order: true` is not a start number.
+    start = (
+        raw_order
+        if isinstance(raw_order, int) and not isinstance(raw_order, bool) and raw_order >= 0
+        else 1
+    )
+    # More than nine digits is not a list start at all: CommonMark renders
+    # `1000000000. a` as a PARAGRAPH, so an out-of-range order would turn the
+    # whole list into literal text carrying visible numbers. The LAST item's
+    # marker is the one that has to fit, since a start of 999999999 overflows on
+    # its second item.
+    if start + max(len(items) - 1, 0) > _MD_MAX_LIST_START:
+        start = 1
+    lines: list[str] = []
+    for index, item in enumerate(items):
+        marker = f"{start + index}. " if ordered else "- "
+        rendered = _md_hang_indent(_adf_item_body(item, _depth=_depth + 1), marker)
+        if rendered:
+            lines.append(rendered)
+    return "\n".join(lines)
+
+
+def _adf_task_list_to_markdown(node: dict[str, Any], *, _depth: int) -> str:
+    """Render an ADF task list as a GFM checklist."""
+    lines: list[str] = []
+    for item in _as_list(node.get("content")):
+        state = str(_as_dict(item.get("attrs")).get("state") or "").upper()
+        marker = "- [x] " if state == "DONE" else "- [ ] "
+        rendered = _md_hang_indent(_adf_item_body(item, _depth=_depth + 1), marker)
+        if rendered:
+            lines.append(rendered)
+    return "\n".join(lines)
+
+
+def _adf_table_to_markdown(node: dict[str, Any], *, _depth: int) -> str:
+    """Render an ADF table as a GFM table, using its first row as the header.
+
+    GFM requires a header row and cannot express merged cells or block content
+    inside a cell, so cell text is flattened to a single line and any
+    colspan/rowspan is ignored.
+
+    Each BODY row emits its own cells and nothing more, because GFM inserts empty
+    cells for a row shorter than the header. The HEADER and separator are widened
+    to the widest row, because the other direction is not symmetric: GFM fixes the
+    table's width at the header and a row with MORE cells than the header has the
+    excess dropped -- the text is gone, not wrapped. Widening two lines is linear
+    in the width; padding every row is what made this quadratic before, since a
+    table with one wide row and many narrow ones emitted rows x width cells for
+    the handful it actually carried, and a provider controls both numbers.
+    """
+    rows: list[list[str]] = []
+    for row in _as_list(node.get("content")):
+        if str(row.get("type") or "") != "tableRow":
+            continue
+        cells = [
+            _adf_cell_text(cell, _depth=_depth + 1)
+            for cell in _as_list(row.get("content"))
+            if str(cell.get("type") or "") in ("tableHeader", "tableCell")
+        ]
+        if cells:
+            rows.append(cells)
+    if not rows:
+        return ""
+    header, *body = rows
+    width = max(len(row) for row in rows)
+    lines = [
+        "| " + " | ".join(header + [""] * (width - len(header))) + " |",
+        "| " + " | ".join(["---"] * width) + " |",
+    ]
+    lines.extend("| " + " | ".join(row) + " |" for row in body)
+    return "\n".join(lines)
+
+
+def _adf_cell_text(cell: dict[str, Any], *, _depth: int) -> str:
+    """Flatten one table cell to a single line (a GFM cell cannot wrap).
+
+    Only line breaks are folded: repeated spaces and tabs survive, because a code
+    span's whitespace is literal and a blanket collapse would silently rewrite
+    ``a  b`` as ``a b``.
+
+    Any pipe still unescaped after rendering is escaped here. A text pipe is
+    already escaped by ``_md_escape_inline``, but a code span is emitted
+    literally by definition, so ``a|b`` inside one would split the cell in two.
+    GFM honours ``\\|`` inside a code span for exactly this case. The one thing
+    this cannot express is a literal backslash-pipe pair inside a code span in a
+    table, which GFM has no spelling for.
+    """
+    text = _md_one_line(_adf_join_blocks(cell, _depth=_depth))
+    return re.sub(r"(?<!\\)\|", r"\\|", text)
 
 
 def _jira_linked_changes(fields: dict[str, Any], base_url: str) -> list[dict[str, Any]]:
@@ -3233,8 +4074,11 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
     # Extract description
     raw_desc = fields.get("description")
     if isinstance(raw_desc, dict):
-        # ADF (Cloud v3)
-        description = _adf_to_plain_text(raw_desc).strip()
+        # ADF (Cloud v3). The converter redacts internally, where it escapes:
+        # `_adf_inline_sequence` for a run's text and `_adf_attr_label` for an
+        # attribute. Both run inside its depth-capped traversal, so no unbounded
+        # pre-pass walks a provider-controlled tree.
+        description = _adf_to_markdown(raw_desc).strip()
     elif isinstance(raw_desc, str):
         # Plain text or wiki markup (Server v2)
         description = raw_desc
@@ -3302,7 +4146,7 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
         c_author = _as_dict(c.get("author"))
         c_body_raw = c.get("body")
         if isinstance(c_body_raw, dict):
-            c_body = _adf_to_plain_text(c_body_raw).strip()
+            c_body = _adf_to_markdown(c_body_raw).strip()
         elif isinstance(c_body_raw, str):
             c_body = c_body_raw
         else:

--- a/test/fixtures/adf_markdown_safety.json
+++ b/test/fixtures/adf_markdown_safety.json
@@ -1,0 +1,106 @@
+{
+  "_comment": [
+    "Shared contract for the Jira ADF -> markdown converter's safety claims.",
+    "The BACKEND test (test/test_source_providers.py) asserts that the converter",
+    "turns each `adf` into exactly `markdown`, so this file cannot drift from the",
+    "converter. The FRONTEND test (website/src/test/MarkdownRenderer.adfSafety",
+    ".test.tsx) renders each `markdown` through the real MarkdownRenderer plugin",
+    "stack and asserts the selectors, so the escape set is checked against the",
+    "renderer that actually runs rather than against a comment describing it.",
+    "Adding a case here makes BOTH sides assert it. If the frontend side starts",
+    "failing, the escape set in source_providers.py is what needs to change --",
+    "not this file."
+  ],
+  "cases": [
+    {
+      "name": "literal emphasis stays text",
+      "adf": {
+        "type": "doc",
+        "content": [
+          {"type": "paragraph", "content": [{"type": "text", "text": "**bold** _it_"}]}
+        ]
+      },
+      "markdown": "\\*\\*bold\\*\\* \\_it\\_",
+      "expectText": "**bold** _it_",
+      "forbidSelectors": ["strong", "em"]
+    },
+    {
+      "name": "literal html stays text",
+      "adf": {
+        "type": "doc",
+        "content": [
+          {"type": "paragraph", "content": [{"type": "text", "text": "<b>x</b> & <img src=y>"}]}
+        ]
+      },
+      "markdown": "\\<b\\>x\\</b\\> \\& \\<img src=y\\>",
+      "expectText": "<b>x</b> & <img src=y>",
+      "forbidSelectors": ["b", "img"]
+    },
+    {
+      "name": "literal math stays text",
+      "adf": {
+        "type": "doc",
+        "content": [
+          {"type": "paragraph", "content": [{"type": "text", "text": "$$x^2$$"}]}
+        ]
+      },
+      "markdown": "\\$\\$x^2\\$\\$",
+      "expectText": "$$x^2$$",
+      "forbidSelectors": [".katex", ".katex-display", "math"]
+    },
+    {
+      "name": "literal image syntax stays text",
+      "adf": {
+        "type": "doc",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [{"type": "text", "text": "![a](http://e.com/i.png)"}]
+          }
+        ]
+      },
+      "markdown": "\\!\\[a\\](http://e.com/i.png)",
+      "expectText": "![a](http://e.com/i.png)",
+      "forbidSelectors": ["img"]
+    },
+    {
+      "name": "external media is a link not an image",
+      "adf": {
+        "type": "doc",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [
+              {
+                "type": "media",
+                "attrs": {"type": "external", "url": "http://e.com/i.png", "alt": "shot"}
+              }
+            ]
+          }
+        ]
+      },
+      "markdown": "[shot](http://e.com/i.png)",
+      "forbidSelectors": ["img"],
+      "requireSelector": "a[href=\"http://e.com/i.png\"]"
+    },
+    {
+      "name": "a credential split across marks is redacted",
+      "adf": {
+        "type": "doc",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [
+              {"type": "text", "text": "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4"},
+              {"type": "text", "text": "Yz7Bc0Ef3Gh6", "marks": [{"type": "strong"}]}
+            ]
+          }
+        ]
+      },
+      "markdown": "\\[REDACTED: credential\\]",
+      "expectText": "[REDACTED: credential]",
+      "forbidSelectors": ["strong"],
+      "forbidText": "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4Yz7Bc0Ef3Gh6"
+    }
+  ]
+}

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
+import pathlib
+import re
 import sys
 import tempfile
 import threading
@@ -7622,72 +7625,1367 @@ class TestBranchPatternSlashSemantics:
 # ── Jira issue fetching tests ────────────────────────────────────────────────
 
 
-class TestAdfToPlainText:
-    """The ADF plain-text extractor handles Atlassian Document Format JSON."""
+class TestAdfToMarkdown:
+    """The ADF converter emits markdown for Atlassian Document Format JSON."""
+
+    @staticmethod
+    def _doc(*content):
+        return {"type": "doc", "version": 1, "content": list(content)}
+
+    @staticmethod
+    def _para(*content):
+        return {"type": "paragraph", "content": list(content)}
+
+    @staticmethod
+    def _text(text, marks=None):
+        node = {"type": "text", "text": text}
+        if marks is not None:
+            node["marks"] = marks
+        return node
 
     def test_simple_paragraph(self):
-        adf = {
-            "type": "doc",
-            "version": 1,
-            "content": [
+        adf = self._doc(self._para(self._text("Hello world")))
+        assert source._adf_to_markdown(adf) == "Hello world"
+
+    def test_multiple_paragraphs_separated_by_blank_line(self):
+        adf = self._doc(self._para(self._text("Line 1")), self._para(self._text("Line 2")))
+        assert source._adf_to_markdown(adf) == "Line 1\n\nLine 2"
+
+    def test_heading_becomes_hashes(self):
+        adf = self._doc(
+            {"type": "heading", "attrs": {"level": 3}, "content": [self._text("Title")]}
+        )
+        assert source._adf_to_markdown(adf) == "### Title"
+
+    def test_heading_level_is_clamped(self):
+        adf = self._doc(
+            {"type": "heading", "attrs": {"level": 99}, "content": [self._text("Deep")]}
+        )
+        assert source._adf_to_markdown(adf) == "###### Deep"
+
+    def test_heading_stays_on_one_line(self):
+        """Only a heading's first line carries the `#`, so a hardBreak inside it
+        would leave a second line whose `-` renders as a list."""
+        adf = self._doc(
+            {
+                "type": "heading",
+                "attrs": {"level": 3},
+                "content": [self._text("Title"), {"type": "hardBreak"}, self._text("- x")],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "### Title - x"
+
+    def test_emphasis_marks(self):
+        adf = self._doc(
+            self._para(
+                self._text("bold", [{"type": "strong"}]),
+                self._text(" "),
+                self._text("italic", [{"type": "em"}]),
+                self._text(" "),
+                self._text("gone", [{"type": "strike"}]),
+            )
+        )
+        assert source._adf_to_markdown(adf) == "**bold** *italic* ~~gone~~"
+
+    def test_adjacent_identical_marks_are_merged(self):
+        """`**a****b**` renders as a bold `a****b` -- the delimiters become
+        content -- so equally marked neighbours must merge before wrapping."""
+        adf = self._doc(
+            self._para(
+                self._text("a", [{"type": "strong"}]),
+                self._text("b", [{"type": "strong"}]),
+            )
+        )
+        assert source._adf_to_markdown(adf) == "**ab**"
+
+    def test_adjacent_code_marks_are_merged(self):
+        """Worse than emphasis: `` `a``b` `` collapses into one span holding
+        literal backticks."""
+        adf = self._doc(
+            self._para(
+                self._text("a", [{"type": "code"}]),
+                self._text("b", [{"type": "code"}]),
+            )
+        )
+        assert source._adf_to_markdown(adf) == "`ab`"
+
+    def test_adjacent_different_marks_are_not_merged(self):
+        adf = self._doc(
+            self._para(
+                self._text("a", [{"type": "strong"}]),
+                self._text("b", [{"type": "em"}]),
+            )
+        )
+        # `_` rather than `*` for the em: it abuts the strong's closing `**`, and
+        # two asterisk runs that touch are re-lexed as one. `**a**_b_` parses as
+        # <strong>a</strong><em>b</em>.
+        assert source._adf_to_markdown(adf) == "**a**_b_"
+
+    def test_an_italic_between_plain_neighbours_keeps_its_emphasis(self):
+        """CommonMark will not open underscore emphasis intraword, so `a_b_c`
+        would render with visible underscores and no italic."""
+        adf = self._doc(
+            self._para(
+                self._text("a"),
+                self._text("b", [{"type": "em"}]),
+                self._text("c"),
+            )
+        )
+        assert source._adf_to_markdown(adf) == "a*b*c"
+
+    def test_a_hard_break_keeps_marked_neighbours_apart(self):
+        adf = self._doc(
+            self._para(
+                self._text("a", [{"type": "strong"}]),
+                {"type": "hardBreak"},
+                self._text("b", [{"type": "strong"}]),
+            )
+        )
+        assert source._adf_to_markdown(adf) == "**a**  \n**b**"
+
+    def test_code_mark_is_literal_and_not_escaped(self):
+        adf = self._doc(self._para(self._text("a_b*c", [{"type": "code"}])))
+        assert source._adf_to_markdown(adf) == "`a_b*c`"
+
+    def test_code_span_keeps_its_boundary_spaces(self):
+        """CommonMark strips one space from each end of ` x `, so pad it."""
+        adf = self._doc(self._para(self._text(" foo ", [{"type": "code"}])))
+        assert source._adf_to_markdown(adf) == "`  foo  `"
+
+    def test_all_whitespace_code_span_is_not_padded(self):
+        """Whitespace-only content is exempt from the strip rule, so padding it
+        would silently add two spaces."""
+        adf = self._doc(self._para(self._text("   ", [{"type": "code"}])))
+        assert source._adf_to_markdown(adf) == "`   `"
+
+    def test_one_sided_space_in_a_code_span_is_not_padded(self):
+        adf = self._doc(self._para(self._text(" foo", [{"type": "code"}])))
+        assert source._adf_to_markdown(adf) == "` foo`"
+
+    def test_empty_marked_text_emits_nothing(self):
+        """A marked empty text node must not leave its bare delimiters behind."""
+        for mark in ("strong", "em", "strike", "code"):
+            adf = self._doc(self._para(self._text("", [{"type": mark}])))
+            assert source._adf_to_markdown(adf) == "", mark
+
+    def test_external_media_becomes_a_link_not_an_image(self):
+        """A link keeps the URL recoverable without the panel auto-fetching it."""
+        adf = self._doc(
+            self._para(
                 {
-                    "type": "paragraph",
-                    "content": [{"type": "text", "text": "Hello world"}],
+                    "type": "media",
+                    "attrs": {"type": "external", "url": "https://ex.com/a.png", "alt": "chart"},
                 }
-            ],
-        }
-        assert source._adf_to_plain_text(adf) == "Hello world\n"
+            )
+        )
+        assert source._adf_to_markdown(adf) == "[chart](https://ex.com/a.png)"
 
-    def test_multiple_paragraphs(self):
-        adf = {
-            "type": "doc",
-            "version": 1,
+    def test_media_without_a_url_contributes_nothing(self):
+        """An attachment reference carries no fetchable address."""
+        adf = self._doc(
+            self._para({"type": "media", "attrs": {"type": "file", "id": "abc", "alt": "shot"}})
+        )
+        assert source._adf_to_markdown(adf) == ""
+
+    def test_link_mark_keeps_the_url(self):
+        adf = self._doc(
+            self._para(
+                self._text(
+                    "the docs",
+                    [{"type": "link", "attrs": {"href": "https://example.com/a"}}],
+                )
+            )
+        )
+        assert source._adf_to_markdown(adf) == "[the docs](https://example.com/a)"
+
+    def test_link_with_parentheses_uses_the_angle_bracket_form(self):
+        adf = self._doc(
+            self._para(
+                self._text(
+                    "wiki",
+                    [{"type": "link", "attrs": {"href": "https://ex.com/a(b)"}}],
+                )
+            )
+        )
+        assert source._adf_to_markdown(adf) == "[wiki](<https://ex.com/a(b)>)"
+
+    def test_inline_card_becomes_a_link(self):
+        adf = self._doc(
+            self._para({"type": "inlineCard", "attrs": {"url": "https://example.com"}})
+        )
+        assert source._adf_to_markdown(adf) == "[https://example.com](https://example.com)"
+
+    def test_code_block_is_fenced_with_its_language(self):
+        adf = self._doc(
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python"},
+                "content": [self._text("print(1)\nprint(2)")],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "```python\nprint(1)\nprint(2)\n```"
+
+    def test_code_block_fence_widens_past_inner_backticks(self):
+        adf = self._doc({"type": "codeBlock", "content": [self._text("a ``` b")]})
+        assert source._adf_to_markdown(adf) == "````\na ``` b\n````"
+
+    def test_code_block_language_cannot_leave_its_fence_line(self):
+        """A fence info string runs to end of line, so a newline in the
+        `language` attribute would close the fence and inject real markdown."""
+        adf = self._doc(
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python\n\n![x](https://evil.example/beacon.png)\n\n```"},
+                "content": [self._text("safe")],
+            }
+        )
+        result = source._adf_to_markdown(adf)
+        assert result == "```\nsafe\n```"
+        assert "evil.example" not in result
+
+    def test_code_block_keeps_a_real_language_token(self):
+        adf = self._doc(
+            {"type": "codeBlock", "attrs": {"language": "c++"}, "content": [self._text("x;")]}
+        )
+        assert source._adf_to_markdown(adf) == "```c++\nx;\n```"
+
+    def test_code_block_drops_a_multi_token_language(self):
+        adf = self._doc(
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python rm -rf"},
+                "content": [self._text("x")],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "```\nx\n```"
+
+    def test_expand_title_stays_on_one_line(self):
+        adf = self._doc(
+            {
+                "type": "expand",
+                "attrs": {"title": "Details\n\n# Injected"},
+                "content": [self._para(self._text("inner"))],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "**Details # Injected**\n\ninner"
+
+    def test_mention_name_stays_on_one_line(self):
+        adf = self._doc(self._para({"type": "mention", "attrs": {"text": "Alice\n# Injected"}}))
+        assert source._adf_to_markdown(adf) == "@Alice # Injected"
+
+    def test_bullet_list_gets_markers(self):
+        adf = self._doc(
+            {
+                "type": "bulletList",
+                "content": [
+                    {"type": "listItem", "content": [self._para(self._text("one"))]},
+                    {"type": "listItem", "content": [self._para(self._text("two"))]},
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "- one\n- two"
+
+    def test_nested_list_is_indented_under_its_parent(self):
+        adf = self._doc(
+            {
+                "type": "bulletList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            self._para(self._text("outer")),
+                            {
+                                "type": "bulletList",
+                                "content": [
+                                    {
+                                        "type": "listItem",
+                                        "content": [self._para(self._text("inner"))],
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "- outer\n  - inner"
+
+    def test_ordered_list_honours_its_start_number(self):
+        adf = self._doc(
+            {
+                "type": "orderedList",
+                "attrs": {"order": 3},
+                "content": [
+                    {"type": "listItem", "content": [self._para(self._text("a"))]},
+                    {"type": "listItem", "content": [self._para(self._text("b"))]},
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "3. a\n4. b"
+
+    def test_task_list_becomes_a_checklist(self):
+        adf = self._doc(
+            {
+                "type": "taskList",
+                "content": [
+                    {
+                        "type": "taskItem",
+                        "attrs": {"state": "DONE"},
+                        "content": [self._text("shipped")],
+                    },
+                    {
+                        "type": "taskItem",
+                        "attrs": {"state": "TODO"},
+                        "content": [self._text("pending")],
+                    },
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "- [x] shipped\n- [ ] pending"
+
+    def test_blockquote_prefixes_every_line(self):
+        adf = self._doc(
+            {
+                "type": "blockquote",
+                "content": [self._para(self._text("first")), self._para(self._text("second"))],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "> first\n>\n> second"
+
+    def test_panel_renders_as_a_blockquote(self):
+        adf = self._doc(
+            {
+                "type": "panel",
+                "attrs": {"panelType": "warning"},
+                "content": [self._para(self._text("careful"))],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "> careful"
+
+    def test_rule_becomes_a_thematic_break(self):
+        adf = self._doc(self._para(self._text("a")), {"type": "rule"}, self._para(self._text("b")))
+        assert source._adf_to_markdown(adf) == "a\n\n---\n\nb"
+
+    def test_table_becomes_gfm(self):
+        adf = self._doc(
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {"type": "tableHeader", "content": [self._para(self._text("H1"))]},
+                            {"type": "tableHeader", "content": [self._para(self._text("H2"))]},
+                        ],
+                    },
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {"type": "tableCell", "content": [self._para(self._text("a"))]},
+                            {"type": "tableCell", "content": [self._para(self._text("b"))]},
+                        ],
+                    },
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "| H1 | H2 |\n| --- | --- |\n| a | b |"
+
+    def test_short_table_row_emits_only_its_own_cells(self):
+        """GFM fills a short row itself, so padding it here buys nothing."""
+        adf = self._doc(
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {"type": "tableHeader", "content": [self._para(self._text("H1"))]},
+                            {"type": "tableHeader", "content": [self._para(self._text("H2"))]},
+                        ],
+                    },
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {"type": "tableCell", "content": [self._para(self._text("only"))]}
+                        ],
+                    },
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "| H1 | H2 |\n| --- | --- |\n| only |"
+
+    def test_a_ragged_table_does_not_amplify_its_output(self):
+        """A wide header plus many narrow rows must stay linear in cell count."""
+        cells = 200
+        wide = {
+            "type": "tableRow",
             "content": [
-                {"type": "paragraph", "content": [{"type": "text", "text": "Line 1"}]},
-                {"type": "paragraph", "content": [{"type": "text", "text": "Line 2"}]},
+                {"type": "tableHeader", "content": [self._para(self._text("h"))]}
+                for _ in range(cells)
             ],
         }
-        assert source._adf_to_plain_text(adf) == "Line 1\nLine 2\n"
+        narrow = [
+            {
+                "type": "tableRow",
+                "content": [{"type": "tableCell", "content": [self._para(self._text("c"))]}],
+            }
+            for _ in range(cells)
+        ]
+        rendered = source._adf_to_markdown(self._doc({"type": "table", "content": [wide, *narrow]}))
+        # 400 real cells. Padding every short row to the widest emits 200*200.
+        assert rendered.count("|") < 2000
 
-    def test_inline_card_extracts_url(self):
+    def test_mention_gets_an_at_prefix_without_doubling_it(self):
+        adf = self._doc(
+            self._para(
+                {"type": "mention", "attrs": {"text": "Alice"}},
+                self._text(" and "),
+                {"type": "mention", "attrs": {"text": "@Bob"}},
+            )
+        )
+        assert source._adf_to_markdown(adf) == "@Alice and @Bob"
+
+    def test_hard_break_is_a_markdown_line_break(self):
+        adf = self._doc(self._para(self._text("a"), {"type": "hardBreak"}, self._text("b")))
+        assert source._adf_to_markdown(adf) == "a  \nb"
+
+    def test_literal_markdown_in_text_is_escaped(self):
+        adf = self._doc(self._para(self._text("**not bold** and <b>tag</b> and _u_")))
+        result = source._adf_to_markdown(adf)
+        assert result == r"\*\*not bold\*\* and \<b\>tag\</b\> and \_u\_"
+
+    def test_literal_html_entity_in_text_is_escaped(self):
+        """rehypeRaw would otherwise decode `&copy;` to a copyright sign."""
+        adf = self._doc(self._para(self._text("&copy; 2026 &amp; friends")))
+        assert source._adf_to_markdown(adf) == r"\&copy; 2026 \&amp; friends"
+
+    def test_a_credential_in_text_is_redacted_by_the_converter_itself(self):
+        secret = "Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4Yz7Bc0Ef3Gh6"
+        adf = self._doc(self._para(self._text(f"use ghp_{secret} to clone")))
+        assert secret not in source._adf_to_markdown(adf)
+
+    def test_a_credential_in_an_attribute_is_redacted_inside_the_bounded_walk(self):
+        """`_adf_attr_label` redacts before it escapes.
+
+        Escaping would insert a backslash into `ghp_...` and hide it from the
+        payload-level redactor that runs afterwards, and doing this inside the
+        converter's depth-capped traversal is what avoids an unbounded pre-pass
+        over a provider-controlled tree.
+        """
+        secret = "Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4Yz7Bc0Ef3Gh6"
+        adf = self._doc(
+            self._para(
+                {
+                    "type": "media",
+                    "attrs": {
+                        "type": "external",
+                        "url": "https://ex.com/a.png",
+                        "alt": f"use ghp_{secret}",
+                    },
+                }
+            )
+        )
+        assert secret not in source._adf_to_markdown(adf)
+
+    def test_a_credential_split_across_marked_siblings_is_still_redacted(self):
+        """A plain-text walk joins sibling text nodes seamlessly, so the payload
+        redactor catches a credential spanning them. Marks would put delimiters
+        between the halves and hide it, so an inline run whose own raw text
+        carries a credential is emitted as one redacted string."""
+        head, tail = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4", "Yz7Bc0Ef3Gh6"
+        adf = self._doc(
+            self._para(self._text(head), self._text(tail, [{"type": "strong"}]))
+        )
+        rendered = source._adf_to_markdown(source._redact_provider_data(adf))
+        assert tail not in rendered
+        assert head not in rendered
+
+    def test_redacting_a_run_keeps_every_node_s_text(self):
+        """The fallback emits the plain rendition of the WHOLE run, so a mention
+        or card in the same paragraph keeps its text instead of disappearing."""
+        secret = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4Yz7Bc0Ef3Gh6"
+        adf = self._doc(
+            self._para(
+                self._text(f"token {secret} for "),
+                {"type": "mention", "attrs": {"text": "Alice"}},
+                self._text(" see "),
+                {"type": "inlineCard", "attrs": {"url": "https://example.com/doc"}},
+            )
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert secret not in rendered
+        assert "Alice" in rendered
+        assert "https://example.com/doc" in rendered
+
+    def test_a_credential_split_across_a_label_boundary_is_redacted(self):
+        """An emoji label contributes text with no delimiter of its own, so a
+        secret continued inside one is contiguous in the rendered output."""
+        head, tail = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4", "Yz7Bc0Ef3Gh6"
+        adf = self._doc(
+            self._para(self._text(head), {"type": "emoji", "attrs": {"text": tail}})
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert head not in rendered
+        assert tail not in rendered
+
+    def test_a_credential_split_through_an_unknown_container_is_redacted(self):
+        """An unrecognised inline container emits nothing of its own, so a
+        plain-text walk joined the halves either side of it seamlessly. It has to
+        stay inside the span the credential check reads."""
+        head, tail = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4", "Yz7Bc0Ef3Gh6"
+        adf = self._doc(
+            self._para(
+                self._text(head),
+                {"type": "someFutureInline", "content": [self._text(tail)]},
+            )
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert head not in rendered
+        assert tail not in rendered
+
+    def test_literal_math_syntax_is_escaped(self):
+        """The same renderer runs remark-math, so a literal `$$x$$` would
+        otherwise render as KaTeX instead of as the characters typed."""
+        adf = self._doc(self._para(self._text("costs $$5 and $x$ too")))
+        assert source._adf_to_markdown(adf) == r"costs \$\$5 and \$x\$ too"
+
+    def test_a_credential_split_inside_an_unknown_container_is_redacted(self):
+        """Both halves inside the container, the second one marked."""
+        head, tail = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4", "Yz7Bc0Ef3Gh6"
+        adf = self._doc(
+            self._para(
+                {
+                    "type": "someFutureInline",
+                    "content": [self._text(head), self._text(tail, [{"type": "strong"}])],
+                }
+            )
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert head not in rendered
+        assert tail not in rendered
+
+    def test_adjacent_identical_marks_inside_an_unknown_container_are_merged(self):
+        adf = self._doc(
+            self._para(
+                {
+                    "type": "someFutureInline",
+                    "content": [
+                        self._text("a", [{"type": "strong"}]),
+                        self._text("b", [{"type": "strong"}]),
+                    ],
+                }
+            )
+        )
+        assert source._adf_to_markdown(adf) == "**ab**"
+
+    def test_a_literal_bang_cannot_splice_an_image_onto_a_link(self):
+        """`!` before an emitted `[` would form image syntax, and an image
+        auto-fetches the URL -- the exact beacon the media-as-link form avoids."""
+        adf = self._doc(
+            self._para(
+                self._text("!"),
+                {
+                    "type": "media",
+                    "attrs": {"type": "external", "url": "https://evil.example/beacon.png"},
+                },
+            )
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert rendered == r"\![https://evil.example/beacon.png](https://evil.example/beacon.png)"
+
+    def test_a_wide_run_of_text_nodes_merges_in_one_pass(self):
+        """Only traversal DEPTH is capped, so a provider can put hundreds of
+        thousands of adjacent text nodes in one paragraph. The run's text is
+        joined once rather than rebuilt per node."""
+        n = 100000
+        adf = self._doc(
+            {"type": "paragraph", "content": [{"type": "text", "text": "a"} for _ in range(n)]}
+        )
+        assert source._adf_to_markdown(adf) == "a" * n
+
+    def test_a_credential_split_deep_inside_nested_containers_is_redacted(self):
+        """The scan runs once at the outermost run and inner containers reuse it,
+        so the guarantee has to hold at depth, not just at the top level."""
+        head, tail = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4", "Yz7Bc0Ef3Gh6"
+        node = {
+            "type": "someFutureInline",
+            "content": [self._text(head), self._text(tail, [{"type": "strong"}])],
+        }
+        for _ in range(3):
+            node = {"type": "someFutureInline", "content": [node]}
+        rendered = source._adf_to_markdown(self._doc(self._para(node)))
+        assert head not in rendered
+        assert tail not in rendered
+
+    def test_a_link_whose_href_fails_the_scan_emits_no_destination(self):
+        """`_URL_RE` stops at `)`, so a paren in the path puts the whole query
+        outside every exfiltration check. The href is scanned paren-encoded and
+        the link is dropped rather than emitted partly redacted."""
+        blob = "Xk7Qm2Rt9Wz4Yb6Nc1Vf8Hj3Lp5Sd0Ag7Ke4Ou2"
+        href = f"https://evil.example.com/a)b?data={blob}"
+        adf = self._doc(
+            self._para(self._text("click", [{"type": "link", "attrs": {"href": href}}]))
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert rendered == "click"
+        assert blob not in rendered
+        assert "evil.example.com" not in rendered
+
+    def test_a_benign_url_with_parentheses_keeps_its_link(self):
+        """The scan must not cost legitimate links: wiki and Confluence URLs
+        carry parentheses routinely, and one is not evidence of anything."""
+        for href in (
+            "https://en.wikipedia.org/wiki/Salt_(chemistry)",
+            "https://co.atlassian.net/wiki/spaces/X/pages/1/Plan_(v2)?focus=1",
+        ):
+            adf = self._doc(
+                self._para(self._text("doc", [{"type": "link", "attrs": {"href": href}}]))
+            )
+            assert source._adf_to_markdown(adf) == f"[doc](<{href}>)"
+
+    def test_a_layout_keeps_its_columns_as_blocks(self):
+        """Markdown has no columns, so a layout flattens -- but its children are
+        BLOCKS. Reaching the inline path concatenated them into `firstsecond`,
+        losing both the separator and the heading's `##`."""
         adf = {
             "type": "doc",
-            "version": 1,
             "content": [
                 {
-                    "type": "paragraph",
+                    "type": "layoutSection",
                     "content": [
-                        {"type": "inlineCard", "attrs": {"url": "https://example.com"}},
+                        {
+                            "type": "layoutColumn",
+                            "content": [
+                                {"type": "paragraph", "content": [{"type": "text", "text": "first"}]}
+                            ],
+                        },
+                        {
+                            "type": "layoutColumn",
+                            "content": [
+                                {
+                                    "type": "heading",
+                                    "attrs": {"level": 2},
+                                    "content": [{"type": "text", "text": "second"}],
+                                }
+                            ],
+                        },
                     ],
                 }
             ],
         }
-        assert "https://example.com" in source._adf_to_plain_text(adf)
+        assert source._adf_to_markdown(adf) == "first\n\n## second"
 
-    def test_empty_and_non_dict_returns_empty(self):
-        assert source._adf_to_plain_text(None) == ""
-        assert source._adf_to_plain_text("just a string") == ""
-        assert source._adf_to_plain_text({}) == ""
+    def test_a_bodied_extension_and_decision_list_keep_their_blocks(self):
+        for container, item, expected in (
+            ("bodiedExtension", "paragraph", "alpha\n\nbeta"),
+            ("decisionList", "decisionItem", "alpha\n\nbeta"),
+        ):
+            adf = {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": container,
+                        "content": [
+                            {"type": item, "content": [{"type": "text", "text": "alpha"}]},
+                            {"type": item, "content": [{"type": "text", "text": "beta"}]},
+                        ],
+                    }
+                ],
+            }
+            assert source._adf_to_markdown(adf) == expected
 
-    def test_nested_list_structure(self):
-        adf = {
-            "type": "doc",
-            "content": [
+    def test_a_block_card_keeps_its_url(self):
+        """A block-level card carries its URL in an attribute and has no content,
+        so the inline fallthrough rendered it as the empty string -- the URL was
+        lost outright, the same unrecoverable loss this change exists to fix."""
+        for card in ("blockCard", "embedCard"):
+            adf = {"type": "doc", "content": [{"type": card, "attrs": {"url": "https://e.com/p"}}]}
+            assert source._adf_to_markdown(adf) == "[https://e.com/p](https://e.com/p)"
+
+    def test_no_node_type_emits_an_attribute_without_passing_a_gate(self):
+        """Redaction lives at two chokepoints -- `_adf_attr_label` for attribute
+        text and `_adf_url_link` for a URL destination. That invariant is
+        conventional unless something checks it, so the node types and attribute
+        names are read back OUT of the module and every combination is tried:
+        a type added later is covered without anyone remembering this test."""
+        src = inspect.getsource(source)
+        body = src[src.index("def _adf_block_to_markdown") : src.index("def _adf_plain_text")]
+        attr_names = set(re.findall(r'attrs\.get\("([a-zA-Z]+)"\)', body))
+        node_types = set(source._ADF_BLOCK_TYPES) | set(
+            re.findall(r'node_type (?:==|in \()\s*"([a-zA-Z]+)"', body)
+        )
+        assert "url" in attr_names and len(node_types) > 10, (attr_names, node_types)
+
+        secret = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv1Wx4Yz7Bc0Ef3Gh6"
+        leaked = []
+        for node_type in sorted(node_types):
+            node = {
+                "type": node_type,
+                "attrs": {name: secret for name in attr_names},
+                "content": [{"type": "text", "text": "body"}],
+            }
+            rendered = source._adf_to_markdown({"type": "doc", "content": [node]})
+            if secret in rendered.replace("\\", ""):
+                leaked.append(node_type)
+        assert not leaked, f"attribute reached the document unredacted for: {leaked}"
+
+    def test_overlapping_adjacent_marks_stay_unambiguous(self):
+        """Wrapping each node on its own emitted `**a*****b****c*`, which a
+        CommonMark parser reads as strong(a), a LITERAL `***b***`, then em(c):
+        the delimiters showed as text and the middle node lost both marks. Each
+        expectation below was checked through a parser, not reasoned about.
+        """
+
+        def t(txt, *kinds):
+            return self._text(txt, [{"type": k} for k in kinds])
+
+        # `**a*b***_c_`   -> <strong>a<em>b</em></strong><em>c</em>
+        # `_a**b**_**c**` -> <em>a<strong>b</strong></em><strong>c</strong>
+        # `**a**_b_**c**` -> <strong>a</strong><em>b</em><strong>c</strong>
+        for nodes, expected in (
+            ((t("a", "strong"), t("b", "strong", "em"), t("c", "em")), "**a*b***_c_"),
+            ((t("a", "em"), t("b", "em", "strong"), t("c", "strong")), "_a**b**_**c**"),
+            ((t("a", "strong"), t("b", "em"), t("c", "strong")), "**a**_b_**c**"),
+        ):
+            rendered = source._adf_to_markdown(self._doc(self._para(*nodes)))
+            assert rendered == expected
+            # No delimiter run longer than the three of a nested strong+em.
+            assert "****" not in rendered
+
+    def test_an_unrenderable_emphasis_is_dropped_not_corrupted(self):
+        """When a run needs `*` at one end and `_` at the other -- an em that
+        both abuts an asterisk run and is followed by a word -- neither spelling
+        works. The mark is dropped and the text kept, because emitting a
+        delimiter anyway would show it as content AND lose the italic."""
+
+        def t(txt, *kinds):
+            return self._text(txt, [{"type": k} for k in kinds])
+
+        rendered = source._adf_to_markdown(
+            self._doc(
+                self._para(
+                    t("a", "strong"), t("b", "strong", "em"), t("c", "em"), t("d")
+                )
+            )
+        )
+        assert rendered == "**a*b***cd"
+        assert "_" not in rendered
+
+    def test_a_language_with_a_trailing_newline_is_rejected(self):
+        """`$` also matches just before a trailing newline, so `re.match` accepted
+        `"python\\n"` and the fence emitted a blank first line inside the block."""
+        adf = self._doc(
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python\n"},
+                "content": [{"type": "text", "text": "body"}],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "```\nbody\n```"
+
+    def test_a_wide_alternating_mark_run_stays_unambiguous(self):
+        """The emitter looks at the character before each mark, so it must carry
+        one character forward rather than the accumulated output -- passing the
+        prefix made it quadratic (13.85s for 100k nodes against 0.72s)."""
+        nodes = []
+        for i in range(3000):
+            kinds = (("strong",), ("strong", "em"), ("em",))[i % 3]
+            nodes.append(self._text(f"w{i}", [{"type": k} for k in kinds]))
+        rendered = source._adf_to_markdown(self._doc({"type": "paragraph", "content": nodes}))
+        # Four in a row is the signature of two delimiter runs that have merged.
+        assert "****" not in rendered
+        assert "w2999" in rendered
+
+    def test_a_code_body_round_trips_its_own_trailing_newlines(self):
+        """The newline before the closing fence SEPARATES the body from it. Adding
+        it unconditionally changed the content: a source ending in one newline came
+        back with two, and an empty body became a block holding a blank line."""
+        for body, expected in (
+            ("x", "```\nx\n```"),
+            ("x\n", "```\nx\n```"),
+            ("", "```\n```"),
+            ("x\n\n", "```\nx\n\n```"),
+            ("a\nb", "```\na\nb\n```"),
+        ):
+            adf = self._doc(
                 {
-                    "type": "bulletList",
+                    "type": "codeBlock",
+                    "content": [{"type": "text", "text": body}] if body else [],
+                }
+            )
+            assert source._adf_to_markdown(adf) == expected
+
+    def test_an_explicit_zero_start_is_preserved(self):
+        """ADF allows `order: 0` and CommonMark honours it as `<ol start="0">`.
+        Coercing with `or 1` silently renumbered the list from 1."""
+        adf = self._doc(
+            {
+                "type": "orderedList",
+                "attrs": {"order": 0},
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {"type": "paragraph", "content": [{"type": "text", "text": t}]}
+                        ],
+                    }
+                    for t in ("a", "b")
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf) == "0. a\n1. b"
+
+    def test_an_out_of_range_list_start_falls_back(self):
+        """A marker of more than nine digits is not a list start: CommonMark reads
+        `1000000000. a` as a paragraph, so the whole list would render as literal
+        text. The last item's marker is what has to fit."""
+        for order, expected_first in ((10**9, "1."), (999999999, "1."), (999999998, "999999998.")):
+            adf = self._doc(
+                {
+                    "type": "orderedList",
+                    "attrs": {"order": order},
                     "content": [
                         {
                             "type": "listItem",
                             "content": [
-                                {"type": "paragraph", "content": [{"type": "text", "text": "item"}]}
+                                {"type": "paragraph", "content": [{"type": "text", "text": t}]}
+                            ],
+                        }
+                        for t in ("a", "b")
+                    ],
+                }
+            )
+            assert source._adf_to_markdown(adf).startswith(expected_first)
+
+    def test_a_non_integer_order_falls_back_to_one(self):
+        for order in ("3", True, -1, None, 1.5):
+            adf = self._doc(
+                {
+                    "type": "orderedList",
+                    "attrs": {"order": order},
+                    "content": [
+                        {
+                            "type": "listItem",
+                            "content": [
+                                {"type": "paragraph", "content": [{"type": "text", "text": "a"}]}
                             ],
                         }
                     ],
                 }
+            )
+            assert source._adf_to_markdown(adf) == "1. a"
+
+    def test_every_scan_terminating_character_is_covered(self):
+        """`_URL_RE`'s path class is `[^\\s)\\"'>]*`, so a character from it ends
+        the match and puts the rest of the query outside every exfiltration check.
+
+        A link DESTINATION is scanned as one address, whitespace included, because
+        that is what gets emitted: the angle-bracket form percent-encodes a space,
+        so a space does not end the URL there. All ten characters are therefore
+        sealed on this path -- each one measured as leaking before.
+        """
+        blob = "Xk7Qm2Rt9Wz4Yb6Nc1Vf8Hj3Lp5Sd0Ag7Ke4Ou2"
+        for ch in (")", "'", '"', ">", " ", "\t", "\n", "\r", "\v", "\f"):
+            href = f"https://evil.example.com/a{ch}b?data={blob}"
+            adf = self._doc(
+                self._para(self._text("click", [{"type": "link", "attrs": {"href": href}}]))
+            )
+            rendered = source._adf_to_markdown(adf)
+            assert blob not in rendered, f"leaked past {ch!r}"
+            assert "evil.example.com" not in rendered
+
+    def test_a_url_followed_by_prose_is_left_alone(self):
+        """In PROSE a space really does end the URL -- verified against the real
+        renderer, where `https://host/a?data= <blob>` yields an anchor whose href
+        is `https://host/a?data=`, so following text cannot ride along in a
+        fetchable address. Encoding whitespace here anyway treated a URL and the
+        next word as one address: a URL followed by a 40-character commit SHA
+        scanned as a query carrying the SHA, the entropy heuristic fired, and the
+        whole paragraph became `see%20[REDACTED: suspicious URL ...]` with every
+        word after the URL gone."""
+        sha = "9f2c1ab4de5607893bcf24e01a7d6b3958e04c12"
+        text = f"see https://example.com/pr?id=7 {sha} for detail"
+        rendered = source._adf_to_markdown(self._doc(self._para(self._text(text))))
+        assert rendered == text
+        assert "%20" not in rendered and "REDACTED" not in rendered
+
+    def test_a_benign_url_with_an_apostrophe_keeps_its_link(self):
+        """The scan must not cost legitimate links: a page title with an
+        apostrophe is ordinary, and encoding it is only for the scan."""
+        href = "https://co.atlassian.net/wiki/spaces/X/pages/1/Bob's_Plan?focus=1"
+        adf = self._doc(self._para(self._text("doc", [{"type": "link", "attrs": {"href": href}}])))
+        assert source._adf_to_markdown(adf) == f"[doc]({href})"
+
+    @staticmethod
+    def _table_row(*cells):
+        return {
+            "type": "tableRow",
+            "content": [
+                {
+                    "type": "tableCell",
+                    "content": [{"type": "paragraph", "content": [{"type": "text", "text": c}]}],
+                }
+                for c in cells
             ],
         }
-        result = source._adf_to_plain_text(adf)
-        assert "item" in result
+
+    def test_a_row_wider_than_the_header_keeps_its_cells(self):
+        """GFM fixes the table width at the HEADER and DROPS a longer row's excess
+        -- the text is gone, not wrapped. Verified against a GFM parser: under a
+        two-column header, `| c | d | e | f |` renders only c and d."""
+        adf = self._doc(
+            {
+                "type": "table",
+                "content": [self._table_row("a", "b"), self._table_row("c", "d", "e", "f")],
+            }
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert rendered == "| a | b |  |  |\n| --- | --- | --- | --- |\n| c | d | e | f |"
+
+    def test_widening_the_header_does_not_pad_every_row(self):
+        """Only the header and separator grow. Padding every row to the widest is
+        what made this quadratic before: one wide row among many narrow ones cost
+        rows x width cells for the handful actually carried."""
+        rows = [self._table_row(*[f"c{i}" for i in range(400)])]
+        rows.extend(self._table_row("x") for _ in range(400))
+        rendered = source._adf_to_markdown(self._doc({"type": "table", "content": rows}))
+        # Header + separator carry 400 each; the 400 narrow rows carry one apiece.
+        assert rendered.count("|") < 2500
+
+    def test_the_escape_set_is_pinned_to_the_renderers_plugins(self):
+        """This escape set is DERIVED from the plugins the panel's renderer runs:
+        `$` is escaped because remark-math is in that stack, `!` because rehypeRaw
+        admits an image that would auto-fetch, `~` because of GFM strikethrough.
+        The coupling crosses a language boundary, so adding a remark plugin with
+        new syntax would reopen a hole here with nothing going red.
+
+        This pins the stack rather than the conclusion: if the list changes,
+        re-derive the escape set and only then update this test. It is the shared
+        contract Design Review asked for, in the one place that can fail.
+        """
+        renderer = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "website"
+            / "src"
+            / "components"
+            / "MarkdownRenderer.tsx"
+        )
+        if not renderer.is_file():
+            pytest.skip("frontend renderer is not part of this checkout")
+        imported = set(re.findall(r"from '((?:remark|rehype)-[a-z0-9-]+)'", renderer.read_text()))
+        assert imported == {
+            "remark-parse",
+            "remark-gfm",
+            "remark-math",
+            "remark-cjk-friendly",
+            "remark-cjk-friendly-gfm-strikethrough",
+            "rehype-raw",
+            "rehype-katex",
+        }, "renderer plugin stack changed -- re-derive the escape set in _MD_INLINE_ESCAPE"
+
+    def test_the_shared_safety_fixture_matches_the_converter(self):
+        """Half of a contract the FRONTEND test asserts the other half of.
+
+        This side pins that the converter turns each fixture `adf` into exactly
+        that `markdown`, so the fixture cannot drift from the converter. The
+        frontend side renders the same `markdown` through the real
+        MarkdownRenderer plugin stack and asserts the selectors, which is what
+        checks the escape set against the renderer that actually runs instead of
+        against a comment describing it.
+        """
+        import json
+
+        fixture = pathlib.Path(__file__).resolve().parent / "fixtures" / "adf_markdown_safety.json"
+        cases = json.loads(fixture.read_text())["cases"]
+        assert len(cases) >= 6
+        for case in cases:
+            rendered = source._adf_to_markdown(case["adf"])
+            assert rendered == case["markdown"], case["name"]
+            if case.get("forbidText"):
+                assert case["forbidText"] not in rendered.replace("\\", ""), case["name"]
+
+    def test_no_emission_site_scans_a_truncated_url(self):
+        """The truncation gap is per-CALL-SITE, not per-node-type. When only the
+        link destination normalised the URL before scanning, an expand title, a
+        mention label, an inline card and a media URL each still leaked a
+        high-entropy query -- measured one by one. All of them now go through the
+        one redaction primitive."""
+        blob = "Xk7Qm2Rt9Wz4Yb6Nc1Vf8Hj3Lp5Sd0Ag7Ke4Ou2"
+        url = f"https://evil.example.com/a)b?data={blob}"
+        sites = {
+            "expand title": self._doc(
+                {
+                    "type": "expand",
+                    "attrs": {"title": f"see {url}"},
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "x"}]}
+                    ],
+                }
+            ),
+            "mention label": self._doc(
+                self._para({"type": "mention", "attrs": {"text": url}})
+            ),
+            "inline card": self._doc(self._para({"type": "inlineCard", "attrs": {"url": url}})),
+            "media url": self._doc(
+                self._para({"type": "media", "attrs": {"type": "external", "url": url}})
+            ),
+            "link destination": self._doc(
+                self._para(self._text("c", [{"type": "link", "attrs": {"href": url}}]))
+            ),
+        }
+        for name, adf in sites.items():
+            rendered = source._adf_to_markdown(adf)
+            assert blob not in rendered, name
+
+    def test_redaction_leaves_ordinary_text_byte_identical(self):
+        """The scan form is only a scan form: when nothing is found the original
+        text is emitted, so no percent escape shows up in the common case."""
+        adf = self._doc(
+            self._para(self._text("see https://example.com/a(b)c?page=2 and 'x' > y"))
+        )
+        rendered = source._adf_to_markdown(adf)
+        assert "%28" not in rendered and "%29" not in rendered and "%27" not in rendered
+        assert "https://example.com/a(b)c?page=2" in rendered
+
+    def test_a_bare_url_in_prose_is_scanned(self):
+        """This is the case that actually linkifies. Verified against the real
+        renderer: bare text `https://host/a)b?data=<blob>` becomes an anchor whose
+        href carries the paren AND the whole query, so the truncated scan has to
+        be corrected here or a fetchable address reaches the panel."""
+        blob = "Xk7Qm2Rt9Wz4Yb6Nc1Vf8Hj3Lp5Sd0Ag7Ke4Ou2"
+        text = f"look at https://evil.example.com/a)b?data={blob} please"
+        rendered = source._adf_to_markdown(self._doc(self._para(self._text(text))))
+        assert blob not in rendered
+        # The marker names the host on purpose, so the reader knows what went.
+        assert "REDACTED: suspicious URL to evil.example.com" in rendered
+        assert rendered.startswith("look at ") and rendered.endswith(" please")
+
+    def test_a_code_block_url_is_not_a_link_so_it_is_not_url_scanned(self):
+        """A code body deliberately does NOT get the URL-entropy scan.
+
+        Verified against the real renderer: for a fenced block and for an inline
+        code span the rendered output has zero anchors and zero images, so a URL
+        in code is text and not a fetchable address -- the same reasoning that
+        makes whitespace end a URL in prose. Running the entropy heuristic here
+        would replace legitimate code samples (an API example with a long opaque
+        token reads exactly like an exfiltration query) for no reachable gain.
+
+        Credentials are still covered: the payload-level pass is token-shaped, so
+        it catches `ghp_...` inside a code block regardless of any URL truncation.
+        """
+        blob = "Xk7Qm2Rt9Wz4Yb6Nc1Vf8Hj3Lp5Sd0Ag7Ke4Ou2"
+        url = f"https://api.example.com/v1)x?token={blob}"
+        adf = self._doc(
+            {"type": "codeBlock", "content": [{"type": "text", "text": f"curl {url}"}]}
+        )
+        assert source._adf_to_markdown(adf) == f"```\ncurl {url}\n```"
+
+    def test_a_credential_split_across_a_media_alt_is_redacted(self):
+        """This supersedes an earlier, narrower claim of mine.
+
+        In round 16 I rebutted this by showing the emitted `[alt](url)` brackets
+        the alt, so the halves cannot form one token. That was true of the code at
+        the time. Round 17 then added a path where a URL failing the destination
+        scan drops the link and emits the LABEL ALONE -- no brackets -- and the
+        rebuttal quietly stopped holding. Measured on that path, the output was
+        `ghp\\_Ab3Df6Hj9Kl2Np5Qr8TvWx4Yz7Bc0Ef3`: one recoverable credential, with
+        the backslash from escaping `ghp_` defeating the payload-level pass.
+
+        So the run gate now reads the media ALT rather than its URL. It sees the
+        contiguity the output can actually have, and errs toward MORE contiguity
+        than the output has when the brackets do survive, which is the safe way to
+        be wrong.
+        """
+        head = "ghp_Ab3Df6Hj9Kl2Np5Qr8Tv"
+        tail = "Wx4Yz7Bc0Ef3"
+        blob = "Xk7Qm2Rt9Wz4Yb6Nc1Vf8Hj3Lp5Sd0Ag7Ke4Ou2"
+        for url in (
+            "https://ex.com/a.png",
+            # Fails the destination scan (whitespace is encoded there), so the
+            # link is dropped and the alt would be emitted bare.
+            f"https://evil.example.com/a b?data={blob}",
+        ):
+            adf = self._doc(
+                self._para(
+                    self._text(head),
+                    {"type": "media", "attrs": {"type": "external", "url": url, "alt": tail}},
+                )
+            )
+            rendered = source._adf_to_markdown(adf)
+            assert (head + tail) not in rendered.replace("\\", ""), url
+            assert "REDACTED: credential" in rendered, url
+
+    def test_an_ordinary_media_alt_still_renders_as_a_link(self):
+        """The gate reading the alt must not cost the ordinary case."""
+        adf = self._doc(
+            self._para(
+                self._text("before "),
+                {
+                    "type": "media",
+                    "attrs": {"type": "external", "url": "https://ex.com/a.png", "alt": "shot"},
+                },
+            )
+        )
+        assert source._adf_to_markdown(adf) == "before [shot](https://ex.com/a.png)"
+
+    def test_line_leading_list_marker_in_text_is_escaped(self):
+        adf = self._doc(self._para(self._text("- not a list")), self._para(self._text("1. nor this")))
+        assert source._adf_to_markdown(adf) == "\\- not a list\n\n1\\. nor this"
+
+    def test_a_setext_underline_in_text_cannot_promote_the_line_above(self):
+        """A line of `=` or `-` under a paragraph line makes it a heading, so both
+        underline characters have to be escaped, not just the list-marker one."""
+        adf = self._doc(self._para(self._text("Title\n===")), self._para(self._text("Sub\n---")))
+        assert source._adf_to_markdown(adf) == "Title\n\\===\n\nSub\n\\---"
+
+    def test_pipe_in_a_table_cell_is_escaped(self):
+        adf = self._doc(
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableHeader",
+                                "content": [self._para(self._text("a|b"))],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf).startswith("| a\\|b |")
+
+    def test_line_expansion_guard_refuses_a_projected_overflow(self):
+        """Per-line expansion is checked by projection, before any allocation."""
+        many = "x\n" * 100000
+        with pytest.raises(source.SourceProviderError):
+            source._md_guard_line_expansion(many, 120)
+        # The same text with a two-character indent projects well under the cap.
+        source._md_guard_line_expansion(many, 2)
+
+    def test_deeply_nested_quotes_over_the_ceiling_are_refused_not_rendered(self):
+        """Newlines inside one text node cost ~3 payload bytes each while 60
+        levels of nesting adds 120 characters to every one, so a small document
+        can project past the payload ceiling. It must raise, not allocate."""
+        inner = {"type": "paragraph", "content": [{"type": "text", "text": "x\n" * 100000}]}
+        node = {"type": "blockquote", "content": [inner]}
+        for _ in range(59):
+            node = {"type": "blockquote", "content": [node]}
+        with pytest.raises(source.SourceProviderError):
+            source._adf_to_markdown(self._doc(node))
+
+    def test_nested_blockquotes_get_one_marker_per_level(self):
+        """A chain of single-child quotes is prefixed in one pass, so the marker
+        count must still match the nesting depth."""
+        node = {"type": "blockquote", "content": [self._para(self._text("deep"))]}
+        for _ in range(2):
+            node = {"type": "blockquote", "content": [node]}
+        assert source._adf_to_markdown(self._doc(node)) == "> > > deep"
+
+    def test_code_span_whitespace_survives_cell_flattening(self):
+        """A cell is folded to one line by collapsing NEWLINES only -- a code
+        span's repeated spaces are literal content."""
+        adf = self._doc(
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableHeader",
+                                "content": [
+                                    self._para(self._text("a  b", [{"type": "code"}]))
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf).startswith("| `a  b` |")
+
+    def test_pipe_inside_a_code_span_in_a_cell_is_escaped(self):
+        """A code span is emitted literally, so its pipe would split the cell.
+        GFM honours a backslash-escaped pipe inside a code span."""
+        adf = self._doc(
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableHeader",
+                                "content": [
+                                    self._para(self._text("a|b", [{"type": "code"}]))
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        assert source._adf_to_markdown(adf).startswith("| `a\\|b` |")
+
+    def test_empty_and_non_dict_returns_empty(self):
+        assert source._adf_to_markdown(None) == ""
+        assert source._adf_to_markdown("just a string") == ""
+        assert source._adf_to_markdown({}) == ""
+
+    def test_unknown_node_type_still_contributes_its_text(self):
+        adf = self._doc(
+            {"type": "someFutureNode", "content": [self._text("kept")]},
+        )
+        assert source._adf_to_markdown(adf) == "kept"
+
+    def test_traversal_is_depth_limited(self):
+        def nest(levels):
+            node = self._para(self._text("deep"))
+            for _ in range(levels):
+                node = {"type": "blockquote", "content": [node]}
+            return self._doc(node)
+
+        assert "deep" in source._adf_to_markdown(nest(3))
+        assert "deep" not in source._adf_to_markdown(nest(200))
+
+    @staticmethod
+    def _nest(container, levels):
+        """Wrap a 'deep' paragraph in *levels* nested *container* blocks."""
+        node = {"type": "paragraph", "content": [{"type": "text", "text": "deep"}]}
+        for _ in range(levels):
+            if container == "blockquote":
+                node = {"type": "blockquote", "content": [node]}
+            elif container == "taskList":
+                node = {"type": "taskList", "content": [{"type": "taskItem", "content": [node]}]}
+            elif container == "table":
+                node = {
+                    "type": "table",
+                    "content": [
+                        {
+                            "type": "tableRow",
+                            "content": [{"type": "tableCell", "content": [node]}],
+                        }
+                    ],
+                }
+            elif container == "someFutureInline":
+                node = {"type": "paragraph", "content": [{"type": "someFutureInline", "content": [node]}]}
+            elif container in ("layoutSection", "bodiedExtension", "decisionList"):
+                node = {"type": container, "content": [node]}
+            else:
+                node = {"type": container, "content": [{"type": "listItem", "content": [node]}]}
+        return {"type": "doc", "content": [node]}
+
+    @pytest.mark.parametrize(
+        "container",
+        [
+            "blockquote",
+            "bulletList",
+            "orderedList",
+            "taskList",
+            "table",
+            "someFutureInline",
+            "layoutSection",
+            "bodiedExtension",
+            "decisionList",
+        ],
+    )
+    def test_every_nesting_container_respects_the_depth_limit(self, container):
+        """No recursing container may reach its renderer past the guarded entry.
+
+        The depth cap lives in `_adf_to_markdown`, so a container whose renderer
+        recursed straight back into the block renderer would skip the cap and
+        exhaust the stack on a deeply nested document.
+        """
+        assert "deep" in source._adf_to_markdown(self._nest(container, 3))
+        assert "deep" not in source._adf_to_markdown(self._nest(container, 350))
+
+    def test_realistic_description_round_trips_to_markdown(self):
+        """One document exercising every structure a Jira description carries."""
+        adf = self._doc(
+            {"type": "heading", "attrs": {"level": 2}, "content": [self._text("Problem")]},
+            self._para(
+                self._text("The "),
+                self._text("fetch_issue", [{"type": "code"}]),
+                self._text(" helper drops "),
+                self._text("every", [{"type": "strong"}]),
+                self._text(" mark."),
+            ),
+            {
+                "type": "bulletList",
+                "content": [
+                    {"type": "listItem", "content": [self._para(self._text("headings"))]},
+                    {
+                        "type": "listItem",
+                        "content": [
+                            self._para(
+                                self._text("links like "),
+                                self._text(
+                                    "the docs",
+                                    [
+                                        {
+                                            "type": "link",
+                                            "attrs": {"href": "https://example.com/docs"},
+                                        }
+                                    ],
+                                ),
+                            )
+                        ],
+                    },
+                ],
+            },
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python"},
+                "content": [self._text("x = 1")],
+            },
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {"type": "tableHeader", "content": [self._para(self._text("a"))]},
+                            {"type": "tableHeader", "content": [self._para(self._text("b"))]},
+                        ],
+                    },
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {"type": "tableCell", "content": [self._para(self._text("1"))]},
+                            {"type": "tableCell", "content": [self._para(self._text("2"))]},
+                        ],
+                    },
+                ],
+            },
+            {"type": "rule"},
+            self._para(self._text("See "), {"type": "mention", "attrs": {"text": "Alice"}}),
+        )
+        expected = "\n".join(
+            [
+                "## Problem",
+                "",
+                "The `fetch_issue` helper drops **every** mark.",
+                "",
+                "- headings",
+                "- links like [the docs](https://example.com/docs)",
+                "",
+                "```python",
+                "x = 1",
+                "```",
+                "",
+                "| a | b |",
+                "| --- | --- |",
+                "| 1 | 2 |",
+                "",
+                "---",
+                "",
+                "See @Alice",
+            ]
+        )
+        assert source._adf_to_markdown(adf) == expected
 
 
 class TestGetJiraAuth:

--- a/website/src/test/MarkdownRenderer.adfSafety.test.tsx
+++ b/website/src/test/MarkdownRenderer.adfSafety.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+// The backend's Jira ADF -> markdown converter escapes literal text so it cannot
+// become markup, and emits external media as a LINK so opening an issue cannot
+// auto-fetch a provider-controlled address. Both claims are about what THIS
+// renderer does with the converter's output -- which plugins are in the stack
+// decides which characters have to be escaped -- so they are asserted here,
+// against the real plugin stack, rather than only in a Python comment.
+//
+// The fixture is shared: test/test_source_providers.py pins that the converter
+// produces each `markdown` from each `adf`, so a case cannot drift from the
+// converter, and this file pins what the renderer then does with it. A failure
+// here means the escape set in source_providers.py needs re-deriving, not that
+// the fixture needs editing.
+
+type SafetyCase = {
+  name: string
+  markdown: string
+  expectText?: string
+  forbidSelectors?: string[]
+  requireSelector?: string
+  forbidText?: string
+}
+
+const fixturePath = resolve(__dirname, '../../../test/fixtures/adf_markdown_safety.json')
+const cases: SafetyCase[] = JSON.parse(readFileSync(fixturePath, 'utf8')).cases
+
+describe('ADF converter output through the real renderer', () => {
+  it('has cases to check', () => {
+    expect(cases.length).toBeGreaterThanOrEqual(6)
+  })
+
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      const { container } = render(<MarkdownRenderer content={testCase.markdown} />)
+
+      for (const selector of testCase.forbidSelectors ?? []) {
+        expect(container.querySelector(selector), `${selector} rendered`).toBeNull()
+      }
+      if (testCase.requireSelector) {
+        expect(container.querySelector(testCase.requireSelector)).not.toBeNull()
+      }
+      if (testCase.expectText) {
+        // The escaping backslashes must not survive into what the reader sees.
+        expect(container.textContent).toContain(testCase.expectText)
+      }
+      if (testCase.forbidText) {
+        expect(container.textContent).not.toContain(testCase.forbidText)
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Problem / Motivation

Jira Cloud v3 returns an issue description and every comment body as ADF
(Atlassian Document Format), a JSON document tree. The walker that read it,
`_adf_to_plain_text()`, collected text leaf nodes only, so all structure was
gone before the field left the backend: headings became unstyled text,
bold/italic/code spans were stripped, links kept their anchor text and lost
the URL entirely, code blocks lost their fences, list items lost their
bullets, and tables lost every cell boundary.

## Why it matters

`IssuePanel.tsx` renders `source.description` and each `comment.body` through
`MarkdownRenderer`, and both other providers already put real markdown in that
same payload key -- a GitHub issue `body`, a GitLab `description`. Jira Cloud was
the one source whose rich text arrived pre-flattened, so a Jira issue opened in
the panel was a wall of undifferentiated text while the same panel rendered a
GitHub issue properly.

One loss is worse than cosmetic. A link's URL was unrecoverable from the
panel, because the walker kept only the anchor text, so an issue whose
reproduction steps are a list of links arrived as a list of bare phrases.

Feeding plain text into a markdown renderer also had it both ways: text that
merely looked like markup was still re-parsed as markup, so a literal `**` in
a Jira description turned bold and a literal `<b>` was dropped by the HTML
sanitizer -- while the real structure beside it was already gone.

## What changed (motivation -> approach -> change)

Symptom: a Jira description renders as one undifferentiated block. Root
cause: the traversal was lossy by construction. It returned `node["text"]`
for a leaf and appended a newline after a known block type, and that was the
entire use it made of a node's type; marks were never read at all. No amount
of post-processing recovers formatting from that output, so the traversal
itself has to emit per node type.

`_adf_to_markdown()` replaces it and dispatches on node type:

- Blocks (`_adf_block_to_markdown`): heading level to `#` repeated, code block
  to a fence carrying the `language` attribute, bullet and ordered lists to
  `- ` / `N. ` markers with a hanging indent so a nested list stays nested, an
  ADF task list to a GFM checklist, table to a GFM table, blockquote and panel
  to `> `, rule to `---`, expand to its bold title plus its content. A chain of
  single-child quotes is collapsed and marked in one pass rather than re-marking
  at every level, which is quadratic in the nesting depth: a 6.7MB document
  nested 60 deep measured 2.57s of blocking work against 0.47s for the same
  content unnested, and 0.51s after the collapse, with byte-identical output. A
  heading
  collapses its internal newlines, since only its first line carries the `#` and
  a hardBreak would otherwise leave a second line whose leading `-` renders as a
  list.
- Inline (`_adf_inline_to_markdown`): marks to `**`, `*`/`_`, backticks and `~~`.
  A mark shared by adjacent nodes is emitted ONCE around all of them, because
  wrapping each node on its own produced `**a*****b****c*` for strong, strong+em,
  em -- which a CommonMark parser reads as strong(a), a LITERAL `***b***`, then
  em(c): the delimiters became visible text and the middle node lost both marks.
  Italic takes `*` normally, since underscore will not open emphasis intraword and
  `a_b_c` loses the italic, and `_` where a `*` would touch another asterisk run.
  Where neither spelling is safe at both ends the mark is dropped and the text
  kept, which loses an italic instead of showing a delimiter as content;
  a link mark and an `inlineCard` to `[text](url)`; a mention to `@name`; a
  hard break to a two-space line break, which is what the panel needs since it
  renders with CommonMark soft-break collapse. An external `media` node (one
  carrying a public `url`) becomes a plain link as well, not an image: that
  keeps the address recoverable without the panel auto-fetching a
  provider-controlled URL when someone opens the issue. A `media` node that
  only references an attachment by id has no fetchable address and contributes
  nothing, exactly as before.
- A node type that is neither recurses into its children through the same span
  handling the top level uses, so an ADF type Atlassian adds later still
  contributes its text -- and gets the same mark merging and credential check its
  children would get at the top level.

`_adf_to_markdown()` is also the ONE guarded entry to the recursion: it holds
the 64-level depth cap, and every descent -- a container's children, a list
item's nested list, a table cell -- re-enters through it rather than calling a
renderer directly. Without that, a list nested a few hundred deep re-entered
its own renderer past the cap and exhausted the stack, turning one hostile or
machine-generated Jira description into an HTTP 500 on issue fetch.

Literal text is escaped on the way out (`_md_escape_inline` for the inline
syntax openers, `_md_escape_block_leads` for a line-leading `-`, `+`, `#`, `1.` or a setext
underline of `=`).
That is what closes the second half of the bug on the ADF path -- and only
there: the old walker emitted raw provider text into a markdown renderer, so the
panel could not tell a description's real formatting from text that happened to
look like formatting. The Jira Server/DC v2 branches keep that misrender, so for
those issues this half of the bug stays open; the scope note below says why.
Block containers are classified as blocks. `layoutSection` / `layoutColumn`,
`bodiedExtension` and `decisionList` group other blocks, and reaching the inline
fallthrough concatenated them: a two-column layout of a paragraph and a heading
rendered as `firstsecond`, losing both the separator and the `##`. `blockCard`
and `embedCard` carry their URL in an attribute with no content, so the same
fallthrough rendered them as the empty string and the URL was lost outright --
the same unrecoverable loss this change exists to fix. Markdown has no columns,
so a layout flattens to its children in document order.

A link destination is scanned before it is emitted, and a URL that fails is
dropped to plain text rather than linked. The old walker emitted no href at all,
so a provider-controlled destination reaching the panel is new here, and the
payload-level scan cannot be relied on to clean one up: `_URL_RE`'s path group
excludes whitespace, `)`, `"`, `'` and `>`, so ANY of those in the path truncates
the match and puts the entire query outside every check that follows. Measured: a high-entropy query blob is redacted
without the paren and not redacted with it, and no credential-pattern pass covers
a bare blob. Every site that emits provider text runs its redaction through one primitive,
`_md_redact_untruncated` -- the gap is per-CALL-SITE, not per-node-type, so when
only the link destination was covered an expand title, a mention label, an inline
card and a media URL each still leaked. The rule is to scan the form that will
actually be EMITTED, which is why whitespace differs per site: a link DESTINATION
is one address and the angle-bracket form emits a space as `%20`, so the scan
encodes it too, while in PROSE a space genuinely ends the URL (the renderer's
autolinker stops there) and encoding it treated a URL followed by a commit SHA as
one address, firing the entropy heuristic and replacing the whole paragraph. The
scan form is only a scan form:
used only to decide, never emitted -- and a URL with parentheses that passes, such
as a wiki or Confluence page, keeps its link in the angle-bracket form. The
truncation itself is in the shared scanner and affects its other callers, so it
is filed as #7611 rather than recorded only in a docstring here.

A table's header is widened to the widest row. GFM fixes the width at the header
and DROPS a longer row's excess -- the text is gone, not wrapped -- so a narrow
first row silently lost the later rows' cells. Only the header and separator grow,
which is linear in the width; padding every row is what made this quadratic
before.

An ordered list keeps its own start number, including an explicit `order: 0`,
which ADF allows and CommonMark honours as `<ol start="0">`. The start is bounded
so the LAST item's marker still fits in nine digits: ten digits is not a list
marker at all, so an out-of-range order would render the whole list as paragraphs
carrying visible numbers, and a start of 999999999 overflows on its second item.

The run gate reads a media node's ALT, not its URL. When a URL fails the
destination scan the link is dropped and the label is emitted with no brackets, so
the alt is what can join a neighbour's text into one credential -- measured as a
recoverable 32-character token before this, with the backslash from escaping
`ghp_` then defeating the payload pass. Reading the alt errs toward MORE
contiguity than the output has when the brackets do survive, which is the safe way
to be wrong. An inline card keeps the URL, since its label IS the redacted URL.

A code body is deliberately NOT URL-scanned. Verified against the real renderer:
a fenced block and an inline code span both render with zero anchors and zero
images, so a URL in code is text rather than a fetchable address -- the same
reason whitespace ends a URL in prose. Running the entropy heuristic there would
replace legitimate code samples (an API example with a long opaque token reads
exactly like an exfiltration query) for no reachable gain, and credentials in code
are still caught by the token-shaped payload pass.

A code block's body keeps its own trailing newlines. The newline before the
closing fence separates the body from it, so emitting one unconditionally changed
the CONTENT: a source ending in one newline came back with two, and an empty body
became a block holding a blank line.

A `code` mark is exclusive -- a code span is literal by definition, so nothing
is escaped inside one, the fence widens past any backticks in the content, and
content that would lose a boundary space to CommonMark's own strip rule is
padded so it survives. `!` is in the escape set for its own reason: this
converter emits a real `[` for a link, an inline card and a media node, so a
literal `!` landing immediately before one would splice into image syntax and
the panel would auto-fetch the URL -- the beacon the media-as-link form exists
to avoid. `$` is there because the same renderer runs remark-math, so a literal
`$$x$$` would render as KaTeX rather than as the characters someone typed. Both
were checked against the project's own parser rather than assumed.

Node ATTRIBUTES take a stricter path than text does, because they are labels
rather than prose and every one of them is provider-controlled. A newline
inside an attribute would end the construct the attribute sits in and let the
remainder become document structure, so `_adf_attr_label` collapses whitespace
before escaping (a mention's name, an expand's title, a media alt text, an
inline card's URL label). A code block's `language` is stricter still: a
fence's info string runs to the end of its line, so only a single highlighter
token is admitted (`_MD_CODE_LANGUAGE_RE` -- letters, digits and the
punctuation real names carry, as in `c++` or `shell_session`) and anything else
drops to a bare fence, costing syntax highlighting and nothing else.

Escaping also forces a REDACTION contract, because `_redact_provider_data` runs
over the finished payload and matches contiguous secrets (`ghp_...`) that
markdown punctuation would break apart -- something the old unescaped, seamless
plain-text walk could not do. Redaction therefore happens exactly where this
converter inserts characters, and in both cases inside its own depth-capped
traversal:

- `_adf_inline_sequence` checks each inline run ONCE, against the plain-text
  rendition a seamless walk would produce -- every node's own text in order with
  no markup between any of it, which is exactly the string the payload pass used
  to see. When it fires, the run is emitted as that redacted string: it loses its
  formatting, but no node's text is lost with it. Checking the whole run rather
  than some span of it is deliberate: any narrower boundary has to answer "which
  nodes contribute text seamlessly", and that answer kept turning out wider than
  the last one -- a bold sibling, an unrecognised container, then a mention or
  emoji label, each contributing text with no delimiter of its own. The run has
  no such boundary to get wrong. A nested container reuses its ancestor's scan
  rather than repeating it, since `_adf_plain_text` recurses and so the outer
  scan already covered every descendant: rescanning per level is depth-times-text
  work, measured at 7.0s for 1MiB under 60 unrecognised containers and 27.8s for
  4MiB, against 0.12s and 0.50s after.
- `_adf_attr_label` redacts, collapses whitespace, then escapes, and owns every
  attribute label. That covers a credential in a free-form attribute (a media
  alt text, an expand title), which is not part of any inline run's text.

The same span handling fixes a display bug that has nothing to do with
redaction: adjacent text nodes carrying identical marks are merged before those
marks are applied. Wrapping each separately emits `**a****b**`, which CommonMark
renders as a bold `a****b` -- the delimiters become visible content -- and a code
mark is worse, since two adjacent code-marked nodes collapse into one span
holding literal backticks. Verified against a CommonMark parser, not assumed.
Each run's text is joined once rather than rebuilt per node: only traversal
DEPTH is capped, so a provider can put 300k adjacent text nodes inside the 8MiB
fetch cap, which measured 1.48s of blocking work against 0.23s after the change.

Everything else the converter emits verbatim -- a link destination, a code
block's body -- stays contiguous and is caught by the payload pass as before.

Deliberately NOT a pre-pass over the raw ADF tree: `_redact_provider_data`
recurses without a depth cap, so redacting a provider-controlled document before
converting it raises `RecursionError` a few hundred levels down (measured: fine
at 400, raising at 800 against the default limit of 1000) and turns a valid
issue fetch into a 500. Redacting inside the converter is bounded by the same 64
levels as everything else.

Per-line expansion is bounded by projection. Marking a quote and indenting a
list item both add characters to EVERY line, and a provider controls the line
count as well as the nesting depth that sets the per-line cost: newlines embedded
in a single text node cost about three bytes of payload each, while sixty levels
of nesting adds a hundred and twenty characters to each of them. The payload gate
runs only after conversion, so `_md_guard_line_expansion` projects the expanded
size first and refuses the document instead of allocating it -- measured before
the guard, a 2.3MiB payload rendered 93MiB of markdown with a 224MiB peak, and
the 8MiB fetch cap extrapolated to roughly 780MiB. The check lives inside both
expanders rather than at their call sites, so a new caller cannot forget it, and
it refuses the way an oversized response is already refused.

Unchanged, and this is the scope boundary of the fix: the
`isinstance(raw_desc, str)` branch carries Jira Server/DC v2, which returns wiki
markup rather than ADF, and it still passes that string to the renderer
untouched. So the "literal text re-parsed as markup" half is fixed for Cloud v3
only -- a literal `**` in a Server description still turns bold there, and its
wiki markup still misrenders. Escaping that path without converting it would be
a regression of its own (visible backslashes where markup used to partly work),
and converting it means a second grammar with its own node vocabulary and tests.
Issue #2581 names the ADF path; the Server path is recorded for its own change.
Both fetch call sites keep their `.strip()`.

`_adf_to_plain_text` is removed rather than left beside the new function: its
only two callers are the two converted here, so keeping it would leave an
unreachable helper and a test class pinning output nothing consumes.

## Tests

`test/test_source_providers.py`: `TestAdfToPlainText` becomes
`TestAdfToMarkdown`, 102 tests. Beyond the four cases carried over from the old
class, they lock in:

- The node-type mapping: heading and its level clamp, emphasis marks, link
  marks, `inlineCard`, fenced code with a language, bullet and ordered lists, an
  ordered list's explicit `order` start, nested-list indentation, task list,
  blockquote, panel, rule, GFM table, mention, and external `media` as a link
  (plus an id-only `media` contributing nothing).
- Span handling: adjacent identical marks merge (emphasis and code), adjacent
  DIFFERENT marks do not, a hardBreak between two equally marked nodes keeps them
  apart, both hold one level down inside an unrecognised container, an italic
  between two plain neighbours keeps its emphasis, and a 100k-node run merges to
  the right string.
- Nesting shape: a chain of three quotes emits three markers, so the one-pass
  collapse cannot lose a level; and a document whose projected expansion
  exceeds the payload ceiling is refused rather than rendered, checked both
  through the quote path and against the guard directly.
- Table shape: a short row emits only its own cells, and a wide header with many
  narrow rows stays linear in cell count rather than padding to rows x width.
- The escaping contract: literal `**`/`<b>`/`_` survive as text, a literal
  `&copy;` is not decoded to a copyright sign, a literal `$$x$$` is not rendered
  as math, a line-leading `-`/`1.` stays text, a `===` or `---` line cannot
  promote the line above it into a heading, a pipe inside a table cell is
  escaped -- including one inside a code span, which is emitted literally and
  would otherwise split the cell -- a cell folds to one line by collapsing
  newlines only, so a code span's repeated spaces survive, a literal `!` before a media node cannot
  splice the pair into an auto-fetching image, and a heading with a hardBreak
  stays on one line.
- The escape set is DERIVED from the frontend renderer's plugin stack (`$` for
  remark-math, `!` for the image rehypeRaw admits, `~` for GFM strikethrough), so
  that coupling is pinned from both sides rather than described in a comment.
  `test/fixtures/adf_markdown_safety.json` is shared: the backend test asserts the
  converter turns each `adf` into exactly that `markdown`, and
  `website/src/test/MarkdownRenderer.adfSafety.test.tsx` renders the same markdown
  through the REAL plugin stack and asserts no `<strong>`, no `<b>`, no `<img>`, no
  KaTeX, and no recoverable credential. A second backend test pins the plugin list
  itself, so adding a plugin goes red with a message to re-derive the escapes.
- Redaction, one test per shape a credential can take: whole in one text node,
  split across a plain and a bold sibling, split either side of an unknown inline
  container, split inside such a container, split deep inside nested containers
  (which is what the reused scan could have broken), split across a label
  boundary (an emoji's text), and sitting in a free-form attribute. Plus one
  recording why a media alt is NOT such a shape: the node emits `[alt](url)`, so
  its label is always bracketed and cannot continue a credential from the text
  before it. Plus one asserting the
  fallback keeps every node's text, so a mention and a card in a redacted
  paragraph do not disappear.
- The attribute contract: a newline-bearing `language` cannot close its own
  fence and inject markdown, a real token like `c++` survives, a multi-token
  value drops to a bare fence, and an expand title and a mention name each stay
  on one line when the attribute carries newlines.
- The code-span contract: a fence widening past inner backticks, boundary
  spaces padded so CommonMark's strip rule cannot eat them, whitespace-only and
  one-sided-space content deliberately NOT padded, and a marked empty text node
  emitting nothing rather than bare `****`.
- The depth cap, parametrized over every recursing container (blockquote,
  bulletList, orderedList, taskList, table, and an unrecognised inline
  container): content nested 350 deep is dropped and nothing raises, while
  content nested 3 deep survives. This is the test that pins the
  single-guarded-entry invariant -- it fails with `RecursionError` on the three
  list containers if a renderer is re-entered directly.
- The edges: non-dict input, an unknown node type keeping its text, a link with
  parentheses switching to the angle-bracket destination form.

`test_realistic_description_round_trips_to_markdown` pins one whole document
-- heading, code mark, strong mark, a list containing a link, fenced code,
table, rule, mention -- against its exact expected markdown.

Mutation-verified, each reverted after: making `_md_escape_inline` return its
input fails exactly the two escaping tests; replacing the hanging-indent
padding with `""` fails exactly the nested-list test; making
`_md_code_language` accept any value fails the fence-injection and multi-token
tests; dropping the whitespace collapse from `_adf_attr_label` fails the expand
and mention tests. The depth test was written first and observed to fail with
`RecursionError` on `bulletList`, `orderedList` and `taskList` before the
guarded-entry fix, and to pass after.

Targeted runs only (the full suite was not run locally; that is what CI is
for):

- `pytest test/test_source_providers.py -k AdfToMarkdown -q -n 4` -> 102 passed
- `pytest test/test_source_providers.py -k "jira or Jira" -q -n 4` -> 46 passed
- `flake8` and `isort` clean on both files;
  `scripts/check_black_formatting.py` passes; `mypy src/kiro_crew/` reports
  nothing for this file.

## Manual verification

N/A -- reaching this path needs a live Jira Cloud v3 instance and credentials.
The converter is a pure function of the ADF payload, and the whole-document
test above asserts the exact string the panel would be handed, so the unit
coverage is the same evidence a manual pass would produce.

## Related Issues

Closes #2581

## Pattern harvest

Rule candidate: semgrep

Pattern: a recursive walker whose depth cap lives in ONE entry function, with a
sibling in the same family calling an inner renderer directly and re-entering
the cycle past the cap. Here `_adf_to_markdown` held the guard while the
list-item helper called `_adf_block_to_markdown` straight, so three of the five
nesting containers exhausted the stack while the two that happened to route
through the entry were fine. The greppable shape is a mutually recursive
function group where the guard predicate appears in a strict subset of its
members; a checker can flag a call that closes a cycle without passing through
a guarded member. The test form generalizes too, and is what this PR ships:
parametrize the depth test over EVERY container that can nest, so a container
added later cannot quietly bypass the cap.

Second pattern, confirmed rather than hypothetical: a provider-controlled
string interpolated into a LINE-ORIENTED markdown construct -- a fence's info
string, a heading, an emphasis run -- without collapsing newlines first. The
construct ends at the newline, so the remainder of the attribute becomes
document structure. This diff had it in six places (a code block's `language`
plus five attribute labels) and closes all six through two chokepoints,
`_adf_attr_label` and `_md_code_language`. The greppable shape is an f-string
that places an externally-sourced value on the same line as markdown
punctuation without a single-line guarantee; the durable fix is having exactly
one escaper per sink shape and no direct interpolation at the call sites, which
is what a checker should assert.

Third pattern, the deepest one this change surfaced: a transform that INSERTS
characters into text which a downstream security scanner must still match. Both
credential findings here are that shape -- escaping put a backslash inside
`ghp_`, and marks put `**` between a secret's halves, in each case defeating a
redactor that ran afterwards and had matched fine before. The rule generalizes
past markdown to any encoder, escaper or formatter placed upstream of a
pattern-matching gate: when you add one, the gate either has to move upstream of
it or be told what the transform can break. A checker cannot see that coupling,
but a reviewer can be told to look for it whenever a diff adds an escaping step
to a value that already flows through a scanner.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- no doc references the ADF walker
- [x] No secrets, credentials, or internal references in the diff
