### PR TITLE
refactor(acp): flatten the runtime timeout diagnostic and drop a dead constant

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -154,7 +154,6 @@ _DROP_IDS_IN_LOG = 8
 # server→client request with this itself (see _answer_ownerless_request);
 # mirrors the private constant AcpClient keeps for its own dispatch sites.
 _JSONRPC_METHOD_NOT_FOUND = -32601
-_INIT_TIMEOUT = 30.0
 _REQUEST_TIMEOUT = 30.0
 # One gateway event loop owns many independent SessionManager and worker-pool
 # callers. Keep their expensive subprocess spawn + initialize handshakes behind
@@ -223,7 +222,7 @@ def _cold_start_counts() -> tuple[int, int]:
 # ABOVE the backend's 30s OAuth wait plus the initialization tail that follows
 # it (observed: remaining servers register within ~1s after the wait; a
 # 71-server agent with no pending OAuth completes in ~14s) — do NOT "tidy" it
-# back down to _REQUEST_TIMEOUT. See issue #2946.
+# back down to _REQUEST_TIMEOUT.
 # This is the built-in default AND floor; ``agent.session_start_timeout_secs``
 # raises it for agents whose MCP fleet legitimately needs longer (see
 # _resolve_session_start_timeout below).
@@ -424,9 +423,10 @@ def _get_rss_mb(pid: int) -> float | None:
 
     Linux: reads /proc/<pid>/status. macOS (no /proc): shells out to
     ``ps -o rss= -p <pid>`` (ps reports RSS in KiB on both platforms).
-    Returns None on any failure (missing /proc, permission error, process
-    gone, ps not found) so callers can treat "unknown" the same as "not over
-    threshold" rather than raising.
+    Windows: WorkingSetSize through the ``platform_compat`` shim, since no
+    ``ps`` is resolvable there. Returns None on any failure (missing /proc,
+    permission error, process gone, ps not found) so callers can treat
+    "unknown" the same as "not over threshold" rather than raising.
     """
     if sys.platform == "linux":
         try:
@@ -441,9 +441,14 @@ def _get_rss_mb(pid: int) -> float | None:
         return None
 
     if platform_compat.IS_WINDOWS:
-        # No `ps` on a normal Windows PATH — the POSIX fallback below returned
-        # None for every pid, so the watchdog's RSS-recycle ceiling never fired.
-        # Read WorkingSetSize via GetProcessMemoryInfo through the shim.
+        # Windows ships no `ps` in the fixed system directories the POSIX
+        # fallback below resolves through (trusted_system_bin ignores PATH on
+        # purpose), so that fallback can only ever answer None here. Read
+        # WorkingSetSize via GetProcessMemoryInfo through the shim instead.
+        # The watchdog's RSS-recycle ceiling does not depend on this branch —
+        # _get_rss_tree_mb serves Windows from proc_rss_tree_mb_for_pid and
+        # never calls this function — so this keeps a direct single-pid read
+        # honest for a direct caller.
         rss = platform_compat.proc_rss_bytes_for_pid(pid)
         return None if rss is None else rss / (1024.0 * 1024.0)
 
@@ -657,7 +662,7 @@ def _resolve_session_start_timeout() -> float:
     [SESSION_START_TIMEOUT_MIN, SESSION_START_TIMEOUT_MAX]; the ``max`` here
     is belt-and-braces so a degraded load can never shrink the budget below
     the built-in floor — a session-start budget under the backend's 30s OAuth
-    wait recreates the race issue #2946 fixed.
+    wait recreates the race that floor exists to prevent.
     """
     try:
         # circular import: config.loader -> dashboard -> session -> acp
@@ -1266,7 +1271,7 @@ class AcpRuntime:
                     browser_socket_env, lifecycle_env
                 )
             )
-        # Per-process scratch containment (#5063): the agent's temp AND its
+        # Per-process scratch containment: the agent's temp AND its
         # prompt-guided work products land in an owned directory instead of
         # the shared system temp dir. Allocated off-loop (mkdir + config read)
         # through the sandbox guard like the env resolution above, and
@@ -1427,8 +1432,8 @@ class AcpRuntime:
             # leaks for the rest of the host's uptime.
             #
             # ERROR, not debug: this log line is the only signal that will ever
-            # be emitted for that leak. #2985 made a failed PID-file REWRITE
-            # loud for the same reason; this is the append half.
+            # be emitted for that leak. A failed PID-file REWRITE is loud for
+            # the same reason; this is the append half.
             logger.error(
                 "AcpRuntime: PID tracking failed for %s — this runtime is now "
                 "invisible to every reaper and will leak until the host reboots",
@@ -2139,8 +2144,9 @@ class AcpRuntime:
                         #   IDENTICAL to the main agent's. Dropping a REQUEST
                         #   is never an option: it strands the backend's
                         #   response oneshot and wedges the child's whole tool
-                        #   batch until process teardown (2h incident,
-                        #   2026-08-15, 13 approvals hung invisibly).
+                        #   batch until process teardown, with every approval in
+                        #   that batch hanging invisibly for as long as that
+                        #   runtime lives.
                         #
                         # With several registered sessions the frame names no
                         # owner; a permission request then falls to the
@@ -2184,9 +2190,12 @@ class AcpRuntime:
                             await asyncio.sleep(0)
                         else:
                             # Hang-resilience series: a child permission
-                            # request delivered to the mode-parity pipeline —
-                            # each one is a request that, before #3786, was
-                            # silently dropped and wedged its crew for 2h.
+                            # request delivered to the mode-parity pipeline.
+                            # Counted so routed requests are observable next
+                            # to the dropped-frame counter — a permission
+                            # request that is neither routed nor answered
+                            # leaves its crew waiting on a prompt nobody can
+                            # see.
                             if msg.id is not None and msg.is_method(
                                 METHOD_REQUEST_PERMISSION
                             ):
@@ -3219,11 +3228,12 @@ class AcpRuntime:
         except asyncio.TimeoutError:
             self._pending_requests.pop(req_id, None)
             active_starts, queued_starts = _cold_start_counts()
-            process_state = (
-                "absent"
-                if self._process is None
-                else "running" if self._process.returncode is None else "exited"
-            )
+            if self._process is None:
+                process_state = "absent"
+            elif self._process.returncode is None:
+                process_state = "running"
+            else:
+                process_state = "exited"
             logger.warning(
                 "acp_startup_stage stage=%s outcome=timeout timeout_method=%s "
                 "timeout_budget_s=%g duration_ms=%.1f active_starts=%d "


### PR DESCRIPTION
## Problem / Motivation

The module-simplification detector reports one chained ternary in
`src/kiro_crew/acp/runtime.py` — the `process_state` label built inside
`_send_and_await`'s `asyncio.TimeoutError` handler. `acp` was swept once before
(#3667), which is the point: the two mechanically decidable classes re-accumulate
as new code lands, so a module does not stay clean.

Reading the file for that one site turned up three more things that are wrong today:

- `_INIT_TIMEOUT = 30.0` at module scope has **no reader** — not in `runtime.py`,
  not anywhere in the repo. `acp/client.py` defines its own `_INIT_TIMEOUT`
  (`240.0`) module-locally, and both doc rows that name the constant
  (`docs/architecture/resource-protection.md:25`,
  `docs/system-specs/common/code-style.md:18`) attribute it to `client.py`.
- Five comments and one docstring carry issue numbers and one incident date, which
  `AGENTS.md` § Code style bans from comments (that history lives in git).
- `_get_rss_mb`'s Windows comment states a **false causal claim**: that the absent
  `ps` is what stopped the watchdog's RSS-recycle ceiling from firing. It is not.
  The ceiling reaches Windows through `_get_rss_tree_mb`, which returns from
  `platform_compat.proc_rss_tree_mb_for_pid` and never calls `_get_rss_mb` at all.

## Why it matters

A chained ternary that spans a line-continuation is read wrong at a glance —
whether the second condition guards the attribute access is exactly the kind of
thing a reader has to re-derive. A dead constant next to a live one with the same
name and a different value in a sibling module is a trap: the next person to
"reuse" it silently changes a 240s budget to 30s. And a comment asserting a
dependency that does not exist is worse than no comment — it tells a maintainer
this branch is load-bearing for the watchdog when the watchdog never reaches it.

## What changed (motivation → approach → change)

One module, one commit. Only `src/kiro_crew/acp/runtime.py` is touched.

**Mechanical class — chained ternary → `if`/`elif`/`else`** (`_send_and_await`
timeout handler). Same three conditions in the same order, same three literals,
and `self._process.returncode` is still evaluated only once `self._process is
None` is false. This also brings the block into line with the sibling
`process_state` computation earlier in the same file, which already used
`if`/`elif`/`else`.

**Judgment class — provably dead code.** `_INIT_TIMEOUT = 30.0` deleted. It is not
in `__all__`, has no importer, no module-alias attribute reader, no `getattr`
lookup, and no test patch idiom targets it; `runtime.py`'s own `initialize`
handshake has always taken `_send_and_await`'s `_REQUEST_TIMEOUT` default (also
`30.0`), so no effective timeout moves. No doc goes stale.

**Judgment class — comment hygiene**, in the file already being edited for a
structural reason. The issue numbers and the incident date are dropped and every
rationale they were attached to is kept in present tense. The `_get_rss_mb`
Windows comment is *corrected*, not merely detensed: it now names the real
mechanism (`trusted_system_bin` resolves from fixed system directories and ignores
`PATH`, so the POSIX fallback can only answer `None` there) and states plainly
that the watchdog does not depend on this branch. Its docstring gains the Windows
path it never mentioned.

Deliberately **not** done, and why:

- The `service` module's one detector site is a security ownership guard
  (`check_uid` in `service/apparmor.py`). A verbose explicit guard stays verbose.
- `"Hang-resilience series:"` is left on all three of its sites in this file. It
  reads like a milestone tag, but `src/kiro_crew/metrics/events.py:33` heads that
  counter group with `# Hang-resilience series (see docs in the emitting call
  sites)` — it is a live cross-module pointer used by six files, not a task log.
- The issue numbers in `client.py`, `session_handle.py`, `types.py`,
  `_dispatch.py`, `session_provider.py` and `metrics/events.py` are untouched.
  One module per PR.

## Review fleet

Five parallel review agents ran before this PR opened, each on a distinct lens
grounded in this repo's own contracts (AUTOSDE blocking rules + the deterministic
`code-review.yml` greps; behavior preservation; comment accuracy; security
keystone + boot path; test observability). Four returned no findings. The
behavior-preservation pass proved equivalence by diffing the `tokenize` stream of
base vs head with comments stripped: the entire non-comment delta is the branch
rewrite plus the deleted constant (10261 → 10262 tokens).

The comment-accuracy pass raised three, all verified against the code before
acting:

- **Fixed.** The `_get_rss_mb` Windows comment asserted a watchdog dependency that
  does not exist. Confirmed by enumerating both callers of `_get_rss_mb` (one
  under `sys.platform == "linux"`, one in the macOS/other tail) and tracing the
  ceiling through `_is_stale` → `_get_rss_tree_mb` → `proc_rss_tree_mb_for_pid`.
  Rewritten to state what is true. This is the finding worth the round: the
  pre-existing comment was wrong and a tense-only rewrite would have made it
  confidently wrong.
- **Fixed.** "hanging invisibly for hours" is an incident duration, not derivable
  from "until process teardown". Now "for as long as that runtime lives".
- **Reverted my own change.** An earlier revision of this branch removed
  `"Hang-resilience series:"` at all three sites for consistency. The pointer from
  `metrics/events.py` refutes that reading, so the removals were reverted rather
  than extended into a six-file cross-module sweep.

A verifier agent then confirmed all three closed and raised two accuracy nits
("for any other caller" over-promised a caller that does not exist on Windows; the
docstring omitted Windows entirely) — both taken, both one line.

### Second pass, after the rebase

The first pushed head went red on `Backend Tests` shard 3 of 4 across all three
platforms (3.10, 3.12, Windows) plus the dependent `Coverage Gate`. That was
`main`'s own failure at this branch's then-merge-base, not this diff's: `main`'s
run for `5603ae74` failed the identical single test,
`test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor`
(`dashboard/handlers/memory.py: 2 sites, census says 0`) — a file this PR does not
touch. It has since been fixed upstream, so this branch is rebased onto `2c4d05d3`
where `main` is green, and the test passes locally here.

The rebase changed no content: the `BASE...HEAD` patch is byte-identical to the one
the previous head carried, so nothing needed re-deciding. The five lenses were
re-run against the new base anyway, because a rebase can introduce new sites. The
detector reports **0 actionable sites** in `acp` at the new base, and four lenses
returned no findings.

The comment-accuracy lens re-flagged one clause — "so this keeps a direct
single-pid read honest for a direct caller" on the `_get_rss_mb` Windows branch —
claiming it asserts a consumer that does not exist. **Refuted, and dropped.** Two
independent grounds: the clause is a purpose clause explaining why the branch is
kept, not an existence claim (it sits two clauses after the sentence that *proves*
the only shipped consumer cannot reach here); and a direct caller does in fact
exist and runs on the platform in question —
`test/test_acp_runtime.py:1586` calls `_get_rss_mb(os.getpid())` and asserts
`rss > 0.0`, on the `windows-latest` shard, where it is not in
`test/windows-expected-failures.txt`. Without this branch that assertion degrades
to a skip.

The proposed replacement was also checked and is *less* accurate: "no other caller
reads a single pid" is false (both existing call sites read a single pid), and
"nothing in shipped code reaches this branch" would invite deleting it — which
would leave `platform_compat.proc_rss_bytes_for_pid` with no external caller at
all, reading as dead code even though `proc_rss_tree_mb_for_pid` depends on it.
Recorded here rather than acted on, so a reviewer with the same reaction can see it
already adjudicated.

## Tests

No new tests: there is no new behavior to lock in, and adding a test for a log
label this PR does not change would be coverage-chasing. Coverage of the rewritten
branch is unchanged — `test_send_and_await_timeout_error_names_the_budget` already
executes it.

Verified nothing observes what changed: no test in `test/` or under
`src/kiro_crew/apps/builtins/*/tests/` references `runtime._INIT_TIMEOUT` under any
patch idiom (dotted-string, `patch.object`, module alias, direct attribute
assignment), none asserts on the `acp_startup_stage ... process_state=%s` log line,
and the two `inspect.getsource` ratchets over this module
(`test_acp_runtime.py:4322`, `test_harness_parity.py:347`) assert on identifiers
this diff does not touch. `test_spawn_audit.py`'s `BENIGN_SPAWNS` entry
`acp/runtime.py::_get_rss_mb` is keyed by function, not line, and that function
still spawns `ps` on its macOS path.

## Manual verification

N/A — unit coverage sufficient. There is no reachable behavior change to exercise:
the non-comment delta is one equivalent branch rewrite and one constant with no
reader.

Gates run from the worktree on the Python 3.12 CI-parity venv, all exit 0:
`flake8`, `isort --check-only`, `mypy src/kiro_crew` (1237 files),
`check_brand_name.py`, `check_harness_parity.py`, `check_black_formatting.py`,
`check_subprocess_encoding.py`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`, and `push_guard.py` in both modes. Targeted suites:
1219 tests across `test_acp_runtime`, `test_acp_runtime_kill`,
`test_macos_process_table`, `test_session_start_timeout_diagnostics`,
`test_harness_parity`, `test_acp_session_provider`, `test_hang_resilience_metrics`,
`test_spawn_audit`, `test_pid_lifecycle`, `test_acp_client`,
`test_acp_client_capabilities`, `test_acp_liveness` — all pass.

Re-run in full after the rebase, all exit 0 again, plus `push_guard.py` in both
modes. `test_acp_runtime` + `test_acp_runtime_kill`: 298 passed. The whole backend
suite: 78886 passed, 83 failed — every failure in a subsystem this diff does not
touch (`ops_mission_control/tests/test_ledger_sync_git.py`, `test_file_sheet.py`,
`auto_improvement/tests/*`, `test_terminal_commands.py`), all with the same cause,
`sandbox: BLOCKED -- sealing read-only directory ... errno 1 (Operation not
permitted)`: this dev host cannot establish an OS-level sandbox seal. Zero of the 83
are `acp`. CI is the authoritative signal and it has a working sandbox — on the
byte-identical previous head it reported exactly one test failure repo-wide, the
base's own posture test above, and none of these 83.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff in one Python module, entirely comments
plus an equivalent branch rewrite and an unread constant — nothing rendered
changes, and CI's `changes` job reports `only_backend=true`.

## Related Issues

no linked issue: routine module-simplification sweep, no tracked defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

