### PR TITLE
fix(file-explorer): decode git and ripgrep output as utf-8, not the host codepage

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -26,7 +26,6 @@
 3 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/narrate.py
 1 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/record_template.py
 3 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/verify_align.py
-3 src/kiro_crew/apps/builtins/file_explorer/server.py
 1 src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
 3 src/kiro_crew/apps/builtins/md_notebook/server.py
 1 src/kiro_crew/apps/builtins/pptx_maker/backend/engine.py

--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -631,6 +631,9 @@ def _git_status(repo_root: Path) -> dict:
             cmd_branch,
             capture_output=True,
             text=True,
+            # git writes refnames in UTF-8; `text=True` alone would decode them
+            # with the host's locale codec. See the note on the status call below.
+            encoding="utf-8",
             timeout=GIT_TIMEOUT_SEC,
             check=False,
         )
@@ -645,6 +648,16 @@ def _git_status(repo_root: Path) -> dict:
             cmd_status,
             capture_output=True,
             text=True,
+            # `-z` is what makes this mandatory. Without it git C-quotes a
+            # non-ASCII path into pure ASCII (`"caf\303\251.txt"`); WITH it the
+            # path comes back verbatim as raw UTF-8 bytes. `text=True` alone then
+            # hands those bytes to the host's locale codec, so on a Windows
+            # console codepage (cp950, cp932, cp1252, ...) one file with a
+            # non-ASCII name either raises UnicodeDecodeError -- which neither
+            # `except` clause here catches, so the whole repo's status 500s -- or
+            # silently mojibakes the path so it matches no tree entry. git's
+            # output is UTF-8, so name the encoding rather than inheriting one.
+            encoding="utf-8",
             timeout=GIT_TIMEOUT_SEC,
             check=False,
         )
@@ -774,6 +787,14 @@ def _search_rg(root: Path, query: str, include: str, exclude: str) -> list[dict]
             wrapped_cmd,
             capture_output=True,
             text=True,
+            # ripgrep's `--json` stream is UTF-8 by definition, and it carries
+            # both the matched path and the matched line, so a non-ASCII byte is
+            # the norm rather than the exception. Same reasoning as the git calls
+            # in `_git_status`: `text=True` alone would decode it with the host
+            # code page, and a `UnicodeDecodeError` is not an `OSError`, so it
+            # would escape the fallback below and 500 the search instead of
+            # degrading to `_search_python`.
+            encoding="utf-8",
             timeout=SEARCH_TIMEOUT_SEC,
             check=False,
         )

--- a/test/test_file_explorer_git_status_encoding.py
+++ b/test/test_file_explorer_git_status_encoding.py
@@ -1,0 +1,175 @@
+"""``_git_status`` must decode git's output as UTF-8, not as the host locale.
+
+``git status --porcelain=1 -z`` is the one porcelain form that does **not**
+C-quote a non-ASCII path. Verified against real git:
+
+    $ git status --porcelain=1     ->  ?? "caf\\303\\251-\\346\\227\\245....txt"
+    $ git status --porcelain=1 -z  ->  ?? caf\\303\\251-\\346\\227\\245....txt\\0
+
+The first is pure ASCII whatever the filename is; the second is raw UTF-8. So the
+moment ``-z`` was added, ``text=True`` stopped being safe on its own: it decodes
+with ``locale.getpreferredencoding(False)``, which on a Windows console codepage
+is cp950 / cp932 / cp1252 rather than UTF-8. One file with a non-ASCII name then
+takes out the whole repository's status — ``UnicodeDecodeError`` is neither an
+``OSError`` nor a ``TimeoutExpired``, so it escapes both handlers in
+``_git_status`` and 500s the endpoint.
+
+``platform/update_capability.py`` already pins ``encoding="utf-8"`` on its own git
+call for exactly this reason; these tests hold the same line here.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.apps.builtins.file_explorer import server
+
+# What real git writes for an untracked `café-日本.txt` under `--porcelain=1 -z`,
+# captured from git itself rather than hand-written: two status chars, a space,
+# the path verbatim in UTF-8, then NUL.
+NON_ASCII_NAME = "café-日本.txt"
+RAW_STATUS = f"?? {NON_ASCII_NAME}\x00".encode()
+RAW_BRANCH = "main\n".encode()
+
+
+def _decoding_run_limited(host_encoding: str):
+    """A ``run_limited`` stand-in that decodes the way ``subprocess`` documents.
+
+    The bytes are fixed and real; the only variable is which codec the child's
+    output is decoded with. ``subprocess`` uses the ``encoding=`` keyword when one
+    is given and ``locale.getpreferredencoding(False)`` when it is not, so this
+    reproduces the contract under test on every platform — no console codepage to
+    switch, and nothing timing-dependent.
+    """
+    calls: list[dict] = []
+
+    def _fake(argv, **kwargs):
+        calls.append(kwargs)
+        raw = RAW_STATUS if "status" in argv else RAW_BRANCH
+        codec = kwargs.get("encoding") or host_encoding
+        # A decode failure surfaces from `run_limited` exactly as it would from
+        # `subprocess.run`, which is the whole point: `_git_status` does not
+        # catch it.
+        return subprocess.CompletedProcess(argv, 0, raw.decode(codec), "")
+
+    return _fake, calls
+
+
+@pytest.fixture(autouse=True)
+def _no_sandbox_wrappers():
+    """Neutralise the spawn wrappers, which are not what these tests are about.
+
+    wrap_argv refuses outright on a host with no OS sandbox backend (this box
+    and every Windows runner), and cgroup_scope_argv is a Linux-only ceiling.
+    Both sit between _git_status and run_limited and neither touches
+    decoding, so stubbing them to identity keeps the test measuring one thing and
+    keeps it portable. The same idiom is already used elsewhere in
+    test_file_explorer_app.py.
+    """
+    with (
+        patch.object(server, "wrap_argv", side_effect=lambda cmd: (cmd, None)),
+        patch.object(server, "cgroup_scope_argv", side_effect=lambda cmd: cmd),
+    ):
+        yield
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+@pytest.mark.parametrize("host_encoding", ["cp950", "ascii"])
+def test_a_non_ascii_path_survives_a_non_utf8_host_codepage(repo: Path, host_encoding: str) -> None:
+    """The load-bearing one.
+
+    On a host whose preferred encoding cannot represent the path, inheriting the
+    locale codec raises inside the subprocess call. `cp950` is a real, shipped
+    Windows codepage (Traditional Chinese) and `ascii` is the degenerate POSIX
+    `LC_ALL=C` case; both fail on the same bytes, from opposite directions.
+    """
+    fake, calls = _decoding_run_limited(host_encoding)
+    with patch.object(server, "run_limited", side_effect=fake):
+        out = server._git_status(repo)
+
+    assert out["statuses"] == {NON_ASCII_NAME: "??"}, (
+        "the non-ASCII path did not survive decoding; git's own bytes were read "
+        f"with the host codec instead of UTF-8 (out={out!r})"
+    )
+    # `_git_status` swallows OSError into `status_error`, so a regression could
+    # otherwise look like an empty-but-successful result.
+    assert "status_error" not in out and "branch_error" not in out
+    assert out["branch"] == "main"
+    assert len(calls) == 2, "both git calls must run"
+
+
+def test_a_locale_that_silently_mojibakes_is_also_refused(repo: Path) -> None:
+    """The quieter half, and the reason `errors=` would not be a fix.
+
+    cp1252 maps every byte to *something*, so it does not raise — it returns a
+    corrupted path. The endpoint stays 200 and the file simply never matches its
+    tree entry, which is harder to notice than the crash. Asserting on the path
+    itself catches both failures with one assertion.
+    """
+    fake, _ = _decoding_run_limited("cp1252")
+    with patch.object(server, "run_limited", side_effect=fake):
+        out = server._git_status(repo)
+
+    assert out["statuses"] == {NON_ASCII_NAME: "??"}
+
+
+def test_an_ascii_path_is_unaffected(repo: Path) -> None:
+    """Over-fix guard: the ordinary case must be byte-identical to before.
+
+    Without this, pinning UTF-8 could not be told apart from a change that
+    happened to fix the non-ASCII case by mangling every path.
+    """
+
+    def _fake(argv, **kwargs):
+        raw = b" M plain.txt\x00" if "status" in argv else b"main\n"
+        codec = kwargs.get("encoding") or "cp950"
+        return subprocess.CompletedProcess(argv, 0, raw.decode(codec), "")
+
+    with patch.object(server, "run_limited", side_effect=_fake):
+        out = server._git_status(repo)
+
+    assert out["statuses"] == {"plain.txt": "M"}
+    assert out["branch"] == "main"
+
+
+def test_a_ripgrep_match_survives_a_non_utf8_host_codepage(tmp_path: Path, monkeypatch) -> None:
+    """The same rule on the other spawn in this file.
+
+    ripgrep's ``--json`` stream is UTF-8 by definition and carries both the
+    matched path and the matched line, so non-ASCII is the norm. The fallback
+    below `_search_rg`'s `try` catches only `OSError` / `TimeoutExpired`, so a
+    decode failure does not degrade to `_search_python` — it 500s the search.
+    """
+    monkeypatch.setattr(server, "_has_rg", lambda: True)
+
+    hit = {
+        "type": "match",
+        "data": {
+            "path": {"text": str(tmp_path / NON_ASCII_NAME)},
+            "line_number": 1,
+            "lines": {"text": "naïve café — 日本\n"},
+            "submatches": [{"start": 0, "end": 5}],
+        },
+    }
+    raw = (json.dumps(hit, ensure_ascii=False) + "\n").encode("utf-8")
+
+    def _fake(argv, **kwargs):
+        codec = kwargs.get("encoding") or "cp950"
+        return subprocess.CompletedProcess(argv, 0, raw.decode(codec), "")
+
+    with patch.object(server, "run_limited", side_effect=_fake):
+        results = server._search_rg(tmp_path, "café", "", "")
+
+    assert results, "the match was dropped"
+    assert results[0]["file"].endswith(NON_ASCII_NAME)
+    assert results[0]["preview"] == "naïve café — 日本"


### PR DESCRIPTION
## Problem / Motivation

`file_explorer`'s `_git_status` runs

```python
["git", "-C", str(repo_root), "status", "--porcelain=1", "-z"]
```

with `text=True` and **no `encoding=`**, so git's bytes are decoded with
`locale.getpreferredencoding(False)`.

`-z` is what makes that unsafe, and it is worth being exact about. Measured against
real git on a repo containing one untracked `café-日本.txt`:

```
$ git status --porcelain=1 | od -c
?? " c a f \ 3 0 3 \ 2 5 1 - \ 3 4 6 \ 2 2 7 ... "     <- C-quoted, pure ASCII

$ git status --porcelain=1 -z | od -c
?? c a f 303 251 - 346 227 245 346 234 254 . t x t \0  <- verbatim, raw UTF-8
```

The default form is ASCII whatever the filename is. `-z` deliberately turns that
off. So on any host whose preferred encoding is not UTF-8 — which is every Windows
console codepage — the handler decodes UTF-8 bytes with cp950 / cp932 / cp1252.

The same call is made for `rev-parse --abbrev-ref HEAD`, and git refnames are UTF-8
too.

## Why it matters

**One file with a non-ASCII name takes out the whole repository's status.**
`UnicodeDecodeError` is neither an `OSError` nor a `subprocess.TimeoutExpired`, so
it escapes *both* `except` clauses in `_git_status` and the endpoint 500s — there is
no `status_error` fallback for it. Measured on a live cp950 host:

```
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe6 in position 9
```

**Where the codepage is lenient the failure is quieter and worse.** cp1252 maps
every byte to *something*, so nothing raises: the path comes back mojibaked
(`café-日本.txt` → `cafÃ©-æ—¥æœ¬.txt`), the endpoint returns 200, and that key
simply never matches its tree entry. The file silently shows no git status at all.

This is not a hypothetical class either — the repository ships a CI gate for it,
`scripts/check_subprocess_encoding.py`, with `file_explorer/server.py` already on
its baseline at 3 calls.

## What changed (motivation → approach → change)

Symptom: non-ASCII paths crash or corrupt git status. Root cause: git's UTF-8 output
decoded with the host codepage. Fix: name the encoding, on both git calls in
`_git_status`.

```python
 branch = run_limited(
     cmd_branch,
     capture_output=True,
     text=True,
+    encoding="utf-8",
     timeout=GIT_TIMEOUT_SEC,
     check=False,
 )
```

`run_limited` forwards every keyword to `subprocess.run` untouched, so this needs no
new plumbing. It is also **not a new convention**: `platform/update_capability.py`
already pins `encoding="utf-8"` on its own git call, with a comment naming non-ASCII
paths as the reason.

`errors=` is deliberately **not** added. `errors="replace"` would convert the crash
into the silent-mojibake case, which the tests below treat as equally wrong; UTF-8 is
what git actually writes, so the right move is to say so.

The subprocess-encoding baseline goes from `3` to **`0`** for this file, the way the
gate asks (`--update-baseline`), so its row is pruned rather than lowered.

**The third spawn in this file is the same defect, and is fixed here too.**
`_search_rg` runs ripgrep with `--json`, a stream that is UTF-8 by definition and
that carries both the matched path *and* the matched line — so non-ASCII is the norm
there, not the exception. Its `except` clause is also `OSError` / `TimeoutExpired`
only, which means a decode failure does not degrade to the `_search_python` fallback
the way a spawn failure does: it 500s the search.

Contention was checked before folding it in rather than assumed. Open PR **#4650**
rewrites `_search` (its `server.py` hunk is anchored there and adds ~170 lines) and
leaves `def _search_rg` as unchanged context, so the one line changed here is not a
line that PR touches.

With all three pinned, this file leaves `.github/subprocess-encoding-baseline.txt`
entirely — the diff to that file is the removal of its row, not a lowered count.

## Tests

New file `test/test_file_explorer_git_status_encoding.py` — deliberately a new file
rather than an addition to `test_file_explorer_app.py`, which #4650 also edits.

The harness feeds `_git_status` **git's real `-z` bytes** through a `run_limited`
stand-in that decodes the way `subprocess` documents: the `encoding=` keyword when
one is given, `locale.getpreferredencoding(False)` otherwise. That makes the
interesting codepage a test parameter instead of a property of the runner, so these
are deterministic on a UTF-8 Linux CI box and on a cp950 laptop alike — no console
codepage to switch, no timing, no skip.

| Test | Locks in |
|---|---|
| `..._a_non_ascii_path_survives_a_non_utf8_host_codepage[cp950]` / `[ascii]` | the raising case from both directions — a real shipped Windows DBCS codepage, and the degenerate POSIX `LC_ALL=C` one. Also asserts no `status_error`/`branch_error` was set and that both git calls ran, so a regression cannot pass as an empty-but-successful result |
| `..._a_locale_that_silently_mojibakes_is_also_refused` | cp1252, which never raises. This is the case `errors="replace"` would leave in place, and asserting on the path itself catches both failure modes with one assertion |
| `..._an_ascii_path_is_unaffected` | over-fix guard: the ordinary path is unchanged. Passes on both sides, which is the point |
| `..._a_ripgrep_match_survives_a_non_utf8_host_codepage` | the search spawn, driven with ripgrep's own `--json` record. Asserts the decoded path **and** the matched line survive exactly, so a lenient codepage's mojibake fails it as loudly as a raising one |

An autouse fixture stubs `wrap_argv` and `cgroup_scope_argv` to identity. Neither
touches decoding; `wrap_argv` refuses outright on a host with no OS sandbox backend
(every Windows runner), so stubbing them keeps the test measuring one thing and keeps
it portable. The same idiom is already used in `test_file_explorer_app.py`.

**Red-before**, with `server.py` restored to current `origin/main` (`7308a8b30`) and
nothing else changed — **3 failed, 1 passed**, and the three failures are the three
distinct mechanisms:

```
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe6 in position 9
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 6
AssertionError: assert {'cafÃ©-æ—¥æœ¬.txt': '??'} == {'café-日本.txt': '??'}
```

The one that passed is the ASCII over-fix guard, which must pass on both sides.

The ripgrep case has its own red-before against the same tree:

```
FAILED ...::test_a_ripgrep_match_survives_a_non_utf8_host_codepage
  UnicodeDecodeError: 'cp950' codec can't decode byte 0xe6 in position 152
```

**Green after:** the new file plus `test/test_file_explorer_app.py` — **100 passed,
2 skipped**.

Gates on the touched files: `scripts/check_subprocess_encoding.py` **passed**
(239 known calls in 117 files remain, down from 242 in 118), `scripts/check_black_formatting.py`
**passed in scope**, `flake8` and `isort --check-only` clean, `git diff --check`
clean, and `mypy src/kiro_crew/apps/builtins/file_explorer/server.py` — *Success: no
issues found in 1 source file*. No repository-wide suite; server CI owns that.

## Manual verification

N/A — unit coverage sufficient: the defect is a decoding choice, and the tests drive
the real `_git_status` with the exact bytes git emits under `-z`, which is closer to
the failure than opening the panel on one machine would be.

## Related Issues

None. Found by auditing spawns that ask a tool for raw bytes and then decode with the
host locale, against `scripts/check_subprocess_encoding.py`'s own baseline.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a flag that turns OFF a tool's ASCII-escaping (`-z`, `--null`,
`core.quotePath=false`, `--porcelain` variants) added to a call that decodes with the
host locale.

The generalizable question is narrower and more useful than "does this call pass
`encoding=`": **did someone ask the tool for raw bytes, and is anything downstream
still assuming ASCII?** `-z` and `core.quotePath=false` exist precisely to remove the
escaping that was making the locale codec harmless, so adding one silently converts a
latent issue into a live one — and the failure lands only on hosts whose codepage is
not UTF-8, which is nobody on the CI matrix.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
