### PR TITLE
fix(irq): preserve sticky window age across epochs

### DIFF
--- a/docs/system-specs/features/agent-interrupt-controller.md
+++ b/docs/system-specs/features/agent-interrupt-controller.md
@@ -84,15 +84,16 @@ When a nonempty `Tick.epoch` changes, `irq.run` removes epoch-scoped alerts and
 open-window entries, then retains epoch-independent alerts and open-window
 entries. Check-derived observations must not survive a head change, or an old
 head can be reported as current. Conversation-derived observations must survive,
-or a head change replays already-reported discussion. Each carried entry's own
-open time is dropped, so its clock restarts on the new epoch: this preserves the
-pending delivery while ensuring a fresh head receives its full settling floor,
-and because the entry itself is carried, the restart is a delay and never a loss.
+or a head change replays already-reported discussion. Each carried entry keeps
+its own open time, so a force-push does not make a settled discussion wake serve
+the floor again. A fresh head observation is a separate entry with a fresh open
+time, so it still receives the full settling floor; on the transition tick it
+cannot ride on a carried entry that is already ready to fire.
 These invariants are pinned by
 `test_an_open_epoch_scoped_window_is_dropped_by_an_epoch_change`,
 `test_a_sticky_key_survives_an_epoch_change`,
 `test_a_fresh_epoch_anomaly_still_gets_a_full_settling_floor`, and
-`test_a_carried_sticky_entry_is_delayed_not_lost_by_the_restart`.
+`test_a_carried_sticky_entry_keeps_its_served_floor_across_epoch_change`.
 
 Dedupe re-arms after the configured re-alert interval. Future timestamps read
 as stale, and recovery clears the blind marker. The error threshold comparison

--- a/src/kiro_crew/irq.py
+++ b/src/kiro_crew/irq.py
@@ -703,7 +703,8 @@ def run(
         # alerts promptly instead of inheriting up to realert_secs of dedupe.
         state.get("alerted", {}).pop("blind", None)
 
-    if tick.epoch and state.get("epoch") != tick.epoch:
+    epoch_changed = bool(tick.epoch and state.get("epoch") != tick.epoch)
+    if epoch_changed:
         # The subject became a different subject: fresh epoch, fresh memory.
         #
         # Sticky state is the exception, and the reason the sentinel exists: a
@@ -722,31 +723,19 @@ def run(
         # back. Epoch-scoped window entries ARE dropped -- they describe checks
         # on a commit that is no longer under review.
         #
-        # The carried entry's own stamp is deliberately NOT kept, so its clock
-        # restarts on the new epoch. A freshly pushed commit briefly shows an
-        # almost-empty rollup, so ``pending == 0`` can be true while nothing has
-        # run, which is the entire reason DEFAULT_COALESCE_SECS is a floor;
-        # re-installing an aged stamp left that floor already satisfied, so a
-        # ``ready`` observation on the new head fired at once and announced
-        # "all checks green" before its checks existed. Per-entry ages now keep
-        # the two apart on their own -- the fresh ``ready`` gets its own floor
-        # regardless -- so keeping the carried stamp is a one-line change. It is
-        # left out of this change on purpose: it is a shift in WAKE TIMING on a
-        # different trigger (a push cadence faster than the floor re-delaying a
-        # carried comment), and this module's rule is that a timing change ships
-        # as its own attributable step rather than riding along with a
-        # structural one.
-        #
-        # Restarting costs the carried entry one more floor of latency after a
-        # force-push. That is a DELAY, and the invariant that matters is that it
-        # is not a LOSS: the entry itself is carried, so it still fires.
+        # Keep each carried entry's own stamp so a force-push does not make an
+        # already-settled comment pay the floor again. A freshly pushed commit
+        # briefly shows an almost-empty rollup, so ``pending == 0`` can be true
+        # while nothing has run. Per-entry ages keep that case separate: a new
+        # epoch-scoped ``ready`` observation gets a new stamp and therefore its
+        # own full floor, regardless of the carried comment's age.
         carried = {
             key: value
             for key, value in (state.get("alerted") or {}).items()
             if isinstance(key, str) and key.startswith(_STICKY_SENTINEL)
         }
         carried_window = {
-            key: {"brief": row["brief"]}
+            key: {"brief": row["brief"], "opened_at": row.get("opened_at")}
             for key, row in (state.get("coalescing") or {}).items()
             if isinstance(key, str)
             and key.startswith(_STICKY_SENTINEL)
@@ -909,8 +898,14 @@ def run(
     # its own arrival. The shift is therefore always toward a LATER wake, never
     # an earlier one and never a lost one.
     if oldest >= coalesce_max_secs:
-        fire = {key: row["brief"] for key, row in window.items()}
-        triggered = True
+        fire = {
+            key: row["brief"]
+            for key, row in window.items()
+            if not (
+                epoch_changed and not key.startswith(_STICKY_SENTINEL) and ages[key] < coalesce_secs
+            )
+        }
+        triggered = bool(fire)
     else:
         # Two separate questions, and keeping them separate is the whole change.
         #
@@ -943,6 +938,11 @@ def run(
         triggered = False
         for key, row in window.items():
             if not (converged or key.startswith(_STICKY_SENTINEL)):
+                continue
+            # A carried sticky entry may already be old enough to trigger on
+            # the transition tick. Do not let a brand-new head observation ride
+            # on that wake before serving its own floor.
+            if epoch_changed and not key.startswith(_STICKY_SENTINEL) and ages[key] < coalesce_secs:
                 continue
             fire[key] = row["brief"]
             if ages[key] >= coalesce_secs:

--- a/test/test_irq.py
+++ b/test/test_irq.py
@@ -877,15 +877,79 @@ def test_a_fresh_epoch_anomaly_still_gets_a_full_settling_floor():
             # converge (pending > 0).
             Tick(epoch="e1", observations=[_sticky("comment:1")], pending=3),
             # Force-push. The fresh head momentarily looks converged.
-            Tick(epoch="e2", observations=[_wake("ready")], pending=0),
+            Tick(
+                epoch="e2",
+                observations=[_wake("ready", "all checks green")],
+                pending=0,
+            ),
+            Tick(
+                epoch="e2",
+                observations=[_wake("ready", "all checks green")],
+                pending=0,
+            ),
         ]
     )
     assert isinstance(_verdict(probe, coalesce_secs=_COALESCE), Skip)
     _settle()  # the OLD window is now older than the floor
-    assert isinstance(_verdict(probe, coalesce_secs=_COALESCE), Skip)
+    carried = _verdict(probe, coalesce_secs=_COALESCE)
+    assert isinstance(carried, Report)
+    assert "brief" in str(carried)
+    assert "green" not in str(carried)
+    _settle()
+    fresh = _verdict(probe, coalesce_secs=_COALESCE)
+    assert isinstance(fresh, Report)
+    assert "green" in str(fresh)
 
 
-def test_a_carried_sticky_entry_is_delayed_not_lost_by_the_restart():
+def test_a_fresh_epoch_anomaly_does_not_ride_on_a_carried_entrys_hard_cap():
+    """The cap belongs to the old window, not to a fresh-head observation.
+
+    A carried sticky entry can already be older than the cap on the transition
+    tick. The new observation must still serve its own floor before it can ride
+    on any wake, including the cap flush.
+    """
+    path = state_path("test-kind", "sub-1", "job-1")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = dedupe_key(_sticky("comment:1", "said"))
+    path.write_text(
+        json.dumps(
+            {
+                "epoch": "e1",
+                "coalescing": {key: {"brief": "said", "opened_at": time.time() - 600}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    probe = ScriptedProbe(
+        [Tick(epoch="e2", observations=[_wake("ready", "all checks green")], pending=0)]
+    )
+    verdict = _verdict(probe, coalesce_secs=300, coalesce_max_secs=30)
+    assert isinstance(verdict, Report)
+    assert "said" in str(verdict)
+    assert "green" not in str(verdict)
+
+
+def test_an_unstamped_carried_sticky_entry_restarts_instead_of_disappearing():
+    """Recoverable persisted rows survive an epoch reset.
+
+    Normalization owns repairing a missing timestamp. Filtering the row before
+    that repair turns a recoverable delay into a permanent lost wake.
+    """
+    path = state_path("test-kind", "sub-1", "job-1")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = dedupe_key(_sticky("comment:1", "said"))
+    path.write_text(
+        json.dumps({"epoch": "e1", "coalescing": {key: {"brief": "said"}}}),
+        encoding="utf-8",
+    )
+    probe = ScriptedProbe([Tick(epoch="e2", observations=[], pending=0)])
+    assert isinstance(_verdict(probe, coalesce_secs=300), Skip)
+    state = load_state(path)
+    assert state["coalescing"][key]["brief"] == "said"
+    assert state["coalescing"][key]["opened_at"] > 0
+
+
+def test_a_carried_sticky_entry_keeps_its_served_floor_across_epoch_change():
     """`alerted` stops a DELIVERED signal repeating; an open `coalescing` entry
     holds one that has NOT been delivered. Dropping the window at the epoch reset
     destroys that wake outright, because the probe may legitimately stop
@@ -893,20 +957,16 @@ def test_a_carried_sticky_entry_is_delayed_not_lost_by_the_restart():
     it back -- reachable on shipped defaults by observing a near-horizon comment
     then pushing a fix.
 
-    Carrying the entry while RESTARTING the stamp is what makes that a delay
-    rather than a loss, and this pins the difference: the probe reports nothing
-    on either new-epoch tick, and the carried entry must still fire once its
-    fresh window closes."""
+    Carrying the entry with its own open time preserves the settling floor it
+    already served before the push. The probe reports nothing on the new-epoch
+    tick, but the carried entry must still fire without paying the same floor a
+    second time."""
     probe = ScriptedProbe(
         [
             Tick(epoch="e1", observations=[_sticky("comment:1")], pending=3),
             Tick(epoch="e2", observations=[], pending=0),
-            Tick(epoch="e2", observations=[], pending=0),
         ]
     )
-    assert isinstance(_verdict(probe, coalesce_secs=_COALESCE), Skip)
-    _settle()
-    # First new-epoch tick: the carried entry is present but its window restarted.
     assert isinstance(_verdict(probe, coalesce_secs=_COALESCE), Skip)
     _settle()
     verdict = _verdict(probe, coalesce_secs=_COALESCE)


### PR DESCRIPTION
## Problem / Motivation

An epoch change carried an undelivered epoch-independent IRQ window entry but discarded its `opened_at` timestamp. A sticky discussion wake that had already served the coalescing floor therefore paid the same floor again after every force-push.

## Why it matters

Repositories with frequent pushes could repeatedly postpone an actionable review/comment wake even though that signal belongs to the conversation, not to any one head commit.

## What changed (motivation → approach → change)

The coalescing window already tracks age per entry, so the carried sticky entry can retain its own validated timestamp while a new-head observation receives a fresh timestamp. The epoch transition now preserves `opened_at` for sticky entries and prevents a brand-new epoch-scoped entry from riding on an older carried wake during that transition tick.

The IRQ system spec now records both sides of that contract: the carried discussion wake does not restart, and the fresh-head observation still serves its full floor.

## Tests

- Deterministic red-before: `test_a_carried_sticky_entry_keeps_its_served_floor_across_epoch_change` failed because the carried entry returned `SkipError('coalescing window open ...')` after it had already served the floor.
- Focused green: 4/4 tests covering carried sticky age, fresh-epoch settling, epoch-scoped reset, and sticky retention.
- Touched checks: Black, isort, Flake8, mypy, and `git diff --check` passed.

## Manual verification

N/A — the persisted state transition and timing boundary are covered directly by focused contract tests.

## Related Issues

Reviewer-counted follow-up from merged PR #7431.

## Pattern harvest

Rule candidate: review-prompt
Pattern: When state is carried across an epoch boundary, preserve per-entry age and separately prove that fresh epoch-scoped entries cannot inherit or ride on that age.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
