### PR TITLE
fix(irq): inject the watch kernel's clock so floor tests are deterministic

### DIFF
--- a/src/kiro_crew/irq.py
+++ b/src/kiro_crew/irq.py
@@ -68,6 +68,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Callable
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.cron_script import Done, Report, Skip
@@ -521,6 +522,7 @@ def run(
     max_consecutive_errors: int = DEFAULT_MAX_CONSECUTIVE_ERRORS,
     coalesce_secs: float = DEFAULT_COALESCE_SECS,
     coalesce_max_secs: float = DEFAULT_COALESCE_MAX_SECS,
+    clock: Callable[[], float] = time.time,
 ) -> None:
     """Run one tick of *probe* and raise the kernel's verdict.
 
@@ -562,6 +564,11 @@ def run(
     convergence that never happened. ``coalesce_max_secs`` is the wall-clock
     wall for a ``pending`` count that never drains, so the worst case is a
     delayed wake, never a dropped one.
+
+    ``clock`` is the wall-clock source, injectable so tests can freeze it and
+    step it by hand: with a clock that only moves when the test moves it, the
+    floor/cap/age math becomes exact instead of racing real scheduling. It
+    defaults to ``time.time``; production callers pass nothing.
     """
     try:
         subject_kind, subject_id = probe.identity(ctx)
@@ -681,7 +688,7 @@ def run(
             # persisted count passes the threshold and never equals it again.
             alerted = state.setdefault("alerted", {})
             blind_ts = _coerce_ts(alerted.get("blind"))
-            now = time.time()
+            now = clock()
             # 0 <= elapsed: a future timestamp (clock rollback, corrupt
             # state) must read as stale, not suppress the alert forever.
             fresh = blind_ts is not None and 0 <= now - blind_ts < realert_secs
@@ -758,7 +765,7 @@ def run(
             state["coalescing"] = carried_window
 
     alerted = state.setdefault("alerted", {})
-    now = time.time()
+    now = clock()
 
     # Epoch-scoped keys are bounded by the epoch reset that wipes them. Sticky
     # keys have no such bound, so a long-lived watch on a busy subject would

--- a/test/test_irq.py
+++ b/test/test_irq.py
@@ -41,20 +41,53 @@ from kiro_crew.irq import (
 _COALESCE = 0.01
 
 
+class _Clock:
+    """A controllable time source threaded into ``run()`` as its ``clock``.
+
+    It starts at the real ``time.time()`` so on-disk state seeded with real
+    epoch offsets (``opened_at = time.time() - 600``, ``alerted red:a = 2**40``)
+    still reads correctly, and it only moves when a test moves it. That makes
+    the floor/cap/age math exact: an interval the test does not advance cannot
+    expire, so the 'has NOT waited' assertions stop racing wall-clock
+    scheduling on a loaded runner.
+    """
+
+    def __init__(self) -> None:
+        self._now = time.time()
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+#: The fake clock for the current test, reset per test by ``_isolated_home``.
+_CLOCK = _Clock()
+
+
 def _settle() -> None:
-    """Advance wall clock past ``_COALESCE`` so an OPEN window may now fire.
+    """Advance the fake clock past ``_COALESCE`` so an OPEN window may now fire.
 
     A window cannot open and fire within one tick -- ``elapsed`` is zero at
     the moment it opens -- so every coalesced wake costs at least one extra
     tick. See ``test_coalesced_wake_always_costs_an_extra_tick``.
+
+    This steps the injected clock instead of sleeping real wall clock: time
+    only moves when the test moves it, which makes the floor assertions exact
+    (and drops the per-tick sleep from the suite).
     """
-    time.sleep(_COALESCE * 3)
+    _CLOCK.advance(_COALESCE * 3)
 
 
 @pytest.fixture(autouse=True)
 def _isolated_home(tmp_path, monkeypatch):
     """Point the kernel's state directory at a private tmp home."""
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    # Fresh clock per test, seeded at real wall time, so disk-seeded epoch
+    # offsets stay valid and no time bleeds between tests.
+    global _CLOCK
+    _CLOCK = _Clock()
     return tmp_path
 
 
@@ -80,6 +113,7 @@ class ScriptedProbe(Probe):
 
 def _verdict(probe: Probe, ctx=None, **kwargs):
     """Run one tick and return the raised verdict exception."""
+    kwargs.setdefault("clock", _CLOCK)
     try:
         run(ctx or _ctx(), probe, **kwargs)
     except (Skip, Report, Done) as exc:
@@ -767,7 +801,7 @@ def test_a_sticky_key_is_dropped_once_past_the_realert_window():
         ]
     )
     assert isinstance(_verdict(probe, coalesce_secs=0, realert_secs=0.01), Report)
-    time.sleep(0.05)
+    _CLOCK.advance(0.05)
     assert isinstance(_verdict(probe, coalesce_secs=0, realert_secs=0.01), Skip)
     state = load_state(state_path("test-kind", "sub-1", "job-1"))
     assert not [k for k in state.get("alerted", {}) if "comment:1" in k]
@@ -806,7 +840,7 @@ def test_state_written_before_the_sentinels_existed_costs_no_extra_wake():
     path = state_path("test-kind", "sub-1", "job-1")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        json.dumps({"epoch": "e1", "alerted": {"red:a": time.time()}}), encoding="utf-8"
+        json.dumps({"epoch": "e1", "alerted": {"red:a": _CLOCK()}}), encoding="utf-8"
     )
     probe = ScriptedProbe([Tick(epoch="e1", observations=[_wake("red:a")])])
     assert isinstance(_verdict(probe, coalesce_secs=0), Skip)


### PR DESCRIPTION
Fixes the intermittent failure of `test/test_irq.py::test_an_entry_joining_after_a_partial_fire_serves_its_own_floor` reported in #7598.

## Problem

The target test budgeted its coalescing floor in real wall clock (`_COALESCE = 0.01`, `_settle()` sleeping `_COALESCE * 3`). Two of its assertions require that a floor has NOT expired, but they were separated only by the call/return between two `_verdict()` invocations. On a loaded xdist CI runner, any scheduling stall past 10 ms let the joining entry's own floor close, so it reported instead of skipping and the assertion flipped to a bare `assert False`. Sibling tests that assert a window HAS closed were safe because a stall only helps them; the exposure was specific to the 'must stay short' assertions.

## Fix

Stop measuring the guard in wall clock by making the kernel's time source injectable (the reporter's recommended approach; raising `_COALESCE` was explicitly rejected).

- **src/kiro_crew/irq.py**: added `from typing import Callable`; added a keyword-only `clock: Callable[[], float] = time.time` parameter to `run()` (positional `(ctx, probe)` signature unchanged); routed the module's only two wall-clock reads (`now = time.time()` in the blind-alert re-arm path and in the main coalescing/dedupe path) through `now = clock()`; added a short docstring note. No other clock read remains in `run()`.
- **test/test_irq.py**: added a `_Clock` (callable, seeded at real `time.time()`, with `advance()`); a module-level `_CLOCK` reset per test inside the existing autouse `_isolated_home` fixture; `_settle()` now advances `_CLOCK` by `_COALESCE * 3` instead of `time.sleep`; `_verdict` injects `clock=_CLOCK`. Two sibling tests were made consistent with the frozen clock (`_CLOCK.advance(0.05)` and seeding from `_CLOCK()`). `_COALESCE` stays `0.01`. The guarded test is intact (not deleted/skipped/xfailed).

The sole production caller `pr_watch.py:603 run(ctx, PrWatchProbe())` is unchanged and uses the `time.time` default (backward-compatible).

## Testing

- Full module `test/test_irq.py`: **60 passed**, 0 skips/xfails/failures (Python 3.12, `PYTHONPATH=src:<site-packages>`, `--noconftest` because the repo root conftest needs `hypothesis`, not installable under the sandbox's repository-access-only network mode).
- Target test deterministic: **30/30** in a stress loop.
- Test-meaningfulness check: reverting the guarded per-entry-floor behavior (#7431) makes the target test fail deterministically at the 'No _settle() on purpose' joined assertion, then pass again after restore, confirming the guard still bites and now fails cleanly instead of racing.

## Notes

- No build/Docker verification was possible under the sandbox's repository-access-only network mode (no PyPI/registry access). This is a pure-Python change and the affected module's tests are self-contained and green.
- No overlap with open PR #7584 (its edits are in the epoch-change tests around line 877; this change touches shared fixtures plus the target/sibling tests and the two `clock()` reads).