### PR TITLE
fix(feishu): log every inbound drop with reason and message_type

### DIFF
--- a/src/kiro_crew/feishu/client.py
+++ b/src/kiro_crew/feishu/client.py
@@ -242,13 +242,16 @@ class LarkClient:
         """Sync P2ImMessageReceiveV1 handler injected into the WS dispatcher."""
         event = getattr(data, "event", None)
         if event is None:
+            logger.debug("Feishu inbound drop: missing event")
             return
         message = getattr(event, "message", None)
         if message is None:
+            logger.debug("Feishu inbound drop: missing message")
             return
 
         msg_id: str = message.message_id or ""
         if not msg_id:
+            logger.debug("Feishu inbound drop: empty message_id")
             return
 
         # NOTE: redelivery dedup deliberately does NOT happen here. Everything
@@ -261,18 +264,27 @@ class LarkClient:
 
         # Only handle plain-text messages for now.
         if (message.message_type or "") != "text":
+            logger.info(
+                "Feishu inbound drop: unsupported message_type=%s message_id=%s",
+                message.message_type,
+                msg_id,
+            )
             return
 
         sender = getattr(event, "sender", None)
         sid = getattr(sender, "sender_id", None) if sender else None
         open_id: str = (getattr(sid, "open_id", None) or "") if sid else ""
         if not open_id:
+            logger.debug("Feishu inbound drop: missing open_id message_id=%s", msg_id)
             return
 
         try:
             content = json.loads(message.content or "{}")
             raw_text: str = content.get("text", "").strip()
         except Exception:
+            logger.debug(
+                "Feishu inbound drop: JSON parse failed message_id=%s", msg_id, exc_info=True
+            )
             return
 
         # Feishu sends mentions as opaque placeholders (``@_user_1``) with the
@@ -283,6 +295,7 @@ class LarkClient:
         # which is what keeps a bare "@bot" from driving an empty turn.
         mention_free = _AT_RE.sub("", raw_text).strip()
         if not mention_free:
+            logger.debug("Feishu inbound drop: mention-only body message_id=%s", msg_id)
             return
         # NOT ``mention_free``: that deletes every placeholder, which would read
         # "@bot /new @alice" as the bare command "/new" and reset the
@@ -290,6 +303,7 @@ class LarkClient:
         command_body = _command_body(raw_text)
         text = _resolve_mentions(raw_text, getattr(message, "mentions", None)).strip()
         if not text:
+            logger.debug("Feishu inbound drop: empty text after resolve message_id=%s", msg_id)
             return
 
         inbound = LarkInbound(


### PR DESCRIPTION
## Problem / Motivation
Feishu's `_handle_receive_v1` (`src/kiro_crew/feishu/client.py:242`) had seven bare `return` branches for non-text or malformed inbound frames (missing event/message, empty message_id, unsupported `message_type`, missing `open_id`, JSON parse failure, mention-only body, empty text) with no log and no user reply. The only inbound log lived downstream in `FeishuDispatcher.handle_message`, so a dropped sticker/image/voice note left no trace in `gateway.log` and was indistinguishable from a dead WebSocket, wrong App ID, or missing scope. Diagnosing took hours of elimination.

## Why it matters
Every dropped Feishu message is silently ACKed HTTP 200 by Feishu, so the sender sees delivered but the bot stays silent; operators cannot tell "deliberately ignored" from "never arrived".

## What changed (motivation → approach → change)
Observability gap → log at the drop point. Added distinct `logger.debug`/`info` at each `return`: missing event/message → debug, unsupported `message_type` → `info` with type+message_id, missing `open_id` → debug with message_id, JSON parse → debug with `exc_info`, mention-only/empty text → debug with message_id. No behavior change for text messages.

## Tests
- No new unit test needed — change is logging only; wide path still forwards to `handler(inbound)` via `run_coroutine_threadsafe`.
- `isort`/`flake8`/`black` clean.

## Manual verification
Sent non-text Feishu message in dev gateway, verified `gateway.log` now shows `Feishu inbound drop: unsupported message_type=sticker message_id=…` instead of silence.

## Screenshots / video
N/A — log line only.

## Related Issues
Fixes #7520

## Checklist
- [x] At most two commits (one), Conventional Commits title `fix(feishu): log every inbound drop with reason and message_type`
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation not applicable
- [x] No secrets, credentials, or internal references in the diff
