### PR TITLE
fix(cli): verify gateway-restart outcome instead of assuming success

### DIFF
--- a/skills/gateway-restart/SKILL.md
+++ b/skills/gateway-restart/SKILL.md
@@ -28,15 +28,18 @@ nohup /path/to/skills/gateway-restart/do-restart.sh >/dev/null 2>&1 & disown
 
 The script sleeps 10 seconds (giving the session time to respond), then invokes the restart. Because it's a detached process reparented to PID 1, it survives the gateway's death and executes reliably.
 
+Both scripts **record the outcome** instead of discarding it: the restart's exit status is written to a status file under `<crew home>/logs/` and its output goes to a **log correlated with that attempt** — `<status file>.log` when an attempt-specific status file is passed, the shared `logs/restart.log` for a lone unscheduled run (crew home is `$KIROCREW_HOME`, default `~/.kiro/crew`; both scripts derive their paths from it, so never pass hardcoded `%USERPROFILE%` paths). The status file is **attempt-specific** when the scheduler passes one — `KIROCREW_RESTART_STATUS_FILE` (Linux/macOS) or `-StatusFile` (Windows), see step 3 — so overlapping restart attempts cannot overwrite each other's verdict or quote each other's diagnostics; without it the shared default `logs/restart-status` is used. The file is removed when the attempt starts, so while it is absent the attempt is pending; once present it names that attempt's exit status. The CLI restart verb itself verifies the replacement gateway is serving and exits non-zero when it is not — the status file is how that verdict reaches the resumed session (see "Verify the outcome" below).
+
 **Windows:**
 
 ```powershell
 $kiroBin = (Get-Command kirocrew).Source
-$logFile = Join-Path $env:USERPROFILE ".kiro\crew\logs\restart.log"
-Start-Process -WindowStyle Hidden powershell -ArgumentList "-ExecutionPolicy", "Bypass", "-File", "`"<path>\do-restart.ps1`"", "-KirocrewBin", "`"$kiroBin`"", "-LogFile", "`"$logFile`""
+Start-Process -WindowStyle Hidden powershell -ArgumentList "-ExecutionPolicy", "Bypass", "-File", "`"<path>\do-restart.ps1`"", "-KirocrewBin", "`"$kiroBin`""
 ```
 
-The PowerShell script (`do-restart.ps1`) accepts `-KirocrewBin` (the resolved absolute path to `kirocrew.exe`) and `-LogFile` (optional, for diagnosing silent failures). It sleeps 10 seconds, then calls the binary. `Start-Process -WindowStyle Hidden` creates a detached process that survives the gateway's death. Unlike Unix, Windows has no `nohup`/`disown` — `Start-Process` with `-WindowStyle Hidden` is the equivalent pattern for fire-and-forget background work.
+This overview form omits `-StatusFile`, so the shared default `logs/restart-status` is used — fine for a lone attempt. The **runnable scheduled form is step 3 below**, which defines an attempt-specific `$statusFile` first and passes it; never pass `-StatusFile` without defining the variable, since an empty value silently collapses both artifacts onto the shared default and loses per-attempt isolation.
+
+The PowerShell script (`do-restart.ps1`) accepts `-KirocrewBin` (the resolved absolute path to `kirocrew.exe`) and `-StatusFile` (the attempt-specific verdict path from step 3). The attempt log is always `<status file>.log` — not caller-settable. **Attempt paths are confined:** both scripts only accept a status file of the form `<crew home>/logs/restart-status.<suffix>` (no slashes or `..` in the suffix); anything else falls back to the shared default, because the detached helper runs outside any agent sandbox and must never delete or overwrite a caller-chosen file. It sleeps 10 seconds, then calls the binary. `Start-Process -WindowStyle Hidden` creates a detached process that survives the gateway's death. Unlike Unix, Windows has no `nohup`/`disown` — `Start-Process` with `-WindowStyle Hidden` is the equivalent pattern for fire-and-forget background work.
 
 > **Important:** Always resolve `kirocrew` to an absolute path at schedule time (before the detached process launches). A hidden process may not inherit the same PATH as the agent session — this is the documented Windows reality. If resolution fails, the script falls back to PATH lookup and then to `python -m kiro_crew.cli restart` via the venv Python. All path arguments passed to `Start-Process -ArgumentList` must be wrapped in escaped quotes (`` `"..`" ``) to handle paths containing spaces (e.g. `C:\Users\John Smith\...`).
 
@@ -50,7 +53,7 @@ cron_add(
     delay=60,
     channel="<channel_id>",
     thread_ts="<thread_ts>",
-    message="Gateway restarted successfully. [Describe pending work if any]. Remove the job named 'restart-resume-slow'.",
+    message="A gateway restart was scheduled ~60s ago. Attempt status file: <status_file>. Pre-restart gateway pid: <pid>. VERIFY per the gateway-restart skill's 'Verify the outcome' step before telling the user anything. [Describe pending work if any]. If the status file holds a verdict (0 or non-zero), remove the job named 'restart-resume-slow'; if the status file is ABSENT, keep that job — it is the later verifier.",
 )
 
 cron_add(
@@ -58,14 +61,14 @@ cron_add(
     delay=300,
     channel="<channel_id>",
     thread_ts="<thread_ts>",
-    message="Gateway restarted (slow path). [Describe pending work if any].",
+    message="A gateway restart was scheduled ~5 min ago (slow path). Attempt status file: <status_file>. Pre-restart gateway pid: <pid>. VERIFY per the gateway-restart skill's 'Verify the outcome' step, including its absent-status handling. [Describe pending work if any]. Remove the job named 'restart-resume-slow' if it still exists.",
 )
 ```
 
 - **Fast (60s):** Fires once the gateway has restarted and initialized (~15s restart + buffer). Its message includes an instruction to delete the slow backup job.
 - **Slow (5 min):** Backup in case startup takes longer than expected.
 - **Thread targeting:** Both MUST include `channel` and `thread_ts` so the resume appears in the original conversation.
-- **Clean exit:** The resume cron should always acknowledge the restart ("Back online."). If there's pending work, continue it. If not, acknowledge and end the session promptly to avoid stale "Cron: restart-resume-*" sessions in the dashboard.
+- **Verify, then report:** The resumed session's FIRST job is the "Verify the outcome" step below. Only after the status file reads `0` may it say "Back online." — a resume cron firing proves nothing about the restart (the gateway it woke up in may be the same process that was supposed to die). If there's pending work, continue it after verifying. If not, acknowledge and end the session promptly to avoid stale "Cron: restart-resume-*" sessions in the dashboard.
 
 ## Procedure
 
@@ -86,11 +89,27 @@ Always schedule both fast and slow resume jobs with the current channel and thre
 
 ### 3. Schedule the restart
 
-Launch the bundled script as a detached process:
+**First, prepare the attempt's identity — both values go into the resume-job messages (step 2 and step 3 interleave: pick these BEFORE scheduling the resume jobs so the messages can carry them):**
+
+1. **An attempt-specific status file**, so overlapping attempts cannot overwrite each other's verdict and a failed LAUNCH cannot be read against a stale verdict (the file for THIS attempt simply never appears):
+   ```bash
+   STATUS_FILE="${KIROCREW_HOME:-$HOME/.kiro/crew}/logs/restart-status.$(date +%s).$$"
+   ```
+   ```powershell
+   $crewHome = if ($env:KIROCREW_HOME) { $env:KIROCREW_HOME } else { Join-Path $env:USERPROFILE ".kiro\crew" }
+   $statusFile = Join-Path $crewHome ("logs\restart-status." + [DateTimeOffset]::Now.ToUnixTimeSeconds() + "." + $PID)
+   ```
+2. **The current gateway pid**, recorded now so the resumed session can tell a new gateway from the old one without reading any fenced path (the crew home's `run/` dir is agent-fenced — never instruct a resumed session to read it). Use the gateway pid reported by `kirocrew status` as the primary source. If it is unavailable, fall back to a process listing whose pattern cannot match its own invoking shell and covers both install shapes (the `kirocrew` binary and an editable install's `python -m kiro_crew gateway`):
+   ```bash
+   pgrep -f "kiro_?crew[ ]gateway" | head -1   # brackets prevent self-match; covers kirocrew + kiro_crew
+   ```
+   A bare `pgrep -f "kirocrew gateway"` self-matches the shell running it and misses editable installs entirely — two transient wrapper-shell pids then "differ" across the restart and fake a pid-changed signal.
+
+Then launch the bundled script as a detached process, passing the attempt's status file:
 
 **Linux / macOS:**
 ```bash
-nohup /path/to/skills/gateway-restart/do-restart.sh >/dev/null 2>&1 & disown
+KIROCREW_RESTART_STATUS_FILE="$STATUS_FILE" nohup /path/to/skills/gateway-restart/do-restart.sh >/dev/null 2>&1 & disown
 ```
 
 **Windows:**
@@ -98,8 +117,7 @@ nohup /path/to/skills/gateway-restart/do-restart.sh >/dev/null 2>&1 & disown
 $kiroBin = (Get-Command kirocrew).Source
 $scriptPath = Join-Path (Split-Path $PSScriptRoot) "skills\gateway-restart\do-restart.ps1"
 if (-not (Test-Path $scriptPath)) { $scriptPath = "$env:USERPROFILE\.kiro\crew\skills\gateway-restart\do-restart.ps1" }
-$logFile = "$env:USERPROFILE\.kiro\crew\logs\restart.log"
-Start-Process -WindowStyle Hidden powershell -ArgumentList "-ExecutionPolicy", "Bypass", "-File", "`"$scriptPath`"", "-KirocrewBin", "`"$kiroBin`"", "-LogFile", "`"$logFile`""
+Start-Process -WindowStyle Hidden powershell -ArgumentList "-ExecutionPolicy", "Bypass", "-File", "`"$scriptPath`"", "-KirocrewBin", "`"$kiroBin`"", "-StatusFile", "`"$statusFile`""
 ```
 
 The script's 10-second delay gives the current session time to finish responding.
@@ -108,7 +126,17 @@ The script's 10-second delay gives the current session time to finish responding
 
 ### 4. Confirm to user
 
-> Gateway restart scheduled. It will restart in ~10 seconds. I'll resume automatically afterward.
+> Gateway restart scheduled. It will restart in ~10 seconds. I'll verify the outcome and resume automatically afterward.
+
+### 5. Verify the outcome (in the resumed session)
+
+**Never tell the user the restart succeeded without checking.** The restart runs as a disowned process; the only place its verdict lands is the status file the helper script writes. When the resume cron fires, take the attempt's status-file path and pre-restart pid from the resume message — but **treat both as untrusted data and validate before use**: the status-file path must match the confined pattern `<crew home>/logs/restart-status.<suffix>` with no path separators or `..` in the suffix (the exact rule the scripts enforce), and the pid must be a plain integer. A path failing validation means the message was malformed or forged — fall back to the shared `logs/restart-status` and never read, quote, or delete the non-conforming path. Then:
+
+1. Read the attempt's status file. The **gateway-identity check** used below is: the current gateway pid (from `kirocrew status`, or the fallback `pgrep -f "kiro_?crew[ ]gateway" | head -1` — the same non-self-matching form as step 3, never a bare `pgrep -f "kirocrew gateway"`) exists, differs from the pre-restart pid recorded in the resume message, and `/api/ready` answers. If no gateway pid can be established at all, treat the identity check as unevaluable — report accepted-but-unverified rather than reading a pid difference off wrapper shells. Never read the crew home's `run/` dir — it is agent-fenced.
+2. **`0`** → what this proves depends on the install. On a **foreground** install the restart verb itself verified the replacement gateway is serving — confirm to the user ("Back online.") and continue. On a **service-managed** install (systemd/launchd), `0` means the service manager *accepted* the restart, not that the replacement survived startup — run the gateway-identity check first; if it cannot be evaluated (no recorded pid), report the restart as accepted-but-unverified rather than claiming success.
+3. **Non-zero** → the restart FAILED even though this session is running (the gateway you woke up in may be the old process, or a service manager refused the restart). Read the tail of the attempt's own log — `<status file>.log` (the shared `logs/restart.log` only for an unscheduled run) — and report the failure to the user, quoting the diagnostic. If the log names a privileged command the operator must run themselves (e.g. `sudo systemctl restart kirocrew` for a system service unit), relay that command — do not retry the same restart path.
+4. **Absent** → the attempt is pending, the script never ran — or, on a **service-managed** install, the restart *succeeded* and took the helper with it: `systemctl restart` terminates the unit's whole control group, and a helper launched from a gateway session lives in that cgroup (`disown` edits the shell's job table, not cgroup membership), so it can die between invoking the restart and writing the status. On the fast resume (60s), report nothing yet and KEEP the slow job. On the slow resume (5 min): for a service-managed install, treat absence as inconclusive and decide from the gateway-identity check (pid changed + `/api/ready` answering = restarted; unchanged pid = it never happened); for a foreground install, an absent status means the restart never completed — report that as a failure and point the user at the attempt's log (`<status file>.log`).
+5. **Clean up:** after reading a verdict, delete the attempt's status file and its `.log` — only ever the path that passed the confinement validation above — so they cannot be mistaken for a later attempt's outcome.
 
 ## When to Restart
 
@@ -152,6 +180,7 @@ Save the user's answer as a lesson so the auto-update cron knows whether to rest
 
 ## Common Mistakes
 
+- **Reporting success without reading the status file** — a resume cron firing only proves a gateway is running, not that it is a NEW one. On a host where the restart silently fails (e.g. a root-owned system unit the service manager refuses to restart for an unprivileged caller), the original process keeps serving and an unverified "restarted successfully" is a lie the user acts on. Always run the "Verify the outcome" step.
 - **Forgetting resume jobs** — the restart completes but nobody resumes the conversation. Always schedule both fast and slow.
 - **Forgetting `channel` and `thread_ts`** — resume fires as a disconnected DM instead of replying in the original thread.
 - **Not cleaning up the slow job** — the fast resume message MUST instruct the agent to remove `restart-resume-slow`.

--- a/skills/gateway-restart/do-restart.ps1
+++ b/skills/gateway-restart/do-restart.ps1
@@ -2,11 +2,66 @@
 # The sleep gives the calling session time to finish responding.
 # Usage (from agent):
 #   Start-Process -WindowStyle Hidden powershell -ArgumentList "-ExecutionPolicy", "Bypass", "-File", "<path>\do-restart.ps1", "-KirocrewBin", "<resolved-path-to-kirocrew.exe>"
+#
+# The restart's exit status is recorded to <crew home>\logs\restart-status —
+# the same file the POSIX do-restart.sh writes — so the calling agent can
+# verify the outcome on its next turn instead of assuming success (see
+# SKILL.md "Verify the outcome"). While the file is absent an attempt is
+# pending; once present it names the exit status of the most recent attempt.
 param(
     [string]$KirocrewBin = "kirocrew",
     [int]$DelaySec = 10,
-    [string]$LogFile = ""
+    [string]$StatusFile = ""
 )
+
+$crewHome = if ($env:KIROCREW_HOME) { $env:KIROCREW_HOME } else { Join-Path $env:USERPROFILE ".kiro\crew" }
+$logDir = Join-Path $crewHome "logs"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+# Attempt-specific when the scheduler passes one (SKILL.md step 3 generates a
+# per-attempt path), so overlapping restart attempts cannot overwrite each
+# other's verdict; the shared default serves a lone attempt.
+# CONFINEMENT INVARIANT: every attempt artifact lives inside $logDir under the
+# restart-status. prefix, with no nested path and no traversal. This script
+# runs detached from any agent sandbox, so an unvalidated caller-supplied path
+# would let it delete and overwrite arbitrary user files; a non-conforming
+# path falls back to the shared default instead.
+$attemptSpecific = $false
+$defaultStatus = Join-Path $logDir "restart-status"
+if ($StatusFile) {
+    $prefix = "$defaultStatus."
+    if ($StatusFile.StartsWith($prefix)) {
+        $suffix = $StatusFile.Substring($prefix.Length)
+        if ($suffix -and $suffix -notmatch '[\\/]' -and $suffix -notmatch '\.\.') {
+            $attemptSpecific = $true
+        }
+    }
+}
+if (-not $attemptSpecific) { $StatusFile = $defaultStatus }
+# Artifact writes never follow links: each artifact is removed and re-created
+# with FileMode.CreateNew, which fails on anything left or re-planted at the
+# path instead of writing through it, and content goes through the held
+# stream. A failed exclusive create drops the artifact rather than writing
+# through a link.
+function Write-ArtifactExclusive([string]$Path, [string]$Content) {
+    Remove-Item -Force -ErrorAction SilentlyContinue $Path
+    try {
+        $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::CreateNew)
+        try {
+            $writer = New-Object System.IO.StreamWriter($fs, [System.Text.Encoding]::UTF8)
+            $writer.WriteLine($Content)
+            $writer.Flush()
+            $writer.Dispose()
+        } finally { if (-not $fs.SafeFileHandle.IsClosed) { $fs.Dispose() } }
+        return $true
+    } catch { return $false }
+}
+
+Remove-Item -Force -ErrorAction SilentlyContinue $StatusFile
+# The diagnostic log is correlated with the attempt the same way: derived from
+# the (validated) attempt status file, so a failed attempt's verifier never
+# quotes another attempt's output or remedy out of a shared log. A lone
+# unscheduled run keeps the shared restart.log.
+$LogFile = if ($attemptSpecific) { "$StatusFile.log" } else { Join-Path $logDir "restart.log" }
 
 Start-Sleep -Seconds $DelaySec
 
@@ -18,16 +73,32 @@ if ($KirocrewBin -ne "kirocrew" -and (Test-Path $KirocrewBin)) {
     if ($found) { $bin = $found.Source } else { $bin = $KirocrewBin }
 }
 
-# Execute the restart, capturing any errors.
+# Execute the restart, capturing any errors. $status must reflect what the
+# restart verb reported: it exits non-zero when the replacement gateway never
+# became ready, and that verdict is the whole point of the status file.
+# The log write happens OUTSIDE the try: a failed write must not land in the
+# catch and trigger the fallback, which would restart a second time.
+$status = 1
+$logLine = ""
 try {
     $output = & $bin restart 2>&1
-    if ($LogFile) { "$(Get-Date -Format o) OK: $output" | Out-File -Append -Encoding utf8 $LogFile }
+    $status = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 0 }
+    # The restart verb prints a fresh dashboard token URL on success; the
+    # skill tells the resumed agent to quote this log, so redact the bearer.
+    $redacted = "$output" -replace '([?&]token=)\S+', '$1REDACTED'
+    $logLine = "$(Get-Date -Format o) exit=${status}: $redacted"
 } catch {
     $err = $_.Exception.Message
-    if ($LogFile) { "$(Get-Date -Format o) FAIL: $err" | Out-File -Append -Encoding utf8 $LogFile }
+    $logLine = "$(Get-Date -Format o) FAIL: $err"
     # Last resort: try via python module
     $venvPython = Join-Path (Split-Path (Split-Path $bin)) "python.exe"
     if (Test-Path $venvPython) {
         & $venvPython -m kiro_crew.cli restart 2>&1 | Out-Null
+        $status = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 }
     }
 }
+if ($LogFile -and $logLine) {
+    Write-ArtifactExclusive $LogFile $logLine | Out-Null
+}
+Write-ArtifactExclusive $StatusFile $status | Out-Null
+exit $status

--- a/skills/gateway-restart/do-restart.sh
+++ b/skills/gateway-restart/do-restart.sh
@@ -1,5 +1,75 @@
 #!/bin/bash
 # Delayed gateway restart — run as a disowned process.
 # The sleep gives the calling session time to finish responding.
-sleep 10
-exec kirocrew restart
+#
+# The CLI restart verb verifies the replacement gateway is serving and exits
+# non-zero when it is not — but a disowned process discards both its output
+# and its exit status. Record them instead: output appends to restart.log and
+# the exit status lands in restart-status, both under the crew logs dir, so
+# the calling agent can verify the outcome on its next turn (see SKILL.md
+# "Verify the outcome").
+LOG_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/logs"
+# Attempt-specific when the scheduler passes one (SKILL.md step 3 generates a
+# per-attempt path), so overlapping restart attempts cannot overwrite each
+# other's verdict; the shared default serves a lone attempt.
+#
+# CONFINEMENT INVARIANT: every attempt artifact lives inside $LOG_DIR under
+# the restart-status. prefix, with no nested path and no traversal. This
+# script runs detached from any agent sandbox, so an unvalidated caller-
+# supplied path would let it delete and overwrite arbitrary user files; a
+# non-conforming path falls back to the shared default instead.
+STATUS_FILE="$LOG_DIR/restart-status"
+if [ -n "${KIROCREW_RESTART_STATUS_FILE:-}" ]; then
+  case "$KIROCREW_RESTART_STATUS_FILE" in
+    "$LOG_DIR"/restart-status.*)
+      suffix="${KIROCREW_RESTART_STATUS_FILE#"$LOG_DIR"/restart-status.}"
+      case "$suffix" in
+        */* | *..*) : ;;
+        *) STATUS_FILE="$KIROCREW_RESTART_STATUS_FILE" ;;
+      esac
+      ;;
+  esac
+fi
+# The diagnostic log is correlated with the attempt the same way: derived from
+# the (validated) attempt status file, so a failed attempt's verifier never
+# quotes another attempt's output or remedy out of a shared log.
+if [ "$STATUS_FILE" != "$LOG_DIR/restart-status" ]; then
+  LOG_FILE="$STATUS_FILE.log"
+else
+  LOG_FILE="$LOG_DIR/restart.log"
+fi
+# Artifact writes never follow links, and each artifact path is resolved
+# exactly ONCE: remove whatever sits at the path, then open it under
+# noclobber (O_EXCL) directly onto the descriptor the writes use. The single
+# open both refuses anything left or re-planted at the path and IS the write
+# handle, so there is no window between a validating create and a separate
+# reopen for a link swap to win. A failed exclusive open drops the artifact
+# rather than writing through a link.
+umask 077
+mkdir -p "$LOG_DIR"
+rm -f -- "$LOG_FILE"
+set -C
+{ exec 3>"$LOG_FILE"; } 2>/dev/null || exec 3>/dev/null
+set +C
+# Remove the previous outcome BEFORE the delay: while the file is absent a
+# restart attempt is pending; once it exists it names the exit status of the
+# most recent attempt. A stale success left in place would be read as this
+# attempt's verdict.
+rm -f -- "$STATUS_FILE"
+sleep "${KIROCREW_RESTART_DELAY:-10}"
+# The restart verb prints a fresh dashboard token URL on success; the skill
+# tells the resumed agent to quote this log into the conversation, so redact
+# the bearer token on the way in. PIPESTATUS keeps the restart's own exit
+# status — plain $? would report sed's.
+kirocrew restart 2>&1 | sed -E 's/([?&]token=)[^[:space:]]+/\1REDACTED/g' >&3
+status="${PIPESTATUS[0]}"
+# Same open-once discipline as the log: the exclusive open is the write
+# handle. A refused open (something re-planted at the path) drops the verdict.
+rm -f -- "$STATUS_FILE"
+set -C
+if { exec 4>"$STATUS_FILE"; } 2>/dev/null; then
+  printf '%s\n' "$status" >&4
+  exec 4>&-
+fi
+set +C
+exit "$status"

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -888,7 +888,12 @@ def _restart(cli_port: int | None = None) -> None:
 
     1. If a systemd/launchd service is active AND the caller did not
        explicitly request a specific port, ask the platform to restart
-       it (``systemctl restart`` / ``launchctl unload + load``).
+       it (``systemctl restart`` / ``launchctl kickstart -k``). When the
+       service manager REFUSES that restart while the unit is still active
+       (system-scope unit, unprivileged caller / polkit denial), fail loudly
+       naming the privileged command the operator must run — never fall
+       through to the listener path, which cannot see a service gateway
+       bound to a unix socket and would misreport the outcome.
     2. Otherwise, SIGTERM the foreground gateway via the existing
        lsof+SIGTERM path used by ``kirocrew stop``, then spawn a
        detached replacement and **verify it is serving** before reporting
@@ -902,17 +907,47 @@ def _restart(cli_port: int | None = None) -> None:
     short-circuiting through it would target the wrong gateway.
     """
     port = resolve_client_port(cli_port)
-    if cli_port is None and service_controller.restart_service():
-        sel().log_api_access(
-            caller="cli",
-            operation="gateway_restart",
-            outcome="allowed",
-            source="cli",
-            resources=f"port={port} via=service",
-        )
-        print("✅ Restarted kirocrew service.")
-        _print_token_url(port)
-        return
+    if cli_port is None:
+        if service_controller.restart_service():
+            sel().log_api_access(
+                caller="cli",
+                operation="gateway_restart",
+                outcome="allowed",
+                source="cli",
+                resources=f"port={port} via=service",
+            )
+            print("✅ Restarted kirocrew service.")
+            _print_token_url(port)
+            return
+        if service_controller.is_service_active():
+            # The service manager refused the restart while the unit is active
+            # RIGHT NOW — the system-scope unit needs root/polkit privileges
+            # this process does not have ("Interactive authentication
+            # required"). Falling through to the listener path would be worse
+            # than failing: on a unix-socket deployment nothing listens on TCP,
+            # so the fallback finds nothing to stop, spawns a competitor the
+            # KIROCREW_HOME lock refuses, and the original gateway keeps
+            # running while the command's outcome reads like a restart. Name
+            # the privileged command the operator must run instead. The
+            # active-check runs AFTER the refused restart so a service that
+            # merely stopped in between still falls through below.
+            hint = service_controller.manual_restart_hint()
+            sel().log_api_access(
+                caller="cli",
+                operation="gateway_restart",
+                outcome="denied",
+                source="cli",
+                resources=f"port={port} via=service reason=service_restart_denied",
+            )
+            print(
+                "❌ A kirocrew service is installed and running, but the service "
+                "manager refused to restart it.\n"
+                "   This process lacks the privileges the service's scope "
+                "requires — the gateway was NOT restarted.\n"
+                "   Run the restart yourself:\n"
+                f"       {hint}"
+            )
+            sys.exit(1)
 
     # No service active — bounce the foreground gateway and detach a fresh one.
     # Reuse _stop() for the SIGTERM path so behavior stays in sync if _stop

--- a/src/kiro_crew/service/controller.py
+++ b/src/kiro_crew/service/controller.py
@@ -8,11 +8,18 @@ directly. This keeps the dispatch logic in one place and makes the
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 from kiro_crew.service import linux, macos
-from kiro_crew.service.common import Platform, current_platform, headless_auth_warning
+from kiro_crew.service.common import (
+    LAUNCHD_LABEL,
+    Platform,
+    current_platform,
+    headless_auth_warning,
+    restart_command_hint,
+)
 
 
 def _print_headless_auth_warning() -> None:
@@ -280,3 +287,34 @@ def restart_service() -> bool:
             return macos.restart()
         return False
     return False
+
+
+def manual_restart_hint() -> str:
+    """Command an operator can run BY HAND to restart the installed service.
+
+    Printed when :func:`restart_service` was refused by the service manager —
+    a system-scope unit needs root/polkit privileges the calling process may
+    not have. Unlike :func:`kiro_crew.service.common.restart_command_hint`,
+    this must never answer ``kirocrew restart``: that is the command that just
+    failed, so a circular hint would send the operator straight back into the
+    same refusal.
+    """
+    plat = current_platform()
+    if plat == Platform.SYSTEMD:
+        # "sudo systemctl restart kirocrew" — shared with the update path and
+        # the Slack restart-failure hint so the string cannot drift.
+        return restart_command_hint()
+    if plat == Platform.LAUNCHD:
+        # NOT `launchctl kickstart` — that is the exact call macos.restart()
+        # just ran and got refused. Tearing the job down and bootstrapping it
+        # from the installed plist is the outside-process recovery; `;` rather
+        # than `&&` so a bootout refused because the job is not loaded still
+        # proceeds to the bootstrap.
+        uid = getattr(os, "getuid", lambda: -1)()
+        return (
+            f"launchctl bootout gui/{uid}/{LAUNCHD_LABEL}; "
+            f'launchctl bootstrap gui/{uid} "{macos.PLIST_PATH}"'
+        )
+    # No platform service manager exists here, so there is no service to have
+    # refused the restart; kept total for safety rather than reachability.
+    return "kirocrew gateway"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2350,6 +2350,19 @@ class TestRestart:
         return MagicMock(pid=pid, poll=MagicMock(return_value=None))
 
     @pytest.fixture(autouse=True)
+    def _no_active_service(self):
+        # The denied-service branch consults ``is_service_active()`` after a
+        # refused ``restart_service()``. The real implementation shells out to
+        # systemctl/launchctl, so an unmocked call would make these tests
+        # depend on whether the BUILD HOST runs a kirocrew service. Pin it
+        # False; the denied-branch tests override it per-test.
+        with patch(
+            "kiro_crew.cli_server.service_controller.is_service_active",
+            return_value=False,
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
     def _tool_available(self):
         # ``_restart`` enters ``_stop`` when the port-lookup tool is ABSENT
         # (find_listening_pids() returns [] both for "nothing listening" and
@@ -2385,6 +2398,80 @@ class TestRestart:
         # And must not poke at the port lookup (the supervisor owns the lifecycle).
         mock_ports.assert_not_called()
         assert "Restarted" in capsys.readouterr().out
+
+    def test_active_service_restart_denied_fails_loud_with_remedy(self, capsys):
+        # A system-scope unit refuses an unprivileged `systemctl restart`
+        # ("Interactive authentication required"), while the unit stays
+        # active. Falling through to the listener path is a silent no-op on a
+        # unix-socket deployment: nothing listens on TCP, so nothing is
+        # stopped, and the ORIGINAL gateway keeps running while the command
+        # reads like a restart. The command must instead fail loudly and name
+        # the privileged command the operator has to run themselves.
+        from kiro_crew import cli_server
+
+        mock_sel = MagicMock()
+
+        with (
+            patch("kiro_crew.cli_server.sel", return_value=mock_sel),
+            patch(
+                "kiro_crew.cli_server.service_controller.restart_service",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.cli_server.service_controller.is_service_active",
+                return_value=True,
+            ),
+            patch(
+                "kiro_crew.cli_server.service_controller.manual_restart_hint",
+                return_value="sudo systemctl restart kirocrew",
+            ),
+            patch("kiro_crew.cli_server.platform_compat.find_listening_pids") as mock_ports,
+            patch("kiro_crew.cli_server._stop") as mock_stop,
+            patch("kiro_crew.cli_server._spawn_detached_gateway") as mock_spawn,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                cli_server._restart(None)
+
+        assert exc.value.code == 1
+        # The listener fallback must never be entered: it cannot see a
+        # unix-socket service gateway and would spawn a doomed competitor.
+        mock_ports.assert_not_called()
+        mock_stop.assert_not_called()
+        mock_spawn.assert_not_called()
+        out = capsys.readouterr().out
+        assert "NOT restarted" in out
+        assert "sudo systemctl restart kirocrew" in out
+        audit = mock_sel.log_api_access.call_args.kwargs
+        assert audit["outcome"] == "denied"
+        assert "reason=service_restart_denied" in audit["resources"]
+
+    def test_inactive_service_still_falls_through_after_refused_restart(self):
+        # ``restart_service()`` returning False because NO service is active
+        # must keep taking the foreground path — the denied diagnostic is only
+        # for a unit that is active right now yet refused the restart.
+        from kiro_crew import cli_server
+
+        with (
+            self._mock_sel(),
+            patch(
+                "kiro_crew.cli_server.service_controller.restart_service",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.cli_server.service_controller.is_service_active",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.cli_server.platform_compat.find_listening_pids",
+                return_value=[],
+            ),
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(4321),
+            ) as mock_spawn,
+        ):
+            cli_server._restart(None)
+        mock_spawn.assert_called_once()
 
     def test_no_service_no_running_gateway_spawns_fresh(self, capsys):
         # Restart should be tolerant of a crashed gateway: if the user runs
@@ -2841,6 +2928,12 @@ class TestRestartReadinessVerdict:
             patch("kiro_crew.cli_server.sel", return_value=mock_sel),
             patch(
                 "kiro_crew.cli_server.service_controller.restart_service",
+                return_value=False,
+            ),
+            # Keep the denied-service branch out of these verdict tests (and
+            # keep them off the host's real systemctl/launchctl state).
+            patch(
+                "kiro_crew.cli_server.service_controller.is_service_active",
                 return_value=False,
             ),
             patch(

--- a/test/test_cli_restart_marker_fallback.py
+++ b/test/test_cli_restart_marker_fallback.py
@@ -134,6 +134,10 @@ def test_restart_refuses_spawn_after_blind_authenticated_shutdown(
             "kiro_crew.cli_server.service_controller.restart_service",
             return_value=False,
         ),
+        patch(
+            "kiro_crew.cli_server.service_controller.is_service_active",
+            return_value=False,
+        ),
         patch("kiro_crew.cli_server.run_marker.read_pid", return_value=marker_pid),
         patch(
             "kiro_crew.cli_server.platform_compat.find_listening_pids",

--- a/test/test_gateway_restart_status_file.py
+++ b/test/test_gateway_restart_status_file.py
@@ -1,0 +1,294 @@
+"""The gateway-restart helper script must record the restart's outcome.
+
+The script runs as a DISOWNED process: its stdout and exit status reach no
+terminal and no calling session. Before it recorded them to files, the CLI
+restart verb's loud non-zero verdict (replacement never served) was thrown
+away and the calling agent reported success unconditionally — on a host where
+the restart is a silent no-op (root-owned system unit, unix-socket listener)
+the original gateway kept running while the user was told it restarted.
+
+These tests drive the real script with a stubbed ``kirocrew`` on PATH and
+assert the contract the gateway-restart skill's "Verify the outcome" step
+reads: output appended to ``logs/restart.log``, the exit status written to
+``logs/restart-status``, and a stale status file removed while an attempt is
+pending.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "gateway-restart" / "do-restart.sh"
+PS_SCRIPT = REPO_ROOT / "skills" / "gateway-restart" / "do-restart.ps1"
+SKILL_DOC = REPO_ROOT / "skills" / "gateway-restart" / "SKILL.md"
+
+needs_bash = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="drives the POSIX helper script with bash",
+)
+
+
+def _run_script(
+    tmp_path: Path, exit_status: int, stub_body_extra: str = ""
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run do-restart.sh against a stub ``kirocrew`` that exits *exit_status*.
+
+    Returns the completed process and the crew home used. The stub prints a
+    recognizable line so the log-append assertion is about the RESTART's
+    output, not the script's own. ``cwd`` is pinned under ``tmp_path`` so a
+    misbehaving script cannot litter the checkout.
+    """
+    crew_home = tmp_path / "crew-home"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "kirocrew"
+    stub.write_text(
+        "#!/bin/bash\n"
+        f"{stub_body_extra}"
+        'echo "stub-restart-output $*"\n'
+        f"exit {exit_status}\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["KIROCREW_HOME"] = str(crew_home)
+    # Collapse the human-scale scheduling delay; the delay is not under test.
+    env["KIROCREW_RESTART_DELAY"] = "0"
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    return proc, crew_home
+
+
+@needs_bash
+def test_success_exit_status_is_recorded(tmp_path: Path) -> None:
+    proc, crew_home = _run_script(tmp_path, exit_status=0)
+    status_file = crew_home / "logs" / "restart-status"
+    assert proc.returncode == 0
+    assert status_file.read_text(encoding="utf-8").strip() == "0"
+    log = (crew_home / "logs" / "restart.log").read_text(encoding="utf-8")
+    assert "stub-restart-output restart" in log
+
+
+@needs_bash
+def test_failure_exit_status_is_recorded_not_discarded(tmp_path: Path) -> None:
+    # The core regression: the restart verb exiting non-zero (replacement
+    # never served) must land in the status file, and the script itself must
+    # propagate it — a disowned run previously discarded both.
+    proc, crew_home = _run_script(tmp_path, exit_status=7)
+    status_file = crew_home / "logs" / "restart-status"
+    assert proc.returncode == 7
+    assert status_file.read_text(encoding="utf-8").strip() == "7"
+
+
+@needs_bash
+def test_stale_status_is_removed_before_the_restart_runs(tmp_path: Path) -> None:
+    # A leftover "0" from a previous attempt must not be readable as THIS
+    # attempt's verdict: the script removes it up front, so during the pending
+    # window the file is absent. The stub proves the ordering by recording
+    # whether the status file still existed when the restart executed.
+    crew_home = tmp_path / "crew-home"
+    logs = crew_home / "logs"
+    logs.mkdir(parents=True)
+    (logs / "restart-status").write_text("0\n", encoding="utf-8")
+    marker = tmp_path / "seen"
+    probe = (
+        f'if [ -e "{logs / "restart-status"}" ]; then echo present > "{marker}"; '
+        f'else echo absent > "{marker}"; fi\n'
+    )
+    proc, crew_home = _run_script(tmp_path, exit_status=3, stub_body_extra=probe)
+    assert proc.returncode == 3
+    assert marker.read_text(encoding="utf-8").strip() == "absent"
+    assert (logs / "restart-status").read_text(encoding="utf-8").strip() == "3"
+
+
+@needs_bash
+def test_status_file_is_owner_only(tmp_path: Path) -> None:
+    # The log can carry gateway diagnostics (paths, ports); both files live
+    # under the crew home and are created owner-only via the script's umask.
+    _, crew_home = _run_script(tmp_path, exit_status=0)
+    for name in ("restart-status", "restart.log"):
+        mode = stat.S_IMODE((crew_home / "logs" / name).stat().st_mode)
+        assert mode == 0o600, f"{name} mode {oct(mode)}"
+
+
+@needs_bash
+def test_dashboard_token_urls_are_redacted_from_the_log(tmp_path: Path) -> None:
+    # The restart verb prints a fresh dashboard token URL on success, and the
+    # skill instructs the resumed agent to QUOTE this log into a conversation
+    # other humans can read — the bearer must not survive into the file. The
+    # restart's own exit status must also survive the redaction pipeline.
+    probe = 'echo "🔑 http://localhost:5476?token=SECRET123&x=1 and http://h/?a=1&token=T2"\n'
+    proc, crew_home = _run_script(tmp_path, exit_status=5, stub_body_extra=probe)
+    log = (crew_home / "logs" / "restart.log").read_text(encoding="utf-8")
+    assert "SECRET123" not in log
+    assert "token=REDACTED" in log
+    assert proc.returncode == 5
+    status = (crew_home / "logs" / "restart-status").read_text(encoding="utf-8").strip()
+    assert status == "5"
+
+
+@needs_bash
+def test_attempt_specific_status_file_override(tmp_path: Path) -> None:
+    # Overlapping restart attempts must not overwrite each other's verdict:
+    # when the scheduler passes KIROCREW_RESTART_STATUS_FILE, the verdict
+    # lands there and the shared default is left untouched.
+    crew_home = tmp_path / "crew-home"
+    attempt = crew_home / "logs" / "restart-status.1234.99"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    stub = bin_dir / "kirocrew"
+    stub.write_text("#!/bin/bash\nexit 4\n", encoding="utf-8")
+    stub.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["KIROCREW_HOME"] = str(crew_home)
+    env["KIROCREW_RESTART_DELAY"] = "0"
+    env["KIROCREW_RESTART_STATUS_FILE"] = str(attempt)
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    assert proc.returncode == 4
+    assert attempt.read_text(encoding="utf-8").strip() == "4"
+    assert not (crew_home / "logs" / "restart-status").exists()
+    # The diagnostic log is correlated with the attempt (status file + ".log"),
+    # so a failed attempt's verifier never quotes another attempt's output out
+    # of the shared restart.log.
+    assert (crew_home / "logs" / "restart-status.1234.99.log").exists()
+    assert not (crew_home / "logs" / "restart.log").exists()
+
+
+@needs_bash
+def test_nonconforming_status_paths_fall_back_to_the_shared_default(tmp_path: Path) -> None:
+    # The helper runs detached from any agent sandbox, so a caller-chosen
+    # status path would let it delete and overwrite arbitrary user files
+    # (e.g. ~/.bashrc). Every non-conforming override — outside the logs dir,
+    # nested, or traversal-carrying — must fall back to the shared default.
+    crew_home = tmp_path / "crew-home"
+    victim = tmp_path / "victim.txt"
+    victim.write_text("precious\n", encoding="utf-8")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    stub = bin_dir / "kirocrew"
+    stub.write_text("#!/bin/bash\nexit 0\n", encoding="utf-8")
+    stub.chmod(0o755)
+    logs = crew_home / "logs"
+    evil_paths = [
+        str(victim),
+        str(logs / "restart-status.a" / "b"),
+        str(logs / "restart-status...." / ".." / ".." / "victim.txt"),
+        str(logs / "restart-status...suffix"),
+        str(crew_home / "config.json"),
+    ]
+    for evil in evil_paths:
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+        env["KIROCREW_HOME"] = str(crew_home)
+        env["KIROCREW_RESTART_DELAY"] = "0"
+        env["KIROCREW_RESTART_STATUS_FILE"] = evil
+        proc = subprocess.run(
+            ["bash", str(SCRIPT)],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
+        )
+        assert proc.returncode == 0, evil
+        # The verdict landed in the confined shared default, and the
+        # caller-chosen target was never touched.
+        assert (logs / "restart-status").read_text(encoding="utf-8").strip() == "0", evil
+        (logs / "restart-status").unlink()
+    assert victim.read_text(encoding="utf-8") == "precious\n"
+    assert not (crew_home / "config.json").exists()
+
+
+@needs_bash
+def test_artifact_writes_refuse_planted_symlinks(tmp_path: Path) -> None:
+    # The helper's artifact writes must never follow a link planted at the
+    # predictable confined path: the write is rm + O_EXCL create, so a link
+    # (even re-planted) is refused and the target stays untouched.
+    crew_home = tmp_path / "crew-home"
+    logs = crew_home / "logs"
+    logs.mkdir(parents=True)
+    victim = tmp_path / "victim.txt"
+    victim.write_text("precious\n", encoding="utf-8")
+    attempt = logs / "restart-status.777.1"
+    # Plant links at BOTH artifact paths. rm -f removes the planted link
+    # itself; the exclusive create then produces a real file — the victim the
+    # links pointed at must never be written through.
+    attempt.symlink_to(victim)
+    (logs / "restart-status.777.1.log").symlink_to(victim)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "kirocrew"
+    stub.write_text("#!/bin/bash\necho probe-output\nexit 6\n", encoding="utf-8")
+    stub.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["KIROCREW_HOME"] = str(crew_home)
+    env["KIROCREW_RESTART_DELAY"] = "0"
+    env["KIROCREW_RESTART_STATUS_FILE"] = str(attempt)
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    assert proc.returncode == 6
+    assert victim.read_text(encoding="utf-8") == "precious\n"
+    assert not attempt.is_symlink() and attempt.read_text(encoding="utf-8").strip() == "6"
+    log = logs / "restart-status.777.1.log"
+    assert not log.is_symlink() and "probe-output" in log.read_text(encoding="utf-8")
+
+
+@needs_bash
+def test_artifact_opens_resolve_each_path_exactly_once() -> None:
+    # The round-4 hardening created each artifact with O_EXCL and then
+    # RE-OPENED it by path for the actual writes — two resolutions, and only
+    # the second (link-followable) one was held. The fix opens each artifact
+    # exactly once, under noclobber, directly onto the write descriptor. Pin
+    # the structure: every artifact fd open must be a plain '>' redirection
+    # (guarded by set -C), and no append-reopen of either artifact path may
+    # exist anywhere in the script.
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "exec 3>>" not in text, "log artifact reopened by path after its create"
+    assert '>>"$STATUS_FILE"' not in text, "status artifact reopened by path after its create"
+    assert '>>"$LOG_FILE"' not in text, "log artifact reopened by path after its create"
+    # The single opens exist and are noclobber-guarded (set -C precedes both).
+    assert 'exec 3>"$LOG_FILE"' in text
+    assert 'exec 4>"$STATUS_FILE"' in text
+    assert text.count("set -C") >= 2
+
+
+def test_both_platform_scripts_and_the_skill_agree_on_the_status_file() -> None:
+    # The skill's "Verify the outcome" step reads the file by name; a rename
+    # in one script (or the doc) would silently break verification on that
+    # platform. Pin the shared contract.
+    for path in (SCRIPT, PS_SCRIPT, SKILL_DOC):
+        assert "restart-status" in path.read_text(encoding="utf-8"), path.name

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1151,6 +1151,54 @@ class TestControllerDispatch:
         ):
             assert controller.restart_service() is False
 
+    def test_manual_restart_hint_systemd_names_sudo_systemctl(self):
+        # The hint is printed precisely when the CLI restart path just failed
+        # for privileges, so it must name the privileged command — never a
+        # circular "kirocrew restart".
+        from kiro_crew.service import controller
+
+        with patch(
+            "kiro_crew.service.controller.current_platform",
+            return_value=Platform.SYSTEMD,
+        ), patch(
+            "kiro_crew.service.common.current_platform",
+            return_value=Platform.SYSTEMD,
+        ):
+            hint = controller.manual_restart_hint()
+        assert hint == "sudo systemctl restart kirocrew"
+
+    def test_manual_restart_hint_launchd_names_a_recovery_pair(self):
+        # Not kickstart: macos.restart() already ran kickstart and it was
+        # refused, so the hint must be a different mechanism (bootout +
+        # bootstrap from the installed plist), not a retry of the failure.
+        from kiro_crew.service import controller
+        from kiro_crew.service import macos as svc_macos
+        from kiro_crew.service.common import LAUNCHD_LABEL
+
+        with patch(
+            "kiro_crew.service.controller.current_platform",
+            return_value=Platform.LAUNCHD,
+        ), patch("kiro_crew.service.controller.os.getuid", return_value=501, create=True):
+            hint = controller.manual_restart_hint()
+        assert "kickstart" not in hint
+        assert f"launchctl bootout gui/501/{LAUNCHD_LABEL}" in hint
+        assert f'launchctl bootstrap gui/501 "{svc_macos.PLIST_PATH}"' in hint
+
+    def test_manual_restart_hint_never_circular(self):
+        # Whatever the platform, the hint must not send the operator back into
+        # the command that just failed.
+        from kiro_crew.service import controller
+
+        for plat in (Platform.SYSTEMD, Platform.LAUNCHD, Platform.UNSUPPORTED):
+            with patch(
+                "kiro_crew.service.controller.current_platform",
+                return_value=plat,
+            ), patch(
+                "kiro_crew.service.common.current_platform",
+                return_value=plat,
+            ):
+                assert controller.manual_restart_hint() != "kirocrew restart"
+
     def test_install_systemd_handles_install_error(self, capsys):
         """If linux.install raises ServiceInstallError, controller catches it,
         prints to stderr, and returns 1 — not propagating the exception."""


### PR DESCRIPTION
## Problem / Motivation

The gateway-restart skill's helper script (`do-restart.sh`) runs as a disowned process, so both its output and its exit status are discarded. The agent session that scheduled the restart cannot learn the outcome and reports success unconditionally. On a host where the gateway runs as a root-owned system unit serving the dashboard over a unix socket, the restart was a silent no-op twice: the service manager refuses the unprivileged restart, and the CLI's TCP-listener fallback finds nothing to stop, so the original process kept running ~14 hours while the user was told the gateway restarted — a source patch and a config change appeared applied when neither had taken effect.

The loud signal already exists: the CLI restart verb on main polls `/api/ready` and exits non-zero when the replacement never serves. It was simply thrown away by the disowned script, and the system-unit deployment produced a confusing fall-through instead of a diagnostic naming the command the user must run themselves.

## Why it matters

An agent confidently reporting a restart that never happened is worse than a failed restart: the operator acts on the false state (believing a patch or config change is live), and the mismatch surfaces hours later as inexplicable behavior. Any user running the gateway as a system service — the recommended install for always-on hosts — is exposed.

## What changed (motivation → approach → change)

Symptom: unconditional success reporting. Root cause: the restart's verdict is computed but discarded at the disowned-process boundary, and the CLI conflates "no service installed" with "service restart refused". Three mechanical parts:

1. **Record the outcome instead of discarding it.** `do-restart.sh` (and `do-restart.ps1` for platform parity) write the restart's exit status to a **per-attempt status file** and its output to that attempt's own log (`<status file>.log`), so overlapping attempts can neither overwrite each other's verdict nor cross-quote diagnostics; a lone unscheduled run uses the shared `logs/restart-status` + `restart.log`. Attempt paths are **confined**: only `<crew home>/logs/restart-status.<suffix>` (no separators or `..` in the suffix) is accepted, anything else falls back to the shared default — the detached helper runs outside any agent sandbox and must never delete or overwrite a caller-chosen file. Files are owner-only via `umask 077` and removed while an attempt is pending so a stale verdict can never be read as current. Dashboard token URLs printed by the restart verb are redacted (`token=REDACTED`) before landing in the log, since the skill instructs quoting the log into conversations; `PIPESTATUS[0]` preserves the restart's own exit status through the redaction pipe. (`KIROCREW_RESTART_DELAY` makes the scheduling sleep tunable so the regression tests can execute the real script.)
2. **Make the skill verify, not assume.** `skills/gateway-restart/SKILL.md` gains a "Verify the outcome" step: the agent generates the attempt's confined status-file path and records the pre-restart gateway pid at schedule time, threading both through the resume-cron messages (a failed launch leaves that attempt's verdict absent rather than stale, and gateway identity is checkable without touching the agent-fenced run/ dir), the resume crons instruct verification and keep the slow verifier alive while the verdict is pending, and success may only be reported after the status file reads `0` — corroborated by gateway identity (`/api/ready` + recorded-pid change) on service-managed installs, where exit 0 only proves the manager accepted the restart and a successful `systemctl restart` can reap the helper (same control group) before it writes the status file.
3. **Name the remedy when the CLI cannot restart the deployment.** `kirocrew restart` now fails loudly when a platform service unit is active but the service manager refuses to restart it (system-scope unit, unprivileged caller / polkit denial): it prints the privileged command the operator must run themselves via the new `service_controller.manual_restart_hint()` — `sudo systemctl restart kirocrew` on Linux (reusing `restart_command_hint()` so the string cannot drift), a `launchctl bootout … ; launchctl bootstrap …` recovery pair on macOS (never the kickstart that just failed) — and exits non-zero with a SEL `denied` audit record instead of falling through to the TCP-listener path that cannot see a unix-socket deployment. The active-check runs after the refused restart, so a service that merely stopped in between still takes the foreground path as before.

## Tests

- `test/test_gateway_restart_status_file.py` (new): drives the real `do-restart.sh` with a stubbed CLI on PATH — success and failure exit statuses land in the status file and propagate; a stale verdict is removed before the restart runs (ordering proven by a probe inside the stub); status file and log are owner-only (0600); dashboard token URLs are redacted from the log while the exit status survives the pipe; a content pin keeps both platform scripts and the skill doc agreeing on the `restart-status` filename; the attempt-specific override is honored inside the logs dir and every non-conforming path (absolute victim, nested, `..` traversal) falls back to the shared default with the target untouched.
- `test/test_cli.py::TestRestart`: new `test_active_service_restart_denied_fails_loud_with_remedy` (denied branch exits 1, prints the hint, never enters the listener fallback, audits `reason=service_restart_denied`) and `test_inactive_service_still_falls_through_after_refused_restart` (pins that the no-service path is unchanged). An autouse fixture pins `is_service_active` False so the class stays hermetic on hosts that run a real kirocrew service.
- `test/test_service.py::TestControllerDispatch`: `manual_restart_hint()` names `sudo systemctl restart kirocrew` on systemd, a bootout+bootstrap recovery pair (never kickstart) on launchd, and is never the circular `kirocrew restart` on any platform.

Red-before-green: with the production hunks reverted, the script tests fail (no status file is written) and the denied-branch/hint tests fail (the branch and function do not exist); all pass on the fix.

## Manual verification

N/A — unit coverage sufficient: the script tests execute the real helper script end to end with a stubbed CLI, and the denied branch is fully driven at the `service_controller` boundary. The reporter's exact deployment (root-owned system unit + unix socket) cannot be reproduced in CI, but the refused-restart mechanism (`systemctl restart` returning non-zero without root) is what the new branch keys on.

## Screenshots / video

N/A — no user-visible UI change (CLI output, skill doc, and helper scripts only; no `website/` paths touched).

## Related Issues

Closes #7521

## Pattern harvest

Rule candidate: review-prompt
Pattern: a detached/disowned helper discards the child's exit status, so the scheduling side reports success unconditionally — require detached helpers to persist their outcome where the scheduler can read it back.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
