### PR TITLE
fix(discord): deny uploads by default when caller forgets the gate

### DIFF
--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -449,7 +449,7 @@ class DiscordRenderer(Renderer):
         capabilities: TransportCapabilities,
         *,
         session_key: str = "",
-        uploads_allowed: bool = True,
+        uploads_allowed: bool = False,
         upload_root: str = "",
         react_message_id: str = "",
         reactions_enabled: bool = True,

--- a/test/test_channel_table_rendering.py
+++ b/test/test_channel_table_rendering.py
@@ -1058,7 +1058,11 @@ class TestTableCardNeverBuriesAnUpload:
     @staticmethod
     def _uploading_renderer() -> tuple[FakeDiscordClient, DiscordRenderer]:
         client = FakeDiscordClient()
-        renderer = DiscordRenderer(client, "chan", DISCORD_CAPABILITIES, session_key="sk")
+        # Explicit opt-in: the renderer defaults to deny, so upload-exercising
+        # fixtures must pass the gate like production does.
+        renderer = DiscordRenderer(
+            client, "chan", DISCORD_CAPABILITIES, session_key="sk", uploads_allowed=True
+        )
         renderer.authorize_upload_root("/tmp")  # string only; touches no filesystem
         assert renderer._uploads_enabled(), "fixture must model an upload-capable transport"
         return client, renderer
@@ -1105,7 +1109,9 @@ class TestTableCardNeverBuriesAnUpload:
         image = tmp_path / "cat.png"
         image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 128)
         client = FakeDiscordClient()
-        renderer = DiscordRenderer(client, "chan", DISCORD_CAPABILITIES, session_key="sk")
+        renderer = DiscordRenderer(
+            client, "chan", DISCORD_CAPABILITIES, session_key="sk", uploads_allowed=True
+        )
         renderer.authorize_upload_root(str(tmp_path))
         rows = "\n".join(
             "| Provider "

--- a/test/test_discord_outbound_files.py
+++ b/test/test_discord_outbound_files.py
@@ -48,6 +48,10 @@ def _file(path: str = "/tmp/a.png", *, data: bytes = _PNG, alt: str = "", mime: 
 def _renderer(**kw: Any) -> tuple[DiscordRenderer, FakeClient]:
     cli, caps = FakeClient(), kw.pop("capabilities", None) or DISCORD_CAPABILITIES
     root = kw.pop("upload_root", _TEST_UPLOAD_ROOT)
+    # Explicit opt-in: the renderer defaults to deny, so upload-exercising
+    # tests must pass the gate like production does (tests for the denied
+    # path pass uploads_allowed=False explicitly).
+    kw.setdefault("uploads_allowed", True)
     r = DiscordRenderer(cli, "chan1", caps, session_key="discord:u1", upload_root=root, **kw)  # type: ignore[arg-type]
     return r, cli
 


### PR DESCRIPTION
## Problem / Motivation
`DiscordRenderer.__init__` (`src/kiro_crew/discord/renderer.py:471`) defaulted `uploads_allowed=True`. The only production construction passes the resolved gate (`transport_dispatch.py:538` `uploads_allowed=not _uploads_restricted`), so the permissive default is only reachable by a caller that forgot to pass the gate.

## Why it matters
A forgotten upload gate should deny, not open an upload path. The permissive default is the unsafe answer for a forgotten flag.

## What changed (motivation â†’ approach â†’ change)
Permissive default â†’ deny-by-default. Flipped `uploads_allowed: bool = True` â†’ `False`. No caller change needed; production already passes the resolved value. The other half of #7540 (declare context-degrading tier in `split_markdown_safe`) needs a design call on API shape and is left for a human.

## Tests
- No behavior change for production path (`transport_dispatch.py` still passes `not _uploads_restricted`).
- Upload-exercising fixtures now pass `uploads_allowed=True` explicitly (`test_discord_outbound_files._renderer` default, `test_channel_table_rendering._uploading_renderer` + overlong-card case), mirroring production's resolved pass-through; denied-path tests already passed the flag and are untouched (78 + 82 + 227 passed locally).
- `black`/`isort`/`flake8` clean.

## Manual verification
N/A â€” unit coverage sufficient; manual would require constructing a renderer without `uploads_allowed` and attempting an upload.

## Screenshots / video
N/A â€” no UI change.

## Related Issues
Part of #7540

## Pattern harvest

Rule candidate: deny-by-default

Pattern: a permissive default (`uploads_allowed=True`) is only reachable by a caller that forgot to pass the resolved gate; flipping to `False` makes the forgotten case safe.

## Checklist
- [x] At most two commits (two: fix + fixture follow-up), Conventional Commits titles
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation not applicable
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
