### PR TITLE
feat(cloud): fail launch preflight when a private hosted zone shadows a bootstrap download host

### DIFF
--- a/src/kiro_crew/cloud/ec2.py
+++ b/src/kiro_crew/cloud/ec2.py
@@ -211,6 +211,104 @@ def azs_offering_instance_type(instance_type: str, profile: str, region: str) ->
     return {o.get("Location", "") for o in offerings if o.get("Location")}
 
 
+# Hosts the bootstrap MUST resolve to build the box. Keep in sync with the
+# UserData in templates/kirocrew-ec2.yaml — the kiro-cli URL is pinned to
+# us-east-1 there regardless of the launch region, so it is literal here too.
+_BOOTSTRAP_DOWNLOAD_HOSTS = (
+    "desktop-release.q.us-east-1.amazonaws.com",  # kiro-cli musl build
+    "nodejs.org",  # Node >= NODE_MAJOR_MIN tarball
+)
+
+
+def _zone_shadows_host(zone: str, host: str) -> bool:
+    """True when a hosted zone named ``zone`` is authoritative for ``host``.
+
+    A private hosted zone owns its apex **and every subdomain**, so
+    ``q.us-east-1.amazonaws.com`` shadows ``desktop-release.q.us-east-1.amazonaws.com``.
+    Matching is done on label boundaries so ``xq.us-east-1.amazonaws.com`` does
+    not match — a plain ``endswith`` would produce false positives.
+    """
+    zone = zone.rstrip(".").lower()
+    host = host.rstrip(".").lower()
+    if not zone or not host:
+        return False
+    return host == zone or host.endswith("." + zone)
+
+
+def shadowed_download_hosts(
+    vpc_id: str, profile: str, region: str
+) -> list[tuple[str, str]]:
+    """``(host, zone)`` pairs where a private hosted zone hides a download host.
+
+    An interface VPC endpoint with private DNS enabled creates a private hosted
+    zone that is authoritative for its whole domain. Amazon Q's
+    ``com.amazonaws.<region>.q`` endpoint creates one for
+    ``q.<region>.amazonaws.com`` — and kiro-cli is downloaded from
+    ``desktop-release.q.us-east-1.amazonaws.com``, which sits inside it. In such
+    a VPC the lookup is answered by the private zone, finds no matching record,
+    and returns NXDOMAIN **without falling through to public DNS**, so the
+    bootstrap dies ~4 minutes in on a name that resolves fine everywhere else.
+
+    The failure is deterministic — retries do not help — and it surfaces as
+    "kiro-cli did not install", which names the wrong layer. One read-only call
+    here turns it into a pre-launch error.
+
+    Returns an empty list when the check cannot be performed (for example the
+    launch role predates ``route53:ListHostedZonesByVPC``): a missing optional
+    permission must never block a launch that would otherwise succeed.
+    """
+    try:
+        data = aws.checked_json(
+            [
+                "route53",
+                "list-hosted-zones-by-vpc",
+                "--vpc-id",
+                vpc_id,
+                "--vpc-region",
+                region,
+            ],
+            profile,
+            region,
+            action="route53:ListHostedZonesByVPC",
+        )
+    except aws.AWSError:
+        # Non-fatal by design — see the docstring.
+        logger.info("could not list private hosted zones for %s; skipping DNS preflight", vpc_id)
+        return []
+
+    summaries = data.get("HostedZoneSummaries", []) if isinstance(data, dict) else []
+    hits: list[tuple[str, str]] = []
+    for host in _BOOTSTRAP_DOWNLOAD_HOSTS:
+        for zone in summaries:
+            name = zone.get("Name", "") if isinstance(zone, dict) else ""
+            if _zone_shadows_host(name, host):
+                hits.append((host, name.rstrip(".")))
+                break
+    return hits
+
+
+def assert_download_hosts_resolvable(vpc_id: str, profile: str, region: str) -> None:
+    """Fail fast when a private hosted zone shadows a bootstrap download host.
+
+    Raises :class:`aws.AWSError` naming the zone, the host, and the ``--subnet``
+    remedy. See :func:`shadowed_download_hosts` for why this is worth a check.
+    """
+    hits = shadowed_download_hosts(vpc_id, profile, region)
+    if not hits:
+        return
+    detail = "; ".join(f"{host} is inside private zone {zone}" for host, zone in hits)
+    raise aws.AWSError(
+        f"VPC {vpc_id} has a private hosted zone that shadows a host the bootstrap "
+        f"must download from ({detail}). Inside this VPC that name resolves to "
+        "NXDOMAIN instead of falling through to public DNS, so the install would "
+        "fail several minutes from now with a misleading error. This is usually an "
+        "interface VPC endpoint with private DNS enabled (e.g. Amazon Q's "
+        "`com.amazonaws.<region>.q`). Launch into a VPC without that endpoint via "
+        "`--subnet <subnet-id>`, or disable private DNS on the endpoint, then retry.",
+        action="route53:ListHostedZonesByVPC",
+    )
+
+
 def discover_network(
     profile: str, region: str, instance_type: str = ""
 ) -> tuple[str, str, str]:
@@ -594,6 +692,10 @@ def deploy(
             vpc_id, subnet_id, egress_kind = discover_network(
                 profile, region, tier.instance_type
             )
+        # Both paths above settle on a VPC; check the resolver BEFORE provisioning
+        # anything. A private hosted zone that shadows a download host makes the
+        # bootstrap fail deterministically minutes later, blaming the wrong layer.
+        assert_download_hosts_resolvable(vpc_id, profile, region)
     except Exception:
         _cleanup_uploaded_source()
         raise

--- a/src/kiro_crew/cloud/iam.py
+++ b/src/kiro_crew/cloud/iam.py
@@ -214,6 +214,20 @@ def policy_document() -> dict[str, Any]:
             "Resource": "*",
         },
         {
+            # DNS preflight: a private hosted zone bound to the target VPC can be
+            # authoritative for a host the bootstrap downloads from (e.g. Amazon
+            # Q's `q.<region>.amazonaws.com` endpoint zone shadows
+            # desktop-release.q.us-east-1.amazonaws.com), which makes the install
+            # fail on NXDOMAIN with no fallthrough to public DNS. The launch
+            # degrades gracefully without this action — it just loses the early
+            # warning — so it is safe to omit on an older policy.
+            # ListHostedZonesByVPC does not support resource-level permissions.
+            "Sid": "Route53DnsPreflight",
+            "Effect": "Allow",
+            "Action": ["route53:ListHostedZonesByVPC"],
+            "Resource": "*",
+        },
+        {
             # ec2:RunInstances — request-tag-gated on the NEW instance only.
             #
             # RunInstances authorizes PER-RESOURCE across every ARN the call

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -802,6 +802,84 @@ def _nat_route_table(subnet_ids):
     }
 
 
+class TestDnsPreflight:
+    """A private hosted zone on the target VPC can hide a bootstrap download host.
+
+    The zone is authoritative for its whole subtree, so the lookup returns
+    NXDOMAIN instead of falling through to public DNS and the bootstrap fails
+    minutes later blaming the wrong layer. These cover the detection only.
+    """
+
+    def test_zone_shadows_subdomain_and_apex(self):
+        assert ec2._zone_shadows_host(
+            "q.us-east-1.amazonaws.com.", "desktop-release.q.us-east-1.amazonaws.com"
+        )
+        assert ec2._zone_shadows_host("nodejs.org", "nodejs.org")
+
+    def test_match_is_on_label_boundaries(self):
+        # A plain endswith would wrongly match these.
+        assert not ec2._zone_shadows_host(
+            "xq.us-east-1.amazonaws.com", "desktop-release.q.us-east-1.amazonaws.com"
+        )
+        assert not ec2._zone_shadows_host("notnodejs.org", "nodejs.org")
+        # A narrower zone does not shadow a shorter name.
+        assert not ec2._zone_shadows_host("a.b.nodejs.org", "nodejs.org")
+
+    def test_empty_zone_never_shadows(self):
+        assert not ec2._zone_shadows_host("", "nodejs.org")
+        assert not ec2._zone_shadows_host(".", "nodejs.org")
+
+    def test_detects_q_endpoint_zone(self, monkeypatch):
+        def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
+            if "list-hosted-zones-by-vpc" in args:
+                return {
+                    "HostedZoneSummaries": [
+                        {"Name": "q.us-east-1.amazonaws.com.", "HostedZoneId": "Z1"},
+                        {"Name": "efs.us-east-1.amazonaws.com.", "HostedZoneId": "Z2"},
+                    ]
+                }
+            return {}
+
+        monkeypatch.setattr(aws, "checked_json", fake_json)
+        hits = ec2.shadowed_download_hosts("vpc-1", "dev", "us-east-1")
+        assert hits == [
+            ("desktop-release.q.us-east-1.amazonaws.com", "q.us-east-1.amazonaws.com")
+        ]
+
+    def test_clean_vpc_has_no_hits(self, monkeypatch):
+        def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
+            if "list-hosted-zones-by-vpc" in args:
+                return {"HostedZoneSummaries": [{"Name": "internal.example.com."}]}
+            return {}
+
+        monkeypatch.setattr(aws, "checked_json", fake_json)
+        assert ec2.shadowed_download_hosts("vpc-1", "dev", "us-east-1") == []
+
+    def test_missing_permission_is_not_fatal(self, monkeypatch):
+        # An older launch policy has no route53:ListHostedZonesByVPC. Losing the
+        # early warning is acceptable; blocking an otherwise-fine launch is not.
+        def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
+            raise aws.AWSError("AccessDenied", action="route53:ListHostedZonesByVPC")
+
+        monkeypatch.setattr(aws, "checked_json", fake_json)
+        assert ec2.shadowed_download_hosts("vpc-1", "dev", "us-east-1") == []
+        # ...and the assert wrapper stays quiet too.
+        ec2.assert_download_hosts_resolvable("vpc-1", "dev", "us-east-1")
+
+    def test_assert_raises_with_actionable_text(self, monkeypatch):
+        def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
+            if "list-hosted-zones-by-vpc" in args:
+                return {"HostedZoneSummaries": [{"Name": "q.us-east-1.amazonaws.com."}]}
+            return {}
+
+        monkeypatch.setattr(aws, "checked_json", fake_json)
+        with pytest.raises(aws.AWSError) as err:
+            ec2.assert_download_hosts_resolvable("vpc-1", "dev", "us-east-1")
+        msg = str(err.value)
+        assert "q.us-east-1.amazonaws.com" in msg
+        assert "--subnet" in msg  # the user needs a way forward, not just a diagnosis
+
+
 class TestDiscoverNetwork:
     def test_prefers_default_vpc_and_public_subnet(self, monkeypatch):
         def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):

--- a/test/test_cloud_iam.py
+++ b/test/test_cloud_iam.py
@@ -30,6 +30,9 @@ class TestPolicyDocument:
             "ec2:DescribeInstanceTypeOfferings",
             # discover_network verifies subnet egress via route tables
             "ec2:DescribeRouteTables",
+            # DNS preflight: detect a private hosted zone that shadows a host the
+            # bootstrap downloads from (NXDOMAIN with no public fallthrough).
+            "route53:ListHostedZonesByVPC",
             "s3:CreateBucket",
             "s3:PutObject",
             # `aws cloudformation deploy` always goes through a change set.


### PR DESCRIPTION
## Problem / Motivation

`kirocrew cloud launch` can fail deterministically, ~4 minutes in, with an error that names the wrong layer:

```
'kiro-cli did not install (the chat backend would not work) :: ...brotli-1.0.9-4.amzn2023.0.2.aarch64  |  nodejs-1:18.20.8-
```

The real error, visible only in the untruncated reason:

```
--- installing kiro-cli ---
curl: (6) Could not resolve host: desktop-release.q.us-east-1.amazonaws.com
```

A private hosted zone owns its apex **and every subdomain**. An interface VPC endpoint with private DNS enabled creates one — Amazon Q's `com.amazonaws.<region>.q` endpoint creates a zone for `q.<region>.amazonaws.com`. kiro-cli is downloaded from `desktop-release.q.us-east-1.amazonaws.com`, which sits inside that subtree, so the lookup is answered by the private zone, finds no record, and returns **NXDOMAIN without falling through to public DNS**.

Nothing in the preflight looks at the resolver path. `cloud doctor` and `[1/6]`–`[2/6]` validate the aws CLI, `session-manager-plugin`, and EC2/CloudFormation/SSM reachability — all of which go green — and then the launch spends ~4 minutes creating an IAM role, security group, instance profile and EC2 instance before dying on a condition that was knowable from one API call up front.

## Why it matters

`discover_network()` targets the account's default VPC by design (`isDefault=true`, `ec2.py`), so **a Q endpoint in the default VPC means remote crew cannot launch at all** — deterministically, on every attempt. Q endpoints via PrivateLink are common in enterprise and regulated accounts, and such an account is *more* likely to have one, not less.

The cost is not just the wasted provisioning, it is the misdirection. In the reported case this took **six launches** to identify, and produced two confidently wrong root causes on the way:

1. The `fail()` reason budget (~1 KB) was filled with *successful* `dnf` transaction output — `brotli`, `nodejs 18`, `python3.11-setuptools` — while the actual error was truncated away. Those RPM names look exactly like a failing package install, so the first three attempts chased a "transient dnf mirror race".
2. Once the real error was visible, the absent `--retry` on that `curl` looked like the cause. Adding `--retry 5 --retry-delay 2 --retry-connrefused` and relaunching produced **6 consecutive failures over ~10 seconds** — proving the failure is deterministic and that retries cannot help.

Meanwhile `cdn.amazonlinux.com` and `nodejs.org` resolve fine in the same run, which is what makes this look impossible until you inspect the VPC's resolver config.

## What changed (motivation → approach → change)

**Goal:** turn a deterministic, misattributed, post-provisioning failure into a pre-launch error with a working suggestion.

**Approach.** Detect the *general* condition rather than special-casing Amazon Q: "is any private hosted zone bound to the selected VPC authoritative for a host the bootstrap must download from?" One read-only call, no new infrastructure, and it catches future shadowing by any endpoint or user-created zone. Rejected alternatives: resolving the name from the launching machine (wrong vantage point — the machine outside the VPC resolves it fine), and probing from the instance (too late, the instance is the thing we are trying not to create).

**What was built:**

- `_BOOTSTRAP_DOWNLOAD_HOSTS` — the hosts the UserData fetches. The kiro-cli URL is pinned to `us-east-1` in the template regardless of launch region, so the constant is literal to match rather than interpolating the region.
- `_zone_shadows_host()` — pure, label-boundary suffix match. A plain `endswith` would report `xq.us-east-1.amazonaws.com` as shadowing `desktop-release.q.us-east-1.amazonaws.com`; this does not.
- `shadowed_download_hosts()` — one `route53:ListHostedZonesByVPC` call, returns `(host, zone)` pairs.
- `assert_download_hosts_resolvable()` — raises `aws.AWSError` naming the zone, the host, and the `--subnet` remedy.
- Wired at the **single point where the `--subnet` and auto-discovery paths converge**, so both are covered by one call site, inside the existing `try` that cleans up the uploaded source on failure.
- `iam.py`: new `Route53DnsPreflight` statement. `ListHostedZonesByVPC` does not support resource-level permissions, hence `Resource: "*"`.

**A missing permission is deliberately non-fatal.** `iam.py` is an explicit action allowlist with no describe wildcard, so anyone running an older launch policy has no `route53:ListHostedZonesByVPC`. On `AWSError` the check logs and returns empty. Losing the early warning is acceptable; breaking a launch that would otherwise succeed is not.

### Design question for reviewers

A positive finding is currently **fatal**. The tradeoff: it can false-positive. If someone runs a private zone for `nodejs.org` pointing at a legitimate internal mirror, resolution works today and this check would start blocking them.

Alternatives if you would rather not take that risk:

- warn instead of raise (keeps the diagnosis, loses the guarantee);
- only raise for hosts in an AWS service-endpoint namespace (`*.amazonaws.com`), warn for the rest — the collision this addresses is in that namespace, a third-party internal mirror never is;
- confirm the record is genuinely absent via `ListResourceRecordSets` before raising. This needs another permission and does not always work: the Q endpoint's zone is service-managed and returned `AccessDenied` when enumerated.

Happy to switch to any of these — say which and I will update.

## Tests

`pytest test/test_cloud_ec2.py test/test_cloud_iam.py` → **139 passed**.

7 new tests in `TestDnsPreflight` (`test/test_cloud_ec2.py`), mocking AWS at the `cloud.aws.checked_json` chokepoint per the file's existing convention:

| Test | Locks in |
|---|---|
| `test_zone_shadows_subdomain_and_apex` | a zone shadows both its apex and any subdomain |
| `test_match_is_on_label_boundaries` | `xq.…` / `notnodejs.org` do **not** match — the `endswith` false positive |
| `test_empty_zone_never_shadows` | empty and root (`.`) zone names are inert |
| `test_detects_q_endpoint_zone` | the real case: `q.us-east-1.amazonaws.com` flags the kiro-cli host, `efs.…` does not |
| `test_clean_vpc_has_no_hits` | an unrelated private zone produces no finding |
| `test_missing_permission_is_not_fatal` | `AccessDenied` returns empty and the assert wrapper stays quiet — the backwards-compat guarantee |
| `test_assert_raises_with_actionable_text` | the raised message contains both the zone and `--subnet`, so the user gets a way forward and not just a diagnosis |

Extended `test_covers_core_launch_actions` (`test/test_cloud_iam.py`) so `route53:ListHostedZonesByVPC` is guarded by a test rather than only present in the policy.

## Manual verification

Verified against a live account, as a controlled experiment — same instance size, region, AMI and template, with **only the VPC changed**:

| | Default VPC (has `com.amazonaws.us-east-1.q`, private DNS on) | VPC without that endpoint |
|---|---|---|
| Result | **5/5 launches failed**, same NXDOMAIN on `desktop-release.q.us-east-1.amazonaws.com` | **`CREATE_COMPLETE`**, signed in, dashboard up |

The read-only calls this change relies on were exercised by hand against both VPCs: `route53 list-hosted-zones-by-vpc` returns `q.us-east-1.amazonaws.com.` for the failing VPC and no shadowing zone for the working one — i.e. the check would have raised on the first and passed on the second, before any resource was created.

One limit worth stating: the private zone's record set could **not** be enumerated (`AccessDenied` — it is service-managed by the endpoint), so "the zone has no `desktop-release` record" is inferred from the observed NXDOMAIN rather than read directly. The A/B narrows the alternatives considerably but does not independently rule out some other property of that VPC.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — two Python modules under `src/kiro_crew/cloud/` and their tests. No frontend path is touched and nothing renders differently.

## Related Issues

Fixes #7522

**Scope of that `Fixes`, stated explicitly.** This PR resolves what #7522 reports — a launch that dies ~4 minutes into provisioning with a failure reason naming the wrong step — by detecting the shadowing before any resource is created. It does **not** remove the underlying namespace collision. That durable fix (serve the kiro-cli artifact from a domain no customer-createable private hosted zone can be authoritative for) is tracked separately in #7822, so it survives this merge instead of closing with it.

I originally withheld the closing keyword to keep the scope honest. In practice that was the wrong call: with no linked PR, `closedByPullRequestsReferences` stayed empty, automated triage lanes screened #7522 as uncovered and re-selected it repeatedly, and one of those passes built a diagnosis on the retracted root cause still sitting in the issue body. The body now carries a retraction banner, and splitting the durable fix into #7822 keeps the tracker accurate without leaving the reported defect unlinked.

Also unaddressed here, and carried into #7822: `fail()`'s ~1 KB reason budget keeping successful `dnf` output while truncating the actual error away, and the failure message naming the install rather than the download.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a host the bootstrap must reach lives under a domain that a VPC-endpoint private hosted zone can be authoritative for — any such host is unreachable inside that VPC regardless of public DNS, and no retry helps.

The generalizable form is the check itself (suffix-match every required download host against the VPC's private zones) rather than a lint rule, which is why it ships as a preflight instead of a static check. The narrower reviewable invariant: **a new hard-coded download host in the bootstrap should be added to `_BOOTSTRAP_DOWNLOAD_HOSTS` in the same change**, or the preflight silently stops covering it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no user-facing doc change; the new failure text is self-describing and names the `--subnet` remedy inline
- [x] No secrets, credentials, or internal references in the diff


## CI status after rebase

**Rebased onto current `main` (`af861783`).** The four checks previously red here were failing identically on the old base `5603ae7` (`test_security_posture.py::…test_no_new_gate_side_log_line_reads_the_baseline_redactor`, on `dashboard/handlers/memory.py`). That has since been fixed on `main`, and the rebase cleared them:

| Check | on old base `5603ae7` | after rebase onto `af861783` |
|---|---|---|
| Backend Tests (3.10, 3) | FAIL | **pass** |
| Backend Tests (3.12, 3) | FAIL | **pass** |
| Backend Tests (Windows) (3) | FAIL | flake, see below |
| Coverage Gate | FAIL (`backend-test=failure`) | **pass** |

The rebase reused this branch's four file blobs on top of `main`'s current tree, so the diff is byte-identical (`+197/−0`, same four files) and the branch is now `behind_by: 0`, `MERGEABLE`.

### One remaining red is a pre-existing test-isolation bug, not this change

`Backend Tests (Windows) (3)` now fails on a **different, unrelated test** — a rate limiter tripping under parallel execution:

```
test/test_session_control.py::test_the_audit_write_does_not_run_on_the_event_loop
test/test_session_control.py::test_the_created_agent_name_is_sanitized_before_storage
  SessionControlError: too many sessions created recently; retry shortly
```

The census test no longer appears in that job's annotations, none of this PR's files are implicated, and session-creation rate limiting has no path to the `route53:ListHostedZonesByVPC` call this PR adds. `retry shortly` is the limiter's own transient message. The same shard passes on `3.10` and `3.12`.

**Root-caused since, and it is not actually a flake — the fix is up as #7852.** `create_rate_limit._buckets` is process-wide module state keyed `(verb, caller_key)`. Every test in `test/test_session_control.py` builds its caller as `_slot(state, "chat-1")`, so all 36 `create_session(` call sites share one bucket key against a budget of 20 per 300 s; the file runs in ~1.5 s, so the creates accumulate and the 21st onward is refused. Running the file whole fails **deterministically** (`2 failed, 140 passed`); `pytest-split` distributing it across 4 groups is what makes it look intermittent, and is also why the same shard number passes on 3.10/3.12.

`main` shows the same two tests failing in 2 of the 9 runs that completed that job in a ~5.5-hour window ([33604886863](https://github.com/kirodotdev/KiroCrew/actions/runs/33604886863), [33599188871](https://github.com/kirodotdev/KiroCrew/actions/runs/33599188871)), with byte-identical annotations — full table in [this comment](https://github.com/kirodotdev/KiroCrew/pull/7553#issuecomment-5508557731).

**So please don't re-run this job on my behalf** — it is a ~78% coin flip that fixes nothing and will re-redden another PR later. Merging #7852 (one import, one autouse reset fixture, matching `test_create_rate_limit.py` and `test_chat_folder_cap.py`) clears it here and everywhere. Failing that, this red is safe to accept as pre-existing: this PR's diff has no path to `dashboard/session_control.py`, and a `route53:ListHostedZonesByVPC` call cannot reach a session-creation rate limiter.


