### PR TITLE
fix(theme): keep overlay below topbar in macOS fullscreen

### DIFF
--- a/website/src/components/ThemeExperienceLayer.tsx
+++ b/website/src/components/ThemeExperienceLayer.tsx
@@ -50,9 +50,9 @@ const MAX_CONCURRENT_SOUNDS = 4
 // on the runtime resize path (see the Message Router).
 const TOPBAR_MAX_PX = 200
 // Overlay zIndex ceiling: the backend allows up to 9999, but overlays must sit
-// below the topbar's peers and, critically, below the mute button (z=50) and
-// the consent modal (z=120) so those stay clickable. Clamp to the 45 band.
-const OVERLAY_Z_MAX = 45
+// below the topbar (z=45) and, critically, below the mute button (z=50) and
+// the consent modal (z=120) so those stay clickable. Clamp below the topbar.
+const OVERLAY_Z_MAX = 44
 // `activate` + `once` overlays play a one-shot animation on theme activation.
 // The wire carries no per-overlay duration, so we auto-unmount after this
 // window (agent-chosen default; the overlay may also self-hide via


### PR DESCRIPTION
## Problem / Motivation
Fullscreen theme overlays (Knight Rider / Miami Vice) default to `position: fullscreen` with `OVERLAY_Z_MAX=45` (`website/src/components/ThemeExperienceLayer.tsx:54`). The topbar header is also `z-[45]` (`website/src/App.tsx:2786`). At 45 they tie and DOM paint order wins, visible as animation over the top panel in macOS native fullscreen.

## Why it matters
macOS fullscreen leaves the topbar as the only window chrome; an overlay that paints over it breaks the only navigation chrome left.

## What changed (motivation â†’ approach â†’ change)
Tie at 45 â†’ clamp below the topbar. `OVERLAY_Z_MAX 45â†’44` (`ThemeExperienceLayer.tsx:54`) so `overlay 44 < topbar 45 < mute 50 < modal 120` and the existing mute/consent contracts stay intact. Comment updated to name the topbar order.

## Tests
- Verified header `z-[45]` and overlay `45` tie on main; after, overlay `44`.
- `tsc -p tsconfig.app.json --noEmit` shows no errors for changed files.

## Manual verification
Would require macOS fullscreen with Knight Rider pack; change is contract-only (no pack CSS in repo).

## Screenshots / video
N/A â€” z-index contract change; visual proof requires macOS fullscreen video commit in `temp-screenshots/` but not needed for review (pack CSS not in repo).

## Related Issues
Fixes #7377

## Pattern harvest

Rule candidate: z-index tie

Pattern: a fullscreen overlay clamped to the same z-index as the topbar chrome (`45`) ties and DOM order decides the winner; lowering the clamp to `44` restores the documented order `overlay < topbar < mute < modal`.

## Checklist
- [x] At most two commits (one), Conventional Commits title `fix(theme): keep overlay below topbar in macOS fullscreen`
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation not applicable
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
