### PR TITLE
refactor: extract issue radar client boundaries

### DIFF
--- a/docs/system-specs/modules/issue-radar.md
+++ b/docs/system-specs/modules/issue-radar.md
@@ -32,6 +32,19 @@ always the other client drifting and the failure names which one. That class als
 asserts its own table covers every entry in `provider.PROVIDERS`, so a fourth
 provider cannot be registered while the gate silently keeps comparing three.
 
+**Each client module is the stable composition façade for its provider.** The
+routes and tests continue to import `github_client`, `gitlab_client` and
+`azure_client`; those modules retain the protocol surface, exception aliases,
+constants and patchable I/O chokepoints. Provider-specific sibling modules keep
+the implementation boundaries explicit: `*_transport.py` owns URL, environment,
+request and pagination mechanics; `*_normalization.py` converts provider payloads
+into the shared GitHub-shaped records; and `github_queries.py` owns GitHub's
+GraphQL, dependency and search query plans. The façades inject their current
+bindings into those helpers so established monkeypatch seams remain authoritative.
+The reviewed real `glab` and `az` process spawns remain in
+`gitlab_client._glab_run` and `azure_client._az_run`, respectively, which keeps
+the spawn-audit allowlist tied to the same security chokepoints.
+
 | | GitHub | GitLab | Azure DevOps |
 |---|---|---|---|
 | Provider id | `github` | `gitlab` | `azure` |

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
@@ -52,25 +52,29 @@ instead of silently targeting a host the caller never named.
 
 from __future__ import annotations
 
-import json
+import json  # noqa: F401 -- historical module export
 import os
 import re
 import subprocess
 import sys
-import tempfile
+import tempfile  # noqa: F401 -- historical module export
 from urllib.parse import quote, unquote, urlparse
 
 from kiro_crew.apps.registry import minimal_env
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
+from . import azure_normalization as _normalization
+from . import azure_transport as _transport
 from .errors import (
     ProviderCliError,
     ProviderInvalidInputError,
     ProviderPermissionError,
     ProviderSetupError,
     PrSearchError,
-    RepoUrlError,
+)
+from .errors import RepoUrlError as RepoUrlError  # noqa: F401 -- public re-export
+from .errors import (
     sanitize_cli_stderr,
 )
 
@@ -98,10 +102,8 @@ MAX_WINDOW_DAYS = 3650
 PR_SEARCH_MAX = 300
 
 # The one supported host. Azure DevOps Server (on-premises) is out of scope.
-AZURE_HOST = "dev.azure.com"
-# Legacy per-organization host, accepted when PARSING a pasted URL and
-# canonicalized to AZURE_HOST so one organization cannot become two identities.
-_LEGACY_HOST_SUFFIX = ".visualstudio.com"
+AZURE_HOST = _transport.AZURE_HOST
+_LEGACY_HOST_SUFFIX = _transport._LEGACY_HOST_SUFFIX
 
 # ``--api-version`` is MANDATORY on every ``az devops invoke`` call and differs
 # per endpoint: the CLI's own default is 5.0, which predates most of what this
@@ -122,10 +124,10 @@ _API_IDENTITY = "7.1-preview.1"
 
 # Azure list responses come back as ``{"count": n, "value": [...]}`` and are
 # paged with ``$top``/``$skip`` rather than a page number.
-_PAGE_SIZE = 100
+_PAGE_SIZE = _transport._PAGE_SIZE
 # Hard cap on pages walked by one paginated read, so a pathological project
 # cannot make a single request loop indefinitely.
-_MAX_PAGES = 40
+_MAX_PAGES = _transport._MAX_PAGES
 # Work-item comments are their own paged resource, keyed by a continuation token
 # rather than $skip, and Azure caps this page at 200.
 _COMMENT_PAGE_SIZE = 200
@@ -150,178 +152,34 @@ _PR_LOOKUP_TOP = 200
 
 # Azure has no colour on a work-item tag, so one is synthesized. Same neutral
 # default the other two clients fall back to, so a tag renders like a label.
-_SYNTHETIC_LABEL_COLOR = "888888"
+_SYNTHETIC_LABEL_COLOR = _normalization._SYNTHETIC_LABEL_COLOR
 
-# Conservative charset for an organization / project / repository segment.
-# Azure allows spaces in project and repository names, so a space is permitted
-# (values reach a subprocess as their own argv element, never a shell string),
-# but nothing that could act as a path or query separator is.
-_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$")
-# Segments that are part of Azure's own routing rather than a name.
-_RESERVED_SEGMENTS = frozenset({"_git", "_apis", "_workitems", "_build", "_settings", "_apps"})
+# Kept importable from the historical facade for direct tests and diagnostics.
+_SEGMENT_RE = _transport._SEGMENT_RE
+_RESERVED_SEGMENTS = _transport._RESERVED_SEGMENTS
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
-# A GUID as Azure returns identity ids. Validated before one reaches an argv or a
-# query string, since it is the one value here that comes from a prior response.
-_GUID_RE = re.compile(
-    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-)
+_GUID_RE = _normalization._GUID_RE
 # A login as the person filters accept it: an Azure unique name is usually an
 # email/UPN, so "@" and "+" are legal where they would not be on the other
 # providers.
 _LOGIN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+@' -]{0,254}$")
 
 
-def _bad_segment(segment: str) -> bool:
-    """Whether a path segment is unusable as an org / project / repo name."""
-    if not segment or segment in (".", ".."):
-        return True
-    if segment.lower() in _RESERVED_SEGMENTS:
-        return True
-    return not _SEGMENT_RE.match(segment)
-
-
-_URL_PATH_SEPARATOR = re.compile(r"/+")
-
-
-def _url_path_segments(path: str) -> list[str]:
-    """The non-empty segments of a URL path.
-
-    A URL path separator is ``/`` on every host platform, so this deliberately
-    does NOT go through ``pathlib``/``os.path``: those rewrite the separator on
-    Windows and would take the URL apart with the wrong one. Runs of separators
-    collapse, so a doubled ``//`` yields no empty segment for a caller to mistake
-    for a real one.
-    """
-    return [segment for segment in _URL_PATH_SEPARATOR.split(path or "") if segment]
-
-
 def parse_azure_repo_url(link: str) -> tuple[str, str]:
-    """Parse ``("{organization}/{project}", repository)`` from an Azure DevOps URL.
-
-    Accepts the three forms a user can paste:
-
-    * ``https://dev.azure.com/{org}/{project}/_git/{repo}`` -- the repository page
-    * ``https://dev.azure.com/{org}/{project}`` -- the project page, where the
-      repository defaults to the project name (Azure creates one so named)
-    * ``https://{org}.visualstudio.com/{project}/_git/{repo}`` -- the legacy host,
-      canonicalized to the modern identity so one organization does not end up
-      with two cache trees
-
-    A trailing ``/``, a ``.git`` suffix, and any deeper path or query after the
-    repository segment (``/pullrequest/12``, ``?path=/src``) are IGNORED rather
-    than folded into the name -- users paste whichever tab they are on.
-
-    Deliberately strict, for the same reasons as the other two parsers: full URL
-    only, HTTPS only, no userinfo, host must be Azure's, and every segment is
-    charset-constrained before any value can reach a subprocess argv.
-    """
-    if not link or not isinstance(link, str):
-        raise RepoUrlError("repo link is empty")
-    try:
-        parsed = urlparse(link.strip())
-    except ValueError as exc:
-        raise RepoUrlError(f"unparseable URL: {link!r}") from exc
-    if parsed.scheme != "https":
-        raise RepoUrlError(f"not an https URL: {link!r}")
-    if parsed.username or parsed.password:
-        raise RepoUrlError("URLs with embedded credentials are not accepted")
-    # `hostname`/`port` parse the authority lazily, so a malformed one raises
-    # HERE rather than in urlparse; both are client input, so both become the
-    # same RepoUrlError the connect route maps to a 400.
-    try:
-        host = (parsed.hostname or "").lower().rstrip(".")
-        _ = parsed.port
-    except ValueError as exc:
-        raise RepoUrlError(f"malformed host or port in {link!r}") from exc
-
-    legacy_org = ""
-    if host == AZURE_HOST:
-        pass
-    elif host.endswith(_LEGACY_HOST_SUFFIX):
-        # The organization is the host's first label on the legacy form, so it is
-        # taken from there rather than from the path.
-        legacy_org = host[: -len(_LEGACY_HOST_SUFFIX)]
-        if _bad_segment(legacy_org):
-            raise RepoUrlError(f"invalid organization in {link!r}")
-    else:
-        raise RepoUrlError(
-            f"not a supported Azure DevOps host: {link!r} -- only {AZURE_HOST} and the "
-            "legacy {org}.visualstudio.com form are accepted (Azure DevOps Server is not supported)"
-        )
-
-    # Percent-decoded per segment, because a project or repository name may
-    # legitimately contain a space. Decoding cannot be allowed to reintroduce a
-    # separator, so a decoded segment carrying one is refused outright.
-    raw_parts = _url_path_segments(parsed.path or "")
-    parts: list[str] = []
-    for raw in raw_parts:
-        seg = unquote(raw)
-        if "/" in seg or "\\" in seg or "?" in seg or "#" in seg:
-            raise RepoUrlError(f"invalid path segment in {link!r}")
-        parts.append(seg)
-
-    if legacy_org:
-        org = legacy_org
-    else:
-        if not parts:
-            raise RepoUrlError(f"not a full Azure DevOps URL: {link!r}")
-        org, parts = parts[0], parts[1:]
-    if not parts:
-        raise RepoUrlError(
-            f"not a full Azure DevOps URL: {link!r} (expected .../{{project}} or .../{{project}}/_git/{{repo}})"
-        )
-    project, parts = parts[0], parts[1:]
-
-    # Everything from the `_git` marker onward addresses a repository; without
-    # the marker the URL names the project, whose default repository shares its
-    # name. Anything after the repository segment is a page within it.
-    if parts and parts[0] == "_git":
-        repo = parts[1] if len(parts) > 1 else project
-    elif parts and parts[0].lower() in _RESERVED_SEGMENTS:
-        # A project-level page that is not a repository page (boards, pipelines).
-        repo = project
-    else:
-        repo = project
-    repo = re.sub(r"\.git$", "", repo)
-
-    for seg in (org, project, repo):
-        if _bad_segment(seg):
-            raise RepoUrlError(f"invalid path segment in {link!r}")
-    return f"{org}/{project}", repo
+    """Parse the provider key from a supported Azure DevOps URL."""
+    return _transport.parse_azure_repo_url(link)
 
 
-def _split_owner(owner: str) -> tuple[str, str]:
-    """``"{org}/{project}"`` -> ``(org, project)``, split on the FIRST ``/`` only.
-
-    Azure's ``owner`` carries two independent names, and neither may contain a
-    slash, so a single split is exact. An owner with no ``/`` cannot address
-    anything -- every route below needs both halves -- so it is refused rather
-    than guessed at (defaulting the project to the organization would read a
-    different project's work items).
-    """
-    text = str(owner or "").strip().strip("/")
-    org, sep, project = text.partition("/")
-    if not sep:
-        raise ProviderCliError(
-            f"an Azure DevOps owner must be '{{organization}}/{{project}}' (got {owner!r})"
-        )
-    org, project = org.strip(), project.strip()
-    if _bad_segment(org) or _bad_segment(project):
-        raise ProviderCliError(f"invalid Azure DevOps organization/project: {owner!r}")
-    return org, project
-
-
-def _check_repo(repo: str) -> str:
-    """Validate a repository name before it reaches a route parameter."""
-    name = str(repo or "").strip()
-    if _bad_segment(name):
-        raise ProviderCliError(f"invalid Azure DevOps repository name: {repo!r}")
-    return name
+_bad_segment = _transport._bad_segment
+_URL_PATH_SEPARATOR = _transport._URL_PATH_SEPARATOR
+_url_path_segments = _transport._url_path_segments
+_split_owner = _transport._split_owner
+_check_repo = _transport._check_repo
 
 
 def _org_url(org: str) -> str:
-    """The ``--org`` value for an organization, always on the pinned host."""
-    return f"https://{AZURE_HOST}/{quote(org, safe='')}"
+    """Return the pinned organization URL through the current quote binding."""
+    return _transport._org_url(org, quote_value=quote)
 
 
 # ── az spawn hardening ───────────────────────────────────────────────────────
@@ -335,25 +193,7 @@ def _org_url(org: str) -> str:
 # hands the child a MINIMAL environment (PATH/HOME/XDG plus az's own auth and
 # network vars) instead of the gateway's full env, so unrelated secrets
 # (AWS/Slack/SSH) can never reach a substituted or compromised az.
-_AZ_ENV_PASSTHROUGH = (
-    # The Azure DevOps extension's own credential, and az's config/extension roots
-    # (which is where the `az login` session lives).
-    "AZURE_DEVOPS_EXT_PAT",
-    "AZURE_CONFIG_DIR",
-    "AZURE_EXTENSION_DIR",
-    "HTTP_PROXY",
-    "HTTPS_PROXY",
-    "NO_PROXY",
-    "ALL_PROXY",
-    "http_proxy",
-    "https_proxy",
-    "no_proxy",
-    "all_proxy",
-    "SSL_CERT_FILE",
-    "SSL_CERT_DIR",
-    "REQUESTS_CA_BUNDLE",
-    "CURL_CA_BUNDLE",
-)
+_AZ_ENV_PASSTHROUGH = _transport._AZ_ENV_PASSTHROUGH
 
 _az_bin_cache: str | None = None
 
@@ -432,53 +272,17 @@ def _az_bin() -> str:
     )
 
 
-def _resolve_host(host: str) -> str:
-    """Re-check ``host`` at the spawn boundary; only ``dev.azure.com`` passes.
-
-    Azure's host is pinned by ``provider.normalize_host``, but it is re-checked
-    here so a corrupted config entry or a future code path that forgets to
-    normalize cannot reach another server with the user's credential. An omitted
-    host is refused rather than defaulted, mirroring
-    ``gitlab_client._resolve_host``: a call that forgot the host must fail loudly
-    instead of silently targeting a host the caller never named.
-
-    Azure DevOps Server (on-premises) is refused because the ``azure-devops``
-    extension does not support it at all -- there is no credential path for it,
-    so accepting the host would only produce a confusing CLI failure.
-    """
-    if not host:
-        raise ProviderCliError("an Azure DevOps host is required for az calls")
-    normalized = host.lower().rstrip(".")
-    if normalized != AZURE_HOST:
-        raise ProviderCliError(
-            f"Azure DevOps host {normalized!r} is not supported -- only {AZURE_HOST} "
-            "(Azure DevOps Server / on-premises has no supported credential path)"
-        )
-    return normalized
+_resolve_host = _transport._resolve_host
 
 
 def _az_env(host: str) -> dict[str, str]:
-    """A minimal environment for ``az``: the platform's safe-key base plus az's
-    own auth and network/TLS vars when set -- NOT the gateway's full environment.
-
-    ``AZURE_DEVOPS_EXT_PAT`` is forwarded only for the pinned cloud host. It is a
-    single ambient credential with no host binding, so forwarding it to anything
-    else would hand a dev.azure.com token to that server.
-
-    ``AZURE_EXTENSION_USE_DYNAMIC_INSTALL=no`` is a security setting, not a
-    convenience one: with dynamic install enabled, a call naming an unknown
-    command group makes az download and execute an extension wheel. An automated
-    spawn must never install code, so a missing extension has to surface as an
-    error the user resolves themselves.
-    """
-    passthrough = {k: os.environ[k] for k in _AZ_ENV_PASSTHROUGH if k in os.environ}
-    if host != AZURE_HOST:
-        passthrough.pop("AZURE_DEVOPS_EXT_PAT", None)
-    passthrough["AZURE_EXTENSION_USE_DYNAMIC_INSTALL"] = "no"
-    passthrough["AZURE_CORE_COLLECT_TELEMETRY"] = "0"
-    passthrough["AZURE_CORE_NO_COLOR"] = "1"
-    passthrough["NO_COLOR"] = "1"
-    return minimal_env(**passthrough)
+    """Build the minimal ``az`` environment through the transport helper."""
+    return _transport._az_env(
+        host,
+        source_env=os.environ,
+        passthrough_keys=_AZ_ENV_PASSTHROUGH,
+        minimal_env=minimal_env,
+    )
 
 
 def _audit(op: str, target: str, outcome: str, *, error: str = "") -> None:
@@ -555,83 +359,24 @@ def _az_run(argv: list[str], *, host: str, timeout: float) -> subprocess.Complet
 # login instruction instead of an opaque exit code. TF400813 is Azure DevOps's
 # own "the user is not authorized" code, which it also returns for an expired or
 # absent session.
-_AZ_AUTH_MARKERS = (
-    "az login",
-    "az devops login",
-    "tf400813",
-    "please run 'az login'",
-    "unauthorized",
-    "401",
-    "before you can run this command you need to log in",
-)
+_AZ_AUTH_MARKERS = _transport._AZ_AUTH_MARKERS
 
 # Markers that mean the CLI or its azure-devops EXTENSION is missing. A missing
 # extension is reported as ``not_installed`` too: the fix is the same class of
 # user action (install something), and the connect dialog names it.
-_AZ_MISSING_MARKERS = (
-    'is not in the "az" command group',
-    "az extension add",
-    "extension is not installed",
-    "no such command",
-    "command not found",
-)
+_AZ_MISSING_MARKERS = _transport._AZ_MISSING_MARKERS
 
 
-def _raise_if_setup_failure(stderr_tail: str) -> None:
-    """Re-classify a missing-CLI / missing-extension / unauthenticated failure.
-
-    Order matters: the missing-extension check runs FIRST, because az's message
-    for an absent extension can also mention logging in, and telling a user to
-    authenticate a CLI that cannot serve the command at all sends them down the
-    wrong path.
-    """
-    low = (stderr_tail or "").lower()
-    if any(m in low for m in _AZ_MISSING_MARKERS):
-        raise ProviderSetupError(
-            "the `azure-devops` extension for the `az` CLI is not available -- "
-            "install it with `az extension add --name azure-devops`",
-            reason="not_installed",
-        )
-    if any(m in low for m in _AZ_AUTH_MARKERS):
-        raise ProviderSetupError(
-            f"the `az` CLI is not authenticated for {AZURE_HOST} -- run `az login` "
-            "(or `az devops login` with a personal access token)",
-            reason="not_authenticated",
-        )
+_raise_if_setup_failure = _transport._raise_if_setup_failure
 
 
 def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
-    return sanitize_cli_stderr(" ".join((proc.stderr or "").strip().splitlines()[-3:]))
+    """Return sanitized stderr through the current facade binding."""
+    return _transport._stderr_tail(proc, sanitize=sanitize_cli_stderr)
 
 
-def _is_forbidden(tail: str) -> bool:
-    low = (tail or "").lower()
-    return "403" in low or "forbidden" in low or "does not have permission" in low
-
-
-def _body_file(body: object) -> str:
-    """Write a request body to a fresh 0600 temp file and return its path.
-
-    Azure's REST passthrough takes a body from a FILE (``--in-file``), not from
-    stdin, so a body has to be materialized on disk. Two properties matter:
-
-    * The mode is 0600 from creation (``mkstemp`` guarantees it), so a body is
-      never briefly world-readable -- bodies here carry comment prose and, for a
-      merge, the commit a merge is pinned to.
-    * The name is UNIQUE per call. A fixed name would let two concurrent requests
-      overwrite each other's body, so a merge could complete with another call's
-      payload, and would be a symlink-attack target in a shared temp directory.
-
-    The caller deletes it in a ``finally``.
-    """
-    fd, path = tempfile.mkstemp(prefix="kirocrew-az-", suffix=".json")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(body, handle)
-    except Exception:
-        os.unlink(path)
-        raise
-    return path
+_is_forbidden = _transport._is_forbidden
+_body_file = _transport._body_file
 
 
 def _az_invoke(
@@ -648,80 +393,26 @@ def _az_invoke(
     api_version: str,
     media_type: str = "",
 ) -> object:
-    """Run one ``az devops invoke`` call and parse the JSON response.
-
-    ``az devops invoke`` is the Azure CLI's generic REST passthrough: the
-    ``area``/``resource`` pair is resolved against the organization's own
-    ``_apis`` resource-location document, so an unsupported pair fails loudly
-    instead of silently addressing a different endpoint.
-
-    ``route`` supplies the route template's placeholders (``project``,
-    ``repositoryId``, ``pullRequestId``, ...) and ``query`` the query string.
-    Both are passed as separate argv elements -- never assembled into a shell
-    string -- so a value containing a space or an ``&`` cannot smuggle in another
-    parameter.
-
-    ``--detect false`` is always passed: detection would try to infer the
-    organization from the current git remote, and the cwd of a gateway process is
-    unrelated to the project being read.
-    """
-    argv = [
-        "az",
-        "devops",
-        "invoke",
-        "--org",
-        _org_url(org),
-        "--area",
-        area,
-        "--resource",
-        resource,
-        "--http-method",
-        method,
-        "--api-version",
-        api_version,
-        "--detect",
-        "false",
-        "--output",
-        "json",
-    ]
-    if route:
-        argv.append("--route-parameters")
-        argv.extend(f"{key}={value}" for key, value in route.items())
-    if query:
-        argv.append("--query-parameters")
-        argv.extend(f"{key}={value}" for key, value in query.items())
-    if media_type:
-        argv += ["--media-type", media_type]
-
-    path = ""
-    try:
-        if body is not None:
-            path = _body_file(body)
-            argv += ["--in-file", path]
-        proc = _az_run(argv, host=host, timeout=timeout)
-    finally:
-        if path:
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
-
-    target = f"{area}/{resource}"
-    if proc.returncode != 0:
-        tail = _stderr_tail(proc)
-        _raise_if_setup_failure(tail)
-        if _is_forbidden(tail):
-            raise ProviderPermissionError(
-                f"az devops invoke {target} was forbidden (exit {proc.returncode}): {tail}"
-            )
-        raise ProviderCliError(f"az devops invoke {target} failed (exit {proc.returncode}): {tail}")
-    text = (proc.stdout or "").strip()
-    if not text:
-        return {}
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise ProviderCliError(f"az returned unexpected output for {target}") from exc
+    """Invoke through the extracted transport using this facade's patch seams."""
+    return _transport.invoke(
+        run=_az_run,
+        body_file=_body_file,
+        org_url=_org_url,
+        raise_if_setup_failure=_raise_if_setup_failure,
+        stderr_tail=_stderr_tail,
+        is_forbidden=_is_forbidden,
+        org=org,
+        area=area,
+        resource=resource,
+        host=host,
+        timeout=timeout,
+        route=route,
+        query=query,
+        method=method,
+        body=body,
+        api_version=api_version,
+        media_type=media_type,
+    )
 
 
 def _az_invoke_paged(
@@ -736,244 +427,39 @@ def _az_invoke_paged(
     api_version: str,
     limit: int = 0,
 ) -> list[dict]:
-    """Walk ``$top``/``$skip`` over a list endpoint and concatenate the values.
-
-    Azure pages by offset rather than by page number, and reports no "next page"
-    link on most of these routes, so a short page is the end-of-data signal.
-    Bounded by :data:`_MAX_PAGES` so one request cannot loop indefinitely on a
-    pathological project, and by ``limit`` when the caller wants fewer.
-    """
-    out: list[dict] = []
-    skip = 0
-    for _ in range(_MAX_PAGES):
-        top = _PAGE_SIZE
-        if limit:
-            remaining = limit - len(out)
-            if remaining <= 0:
-                break
-            top = min(_PAGE_SIZE, remaining)
-        page_query = dict(query or {})
-        page_query["$top"] = top
-        page_query["$skip"] = skip
-        rows = _values(
-            _az_invoke(
-                org=org,
-                area=area,
-                resource=resource,
-                host=host,
-                timeout=timeout,
-                route=route,
-                query=page_query,
-                api_version=api_version,
-            )
-        )
-        out.extend(rows)
-        if len(rows) < top:
-            break
-        skip += top
-    return out
+    """Page through the extracted transport using the current invoke binding."""
+    return _transport.invoke_paged(
+        invoke_one=_az_invoke,
+        values=_values,
+        page_size=_PAGE_SIZE,
+        max_pages=_MAX_PAGES,
+        org=org,
+        area=area,
+        resource=resource,
+        host=host,
+        timeout=timeout,
+        route=route,
+        query=query,
+        api_version=api_version,
+        limit=limit,
+    )
 
 
-def _obj(data: object) -> dict:
-    return data if isinstance(data, dict) else {}
+_obj = _normalization._obj
+_values = _normalization._values
+_identity_login = _normalization._identity_login
+_identity_logins = _normalization._identity_logins
+_identity_id = _normalization._identity_id
+_tag_names = _normalization._tag_names
+_tags_field = _normalization._tags_field
+_check_label = _normalization._check_label
+_shape_labels = _normalization._shape_labels
+_work_item_url = _normalization._work_item_url
+_field = _normalization._field
 
 
-def _values(data: object) -> list[dict]:
-    """The rows of an Azure list response.
-
-    Azure wraps a collection in ``{"count": n, "value": [...]}``, but a few
-    routes answer with a bare array, so both shapes are accepted.
-    """
-    if isinstance(data, list):
-        return [row for row in data if isinstance(row, dict)]
-    inner = _obj(data).get("value")
-    if isinstance(inner, list):
-        return [row for row in inner if isinstance(row, dict)]
-    return []
-
-
-# ── normalization: Azure DevOps -> the GitHub-shaped vocabulary the app speaks ─
-
-
-def _identity_login(raw: object) -> str | None:
-    """An Azure identity reference -> a login string.
-
-    ``uniqueName`` is the stable, human-typeable handle (usually an email/UPN) and
-    is what the person filters match on, so it is preferred; ``displayName`` is
-    the fallback for a service identity that has none.
-    """
-    if not isinstance(raw, dict):
-        return None
-    name = raw.get("uniqueName") or raw.get("displayName") or raw.get("principalName")
-    text = str(name).strip() if name else ""
-    return text or None
-
-
-def _identity_logins(raw: object) -> list[str]:
-    if not isinstance(raw, list):
-        return []
-    return [login for login in (_identity_login(item) for item in raw) if login]
-
-
-def _identity_id(raw: object) -> str | None:
-    """The GUID of an identity reference, validated before it can reach an argv."""
-    if not isinstance(raw, dict):
-        return None
-    value = str(raw.get("id") or "").strip()
-    return value if _GUID_RE.match(value) else None
-
-
-def _tag_names(raw: object) -> list[str]:
-    """``System.Tags`` -> a list of tag names.
-
-    Azure stores tags as ONE delimited string (``"needs-triage; blocked"``), so
-    this is a parse, not a field read. Tags are case sensitive and may contain
-    neither ``,`` nor ``;`` -- the delimiter is why -- and Azure normalizes the
-    separator to ``"; "`` on write.
-    """
-    text = str(raw or "").strip()
-    if not text:
-        return []
-    return [part.strip() for part in text.split(";") if part.strip()]
-
-
-def _tags_field(names: list[str]) -> str:
-    """A tag list -> the delimited ``System.Tags`` string Azure stores."""
-    return "; ".join(names)
-
-
-def _check_label(label: str) -> str:
-    """Validate one tag name before it is written into ``System.Tags``.
-
-    ``,`` and ``;`` are the delimiters Azure splits the field on, so a name
-    containing either would silently become two tags -- or corrupt a neighbouring
-    one -- on the read-modify-write below. Refusing is the only honest answer:
-    there is no escaping mechanism to fall back on.
-    """
-    name = str(label or "").strip()
-    if not name:
-        raise ProviderCliError("a tag name cannot be empty")
-    if "," in name or ";" in name:
-        raise ProviderCliError(
-            f"Azure DevOps tags cannot contain ',' or ';' (got {label!r}) -- those are "
-            "the delimiters the tag field is stored with"
-        )
-    if len(name) > 400:
-        raise ProviderCliError(f"tag name is too long: {label!r}")
-    return name
-
-
-def _shape_labels(names: list[str]) -> list[dict]:
-    """Tag names -> ``[{name, color, description}]``.
-
-    The colour is SYNTHETIC: an Azure work-item tag has no colour and no
-    description, so every tag renders in the same neutral colour the other two
-    clients fall back to for an uncoloured label.
-    """
-    return [{"name": name, "color": _SYNTHETIC_LABEL_COLOR, "description": ""} for name in names]
-
-
-def _work_item_url(org: str, project: str, number: int) -> str:
-    """The web URL of a work item.
-
-    Synthesized rather than read: the batch hydrate selects FIELDS, and Azure
-    only returns ``_links`` for a full (unselected) read, so asking for the link
-    would double the payload of every list refresh.
-    """
-    return f"https://{AZURE_HOST}/{quote(org, safe='')}/{quote(project, safe='')}/_workitems/edit/{int(number)}"
-
-
-def _field(fields: dict, name: str, default: object = None) -> object:
-    value = fields.get(name)
-    return default if value is None else value
-
-
-def _norm_issue(raw: dict, *, org: str, project: str, closed_states: frozenset[str]) -> dict:
-    """One work item -> the list-view row shape ``github_client._ISSUE_JQ`` produces.
-
-    ``author_association`` is ``None``: Azure has no computed
-    contributor-relationship concept at all, so reporting one would be fiction.
-    It only feeds :func:`derive_members`, which is honest about returning nothing.
-
-    ``reactions``/``thumbs_up`` are ``0`` rather than ``None`` because a work item
-    carries no reaction data of any kind -- zero is the true count, not an
-    unknown.
-    """
-    fields = _obj(raw.get("fields"))
-    number = raw.get("id")
-    state = str(_field(fields, "System.State", "") or "")
-    return {
-        "number": number,
-        "title": str(_field(fields, "System.Title", "") or ""),
-        "url": _work_item_url(org, project, int(number)) if isinstance(number, int) else "",
-        "labels": _tag_names(fields.get("System.Tags")),
-        "comments": _field(fields, "System.CommentCount", 0),
-        "reactions": 0,
-        "thumbs_up": 0,
-        "author_association": None,
-        "updated_at": _field(fields, "System.ChangedDate"),
-        "created_at": _field(fields, "System.CreatedDate"),
-        "state": "closed" if state in closed_states else "open",
-        "author": _identity_login(fields.get("System.CreatedBy")),
-        # Azure allows exactly ONE assignee per work item, so the list is either
-        # empty or a single entry -- the plural key is the app's shape, not a claim
-        # that Azure supports several.
-        "assignees": [
-            login for login in (_identity_login(fields.get("System.AssignedTo")),) if login
-        ],
-        "body": str(_field(fields, "System.Description", "") or ""),
-    }
-
-
-def _norm_issue_detail(raw: dict, *, org: str, project: str, closed_states: frozenset[str]) -> dict:
-    """One work item -> the detail-pane shape ``_ISSUE_DETAIL_JQ`` produces.
-
-    ``state_reason`` is ``None``: Azure's closing REASON (``System.Reason``) is a
-    process-template value ("Fixed", "Duplicate", "As Designed") with no mapping
-    onto GitHub's two-valued ``completed``/``not_planned``, and inventing one
-    would put a value the UI renders as a verdict behind a guess.
-
-    ``locked`` is always ``False`` -- a work item has no discussion lock -- and
-    ``milestone`` reports the iteration path, which is the closest Azure analogue
-    of a milestone and is what a triage reader is looking for.
-    """
-    fields = _obj(raw.get("fields"))
-    number = raw.get("id")
-    state = str(_field(fields, "System.State", "") or "")
-    is_closed = state in closed_states
-    iteration = str(_field(fields, "System.IterationPath", "") or "")
-    return {
-        "number": number,
-        "title": str(_field(fields, "System.Title", "") or ""),
-        "body": str(_field(fields, "System.Description", "") or ""),
-        "state": "closed" if is_closed else "open",
-        "state_reason": None,
-        "url": _work_item_url(org, project, int(number)) if isinstance(number, int) else "",
-        "author": _identity_login(fields.get("System.CreatedBy")),
-        "author_association": None,
-        "created_at": _field(fields, "System.CreatedDate"),
-        "updated_at": _field(fields, "System.ChangedDate"),
-        # Azure records no separate close timestamp unless the template defines
-        # Microsoft.VSTS.Common.ClosedDate, so it is read when present and the
-        # last change is NOT substituted for it -- that would date the close to
-        # whatever happened most recently.
-        "closed_at": _field(fields, "Microsoft.VSTS.Common.ClosedDate") if is_closed else None,
-        "closed_by": (
-            _identity_login(fields.get("Microsoft.VSTS.Common.ClosedBy")) if is_closed else None
-        ),
-        "comments": _field(fields, "System.CommentCount", 0),
-        "locked": False,
-        "labels": _shape_labels(_tag_names(fields.get("System.Tags"))),
-        "assignees": [
-            login for login in (_identity_login(fields.get("System.AssignedTo")),) if login
-        ],
-        "milestone": (
-            {"title": iteration.rsplit("\\", 1)[-1], "state": None, "due_on": None}
-            if iteration
-            else None
-        ),
-        "reactions": None,
-    }
+_norm_issue = _normalization._norm_issue
+_norm_issue_detail = _normalization._norm_issue_detail
 
 
 # ── project metadata: ids, identities, and the template's own state names ─────
@@ -1915,169 +1401,14 @@ def get_ref_summary(
 
 # Field -> the event kind its change becomes. Only fields the triage pane renders
 # are listed; everything else in an update is noise here.
-_TRACKED_UPDATE_FIELDS = (
-    "System.Tags",
-    "System.State",
-    "System.AssignedTo",
-    "System.Title",
-    "System.IterationPath",
-)
-
-
-def _update_actor(update: dict) -> str | None:
-    return _identity_login(update.get("revisedBy"))
-
-
-def _update_when(update: dict) -> object:
-    fields = _obj(update.get("fields"))
-    changed = _obj(fields.get("System.ChangedDate")).get("newValue")
-    return changed or update.get("revisedDate")
-
-
-def _tag_events(update: dict, actor: str | None, created: object) -> list[dict]:
-    """Label add/remove events reconstructed from a ``System.Tags`` diff.
-
-    Azure records the whole delimited string before and after, not a per-tag
-    event, so the two sets are differenced here. Order within the field is not
-    meaningful, so a pure reordering produces no events.
-    """
-    change = _obj(_obj(update.get("fields")).get("System.Tags"))
-    before = set(_tag_names(change.get("oldValue")))
-    after = set(_tag_names(change.get("newValue")))
-    events: list[dict] = []
-    for name in sorted(after - before):
-        events.append(
-            {
-                "kind": "labeled",
-                "actor": actor,
-                "created_at": created,
-                "label": {"name": name, "color": _SYNTHETIC_LABEL_COLOR},
-            }
-        )
-    for name in sorted(before - after):
-        events.append(
-            {
-                "kind": "unlabeled",
-                "actor": actor,
-                "created_at": created,
-                "label": {"name": name, "color": _SYNTHETIC_LABEL_COLOR},
-            }
-        )
-    return events
-
-
-def _state_events(
-    update: dict, actor: str | None, created: object, closed_states: frozenset[str]
-) -> list[dict]:
-    """close / reopen events reconstructed from a ``System.State`` diff.
-
-    A move between two OPEN states (New -> Active) is not a timeline event in
-    GitHub's vocabulary and is dropped, so the pane does not fill with workflow
-    churn the UI cannot render.
-    """
-    change = _obj(_obj(update.get("fields")).get("System.State"))
-    before = str(change.get("oldValue") or "")
-    after = str(change.get("newValue") or "")
-    if not after or before == after:
-        return []
-    was_closed, is_closed = before in closed_states, after in closed_states
-    if is_closed and not was_closed:
-        return [
-            {
-                "kind": "closed",
-                "actor": actor,
-                "created_at": created,
-                # Azure's System.Reason is a process-template value with no mapping
-                # onto GitHub's completed / not_planned pair -- see _norm_issue_detail.
-                "state_reason": None,
-                "commit_id": None,
-            }
-        ]
-    if was_closed and not is_closed:
-        return [{"kind": "reopened", "actor": actor, "created_at": created}]
-    return []
-
-
-def _assignee_events(update: dict, actor: str | None, created: object) -> list[dict]:
-    change = _obj(_obj(update.get("fields")).get("System.AssignedTo"))
-    before = _identity_login(change.get("oldValue"))
-    after = _identity_login(change.get("newValue"))
-    events: list[dict] = []
-    if before and before != after:
-        events.append(
-            {
-                "kind": "unassigned",
-                "actor": actor,
-                "created_at": created,
-                "assignee": before,
-            }
-        )
-    if after and after != before:
-        events.append(
-            {
-                "kind": "assigned",
-                "actor": actor,
-                "created_at": created,
-                "assignee": after,
-            }
-        )
-    return events
-
-
-def _norm_update(update: dict, closed_states: frozenset[str]) -> list[dict]:
-    """One work item revision -> zero or more normalized timeline events."""
-    fields = _obj(update.get("fields"))
-    if not any(name in fields for name in _TRACKED_UPDATE_FIELDS):
-        return []
-    actor = _update_actor(update)
-    created = _update_when(update)
-    events: list[dict] = []
-    events.extend(_tag_events(update, actor, created))
-    events.extend(_state_events(update, actor, created, closed_states))
-    events.extend(_assignee_events(update, actor, created))
-    title = _obj(fields.get("System.Title"))
-    if title.get("newValue") and title.get("oldValue") != title.get("newValue"):
-        events.append(
-            {
-                "kind": "renamed",
-                "actor": actor,
-                "created_at": created,
-                "rename": {"from": title.get("oldValue"), "to": title.get("newValue")},
-            }
-        )
-    iteration = _obj(fields.get("System.IterationPath"))
-    if iteration.get("newValue") and iteration.get("oldValue") != iteration.get("newValue"):
-        events.append(
-            {
-                "kind": "milestoned",
-                "actor": actor,
-                "created_at": created,
-                "milestone": str(iteration["newValue"]).rsplit("\\", 1)[-1],
-            }
-        )
-    return events
-
-
-def _norm_work_item_comment(comment: dict) -> dict:
-    """One work item comment -> the normalized ``comment`` timeline entry.
-
-    ``id`` and ``updated_at`` are load-bearing rather than decoration: the crew
-    claim protocol keeps ONE comment as its public ledger and rewrites it, so it
-    needs the id to address its own comment and the modified time to prove the
-    claim is alive (``created_at`` on an edited comment is still the original post
-    time). Azure supplies both.
-    """
-    modified = comment.get("modifiedDate") or comment.get("createdDate")
-    return {
-        "kind": "comment",
-        "id": comment.get("id"),
-        "actor": _identity_login(comment.get("createdBy")),
-        "created_at": comment.get("createdDate"),
-        "updated_at": modified,
-        "body": str(comment.get("text") or ""),
-        "author_association": None,
-        "reactions": None,
-    }
+_TRACKED_UPDATE_FIELDS = _normalization._TRACKED_UPDATE_FIELDS
+_update_actor = _normalization._update_actor
+_update_when = _normalization._update_when
+_tag_events = _normalization._tag_events
+_state_events = _normalization._state_events
+_assignee_events = _normalization._assignee_events
+_norm_update = _normalization._norm_update
+_norm_work_item_comment = _normalization._norm_work_item_comment
 
 
 def list_issue_timeline(
@@ -2144,75 +1475,10 @@ def list_issue_timeline(
 
 # Azure records a reviewer's vote as a SYSTEM thread carrying this property, so a
 # vote is recoverable even though system comments are otherwise dropped.
-_VOTE_PROPERTY_KEYS = ("CodeReviewVoteResult", "Microsoft.TeamFoundation.Discussion.VoteResult")
-# Azure's vote scale. 5 ("approved with suggestions") maps to APPROVED rather than
-# to a fourth UI state: it IS an approval, and inventing a state the shared pane
-# does not render would show nothing at all.
-_VOTE_STATES = {
-    10: "APPROVED",
-    5: "APPROVED",
-    0: "COMMENTED",
-    -5: "CHANGES_REQUESTED",
-    -10: "CHANGES_REQUESTED",
-}
-
-
-def _thread_property(thread: dict, keys: tuple[str, ...]) -> object:
-    """Read one of Azure's thread ``properties`` entries.
-
-    A property value is wrapped as ``{"type": ..., "$value": ...}``, and the key
-    spelling has varied across API versions, so several are tried.
-    """
-    props = _obj(thread.get("properties"))
-    for key in keys:
-        if key in props:
-            entry = props[key]
-            if isinstance(entry, dict):
-                return entry.get("$value")
-            return entry
-    return None
-
-
-def _norm_thread_comment(thread: dict, comment: dict) -> dict | None:
-    """One PR thread comment -> a normalized timeline entry, or ``None`` to drop it.
-
-    ``commentType == "system"`` is dropped: Azure writes an entry there for every
-    vote, every reviewer addition and every push, so keeping them would bury the
-    human discussion under "X voted" noise. A thread with a ``threadContext``
-    (a file and line) becomes a ``review_comment``, which is what makes a review's
-    substance visible; everything else is a plain ``comment``.
-    """
-    if str(comment.get("commentType") or "") == "system":
-        return None
-    body = str(comment.get("content") or "")
-    if not body.strip():
-        return None
-    context = _obj(thread.get("threadContext"))
-    path = context.get("filePath")
-    if not path:
-        return {
-            "kind": "comment",
-            "id": comment.get("id"),
-            "actor": _identity_login(comment.get("author")),
-            "created_at": comment.get("publishedDate"),
-            "updated_at": comment.get("lastUpdatedDate") or comment.get("publishedDate"),
-            "body": body,
-            "author_association": None,
-            "reactions": None,
-        }
-    line = _obj(context.get("rightFileStart")).get("line") or _obj(
-        context.get("leftFileStart")
-    ).get("line")
-    return {
-        "kind": "review_comment",
-        "actor": _identity_login(comment.get("author")),
-        "created_at": comment.get("publishedDate"),
-        "body": body,
-        "author_association": None,
-        "path": path,
-        "line": line,
-        "url": None,
-    }
+_VOTE_PROPERTY_KEYS = _normalization._VOTE_PROPERTY_KEYS
+_VOTE_STATES = _normalization._VOTE_STATES
+_thread_property = _normalization._thread_property
+_norm_thread_comment = _normalization._norm_thread_comment
 
 
 def list_pr_timeline(
@@ -2587,17 +1853,7 @@ def create_label(
     host: str = "",
     timeout: float = AZ_TIMEOUT_SEC,
 ) -> dict:
-    """Register a tag for use on the project's work items.
-
-    Azure has NO create-tag endpoint: a tag definition comes into existence when a
-    tag is first applied to a work item (the tags API can rename and delete, not
-    create). So this validates the name, returns the existing definition when the
-    project already has one, and otherwise returns the shaped tag without a write
-    -- the definition materializes the first time :func:`add_issue_labels` applies
-    it, which is what every caller of this function does next.
-
-    ``color`` and ``description`` are accepted for signature parity and cannot be
-    stored: an Azure tag has neither.
+    """Return an existing project tag or refuse a name Azure cannot pre-create.
 
     Azure has no create-tag-definition endpoint -- a tag comes into existence when
     it is first APPLIED to a work item -- so this cannot create anything. It
@@ -2736,120 +1992,11 @@ def add_pr_comment(
 # ── pull requests ───────────────────────────────────────────────────────────
 
 
-def _branch_name(ref: object) -> str | None:
-    """``refs/heads/main`` -> ``main``; anything else passes through unchanged."""
-    text = str(ref or "")
-    if not text:
-        return None
-    return text[len("refs/heads/") :] if text.startswith("refs/heads/") else text
-
-
-def _pr_labels(raw: object) -> list[str]:
-    """Azure PR labels, which are its own tag objects and may be deactivated."""
-    return [
-        str(row.get("name")) for row in _values(raw) if row.get("name") and row.get("active", True)
-    ]
-
-
-def _norm_pull(raw: dict) -> dict:
-    """One Azure pull request -> the row shape ``github_client._PR_JQ`` produces.
-
-    ``state`` folds ``completed`` (merged) and ``abandoned`` into ``closed``,
-    because that is what the app's open/closed filter means; the distinction
-    survives in ``merged_at``, exactly as it does on the other two providers.
-
-    ``updated_at`` needs an explanation: Azure exposes NO modification timestamp
-    on a pull request. The closing date is used when the PR is closed and the
-    creation date otherwise, which is the best available answer -- so an edit to an
-    open PR does not move it in a most-recently-updated ordering. The list is
-    therefore ordered by creation on this provider (see :func:`_list_pulls`), and
-    the probe that gates polling does not claim otherwise.
-
-    ``assignees`` is always empty: an Azure pull request has reviewers, not
-    assignees, and reporting reviewers as assignees would badge a reviewer as
-    owning the change.
-    """
-    status = str(raw.get("status") or "").lower()
-    merged = status == "completed"
-    closed_at = raw.get("closedDate")
-    return {
-        "number": raw.get("pullRequestId"),
-        "title": str(raw.get("title") or ""),
-        "url": _pr_web_url(raw),
-        "state": "open" if status == "active" else "closed",
-        "draft": bool(raw.get("isDraft")),
-        "labels": _pr_labels(raw.get("labels")),
-        "author": _identity_login(raw.get("createdBy")),
-        "author_association": None,
-        "updated_at": closed_at or raw.get("creationDate"),
-        "created_at": raw.get("creationDate"),
-        "closed_at": closed_at if status in ("completed", "abandoned") else None,
-        "merged_at": closed_at if merged else None,
-        "assignees": [],
-        "requested_reviewers": _identity_logins(raw.get("reviewers")),
-        "base": _branch_name(raw.get("targetRefName")),
-        "head": _branch_name(raw.get("sourceRefName")),
-        # The head COMMIT, for the same reason the other clients carry it in the
-        # list row: a bulk approve or a merge has to name the revision the row was
-        # rendered at. Azure calls it the last merge SOURCE commit.
-        "head_sha": _obj(raw.get("lastMergeSourceCommit")).get("commitId"),
-        "body": str(raw.get("description") or ""),
-        # Card enrichment is NOT available in the list payload on Azure (checks are
-        # policy evaluations, addressed per PR), so these stay unknown here and
-        # ``enrich_pulls`` fills them. ``checks_counts: None`` is what keeps an
-        # unenriched row out of the on-disk cache via ``enrichment_complete``.
-        "additions": None,
-        "deletions": None,
-        "changed_files": None,
-        "checks_state": None,
-        "checks_counts": None,
-        "checks_truncated": False,
-    }
-
-
-def _pr_web_url(raw: dict) -> str:
-    """The PR's web URL.
-
-    Azure's payload carries only an API ``url`` (and a ``_links.web`` that is
-    absent on the list route), so the human URL is composed from the repository's
-    project and name when the web link is missing.
-    """
-    web = _obj(_obj(raw.get("_links")).get("web")).get("href")
-    if web:
-        return str(web)
-    repo = _obj(raw.get("repository"))
-    project = _obj(repo.get("project")).get("name")
-    org = _org_from_api_url(repo.get("url"))
-    number = raw.get("pullRequestId")
-    if not (project and org and repo.get("name") and number):
-        return ""
-    return (
-        f"https://{AZURE_HOST}/{quote(str(org), safe='')}/{quote(str(project), safe='')}"
-        f"/_git/{quote(str(repo['name']), safe='')}/pullrequest/{int(number)}"
-    )
-
-
-def _org_from_api_url(url: object) -> str | None:
-    """The organization from an Azure API URL, for composing a web link.
-
-    Azure's API URLs come in two forms -- ``dev.azure.com/{org}/...`` and the
-    legacy ``{org}.visualstudio.com/...`` -- so both are read here rather than
-    assuming the modern one.
-    """
-    try:
-        parsed = urlparse(str(url or ""))
-        host = (parsed.hostname or "").lower()
-    except ValueError:
-        return None
-    if host.endswith(_LEGACY_HOST_SUFFIX):
-        candidate = host[: -len(_LEGACY_HOST_SUFFIX)]
-        return candidate if not _bad_segment(candidate) else None
-    if host == AZURE_HOST:
-        segments = _url_path_segments(parsed.path or "")
-        if segments:
-            candidate = unquote(segments[0])
-            return candidate if not _bad_segment(candidate) else None
-    return None
+_branch_name = _normalization._branch_name
+_pr_labels = _normalization._pr_labels
+_norm_pull = _normalization._norm_pull
+_pr_web_url = _normalization._pr_web_url
+_org_from_api_url = _normalization._org_from_api_url
 
 
 def _list_pulls(
@@ -2923,15 +2070,9 @@ def list_closed_pulls(
 # it the exact analogue of GitHub's weak ``mergeable`` field -- and NOT of a merge
 # gate. Anything not yet computed is reported as unknown (None) rather than as
 # not-mergeable, so the UI does not flash a false conflict warning mid-computation.
-_MERGE_SUCCEEDED = frozenset({"succeeded"})
-_MERGE_PENDING = frozenset({"queued", "notset", "", "none"})
-
-
-def _mergeable(raw: dict) -> bool | None:
-    status = str(raw.get("mergeStatus") or "").lower()
-    if status in _MERGE_PENDING:
-        return None
-    return status in _MERGE_SUCCEEDED
+_MERGE_SUCCEEDED = _normalization._MERGE_SUCCEEDED
+_MERGE_PENDING = _normalization._MERGE_PENDING
+_mergeable = _normalization._mergeable
 
 
 def get_pr_detail(
@@ -3092,91 +2233,13 @@ def _policy_evaluations(
 # ``gitlab_client._norm_job`` uses so the shared summary logic and UI colours
 # apply unchanged, including its behaviour that a cancelled unit is
 # informational rather than failing.
-_EVALUATION_BUCKETS = {
-    "approved": "success",
-    "rejected": "failure",
-    "broken": "failure",
-    "queued": "running",
-    "running": "running",
-    "notapplicable": "other",
-}
-_BUILD_RESULT_BUCKETS = {
-    "succeeded": "success",
-    "failed": "failure",
-    # Azure's "partially succeeded" means some tasks failed but were allowed to:
-    # the build did not fail, so reporting it red would show a red PR that Azure
-    # itself considers passing -- the same reason GitLab's allow_failure jobs
-    # bucket as informational.
-    "partiallysucceeded": "other",
-    "canceled": "other",
-    "cancelled": "other",
-    "none": "other",
-}
-_BUILD_RUNNING_STATUSES = frozenset({"notstarted", "inprogress", "postponed", "none", ""})
-_BUILD_FINISHED_STATUSES = frozenset({"completed"})
-
-
-def _evaluation_bucket(status: str) -> str:
-    return _EVALUATION_BUCKETS.get((status or "").lower(), "other")
-
-
-def _norm_evaluation(evaluation: dict) -> dict:
-    """One policy evaluation -> the check-row shape ``_CHECK_RUN_JQ`` produces.
-
-    ``bucket`` is precomputed because :func:`summarize_checks` reads it, and
-    ``source`` carries the publisher identity the dedupe keys on -- the policy
-    TYPE, so a required-reviewers policy and a build policy are distinct
-    publishers rather than one lump.
-    """
-    status = str(evaluation.get("status") or "")
-    bucket = _evaluation_bucket(status)
-    config = _obj(evaluation.get("configuration"))
-    policy_type = _obj(config.get("type"))
-    display = str(policy_type.get("displayName") or "policy")
-    settings = _obj(config.get("settings"))
-    detail = str(settings.get("displayName") or "")
-    blocking = bool(config.get("isBlocking", True))
-    return {
-        "name": detail or display,
-        "status": "in_progress" if bucket == "running" else "completed",
-        "conclusion": {"failure": "failure", "success": "success", "running": None}.get(
-            bucket, "neutral"
-        ),
-        "bucket": bucket if blocking or bucket != "failure" else "other",
-        "url": None,
-        "started_at": evaluation.get("startedDate"),
-        "completed_at": evaluation.get("completedDate"),
-        "summary": display if detail else "",
-        "app": "Azure DevOps policy",
-        "source": str(policy_type.get("id") or "policy"),
-    }
-
-
-def _norm_build(build: dict) -> dict:
-    """One pipeline build -> the check-row shape ``_CHECK_RUN_JQ`` produces."""
-    status = str(build.get("status") or "").lower()
-    result = str(build.get("result") or "").lower()
-    if status in _BUILD_FINISHED_STATUSES:
-        bucket = _BUILD_RESULT_BUCKETS.get(result, "other")
-    elif status in _BUILD_RUNNING_STATUSES:
-        bucket = "running"
-    else:
-        bucket = "other"
-    definition = _obj(build.get("definition"))
-    return {
-        "name": str(definition.get("name") or build.get("buildNumber") or "build"),
-        "status": "completed" if status in _BUILD_FINISHED_STATUSES else "in_progress",
-        "conclusion": {"failure": "failure", "success": "success", "running": None}.get(
-            bucket, "neutral"
-        ),
-        "bucket": bucket,
-        "url": _obj(_obj(build.get("_links")).get("web")).get("href"),
-        "started_at": build.get("startTime") or build.get("queueTime"),
-        "completed_at": build.get("finishTime"),
-        "summary": str(build.get("buildNumber") or ""),
-        "app": "Azure Pipelines",
-        "source": "azure-pipelines",
-    }
+_EVALUATION_BUCKETS = _normalization._EVALUATION_BUCKETS
+_BUILD_RESULT_BUCKETS = _normalization._BUILD_RESULT_BUCKETS
+_BUILD_RUNNING_STATUSES = _normalization._BUILD_RUNNING_STATUSES
+_BUILD_FINISHED_STATUSES = _normalization._BUILD_FINISHED_STATUSES
+_evaluation_bucket = _normalization._evaluation_bucket
+_norm_evaluation = _normalization._norm_evaluation
+_norm_build = _normalization._norm_build
 
 
 def _builds_for_sha(
@@ -3282,30 +2345,12 @@ def list_pr_checks(
     return rows
 
 
-_CHECK_BUCKETS = ("failure", "running", "success", "other")
+_CHECK_BUCKETS = _normalization._CHECK_BUCKETS
 
 
 def summarize_checks(checks: list[dict]) -> dict:
-    """``{checks_counts, checks_state, checks_truncated}`` from bucketed rows.
-
-    Byte-identical contract to the other two clients', including the
-    ``checks_state`` priority (anything failing dominates, then running, then
-    success, then informational) so the card's dot never reads greener than the
-    list it summarizes, and ``None`` when there are no checks at all.
-    """
-    counts = dict.fromkeys(_CHECK_BUCKETS, 0)
-    for row in checks:
-        if not isinstance(row, dict):
-            continue
-        bucket = row.get("bucket")
-        counts[bucket if isinstance(bucket, str) and bucket in counts else "other"] += 1
-    for bucket in _CHECK_BUCKETS:
-        if counts[bucket]:
-            state: str | None = bucket
-            break
-    else:
-        state = None  # no checks at all -> the card shows no dot
-    return {"checks_counts": counts, "checks_state": state, "checks_truncated": False}
+    """Return the provider-neutral check summary."""
+    return _normalization.summarize_checks(checks)
 
 
 def _enrich_rows(owner: str, repo: str, pulls: list[dict], *, host: str) -> list[dict]:
@@ -3359,13 +2404,8 @@ def enrich_pulls_by_number(
 
 
 def enrichment_complete(pulls: list[dict]) -> bool:
-    """Whether every row carries its card enrichment.
-
-    Reads the same ``checks_counts is not None`` invariant the other clients do:
-    a row that arrived unenriched must keep itself OUT of the on-disk list cache
-    rather than being cached as authoritative.
-    """
-    return all(pr.get("checks_counts") is not None for pr in pulls)
+    """Whether every row is safe to persist in the pull-request cache."""
+    return _normalization.enrichment_complete(pulls)
 
 
 # ── cheap open-list probe (poll gating) ─────────────────────────────────────
@@ -3594,9 +2634,9 @@ def search_pulls(
 #   auto-merge          -> ``autoCompleteSetBy``, a real reversible armed state
 #   cancel / re-run CI  -> a pipeline BUILD, not a workflow run
 #
-# Unlike GitLab, Azure can express all three review verdicts and all three merge
-# strategies, and it has a genuine arm-and-cancel auto-merge -- so nothing here is
-# refused for want of a native equivalent.
+# Azure supports all three merge strategies and reversible auto-complete, but its
+# reviewer vote is PR-scoped rather than revision-scoped. Verdicts are therefore
+# refused below; only a comment can be bound safely to the displayed discussion.
 
 
 def _pr_patch(

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/azure_normalization.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/azure_normalization.py
@@ -1,0 +1,563 @@
+"""Pure Azure DevOps-to-Issue-Radar payload normalization."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import quote, unquote, urlparse
+
+from .azure_transport import (
+    _LEGACY_HOST_SUFFIX,
+    AZURE_HOST,
+    _bad_segment,
+    _url_path_segments,
+)
+from .errors import ProviderCliError
+
+_GUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+_SYNTHETIC_LABEL_COLOR = "888888"
+
+
+def _obj(data: object) -> dict:
+    return data if isinstance(data, dict) else {}
+
+
+def _values(data: object) -> list[dict]:
+    """Read either Azure's wrapped collection shape or a bare array."""
+    if isinstance(data, list):
+        return [row for row in data if isinstance(row, dict)]
+    inner = _obj(data).get("value")
+    if isinstance(inner, list):
+        return [row for row in inner if isinstance(row, dict)]
+    return []
+
+
+def _identity_login(raw: object) -> str | None:
+    """Prefer Azure's stable human-typeable identity handle."""
+    if not isinstance(raw, dict):
+        return None
+    name = raw.get("uniqueName") or raw.get("displayName") or raw.get("principalName")
+    text = str(name).strip() if name else ""
+    return text or None
+
+
+def _identity_logins(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    return [login for login in (_identity_login(item) for item in raw) if login]
+
+
+def _identity_id(raw: object) -> str | None:
+    """Return a validated Azure identity GUID."""
+    if not isinstance(raw, dict):
+        return None
+    value = str(raw.get("id") or "").strip()
+    return value if _GUID_RE.match(value) else None
+
+
+def _tag_names(raw: object) -> list[str]:
+    """Parse Azure's semicolon-delimited, case-sensitive tag field."""
+    text = str(raw or "").strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.split(";") if part.strip()]
+
+
+def _tags_field(names: list[str]) -> str:
+    return "; ".join(names)
+
+
+def _check_label(label: str) -> str:
+    """Reject delimiters Azure cannot escape in its stored tag field."""
+    name = str(label or "").strip()
+    if not name:
+        raise ProviderCliError("a tag name cannot be empty")
+    if "," in name or ";" in name:
+        raise ProviderCliError(
+            f"Azure DevOps tags cannot contain ',' or ';' (got {label!r}) -- those are "
+            "the delimiters the tag field is stored with"
+        )
+    if len(name) > 400:
+        raise ProviderCliError(f"tag name is too long: {label!r}")
+    return name
+
+
+def _shape_labels(names: list[str]) -> list[dict]:
+    """Shape colourless Azure tags with the shared neutral colour."""
+    return [{"name": name, "color": _SYNTHETIC_LABEL_COLOR, "description": ""} for name in names]
+
+
+def _work_item_url(org: str, project: str, number: int) -> str:
+    """Compose the web URL omitted by field-selected batch hydration."""
+    return (
+        f"https://{AZURE_HOST}/{quote(org, safe='')}/{quote(project, safe='')}"
+        f"/_workitems/edit/{int(number)}"
+    )
+
+
+def _field(fields: dict, name: str, default: object = None) -> object:
+    value = fields.get(name)
+    return default if value is None else value
+
+
+def _norm_issue(raw: dict, *, org: str, project: str, closed_states: frozenset[str]) -> dict:
+    """Normalize one work item for the shared list view."""
+    fields = _obj(raw.get("fields"))
+    number = raw.get("id")
+    state = str(_field(fields, "System.State", "") or "")
+    return {
+        "number": number,
+        "title": str(_field(fields, "System.Title", "") or ""),
+        "url": _work_item_url(org, project, int(number)) if isinstance(number, int) else "",
+        "labels": _tag_names(fields.get("System.Tags")),
+        "comments": _field(fields, "System.CommentCount", 0),
+        "reactions": 0,
+        "thumbs_up": 0,
+        "author_association": None,
+        "updated_at": _field(fields, "System.ChangedDate"),
+        "created_at": _field(fields, "System.CreatedDate"),
+        "state": "closed" if state in closed_states else "open",
+        "author": _identity_login(fields.get("System.CreatedBy")),
+        "assignees": [
+            login for login in (_identity_login(fields.get("System.AssignedTo")),) if login
+        ],
+        "body": str(_field(fields, "System.Description", "") or ""),
+    }
+
+
+def _norm_issue_detail(raw: dict, *, org: str, project: str, closed_states: frozenset[str]) -> dict:
+    """Normalize one work item for the shared detail view."""
+    fields = _obj(raw.get("fields"))
+    number = raw.get("id")
+    state = str(_field(fields, "System.State", "") or "")
+    is_closed = state in closed_states
+    iteration = str(_field(fields, "System.IterationPath", "") or "")
+    return {
+        "number": number,
+        "title": str(_field(fields, "System.Title", "") or ""),
+        "body": str(_field(fields, "System.Description", "") or ""),
+        "state": "closed" if is_closed else "open",
+        # Azure process reasons cannot be mapped honestly to GitHub's two values.
+        "state_reason": None,
+        "url": _work_item_url(org, project, int(number)) if isinstance(number, int) else "",
+        "author": _identity_login(fields.get("System.CreatedBy")),
+        "author_association": None,
+        "created_at": _field(fields, "System.CreatedDate"),
+        "updated_at": _field(fields, "System.ChangedDate"),
+        # Do not substitute ChangedDate: it may describe a later unrelated edit.
+        "closed_at": (_field(fields, "Microsoft.VSTS.Common.ClosedDate") if is_closed else None),
+        "closed_by": (
+            _identity_login(fields.get("Microsoft.VSTS.Common.ClosedBy")) if is_closed else None
+        ),
+        "comments": _field(fields, "System.CommentCount", 0),
+        "locked": False,
+        "labels": _shape_labels(_tag_names(fields.get("System.Tags"))),
+        "assignees": [
+            login for login in (_identity_login(fields.get("System.AssignedTo")),) if login
+        ],
+        "milestone": (
+            {"title": iteration.rsplit("\\", 1)[-1], "state": None, "due_on": None}
+            if iteration
+            else None
+        ),
+        "reactions": None,
+    }
+
+
+_TRACKED_UPDATE_FIELDS = (
+    "System.Tags",
+    "System.State",
+    "System.AssignedTo",
+    "System.Title",
+    "System.IterationPath",
+)
+
+
+def _update_actor(update: dict) -> str | None:
+    return _identity_login(update.get("revisedBy"))
+
+
+def _update_when(update: dict) -> object:
+    fields = _obj(update.get("fields"))
+    changed = _obj(fields.get("System.ChangedDate")).get("newValue")
+    return changed or update.get("revisedDate")
+
+
+def _tag_events(update: dict, actor: str | None, created: object) -> list[dict]:
+    """Reconstruct label events by differencing Azure's whole tag field."""
+    change = _obj(_obj(update.get("fields")).get("System.Tags"))
+    before = set(_tag_names(change.get("oldValue")))
+    after = set(_tag_names(change.get("newValue")))
+    events: list[dict] = []
+    for name in sorted(after - before):
+        events.append(
+            {
+                "kind": "labeled",
+                "actor": actor,
+                "created_at": created,
+                "label": {"name": name, "color": _SYNTHETIC_LABEL_COLOR},
+            }
+        )
+    for name in sorted(before - after):
+        events.append(
+            {
+                "kind": "unlabeled",
+                "actor": actor,
+                "created_at": created,
+                "label": {"name": name, "color": _SYNTHETIC_LABEL_COLOR},
+            }
+        )
+    return events
+
+
+def _state_events(
+    update: dict, actor: str | None, created: object, closed_states: frozenset[str]
+) -> list[dict]:
+    """Reconstruct only close/reopen transitions, dropping open-state churn."""
+    change = _obj(_obj(update.get("fields")).get("System.State"))
+    before = str(change.get("oldValue") or "")
+    after = str(change.get("newValue") or "")
+    if not after or before == after:
+        return []
+    was_closed, is_closed = before in closed_states, after in closed_states
+    if is_closed and not was_closed:
+        return [
+            {
+                "kind": "closed",
+                "actor": actor,
+                "created_at": created,
+                "state_reason": None,
+                "commit_id": None,
+            }
+        ]
+    if was_closed and not is_closed:
+        return [{"kind": "reopened", "actor": actor, "created_at": created}]
+    return []
+
+
+def _assignee_events(update: dict, actor: str | None, created: object) -> list[dict]:
+    change = _obj(_obj(update.get("fields")).get("System.AssignedTo"))
+    before = _identity_login(change.get("oldValue"))
+    after = _identity_login(change.get("newValue"))
+    events: list[dict] = []
+    if before and before != after:
+        events.append(
+            {
+                "kind": "unassigned",
+                "actor": actor,
+                "created_at": created,
+                "assignee": before,
+            }
+        )
+    if after and after != before:
+        events.append(
+            {
+                "kind": "assigned",
+                "actor": actor,
+                "created_at": created,
+                "assignee": after,
+            }
+        )
+    return events
+
+
+def _norm_update(update: dict, closed_states: frozenset[str]) -> list[dict]:
+    """Normalize one work-item revision into zero or more timeline events."""
+    fields = _obj(update.get("fields"))
+    if not any(name in fields for name in _TRACKED_UPDATE_FIELDS):
+        return []
+    actor = _update_actor(update)
+    created = _update_when(update)
+    events: list[dict] = []
+    events.extend(_tag_events(update, actor, created))
+    events.extend(_state_events(update, actor, created, closed_states))
+    events.extend(_assignee_events(update, actor, created))
+    title = _obj(fields.get("System.Title"))
+    if title.get("newValue") and title.get("oldValue") != title.get("newValue"):
+        events.append(
+            {
+                "kind": "renamed",
+                "actor": actor,
+                "created_at": created,
+                "rename": {"from": title.get("oldValue"), "to": title.get("newValue")},
+            }
+        )
+    iteration = _obj(fields.get("System.IterationPath"))
+    if iteration.get("newValue") and iteration.get("oldValue") != iteration.get("newValue"):
+        events.append(
+            {
+                "kind": "milestoned",
+                "actor": actor,
+                "created_at": created,
+                "milestone": str(iteration["newValue"]).rsplit("\\", 1)[-1],
+            }
+        )
+    return events
+
+
+def _norm_work_item_comment(comment: dict) -> dict:
+    """Normalize a comment while preserving claim-ledger id and modified time."""
+    modified = comment.get("modifiedDate") or comment.get("createdDate")
+    return {
+        "kind": "comment",
+        "id": comment.get("id"),
+        "actor": _identity_login(comment.get("createdBy")),
+        "created_at": comment.get("createdDate"),
+        "updated_at": modified,
+        "body": str(comment.get("text") or ""),
+        "author_association": None,
+        "reactions": None,
+    }
+
+
+_VOTE_PROPERTY_KEYS = (
+    "CodeReviewVoteResult",
+    "Microsoft.TeamFoundation.Discussion.VoteResult",
+)
+_VOTE_STATES = {
+    10: "APPROVED",
+    5: "APPROVED",
+    0: "COMMENTED",
+    -5: "CHANGES_REQUESTED",
+    -10: "CHANGES_REQUESTED",
+}
+
+
+def _thread_property(thread: dict, keys: tuple[str, ...]) -> object:
+    """Unwrap the first matching Azure thread property."""
+    properties = _obj(thread.get("properties"))
+    for key in keys:
+        if key in properties:
+            entry = properties[key]
+            if isinstance(entry, dict):
+                return entry.get("$value")
+            return entry
+    return None
+
+
+def _norm_thread_comment(thread: dict, comment: dict) -> dict | None:
+    """Normalize a human PR comment; drop empty and system-generated noise."""
+    if str(comment.get("commentType") or "") == "system":
+        return None
+    body = str(comment.get("content") or "")
+    if not body.strip():
+        return None
+    context = _obj(thread.get("threadContext"))
+    path = context.get("filePath")
+    if not path:
+        return {
+            "kind": "comment",
+            "id": comment.get("id"),
+            "actor": _identity_login(comment.get("author")),
+            "created_at": comment.get("publishedDate"),
+            "updated_at": comment.get("lastUpdatedDate") or comment.get("publishedDate"),
+            "body": body,
+            "author_association": None,
+            "reactions": None,
+        }
+    line = _obj(context.get("rightFileStart")).get("line") or _obj(
+        context.get("leftFileStart")
+    ).get("line")
+    return {
+        "kind": "review_comment",
+        "actor": _identity_login(comment.get("author")),
+        "created_at": comment.get("publishedDate"),
+        "body": body,
+        "author_association": None,
+        "path": path,
+        "line": line,
+        "url": None,
+    }
+
+
+def _branch_name(ref: object) -> str | None:
+    text = str(ref or "")
+    if not text:
+        return None
+    return text[len("refs/heads/") :] if text.startswith("refs/heads/") else text
+
+
+def _pr_labels(raw: object) -> list[str]:
+    return [
+        str(row.get("name")) for row in _values(raw) if row.get("name") and row.get("active", True)
+    ]
+
+
+def _norm_pull(raw: dict) -> dict:
+    """Normalize one Azure pull request for the shared list view."""
+    status = str(raw.get("status") or "").lower()
+    merged = status == "completed"
+    closed_at = raw.get("closedDate")
+    return {
+        "number": raw.get("pullRequestId"),
+        "title": str(raw.get("title") or ""),
+        "url": _pr_web_url(raw),
+        "state": "open" if status == "active" else "closed",
+        "draft": bool(raw.get("isDraft")),
+        "labels": _pr_labels(raw.get("labels")),
+        "author": _identity_login(raw.get("createdBy")),
+        "author_association": None,
+        # Azure exposes no PR modification timestamp.
+        "updated_at": closed_at or raw.get("creationDate"),
+        "created_at": raw.get("creationDate"),
+        "closed_at": closed_at if status in ("completed", "abandoned") else None,
+        "merged_at": closed_at if merged else None,
+        "assignees": [],
+        "requested_reviewers": _identity_logins(raw.get("reviewers")),
+        "base": _branch_name(raw.get("targetRefName")),
+        "head": _branch_name(raw.get("sourceRefName")),
+        "head_sha": _obj(raw.get("lastMergeSourceCommit")).get("commitId"),
+        "body": str(raw.get("description") or ""),
+        # Per-PR policy enrichment decides whether this row is safe to persist.
+        "additions": None,
+        "deletions": None,
+        "changed_files": None,
+        "checks_state": None,
+        "checks_counts": None,
+        "checks_truncated": False,
+    }
+
+
+def _pr_web_url(raw: dict) -> str:
+    web = _obj(_obj(raw.get("_links")).get("web")).get("href")
+    if web:
+        return str(web)
+    repo = _obj(raw.get("repository"))
+    project = _obj(repo.get("project")).get("name")
+    org = _org_from_api_url(repo.get("url"))
+    number = raw.get("pullRequestId")
+    if not (project and org and repo.get("name") and number):
+        return ""
+    return (
+        f"https://{AZURE_HOST}/{quote(str(org), safe='')}/{quote(str(project), safe='')}"
+        f"/_git/{quote(str(repo['name']), safe='')}/pullrequest/{int(number)}"
+    )
+
+
+def _org_from_api_url(url: object) -> str | None:
+    try:
+        parsed = urlparse(str(url or ""))
+        host = (parsed.hostname or "").lower()
+    except ValueError:
+        return None
+    if host.endswith(_LEGACY_HOST_SUFFIX):
+        candidate = host[: -len(_LEGACY_HOST_SUFFIX)]
+        return candidate if not _bad_segment(candidate) else None
+    if host == AZURE_HOST:
+        segments = _url_path_segments(parsed.path or "")
+        if segments:
+            candidate = unquote(segments[0])
+            return candidate if not _bad_segment(candidate) else None
+    return None
+
+
+_MERGE_SUCCEEDED = frozenset({"succeeded"})
+_MERGE_PENDING = frozenset({"queued", "notset", "", "none"})
+
+
+def _mergeable(raw: dict) -> bool | None:
+    status = str(raw.get("mergeStatus") or "").lower()
+    if status in _MERGE_PENDING:
+        return None
+    return status in _MERGE_SUCCEEDED
+
+
+_EVALUATION_BUCKETS = {
+    "approved": "success",
+    "rejected": "failure",
+    "broken": "failure",
+    "queued": "running",
+    "running": "running",
+    "notapplicable": "other",
+}
+_BUILD_RESULT_BUCKETS = {
+    "succeeded": "success",
+    "failed": "failure",
+    "partiallysucceeded": "other",
+    "canceled": "other",
+    "cancelled": "other",
+    "none": "other",
+}
+_BUILD_RUNNING_STATUSES = frozenset({"notstarted", "inprogress", "postponed", "none", ""})
+_BUILD_FINISHED_STATUSES = frozenset({"completed"})
+
+
+def _evaluation_bucket(status: str) -> str:
+    return _EVALUATION_BUCKETS.get((status or "").lower(), "other")
+
+
+def _norm_evaluation(evaluation: dict) -> dict:
+    status = str(evaluation.get("status") or "")
+    bucket = _evaluation_bucket(status)
+    config = _obj(evaluation.get("configuration"))
+    policy_type = _obj(config.get("type"))
+    display = str(policy_type.get("displayName") or "policy")
+    settings = _obj(config.get("settings"))
+    detail = str(settings.get("displayName") or "")
+    blocking = bool(config.get("isBlocking", True))
+    return {
+        "name": detail or display,
+        "status": "in_progress" if bucket == "running" else "completed",
+        "conclusion": {"failure": "failure", "success": "success", "running": None}.get(
+            bucket, "neutral"
+        ),
+        "bucket": bucket if blocking or bucket != "failure" else "other",
+        "url": None,
+        "started_at": evaluation.get("startedDate"),
+        "completed_at": evaluation.get("completedDate"),
+        "summary": display if detail else "",
+        "app": "Azure DevOps policy",
+        "source": str(policy_type.get("id") or "policy"),
+    }
+
+
+def _norm_build(build: dict) -> dict:
+    status = str(build.get("status") or "").lower()
+    result = str(build.get("result") or "").lower()
+    if status in _BUILD_FINISHED_STATUSES:
+        bucket = _BUILD_RESULT_BUCKETS.get(result, "other")
+    elif status in _BUILD_RUNNING_STATUSES:
+        bucket = "running"
+    else:
+        bucket = "other"
+    definition = _obj(build.get("definition"))
+    return {
+        "name": str(definition.get("name") or build.get("buildNumber") or "build"),
+        "status": "completed" if status in _BUILD_FINISHED_STATUSES else "in_progress",
+        "conclusion": {"failure": "failure", "success": "success", "running": None}.get(
+            bucket, "neutral"
+        ),
+        "bucket": bucket,
+        "url": _obj(_obj(build.get("_links")).get("web")).get("href"),
+        "started_at": build.get("startTime") or build.get("queueTime"),
+        "completed_at": build.get("finishTime"),
+        "summary": str(build.get("buildNumber") or ""),
+        "app": "Azure Pipelines",
+        "source": "azure-pipelines",
+    }
+
+
+_CHECK_BUCKETS = ("failure", "running", "success", "other")
+
+
+def summarize_checks(checks: list[dict]) -> dict:
+    """Summarize check buckets using the shared failure-first priority."""
+    counts = dict.fromkeys(_CHECK_BUCKETS, 0)
+    for row in checks:
+        if not isinstance(row, dict):
+            continue
+        bucket = row.get("bucket")
+        counts[bucket if isinstance(bucket, str) and bucket in counts else "other"] += 1
+    for bucket in _CHECK_BUCKETS:
+        if counts[bucket]:
+            state: str | None = bucket
+            break
+    else:
+        state = None
+    return {"checks_counts": counts, "checks_state": state, "checks_truncated": False}
+
+
+def enrichment_complete(pulls: list[dict]) -> bool:
+    """Require every PR row's policy enrichment before persistence."""
+    return all(pr.get("checks_counts") is not None for pr in pulls)

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/azure_transport.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/azure_transport.py
@@ -1,0 +1,375 @@
+"""Azure DevOps URL and ``az devops invoke`` transport helpers.
+
+The security-sensitive spawn remains in :mod:`azure_client`.  Helpers in this
+module build and interpret a call, while the facade injects its current spawn and
+response bindings so the established ``azure_client`` monkeypatch seam remains
+authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping
+from urllib.parse import quote, unquote, urlparse
+
+from .errors import (
+    ProviderCliError,
+    ProviderPermissionError,
+    ProviderSetupError,
+    RepoUrlError,
+    sanitize_cli_stderr,
+)
+
+AZURE_HOST = "dev.azure.com"
+_LEGACY_HOST_SUFFIX = ".visualstudio.com"
+
+_PAGE_SIZE = 100
+_MAX_PAGES = 40
+
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$")
+_RESERVED_SEGMENTS = frozenset({"_git", "_apis", "_workitems", "_build", "_settings", "_apps"})
+_URL_PATH_SEPARATOR = re.compile(r"/+")
+
+_AZ_ENV_PASSTHROUGH = (
+    "AZURE_DEVOPS_EXT_PAT",
+    "AZURE_CONFIG_DIR",
+    "AZURE_EXTENSION_DIR",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "all_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+_AZ_AUTH_MARKERS = (
+    "az login",
+    "az devops login",
+    "tf400813",
+    "please run 'az login'",
+    "unauthorized",
+    "401",
+    "before you can run this command you need to log in",
+)
+
+_AZ_MISSING_MARKERS = (
+    'is not in the "az" command group',
+    "az extension add",
+    "extension is not installed",
+    "no such command",
+    "command not found",
+)
+
+
+def _bad_segment(segment: str) -> bool:
+    """Whether a path segment is unusable as an org / project / repo name."""
+    if not segment or segment in (".", ".."):
+        return True
+    if segment.lower() in _RESERVED_SEGMENTS:
+        return True
+    return not bool(_SEGMENT_RE.match(segment))
+
+
+def _url_path_segments(path: str) -> list[str]:
+    """Return non-empty URL path segments without platform path semantics."""
+    return [segment for segment in _URL_PATH_SEPARATOR.split(path or "") if segment]
+
+
+def parse_azure_repo_url(link: str) -> tuple[str, str]:
+    """Parse ``("{organization}/{project}", repository)`` from an Azure URL."""
+    if not link or not isinstance(link, str):
+        raise RepoUrlError("repo link is empty")
+    try:
+        parsed = urlparse(link.strip())
+    except ValueError as exc:
+        raise RepoUrlError(f"unparseable URL: {link!r}") from exc
+    if parsed.scheme != "https":
+        raise RepoUrlError(f"not an https URL: {link!r}")
+    if parsed.username or parsed.password:
+        raise RepoUrlError("URLs with embedded credentials are not accepted")
+    try:
+        host = (parsed.hostname or "").lower().rstrip(".")
+        _ = parsed.port
+    except ValueError as exc:
+        raise RepoUrlError(f"malformed host or port in {link!r}") from exc
+
+    legacy_org = ""
+    if host == AZURE_HOST:
+        pass
+    elif host.endswith(_LEGACY_HOST_SUFFIX):
+        legacy_org = host[: -len(_LEGACY_HOST_SUFFIX)]
+        if _bad_segment(legacy_org):
+            raise RepoUrlError(f"invalid organization in {link!r}")
+    else:
+        raise RepoUrlError(
+            f"not a supported Azure DevOps host: {link!r} -- only {AZURE_HOST} and the "
+            "legacy {org}.visualstudio.com form are accepted (Azure DevOps Server is not supported)"
+        )
+
+    parts: list[str] = []
+    for raw in _url_path_segments(parsed.path or ""):
+        segment = unquote(raw)
+        if "/" in segment or "\\" in segment or "?" in segment or "#" in segment:
+            raise RepoUrlError(f"invalid path segment in {link!r}")
+        parts.append(segment)
+
+    if legacy_org:
+        org = legacy_org
+    else:
+        if not parts:
+            raise RepoUrlError(f"not a full Azure DevOps URL: {link!r}")
+        org, parts = parts[0], parts[1:]
+    if not parts:
+        raise RepoUrlError(
+            f"not a full Azure DevOps URL: {link!r} "
+            "(expected .../{project} or .../{project}/_git/{repo})"
+        )
+    project, parts = parts[0], parts[1:]
+
+    if parts and parts[0] == "_git":
+        repo = parts[1] if len(parts) > 1 else project
+    else:
+        repo = project
+    repo = re.sub(r"\.git$", "", repo)
+
+    for segment in (org, project, repo):
+        if _bad_segment(segment):
+            raise RepoUrlError(f"invalid path segment in {link!r}")
+    return f"{org}/{project}", repo
+
+
+def _split_owner(owner: str) -> tuple[str, str]:
+    """Split and validate the provider-neutral Azure owner value."""
+    text = str(owner or "").strip().strip("/")
+    org, separator, project = text.partition("/")
+    if not separator:
+        raise ProviderCliError(
+            f"an Azure DevOps owner must be '{{organization}}/{{project}}' (got {owner!r})"
+        )
+    org, project = org.strip(), project.strip()
+    if _bad_segment(org) or _bad_segment(project):
+        raise ProviderCliError(f"invalid Azure DevOps organization/project: {owner!r}")
+    return org, project
+
+
+def _check_repo(repo: str) -> str:
+    """Validate a repository name before it reaches a route parameter."""
+    name = str(repo or "").strip()
+    if _bad_segment(name):
+        raise ProviderCliError(f"invalid Azure DevOps repository name: {repo!r}")
+    return name
+
+
+def _org_url(org: str, *, quote_value: Callable[..., str] = quote) -> str:
+    """Return the pinned-cloud organization URL consumed by ``az``."""
+    return f"https://{AZURE_HOST}/{quote_value(org, safe='')}"
+
+
+def _resolve_host(host: str) -> str:
+    """Re-check the pinned Azure cloud host at the spawn boundary."""
+    if not host:
+        raise ProviderCliError("an Azure DevOps host is required for az calls")
+    normalized = host.lower().rstrip(".")
+    if normalized != AZURE_HOST:
+        raise ProviderCliError(
+            f"Azure DevOps host {normalized!r} is not supported -- only {AZURE_HOST} "
+            "(Azure DevOps Server / on-premises has no supported credential path)"
+        )
+    return normalized
+
+
+def _az_env(
+    host: str,
+    *,
+    source_env: Mapping[str, str],
+    passthrough_keys: tuple[str, ...],
+    minimal_env: Callable[..., dict[str, str]],
+) -> dict[str, str]:
+    """Build the minimal ``az`` environment for the already-resolved host."""
+    passthrough = {key: source_env[key] for key in passthrough_keys if key in source_env}
+    if host != AZURE_HOST:
+        passthrough.pop("AZURE_DEVOPS_EXT_PAT", None)
+    # Automated provider calls must never download and execute an extension.
+    passthrough["AZURE_EXTENSION_USE_DYNAMIC_INSTALL"] = "no"
+    passthrough["AZURE_CORE_COLLECT_TELEMETRY"] = "0"
+    passthrough["AZURE_CORE_NO_COLOR"] = "1"
+    passthrough["NO_COLOR"] = "1"
+    return minimal_env(**passthrough)
+
+
+def _raise_if_setup_failure(stderr_tail: str) -> None:
+    """Classify extension/auth failures before generic CLI failures."""
+    low = (stderr_tail or "").lower()
+    if any(marker in low for marker in _AZ_MISSING_MARKERS):
+        raise ProviderSetupError(
+            "the `azure-devops` extension for the `az` CLI is not available -- "
+            "install it with `az extension add --name azure-devops`",
+            reason="not_installed",
+        )
+    if any(marker in low for marker in _AZ_AUTH_MARKERS):
+        raise ProviderSetupError(
+            f"the `az` CLI is not authenticated for {AZURE_HOST} -- run `az login` "
+            "(or `az devops login` with a personal access token)",
+            reason="not_authenticated",
+        )
+
+
+def _stderr_tail(
+    proc: subprocess.CompletedProcess, *, sanitize: Callable[[str], str] = sanitize_cli_stderr
+) -> str:
+    return sanitize(" ".join((proc.stderr or "").strip().splitlines()[-3:]))
+
+
+def _is_forbidden(tail: str) -> bool:
+    low = (tail or "").lower()
+    return "403" in low or "forbidden" in low or "does not have permission" in low
+
+
+def _body_file(body: object) -> str:
+    """Write a request body to a unique 0600 file; the caller must unlink it."""
+    fd, path = tempfile.mkstemp(prefix="kirocrew-az-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(body, handle)
+    except Exception:
+        os.unlink(path)
+        raise
+    return path
+
+
+def invoke(
+    *,
+    run: Callable[..., subprocess.CompletedProcess],
+    body_file: Callable[[object], str],
+    org_url: Callable[[str], str],
+    raise_if_setup_failure: Callable[[str], None],
+    stderr_tail: Callable[[subprocess.CompletedProcess], str],
+    is_forbidden: Callable[[str], bool],
+    org: str,
+    area: str,
+    resource: str,
+    host: str,
+    timeout: float,
+    route: dict[str, object] | None,
+    query: dict[str, object] | None,
+    method: str,
+    body: object | None,
+    api_version: str,
+    media_type: str,
+) -> object:
+    """Build one invoke argv, run it through the facade, and parse its response."""
+    argv = [
+        "az",
+        "devops",
+        "invoke",
+        "--org",
+        org_url(org),
+        "--area",
+        area,
+        "--resource",
+        resource,
+        "--http-method",
+        method,
+        "--api-version",
+        api_version,
+        "--detect",
+        "false",
+        "--output",
+        "json",
+    ]
+    if route:
+        argv.append("--route-parameters")
+        argv.extend(f"{key}={value}" for key, value in route.items())
+    if query:
+        argv.append("--query-parameters")
+        argv.extend(f"{key}={value}" for key, value in query.items())
+    if media_type:
+        argv += ["--media-type", media_type]
+
+    path = ""
+    try:
+        if body is not None:
+            path = body_file(body)
+            argv += ["--in-file", path]
+        proc = run(argv, host=host, timeout=timeout)
+    finally:
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+    target = f"{area}/{resource}"
+    if proc.returncode != 0:
+        tail = stderr_tail(proc)
+        raise_if_setup_failure(tail)
+        if is_forbidden(tail):
+            raise ProviderPermissionError(
+                f"az devops invoke {target} was forbidden (exit {proc.returncode}): {tail}"
+            )
+        raise ProviderCliError(f"az devops invoke {target} failed (exit {proc.returncode}): {tail}")
+    text = (proc.stdout or "").strip()
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ProviderCliError(f"az returned unexpected output for {target}") from exc
+
+
+def invoke_paged(
+    *,
+    invoke_one: Callable[..., object],
+    values: Callable[[object], list[dict]],
+    page_size: int,
+    max_pages: int,
+    org: str,
+    area: str,
+    resource: str,
+    host: str,
+    timeout: float,
+    route: dict[str, object] | None,
+    query: dict[str, object] | None,
+    api_version: str,
+    limit: int,
+) -> list[dict]:
+    """Walk Azure's bounded ``$top``/``$skip`` pagination."""
+    out: list[dict] = []
+    skip = 0
+    for _ in range(max_pages):
+        top = page_size
+        if limit:
+            remaining = limit - len(out)
+            if remaining <= 0:
+                break
+            top = min(page_size, remaining)
+        page_query = dict(query or {})
+        page_query["$top"] = top
+        page_query["$skip"] = skip
+        rows = values(
+            invoke_one(
+                org=org,
+                area=area,
+                resource=resource,
+                host=host,
+                timeout=timeout,
+                route=route,
+                query=page_query,
+                api_version=api_version,
+            )
+        )
+        out.extend(rows)
+        if len(rows) < top:
+            break
+        skip += top
+    return out

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
@@ -27,6 +27,7 @@ from urllib.parse import quote
 
 from kiro_crew import github_runner
 
+from . import github_normalization, github_queries, github_transport
 from .errors import (
     ProviderCliError,
     ProviderInvalidInputError,
@@ -100,7 +101,7 @@ parse_github_repo_url = github_runner.parse_github_repo_url
 # unrelated secrets (AWS/Slack/SSH) can never leak to a substituted or
 # compromised gh.
 
-_GH_OVERRIDE_ENV = "KIROCREW_ISSUE_RADAR_GH"
+_GH_OVERRIDE_ENV = github_transport.GH_OVERRIDE_ENV
 
 
 def _gh_bin() -> str:
@@ -112,14 +113,7 @@ def _gh_bin() -> str:
     ``KIROCREW_ISSUE_RADAR_GH`` to an absolute path to override (still
     validated), or ``KIROCREW_PROVIDER_BIN_STRICT=1`` to require a root-owned
     ``gh``. Raises :class:`GhSetupError` if no acceptable executable is found."""
-    try:
-        return github_runner.resolve_gh(override_env=_GH_OVERRIDE_ENV)
-    except github_runner.SetupError as exc:
-        # A host-setup problem the user must fix (gh absent, wrong override
-        # path, a binary owned by another user), not a transient API failure —
-        # surface it as a GhSetupError so the connect dialog offers
-        # instructions.
-        raise GhSetupError(str(exc), reason="not_installed") from exc
+    return github_transport.resolve_binary(override_env=_GH_OVERRIDE_ENV)
 
 
 def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
@@ -129,7 +123,7 @@ def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
     paths and private hosts are stripped while the actionable phrasing (auth,
     not-found, 403, timeout) is preserved.
     """
-    return sanitize_cli_stderr(" ".join((proc.stderr or "").strip().splitlines()[-3:]))
+    return github_transport.stderr_tail(proc, sanitize=sanitize_cli_stderr)
 
 
 def _gh_run(
@@ -141,29 +135,12 @@ def _gh_run(
     success, failure, and timeout. This wrapper keeps Issue Radar's error
     taxonomy (GhSetupError/GhCliError) so routes and the connect dialog are
     untouched."""
-    gh = _gh_bin()
-    try:
-        # pin_host: Issue Radar is github.com-only by design (its connect
-        # validation rejects every other host) and its API paths never pass
-        # --hostname, so an ambient GH_HOST must not be able to steer them to
-        # an enterprise instance.
-        return github_runner.run_gh(
-            [gh, *argv[1:]],
-            timeout=timeout,
-            input_text=input_text,
-            audit_caller="core:issue-radar",
-            pin_host="github.com",
-        )
-    except FileNotFoundError as exc:  # pragma: no cover — _gh_bin guards first
-        raise GhSetupError(
-            "the `gh` CLI is not installed on this host", reason="not_installed"
-        ) from exc
-    except subprocess.TimeoutExpired as exc:
-        raise GhCliError(f"`gh` timed out after {timeout}s") from exc
-    except github_runner.SetupError as exc:
-        # Audit-or-deny refusal (SEL unavailable): a transient host problem,
-        # not a connect-dialog setup issue — surface as the retryable class.
-        raise GhCliError(str(exc)) from exc
+    return github_transport.run(
+        argv,
+        timeout=timeout,
+        input_text=input_text,
+        gh_bin=_gh_bin,
+    )
 
 
 def _run_gh_api(
@@ -177,41 +154,22 @@ def _run_gh_api(
     ``paginate=False`` to cap at a single ``per_page`` page (used for closed
     issues, which can number in the thousands).
     """
-    argv = ["gh", "api", path]
-    if paginate:
-        argv.append("--paginate")
-    argv += ["--jq", jq_filter]
-    proc = _gh_run(argv, timeout=timeout)
-
-    if proc.returncode != 0:
-        tail = _stderr_tail(proc)
-        _raise_if_auth_failure(tail)
-        raise GhCliError(f"gh api {path} failed (exit {proc.returncode}): {tail}")
-
-    out: list[dict] = []
-    for line in (proc.stdout or "").splitlines():  # --jq emits JSONL, one object per line
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            out.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return out
+    return github_transport.run_api(
+        path,
+        jq_filter,
+        timeout=timeout,
+        paginate=paginate,
+        gh_run=_gh_run,
+        auth_classifier=_raise_if_auth_failure,
+        sanitize=sanitize_cli_stderr,
+    )
 
 
 # Markers `gh` prints when the CLI itself has no usable credentials (as opposed
 # to a repo simply being out of reach for an authenticated user). Matched
 # case-insensitively against the stderr tail so the connect dialog can offer
 # `gh auth login` instead of echoing an opaque exit code.
-_GH_AUTH_MARKERS = (
-    "gh auth login",
-    "not logged in",
-    "authentication required",
-    "requires authentication",
-    "bad credentials",
-    "http 401",
-)
+_GH_AUTH_MARKERS = github_transport.GH_AUTH_MARKERS
 
 
 def _raise_if_auth_failure(stderr_tail: str) -> None:
@@ -220,12 +178,7 @@ def _raise_if_auth_failure(stderr_tail: str) -> None:
     No-op for every other failure, so the caller still raises its own, more
     specific ``GhCliError`` with the full context.
     """
-    low = (stderr_tail or "").lower()
-    if any(m in low for m in _GH_AUTH_MARKERS):
-        raise GhSetupError(
-            "the `gh` CLI is not authenticated — run `gh auth login`",
-            reason="not_authenticated",
-        )
+    github_transport.raise_if_auth_failure(stderr_tail, markers=_GH_AUTH_MARKERS)
 
 
 def verify_repo_access(owner: str, repo: str, *, timeout: float = GH_TIMEOUT_SEC) -> dict:
@@ -510,12 +463,7 @@ def list_contributed_repos(
 def _parse_gh_timestamp(value: object) -> datetime | None:
     """Parse a GitHub ISO-8601 UTC stamp (``2026-07-25T20:57:01Z``) to an aware
     datetime, or None when absent/malformed."""
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
+    return github_normalization.parse_gh_timestamp(value)
 
 
 def get_current_login(*, timeout: float = GH_TIMEOUT_SEC) -> str | None:
@@ -565,7 +513,7 @@ def list_repo_labels(owner: str, repo: str, *, timeout: float = GH_TIMEOUT_SEC) 
 # available to any reader. Callers cache whichever result they get (with a
 # ``source`` marker) so the detail badge and the "created by member" filter read
 # it instantly.
-_MEMBER_ASSOC_RANK = {"OWNER": 3, "MEMBER": 2, "COLLABORATOR": 1}
+_MEMBER_ASSOC_RANK = github_normalization.MEMBER_ASSOC_RANK
 
 
 def list_repo_collaborators(
@@ -604,16 +552,7 @@ def derive_members(issues: list[dict]) -> list[dict]:
     author-less issues are ignored. This only ever sees members who happened to
     open an issue — hence it is a fallback, not the primary source.
     """
-    best: dict[str, str] = {}
-    for iss in issues:
-        login = iss.get("author")
-        assoc = iss.get("author_association")
-        if not login or assoc not in _MEMBER_ASSOC_RANK:
-            continue
-        current = best.get(login)
-        if current is None or _MEMBER_ASSOC_RANK[assoc] > _MEMBER_ASSOC_RANK[current]:
-            best[login] = assoc
-    return [{"login": login, "association": assoc} for login, assoc in sorted(best.items())]
+    return github_normalization.derive_members(issues)
 
 
 # ── single-issue detail + timeline (powers the detail pane) ──────────────────
@@ -721,26 +660,11 @@ def get_ref_summary(owner: str, repo: str, number: int, *, timeout: float = GH_T
 def _norm_reactions(r: dict | None) -> dict | None:
     """Normalize a GitHub reactions object; ``None`` when there are none (so the
     UI only renders a reactions strip when it carries signal)."""
-    if not r:
-        return None
-    total = r.get("total_count") or 0
-    if total <= 0:
-        return None
-    return {
-        "total": total,
-        "plus1": r.get("+1", 0),
-        "minus1": r.get("-1", 0),
-        "laugh": r.get("laugh", 0),
-        "hooray": r.get("hooray", 0),
-        "confused": r.get("confused", 0),
-        "heart": r.get("heart", 0),
-        "rocket": r.get("rocket", 0),
-        "eyes": r.get("eyes", 0),
-    }
+    return github_normalization.norm_reactions(r)
 
 
 def _actor_login(ev: dict) -> str | None:
-    return (ev.get("actor") or {}).get("login")
+    return github_normalization.actor_login(ev)
 
 
 def _normalize_timeline_event(ev: dict) -> dict | None:
@@ -753,114 +677,11 @@ def _normalize_timeline_event(ev: dict) -> dict | None:
     review_requested, head_ref_*, and similar bookkeeping — are noise here and
     are dropped.
     """
-    etype = ev.get("event")
-    created = ev.get("created_at")
-    if etype == "commented":
-        return {
-            "kind": "comment",
-            # ``id`` and ``updated_at`` are load-bearing for the crew claim
-            # protocol, not decoration. A crew keeps ONE comment as its public
-            # claim ledger and rewrites it (``update_issue_comment``), so without
-            # ``id`` it cannot address its own comment to PATCH it — and
-            # ``created_at`` on an EDITED comment is still the ORIGINAL post time,
-            # so a crew heartbeating every 20 minutes would read as days stale and
-            # lose a claim it is actively working. Both are on the timeline's
-            # ``commented`` event already, so this costs nothing.
-            "id": ev.get("id"),
-            "actor": (ev.get("user") or {}).get("login"),
-            "created_at": created,
-            "updated_at": ev.get("updated_at"),
-            "body": ev.get("body") or "",
-            "author_association": ev.get("author_association"),
-            "reactions": _norm_reactions(ev.get("reactions")),
-        }
-    if etype in ("labeled", "unlabeled"):
-        lab = ev.get("label") or {}
-        return {
-            "kind": etype,
-            "actor": _actor_login(ev),
-            "created_at": created,
-            "label": {"name": lab.get("name"), "color": lab.get("color")},
-        }
-    if etype in ("assigned", "unassigned"):
-        return {
-            "kind": etype,
-            "actor": _actor_login(ev),
-            "created_at": created,
-            "assignee": (ev.get("assignee") or {}).get("login"),
-        }
-    if etype == "closed":
-        return {
-            "kind": "closed",
-            "actor": _actor_login(ev),
-            "created_at": created,
-            "state_reason": ev.get("state_reason"),
-            "commit_id": ev.get("commit_id"),
-        }
-    if etype == "reopened":
-        return {"kind": "reopened", "actor": _actor_login(ev), "created_at": created}
-    if etype == "renamed":
-        rn = ev.get("rename") or {}
-        return {
-            "kind": "renamed",
-            "actor": _actor_login(ev),
-            "created_at": created,
-            "rename": {"from": rn.get("from"), "to": rn.get("to")},
-        }
-    if etype in ("milestoned", "demilestoned"):
-        return {
-            "kind": etype,
-            "actor": _actor_login(ev),
-            "created_at": created,
-            "milestone": (ev.get("milestone") or {}).get("title"),
-        }
-    if etype == "cross-referenced":
-        src = (ev.get("source") or {}).get("issue") or {}
-        return {
-            "kind": "cross-referenced",
-            "actor": _actor_login(ev),
-            "created_at": created,
-            "source": {
-                "number": src.get("number"),
-                "title": src.get("title"),
-                "url": src.get("html_url"),
-                "state": src.get("state"),
-                "is_pr": bool(src.get("pull_request")),
-            },
-        }
-    if etype == "referenced":
-        return {
-            "kind": "referenced",
-            "actor": _actor_login(ev),
-            "created_at": created,
-            "commit_id": ev.get("commit_id"),
-        }
-    # ── pull-request-only timeline events (never emitted for plain issues) ──
-    # A PR's timeline additionally carries code reviews and commits. They are
-    # additive here: an issue timeline never contains them, so keeping them in
-    # the shared normalizer only enriches the PR detail pane. ``reviewed`` uses
-    # ``submitted_at`` (not ``created_at``) and ``committed`` uses the commit
-    # author's date, so both fall back to those before the generic ``created``.
-    if etype == "reviewed":
-        return {
-            "kind": "reviewed",
-            "actor": (ev.get("user") or {}).get("login"),
-            "created_at": ev.get("submitted_at") or created,
-            "review_state": ev.get("state"),
-            "body": ev.get("body") or "",
-        }
-    if etype == "committed":
-        # Commit events have no ``actor`` object — the author is embedded, and
-        # the human-facing login (when present) lives on ``.author`` too.
-        author = ev.get("author") or {}
-        return {
-            "kind": "committed",
-            "actor": author.get("name") or (ev.get("committer") or {}).get("name"),
-            "created_at": author.get("date") or (ev.get("committer") or {}).get("date") or created,
-            "commit_id": ev.get("sha"),
-            "message": (ev.get("message") or "").splitlines()[0] if ev.get("message") else "",
-        }
-    return None
+    return github_normalization.normalize_timeline_event(
+        ev,
+        reaction_normalizer=_norm_reactions,
+        actor_reader=_actor_login,
+    )
 
 
 def list_issue_timeline(
@@ -977,13 +798,11 @@ def list_pr_timeline(
 
 # The dependencies API answers a list of issue objects; only the number, state,
 # title and PR-ness are needed to both draw the edge and seed the node.
-_DEP_ISSUE_JQ = (
-    ".[] | {number: .number, title: .title, state: .state, " "is_pr: (.pull_request != null)}"
-)
+_DEP_ISSUE_JQ = github_queries.DEP_ISSUE_JQ
 
 
 def _dep_node_kind(is_pr: bool) -> str:
-    return "pull" if is_pr else "issue"
+    return github_normalization.dep_node_kind(is_pr)
 
 
 def _dep_node_state(state: Any, merged_at: Any = None) -> str:
@@ -992,12 +811,7 @@ def _dep_node_state(state: Any, merged_at: Any = None) -> str:
     A PR that GitHub reports as ``closed`` but carries a ``merged_at`` is shown as
     ``merged`` — the auto-unlock semantics turn on merged-vs-closed, and the graph
     view colours by it — while everything else collapses to open/closed."""
-    if merged_at:
-        return "merged"
-    s = str(state or "").lower()
-    if s == "merged":
-        return "merged"
-    return "closed" if s == "closed" else "open"
+    return github_normalization.dep_node_state(state, merged_at)
 
 
 def _is_deps_feature_absent(exc: GhCliError) -> bool:
@@ -1012,8 +826,7 @@ def _is_deps_feature_absent(exc: GhCliError) -> bool:
     it would let a refresh overwrite the cached graph with a wrong-empty one and
     fire a false unlock (blocker count 1 -> 0) for every dependent item.
     """
-    msg = str(exc)
-    return "HTTP 404" in msg or "HTTP 410" in msg
+    return github_queries.is_deps_feature_absent(exc)
 
 
 def list_issue_blocked_by(
@@ -1028,14 +841,14 @@ def list_issue_blocked_by(
     dependencies still gets its inferred graph. ``number`` is coerced to ``int``
     before it reaches the path so it cannot inject segments.
     """
-    path = f"repos/{owner}/{repo}/issues/{int(number)}/dependencies/blocked_by?per_page=100"
-    try:
-        rows = _run_gh_api(path, _DEP_ISSUE_JQ, timeout=timeout, paginate=True)
-    except GhCliError as exc:
-        if _is_deps_feature_absent(exc):
-            return []  # feature absent for this repo/host — zero native edges
-        raise
-    return [r for r in rows if isinstance(r, dict) and isinstance(r.get("number"), int)]
+    return github_queries.list_issue_blocked_by(
+        owner,
+        repo,
+        number,
+        timeout=timeout,
+        run_api=_run_gh_api,
+        absent_classifier=_is_deps_feature_absent,
+    )
 
 
 def _inferred_blockers_from_timeline(
@@ -1050,16 +863,15 @@ def _inferred_blockers_from_timeline(
     same-repo only). Returns the compact node shape so the caller can seed
     ``nodes`` without a second read.
     """
-    try:
-        events = list_issue_timeline(owner, repo, number, timeout=timeout)
-    except GhCliError as exc:
-        # Same narrow tolerance as the native reads: only unambiguous absence
-        # (404/410) is an empty result. A 403 propagates — swallowing it would
-        # persist a wrong-empty graph and falsely unlock dependents.
-        if _is_deps_feature_absent(exc):
-            return []
-        raise
-    return _inferred_blockers_from_events(events, owner, repo, number)
+    return github_queries.inferred_blockers_from_timeline(
+        owner,
+        repo,
+        number,
+        timeout=timeout,
+        timeline_loader=list_issue_timeline,
+        absent_classifier=_is_deps_feature_absent,
+        event_filter=_inferred_blockers_from_events,
+    )
 
 
 def _inferred_blockers_from_events(
@@ -1069,155 +881,25 @@ def _inferred_blockers_from_events(
     cross-reference sources, drop self-references and anything whose URL does not
     name THIS owner/repo (an empty URL is dropped rather than assumed local, so a
     cross-repo edge can never sneak in via a missing field)."""
-    out: list[dict] = []
-    prefix = f"/{owner}/{repo}/"
-    for ev in events:
-        if not isinstance(ev, dict) or ev.get("kind") != "cross-referenced":
-            continue
-        src = ev.get("source") or {}
-        src_number = src.get("number")
-        if not isinstance(src_number, int) or src_number <= 0 or src_number == number:
-            continue
-        url = str(src.get("url") or "")
-        if prefix not in url:
-            continue
-        out.append(
-            {
-                "number": src_number,
-                "title": src.get("title"),
-                "state": src.get("state"),
-                "is_pr": bool(src.get("is_pr")),
-            }
-        )
-    return out
+    return github_queries.inferred_blockers_from_events(events, owner, repo, number)
 
 
 def _batch_dependency_graph(
     owner: str, repo: str, *, timeout: float = GH_TIMEOUT_SEC
 ) -> dict[int, dict] | None:
-    """ONE paginated GraphQL walk of the repo's open issues, carrying native
-    ``blockedBy`` and cross-referenced timeline sources per issue.
-
-    This exists because the per-issue REST path costs two ``gh`` subprocesses per
-    open issue — ~2N spawns; measured against a live repo with 561 open issues the
-    first ``/deps`` fetch did not return within five minutes. The connection query
-    reads 100 issues per call, so the same repo costs ~6 calls.
-
-    Returns ``{number: {"row": {...}, "native": [rows], "refs": [rows]}}`` in the
-    same compact row shape the per-issue helpers emit, or ``None`` when GraphQL is
-    unavailable for this host/token — the caller then falls back to the per-issue
-    REST path (which stays correct, just slow, and remains the seam the unit tests
-    stub).
-    """
-    query = (
-        "query($owner:String!,$name:String!,$after:String){"
-        "repository(owner:$owner,name:$name){"
-        "issues(states:OPEN,first:100,after:$after){"
-        "pageInfo{hasNextPage endCursor}"
-        "nodes{number title state "
-        "blockedBy(first:50){pageInfo{hasNextPage} nodes{number title state}}"
-        "timelineItems(itemTypes:[CROSS_REFERENCED_EVENT],first:100){pageInfo{hasNextPage} nodes{"
-        "... on CrossReferencedEvent{source{"
-        "... on Issue{number title state url repository{nameWithOwner}}"
-        "... on PullRequest{number title state url merged repository{nameWithOwner}}"
-        "}}}}}}}}"
-    )
-
-    def _row(node: dict) -> dict:
-        state = str(node.get("state") or "open").lower()
-        return {
-            "number": node.get("number"),
-            "title": node.get("title") or "",
-            "state": "closed" if state in ("closed", "merged") else "open",
-            "is_pr": "merged" in node,  # PullRequest fragments carry ``merged``
-            "merged_at": "merged" if node.get("merged") else None,
-        }
-
-    out: dict[int, dict] = {}
-    after: str | None = None
-    full_name = f"{owner}/{repo}".lower()
-    for _page in range(_DEPS_GRAPHQL_MAX_PAGES):
-        argv = [
-            "api",
-            "graphql",
-            "-f",
-            f"query={query}",
-            "-F",
-            f"owner={owner}",
-            "-F",
-            f"name={repo}",
-        ]
-        if after:
-            argv += ["-F", f"after={after}"]
-        proc = _gh_run(["gh", *argv], timeout=timeout)
-        if proc.returncode != 0:
-            logger.info(
-                "issue-radar: deps graphql batch unavailable for %s/%s; "
-                "falling back to per-issue reads",
-                owner,
-                repo,
-            )
-            return None
-        try:
-            conn = json.loads(proc.stdout)["data"]["repository"]["issues"]
-        except (ValueError, KeyError, TypeError):
-            logger.info("issue-radar: deps graphql batch returned an unexpected shape")
-            return None
-        for node in conn.get("nodes") or []:
-            if not isinstance(node, dict) or not isinstance(node.get("number"), int):
-                continue
-            num = node["number"]
-            native: list[dict] = []
-            for b in (node.get("blockedBy") or {}).get("nodes") or []:
-                if isinstance(b, dict) and isinstance(b.get("number"), int):
-                    native.append(_row(b))
-            refs: list[dict] = []
-            for item in (node.get("timelineItems") or {}).get("nodes") or []:
-                src = (item or {}).get("source") or {}
-                repo_name = str(((src.get("repository") or {}).get("nameWithOwner")) or "")
-                if not isinstance(src.get("number"), int) or repo_name.lower() != full_name:
-                    continue  # same-repo only, and an unnamed repo never sneaks in
-                refs.append(
-                    {
-                        "kind": "cross-referenced",
-                        "source": {
-                            **_row(src),
-                            "url": str(src.get("url") or ""),
-                        },
-                    }
-                )
-            out[num] = {
-                "row": _row(node),
-                "native": native,
-                "refs": refs,
-                # Either nested connection having another page means this
-                # issue's edge set here is INCOMPLETE — the caller must use the
-                # per-issue paginated reads for it instead of persisting a
-                # silently-partial graph.
-                "truncated": bool(
-                    ((node.get("blockedBy") or {}).get("pageInfo") or {}).get("hasNextPage")
-                    or ((node.get("timelineItems") or {}).get("pageInfo") or {}).get("hasNextPage")
-                ),
-            }
-        info = conn.get("pageInfo") or {}
-        if not info.get("hasNextPage"):
-            return out
-        after = str(info.get("endCursor") or "") or None
-        if after is None:
-            return out
-    logger.info(
-        "issue-radar: deps graphql batch exceeded %d pages for %s/%s; using partial graph",
-        _DEPS_GRAPHQL_MAX_PAGES,
+    """Read native and inferred dependency inputs in one bounded GraphQL walk."""
+    return github_queries.batch_dependency_graph(
         owner,
         repo,
+        timeout=timeout,
+        gh_run=_gh_run,
     )
-    return out
 
 
 # Hard page ceiling for the batched walk: 100 issues/page × 40 = 4000 open
 # issues, far past any repo this app realistically triages. A repo beyond it
 # still gets a graph for its first 4000 — bounded, never unbounded pagination.
-_DEPS_GRAPHQL_MAX_PAGES = 40
+_DEPS_GRAPHQL_MAX_PAGES = github_queries.DEPS_GRAPHQL_MAX_PAGES
 
 
 def fetch_dependency_edges(
@@ -1228,119 +910,21 @@ def fetch_dependency_edges(
     *,
     timeout: float = GH_TIMEOUT_SEC,
 ) -> tuple[list[dict], dict[str, dict]]:
-    """Build the repo's dependency graph for its OPEN issues.
-
-    ``open_issues`` is the issues-list cache rows (each a dict with at least
-    ``number``); the graph is scoped to these so the cost is bounded to N native
-    reads + N timeline reads for the open backlog, not the whole repo history.
-    ``node_hints`` maps ``number -> {kind, state, title}`` already known from the
-    issues/pulls caches, so a node in those caches costs NO extra API call; only
-    a number that appears in an edge yet is absent from the hints (typically a
-    closed blocker) falls back to one ``get_ref_summary`` call.
-
-    Returns ``(edges, nodes)`` in the store's shape. Dedup and native-wins are
-    left to ``store._normalize_deps`` (single source of truth), so this may emit
-    a native and an inferred edge for the same pair — the store collapses them.
-    """
-    hints = dict(node_hints or {})
-    open_rows: dict[int, dict] = {}
-    numbers: list[int] = []
-    for row in open_issues:
-        if isinstance(row, dict) and isinstance(row.get("number"), int) and row["number"] > 0:
-            n = int(row["number"])
-            numbers.append(n)
-            open_rows[n] = row
-    edges: list[dict] = []
-    # Node shape accumulator, keyed by int; serialized to str keys at the end.
-    nodes: dict[int, dict] = {}
-    # Numbers whose node entry came from a FORGE-FRESH row (batch/native/timeline
-    # result from this very fetch) rather than a possibly-stale cache row.
-    fresh: set[int] = set()
-
-    def _seed(num: int, row: dict | None, *, is_fresh: bool = False) -> None:
-        """Record a node from a compact row.
-
-        Freshness wins: a row from THIS fetch (a dependencies/timeline/batch
-        result) overwrites a seed taken from the cached open-issues list or the
-        node hints — otherwise a stale-open cache row would pin a blocker open
-        and the persisted graph could never unlock its dependents. A cache row
-        never overwrites anything, and an unseedable number is left for the
-        ref-summary fallback below.
-        """
-        if num in nodes and (num in fresh or not is_fresh):
-            return
-        if isinstance(row, dict):
-            nodes[num] = {
-                "kind": _dep_node_kind(bool(row.get("is_pr"))),
-                "state": _dep_node_state(row.get("state"), row.get("merged_at")),
-                "title": str(row.get("title") or ""),
-            }
-            if is_fresh:
-                fresh.add(num)
-        elif num in hints and num not in nodes:
-            nodes[num] = dict(hints[num])
-
-    for num in numbers:
-        # The blocked node is an open issue we already hold a row for — seed it
-        # from that row so it never costs a fallback. Cache-grade: a fresh row
-        # from the fetch below overwrites it.
-        _seed(num, open_rows.get(num))
-
-    # One batched GraphQL walk covers every open issue's native blockers AND its
-    # cross-reference events; the per-issue REST reads below are the fallback
-    # when GraphQL is unavailable (and the seam the unit tests stub).
-    batch = _batch_dependency_graph(owner, repo, timeout=timeout)
-
-    for num in numbers:
-        entry = batch.get(num) if batch is not None else None
-        if entry is not None and not entry.get("truncated"):
-            # The batch row for this issue is from THIS fetch — fresher than any
-            # cached open-issues row it was seeded from above.
-            _seed(num, entry.get("row"), is_fresh=True)
-            native_rows = entry.get("native") or []
-            inferred_rows = _inferred_blockers_from_events(
-                entry.get("refs") or [], owner, repo, num
-            )
-        else:
-            # No batch, or THIS issue's nested connections were truncated in the
-            # batch (over `first:` blockers/cross-refs): its edge set would be
-            # silently incomplete, so this issue alone pays the per-issue reads.
-            native_rows = list_issue_blocked_by(owner, repo, num, timeout=timeout)
-            inferred_rows = _inferred_blockers_from_timeline(owner, repo, num, timeout=timeout)
-
-        for blocker in native_rows:
-            b = int(blocker["number"])
-            edges.append({"blocked": num, "blocker": b, "source": "native"})
-            _seed(b, blocker, is_fresh=True)
-
-        for blocker in inferred_rows:
-            b = int(blocker["number"])
-            edges.append({"blocked": num, "blocker": b, "source": "inferred"})
-            _seed(b, blocker, is_fresh=True)
-
-    # Any number referenced by an edge but still unseeded (a blocker not in the
-    # open-issues rows and not in the hints) gets ONE ref-summary call — the only
-    # per-node fetch, and only when a cache genuinely cannot answer.
-    referenced: set[int] = {e["blocked"] for e in edges} | {e["blocker"] for e in edges}
-    for num in sorted(referenced):
-        if num in nodes:
-            continue
-        if num in hints:
-            nodes[num] = dict(hints[num])
-            continue
-        try:
-            summary = get_ref_summary(owner, repo, num, timeout=timeout)
-        except GhCliError:
-            logger.debug("issue-radar: deps node summary failed for #%s", num, exc_info=True)
-            nodes[num] = {"kind": "issue", "state": "open", "title": ""}
-            continue
-        nodes[num] = {
-            "kind": _dep_node_kind(bool(summary.get("is_pr"))),
-            "state": _dep_node_state(summary.get("state"), summary.get("merged_at")),
-            "title": str(summary.get("title") or ""),
-        }
-
-    return edges, {str(k): v for k, v in nodes.items()}
+    """Build normalized dependency edges and nodes for the open issue set."""
+    return github_queries.fetch_dependency_edges(
+        owner,
+        repo,
+        open_issues,
+        node_hints,
+        timeout=timeout,
+        batch_loader=_batch_dependency_graph,
+        blockers_loader=list_issue_blocked_by,
+        inferred_loader=_inferred_blockers_from_timeline,
+        event_filter=_inferred_blockers_from_events,
+        ref_loader=get_ref_summary,
+        node_kind=_dep_node_kind,
+        node_state=_dep_node_state,
+    )
 
 
 # ── write primitives (triage actions: label + state) ────────────────────────
@@ -1370,49 +954,21 @@ def _run_gh_write(
     HTTP 403 instead of a generic 502. ``payload`` is serialized to JSON and fed
     on stdin, never interpolated into argv.
     """
-    argv = ["gh", "api", "--method", method, path]
-    input_text: str | None = None
-    if payload is not None:
-        argv += ["--input", "-"]
-        input_text = json.dumps(payload)
-    proc = _gh_run(argv, timeout=timeout, input_text=input_text)
-
-    if proc.returncode != 0:
-        stderr = proc.stderr or ""
-        tail = sanitize_cli_stderr(" ".join(stderr.strip().splitlines()[-3:]))
-        if "HTTP 403" in stderr or "HTTP 401" in stderr:
-            raise GhPermissionError(
-                f"GitHub refused the write ({method} {path}) — your `gh` session "
-                f"lacks the required triage/push access: {tail}"
-            )
-        raise GhCliError(f"gh api {method} {path} failed (exit {proc.returncode}): {tail}")
-
-    out = (proc.stdout or "").strip()
-    if not out:
-        return None
-    try:
-        return json.loads(out)
-    except json.JSONDecodeError:
-        return None
+    return github_transport.run_write(
+        method,
+        path,
+        payload,
+        timeout=timeout,
+        gh_run=_gh_run,
+        sanitize=sanitize_cli_stderr,
+    )
 
 
 def _shape_labels(raw: object) -> list[dict]:
     """Normalize a GitHub label array (as returned by the labels endpoints) to
     the ``[{name, color, description}]`` shape the detail pane + caches use.
     Tolerates a non-list (returns ``[]``)."""
-    if not isinstance(raw, list):
-        return []
-    out: list[dict] = []
-    for lab in raw:
-        if isinstance(lab, dict) and lab.get("name"):
-            out.append(
-                {
-                    "name": lab.get("name"),
-                    "color": lab.get("color") or "888888",
-                    "description": lab.get("description") or "",
-                }
-            )
-    return out
+    return github_normalization.shape_labels(raw)
 
 
 def get_repo_permissions(owner: str, repo: str, *, timeout: float = GH_TIMEOUT_SEC) -> dict:
@@ -1824,24 +1380,9 @@ _COMMIT_STATUS_JQ = (
 
 # GitHub conclusion / state -> coarse bucket. Anything unrecognized is treated as
 # "other" (informational), never silently as success.
-_CHECK_FAILURE_CONCLUSIONS = {
-    "failure",
-    "timed_out",
-    "action_required",
-    "startup_failure",
-    "stale",
-    "error",
-}
-_CHECK_RUNNING_STATES = {
-    "queued",
-    "in_progress",
-    "pending",
-    "waiting",
-    "requested",
-    # GraphQL's rollup/context vocabulary adds this one; harmless for REST.
-    "expected",
-}
-_CHECK_OTHER_CONCLUSIONS = {"neutral", "skipped", "cancelled", "canceled"}
+_CHECK_FAILURE_CONCLUSIONS = github_normalization.CHECK_FAILURE_CONCLUSIONS
+_CHECK_RUNNING_STATES = github_normalization.CHECK_RUNNING_STATES
+_CHECK_OTHER_CONCLUSIONS = github_normalization.CHECK_OTHER_CONCLUSIONS
 
 
 def _check_bucket(status: str | None, conclusion: str | None) -> str:
@@ -1856,18 +1397,7 @@ def _check_bucket(status: str | None, conclusion: str | None) -> str:
     "a card dot and the detail sidebar can never disagree about red" true —
     parallel tables would only be edit-locked by convention.
     """
-    st = (status or "").lower()
-    cc = (conclusion or "").lower()
-    if st in _CHECK_RUNNING_STATES or cc in _CHECK_RUNNING_STATES:
-        return "running"
-    if cc in _CHECK_FAILURE_CONCLUSIONS:
-        return "failure"
-    if cc == "success":
-        return "success"
-    if cc in _CHECK_OTHER_CONCLUSIONS:
-        return "other"
-    # Completed with an unknown/absent conclusion — informational, not passing.
-    return "other"
+    return github_normalization.check_bucket(status, conclusion)
 
 
 def _check_identity(row: dict) -> tuple[str, str]:
@@ -1878,7 +1408,7 @@ def _check_identity(row: dict) -> tuple[str, str]:
     let one app's later success hide another app's failure. ``source`` is the
     publishing app's slug (or ``"status"`` for a commit status).
     """
-    return (str(row.get("source") or ""), str(row.get("name") or ""))
+    return github_normalization.check_identity(row)
 
 
 def _dedupe_checks(rows: list[dict]) -> list[dict]:
@@ -1892,23 +1422,7 @@ def _dedupe_checks(rows: list[dict]) -> list[dict]:
     run supersedes the earlier one, so latest wins.
     """
 
-    def _key(r: dict) -> tuple[str, str]:
-        # started_at first: an OLDER run that finished (completed 10:10) must not
-        # outrank a NEWER run that is still going (started 10:15, no completed_at),
-        # which is exactly what comparing completed_at first would do — the UI
-        # would show a stale pass while its replacement was still running.
-        return (str(r.get("started_at") or ""), str(r.get("completed_at") or ""))
-
-    best: dict[tuple[str, str], dict] = {}
-    for r in rows:
-        if not r.get("name"):
-            # A nameless row would render as a blank line.
-            continue
-        ident = _check_identity(r)
-        prev = best.get(ident)
-        if prev is None or _key(r) >= _key(prev):
-            best[ident] = r
-    return list(best.values())
+    return github_normalization.dedupe_checks(rows, identity=_check_identity)
 
 
 def list_pr_checks(
@@ -1994,62 +1508,26 @@ def list_pr_checks(
 # Our own lifecycle names -> GraphQL PullRequestState literals. The values are
 # interpolated into the query, so they come from THIS map only — never from
 # caller input — which keeps the query free of injection surface.
-_GRAPHQL_PR_STATES = {"open": "OPEN", "closed": "CLOSED, MERGED"}
+_GRAPHQL_PR_STATES = github_queries.GRAPHQL_PR_STATES
 
 # The bucket keys every counts dict carries, so the frontend never has to guard a
 # missing key and the render order of the card's badges is fixed.
-_CHECK_BUCKETS = ("failure", "running", "success", "other")
+_CHECK_BUCKETS = github_normalization.CHECK_BUCKETS
 
 # How many rollup contexts one GraphQL page carries. A PR with more than this has
 # a TRUNCATED tally, which the row reports so the card can fall back to the
 # aggregate rollup instead of presenting an incomplete count as complete.
-_ROLLUP_CONTEXT_PAGE = 100
+_ROLLUP_CONTEXT_PAGE = github_queries.ROLLUP_CONTEXT_PAGE
 
 # One PR's contexts, projected into the SAME row shape the REST check list uses
 # (name / source / status / conclusion / timestamps) so they can go through
-# _dedupe_checks and _check_bucket unchanged. Re-implementing either on a
-# bespoke string protocol is what previously let the card and the sidebar
-# disagree; sharing the code makes agreement structural.
-_ROLLUP_CONTEXTS_JQ = (
-    "[(.commits.nodes[0].commit.statusCheckRollup.contexts.nodes[]? | "
-    '{name: ((.name // .context) // ""), '
-    'source: ((.checkSuite.app.slug // .checkSuite.app.name) // "status"), '
-    "status: (.status // null), "
-    "conclusion: ((.conclusion // .state) // null), "
-    "started_at: ((.startedAt // .createdAt) // null), "
-    "completed_at: (.completedAt // null)})]"
-)
+# _dedupe_checks and _check_bucket unchanged, so card and sidebar classification
+# remain structurally identical.
+_ROLLUP_CONTEXTS_JQ = github_queries.ROLLUP_CONTEXTS_JQ
 
 # The GraphQL selection for one PR's card enrichment, shared by both fetchers so
 # the two paths can never drift apart in what they ask for.
-_PR_SUMMARY_SELECTION = (
-    " number additions deletions changedFiles"
-    # ``state`` + ``mergedAt`` fix the "already merged" half of the auto-merge defect: a
-    # row cached before a PR merged was still offered auto-merge, and the provider
-    # answered "Pull request is already merged". The list row has a ``state`` from its
-    # own source, but a SEARCH row's can be equally stale, and this is the read that
-    # happens closest to the action. ``mergedAt`` is required alongside ``state``
-    # because ``state`` alone cannot express the lifecycle in REST's vocabulary:
-    # GraphQL has a distinct ``MERGED`` state, REST has only ``open``/``closed`` plus a
-    # ``merged_at`` timestamp, and the row shape is REST's — correcting a stale
-    # ``state`` to ``closed`` without the timestamp would render a merged PR with the
-    # red closed-unmerged icon.
-    #
-    # These three ARE free (measured: adding them changes neither this query's latency
-    # nor its success rate). ``mergeStateStatus`` is deliberately NOT here — it is the
-    # one field that is not. See :data:`_PR_READINESS_SELECTION`.
-    " mergeable state mergedAt"
-    # ``oid`` is the head COMMIT. Free here — this selection already walks the last
-    # commit for its check rollup — and it is what gives SEARCH rows a head sha:
-    # ``_PR_SEARCH_JQ`` cannot supply one (GitHub's search API does not expose it),
-    # so without this a person-filtered selection could not be bulk-approved, since
-    # a review has to name the revision it was formed on.
-    " commits(last:1){nodes{commit{oid statusCheckRollup{state"
-    f"  contexts(first:{_ROLLUP_CONTEXT_PAGE}){{pageInfo{{hasNextPage}} nodes{{ __typename"
-    "   ... on CheckRun{name conclusion status startedAt completedAt"
-    "    checkSuite{app{slug name}}}"
-    "   ... on StatusContext{context state createdAt} }}}}}}"
-)
+_PR_SUMMARY_SELECTION = github_queries.PR_SUMMARY_SELECTION
 
 # ``mergeStateStatus`` — its OWN query, deliberately, and this is the expensive one.
 #
@@ -2077,233 +1555,88 @@ _PR_SUMMARY_SELECTION = (
 # ``first:100``. So it gets a second, LEAN call: one extra request per list fetch,
 # independently failable, and a failure costs only the readiness field rather than the
 # whole card payload.
-_PR_READINESS_SELECTION = " number mergeStateStatus"
+_PR_READINESS_SELECTION = github_queries.PR_READINESS_SELECTION
 
-_PR_READINESS_JQ_BODY = "{number: .number, merge_state_status: (.mergeStateStatus // null)}"
+_PR_READINESS_JQ_BODY = github_queries.PR_READINESS_JQ_BODY
 
 # Smaller than `_SUMMARY_BATCH` (100) on purpose: this is the field GitHub COMPUTES, and
 # the by-number form asks for N of them in one query. 50 is the largest page measured
 # comfortable; the page-size ceiling is exactly what the split exists to respect.
-_READINESS_BATCH = 50
+_READINESS_BATCH = github_queries.READINESS_BATCH
 
 # The JQ projection applied to ONE PR node (shared for the same reason).
-_PR_SUMMARY_JQ_BODY = (
-    "{number: .number, additions: .additions, deletions: .deletions, "
-    "changed_files: (.changedFiles // 0), "
-    # Carried through under GraphQL's own names; `_parse_summary_rows` lowercases them
-    # into REST's vocabulary, which is the spelling every reader already uses.
-    "mergeable_raw: (.mergeable // null), "
-    "pr_state: (.state // null), "
-    "pr_merged_at: (.mergedAt // null), "
-    "head_sha: (.commits.nodes[0].commit.oid // null), "
-    "rollup: (.commits.nodes[0].commit.statusCheckRollup.state // null), "
-    "contexts_truncated: "
-    "(.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage // false), "
-    f"contexts: {_ROLLUP_CONTEXTS_JQ}}}"
-)
+_PR_SUMMARY_JQ_BODY = github_queries.PR_SUMMARY_JQ_BODY
 
 
 def fetch_pr_summaries(
     owner: str, repo: str, state: str = "open", *, timeout: float = GH_TIMEOUT_SEC
 ) -> dict[int, dict]:
-    """``{number: {additions, deletions, changed_files, checks_state, checks_counts}}``
-    for a repo's PRs, in ONE GraphQL call (see the module note above).
-
-    ``checks_state`` is the aggregate status-check rollup and ``checks_counts`` the
-    per-bucket tally of the individual checks, both bucketed the same way as
-    :func:`list_pr_checks` (``success`` / ``failure`` / ``running`` / ``other``).
-    ``checks_state`` is ``None`` when the PR has no checks at all. Raises
-    :class:`GhCliError` on a failed call — callers treat the enrichment as
-    optional and continue without it.
-    """
-    gql_state = _GRAPHQL_PR_STATES.get(state)
-    if gql_state is None:
-        raise GhCliError(f"unsupported state for PR summaries: {state!r}")
-    query = (
-        "query($owner:String!,$name:String!){"
-        " repository(owner:$owner,name:$name){"
-        f"  pullRequests(states:[{gql_state}], first:100,"
-        "   orderBy:{field:UPDATED_AT,direction:DESC}){"
-        "   nodes{" + _PR_SUMMARY_SELECTION + " } } } }"
+    """Fetch one state window of card summaries with the lean query family."""
+    return github_queries.fetch_pr_summaries(
+        owner,
+        repo,
+        state,
+        timeout=timeout,
+        gh_run=_gh_run,
+        stderr_tail=_stderr_tail,
+        parse_rows=_parse_summary_rows,
     )
-    argv = [
-        "gh",
-        "api",
-        "graphql",
-        "-f",
-        f"query={query}",
-        "-F",
-        f"owner={owner}",
-        "-F",
-        f"name={repo}",
-        "--jq",
-        f".data.repository.pullRequests.nodes[] | {_PR_SUMMARY_JQ_BODY}",
-    ]
-    proc = _gh_run(argv, timeout=timeout)
-    if proc.returncode != 0:
-        tail = _stderr_tail(proc)
-        raise GhCliError(f"gh api graphql (pr summaries) failed (exit {proc.returncode}): {tail}")
-
-    return _parse_summary_rows(proc.stdout or "")
 
 
 def fetch_pr_readiness(
     owner: str, repo: str, state: str = "open", *, timeout: float = GH_TIMEOUT_SEC
 ) -> dict[int, str | None]:
-    """``{number: mergeable_state}`` for a repo's PRs — its own LEAN GraphQL call.
-
-    Separate from :func:`fetch_pr_summaries` because ``mergeStateStatus`` is the one
-    field here GitHub has to COMPUTE (a merge commit per PR); folded into the card
-    selection the combined query 502s at this page size. See
-    :data:`_PR_READINESS_SELECTION` for the measurements.
-
-    Best-effort, like the card enrichment: raises :class:`GhCliError` and the caller
-    continues without readiness, which costs the bulk bar's merge/arm split for that
-    fetch but leaves every other field intact.
-    """
-    gql_state = _GRAPHQL_PR_STATES.get(state)
-    if gql_state is None:
-        raise GhCliError(f"unsupported state for PR readiness: {state!r}")
-    query = (
-        "query($owner:String!,$name:String!){"
-        " repository(owner:$owner,name:$name){"
-        f"  pullRequests(states:[{gql_state}], first:100,"
-        "   orderBy:{field:UPDATED_AT,direction:DESC}){"
-        "   nodes{" + _PR_READINESS_SELECTION + " } } } }"
+    """Fetch merge readiness separately from the heavier card summary query."""
+    return github_queries.fetch_pr_readiness(
+        owner,
+        repo,
+        state,
+        timeout=timeout,
+        gh_run=_gh_run,
+        stderr_tail=_stderr_tail,
+        parse_rows=_parse_readiness_rows,
     )
-    argv = [
-        "gh",
-        "api",
-        "graphql",
-        "-f",
-        f"query={query}",
-        "-F",
-        f"owner={owner}",
-        "-F",
-        f"name={repo}",
-        "--jq",
-        f".data.repository.pullRequests.nodes[] | {_PR_READINESS_JQ_BODY}",
-    ]
-    proc = _gh_run(argv, timeout=timeout)
-    if proc.returncode != 0:
-        tail = _stderr_tail(proc)
-        raise GhCliError(f"gh api graphql (pr readiness) failed (exit {proc.returncode}): {tail}")
-    return _parse_readiness_rows(proc.stdout or "")
 
 
 def fetch_pr_readiness_by_number(
     owner: str, repo: str, numbers: list[int], *, timeout: float = GH_TIMEOUT_SEC
 ) -> dict[int, str | None]:
-    """:func:`fetch_pr_readiness` for an EXPLICIT number list (the SEARCH path).
-
-    Same reason :func:`fetch_pr_summaries_by_number` exists: a person-filtered search
-    can return a PR that ranks outside the state-scoped window.
-    """
-    out: dict[int, str | None] = {}
-    wanted = [n for n in numbers if isinstance(n, int) and n > 0]
-    for start in range(0, len(wanted), _READINESS_BATCH):
-        batch = wanted[start : start + _READINESS_BATCH]
-        fields = " ".join(
-            f"p{n}: pullRequest(number:{n}){{{_PR_READINESS_SELECTION} }}" for n in batch
-        )
-        query = (
-            "query($owner:String!,$name:String!){"
-            f" repository(owner:$owner,name:$name){{ {fields} }} }}"
-        )
-        argv = [
-            "gh",
-            "api",
-            "graphql",
-            "-f",
-            f"query={query}",
-            "-F",
-            f"owner={owner}",
-            "-F",
-            f"name={repo}",
-            "--jq",
-            ".data.repository | to_entries[] | .value | select(. != null) | "
-            + _PR_READINESS_JQ_BODY,
-        ]
-        proc = _gh_run(argv, timeout=timeout)
-        if proc.returncode != 0:
-            tail = _stderr_tail(proc)
-            raise GhCliError(
-                f"gh api graphql (pr readiness by number) failed "
-                f"(exit {proc.returncode}): {tail}"
-            )
-        out.update(_parse_readiness_rows(proc.stdout or ""))
-    return out
+    """Fetch the independent readiness field for explicit PR numbers."""
+    return github_queries.fetch_pr_readiness_by_number(
+        owner,
+        repo,
+        numbers,
+        timeout=timeout,
+        gh_run=_gh_run,
+        stderr_tail=_stderr_tail,
+        parse_rows=_parse_readiness_rows,
+    )
 
 
 def _parse_readiness_rows(stdout: str) -> dict[int, str | None]:
-    """Parse the readiness JQ stream into ``{number: mergeable_state}`` (lowercased)."""
-    out: dict[int, str | None] = {}
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        number = row.get("number")
-        if not isinstance(number, int):
-            continue
-        out[number] = _lower_or_none(row.get("merge_state_status"))
-    return out
+    """Parse readiness rows while preserving the facade normalization seam."""
+    return github_queries.parse_readiness_rows(stdout, lower=_lower_or_none)
 
 
 # How many PR numbers to request per by-number GraphQL call. Each number costs
 # one aliased field, so this bounds the query size while keeping the call count
 # low (the search cap of 300 rows -> at most 3 calls).
-_SUMMARY_BATCH = 100
+_SUMMARY_BATCH = github_queries.SUMMARY_BATCH
 
 
 def fetch_pr_summaries_by_number(
     owner: str, repo: str, numbers: list[int], *, timeout: float = GH_TIMEOUT_SEC
 ) -> dict[int, dict]:
-    """Same payload as :func:`fetch_pr_summaries`, but for an EXPLICIT number list.
-
-    The state-scoped variant only covers the most recently updated 100 PRs, which
-    is exactly the window the search path exists to escape: a person filter can
-    legitimately return a PR that ranks 147th by update time. Addressing PRs by
-    number keeps enrichment complete for whatever the search returned.
-
-    Numbers are ints (validated by the caller's own parsing), so they carry no
-    injection surface even though they are interpolated as GraphQL aliases.
-    """
-    out: dict[int, dict] = {}
-    wanted = [n for n in numbers if isinstance(n, int) and n > 0]
-    for start in range(0, len(wanted), _SUMMARY_BATCH):
-        batch = wanted[start : start + _SUMMARY_BATCH]
-        fields = " ".join(
-            f"p{n}: pullRequest(number:{n}){{{_PR_SUMMARY_SELECTION} }}" for n in batch
-        )
-        query = (
-            "query($owner:String!,$name:String!){"
-            f" repository(owner:$owner,name:$name){{ {fields} }} }}"
-        )
-        argv = [
-            "gh",
-            "api",
-            "graphql",
-            "-f",
-            f"query={query}",
-            "-F",
-            f"owner={owner}",
-            "-F",
-            f"name={repo}",
-            "--jq",
-            ".data.repository | to_entries[] | .value | select(. != null) | " + _PR_SUMMARY_JQ_BODY,
-        ]
-        proc = _gh_run(argv, timeout=timeout)
-        if proc.returncode != 0:
-            tail = _stderr_tail(proc)
-            raise GhCliError(
-                f"gh api graphql (pr summaries by number) failed (exit {proc.returncode}): {tail}"
-            )
-        out.update(_parse_summary_rows(proc.stdout or ""))
-    return out
+    """Fetch card summaries for explicit PR numbers in bounded batches."""
+    return github_queries.fetch_pr_summaries_by_number(
+        owner,
+        repo,
+        numbers,
+        timeout=timeout,
+        gh_run=_gh_run,
+        stderr_tail=_stderr_tail,
+        parse_rows=_parse_summary_rows,
+    )
 
 
 def _count_context_buckets(contexts: object) -> dict[str, int]:
@@ -2318,11 +1651,11 @@ def _count_context_buckets(contexts: object) -> dict[str, int]:
     Every bucket key is always present so the card never has to guard a hole, and
     an unrecognized state counts as ``other`` rather than passing.
     """
-    rows = [c for c in contexts if isinstance(c, dict)] if isinstance(contexts, list) else []
-    counts = {bucket: 0 for bucket in _CHECK_BUCKETS}
-    for row in _dedupe_checks(rows):
-        counts[_check_bucket(row.get("status"), row.get("conclusion"))] += 1
-    return counts
+    return github_normalization.count_context_buckets(
+        contexts,
+        dedupe=_dedupe_checks,
+        bucket=_check_bucket,
+    )
 
 
 def _lower_or_none(value: object) -> str | None:
@@ -2334,7 +1667,7 @@ def _lower_or_none(value: object) -> str | None:
     string would compare unequal to every ready-state and so read as a confident
     "not ready".
     """
-    return value.strip().lower() or None if isinstance(value, str) else None
+    return github_normalization.lower_or_none(value)
 
 
 def _graphql_mergeable(value: object) -> bool | None:
@@ -2347,14 +1680,7 @@ def _graphql_mergeable(value: object) -> bool | None:
     Note that ``mergeable`` alone never means "ready to merge": it means "no merge
     CONFLICTS", which is why the readiness gate keys off ``mergeable_state``.
     """
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip().upper()
-    if normalized == "MERGEABLE":
-        return True
-    if normalized == "CONFLICTING":
-        return False
-    return None
+    return github_normalization.graphql_mergeable(value)
 
 
 def _rest_pr_state(value: object) -> str | None:
@@ -2367,70 +1693,18 @@ def _rest_pr_state(value: object) -> str | None:
     distinguished by the accompanying ``pr_merged_at``. Returning ``"merged"`` would
     match no branch in any of those readers and paint a merged PR as open.
     """
-    normalized = _lower_or_none(value)
-    if normalized is None:
-        return None
-    return "closed" if normalized in ("closed", "merged") else normalized
+    return github_normalization.rest_pr_state(value)
 
 
 def _parse_summary_rows(stdout: str) -> dict[int, dict]:
     """Parse the shared per-PR summary JQ stream (see ``_PR_SUMMARY_JQ_BODY``)."""
-    out: dict[int, dict] = {}
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        number = row.get("number")
-        if not isinstance(number, int):
-            continue
-        rollup = row.get("rollup")
-        out[number] = {
-            "additions": row.get("additions") or 0,
-            "deletions": row.get("deletions") or 0,
-            "changed_files": row.get("changed_files") or 0,
-            # Deliberately NOT coerced to "" — an absent oid means "we do not know
-            # this row's head commit", and a blank string would read as a known
-            # value that then fails the caller's sha validation with a confusing
-            # error instead of simply leaving the row un-approvable in bulk.
-            "head_sha": row.get("head_sha") or None,
-            # GraphQL SHOUTS its enums (`CLEAN`, `MERGEABLE`, `OPEN`) where REST speaks
-            # lowercase (`clean`, `open`). Normalized here, at the single point where
-            # GraphQL output becomes an internal row, so no reader has to know which
-            # transport its row came from — `routes._MERGE_ALLOWED_STATES` and the
-            # frontend's `MERGE_READY_STATES` both compare lowercase, and an un-lowered
-            # `CLEAN` would silently miss both and read as "not ready".
-            #
-            # `None` stays `None`: unknown mergeability must not collapse to a value.
-            # GitHub computes it asynchronously and answers `UNKNOWN` on a cold read,
-            # and treating that as "not ready" would be a guess presented as a fact.
-            #
-            # `mergeable_state` is filled by the SEPARATE readiness call
-            # (`_PR_READINESS_SELECTION`) and is seeded None here so the key always
-            # exists — absent would be falsy, i.e. indistinguishable from "not ready".
-            "mergeable_state": None,
-            "mergeable": _graphql_mergeable(row.get("mergeable_raw")),
-            # GraphQL's MERGED/CLOSED/OPEN collapsed into REST's open|closed, because
-            # the row shape is REST's and every reader compares against those two.
-            # `MERGED` becomes `closed` and is distinguished by `pr_merged_at`, exactly
-            # as REST does it (`PrList.prStateVisual` checks `merged_at` FIRST, so
-            # reporting `merged` here would match no branch and paint a merged PR as
-            # open — the bug this normalization exists to avoid).
-            "pr_state": _rest_pr_state(row.get("pr_state")),
-            "pr_merged_at": row.get("pr_merged_at") or None,
-            # Same bucketing table as every other surface; an unrecognized rollup
-            # value lands in "other" and so must not read as passing.
-            "checks_state": _check_bucket(None, rollup) if rollup else None,
-            "checks_counts": _count_context_buckets(row.get("contexts")),
-            # More contexts than one page: the tally is incomplete, so the card
-            # must show the aggregate rollup rather than a partial count that
-            # could omit the only failing check.
-            "checks_truncated": bool(row.get("contexts_truncated")),
-        }
-    return out
+    return github_normalization.parse_summary_rows(
+        stdout,
+        mergeable_normalizer=_graphql_mergeable,
+        state_normalizer=_rest_pr_state,
+        bucket=_check_bucket,
+        context_counter=_count_context_buckets,
+    )
 
 
 def summarize_checks(checks: list[dict]) -> dict:
@@ -2443,21 +1717,7 @@ def summarize_checks(checks: list[dict]) -> dict:
     dominates, then anything still running, then passing, then informational —
     so the dot never reads greener than the list it summarizes.
     """
-    counts = {bucket: 0 for bucket in _CHECK_BUCKETS}
-    for c in checks:
-        if not isinstance(c, dict):
-            continue
-        bucket = c.get("bucket")
-        counts[bucket if isinstance(bucket, str) and bucket in counts else "other"] += 1
-    for bucket in ("failure", "running", "success", "other"):
-        if counts[bucket]:
-            state: str | None = bucket
-            break
-    else:
-        state = None  # no checks at all -> the card shows no dot
-    # Derived from the authoritative, fully-paginated detail read, so the tally is
-    # complete by construction.
-    return {"checks_counts": counts, "checks_state": state, "checks_truncated": False}
+    return github_normalization.summarize_checks(checks)
 
 
 def _enrich_summaries(owner: str, repo: str, pulls: list[dict], state: str) -> dict[int, dict]:
@@ -2588,61 +1848,7 @@ def _apply_summaries(
     applied independently of ``summaries``: either can fail on its own, and a row can
     legitimately have a diff size but unknown readiness (or the reverse).
     """
-    ready = readiness or {}
-    for pr in pulls:
-        number = pr.get("number")
-        # Readiness first, and OUTSIDE the summary branch — the two calls fail
-        # independently, so a row with no summary can still have a known merge state.
-        # Always assigned so the key exists even when unknown: absent is falsy, i.e.
-        # indistinguishable from "not ready", which would put the row back into the
-        # auto-merge batch the provider refuses.
-        pr["mergeable_state"] = ready.get(number) if isinstance(number, int) else None
-        extra = summaries.get(number) if isinstance(number, int) else None
-        if not extra:
-            pr["additions"] = None
-            pr["deletions"] = None
-            pr["changed_files"] = None
-            pr["checks_state"] = None
-            pr["checks_counts"] = None
-            pr["checks_truncated"] = False
-            # `mergeable_state` was already set above from the independent readiness
-            # call — do NOT clear it here; that call may well have succeeded.
-            pr["mergeable"] = None
-            # NOT cleared: an un-enriched row keeps whatever head sha its source
-            # gave it. The LIST path already carries one from `_PR_JQ`, and blanking
-            # it here on a failed GraphQL call would take bulk approve away from
-            # rows that never needed the enrichment for it.
-            pr.setdefault("head_sha", None)
-            continue
-        pr["additions"] = extra.get("additions", 0)
-        pr["deletions"] = extra.get("deletions", 0)
-        pr["changed_files"] = extra.get("changed_files", 0)
-        # Only fills a GAP. The list rows already have it from `_PR_JQ`; the SEARCH
-        # rows do not (GitHub's search API does not expose the head commit), and
-        # this is the one call that already walks the head commit anyway.
-        if not pr.get("head_sha"):
-            pr["head_sha"] = extra.get("head_sha")
-        # `mergeable` is "no merge CONFLICTS" — NOT "ready to merge". A PR with
-        # unsatisfied required reviews is `mergeable: true` with
-        # `mergeable_state: "blocked"`, which is why the readiness gate keys off the
-        # latter (set above, from its own call).
-        pr["mergeable"] = extra.get("mergeable")
-        # A row whose live state disagrees with its cached one is corrected HERE, which
-        # is the closest read to the action. #1265 was armed for auto-merge from a row
-        # cached while it was still open, and GitHub answered "already merged".
-        live_state = extra.get("pr_state")
-        if live_state:
-            pr["state"] = live_state
-            # Written TOGETHER with the state, never separately: the two are one fact in
-            # REST's shape, and a `closed` with no `merged_at` is the red
-            # closed-unmerged icon. Only ever fills a gap — a row that already carries a
-            # timestamp keeps it.
-            if extra.get("pr_merged_at") and not pr.get("merged_at"):
-                pr["merged_at"] = extra.get("pr_merged_at")
-        pr["checks_state"] = extra.get("checks_state")
-        pr["checks_counts"] = extra.get("checks_counts") or {b: 0 for b in _CHECK_BUCKETS}
-        pr["checks_truncated"] = bool(extra.get("checks_truncated"))
-    return pulls
+    return github_normalization.apply_summaries(pulls, summaries, readiness)
 
 
 def enrichment_complete(pulls: list[dict]) -> bool:
@@ -2653,7 +1859,7 @@ def enrichment_complete(pulls: list[dict]) -> bool:
     the on-disk list cache so the next read retries instead of serving unknowns
     forever.
     """
-    return all(pr.get("checks_counts") is not None for pr in pulls)
+    return github_normalization.enrichment_complete(pulls)
 
 
 # ── server-side PR search ("by person" filters) ──────────────────────────────
@@ -2674,43 +1880,24 @@ def enrichment_complete(pulls: list[dict]) -> bool:
 # that need them are expressed as QUALIFIERS (``review-requested:<login>``), so
 # the query itself does the work and the missing field is never read back.
 
-_PR_SEARCH_JQ = (
-    ".items[] | {number: .number, title: .title, url: .html_url, "
-    "state: .state, draft: (.draft // false), labels: [.labels[].name], "
-    "author: (.user.login // null), "
-    "author_association: (.author_association // null), "
-    "updated_at: .updated_at, created_at: .created_at, "
-    "closed_at: .closed_at, "
-    "merged_at: (.pull_request.merged_at // null), "
-    "assignees: [.assignees[].login], "
-    "requested_reviewers: [], base: null, head: null, "
-    # Present but NULL: GitHub's search API does not expose the head commit, so the
-    # key exists for row-shape parity with `_PR_JQ` and is filled in by the
-    # by-number enrichment (`_apply_summaries`), which already walks that commit.
-    "head_sha: null, "
-    'body: (.body // "")}'
-)
+_PR_SEARCH_JQ = github_queries.PR_SEARCH_JQ
 
 # Bound the search too — a person filter should never stream thousands of rows.
 # Public because the route reports it to the client: the UI has to be able to say
 # "newest 300" rather than implying completeness.
-PR_SEARCH_MAX = 300
+PR_SEARCH_MAX = github_queries.PR_SEARCH_MAX
 
 # Hard stop on pages walked, so a pathological `per_page`/`limit` combination can
 # never turn one filter toggle into an unbounded request loop.
-_SEARCH_MAX_PAGES = 10
+_SEARCH_MAX_PAGES = github_queries.SEARCH_MAX_PAGES
 
 # GitHub logins: alphanumerics and hyphens only. Validated before a login can
 # reach the search query string, so it cannot inject extra qualifiers.
-_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+_LOGIN_RE = github_queries.LOGIN_RE
 
 # PR lifecycle -> search qualifiers. ``closed`` means closed WITHOUT being
 # merged, matching the frontend's three-way split (open / merged / closed).
-_PR_STATE_QUALIFIERS = {
-    "open": ["is:open"],
-    "merged": ["is:merged"],
-    "closed": ["is:closed", "is:unmerged"],
-}
+_PR_STATE_QUALIFIERS = github_queries.PR_STATE_QUALIFIERS
 
 
 def build_pr_search_query(
@@ -2722,34 +1909,15 @@ def build_pr_search_query(
     assignee: str | None = None,
     review_requested: str | None = None,
 ) -> str:
-    """Assemble the search ``q`` for a per-person PR query.
-
-    Scoped to one repo and to pull requests, plus the lifecycle qualifiers for
-    ``state`` and one qualifier per supplied login. Every login is charset-
-    validated (:data:`_LOGIN_RE`) BEFORE it lands in the query, so a hostile
-    value cannot smuggle in extra qualifiers. Raises :class:`PrSearchError` on an
-    unknown state, an invalid login, or when no person qualifier was given (an
-    unfiltered search would just duplicate the list endpoint).
-    """
-    if state not in _PR_STATE_QUALIFIERS:
-        raise PrSearchError(f"unsupported state for PR search: {state!r}")
-    parts = [f"repo:{owner}/{repo}", "is:pr", *_PR_STATE_QUALIFIERS[state]]
-    people = [
-        ("author", author),
-        ("assignee", assignee),
-        ("review-requested", review_requested),
-    ]
-    added = 0
-    for qualifier, login in people:
-        if not login:
-            continue
-        if not _LOGIN_RE.match(login):
-            raise PrSearchError(f"invalid GitHub login: {login!r}")
-        parts.append(f"{qualifier}:{login}")
-        added += 1
-    if added == 0:
-        raise PrSearchError("PR search needs at least one person qualifier")
-    return " ".join(parts)
+    """Build a validated, repo-scoped GitHub PR search query."""
+    return github_queries.build_pr_search_query(
+        owner,
+        repo,
+        state=state,
+        author=author,
+        assignee=assignee,
+        review_requested=review_requested,
+    )
 
 
 def search_pulls(
@@ -2763,40 +1931,19 @@ def search_pulls(
     timeout: float = GH_PAGINATE_TIMEOUT_SEC,
     limit: int = PR_SEARCH_MAX,
 ) -> list[dict]:
-    """Search a repo's PRs by person, server-side (see the module note above).
-
-    Returns rows in the SAME shape as ``list_open_pulls`` so the frontend can
-    swap data sources without a second row type — with ``base``/``head`` null and
-    ``requested_reviewers`` empty (not exposed by the search API). Paginated and
-    then capped at ``limit``.
-    """
-    q = build_pr_search_query(
+    """Search PRs by person with explicit, bounded page reads."""
+    return github_queries.search_pulls(
         owner,
         repo,
         state=state,
         author=author,
         assignee=assignee,
         review_requested=review_requested,
+        timeout=timeout,
+        limit=limit,
+        query_builder=build_pr_search_query,
+        run_api=_run_gh_api,
     )
-    cap = max(1, int(limit))
-    # Paginated EXPLICITLY, one page at a time, stopping as soon as the cap is
-    # met: `gh --paginate` would walk every page GitHub offers (up to the search
-    # maximum) before we sliced it down, so a prolific author's filter could burn
-    # a dozen extra requests — and hit the timeout — for rows nobody asked for.
-    per_page = min(100, cap)
-    rows: list[dict] = []
-    page = 1
-    while len(rows) < cap and page <= _SEARCH_MAX_PAGES:
-        path = (
-            f"search/issues?q={quote(q, safe='')}&sort=updated&order=desc"
-            f"&per_page={per_page}&page={page}"
-        )
-        batch = _run_gh_api(path, _PR_SEARCH_JQ, timeout=timeout, paginate=False)
-        rows.extend(batch)
-        if len(batch) < per_page:
-            break  # last page
-        page += 1
-    return rows[:cap]
 
 
 # ── pull-request actions (the write surface the PR pane's buttons drive) ──────
@@ -3102,32 +2249,13 @@ def _run_gh_graphql_mutation(mutation: str, variables: dict[str, str], *, timeou
     :func:`_run_gh_write` does — GraphQL reports authorization in the errors array
     with a 200 status, so the string check is on stdout as well as stderr.
     """
-    argv = ["gh", "api", "graphql", "-f", f"query={mutation}"]
-    for name, value in variables.items():
-        argv += ["-F", f"{name}={value}"]
-    proc = _gh_run(argv, timeout=timeout)
-    combined = f"{proc.stdout or ''}\n{proc.stderr or ''}"
-    if proc.returncode != 0 or '"errors"' in (proc.stdout or ""):
-        tail = sanitize_cli_stderr(" ".join(combined.strip().splitlines()[-3:]))
-        lowered = combined.lower()
-        if (
-            "HTTP 403" in combined
-            or "HTTP 401" in combined
-            or "not authorized" in lowered
-            or "must have push access" in lowered
-            or "resource not accessible" in lowered
-        ):
-            raise GhPermissionError(
-                f"GitHub refused the request — your `gh` session lacks the "
-                f"required access: {tail}"
-            )
-        raise GhCliError(f"gh api graphql failed (exit {proc.returncode}): {tail}")
-    try:
-        parsed = json.loads((proc.stdout or "").strip() or "{}")
-    except json.JSONDecodeError as exc:
-        raise GhCliError("gh returned unexpected output for a GraphQL mutation") from exc
-    data = parsed.get("data") if isinstance(parsed, dict) else None
-    return data if isinstance(data, dict) else {}
+    return github_transport.run_graphql_mutation(
+        mutation,
+        variables,
+        timeout=timeout,
+        gh_run=_gh_run,
+        sanitize=sanitize_cli_stderr,
+    )
 
 
 _ENABLE_AUTO_MERGE = (
@@ -3387,12 +2515,12 @@ def rerun_workflow_run(
 # ``<!-- kirocrew-crew-brief v1 -->`` from matching: the next character there is a
 # hyphen, not whitespace. Lazy ``[^>]*?`` stops at the marker's own ``-->`` and
 # cannot run on into later prose.
-_CREW_CLAIM_MARKER_RE = re.compile(r"<!--\s*kirocrew-crew\s+([^>]*?)\s*-->")
+_CREW_CLAIM_MARKER_RE = github_normalization.CREW_CLAIM_MARKER_RE
 
 # ``key=value`` pairs inside the marker; values are whitespace-delimited. Unknown
 # keys are simply not read, so the marker can grow a field without this parser (or
 # an older crew reading a newer marker) breaking.
-_CREW_CLAIM_FIELD_RE = re.compile(r"([A-Za-z][A-Za-z0-9_-]*)=(\S+)")
+_CREW_CLAIM_FIELD_RE = github_normalization.CREW_CLAIM_FIELD_RE
 
 # The ONLY accepted timestamp shape: ISO-8601 UTC with a trailing ``Z``.
 #
@@ -3404,7 +2532,7 @@ _CREW_CLAIM_FIELD_RE = re.compile(r"([A-Za-z][A-Za-z0-9_-]*)=(\S+)")
 # of reading as stale. Refusing it up front makes "unparseable" mean "not fresh",
 # which is the safe direction: a claim that cannot prove it is alive must not be
 # treated as alive.
-_CREW_CLAIM_ISO_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+_CREW_CLAIM_ISO_Z_RE = github_normalization.CREW_CLAIM_ISO_Z_RE
 
 
 def _parse_crew_marker(body: str) -> dict | None:
@@ -3418,23 +2546,7 @@ def _parse_crew_marker(body: str) -> dict | None:
     and first-wins at least makes which one is honoured deterministic rather than
     dependent on how the prose was assembled.
     """
-    match = _CREW_CLAIM_MARKER_RE.search(body or "")
-    if match is None:
-        return None
-    fields = dict(_CREW_CLAIM_FIELD_RE.findall(match.group(1)))
-    pr = fields.get("pr") or ""
-    updated = fields.get("updated") or ""
-    return {
-        # A marker with no ``id`` names nobody, so it can never be MATCHED against a
-        # crew id — but it is still reported (as ``""``) rather than dropped: it is
-        # evidence that some crew claimed this issue, and losing that evidence is
-        # how two crews end up working the same issue. Losing throughput to an
-        # over-cautious skip is the cheaper failure.
-        "crew_id": fields.get("id") or "",
-        "phase": fields.get("phase") or "",
-        "pr": int(pr) if pr.isdigit() else None,
-        "updated": updated if _CREW_CLAIM_ISO_Z_RE.match(updated) else None,
-    }
+    return github_normalization.parse_crew_marker(body)
 
 
 def find_crew_claim(timeline_rows: list[dict], crew_id: str = "") -> list[dict]:
@@ -3460,29 +2572,8 @@ def find_crew_claim(timeline_rows: list[dict], crew_id: str = "") -> list[dict]:
     whose comment id is unknown sorts LAST: it cannot demonstrate it was first, so it
     must not be able to win a collision, while still being visible as a claim.
     """
-    out: list[dict] = []
-    for row in timeline_rows or []:
-        if not isinstance(row, dict) or row.get("kind") != "comment":
-            continue
-        parsed = _parse_crew_marker(row.get("body") or "")
-        if parsed is None:
-            continue
-        raw_id = row.get("id")
-        out.append(
-            {
-                # bool is a subclass of int, so it is excluded explicitly — a truthy
-                # non-id must not become comment_id 1.
-                "comment_id": (
-                    raw_id if isinstance(raw_id, int) and not isinstance(raw_id, bool) else None
-                ),
-                **parsed,
-                "actor": row.get("actor"),
-                "created_at": row.get("created_at"),
-            }
-        )
-    if crew_id:
-        out = [e for e in out if e["crew_id"] == crew_id]
-    # Two-part key: known ids ascending, unknown ids after them (stable, so their
-    # timeline order is preserved). See the ordering note in the docstring.
-    out.sort(key=lambda e: (e["comment_id"] is None, e["comment_id"] or 0))
-    return out
+    return github_normalization.find_crew_claim(
+        timeline_rows,
+        crew_id,
+        marker_parser=_parse_crew_marker,
+    )

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/github_normalization.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/github_normalization.py
@@ -1,0 +1,418 @@
+"""Pure GitHub response normalization for Issue Radar."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+MEMBER_ASSOC_RANK = {"OWNER": 3, "MEMBER": 2, "COLLABORATOR": 1}
+CHECK_FAILURE_CONCLUSIONS = {
+    "failure",
+    "timed_out",
+    "action_required",
+    "startup_failure",
+    "stale",
+    "error",
+}
+CHECK_RUNNING_STATES = {
+    "queued",
+    "in_progress",
+    "pending",
+    "waiting",
+    "requested",
+    "expected",
+}
+CHECK_OTHER_CONCLUSIONS = {"neutral", "skipped", "cancelled", "canceled"}
+CHECK_BUCKETS = ("failure", "running", "success", "other")
+
+CREW_CLAIM_MARKER_RE = re.compile(r"<!--\s*kirocrew-crew\s+([^>]*?)\s*-->")
+CREW_CLAIM_FIELD_RE = re.compile(r"([A-Za-z][A-Za-z0-9_-]*)=(\S+)")
+CREW_CLAIM_ISO_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+
+
+def parse_gh_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def derive_members(issues: list[dict]) -> list[dict]:
+    best: dict[str, str] = {}
+    for issue in issues:
+        login = issue.get("author")
+        association = issue.get("author_association")
+        if not login or association not in MEMBER_ASSOC_RANK:
+            continue
+        current = best.get(login)
+        if current is None or MEMBER_ASSOC_RANK[association] > MEMBER_ASSOC_RANK[current]:
+            best[login] = association
+    return [
+        {"login": login, "association": association} for login, association in sorted(best.items())
+    ]
+
+
+def norm_reactions(reactions: dict | None) -> dict | None:
+    if not reactions:
+        return None
+    total = reactions.get("total_count") or 0
+    if total <= 0:
+        return None
+    return {
+        "total": total,
+        "plus1": reactions.get("+1", 0),
+        "minus1": reactions.get("-1", 0),
+        "laugh": reactions.get("laugh", 0),
+        "hooray": reactions.get("hooray", 0),
+        "confused": reactions.get("confused", 0),
+        "heart": reactions.get("heart", 0),
+        "rocket": reactions.get("rocket", 0),
+        "eyes": reactions.get("eyes", 0),
+    }
+
+
+def actor_login(event: dict) -> str | None:
+    return (event.get("actor") or {}).get("login")
+
+
+def normalize_timeline_event(
+    event: dict,
+    *,
+    reaction_normalizer: Callable[[dict | None], dict | None] = norm_reactions,
+    actor_reader: Callable[[dict], str | None] = actor_login,
+) -> dict | None:
+    event_type = event.get("event")
+    created = event.get("created_at")
+    if event_type == "commented":
+        return {
+            "kind": "comment",
+            "id": event.get("id"),
+            "actor": (event.get("user") or {}).get("login"),
+            "created_at": created,
+            "updated_at": event.get("updated_at"),
+            "body": event.get("body") or "",
+            "author_association": event.get("author_association"),
+            "reactions": reaction_normalizer(event.get("reactions")),
+        }
+    if event_type in ("labeled", "unlabeled"):
+        label = event.get("label") or {}
+        return {
+            "kind": event_type,
+            "actor": actor_reader(event),
+            "created_at": created,
+            "label": {"name": label.get("name"), "color": label.get("color")},
+        }
+    if event_type in ("assigned", "unassigned"):
+        return {
+            "kind": event_type,
+            "actor": actor_reader(event),
+            "created_at": created,
+            "assignee": (event.get("assignee") or {}).get("login"),
+        }
+    if event_type == "closed":
+        return {
+            "kind": "closed",
+            "actor": actor_reader(event),
+            "created_at": created,
+            "state_reason": event.get("state_reason"),
+            "commit_id": event.get("commit_id"),
+        }
+    if event_type == "reopened":
+        return {"kind": "reopened", "actor": actor_reader(event), "created_at": created}
+    if event_type == "renamed":
+        rename = event.get("rename") or {}
+        return {
+            "kind": "renamed",
+            "actor": actor_reader(event),
+            "created_at": created,
+            "rename": {"from": rename.get("from"), "to": rename.get("to")},
+        }
+    if event_type in ("milestoned", "demilestoned"):
+        return {
+            "kind": event_type,
+            "actor": actor_reader(event),
+            "created_at": created,
+            "milestone": (event.get("milestone") or {}).get("title"),
+        }
+    if event_type == "cross-referenced":
+        source = (event.get("source") or {}).get("issue") or {}
+        return {
+            "kind": "cross-referenced",
+            "actor": actor_reader(event),
+            "created_at": created,
+            "source": {
+                "number": source.get("number"),
+                "title": source.get("title"),
+                "url": source.get("html_url"),
+                "state": source.get("state"),
+                "is_pr": bool(source.get("pull_request")),
+            },
+        }
+    if event_type == "referenced":
+        return {
+            "kind": "referenced",
+            "actor": actor_reader(event),
+            "created_at": created,
+            "commit_id": event.get("commit_id"),
+        }
+    if event_type == "reviewed":
+        return {
+            "kind": "reviewed",
+            "actor": (event.get("user") or {}).get("login"),
+            "created_at": event.get("submitted_at") or created,
+            "review_state": event.get("state"),
+            "body": event.get("body") or "",
+        }
+    if event_type == "committed":
+        author = event.get("author") or {}
+        return {
+            "kind": "committed",
+            "actor": author.get("name") or (event.get("committer") or {}).get("name"),
+            "created_at": author.get("date")
+            or (event.get("committer") or {}).get("date")
+            or created,
+            "commit_id": event.get("sha"),
+            "message": (event.get("message") or "").splitlines()[0] if event.get("message") else "",
+        }
+    return None
+
+
+def dep_node_kind(is_pr: bool) -> str:
+    return "pull" if is_pr else "issue"
+
+
+def dep_node_state(state: Any, merged_at: Any = None) -> str:
+    if merged_at:
+        return "merged"
+    normalized = str(state or "").lower()
+    if normalized == "merged":
+        return "merged"
+    return "closed" if normalized == "closed" else "open"
+
+
+def shape_labels(raw: object) -> list[dict]:
+    if not isinstance(raw, list):
+        return []
+    return [
+        {
+            "name": label.get("name"),
+            "color": label.get("color") or "888888",
+            "description": label.get("description") or "",
+        }
+        for label in raw
+        if isinstance(label, dict) and label.get("name")
+    ]
+
+
+def check_bucket(status: str | None, conclusion: str | None) -> str:
+    normalized_status = (status or "").lower()
+    normalized_conclusion = (conclusion or "").lower()
+    if normalized_status in CHECK_RUNNING_STATES or normalized_conclusion in CHECK_RUNNING_STATES:
+        return "running"
+    if normalized_conclusion in CHECK_FAILURE_CONCLUSIONS:
+        return "failure"
+    if normalized_conclusion == "success":
+        return "success"
+    return "other"
+
+
+def check_identity(row: dict) -> tuple[str, str]:
+    return (str(row.get("source") or ""), str(row.get("name") or ""))
+
+
+def dedupe_checks(
+    rows: list[dict],
+    *,
+    identity: Callable[[dict], tuple[str, str]] = check_identity,
+) -> list[dict]:
+    def timestamp_key(row: dict) -> tuple[str, str]:
+        return (
+            str(row.get("started_at") or ""),
+            str(row.get("completed_at") or ""),
+        )
+
+    best: dict[tuple[str, str], dict] = {}
+    for row in rows:
+        if not row.get("name"):
+            continue
+        row_identity = identity(row)
+        previous = best.get(row_identity)
+        if previous is None or timestamp_key(row) >= timestamp_key(previous):
+            best[row_identity] = row
+    return list(best.values())
+
+
+def count_context_buckets(
+    contexts: object,
+    *,
+    dedupe: Callable[[list[dict]], list[dict]] = dedupe_checks,
+    bucket: Callable[[str | None, str | None], str] = check_bucket,
+) -> dict[str, int]:
+    rows = [row for row in contexts if isinstance(row, dict)] if isinstance(contexts, list) else []
+    counts = {name: 0 for name in CHECK_BUCKETS}
+    for row in dedupe(rows):
+        counts[bucket(row.get("status"), row.get("conclusion"))] += 1
+    return counts
+
+
+def lower_or_none(value: object) -> str | None:
+    return value.strip().lower() or None if isinstance(value, str) else None
+
+
+def graphql_mergeable(value: object) -> bool | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().upper()
+    if normalized == "MERGEABLE":
+        return True
+    if normalized == "CONFLICTING":
+        return False
+    return None
+
+
+def rest_pr_state(value: object) -> str | None:
+    normalized = lower_or_none(value)
+    if normalized is None:
+        return None
+    return "closed" if normalized in ("closed", "merged") else normalized
+
+
+def parse_summary_rows(
+    stdout: str,
+    *,
+    mergeable_normalizer: Callable[[object], bool | None] = graphql_mergeable,
+    state_normalizer: Callable[[object], str | None] = rest_pr_state,
+    bucket: Callable[[str | None, str | None], str] = check_bucket,
+    context_counter: Callable[[object], dict[str, int]] = count_context_buckets,
+) -> dict[int, dict]:
+    rows: dict[int, dict] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        number = row.get("number")
+        if not isinstance(number, int):
+            continue
+        rollup = row.get("rollup")
+        rows[number] = {
+            "additions": row.get("additions") or 0,
+            "deletions": row.get("deletions") or 0,
+            "changed_files": row.get("changed_files") or 0,
+            "head_sha": row.get("head_sha") or None,
+            "mergeable_state": None,
+            "mergeable": mergeable_normalizer(row.get("mergeable_raw")),
+            "pr_state": state_normalizer(row.get("pr_state")),
+            "pr_merged_at": row.get("pr_merged_at") or None,
+            "checks_state": bucket(None, rollup) if rollup else None,
+            "checks_counts": context_counter(row.get("contexts")),
+            "checks_truncated": bool(row.get("contexts_truncated")),
+        }
+    return rows
+
+
+def summarize_checks(checks: list[dict]) -> dict:
+    counts = {bucket: 0 for bucket in CHECK_BUCKETS}
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        bucket = check.get("bucket")
+        counts[bucket if isinstance(bucket, str) and bucket in counts else "other"] += 1
+    state = next((bucket for bucket in CHECK_BUCKETS if counts[bucket]), None)
+    return {"checks_counts": counts, "checks_state": state, "checks_truncated": False}
+
+
+def apply_summaries(
+    pulls: list[dict],
+    summaries: dict[int, dict],
+    readiness: dict[int, str | None] | None = None,
+) -> list[dict]:
+    ready = readiness or {}
+    for pull in pulls:
+        number = pull.get("number")
+        pull["mergeable_state"] = ready.get(number) if isinstance(number, int) else None
+        extra = summaries.get(number) if isinstance(number, int) else None
+        if not extra:
+            pull["additions"] = None
+            pull["deletions"] = None
+            pull["changed_files"] = None
+            pull["checks_state"] = None
+            pull["checks_counts"] = None
+            pull["checks_truncated"] = False
+            pull["mergeable"] = None
+            pull.setdefault("head_sha", None)
+            continue
+        pull["additions"] = extra.get("additions", 0)
+        pull["deletions"] = extra.get("deletions", 0)
+        pull["changed_files"] = extra.get("changed_files", 0)
+        if not pull.get("head_sha"):
+            pull["head_sha"] = extra.get("head_sha")
+        pull["mergeable"] = extra.get("mergeable")
+        live_state = extra.get("pr_state")
+        if live_state:
+            pull["state"] = live_state
+            if extra.get("pr_merged_at") and not pull.get("merged_at"):
+                pull["merged_at"] = extra.get("pr_merged_at")
+        pull["checks_state"] = extra.get("checks_state")
+        pull["checks_counts"] = extra.get("checks_counts") or {
+            bucket: 0 for bucket in CHECK_BUCKETS
+        }
+        pull["checks_truncated"] = bool(extra.get("checks_truncated"))
+    return pulls
+
+
+def enrichment_complete(pulls: list[dict]) -> bool:
+    return all(pull.get("checks_counts") is not None for pull in pulls)
+
+
+def parse_crew_marker(body: str) -> dict | None:
+    match = CREW_CLAIM_MARKER_RE.search(body or "")
+    if match is None:
+        return None
+    fields = dict(CREW_CLAIM_FIELD_RE.findall(match.group(1)))
+    pull_number = fields.get("pr") or ""
+    updated = fields.get("updated") or ""
+    return {
+        "crew_id": fields.get("id") or "",
+        "phase": fields.get("phase") or "",
+        "pr": int(pull_number) if pull_number.isdigit() else None,
+        "updated": updated if CREW_CLAIM_ISO_Z_RE.match(updated) else None,
+    }
+
+
+def find_crew_claim(
+    timeline_rows: list[dict],
+    crew_id: str = "",
+    *,
+    marker_parser: Callable[[str], dict | None] = parse_crew_marker,
+) -> list[dict]:
+    claims: list[dict] = []
+    for row in timeline_rows or []:
+        if not isinstance(row, dict) or row.get("kind") != "comment":
+            continue
+        parsed = marker_parser(row.get("body") or "")
+        if parsed is None:
+            continue
+        raw_id = row.get("id")
+        claims.append(
+            {
+                "comment_id": (
+                    raw_id if isinstance(raw_id, int) and not isinstance(raw_id, bool) else None
+                ),
+                **parsed,
+                "actor": row.get("actor"),
+                "created_at": row.get("created_at"),
+            }
+        )
+    if crew_id:
+        claims = [claim for claim in claims if claim["crew_id"] == crew_id]
+    claims.sort(key=lambda claim: (claim["comment_id"] is None, claim["comment_id"] or 0))
+    return claims

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/github_queries.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/github_queries.py
@@ -1,0 +1,605 @@
+"""GitHub-specific dependency, enrichment, and search queries."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from collections.abc import Callable
+from urllib.parse import quote
+
+from .errors import ProviderCliError, PrSearchError
+
+GhCliError = ProviderCliError
+logger = logging.getLogger(__name__)
+
+DEP_ISSUE_JQ = (
+    ".[] | {number: .number, title: .title, state: .state, " "is_pr: (.pull_request != null)}"
+)
+DEPS_GRAPHQL_MAX_PAGES = 40
+
+GRAPHQL_PR_STATES = {"open": "OPEN", "closed": "CLOSED, MERGED"}
+ROLLUP_CONTEXT_PAGE = 100
+ROLLUP_CONTEXTS_JQ = (
+    "[(.commits.nodes[0].commit.statusCheckRollup.contexts.nodes[]? | "
+    '{name: ((.name // .context) // ""), '
+    'source: ((.checkSuite.app.slug // .checkSuite.app.name) // "status"), '
+    "status: (.status // null), "
+    "conclusion: ((.conclusion // .state) // null), "
+    "started_at: ((.startedAt // .createdAt) // null), "
+    "completed_at: (.completedAt // null)})]"
+)
+PR_SUMMARY_SELECTION = (
+    " number additions deletions changedFiles"
+    " mergeable state mergedAt"
+    " commits(last:1){nodes{commit{oid statusCheckRollup{state"
+    f"  contexts(first:{ROLLUP_CONTEXT_PAGE}){{pageInfo{{hasNextPage}} nodes{{ __typename"
+    "   ... on CheckRun{name conclusion status startedAt completedAt"
+    "    checkSuite{app{slug name}}}"
+    "   ... on StatusContext{context state createdAt} }}}}}}"
+)
+PR_READINESS_SELECTION = " number mergeStateStatus"
+PR_READINESS_JQ_BODY = "{number: .number, merge_state_status: (.mergeStateStatus // null)}"
+READINESS_BATCH = 50
+PR_SUMMARY_JQ_BODY = (
+    "{number: .number, additions: .additions, deletions: .deletions, "
+    "changed_files: (.changedFiles // 0), "
+    "mergeable_raw: (.mergeable // null), "
+    "pr_state: (.state // null), "
+    "pr_merged_at: (.mergedAt // null), "
+    "head_sha: (.commits.nodes[0].commit.oid // null), "
+    "rollup: (.commits.nodes[0].commit.statusCheckRollup.state // null), "
+    "contexts_truncated: "
+    "(.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage // false), "
+    f"contexts: {ROLLUP_CONTEXTS_JQ}}}"
+)
+SUMMARY_BATCH = 100
+
+PR_SEARCH_JQ = (
+    ".items[] | {number: .number, title: .title, url: .html_url, "
+    "state: .state, draft: (.draft // false), labels: [.labels[].name], "
+    "author: (.user.login // null), "
+    "author_association: (.author_association // null), "
+    "updated_at: .updated_at, created_at: .created_at, "
+    "closed_at: .closed_at, "
+    "merged_at: (.pull_request.merged_at // null), "
+    "assignees: [.assignees[].login], "
+    "requested_reviewers: [], base: null, head: null, "
+    "head_sha: null, "
+    'body: (.body // "")}'
+)
+PR_SEARCH_MAX = 300
+SEARCH_MAX_PAGES = 10
+LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+PR_STATE_QUALIFIERS = {
+    "open": ["is:open"],
+    "merged": ["is:merged"],
+    "closed": ["is:closed", "is:unmerged"],
+}
+
+
+def is_deps_feature_absent(exc: GhCliError) -> bool:
+    message = str(exc)
+    return "HTTP 404" in message or "HTTP 410" in message
+
+
+def list_issue_blocked_by(
+    owner: str,
+    repo: str,
+    number: int,
+    *,
+    timeout: float,
+    run_api: Callable[..., list[dict]],
+    absent_classifier: Callable[[GhCliError], bool],
+) -> list[dict]:
+    path = f"repos/{owner}/{repo}/issues/{int(number)}/dependencies/blocked_by?per_page=100"
+    try:
+        rows = run_api(path, DEP_ISSUE_JQ, timeout=timeout, paginate=True)
+    except GhCliError as exc:
+        if absent_classifier(exc):
+            return []
+        raise
+    return [row for row in rows if isinstance(row, dict) and isinstance(row.get("number"), int)]
+
+
+def inferred_blockers_from_events(
+    events: list[dict], owner: str, repo: str, number: int
+) -> list[dict]:
+    blockers: list[dict] = []
+    prefix = f"/{owner}/{repo}/"
+    for event in events:
+        if not isinstance(event, dict) or event.get("kind") != "cross-referenced":
+            continue
+        source = event.get("source") or {}
+        source_number = source.get("number")
+        if not isinstance(source_number, int) or source_number <= 0 or source_number == number:
+            continue
+        if prefix not in str(source.get("url") or ""):
+            continue
+        blockers.append(
+            {
+                "number": source_number,
+                "title": source.get("title"),
+                "state": source.get("state"),
+                "is_pr": bool(source.get("is_pr")),
+            }
+        )
+    return blockers
+
+
+def inferred_blockers_from_timeline(
+    owner: str,
+    repo: str,
+    number: int,
+    *,
+    timeout: float,
+    timeline_loader: Callable[..., list[dict]],
+    absent_classifier: Callable[[GhCliError], bool],
+    event_filter: Callable[[list[dict], str, str, int], list[dict]],
+) -> list[dict]:
+    try:
+        events = timeline_loader(owner, repo, number, timeout=timeout)
+    except GhCliError as exc:
+        if absent_classifier(exc):
+            return []
+        raise
+    return event_filter(events, owner, repo, number)
+
+
+def batch_dependency_graph(
+    owner: str,
+    repo: str,
+    *,
+    timeout: float,
+    gh_run: Callable[..., subprocess.CompletedProcess],
+) -> dict[int, dict] | None:
+    query = (
+        "query($owner:String!,$name:String!,$after:String){"
+        "repository(owner:$owner,name:$name){"
+        "issues(states:OPEN,first:100,after:$after){"
+        "pageInfo{hasNextPage endCursor}"
+        "nodes{number title state "
+        "blockedBy(first:50){pageInfo{hasNextPage} nodes{number title state}}"
+        "timelineItems(itemTypes:[CROSS_REFERENCED_EVENT],first:100){pageInfo{hasNextPage} nodes{"
+        "... on CrossReferencedEvent{source{"
+        "... on Issue{number title state url repository{nameWithOwner}}"
+        "... on PullRequest{number title state url merged repository{nameWithOwner}}"
+        "}}}}}}}}"
+    )
+
+    def compact_row(node: dict) -> dict:
+        state = str(node.get("state") or "open").lower()
+        return {
+            "number": node.get("number"),
+            "title": node.get("title") or "",
+            "state": "closed" if state in ("closed", "merged") else "open",
+            "is_pr": "merged" in node,
+            "merged_at": "merged" if node.get("merged") else None,
+        }
+
+    rows: dict[int, dict] = {}
+    after: str | None = None
+    full_name = f"{owner}/{repo}".lower()
+    for _page in range(DEPS_GRAPHQL_MAX_PAGES):
+        argv = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={repo}",
+        ]
+        if after:
+            argv += ["-F", f"after={after}"]
+        proc = gh_run(["gh", *argv], timeout=timeout)
+        if proc.returncode != 0:
+            logger.info(
+                "issue-radar: deps graphql batch unavailable for %s/%s; "
+                "falling back to per-issue reads",
+                owner,
+                repo,
+            )
+            return None
+        try:
+            connection = json.loads(proc.stdout)["data"]["repository"]["issues"]
+        except (ValueError, KeyError, TypeError):
+            logger.info("issue-radar: deps graphql batch returned an unexpected shape")
+            return None
+        for node in connection.get("nodes") or []:
+            if not isinstance(node, dict) or not isinstance(node.get("number"), int):
+                continue
+            number = node["number"]
+            native = [
+                compact_row(blocker)
+                for blocker in (node.get("blockedBy") or {}).get("nodes") or []
+                if isinstance(blocker, dict) and isinstance(blocker.get("number"), int)
+            ]
+            references: list[dict] = []
+            for item in (node.get("timelineItems") or {}).get("nodes") or []:
+                source = (item or {}).get("source") or {}
+                source_repo = str(((source.get("repository") or {}).get("nameWithOwner")) or "")
+                if not isinstance(source.get("number"), int) or source_repo.lower() != full_name:
+                    continue
+                references.append(
+                    {
+                        "kind": "cross-referenced",
+                        "source": {
+                            **compact_row(source),
+                            "url": str(source.get("url") or ""),
+                        },
+                    }
+                )
+            rows[number] = {
+                "row": compact_row(node),
+                "native": native,
+                "refs": references,
+                "truncated": bool(
+                    ((node.get("blockedBy") or {}).get("pageInfo") or {}).get("hasNextPage")
+                    or ((node.get("timelineItems") or {}).get("pageInfo") or {}).get("hasNextPage")
+                ),
+            }
+        page_info = connection.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            return rows
+        after = str(page_info.get("endCursor") or "") or None
+        if after is None:
+            return rows
+    logger.info(
+        "issue-radar: deps graphql batch exceeded %d pages for %s/%s; using partial graph",
+        DEPS_GRAPHQL_MAX_PAGES,
+        owner,
+        repo,
+    )
+    return rows
+
+
+def fetch_dependency_edges(
+    owner: str,
+    repo: str,
+    open_issues: list[dict],
+    node_hints: dict[int, dict] | None,
+    *,
+    timeout: float,
+    batch_loader: Callable[..., dict[int, dict] | None],
+    blockers_loader: Callable[..., list[dict]],
+    inferred_loader: Callable[..., list[dict]],
+    event_filter: Callable[[list[dict], str, str, int], list[dict]],
+    ref_loader: Callable[..., dict],
+    node_kind: Callable[[bool], str],
+    node_state: Callable[..., str],
+) -> tuple[list[dict], dict[str, dict]]:
+    hints = dict(node_hints or {})
+    open_rows: dict[int, dict] = {}
+    numbers: list[int] = []
+    for row in open_issues:
+        if isinstance(row, dict) and isinstance(row.get("number"), int) and row["number"] > 0:
+            number = int(row["number"])
+            numbers.append(number)
+            open_rows[number] = row
+    edges: list[dict] = []
+    nodes: dict[int, dict] = {}
+    fresh: set[int] = set()
+
+    def seed(number: int, row: dict | None, *, is_fresh: bool = False) -> None:
+        if number in nodes and (number in fresh or not is_fresh):
+            return
+        if isinstance(row, dict):
+            nodes[number] = {
+                "kind": node_kind(bool(row.get("is_pr"))),
+                "state": node_state(row.get("state"), row.get("merged_at")),
+                "title": str(row.get("title") or ""),
+            }
+            if is_fresh:
+                fresh.add(number)
+        elif number in hints and number not in nodes:
+            nodes[number] = dict(hints[number])
+
+    for number in numbers:
+        seed(number, open_rows.get(number))
+
+    batch = batch_loader(owner, repo, timeout=timeout)
+    for number in numbers:
+        entry = batch.get(number) if batch is not None else None
+        if entry is not None and not entry.get("truncated"):
+            seed(number, entry.get("row"), is_fresh=True)
+            native_rows = entry.get("native") or []
+            inferred_rows = event_filter(entry.get("refs") or [], owner, repo, number)
+        else:
+            native_rows = blockers_loader(owner, repo, number, timeout=timeout)
+            inferred_rows = inferred_loader(owner, repo, number, timeout=timeout)
+
+        for blocker in native_rows:
+            blocker_number = int(blocker["number"])
+            edges.append({"blocked": number, "blocker": blocker_number, "source": "native"})
+            seed(blocker_number, blocker, is_fresh=True)
+        for blocker in inferred_rows:
+            blocker_number = int(blocker["number"])
+            edges.append(
+                {
+                    "blocked": number,
+                    "blocker": blocker_number,
+                    "source": "inferred",
+                }
+            )
+            seed(blocker_number, blocker, is_fresh=True)
+
+    referenced = {edge["blocked"] for edge in edges} | {edge["blocker"] for edge in edges}
+    for number in sorted(referenced):
+        if number in nodes:
+            continue
+        if number in hints:
+            nodes[number] = dict(hints[number])
+            continue
+        try:
+            summary = ref_loader(owner, repo, number, timeout=timeout)
+        except GhCliError:
+            logger.debug("issue-radar: deps node summary failed for #%s", number, exc_info=True)
+            nodes[number] = {"kind": "issue", "state": "open", "title": ""}
+            continue
+        nodes[number] = {
+            "kind": node_kind(bool(summary.get("is_pr"))),
+            "state": node_state(summary.get("state"), summary.get("merged_at")),
+            "title": str(summary.get("title") or ""),
+        }
+    return edges, {str(number): row for number, row in nodes.items()}
+
+
+def parse_readiness_rows(
+    stdout: str, *, lower: Callable[[object], str | None]
+) -> dict[int, str | None]:
+    rows: dict[int, str | None] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        number = row.get("number")
+        if isinstance(number, int):
+            rows[number] = lower(row.get("merge_state_status"))
+    return rows
+
+
+def fetch_pr_summaries(
+    owner: str,
+    repo: str,
+    state: str,
+    *,
+    timeout: float,
+    gh_run: Callable[..., subprocess.CompletedProcess],
+    stderr_tail: Callable[[subprocess.CompletedProcess], str],
+    parse_rows: Callable[[str], dict[int, dict]],
+) -> dict[int, dict]:
+    graphql_state = GRAPHQL_PR_STATES.get(state)
+    if graphql_state is None:
+        raise GhCliError(f"unsupported state for PR summaries: {state!r}")
+    query = (
+        "query($owner:String!,$name:String!){"
+        " repository(owner:$owner,name:$name){"
+        f"  pullRequests(states:[{graphql_state}], first:100,"
+        "   orderBy:{field:UPDATED_AT,direction:DESC}){"
+        "   nodes{" + PR_SUMMARY_SELECTION + " } } } }"
+    )
+    argv = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={repo}",
+        "--jq",
+        f".data.repository.pullRequests.nodes[] | {PR_SUMMARY_JQ_BODY}",
+    ]
+    proc = gh_run(argv, timeout=timeout)
+    if proc.returncode != 0:
+        tail = stderr_tail(proc)
+        raise GhCliError(f"gh api graphql (pr summaries) failed (exit {proc.returncode}): {tail}")
+    return parse_rows(proc.stdout or "")
+
+
+def fetch_pr_readiness(
+    owner: str,
+    repo: str,
+    state: str,
+    *,
+    timeout: float,
+    gh_run: Callable[..., subprocess.CompletedProcess],
+    stderr_tail: Callable[[subprocess.CompletedProcess], str],
+    parse_rows: Callable[[str], dict[int, str | None]],
+) -> dict[int, str | None]:
+    graphql_state = GRAPHQL_PR_STATES.get(state)
+    if graphql_state is None:
+        raise GhCliError(f"unsupported state for PR readiness: {state!r}")
+    query = (
+        "query($owner:String!,$name:String!){"
+        " repository(owner:$owner,name:$name){"
+        f"  pullRequests(states:[{graphql_state}], first:100,"
+        "   orderBy:{field:UPDATED_AT,direction:DESC}){"
+        "   nodes{" + PR_READINESS_SELECTION + " } } } }"
+    )
+    argv = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={repo}",
+        "--jq",
+        f".data.repository.pullRequests.nodes[] | {PR_READINESS_JQ_BODY}",
+    ]
+    proc = gh_run(argv, timeout=timeout)
+    if proc.returncode != 0:
+        tail = stderr_tail(proc)
+        raise GhCliError(f"gh api graphql (pr readiness) failed (exit {proc.returncode}): {tail}")
+    return parse_rows(proc.stdout or "")
+
+
+def fetch_pr_readiness_by_number(
+    owner: str,
+    repo: str,
+    numbers: list[int],
+    *,
+    timeout: float,
+    gh_run: Callable[..., subprocess.CompletedProcess],
+    stderr_tail: Callable[[subprocess.CompletedProcess], str],
+    parse_rows: Callable[[str], dict[int, str | None]],
+) -> dict[int, str | None]:
+    rows: dict[int, str | None] = {}
+    wanted = [number for number in numbers if isinstance(number, int) and number > 0]
+    for start in range(0, len(wanted), READINESS_BATCH):
+        batch = wanted[start : start + READINESS_BATCH]
+        fields = " ".join(
+            f"p{number}: pullRequest(number:{number}){{{PR_READINESS_SELECTION} }}"
+            for number in batch
+        )
+        query = (
+            "query($owner:String!,$name:String!){"
+            f" repository(owner:$owner,name:$name){{ {fields} }} }}"
+        )
+        argv = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={repo}",
+            "--jq",
+            ".data.repository | to_entries[] | .value | select(. != null) | "
+            + PR_READINESS_JQ_BODY,
+        ]
+        proc = gh_run(argv, timeout=timeout)
+        if proc.returncode != 0:
+            tail = stderr_tail(proc)
+            raise GhCliError(
+                "gh api graphql (pr readiness by number) failed "
+                f"(exit {proc.returncode}): {tail}"
+            )
+        rows.update(parse_rows(proc.stdout or ""))
+    return rows
+
+
+def fetch_pr_summaries_by_number(
+    owner: str,
+    repo: str,
+    numbers: list[int],
+    *,
+    timeout: float,
+    gh_run: Callable[..., subprocess.CompletedProcess],
+    stderr_tail: Callable[[subprocess.CompletedProcess], str],
+    parse_rows: Callable[[str], dict[int, dict]],
+) -> dict[int, dict]:
+    rows: dict[int, dict] = {}
+    wanted = [number for number in numbers if isinstance(number, int) and number > 0]
+    for start in range(0, len(wanted), SUMMARY_BATCH):
+        batch = wanted[start : start + SUMMARY_BATCH]
+        fields = " ".join(
+            f"p{number}: pullRequest(number:{number}){{{PR_SUMMARY_SELECTION} }}"
+            for number in batch
+        )
+        query = (
+            "query($owner:String!,$name:String!){"
+            f" repository(owner:$owner,name:$name){{ {fields} }} }}"
+        )
+        argv = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={repo}",
+            "--jq",
+            ".data.repository | to_entries[] | .value | select(. != null) | " + PR_SUMMARY_JQ_BODY,
+        ]
+        proc = gh_run(argv, timeout=timeout)
+        if proc.returncode != 0:
+            tail = stderr_tail(proc)
+            raise GhCliError(
+                "gh api graphql (pr summaries by number) failed "
+                f"(exit {proc.returncode}): {tail}"
+            )
+        rows.update(parse_rows(proc.stdout or ""))
+    return rows
+
+
+def build_pr_search_query(
+    owner: str,
+    repo: str,
+    *,
+    state: str,
+    author: str | None,
+    assignee: str | None,
+    review_requested: str | None,
+) -> str:
+    if state not in PR_STATE_QUALIFIERS:
+        raise PrSearchError(f"unsupported state for PR search: {state!r}")
+    parts = [f"repo:{owner}/{repo}", "is:pr", *PR_STATE_QUALIFIERS[state]]
+    added = 0
+    for qualifier, login in (
+        ("author", author),
+        ("assignee", assignee),
+        ("review-requested", review_requested),
+    ):
+        if not login:
+            continue
+        if not LOGIN_RE.match(login):
+            raise PrSearchError(f"invalid GitHub login: {login!r}")
+        parts.append(f"{qualifier}:{login}")
+        added += 1
+    if added == 0:
+        raise PrSearchError("PR search needs at least one person qualifier")
+    return " ".join(parts)
+
+
+def search_pulls(
+    owner: str,
+    repo: str,
+    *,
+    state: str,
+    author: str | None,
+    assignee: str | None,
+    review_requested: str | None,
+    timeout: float,
+    limit: int,
+    query_builder: Callable[..., str],
+    run_api: Callable[..., list[dict]],
+) -> list[dict]:
+    query = query_builder(
+        owner,
+        repo,
+        state=state,
+        author=author,
+        assignee=assignee,
+        review_requested=review_requested,
+    )
+    cap = max(1, int(limit))
+    per_page = min(100, cap)
+    rows: list[dict] = []
+    page = 1
+    while len(rows) < cap and page <= SEARCH_MAX_PAGES:
+        path = (
+            f"search/issues?q={quote(query, safe='')}&sort=updated&order=desc"
+            f"&per_page={per_page}&page={page}"
+        )
+        batch = run_api(path, PR_SEARCH_JQ, timeout=timeout, paginate=False)
+        rows.extend(batch)
+        if len(batch) < per_page:
+            break
+        page += 1
+    return rows[:cap]

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/github_transport.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/github_transport.py
@@ -1,0 +1,199 @@
+"""GitHub-specific transport behind :mod:`github_client`'s patchable facade."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from typing import Protocol
+
+from kiro_crew import github_runner
+
+from .errors import (
+    ProviderCliError,
+    ProviderPermissionError,
+    ProviderSetupError,
+    sanitize_cli_stderr,
+)
+
+GhCliError = ProviderCliError
+GhPermissionError = ProviderPermissionError
+GhSetupError = ProviderSetupError
+
+GH_OVERRIDE_ENV = "KIROCREW_ISSUE_RADAR_GH"
+GH_AUTH_MARKERS = (
+    "gh auth login",
+    "not logged in",
+    "authentication required",
+    "requires authentication",
+    "bad credentials",
+    "http 401",
+)
+
+
+class GhRun(Protocol):
+    def __call__(
+        self,
+        argv: list[str],
+        *,
+        timeout: float,
+        input_text: str | None = None,
+    ) -> subprocess.CompletedProcess: ...
+
+
+def resolve_binary(*, override_env: str = GH_OVERRIDE_ENV) -> str:
+    """Resolve the trusted ``gh`` binary for Issue Radar."""
+    try:
+        return github_runner.resolve_gh(override_env=override_env)
+    except github_runner.SetupError as exc:
+        raise GhSetupError(str(exc), reason="not_installed") from exc
+
+
+def stderr_tail(
+    proc: subprocess.CompletedProcess, *, sanitize: Callable[[str], str] = sanitize_cli_stderr
+) -> str:
+    """Return the sanitized final stderr lines suitable for a response body."""
+    return sanitize(" ".join((proc.stderr or "").strip().splitlines()[-3:]))
+
+
+def run(
+    argv: list[str],
+    *,
+    timeout: float,
+    input_text: str | None,
+    gh_bin: Callable[[], str],
+) -> subprocess.CompletedProcess:
+    """Run one audited, host-pinned ``gh`` command with client error mapping."""
+    executable = gh_bin()
+    try:
+        return github_runner.run_gh(
+            [executable, *argv[1:]],
+            timeout=timeout,
+            input_text=input_text,
+            audit_caller="core:issue-radar",
+            pin_host="github.com",
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - resolve_binary guards first
+        raise GhSetupError(
+            "the `gh` CLI is not installed on this host", reason="not_installed"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GhCliError(f"`gh` timed out after {timeout}s") from exc
+    except github_runner.SetupError as exc:
+        # An audit-or-deny refusal is retryable host state, not missing setup.
+        raise GhCliError(str(exc)) from exc
+
+
+def raise_if_auth_failure(stderr: str, *, markers: tuple[str, ...] = GH_AUTH_MARKERS) -> None:
+    """Classify a missing GitHub CLI session as a setup error."""
+    if any(marker in (stderr or "").lower() for marker in markers):
+        raise GhSetupError(
+            "the `gh` CLI is not authenticated — run `gh auth login`",
+            reason="not_authenticated",
+        )
+
+
+def run_api(
+    path: str,
+    jq_filter: str,
+    *,
+    timeout: float,
+    paginate: bool,
+    gh_run: GhRun,
+    auth_classifier: Callable[[str], None],
+    sanitize: Callable[[str], str] = sanitize_cli_stderr,
+) -> list[dict]:
+    """Run a read-only ``gh api`` request and parse its JSONL output."""
+    argv = ["gh", "api", path]
+    if paginate:
+        argv.append("--paginate")
+    argv += ["--jq", jq_filter]
+    proc = gh_run(argv, timeout=timeout)
+    if proc.returncode != 0:
+        tail = stderr_tail(proc, sanitize=sanitize)
+        auth_classifier(tail)
+        raise GhCliError(f"gh api {path} failed (exit {proc.returncode}): {tail}")
+
+    rows: list[dict] = []
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def run_write(
+    method: str,
+    path: str,
+    payload: dict | None,
+    *,
+    timeout: float,
+    gh_run: GhRun,
+    sanitize: Callable[[str], str] = sanitize_cli_stderr,
+) -> dict | list | None:
+    """Run a REST mutation with payload-on-stdin and write error mapping."""
+    argv = ["gh", "api", "--method", method, path]
+    input_text = None
+    if payload is not None:
+        argv += ["--input", "-"]
+        input_text = json.dumps(payload)
+    proc = gh_run(argv, timeout=timeout, input_text=input_text)
+
+    if proc.returncode != 0:
+        stderr = proc.stderr or ""
+        tail = sanitize(" ".join(stderr.strip().splitlines()[-3:]))
+        if "HTTP 403" in stderr or "HTTP 401" in stderr:
+            raise GhPermissionError(
+                f"GitHub refused the write ({method} {path}) — your `gh` session "
+                f"lacks the required triage/push access: {tail}"
+            )
+        raise GhCliError(f"gh api {method} {path} failed (exit {proc.returncode}): {tail}")
+
+    output = (proc.stdout or "").strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        return None
+
+
+def run_graphql_mutation(
+    query: str,
+    variables: dict[str, str],
+    *,
+    timeout: float,
+    gh_run: GhRun,
+    sanitize: Callable[[str], str] = sanitize_cli_stderr,
+) -> dict:
+    """Run one GitHub GraphQL mutation and return its ``data`` object."""
+    argv = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        argv += ["-F", f"{key}={value}"]
+    proc = gh_run(argv, timeout=timeout)
+    combined = f"{proc.stdout or ''}\n{proc.stderr or ''}"
+    if proc.returncode != 0 or '"errors"' in (proc.stdout or ""):
+        tail = sanitize(" ".join(combined.strip().splitlines()[-3:]))
+        lowered = combined.lower()
+        if (
+            "HTTP 403" in combined
+            or "HTTP 401" in combined
+            or "not authorized" in lowered
+            or "must have push access" in lowered
+            or "resource not accessible" in lowered
+        ):
+            raise GhPermissionError(
+                "GitHub refused the request — your `gh` session lacks the "
+                f"required access: {tail}"
+            )
+        raise GhCliError(f"gh api graphql failed (exit {proc.returncode}): {tail}")
+    try:
+        parsed = json.loads((proc.stdout or "").strip() or "{}")
+    except json.JSONDecodeError as exc:
+        raise GhCliError("gh returned unexpected output for a GraphQL mutation") from exc
+    data = parsed.get("data") if isinstance(parsed, dict) else None
+    return data if isinstance(data, dict) else {}

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_client.py
@@ -46,24 +46,28 @@ is the security-sensitive one. Three rules, all mirrored from
 
 from __future__ import annotations
 
-import json
+import json  # noqa: F401 -- historical module export
 import os
 import re
 import subprocess
 from datetime import datetime, timedelta, timezone
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urlparse  # noqa: F401 -- historical module export
 
 from kiro_crew.apps.registry import minimal_env
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.sel import sel
 
+from . import gitlab_normalization as _normalization
+from . import gitlab_transport as _transport
 from .errors import (
     ProviderCliError,
     ProviderInvalidInputError,
     ProviderPermissionError,
     ProviderSetupError,
     PrSearchError,
-    RepoUrlError,
+)
+from .errors import RepoUrlError as RepoUrlError  # noqa: F401 — public re-export
+from .errors import (
     sanitize_cli_stderr,
 )
 
@@ -93,110 +97,20 @@ _PAGE_SIZE = 100
 # arbitrary API paths, so pagination is explicit here).
 _MAX_PAGES = 40
 
-_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_SEGMENT_RE = _transport.SEGMENT_RE
 # A GitLab username is used in search filters that ride in a query string.
 _USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
-
-# Reserved path segments that are part of GitLab's own routing rather than a
-# project's namespace. A URL like /group/project/-/issues/5 must resolve to the
-# project "group/project", so everything from "/-/" onward is stripped, and a
-# namespace may never contain one of these.
-_GITLAB_RESERVED_SEGMENTS = frozenset(
-    {"-", "groups", "projects", "admin", "dashboard", "explore", "help", "users", "api"}
-)
+_GITLAB_RESERVED_SEGMENTS = _transport.GITLAB_RESERVED_SEGMENTS
 
 
 def parse_gitlab_repo_url(link: str, *, allowed_hosts: frozenset[str] = frozenset()) -> tuple[str, str, str]:
-    """Parse ``(host, namespace, project)`` from a GitLab project URL.
-
-    Accepts the project root (``https://gitlab.com/group/sub/proj``) as well as
-    any deeper page (``.../-/issues``, ``.../-/merge_requests/7``), since users
-    paste whatever tab they happen to be on. ``namespace`` may contain ``/``:
-    GitLab projects live in nested groups, and the full namespace is part of the
-    project's identity.
-
-    Deliberately strict, for the same reasons as
-    :func:`github_client.parse_github_repo_url`: full URL only, HTTPS only, no
-    userinfo, host must be gitlab.com or in ``allowed_hosts`` (SSRF guard), and
-    every path segment is charset-constrained before any value can reach a
-    subprocess argv.
-    """
-    if not link or not isinstance(link, str):
-        raise RepoUrlError("repo link is empty")
-    # urlparse itself raises on some malformed authorities (an unclosed IPv6
-    # bracket, for one), so even reaching the scheme check is not guaranteed.
-    try:
-        parsed = urlparse(link.strip())
-    except ValueError as exc:
-        raise RepoUrlError(f"unparseable URL: {link!r}") from exc
-    if parsed.scheme != "https":
-        raise RepoUrlError(f"not an https URL: {link!r}")
-    if parsed.username or parsed.password:
-        raise RepoUrlError("URLs with embedded credentials are not accepted")
-
-    # Strip a trailing dot so an absolute-FQDN URL (``gitlab.acme.internal.``)
-    # matches the allowlist, whose entries are canonicalized the same way by the
-    # config loader. Without this the two sides can never agree (fails closed).
-    # `hostname`/`port` parse the authority lazily, so a malformed one
-    # (``https://gitlab.com:notaport/g/p``) raises ValueError HERE rather than in
-    # urlparse. Uncaught it escaped /connect as an HTTP 500; a malformed URL is
-    # client input, so it becomes the same RepoUrlError (400) as every other
-    # unusable link.
-    try:
-        host = (parsed.hostname or "").lower().rstrip(".")
-        port = parsed.port
-    except ValueError as exc:
-        raise RepoUrlError(f"malformed host or port in {link!r}") from exc
-    # A self-managed instance may listen on a non-default port, so the allowlist
-    # is matched against host and host:port -- an entry without a port does not
-    # authorize an arbitrary port on the same host. An explicit :443 is treated
-    # as absent, matching the browser URL API, so the same URL resolves
-    # identically on both sides.
-    candidate = f"{host}:{port}" if port and port != 443 else host
-
-    if host in {"gitlab.com", "www.gitlab.com"}:
-        resolved_host = "gitlab.com"
-    elif host and candidate in allowed_hosts:
-        resolved_host = candidate
-    else:
-        raise RepoUrlError(
-            f"not a supported GitLab host: {link!r} — gitlab.com is always accepted; "
-            "a self-managed instance must be listed in the dashboard.gitlab_hosts config"
-        )
-
-    path = (parsed.path or "").rstrip("/")
-    # Everything from GitLab's "/-/" routing marker onward is a page within the
-    # project, not part of its path. String ops (not a regex) because a
-    # /(.+)/-/… pattern backtracks polynomially on adversarial input.
-    marker = "/-/"
-    idx = path.find(marker)
-    if idx >= 0:
-        path = path[:idx]
-    parts = [p for p in path.split("/") if p]
-    if len(parts) < 2:
-        raise RepoUrlError(
-            f"not a full project URL: {link!r} (expected .../<group>/<project>)"
-        )
-    parts[-1] = re.sub(r"\.git$", "", parts[-1])
-    for seg in parts:
-        if seg in (".", "..") or not _SEGMENT_RE.match(seg):
-            raise RepoUrlError(f"invalid path segment in {link!r}")
-    if any(seg.lower() in _GITLAB_RESERVED_SEGMENTS for seg in parts):
-        raise RepoUrlError(f"{link!r} is a GitLab system path, not a project")
-    namespace, project = "/".join(parts[:-1]), parts[-1]
-    return resolved_host, namespace, project
+    """Parse a project URL through the provider-specific transport boundary."""
+    return _transport.parse_gitlab_repo_url(link, allowed_hosts=allowed_hosts)
 
 
 def project_path(owner: str, repo: str) -> str:
-    """URL-encode ``owner/repo`` into GitLab's single ``:id`` path parameter.
-
-    GitLab addresses a project either by numeric id or by its URL-encoded full
-    path, where the namespace separators become ``%2F`` (``group/sub/proj`` ->
-    ``group%2Fsub%2Fproj``). Encoding here -- rather than at each of the ~25 call
-    sites -- means no endpoint can accidentally emit a raw slash and address the
-    wrong resource.
-    """
-    return quote(f"{owner}/{repo}", safe="")
+    """URL-encode ``owner/repo`` into GitLab's single ``:id`` path parameter."""
+    return _transport.project_path(owner, repo)
 
 
 # ── glab spawn hardening ─────────────────────────────────────────────────────
@@ -211,12 +125,7 @@ def project_path(owner: str, repo: str) -> str:
 # -- PATH/HOME/XDG plus glab's own auth/network vars -- instead of the gateway's
 # full env, so unrelated secrets (AWS/Slack/SSH) can never leak to a substituted
 # or compromised glab.
-_GLAB_ENV_PASSTHROUGH = (
-    "GITLAB_TOKEN", "GLAB_CONFIG_DIR",
-    "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY",
-    "http_proxy", "https_proxy", "no_proxy", "all_proxy",
-    "SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE",
-)
+_GLAB_ENV_PASSTHROUGH = _transport.GLAB_ENV_PASSTHROUGH
 
 _glab_bin_cache: str | None = None
 
@@ -305,16 +214,7 @@ def _resolve_host(host: str) -> str:
     an already-connected project. An omitted host is refused rather than
     silently resolved to gitlab.com.
     """
-    if not host:
-        raise ProviderCliError("a GitLab host is required for glab calls")
-    normalized = host.lower().rstrip(".")
-    if normalized in {"gitlab.com", "www.gitlab.com"}:
-        return "gitlab.com"
-    if normalized not in allowed_hosts():
-        raise ProviderCliError(
-            f"GitLab host {normalized!r} is not listed in the dashboard.gitlab_hosts allowlist"
-        )
-    return normalized
+    return _transport.resolve_host(host, allowed_hosts=allowed_hosts())
 
 
 def _glab_env(host: str) -> dict[str, str]:
@@ -327,13 +227,12 @@ def _glab_env(host: str) -> dict[str, str]:
     ``GITLAB_TOKEN`` is withheld for non-gitlab.com hosts (see the module
     docstring, rule 3).
     """
-    passthrough = {k: os.environ[k] for k in _GLAB_ENV_PASSTHROUGH if k in os.environ}
-    if host != "gitlab.com":
-        passthrough.pop("GITLAB_TOKEN", None)
-    passthrough["GITLAB_HOST"] = host
-    passthrough["GLAB_PAGER"] = "cat"
-    passthrough["NO_COLOR"] = "1"
-    return minimal_env(**passthrough)
+    return _transport.glab_env(
+        host,
+        source_env=os.environ,
+        passthrough_keys=_GLAB_ENV_PASSTHROUGH,
+        minimal_env=minimal_env,
+    )
 
 
 def _audit(op: str, target: str, outcome: str, *, error: str = "") -> None:
@@ -402,35 +301,20 @@ def _glab_run(
 # target host (as opposed to a project simply being out of reach for an
 # authenticated user). Matched case-insensitively against the stderr tail so the
 # connect dialog can offer `glab auth login` instead of an opaque exit code.
-_GLAB_AUTH_MARKERS = (
-    "glab auth login",
-    "not logged in",
-    "no token provided",
-    "authentication required",
-    "requires authentication",
-    "401 unauthorized",
-    "http 401",
-)
+_GLAB_AUTH_MARKERS = _transport.GLAB_AUTH_MARKERS
 
 
 def _raise_if_auth_failure(stderr_tail: str, host: str) -> None:
     """Re-classify an unauthenticated ``glab`` failure as ProviderSetupError."""
-    low = (stderr_tail or "").lower()
-    if any(m in low for m in _GLAB_AUTH_MARKERS):
-        raise ProviderSetupError(
-            f"the `glab` CLI is not authenticated for {host} — "
-            f"run `glab auth login --hostname {host}`",
-            reason="not_authenticated",
-        )
+    _transport.raise_if_auth_failure(stderr_tail, host, markers=_GLAB_AUTH_MARKERS)
 
 
 def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
-    return sanitize_cli_stderr(" ".join((proc.stderr or "").strip().splitlines()[-3:]))
+    return _transport.stderr_tail(proc, sanitize=sanitize_cli_stderr)
 
 
 def _is_forbidden(tail: str) -> bool:
-    low = (tail or "").lower()
-    return "403" in low or "forbidden" in low or "insufficient" in low
+    return _transport.is_forbidden(tail)
 
 
 def _glab_api(
@@ -450,270 +334,76 @@ def _glab_api(
     already be built from validated segments by the caller; ``body`` rides on
     stdin as JSON so values with spaces/specials are never argv.
     """
-    pages: list[object] = []
-    page = 1
-    while True:
-        sep = "&" if "?" in path else "?"
-        target = f"{path}{sep}page={page}&per_page={_PAGE_SIZE}" if paginate else path
-        argv = ["glab", "api", target]
-        if method != "GET":
-            argv += ["--method", method]
-        input_text = None
-        if body is not None:
-            # glab reads a request body from stdin when given "--input -".
-            argv += ["--input", "-"]
-            input_text = json.dumps(body)
-        proc = _glab_run(argv, host=host, timeout=timeout, input_text=input_text)
-        if proc.returncode != 0:
-            tail = _stderr_tail(proc)
-            _raise_if_auth_failure(tail, host)
-            if _is_forbidden(tail):
-                raise ProviderPermissionError(
-                    f"glab api {path} was forbidden (exit {proc.returncode}): {tail}"
-                )
-            raise ProviderCliError(f"glab api {path} failed (exit {proc.returncode}): {tail}")
-        text = (proc.stdout or "").strip()
-        if not text:
-            data: object = [] if paginate else {}
-        else:
-            try:
-                data = json.loads(text)
-            except json.JSONDecodeError as exc:
-                raise ProviderCliError(f"glab returned unexpected output for {path}") from exc
-        if not paginate:
-            return data
-        if not isinstance(data, list):
-            return data
-        pages.extend(data)
-        if len(data) < _PAGE_SIZE or page >= _MAX_PAGES:
-            return pages
-        page += 1
+    return _transport.glab_api(
+        path,
+        host=host,
+        timeout=timeout,
+        paginate=paginate,
+        method=method,
+        body=body,
+        run=_glab_run,
+        page_size=_PAGE_SIZE,
+        max_pages=_MAX_PAGES,
+        stderr_tail=_stderr_tail,
+        raise_if_auth_failure=_raise_if_auth_failure,
+        is_forbidden=_is_forbidden,
+    )
 
 
 def _rows(data: object) -> list[dict]:
-    """Coerce an API response into a list of dicts (tolerating a non-list)."""
-    if not isinstance(data, list):
-        return []
-    return [row for row in data if isinstance(row, dict)]
+    return _normalization._rows(data)
 
 
 def _obj(data: object) -> dict:
-    return data if isinstance(data, dict) else {}
+    return _normalization._obj(data)
 
 
-# ── normalization: GitLab -> the GitHub-shaped vocabulary the app speaks ─────
-
-
+# Compatibility wrappers keep the longstanding gitlab_client patch/import surface.
 def _norm_state(state: object) -> str:
-    """``opened`` -> ``open``; ``locked`` -> ``open``; everything else verbatim.
-
-    GitLab's issue/MR states are opened/closed/merged/locked. The app's filters,
-    caches, and components are written against GitHub's open/closed (plus
-    ``merged_at`` for a merged MR), so ``opened`` is renamed here and ``locked``
-    -- a rarely-used GitLab state that still means the item is not closed -- is
-    folded into ``open`` rather than leaking a third value the UI cannot render.
-    """
-    text = str(state or "").lower()
-    if text in {"opened", "locked"}:
-        return "open"
-    return text or "open"
+    return _normalization._norm_state(state)
 
 
 def _hex_color(value: object) -> str:
-    """GitLab returns ``#RRGGBB``; the app (and GitHub) use bare 6-hex."""
-    text = str(value or "").strip().lstrip("#")
-    return text or "888888"
+    return _normalization._hex_color(value)
 
 
 def _label_names(raw: object) -> list[str]:
-    """GitLab issue/MR payloads carry labels as a plain array of names."""
-    if not isinstance(raw, list):
-        return []
-    return [str(name) for name in raw if isinstance(name, str) and name]
+    return _normalization._label_names(raw)
 
 
 def _username(user: object) -> str | None:
-    if not isinstance(user, dict):
-        return None
-    name = user.get("username")
-    return str(name) if name else None
+    return _normalization._username(user)
 
 
 def _usernames(raw: object) -> list[str]:
-    if not isinstance(raw, list):
-        return []
-    return [u for u in (_username(item) for item in raw) if u]
+    return _normalization._usernames(raw)
 
 
-# GitLab access levels -> the role vocabulary the members UI already renders.
-# GitLab has no "triage" role; Reporter is its closest analogue (can label and
-# close issues but not push), so it maps there.
-_ACCESS_LEVEL_ROLES = (
-    (50, "admin"),      # Owner
-    (40, "maintain"),   # Maintainer
-    (30, "write"),      # Developer
-    (20, "triage"),     # Reporter
-    (10, "read"),       # Guest
-)
+_ACCESS_LEVEL_ROLES = _normalization._ACCESS_LEVEL_ROLES
 
 
 def _role_for_access_level(level: object) -> str:
-    if not isinstance(level, (int, str)):
-        return "read"
-    try:
-        value = int(level)
-    except (TypeError, ValueError):
-        return "read"
-    for threshold, role in _ACCESS_LEVEL_ROLES:
-        if value >= threshold:
-            return role
-    return "read"
+    return _normalization._role_for_access_level(level)
 
 
 def _permissions_for_access_level(level: int) -> dict:
-    """Project access level -> GitHub's ``{admin, maintain, push, triage, pull}``.
-
-    The write routes gate on ``triage``/``push``, so this mapping is what decides
-    whether a GitLab user may label or close an issue from Issue Radar. It is
-    deliberately conservative: Reporter (20) gets triage but NOT push, matching
-    what GitLab itself permits.
-    """
-    return {
-        "admin": level >= 50,
-        "maintain": level >= 40,
-        "push": level >= 30,
-        "triage": level >= 20,
-        "pull": level >= 10,
-    }
+    return _normalization._permissions_for_access_level(level)
 
 
 def _access_level(details: dict) -> int:
-    """Highest effective access level the caller has on a project.
-
-    GitLab reports project access and inherited group access separately, and a
-    user may hold either or both; the effective right is the maximum.
-    """
-    perms = _obj(details.get("permissions"))
-    best = 0
-    for key in ("project_access", "group_access"):
-        entry = _obj(perms.get(key))
-        try:
-            level = int(entry.get("access_level") or 0)
-        except (TypeError, ValueError):
-            level = 0
-        best = max(best, level)
-    return best
+    return _normalization._access_level(details)
 
 
 def _norm_issue(raw: dict) -> dict:
-    """One GitLab issue -> the list-view row shape ``_ISSUE_JQ`` produces.
-
-    ``author_association`` has no GitLab equivalent (it is a GitHub-computed
-    relationship), so it is ``None`` here. That is safe rather than lossy: it
-    only feeds ``derive_members``, which is the FALLBACK roster for repos where
-    the members endpoint is forbidden -- and on GitLab the members endpoint is
-    readable by any project member, so the authoritative roster is used instead.
-    """
-    return {
-        "number": raw.get("iid"),
-        "title": raw.get("title") or "",
-        "url": raw.get("web_url") or "",
-        "labels": _label_names(raw.get("labels")),
-        "comments": raw.get("user_notes_count") or 0,
-        # GitLab has award emoji but does not summarize them on the issue; the
-        # up/down votes it does report are the meaningful triage signal.
-        "reactions": (raw.get("upvotes") or 0) + (raw.get("downvotes") or 0),
-        "thumbs_up": raw.get("upvotes") or 0,
-        "author_association": None,
-        "updated_at": raw.get("updated_at"),
-        "created_at": raw.get("created_at"),
-        "state": _norm_state(raw.get("state")),
-        "author": _username(raw.get("author")),
-        "assignees": _usernames(raw.get("assignees")),
-        "body": raw.get("description") or "",
-    }
+    return _normalization._norm_issue(raw)
 
 
 def _norm_issue_detail(raw: dict, labels_by_name: dict[str, dict]) -> dict:
-    """One GitLab issue -> the detail-pane shape ``_ISSUE_DETAIL_JQ`` produces.
-
-    GitLab's issue payload carries label NAMES only, but the detail pane renders
-    each label in its configured colour, so ``labels_by_name`` (from
-    :func:`list_repo_labels`) supplies the colour/description. A label missing
-    from that map still renders, with the neutral default colour.
-    """
-    upvotes = raw.get("upvotes") or 0
-    downvotes = raw.get("downvotes") or 0
-    total = upvotes + downvotes
-    milestone = _obj(raw.get("milestone"))
-    return {
-        "number": raw.get("iid"),
-        "title": raw.get("title") or "",
-        "body": raw.get("description") or "",
-        "state": _norm_state(raw.get("state")),
-        # GitLab has no close-reason concept.
-        "state_reason": None,
-        "url": raw.get("web_url") or "",
-        "author": _username(raw.get("author")),
-        "author_association": None,
-        "created_at": raw.get("created_at"),
-        "updated_at": raw.get("updated_at"),
-        "closed_at": raw.get("closed_at"),
-        "closed_by": _username(raw.get("closed_by")),
-        "comments": raw.get("user_notes_count") or 0,
-        "locked": bool(raw.get("discussion_locked")),
-        "labels": [
-            {
-                "name": name,
-                "color": _hex_color(labels_by_name.get(name, {}).get("color")),
-                "description": labels_by_name.get(name, {}).get("description") or "",
-            }
-            for name in _label_names(raw.get("labels"))
-        ],
-        "assignees": _usernames(raw.get("assignees")),
-        "milestone": (
-            {
-                "title": milestone.get("title"),
-                "state": milestone.get("state"),
-                "due_on": milestone.get("due_date"),
-            }
-            if milestone
-            else None
-        ),
-        "reactions": (
-            {
-                "total": total,
-                "plus1": upvotes,
-                "minus1": downvotes,
-                "laugh": 0,
-                "hooray": 0,
-                "confused": 0,
-                "heart": 0,
-                "rocket": 0,
-                "eyes": 0,
-            }
-            if total > 0
-            else None
-        ),
-    }
+    return _normalization._norm_issue_detail(raw, labels_by_name)
 
 
 def _shape_labels(raw: object) -> list[dict]:
-    """Normalize a GitLab label array to ``[{name, color, description}]``."""
-    out: list[dict] = []
-    for lab in _rows(raw):
-        if lab.get("name"):
-            out.append(
-                {
-                    "name": lab.get("name"),
-                    "color": _hex_color(lab.get("color")),
-                    "description": lab.get("description") or "",
-                }
-            )
-    return out
-
-
-# ── public surface: mirrors github_client function-for-function ──────────────
+    return _normalization._shape_labels(raw)
 
 
 def verify_repo_access(owner: str, repo: str, *, host: str = "", timeout: float = GL_TIMEOUT_SEC) -> dict:
@@ -846,16 +536,8 @@ def list_repo_collaborators(
 
 
 def derive_members(issues: list[dict]) -> list[dict]:
-    """FALLBACK roster. Always ``[]`` on GitLab.
-
-    GitHub derives membership from ``author_association``, which GitLab does not
-    report (see :func:`_norm_issue`). Returning empty is honest: the caller only
-    reaches this when the members endpoint was forbidden, and inventing a roster
-    from issue authors — who on GitLab may be complete strangers — would badge
-    non-members as members. The route surfaces the empty roster with its
-    ``source`` marker so the UI can say so.
-    """
-    return []
+    """Return no inferred roster when GitLab's authoritative endpoint is forbidden."""
+    return _normalization.derive_members(issues)
 
 
 def get_current_login(*, host: str = "", timeout: float = GL_TIMEOUT_SEC) -> str | None:
@@ -1043,114 +725,23 @@ _SYSTEM_NOTE_PATTERNS: tuple[tuple[str, str], ...] = (
     ("removed milestone", "demilestoned"),
 )
 
-_TITLE_CHANGE_RE = re.compile(r"changed title from \*\*(.*?)\*\* to \*\*(.*?)\*\*", re.DOTALL)
-_MENTION_REF_RE = re.compile(r"mentioned in (issue|merge request) ([\w./-]*[!#])(\d+)")
-_ASSIGNEE_RE = re.compile(r"@([A-Za-z0-9._-]+)")
-_COMMIT_REF_RE = re.compile(r"mentioned in commit ([0-9a-f]{7,40})")
+_TITLE_CHANGE_RE = _normalization._TITLE_CHANGE_RE
+_MENTION_REF_RE = _normalization._MENTION_REF_RE
+_ASSIGNEE_RE = _normalization._ASSIGNEE_RE
+_COMMIT_REF_RE = _normalization._COMMIT_REF_RE
 
 
 def _norm_note(note: dict) -> dict | None:
-    """One GitLab note -> a normalized timeline entry, or ``None`` to drop it."""
-    body = str(note.get("body") or "")
-    created = note.get("created_at")
-    actor = _username(note.get("author"))
-    if not note.get("system"):
-        upvotes = 0  # per-note award emoji need an extra call per note; not worth it
-        return {
-            "kind": "comment",
-            "actor": actor,
-            "created_at": created,
-            "body": body,
-            "author_association": None,
-            "reactions": None if upvotes <= 0 else {"total": upvotes, "plus1": upvotes},
-        }
-    low = body.lower()
-    kind = next((k for prefix, k in _SYSTEM_NOTE_PATTERNS if low.startswith(prefix)), None)
-    if kind is None:
-        return None
-    if kind in ("assigned", "unassigned"):
-        match = _ASSIGNEE_RE.search(body)
-        return {
-            "kind": kind,
-            "actor": actor,
-            "created_at": created,
-            "assignee": match.group(1) if match else None,
-        }
-    if kind == "renamed":
-        match = _TITLE_CHANGE_RE.search(body)
-        return {
-            "kind": "renamed",
-            "actor": actor,
-            "created_at": created,
-            "rename": {
-                "from": match.group(1) if match else None,
-                "to": match.group(2) if match else None,
-            },
-        }
-    if kind == "cross-referenced":
-        match = _MENTION_REF_RE.search(body)
-        return {
-            "kind": "cross-referenced",
-            "actor": actor,
-            "created_at": created,
-            "source": {
-                "number": int(match.group(3)) if match else None,
-                "title": None,
-                "url": None,
-                "state": None,
-                # "!" is GitLab's merge-request sigil; "#" is an issue.
-                "is_pr": bool(match and match.group(2).endswith("!")),
-            },
-        }
-    if kind == "referenced":
-        match = _COMMIT_REF_RE.search(body)
-        return {
-            "kind": "referenced",
-            "actor": actor,
-            "created_at": created,
-            "commit_id": match.group(1) if match else None,
-        }
-    if kind in ("milestoned", "demilestoned"):
-        return {"kind": kind, "actor": actor, "created_at": created, "milestone": None}
-    return None
+    # Read the facade table at call time so monkeypatches and extensions keep working.
+    return _normalization.norm_note(note, patterns=_SYSTEM_NOTE_PATTERNS)
 
 
 def _norm_label_event(event: dict, labels_by_name: dict[str, dict]) -> dict | None:
-    action = str(event.get("action") or "").lower()
-    if action not in ("add", "remove"):
-        return None
-    label = _obj(event.get("label"))
-    name = label.get("name")
-    if not name:
-        return None
-    return {
-        "kind": "labeled" if action == "add" else "unlabeled",
-        "actor": _username(event.get("user")),
-        "created_at": event.get("created_at"),
-        "label": {
-            "name": name,
-            "color": _hex_color(label.get("color") or labels_by_name.get(str(name), {}).get("color")),
-        },
-    }
+    return _normalization._norm_label_event(event, labels_by_name)
 
 
 def _norm_state_event(event: dict) -> dict | None:
-    state = str(event.get("state") or "").lower()
-    if state == "closed":
-        return {
-            "kind": "closed",
-            "actor": _username(event.get("user")),
-            "created_at": event.get("created_at"),
-            "state_reason": None,
-            "commit_id": None,
-        }
-    if state in ("reopened", "opened"):
-        return {
-            "kind": "reopened",
-            "actor": _username(event.get("user")),
-            "created_at": event.get("created_at"),
-        }
-    return None
+    return _normalization._norm_state_event(event)
 
 
 def _assemble_timeline(
@@ -1485,40 +1076,7 @@ def create_label(
 
 
 def _norm_pull(raw: dict) -> dict:
-    """One GitLab merge request -> the row shape ``_PR_JQ`` produces.
-
-    ``state`` folds ``merged`` into ``closed`` because that is what the app's
-    open/closed filter means; the distinction survives in ``merged_at``, which is
-    exactly how github_client distinguishes a merged PR from one closed unmerged.
-    """
-    state = str(raw.get("state") or "").lower()
-    row = {
-        "number": raw.get("iid"),
-        "title": raw.get("title") or "",
-        "url": raw.get("web_url") or "",
-        "state": "open" if state in ("opened", "locked") else "closed",
-        "draft": bool(raw.get("draft") if raw.get("draft") is not None else raw.get("work_in_progress")),
-        "labels": _label_names(raw.get("labels")),
-        "author": _username(raw.get("author")),
-        "author_association": None,
-        "updated_at": raw.get("updated_at"),
-        "created_at": raw.get("created_at"),
-        "closed_at": raw.get("closed_at"),
-        "merged_at": raw.get("merged_at"),
-        "assignees": _usernames(raw.get("assignees")),
-        "requested_reviewers": _usernames(raw.get("reviewers")),
-        "base": raw.get("target_branch"),
-        "head": raw.get("source_branch"),
-        # The head COMMIT, for the same reason github_client's list JQ carries it: a
-        # bulk approve has to name the revision the row was rendered at. GitLab's list
-        # payload gives ``sha`` directly; ``diff_refs`` is the detail-only richer form.
-        "head_sha": (_obj(raw.get("diff_refs")).get("head_sha") or raw.get("sha")),
-        "body": raw.get("description") or "",
-    }
-    # The card enrichment GitHub needs a second round trip for is already in this
-    # payload, so it is written here rather than by a separate enrich_* pass.
-    row.update(_pipeline_summary(raw))
-    return row
+    return _normalization._norm_pull(raw)
 
 
 def _list_pulls(owner: str, repo: str, state: str, *, host: str, timeout: float, paginate: bool) -> list[dict]:
@@ -1633,75 +1191,25 @@ def get_pr_detail(
 # (the reader wants a conflict signal) and would be wrong for a merge gate — which is
 # why ``routes._MERGE_ALLOWED_STATES`` keys off the raw status instead and admits only
 # the modern value.
-_MERGEABLE_STATUSES = frozenset({"mergeable", "can_be_merged"})
-# Values that mean "GitLab has not finished computing it yet" — reported as
-# unknown (None) rather than as not-mergeable, so the UI does not flash a false
-# conflict warning while the check is still running.
-_MERGE_STATUS_PENDING = frozenset({"checking", "unchecked", "preparing", ""})
+_MERGEABLE_STATUSES = _normalization._MERGEABLE_STATUSES
+_MERGE_STATUS_PENDING = _normalization._MERGE_STATUS_PENDING
 
 
 def _mergeable(raw: dict) -> bool | None:
-    status = str(raw.get("detailed_merge_status") or raw.get("merge_status") or "").lower()
-    if status in _MERGE_STATUS_PENDING:
-        return None
-    return status in _MERGEABLE_STATUSES
+    return _normalization._mergeable(raw)
 
 
-# ── pipelines as checks ─────────────────────────────────────────────────────
-#
-# GitHub reports per-PR status as check runs + commit statuses. GitLab reports a
-# pipeline per commit, with jobs inside it. A job is the closest analogue of a
-# check run (a named unit that passes or fails), so the MR's LATEST pipeline's
-# jobs become the check list. Bucketing mirrors github_client._check_bucket so
-# the same summary logic and UI colours apply, including its hard-won behaviour
-# that a CANCELLED job is informational rather than failing.
-_JOB_FAILURE_STATUSES = frozenset({"failed"})
-_JOB_RUNNING_STATUSES = frozenset({"running", "pending", "created", "waiting_for_resource", "preparing", "scheduled"})
-_JOB_OTHER_STATUSES = frozenset({"canceled", "cancelled", "skipped", "manual"})
+_JOB_FAILURE_STATUSES = _normalization._JOB_FAILURE_STATUSES
+_JOB_RUNNING_STATUSES = _normalization._JOB_RUNNING_STATUSES
+_JOB_OTHER_STATUSES = _normalization._JOB_OTHER_STATUSES
 
 
 def _job_bucket(status: str, allow_failure: bool) -> str:
-    """Map a GitLab job status to github_client's bucket vocabulary.
-
-    ``allow_failure`` jobs are bucketed as ``other``, not ``failure``: GitLab
-    does not fail the pipeline for them, so surfacing them as a failing check
-    would report a red PR that GitLab itself considers green.
-    """
-    text = (status or "").lower()
-    if text in _JOB_FAILURE_STATUSES:
-        return "other" if allow_failure else "failure"
-    if text in _JOB_RUNNING_STATUSES:
-        return "running"
-    if text == "success":
-        return "success"
-    if text in _JOB_OTHER_STATUSES:
-        return "other"
-    return "other"
+    return _normalization._job_bucket(status, allow_failure)
 
 
 def _norm_job(job: dict) -> dict:
-    """One GitLab job -> the check-row shape ``_CHECK_RUN_JQ`` produces.
-
-    ``bucket`` is precomputed because :func:`summarize_checks` reads it, and
-    ``source`` carries the publisher identity github_client's dedupe keys on --
-    ``gitlab-ci`` for every job, since one pipeline is one publisher.
-    """
-    status = str(job.get("status") or "")
-    bucket = _job_bucket(status, bool(job.get("allow_failure")))
-    stage = job.get("stage")
-    return {
-        "name": job.get("name") or "job",
-        # GitLab has no separate status/conclusion split; the job status is both.
-        "status": "in_progress" if bucket == "running" else "completed",
-        "conclusion": {"failure": "failure", "success": "success", "running": None}.get(bucket, "neutral"),
-        "bucket": bucket,
-        "url": job.get("web_url"),
-        "started_at": job.get("started_at") or job.get("created_at"),
-        "completed_at": job.get("finished_at"),
-        "summary": f"stage: {stage}" if stage else "",
-        "app": "GitLab CI",
-        "source": "gitlab-ci",
-    }
+    return _normalization._norm_job(job)
 
 
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
@@ -1749,89 +1257,27 @@ def list_pr_checks(
     return [_norm_job(job) for job in jobs]
 
 
-_CHECK_BUCKETS = ("failure", "running", "success", "other")
+_CHECK_BUCKETS = _normalization._CHECK_BUCKETS
 
 
 def summarize_checks(checks: list[dict]) -> dict:
-    """``{checks_counts, checks_state, checks_truncated}`` from bucketed rows.
-
-    Byte-identical contract to ``github_client.summarize_checks``, including the
-    ``checks_state`` priority (anything failing dominates, then running, then
-    success, then informational) so the card's dot never reads greener than the
-    list it summarizes, and ``None`` when there are no checks at all.
-    """
-    counts = dict.fromkeys(_CHECK_BUCKETS, 0)
-    for row in checks:
-        if not isinstance(row, dict):
-            continue
-        bucket = row.get("bucket")
-        counts[bucket if isinstance(bucket, str) and bucket in counts else "other"] += 1
-    for bucket in _CHECK_BUCKETS:
-        if counts[bucket]:
-            state: str | None = bucket
-            break
-    else:
-        state = None  # no checks at all -> the card shows no dot
-    return {"checks_counts": counts, "checks_state": state, "checks_truncated": False}
+    return _normalization.summarize_checks(checks)
 
 
 def enrich_pulls(owner: str, repo: str, pulls: list[dict], state: str, *, host: str = "") -> list[dict]:
-    """Attach card enrichment to each MR row. A no-op on GitLab, by construction.
-
-    GitHub needs a batched GraphQL round trip here because its REST list omits
-    diff size and check state. GitLab returns each MR's ``head_pipeline`` inline,
-    so :func:`_norm_pull` has already written the enrichment fields and there is
-    nothing left to fetch. Kept for signature parity so the route calls one shape.
-    """
-    del owner, repo, state, host
-    return pulls
+    return _normalization.enrich_pulls(owner, repo, pulls, state, host=host)
 
 
 def enrich_pulls_by_number(owner: str, repo: str, pulls: list[dict], *, host: str = "") -> list[dict]:
-    """Signature-parity counterpart to :func:`enrich_pulls`; also a no-op."""
-    del owner, repo, host
-    return pulls
+    return _normalization.enrich_pulls_by_number(owner, repo, pulls, host=host)
 
 
 def enrichment_complete(pulls: list[dict]) -> bool:
-    """Whether every row carries its card enrichment.
-
-    Reads the same ``checks_counts is not None`` invariant github_client does,
-    rather than hard-coding ``True``: a row that somehow arrived without
-    enrichment must keep itself OUT of the on-disk list cache, exactly as on
-    GitHub, instead of being cached as authoritative.
-    """
-    return all(pr.get("checks_counts") is not None for pr in pulls)
+    return _normalization.enrichment_complete(pulls)
 
 
 def _pipeline_summary(raw: dict) -> dict:
-    """Card enrichment derived from an MR's head pipeline.
-
-    A GitLab pipeline is one aggregate signal, not a set of named checks, so this
-    reports a single unit in the matching bucket -- enough for the row's coloured
-    dot, with the real per-job list arriving from :func:`list_pr_checks` when the
-    detail pane opens.
-
-    Diff size is reported as ``None`` (unknown), never ``0``: the list response
-    carries no line counts, and these rows are PERSISTED -- zeros would present
-    an unread diff as a confident "no changes" and the cache would serve that
-    until a manual refresh.
-    """
-    pipeline = _obj(raw.get("head_pipeline")) or _obj(raw.get("pipeline"))
-    status = str(pipeline.get("status") or "").lower()
-    counts = dict.fromkeys(_CHECK_BUCKETS, 0)
-    state: str | None = None
-    if status:
-        state = _job_bucket(status, False)
-        counts[state] = 1
-    return {
-        "additions": None,
-        "deletions": None,
-        "changed_files": None,
-        "checks_state": state,
-        "checks_counts": counts,
-        "checks_truncated": False,
-    }
+    return _normalization._pipeline_summary(raw)
 
 
 # ── cheap open-list probe (poll gating) ─────────────────────────────────────
@@ -2293,28 +1739,14 @@ def disable_auto_merge(
     )
 
 
-# GitLab pipeline statuses that mean "not finished", so cancelling is meaningful.
-_PIPELINE_CANCELLABLE_STATES = frozenset({
-    "created", "waiting_for_resource", "preparing", "pending", "running", "scheduled",
-})
+_PIPELINE_CANCELLABLE_STATES = _normalization._PIPELINE_CANCELLABLE_STATES
+_PIPELINE_RETRYABLE_STATES = _normalization._PIPELINE_RETRYABLE_STATES
+_PIPELINE_FINISHED_STATES = _normalization._PIPELINE_FINISHED_STATES
+_PIPELINE_CONCLUSION = _normalization._PIPELINE_CONCLUSION
 
-# A pipeline in one of these has finished AND has something for /retry to do.
-#
-# GitLab's ``/retry`` retries only the failed and canceled jobs, so a fully successful
-# or skipped pipeline has nothing to retry — offering the control there produced a
-# button that reported success while performing no work, which is worse than not
-# offering it. ``success`` and ``skipped`` are therefore absent: those pipelines are
-# still shown, just without a re-run affordance.
-_PIPELINE_RETRYABLE_STATES = frozenset({"failed", "canceled", "cancelled"})
 
-# Statuses that mean the pipeline has FINISHED, regardless of whether it can be
-# retried. This is what decides `status: "completed"` and whether `conclusion` is
-# populated -- a successful pipeline is finished even though it is not retryable.
-_PIPELINE_FINISHED_STATES = frozenset({"failed", "success", "canceled", "cancelled", "skipped"})
-
-# GitLab pipeline status -> the GitHub CONCLUSION vocabulary the shared UI reads.
-# Only the spellings that actually differ need an entry; the rest pass through.
-_PIPELINE_CONCLUSION = {"canceled": "cancelled"}
+def _norm_pipeline_run(row: dict) -> dict | None:
+    return _normalization._norm_pipeline_run(row)
 
 
 def list_pr_workflow_runs(
@@ -2337,33 +1769,8 @@ def list_pr_workflow_runs(
             paginate=False,
         )
     )
-    out: list[dict] = []
-    for row in rows:
-        if not isinstance(row, dict) or not row.get("id"):
-            continue
-        status = str(row.get("status") or "")
-        out.append({
-            "id": row.get("id"),
-            "name": row.get("name") or f"pipeline #{row.get('iid') or row.get('id')}",
-            # Normalized to the same two fields the GitHub rows use, so the UI
-            # reads one shape: GitLab reports a single status where GitHub splits
-            # status from conclusion.
-            "status": "completed" if status in _PIPELINE_FINISHED_STATES else status,
-            # Normalized to GITHUB's conclusion vocabulary, which is what the shared
-            # UI compares against: GitLab spells it "canceled" (one l) where GitHub
-            # uses "cancelled", so passing it through would leave a consumer keying
-            # on the GitHub spelling silently unable to see a cancelled pipeline.
-            "conclusion": (
-                _PIPELINE_CONCLUSION.get(status, status)
-                if status in _PIPELINE_FINISHED_STATES else None
-            ),
-            "url": row.get("web_url"),
-            "event": row.get("source"),
-            "created_at": row.get("created_at"),
-            "cancellable": status in _PIPELINE_CANCELLABLE_STATES,
-            "rerunnable": status in _PIPELINE_RETRYABLE_STATES,
-        })
-    return out
+    out = [_norm_pipeline_run(row) for row in rows]
+    return [row for row in out if row is not None]
 
 
 def cancel_workflow_run(

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_normalization.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_normalization.py
@@ -1,0 +1,495 @@
+"""Pure GitLab payload normalization for Issue Radar's shared data shapes."""
+
+from __future__ import annotations
+
+import re
+
+
+def _rows(data: object) -> list[dict]:
+    """Coerce an API response into a list of dictionaries."""
+    if not isinstance(data, list):
+        return []
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _obj(data: object) -> dict:
+    return data if isinstance(data, dict) else {}
+
+
+def _norm_state(state: object) -> str:
+    """Translate GitLab's open states to the vocabulary shared by the UI."""
+    text = str(state or "").lower()
+    if text in {"opened", "locked"}:
+        return "open"
+    return text or "open"
+
+
+def _hex_color(value: object) -> str:
+    text = str(value or "").strip().lstrip("#")
+    return text or "888888"
+
+
+def _label_names(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    return [str(name) for name in raw if isinstance(name, str) and name]
+
+
+def _username(user: object) -> str | None:
+    if not isinstance(user, dict):
+        return None
+    name = user.get("username")
+    return str(name) if name else None
+
+
+def _usernames(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    return [username for username in (_username(item) for item in raw) if username]
+
+
+_ACCESS_LEVEL_ROLES = (
+    (50, "admin"),
+    (40, "maintain"),
+    (30, "write"),
+    (20, "triage"),
+    (10, "read"),
+)
+
+
+def _role_for_access_level(level: object) -> str:
+    if not isinstance(level, (int, str)):
+        return "read"
+    try:
+        value = int(level)
+    except (TypeError, ValueError):
+        return "read"
+    for threshold, role in _ACCESS_LEVEL_ROLES:
+        if value >= threshold:
+            return role
+    return "read"
+
+
+def _permissions_for_access_level(level: int) -> dict:
+    """Map GitLab access without overstating a Reporter's push rights."""
+    return {
+        "admin": level >= 50,
+        "maintain": level >= 40,
+        "push": level >= 30,
+        "triage": level >= 20,
+        "pull": level >= 10,
+    }
+
+
+def _access_level(details: dict) -> int:
+    """Return the highest direct or inherited project access level."""
+    permissions = _obj(details.get("permissions"))
+    best = 0
+    for key in ("project_access", "group_access"):
+        entry = _obj(permissions.get(key))
+        try:
+            level = int(entry.get("access_level") or 0)
+        except (TypeError, ValueError):
+            level = 0
+        best = max(best, level)
+    return best
+
+
+def _norm_issue(raw: dict) -> dict:
+    """Normalize one GitLab issue to the shared list-row shape."""
+    return {
+        "number": raw.get("iid"),
+        "title": raw.get("title") or "",
+        "url": raw.get("web_url") or "",
+        "labels": _label_names(raw.get("labels")),
+        "comments": raw.get("user_notes_count") or 0,
+        "reactions": (raw.get("upvotes") or 0) + (raw.get("downvotes") or 0),
+        "thumbs_up": raw.get("upvotes") or 0,
+        "author_association": None,
+        "updated_at": raw.get("updated_at"),
+        "created_at": raw.get("created_at"),
+        "state": _norm_state(raw.get("state")),
+        "author": _username(raw.get("author")),
+        "assignees": _usernames(raw.get("assignees")),
+        "body": raw.get("description") or "",
+    }
+
+
+def _norm_issue_detail(raw: dict, labels_by_name: dict[str, dict]) -> dict:
+    """Normalize one issue, enriching GitLab's label names with label metadata."""
+    upvotes = raw.get("upvotes") or 0
+    downvotes = raw.get("downvotes") or 0
+    total = upvotes + downvotes
+    milestone = _obj(raw.get("milestone"))
+    return {
+        "number": raw.get("iid"),
+        "title": raw.get("title") or "",
+        "body": raw.get("description") or "",
+        "state": _norm_state(raw.get("state")),
+        "state_reason": None,
+        "url": raw.get("web_url") or "",
+        "author": _username(raw.get("author")),
+        "author_association": None,
+        "created_at": raw.get("created_at"),
+        "updated_at": raw.get("updated_at"),
+        "closed_at": raw.get("closed_at"),
+        "closed_by": _username(raw.get("closed_by")),
+        "comments": raw.get("user_notes_count") or 0,
+        "locked": bool(raw.get("discussion_locked")),
+        "labels": [
+            {
+                "name": name,
+                "color": _hex_color(labels_by_name.get(name, {}).get("color")),
+                "description": labels_by_name.get(name, {}).get("description") or "",
+            }
+            for name in _label_names(raw.get("labels"))
+        ],
+        "assignees": _usernames(raw.get("assignees")),
+        "milestone": (
+            {
+                "title": milestone.get("title"),
+                "state": milestone.get("state"),
+                "due_on": milestone.get("due_date"),
+            }
+            if milestone
+            else None
+        ),
+        "reactions": (
+            {
+                "total": total,
+                "plus1": upvotes,
+                "minus1": downvotes,
+                "laugh": 0,
+                "hooray": 0,
+                "confused": 0,
+                "heart": 0,
+                "rocket": 0,
+                "eyes": 0,
+            }
+            if total > 0
+            else None
+        ),
+    }
+
+
+def _shape_labels(raw: object) -> list[dict]:
+    out: list[dict] = []
+    for label in _rows(raw):
+        if label.get("name"):
+            out.append(
+                {
+                    "name": label.get("name"),
+                    "color": _hex_color(label.get("color")),
+                    "description": label.get("description") or "",
+                }
+            )
+    return out
+
+
+def derive_members(issues: list[dict]) -> list[dict]:
+    """Return no inferred GitLab members when the authoritative endpoint fails."""
+    # Issue authors may be external users, so treating them as members would grant
+    # a false membership badge.
+    del issues
+    return []
+
+
+_TITLE_CHANGE_RE = re.compile(r"changed title from \*\*(.*?)\*\* to \*\*(.*?)\*\*", re.DOTALL)
+_MENTION_REF_RE = re.compile(r"mentioned in (issue|merge request) ([\w./-]*[!#])(\d+)")
+_ASSIGNEE_RE = re.compile(r"@([A-Za-z0-9._-]+)")
+_COMMIT_REF_RE = re.compile(r"mentioned in commit ([0-9a-f]{7,40})")
+
+
+def norm_note(note: dict, *, patterns: tuple[tuple[str, str], ...]) -> dict | None:
+    """Normalize a note using the facade's current system-note pattern table."""
+    body = str(note.get("body") or "")
+    created = note.get("created_at")
+    actor = _username(note.get("author"))
+    if not note.get("system"):
+        return {
+            "kind": "comment",
+            "actor": actor,
+            "created_at": created,
+            "body": body,
+            "author_association": None,
+            "reactions": None,
+        }
+
+    low = body.lower()
+    kind = next(
+        (kind for prefix, kind in patterns if low.startswith(prefix)),
+        None,
+    )
+    if kind is None:
+        return None
+    if kind in ("assigned", "unassigned"):
+        match = _ASSIGNEE_RE.search(body)
+        return {
+            "kind": kind,
+            "actor": actor,
+            "created_at": created,
+            "assignee": match.group(1) if match else None,
+        }
+    if kind == "renamed":
+        match = _TITLE_CHANGE_RE.search(body)
+        return {
+            "kind": "renamed",
+            "actor": actor,
+            "created_at": created,
+            "rename": {
+                "from": match.group(1) if match else None,
+                "to": match.group(2) if match else None,
+            },
+        }
+    if kind == "cross-referenced":
+        match = _MENTION_REF_RE.search(body)
+        return {
+            "kind": "cross-referenced",
+            "actor": actor,
+            "created_at": created,
+            "source": {
+                "number": int(match.group(3)) if match else None,
+                "title": None,
+                "url": None,
+                "state": None,
+                "is_pr": bool(match and match.group(2).endswith("!")),
+            },
+        }
+    if kind == "referenced":
+        match = _COMMIT_REF_RE.search(body)
+        return {
+            "kind": "referenced",
+            "actor": actor,
+            "created_at": created,
+            "commit_id": match.group(1) if match else None,
+        }
+    if kind in ("milestoned", "demilestoned"):
+        return {"kind": kind, "actor": actor, "created_at": created, "milestone": None}
+    return None
+
+
+def _norm_label_event(event: dict, labels_by_name: dict[str, dict]) -> dict | None:
+    action = str(event.get("action") or "").lower()
+    if action not in ("add", "remove"):
+        return None
+    label = _obj(event.get("label"))
+    name = label.get("name")
+    if not name:
+        return None
+    return {
+        "kind": "labeled" if action == "add" else "unlabeled",
+        "actor": _username(event.get("user")),
+        "created_at": event.get("created_at"),
+        "label": {
+            "name": name,
+            "color": _hex_color(
+                label.get("color") or labels_by_name.get(str(name), {}).get("color")
+            ),
+        },
+    }
+
+
+def _norm_state_event(event: dict) -> dict | None:
+    state = str(event.get("state") or "").lower()
+    if state == "closed":
+        return {
+            "kind": "closed",
+            "actor": _username(event.get("user")),
+            "created_at": event.get("created_at"),
+            "state_reason": None,
+            "commit_id": None,
+        }
+    if state in ("reopened", "opened"):
+        return {
+            "kind": "reopened",
+            "actor": _username(event.get("user")),
+            "created_at": event.get("created_at"),
+        }
+    return None
+
+
+_MERGEABLE_STATUSES = frozenset({"mergeable", "can_be_merged"})
+_MERGE_STATUS_PENDING = frozenset({"checking", "unchecked", "preparing", ""})
+
+
+def _mergeable(raw: dict) -> bool | None:
+    status = str(raw.get("detailed_merge_status") or raw.get("merge_status") or "").lower()
+    if status in _MERGE_STATUS_PENDING:
+        return None
+    return status in _MERGEABLE_STATUSES
+
+
+_JOB_FAILURE_STATUSES = frozenset({"failed"})
+_JOB_RUNNING_STATUSES = frozenset(
+    {
+        "running",
+        "pending",
+        "created",
+        "waiting_for_resource",
+        "preparing",
+        "scheduled",
+    }
+)
+_JOB_OTHER_STATUSES = frozenset({"canceled", "cancelled", "skipped", "manual"})
+
+
+def _job_bucket(status: str, allow_failure: bool) -> str:
+    """Map job status without treating allowed failures as blocking."""
+    text = (status or "").lower()
+    if text in _JOB_FAILURE_STATUSES:
+        return "other" if allow_failure else "failure"
+    if text in _JOB_RUNNING_STATUSES:
+        return "running"
+    if text == "success":
+        return "success"
+    return "other"
+
+
+def _norm_job(job: dict) -> dict:
+    status = str(job.get("status") or "")
+    bucket = _job_bucket(status, bool(job.get("allow_failure")))
+    stage = job.get("stage")
+    return {
+        "name": job.get("name") or "job",
+        "status": "in_progress" if bucket == "running" else "completed",
+        "conclusion": {
+            "failure": "failure",
+            "success": "success",
+            "running": None,
+        }.get(bucket, "neutral"),
+        "bucket": bucket,
+        "url": job.get("web_url"),
+        "started_at": job.get("started_at") or job.get("created_at"),
+        "completed_at": job.get("finished_at"),
+        "summary": f"stage: {stage}" if stage else "",
+        "app": "GitLab CI",
+        "source": "gitlab-ci",
+    }
+
+
+_CHECK_BUCKETS = ("failure", "running", "success", "other")
+
+
+def summarize_checks(checks: list[dict]) -> dict:
+    """Summarize checks using the shared failure-first priority."""
+    counts = dict.fromkeys(_CHECK_BUCKETS, 0)
+    for row in checks:
+        if not isinstance(row, dict):
+            continue
+        bucket = row.get("bucket")
+        counts[bucket if isinstance(bucket, str) and bucket in counts else "other"] += 1
+    for bucket in _CHECK_BUCKETS:
+        if counts[bucket]:
+            state: str | None = bucket
+            break
+    else:
+        state = None
+    return {
+        "checks_counts": counts,
+        "checks_state": state,
+        "checks_truncated": False,
+    }
+
+
+def _pipeline_summary(raw: dict) -> dict:
+    """Derive cache-safe card enrichment from an MR's aggregate pipeline."""
+    pipeline = _obj(raw.get("head_pipeline")) or _obj(raw.get("pipeline"))
+    status = str(pipeline.get("status") or "").lower()
+    counts = dict.fromkeys(_CHECK_BUCKETS, 0)
+    state: str | None = None
+    if status:
+        state = _job_bucket(status, False)
+        counts[state] = 1
+    # GitLab's list payload has no diff counts; None avoids persisting a false 0.
+    return {
+        "additions": None,
+        "deletions": None,
+        "changed_files": None,
+        "checks_state": state,
+        "checks_counts": counts,
+        "checks_truncated": False,
+    }
+
+
+def _norm_pull(raw: dict) -> dict:
+    """Normalize one merge request to the shared pull-request row shape."""
+    state = str(raw.get("state") or "").lower()
+    row = {
+        "number": raw.get("iid"),
+        "title": raw.get("title") or "",
+        "url": raw.get("web_url") or "",
+        "state": "open" if state in ("opened", "locked") else "closed",
+        "draft": bool(
+            raw.get("draft") if raw.get("draft") is not None else raw.get("work_in_progress")
+        ),
+        "labels": _label_names(raw.get("labels")),
+        "author": _username(raw.get("author")),
+        "author_association": None,
+        "updated_at": raw.get("updated_at"),
+        "created_at": raw.get("created_at"),
+        "closed_at": raw.get("closed_at"),
+        "merged_at": raw.get("merged_at"),
+        "assignees": _usernames(raw.get("assignees")),
+        "requested_reviewers": _usernames(raw.get("reviewers")),
+        "base": raw.get("target_branch"),
+        "head": raw.get("source_branch"),
+        # List rows must carry the reviewed commit so bulk approval can be pinned.
+        "head_sha": _obj(raw.get("diff_refs")).get("head_sha") or raw.get("sha"),
+        "body": raw.get("description") or "",
+    }
+    row.update(_pipeline_summary(raw))
+    return row
+
+
+def enrich_pulls(
+    owner: str, repo: str, pulls: list[dict], state: str, *, host: str = ""
+) -> list[dict]:
+    """Return rows already enriched from GitLab's inline head pipeline."""
+    del owner, repo, state, host
+    return pulls
+
+
+def enrich_pulls_by_number(
+    owner: str, repo: str, pulls: list[dict], *, host: str = ""
+) -> list[dict]:
+    del owner, repo, host
+    return pulls
+
+
+def enrichment_complete(pulls: list[dict]) -> bool:
+    """Keep incomplete rows out of the persistent list cache."""
+    return all(pull.get("checks_counts") is not None for pull in pulls)
+
+
+_PIPELINE_CANCELLABLE_STATES = frozenset(
+    {
+        "created",
+        "waiting_for_resource",
+        "preparing",
+        "pending",
+        "running",
+        "scheduled",
+    }
+)
+_PIPELINE_RETRYABLE_STATES = frozenset({"failed", "canceled", "cancelled"})
+_PIPELINE_FINISHED_STATES = frozenset({"failed", "success", "canceled", "cancelled", "skipped"})
+_PIPELINE_CONCLUSION = {"canceled": "cancelled"}
+
+
+def _norm_pipeline_run(row: dict) -> dict | None:
+    """Normalize a pipeline and expose only actions GitLab can honor."""
+    if not row.get("id"):
+        return None
+    status = str(row.get("status") or "")
+    finished = status in _PIPELINE_FINISHED_STATES
+    return {
+        "id": row.get("id"),
+        "name": row.get("name") or f"pipeline #{row.get('iid') or row.get('id')}",
+        "status": "completed" if finished else status,
+        "conclusion": _PIPELINE_CONCLUSION.get(status, status) if finished else None,
+        "url": row.get("web_url"),
+        "event": row.get("source"),
+        "created_at": row.get("created_at"),
+        "cancellable": status in _PIPELINE_CANCELLABLE_STATES,
+        "rerunnable": status in _PIPELINE_RETRYABLE_STATES,
+    }

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_transport.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_transport.py
@@ -1,0 +1,225 @@
+"""Pure GitLab URL, environment, and API transport helpers.
+
+The executable lookup and real subprocess spawn stay in ``gitlab_client``: the
+spawn audit identifies that exact module/function as the reviewed chokepoint.
+Callers inject the current facade bindings so tests and provider integrations can
+continue patching ``gitlab_client`` without reaching into this module.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping
+from urllib.parse import quote, urlparse
+
+from .errors import (
+    ProviderCliError,
+    ProviderPermissionError,
+    ProviderSetupError,
+    RepoUrlError,
+)
+
+SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_URL_PATH_SEPARATOR = "/"
+GITLAB_RESERVED_SEGMENTS = frozenset(
+    {"-", "groups", "projects", "admin", "dashboard", "explore", "help", "users", "api"}
+)
+
+GLAB_ENV_PASSTHROUGH = (
+    "GITLAB_TOKEN",
+    "GLAB_CONFIG_DIR",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "all_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+GLAB_AUTH_MARKERS = (
+    "glab auth login",
+    "not logged in",
+    "no token provided",
+    "authentication required",
+    "requires authentication",
+    "401 unauthorized",
+    "http 401",
+)
+
+
+def parse_gitlab_repo_url(
+    link: str, *, allowed_hosts: frozenset[str] = frozenset()
+) -> tuple[str, str, str]:
+    """Parse a validated ``(host, namespace, project)`` from a GitLab URL."""
+    if not link or not isinstance(link, str):
+        raise RepoUrlError("repo link is empty")
+    try:
+        parsed = urlparse(link.strip())
+    except ValueError as exc:
+        raise RepoUrlError(f"unparseable URL: {link!r}") from exc
+    if parsed.scheme != "https":
+        raise RepoUrlError(f"not an https URL: {link!r}")
+    if parsed.username or parsed.password:
+        raise RepoUrlError("URLs with embedded credentials are not accepted")
+
+    # hostname/port parse lazily, so malformed authorities must be translated to
+    # the same client-input error as every other unusable URL.
+    try:
+        host = (parsed.hostname or "").lower().rstrip(".")
+        port = parsed.port
+    except ValueError as exc:
+        raise RepoUrlError(f"malformed host or port in {link!r}") from exc
+
+    # A portless allowlist entry must not authorize arbitrary ports. Explicit
+    # HTTPS :443 is canonicalized away to match browser URL handling.
+    candidate = f"{host}:{port}" if port and port != 443 else host
+    if host in {"gitlab.com", "www.gitlab.com"}:
+        resolved_host = "gitlab.com"
+    elif host and candidate in allowed_hosts:
+        resolved_host = candidate
+    else:
+        raise RepoUrlError(
+            f"not a supported GitLab host: {link!r} — gitlab.com is always accepted; "
+            "a self-managed instance must be listed in the dashboard.gitlab_hosts config"
+        )
+
+    path = (parsed.path or "").rstrip("/")
+    marker_index = path.find("/-/")
+    if marker_index >= 0:
+        path = path[:marker_index]
+    # URL paths use a forward slash on every host platform; this is not a
+    # filesystem path separator.
+    parts = [part for part in path.split(_URL_PATH_SEPARATOR) if part]
+    if len(parts) < 2:
+        raise RepoUrlError(f"not a full project URL: {link!r} (expected .../<group>/<project>)")
+    parts[-1] = re.sub(r"\.git$", "", parts[-1])
+    for segment in parts:
+        if segment in (".", "..") or not SEGMENT_RE.match(segment):
+            raise RepoUrlError(f"invalid path segment in {link!r}")
+    if any(segment.lower() in GITLAB_RESERVED_SEGMENTS for segment in parts):
+        raise RepoUrlError(f"{link!r} is a GitLab system path, not a project")
+    return resolved_host, _URL_PATH_SEPARATOR.join(parts[:-1]), parts[-1]
+
+
+def project_path(owner: str, repo: str) -> str:
+    """Encode a namespace/project as GitLab's single ``:id`` parameter."""
+    return quote(f"{owner}/{repo}", safe="")
+
+
+def resolve_host(host: str, *, allowed_hosts: frozenset[str]) -> str:
+    """Authorize and canonicalize a host at the subprocess boundary."""
+    if not host:
+        raise ProviderCliError("a GitLab host is required for glab calls")
+    normalized = host.lower().rstrip(".")
+    if normalized in {"gitlab.com", "www.gitlab.com"}:
+        return "gitlab.com"
+    if normalized not in allowed_hosts:
+        raise ProviderCliError(
+            f"GitLab host {normalized!r} is not listed in the dashboard.gitlab_hosts allowlist"
+        )
+    return normalized
+
+
+def glab_env(
+    host: str,
+    *,
+    source_env: Mapping[str, str],
+    passthrough_keys: tuple[str, ...],
+    minimal_env: Callable[..., dict[str, str]],
+) -> dict[str, str]:
+    """Build a minimal, host-pinned environment for ``glab``."""
+    passthrough = {key: source_env[key] for key in passthrough_keys if key in source_env}
+    # GITLAB_TOKEN has no host binding and must never cross into a private host.
+    if host != "gitlab.com":
+        passthrough.pop("GITLAB_TOKEN", None)
+    passthrough["GITLAB_HOST"] = host
+    passthrough["GLAB_PAGER"] = "cat"
+    passthrough["NO_COLOR"] = "1"
+    return minimal_env(**passthrough)
+
+
+def raise_if_auth_failure(stderr_tail: str, host: str, *, markers: tuple[str, ...]) -> None:
+    """Map an unauthenticated CLI failure to an actionable setup error."""
+    low = (stderr_tail or "").lower()
+    if any(marker in low for marker in markers):
+        raise ProviderSetupError(
+            f"the `glab` CLI is not authenticated for {host} — "
+            f"run `glab auth login --hostname {host}`",
+            reason="not_authenticated",
+        )
+
+
+def stderr_tail(proc: subprocess.CompletedProcess, *, sanitize: Callable[[str], str]) -> str:
+    """Return the sanitized final three stderr lines."""
+    return sanitize(" ".join((proc.stderr or "").strip().splitlines()[-3:]))
+
+
+def is_forbidden(tail: str) -> bool:
+    """Whether stderr identifies an authorization failure."""
+    low = (tail or "").lower()
+    return "403" in low or "forbidden" in low or "insufficient" in low
+
+
+def glab_api(
+    path: str,
+    *,
+    host: str,
+    timeout: float,
+    paginate: bool,
+    method: str,
+    body: dict | None,
+    run: Callable[..., subprocess.CompletedProcess],
+    page_size: int,
+    max_pages: int,
+    stderr_tail: Callable[[subprocess.CompletedProcess], str],
+    raise_if_auth_failure: Callable[[str, str], None],
+    is_forbidden: Callable[[str], bool],
+) -> object:
+    """Run ``glab api`` through an injected spawn and parse explicit pages."""
+    pages: list[object] = []
+    page = 1
+    while True:
+        separator = "&" if "?" in path else "?"
+        target = f"{path}{separator}page={page}&per_page={page_size}" if paginate else path
+        argv = ["glab", "api", target]
+        if method != "GET":
+            argv += ["--method", method]
+        input_text = None
+        if body is not None:
+            argv += ["--input", "-"]
+            input_text = json.dumps(body)
+
+        proc = run(argv, host=host, timeout=timeout, input_text=input_text)
+        if proc.returncode != 0:
+            tail = stderr_tail(proc)
+            raise_if_auth_failure(tail, host)
+            if is_forbidden(tail):
+                raise ProviderPermissionError(
+                    f"glab api {path} was forbidden (exit {proc.returncode}): {tail}"
+                )
+            raise ProviderCliError(f"glab api {path} failed (exit {proc.returncode}): {tail}")
+
+        text = (proc.stdout or "").strip()
+        if not text:
+            data: object = [] if paginate else {}
+        else:
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ProviderCliError(f"glab returned unexpected output for {path}") from exc
+        if not paginate:
+            return data
+        if not isinstance(data, list):
+            return data
+        pages.extend(data)
+        if len(data) < page_size or page >= max_pages:
+            return pages
+        page += 1

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_azure_transport.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_azure_transport.py
@@ -81,6 +81,11 @@ class TestOrgUrl(unittest.TestCase):
     def test_the_org_url_is_always_on_the_pinned_host(self):
         self.assertEqual(azure_client._org_url("contoso"), "https://dev.azure.com/contoso")
 
+    def test_facade_quote_patch_seam_remains_authoritative(self):
+        with mock.patch.object(azure_client, "quote", return_value="encoded") as quote:
+            self.assertEqual(azure_client._org_url("contoso"), "https://dev.azure.com/encoded")
+        quote.assert_called_once_with("contoso", safe="")
+
     def test_the_org_becomes_exactly_one_path_segment(self):
         # Encoded with safe='', so a separator inside the name cannot add a
         # segment and retarget the call at a different organization. The segment
@@ -367,6 +372,12 @@ class TestAzEnv(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(env.get(key), value)
 
+    def test_facade_minimal_env_patch_seam_remains_authoritative(self):
+        shaped = {"SENTINEL": "facade"}
+        with mock.patch.object(azure_client, "minimal_env", return_value=shaped) as build:
+            self.assertIs(azure_client._az_env(HOST), shaped)
+        build.assert_called_once()
+
     def test_the_personal_access_token_is_forwarded_only_for_the_pinned_host(self):
         # It is one ambient credential with no host binding, so forwarding it to
         # any other host would hand that server a dev.azure.com credential.
@@ -595,6 +606,14 @@ class TestFailureClassification(unittest.TestCase):
         proc = _proc(stderr="usage: az\nline2\nfirst\nsecond\nthird\n")
         self.assertEqual(azure_client._stderr_tail(proc), "first second third")
         self.assertEqual(azure_client._stderr_tail(_proc(stderr="")), "")
+
+    def test_facade_sanitizer_patch_seam_remains_authoritative(self):
+        proc = _proc(stderr="secret")
+        with mock.patch.object(
+            azure_client, "sanitize_cli_stderr", return_value="clean"
+        ) as sanitize:
+            self.assertEqual(azure_client._stderr_tail(proc), "clean")
+        sanitize.assert_called_once_with("secret")
 
     def test_forbidden_is_detected_by_status_and_by_prose(self):
         # Azure answers a permission problem three different ways depending on the
@@ -965,6 +984,57 @@ class TestAzInvokePaged(unittest.TestCase):
             return [{"id": 1}, {"id": 2}]
 
         self.assertEqual(self._walk(invoke, limit=2), [{"id": 1}, {"id": 2}])
+
+
+class TestTransportFacadeBindings(unittest.TestCase):
+    """The extracted helpers must still obey azure_client's patch boundary."""
+
+    def test_invoke_injects_the_facades_current_spawn_and_body_bindings(self):
+        captured: dict = {}
+        spawn = mock.Mock(name="patched_az_run")
+        body_file = mock.Mock(name="patched_body_file")
+
+        def invoke(**kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+        with mock.patch.object(azure_client._transport, "invoke", side_effect=invoke):
+            with mock.patch.object(azure_client, "_az_run", spawn):
+                with mock.patch.object(azure_client, "_body_file", body_file):
+                    out = azure_client._az_invoke(
+                        org="contoso",
+                        area="git",
+                        resource="repositories",
+                        host=HOST,
+                        api_version="7.1",
+                    )
+
+        self.assertEqual(out, {"ok": True})
+        self.assertIs(captured["run"], spawn)
+        self.assertIs(captured["body_file"], body_file)
+
+    def test_pager_injects_the_facades_current_invoke_binding(self):
+        captured: dict = {}
+        invoke_one = mock.Mock(name="patched_az_invoke")
+
+        def invoke_paged(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with mock.patch.object(azure_client._transport, "invoke_paged", side_effect=invoke_paged):
+            with mock.patch.object(azure_client, "_az_invoke", invoke_one):
+                out = azure_client._az_invoke_paged(
+                    org="contoso",
+                    area="git",
+                    resource="repositories",
+                    host=HOST,
+                    timeout=3.0,
+                    api_version="7.1",
+                )
+
+        self.assertEqual(out, [])
+        self.assertIs(captured["invoke_one"], invoke_one)
+        self.assertIs(captured["values"], azure_client._values)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_github_client_boundaries.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_github_client_boundaries.py
@@ -1,0 +1,85 @@
+"""Compatibility seams for the split GitHub client facade."""
+
+import subprocess
+from unittest import mock
+
+from kiro_crew.apps.builtins.issue_radar.backend import github_client as gh
+
+
+def test_api_transport_uses_the_facades_current_runner():
+    proc = subprocess.CompletedProcess([], 0, stdout='{"number": 7}\n', stderr="")
+    with mock.patch.object(gh, "_gh_run", return_value=proc) as run:
+        assert gh._run_gh_api("repos/o/r/issues", ".[]", paginate=False) == [{"number": 7}]
+
+    run.assert_called_once_with(
+        ["gh", "api", "repos/o/r/issues", "--jq", ".[]"],
+        timeout=gh.GH_TIMEOUT_SEC,
+    )
+
+
+def test_transport_errors_use_the_facades_current_sanitizer():
+    proc = subprocess.CompletedProcess([], 1, stdout="", stderr="private path")
+    with (
+        mock.patch.object(gh, "_gh_run", return_value=proc),
+        mock.patch.object(gh, "sanitize_cli_stderr", return_value="clean") as sanitize,
+    ):
+        try:
+            gh._run_gh_api("repos/o/r/issues", ".[]", paginate=False)
+        except gh.GhCliError as exc:
+            assert str(exc).endswith(": clean")
+        else:  # pragma: no cover - the transport must reject a non-zero exit
+            raise AssertionError("expected GhCliError")
+
+    sanitize.assert_called_once_with("private path")
+
+
+def test_timeline_normalizer_uses_the_facades_current_reaction_helper():
+    shaped = {"total": 41}
+    event = {
+        "event": "commented",
+        "user": {"login": "octo"},
+        "reactions": {"total_count": 1},
+    }
+    with mock.patch.object(gh, "_norm_reactions", return_value=shaped) as normalize:
+        normalized = gh._normalize_timeline_event(event)
+        assert normalized is not None
+        assert normalized["reactions"] is shaped
+
+    normalize.assert_called_once_with({"total_count": 1})
+
+
+def test_summary_query_uses_the_facades_current_runner_and_parser():
+    proc = subprocess.CompletedProcess([], 0, stdout="raw rows", stderr="")
+    expected = {7: {"additions": 2}}
+    with (
+        mock.patch.object(gh, "_gh_run", return_value=proc) as run,
+        mock.patch.object(gh, "_parse_summary_rows", return_value=expected) as parse,
+    ):
+        assert gh.fetch_pr_summaries("o", "r") == expected
+
+    run.assert_called_once()
+    parse.assert_called_once_with("raw rows")
+
+
+def test_search_uses_the_facades_current_builder_and_api_reader():
+    query = "repo:o/r is:pr is:open author:octo"
+    rows = [{"number": 7}]
+    with (
+        mock.patch.object(gh, "build_pr_search_query", return_value=query) as build,
+        mock.patch.object(gh, "_run_gh_api", return_value=rows) as run_api,
+    ):
+        assert gh.search_pulls("o", "r", author="octo", limit=1) == rows
+
+    build.assert_called_once_with(
+        "o",
+        "r",
+        state="open",
+        author="octo",
+        assignee=None,
+        review_requested=None,
+    )
+    assert run_api.call_args.args[1] is gh._PR_SEARCH_JQ
+    assert run_api.call_args.kwargs == {
+        "timeout": gh.GH_PAGINATE_TIMEOUT_SEC,
+        "paginate": False,
+    }

--- a/test/test_gitlab_client_boundaries.py
+++ b/test/test_gitlab_client_boundaries.py
@@ -1,0 +1,23 @@
+"""Compatibility tests for the GitLab client facade boundaries."""
+
+from kiro_crew.apps.builtins.issue_radar.backend import gitlab_client as gl
+
+
+def test_api_facade_injects_current_patch_bindings(monkeypatch):
+    patched_run = object()
+    captured = {}
+
+    def api_helper(path, **kwargs):
+        captured["path"] = path
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(gl, "_glab_run", patched_run)
+    monkeypatch.setattr(gl, "_PAGE_SIZE", 17)
+    monkeypatch.setattr(gl, "_MAX_PAGES", 9)
+    monkeypatch.setattr(gl._transport, "glab_api", api_helper)
+
+    assert gl._glab_api("user", host="gitlab.com", paginate=True) == {"ok": True}
+    assert captured["run"] is patched_run
+    assert captured["page_size"] == 17
+    assert captured["max_pages"] == 9


### PR DESCRIPTION
## Problem / Motivation

Issue Radar's provider clients combine their stable route-facing API with transport mechanics, payload normalization, and query orchestration. That coupling makes provider changes harder to review and risks breaking long-standing import and monkeypatch seams.

## Why it matters

Routes, parity checks, tests, and spawn audits rely on `github_client`, `gitlab_client`, and `azure_client` as stable provider boundaries. Separating responsibilities makes those implementations easier to maintain without changing provider behavior.

## What changed (motivation → approach → change)

- Kept the three client modules as composition façades, retaining their protocol surface, exception aliases, constants, and patchable I/O chokepoints.
- Extracted provider transport and normalization into `*_transport.py` and `*_normalization.py`.
- Extracted GitHub GraphQL, dependency, readiness, and search planning into `github_queries.py`.
- Injected each façade's current bindings into the helpers so existing monkeypatch seams remain authoritative.
- Updated the Issue Radar system spec to document these boundaries and the retained CLI spawn chokepoints.

This refactor is intended to be behavior-preserving: no request or provider behavior is meant to change, and no UI files or user-facing workflows changed.

## Tests

- Added compatibility coverage for Azure façade bindings, GitHub transport/normalization/query seams, and GitLab runner and pagination bindings.
- SHA-current targeted suite at `e7a1d3d`: **1,364 passed, 57 skipped**, with one xdist deprecation warning.
- Static validation at the same SHA was green, including Black ratchet, isort, flake8, mypy across 1,245 source files, repository policy checks, documentation across 251 Markdown files, the 46-file vendor manifest, scrub, and committed/worktree diff checks.
- Frontend validation was green after retrying two host-level startup races: 5,347 scoped tests, 1,499 Electron tests with 2 skips, TypeScript, ESLint at the 603-warning ceiling, production build, duplicate-code, analyze, and bundle-size gates.
- The canonical backend diagnostic collected 76,252 tests and stopped at five setup errors after 4,950 passed and 137 skipped. All five occurred in `test/test_app_art_route.py` because this Windows host lacks symlink privilege (`OSError [WinError 1314]`); no Issue Radar test failed. Linux CI remains authoritative for those symlink-dependent cases.

## Manual verification

Local GPT-contract and reduced-fidelity Opus-contract reviews at `e7a1d3d` reported no findings; true Claude was unavailable locally.

N/A — there is no UI change, so product walkthroughs and screenshots/video are not applicable.

## Related Issues

No linked issue: this is an internal behavior-preserving refactor.

At review time, the sole overlap with an open PR is #7560, which adds explicit UTF-8 decoding to `azure_client.py`. That behavior change is intentionally not absorbed here: `_az_run` retains its current `text=True` decoding so this refactor remains behavior-preserving.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->