### PR TITLE
fix(issue-radar): decode az output as utf-8, not the host code page

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -25,7 +25,6 @@
 1 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/record_template.py
 3 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/verify_align.py
 3 src/kiro_crew/apps/builtins/file_explorer/server.py
-1 src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
 3 src/kiro_crew/apps/builtins/md_notebook/server.py
 1 src/kiro_crew/apps/builtins/pptx_maker/backend/engine.py
 1 src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
@@ -335,6 +335,16 @@ def _az_run(argv: list[str], *, host: str, timeout: float) -> subprocess.Complet
             [az, *argv[1:]],
             capture_output=True,
             text=True,
+            # `az devops invoke` answers with work-item JSON -- titles, descriptions
+            # and comments written by people -- so non-ASCII is the normal case, not
+            # an edge one. `text=True` alone decodes it with
+            # `locale.getpreferredencoding(False)`, which on a Windows console code
+            # page is cp950 / cp932 / cp1252. A `UnicodeDecodeError` is neither
+            # `FileNotFoundError` nor `TimeoutExpired`, so it would escape both
+            # handlers below and this chokepoint's own error contract with it; a
+            # lenient code page is quieter and worse, mojibaking every title that
+            # reaches the board. az writes UTF-8, so name it.
+            encoding="utf-8",
             timeout=timeout,
             check=False,
             env=_az_env(resolved_host),

--- a/test/test_issue_radar_az_encoding.py
+++ b/test/test_issue_radar_az_encoding.py
@@ -1,0 +1,112 @@
+"""``_az_run`` must decode ``az`` output as UTF-8, not as the host code page.
+
+``_az_run`` is Issue Radar's single spawn chokepoint for every ``az`` call, and
+what comes back through it is ``az devops invoke`` JSON: work-item titles,
+descriptions and comments, written by people. Non-ASCII is the normal case there,
+not an edge one.
+
+The call used ``text=True`` with no ``encoding=``, so that JSON was decoded with
+``locale.getpreferredencoding(False)`` — cp950 / cp932 / cp1252 on a Windows
+console code page. Two distinct failures follow, and both are asserted below:
+
+* a code page that **cannot** decode the bytes raises ``UnicodeDecodeError``,
+  which is neither ``FileNotFoundError`` nor ``TimeoutExpired``. It escapes both
+  handlers in ``_az_run``, so the caller never sees a ``ProviderCliError`` and the
+  route answers an opaque 500 instead of its own 502 contract;
+* a code page that decodes *most* bytes (cp1252) fails the other way, and does it
+  inconsistently: five byte values are undefined there, so the same title may raise
+  on one work item and come back mojibaked on the next.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.apps.builtins.issue_radar.backend import azure_client
+
+# A work item as Azure DevOps actually returns one, with prose in it.
+WORK_ITEM = {
+    "id": 4211,
+    "fields": {
+        "System.Title": "Café にログインできない — 認証が 401 を返す",
+        "System.Description": "<div>Größe: naïve</div>",
+    },
+}
+RAW_JSON = json.dumps(WORK_ITEM, ensure_ascii=False)
+
+
+@pytest.fixture(autouse=True)
+def _stub_chokepoint_preflight(monkeypatch: pytest.MonkeyPatch):
+    """Neutralise the host/binary/audit preflight, which is not under test here.
+
+    ``_az_run`` re-resolves the host, re-validates the binary and writes the
+    ``invoked`` audit before it spawns; none of that touches decoding, and all of
+    it needs a configured host. Stubbing it keeps these tests about the one thing
+    they are about.
+    """
+    monkeypatch.setattr(azure_client, "_resolve_host", lambda host: host)
+    monkeypatch.setattr(azure_client, "_az_bin", lambda: "az")
+    monkeypatch.setattr(azure_client, "_az_env", lambda host: {})
+    monkeypatch.setattr(azure_client, "_audit", lambda *a, **k: None)
+
+
+def _decoding_run(host_encoding: str, payload: bytes = RAW_JSON.encode()):
+    """A ``subprocess.run`` stand-in that decodes the way ``subprocess`` documents.
+
+    The bytes are what ``az`` writes; the only variable is the codec. ``subprocess``
+    uses the ``encoding=`` keyword when one is given and
+    ``locale.getpreferredencoding(False)`` when it is not, so the interesting code
+    page is a parameter here rather than a property of the test runner — these are
+    deterministic on a UTF-8 CI box and on a cp950 laptop alike.
+    """
+
+    def _fake(argv, **kwargs):
+        codec = kwargs.get("encoding") or host_encoding
+        return subprocess.CompletedProcess(argv, 0, payload.decode(codec), "")
+
+    return _fake
+
+
+@pytest.mark.parametrize("host_encoding", ["cp950", "ascii"])
+def test_work_item_json_survives_a_non_utf8_host_codepage(host_encoding: str) -> None:
+    """The load-bearing one: the JSON must come back byte-for-byte as az wrote it.
+
+    ``cp950`` is a real shipped Windows code page and ``ascii`` is the degenerate
+    POSIX ``LC_ALL=C`` case; both fail on the same bytes, from opposite directions.
+    """
+    with patch.object(subprocess, "run", side_effect=_decoding_run(host_encoding)):
+        proc = azure_client._az_run(["az", "devops", "invoke"], host="dev.azure.com", timeout=30)
+
+    assert proc.stdout == RAW_JSON, "az's JSON did not survive decoding"
+    # The consequence, not just the string: the caller parses this.
+    assert json.loads(proc.stdout)["fields"]["System.Title"] == (
+        WORK_ITEM["fields"]["System.Title"]
+    )
+
+
+def test_a_codepage_that_silently_mojibakes_is_also_refused() -> None:
+    """The inconsistent half, and why ``errors=`` would not be a fix.
+
+    cp1252 decodes most bytes to *something* and leaves five undefined, so the same
+    UTF-8 title can raise on one work item and come back as garbage on the next —
+    which is worse to diagnose than a clean failure. Asserting on the decoded text
+    refuses both outcomes with one assertion, where ``errors="replace"`` would
+    convert the raising case into the silent one.
+    """
+    with patch.object(subprocess, "run", side_effect=_decoding_run("cp1252")):
+        proc = azure_client._az_run(["az", "devops", "invoke"], host="dev.azure.com", timeout=30)
+
+    assert proc.stdout == RAW_JSON
+
+
+def test_ascii_output_is_unaffected() -> None:
+    """Over-fix guard: the ordinary case is unchanged, and passes on both sides."""
+    plain = b'{"id": 7, "fields": {"System.Title": "plain title"}}'
+    with patch.object(subprocess, "run", side_effect=_decoding_run("cp950", plain)):
+        proc = azure_client._az_run(["az", "devops", "invoke"], host="dev.azure.com", timeout=30)
+
+    assert json.loads(proc.stdout)["fields"]["System.Title"] == "plain title"


### PR DESCRIPTION
## Problem / Motivation

`_az_run` is Issue Radar's **single spawn chokepoint for every `az` call** — its own
docstring says so, and `test/test_spawn_audit.py` pins it as such. Every Azure DevOps
request in the app funnels through this one `subprocess.run`:

```python
proc = subprocess.run(
    [az, *argv[1:]],
    capture_output=True,
    text=True,          # <- no encoding=
    timeout=timeout,
    env=_az_env(resolved_host),
)
```

What comes back through it is `az devops invoke` JSON: **work-item titles,
descriptions and comments, written by people.** Non-ASCII is the normal case there,
not an edge one — and `_az_invoke` feeds `proc.stdout` straight into `json.loads`.

`text=True` with no `encoding=` decodes those bytes with
`locale.getpreferredencoding(False)`, which on a Windows console code page is
cp950 / cp932 / cp1252, not UTF-8.

## Why it matters

**The chokepoint loses its own error contract.** `_az_run` catches exactly
`FileNotFoundError` and `subprocess.TimeoutExpired`, translating each into a typed
`ProviderSetupError` / `ProviderCliError` so the route can answer a 502 with a real
reason. A `UnicodeDecodeError` is neither, so it escapes both handlers, skips the
`failure` audit line, and surfaces as an opaque 500. Measured with a real Azure DevOps
work item:

```
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe3 in position 47
```

**cp1252 fails the other way, and inconsistently** — which is harder to diagnose than
a clean crash. It decodes most bytes to *something*, but five byte values are
undefined in it, so the same UTF-8 title can raise on one work item and arrive
mojibaked on the next. A user sees a board that is sometimes garbled and sometimes
broken, with no pattern.

The repository already gates this class (`scripts/check_subprocess_encoding.py`), and
this file was on its baseline.

## What changed (motivation → approach → change)

Symptom: non-ASCII work items crash or garble the board on non-UTF-8 hosts. Root
cause: `az`'s UTF-8 JSON decoded with the host code page. Fix: name the encoding, at
the chokepoint, so every caller inherits it.

```python
 proc = subprocess.run(
     [az, *argv[1:]],
     capture_output=True,
     text=True,
+    encoding="utf-8",
     timeout=timeout,
     env=_az_env(resolved_host),
 )
```

One line, at the one place every `az` call already passes through — no new plumbing,
and no per-call-site sweep to keep in sync. It is **not a new convention** either:
`platform/update_capability.py` and `pod/runtime.py` already pin UTF-8 on their own
spawns, the latter through the shared `kiro_crew.subprocess_utf8.UTF8_TEXT`.

`errors=` is deliberately **not** added: it would convert the raising case into the
silent-mojibake case, which the tests below treat as equally wrong. `az` writes UTF-8,
so the correct move is to say so.

The subprocess-encoding baseline row for this file is pruned rather than lowered — it
goes to zero unpinned calls.

## Tests

New file `test/test_issue_radar_az_encoding.py`.

The harness drives the **real `_az_run`** with a `subprocess.run` stand-in that decodes
the way `subprocess` documents: the `encoding=` keyword when one is given,
`locale.getpreferredencoding(False)` otherwise. That makes the interesting code page a
test parameter rather than a property of the runner — deterministic on a UTF-8 Linux CI
box and on a cp950 laptop alike, with no console code page to switch, no timing and no
skip. The payload is an Azure DevOps work item with prose in it, not a synthetic byte
string.

| Test | Locks in |
|---|---|
| `..._work_item_json_survives_a_non_utf8_host_codepage[cp950]` / `[ascii]` | the raising case from both directions — a real shipped Windows DBCS code page, and the degenerate POSIX `LC_ALL=C` one. Asserts the JSON is byte-identical **and** that `json.loads` recovers the exact title, so the consequence is pinned, not just the string |
| `..._a_codepage_that_silently_mojibakes_is_also_refused` | cp1252, the inconsistent case. This is what `errors="replace"` would leave behind, and the same assertion refuses both of its outcomes |
| `..._ascii_output_is_unaffected` | over-fix guard: the ordinary case is unchanged. Passes on both sides, which is the point |

An autouse fixture stubs the chokepoint's preflight (`_resolve_host`, `_az_bin`,
`_az_env`, `_audit`). None of it touches decoding and all of it needs a configured
host, so stubbing it keeps each test measuring one thing.

**Red-before**, with `azure_client.py` restored to current `origin/main`
(`5603ae744`) and nothing else changed — **3 failed, 1 passed**:

```
UnicodeDecodeError: 'cp950'   codec can't decode byte 0xe3 in position 47
UnicodeDecodeError: 'ascii'   codec can't decode byte 0xc3 in position 44
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 48
```

The third line is the cp1252 case, and it is why this PR's description says
"inconsistently" rather than "always mojibakes": on this payload cp1252 happens to hit
one of its five undefined bytes. The one test that passed is the ASCII over-fix guard,
which must pass on both sides.

**Green after:** the new file plus `test/test_spawn_audit.py`, which is the existing
suite that pins `_az_run` as the sole chokepoint — **16 passed**.

Gates on the touched files: `scripts/check_subprocess_encoding.py` **passed** (116
files remain on the baseline, down from 117), `scripts/check_black_formatting.py`
**passed in scope**, `flake8` and `isort --check-only` clean, `git diff --check` clean,
and `mypy src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py` — *Success:
no issues found in 1 source file*. No repository-wide suite; server CI owns that.

## Manual verification

N/A — unit coverage sufficient: the defect is a decoding choice at one spawn, and the
tests drive the real chokepoint with a real work-item payload, which is closer to the
failure than pointing one machine at an Azure DevOps org would be.

## Related Issues

None. Found by auditing spawns whose output is user-authored prose and which decode
with the host locale, against `scripts/check_subprocess_encoding.py`'s own baseline.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a **typed error contract** wrapped around a spawn, where the decode step sits
inside the `try` but its exception type is not in the `except`.

The narrow version of this ("pass `encoding=`") is already a gate. The generalizable
half is not: `_az_run` is careful to translate every failure it expects into a provider
error, and the decode is the one failure that walks straight through that translation —
so the symptom is not "wrong characters" but "this endpoint stopped honouring its own
error contract". A reviewer looking at any `except (FileNotFoundError, TimeoutExpired)`
around a `text=True` spawn can ask whether `UnicodeDecodeError` was meant to be in that
list, or meant to be impossible.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
