### PR TITLE
fix(knowledge): pace the unattended re-embed sweep (#7367)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -1718,7 +1718,11 @@ async def _rebuild_embeddings_job(app: web.Application, store, embedder, job_id:
     degrades gracefully during the rebuild instead of going dark.
     """
     try:
-        processed = await rebuild_embeddings(store, embedder, job_id=job_id, force=force)
+        # pace=False: this is the user-attended dashboard trigger (a human is
+        # watching the progress bar), so run it at full speed (PRIORITY_NORMAL, no
+        # idling). The watcher self-heal path stays paced (pace=True default).
+        processed = await rebuild_embeddings(store, embedder, job_id=job_id, force=force,
+                                             pace=False)
         store.db.execute(
             "UPDATE ingestion_jobs SET status = 'completed', items_processed = ?, updated_at = ? "
             "WHERE id = ?",

--- a/src/kiro_crew/knowledge/embedder.py
+++ b/src/kiro_crew/knowledge/embedder.py
@@ -110,13 +110,21 @@ class InProcessEmbedder:
             return self._available
         return await run_in_embed_pool(self.is_available)
 
-    def embed(self, text: str) -> list[float] | None:
-        """Embed a single text. Returns float list or None on failure."""
+    def embed(
+        self, text: str, *, priority: int = _embeddings.PRIORITY_NORMAL
+    ) -> list[float] | None:
+        """Embed a single text. Returns float list or None on failure.
+
+        ``priority`` selects the shared backend's scheduling class. A corpus
+        loop (the sig-gated rebuild) passes ``PRIORITY_BULK`` so
+        ``memory.embedding_bulk_threads`` sizes its pool; single-item callers
+        leave the default ``PRIORITY_NORMAL`` and are unchanged.
+        """
         if not text.strip():
             return None
         if not self.is_available():
             return None
-        vec = self._get_embedder().embed(text)
+        vec = self._get_embedder().embed(text, priority=priority)
         if vec is None:
             # The backend stopped producing vectors (reset/reload failure) —
             # invalidate the cached availability so the next call re-probes
@@ -125,9 +133,18 @@ class InProcessEmbedder:
         return vec
 
     def embed_for_item(
-        self, title: str, summary: str | None, content: str | None = None
+        self,
+        title: str,
+        summary: str | None,
+        content: str | None = None,
+        *,
+        priority: int = _embeddings.PRIORITY_NORMAL,
     ) -> list[float] | None:
-        """Embed title + summary + chunk content for knowledge items."""
+        """Embed title + summary + chunk content for knowledge items.
+
+        ``priority`` is forwarded to :meth:`embed` so a bulk rebuild loop can
+        reach the ``PRIORITY_BULK`` lane; single-item callers keep the default.
+        """
         parts = [title]
         if summary:
             parts.append(summary)
@@ -142,7 +159,7 @@ class InProcessEmbedder:
                 )
                 content = content[: self.content_budget]
             parts.append(content)
-        return self.embed(" ".join(parts))
+        return self.embed(" ".join(parts), priority=priority)
 
 
 # Keep the old name as an alias so references to OllamaEmbedder in type

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import hashlib
 import json
 import logging
@@ -14,6 +15,7 @@ from pathlib import Path
 from typing import TypeVar
 from uuid import uuid4
 
+from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_NORMAL, bulk_pace_delay
 from kiro_crew.llm_helpers import _extract_json_of_type
 from kiro_crew.security import (
     is_sensitive_path,
@@ -1231,7 +1233,7 @@ def count_stale_items(store, sig: str, *, now: datetime | None = None) -> int:
 
 
 async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
-                             force: bool = False) -> int:
+                             force: bool = False, pace: bool = True) -> int:
     """Re-embed active items in place, stamping the current embedding signature.
 
     Sig-gated by default: only items whose stored ``embedding_sig`` differs from the
@@ -1245,10 +1247,19 @@ async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
     same function powers the dashboard trigger and the watcher self-heal. Returns the
     number of items successfully re-embedded.
 
+    ``pace`` selects both the idling AND the scheduling class: attendance, not
+    corpus size, is what the bulk dials key on. When ``pace=True`` (the watcher
+    self-heal, where nobody is waiting) each row embeds at ``PRIORITY_BULK`` so
+    ``memory.embedding_bulk_threads`` sizes its pool, and is followed by an idle
+    window from ``bulk_pace_delay`` proportional to the work it just did. When
+    ``pace=False`` (the dashboard trigger, where a user watches the progress bar)
+    the loop embeds at ``PRIORITY_NORMAL`` and never idles.
+
     Serial single-item embed (the in-process embedder is the CPU floor and fans out
     internally); batch size is only the commit/progress cadence, not a throttle.
     """
     loop = asyncio.get_running_loop()
+    priority = PRIORITY_BULK if pace else PRIORITY_NORMAL
     sig = embedder_signature(embedder)
     processed = 0
     failed = 0
@@ -1278,9 +1289,27 @@ async def rebuild_embeddings(store, embedder, *, job_id: str | None = None,
         if not rows:
             break
         for row in rows:
+            # Measure the embed's own elapsed time around the call regardless of
+            # success: a row that returns no vector still ran the model, so it is
+            # paced by the work it did, not by whether a vector came back.
+            started = _time.monotonic()
             vec = await loop.run_in_executor(
-                None, embedder.embed_for_item, row["title"], row["summary"], row["content"]
+                None,
+                functools.partial(
+                    embedder.embed_for_item,
+                    row["title"],
+                    row["summary"],
+                    row["content"],
+                    priority=priority,
+                ),
             )
+            if pace:
+                delay = bulk_pace_delay(_time.monotonic() - started)
+                if delay > 0:
+                    # Idle OFF the loop's work: awaiting sleep here yields the
+                    # gateway loop (holding neither the DB lock nor the model) so
+                    # the pause quiets the sweep without freezing chat/liveness.
+                    await asyncio.sleep(delay)
             now_iso = datetime.now().isoformat()
             # Per-item SQLite writes are OFFLOADED (asyncio.to_thread): a sync
             # write can block up to the busy_timeout under a concurrent writer,

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -473,7 +473,9 @@ class KnowledgeWatcher:
 
     async def _run_reembed_job(self, embedder, job_id: str) -> None:
         try:
-            processed = await rebuild_embeddings(self.store, embedder, job_id=job_id)
+            # Unattended self-heal: keep it paced (pace=True default) so the
+            # post-migration re-embed sweep doesn't pin cores for the user.
+            processed = await rebuild_embeddings(self.store, embedder, job_id=job_id, pace=True)
             # OFFLOADED: single-row write, but a commit can block up to the
             # busy_timeout behind a concurrent writer — keep it off the loop.
             await asyncio.to_thread(self._finalize_reembed_job, job_id, processed)

--- a/test/test_knowledge_bulk_pacing.py
+++ b/test/test_knowledge_bulk_pacing.py
@@ -1,0 +1,247 @@
+"""The knowledge re-embed sweep paces itself; an explicitly-requested one does not.
+
+Mirrors ``test/test_vector_memory_bulk_pacing.py`` for the knowledge path. Locks in
+the behaviour that keeps an unattended post-migration rebuild from pinning several
+cores for tens of minutes: every bulk row is followed by an idle window
+proportional to the work it just did (taken by awaiting off the loop, so it holds
+neither the DB lock nor the model), and skipped entirely when a human triggered the
+rebuild and is watching its progress bar.
+
+Runs WITHOUT ``test/conftest.py`` and WITHOUT pytest-asyncio: the coroutine is
+driven via ``asyncio.run`` inside plain sync tests, the store is a minimal fake,
+and the per-item DB-write helpers are monkeypatched so no SQLite is touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from kiro_crew import embeddings as _embeddings
+from kiro_crew.knowledge import embedder as emb
+from kiro_crew.knowledge import ingestion as ing
+
+PRIORITY_NORMAL = _embeddings.PRIORITY_NORMAL
+PRIORITY_BULK = _embeddings.PRIORITY_BULK
+
+
+class _FakeEmbedder:
+    """Records the priority each row was embedded at; returns a fixed vector."""
+
+    model = "fake-model:0.1b"
+    content_budget = 1000
+
+    def __init__(self, vector):
+        self._vector = vector
+        self.priorities: list[int] = []
+
+    def embed_for_item(self, title, summary, content=None, *, priority=None):
+        self.priorities.append(priority)
+        return self._vector
+
+
+class _FakeStore:
+    """Only needs a ``.db`` whose ``commit()`` is a no-op; every read/write helper
+    that touches ``store.db`` is monkeypatched out in the tests."""
+
+    class _DB:
+        def commit(self):
+            pass
+
+    def __init__(self):
+        self.db = self._DB()
+
+
+def _install_rows(monkeypatch, rows):
+    """Feed ``rows`` to the loop as a single page, then stop.
+
+    ``rebuild_embeddings`` pages via ``_fetch_rebuild_page`` until it returns an
+    empty list, so the first call returns all rows and the second returns ``[]``.
+    Also stub out every per-item DB write helper so the fake store is never hit.
+    """
+    pages = [list(rows), []]
+
+    def _fetch(store, page_where, params_tail, last_id):
+        return pages.pop(0) if pages else []
+
+    writes: list[str] = []
+
+    def _write(store, item_id, blob, sig, now_iso, snap):
+        writes.append(item_id)
+        return True
+
+    monkeypatch.setattr(ing, "_fetch_rebuild_page", _fetch)
+    monkeypatch.setattr(ing, "_write_item_embedding", _write)
+    monkeypatch.setattr(ing, "_stamp_embed_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(ing, "_commit_rebuild_progress", lambda *a, **k: None)
+    return writes
+
+
+def _row(item_id):
+    return {
+        "id": item_id,
+        "title": f"title {item_id}",
+        "summary": f"summary {item_id}",
+        "content": f"content {item_id}",
+        "updated_at": "2024-01-01T00:00:00",
+    }
+
+
+def _record_sleeps(monkeypatch):
+    """Capture pace pauses instead of really sleeping."""
+    recorded: list[float] = []
+
+    async def _sleep(seconds):
+        recorded.append(seconds)
+
+    monkeypatch.setattr(ing.asyncio, "sleep", _sleep)
+    return recorded
+
+
+def _run(store, embedder, **kwargs):
+    return asyncio.run(ing.rebuild_embeddings(store, embedder, **kwargs))
+
+
+def test_each_bulk_row_is_paced(monkeypatch):
+    """The default (watcher self-heal) path idles once per row at PRIORITY_BULK."""
+    monkeypatch.setattr(ing, "bulk_pace_delay", lambda elapsed: 0.125)
+    writes = _install_rows(monkeypatch, [_row("a"), _row("b"), _row("c")])
+    sleeps = _record_sleeps(monkeypatch)
+    embedder = _FakeEmbedder([0.5, 0.5, 0.5, 0.5])
+
+    assert _run(_FakeStore(), embedder) == 3
+    assert writes == ["a", "b", "c"]
+    assert sleeps == [0.125, 0.125, 0.125]
+    assert embedder.priorities == [ing.PRIORITY_BULK] * 3
+
+
+def test_pace_false_never_sleeps(monkeypatch):
+    """The dashboard trigger path (pace=False) never idles and stays PRIORITY_NORMAL."""
+    monkeypatch.setattr(ing, "bulk_pace_delay", lambda elapsed: 0.125)
+    _install_rows(monkeypatch, [_row("a"), _row("b"), _row("c")])
+    sleeps = _record_sleeps(monkeypatch)
+    embedder = _FakeEmbedder([0.5, 0.5, 0.5, 0.5])
+
+    assert _run(_FakeStore(), embedder, pace=False) == 3
+    assert sleeps == []
+    assert embedder.priorities == [ing.PRIORITY_NORMAL] * 3
+
+
+def test_zero_delay_does_not_call_sleep(monkeypatch):
+    """Pacing off (duty 1.0 -> zero delay) must not add a sleep per row."""
+    monkeypatch.setattr(ing, "bulk_pace_delay", lambda elapsed: 0.0)
+    _install_rows(monkeypatch, [_row("a"), _row("b")])
+    sleeps = _record_sleeps(monkeypatch)
+    embedder = _FakeEmbedder([0.5, 0.5, 0.5, 0.5])
+
+    assert _run(_FakeStore(), embedder) == 2
+    assert sleeps == []
+    assert embedder.priorities == [ing.PRIORITY_BULK] * 2
+
+
+def test_a_failed_row_is_still_paced_by_measured_time(monkeypatch):
+    """A row returning no vector still ran the model; pace on elapsed, not success."""
+    monkeypatch.setattr(ing, "bulk_pace_delay", lambda elapsed: 0.05)
+    _install_rows(monkeypatch, [_row("a"), _row("b")])
+    sleeps = _record_sleeps(monkeypatch)
+    embedder = _FakeEmbedder(None)  # embed fails -> None
+
+    # No vector landed, so nothing is counted as processed.
+    assert _run(_FakeStore(), embedder) == 0
+    # But each failed row is still paced by its measured elapsed time.
+    assert sleeps == [0.05, 0.05]
+    assert embedder.priorities == [ing.PRIORITY_BULK] * 2
+
+
+def test_delay_is_derived_from_the_row_s_own_elapsed_time(monkeypatch):
+    """bulk_pace_delay is fed the row's own measured elapsed time, once per row."""
+    seen: list[float] = []
+
+    def _record(elapsed):
+        seen.append(elapsed)
+        return 0.0
+
+    monkeypatch.setattr(ing, "bulk_pace_delay", _record)
+    _install_rows(monkeypatch, [_row("a")])
+    _record_sleeps(monkeypatch)
+    embedder = _FakeEmbedder([0.5, 0.5, 0.5, 0.5])
+
+    _run(_FakeStore(), embedder)
+    assert len(seen) == 1
+    assert seen[0] >= 0.0
+
+
+def test_pace_false_does_not_measure_or_pace(monkeypatch):
+    """The attended path never calls bulk_pace_delay at all."""
+    calls: list[float] = []
+    monkeypatch.setattr(ing, "bulk_pace_delay", lambda elapsed: calls.append(elapsed) or 0.1)
+    _install_rows(monkeypatch, [_row("a"), _row("b")])
+    sleeps = _record_sleeps(monkeypatch)
+    embedder = _FakeEmbedder([0.5, 0.5, 0.5, 0.5])
+
+    _run(_FakeStore(), embedder, pace=False)
+    assert calls == []
+    assert sleeps == []
+
+
+class _FakeBackend:
+    """A shared-embedder stand-in that records the priority landing on ``embed``.
+
+    Reports ready (so ``InProcessEmbedder.embed`` skips the availability probe
+    embed and proceeds to the real forwarding call) and returns a fixed vector
+    so ``embed`` does not treat the row as a failure.
+    """
+
+    model_id = "fake-backend:0.1b"
+
+    def __init__(self):
+        self.priorities: list[int] = []
+
+    def is_ready(self):
+        return True
+
+    def embed(self, text, *, priority=PRIORITY_NORMAL):
+        self.priorities.append(priority)
+        return [0.5, 0.5, 0.5, 0.5]
+
+
+def test_embed_for_item_forwards_bulk_priority_to_backend(monkeypatch):
+    """The priority requested at ``embed_for_item`` must reach ``backend.embed``.
+
+    This closes the gap the ``ingestion`` tests leave open: they assert the
+    priority reaching ``embed_for_item``, but nothing verifies
+    ``embed_for_item``/``embed`` FORWARD it into the shared backend's
+    ``embed(text, priority=...)`` — the link that actually sizes the bulk pool
+    via ``bulk_embed_threads()``. A regression dropping ``priority=priority`` in
+    either ``embedder.py`` call site would slip past the ingestion tests but
+    fail here.
+    """
+    backend = _FakeBackend()
+    # Module-attribute lookup (matches InProcessEmbedder._get_embedder).
+    monkeypatch.setattr(_embeddings, "get_shared_embedder", lambda: backend)
+
+    vec = emb.InProcessEmbedder().embed_for_item("t", "s", "c", priority=PRIORITY_BULK)
+
+    assert vec == [0.5, 0.5, 0.5, 0.5]
+    assert backend.priorities == [PRIORITY_BULK]
+
+
+def test_embed_for_item_defaults_to_normal_priority_on_backend(monkeypatch):
+    """With no priority arg, ``embed_for_item`` must land ``PRIORITY_NORMAL``."""
+    backend = _FakeBackend()
+    monkeypatch.setattr(_embeddings, "get_shared_embedder", lambda: backend)
+
+    emb.InProcessEmbedder().embed_for_item("t", "s", "c")
+
+    assert backend.priorities == [PRIORITY_NORMAL]
+
+
+def test_embed_forwards_priority_to_backend(monkeypatch):
+    """The lower-level ``embed`` forwards its priority to ``backend.embed`` too."""
+    backend = _FakeBackend()
+    monkeypatch.setattr(_embeddings, "get_shared_embedder", lambda: backend)
+
+    inst = emb.InProcessEmbedder()
+    inst.embed("hello", priority=PRIORITY_BULK)
+    inst.embed("world")  # default
+
+    assert backend.priorities == [PRIORITY_BULK, PRIORITY_NORMAL]


### PR DESCRIPTION
## Summary

Closes #7367.

`rebuild_embeddings` in `src/kiro_crew/knowledge/ingestion.py` is the same shape as the memory re-embed loop that #7351 quieted, but neither bulk dial reached it:
- It embedded through the knowledge embedder rather than the `PRIORITY_BULK` lane, so `bulk_embed_threads()` never applied.
- It never called `bulk_pace_delay()`, so it ran flat out.

Consequence: a KB setup change that invalidates the stored embedding signature reproduced the same fan-noise report #7351 answers for memory, on a corpus that can be larger.

## Changes

1. **PRIORITY_BULK routing.** `InProcessEmbedder.embed` and `embed_for_item` (`knowledge/embedder.py`) gain a keyword-only `priority` (default `PRIORITY_NORMAL`) forwarded to the shared backend's `embed(text, priority=...)`, so `memory.embedding_bulk_threads` (via `bulk_embed_threads()`) sizes the pool.
2. **Pacing with an attended/unattended split.** `rebuild_embeddings` gains keyword-only `pace: bool = True`; `priority = PRIORITY_BULK if pace else PRIORITY_NORMAL`. When paced, it measures monotonic elapsed strictly around the embed (so a failed/None embed is still paced by the work it did) and `await asyncio.sleep(bulk_pace_delay(elapsed))` when > 0, off the loop, holding neither the DB lock nor the model.
   - Dashboard trigger (`dashboard/handlers/knowledge.py`) passes `pace=False` (a user watches the progress bar): full speed, `PRIORITY_NORMAL`, no idling.
   - Watcher self-heal (`knowledge/watcher.py`) stays paced-by-default (`pace=True`).
3. **Tests.** New `test/test_knowledge_bulk_pacing.py` mirrors `test/test_vector_memory_bulk_pacing.py`: the paced (watcher) path idles once per row at `PRIORITY_BULK`; the dashboard path (`pace=False`) never idles and stays `PRIORITY_NORMAL`; zero delay adds no sleep; a failed row is still paced by measured elapsed. Plus 3 `InProcessEmbedder`-level tests proving the priority forwards all the way into the backend `embed(text, priority=...)`.

## Testing

The sandbox is `INTEGRATIONS_ONLY` (no external network, no package installs), so the full `make test` suite and `test_vector_memory_bulk_pacing.py` cannot run here (conftest imports `hypothesis`; `vector_memory` imports `snowballstemmer`; async tests need `pytest-asyncio`). **CI must run the full suite.**

Sandbox-feasible checks are green:
- `py_compile` on all changed files; clean import of the two knowledge modules.
- New `test/test_knowledge_bulk_pacing.py` 9/9 pass via `PYTHONPATH=src python -m pytest test/test_knowledge_bulk_pacing.py --noconftest -p no:cacheprovider -o addopts=''`.
- `ruff` + `black` clean on the new test file.
- Priority signatures verified end-to-end: `rebuild_embeddings -> embed_for_item(priority=) -> embed(priority=) -> backend.embed(text, priority=)`.

Diff scope is limited to the 4 intended source files plus the new test.