### PR TITLE
fix(scrub): add narrow test/ pass for internal review URLs and review ids (#7416)

### DIFF
--- a/scripts/scrub-allowlist.txt
+++ b/scripts/scrub-allowlist.txt
@@ -61,6 +61,15 @@ AGENTS.md:.*device-posture tunnels
 scripts/scrub-lint.sh
 scripts/scrub-allowlist.txt
 
+# Self-test fixture for the review-marker test/ pass: the file exists only
+# while ``./scripts/scrub-lint.sh --test`` runs, planted to prove that an
+# allowlisted entry is honoured. Anchored to the WHOLE reported line
+# (^path:lineno:exact-probe-text$), so the only line this can ever drop is the
+# harmless probe text itself — a line that carries the review id PLUS any other
+# content (an internal URL, a real marker) does not match and still fails the
+# gate, and so does any other marker in this path.
+^test/__scrub_test_marker_allowed\.py:[0-9]*:# test marker: review CR-9999999$
+
 # Security path-blocklists: ``.midway`` is blocked so the agent cannot read a
 # credential dir an enterprise companion may create (a security feature, kept).
 website/src/utils/safePath.ts:.*\.midway

--- a/scripts/scrub-lint.sh
+++ b/scripts/scrub-lint.sh
@@ -31,6 +31,26 @@ dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
 if [[ "${1:-}" == "--test" ]]; then
   dim "Running self-test..."
   MARKER_FILE="src/__scrub_test_marker.py"
+  TEST_MARKER_FILE="test/__scrub_test_marker.py"
+  ALLOWED_MARKER_FILE="test/__scrub_test_marker_allowed.py"
+
+  # The probe paths are fixed (the allowlist anchors to one of them), so refuse
+  # to run if any already exists: planting would truncate a file this process
+  # does not own — leftover residue from an aborted run, or a concurrent
+  # self-test's live probe. -L catches what -e misses: a DANGLING symlink at a
+  # probe path would be followed by the redirection, creating its target
+  # outside the checkout while cleanup removed only the link.
+  for f in "$MARKER_FILE" "$TEST_MARKER_FILE" "$ALLOWED_MARKER_FILE"; do
+    if [[ -e "$f" || -L "$f" ]]; then
+      red "SELF-TEST ABORT: $f already exists — refusing to overwrite it."
+      red "  Remove it (or wait for a concurrent self-test to finish) and re-run."
+      exit 1
+    fi
+  done
+  # Remove the probes on EVERY exit, interrupts included: residue under test/
+  # is collected by pytest, and residue at the allowlisted path is the one file
+  # the gate is blind to — the only residue that could be committed CI-green.
+  trap 'rm -f "$MARKER_FILE" "$TEST_MARKER_FILE" "$ALLOWED_MARKER_FILE"' EXIT
 
   # Plant markers that should each trigger the scan. One probe per pattern
   # FAMILY, so a typo that silently breaks a family is caught here rather than
@@ -59,8 +79,42 @@ if [[ "${1:-}" == "--test" ]]; then
     fi
     rm -f "$MARKER_FILE"
   done
+  # The narrow ``test/`` passes need probes planted UNDER test/: a marker there
+  # exercises the test-tree pass wiring itself, which a probe under src/
+  # (already caught by check 1's broad pattern) cannot.
+  TEST_PROBES=(
+    'review-url|# test marker: see code.amazon.com/reviews/example'
+    'review-id|# test marker: review CR-1200456'
+  )
+  for probe in "${TEST_PROBES[@]}"; do
+    probe_label="${probe%%|*}"
+    probe_line="${probe#*|}"
+    printf '%s\n' "$probe_line" > "$TEST_MARKER_FILE"
+    if "$SELF" --no-history >/dev/null 2>&1 </dev/null; then
+      red "SELF-TEST FAIL: planted $probe_label marker under test/ was not detected"
+      probe_fail=1
+    else
+      green "  ✓ Planted $probe_label marker under test/ correctly detected"
+    fi
+    rm -f "$TEST_MARKER_FILE"
+  done
+  # An allowlisted entry must still pass: the allowlist carries a line-anchored
+  # entry for THIS marker file and id, so the same review-id shape planted there
+  # is filtered out. Judge by whether the OUTPUT names the marker file, not by
+  # the child's whole-run exit code — an unrelated failure elsewhere in the tree
+  # (alias file present locally, an identity or credential hit) would otherwise
+  # be misreported as this probe's failure. Same style as the clean-tree block
+  # below, and for the same reason.
+  printf '%s\n' '# test marker: review CR-9999999' > "$ALLOWED_MARKER_FILE"
+  allowed_output=$("$SELF" --no-history 2>&1 </dev/null || true)
+  if echo "$allowed_output" | grep -q "__scrub_test_marker_allowed"; then
+    red "SELF-TEST FAIL: allowlisted review-id marker under test/ was reported"
+    probe_fail=1
+  else
+    green "  ✓ Allowlisted review-id marker under test/ correctly ignored"
+  fi
+  rm -f "$ALLOWED_MARKER_FILE"
   if [[ $probe_fail -ne 0 ]]; then
-    rm -f "$MARKER_FILE"
     exit 1
   fi
 
@@ -86,7 +140,19 @@ fi
 # ---------------------------------------------------------------------------
 dim "[1/5] Scanning working tree for internal markers..."
 
-INTERNAL_PATTERN='amazon\.com|a2z\.com|aws\.dev|\.amazon\.|code\.amazon|t\.corp|sim\.amazon|isengard|phonetool|midway-auth|mwinit|brazil ws|brazil-build|brazil-runtime|brazil-pkg-cache|meshclaw|Mesh-[0-9]|AVP-[0-9]|account.?[0-9]{12}|CR-[0-9]{6,}|\bP[0-9]{6,}\b'
+# Internal code-review markers — the review host and the review-id shape — are
+# needed in two working-tree scans: as alternatives of check 1's broad pattern
+# (as always) and by a narrow ``test/`` pass further down (see the ARCC pass for
+# why ``test/`` gets narrow per-class passes instead of the broad pattern).
+# Defined once so those two scans cannot drift apart. The git-history scan
+# (check 5) keeps its own copies of these literals: HISTORY_PATTERN scans commit
+# metadata, is tracked as a separate sign-off-gated task, and is deliberately
+# not restructured here.
+REVIEW_PATTERN='code\.amazon|CR-[0-9]{6,}'
+
+INTERNAL_PATTERN='amazon\.com|a2z\.com|aws\.dev|\.amazon\.|t\.corp|sim\.amazon|isengard|phonetool|midway-auth|mwinit|brazil ws|brazil-build|brazil-runtime|brazil-pkg-cache|meshclaw|Mesh-[0-9]|AVP-[0-9]|account.?[0-9]{12}|\bP[0-9]{6,}\b'
+
+INTERNAL_PATTERN="$INTERNAL_PATTERN|$REVIEW_PATTERN"
 
 # The internal package manager (AIM) needs a NARROW pattern, not a bare word:
 # ``--aim``/``bg-aim``/``text-aim`` is an unrelated CSS color token used ~40
@@ -133,6 +199,22 @@ arcc_test_matches=$(grep -rniE "$ARCC_PATTERN" test/ \
   --include='*.py' --include='*.md' --include='*.json' 2>/dev/null || true)
 matches=$(printf '%s\n%s\n' "$matches" "$arcc_test_matches")
 matches=$(echo "$matches" | grep -v '^$' || true)
+
+# Internal code-review markers get the same narrow treatment — the third
+# instance of the pattern the ARCC comment above describes. Check 1's broad
+# pattern already carries the review host and the review-id shape (via
+# REVIEW_PATTERN above), but check 1 never scans ``test/``, and the passes that
+# do (the ARCC pass above, the identity scan below) match neither alternative —
+# so a review URL or review id under ``test/`` was reported by no pass at all.
+# A legitimate review-id-shaped FIXTURE under ``test/`` takes a line-anchored
+# allowlist entry; an incidental one is better reshaped to a non-matching
+# token (e.g. ``TICKET-1234567``).
+review_test_matches=$(grep -rniE "$REVIEW_PATTERN" test/ \
+  --include='*.py' --include='*.md' --include='*.json' 2>/dev/null || true)
+matches=$(printf '%s\n%s\n' "$matches" "$review_test_matches")
+# Dedupe: a test/ line can match more than one narrow pass (ARCC + review) and
+# would otherwise be reported and counted twice.
+matches=$(echo "$matches" | grep -v '^$' | awk '!seen[$0]++' || true)
 
 # Filter out allowlisted paths
 if [[ -f "$ALLOWLIST" ]]; then

--- a/test/test_dashboard_sessions_search.py
+++ b/test/test_dashboard_sessions_search.py
@@ -35,10 +35,10 @@ class TestSessionsSearchHandler:
     @pytest.mark.asyncio
     async def test_matches_content(self, tmp_path):
         log = ConversationLog(base_dir=tmp_path)
-        log.append("alpha", "user", "discussed CR-1234567 today")
+        log.append("alpha", "user", "discussed TICKET-1234567 today")
         log.append("beta", "user", "unrelated")
         async with TestClient(TestServer(_make_app(log))) as client:
-            resp = await client.get("/api/sessions/search?q=CR-1234567")
+            resp = await client.get("/api/sessions/search?q=TICKET-1234567")
             keys = [s["key"] for s in (await resp.json())["sessions"]]
             assert keys == ["alpha"]
 

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -554,9 +554,9 @@ class TestSearchSessions:
 
     def test_matches_content(self, tmp_path):
         log = ConversationLog(base_dir=tmp_path)
-        log.append("alpha", "user", "discussed CR-1234567 today")
+        log.append("alpha", "user", "discussed TICKET-1234567 today")
         log.append("beta", "user", "unrelated chat")
-        results = log.search_sessions("CR-1234567")
+        results = log.search_sessions("TICKET-1234567")
         keys = [s["key"] for s in results]
         assert keys == ["alpha"]
 


### PR DESCRIPTION
## Summary

`scripts/scrub-lint.sh` check 1 carries the internal code-review host and the review-id shape (`CR-` + 6+ digits) in its broad `INTERNAL_PATTERN`, but check 1 never scans `test/` — and the passes that do (the narrow ARCC pass, the identity scan) match neither alternative. An internal review URL or review id placed under `test/` was therefore reported by no pass and the gate exited 0, while the same marker under `src/` exits 1.

This is the third instance of the pattern the script's own ARCC comment documents: a marker class that reaches the public tree via `test/` gets its own NARROW pass covering `test/`. Widening check 1 to `test/` stays deliberately out of scope (the script records it hits 291 legitimate fixture lines across 29 files).

## Changes

- **`scripts/scrub-lint.sh`**
  - Extract the two review-marker alternatives into `REVIEW_PATTERN`, single-sourced between check 1 (re-appended, semantics unchanged — alternation order is match-irrelevant) and a new narrow pass. The git-history scan keeps its own literals, as the comment now states explicitly: it is a separate sign-off-gated task and deliberately untouched here.
  - Add the narrow `test/` pass mirroring the ARCC pass structure: `grep -rniE` over `test/` with the same includes, merged into `matches` before allowlist filtering, same failure reporting. Merged matches are deduped so a line matching two narrow passes is reported once.
  - Self-test: two new probes planted UNDER `test/` (a review URL and a review id — a probe under `src/` cannot exercise the test-tree wiring), plus a positive case proving an allowlisted entry passes. The allowlisted probe is judged by whether the output names the marker file, not the child's whole-run exit code, matching the existing clean-tree block's style. Probe paths are declared up front, the self-test refuses to run if any probe path already exists (never truncates a file it did not create), and an `EXIT` trap removes the probes on every exit path including interrupts — residue at the allowlisted path would be the one file the gate is blind to.
- **`scripts/scrub-allowlist.txt`** — line-anchored entry for the self-test's allowlisted-pass fixture (`test/__scrub_test_marker_allowed.py:.*CR-9999999`); any other marker in that path still fails.
- **`test/test_dashboard_sessions_search.py`, `test/test_history.py`** — corpus sweep found exactly 4 incidental `CR-1234567` search-fixture tokens (the only 6+-digit `CR-` strings under `test/`; every other `CR-` fixture is ≤5 digits, below the `{6,}` floor). Reshaped to `TICKET-1234567` per the issue's preference for non-matching shapes over allowlist growth; the reshape preserves the hyphen + uppercase + digits shape the search assertions depend on.

## Testing

- `./scripts/scrub-lint.sh --test`: all 9 probes green, including the two new `test/`-planted probes and the allowlisted-pass case.
- Direct repro: a review URL / review id planted under `test/` now exits 1 with the standard failure report; the same marker under `src/` still exits 1 (check 1 unchanged); clean tree exits 0.
- Abort path verified: a pre-existing file at a probe path makes `--test` refuse and exit without touching it.
- `isort --check-only`, `flake8`, `mypy` (1237 files, clean), diff-scoped black / subprocess-encoding / brand gates all pass post-commit.
- `test/test_dashboard_sessions_search.py` + `test/test_history.py`: 314 passed.
- Full backend suite: 78,780 passed; the 92 fails + 2 errors are host-environmental on this desk (AF_UNIX path length under a deep scratch dir, AppArmor ancestor-chain and gh-binary provider checks) in files this change does not touch.

Pre-push review: GPT (`gpt-5.6-sol`) and Opus (`claude-opus-5`) lanes both run; all findings (1 Medium from GPT, 3 Medium + 1 Low from Opus) fixed in this commit — probe clobber refusal + EXIT trap, output-keyed allowlist probe, history-pattern comment correction, merged-match dedupe.

## Pattern harvest

Rule candidate: scrub-lint self-review step
Pattern: a marker class whose alternatives live only in check 1's broad `INTERNAL_PATTERN` is invisible under `test/` — check 1 deliberately excludes that tree. This is the third narrow-pass instance (ARCC, identity, now review markers), so the recurring defect is "new marker class added to the broad pattern without asking whether it can reach the public tree via `test/`". The new pass's self-test probes lock this instance in; the generalizable check is a review-time question on any future `INTERNAL_PATTERN` addition: can this class appear under `test/`, and if so does it need its own narrow pass or an explicit fixture-legitimacy note in the script comment.

Closes #7416
