### PR TITLE
fix(doctor): ignore identifier-flag operands that look like absolute paths

### DIFF
--- a/src/kiro_crew/doctor_deadpath.py
+++ b/src/kiro_crew/doctor_deadpath.py
@@ -239,6 +239,13 @@ _CREDENTIAL_KEY_MARKERS: tuple[str, ...] = (
     "PRIVATE",
 )
 
+# Opaque identifier flag operands that merely look like absolute paths
+# (e.g. --scope /spaces/nsp_abc123). Not filesystem paths — must not be
+# stat-ed, otherwise a healthy install is permanently red (see #7375).
+# Strict literal set: a heuristic would trade bounded false positive for
+# unbounded false negative.
+_IDENTIFIER_FLAGS: frozenset[str] = frozenset({"--scope", "--namespace", "--space"})
+
 _REDACTED_VALUE = "<redacted: credential-shaped key>"
 
 
@@ -263,6 +270,12 @@ def _walk_server_paths(server: str, entry: dict) -> list[DeadPath]:
                 and _looks_like_single_absolute_path(arg)
                 and _path_is_dead(arg)
             ):
+                # Skip an arg whose preceding arg is an identifier flag — the
+                # value is an opaque id, not a filesystem path. Safe on
+                # non-string / out-of-bounds / args[0]: those fall through to
+                # the normal dead-path check.
+                if i > 0 and isinstance(args[i - 1], str) and args[i - 1] in _IDENTIFIER_FLAGS:
+                    continue
                 dead.append(DeadPath(spec="", server=server, where=f"args[{i}]", path=arg))
 
     env = entry.get("env")


### PR DESCRIPTION
## Problem / Motivation
`kirocrew doctor`'s dead-path walk stat-ed every absolute `args` value in isolation. An MCP server launched as `mcp start --scope /spaces/nsp_abc123` had its opaque namespace id `/spaces/nsp_abc123` reported as a dead path (via `_walk_server_paths` â†’ `_looks_like_single_absolute_path` â†’ `_path_is_dead`), so a healthy install stayed permanently red.

## Why it matters
Doctor's overall status goes red and exits non-zero on a healthy machine; operators learn to ignore it, so genuinely dead paths stop being noticed.

## What changed (motivation â†’ approach â†’ change)
Flag operands that merely look like absolute paths â†’ need positional signal, not lexical. Strict literal set `_IDENTIFIER_FLAGS={--scope,--namespace,--space}` in `src/kiro_crew/doctor_deadpath.py:242`; `_walk_server_paths` now skips an `args[i]` whose predecessor is in that set. Whitespace-free literal only â€” heuristic would hide real dead paths. Handles `args[0]`, non-string, out-of-bounds, two-positions-later correctly.

## Tests
- Replayed ` _walk_server_paths` with mocked `_path_is_dead`: `--scope /spaces/nsp_abc123` â†’ `[]` (was `[DeadPath]`), `--config /gone` still reported, two-positions-later still reported, `args[0]` not swallowed, non-string safe.
- `isort`, `flake8`, `black` clean.

## Manual verification
N/A â€” unit coverage sufficient. Doctor is CLI; manual would be `kirocrew doctor` with a fixture `~/.kiro/agents/policy-scope.json` containing the scoped server.

## Screenshots / video
N/A â€” CLI output change only.

## Related Issues
Fixes #7375

## Pattern harvest

Rule candidate: position-sensitive dead-path walk

Pattern: a dead-path walk that stats every absolute arg value in isolation, without looking at its predecessor, treats an opaque identifier operand (`--scope /spaces/...`) as a filesystem path. A positional check against a strict literal flag set fixes it.

## Checklist
- [x] At most two commits (one), Conventional Commits title `fix(doctor): ignore identifier-flag operands that look like absolute paths`
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation not applicable
- [x] No secrets, credentials, or internal references in the diff
