### PR TITLE
refactor(agents): route all KAS derives through the shared wrapper

### DIFF
--- a/.github/agent-sdk-boundary-baseline.txt
+++ b/.github/agent-sdk-boundary-baseline.txt
@@ -22,7 +22,6 @@
 #
 # Refresh (after removing something listed here):
 #   python3 scripts/check_agent_sdk_boundary.py --update-baseline
-2 src/kiro_crew/agent.py
 1 src/kiro_crew/apps/builtins/auto_improvement/backend/pr_watchers.py
 1 src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
 1 src/kiro_crew/apps/builtins/auto_improvement/spine/agent_runner.py

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -3278,18 +3278,17 @@ def _seed_kas_permissions(config: dict[str, Any]) -> None:
     if config.get("permissions") is not None:
         return
 
-    # circular import: `kiro_crew.acp.__init__` pulls in the runtime, which reaches
-    # back into config/agent — and it is also the whole ACP stack, which this
-    # module has no business dragging onto the gateway boot path just to write one
-    # JSON field. The imported module itself depends on nothing in the package.
-    from kiro_crew.acp.kas_permissions import (  # noqa: PLC0415
-        allowed_tools_to_permissions,
+    # Routed through the agent-sdk boundary: ``drivers.acp`` is the one layer
+    # permitted to import ``kiro_crew.acp``, and agent.py's direct-import count
+    # is a shrink-only baseline that must not grow. Function-local for the same
+    # boot-path reason as every import here — this module has no business
+    # dragging the ACP stack onto the gateway boot path just to write one JSON
+    # field.
+    from kiro_crew.agent_sdk.drivers.acp import (  # noqa: PLC0415 - boot path
+        derived_agent_permissions,
     )
 
-    derived = allowed_tools_to_permissions(
-        config.get("allowedTools"), agent_id=Path(AGENT_FILENAME).stem
-    )
-    config["permissions"] = derived if derived is not None else {"rules": []}
+    config["permissions"] = derived_agent_permissions(config.get("allowedTools"), AGENT_FILENAME)
 
 
 def _may_auto_approve(ref: str) -> bool:
@@ -5148,16 +5147,17 @@ def _install_conductor_agent() -> None:
     # as a literal: the rules come out byte-identical, a later edit to
     # ``allowedTools`` carries through, and a ceiling that strips a grant strips
     # its KAS rule with it (a hand-written ``kirocrew-core/*`` allow would have
-    # survived the filter on the KAS backend). ``{"rules": []}`` when nothing
-    # qualifies — the key's mere PRESENCE is what makes KAS load the spec at all.
-    from kiro_crew.acp.kas_permissions import (  # noqa: PLC0415 - circular import
-        allowed_tools_to_permissions,
+    # survived the filter on the KAS backend). Routed through the agent-sdk
+    # boundary like the pipeline conductor below: ``drivers.acp`` is the one
+    # layer permitted to import ``kiro_crew.acp``, and agent.py's direct-import
+    # count is a shrink-only baseline that must not grow.
+    from kiro_crew.agent_sdk.drivers.acp import (  # noqa: PLC0415 - boot path
+        derived_agent_permissions,
     )
 
-    derived = allowed_tools_to_permissions(
-        config["allowedTools"], agent_id=Path(_CONDUCTOR_AGENT_FILENAME).stem
+    config["permissions"] = derived_agent_permissions(
+        config["allowedTools"], _CONDUCTOR_AGENT_FILENAME
     )
-    config["permissions"] = derived if derived is not None else {"rules": []}
     kiro_agents_dir_path().mkdir(parents=True, exist_ok=True)
     path = kiro_agents_dir_path() / _CONDUCTOR_AGENT_FILENAME
     _atomic_json_write(path, config)

--- a/src/kiro_crew/agent_sdk/drivers/acp.py
+++ b/src/kiro_crew/agent_sdk/drivers/acp.py
@@ -44,7 +44,7 @@ __all__ = [
 ]
 
 
-def derived_agent_permissions(allowed_tools: list, agent_filename: str) -> dict:
+def derived_agent_permissions(allowed_tools: object, agent_filename: str) -> dict:
     """The KAS policy a generated agent spec should carry, from its grant list.
 
     Deriving from the FILTERED ``allowedTools`` instead of restating a literal
@@ -55,7 +55,11 @@ def derived_agent_permissions(allowed_tools: list, agent_filename: str) -> dict:
 
     Plain data in, plain data out: a list of grant refs and a spec filename
     (the KAS ``agent_id`` is its stem), a JSON-ready dict back -- no ACP type
-    crosses the boundary. Function-local import for the same boot-path reason
+    crosses the boundary. ``allowed_tools`` is typed ``object`` because the
+    wrapped derive owns the validation and fails closed on any non-list
+    (including the absent-key ``None`` a caller reads off a config dict) --
+    narrowing it here would just force casts at call sites for a check the
+    derive already makes. Function-local import for the same boot-path reason
     as every other function here, though ``kas_permissions`` itself is a leaf
     that depends on nothing else in the package.
     """

--- a/test/test_derived_agent_permissions_consumers.py
+++ b/test/test_derived_agent_permissions_consumers.py
@@ -1,4 +1,4 @@
-"""Every KAS-policy derive goes through ``derived_agent_permissions`` (#7513).
+"""The KAS derive-plus-fallback is spelled once, in ``derived_agent_permissions`` (#7513).
 
 PR #7238 introduced the wrapper as the shared spelling of derive-plus-fallback
 (``allowed_tools_to_permissions`` then ``{"rules": []}`` when nothing
@@ -8,14 +8,16 @@ divergence between them would have been invisible: all three behaved
 identically, so no behavioural test could tell them apart.
 
 The guard here is structural, not behavioural, for exactly that reason: it
-pins WHERE the derive is spelled. ``allowed_tools_to_permissions`` may be
-imported only by the boundary itself -- the ``agent_sdk`` driver that wraps it
-and the ``acp`` package that defines it. Application code that wants a KAS
-policy goes through the wrapper, which is also what keeps ``agent.py`` out of
-``.github/agent-sdk-boundary-baseline.txt`` (a shrink-only ratchet this
-migration shrank to zero for that file).
+pins WHERE the fallback is spelled. The IMPORT half of the invariant is
+already held by the live CI boundary gate -- after this migration pruned
+``agent.py`` from ``.github/agent-sdk-boundary-baseline.txt`` (shrink-only),
+``scripts/check_agent_sdk_boundary.py`` reds any re-grown
+``kiro_crew.acp.kas_permissions`` import in application code, including the
+dynamic-import spellings a second scanner would miss. This module guards only
+the half nothing else covers: the fallback expression itself re-growing
+around some other derive path.
 
-Behavioural coverage of the fallback itself lives with each call site
+Behavioural coverage of the fallback lives with each call site
 (``test_kas_permissions.TestTheDiskWriter``, ``test_conductor_agent``,
 ``test_pipeline_conductor_agent``) -- those are the tests that red when the
 wrapper's fallback changes, now for every site at once.
@@ -23,88 +25,37 @@ wrapper's fallback changes, now for every site at once.
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src" / "kiro_crew"
 
-#: The one symbol whose import location this guard pins.
-DERIVE_SYMBOL = "allowed_tools_to_permissions"
-DERIVE_MODULE = "kiro_crew.acp.kas_permissions"
-
-#: Trees allowed to reach the raw derive, as ``as_posix()`` prefixes relative
+#: Trees allowed to spell the fallback, as ``as_posix()`` prefixes relative
 #: to the repo root (Windows ``relative_to`` yields backslashes; the table
 #: must not depend on the host separator):
-#: - the ``acp`` package that defines it (package-internal use, e.g.
-#:   ``kas_agents.py``, is not a boundary crossing -- the same exemption
+#: - the ``acp`` package that defines the derive (package-internal use is not
+#:   a boundary crossing -- the same exemption
 #:   ``scripts/check_agent_sdk_boundary.py`` applies);
-#: - the ``agent_sdk`` driver, the boundary layer whose
-#:   ``derived_agent_permissions`` wrapper is the spelling everyone else uses.
+#: - the ``agent_sdk`` driver, whose ``derived_agent_permissions`` wrapper is
+#:   the one legitimate spelling.
 ALLOWED_PREFIXES = (
     "src/kiro_crew/acp/",
     "src/kiro_crew/agent_sdk/drivers/acp.py",
 )
 
-#: Vendored third-party code: not ours, never imports the derive, and parsing
-#: it would only slow the scan.
+#: Vendored third-party code: not ours, never spells the fallback, and
+#: reading it would only slow the scan.
 EXCLUDED_PARTS = ("_vendor",)
-
-
-def _imports_raw_derive(tree: ast.AST) -> bool:
-    """True when *tree* imports the derive symbol or its defining module.
-
-    AST-based so a multi-line or function-local import is judged the same as a
-    top-level one -- both inline sites this guard was written against were
-    function-local imports.
-    """
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            if node.module == DERIVE_MODULE and any(
-                alias.name == DERIVE_SYMBOL for alias in node.names
-            ):
-                return True
-            if node.module == "kiro_crew.acp" and any(
-                alias.name == "kas_permissions" for alias in node.names
-            ):
-                return True
-        elif isinstance(node, ast.Import):
-            if any(alias.name == DERIVE_MODULE for alias in node.names):
-                return True
-    return False
-
-
-def test_no_application_code_imports_the_raw_derive():
-    """The derive-plus-fallback is spelled once, in the wrapper.
-
-    Red on any ``src/`` module outside the boundary importing
-    ``allowed_tools_to_permissions`` (or its module) directly -- which is the
-    state this test was born red against: ``agent.py`` held two such imports,
-    each followed by its own copy of the ``{"rules": []}`` fallback.
-    """
-    offenders: list[str] = []
-    for path in sorted(SRC_ROOT.rglob("*.py")):
-        rel = path.relative_to(REPO_ROOT).as_posix()
-        if any(part in path.parts for part in EXCLUDED_PARTS):
-            continue
-        if rel.startswith(ALLOWED_PREFIXES):
-            continue
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
-        if _imports_raw_derive(tree):
-            offenders.append(rel)
-    assert offenders == [], (
-        "these modules import the raw KAS derive instead of "
-        f"kiro_crew.agent_sdk.drivers.acp.derived_agent_permissions: {offenders}"
-    )
 
 
 def test_the_inline_fallback_spelling_is_gone_from_application_code():
     """No copy of the wrapper's fallback survives outside the wrapper.
 
-    The import guard above catches the derive; this one catches the fallback
-    half re-growing around some other derive path. Textual on purpose: the
+    Born red against unmodified main, where ``agent.py`` held two copies of
+    the spelling (one per inline derive site). Textual on purpose: the
     duplication being removed was a byte-identical one-line spelling, so the
-    exact spelling is the thing to pin.
+    exact spelling is the thing to pin. The import half of the invariant is
+    the CI boundary gate's (see the module docstring).
     """
     needle = 'if derived is not None else {"rules": []}'
     offenders: list[str] = []

--- a/test/test_derived_agent_permissions_consumers.py
+++ b/test/test_derived_agent_permissions_consumers.py
@@ -1,0 +1,119 @@
+"""Every KAS-policy derive goes through ``derived_agent_permissions`` (#7513).
+
+PR #7238 introduced the wrapper as the shared spelling of derive-plus-fallback
+(``allowed_tools_to_permissions`` then ``{"rules": []}`` when nothing
+qualifies), but migrated only one of the three call sites. The other two kept
+the inline spelling, so the fallback existed in three places and a future
+divergence between them would have been invisible: all three behaved
+identically, so no behavioural test could tell them apart.
+
+The guard here is structural, not behavioural, for exactly that reason: it
+pins WHERE the derive is spelled. ``allowed_tools_to_permissions`` may be
+imported only by the boundary itself -- the ``agent_sdk`` driver that wraps it
+and the ``acp`` package that defines it. Application code that wants a KAS
+policy goes through the wrapper, which is also what keeps ``agent.py`` out of
+``.github/agent-sdk-boundary-baseline.txt`` (a shrink-only ratchet this
+migration shrank to zero for that file).
+
+Behavioural coverage of the fallback itself lives with each call site
+(``test_kas_permissions.TestTheDiskWriter``, ``test_conductor_agent``,
+``test_pipeline_conductor_agent``) -- those are the tests that red when the
+wrapper's fallback changes, now for every site at once.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src" / "kiro_crew"
+
+#: The one symbol whose import location this guard pins.
+DERIVE_SYMBOL = "allowed_tools_to_permissions"
+DERIVE_MODULE = "kiro_crew.acp.kas_permissions"
+
+#: Trees allowed to reach the raw derive, as ``as_posix()`` prefixes relative
+#: to the repo root (Windows ``relative_to`` yields backslashes; the table
+#: must not depend on the host separator):
+#: - the ``acp`` package that defines it (package-internal use, e.g.
+#:   ``kas_agents.py``, is not a boundary crossing -- the same exemption
+#:   ``scripts/check_agent_sdk_boundary.py`` applies);
+#: - the ``agent_sdk`` driver, the boundary layer whose
+#:   ``derived_agent_permissions`` wrapper is the spelling everyone else uses.
+ALLOWED_PREFIXES = (
+    "src/kiro_crew/acp/",
+    "src/kiro_crew/agent_sdk/drivers/acp.py",
+)
+
+#: Vendored third-party code: not ours, never imports the derive, and parsing
+#: it would only slow the scan.
+EXCLUDED_PARTS = ("_vendor",)
+
+
+def _imports_raw_derive(tree: ast.AST) -> bool:
+    """True when *tree* imports the derive symbol or its defining module.
+
+    AST-based so a multi-line or function-local import is judged the same as a
+    top-level one -- both inline sites this guard was written against were
+    function-local imports.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == DERIVE_MODULE and any(
+                alias.name == DERIVE_SYMBOL for alias in node.names
+            ):
+                return True
+            if node.module == "kiro_crew.acp" and any(
+                alias.name == "kas_permissions" for alias in node.names
+            ):
+                return True
+        elif isinstance(node, ast.Import):
+            if any(alias.name == DERIVE_MODULE for alias in node.names):
+                return True
+    return False
+
+
+def test_no_application_code_imports_the_raw_derive():
+    """The derive-plus-fallback is spelled once, in the wrapper.
+
+    Red on any ``src/`` module outside the boundary importing
+    ``allowed_tools_to_permissions`` (or its module) directly -- which is the
+    state this test was born red against: ``agent.py`` held two such imports,
+    each followed by its own copy of the ``{"rules": []}`` fallback.
+    """
+    offenders: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if any(part in path.parts for part in EXCLUDED_PARTS):
+            continue
+        if rel.startswith(ALLOWED_PREFIXES):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+        if _imports_raw_derive(tree):
+            offenders.append(rel)
+    assert offenders == [], (
+        "these modules import the raw KAS derive instead of "
+        f"kiro_crew.agent_sdk.drivers.acp.derived_agent_permissions: {offenders}"
+    )
+
+
+def test_the_inline_fallback_spelling_is_gone_from_application_code():
+    """No copy of the wrapper's fallback survives outside the wrapper.
+
+    The import guard above catches the derive; this one catches the fallback
+    half re-growing around some other derive path. Textual on purpose: the
+    duplication being removed was a byte-identical one-line spelling, so the
+    exact spelling is the thing to pin.
+    """
+    needle = 'if derived is not None else {"rules": []}'
+    offenders: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if any(part in path.parts for part in EXCLUDED_PARTS):
+            continue
+        if rel.startswith(ALLOWED_PREFIXES):
+            continue
+        if needle in path.read_text(encoding="utf-8"):
+            offenders.append(rel)
+    assert offenders == [], f"inline {needle!r} fallback re-grown in: {offenders}"

--- a/test/test_pipeline_conductor_probe_roundtrip.py
+++ b/test/test_pipeline_conductor_probe_roundtrip.py
@@ -1,0 +1,158 @@
+"""Round-trip contracts: the conductor's probe scripts read the REAL writers.
+
+The two pipeline-conductor scripts re-implement readers for three on-disk
+formats this package itself writes:
+
+1. the session-transcript JSONL entry shape -- written by
+   ``kiro_crew.history.ConversationLog.append``;
+2. the ``dashboard_`` transcript-filename prefix -- a dashboard slot key
+   becomes ``dashboard:<slot>`` via ``chat_utils._history_key_for`` and then
+   the ``dashboard_<slot>.jsonl`` stem via ``history._safe_key``;
+3. the usage-shard token-row schema -- written by
+   ``dashboard.handlers.usage._build_token_record`` /
+   ``_write_token_record`` (via ``persist_token_record``).
+
+The sibling tests in ``test_pipeline_conductor_agent.py`` exercise the scripts
+over HAND-AUTHORED fixtures. A fixture authored to match a format another
+module owns cannot detect that module changing the format: drift keeps every
+fixture test green while the live probe silently misclassifies -- and the
+conductor's reclaim decision runs off that classification, so the failure mode
+is a running session read as GONE and its work item dispatched twice.
+
+Each test here drives the real writer and lets the script classify what the
+writer produced, so the writer changing its format reds a test. Mutation-
+verified for all three formats (see the PR): renaming the transcript
+``content`` field, changing ``_history_key_for``'s prefix, and renaming the
+token row's ``_type`` each red exactly these tests while every fixture test
+stays green.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skill_script_helpers import load_skill_script
+
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.dashboard.chat_utils import _history_key_for
+from kiro_crew.dashboard.handlers import usage as usage_mod
+from kiro_crew.history import ConversationLog
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "pipeline-conductor"
+)
+
+
+def _probe(tmp_path: Path, monkeypatch, sessions: list[str]):
+    """The fleet-probe module plus a config, with the script's derived paths
+    (``$KIROCREW_HOME/sessions``, the ``/proc`` seam) pointed into the tmp
+    tree -- same harness shape as ``test_pipeline_conductor_agent``."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "crew"))
+    monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(tmp_path / "no-proc"))
+    cfg_path = tmp_path / "probe-config.json"
+    cfg_path.write_text(json.dumps({"sessions": sessions}), encoding="utf-8")
+    mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+    return mod, cfg_path
+
+
+class TestTranscriptShapeRoundTrip:
+    def test_probe_classifies_what_conversation_log_wrote(self, tmp_path, capsys, monkeypatch):
+        """Format 1: the JSONL entry shape.
+
+        ``fleet_probe._classify`` walks entries for ``role``/``content`` and
+        tags the last assistant line. Here those entries come from the real
+        writer -- ``ConversationLog.append`` into the same
+        ``<data home>/sessions`` directory the probe derives -- so a change to
+        the persisted entry shape (field names, content encoding, the
+        metadata header line) surfaces as a misclassification here.
+        """
+        mod, cfg = _probe(tmp_path, monkeypatch, ["s-real-writer"])
+        log = ConversationLog(base_dir=tmp_path / "crew" / "sessions")
+        log.append("s-real-writer", "user", "seed")
+        log.append("s-real-writer", "assistant", "GREEN: PR #12 head abc123")
+        assert mod.main(["--config", str(cfg)]) == 0
+        out = capsys.readouterr().out
+        assert "s-real-writer" in out and "GREEN" in out
+        assert "GONE" not in out
+        assert "OK 1 watched, 1 fired" in out
+
+
+class TestFilenamePrefixRoundTrip:
+    def test_raw_slot_key_finds_the_transcript_the_dashboard_writes(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Format 2: the ``dashboard_`` filename prefix.
+
+        The conductor watches raw slot keys while the store prefixes the
+        surface. Derive the on-disk name the way production does -- the slot
+        key through ``_history_key_for`` (``dashboard:<slot>``), folded to a
+        filename stem by ``ConversationLog``'s own ``_safe_key`` -- and the
+        probe, given only the RAW slot key, must still find and classify the
+        transcript. A false GONE here is the reclaim-and-double-dispatch
+        failure mode, so the assertion is spelled both ways.
+        """
+        slot = "chat-7-1756700000"
+        mod, cfg = _probe(tmp_path, monkeypatch, [slot])
+        log = ConversationLog(base_dir=tmp_path / "crew" / "sessions")
+        history_key = _history_key_for(slot)
+        log.append(history_key, "user", "seed")
+        log.append(history_key, "assistant", "GREEN: PR #12 head abc123")
+        assert mod.main(["--config", str(cfg)]) == 0
+        out = capsys.readouterr().out
+        assert "GONE" not in out, "raw slot key must not read as a missing session"
+        assert slot in out and "GREEN" in out
+
+
+class TestUsageShardRoundTrip:
+    class _Event:
+        """Event double carrying a REAL ``TurnUsage`` -- the shape
+        ``_build_token_record`` reads its billing dimensions from."""
+
+        def __init__(self, usage: TurnUsage) -> None:
+            self.usage = usage
+
+    def test_credit_spend_sums_what_the_recorder_wrote(self, tmp_path, capsys, monkeypatch):
+        """Format 3: the token-row schema.
+
+        Rows come from the real recorder (``persist_token_record`` ->
+        ``_build_token_record`` -> ``_write_token_record``), so a renamed
+        field, a changed ``_type``, or the per-row ``turns: 0`` contract
+        changing all surface here. The turns assertion pins the row-counting
+        contract the script documents: production rows are per-turn with a
+        literal ``turns: 0`` field, so accepted rows ARE turns.
+        """
+        shard_dir = tmp_path / "tokens"
+        monkeypatch.setattr(usage_mod, "_TOKEN_USAGE_DIR", shard_dir)
+        slot = "chat-7-1756700000"
+        usage_mod.persist_token_record(slot, "model-x", self._Event(TurnUsage(credits=2.5)))
+        usage_mod.persist_token_record(slot, "model-x", self._Event(TurnUsage(credits=1.5)))
+        usage_mod.persist_token_record(
+            "other-slot", "model-x", self._Event(TurnUsage(credits=99.0))
+        )
+        mod = load_skill_script("credit_spend", SKILL_DIR / "scripts" / "credit_spend.py")
+        rc = mod.main(["--slots", slot, "--budget", "100", "--usage-dir", str(shard_dir)])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["slots"][slot]["credits"] == 4.0
+        assert out["slots"][slot]["turns"] == 2  # two recorded turns = two rows
+        assert "unmetered" not in out["slots"][slot]
+        assert out["truncated"] is False
+        assert out["verdict"] == "within"
+
+    def test_a_slot_the_recorder_never_wrote_is_unmetered(self, tmp_path, capsys, monkeypatch):
+        """Negative half of the same contract: real shards on disk, a watched
+        slot with no recorded row -- the verdict must be ``unmetered``, never
+        a silent zero-spend ``within``."""
+        shard_dir = tmp_path / "tokens"
+        monkeypatch.setattr(usage_mod, "_TOKEN_USAGE_DIR", shard_dir)
+        usage_mod.persist_token_record("other-slot", "model-x", self._Event(TurnUsage(credits=1.0)))
+        mod = load_skill_script("credit_spend", SKILL_DIR / "scripts" / "credit_spend.py")
+        rc = mod.main(["--slots", "never-ran", "--budget", "100", "--usage-dir", str(shard_dir)])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["verdict"] == "unmetered"


### PR DESCRIPTION
Fixes #7513

## Symptom

PR #7238 introduced `derived_agent_permissions` (in `src/kiro_crew/agent_sdk/drivers/acp.py`) as the shared spelling of the KAS derive-plus-fallback, but migrated only one of the three call sites. The other two still spelled the same derive inline, so the `{"rules": []}` fallback existed in three byte-identical copies — a future divergence between them would have been invisible to any behavioural test. Separately, the two pipeline-conductor probe scripts re-implement readers for three on-disk formats this package itself writes, and their tests used hand-authored fixtures, which cannot detect the owning writer changing its format. The conductor's reclaim decision runs off that classification, so the live failure mode is a running session read as GONE and its work item dispatched twice.

Note: every line number in the issue body had drifted; sites below are located by symbol at main `1d705a03f`. The issue calls site A `_write_agent_permissions` — the enclosing function on main is `_seed_kas_permissions` (its corrected location matches the issue's described site).

## Root cause

- Site A: `_seed_kas_permissions` (`src/kiro_crew/agent.py`, import was at `:3285`, fallback at `:3292`) — inline `allowed_tools_to_permissions` + `{"rules": []}` fallback.
- Site B: `_install_conductor_agent`, the goal-conductor installer (import was at `:5153`, fallback at `:5160`) — same inline spelling.
- Both inline fallbacks were byte-identical to what the wrapper does, which is precisely why the duplication was invisible behaviourally.
- The probe scripts (`fleet_probe.py`, `credit_spend.py`) read the session-transcript JSONL shape, the `dashboard_` session-filename prefix, and the usage-shard token-row schema with re-implemented readers; only hand-authored fixtures covered them.

## Fix

**Item 1 (mechanical migration).** Replaced both inline derive-plus-fallback sites with a call to the existing `derived_agent_permissions` wrapper, following the in-tree precedent already at `_install_pipeline_conductor_agent` (`agent.py:5370`, the site #7238 migrated). Pure substitution at both sites — argument values and fallback are identical.

One real difference surfaced by the migration (reported, not papered over): the wrapper's `allowed_tools: list` annotation was narrower than the derive it wraps, whose parameter is `Any` with fail-closed validation (a non-list — including the absent-key `None` site A reads via `config.get("allowedTools")` — yields no policy, and the wrapper then supplies `{"rules": []}`). mypy rejected the pure substitution at site A on that annotation alone. Widened the wrapper's annotation to `object` to match the domain of the function it wraps; runtime behaviour is untouched (the derive owns validation, per its `TestUnclassifiableEntriesFailClosed` / non-list tests).

**Boundary baseline.** The migration removes `agent.py`'s last two direct `kiro_crew.acp` imports — the boundary checker counted exactly 2 edges for `agent.py`, and both were these imports. The count drops to a provable floor of 0, and the shrink-only gate itself mandates the prune for a touched file whose count shrank (`--update-baseline`, which only lowers/deletes). The `agent.py` line is therefore removed from `.github/agent-sdk-boundary-baseline.txt`. No open PR modifies that entry (PR #7325 adds a different file's line; disjoint hunks).

**Item 2 (round-trip contract tests).** New `test/test_pipeline_conductor_probe_roundtrip.py` drives the REAL writer for each format and lets the script (loaded via `load_skill_script`) classify the output:

1. transcript JSONL entry shape — written by `ConversationLog.append` into the same `<data home>/sessions` directory the probe derives;
2. `dashboard_` filename prefix — the slot key through the real derivation chain (`chat_utils._history_key_for` → `history._safe_key` via `ConversationLog`), probe given only the RAW slot key must not read GONE;
3. usage-shard token-row schema — rows written by `persist_token_record` → `_build_token_record` → `_write_token_record` with a real `TurnUsage`, summed by `credit_spend`; includes the rows-are-turns contract and the negative (`unmetered`) half.

All three real writers were drivable in-process, so no format needed a hand-rolled substitute. The scripts themselves are untouched — their subprocess-free design survives.

**Item-1 guard.** New `test/test_derived_agent_permissions_consumers.py`: a textual guard that the inline fallback spelling does not re-grow outside the boundary (`kiro_crew/acp/` and the `agent_sdk` driver). The IMPORT half of the invariant is held by the live CI boundary gate: after this PR's baseline prune, `scripts/check_agent_sdk_boundary.py` reds any re-grown `kiro_crew.acp.kas_permissions` import in application code, including dynamic-import spellings a second scanner would miss.

## Verification

- **Red before green (item 1):** the guard was born red against unmodified main, naming `src/kiro_crew/agent.py` as the only offender (after exempting `acp/kas_agents.py`, package-internal use inside the boundary). Green after the migration.
- **Mutant (a), re-verified after the review-driven guard subtraction:** restoring one inline fallback in `agent.py` reds BOTH the surviving textual guard AND `scripts/check_agent_sdk_boundary.py` (`agent.py:3291` flagged; the baseline no longer lists the file). Restore → both green.
- **Red against drifted writers (item 2):** each round-trip test was mutation-verified against a deliberately drifted writer, and in every case the sibling hand-fixture tests STAYED GREEN — demonstrating the exact gap being closed:
  - transcript `content` field renamed in `ConversationLog.append` → round-trip red, `TestFleetProbe` fixtures green;
  - `_history_key_for` prefix changed `dashboard:` → `dash:` → round-trip red (false GONE), fixtures green;
  - token row `_type` renamed in `_build_token_record` → round-trip red, `TestCreditSpend` fixtures green.
- **Mutants killed (both directions recorded):**
  - (a) restore one inline fallback at site A → guard tests red; restore fix → green.
  - (b) wrapper fallback `{"rules": []}` → `None` → behavioural tests red at BOTH migrated sites (`test_kas_permissions.py::TestTheDiskWriter` for site A, `test_conductor_agent.py::TestConductorInstaller::test_a_fully_governed_host_still_emits_the_permissions_key` for site B) — the divergence the issue said was invisible is now visible at every consumer at once; restore → green.
- Focused suites: `test_derived_agent_permissions_consumers.py`, `test_pipeline_conductor_probe_roundtrip.py`, `test_kas_permissions.py`, `test_conductor_agent.py`, `test_pipeline_conductor_agent.py` — 145/145 pass.
- `mypy src/kiro_crew`: no issues in 1237 files. black/isort/flake8 gates clean.
- `scripts/local-gate.py --base origin/main`: backend (full) `-n auto --dist loadgroup` — 225 failed, 78615 passed, 376 skipped, 5 xfailed, 2 errors. The failure set is this host's known environmental baseline (sandbox userns EPERM, AF_UNIX path-length, host-budget/xdist assumptions), proven below.
- **Zero-regression proof:** full backend suite on this branch vs a `git worktree` at `origin/main` (`1d705a03f`), sorted failing-test id sets diffed both directions: branch 227 failing ids vs origin/main worktree 227 failing ids; `comm -23` = 0 lines, `comm -13` = 0 lines — the sets are byte-identical in both directions (main run: 225 failed, 78607 passed, 2 errors in 510s).

<!-- no-visual-delta --> No frontend surface is touched; there is no visual delta to screenshot. Evidence is the test/gate output above.

## Review-driven changes

- **First Principles (advisory CONCERNS) — subtraction ADOPTED:** deleted `test_no_application_code_imports_the_raw_derive`. The lane is right that after the baseline prune the CI boundary gate (`ci.yml`, `scripts/check_agent_sdk_boundary.py`) permanently holds the import half of the invariant — AST-scanning the same tree, catching dynamic-import spellings the deleted test could not, and redding `agent.py` on any re-grown import. Two scanners for one symbol drift, and the weaker one loses. The textual fallback-spelling guard (the half nothing else covers) stays and still kills mutant (a); the gate's coverage of the import half was verified empirically, not assumed (see mutant (a) above). This also resolves the lane's Watch item.
