### PR TITLE
fix(ci): route the pip-stderr log lines through the context redactor

### DIFF
--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -41,6 +41,7 @@ from kiro_crew.embeddings import (
 from kiro_crew.executors import embed_executor, run_in_embed_pool
 from kiro_crew.history import is_incognito_transcript
 from kiro_crew.loop_lock import LoopBoundLock
+from kiro_crew.platform.context import redact_log_via_context
 from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
@@ -49,7 +50,7 @@ from kiro_crew.sandbox import (
     wrap_argv,
     wrap_argv_async,
 )
-from kiro_crew.security import redact_and_truncate, redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 from ._shared import _get_memory, _is_restricted_session, _redact_memory_field, read_bounded_json
 from .cron import _recognize_session
@@ -73,7 +74,7 @@ _history_write_lock = LoopBoundLock()
 _MODEL_LOAD_TIMEOUT_SECS = 600.0
 
 # Log-line budget for pip/ensurepip stderr in the warnings below. The bound is
-# applied by redact_and_truncate AFTER redaction runs over the FULL decoded
+# a slice applied AFTER redact_log_via_context runs over the FULL decoded
 # stderr, so a credential straddling the boundary cannot survive as an
 # unredacted fragment (the redact-before-bound invariant; see security.py).
 _PIP_STDERR_LOG_CHARS = 500
@@ -908,7 +909,7 @@ async def _ensure_pip_available() -> tuple[bool, str]:
         if proc.returncode != 0:
             logger.warning(
                 "ensurepip bootstrap failed: %s",
-                redact_and_truncate(stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS),
+                redact_log_via_context(stderr.decode(errors="replace"))[:_PIP_STDERR_LOG_CHARS],
             )
             return False, "pip bootstrap (ensurepip) failed"
         importlib.invalidate_caches()
@@ -1062,9 +1063,9 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
                     if proc.returncode != 0:
                         logger.warning(
                             "faiss-cpu install failed: %s",
-                            redact_and_truncate(
-                                stderr.decode(errors="replace"), _PIP_STDERR_LOG_CHARS
-                            ),
+                            redact_log_via_context(stderr.decode(errors="replace"))[
+                                :_PIP_STDERR_LOG_CHARS
+                            ],
                         )
                         _embedding_setup_status = {
                             "step": "idle",


### PR DESCRIPTION
## Summary

`main` is red on Backend Tests shards + Coverage Gate:
`test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor` fails with `dashboard/handlers/memory.py: 2 sites, census says 0`.

Cross-merge: the pip-stderr redaction (#7283) added two `redact_and_truncate` log sites to `memory.py`, and the census ratchet (#7278) landed with a pre-#7283 count. Nothing re-measures the census at merge, so main merged red — same class as #7492's files.py re-measure.

This takes the ratchet's preferred remedy (convert, not re-count): both install-failure warnings now reach their text through `redact_log_via_context`, so a loaded companion's extra credential regexes apply instead of the OSS baseline. The `_PIP_STDERR_LOG_CHARS` bound is a slice applied after redaction saw the full decoded stderr, preserving the redact-before-bound invariant. The census entry for `memory.py` stays at 0, which the scanner now agrees with. The diff is the two call sites plus the import and the constant's comment — `memory.py` stays in the black baseline untouched.

## Pattern harvest

Rule candidate: when two PRs land concurrently and one adds a ratchet whose baseline was measured before the other's sites existed, main merges red with neither PR at fault; a merge-time re-measure of ratchet baselines (or a required merge-queue) is the structural fix. Until then, unblockers should prefer the ratchet's own named remedy (convert the site) over re-counting the baseline, so the debt shrinks instead of being re-legitimized.

## Testing

- `test/test_security_posture.py` — 47 passed (the failing census test now green)
- `test/test_handlers_memory_coverage.py` — passed (228 total in the combined run)
- `black` baseline gate / `flake8` / `isort` / `mypy` clean on the touched file

no linked issue: main-breakage unblocker, same shape as #7492.
