### PR TITLE
fix(knowledge): pace the unattended re-embed sweep (#7367)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -816,7 +816,6 @@ test/test_knowledge_ingest_magic_byte.py
 test/test_knowledge_items_source_filter.py
 test/test_knowledge_kiroignore.py
 test/test_knowledge_project_docs.py
-test/test_knowledge_search_upgrade.py
 test/test_knowledge_source_spend.py
 test/test_knowledge_sync_local_file.py
 test/test_knowledge_workspace_autosource.py

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -1718,7 +1718,12 @@ async def _rebuild_embeddings_job(app: web.Application, store, embedder, job_id:
     degrades gracefully during the rebuild instead of going dark.
     """
     try:
-        processed = await rebuild_embeddings(store, embedder, job_id=job_id, force=force)
+        # pace=False: this job exists because a human clicked Rebuild and is
+        # watching its progress bar — the load is expected, so it runs at the
+        # interactive scheduling class with no idling. The watcher self-heal
+        # path stays on the paced default.
+        processed = await rebuild_embeddings(store, embedder, job_id=job_id, force=force,
+                                             pace=False)
         store.db.execute(
             "UPDATE ingestion_jobs SET status = 'completed', items_processed = ?, updated_at = ? "
             "WHERE id = ?",

--- a/src/kiro_crew/knowledge/embedder.py
+++ b/src/kiro_crew/knowledge/embedder.py
@@ -16,6 +16,7 @@ import time
 from typing import TYPE_CHECKING
 
 from kiro_crew import embeddings as _embeddings
+from kiro_crew.embeddings import PRIORITY_NORMAL
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.knowledge.chunker import CHUNK_OVERLAP, CHUNK_TOKEN_SIZE
 
@@ -110,13 +111,20 @@ class InProcessEmbedder:
             return self._available
         return await run_in_embed_pool(self.is_available)
 
-    def embed(self, text: str) -> list[float] | None:
-        """Embed a single text. Returns float list or None on failure."""
+    def embed(self, text: str, *, priority: int = PRIORITY_NORMAL) -> list[float] | None:
+        """Embed a single text. Returns float list or None on failure.
+
+        *priority* is the scheduling class (``PRIORITY_*``) forwarded to the
+        shared backend, which orders competing callers on the one in-process
+        model and sizes its thread pool per class — corpus loops pass
+        ``PRIORITY_BULK`` so they run on the reduced bulk pool and an
+        interactive embed is served ahead of them.
+        """
         if not text.strip():
             return None
         if not self.is_available():
             return None
-        vec = self._get_embedder().embed(text)
+        vec = self._get_embedder().embed(text, priority=priority)
         if vec is None:
             # The backend stopped producing vectors (reset/reload failure) —
             # invalidate the cached availability so the next call re-probes
@@ -125,9 +133,18 @@ class InProcessEmbedder:
         return vec
 
     def embed_for_item(
-        self, title: str, summary: str | None, content: str | None = None
+        self,
+        title: str,
+        summary: str | None,
+        content: str | None = None,
+        *,
+        priority: int = PRIORITY_NORMAL,
     ) -> list[float] | None:
-        """Embed title + summary + chunk content for knowledge items."""
+        """Embed title + summary + chunk content for knowledge items.
+
+        *priority* is forwarded to :meth:`embed` (see there); the default keeps
+        every existing caller on the normal interactive class.
+        """
         parts = [title]
         if summary:
             parts.append(summary)
@@ -142,7 +159,7 @@ class InProcessEmbedder:
                 )
                 content = content[: self.content_budget]
             parts.append(content)
-        return self.embed(" ".join(parts))
+        return self.embed(" ".join(parts), priority=priority)
 
 
 # Keep the old name as an alias so references to OllamaEmbedder in type

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import hashlib
 import json
 import logging
@@ -14,6 +15,7 @@ from pathlib import Path
 from typing import TypeVar
 from uuid import uuid4
 
+from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_NORMAL, bulk_pace_delay
 from kiro_crew.llm_helpers import _extract_json_of_type
 from kiro_crew.security import (
     is_sensitive_path,
@@ -1230,8 +1232,30 @@ def count_stale_items(store, sig: str, *, now: datetime | None = None) -> int:
         (sig, cutoff)).fetchone()["c"]
 
 
+def _embed_row_paced(embedder, title, summary, content, priority: int,
+                     pace: bool) -> "tuple[list[float] | None, float]":
+    """Embed one row and derive its pace delay, both on the worker thread.
+
+    Runs via ``run_in_executor`` — the inference is the CPU floor, and the
+    delay is computed here rather than on the event loop because
+    ``bulk_pace_delay`` re-reads the duty cycle from ``config.json`` on every
+    call (an uncached stat + read + parse that must not run per row on the
+    gateway loop; the no-blocking-call-on-event-loop rule). This is the same
+    division the vector-memory sweep uses: measure and derive on the sweep's
+    own thread, never on the loop. Measuring around the embed call itself also
+    keeps the executor queue wait out of the paced elapsed. The delay derives
+    from measured elapsed time (0.0 for ``elapsed <= 0``), so a row that
+    failed fast paces to nothing on its own — failures need no separate
+    branch. Returns ``(vec, delay)``; ``delay`` is always 0.0 when unpaced.
+    """
+    started = _time.monotonic()
+    vec = embedder.embed_for_item(title, summary, content, priority=priority)
+    delay = bulk_pace_delay(_time.monotonic() - started) if pace else 0.0
+    return vec, delay
+
+
 async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
-                             force: bool = False) -> int:
+                             force: bool = False, pace: bool = True) -> int:
     """Re-embed active items in place, stamping the current embedding signature.
 
     Sig-gated by default: only items whose stored ``embedding_sig`` differs from the
@@ -1247,9 +1271,24 @@ async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
 
     Serial single-item embed (the in-process embedder is the CPU floor and fans out
     internally); batch size is only the commit/progress cadence, not a throttle.
+
+    ``pace`` keys the sweep's resource envelope on attendance. This is an
+    unattended corpus loop when the watcher self-heal fires it — to a user, a
+    full-corpus re-embed at full speed is indistinguishable from a runaway
+    process — so the paced default embeds at ``PRIORITY_BULK`` (the reduced
+    ``memory.embedding_bulk_threads`` pool) and idles between rows per
+    ``memory.embedding_bulk_duty`` (see :func:`kiro_crew.embeddings.bulk_pace_delay`).
+    Paced is the default so a caller that forgets the argument gets the quiet
+    behaviour. ``pace=False`` is for a sweep a human explicitly asked for and is
+    watching a progress bar on: it embeds at ``PRIORITY_NORMAL`` and never idles.
+    ``pace`` selects the scheduling class as well as the idling — an attended
+    sweep that only skipped the pauses would stay on the reduced bulk pool and
+    run several times slower than before pacing existed, on exactly the path
+    declared "full speed".
     """
     loop = asyncio.get_running_loop()
     sig = embedder_signature(embedder)
+    priority = PRIORITY_BULK if pace else PRIORITY_NORMAL
     processed = 0
     failed = 0
     # Keep the COUNT predicate and the page predicate as separate strings so neither
@@ -1278,9 +1317,30 @@ async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
         if not rows:
             break
         for row in rows:
-            vec = await loop.run_in_executor(
-                None, embedder.embed_for_item, row["title"], row["summary"], row["content"]
+            # functools.partial rather than a local closure: run_in_executor
+            # forwards positional args only, and the partial names the bound
+            # arguments at the call site instead of one hop away in a nested
+            # def. Embed + delay derivation both happen on the worker thread
+            # (see _embed_row_paced); only the idle itself runs here.
+            vec, delay = await loop.run_in_executor(
+                None,
+                functools.partial(
+                    _embed_row_paced,
+                    embedder,
+                    row["title"], row["summary"], row["content"],
+                    priority, pace,
+                ),
             )
+            if delay > 0:
+                # Idle between this row's inference and its write — the
+                # interruption-safe point: a sweep killed mid-pause leaves the
+                # row's sig stale and the next sweep re-embeds it, the same
+                # idempotent contract every row it never reached already has.
+                # ``await asyncio.sleep`` is this coroutine's equivalent of the
+                # vector-memory sweep's on-thread pause: it yields the event
+                # loop and holds neither the DB connection nor the model, so an
+                # interactive embed arriving mid-pause is served at full speed.
+                await asyncio.sleep(delay)
             now_iso = datetime.now().isoformat()
             # Per-item SQLite writes are OFFLOADED (asyncio.to_thread): a sync
             # write can block up to the busy_timeout under a concurrent writer,

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -473,6 +473,11 @@ class KnowledgeWatcher:
 
     async def _run_reembed_job(self, embedder, job_id: str) -> None:
         try:
+            # Paced (the default) on purpose: nobody is waiting on a self-heal
+            # sweep, so it embeds at the bulk scheduling class on the reduced
+            # thread pool and idles between rows instead of pinning cores for
+            # the whole corpus. The dashboard-triggered rebuild, which a human
+            # watches, is the path that opts out with pace=False.
             processed = await rebuild_embeddings(self.store, embedder, job_id=job_id)
             # OFFLOADED: single-row write, but a commit can block up to the
             # busy_timeout behind a concurrent writer — keep it off the loop.

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 import pytest
 
+from kiro_crew.embeddings import PRIORITY_NORMAL
 from kiro_crew.knowledge import readers
 from kiro_crew.knowledge.chunker import HeadingAwareChunker
 from kiro_crew.knowledge.extractor import EntityExtractor
@@ -1662,7 +1663,7 @@ class _FakeEmbedder:
     async def is_available_async(self) -> bool:
         return self.is_available()
 
-    def embed_for_item(self, title, summary, content=None):
+    def embed_for_item(self, title, summary, content=None, *, priority=PRIORITY_NORMAL):
         self.embedded_titles.append(title)
         return [0.1, 0.2, 0.3, 0.4]
 
@@ -1758,7 +1759,7 @@ class TestRebuildEmbeddingsJob:
 
     async def test_rebuild_marks_job_failed_on_error(self, store):
         class _BoomEmbedder(_FakeEmbedder):
-            def embed_for_item(self, title, summary, content=None):
+            def embed_for_item(self, title, summary, content=None, *, priority=PRIORITY_NORMAL):
                 raise RuntimeError("ollama down mid-rebuild")
 
         job_id = await self._run(store, _BoomEmbedder(), 3)
@@ -1779,7 +1780,7 @@ class TestRebuildEmbeddingsJob:
         seen_updated_at: list[str] = []
 
         class _RecordingEmbedder(_FakeEmbedder):
-            def embed_for_item(self, title, summary, content=None):
+            def embed_for_item(self, title, summary, content=None, *, priority=PRIORITY_NORMAL):
                 row = store.db.execute(
                     "SELECT updated_at FROM ingestion_jobs WHERE id = 'hbjob0000001'"
                 ).fetchone()
@@ -1960,7 +1961,7 @@ class _FlakyEmbedder(_FakeEmbedder):
         super().__init__()
         self.fail_titles = set(fail_titles)
 
-    def embed_for_item(self, title, summary, content=None):
+    def embed_for_item(self, title, summary, content=None, *, priority=PRIORITY_NORMAL):
         self.embedded_titles.append(title)
         if title in self.fail_titles:
             return None
@@ -2059,7 +2060,7 @@ class TestRebuildLostUpdateRace:
                 self._path = path
                 self._iid = iid
 
-            def embed_for_item(self, title, summary, content=None):
+            def embed_for_item(self, title, summary, content=None, *, priority=PRIORITY_NORMAL):
                 # Simulate a concurrent ingestion write landing mid-embed: bump
                 # updated_at into the future relative to the rebuild's snapshot.
                 conn = sqlite3.connect(self._path, timeout=30, isolation_level=None)

--- a/test/test_knowledge_handlers_coverage.py
+++ b/test/test_knowledge_handlers_coverage.py
@@ -1029,7 +1029,7 @@ class TestRebuildEmbeddingsJob:
     async def test_completed_job_records_processed_count(self, store, monkeypatch):
         job_id = _add_job(store, "reb-1")
 
-        async def _fake_rebuild(_store, _emb, *, job_id, force):
+        async def _fake_rebuild(_store, _emb, *, job_id, force, pace):
             return 5
 
         monkeypatch.setattr(f"{MODULE}.rebuild_embeddings", _fake_rebuild)

--- a/test/test_knowledge_rebuild_bulk_pacing.py
+++ b/test/test_knowledge_rebuild_bulk_pacing.py
@@ -1,0 +1,253 @@
+"""The knowledge re-embed sweep paces itself; an explicitly-requested one does not.
+
+Locks in the behaviour that keeps an unattended watcher self-heal sweep from
+pinning several cores for the whole corpus: every bulk row embeds at
+``PRIORITY_BULK`` — the scheduling class that earns it the reduced
+``memory.embedding_bulk_threads`` pool — and is followed by an idle window
+proportional to the work it just did, taken as an ``await asyncio.sleep`` on the
+sweep's own coroutine (holding neither the DB connection nor the model). Both
+are keyed on attendance, not corpus size: the dashboard-triggered rebuild a
+human is watching runs unpaced at ``PRIORITY_NORMAL`` on the full interactive
+pool. Mirrors ``test_vector_memory_bulk_pacing.py`` for the knowledge corpus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from kiro_crew import embeddings as _embeddings
+from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_NORMAL
+from kiro_crew.knowledge import ingestion
+from kiro_crew.knowledge.embedder import InProcessEmbedder
+from kiro_crew.knowledge.ingestion import rebuild_embeddings
+from kiro_crew.knowledge.store import KnowledgeStore
+
+# One sentinel delay for the whole file: every test that arms pacing stubs
+# ``bulk_pace_delay`` to return exactly this value, and the recorders below
+# act only on it. The patch necessarily replaces the GLOBAL ``asyncio.sleep``
+# (``ingestion`` imports the module itself, so there is no per-module alias to
+# scope to) — discriminating on the sentinel keeps any unrelated coroutine's
+# sleep out of the record and leaves its real delay semantics intact.
+_PACE = 0.125
+
+
+class _RecordingBackend:
+    """Shared-backend stub recording the scheduling class of every embed.
+
+    Standing in for the real backend at ``get_shared_embedder`` means the tests
+    drive the REAL knowledge embedder, so a priority that is dropped anywhere
+    along ``rebuild_embeddings -> embed_for_item -> embed -> backend.embed``
+    fails the assertion — a flag merely stored on the way proves nothing.
+    """
+
+    model_id = "fake-embed"
+
+    def __init__(self):
+        self.priorities: list[int] = []
+
+    def is_ready(self) -> bool:
+        return True
+
+    def embed(self, text, *, priority=PRIORITY_NORMAL):
+        self.priorities.append(priority)
+        return [0.1, 0.2, 0.3, 0.4]
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = KnowledgeStore(str(tmp_path / "test.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def backend(monkeypatch):
+    b = _RecordingBackend()
+    monkeypatch.setattr(_embeddings, "get_shared_embedder", lambda: b)
+    return b
+
+
+@pytest.fixture()
+def embedder(backend):
+    return InProcessEmbedder()
+
+
+@pytest.fixture()
+def sleeps(monkeypatch):
+    """Record pace sleeps (the ``_PACE`` sentinel only) instead of performing them."""
+    recorded: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _record(delay, *args, **kwargs):
+        if delay == _PACE:
+            recorded.append(delay)
+            await real_sleep(0)
+            return
+        await real_sleep(delay, *args, **kwargs)
+
+    monkeypatch.setattr(ingestion.asyncio, "sleep", _record)
+    return recorded
+
+
+def _stale_items(store, n):
+    for i in range(n):
+        store.add_item(f"stale row {i}", f"body {i}", "document")
+    store.db.commit()
+
+
+@pytest.mark.asyncio
+class TestRebuildPacing:
+    async def test_each_row_of_an_unattended_sweep_is_paced(
+        self, store, embedder, sleeps, monkeypatch
+    ):
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: _PACE)
+        _stale_items(store, 3)
+
+        assert await rebuild_embeddings(store, embedder) == 3
+        assert sleeps == [_PACE, _PACE, _PACE]
+
+    async def test_pace_false_never_sleeps(self, store, embedder, sleeps, monkeypatch):
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: _PACE)
+        _stale_items(store, 3)
+
+        assert await rebuild_embeddings(store, embedder, pace=False) == 3
+        assert sleeps == []
+
+    async def test_zero_delay_does_not_call_sleep(self, store, embedder, sleeps, monkeypatch):
+        """Pacing off (duty 1.0) must not add an event-loop hop per row."""
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: 0.0)
+        _stale_items(store, 2)
+
+        assert await rebuild_embeddings(store, embedder) == 2
+        assert sleeps == []
+
+    async def test_delay_is_derived_from_the_row_s_own_elapsed_time(
+        self, store, embedder, monkeypatch
+    ):
+        seen: list[float] = []
+
+        def _record(elapsed):
+            seen.append(elapsed)
+            return 0.0
+
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", _record)
+        _stale_items(store, 1)
+
+        await rebuild_embeddings(store, embedder)
+        assert len(seen) == 1
+        assert seen[0] >= 0.0
+
+    async def test_a_failed_row_is_still_paced_by_measured_time(
+        self, store, embedder, backend, sleeps, monkeypatch
+    ):
+        """A row that returns no vector still ran the model; pace on elapsed, not success."""
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: _PACE)
+        backend.embed = lambda text, *, priority=PRIORITY_NORMAL: None
+        _stale_items(store, 2)
+
+        assert await rebuild_embeddings(store, embedder) == 0
+        assert sleeps == [_PACE, _PACE]
+
+    async def test_an_unattended_sweep_embeds_at_the_bulk_class(
+        self, store, embedder, backend, sleeps, monkeypatch
+    ):
+        """PRIORITY_BULK is what earns the sweep the reduced thread pool and lets
+        an interactive embed jump the shared inference queue ahead of it."""
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: 0.0)
+        _stale_items(store, 2)
+
+        await rebuild_embeddings(store, embedder)
+        assert backend.priorities == [PRIORITY_BULK, PRIORITY_BULK]
+
+    async def test_an_attended_sweep_keeps_the_interactive_class(
+        self, store, embedder, backend, sleeps
+    ):
+        """``pace=False`` must switch off the thread dial too, not just the idling —
+        otherwise the "full speed" path would still run on the reduced bulk pool."""
+        _stale_items(store, 2)
+
+        await rebuild_embeddings(store, embedder, pace=False)
+        assert backend.priorities == [PRIORITY_NORMAL, PRIORITY_NORMAL]
+
+    async def test_the_pause_sits_between_a_row_s_inference_and_its_write(
+        self, store, embedder, monkeypatch
+    ):
+        """A sweep killed mid-pause leaves that row's sig stale, and the next sweep
+        re-embeds it — so each pause must run BEFORE its row's write lands, and it
+        must hold no DB state a concurrent writer could block on."""
+        visible: list[int] = []
+        real_sleep = asyncio.sleep
+
+        async def _probe(delay, *args, **kwargs):
+            if delay != _PACE:
+                await real_sleep(delay, *args, **kwargs)
+                return
+            row = store.db.execute(
+                "SELECT count(*) AS n FROM items WHERE embedding_sig IS NOT NULL"
+            ).fetchone()
+            visible.append(int(row["n"]))
+            await real_sleep(0)
+
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: _PACE)
+        monkeypatch.setattr(ingestion.asyncio, "sleep", _probe)
+        _stale_items(store, 2)
+
+        assert await rebuild_embeddings(store, embedder) == 2
+        # One pause per row, each seeing only the rows already finished — never
+        # its own row half-written.
+        assert visible == [0, 1]
+
+
+@pytest.mark.asyncio
+class TestCallerWiring:
+    """The two production callers stay on opposite sides of the attendance split."""
+
+    async def test_watcher_self_heal_sweep_is_paced_on_the_bulk_class(
+        self, store, embedder, backend, sleeps, monkeypatch
+    ):
+        from kiro_crew.knowledge.watcher import KnowledgeWatcher
+
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: _PACE)
+        _stale_items(store, 2)
+
+        class _Pipe:
+            pass
+
+        pipe = _Pipe()
+        pipe.embedder = embedder
+        watcher = KnowledgeWatcher(store, pipe)
+
+        await watcher._maybe_reembed_stale()
+        assert watcher._reembed_task is not None
+        await watcher._reembed_task
+
+        assert sleeps == [_PACE, _PACE]
+        assert backend.priorities == [PRIORITY_BULK, PRIORITY_BULK]
+
+    async def test_dashboard_trigger_runs_unpaced_at_the_interactive_class(
+        self, store, embedder, backend, sleeps, monkeypatch
+    ):
+        from kiro_crew.dashboard.handlers.knowledge import _rebuild_embeddings_job
+
+        monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: _PACE)
+        _stale_items(store, 2)
+        now = datetime.now().isoformat()
+        store.db.execute(
+            "INSERT INTO ingestion_jobs (id, source_id, status, created_at, updated_at) "
+            "VALUES ('dashpace0001', NULL, 'processing', ?, ?)",
+            (now, now),
+        )
+        store.db.commit()
+
+        await _rebuild_embeddings_job(None, store, embedder, "dashpace0001")
+
+        assert sleeps == []
+        assert backend.priorities == [PRIORITY_NORMAL, PRIORITY_NORMAL]
+        row = store.db.execute(
+            "SELECT status, items_processed FROM ingestion_jobs WHERE id = 'dashpace0001'"
+        ).fetchone()
+        assert row["status"] == "completed"
+        assert row["items_processed"] == 2

--- a/test/test_knowledge_search_upgrade.py
+++ b/test/test_knowledge_search_upgrade.py
@@ -1,6 +1,8 @@
 """Tests for knowledge search upgrade: embedding endpoints + search-for-context."""
+
 import pytest
 
+from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_NORMAL
 from kiro_crew.knowledge.embedder import (
     InProcessEmbedder,
     OllamaEmbedder,
@@ -41,10 +43,12 @@ class TestCreateEmbedderFromConfig:
         """The Ollama-era embedding_model key must NOT pin the identity —
         honoring it would mislabel vectors produced by the bundled model and
         defeat swap-triggered re-embeds (model id derives from the backend)."""
-        cfg = {"memory": {
-            "embedding_provider": "llama_cpp",
-            "embedding_model": "custom:latest",
-        }}
+        cfg = {
+            "memory": {
+                "embedding_provider": "llama_cpp",
+                "embedding_model": "custom:latest",
+            }
+        }
         emb = create_embedder_from_config(cfg)
         assert emb is not None
         assert emb.model != "custom:latest"
@@ -75,21 +79,41 @@ class TestInProcessEmbedder:
         class _FakeShared:
             def __init__(self):
                 self.texts = []
+                self.priorities = []
 
             def is_ready(self):
                 return True
 
-            def embed(self, text):
+            def embed(self, text, *, priority=PRIORITY_NORMAL):
                 self.texts.append(text)
+                self.priorities.append(priority)
                 return [0.1, 0.2]
 
         fake = _FakeShared()
-        monkeypatch.setattr(
-            "kiro_crew.embeddings.get_shared_embedder", lambda: fake
-        )
+        monkeypatch.setattr("kiro_crew.embeddings.get_shared_embedder", lambda: fake)
         emb = InProcessEmbedder()
         assert emb.embed("hello world") == [0.1, 0.2]
         assert fake.texts == ["hello world"]
+        # The scheduling class reaches the backend: default and explicit both.
+        assert emb.embed("bulk row", priority=PRIORITY_BULK) == [0.1, 0.2]
+        assert fake.priorities == [PRIORITY_NORMAL, PRIORITY_BULK]
+
+    def test_embed_for_item_forwards_priority_to_embed(self, monkeypatch):
+        """A corpus sweep's scheduling class must survive the embed_for_item hop —
+        silently dropping it puts the unattended sweep back on the full
+        interactive pool (the original flat-out symptom)."""
+        emb = InProcessEmbedder()
+        seen = {}
+
+        def _capture(text, *, priority=PRIORITY_NORMAL):
+            seen["priority"] = priority
+            return [0.1]
+
+        monkeypatch.setattr(emb, "embed", _capture)
+        emb.embed_for_item("T", "S", "content", priority=PRIORITY_BULK)
+        assert seen["priority"] == PRIORITY_BULK
+        emb.embed_for_item("T", "S", "content")
+        assert seen["priority"] == PRIORITY_NORMAL
 
     def test_is_available_negative_cached_when_not_ready(self, monkeypatch):
         """Model not loaded and probe fails → unavailable, negatively cached."""
@@ -106,9 +130,7 @@ class TestInProcessEmbedder:
                 return None  # model still downloading
 
         fake = _FakeShared()
-        monkeypatch.setattr(
-            "kiro_crew.embeddings.get_shared_embedder", lambda: fake
-        )
+        monkeypatch.setattr("kiro_crew.embeddings.get_shared_embedder", lambda: fake)
         emb = InProcessEmbedder()
         assert emb.is_available() is False
         assert emb.is_available() is False  # served from negative cache
@@ -128,7 +150,7 @@ class TestInProcessEmbedder:
         """
         emb = InProcessEmbedder()
         captured = {}
-        monkeypatch.setattr(emb, "embed", lambda text: captured.setdefault("text", text))
+        monkeypatch.setattr(emb, "embed", lambda text, **kw: captured.setdefault("text", text))
         emb.embed_for_item(
             "Short Title",
             "Brief summary",
@@ -150,7 +172,7 @@ class TestInProcessEmbedder:
 
         emb = InProcessEmbedder()
         captured = {}
-        monkeypatch.setattr(emb, "embed", lambda text: captured.setdefault("text", text))
+        monkeypatch.setattr(emb, "embed", lambda text, **kw: captured.setdefault("text", text))
         # ~6 chars/token over the full chunk budget — at the high end of observed
         # corpus chunks (max ~6227 chars) and well past the old 2000-char cap.
         big_chunk = "word " * int((CHUNK_TOKEN_SIZE + CHUNK_OVERLAP) * 6 / 5)
@@ -165,7 +187,7 @@ class TestInProcessEmbedder:
 
         emb = InProcessEmbedder()
         captured = {}
-        monkeypatch.setattr(emb, "embed", lambda text: captured.setdefault("text", text))
+        monkeypatch.setattr(emb, "embed", lambda text, **kw: captured.setdefault("text", text))
         big = "x" * (_EMBED_CONTENT_BUDGET * 3)
         with self._capture_warnings() as warned:
             emb.embed_for_item("T", "S", big)
@@ -201,7 +223,7 @@ class TestInProcessEmbedder:
         """Back-compat: omitting content still embeds title + summary only."""
         emb = InProcessEmbedder()
         captured = {}
-        monkeypatch.setattr(emb, "embed", lambda text: captured.setdefault("text", text))
+        monkeypatch.setattr(emb, "embed", lambda text, **kw: captured.setdefault("text", text))
         emb.embed_for_item("My Title", "A summary")
         assert captured["text"] == "My Title A summary"
 


### PR DESCRIPTION
## Problem / Motivation

The knowledge-base re-embed sweep `rebuild_embeddings` (`src/kiro_crew/knowledge/ingestion.py`) is an unattended corpus loop that neither of the two bulk-embedding dials from #7351 reaches:

- it embeds through the knowledge embedder at the default `PRIORITY_NORMAL`, so `bulk_embed_threads()` (`memory.embedding_bulk_threads`) never sizes the inference pool down, and
- it never consults `bulk_pace_delay()` (`memory.embedding_bulk_duty`), so it runs flat out with no duty cycle.

A knowledge-base setup change that invalidates stored embedding signatures makes the watcher self-heal re-embed the whole corpus at full speed — the same CPU-saturation/fan-noise symptom #7351 fixed for vector memory, on a corpus that can be larger.

## Why it matters

The self-heal path fires with nobody watching: to the user it is indistinguishable from a runaway process, for tens of minutes on a large library (reference numbers from the issue: ~429–1389 ms/row on the bundled model, with CPU-seconds per row essentially constant across thread counts — spreading work over wall time is the only lever). The same function also serves the dashboard-triggered rebuild, where a human is watching a progress bar and slowing down would be paying the cost with none of the benefit — so the two paths must be treated differently, not throttled uniformly.

## What changed (motivation → approach → change)

Symptom → root cause: the two dials act at the shared backend's scheduling seam (`priority >= PRIORITY_BULK` selects the reduced pool) and at the sweep's own loop (`bulk_pace_delay`), and `rebuild_embeddings` participated in neither.

Approach: follow the canonical merged pattern `VectorMemoryStore._embed_bulk_row` rather than invent a shape — including its one non-obvious coupling: **`pace` selects the scheduling class as well as the idling**, because attendance (not corpus size) is what both dials key on. Without that, a `pace=False` attended sweep would switch off idling but stay on the reduced bulk pool and end up several times slower than before pacing existed.

Change:

- `InProcessEmbedder.embed` / `.embed_for_item` gain a keyword-only `priority` (default `PRIORITY_NORMAL`, so every existing caller is unchanged) and forward it to the shared backend, which already accepts it. The content-budget truncation and its warning are intact.
- `rebuild_embeddings` gains `pace: bool = True`. Paced-by-default is the safe default: the unattended watcher path caused the report, and a caller that forgets the argument gets the quiet behaviour. `priority = PRIORITY_BULK if pace else PRIORITY_NORMAL`.
- A new worker-thread helper `_embed_row_paced` runs the embed and derives the pace delay **on the executor thread** (`bulk_pace_delay` re-reads the duty cycle from `config.json` on every call — an uncached stat+read+parse that must not run per row on the gateway loop), measuring elapsed around the embed call itself so executor queue wait stays out of the paced elapsed. The idle is `await asyncio.sleep(delay)` on the sweep's coroutine — never `time.sleep`, per the module's no-blocking-call-on-event-loop rule — holding neither the DB connection nor the model, so an interactive embed arriving mid-pause is served at full speed. The pause sits between a row's inference and its write, the interruption-safe point: a sweep killed mid-pause leaves that row's sig stale and the next sweep re-embeds it.
- Callers: the watcher self-heal (`knowledge/watcher.py`) stays on the paced default, now stated intentionally in a comment; the dashboard trigger (`dashboard/handlers/knowledge.py::_rebuild_embeddings_job`) passes `pace=False`.

Out of scope, deliberately untouched: sig-gating and the `force=True` escape hatch, the lost-update guard around `_write_item_embedding`, the per-item job heartbeat, the duty cycle's default value, and #7368's idle-signal redesign. Also out of scope, now tracked in #7601 (deferred from First Principles review): `_embed_item`'s watcher-driven re-ingest embeds, which stay at the interactive class bounded by the `knowledge.embed_rate_limit` limiter — pacing them needs attendance plumbed through the ingestion pipeline, a design step this mechanical promotion does not own. The pre-existing rate limiter and the bulk dials are complementary spellings: the limiter caps aggregate embeds/minute on ingest paths but cannot shrink the inference thread pool; the dials size the pool and duty-cycle a corpus sweep.

Pre-push review: dual model-pinned review (GPT lane and Opus lane), both PASS with zero blocking findings; four of the Opus advisories adopted (off-loop duty-cycle read, sentinel-discriminating sleep recorder in tests, required `pace` kwarg in a coverage stub, priority round-trip coverage), one declined as inherited from the canonical pattern (backend queue wait inside measured elapsed — the reduced-pool wait is deliberate ordering behind interactive embeds, and excluding it needs backend surgery this PR does not own).

## Tests

New `test/test_knowledge_rebuild_bulk_pacing.py`, mirroring `test/test_vector_memory_bulk_pacing.py`, driving the REAL `InProcessEmbedder` over a recording backend so the assertions prove the priority actually reaches the shared backend (a flag merely stored on the way proves nothing):

- every row of an unattended sweep is paced; `pace=False` never sleeps; zero delay adds no per-row sleep call; the delay derives from the row's own elapsed time; a row that fails to embed is still paced by measured time
- an unattended sweep embeds at `PRIORITY_BULK`; an attended one keeps `PRIORITY_NORMAL` (the coupling most likely to regress silently)
- the pause sits between a row's inference and its write (DB-visible ordering probe)
- caller wiring: the watcher self-heal path is paced on the bulk class; the dashboard trigger runs unpaced at the interactive class

Strengthened existing coverage: the shared-backend delegation test now asserts the priority round-trip (default and explicit), a new test locks `embed_for_item` → `embed` forwarding, and the handlers-coverage rebuild stub now *requires* the `pace` argument so dropping it from the handler fails two independent tests. Existing rebuild/watcher/handler tests pass unchanged apart from fakes accepting the new keyword.

All four targeted mutations are caught by the suite (priority coupling removed → 2 failures; pacing removed → 5; handler drops `pace=False` → 2; watcher opts out of pacing → 1).

## Manual verification

N/A — unit coverage sufficient: the observable contract (scheduling class at the backend, sleep between inference and write, per-caller wiring) is asserted end-to-end through the real embedder; full backend suite fail-set is byte-identical to a pristine-main control run on the same host (98 = 98 pre-existing host-env failures, zero delta).

## Related Issues

Closes #7367

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a per-unit helper called inside an async corpus loop hides an uncached config/filesystem read — verify each per-row call's transitive I/O runs off-loop, not just the obvious embed/DB calls"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the dials are config-level knobs introduced without doc pages; no spec documents `rebuild_embeddings` pacing
- [x] No secrets, credentials, or internal references in the diff
