### PR TITLE
fix(ci): route pip stderr logs through the context redactor

### DIFF
--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -41,6 +41,7 @@ from kiro_crew.embeddings import (
 from kiro_crew.executors import embed_executor, run_in_embed_pool
 from kiro_crew.history import is_incognito_transcript
 from kiro_crew.loop_lock import LoopBoundLock
+from kiro_crew.platform.context import redact_log_via_context
 from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
@@ -49,7 +50,7 @@ from kiro_crew.sandbox import (
     wrap_argv,
     wrap_argv_async,
 )
-from kiro_crew.security import redact_and_truncate, redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 from ._shared import _get_memory, _is_restricted_session, _redact_memory_field, read_bounded_json
 from .cron import _recognize_session
@@ -72,11 +73,28 @@ _history_write_lock = LoopBoundLock()
 # loader publishes into an embedder we close, and close() is terminal.
 _MODEL_LOAD_TIMEOUT_SECS = 600.0
 
-# Log-line budget for pip/ensurepip stderr in the warnings below. The bound is
-# applied by redact_and_truncate AFTER redaction runs over the FULL decoded
-# stderr, so a credential straddling the boundary cannot survive as an
-# unredacted fragment (the redact-before-bound invariant; see security.py).
+# Log-line budget for pip/ensurepip stderr in the warnings below.
 _PIP_STDERR_LOG_CHARS = 500
+
+
+def _redacted_pip_stderr(stderr: bytes) -> str:
+    """One owner for how this module logs a pip/ensurepip stderr blob.
+
+    ``redact_log_via_context``, not the OSS baseline: this handler runs in the
+    dashboard process, which DOES compose a platform context, so an installer's
+    stderr -- prime territory for a host-specific credential shape, an internal
+    registry cookie or an SSO token in a fetch URL -- must be scanned with a
+    loaded companion's regexes rather than the weaker baseline pass. The ``_log_``
+    spelling is the one that cannot raise, which a boot-time install step needs.
+    Same reasoning and same payload class as ``platform/update_provider.py``'s
+    ``CommandProvider.apply``.
+
+    Redaction runs over the FULL decoded stderr and the bound is applied AFTER
+    it: slicing first can cut a credential in half, and half a token no longer
+    matches the redactors' patterns, so the surviving fragment would reach
+    gateway.log verbatim.
+    """
+    return redact_log_via_context(stderr.decode(errors="replace"))[:_PIP_STDERR_LOG_CHARS]
 
 
 def _sel():
@@ -908,7 +926,7 @@ async def _ensure_pip_available() -> tuple[bool, str]:
         if proc.returncode != 0:
             logger.warning(
                 "ensurepip bootstrap failed: %s",
-                redact_and_truncate(stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS),
+                _redacted_pip_stderr(stderr),
             )
             return False, "pip bootstrap (ensurepip) failed"
         importlib.invalidate_caches()
@@ -1062,9 +1080,7 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
                     if proc.returncode != 0:
                         logger.warning(
                             "faiss-cpu install failed: %s",
-                            redact_and_truncate(
-                                stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS
-                            ),
+                            _redacted_pip_stderr(stderr),
                         )
                         _embedding_setup_status = {
                             "step": "idle",

--- a/test/test_enable_embeddings_faiss.py
+++ b/test/test_enable_embeddings_faiss.py
@@ -633,3 +633,83 @@ class TestPipStderrRedaction:
             # No prefix of the token may appear (the old slice leaked one).
             for n in range(3, len(self._SECRET) + 1):
                 assert self._SECRET[:n] not in msg
+
+
+class TestPipStderrReadsTheContextRedactor:
+    """Both pip-stderr logs must reach their text through the CONTEXT spelling.
+
+    The behaviour tests above pass under either redactor, because with no
+    platform context installed ``redact_log_via_context`` degrades to the same
+    OSS pass -- which is exactly why the drift these pin against was silent. On a
+    host that DOES load a companion the two spellings differ: only the context
+    one applies that companion's extra credential regexes, and this handler runs
+    in the dashboard process, which composes one.
+
+    Scoped to the two call sites rather than to the module, because
+    ``memory.py`` still reaches the baseline components legitimately for an API
+    error payload (not a gate-side log line), so the module-wide form of this
+    check in ``test_platform_context.CONVERGED_LOG_SITES`` cannot cover it.
+    """
+
+    _MARKER = "<<via-context>>"
+
+    @pytest.mark.asyncio
+    async def test_ensurepip_failure_log_goes_through_the_context_redactor(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        proc = _mock_proc(rc=1, stderr=b"could not fetch index")
+        with patch.dict("sys.modules", {"pip": None}), \
+             patch(f"{_MOD}.wrap_argv", side_effect=lambda argv, **kw: (argv, None)), \
+             patch(f"{_MOD}.redact_log_via_context", return_value=self._MARKER), \
+             patch("asyncio.create_subprocess_exec", return_value=proc), \
+             caplog.at_level(logging.WARNING, logger=_MOD):
+            ok, _ = await mem_mod._ensure_pip_available()
+
+        assert ok is False
+        messages = [r.getMessage() for r in caplog.records if "ensurepip bootstrap failed" in r.getMessage()]
+        assert messages
+        assert any(self._MARKER in msg for msg in messages)
+
+    @pytest.mark.asyncio
+    async def test_faiss_install_failure_log_goes_through_the_context_redactor(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cfg_path = tmp_path / "kirocrew.json"
+        cfg_path.write_text("{}", encoding="utf-8")
+        patches, _store, _proc, _mgr = _common_patches(
+            cfg_path, faiss_available=False, proc_rc=1, proc_stderr=b"could not fetch index"
+        )
+
+        with patches["mgr"], patches["model_present"], patches["cfg_load"], \
+             patches["cfg_path"], patches["subprocess"], patches["faiss"], \
+             patches["store"], patches["wrap_argv"], \
+             patch(f"{_MOD}.redact_log_via_context", return_value=self._MARKER), \
+             caplog.at_level(logging.WARNING, logger=_MOD):
+            async with TestClient(TestServer(_make_app())) as c:
+                resp = await c.post("/api/memory/enable-embeddings")
+                assert resp.status == 500
+
+        messages = [r.getMessage() for r in caplog.records if "faiss-cpu install failed" in r.getMessage()]
+        assert messages
+        assert any(self._MARKER in msg for msg in messages)
+
+    def test_the_bound_is_applied_after_redaction_not_before(self) -> None:
+        """The helper slices its OWN output, never the redactor's input.
+
+        Truncating first cuts a credential in half, and half a token no longer
+        matches any redactor's pattern, so the fragment would reach gateway.log
+        verbatim. Proven on the helper directly: the fake redactor records what it
+        was handed, so a bound applied to the INPUT is visible as a short call.
+        """
+        seen: list[str] = []
+
+        def _fake(text: str) -> str:
+            seen.append(text)
+            return text
+
+        long_stderr = ("x" * (mem_mod._PIP_STDERR_LOG_CHARS * 3)).encode()
+        with patch(f"{_MOD}.redact_log_via_context", side_effect=_fake):
+            out = mem_mod._redacted_pip_stderr(long_stderr)
+
+        assert seen == [long_stderr.decode()]  # the FULL text was redacted
+        assert len(out) == mem_mod._PIP_STDERR_LOG_CHARS  # the bound came after


### PR DESCRIPTION
## Problem / Motivation

`test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor`
fails on `main`, which reds the `Backend Tests` shard carrying it on every open
pull request.

```
AssertionError: New gate-side log/audit line(s) reading the BASELINE redactor
dashboard/handlers/memory.py: 2 sites, census says 0.
```

`2e627dc10` - "fix(memory): redact pip stderr before logging install failures
(#7279) (#7283)" - added two logging sites in
`src/kiro_crew/dashboard/handlers/memory.py` that redact through
`redact_and_truncate`, the OSS baseline, while
`_BASELINE_LOG_SITE_CENSUS` still records zero sites for that module.

## Why it matters

Two effects. The shard is a required check, so every open PR carries a red lane
it did not cause and authors chase it into their own diffs first. And while the
guard sits red on a known breach it cannot flag the next one - so the class of
defect it exists to catch is unpoliced for as long as this lasts.

## What changed (motivation -> approach -> change)

The guard's assertion names two ways out, and the choice between them is a
security question, not bookkeeping: route the sites through
`redact_log_via_context`, or raise the census and record which process the
baseline is correct for.

Raising the census is the wrong one here. Its precondition, stated in the
assertion message, is that "this PROCESS never composes a companion".
`dashboard/handlers/memory.py` runs in the dashboard process, which does
compose a platform context; the one process documented as deliberately not
composing is `mcp_gateway.gatewayd` (see `redact_log_via_context`'s own
docstring). Raising the number would have recorded a reason that is not true.

So both sites move to `redact_log_via_context`. This is also the established
convention for exactly this payload: `platform/update_provider.py`'s
`CommandProvider.apply` decodes a subprocess `stderr` from an install/update
command, routes it through the same helper for the same reason ("prime
territory for a host-specific credential shape, an internal registry cookie, an
SSO token in a fetch URL"), and then slices. The `_log_` spelling is the one
that cannot raise, which a boot-time install step needs.

One module-local helper, `_redacted_pip_stderr`, owns both decisions for the two
call sites - which redactor, and that the length bound is applied to the
redactor's OUTPUT. That order is the invariant #7283 was built around and it is
preserved exactly: redacting the full text first is what stops a credential
straddling the 500-char boundary from surviving as an unmatchable fragment.

Two things deliberately NOT changed:

- `memory.py` is not added to `test_platform_context.CONVERGED_LOG_SITES`. That
  list's second assertion requires a module to have no direct
  `redact_credentials` / `redact_exfiltration_urls` call at all, and this module
  still has one legitimately - for an API error payload, not a gate-side log
  line, which is why the census scanner counted 2 sites and not 3. The
  property-scanning guard in `test_security_posture` is what covers this module,
  and it now passes.
- The census table itself is untouched. With both sites converted the module's
  live count is zero, which is what the table already records, so
  `test_the_census_holds_no_slack` stays satisfied without an entry.

## Tests

Existing coverage: the four behaviour tests #7283 added
(`TestPipStderrRedaction` - userinfo credential masked on both sites, non-UTF-8
stderr does not raise, credential straddling the log bound leaks no fragment)
all pass unchanged. They pass under either redactor, because with no platform
context installed `redact_log_via_context` degrades to the same OSS pass - which
is precisely why this drift was silent, and why they are not sufficient on their
own.

New: `TestPipStderrReadsTheContextRedactor`, three tests, all three
mutation-verified red against the base source:

- the ensurepip failure log reaches its text through
  `redact_log_via_context` (patched to a marker, asserted present in the record)
- the faiss-cpu install failure log does the same, driven end to end through
  `POST /api/memory/enable-embeddings`
- the bound is applied after redaction, not before: a fake redactor records what
  it was handed, so a bound applied to the INPUT shows up as a short call

Gates run locally: `pytest test/test_enable_embeddings_faiss.py -n 4` (26
passed), the census and converged-sites guards
(`test_security_posture.py` + `test_platform_context.py -k "census or
baseline_redactor or GateSideLogRedactorSpelling or converged"`, 6 passed),
`flake8` and `isort` clean on both files, `mypy` reports nothing in the touched
module, and the repo's baselined black gate passes in scope.

## Manual verification

N/A - the failure and the fix are both fully expressed by the guard, which was
reproduced red at a pristine `main` and is green here. The changed lines only
run on a pip/ensurepip install failure, which the new end-to-end test drives
through the real handler.

## Related Issues

Closes #7549

## Pattern harvest

Rule candidate: `agents-md`
Pattern: a scan-based ratchet has no owner after merge, so it drifts in whichever
direction the last merge pushed it. This is the second census drift in this same
guard family within a day - `test_the_census_holds_no_slack` reported
`dashboard/handlers/files.py: 1 sites, census says 3` earlier and has since
cleared - and both landed because the ratchet's inputs are computed from the
whole package while a PR's CI only ever ran against its own merge ref. Any PR
green at merge time can red the ratchet for everyone the moment a second PR
lands beside it, and nothing re-runs on `main` to catch it before the next
author does.

Worth noting the shape of this one: the breaching change was itself a redaction
fix, and it was the redaction census it breached. A contributor doing the right
thing at the call site had no signal that the helper they reached for was the
wrong spelling for that process, because the two spellings are behaviourally
identical on a host with no companion loaded. The issue's own suggestion is the
cheap half of the remedy - have the guard print the exact census edit it wants -
and the durable half is a note in the contributor guidance that a redaction
call in a gate-side log line picks its spelling by which process it runs in, not
by which import is nearest.
