### PR TITLE
fix(ci): route memory.py's pip-stderr logs through the context redactor

### DIFF
--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -41,6 +41,7 @@ from kiro_crew.embeddings import (
 from kiro_crew.executors import embed_executor, run_in_embed_pool
 from kiro_crew.history import is_incognito_transcript
 from kiro_crew.loop_lock import LoopBoundLock
+from kiro_crew.platform.context import redact_log_via_context
 from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
@@ -49,7 +50,7 @@ from kiro_crew.sandbox import (
     wrap_argv,
     wrap_argv_async,
 )
-from kiro_crew.security import redact_and_truncate, redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 from ._shared import _get_memory, _is_restricted_session, _redact_memory_field, read_bounded_json
 from .cron import _recognize_session
@@ -72,11 +73,28 @@ _history_write_lock = LoopBoundLock()
 # loader publishes into an embedder we close, and close() is terminal.
 _MODEL_LOAD_TIMEOUT_SECS = 600.0
 
-# Log-line budget for pip/ensurepip stderr in the warnings below. The bound is
-# applied by redact_and_truncate AFTER redaction runs over the FULL decoded
-# stderr, so a credential straddling the boundary cannot survive as an
-# unredacted fragment (the redact-before-bound invariant; see security.py).
+# Log-line budget for pip/ensurepip stderr in the warnings below.
 _PIP_STDERR_LOG_CHARS = 500
+
+
+def _redact_pip_stderr(raw: bytes) -> str:
+    """Redact pip/ensurepip stderr for a log line, then bound its length.
+
+    Through the CONTEXT rather than `security.redact_and_truncate`: a pip failure
+    is prime territory for a host-specific credential shape (an internal registry
+    cookie, a token in an index URL), and those live in a loaded companion's
+    regexes rather than in the OSS baseline. Reading the baseline here would scan a
+    companion host's stderr with the weaker pass and log what it missed. The
+    `_log_` spelling is the one that cannot raise, which this path needs: the
+    caller is reporting a failure, and losing the report is worse than losing the
+    line.
+
+    Redact BEFORE bounding. Slicing first can cut a credential in half, and half a
+    token no longer matches the redactors' patterns (an AWS key ID needs its full
+    20 characters), so the surviving fragment would reach gateway.log verbatim. The
+    character cap is for log volume, so it belongs last.
+    """
+    return redact_log_via_context(raw.decode(errors="replace"))[:_PIP_STDERR_LOG_CHARS]
 
 
 def _sel():
@@ -906,10 +924,7 @@ async def _ensure_pip_available() -> tuple[bool, str]:
             logger.warning("ensurepip bootstrap timed out")
             return False, "pip bootstrap (ensurepip) timed out"
         if proc.returncode != 0:
-            logger.warning(
-                "ensurepip bootstrap failed: %s",
-                redact_and_truncate(stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS),
-            )
+            logger.warning("ensurepip bootstrap failed: %s", _redact_pip_stderr(stderr))
             return False, "pip bootstrap (ensurepip) failed"
         importlib.invalidate_caches()
         logger.info("Bootstrapped pip via ensurepip")
@@ -1061,10 +1076,7 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
                         )
                     if proc.returncode != 0:
                         logger.warning(
-                            "faiss-cpu install failed: %s",
-                            redact_and_truncate(
-                                stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS
-                            ),
+                            "faiss-cpu install failed: %s", _redact_pip_stderr(stderr)
                         )
                         _embedding_setup_status = {
                             "step": "idle",


### PR DESCRIPTION
## Problem / Motivation

`test/test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor` is **red on `main`'s own tip**:

```
AssertionError: New gate-side log/audit line(s) reading the BASELINE redactor
dashboard/handlers/memory.py: 2 sites, census says 0
```

Reproduced on a pristine `origin/main` checkout at `1d705a03f`: `1 failed, 46 passed`.

## Why it matters

That test lives in shard 3 of 4, so **every open PR fails `Backend Tests (3.10, 3)`, `(3.12, 3)` and `(Windows) (3)`, and then `Coverage Gate` fails closed behind them** — on a diff that has nothing to do with security posture. Checked against twelve open PRs this morning: all twelve carried the identical four-job failure, and in each case shard 3 was the only shard red. Nobody can reach `readiness: passed` until this is fixed, and the failure reads as the PR's own, so the cost is not just the block — it is twelve people each diagnosing the same main-side red.

## What changed (motivation → approach → change)

**Root cause is a cross-merge, not a bad commit.** Two PRs were each green in isolation and broke `main` when they crossed: `f1f7743bd` added the census ratchet, and `2e627dc10` added two `redact_and_truncate(...)` call sites inside `logger.warning(...)` in `dashboard/handlers/memory.py`. The census counts a *baseline* redactor's result reaching a log write, per module; `memory.py` had never appeared in `_BASELINE_LOG_SITE_CENSUS`, so two new sites read as growth from 0 to 2. Neither PR's own CI could see it, because neither contained the other's half.

**The test offers two remedies, and only one of them is honest here.** Its message says a site is cleared either by routing through `redact_log_via_context`, *or* by raising the module's census number "when the site runs in a process that never composes a companion". Both of these sites are in the aiohttp gateway handler module — `_ensure_pip_available` and `api_memory_enable_embeddings` — and the gateway *is* the composition process. So raising the number would record the wrong answer and leave a companion host's pip stderr scanned with the weaker OSS pass.

So: route them through the context, behind one helper. `_redact_pip_stderr(raw: bytes) -> str` redacts the **full** decoded stderr through `redact_log_via_context` and only then applies the 500-character bound, preserving the redact-before-bound invariant that `2e627dc10` existed to establish — slicing first can cut a credential in half, and half an AWS key ID matches no pattern, so the fragment would reach `gateway.log` verbatim. `redact_log_via_context` is also the spelling that cannot raise, which this path needs: the caller is already reporting a failure, and losing the report is worse than losing the line.

This is deliberately the same shape `platform/update_provider.py:459` already uses for installer stderr, comment and all, rather than a new idiom. The two call sites collapse from four lines each to one, and `redact_and_truncate` is no longer imported here.

Scoped to exactly this: 1 file, +25/−13, no behaviour change on a standalone install (with no context installed, `redact_log_via_context` runs the same OSS pass the old call did — which is why `2e627dc10`'s own regression tests still pass untouched).

## Tests

No new test. The regression is already pinned from both directions, which is why this needs no third assertion:

- `test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor` — the ratchet this fixes. Red before, green after.
- `test_enable_embeddings_faiss.py` — `2e627dc10`'s own two regression tests, which plant a credential straddling the 500-character boundary at each emitter and assert it is redacted. They pass **unchanged**, which is the evidence that this is a redactor-swap and not a behaviour change.

Verified with the CI-parity venv (python 3.12, mypy 1.14.1, no faiss): `70 passed` across both files; `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1237 files) and `scripts/check_black_formatting.py` all exit 0.

## Manual verification

N/A — unit coverage sufficient. The change is a redactor swap on two log lines with a ratchet test asserting the swap happened and two existing tests asserting the redaction still works.

## Related Issues

no linked issue: this is a main-tip CI repair, not a reported defect. `2e627dc10` and `f1f7743bd` were both already merged.

## Pattern harvest

Rule candidate: lint

Pattern: **a scan-based ratchet whose baseline is a per-module count, plus a PR that adds a matching site in a module the baseline does not list.** Both PRs pass their own CI; the red appears only on the merge of the two, on `main`, where it blocks everyone.

This is the second instance of the class on `main` in a week — `ecab0babe` ("re-measure the files.py log-site census after #7293") and `e7f02aeec` ("bring two drifted ratchet gates back in line with the code") are the same shape, and `c412c2ff9` ("repair two cross-merge breakages reding main's own tip") names it outright. That is enough recurrence to treat as a class rather than three coincidences.

The mechanical guard is a **post-merge ratchet job**: run the scan-based ratchet tests (`test_security_posture.py`, `test_agent_sdk_boundary.py`, `test_spawn_audit.py`, the black/subprocess-encoding baselines) on `main`'s tip after every merge, and open an issue or fail loudly on red. CI today validates `refs/pull/N/merge` against the base *at the time the run fired*, which is exactly the window a cross-merge slips through: PR A's run predates PR B's merge, and nothing re-validates the combination afterwards. A `push: [main]` job costs one run per merge and turns a twelve-PR block into a single named alert.

The narrower guard, which would have caught this specific pair, is to make the census **derived rather than declared** — a ratchet that stores per-module counts has to be edited by every PR that legitimately adds a site, and a module absent from the map has an implicit count of 0 that no author sees. The same test already knows how to compute the live census; storing only the *total* (or storing counts but treating an absent module as "not yet ratcheted" rather than "must be zero") removes the sharp edge without weakening the gate.

One refinement worth recording, because it makes the general fix cheaper than it looks. The same `push: [main]` job can carry the frontend ratchet at no extra provisioning cost (`cd website && npx eslint src/ --max-warnings 0`, ~35s), and that case needs no baseline file at all. Which points at the sharper conclusion: a **censused** ratchet has two failure modes — the stored count drifts from the code, and a cross-merge slips through — while a **hard-zero** ratchet has only the second. So wherever the backlog can actually be cleared, driving the gate to 0 and deleting its census is strictly better than maintaining one. That is the direction the in-flight eslint burndown takes for the frontend warning ceiling, and this census is a candidate for the same treatment once the slice-before-redact class is closed.
