### PR TITLE
fix: carry the backend's model-withhold verdict in the slots payload

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -443,7 +443,7 @@ def _campaign_model(config: dict) -> str:
 
     Availability is NOT screened here: no advertised-model list exists outside a
     live session. If the pick stops being served, the session layer's withhold
-    (``_pinned_model_withheld`` in chat_runner) KEEPS the pin, runs the worker on
+    (``_pinned_model_verdict`` in chat_runner) KEEPS the pin, runs the worker on
     the backend default, and posts a notice card — but that card lands in the
     app-owned ``research-<cid>`` transcript, which the Research Lab page does not
     render, so the fallback is not visible on this app's own surfaces.
@@ -1797,7 +1797,7 @@ async def _launch_loop(request: web.Request, cid: str, *, prepared: bool = False
     # Pin the campaign's explicit model pick on the worker slot ('' = inherit
     # the research agent's / backend's default resolution — never a hardcoded
     # id here). If a concrete pick is not served for this account, the session
-    # layer's withhold (_pinned_model_withheld) KEEPS the pin and runs the
+    # layer's withhold (_pinned_model_verdict) KEEPS the pin and runs the
     # worker on the backend default — the notice it posts lands in the hidden
     # research-<cid> transcript, not on the Research Lab page.
     campaign_model = row["model"] or ""

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/repository.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/repository.py
@@ -199,7 +199,7 @@ def _load_settings() -> dict:
     as ``""`` (= inherit the session layer's resolution), never as an error. An
     UNKNOWN model name is deliberately kept: no advertised-model list exists
     outside a live session, and the session layer's withhold
-    (``_pinned_model_withheld`` in chat_runner) already keeps the pin, runs the
+    (``_pinned_model_verdict`` in chat_runner) already keeps the pin, runs the
     worker on the backend default and surfaces a notice when a pick stops being
     served.
     """

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2406,7 +2406,33 @@ async def _reset_slot_session(
     microseconds ago, which cannot have posted a card yet.
     """
     _unblock_pending_waits(state, slot)
-    return await state.sessions.reset(session_key, skip_if_busy=skip_if_busy)
+    try:
+        reloaded = await state.sessions.reset(session_key, skip_if_busy=skip_if_busy)
+    except BaseException:
+        # Raised or cancelled mid-teardown: the session is in a state this slot
+        # cannot vouch for, so neither is its verdict. Unknown fails open.
+        slot.record_model_withheld(None)
+        raise
+    if reloaded:
+        # The withhold verdict describes the session that advertised the model
+        # list, not the slot, so it goes with the session. Routed through this one
+        # funnel for the reason above: the switch handlers that reset a session
+        # are exactly the ones that can change which models the next session will
+        # advertise (agent, workspace, and the model pick itself), and a verdict
+        # surviving that would label the new session from the old one's
+        # entitlement.
+        #
+        # Gated on the reset having HAPPENED. What decides this is whether the
+        # session the verdict describes still exists: `skip_if_busy` DECLINES
+        # while a turn is in flight, leaving that session -- and therefore its
+        # verdict -- alive and accurate, while a completed teardown ends it. The
+        # membership heuristic the frontend falls back to on `null` is not itself
+        # the defect this carries a verdict to remove; inferring entitlement from
+        # that heuristic WHILE an authoritative answer exists is. Dropping on a
+        # decline would throw the authoritative answer away and re-create exactly
+        # that.
+        slot.record_model_withheld(None)
+    return reloaded
 
 
 def _resolve_stop_event(slot: _ChatSlot, outcome: str) -> None:
@@ -3649,6 +3675,9 @@ async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response
         return attached
 
     await state.sessions.discard_conversation(key, replay=replay)
+    # The fresh conversation will advertise its own model list, so the previous
+    # one's withhold verdict no longer describes this slot.
+    slot.record_model_withheld(None)
     sel().log_api_access(
         caller=request.get("app", "") or "dashboard",
         operation="slot_reset_conversation",

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -834,42 +834,52 @@ def _backfill_canonical_model(client: Any, provider: str) -> str:
     return model_registry.canonicalize_for_provider(prov_model, provider)
 
 
-def _pinned_model_withheld(client: Any, model: str, provider: str) -> bool:
-    """True when the live session cannot run the model this slot is pinned to.
+def _pinned_model_verdict(client: Any, model: str, provider: str) -> bool | None:
+    """Whether the live session can run the model this slot is pinned to.
+
+    ``True`` withheld, ``False`` runnable, ``None`` **unknown**. The third state
+    is the reason this exists as its own function: the verdict is carried in the
+    slots payload (#1819) so the composer stops re-deriving "usable?" from
+    picker-list membership, and a consumer must be able to tell "the account
+    cannot run this" from "nothing has told us yet". Every fail-open branch
+    below is a genuine unknown, not a runnable answer:
+
+    * no pin, or the ``auto`` sentinel -- nothing to judge;
+    * ``claude_code`` / the claude backend -- ``slot.model`` holds a canonical
+      key (or a prefixed provider id) against BARE advertised ids, and comparing
+      those two namespaces would call every legitimate model unusable (see
+      :func:`model_is_unusable`'s namespace note);
+    * a provider with no ``available_models`` getter, or one that raised;
+    * an empty advertised set -- no session yet, or a backend that omits
+      ``models``. :func:`model_is_unusable` folds this into "allow the send",
+      which is the right call for the WIRE; for a DISPLAYED verdict it has to
+      stay distinguishable from an entitled answer, so it is caught here.
 
     ``providers.acp`` withholds an inherited/persisted model the account is not
     entitled to and leaves the session on the backend default, so the turn
-    succeeds — but nothing told the user, and the composer chip plus the picker
+    succeeds -- but nothing told the user, and the composer chip plus the picker
     went on reporting a model no turn would ever use (observed after a plan
     downgrade: the chip still read ``claude-opus-5`` while every turn ran on
     auto). This is the read side of that withhold, using the SAME predicate so
     the two cannot disagree about what "usable" means.
 
-    The caller only REPORTS on a true result — it does not clear the pin. The
-    withhold already keeps the model off the wire and the frontend already
-    displays the effective model, so a stale pin is inert and recovers by itself
-    if entitlement returns.
-
-    Only the kiro/acp path is checked. ``slot.model`` is a bare dotted wire id
-    there — the same namespace ``session/new`` advertises — while claude_code
-    holds canonical keys against bare advertised ids, and comparing those two
-    namespaces would call every legitimate model unusable (see
-    :func:`model_is_unusable`'s namespace note). ``model_is_unusable`` itself
-    fails open on an empty advertised set, so a session that advertised nothing
-    (or a provider with no getter) leaves the pin alone: entitlement unknown is
-    not entitlement denied.
+    A ``True`` verdict is REPORTED, never acted on: the caller does not clear the
+    pin. The withhold already keeps the model off the wire, so a stale pin is
+    inert and recovers by itself if entitlement returns.
     """
     if not model or model == "auto" or is_claude_code(provider):
-        return False
+        return None
     if getattr(client, "is_claude_backend", False):
-        return False
+        return None
     getter = getattr(client, "available_models", None)
     if not callable(getter):
-        return False
+        return None
     try:
         advertised = advertised_model_ids(getter())
     except Exception:
-        return False
+        return None
+    if not advertised:
+        return None
     return model_is_unusable(model, advertised)
 
 
@@ -3068,6 +3078,13 @@ async def _consume_pending_reset(
     torn_down = False
     if slot._pending_reset_history_key:
         pending_key = slot._pending_reset_history_key
+        # This reset does not go through `_reset_slot_session`, so it drops the
+        # withhold verdict itself: a project change can resolve a different
+        # agent, and the next session may advertise a different model list. Done
+        # BEFORE the await and regardless of the outcome -- a teardown that
+        # failed leaves the session in a state this slot cannot vouch for, and
+        # "unknown" is the direction that fails open.
+        slot.record_model_withheld(None)
         try:
             await state.sessions.reset(pending_key)
             torn_down = True
@@ -3111,6 +3128,12 @@ async def _consume_pending_reset(
                 )
                 return torn_down
             torn_down = True
+            # The discarded conversation is the one that advertised the model
+            # list, so its verdict goes with it. AFTER the await here, unlike the
+            # reset above: a refusal is a normal outcome on this path (turn in
+            # flight -> flag stays armed, session untouched), so dropping before
+            # would forget a verdict that is still accurate.
+            slot.record_model_withheld(None)
             if slot._pending_discard_conversation_key == discard_key:
                 slot._pending_discard_conversation_key = None
         except Exception:
@@ -5419,6 +5442,11 @@ async def _run_chat(
         # provider so a kiro/acp dotted id (which collides with a claude_code
         # alias spelling) is left as-is.
         withheld_pin = False
+        # None = no verdict this spawn: either nothing is pinned (the backfill
+        # branch below) or the pin is unjudgeable here (see
+        # `_pinned_model_verdict`). Bound before the branch so the backfill path
+        # cannot leave it undefined.
+        verdict: bool | None = None
         if not slot.model and not slot._active_fallback_model:
             # The fallback-active guard is load-bearing: while a throttle
             # fallback is serving this session, the provider's resolved model
@@ -5429,7 +5457,22 @@ async def _run_chat(
             # fallback's duration; the next non-fallback turn backfills as
             # before.
             slot.model = _backfill_canonical_model(client, provider_name) or slot.model
-        elif (is_new or resumed) and _pinned_model_withheld(client, slot.model, provider_name):
+        elif is_new or resumed:
+            # Record the verdict for BOTH answers, not only the withhold: it is
+            # carried in the slots payload (#1819) so the composer reads the
+            # backend's own answer instead of inferring "usable?" from whether
+            # /api/models happened to list the row.
+            #
+            # Recorded UNCONDITIONALLY, including the None (unknown) answer. This
+            # session is a fresh or reloaded one, so whatever the slot was
+            # carrying describes a session that no longer exists: a replacement
+            # that advertises nothing (a dead provider, a backend that omits
+            # `models`) must publish "not known" rather than inherit the previous
+            # session's entitlement. `record_model_withheld(None)` stores exactly
+            # that, and the frontend fails open on it.
+            verdict = _pinned_model_verdict(client, slot.model, provider_name)
+            slot.record_model_withheld(verdict)
+        if verdict:
             withheld_pin = True
             # The session just advertised what this account can run, and the pin
             # is not on the list — the spawn withheld it, so this session runs on
@@ -10043,6 +10086,14 @@ async def _run_chat(
                 except Exception:
                     logger.debug("Stream cleanup failed", exc_info=True)
             if _acquired and (needs_session_reset or needs_conversation_discard):
+                # Neither branch below goes through `_reset_slot_session`, so the
+                # withhold verdict is dropped here: both replace the session that
+                # advertised the model list (an agent switch can even change the
+                # provider), and the verdict describes that session. Dropped for
+                # both branches and before the await, so a failed teardown leaves
+                # the slot at "unknown" rather than carrying a verdict it can no
+                # longer vouch for.
+                slot.record_model_withheld(None)
                 try:
                     if needs_conversation_discard:
                         # Poisoned-conversation escalation: clear ONLY the

--- a/src/kiro_crew/dashboard/slot_projection.py
+++ b/src/kiro_crew/dashboard/slot_projection.py
@@ -195,6 +195,14 @@ class SlotProjection:
             "agent": slot.agent,
             "effective_agent": resolve_effective_agent(slot.agent, slot.project or None),
             "model": slot.model,
+            # The backend's own withhold verdict for `model`: true = the account
+            # cannot run the pin (this session is on the backend default), false
+            # = it can, null = not known yet. Carried so the frontend reads the
+            # answer instead of inferring it from whether the pin appears in
+            # `GET /api/models` -- a list every unrelated filter (deprecation,
+            # curation) narrows, which silently turned those filters into
+            # entitlement signals (#1819). DISPLAY only; never a write source.
+            "model_withheld": slot.model_withheld,
             "reasoning_effort": slot.reasoning_effort,
             "mode": slot.mode,
             "surface": slot.mode,

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2928,6 +2928,8 @@ class _ChatSlot:
         "title",
         "agent",
         "model",
+        "_model_withheld",
+        "_model_withheld_for",
         "reasoning_effort",
         "mode",
         "workspace",
@@ -3087,6 +3089,12 @@ class _ChatSlot:
         self.title = title or key
         self.agent = agent
         self.model = model
+        # Spawn-time withhold verdict for `model`, and the model id it was
+        # computed for. Read through the `model_withheld` property, never these
+        # two directly: the pairing is what makes the verdict self-invalidating
+        # when any of slot.model's writers re-pins the slot.
+        self._model_withheld: bool = False
+        self._model_withheld_for: str = ""
         # Reasoning effort: "" = provider default, else one of low/medium/high/max.
         # Currently consumed by an alternate ACP backend (--effort flag); ACP wired later.
         self.reasoning_effort: str = ""
@@ -4146,6 +4154,47 @@ class _ChatSlot:
     def queue_depth(self) -> int:
         """Number of prompts currently queued behind the active turn."""
         return len(self._queue)
+
+    @property
+    def model_withheld(self) -> bool | None:
+        """Whether the live session withholds this slot's pinned model.
+
+        Tri-state, and the third state carries as much information as the other
+        two: ``True`` the account cannot run the pin (the spawn withheld it and
+        the session is on the backend default), ``False`` it can, ``None``
+        **unknown** -- no session has advertised a comparable list for this pin
+        yet. The frontend must fail open on ``None`` (see ``displayModel``);
+        unknown is not denied.
+
+        Recorded per model id, not per slot: the verdict answers a question
+        about ONE pin, so it is reported only while the slot still carries the
+        model it was computed for. That makes every writer of ``slot.model``
+        (the picker, the bulk pick, the rollback, the restore paths, the
+        canonical backfill) invalidate it for free -- a stale verdict outliving
+        a re-pin would be a display that names the wrong model, and there are
+        too many writers to keep an explicit reset at each one.
+
+        DISPLAY only. This is never a write source: the pin is deliberately
+        KEPT when withheld (it is inert and self-heals on re-upgrade), and the
+        pin-to-agent row writes ``slot.model`` itself.
+        """
+        if not self.model or self._model_withheld_for != self.model:
+            return None
+        return self._model_withheld
+
+    def record_model_withheld(self, withheld: bool | None) -> None:
+        """Pin a spawn-time withhold verdict to the model it was computed for.
+
+        ``None`` forgets the verdict (back to unknown) -- what a session
+        teardown does, since the verdict describes the session that advertised
+        the list, not the slot.
+        """
+        if withheld is None:
+            self._model_withheld = False
+            self._model_withheld_for = ""
+            return
+        self._model_withheld = withheld
+        self._model_withheld_for = self.model or ""
 
     @property
     def is_restricted(self) -> bool:

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -2440,27 +2440,27 @@ class TestPinnedModelWithheld:
         "model,provider", [("", "kiro"), ("auto", "kiro"), ("x", "claude_code")]
     )
     def test_unpinnable_combinations_are_never_withheld(self, model, provider):
-        assert chat_runner._pinned_model_withheld(MagicMock(), model, provider) is False
+        assert chat_runner._pinned_model_verdict(MagicMock(), model, provider) is None
 
     def test_claude_backend_is_exempt(self):
         client = MagicMock()
         client.is_claude_backend = True
 
-        assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is False
+        assert chat_runner._pinned_model_verdict(client, "claude-opus-5", "kiro") is None
 
     def test_provider_without_an_advertiser_leaves_the_pin_alone(self):
         client = MagicMock()
         client.is_claude_backend = False
         client.available_models = "not-callable"
 
-        assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is False
+        assert chat_runner._pinned_model_verdict(client, "claude-opus-5", "kiro") is None
 
     def test_advertiser_failure_fails_open(self):
         client = MagicMock()
         client.is_claude_backend = False
         client.available_models = MagicMock(side_effect=RuntimeError("no session"))
 
-        assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is False
+        assert chat_runner._pinned_model_verdict(client, "claude-opus-5", "kiro") is None
 
     def test_unadvertised_pin_is_reported_as_withheld(self):
         client = MagicMock()
@@ -2468,7 +2468,7 @@ class TestPinnedModelWithheld:
         client.available_models = MagicMock(return_value=[{"modelId": "claude-sonnet-4.6"}])
 
         with patch.object(chat_runner, "advertised_model_ids", return_value={"claude-sonnet-4.6"}):
-            assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is True
+            assert chat_runner._pinned_model_verdict(client, "claude-opus-5", "kiro") is True
 
 
 class TestContextUsagePayload:

--- a/test/test_chat_slot_facade_contract.py
+++ b/test/test_chat_slot_facade_contract.py
@@ -20,6 +20,7 @@ _TO_DICT_KEYS = (
     "agent",
     "effective_agent",
     "model",
+    "model_withheld",
     "reasoning_effort",
     "mode",
     "surface",

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6623,7 +6623,9 @@ class TestPinnedModelWithheld:
     succeeds. Nothing told the slot, so the composer chip and the picker went on
     naming a model no turn would use — the reported symptom after a plan
     downgrade (chip read ``claude-opus-5``; every turn ran on auto). The runner
-    now clears the dead pin using the same predicate the withhold uses.
+    reports the dead pin using the same predicate the withhold uses, and carries
+    the verdict in the slots payload so the frontend reads it instead of
+    inferring it from picker-list membership (#1819).
     """
 
     @staticmethod
@@ -6634,60 +6636,209 @@ class TestPinnedModelWithheld:
         return client
 
     def test_pin_absent_from_advertised_is_withheld(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         client = self._client(["auto", "claude-sonnet-5"])
-        assert _pinned_model_withheld(client, "claude-opus-5", "acp")
+        assert _pinned_model_verdict(client, "claude-opus-5", "acp") is True
 
     def test_advertised_pin_is_kept(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         client = self._client(["auto", "claude-opus-5"])
-        assert not _pinned_model_withheld(client, "claude-opus-5", "acp")
+        assert _pinned_model_verdict(client, "claude-opus-5", "acp") is False
 
     def test_unknown_entitlement_keeps_the_pin(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         # Advertised nothing (no session yet / backend omits the list) must read
-        # as "unknown", never as "nothing is allowed".
-        assert not _pinned_model_withheld(self._client([]), "claude-opus-5", "acp")
+        # as "unknown", never as "nothing is allowed" — and, since the verdict is
+        # displayed, never as "entitled" either: None is its own answer.
+        assert _pinned_model_verdict(self._client([]), "claude-opus-5", "acp") is None
 
     def test_auto_and_empty_are_never_withheld(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         client = self._client(["claude-sonnet-5"])
-        assert not _pinned_model_withheld(client, "auto", "acp")
-        assert not _pinned_model_withheld(client, "", "acp")
+        assert _pinned_model_verdict(client, "auto", "acp") is None
+        assert _pinned_model_verdict(client, "", "acp") is None
 
     def test_claude_code_provider_is_exempt(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         # slot.model is a canonical key there while the backend advertises bare
         # ids — comparing the two namespaces would call every model unusable.
         client = self._client(["claude-opus-4-8[1m]"])
-        assert not _pinned_model_withheld(client, "opus-4.8-1m", "claude_code")
+        assert _pinned_model_verdict(client, "opus-4.8-1m", "claude_code") is None
 
     def test_claude_backend_provider_is_exempt(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         client = self._client(["claude-opus-4-8[1m]"], claude_backend=True)
-        assert not _pinned_model_withheld(client, "claude-opus-4.8", "acp")
+        assert _pinned_model_verdict(client, "claude-opus-4.8", "acp") is None
 
     def test_provider_without_getter_keeps_the_pin(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         client = MagicMock()
         del client.available_models
         client.is_claude_backend = False
-        assert not _pinned_model_withheld(client, "claude-opus-5", "acp")
+        assert _pinned_model_verdict(client, "claude-opus-5", "acp") is None
 
     def test_getter_raising_keeps_the_pin(self):
-        from kiro_crew.dashboard.chat_runner import _pinned_model_withheld
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
 
         client = MagicMock()
         client.is_claude_backend = False
         client.available_models = MagicMock(side_effect=RuntimeError("boom"))
-        assert not _pinned_model_withheld(client, "claude-opus-5", "acp")
+        assert _pinned_model_verdict(client, "claude-opus-5", "acp") is None
+
+    def test_slot_reports_no_verdict_until_one_is_recorded(self):
+        slot = _ChatSlot("s1")
+        slot.model = "claude-opus-5"
+        # A slot that has never spawned knows nothing about entitlement, and the
+        # frontend fails open on that — so the default must be unknown, not False.
+        assert slot.model_withheld is None
+        assert slot.to_dict()["model_withheld"] is None
+
+    def test_slots_payload_carries_both_answers(self):
+        slot = _ChatSlot("s1")
+        slot.model = "claude-opus-5"
+        slot.record_model_withheld(True)
+        assert slot.to_dict()["model_withheld"] is True
+        slot.record_model_withheld(False)
+        assert slot.to_dict()["model_withheld"] is False
+
+    def test_verdict_is_reported_only_for_the_model_it_was_computed_for(self):
+        """Re-pinning must invalidate the verdict without anyone remembering to.
+
+        `slot.model` has many writers (the picker, the bulk pick, the pick
+        rollback, two restore paths, the canonical backfill). A verdict that
+        outlived a re-pin would label the NEW model with the OLD model's
+        entitlement, so the verdict is stored against the id it was computed for
+        instead of relying on each of those writers to clear it.
+        """
+        slot = _ChatSlot("s1")
+        slot.model = "claude-opus-5"
+        slot.record_model_withheld(True)
+        assert slot.model_withheld is True
+
+        slot.model = "claude-sonnet-5"  # the user picks a model they can run
+        assert slot.model_withheld is None, "a verdict must not survive a re-pin"
+
+        slot.model = "claude-opus-5"  # ...and back again
+        assert slot.model_withheld is True, "the verdict still describes this pin"
+
+        slot.model = ""  # pin cleared entirely
+        assert slot.model_withheld is None
+
+    def test_teardown_forgets_the_verdict(self):
+        slot = _ChatSlot("s1")
+        slot.model = "claude-opus-5"
+        slot.record_model_withheld(True)
+        # The verdict describes the session that advertised the list, so a
+        # session teardown drops it rather than leaving the next session labelled
+        # by the previous one's entitlement.
+        slot.record_model_withheld(None)
+        assert slot.model_withheld is None
+
+    def test_every_session_teardown_drops_the_verdict(self):
+        """A teardown site added later must not silently keep a dead verdict.
+
+        The drop cannot live in one chokepoint: `_reset_slot_session` is the
+        funnel for the switch handlers, but the runner tears a session down
+        directly at a turn boundary too (the deferred project-change reset, the
+        deferred conversation discard, the post-turn agent-switch reset) and
+        routing those through the funnel would also cancel pending question cards.
+        So the invariant is pinned here instead of trusting each author to
+        remember it.
+        """
+        from pathlib import Path
+
+        from kiro_crew.dashboard import chat_handlers, chat_runner
+
+        teardowns = ("state.sessions.reset(", "state.sessions.discard_conversation(")
+        for module in (chat_runner, chat_handlers):
+            lines = Path(module.__file__).read_text(encoding="utf-8").splitlines()
+            sites = [i for i, line in enumerate(lines) if any(t in line for t in teardowns)]
+            assert sites, f"no teardown call site found in {module.__name__}"
+            for i in sites:
+                # Asymmetric window: a drop placed AFTER the call has to clear the
+                # multi-line call plus its refusal check (`discard_conversation`
+                # returns False when a turn is in flight), so the trailing half is
+                # the wider one.
+                window = "\n".join(lines[max(0, i - 12) : i + 23])
+                assert "record_model_withheld(None)" in window, (
+                    f"{module.__name__}:{i + 1} replaces the session the withhold "
+                    f"verdict describes without dropping it -> {lines[i].strip()}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_reset_chokepoint_forgets_the_verdict(self):
+        """The one reset funnel must drop it, so all its call sites do."""
+        from kiro_crew.dashboard.chat_handlers import _reset_slot_session
+
+        state = MagicMock()
+
+        async def _reset(_key, *, skip_if_busy=False):
+            return True
+
+        state.sessions.reset = _reset
+        slot = _ChatSlot("s1")
+        slot.model = "claude-opus-5"
+        slot.record_model_withheld(True)
+
+        with patch("kiro_crew.dashboard.chat_handlers._unblock_pending_waits"):
+            await _reset_slot_session(state, slot, "dashboard:s1")
+
+        assert slot.model_withheld is None
+
+    @pytest.mark.asyncio
+    async def test_a_declined_reset_keeps_the_live_session_s_verdict(self):
+        """`skip_if_busy` declining leaves the session -- and its verdict -- alive.
+
+        The reload route resets with ``skip_if_busy=True``, which returns False
+        when a turn is in flight and touches nothing. Dropping the verdict there
+        would republish a runnable pin as `auto` -- the defect the verdict exists
+        to remove -- for a session that never changed.
+        """
+        from kiro_crew.dashboard.chat_handlers import _reset_slot_session
+
+        state = MagicMock()
+
+        async def _declined(_key, *, skip_if_busy=False):
+            return False
+
+        state.sessions.reset = _declined
+        slot = _ChatSlot("s1")
+        slot.model = "claude-opus-5"
+        slot.record_model_withheld(True)
+
+        with patch("kiro_crew.dashboard.chat_handlers._unblock_pending_waits"):
+            reloaded = await _reset_slot_session(state, slot, "dashboard:s1", skip_if_busy=True)
+
+        assert reloaded is False
+        assert slot.model_withheld is True, "a declined reset must not erase the verdict"
+
+    @pytest.mark.asyncio
+    async def test_a_reset_that_raises_drops_the_verdict(self):
+        """A teardown that raised leaves a session the slot cannot vouch for."""
+        from kiro_crew.dashboard.chat_handlers import _reset_slot_session
+
+        state = MagicMock()
+
+        async def _boom(_key, *, skip_if_busy=False):
+            raise RuntimeError("teardown exploded")
+
+        state.sessions.reset = _boom
+        slot = _ChatSlot("s1")
+        slot.model = "claude-opus-5"
+        slot.record_model_withheld(True)
+
+        with patch("kiro_crew.dashboard.chat_handlers._unblock_pending_waits"):
+            with pytest.raises(RuntimeError):
+                await _reset_slot_session(state, slot, "dashboard:s1")
+
+        assert slot.model_withheld is None
 
     @pytest.mark.asyncio
     async def test_run_chat_reports_but_keeps_a_withheld_pin(self, tmp_path, monkeypatch):
@@ -6758,6 +6909,126 @@ class TestPinnedModelWithheld:
         assert any(
             "claude-opus-5" in t and "isn't offered right now" in t for t in notices
         ), f"expected a persisted notice naming the withheld model, got {notices}"
+        # And the verdict is CARRIED, not left for the frontend to re-derive: the
+        # slots payload states it, so the chip does not have to read "absent from
+        # GET /api/models" as "not entitled" (#1819).
+        assert slot.model_withheld is True
+        assert slot.to_dict()["model_withheld"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_chat_records_an_entitled_pin_as_not_withheld(self, tmp_path, monkeypatch):
+        """The false answer must be carried too, not just the withhold.
+
+        It is the half that stops an unrelated `/api/models` filter from acting as
+        an entitlement signal. The verdict is computed against the wire id the
+        session was actually given, so a pin the picker's list omits is still
+        reported runnable.
+
+        Asserted on a DEPRECATED pin's replacement on purpose: `api_models` drops
+        deprecated ids before the entitlement narrowing, and `_normalize_model`
+        rewrites such a pin to its replacement at turn start — so the id the
+        session (and this verdict) sees is the replacement, never the deprecated
+        spelling the slot was carrying.
+        """
+        from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+
+        events = [LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(input_tokens=3, output_tokens=4))]
+        state = TestTokenPersistenceBackfill._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.model = "claude-opus-4.6-1m"  # deprecated spelling: absent from GET /api/models
+
+        client = AsyncMock()
+        client.context_usage_pct = MagicMock(return_value=10.0)
+        client.is_claude_backend = False
+        # The session serves the replacement the pin normalizes to.
+        client.available_models = MagicMock(
+            return_value=[{"modelId": "auto"}, {"modelId": "claude-opus-4.6"}]
+        )
+        inner = MagicMock()
+        inner._model = ""
+        client.client = inner
+
+        async def _stream(msg):
+            del msg
+            for ev in events:
+                yield ev
+
+        client.stream = _stream
+        client.stream_command = _stream
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        async def _fake_persist(k, m, e, provider="", **kwargs):
+            del k, m, e, provider, kwargs
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.persist_token_record_async", _fake_persist
+        )
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "hello")
+
+        assert slot.model == "claude-opus-4.6", "the deprecated pin is rewritten at turn start"
+        assert slot.to_dict()["model_withheld"] is False
+        notices = [m.get("content", "") for m in slot.messages if m.get("role") == "notice"]
+        assert not any(
+            "isn't offered right now" in t for t in notices
+        ), f"an entitled pin must not be reported as withheld, got {notices}"
+
+    @pytest.mark.asyncio
+    async def test_a_replacement_session_that_advertises_nothing_publishes_unknown(
+        self, tmp_path, monkeypatch
+    ):
+        """A new session must never inherit the previous session's verdict.
+
+        A replacement can arrive without a teardown this slot saw (a reaped
+        session, a provider that re-spawned) and can advertise nothing at all --
+        a dead provider, or a backend that omits `models`. That is "not known",
+        and publishing the previous session's answer for it would label a live
+        session from an entitlement snapshot it never took.
+        """
+        from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+
+        events = [LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(input_tokens=3, output_tokens=4))]
+        state = TestTokenPersistenceBackfill._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.model = "claude-opus-5"
+        slot.record_model_withheld(True)  # the PREVIOUS session withheld this pin
+
+        client = AsyncMock()
+        client.context_usage_pct = MagicMock(return_value=10.0)
+        client.is_claude_backend = False
+        client.available_models = MagicMock(return_value=[])  # advertises nothing
+        inner = MagicMock()
+        inner._model = ""
+        client.client = inner
+
+        async def _stream(msg):
+            del msg
+            for ev in events:
+                yield ev
+
+        client.stream = _stream
+        client.stream_command = _stream
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        async def _fake_persist(k, m, e, provider="", **kwargs):
+            del k, m, e, provider, kwargs
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.persist_token_record_async", _fake_persist
+        )
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "hello")
+
+        assert slot.to_dict()["model_withheld"] is None, "a stale verdict must not be republished"
+        assert slot.model == "claude-opus-5", "the pin itself is untouched"
+        notices = [m.get("content", "") for m in slot.messages if m.get("role") == "notice"]
+        assert not any(
+            "isn't offered right now" in t for t in notices
+        ), f"unknown entitlement must not be reported as a withhold, got {notices}"
 
     @pytest.mark.asyncio
     async def test_run_chat_survives_an_unreadable_config_on_a_pinned_slot(

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -245,11 +245,18 @@ export default function ChatPane({
   const availableModels = useAvailableModels()
   const modelDD = useFilteredDropdown(availableModels)
   // See ChatPage: display what will actually run, not a pin the account lost
-  // access to. The degraded flag gates it — a cached list served while
-  // /api/models fails is stale and cannot disprove entitlement — and is
-  // subscribed to, since it can flip while the served list stays identical.
+  // access to. The slot's own `model_withheld` verdict answers that when the
+  // backend has one; the degraded flag gates only the list-membership fallback —
+  // a cached list served while /api/models fails is stale and cannot disprove
+  // entitlement — and is subscribed to, since it can flip while the served list
+  // stays identical.
   const _modelsDegraded = useModelsDegraded(provider.id)
-  const shownModel = displayModel(paneSlot?.model || '', availableModels, _modelsDegraded)
+  const shownModel = displayModel(
+    paneSlot?.model || '',
+    availableModels,
+    _modelsDegraded,
+    paneSlot?.model_withheld,
+  )
 
   // One-time hydrate of this slot's message history via React Query + the api
   // client (caching + cross-pane dedup; staleTime Infinity keeps it one-shot —

--- a/website/src/lib/model.ts
+++ b/website/src/lib/model.ts
@@ -5,7 +5,10 @@
  *  visibly after a plan downgrade, where the slot stays pinned to a premium
  *  model the account can no longer run. The backend withholds such a model at
  *  spawn and runs the session on its own default, so displaying the pin would
- *  name a model no turn will use.
+ *  name a model no turn will use. The slots payload carries the backend's own
+ *  verdict for that case (`model_withheld`), so the answer is read rather than
+ *  cross-referenced out of the two lists; list membership is only the fallback
+ *  for a slot that has no verdict yet.
  */
 
 import { canonicalKey } from '../providers/modelRegistry'
@@ -45,16 +48,32 @@ export function normalizeModelKey(name: string): string {
 
 /** The model id to DISPLAY for a slot pinned to `pinned`.
  *
- *  Returns `'auto'` when the pin is absent from `models` — the picker's list is
- *  narrowed to what the live session says the account can run, so a pin that is
- *  not on it is one the backend withholds.
+ *  `withheld` is the backend's OWN verdict for this pin, carried in the slots
+ *  payload (`model_withheld`), and it wins whenever it exists: it was computed
+ *  at spawn against the live session's advertised list — the same list the
+ *  withhold itself is applied from — so it answers "will a turn use this pin?"
+ *  directly. `true` -> `auto`, `false` -> the pin. Inferring the answer from
+ *  picker-list membership instead made every filter applied to `/api/models` an
+ *  entitlement signal: deprecated ids are dropped there BEFORE the entitlement
+ *  narrowing, so a deprecated-but-runnable pin had no row to match and read as
+ *  `auto` (#1819).
+ *
+ *  `null`/`undefined` is the third state — no verdict yet (no session has
+ *  advertised a comparable list for this pin) — and it must fail open, so it
+ *  falls back to the list-membership heuristic below. Unknown is not denied.
+ *
+ *  Without a verdict: returns `'auto'` when the pin is absent from `models`,
+ *  since the picker's list is narrowed to what the live session says the account
+ *  can run.
  *
  *  `degraded` is the authority on whether the list can be trusted, and it must
  *  come from `modelsDegraded(providerId)` — NOT from the list's shape. A cached
  *  multi-row list served while `/api/models` is failing looks perfectly healthy
  *  by length while being arbitrarily stale, so length alone would relabel a pin
  *  the account has (re)gained access to. When `degraded` is true the pin is
- *  returned untouched: entitlement unknown is not entitlement denied.
+ *  returned untouched: entitlement unknown is not entitlement denied. It gates
+ *  the heuristic only — a verdict does not come from that list, so a stale list
+ *  says nothing about it.
  *
  *  This is a DISPLAY decision only. Never feed the result into a write — a
  *  lossy label must not become persisted state (see ChatPage's pin-to-agent
@@ -64,16 +83,23 @@ export function displayModel(
   pinned: string,
   models: { name: string }[],
   degraded = false,
+  withheld: boolean | null | undefined = null,
 ): string {
   const key = normalizeModelKey(pinned)
   if (!key || key === 'auto') return 'auto'
-  if (degraded || models.length === 0) return pinned
+  if (withheld === true) return 'auto'
   // Return the LIST's spelling of the match, not the caller's. Matching is
   // normalized (dotted vs dashed, case) but `ModelDropdownList` highlights on
   // exact `activeModel === m.name`, so handing back the raw pin would show a
   // model in the chip that checks no row — e.g. a config pin `claude-opus-4.8`
   // against an advertised `claude-opus-4-8`.
   const match = models.find(m => normalizeModelKey(m.name) === key)
+  // Verdict says runnable: show it even when the list omits the row. There is no
+  // row to highlight in that case, which is inherent — a filtered-out model
+  // cannot be a picker row — and naming the user's actual pin beats naming
+  // `auto`, which no turn will run either.
+  if (withheld === false) return match ? match.name : pinned
+  if (degraded || models.length === 0) return pinned
   return match ? match.name : 'auto'
 }
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -5388,15 +5388,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // The model to DISPLAY for this slot. A slot can stay pinned to a model the
   // account can no longer run (a plan downgrade leaves the pin behind): the
   // backend withholds it at spawn and runs the session on its own default, so
-  // showing the pin would name a model no turn will use. The degraded flag is
-  // the authority on whether the list can be trusted — a cached list served
-  // while /api/models fails is stale, not authoritative — and is subscribed to
-  // rather than read, because it can flip without the list changing.
+  // showing the pin would name a model no turn will use. The slot carries the
+  // backend's verdict for exactly that (`model_withheld`), and it is pinned
+  // server-side to the model it was computed for, so it always describes the
+  // first operand below whenever that operand is the slot's own pin. The
+  // degraded flag gates the list-membership fallback used when there is no
+  // verdict — a cached list served while /api/models fails is stale, not
+  // authoritative — and is subscribed to rather than read, because it can flip
+  // without the list changing.
   const _modelsDegraded = useModelsDegraded(provider.id)
   const shownModel = displayModel(
     currentSlot?.model || resolvedModel || '',
     availableModels,
     _modelsDegraded,
+    currentSlot?.model_withheld,
   )
   // True when the pin row would be a no-op: the agent already stores exactly
   // the model the composer is showing. 'auto' is the inherit spelling, never a

--- a/website/src/test/model.displayModel.test.ts
+++ b/website/src/test/model.displayModel.test.ts
@@ -70,6 +70,63 @@ describe('displayModel', () => {
   })
 })
 
+/** The backend computes the withhold at spawn, against the live session's own
+ *  advertised list, and now carries it in the slots payload (#1819). Reading
+ *  that beats re-deriving it from picker-list membership: every filter applied
+ *  to `/api/models` was otherwise an entitlement signal. */
+describe('displayModel with the backend verdict', () => {
+  const list = [
+    { name: 'auto' },
+    { name: 'claude-sonnet-5' },
+    { name: 'claude-opus-4.8' },
+  ]
+
+  it('shows auto when the backend says the pin is withheld', () => {
+    // Even though the list DOES offer it: the verdict comes from the live
+    // session, the list is a separate fetch that can be wider.
+    expect(displayModel('claude-sonnet-5', list, false, true)).toBe('auto')
+  })
+
+  it('honours a withheld verdict while the list is degraded', () => {
+    // The degraded flag says the LIST cannot be trusted. The verdict does not
+    // come from the list, so it is unaffected — and it is not stale either: the
+    // withhold is applied per spawn from the same advertised set, so while the
+    // session lives the verdict describes exactly what that session does.
+    expect(displayModel('claude-sonnet-5', list, true, true)).toBe('auto')
+  })
+
+  it('shows a pin the backend allows even when the list omits it', () => {
+    // The conflation this fixes: `/api/models` is narrowed by filters that have
+    // nothing to do with entitlement (deprecation today, curation or dedup
+    // later), so an absent row is not evidence the account lost the model. With
+    // a verdict, absence no longer relabels a runnable pin as 'auto'.
+    expect(displayModel('claude-opus-4.6-1m', list, false, false)).toBe('claude-opus-4.6-1m')
+  })
+
+  it('still returns the list spelling when the verdict allows a listed pin', () => {
+    // A verdict must not cost the row highlight: matching stays normalized and
+    // the list's own spelling is what ModelDropdownList compares against.
+    expect(displayModel('global.anthropic.claude-opus-4-8[1m]', list, false, false)).toBe(
+      'claude-opus-4.8',
+    )
+  })
+
+  it('falls back to membership when there is no verdict yet', () => {
+    // Unknown is the absence of an answer, not a denial: a slot that has never
+    // spawned a session carries null, and behaviour must be exactly as before.
+    for (const unknown of [null, undefined]) {
+      expect(displayModel('claude-opus-5', list, false, unknown)).toBe('auto')
+      expect(displayModel('claude-sonnet-5', list, false, unknown)).toBe('claude-sonnet-5')
+      expect(displayModel('claude-opus-5', list, true, unknown)).toBe('claude-opus-5')
+    }
+  })
+
+  it('never names a model for an unpinned slot, whatever the verdict', () => {
+    expect(displayModel('', list, false, false)).toBe('auto')
+    expect(displayModel('auto', list, false, false)).toBe('auto')
+  })
+})
+
 describe('pinIsWithheld', () => {
   it('is true when a real pin displays as auto', () => {
     expect(pinIsWithheld('claude-opus-5', 'auto')).toBe(true)

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -768,6 +768,15 @@ export interface ChatSlot {
    *  and it reports "" rather than guessing whenever resolution is unsettled — so
    *  a consumer must treat absent as "no news", never as a mismatch. */
   effective_agent?: string
+  /** The backend's verdict on whether the live session can run `model`:
+   *  `true` it cannot (the spawn withheld the pin and the session is on the
+   *  backend default), `false` it can, `null`/absent NOT KNOWN YET — no session
+   *  has advertised a comparable list for this pin.
+   *
+   *  Consumers must fail open on the unknown state (`displayModel` does): it is
+   *  the absence of an answer, never a denial. DISPLAY only — the pin is
+   *  deliberately kept when withheld, so this must not drive a write. */
+  model_withheld?: boolean | null
   key: string; title?: string; messages: number; running: boolean; stopping?: boolean; pending_approval?: boolean; created?: string; last_ts?: string; last_turn_ts?: string; last_message?: string; agent?: string; model?: string; reasoning_effort?: string; mode?: string; surface?: string; workspace?: string; trust?: boolean; trust_reads?: boolean; folder_id?: string; pinned?: boolean; tags?: string[]; links?: SessionLink[]; slack_linked?: boolean; slack_channel?: string; slack_thread_ts?: string; color_index?: number | null; color_hex?: string | null; memory_mode?: 'persistent' | 'incognito' | 'temporary'; clean_mode?: boolean; project?: string; forked_from?: string | null; source_links?: { provider: SourceProviderId; number: number; url: string; label?: string; repo?: string; ci?: 'running' | 'passed' | 'failed' | null; state?: 'open' | 'draft' | 'merged' | 'closed'; mergeable?: string; mergeStateStatus?: string; kind?: 'change' | 'issue' }[]; source_links_total?: number
   /** Provenance bucket from the backend `SlotOrigin` ("user" | "app" | "cron"
    * | "system"; absent/"" for untagged background slots). The session-pulse


### PR DESCRIPTION
## What is the problem?

The composer's model chip decided "is this pin usable?" by looking for the slot's
pinned model in the picker's list (`GET /api/models`). If it was not on that
list, the chip showed `auto`. The backend already computes the authoritative
answer per slot -- at spawn, against the live session's advertised list -- but
that verdict was never propagated, so the frontend re-derived it from a weaker
signal.

That conflated "not entitled" with "not listed for any reason". `api_models`
narrows its list for reasons that have nothing to do with entitlement (it drops
deprecated ids *before* the entitlement narrowing), so every one of those filters
silently became an entitlement signal and a filtered-but-runnable pin displayed
as `auto`.

The same predicate also had three expressions that had to stay in lockstep
across two languages by convention alone: the backend narrowing
(`_entitled_kiro_models`), the frontend display (`displayModel` plus the
`modelsDegraded` trust gate), and the mirrored `normalizeModelKey`.

## Why this issue matters to the user

The chip names the model a turn will run on. When it is wrong, the user is told
their session runs on a model it does not, and the only recourse is to spot the
mismatch themselves. Today the wrong label is cosmetic and narrow. The real cost
is that it widens with no test tripping, because the heuristic cannot tell *why*
a row vanished from the picker: any future catalog filter (curation, dedup, a new
deprecation) mislabels every slot pinned to a model it removes.

## How our fix solves it

Symptom: the chip reads `auto` for a pin the account can run (or names a pin no
turn will use). Cause: the frontend answers an entitlement question from list
membership, which is not an entitlement signal. Root cause: the one component
that knows the answer -- the session spawn -- never published it.

- `_pinned_model_verdict` (chat_runner) replaces `_pinned_model_withheld` and
  returns a tri-state: `True` withheld, `False` runnable, `None` unknown.
  Unknown is now its own answer: an empty advertised set used to fold into
  "runnable" through `model_is_unusable`, which is correct for the wire and wrong
  for a displayed verdict.
- The spawn records BOTH answers on the slot, and `SlotProjection.to_dict`
  carries it as `model_withheld` (`true` / `false` / `null`).
- `displayModel` reads it: `true` -> `auto`; `false` -> the pin (the list's
  spelling when the list has a row for it, so the picker still highlights);
  `null`/absent -> the existing list-membership heuristic with its `degraded`
  gate. Unknown fails open, as the issue requires.
- The verdict is stored against the model id it was computed for, so a re-pin
  invalidates it with no work from any of `slot.model`'s writers (picker, bulk
  pick, pick rollback, two restore paths, canonical backfill). A verdict
  outliving a re-pin would label the new model with the old model's entitlement.
- A session teardown drops the verdict, because the verdict describes the session
  that advertised the list. There is no single chokepoint for that:
  `_reset_slot_session` is the funnel for the switch handlers (agent, workspace,
  model), but three other sites replace a slot's session directly -- the deferred
  project-change reset and the deferred conversation discard in
  `_consume_pending_teardowns`, and the post-turn agent-switch reset/discard in
  the runner's `finally`. Routing those through the funnel would also cancel any
  pending question card, which is not this change's business, so each drops the
  verdict itself and a test pins the invariant: every
  `state.sessions.reset(` / `discard_conversation(` site in `chat_runner.py` and
  `chat_handlers.py` must carry a `record_model_withheld(None)` beside it.
- Display stays firewalled from writes: the pin is still KEPT when withheld, and
  the pin-to-agent row still writes `slot.model`, never the displayed label.

Deliberately unchanged: a slot that has never spawned a session has no verdict,
so its display still falls back to list membership. The withhold is only knowable
once a session advertises a list, and collapsing unknown into "show the pin"
would re-show an unentitled pin in that window -- the symptom #1611 fixed. The
issue's named deprecated-pin instance lives in exactly that pre-first-turn
window and is separately self-correcting: `_normalize_model` rewrites such a pin
to its replacement at turn start, so from the first turn on the slot carries an
id the picker does list. What the verdict fixes is the class -- wherever a
verdict exists, no `/api/models` filter can relabel a runnable pin, and a
genuinely withheld pin reads `auto` even when the list is wider or degraded.

## What tests we did

Targeted only (no full suite locally).

- Backend: `test/test_dashboard_chat.py -k PinnedModelWithheld` 20 passed;
  `test/test_chat_runner_coverage.py` + `test_dashboard_approval.py` +
  `test_eager_spawn.py` 398 passed; `test_chat_slot_reset_conversation.py` +
  `test_chat_slot_project.py` + `test_reset_conversation_directive.py` +
  `test_mcp_core_set_project.py` 81 passed;
  `test/test_ask_question_roundtrip.py` (the reset funnel's own tests) 63 passed;
  `test_dashboard_chat_handlers_coverage.py` + `test_agent_default_model.py` +
  `test_resume_publishes_hydrated_slot.py` 184 passed.
- Frontend: `vitest run src/test/model.displayModel.test.ts` 23 passed;
  `tsc -b` clean; eslint 0 errors on the five touched files (8 pre-existing
  warnings in ChatPage.tsx, none on changed lines).
- New coverage: a tri-state assertion for every unknown branch (no pin, `auto`,
  claude_code, claude backend, no getter, getter raises, empty advertised set);
  the payload carries both answers; the verdict is not reported after a re-pin
  and is reported again when the same pin returns; a cleared pin reports nothing;
  teardown forgets it; the reset funnel forgets it; the source-level ratchet over
  every teardown call site; and two end-to-end `_run_chat` tests -- a withheld
  pin still gets its notice card and now reports `true`, and a deprecated pin
  (rewritten to its replacement at turn start) reports `false` with no notice.
- Mutation-verified with the tests kept: with `state.py`, `slot_projection.py`
  and `chat_handlers.py` at base, the 7 payload/identity/teardown tests fail;
  with `chat_runner.py` at base, both end-to-end recording tests fail; with the
  reset-conversation route's drop removed, the ratchet fails naming
  `chat_handlers:3658`.
- Gates: flake8 and isort clean; mypy reports no error in the four touched
  dashboard modules (its 2 errors are pre-existing in `src/kiro_crew/transcribe.py`).
  `black --check` flags `apps/builtins/auto_research/handlers.py`; verified
  pre-existing by running the same check on that file at base -- my change there
  is one word inside a comment.

**Why no screenshot:** the chip's label does change, but only for a slot whose
live session withholds its pinned model (or whose pin an `/api/models` filter
removed while the session still advertises it). Neither state can be staged in a
pod without faking the backend's advertised list, so the delta is covered by the
`displayModel` unit tests and the two end-to-end `_run_chat` tests instead.

## Any other suggestions on the work

- The pre-first-turn window could be closed properly by carrying the EFFECTIVE
  model id (the issue's other option) rather than a boolean. The chip could then
  name a deprecated pin's replacement instead of the deprecated spelling, and
  `normalizeModelKey`'s mirror of `_normalize_model_key` could go away. It is a
  wider change (a second field, and the write firewall has to be re-argued for an
  id-shaped field), so it is not folded in here. **Tracked as #7575.**
- Consequently `displayModel`'s membership fallback is unreachable for any slot
  that has run a turn, but cannot be deleted until that unknown state is closed.
  The two spellings of "can this account run it" still coexist; the verdict just
  wins wherever it exists.
- The four teardown sites want one chokepoint. The blocker is layering:
  `SessionManager` is keyed by session key and knows nothing about slots, so it
  cannot drop slot-side state itself. A teardown callback on the manager (or
  moving the deferred-teardown consume behind the funnel once the pending-question
  interaction is settled) would collapse all four -- worth doing when something
  else slot-side needs the same hook.

## Pattern harvest

Rule candidate: **a cached verdict must be keyed to the input it judged, not to
the object that holds it.** The defect class is a stored judgment outliving the
value it was computed for -- here `slot.model` has six writers, so an explicit
reset at each one would eventually be missed. This repo already learned the
same lesson for session resets (`_reset_slot_session` exists because "six call
sites each having to remember an extra line is how one of them gets missed"),
so the convention is worth making mechanical: a stored verdict is spelled as the
pair `(_x, _x_for)` and read only through a property that compares `_x_for`
against the live input. A lint rule can check the shape -- any slot named
`_<name>` that is published in a payload and written by a `record_*` method
should have a sibling `_<name>_for` -- which is cheaper than trying to detect
staleness itself. Where the input is NOT a field the holder owns (a live session,
here), the fallback is the source-level ratchet this PR adds: enumerate the sites
that invalidate, and fail the build when a new one appears without the drop.

Closes #1819

