### PR TITLE
fix(browser): surface extension token clear failures

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -263,7 +263,9 @@ nicety: these tokens are base64url and can legitimately contain `=`, so a looser
 rule would corrupt a bare token. `export`/`set` keywords and a matched pair of
 surrounding quotes are removed for the same reason. Normalization also runs on
 read, so a stored value holding the whole assignment repairs itself instead of
-reporting "stored" while the extension keeps prompting.
+reporting "stored" while the extension keeps prompting. Clearing ignores an
+already-absent file, but any other unlink failure propagates through the API so
+the settings panel cannot report success while the credential remains active.
 
 ### Launch config
 

--- a/src/kiro_crew/browser_cli/token.py
+++ b/src/kiro_crew/browser_cli/token.py
@@ -25,13 +25,10 @@ cloud credential and grants nothing off-host.
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
-
-logger = logging.getLogger(__name__)
 
 #: The variable `playwright-cli` reads. Its name is fixed by the CLI, not by us.
 TOKEN_ENV = "PLAYWRIGHT_MCP_EXTENSION_TOKEN"
@@ -143,13 +140,16 @@ def set_token(value: str) -> None:
 
 
 def clear_token() -> None:
-    """Remove the token. Absent is the default state, so this cannot fail loudly."""
+    """Remove the token, ignoring only the already-absent state.
+
+    Other failures propagate to the caller. Reporting a successful clear while
+    the credential remains on disk would also leave it active in new browser
+    processes, which is worse than making the storage failure visible.
+    """
     try:
         token_path().unlink()
     except FileNotFoundError:
         return
-    except OSError:
-        logger.debug("could not remove the extension token", exc_info=True)
 
 
 def cli_env_overrides() -> dict[str, str]:

--- a/test/test_browser_cli_token.py
+++ b/test/test_browser_cli_token.py
@@ -48,6 +48,18 @@ class TestStorage:
         mod.clear_token()
         assert mod.has_token() is False
 
+    def test_a_failed_clear_is_reported_instead_of_claiming_success(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        mod.set_token("abc123")
+
+        def refuse_unlink(*args, **kwargs):
+            raise PermissionError("token is still in use")
+
+        monkeypatch.setattr(Path, "unlink", refuse_unlink)
+        with pytest.raises(PermissionError, match="still in use"):
+            mod.clear_token()
+
     def test_unreadable_file_reads_as_absent(self, home: Path):
         mod.token_path().mkdir()  # a directory where a file belongs
         assert mod.read_token() is None


### PR DESCRIPTION
## Problem / Motivation

Clearing the Playwright extension token swallowed every `OSError` from deleting the credential file. The dashboard API could therefore return `ok: true` even though the token remained on disk and would still be injected into new browser processes.

## Why it matters

A user who clears the credential needs the operation to be truthful. Silently retaining it creates stale authentication state and gives the settings panel no way to explain or recover from a permission or storage failure.

## What changed (motivation → approach → change)

`clear_token()` now treats only an already-absent file as a successful no-op. Other unlink failures propagate to the existing API error boundary, which can report the failed clear instead of claiming success. The browser system spec now documents that contract.

## Tests

- Added a deterministic storage test that makes `Path.unlink()` raise `PermissionError` and verifies the failure propagates.
- `test/test_browser_cli_token.py`: 29 passed, 1 skipped (POSIX permission-bit test on Windows).
- Relevant browser CLI journeys: 6 passed.
- Black, isort, Flake8, brand-name check, and `git diff --check` pass for the touched diff.
- Targeted mypy reached 12 pre-existing errors in unrelated modules; it reported none in the changed browser-token module.

## Manual verification

N/A — the unit test exercises the exact failed-unlink path and the existing API error boundary already maps raised exceptions to a failed response.

## Related Issues

N/A — found through direct source inspection; no matching open issue or pull request.

## Pattern harvest

Rule candidate: review-prompt
Pattern: destructive storage helpers must not swallow failures when their caller reports success.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder; no contributor action is currently specified.