### PR TITLE
fix(feishu): log every silent-drop branch in _handle_receive_v1

### DIFF
--- a/src/kiro_crew/feishu/client.py
+++ b/src/kiro_crew/feishu/client.py
@@ -242,13 +242,16 @@ class LarkClient:
         """Sync P2ImMessageReceiveV1 handler injected into the WS dispatcher."""
         event = getattr(data, "event", None)
         if event is None:
+            logger.info("Feishu inbound dropped: frame has no event")
             return
         message = getattr(event, "message", None)
         if message is None:
+            logger.info("Feishu inbound dropped: event has no message")
             return
 
         msg_id: str = message.message_id or ""
         if not msg_id:
+            logger.info("Feishu inbound dropped: message has no message_id")
             return
 
         # NOTE: redelivery dedup deliberately does NOT happen here. Everything
@@ -260,19 +263,33 @@ class LarkClient:
         # after authorization instead.
 
         # Only handle plain-text messages for now.
-        if (message.message_type or "") != "text":
+        message_type = message.message_type or ""
+        if message_type != "text":
+            logger.info(
+                "Feishu inbound dropped: unsupported message_type=%r (message_id=%s)",
+                message_type,
+                msg_id,
+            )
             return
 
         sender = getattr(event, "sender", None)
         sid = getattr(sender, "sender_id", None) if sender else None
         open_id: str = (getattr(sid, "open_id", None) or "") if sid else ""
         if not open_id:
+            logger.info(
+                "Feishu inbound dropped: sender has no open_id (message_id=%s)",
+                msg_id,
+            )
             return
 
         try:
             content = json.loads(message.content or "{}")
             raw_text: str = content.get("text", "").strip()
         except Exception:
+            logger.info(
+                "Feishu inbound dropped: message content is not valid JSON (message_id=%s)",
+                msg_id,
+            )
             return
 
         # Feishu sends mentions as opaque placeholders (``@_user_1``) with the
@@ -283,6 +300,11 @@ class LarkClient:
         # which is what keeps a bare "@bot" from driving an empty turn.
         mention_free = _AT_RE.sub("", raw_text).strip()
         if not mention_free:
+            logger.info(
+                "Feishu inbound dropped: message body is mention-only "
+                "(no instruction) (message_id=%s)",
+                msg_id,
+            )
             return
         # NOT ``mention_free``: that deletes every placeholder, which would read
         # "@bot /new @alice" as the bare command "/new" and reset the
@@ -290,6 +312,10 @@ class LarkClient:
         command_body = _command_body(raw_text)
         text = _resolve_mentions(raw_text, getattr(message, "mentions", None)).strip()
         if not text:
+            logger.info(
+                "Feishu inbound dropped: resolved text is empty (message_id=%s)",
+                msg_id,
+            )
             return
 
         inbound = LarkInbound(

--- a/test/test_feishu_client.py
+++ b/test/test_feishu_client.py
@@ -698,6 +698,141 @@ class TestHandleReceiveV1:
 
 
 # ---------------------------------------------------------------------------
+# Tests: _handle_receive_v1 drop logging
+# ---------------------------------------------------------------------------
+
+
+class TestHandleReceiveV1DropLogging:
+    """Every silent-drop branch must emit a log line naming the reason.
+
+    Without a log line a dropped inbound message leaves no trace anywhere --
+    nothing in gateway.log, nothing in the SEL audit log -- making a
+    delivered-and-ignored message indistinguishable from a dead WebSocket. Each
+    drop logs at INFO with its reason (and message_id where one is known), so
+    diagnosis is a one-minute read rather than an hours-long elimination.
+    """
+
+    def _make_client(self):
+        from kiro_crew.feishu.client import LarkClient
+
+        received: list[Any] = []
+
+        async def handler(inbound: Any) -> None:
+            received.append(inbound)
+
+        client = LarkClient(app_id="a", app_secret="s", on_message=handler)
+        return client, received
+
+    def test_missing_event_logs(self, caplog: Any) -> None:
+        client, received = self._make_client()
+
+        class Data:
+            event = None
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(Data())
+
+        assert received == []
+        assert any("no event" in r.message for r in caplog.records)
+
+    def test_missing_message_logs(self, caplog: Any) -> None:
+        client, received = self._make_client()
+
+        class Event:
+            message = None
+
+        class Data:
+            event = Event()
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(Data())
+
+        assert received == []
+        assert any("no message" in r.message for r in caplog.records)
+
+    def test_missing_message_id_logs(self, caplog: Any) -> None:
+        client, received = self._make_client()
+        data = _make_event(message_id="")
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(data)
+
+        assert received == []
+        assert any("no message_id" in r.message for r in caplog.records)
+
+    def test_non_text_message_type_logs_type_and_id(self, caplog: Any) -> None:
+        client, received = self._make_client()
+        data = _make_event(message_id="img-1", message_type="image")
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(data)
+
+        assert received == []
+        drop = next((r for r in caplog.records if "unsupported message_type" in r.message), None)
+        assert drop is not None
+        # The offending type and the message_id are both in the rendered line.
+        assert "image" in drop.getMessage()
+        assert "img-1" in drop.getMessage()
+
+    def test_missing_open_id_logs(self, caplog: Any) -> None:
+        client, received = self._make_client()
+        data = _make_event(message_id="no-sender", open_id="")
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(data)
+
+        assert received == []
+        assert any("open_id" in r.message for r in caplog.records)
+
+    def test_invalid_json_logs(self, caplog: Any) -> None:
+        client, received = self._make_client()
+        data = _make_event(message_id="bad-json", content="not-json{{{")
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(data)
+
+        assert received == []
+        assert any("not valid JSON" in r.message for r in caplog.records)
+
+    def test_mention_only_body_logs(self, caplog: Any) -> None:
+        client, received = self._make_client()
+        data = _make_event(
+            message_id="ws-only",
+            content=json.dumps({"text": "@_user_1   "}),
+        )
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(data)
+
+        assert received == []
+        assert any("mention-only" in r.message for r in caplog.records)
+
+    def test_empty_resolved_text_logs(self, caplog: Any, monkeypatch: Any) -> None:
+        """The empty-resolved-text guard also logs its drop.
+
+        Reaching this branch organically is hard -- any non-mention text keeps
+        the resolved text non-empty, and a mention-only body drops one guard
+        earlier. It is a defensive guard, so we drive it directly by forcing
+        ``_resolve_mentions`` to return whitespace for a body that clears the
+        mention-only check.
+        """
+        import kiro_crew.feishu.client as client_mod
+
+        client, received = self._make_client()
+        monkeypatch.setattr(client_mod, "_resolve_mentions", lambda raw, mentions: "   ")
+        data = _make_event(
+            message_id="empty-resolved",
+            content=json.dumps({"text": "real words here"}),
+        )
+
+        with caplog.at_level("INFO", logger="kiro_crew.feishu.client"):
+            client._handle_receive_v1(data)
+
+        assert received == []
+        assert any("resolved text is empty" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # Tests: start()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Closes the observability gap described in #7520. `LarkClient._handle_receive_v1` in `src/kiro_crew/feishu/client.py` previously returned early on any of its silent-drop conditions without emitting a log line, so a delivered-but-ignored message (sticker, image, voice, file, rich-text `post`, mention-only body, malformed content, etc.) left no trace anywhere. From the outside this was indistinguishable from a dead WebSocket, wrong App ID, missing scope, or allowlist rejection.

This instruments **every** silent-drop branch in the handler with an INFO log line naming the drop reason (and the offending `message_type` / `message_id` where known):

1. missing event on the frame
2. event has no message
3. empty `message_id`
4. unsupported `message_type` (logs the type and message_id)
5. sender has no `open_id`
6. message content is not valid JSON
7. mention-only body (no instruction), plus empty resolved text

The existing module-level `logger = logging.getLogger(__name__)` is reused; no new dependencies.

## Relationship to #7528

PR #7528 is still open and covers only branch 4 (the non-text `message_type` case), leaving the other six branches silent. It edits the same two paths this PR does, so the two overlap: this change covers all seven branches and is a strict superset, closing the full gap tracked in #7520. Close #7528 as superseded, or merge it first and re-verify — in that order branch 4's hunk here becomes a textual conflict rather than a silent double-instrumentation.

## Tests

Added a `TestHandleReceiveV1DropLogging` suite in `test/test_feishu_client.py` asserting each branch logs its reason, following the existing fake-SDK test conventions.

## Verification

Verified in the repo's CI-parity environment: all 161 tests across the six `test_feishu_*.py` modules pass (44 in `test/test_feishu_client.py`, including the eight new drop-branch cases), and `flake8`, `mypy --platform linux`, `black --check`, and `isort --check-only` are clean on both changed files.

## Pattern harvest

Rule candidate: review-prompt

Pattern: an early `return` on a drop/ignore branch of an inbound-event handler that
emits no log line, so a delivered-but-discarded message is indistinguishable from a
dead transport. Review prompt: for every `return` inside a webhook or event handler,
ask whether an operator reading the logs could tell that branch was taken at all.

Fixes #7520

