### PR TITLE
ci: raise backend-test timeout to 40 minutes (#7527)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,7 +578,10 @@ jobs:
     name: Backend Tests
     needs: [changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The slowest 3.12 shard runs ~29 minutes, so a 30-minute cap kills the
+    # job at the coverage step with every test green and Coverage Gate then
+    # reds on the missing shard artifact. Same budget as backend-test-windows.
+    timeout-minutes: 40
     strategy:
       # Don't cancel sibling shards when one fails -- we want the full failure
       # picture across the suite, not just the first shard to break.
@@ -720,12 +723,12 @@ jobs:
   # Python (3.12: the preferred Windows runtime; numpy 1.x ships no 3.13
   # Windows wheel), duration-balanced shards like the POSIX matrix,
   # trace-free (--no-cov: the coverage-combine job merges ubuntu shards
-  # only). Timeout is higher than the POSIX job: windows-latest runners
-  # run the same tests measurably slower.
+  # only).
   backend-test-windows:
     name: Backend Tests (Windows)
     runs-on: windows-latest
-    # windows-latest runs the same shards measurably slower than POSIX.
+    # Same 40-minute budget as backend-test; windows-latest runs the same
+    # shards measurably slower, so this job has the least headroom of the two.
     timeout-minutes: 40
     strategy:
       # Full failure picture across shards, same as backend-test.


### PR DESCRIPTION
<!-- Auto-generated by Kiro Crew Auto-Pipeline for issue #7527 -->

## Problem / Motivation

The `backend-test` job caps at `timeout-minutes: 30` while its slowest shard (3.12, group 2) already runs ~29 minutes on main -- 97% of the cap. When a run crosses it, every test passes but the runner kills the job at the coverage step.

## Why it matters

The failure is misattributed twice: Backend Tests goes red with all tests green, and Coverage Gate goes red on the missing shard-2 coverage artifact. A PR author sees two red checks pointing at their diff with no signal that a wall-clock timeout fired, and burns re-runs (or a wrong fix) on a cap someone else's slow shard exhausted.

## What changed (motivation -> approach -> change)

Symptom: Backend Tests + Coverage Gate red with zero failing tests. Root cause: the job's wall-clock cap, not any test -- shard (3.12, 2) sits at ~29m against a 30m limit. Change: raise `backend-test` `timeout-minutes` from 30 to 40, the value `backend-test-windows` already carries for the same shards, so the two jobs now share one budget. A comment above the value records why it is 40, and the Windows job's comments that justified its budget as "higher than the POSIX job" are updated since both are now equal.

`SHARD_COUNT` and the shard matrix are unchanged. Re-balancing shard durations (the longer-term fix for shard-2 dwell, which would restore real headroom instead of raising the ceiling) is deliberately left to a follow-up.

## Tests

- No test pins this job's timeout (the only workflow-timeout assertions cover the `measure` and dependency-vulnerability jobs).
- Ran the 24 backend test files that parse `.github/workflows/ci.yml`: 1916 passed.
- Standard backend gates all green: isort, flake8, mypy, black gate, brand check, subprocess-encoding check.
- `yaml.safe_load` parse check on the edited workflow passes.

## Manual verification

Confirmed on main that `backend-test` declares 30 and `backend-test-windows` declares 40 for the identical shard matrix, and that issue #7527's duration data has shard (3.12, 2) at ~97% of the 30-minute cap. Config-only change -- no runtime surface to exercise.

## Related Issues

Closes #7527

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality (config-only change; no new test needed -- no test pins this value)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, workflow comments updated in place
- [x] No secrets, credentials, or internal references in the diff
