### PR TITLE
fix(oauth): accept scheme-less loopback paste from iOS

### DIFF
--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -57,6 +57,11 @@ def _validated_loopback_return_address(value: object) -> _LoopbackCallback | Non
     candidate = value.strip()
     if not candidate or len(candidate.encode("utf-8")) > _MAX_RETURN_ADDRESS_BYTES:
         return None
+    # iOS Safari omits http:// when copying loopback URLs (e.g. 127.0.0.1:8976/callback).
+    # Default to http:// so the paste validates — all other constraints still apply
+    # after normalization; a non-loopback host cannot become loopback by prepending.
+    if "://" not in candidate:
+        candidate = f"http://{candidate}"
     try:
         parsed = urlsplit(candidate)
         port = parsed.port

--- a/website/src/utils/loopbackReturnAddress.ts
+++ b/website/src/utils/loopbackReturnAddress.ts
@@ -11,7 +11,11 @@
  */
 export function isValidLoopbackReturnAddress(value: string): boolean {
   try {
-    const url = new URL(value.trim())
+    let normalized = value.trim()
+    // iOS Safari omits http:// when copying loopback URLs (e.g. 127.0.0.1:8976/callback?code=...).
+    // Default to http:// so the paste validates — other constraints still apply.
+    if (normalized && !normalized.includes('://')) normalized = `http://${normalized}`
+    const url = new URL(normalized)
     const loopback =
       url.hostname === '127.0.0.1'
       || url.hostname === '[::1]'


### PR DESCRIPTION
## Problem / Motivation
In the remote-gateway MCP OAuth flow the provider redirects to a loopback callback on the gateway host. Users copy that URL and paste it into the relay affordance. iOS Safari omits `http://` when copying from the address bar, so `127.0.0.1:8976/callback?code=…` has no scheme. Frontend `isValidLoopbackReturnAddress` (`website/src/utils/loopbackReturnAddress.ts`) does `new URL(value)` → throws; backend `_validated_loopback_return_address` (`src/kiro_crew/dashboard/handlers/connections.py`) requires `parsed.scheme=="http"` → `urlsplit("localhost:8976/cb")` reads `localhost` as scheme. Paste is rejected as "invalid return address".

## Why it matters
iPad/iPhone users doing the documented paste-back flow get a dead-end with no hint that `http://` is missing; they cannot complete OAuth without switching browsers or manually prepending the scheme.

## What changed (motivation → approach → change)
Missing scheme → normalize before validation. Both layers now default a missing `://` to `http://` before `new URL`/`urlsplit`: `let normalized=value.trim(); if (!normalized.includes('://')) normalized='http://'+normalized` and `if "://" not in candidate: candidate="http://"+candidate`. The loopback listener is always plain HTTP and every other constraint (loopback host allowlist `127.0.0.1/::1/localhost`, port≥1024, single non-empty `code`, allowlisted query keys, no credentials/fragment, ASCII request-target) still applies; prepending cannot turn a non-loopback host into a loopback one.

## Tests
- Backend ` _validated_loopback_return_address`: `127.0.0.1:8976/cb?code=abc`→valid, `[::1]:8976/cb?code=abc`→valid, `192.168.1.1:8976`→still invalid, `127.0.0.1:80`→invalid (port<1024), no code→invalid.
- Frontend `node` manual `isValidLoopbackReturnAddress` same vectors.
- `isort`/`flake8`/`black` clean.

## Manual verification
Pasted scheme-less loopback URL in iOS Safari emulation, verified relay accepts and delivers to loopback listener; pasted non-loopback still rejected.

## Screenshots / video
N/A — paste affordance is a text input; no visual change beyond accepting the paste.

## Related Issues
Fixes #7406

## Checklist
- [x] At most two commits (one), Conventional Commits title `fix(oauth): accept scheme-less loopback paste from iOS`
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation not applicable
- [x] No secrets, credentials, or internal references in the diff
