### PR TITLE
feat(connections): warm handoff — Connect adopts preminted URLs

### DIFF
--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -6,8 +6,66 @@ process, and every rule below answers an observed failure.
 
 **Placement.** All warm code is in `src/kiro_crew/connections/warm.py`; the dashboard handler
 adds only endpoint wiring and function-local engine imports -- `expire_dead_mints` on the status
-path, `mintable_providers` plus `warm_mint_all` on the premint path -- keeping the mint engine
-off the gateway's boot path.
+path, `mintable_providers` plus `warm_mint_all` on the premint path, and `adopt_shared_mint` on
+the mint path -- keeping the mint engine off the gateway's boot path.
+
+## The handoff: how a premint reaches the click it was minted for
+
+The table and the per-caller Connect flow shared a row store and nothing else, so the slice
+that gave premint a frontend caller made three defects reachable at once. All three came from
+one conflation -- `shared` was being read as if it answered both *who owns this row* and *what
+judges its liveness* -- and the fix separates the two axes:
+
+| axis | mark | meaning |
+|---|---|---|
+| OWNERSHIP | `shared` | nobody has claimed this URL; any Connect may adopt it |
+| PROVENANCE | `generation` / `activation` | the verifier is in the shared process, so `_warm_row_alive` judges redeemability |
+
+`adopt_shared_mint` clears the first and keeps the second. Each defect follows from reading
+one axis where the other was meant:
+
+- **The click threw the answer away.** `api_connections_mint` called `reserve_mint_row`
+  unconditionally, and that pops WHATEVER row is at the slug, so `start_oauth_mint` disposed
+  the URL the premint had just minted and then paid a ~7.5s cold spawn to replace it. Adoption
+  now runs FIRST; a refusal falls through to the cold path, which stays correct and stays the
+  only path for a provider warming never covered. Adoption is atomic by construction -- every
+  step between the read and the last write is synchronous -- so two clicks racing one row
+  serialize on `_mints_lock` and the loser simply finds `shared` already cleared. The token is
+  rotated, which is what fences the adopting tab against both the premint's own rollback and a
+  sibling tab; **the watcher must be re-armed in the same synchronous run**, because every
+  write in `_mint_watcher` is guarded on the token it was started with, so rotating alone would
+  leave the row watched by a task that can no longer touch it -- nothing to flip it `granted`,
+  nothing to expire it, and the shared process resident for good.
+- **One premint flipped every card.** `_classify` read any `minting`/`waiting` row as
+  `awaiting_consent`, and the page's `waitingSlugs` memo folds those slugs into its waiting
+  set -- so warming presented every mintable card as mid-consent with no user action. An
+  unclaimed row now falls THROUGH to the grant branches: the honest verdict for a URL nobody
+  asked for is the one the card would get with no row at all, and a fourth status would be one
+  the frontend has no rendering for. The seam is a `shared` flag on `pending_mint_for`'s view
+  rather than that view hiding the row, because ONE view feeds two readers with opposite
+  needs: the classifier must refuse it as consent, while the mint-state poll must still tell
+  it from `idle`, which its own contract defines as "no mint exists for the provider" -- the
+  lie a filtering view would tell on exactly the slug a card has just adopted.
+- **The poll destroyed what it went looking for.** `_mint_holder_alive` reads the row's own
+  `client`, which a warm row never owns, so it answered False -- and False there is a VERDICT,
+  not a shrug, because `expire_dead_holder` acts on it. The first mint-state poll on a warm
+  slug therefore withdrew a URL whose process and session were both alive. The cold judge now
+  ABSTAINS on any row carrying a `generation`, which makes `expire_dead_mints` the only reader
+  that can withdraw one -- it is also the only reader that can see the registry those stamps
+  name.
+
+Because adoption clears `shared`, every warm-side predicate had to move onto `_warm_table_row`
+(`shared` OR `generation`) rather than `shared` alone, and both disjuncts are load-bearing:
+`shared` is the only mark a row still `minting` carries -- precisely the row a cancelled
+activation must not leave behind -- while `generation` is what an adopted row still has. Five
+readers depend on it, and an ownership-only test breaks each differently: `_live_row_count` and
+`_shared_mints_pending` stop keeping the adopted row's process parked, so **the reaper retires
+the process holding the URL the user is part-way through redeeming**; `_activations_in_use`
+lets the sweep destroy the session answering its redirect; and `_expire_shared_mints` plus
+`expire_dead_mints` stop withdrawing it when its holder dies, leaving a card serving a URL
+nothing can complete. `_claim_shared_mints` needed the mirror-image guard: `_mint_is_cold_held`
+cannot see an adopted row either -- it owns no `client` -- so a later premint sweep displaced a
+URL a user was mid-consent on. `_mint_is_adopted` is that guard.
 
 **Scope boundary: the TABLE, the SPECS, the PROCESS LIFECYCLE and the ENDPOINT WIRING have
 landed.** Shipped: the shared row shape (`shared`/`generation`/`activation`), the

--- a/src/kiro_crew/connections/mint.py
+++ b/src/kiro_crew/connections/mint.py
@@ -804,7 +804,19 @@ def _mint_holder_alive(entry: MintState) -> bool:
     The PKCE verifier and the loopback listener both live in the minting process,
     so a dead process means a URL no paste can complete. Asked of a row that
     already holds a URL; a row still ``minting`` has nothing stamped yet.
+
+    ABSTAINS on a row carrying a ``generation``. That row was minted on the SHARED
+    process (:mod:`kiro_crew.connections.warm`) and owns no ``client`` by design, so
+    the ``client is None`` branch below would answer for it -- and answering is the
+    bug, because False here is a VERDICT, not a shrug: :func:`expire_dead_holder`
+    acts on it, so the first mint-state poll on a warm slug withdrew a URL whose
+    process and session were both alive. Warm rows are judged by generation AND
+    activation liveness at the warm table's own chokepoint
+    (``warm.expire_dead_mints``, called on the status path and by the reaper), which
+    is the only reader that can see the registry those stamps name.
     """
+    if entry.get("generation"):
+        return True
     client = entry.get("client")
     if client is None:
         return False
@@ -877,7 +889,21 @@ def pending_mint_for(slug: str) -> MintState | None:
     token = str(entry.get("token") or "")
     state = entry.get("state", "minting")
     view: MintState = {"state": state, "token": token}
-    if entry.get("oauth_url") and state == "waiting":
+    if entry.get("shared"):
+        # UNCLAIMED: a premint the warm table holds for whoever clicks Connect next,
+        # not a flow any caller started. Reported rather than hidden because this one
+        # view feeds two readers with different needs: the status classifier must
+        # refuse to read it as user consent (see ``status._classify``), while the
+        # mint-state poll must still tell it apart from ``idle``, which its own
+        # contract defines as "no mint exists for the provider". Filtering the row out
+        # would answer the second reader with that lie -- on exactly the slug a card
+        # has just adopted.
+        view["shared"] = True
+    if entry.get("oauth_url") and state == "waiting" and not entry.get("shared"):
+        # The consent URL completes a MACHINE-WIDE grant, so it is served only to
+        # the caller whose click owns the row. An unclaimed premint's view says a
+        # row exists and nothing more; the URL surfaces only after adoption rotates
+        # the token and clears ``shared`` (see ``warm.adopt_shared_mint``).
         view["oauth_url"] = entry["oauth_url"]
     if entry.get("reason"):
         view["reason"] = entry["reason"]

--- a/src/kiro_crew/connections/status.py
+++ b/src/kiro_crew/connections/status.py
@@ -286,11 +286,25 @@ def _reconcile_connected_since_locked(statuses: list[ConnectionStatus], now: str
     return recorded
 
 
-def _classify(granted: bool | None, mint_state: str) -> tuple[str, str]:
-    """The authorization verdict for one provider, from local facts only."""
+def _classify(granted: bool | None, mint_state: str, *, shared: bool = False) -> tuple[str, str]:
+    """The authorization verdict for one provider, from local facts only.
+
+    ``shared`` marks an UNCLAIMED premint -- a row the warm table minted ahead of any
+    click (:mod:`kiro_crew.connections.warm`), holding a URL nobody has asked for. It
+    must not read as consent in flight: the page folds every ``awaiting_consent`` slug
+    into its waiting set, so one premint sweep flipped EVERY mintable card to the
+    in-flight-consent rendering with no user action at all.
+
+    An unclaimed row therefore falls THROUGH to the grant branches rather than
+    reporting a status of its own. That is deliberate: the honest verdict for a URL
+    nobody claimed is the verdict the card would get with no row at all, and a fourth
+    status would be one the frontend has no rendering for. The row is not lost -- it is
+    what a Connect ADOPTS (``warm.adopt_shared_mint``), and adoption clears ``shared``,
+    at which point the same row reads as awaiting consent because now it truly is.
+    """
     if granted:
         return STATUS_CONNECTED, "grant_present"
-    if mint_state in ("minting", "waiting"):
+    if mint_state in ("minting", "waiting") and not shared:
         return STATUS_AWAITING_CONSENT, "mint_in_flight"
     if granted is None:
         # Not a claim that nothing is connected -- a statement that the grant
@@ -354,9 +368,15 @@ async def collect_connection_statuses() -> list[ConnectionStatus]:
     # Read on the loop: the mint table is guarded by an asyncio lock, so it must
     # not be touched from a worker thread.
     mint_states: dict[str, str] = {}
+    #: Slugs whose row is an UNCLAIMED premint. Carried alongside the state rather
+    #: than folded into it, because the row's state is genuinely ``waiting`` -- what
+    #: differs is whose wait it is, and only the classifier needs that distinction.
+    unclaimed: set[str] = set()
     for provider in providers:
         view = pending_mint_for(provider["slug"])
         mint_states[provider["slug"]] = str(view.get("state") or "") if view else ""
+        if view and view.get("shared"):
+            unclaimed.add(str(provider["slug"]))
 
     grants = await asyncio.to_thread(_grant_presence_map, providers)
 
@@ -364,7 +384,7 @@ async def collect_connection_statuses() -> list[ConnectionStatus]:
     for provider in providers:
         slug = provider["slug"]
         granted = grants.get(slug, False)
-        status, reason = _classify(granted, mint_states[slug])
+        status, reason = _classify(granted, mint_states[slug], shared=slug in unclaimed)
         entry: ConnectionStatus = {
             "slug": slug,
             "status": status,

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -101,10 +101,20 @@ where a stat is unbounded -- so they are synchronous, and a coroutine reaches th
 ``test/test_connections_warm.py``, not merely described here.
 
 REQUEST PATH: :func:`warm_mint_all` is driven by ``POST /api/connections/premint``, which the
-Connections page WILL fire once on mount -- no frontend caller exists yet, so today the endpoint
-is reachable through the API only. It scans the candidates and hands them over, so the slugs it
-reports and the rows the engine claims come from one registry read. Proactive refresh attaches
-in :func:`_warm_mint_reaper` when slice N3 lands.
+Connections page fires once on mount. It scans the candidates and hands them over, so the slugs
+it reports and the rows the engine claims come from one registry read. The consumer of what it
+warms is :func:`adopt_shared_mint`, which ``POST /api/connections/mint`` tries BEFORE reserving
+a row of its own -- without it that endpoint's ``reserve_mint_row`` popped the shared row and
+disposed the very URL the click had been warmed for. Proactive refresh attaches in
+:func:`_warm_mint_reaper` when slice N3 lands.
+
+TWO AXES, and conflating them is what the handoff had to separate. ``shared`` is OWNERSHIP: an
+unclaimed premint any Connect may adopt, and the only mark a row still ``minting`` carries.
+``generation``/``activation`` is PROVENANCE: the verifier lives in the shared process, so
+:func:`_warm_row_alive` judges redeemability however the row is owned. Adoption clears the first
+and keeps the second, so every warm-side predicate keys on :func:`_warm_table_row` -- the
+disjunction -- and the cold engine's ``_mint_holder_alive`` ABSTAINS on a row carrying a
+``generation`` rather than reading its absent ``client`` as death.
 """
 
 from __future__ import annotations
@@ -700,12 +710,33 @@ def _runtime_alive(runtime: Any) -> bool:
         return False
 
 
+def _warm_table_row(entry: MintState) -> bool:
+    """True when the SHARED table owns this row's lifecycle -- claimed, or warm-minted.
+
+    TWO disjuncts, and both are load-bearing, because ``shared`` and ``generation``
+    answer different questions and :func:`adopt_shared_mint` moves only the first.
+
+    ``shared`` is OWNERSHIP: an unclaimed premint any Connect may adopt. It is also the
+    ONLY mark a row still ``minting`` carries, which is precisely the row a cancelled
+    activation must not leave behind -- so a generation-only test would stop counting it.
+
+    ``generation`` is PROVENANCE: the PKCE verifier lives in the shared process, so
+    redeemability is judged by :func:`_warm_row_alive` no matter who owns the row.
+    Adoption clears ``shared`` and keeps this, so an ownership-only test drops the
+    adopted row out of every count here -- and the counts are what keep its process
+    parked and its session held. The reaper would then retire the process holding the
+    URL the user is part-way through redeeming, which is the worst outcome available on
+    this path.
+    """
+    return bool(entry.get("shared")) or bool(entry.get("generation"))
+
+
 def _live_row_count(generation: int) -> int:
     """How many cards are still mid-consent on ``generation``."""
     return sum(
         1
         for entry in _mints.values()
-        if entry.get("shared")
+        if _warm_table_row(entry)
         and entry.get("generation") == generation
         and entry.get("state") in _LIVE_STATES
     )
@@ -721,7 +752,7 @@ def _activations_in_use() -> set[int]:
     return {
         int(entry["activation"])
         for entry in _mints.values()
-        if entry.get("shared") and entry.get("activation") and entry.get("state") in _LIVE_STATES
+        if _warm_table_row(entry) and entry.get("activation") and entry.get("state") in _LIVE_STATES
     }
 
 
@@ -1369,7 +1400,7 @@ def _warm_row_alive(entry: MintState) -> bool:
 def _shared_mints_pending() -> bool:
     """True while any card still needs the shared process alive."""
     return any(
-        entry.get("shared") and entry.get("state") in _LIVE_STATES for entry in _mints.values()
+        _warm_table_row(entry) and entry.get("state") in _LIVE_STATES for entry in _mints.values()
     )
 
 
@@ -1385,7 +1416,7 @@ async def _expire_shared_mints(reason: str, *, generation: int | None = None) ->
     flipped: list[str] = []
     async with _mints_lock:
         for slug, entry in _mints.items():
-            if not entry.get("shared") or entry.get("state") not in _LIVE_STATES:
+            if not _warm_table_row(entry) or entry.get("state") not in _LIVE_STATES:
                 continue
             if generation is not None and entry.get("generation") != generation:
                 continue
@@ -1399,11 +1430,16 @@ async def _expire_shared_mints(reason: str, *, generation: int | None = None) ->
 
 
 async def expire_dead_mints() -> list[str]:
-    """Withdraw every shared row whose holding process is gone. THE chokepoint."""
+    """Withdraw every warm-held row whose holding process is gone. THE chokepoint.
+
+    Adopted rows included, and that is not incidental: the cold engine's
+    ``_mint_holder_alive`` deliberately ABSTAINS on a row carrying a ``generation``
+    (it owns no ``client`` to read), so this is the only reader that can withdraw one.
+    """
     doomed: list[str] = []
     async with _mints_lock:
         for slug, entry in _mints.items():
-            if not entry.get("shared") or entry.get("state") != "waiting":
+            if not _warm_table_row(entry) or entry.get("state") != "waiting":
                 continue
             if _warm_row_alive(entry):
                 continue
@@ -1520,6 +1556,85 @@ def _mint_is_cold_held(entry: MintState | None) -> bool:
     return entry is not None and entry.get("state") == "waiting" and entry.get("client") is not None
 
 
+def _mint_is_adopted(entry: MintState | None) -> bool:
+    """True when a caller has taken ownership of a WARM row, so it is nobody's to reclaim.
+
+    :func:`_mint_is_cold_held` cannot answer this and never could: an adopted row owns
+    no ``client`` either -- its verifier is in the shared process -- so the cold test
+    reads it as free and the claim loop below replaces a URL the user is part-way
+    through redeeming. ``shared`` is the whole distinction: it is set while the premint
+    is unclaimed and cleared by :func:`adopt_shared_mint`.
+    """
+    return (
+        entry is not None
+        and entry.get("state") == "waiting"
+        and bool(entry.get("generation"))
+        and not entry.get("shared")
+    )
+
+
+async def adopt_shared_mint(slug: str, mcp_url: str) -> str | None:
+    """Take ownership of ``slug``'s UNCLAIMED premint. Returns its new row token, or None.
+
+    THE handoff, and the reason the premint has a consumer at all. Connect used to call
+    ``reserve_mint_row`` unconditionally, which pops WHATEVER row is at the slug -- so
+    ``start_oauth_mint`` disposed the very URL the warm table had minted for that click
+    and the cold spawn it then paid was the only thing the user ever saw. ``None`` means
+    nothing was adoptable and the caller must fall back to that cold path, which is
+    still correct and still the only path for a provider warming never covered.
+
+    FOUR refusals, each closing a different way to hand back a URL that cannot work: no
+    row; a row that is not an unclaimed premint (``shared`` absent -- a cold flow's or
+    an already-adopted one, whose owner's token fences it); a claim still ``minting``,
+    which holds nothing to give; and a row whose holder is gone, judged by
+    :func:`_warm_row_alive` -- the SAME generation-and-activation pair the reaper uses,
+    because a URL is redeemable only while the process holds its verifier AND the
+    session still answers its redirect.
+
+    ATOMIC BY CONSTRUCTION, like :func:`_claim_shared_mints`: everything between the
+    read and the last write is synchronous, so two clicks racing one row serialize on
+    ``_mints_lock`` and the loser observes ``shared`` already cleared. Nothing is
+    disposed here, so the engine's dispose-outside-the-table-lock rule is not merely
+    respected but unreachable.
+
+    THE TOKEN IS ROTATED, and the watcher with it. A fresh token is what fences the
+    adopting tab against the premint's own rollback and against a sibling tab, but
+    every write in :func:`~kiro_crew.connections.mint._mint_watcher` is guarded on the
+    token it was started with -- so rotating alone would leave the row watched by a
+    task that can no longer touch it: nothing would flip it to ``granted``, nothing
+    would expire it, and it would hold the shared process resident for good. Re-arming
+    is therefore part of the same synchronous run, not a follow-up.
+
+    PROVENANCE IS KEPT. ``generation``/``activation`` stay exactly as the activation
+    stamped them, because ownership moved and the verifier did not: the row is still
+    judged, parked and withdrawn by the warm table (:func:`_warm_table_row`).
+    """
+    adopted: str | None = None
+    async with _mints_lock:
+        entry = _mints.get(slug)
+        if (
+            entry is not None
+            and entry.get("shared")
+            and entry.get("state") == "waiting"
+            and entry.get("oauth_url")
+            and _warm_row_alive(entry)
+        ):
+            adopted = _new_mint_token()
+            stale = entry.pop("watcher", None)
+            if stale is not None:
+                stale.cancel()
+            entry["token"] = adopted
+            entry.pop("shared", None)
+            entry["watcher"] = asyncio.get_running_loop().create_task(
+                _mint_watcher(slug, mcp_url, adopted)
+            )
+    if adopted is not None:
+        # Off the loop: the FIRST ``sel()`` of a process constructs the log, and the warm
+        # module pins every such hop with a drift guard.
+        await asyncio.to_thread(_log_warm_event, "connections_warm_mint_adopt", f"provider:{slug}")
+    return adopted
+
+
 async def _claim_shared_mints(slugs: list[str]) -> tuple[dict[str, str], list[MintState]]:
     """Claim ``slugs`` for the shared process. Returns ``({slug: row token}, displaced rows)``.
 
@@ -1546,9 +1661,10 @@ async def _claim_shared_mints(slugs: list[str]) -> tuple[dict[str, str], list[Mi
     async with _mints_lock:
         for slug in slugs:
             prior = _mints.get(slug)
-            if _mint_is_cold_held(prior):
-                # A dedicated client owns this provider's verifier. Leave its URL on
-                # the card rather than replace a working link.
+            if _mint_is_cold_held(prior) or _mint_is_adopted(prior):
+                # A CALLER owns this provider's URL -- a dedicated client holds its
+                # verifier, or a Connect adopted the warm row this table minted. Leave
+                # its URL on the card rather than replace a working link.
                 continue
             if prior is not None:
                 # Hand it back, don't just drop it: the replaced row may own a watcher, and

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -328,11 +328,37 @@ async def api_connections_mint(request: web.Request) -> web.Response:
 
     # Function-local by DESIGN, not for a cycle: this handlers package is imported
     # on the gateway boot path, and the mint engine drags in the ACP client, the
-    # credential predicate and the PID registry. Keeping it here is what stops a
+    # credential predicate and the PID registry -- the warm engine adds the ACP
+    # runtime and the MCP inventory on top. Keeping both here is what stops a
     # gateway start paying for a subsystem most requests never touch, and
-    # test_the_handlers_package_does_not_import_the_mint_engine enforces it in a
-    # subprocess -- hoisting this to module scope turns that test red.
+    # test_the_handlers_package_does_not_import_the_mint_engine (and its warm twin)
+    # enforce it in a subprocess -- hoisting either to module scope turns them red.
     from kiro_crew.connections.mint import _dispose_mint, reserve_mint_row, start_oauth_mint
+    from kiro_crew.connections.warm import adopt_shared_mint
+
+    # ADOPTION FIRST, because the alternative is throwing the answer away. The premint
+    # sweep may already hold this provider's approval URL, and ``reserve_mint_row``
+    # below pops whatever row is at the slug -- so reserving first disposed the very
+    # URL this click existed to serve and then paid a ~7.5s cold spawn to re-mint it.
+    # A refusal (nothing warmed, a dead holder, another tab got there first) falls
+    # through to that cold path, which stays correct and stays the only path for a
+    # provider warming never covered.
+    adopted = await adopt_shared_mint(slug, str(provider["mcp_url"]))
+    if adopted is not None:
+        # ONE event, outcome ``ok``: unlike the cold path below, this request both
+        # starts and finishes here, so a ``started`` with no completion would leave the
+        # audit trail showing a mint that never ended.
+        await asyncio.to_thread(
+            lambda: sel().log_api_access(
+                caller="dashboard",
+                operation="connections_mint",
+                outcome="ok",
+                resources=f"provider:{slug} reason=adopted_warm_mint",
+            )
+        )
+        # ``waiting`` rather than ``minting``: the URL exists already. The card polls
+        # the mint state either way, and that poll now finds it on the first read.
+        return web.json_response({"ok": True, "slug": slug, "state": "waiting", "token": adopted})
 
     # Reserved BEFORE responding: the response names a row this tab polls
     # immediately, so the row has to be visible first. Allocating only a token here

--- a/test/test_connections_handoff.py
+++ b/test/test_connections_handoff.py
@@ -1,0 +1,578 @@
+"""The warm handoff: an unclaimed premint stays invisible, and Connect ADOPTS it.
+
+The warm table and the per-caller Connect flow shared a row store but no handoff, so the
+moment the gallery gained a premint caller three defects became reachable at once -- each
+in a different seam, each independently enough to make warming useless.
+
+* **NO ADOPTION.** ``api_connections_mint`` reserved a fresh row unconditionally, and
+  ``reserve_mint_row`` pops WHATEVER row is there -- shared warm rows included -- so
+  ``start_oauth_mint`` disposed the very URL the premint had minted for that click. Every
+  Connect paid a cold spawn and the warm table's only product was thrown away by its
+  intended consumer.
+* **MISCLASSIFICATION.** ``_classify`` read any ``minting``/``waiting`` row as
+  ``awaiting_consent``, and the page's ``waitingSlugs`` memo folds those slugs into its
+  waiting set -- so one premint flipped EVERY mintable card to the in-flight-consent
+  rendering with no user action at all.
+* **THE POLL DESTROYED WHAT IT WENT LOOKING FOR.** ``expire_dead_holder`` judges a row by
+  its own ``client``, which a warm row never owns (its verifier lives in the shared
+  process), so ``_mint_holder_alive`` answered False and the first mint-state poll on a
+  warm slug withdrew a perfectly redeemable URL.
+
+Two axes come out of the fix and the tests below keep them apart, because conflating them
+is what produced the defects: ``shared`` is OWNERSHIP -- an unclaimed premint anyone may
+adopt -- while ``generation``/``activation`` is PROVENANCE, saying redeemability is judged
+by the shared process rather than by a row-local client. Adoption clears the first and
+keeps the second.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
+
+# Both autouse resets, imported rather than re-spelled: the warm engine is a module
+# singleton, so a test that leaves a runtime, a digest or a loop-bound lock on it is read
+# by whichever test shares its worker. ``_clean_warm_runtime`` also swaps in a FRESH
+# asyncio.Lock, because a lock binds to the loop that first waits on it.
+from test_connections_warm import (  # noqa: F401 -- autouse fixtures
+    _clean_mint_table,
+    _clean_warm_runtime,
+)
+
+from kiro_crew.connections import mint, status, warm
+from kiro_crew.connections.mint import _mints
+from kiro_crew.connections.registry import Provider
+from kiro_crew.dashboard.handlers import connections
+
+_URL = "https://consent.example/authorize?state=abc"
+
+
+def _provider(slug: str = "notion") -> Provider:
+    return {  # type: ignore[typeddict-item]
+        "slug": slug,
+        "mcp_url": f"https://mcp.{slug}.test/mcp",
+        "l0_expectations": {"dcr": True},
+    }
+
+
+class _Runtime:
+    """A stand-in for one kiro-cli process, with the liveness answer we choose."""
+
+    def __init__(self, alive: bool) -> None:
+        self._alive = alive
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+
+def _warm_process(monkeypatch: pytest.MonkeyPatch, *, generation: int = 1, alive: bool = True):
+    """Make ``generation`` (and activation 1) read live, or dead, to ``_warm_row_alive``."""
+    monkeypatch.setattr(warm._warm_mint, "_generation", generation)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(alive))
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {1: object()} if alive else {})
+
+
+def _row(
+    slug: str = "notion",
+    *,
+    state: str = "waiting",
+    url: str | None = _URL,
+    shared: bool = True,
+    generation: int = 1,
+    activation: int = 1,
+    token: str = "premint-token",
+    watcher: Any = None,
+) -> dict[str, Any]:
+    """Install one warm row and return it. ``shared=False`` is the ADOPTED shape."""
+    row: dict[str, Any] = {"state": state, "token": token, "started": 0.0}
+    if shared:
+        row["shared"] = True
+    if generation:
+        row["generation"] = generation
+    if activation:
+        row["activation"] = activation
+    if url:
+        row["oauth_url"] = url
+    if watcher is not None:
+        row["watcher"] = watcher
+    _mints[slug] = row  # type: ignore[assignment]
+    return row
+
+
+async def _idle_watcher(slug: str, mcp_url: str, token: str) -> None:
+    """A grant watcher that does nothing and finishes at once.
+
+    The real one polls ``grant_observed``, which stats kiro-cli's OAuth cache, and it
+    holds for a full mint TTL -- so a test that let adoption arm the real watcher both
+    reached the filesystem and left a pending task behind for the loop teardown to
+    complain about.
+    """
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _no_real_watcher(monkeypatch: pytest.MonkeyPatch):
+    """Adoption ARMS a watcher, so every test here would otherwise start a real one."""
+    monkeypatch.setattr(warm, "_mint_watcher", _idle_watcher)
+
+
+# ── part 1: an unclaimed premint is not user consent ──
+
+
+def test_the_card_view_reports_an_unclaimed_premint_as_shared():
+    """The classifier cannot refuse a verdict it is never told about.
+
+    ``pending_mint_for`` is the single card-facing view and it feeds BOTH the status
+    classifier and the mint-state poll, so the flag is carried rather than the row hidden:
+    hiding it would make the poll answer ``idle``, which its own contract defines as "no
+    mint exists for the provider" -- a lie about a row that does exist, and the reading the
+    card takes as "nothing pending" right when it has just adopted one.
+    """
+    _row()
+
+    view = mint.pending_mint_for("notion")
+
+    assert view is not None
+    assert view["state"] == "waiting"
+    assert view.get("shared") is True
+
+
+def test_an_unclaimed_premint_never_serves_its_consent_url():
+    """A consent URL completes a MACHINE-WIDE grant, so it is served only to the
+    caller whose click owns the row. An unclaimed premint belongs to nobody: its
+    view says a row exists (``shared``) and nothing more -- the URL surfaces only
+    after adoption rotates the token and clears ``shared``. Without this, any
+    authenticated GET of the mint state could read a grant URL nobody asked for."""
+    _row()
+
+    view = mint.pending_mint_for("notion")
+
+    assert view is not None
+    assert view.get("shared") is True
+    assert "oauth_url" not in view
+
+
+def test_a_caller_owned_row_is_never_reported_as_shared():
+    _row(shared=False)
+
+    view = mint.pending_mint_for("notion")
+
+    assert view is not None
+    assert view.get("shared") is None
+
+
+@pytest.mark.parametrize("state", ["minting", "waiting"])
+def test_an_unclaimed_premint_never_reads_as_user_consent(state: str):
+    """The defect: one premint flipped every mintable card to waiting-for-approval.
+
+    A shared row is a URL nobody asked for yet, so the honest verdict is the one the card
+    would get with no row at all -- which is why this falls through to the grant branches
+    instead of inventing a third status the frontend has no rendering for.
+    """
+    assert status._classify(False, state, shared=True) == (status.STATUS_NOT_CONNECTED, "no_grant")
+
+
+def test_an_unclaimed_premint_does_not_mask_an_unreadable_grant():
+    """Falling through must reach the RIGHT branch: ``None`` is "could not look"."""
+    assert status._classify(None, "waiting", shared=True) == (
+        status.STATUS_NOT_CONNECTED,
+        "grant_unreadable",
+    )
+
+
+@pytest.mark.parametrize("state", ["minting", "waiting"])
+def test_a_caller_owned_mint_still_reads_as_awaiting_consent(state: str):
+    """The regression guard on the other side: a real Connect must still show as waiting."""
+    assert status._classify(False, state) == (status.STATUS_AWAITING_CONSENT, "mint_in_flight")
+
+
+def test_a_granted_provider_outranks_an_unclaimed_premint():
+    assert status._classify(True, "waiting", shared=True) == (
+        status.STATUS_CONNECTED,
+        "grant_present",
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_status_feed_reports_a_premintted_provider_as_not_connected(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """End to end over the real collector, which is where the frontend memo reads."""
+    monkeypatch.setattr(status, "get_visible_providers", lambda: [dict(_provider())])
+    monkeypatch.setattr(status, "_provider_grant_presence", lambda url: False)
+    monkeypatch.setattr(status, "reconcile_connected_since", lambda statuses, now: {})
+    _row()
+
+    statuses = await status.collect_connection_statuses()
+
+    assert [entry["status"] for entry in statuses] == [status.STATUS_NOT_CONNECTED]
+
+
+# ── part 1b: the poll must not destroy the row it went looking for ──
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shared", [True, False], ids=["unclaimed", "adopted"])
+async def test_the_mint_state_poll_never_withdraws_a_live_warm_row(
+    monkeypatch: pytest.MonkeyPatch, shared: bool
+):
+    """``_mint_holder_alive`` must ABSTAIN on a warm row, not vote it dead.
+
+    A warm row owns no ``client`` because its verifier lives in the shared process, so the
+    ``client is None`` reading is a verdict rather than an abstention -- and
+    ``expire_dead_holder`` acts on it, so the very first mint-state poll withdrew a
+    redeemable URL. Withdrawal for these rows belongs to ``warm.expire_dead_mints``, which
+    asks the generation/activation pair.
+    """
+    _warm_process(monkeypatch)
+    _row(shared=shared)
+
+    await mint.expire_dead_holder("notion")
+
+    assert _mints["notion"]["state"] == "waiting"
+    assert _mints["notion"]["oauth_url"] == _URL
+
+
+@pytest.mark.asyncio
+async def test_a_cold_row_whose_process_died_is_still_withdrawn_by_the_poll():
+    """The abstention is scoped to warm provenance; the cold verdict is untouched."""
+    _row(shared=False, generation=0, activation=0)
+
+    await mint.expire_dead_holder("notion")
+
+    assert _mints["notion"]["state"] == "expired"
+    assert _mints["notion"]["reason"] == "mint_process_gone"
+
+
+# ── part 2: adoption ──
+
+
+@pytest.mark.asyncio
+async def test_adoption_hands_over_the_preminted_url_under_a_fresh_token(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _warm_process(monkeypatch)
+    _row()
+
+    token = await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp")
+
+    assert token and token != "premint-token"
+    row = _mints["notion"]
+    # The point of the whole slice: the URL survives the click that came for it.
+    assert row["oauth_url"] == _URL
+    assert row["state"] == "waiting"
+    assert row["token"] == token
+    # Ownership transferred; provenance kept, because the verifier did not move.
+    assert not row.get("shared")
+    assert row["generation"] == 1
+    assert row["activation"] == 1
+
+
+@pytest.mark.asyncio
+async def test_adoption_refuses_a_row_whose_holding_process_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Same liveness the reaper uses: a dead holder's URL is not adoptable, it is garbage."""
+    _warm_process(monkeypatch, alive=False)
+    _row()
+
+    assert await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp") is None
+    # Left exactly as found, for ``expire_dead_mints`` to withdraw on its own terms.
+    assert _mints["notion"].get("shared") is True
+    assert _mints["notion"]["token"] == "premint-token"
+
+
+@pytest.mark.asyncio
+async def test_adoption_refuses_a_row_whose_session_no_longer_listens(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Redeemability takes TWO questions -- the process AND the loopback listener."""
+    _warm_process(monkeypatch)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    _row()
+
+    assert await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp") is None
+
+
+@pytest.mark.asyncio
+async def test_adoption_refuses_a_row_no_premint_left_unclaimed(monkeypatch: pytest.MonkeyPatch):
+    """A row a caller already owns is not up for grabs, however it was minted."""
+    _warm_process(monkeypatch)
+    _row(shared=False)
+
+    assert await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp") is None
+    # Untouched: the owner's token still fences it.
+    assert _mints["notion"]["token"] == "premint-token"
+
+
+@pytest.mark.asyncio
+async def test_adoption_refuses_a_claim_still_minting_even_with_a_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The state guard, pinned ALONE: every other conjunct is deliberately valid
+    (URL present, holder alive), so this red-flags a dropped ``state == "waiting"``
+    check specifically -- a row mid-claim is not handed over even if a URL is
+    already visible on it."""
+    _warm_process(monkeypatch)
+    _row(state="minting")
+
+    assert await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp") is None
+    # Left for its own watcher to finish; nothing rotated, nothing cleared.
+    assert _mints["notion"]["token"] == "premint-token"
+    assert _mints["notion"].get("shared") is True
+
+
+@pytest.mark.asyncio
+async def test_adoption_refuses_a_claim_that_holds_no_url_yet(monkeypatch: pytest.MonkeyPatch):
+    """The URL guard, pinned ALONE: state is ``waiting`` and the holder is alive,
+    so this red-flags a dropped ``oauth_url`` check specifically -- adopting a
+    URL-less row would answer the click with nothing to redeem."""
+    _warm_process(monkeypatch)
+    _row(url=None)
+
+    assert await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp") is None
+
+
+@pytest.mark.asyncio
+async def test_adoption_refuses_a_provider_with_no_row_at_all(monkeypatch: pytest.MonkeyPatch):
+    _warm_process(monkeypatch)
+
+    assert await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp") is None
+
+
+@pytest.mark.asyncio
+async def test_exactly_one_of_two_concurrent_adopters_wins(monkeypatch: pytest.MonkeyPatch):
+    """Two tabs, one URL. The loser gets ``None`` and falls back to its own cold mint."""
+    _warm_process(monkeypatch)
+    _row()
+
+    results = await asyncio.gather(
+        warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp"),
+        warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp"),
+    )
+
+    assert sorted(result is None for result in results) == [False, True]
+    winner = next(result for result in results if result is not None)
+    assert _mints["notion"]["token"] == winner
+
+
+@pytest.mark.asyncio
+async def test_adoption_rearms_the_grant_watcher_under_the_new_token(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Rotating the token without rotating the watcher would leave the row unwatchable.
+
+    Every write in ``_mint_watcher`` is fenced on the token it was started with, so the
+    premint's watcher goes inert the moment the token changes: nothing would ever flip the
+    row to ``granted`` or expire it, and it would keep the shared process resident forever.
+    """
+    _warm_process(monkeypatch)
+    armed: list[tuple[str, str, str]] = []
+
+    async def _recording_watcher(slug: str, mcp_url: str, token: str) -> None:
+        armed.append((slug, mcp_url, token))
+
+    monkeypatch.setattr(warm, "_mint_watcher", _recording_watcher)
+    stale = asyncio.get_running_loop().create_task(asyncio.sleep(3600))
+    _row(watcher=stale)
+
+    token = await warm.adopt_shared_mint("notion", "https://mcp.notion.test/mcp")
+
+    await asyncio.sleep(0)
+    assert stale.cancelled() or stale.cancelling()
+    assert armed == [("notion", "https://mcp.notion.test/mcp", token)]
+    assert _mints["notion"]["watcher"] is not stale
+
+
+# ── part 2b: an adopted row still belongs to the warm table's lifecycle ──
+
+
+def test_an_adopted_row_still_keeps_its_generation_alive():
+    """Killing the process the user is mid-consent on is the worst regression available.
+
+    Every warm-side predicate keyed on ``shared``, so clearing it at adoption -- which
+    ownership demands -- silently took the adopted row out of every count that keeps its
+    process parked.
+    """
+    _row(shared=False, generation=3)
+
+    assert warm._generation_holds_live_rows(3) is True
+
+
+def test_an_adopted_row_still_holds_the_session_answering_its_redirect():
+    _row(shared=False, generation=3, activation=7)
+
+    assert warm._activations_in_use() == {7}
+
+
+def test_an_adopted_row_keeps_the_shared_process_from_being_retired():
+    _row(shared=False, generation=3)
+
+    assert warm._shared_mints_pending() is True
+
+
+@pytest.mark.asyncio
+async def test_an_adopted_row_is_withdrawn_when_its_holder_dies(monkeypatch: pytest.MonkeyPatch):
+    """The other half of the abstention above: someone still has to say no."""
+    _warm_process(monkeypatch, alive=False)
+    _row(shared=False)
+
+    assert await warm.expire_dead_mints() == ["notion"]
+    assert _mints["notion"]["state"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_an_adopted_row_is_expired_when_its_generation_is_retired():
+    _row(shared=False, generation=3)
+
+    assert await warm._expire_shared_mints("mint_process_gone", generation=3) == ["notion"]
+    assert _mints["notion"]["state"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_a_premint_never_displaces_a_row_a_caller_already_adopted():
+    """``_mint_is_cold_held`` cannot see an adopted row: it owns no ``client`` either."""
+    _row(shared=False)
+
+    claimed, displaced = await warm._claim_shared_mints(["notion"])
+
+    assert claimed == {} and displaced == []
+    assert _mints["notion"]["token"] == "premint-token"
+    assert _mints["notion"]["oauth_url"] == _URL
+
+
+@pytest.mark.asyncio
+async def test_a_premint_still_replaces_an_unclaimed_row_of_its_own():
+    """The guard is about CALLER ownership, not about warm rows being untouchable."""
+    _row()
+
+    claimed, displaced = await warm._claim_shared_mints(["notion"])
+
+    assert list(claimed) == ["notion"]
+    assert [row["token"] for row in displaced] == ["premint-token"]
+
+
+# ── part 3: the HTTP surface ──
+
+
+async def _client() -> TestClient:
+    app = web.Application()
+    app.router.add_post("/api/connections/mint", connections.api_connections_mint)
+    app.router.add_get("/api/connections/mint", connections.api_connections_mint_state)
+    as_owner(app)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+@pytest.fixture
+def cold_mint(monkeypatch: pytest.MonkeyPatch):
+    """Record every cold-path call the handler makes, and make none of them real."""
+    calls: dict[str, int] = {"reserved": 0, "spawned": 0, "disposed": 0}
+
+    async def _reserve(slug: str):
+        calls["reserved"] += 1
+        prior = _mints.pop(slug, None)
+        _mints[slug] = {"state": "minting", "started": 0.0, "token": "cold-token"}
+        return "cold-token", prior
+
+    async def _start(slug, mcp_url, token=None, prior=None):
+        calls["spawned"] += 1
+        if prior is not None:
+            calls["disposed"] += 1
+
+    async def _dispose(entry):
+        calls["disposed"] += 1
+
+    monkeypatch.setattr(mint, "reserve_mint_row", _reserve)
+    monkeypatch.setattr(mint, "start_oauth_mint", _start)
+    monkeypatch.setattr(mint, "_dispose_mint", _dispose)
+    monkeypatch.setattr(connections, "get_provider", lambda slug: _provider(slug))
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_connect_adopts_the_preminted_url_instead_of_spawning_a_cold_mint(
+    monkeypatch: pytest.MonkeyPatch, cold_mint: dict[str, int]
+):
+    """THE defect: the click the premint existed for was the click that threw it away."""
+    _warm_process(monkeypatch)
+    _row()
+    client = await _client()
+    try:
+        resp = await client.post("/api/connections/mint", json={"slug": "notion"})
+        body = await resp.json()
+    finally:
+        await client.close()
+
+    assert resp.status == 200
+    assert body["state"] == "waiting"
+    assert body["token"] == _mints["notion"]["token"]
+    # No cold spawn, and nothing displaced the row: the URL is still there to serve.
+    assert cold_mint == {"reserved": 0, "spawned": 0, "disposed": 0}
+    assert _mints["notion"]["oauth_url"] == _URL
+
+
+@pytest.mark.asyncio
+async def test_connect_falls_back_to_a_cold_mint_when_nothing_is_adoptable(
+    monkeypatch: pytest.MonkeyPatch, cold_mint: dict[str, int]
+):
+    _warm_process(monkeypatch, alive=False)
+    _row()
+    client = await _client()
+    try:
+        resp = await client.post("/api/connections/mint", json={"slug": "notion"})
+        body = await resp.json()
+    finally:
+        await client.close()
+
+    assert resp.status == 200
+    assert body["state"] == "minting"
+    assert body["token"] == "cold-token"
+    assert cold_mint["reserved"] == 1 and cold_mint["spawned"] == 1
+
+
+@pytest.mark.asyncio
+async def test_the_premint_then_connect_round_trip_serves_the_warm_url(
+    monkeypatch: pytest.MonkeyPatch, cold_mint: dict[str, int]
+):
+    """premint -> not_connected -> Connect -> the warm URL, over the real endpoints.
+
+    The whole slice in one pass, in the order the page performs it. Each step is the one a
+    separate defect broke: the status read must not flip the card, the POST must adopt, and
+    the poll must both survive and serve.
+    """
+    _warm_process(monkeypatch)
+    monkeypatch.setattr(status, "get_visible_providers", lambda: [dict(_provider())])
+    monkeypatch.setattr(status, "_provider_grant_presence", lambda url: False)
+    monkeypatch.setattr(status, "reconcile_connected_since", lambda statuses, now: {})
+    # What ``warm_mint_all`` leaves behind once an activation has absorbed its challenges.
+    _row()
+
+    # 1. The gallery renders. The premint is held, and no card claims to be mid-consent.
+    statuses = await status.collect_connection_statuses()
+    assert [entry["status"] for entry in statuses] == [status.STATUS_NOT_CONNECTED]
+
+    client = await _client()
+    try:
+        # 2. The user clicks Connect, which adopts rather than re-mints.
+        started = await (await client.post("/api/connections/mint", json={"slug": "notion"})).json()
+        # 3. The card's ordinary mint-state poll finds the warm URL immediately.
+        polled = await (await client.get("/api/connections/mint?slug=notion")).json()
+    finally:
+        await client.close()
+
+    assert cold_mint["spawned"] == 0
+    assert polled["state"] == "waiting"
+    assert polled["oauth_url"] == _URL
+    assert polled["token"] == started["token"]
+    # Ownership actually moved in the TABLE, which is what stops the next premint sweep
+    # reclaiming the row and stops the status feed reporting it as unclaimed. The wire
+    # payload deliberately does not carry the flag: no card consumes it, and the
+    # authorization verdict is the status feed's job.
+    assert not _mints["notion"].get("shared")

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -165,8 +165,13 @@ async def test_a_row_whose_generation_is_gone_is_withdrawn():
 
 @pytest.mark.asyncio
 async def test_a_cold_row_is_left_to_the_cold_engine():
-    """``_mint_holder_alive`` answers False for a shared row, so the warm chokepoint
-    must judge only shared rows -- and leave a cold row's own verdict alone."""
+    """The two chokepoints partition the table, and each must leave the other's rows alone.
+
+    A cold row owns a ``client`` and carries no warm mark at all, so ``_warm_table_row``
+    excludes it and its verdict stays ``_mint_holder_alive``'s. The converse -- that a
+    warm-held row's verdict is THIS chokepoint's, because the cold judge abstains on one
+    -- is pinned in ``test_connections_handoff.py``.
+    """
     _mints["linear"] = {"state": "waiting", "oauth_url": "https://cold", "client": object()}
     assert await warm.expire_dead_mints() == []
     assert _mints["linear"]["state"] == "waiting"

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -2686,6 +2686,17 @@ export const api = {
     post('/api/connections/mint', { slug }).then(j) as Promise<{ ok: boolean; slug: string; state: string; token: string }>,
   connectionsMintState: (slug: string) =>
     fetch(`/api/connections/mint?slug=${encodeURIComponent(slug)}`).then(j) as Promise<ConnectionMintState>,
+  // Warm every mintable provider's URL in one activation, so a later Connect
+  // serves a URL the warm table already holds instead of paying a cold spawn.
+  // Deliberately BODYLESS: what is mintable is a fact about the user's registry
+  // and grant state, never a caller's choice, and the bound on what may be
+  // spawned stays on the server's side of the wire. `preminting` names the
+  // providers warming was STARTED for, which is why it can answer before any of
+  // them holds a URL — a card's verdict remains its mint state, never this.
+  // Owner-gated, so a non-owner session rejects (403); the caller is expected to
+  // treat that as "no warm table", not as an error worth showing.
+  connectionsPremint: () =>
+    post('/api/connections/premint').then(j) as Promise<{ ok: boolean; preminting: string[] }>,
   // Authorization verdict + first-connect time per visible provider. Additive to
   // the mint feed above; never mints.
   connectionsStatus: () =>

--- a/website/src/pages/connections/ConnectionsPage.tsx
+++ b/website/src/pages/connections/ConnectionsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type KeyboardEvent, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import {
@@ -703,6 +703,34 @@ export default function ConnectionsPage({ servicesEnabled = false }: { servicesE
     // provider, flashing a previous attempt's URL that no listener can redeem.
     gcTime: 0,
   })
+
+  /** Latched by the premint effect below, so one page visit warms once. */
+  const premintFiredRef = useRef(false)
+  // Warm every mintable provider's approval URL once, ahead of any click, so a
+  // Connect serves a URL the warm table already holds instead of paying a cold
+  // spawn. This is the documented caller for POST /api/connections/premint.
+  //
+  // Keyed on `servicesEnabled` rather than mount, because the flag arrives with
+  // the config query: the page's FIRST render is always gated-off, so a `[]`
+  // effect would warm on every install that never opted in. Gated for the same
+  // reason as the status feed above — behind a closed flag the gallery offers no
+  // card to connect, and warming would spawn a process for a surface that has no
+  // Connect button.
+  //
+  // The ref guards StrictMode's development double-invoke (an in-flight request
+  // is not cancellable, so a teardown flag cannot un-spawn the first activation).
+  // It is per-mount by design: a later remount from navigation may warm again,
+  // which the engine's warm reuse makes cheap, and suppressing it across visits
+  // would pin the first visit's grant state for the whole session.
+  useEffect(() => {
+    if (!servicesEnabled || premintFiredRef.current) return
+    premintFiredRef.current = true
+    // Strictly fire-and-forget: nothing here reaches render, and the response is
+    // never a verdict (a card's state stays its own mint feed). Every failure is
+    // swallowed on purpose — a non-owner dashboard session is denied by design,
+    // and a cold mint on Connect is the intended fallback either way.
+    void api.connectionsPremint().catch(() => undefined)
+  }, [servicesEnabled])
 
   useEffect(() => {
     // Decided BEFORE any setState: a state updater runs on a later render, so

--- a/website/src/test/ConnectionsPage.coverage.test.tsx
+++ b/website/src/test/ConnectionsPage.coverage.test.tsx
@@ -20,6 +20,7 @@
 // broadcasts. Interactions use `fireEvent` (no fake timers anywhere, so no
 // clock to keep in sync) and every assertion waits on rendered output.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StrictMode } from 'react'
 import { screen, fireEvent, waitFor, within } from '@testing-library/react'
 
 import type { ChatMessage, McpServer, RootState } from '../types'
@@ -33,6 +34,7 @@ const mcpCustomUpdate = vi.fn()
 const mcpOAuthRelay = vi.fn()
 const connectionsMint = vi.fn()
 const connectionsMintState = vi.fn()
+const connectionsPremint = vi.fn()
 const connectionsStatus = vi.fn()
 const connectionsCancel = vi.fn()
 const connectionsDisconnect = vi.fn()
@@ -48,6 +50,7 @@ vi.mock('../api/client', () => ({
     mcpOAuthRelay: (...a: unknown[]) => mcpOAuthRelay(...a),
     connectionsMint: (...a: unknown[]) => connectionsMint(...a),
     connectionsMintState: (...a: unknown[]) => connectionsMintState(...a),
+    connectionsPremint: (...a: unknown[]) => connectionsPremint(...a),
     connectionsStatus: (...a: unknown[]) => connectionsStatus(...a),
     connectionsCancel: (...a: unknown[]) => connectionsCancel(...a),
     connectionsDisconnect: (...a: unknown[]) => connectionsDisconnect(...a),
@@ -92,7 +95,7 @@ interface ChatSeed {
 }
 
 function mount(
-  { servicesEnabled = true, chat = {} }: { servicesEnabled?: boolean; chat?: ChatSeed } = {},
+  { servicesEnabled = true, chat = {}, strict = false }: { servicesEnabled?: boolean; chat?: ChatSeed; strict?: boolean } = {},
 ) {
   const store = createTestStore({
     chat: {
@@ -100,7 +103,8 @@ function mount(
       slotMessages: chat.slotMessages ?? {},
     } as unknown as RootState['chat'],
   })
-  return renderWithProviders(<ConnectionsPage servicesEnabled={servicesEnabled} />, { store })
+  const tree = <ConnectionsPage servicesEnabled={servicesEnabled} />
+  return renderWithProviders(strict ? <StrictMode>{tree}</StrictMode> : tree, { store })
 }
 
 /** The card for one provider, addressed the way the DOM exposes it. */
@@ -139,6 +143,7 @@ beforeEach(() => {
   connectionsMintState.mockReset().mockResolvedValue({
     slug: 'notion', state: 'minting', token: 'tok1',
   })
+  connectionsPremint.mockReset().mockResolvedValue({ ok: true, preminting: ['notion'] })
   // Authorization axis: empty by default, so the reachability-derived card states
   // these tests assert on are unchanged by the status feed.
   connectionsStatus.mockReset().mockResolvedValue({ schema_version: 1, connections: [] })
@@ -162,6 +167,68 @@ describe('the held-back gallery', () => {
     expect(cards()).toHaveLength(0)
     expect(screen.queryByLabelText('Search services')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument()
+  })
+})
+
+// Warming the approval URLs ahead of any click. The engine (POST
+// /api/connections/premint) shipped with zero callers; this is the caller, and
+// what these tests pin is the shape of the call rather than its result — the
+// response is never a verdict, so nothing about the rendered gallery may depend
+// on it.
+describe('premint on mount', () => {
+  it('warms the mintable providers once, with no body, when the gallery mounts', async () => {
+    mount()
+
+    await waitFor(() => expect(connectionsPremint).toHaveBeenCalledTimes(1))
+    // Bodyless by contract: what is mintable is the server's to decide, so the
+    // caller passes nothing — no source, no provider list, no telemetry.
+    expect(connectionsPremint).toHaveBeenCalledWith()
+  })
+
+  it('warms once under StrictMode, where the mount effect is double-invoked', async () => {
+    // The real double-fire hazard: an in-flight warm is not cancellable, so a
+    // teardown flag cannot un-spawn the first activation and only a latching ref
+    // holds. Asserting "once" on a plain mount proves nothing about the guard —
+    // that render invokes the effect a single time either way.
+    mount({ strict: true })
+
+    await waitFor(() => expect(connectionsPremint).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not warm while the services flag is off', async () => {
+    mount({ servicesEnabled: false })
+
+    // The gate offers no card and no Connect button, so there is nothing a warm
+    // URL could serve — and warming spawns a process.
+    expect(await screen.findByText('No services match this search.')).toBeInTheDocument()
+    expect(connectionsPremint).not.toHaveBeenCalled()
+  })
+
+  it('warms when the flag arrives after the first render, still only once', async () => {
+    // The flag rides the config query, so the page's first render is ALWAYS
+    // gated-off. A mount-only effect would either warm every install that never
+    // opted in, or never warm at all — this pins the keyed-on-the-flag shape.
+    const { rerender } = mount({ servicesEnabled: false })
+    expect(connectionsPremint).not.toHaveBeenCalled()
+
+    rerender(<ConnectionsPage servicesEnabled />)
+    await waitFor(() => expect(connectionsPremint).toHaveBeenCalledTimes(1))
+
+    rerender(<ConnectionsPage servicesEnabled />)
+    expect(connectionsPremint).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the gallery unchanged when the warm request rejects', async () => {
+    // A non-owner session is denied by design and the gateway may be older than
+    // the endpoint; either way the cold mint on Connect is the fallback, so the
+    // rejection must reach neither the cards nor an alert.
+    connectionsPremint.mockRejectedValue(new Error('403 forbidden'))
+
+    mount()
+
+    await waitFor(() => expect(cards()).toHaveLength(CONNECTION_PROVIDERS.length))
+    expect(within(card('notion')).getByRole('button', { name: 'Connect' })).toBeEnabled()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION

## Problem / Motivation

The warm-mint engine (shipped in the prior wave) premints OAuth consent URLs into shared table rows so Connect can answer instantly — but nothing could ever *use* a preminted row:

1. **Connect threw the URL away.** `api_connections_mint` unconditionally called `reserve_mint_row`, which pops whatever row exists — shared warm rows included — and disposes it. The user paid the full ~7.5 s cold spawn the premint existed to avoid.
2. **Premint flipped every card to consent UI.** `_classify` mapped any minting/waiting row to `awaiting_consent` and `pending_mint_for` exposed shared rows unfiltered, so the gallery's waiting-set fold rendered every mintable card as an in-flight consent (approval link, no Connect button) with no user action.
3. **The first poll deleted live warm URLs.** The cold-side liveness judge `_mint_holder_alive` read a warm row's absent `client` as a dead holder and withdrew it — so even with (1) and (2) fixed, a preminted URL died on the first status read. (Found during this slice's red-first pass.)

Because of (2), the frontend premint caller was deliberately held un-pushed.

## Why it matters

This is the slice that turns the warm engine from resident-but-unreachable into the product feature: Connect serves a ready URL instead of an ~7.5 s spinner, on the providers in the launch set.

## What changed (motivation → approach → change)

- **Shared-row honesty**: `pending_mint_for`'s view now carries `shared: true` for unclaimed premints, and `_classify(..., shared=)` treats them as *not* consent — the card sees `not_connected`, exactly the verdict it would get with no row at all. A flag (not a filtered view) because the same view feeds two readers with opposite needs: the status classifier must refuse an unclaimed row as consent, while the mint-state poll must still distinguish it from `idle`. The wire payload's shape is unchanged (named-key build; `shared` never crosses the wire), with one deliberate content change: the mint-state poll withholds an **unclaimed** premint's `oauth_url` — a consent URL completes a machine-wide grant, so it is served only after a click adopts the row (adoption clears `shared`). Locked in by `test_an_unclaimed_premint_never_serves_its_consent_url`.
- **Adoption**: new `adopt_shared_mint(slug, mcp_url)` — under `_mints_lock`, await-free (atomic by construction): verifies unclaimed + waiting + URL-bearing + live holder (the reaper's own liveness), rotates the token, pops `shared`, cancels the stale watcher and re-arms a fresh one in the same synchronous run (every watcher write is token-fenced, so rotating without re-arming would orphan the row). `api_connections_mint` tries adoption first; cold mint is the fallback. Concurrent adopters: one wins, the loser falls back cleanly.
- **Ownership vs table-membership (two axes)**: adoption clears `shared`, so warm-side lifecycle predicates moved onto `_warm_table_row(entry)` (= `shared` OR `generation`); the reads that ask *ownership* questions stay raw by design (adopted-detection, the adopt guard, claim release). `_mint_holder_alive` now abstains on any row carrying `generation` — cold rows never carry one, and `warm.expire_dead_mints` (which can see the registry those stamps name) is the sole withdrawer for warm rows.
- **The caller**: cherry-pick of the held premint-caller commit (patch-id-identical to its donor) — API client method + `servicesEnabled`-gated, StrictMode-guarded once-per-visit mount effect.

## Tests

30 new tests red-first on the parent (24 red / 6 opposite-direction guards green), including: shared rows never classify as consent; Connect adopts instead of cold-minting (observed at the seam: no displacement, no spawn); adoption refuses no-row / owned / still-minting / URL-less / dead-process / dead-session rows — the still-minting and URL-less guards each pinned **alone** (every other conjunct valid; mutation-verified: dropping each guard reddens exactly its own test); concurrent adopters (one winner, clean fallback); token rotation + watcher re-arm; the poll never withdraws a live warm row; 5 cherry-picked frontend tests pass unchanged.

Gates: black/isort/flake8/subprocess-encoding 0, mypy 0 (1,237 files), scoped connections pytest 275+31 green, `tsc -b` 0, eslint 0, page suites green.

Known environment note: `test_row_tokens_do_not_repeat_across_a_gateway_restart` fails in the shared local venv only (stale non-editable `kiro_crew`; its subprocess can't see the worktree) — proven pre-existing by failing identically on the pristine base; CI's editable install is the executing gate for it.

## Manual verification

End-to-end premint → adopt shape covered by tests; live-pod validation of the full launch flow lands with the G1 re-test. A same-provider double-Connect race remains last-write-wins exactly as the pre-existing cold path (UI-unreachable: the card disables Connect once waiting).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the only frontend change is a mount effect that renders nothing (it fires one background premint POST, StrictMode-guarded) plus an API client method — zero pixel delta on any surface. The user-visible effect is latency (Connect serves a preminted URL), which a still image cannot show.

## Related Issues

Completes the warm-mint engine's user-facing half (engine shipped via #6697); unblocks the premint caller held from the W-A slice.

## Checklist

- [x] At most two commits (backend + patch-id-proven cherry-pick), Conventional Commits titles
- [x] Existing tests pass and new tests added
- [x] Self-review completed
- [x] Documentation updated (`docs/architecture/design-notes/connections-warm-table.md` — "The handoff" section, same commit)
- [x] No secrets, credentials, or internal references in the diff


