### PR TITLE
fix(subagent): take a run's three state.json writes off the event loop

### DIFF
--- a/src/kiro_crew/subagent_manager/run.py
+++ b/src/kiro_crew/subagent_manager/run.py
@@ -866,13 +866,19 @@ class RunEventCoordinator(ManagerComponent):
         )
         # Stream results to disk for orchestrated chat.
 
-        # Record PID for orphan recovery
+        # Record PID for orphan recovery. Off-loop and drained on cancellation
+        # via _write_state_off_loop (#6288, #7302): update_state ends in a
+        # synchronous fsync, and the reaper, every chat turn and the heartbeat
+        # share this loop. Off-loop also means the write TAKES update_state's
+        # per-agent lock, which on-loop callers skip (#7280), so it can no longer
+        # interleave with another pool writer's read-merge-rewrite.
         try:
-
             pid = self._manager._sessions.get_pid(session_key)
             if pid:
                 info._pid = pid  # make available for _write_tombstone
-                update_state(info.id, pid=pid, pid_recorded_at=time.time())
+                await self._manager._write_state_off_loop(
+                    info, "PID record", pid=pid, pid_recorded_at=time.time()
+                )
         except Exception:
             logger.debug("Failed to record PID for %s", info.id, exc_info=True)
 
@@ -914,7 +920,12 @@ class RunEventCoordinator(ManagerComponent):
                         cc_cwd = str(work_dir)
                 if cc_cwd:
                     state_update["cwd"] = cc_cwd
-            update_state(info.id, **state_update)
+            # Same off-loop, drained write as the PID record above (#6288,
+            # #7302). This one also carries `keep`, the field the two remaining
+            # on-loop writers (promote / release) contend for -- taking the
+            # per-agent lock here is what orders it against any other pool
+            # writer.
+            await self._manager._write_state_off_loop(info, "session record", **state_update)
         except Exception:
             logger.debug("Failed to record session_id for %s", info.id, exc_info=True)
 
@@ -1674,7 +1685,13 @@ class RunEventCoordinator(ManagerComponent):
         info._shared_provider = provider
         if runtime.pid:
             info._pid = runtime.pid
-            update_state(info.id, pid=runtime.pid, pid_recorded_at=time.time())
+            # Same off-loop, drained write as the non-shared spawn path's PID
+            # record (#6288, #7302). Unguarded here as before: this method has no
+            # best-effort contract, so an _atomic_write failure still propagates
+            # to the caller rather than yielding a session with no recorded pid.
+            await self._manager._write_state_off_loop(
+                info, "PID record", pid=runtime.pid, pid_recorded_at=time.time()
+            )
         logger.info(
             "Subagent %s using session sharing on runtime PID %s (session %s, key %s)",
             info.id,

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -274,8 +274,12 @@ def update_state(agent_id: str, **fields: object) -> bool:
     flight. The drain is bounded, so on a wedged FS a worker IS abandoned -- but
     that same gate then holds the conversation until the abandoned worker
     settles, so the two on-loop ``keep`` writes are deferred past it rather than
-    silently undone. Separately, on-loop callers still pay this function's fsync
-    ON the loop; moving them off-loop is tracked as #7302.
+    silently undone. Separately, an on-loop caller still pays this function's
+    fsync ON the loop. Every writer inside a run now goes off-loop through the
+    helper (#7302); the two that remain on the loop are the retention writers
+    ``_promote_conversation`` / ``release_conversation``, which are synchronous
+    functions whose other work (the ``SessionMap`` mutation) is required to stay
+    on the loop -- moving those is the rest of #7302.
     """
     p = _agent_dir(agent_id) / "state.json"
     # Off-loop callers serialize; on-loop callers keep pre-existing behaviour.

--- a/test/test_subagent_provenance_write.py
+++ b/test/test_subagent_provenance_write.py
@@ -1103,3 +1103,359 @@ async def test_the_conversation_hold_covers_the_whole_drain_not_only_expiry() ->
             await asyncio.sleep(0.01)
     assert info.id not in manager._abandoned_state_writers, "hold outlived the worker"
     assert manager._conversation_busy(conv_key) is None
+
+
+async def _await_off_loop_gate(entered: Any, what: str) -> None:
+    """Wait for an off-loop write to reach its gate, BOUNDED.
+
+    The gate only fires when the write goes through ``asyncio.to_thread``, so an
+    unbounded ``await entered.wait()`` turns a regression (the write moved back
+    onto the loop) into a 120s pytest-timeout with no diagnosis -- three of those
+    is six minutes of a shared runner for one mistake. Five seconds is orders of
+    magnitude above the real gate latency (the write is a patched no-op reached
+    within one scheduling pass) and still fails in the same breath as the cause.
+    """
+    import asyncio
+
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=5.0)
+    except (asyncio.TimeoutError, TimeoutError):  # pragma: no cover - regression path
+        raise AssertionError(
+            f"the {what} write never reached asyncio.to_thread, so it ran ON the "
+            "event loop -- update_state ends in a synchronous fsync and must go "
+            "through _write_state_off_loop (#6288, #7302)"
+        ) from None
+
+
+@pytest.mark.asyncio
+async def test_pid_and_session_records_are_written_off_loop() -> None:
+    """#7302: the PID record and the session record must not fsync on the loop.
+
+    Both used to call ``update_state`` directly from ``_run_inner``, an ``async
+    def`` body, so the read-merge-rewrite plus its fsync ran on the gateway's
+    only loop -- the ``no-blocking-call-on-event-loop`` class #6288 names, three
+    lines from a provenance write that #7467 had already moved off it. Real
+    ``asyncio.to_thread`` is used here (not a passthrough double) so the thread
+    identity in the assertion is the production one.
+    """
+    import threading
+
+    sessions = _mock_sessions(served_model="model-served")
+    # The default mock reports no pid, which skips the write under test.
+    sessions.get_pid = MagicMock(return_value=4242)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="offloop1", task="off-loop record task")
+    manager._agents[info.id] = info
+
+    loop_thread = threading.current_thread()
+    seen: list[tuple[str, bool]] = []
+
+    def _spy(_agent_id: str, **fields: Any) -> bool:
+        if "session_id" in fields:
+            label = "session record"
+        elif "pid" in fields:
+            label = "PID record"
+        elif "requested_model" in fields:
+            label = "provenance"
+        else:
+            label = "other"
+        seen.append((label, threading.current_thread() is loop_thread))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", side_effect=_spy),
+    ):
+        await manager._run_inner(info, f"subagent:{info.id}")
+
+    labels = [label for label, _ in seen]
+    assert labels.count("PID record") == 1, f"expected one PID record write, got {labels}"
+    assert labels.count("session record") == 1, f"expected one session record write, got {labels}"
+    on_loop = sorted({label for label, was_on_loop in seen if was_on_loop})
+    assert not on_loop, (
+        "state.json write(s) ran on the event loop: "
+        + ", ".join(on_loop)
+        + ". update_state ends in a synchronous fsync, and the reaper, every chat "
+        "turn and the heartbeat share this loop (#6288, #7302)."
+    )
+    # Off-loop is also what makes the write take update_state's per-agent lock,
+    # which on-loop callers skip (#7280) -- so this is the interleave fix too.
+    assert info._pid == 4242
+
+
+@pytest.mark.asyncio
+async def test_pid_record_write_is_drained_on_cancellation() -> None:
+    """#7302: the newly off-loop PID record inherits #7467's drain contract.
+
+    Moving a writer off the loop is what creates the detached-worker hazard in
+    the first place: cancelling a ``to_thread`` await abandons the worker, and
+    ``update_state`` rewrites the WHOLE file from the snapshot it already read.
+    Going through ``_write_state_off_loop`` rather than a bare ``to_thread`` is
+    what holds cancellation open until the worker lands.
+    """
+    import asyncio
+
+    sessions = _mock_sessions(served_model="model-served")
+    sessions.get_pid = MagicMock(return_value=4242)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="piddr1", task="pid cancel task")
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    landed: list[dict[str, Any]] = []
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        # Only the PID record carries `pid` without `session_id`; the provenance
+        # write ahead of it and every other off-loop call go straight through.
+        if "pid" not in kwargs or "session_id" in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        landed.append(dict(kwargs))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
+        try:
+            await _await_off_loop_gate(entered, "PID record")
+            task.cancel()
+            await _event_loop_checkpoint()
+            assert not task.done(), (
+                "cancelled _run_inner completed while the PID record write was in "
+                "flight -- the detached worker's whole-file rewrite can still roll "
+                "back a recovery run's state (#7302)"
+            )
+            assert (
+                info._state_drain_active is True
+            ), "the PID record drain did not raise the recovery-gate latch"
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert landed and landed[0]["pid"] == 4242
+    assert info._state_drain_active is False, "latch leaked past the drain"
+
+
+@pytest.mark.asyncio
+async def test_session_record_write_is_drained_on_cancellation() -> None:
+    """#7302: same contract for the session record, which also carries ``keep``.
+
+    ``keep`` is the field the two remaining on-loop writers (promote / release)
+    contend for, so an abandoned worker here is the #6298 rollback shape --
+    which is why this site needs the drain and not merely a ``to_thread``.
+    """
+    import asyncio
+
+    sessions = _mock_sessions(served_model="model-served")
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="sessdr1", task="session record cancel task", keep=True)
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    landed: list[dict[str, Any]] = []
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        if "session_id" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        landed.append(dict(kwargs))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
+        try:
+            await _await_off_loop_gate(entered, "session record")
+            task.cancel()
+            await _event_loop_checkpoint()
+            assert not task.done(), (
+                "cancelled _run_inner completed while the session record write was "
+                "in flight -- its detached worker can roll back the `keep` that "
+                "promote / release write on the loop (#6298, #7302)"
+            )
+            assert (
+                info._state_drain_active is True
+            ), "the session record drain did not raise the recovery-gate latch"
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert landed and landed[0]["keep"] is True
+    assert info._state_drain_active is False, "latch leaked past the drain"
+
+
+@pytest.mark.asyncio
+async def test_shared_session_pid_write_is_drained_on_cancellation() -> None:
+    """#7302: the session-sharing PID record is the third moved site.
+
+    ``_create_shared_session`` runs on the loop from the spawn path, and its
+    ``update_state`` was the one of the three with no ``except Exception``
+    around it -- so the swap had to preserve a propagating failure while adding
+    the drain. Unlike the other two this site is reached only when
+    ``agent.session_sharing`` puts the child on the parent's runtime.
+    """
+    import asyncio
+
+    sessions = _mock_sessions(served_model="model-served")
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(
+        id="sharedpid1", task="shared session task", parent_session_key="dashboard:1"
+    )
+    manager._agents[info.id] = info
+
+    runtime = MagicMock()
+    runtime.pid = 9191
+    runtime.create_session = AsyncMock(return_value=MagicMock(session_id="sid-shared"))
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    landed: list[dict[str, Any]] = []
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        if "pid" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        landed.append(dict(kwargs))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.SubagentManager._get_parent_runtime", return_value=runtime),
+        patch("kiro_crew.subagent.AcpSessionProvider", MagicMock()),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+    ):
+        task = asyncio.ensure_future(
+            manager._create_shared_session(info, f"subagent:{info.id}", "")
+        )
+        try:
+            await _await_off_loop_gate(entered, "shared-session PID record")
+            task.cancel()
+            await _event_loop_checkpoint()
+            assert not task.done(), (
+                "cancelled _create_shared_session completed while its PID record "
+                "write was in flight -- a lost pid is an orphan the reaper can no "
+                "longer reach (#7302)"
+            )
+            assert (
+                info._state_drain_active is True
+            ), "the shared-session PID drain did not raise the recovery-gate latch"
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert landed and landed[0]["pid"] == 9191
+    assert info._state_drain_active is False, "latch leaked past the drain"
+
+
+def test_no_on_loop_update_state_inside_a_coroutine() -> None:
+    """Build gate: a coroutine body must not call ``update_state`` directly.
+
+    Sibling of ``test_no_bare_to_thread_update_state_outside_the_drained_helper``
+    for the other half of the same divergence. That gate pins HOW an off-loop
+    write is performed; this one pins WHERE a write may happen at all. An
+    ``async def`` body runs on the gateway's only event loop, so a direct call
+    there is an fsync on the loop by construction (#6288) -- the exact residue
+    #7302 records, and the thing no reviewer caught across five triage passes
+    because the offending line reads identically to a legitimate one two
+    functions away.
+
+    Scope-aware, so it is deterministic rather than a substring heuristic: only
+    the INNERMOST enclosing frame counts, which is what makes a synchronous
+    helper nested inside a coroutine (the shape a worker thread runs) not an
+    offender. The two retention writers -- ``_promote_conversation_impl`` and
+    ``release_conversation_impl`` -- are synchronous ``def``s, so they are
+    outside this gate's reach by that same rule; moving them is the rest of
+    #7302 and needs its own change (their other work, the ``SessionMap``
+    mutation, is required to stay on the loop).
+    """
+    import ast
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+    assert src.is_dir(), src
+
+    class _Scan(ast.NodeVisitor):
+        def __init__(self) -> None:
+            # (name, is_coroutine) per enclosing frame.
+            self.stack: list[tuple[str, bool]] = []
+            self.hits: list[tuple[str, int]] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.stack.append((node.name, False))
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self.stack.append((node.name, True))
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            self.stack.append(("<lambda>", False))
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            fn = node.func
+            name = fn.id if isinstance(fn, ast.Name) else getattr(fn, "attr", "")
+            if name == "update_state" and self.stack and self.stack[-1][1]:
+                self.hits.append((self.stack[-1][0], node.lineno))
+            self.generic_visit(node)
+
+    offenders: list[str] = []
+    for path in sorted(src.rglob("*.py")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - unreadable source
+            continue
+        # Cheap pre-filter; a substring miss cannot hide a call, because the
+        # pattern spells the name literally.
+        if "update_state" not in text:
+            continue
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:  # pragma: no cover - unparseable source
+            continue
+        scan = _Scan()
+        scan.visit(tree)
+        rel = path.relative_to(src.parent.parent)
+        offenders += [f"{rel}:{line} (in {func})" for func, line in scan.hits]
+
+    assert not offenders, (
+        "`update_state(...)` called directly from a coroutine body: "
+        + ", ".join(offenders)
+        + ". A coroutine runs on the gateway's only event loop, and update_state "
+        "ends in a synchronous fsync -- route it through "
+        "`_write_state_off_loop`, which also drains the worker on cancellation "
+        "(#6288, #7302)."
+    )


### PR DESCRIPTION
## 1. What is the problem?

`subagent_persistence.update_state` reads `state.json`, merges the caller's
fields and rewrites the whole file, with a blocking `_atomic_write` (fsync +
rename) between the read and the write.

Three of a run's writers called it **directly from an `async def` body**, so that
fsync ran on the gateway's only event loop:

| Site | Fields |
|---|---|
| `subagent_manager/run.py` `_run_inner` (PID record) | `pid`, `pid_recorded_at` |
| `subagent_manager/run.py` `_run_inner` (session record) | `session_id`, `provider`, `keep`, `conversation_key`, `cwd` |
| `subagent_manager/run.py` `_create_shared_session` | `pid`, `pid_recorded_at` |

That is the `no-blocking-call-on-event-loop` class #6288 names. The divergence is
what makes it easy to miss: PR #7467 moved every OTHER state writer inside a run
through `_write_state_off_loop`, and the PID record sits about thirty lines below
one of them, reading almost identically at the call.

## 2. Why this issue matters to the user

The gateway runs chat turns, the reaper and the heartbeat on that one loop. A
`state.json` write is small, but its cost is not bounded by its size: it is a
read plus an `fsync` plus a `rename` against whatever filesystem the config
directory lives on. On a network mount, a snapshotting volume, or a disk under
load, every one of those calls stalls the loop for as long as the FS takes --
which means an unrelated chat turn stops mid-stream and the heartbeat misses its
window, three times per subagent spawn.

It also left an ordering hole. `update_state` serializes its read-merge-rewrite
per agent for off-loop callers only (#7280); an on-loop caller deliberately takes
no lock, because waiting on a pool thread's fsync from the loop is the very thing
the anchor forbids. So these three writes were unordered against any pool writer:
because the rewrite is whole-file, a writer that read first and wrote last rolls
back **every** field the other landed, not just the fields it names. A lost `pid`
means the reaper can no longer reach the child -- a leaked `kiro-cli` process
holding its memory for the life of the gateway.

## 3. How our fix solves it

The chain is: on-loop write -> fsync on the loop, and no per-agent lock -> an
unordered whole-file rewrite. Moving the caller off-loop closes both links at
once, because `update_state` takes the lock precisely when the caller is not on
the loop.

All three sites now `await self._manager._write_state_off_loop(info, "<label>",
**fields)` -- #7467's helper, unchanged. No new mechanism, no per-site flags:

- **Off-loop** puts the fsync in a pool thread, so a slow FS can no longer freeze
  the loop.
- **Drained on cancellation** is what makes going off-loop safe rather than a
  trade: cancelling a `to_thread` await detaches the worker without stopping it,
  and a detached worker is exactly the stale whole-file writer described above.
  The helper holds cancellation open until the worker lands (bounded at 5s), and
  on expiry marks the run so its conversation stays held.
- **The lock** now covers these writes, so they are ordered against every other
  pool writer.

**Why the two remaining on-loop callers are safe against these three.** The other
`update_state` callers on the loop are the retention writers,
`_promote_conversation` (`keep=True`) and `release_conversation` (`keep=False`).
The session record carries `keep` too, so the interleave question is real -- and
answered by the gate #7467 already leaned on: both retention writers are reached
only through `_conversation_busy`, which refuses while a run is not `done`. All
three sites here run inside `_run_inner` / `_create_shared_session`, i.e. while
the run is live, so a promote or release cannot execute concurrently with them.
`info.conversation_key` is assigned at construction (`continuation.py:328` for a
continuation, `admission.py:448` for a spawn), so the gate cannot miss a live
continuation run either.

One behaviour is deliberately preserved rather than tidied: the
`_create_shared_session` site has no `except Exception` around it, and still does
not. That method has no best-effort contract, so an `_atomic_write` failure keeps
propagating to the caller instead of yielding a session with no recorded pid. At
the two `_run_inner` sites the existing `except Exception` stays correct because
it does not catch `CancelledError`, so the helper's post-drain re-raise
propagates instead of being swallowed.

This also makes an existing docstring true: `_write_state_off_loop` already
claimed "every `state.json` writer inside a run goes through here", which these
three sites falsified.

**Scope.** #7302 lists five on-loop callers. This PR moves the three in `run.py`
-- the self-contained half, and the issue's own suggested first step -- so it is
`Refs`, not `Closes`. The two `continuation.py` retention writers are left, with
the reasons recorded on the issue: they are synchronous functions whose callers
would all have to become awaitable; `release_conversation`'s other work includes
a `_cleanup_session_files_sync` unlink loop that is blocking too, so offloading
only its 1 ms write would be a half-measure; and its `SessionMap` mutation is
*required* to stay on the loop by the Arbiter contract in `continuation.py`. Those
are design decisions, not substitutions.

## 4. What tests we did

Five new tests in `test/test_subagent_provenance_write.py`, all mutation-verified
-- reverting only the two `src/` files to base makes all five fail in 7s, while
the three pre-existing #7467 drain tests stay green:

- `test_pid_and_session_records_are_written_off_loop` -- drives `_run_inner` with
  the REAL `asyncio.to_thread` and asserts neither write ran on the loop thread.
  On base: `state.json write(s) ran on the event loop: PID record, session record`.
- Three drain tests, one per moved site, each gating its own write, cancelling
  mid-flight and asserting the task does not complete, the recovery-gate latch is
  raised, the write still lands, and the latch does not leak.
- `test_no_on_loop_update_state_inside_a_coroutine` -- a static AST gate, sibling
  to #7467's `test_no_bare_to_thread_update_state_outside_the_drained_helper`.
  That one pins HOW an off-loop write is performed; this one pins WHERE a write
  may happen at all. Scope-aware (innermost frame only), so a synchronous helper
  nested inside a coroutine is correctly not an offender.

The three drain tests bound their gate wait at 5s rather than awaiting it
unbounded. Unbounded, a regression turned each one into a 120s pytest-timeout
with no diagnosis -- six minutes of a shared runner for one mistake. Bounded,
base fails in 7s total with the cause in the message.

Gates on the touched files: 338 tests green across the affected families
(`test_subagent`, `test_session_sharing`, `test_subagent_persistence`,
`test_subagent_state_write_serialization`, `test_subagent_provenance_write`,
`test_subagent_continuable`, `test_subagent_manager_boundaries`,
`test_subagent_reap_race`, `test_stop_kill_cancel`,
`test_subagent_stall_activity_scope`); flake8, isort and the baseline black gate
clean. Two `test_acp_backend_kas.py::TestNoImportCycle` failures are
worktree-environment, not the diff: they spawn a bare `python -c "import
kiro_crew"` subprocess and this worktree has no editable install
(`ModuleNotFoundError: No module named 'kiro_crew'`); both pass with
`PYTHONPATH=src`. The two `mypy` errors reported are in
`src/kiro_crew/transcribe.py`, which this commit does not touch.

## 5. Any other suggestions on the work

- The interesting residue is not in this diff: `release_conversation` runs
  `_cleanup_session_files_sync` on the event loop, an unlink loop over provider
  session files. It is a strictly larger blocking call than the `update_state`
  #7302 was filed about, and #7302 does not mention it. Worth folding into the
  continuation half rather than discovering it there.
- `_write_state_off_loop` is keyed on a live `SubagentInfo`
  (`_state_drain_active`, `_cancel_retry_used`, `_abandoned_state_writers` by
  `info.id`). The two retention writers only hold a `conv_id` and may have no
  live run, so they cannot reuse the helper as-is; whoever does that half needs a
  hold/latch decision of their own. Noting it so it is not mistaken for a
  mechanical swap.

## Pattern harvest

Rule candidate: an AST/semgrep gate on call POSITION, not just call form -- a
blocking call (one ending in a synchronous `fsync`, `unlink`, or `rename`) must
not be invoked directly from an `async def` body.

It is already in this PR as a test. The defect class is "a
blocking call reached from a coroutine body", and the reason five triage passes
missed it is that the offending line is textually identical to a legitimate one
in the same file -- convention cannot separate them, position can.
`test_no_on_loop_update_state_inside_a_coroutine` walks the AST of
`src/kiro_crew` and fails on any direct `update_state(...)` whose innermost
enclosing frame is an `async def`. It is deterministic and false-positive-free
for this symbol, because an off-loop write has exactly one legitimate form (the
helper's own `to_thread`, which is an argument and not a call).

The generalization worth taking: the repo already has
`test_no_blocking_call_on_loop.py` and #7467 added a HOW gate for this symbol.
The missing shape was a WHERE gate. Any function that ends in a synchronous
`fsync` or `unlink` deserves one at the point it becomes reachable from a
coroutine -- which would have caught these three sites the day they were written,
and would catch `_cleanup_session_files_sync` today.

Refs #7302
Refs #6288
Refs #7467

