### PR TITLE
docs(computer-use): name all screenshot spool writers

### DIFF
--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -342,8 +342,9 @@ and touches no other application, so it is neither observe nor mutate). The
 class labels above are the code-owned `governance._CU_ACTION_CLASSES` table —
 see [governance.md](governance.md).
 
-Both spool writers (`service._persist_image` and `capture_macos.persist_jpeg`) name
-their files with `tempfile.mkstemp`, not a millisecond timestamp. `_shot_lock`
+All three spool writers (`service._persist_image`, `capture_macos.persist_jpeg`
+and `capture_windows.persist_jpeg`) name their files with `tempfile.mkstemp`, not
+a millisecond timestamp. `_shot_lock`
 serializes writers within one service instance but cannot serialize a second
 PROCESS — the gateway, the CLI and the permission-probe child all spool into the
 same `tempfile.gettempdir()` directory — so a timestamp-only name let two captures
@@ -352,7 +353,9 @@ leaving its caller holding a screenshot of an application it never asked about
 (a cross-capture pixel leak, reviewer finding). `mkstemp` also creates the file
 `0o600` from the outset, so there is no window in which it exists world-readable
 before `restrict_to_owner` runs. The timestamp stays in the *prefix* because the
-ring trim orders by name.
+ring trim orders by name. If descriptor adoption or the write fails, each writer
+removes its invocation-owned partial frame before degrading; it never sweeps a
+neighbouring capture owned by another call or process.
 
 **`computer_list_apps` only omits an app it cannot name.** It used to carry a
 per-app governance filter (`gate.app_is_disclosable` against the `computer_use.apps`

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -1932,6 +1932,18 @@ class TestTheSkillContractMatchesTheRuntime:
 
     _SPEC = Path(__file__).resolve().parents[1] / "docs/system-specs/modules/computer-use.md"
 
+    def test_the_spec_names_every_screenshot_spool_writer(self):
+        """The security contract must cover every place that persists pixels."""
+        text = self._SPEC.read_text(encoding="utf-8")
+        writers = {
+            "service._persist_image",
+            "capture_macos.persist_jpeg",
+            "capture_windows.persist_jpeg",
+        }
+        missing = {writer for writer in writers if writer not in text}
+        assert not missing, missing
+        assert "invocation-owned partial frame" in text
+
     def test_the_skill_does_not_advertise_an_optional_element_index(self):
         text = self._SKILL.read_text(encoding="utf-8")
         assert "element_index?" not in text


### PR DESCRIPTION
## Problem / Motivation

The computer-use system spec said there were two screenshot spool writers and named only the service and macOS paths. Windows has a third pixel-persistence path, `capture_windows.persist_jpeg`, with the same atomic allocation and partial-frame cleanup contract.

## Why it matters

Screenshot spool files can contain sensitive screen pixels. An inventory that omits one writer makes audits of unique allocation, owner-only creation, and failure cleanup incomplete even though the implementation already enforces those properties.

## What changed (motivation → approach → change)

The existing spool paragraph now names all three writers and records their shared failure boundary: descriptor-adoption or write failure removes only the invocation-owned partial frame before the writer degrades. A focused contract test pins the three-writer inventory and cleanup wording so a future writer cannot disappear from the spec unnoticed.

## Tests

- Deterministic red-before: `test_the_spec_names_every_screenshot_spool_writer` failed with `{'capture_windows.persist_jpeg'}` missing.
- Focused green: all 8 tests in `TestTheSkillContractMatchesTheRuntime` passed.
- Touched checks: Black, isort, Flake8, docs lint, and `git diff --check` passed.

## Manual verification

N/A — the change is documentation plus a direct documentation-contract test.

## Related Issues

Reviewer-counted documentation residual from merged PR #5774.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Security documentation that inventories sensitive-data writers must enumerate every production writer and pin the inventory with a contract test.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
