### PR TITLE
fix(connections): Test button agrees with the badge on healthy OAuth providers

### DIFF
--- a/website/src/pages/connections/ConnectionsPage.tsx
+++ b/website/src/pages/connections/ConnectionsPage.tsx
@@ -234,6 +234,40 @@ export function disconnectFeedback(
   }
 }
 
+/**
+ * The ONE reading of a probe status against the authorization axis. Both the
+ * card's badge and the Test button's verdict fold through this, because they
+ * judge the same probe and a second reading is how they came to disagree:
+ * a connected Linear card rendered Connected while its Test click reported a
+ * failure, from `status !== 'ok'` on the exact answer the badge folds as healthy.
+ *
+ * Exported for test.
+ */
+export function probeIndicatesConnected(status: string, grantPresent?: boolean): boolean {
+  // `ok` is REACHABILITY and it is cached, so it outlives a revoked grant. Only
+  // a CONFIRMED absent grant (never the indeterminate or not-yet-loaded
+  // undefined) is a fresher fact than it.
+  if (status === 'ok') return grantPresent !== false
+  // A tokenless probe of a remote OAuth server answers 401, which the gateway
+  // reports as `needs_auth` — kiro-cli owns token custody, so needs_auth beside
+  // a grant IS the healthy shape. The grant axis is the only thing separating
+  // "authorized outside this app" from "nobody authorized this", so an absent
+  // OR indeterminate verdict is not a grant.
+  if (status === 'needs_auth') return grantPresent === true
+  return false
+}
+
+/**
+ * The confirmed-only grant verdict, read once and shared. An indeterminate
+ * lookup reports `grantPresent: false` without knowing anything, so it must
+ * collapse to `undefined` (the honest hedge) rather than to a confirmed absence.
+ *
+ * Exported for test.
+ */
+export function confirmedGrantPresent(status: ConnectionStatus | undefined): boolean | undefined {
+  return status && !status.grantIndeterminate ? status.grantPresent : undefined
+}
+
 export function connectionStateFor(
   server: McpServer | undefined,
   oauth: OAuthState | undefined,
@@ -259,7 +293,7 @@ export function connectionStateFor(
     // or not-yet-loaded undefined) is the fresher authorization fact and wins:
     // render the honest not-verified card instead of a Connected badge for an
     // authorization that no longer exists.
-    return grantPresent === false ? 'not-verified' : 'connected'
+    return probeIndicatesConnected(server.status, grantPresent) ? 'connected' : 'not-verified'
   }
   if (locallyWaiting || awaitingConsent || oauth?.oauthUrl) return 'waiting-for-approval'
   // The status probe carries no OAuth token — kiro-cli owns token custody and
@@ -274,7 +308,9 @@ export function connectionStateFor(
   // Absent `grantPresent` (status feed not yet loaded) keeps the prior behaviour.
   // It must reach neither the error card (#1853) nor the spinner below, which
   // would imply a grant is in flight.
-  if (server.status === 'needs_auth') return grantPresent ? 'connected' : 'not-verified'
+  if (server.status === 'needs_auth') {
+    return probeIndicatesConnected(server.status, grantPresent) ? 'connected' : 'not-verified'
+  }
   if (server.status === 'error' || server.status === 'disabled') return 'needs-attention'
   return 'waiting-for-approval'
 }
@@ -1018,7 +1054,27 @@ export default function ConnectionsPage({ servicesEnabled = false }: { servicesE
     const probed = await api.mcpProbe() as McpServer[]
     queryClient.setQueryData<McpServer[]>(['mcp-servers'], probed)
     const tested = serverForConnection(provider, probed)
-    if (!tested || tested.status !== 'ok') throw new Error(t('pages.connectionsPage.test_failed'))
+    // The verdict is the CARD's fold, not a bare `status === 'ok'`. A healthy
+    // AUTHORIZED remote OAuth provider answers this tokenless probe with 401,
+    // which the gateway reports as `needs_auth` — so reading only `ok` as a pass
+    // told the user "test failed" beside a badge reading the same probe as
+    // Connected. Same predicate, same grant input as the badge, so the button and
+    // the badge cannot report two verdicts for one probe.
+    //
+    // The badge has one more input than the predicate: an OAuth flow completed
+    // in THIS session outranks the possibly-lagging grant feed (the grant was
+    // just watched being written). Without the same precedence here, the very
+    // first Test click after connecting fails beside a Connected badge — the
+    // original bug at the exact moment every new user hits it. A completed flow
+    // is grant EVIDENCE, not a verdict: a genuinely broken probe still fails,
+    // unlike the badge's blanket completed→connected short-circuit.
+    const oauth = effectiveOAuth(oauthByServer[provider.slug], locallyWaiting[provider.slug])
+    const grantEvidence = oauth?.completed && !oauth.failed
+      ? true
+      : confirmedGrantPresent(statusBySlug[provider.slug])
+    if (!tested || !probeIndicatesConnected(tested.status, grantEvidence)) {
+      throw new Error(t('pages.connectionsPage.test_failed'))
+    }
     setFeedback(current => ({
       ...current,
       [provider.slug]: { kind: 'success', text: t('pages.connectionsPage.connection_healthy') },
@@ -1118,7 +1174,7 @@ export default function ConnectionsPage({ servicesEnabled = false }: { servicesE
                   !!pending,
                   // Only a CONFIRMED verdict may steer the card: an indeterminate
                   // lookup reports grantPresent=false without knowing anything.
-                  status && !status.grantIndeterminate ? status.grantPresent : undefined,
+                  confirmedGrantPresent(status),
                   // The backend's mint table outlives this tab's local state, so
                   // a refresh mid-consent still renders the waiting card.
                   status?.status === 'awaiting_consent',
@@ -1134,7 +1190,7 @@ export default function ConnectionsPage({ servicesEnabled = false }: { servicesE
                     connectedSince={status?.connectedSince}
                     // The same confirmed-only verdict the state fold received:
                     // indeterminate stays undefined so the card keeps the hedge.
-                    grantPresent={status && !status.grantIndeterminate ? status.grantPresent : undefined}
+                    grantPresent={confirmedGrantPresent(status)}
                     busy={cardBusy}
                     feedback={feedback[provider.slug]}
                     highlighted={highlightedSlug === provider.slug}

--- a/website/src/test/ConnectionsPage.coverage.test.tsx
+++ b/website/src/test/ConnectionsPage.coverage.test.tsx
@@ -335,6 +335,95 @@ describe('a connected provider', () => {
     expect(failure).toHaveTextContent('Action failed: The provider did not pass the connection test.')
   })
 
+  it('passes a tokenless needs_auth probe when a grant is held', async () => {
+    // The FLAG-2 shape. This app probes WITHOUT a token — kiro-cli owns token
+    // custody — so a healthy AUTHORIZED remote OAuth provider answers 401 and
+    // the gateway reports `needs_auth`. The card folds that plus the grant as
+    // Connected, so the button beside it must not call the same probe a failure.
+    mcpServers.mockResolvedValue([server({ status: 'needs_auth' })])
+    mcpProbe.mockResolvedValue([server({ status: 'needs_auth' })])
+    connectionsStatus.mockResolvedValue({
+      schema_version: 1,
+      connections: [{ slug: 'notion', status: 'connected', grantPresent: true }],
+    })
+    mount()
+
+    // The badge's own verdict on this probe, which is what the button must match.
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'connected'))
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Test' }))
+
+    expect(await screen.findByText('Connection is healthy.')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('still fails a needs_auth probe when no grant is held', async () => {
+    // Same 401, no authorization behind it: the grant axis is the only thing
+    // separating "authorized elsewhere" from "nobody authorized this", so the
+    // fix must not turn every needs_auth into a pass. The card mounts connected
+    // off a cached `ok`; the FRESH probe is what answers needs_auth.
+    mcpServers.mockResolvedValue(connected)
+    mcpProbe.mockResolvedValue([server({ status: 'needs_auth' })])
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Test' })))
+
+    const failure = await screen.findByRole('alert')
+    expect(failure).toHaveTextContent('Action failed: The provider did not pass the connection test.')
+    expect(screen.queryByText('Connection is healthy.')).toBeNull()
+  })
+
+  it('still passes a plain ok probe with the authorization feed populated', async () => {
+    mcpServers.mockResolvedValue(connected)
+    mcpProbe.mockResolvedValue(connected)
+    connectionsStatus.mockResolvedValue({
+      schema_version: 1,
+      connections: [{ slug: 'notion', status: 'connected', grantPresent: true }],
+    })
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Test' })))
+
+    expect(await screen.findByText('Connection is healthy.')).toBeInTheDocument()
+  })
+
+  it('passes right after an in-session OAuth completion while the grant feed lags', async () => {
+    // The onboarding moment: Connect → approve → the badge flips Connected off
+    // the completed `mcp_oauth` banner BEFORE the status feed has re-read the
+    // grant it just watched being written. The fresh probe still answers
+    // needs_auth (tokenless), the feed still says nothing — the button must
+    // honour the same completed-flow precedence the badge does, or the very
+    // first Test click after connecting reports a failure beside a Connected
+    // badge, which is FLAG-2 all over again.
+    mcpServers.mockResolvedValue([server({ status: 'needs_auth' })])
+    mcpProbe.mockResolvedValue([server({ status: 'needs_auth' })])
+    // Status feed deliberately empty: the grant axis is still unknown here.
+    mount({ chat: { messages: [banner('notion', { completed: true })] } })
+
+    // The badge's verdict via the completed-OAuth precedence.
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'connected'))
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Test' }))
+
+    expect(await screen.findByText('Connection is healthy.')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('never lets a held grant launder a broken provider into a pass', async () => {
+    // A grant says the runtime is authorized; it says nothing about an endpoint
+    // that is actually broken. `error` stays a failure with a grant on disk.
+    mcpServers.mockResolvedValue(connected)
+    mcpProbe.mockResolvedValue([server({ status: 'error' })])
+    connectionsStatus.mockResolvedValue({
+      schema_version: 1,
+      connections: [{ slug: 'notion', status: 'connected', grantPresent: true }],
+    })
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Test' })))
+
+    const failure = await screen.findByRole('alert')
+    expect(failure).toHaveTextContent('Action failed: The provider did not pass the connection test.')
+  })
+
   it('shows the busy label while the probe is in flight', async () => {
     const pending = deferred<McpServer[]>()
     mcpServers.mockResolvedValue(connected)

--- a/website/src/test/ConnectionsPage.test.tsx
+++ b/website/src/test/ConnectionsPage.test.tsx
@@ -1,12 +1,15 @@
 import { isValidLoopbackReturnAddress } from '../utils/loopbackReturnAddress'
 import { describe, expect, it } from 'vitest'
+import type { ConnectionStatus } from '../api/client'
 import type { ChatMessage, McpServer } from '../types'
 import {
+  confirmedGrantPresent,
   connectionStateFor,
   disconnectFeedback,
   effectiveOAuth,
   latestOAuthByServer,
   mintOutcome,
+  probeIndicatesConnected,
   uninstallOnCancel,
   withMintedUrl,
   type OAuthState,
@@ -20,6 +23,14 @@ const server = (status: string): McpServer => ({
   status,
   source: 'mcp.json',
   enabled: true,
+})
+
+/** One entry of the /api/connections/status authorization feed. */
+const status = (over: Partial<ConnectionStatus> = {}): ConnectionStatus => ({
+  slug: 'notion',
+  status: 'connected',
+  grantPresent: true,
+  ...over,
 })
 
 describe('Connections card states', () => {
@@ -382,5 +393,46 @@ describe('the authorization axis resolves the needs_auth ambiguity', () => {
       .toBe('needs-attention')
     // A grant says nothing about an endpoint that is actually broken.
     expect(connectionStateFor(server('error'), undefined, false, true)).toBe('needs-attention')
+  })
+})
+
+describe('one probe reading serves both the badge and the Test button', () => {
+  // The badge and the Test button used to fold the SAME probe answer twice, and
+  // disagreed: a connected provider showed Connected beside a "test failed".
+  // This is the single predicate both now consume, so the truth table is pinned
+  // here rather than inferred from either surface.
+  it('reads a tokenless needs_auth beside a grant as connected', () => {
+    expect(probeIndicatesConnected('needs_auth', true)).toBe(true)
+  })
+
+  it('refuses needs_auth when no grant is held', () => {
+    // Absent AND indeterminate: neither is a grant, so neither may claim health.
+    expect(probeIndicatesConnected('needs_auth', false)).toBe(false)
+    expect(probeIndicatesConnected('needs_auth', undefined)).toBe(false)
+  })
+
+  it('accepts ok unless the grant is CONFIRMED absent', () => {
+    // Reachability is cached, so it outlives revocation — only a confirmed
+    // absence is a fresher fact than it. Indeterminate keeps the prior verdict.
+    expect(probeIndicatesConnected('ok', true)).toBe(true)
+    expect(probeIndicatesConnected('ok', undefined)).toBe(true)
+    expect(probeIndicatesConnected('ok', false)).toBe(false)
+  })
+
+  it('never lets a grant launder a broken or unknown probe', () => {
+    for (const status of ['error', 'disabled', 'unknown', 'probing', 'outdated']) {
+      expect(probeIndicatesConnected(status, true)).toBe(false)
+      expect(probeIndicatesConnected(status, undefined)).toBe(false)
+    }
+  })
+
+  it('collapses an indeterminate grant lookup to the honest hedge', () => {
+    // `grantPresent: false` from a lookup that FAILED means "could not look" —
+    // it must not reach either surface as a confirmed absence.
+    expect(confirmedGrantPresent(undefined)).toBeUndefined()
+    expect(confirmedGrantPresent(status({ grantPresent: false, grantIndeterminate: true })))
+      .toBeUndefined()
+    expect(confirmedGrantPresent(status({ grantPresent: false }))).toBe(false)
+    expect(confirmedGrantPresent(status({ grantPresent: true }))).toBe(true)
   })
 })


### PR DESCRIPTION

## Problem / Motivation

A healthy, authorized remote OAuth provider shows two contradictory verdicts on the same Connections card: the badge reads **Connected** while the Test button reports **"The provider did not pass the connection test."** Both read the same probe.

The probe is tokenless by design — kiro-cli owns token custody, Kiro Crew stores no credential — so a healthy authorized remote provider answers it with 401, which the gateway maps to `needs_auth` (`src/kiro_crew/mcp_discovery.py`). The badge folds `needs_auth` + a present OAuth grant into Connected; the Test button demanded `status === 'ok'` and called the identical answer a failure.

## Why it matters

Test is the reassurance button. On every healthy remote OAuth connection (Linear, Notion, Atlassian, …) it currently tells the user their working connection is broken, directly beside a badge saying the opposite — during launch validation this reads as a product defect, and post-launch it generates false bug reports. (Tracked as the expected-fail FLAG-2 item on the G1 launch re-test checklist.)

## What changed (motivation → approach → change)

Symptom → root cause: two call sites derived independent verdicts from one probe — the badge folded `(status, grantPresent)` while the button compared `status === 'ok'` raw.

Approach: one shared predicate, consumed by both, so they cannot drift again:

- `probeIndicatesConnected(status, grantPresent)` — `ok` passes unless the grant is *confirmed absent*; `needs_auth` passes only with a confirmed grant; everything else fails. Both badge branches and the button verdict call it.
- `confirmedGrantPresent(status)` — the grant read once, indeterminate collapsing to `undefined` (the honest hedge), consumed by all three grant readings.
- The button additionally honours the badge's completed-flow precedence: an OAuth flow completed **in this session** counts as grant evidence while the grant feed lags, so the first Test click right after connecting agrees with the badge instead of reproducing the bug at the exact onboarding moment. Unlike the badge's blanket `completed → connected` short-circuit, a genuinely broken probe still fails Test.

One deliberate behavior change beyond the reported bug: the predicate refuses `ok` + **confirmed-absent** grant. The badge already rendered that shape not-verified (cached `ok` reachability outlives a revoked grant), so the old button verdict was the mirror image of the same drift. Pinned by the unit truth table; no DOM-level pin exists because a confirmed-absent card renders no Test button at all.

## Tests

- Unit truth table for `probeIndicatesConnected` / `confirmedGrantPresent` (all status × grant corners, including indeterminate collapse).
- `passes a tokenless needs_auth probe when a grant is held` — the reported bug, red-first on the parent (badge `data-state="connected"` beside the failure alert, attributed via probe).
- `passes right after an in-session OAuth completion while the grant feed lags` — the completed-flow precedence, red-first before that hunk.
- `still fails a needs_auth probe when no grant is held`, `still passes a plain ok probe`, `never lets a held grant launder a broken provider into a pass` — regression pins in both directions.

Full frontend suite green (vitest), `tsc -b` 0, eslint 0.

## Manual verification

Covered by the G1 launch re-test (checklist §4): Test on a healthy connected Linear/Vercel card now reports "Connection is healthy."

## Related Issues

Part of the Connections launch tail; FLAG-2 on the G1 re-test checklist.

## Checklist

- [x] At most two commits (one), Conventional Commits title
- [x] Existing tests pass and new tests added
- [x] Self-review completed
- [ ] Documentation updated (N/A — behavior fix inside one page component)
- [x] No secrets, credentials, or internal references in the diff


## Pattern harvest

Rule candidate: review-prompt — when extracting a shared predicate from N call sites, enumerate each site's FULL input set first; any input consumed by one site but not by the predicate is a future drift. (This fix's round-1 blocker was exactly that: the badge's third input, in-session OAuth completion, was not unified.)

Rule candidate: review-prompt — a refusal test whose fixture fails several guard conjuncts at once pins none of them; construct the fixture so exactly one conjunct fails, and mutation-verify that dropping each guard reddens only its own test.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no component, layout, or user-facing string changes — the fix routes between two feedback renderings that both ship today (the healthy toast and the failure alert); which one appears for a needs_auth-plus-grant probe is the behavioral fix, and that state requires a live OAuth grant. Covered by the G1 manual launch re-test (checklist §4); a live capture can be added from a granted environment on request.
