### PR TITLE
fix(ci): clear five unused-import warnings and ratchet eslint to 603

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1323,7 +1323,7 @@ jobs:
         # The ceiling must EQUAL the measured count, not sit above it: slack is
         # silent admission, and a warning that lands inside it never surfaces
         # again. Re-measure with `cd website && npx eslint src/` when burning down.
-        run: npx eslint src/ --max-warnings 609
+        run: npx eslint src/ --max-warnings 603
 
       - name: Copy/paste detection
         working-directory: website

--- a/website/src/test/extensionSeams.test.tsx
+++ b/website/src/test/extensionSeams.test.tsx
@@ -43,7 +43,6 @@ import {
   registerMobileConnectRenderer,
   getMobileConnectRenderers,
   canRenderMobileConnectKind,
-  BUILTIN_MOBILE_CONNECT_KINDS,
 } from '../components/mobileConnectRenderers'
 import { apiTransport } from '../api/apiTransport'
 // Importing the client installs the blessed transport (installApiTransport runs

--- a/website/src/test/noPageZoom.test.ts
+++ b/website/src/test/noPageZoom.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { readFile, glob } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { installPageZoomSuppression } from '../utils/pageZoom'
 

--- a/website/src/test/tipsApi.test.ts
+++ b/website/src/test/tipsApi.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { checkSessionExpired, __resetAuthRecoveryStateForTests } from '../api/client'
+import { __resetAuthRecoveryStateForTests } from '../api/client'
 
 // We test that the tips API calls go through the shared response handler by
 // verifying the exported api.tipsNext / api.tipsStatus surface the proper
@@ -46,7 +46,7 @@ describe('tips API auth recovery (jNullable)', () => {
       new Response('Internal Server Error', { status: 500, headers: { 'content-type': 'text/plain' } }),
     )
     const { api, ApiError } = await import('../api/client')
-    await expect(api.tipsStatus()).rejects.toThrow()
+    await expect(api.tipsStatus()).rejects.toBeInstanceOf(ApiError)
   })
 
   it('tipsNext invokes checkSessionExpired on 403', async () => {

--- a/website/src/test/useIsTouchDevice.test.ts
+++ b/website/src/test/useIsTouchDevice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useIsTouchDevice } from '../hooks/useIsTouchDevice'
 


### PR DESCRIPTION
## Problem / Motivation

The frontend lint gate runs `npx eslint src/ --max-warnings <n>` as a ratchet baseline. The issue reports the trap firing at 659/660: two PRs each added one warning measured against a tree that lacked the other, both merged green, and the sum breached the ceiling on main -- turning `Frontend Lint & Type Check` red on every open PR regardless of its diff. A later config fix (#7525) re-pinned the ceiling at the then-measured 609, which cleared that breach but left main sitting one warning below the budget, one concurrent-merge race away from the same repo-wide red.

## Why it matters

When main itself breaches the lint budget, every contributor's PR fails a required check for a reason they cannot see in their own diff, and the first response (re-running, bisecting their change) is wasted work. With zero headroom the gate is a coin toss on the next pair of concurrently-merged PRs.

## What changed (motivation -> approach -> change)

Symptom: the gate fails (or is about to fail) for every PR. Root cause: the warning count converged onto the ceiling, and the ceiling only ratchets down when someone clears warnings. Change: clear the five unused-import `@typescript-eslint/no-unused-vars` warnings in website test files and ratchet `--max-warnings` from 609 down to the measured 603, restoring real headroom in the direction the gate's own comment demands (down toward 0, never up).

- `website/src/test/extensionSeams.test.tsx` -- drop top-level `BUILTIN_MOBILE_CONNECT_KINDS`; the test reads `fresh.BUILTIN_MOBILE_CONNECT_KINDS` from its post-`vi.resetModules()` dynamic re-import, so the static binding was a stale-module footgun as well as dead.
- `website/src/test/noPageZoom.test.ts` -- drop `glob` (file asserts against two fixed paths via `readFile`).
- `website/src/test/useIsTouchDevice.test.ts` -- drop `vi` (the `matchMedia` stub is hand-rolled with `Object.defineProperty`).
- `website/src/test/tipsApi.test.ts` -- drop the dead top-level `checkSessionExpired` import; in the `tipsStatus throws ApiError on 500` test, the unused `ApiError` destructure was the vestige of the assertion the test name promises, so restore `rejects.toBeInstanceOf(ApiError)` (matching its `tipsNext` sibling) instead of deleting the binding.
- `.github/workflows/ci.yml` -- `--max-warnings 609` -> `603`.

## Tests

- `npx eslint src/` measures exactly 603 warnings, 0 errors; `npx eslint src/ --max-warnings 603` exits 0.
- `npx tsc -b` clean.
- `npx vitest run` on the four touched test files: 4 files, 74 tests passed -- including the strengthened `tipsStatus` assertion.
- `python3 -m pytest test/test_eslint_warning_ceiling.py`: 2 passed (exactly one ceiling declared in ci.yml; the value is not transcribed into prose).
- `BRAND_BASE_REF=origin/main python3 scripts/check_brand_name.py`: clean.

## Manual verification

N/A -- lint-only change with no runtime surface; the automated gates above cover it.

## Related Issues

Closes #7481

## Pattern harvest

Not generalizable: the defect is the arithmetic of concurrent merges against a shared budget, not a code pattern; the structural guard would be a post-merge lint canary on main (CI infrastructure), which is out of scope for a per-PR rule.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
