### PR TITLE
refactor(design-tweak): split backend server boundaries

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -91,7 +91,6 @@ src/kiro_crew/apps/builtins/crew_companion/tests/test_routes.py
 src/kiro_crew/apps/builtins/crew_companion/tests/test_store.py
 src/kiro_crew/apps/builtins/crew_companion/tests/test_write_failures.py
 src/kiro_crew/apps/builtins/design_critique/tests/test_manifest.py
-src/kiro_crew/apps/builtins/design_tweak/backend/server.py
 src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
 src/kiro_crew/apps/builtins/dev_fleet/server.py
 src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-playwright.py

--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -20,7 +20,6 @@
 9 src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
 1 src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py
 1 src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
-2 src/kiro_crew/apps/builtins/design_tweak/backend/server.py
 1 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/deps.py
 3 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/narrate.py
 1 src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/record_template.py

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/dev_preview.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/dev_preview.py
@@ -1,0 +1,771 @@
+"""Dev-server discovery, lifecycle, and injection-proxy primitives.
+
+``server`` is the Design Tweak composition root and security-policy owner.
+Every mutable collaborator is resolved through ``runtime`` at call time.  This
+module never spawns a process or invokes ``lsof`` itself: those audited process
+sinks remain in ``server._start_dev_proc`` and ``server._lsof_fields``.
+"""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler
+from typing import Any, ClassVar, cast
+
+# Where Node toolchains actually live. The gateway spawns this backend with a
+# minimal PATH — typically /usr/bin:/bin:/usr/sbin:/sbin — so `npm` is NOT
+# resolvable by name even though it works fine in the user's terminal. Two things
+# follow: the binary has to be found absolutely, AND the child's PATH has to
+# include its directory, because `npm run dev` shells out to `node` itself.
+# POSIX-only by nature: these are macOS/Linux install prefixes, and a directory
+# that does not exist is simply dropped by `node_bin_dirs`, so on Windows the
+# tuple contributes nothing and resolution falls back to PATH.
+NODE_BIN_DIRS = (
+    "/opt/homebrew/bin",  # homebrew, Apple silicon
+    "/usr/local/bin",  # homebrew (Intel) / manual installs
+    "/opt/local/bin",  # MacPorts
+    "/usr/bin",
+    "~/.volta/bin",
+    "~/.bun/bin",
+    "~/.asdf/shims",
+    "~/.local/share/fnm/aliases/default/bin",
+    "~/Library/pnpm",
+)
+# nvm keeps a directory per version; prefer the newest.
+NVM_GLOB = "~/.nvm/versions/node/*/bin"
+
+# Environment this backend holds that the user's dev script must NEVER see.
+# `KIROCREW_PROXY_SECRET` is the whole of this backend's authentication: the
+# gateway HMACs every proxied request with it (`kiro_crew.apps.proxy_auth`), and
+# `_authorized()` refuses anything unsigned. Handing it to a project's `npm run
+# dev` — arbitrary code from a folder the operator merely pointed at — would let
+# that code forge signed calls straight to our loopback socket and bypass the
+# gateway's token auth and per-app scope entirely.
+#
+# `PORT` is stripped because `minimal_env()` sets it to THIS backend's port
+# (`apps/backend.py`); a dev server that honours `PORT` (Next, CRA, many Node
+# servers do) would try to bind a socket we already hold and die on EADDRINUSE.
+#
+# `SSH_AUTH_SOCK` / `GIT_SSH_COMMAND` / `GIT_SSH` are stripped because the dev
+# script is untrusted project code, not Kiro Crew's own: an inherited SSH agent
+# socket or SSH override command lets it authenticate to a remote (`git push`,
+# a bare `ssh`) AS the operator, with no confinement of its own — the same
+# credential class `sandbox._SENSITIVE_ENV_PREFIXES` strips for the sandboxed
+# agent spawn path, kept here as its own narrow entry rather than an import
+# across modules for a single-purpose backend that otherwise has none.
+CHILD_ENV_STRIP = (
+    "KIROCREW_PROXY_SECRET",
+    "PORT",
+    "NODE_OPTIONS",
+    "SSH_AUTH_SOCK",
+    "GIT_SSH_COMMAND",
+    "GIT_SSH",
+)
+# Prefixes covering every capability/identity var the host may inject
+# (`KIROCREW_HOME`, `KIROCREW_APP_*`, operator-declared `KIROCREW_DEVFLEET_BIN_*`,
+# `KIROCREW_PROJECT_DIR`, …). None of them are the child's business, and a
+# forward-compatible prefix strip means a var added upstream later cannot leak
+# through this seam by default.
+CHILD_ENV_STRIP_PREFIXES = ("KIROCREW_", "KIRO_CREW_")
+
+LOCKFILES = (
+    ("pnpm-lock.yaml", "pnpm"),
+    ("bun.lockb", "bun"),
+    ("yarn.lock", "yarn"),
+    ("package-lock.json", "npm"),
+)
+DEV_SCRIPTS = ("dev", "start:dev", "dev:web", "serve", "start")
+PROC_TREE_MAX_DEPTH = 16
+
+
+def node_bin_dirs(runtime: Any) -> list[Any]:
+    """Return existing Node toolchain directories in lookup order."""
+
+    dirs = [runtime.Path(directory).expanduser() for directory in runtime._NODE_BIN_DIRS]
+    try:
+        nvm = sorted(
+            runtime.glob.glob(runtime.os.path.expanduser(runtime._NVM_GLOB)),
+            reverse=True,
+        )
+        dirs = [runtime.Path(path) for path in nvm] + dirs
+    except OSError:
+        pass
+    return [directory for directory in dirs if directory.is_dir()]
+
+
+def resolve_bin(runtime: Any, name: str) -> Any | None:
+    """Return the absolute package-manager path, if one can be resolved."""
+
+    found = runtime.shutil.which(name)
+    if found:
+        return runtime.Path(found)
+    for directory in runtime._node_bin_dirs():
+        candidate = directory / name
+        if candidate.is_file() and runtime.os.access(candidate, runtime.os.X_OK):
+            return candidate
+    return None
+
+
+def child_env(runtime: Any, bin_dir: Any) -> dict[str, str]:
+    """Build the untrusted dev child's credential-stripped environment."""
+
+    env = {
+        key: value
+        for key, value in runtime.os.environ.items()
+        if key not in runtime._CHILD_ENV_STRIP
+        and not key.startswith(runtime._CHILD_ENV_STRIP_PREFIXES)
+    }
+    extra = [str(bin_dir)] + [str(directory) for directory in runtime._node_bin_dirs()]
+    seen: set[str] = set()
+    parts: list[str] = []
+    for path in extra + runtime.os.environ.get("PATH", "").split(runtime.os.pathsep):
+        if path and path not in seen:
+            seen.add(path)
+            parts.append(path)
+    env["PATH"] = runtime.os.pathsep.join(parts)
+    return env
+
+
+def pkg_scripts(runtime: Any, root: Any) -> dict[str, Any]:
+    """Load a project's package scripts without letting bad JSON escape."""
+
+    try:
+        raw = runtime.safe_read_file_bytes_nolink(
+            str(root / "package.json"),
+            within_root=str(root),
+            max_bytes=runtime.MAX_BODY_BYTES,
+        )
+        if raw is None:
+            return {}
+        data = runtime.json.loads(raw.decode("utf-8"))
+        scripts = data.get("scripts")
+        return scripts if isinstance(scripts, dict) else {}
+    except (OSError, ValueError, runtime.FileTooLargeError):
+        return {}
+
+
+def dev_command(runtime: Any, root: Any) -> list[str]:
+    """Return the project's preferred package-manager dev command."""
+
+    scripts = runtime._pkg_scripts(root)
+    script = next((name for name in runtime._DEV_SCRIPTS if name in scripts), "")
+    if not script:
+        return []
+    manager = next(
+        (manager for lockfile, manager in runtime._LOCKFILES if (root / lockfile).is_file()),
+        "npm",
+    )
+    return [manager, "run", script]
+
+
+def classify_project(runtime: Any, root: Any) -> dict[str, Any]:
+    """Classify a project as static-previewable or dev-server-backed."""
+
+    entry = runtime._find_entry(root)
+    unbundled = ""
+    if entry is not None:
+        try:
+            raw = runtime.safe_read_file_bytes_nolink(
+                str(entry),
+                within_root=str(root),
+                max_bytes=runtime.MAX_STATIC_BYTES,
+            )
+            if raw is not None:
+                unbundled = runtime._unbundled_entry(raw)
+        except (OSError, ValueError, runtime.FileTooLargeError):
+            unbundled = ""
+    command = runtime._dev_command(root)
+    needs_dev_server = bool(unbundled) or (entry is None and bool(command))
+    return {
+        "needsDevServer": needs_dev_server,
+        "devCommand": " ".join(command),
+        "unbundledEntry": unbundled,
+        "hasEntry": entry is not None,
+    }
+
+
+def loopback_listeners(runtime: Any) -> dict[int, int]:
+    """Return ``{port: pid}`` for listeners reachable from loopback."""
+
+    found: dict[int, int] = {}
+    for record in runtime._lsof_fields(["-nP", "-iTCP", "-sTCP:LISTEN", "-Fpn"]):
+        name = record["name"]
+        if ":" not in name:
+            continue
+        host, _, port_text = name.rpartition(":")
+        host = host.strip("[]")
+        if host not in ("127.0.0.1", "localhost", "::1", "*", ""):
+            continue
+        try:
+            found[int(port_text)] = int(record["pid"])
+        except ValueError:
+            continue
+    return found
+
+
+def cwd_for_pids(runtime: Any, pids: list[int]) -> dict[int, str]:
+    """Resolve process working directories with one late-bound ``lsof`` call."""
+
+    if not pids:
+        return {}
+    joined = ",".join(str(pid) for pid in dict.fromkeys(pids))
+    out: dict[int, str] = {}
+    for record in runtime._lsof_fields(["-a", "-p", joined, "-d", "cwd", "-Fn"]):
+        try:
+            out[int(record["pid"])] = record["name"]
+        except ValueError:
+            continue
+    return out
+
+
+def serves_html(runtime: Any, port: int) -> bool:
+    """Return whether a loopback port answers with an HTML content type."""
+
+    url = f"http://127.0.0.1:{port}/"
+    try:
+        request = runtime.urllib.request.Request(
+            url,
+            headers={"User-Agent": "DesignTweak-Detect"},
+        )
+        # The URL has a literal scheme and host, and ``port`` was parsed as an int.
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        with runtime.urllib.request.urlopen(  # noqa: S310
+            request,
+            timeout=runtime._PROBE_TIMEOUT,
+        ) as response:
+            return "text/html" in (response.headers.get("Content-Type") or "").lower()
+    except runtime.urllib.error.HTTPError as exc:
+        return "text/html" in (exc.headers.get("Content-Type") or "").lower()
+    except (runtime.urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def detect_dev_servers(runtime: Any, root: Any, probe: bool = True) -> list[dict[str, Any]]:
+    """Return dev servers plausibly serving ``root``, best match first."""
+
+    listeners = runtime._loopback_listeners()
+    working_dirs = runtime._cwd_for_pids(list(listeners.values()))
+
+    out: list[dict[str, Any]] = []
+    for port, pid in listeners.items():
+        cwd = working_dirs.get(pid, "")
+        if not cwd:
+            continue
+        try:
+            depth = len(runtime.Path(cwd).resolve().relative_to(root).parts)
+        except ValueError:
+            continue
+        out.append(
+            {
+                "port": port,
+                "pid": pid,
+                "cwd": cwd,
+                "depth": depth,
+                "url": f"http://localhost:{port}",
+                "servesHtml": runtime._serves_html(port) if probe else None,
+            }
+        )
+    out.sort(
+        key=lambda candidate: (
+            candidate["servesHtml"] is False,
+            candidate["depth"],
+            candidate["port"],
+        )
+    )
+    return out
+
+
+def auto_dev_server(runtime: Any, root: Any) -> str:
+    """Return the only unambiguous HTML-serving dev URL, or an empty string."""
+
+    html = [candidate for candidate in runtime._detect_dev_servers(root) if candidate["servesHtml"]]
+    return html[0]["url"] if len(html) == 1 else ""
+
+
+def stop_dev_proc(runtime: Any, project_id: str) -> bool:
+    """Stop an owned process tree, or only the proxy for an adopted server."""
+
+    record = runtime._DEV_PROCS.pop(project_id, None)
+    if not record:
+        return False
+    runtime._stop_inject_proxy(record)
+    process = record.get("proc")
+    if process is None:
+        return True
+    try:
+        runtime.kill_process_tree(process.pid, runtime.SIGTERM)
+        try:
+            process.wait(timeout=runtime._STOP_GRACE)
+        except Exception:  # noqa: BLE001
+            runtime.kill_process_tree(process.pid, runtime.SIGKILL)
+    except (ProcessLookupError, PermissionError, ValueError, OSError):
+        pass
+    return True
+
+
+def stop_all_dev_procs(runtime: Any) -> None:
+    """Stop every tracked owned process and adopted proxy."""
+
+    for project_id in list(runtime._DEV_PROCS):
+        runtime._stop_dev_proc(project_id)
+
+
+def dev_proc_alive(runtime: Any, project_id: str) -> bool:
+    """Return whether an owned process or adopted proxy remains live."""
+
+    record = runtime._DEV_PROCS.get(project_id)
+    if not record:
+        return False
+    process = record.get("proc")
+    if process is None:
+        return bool(record.get("proxy"))
+    return process.poll() is None
+
+
+def in_proc_tree(runtime: Any, pid: int, root_pid: int, pgid: int | None) -> bool:
+    """Return whether a listener belongs to the process tree ``server`` spawned.
+
+    The listener is usually npm's CHILD, not the process we started. POSIX
+    matches on the process group, which catches a grandchild even when the
+    intermediate ``npm`` has already exited; ``pgid`` is therefore non-``None``
+    only where ``server`` could read one, which is POSIX. Windows has no process
+    group to read, so the parent chain is walked instead — bounded because a real
+    chain here is two or three links and ``get_ppid`` returns 0 at the root.
+    """
+
+    if pgid is not None:
+        try:
+            return runtime.os.getpgid(pid) == pgid
+        except OSError:
+            return False
+    seen: set[int] = set()
+    current = pid
+    for _ in range(runtime._PROC_TREE_MAX_DEPTH):
+        if current == root_pid:
+            return True
+        if current <= 0 or current in seen:
+            return False
+        seen.add(current)
+        current = runtime.get_ppid(current)
+    return False
+
+
+class DevProxyHandlerBase(BaseHTTPRequestHandler):
+    """Byte-transparent reverse proxy, except HTML gains the overlay script.
+
+    ``server`` binds a subclass whose ``runtime`` class attribute refers to its
+    module object.  Late binding keeps the server namespace authoritative
+    without importing the composition root back into this boundary.
+    """
+
+    runtime: ClassVar[Any] = None
+    protocol_version = "HTTP/1.1"
+    timeout = 30
+    upstream_host = "127.0.0.1"
+    upstream_port = 0
+    proxy_port = 0
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+    def _upstream(self) -> str:
+        return f"{self.upstream_host}:{self.upstream_port}"
+
+    def _dispatch(self) -> None:
+        runtime = self.runtime
+        if self.path.split("?", 1)[0] == runtime._OVERLAY_PATH:
+            return self._serve_overlay()
+        if "websocket" in self.headers.get("Upgrade", "").lower():
+            return self._relay_ws()
+        return self._relay_http()
+
+    do_GET = _dispatch
+    do_POST = _dispatch
+    do_HEAD = _dispatch
+    do_PUT = _dispatch
+    do_PATCH = _dispatch
+    do_DELETE = _dispatch
+    do_OPTIONS = _dispatch
+
+    def _serve_overlay(self) -> None:
+        runtime = self.runtime
+        try:
+            javascript = runtime.INJECT_FILE.read_bytes()
+        except OSError:
+            javascript = b"// overlay not found"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/javascript; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(javascript)))
+        self.end_headers()
+        self.wfile.write(javascript)
+
+    def _relay_http(self) -> None:
+        runtime = self.runtime
+        # Both directions are buffered whole (the HTML rewrite needs the full
+        # body), so both need a ceiling: without one, a preview request or a
+        # dev-server response larger than available memory takes the backend
+        # down. The request side reuses MAX_BODY_BYTES (inbound payload cap) and
+        # the response side MAX_STATIC_BYTES (one served asset), matching what
+        # the non-proxy paths already enforce.
+        body = b""
+        length = self.headers.get("Content-Length")
+        if length:
+            try:
+                size = int(length)
+            except ValueError:
+                size = -1
+            if size > runtime.MAX_BODY_BYTES:
+                # The unread body stays in the socket, so this connection can no
+                # longer be framed — close rather than desync the next request.
+                self.close_connection = True
+                self.send_error(
+                    413,
+                    f"request body over the {runtime.MAX_BODY_BYTES}-byte proxy limit",
+                )
+                return
+            if size > 0:
+                try:
+                    body = self.rfile.read(size)
+                except OSError:
+                    # Timed out mid-body (see ``CLIENT_READ_TIMEOUT``). Forwarding a
+                    # truncated body would make the dev server act on a partial
+                    # request, so refuse and close.
+                    self.close_connection = True
+                    self.send_error(408, "request body timed out")
+                    return
+                if len(body) != size:
+                    self.close_connection = True
+                    self.send_error(400, "request body shorter than Content-Length")
+                    return
+
+        headers: dict[str, str] = {}
+        for key, value in self.headers.items():
+            low = key.lower()
+            # Accept-Encoding is dropped so the upstream answers in identity
+            # encoding — otherwise the HTML would arrive gzipped and the overlay
+            # tag could not be inserted without decompressing it first.
+            if low in runtime._HOP_BY_HOP or low in ("accept-encoding", "host"):
+                continue
+            # Never forward the browser's credentials to the project's dev
+            # server. This proxy advertises itself as http://127.0.0.1:<port>,
+            # and cookies are host-scoped but PORT-agnostic — so when the
+            # dashboard is served from 127.0.0.1 too, the browser attaches the
+            # dashboard's SameSite=Lax auth cookie to these requests, and
+            # relaying it verbatim would hand a usable session token to an
+            # arbitrary `npm run dev` process. The upstream is the user's own
+            # project and needs no dashboard credential to serve its assets.
+            if low in runtime._CREDENTIAL_REQUEST_HEADERS:
+                continue
+            headers[key] = value
+        headers["Host"] = self._upstream()
+
+        try:
+            connection = runtime.http.client.HTTPConnection(
+                self.upstream_host,
+                self.upstream_port,
+                timeout=runtime._RELAY_TIMEOUT,
+            )
+            connection.request(
+                self.command,
+                self.path,
+                body=body or None,
+                headers=headers,
+            )
+            response = connection.getresponse()
+            # Read one byte past the cap so an oversized body is detectable
+            # without buffering all of it.
+            payload = response.read(runtime.MAX_STATIC_BYTES + 1)
+        except (OSError, runtime.http.client.HTTPException) as exc:
+            self.send_error(502, f"dev server unreachable: {exc}")
+            return
+
+        if len(payload) > runtime.MAX_STATIC_BYTES:
+            connection.close()
+            self.send_error(
+                502,
+                f"dev server response over the {runtime.MAX_STATIC_BYTES}-byte preview limit",
+            )
+            return
+
+        if "text/html" in (response.getheader("Content-Type") or "").lower():
+            payload = runtime._rewrite_html(
+                payload,
+                base=None,
+                script=runtime._OVERLAY_PATH,
+            )
+
+        self.send_response(response.status)
+        for key, value in response.getheaders():
+            low = key.lower()
+            if low in runtime._HOP_BY_HOP or low == "content-length":
+                continue
+            # Never let the dev server set cookies on OUR response. Cookies are
+            # host-scoped but PORT-agnostic, and this proxy shares 127.0.0.1 with
+            # the dashboard — so an upstream `Set-Cookie` naming the gateway's own
+            # cookie would REPLACE the dashboard's session in the browser, logging
+            # the user out or pinning them to an attacker-chosen value. This is the
+            # response-side mirror of the request-side `_CREDENTIAL_REQUEST_HEADERS`
+            # strip: the previewed project has no business touching dashboard state
+            # in either direction.
+            if low in runtime._CREDENTIAL_RESPONSE_HEADERS:
+                continue
+            # Upstream is the project's own dev server, but its headers land in
+            # OUR response: a folded or CR/LF-bearing value forwarded verbatim
+            # would let it append headers or a second body (response splitting).
+            if not runtime._HEADER_NAME_RE.match(key):
+                continue
+            # The upstream is the project's own dev server but still an unaudited
+            # process, so its media type SELECTS one of our literals instead of
+            # being echoed — which is what `PROXY_CTYPES` and
+            # `_safe_upstream_ctype` are for. Forwarding it verbatim would lose the
+            # charset normalisation, letting an upstream `text/html;
+            # charset=iso-8859-1` reach the browser as sent.
+            if low == "content-type":
+                value = runtime._safe_upstream_ctype(value, self.path)
+            # A redirect naming the dev server's OWN origin would take the iframe
+            # off this proxy and onto the bare upstream port — and because cookies
+            # are host-scoped but PORT-agnostic, the browser would then attach the
+            # dashboard's session cookie to the project's `npm run dev` process.
+            # The request-side strip cannot help: that navigation never passes
+            # through here. So keep the redirect INSIDE the proxy by re-pointing
+            # it at our own origin, which preserves the redirect's behaviour while
+            # keeping the cookie boundary intact.
+            if low == "location":
+                value = self._keep_redirect_local(value)
+            self.send_header(key, runtime._header_value(value))
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(payload)
+        connection.close()
+
+    def _keep_redirect_local(self, location: str) -> str:
+        """Re-point an upstream redirect that names the dev server at THIS proxy.
+
+        Only a ``Location`` whose host is loopback AND whose port is the upstream's
+        is rewritten — that is the one case where following it would move the
+        iframe from the proxy's port to the dev server's while staying on the same
+        cookie host. A redirect that is already relative needs nothing (it resolves
+        against our origin), and an off-host absolute redirect is left alone: the
+        dashboard cookie is scoped to this host, so it cannot ride along.
+
+        Path, query and fragment are preserved verbatim; only the authority moves.
+        """
+
+        runtime = self.runtime
+        try:
+            parts = runtime.urlparse(location)
+            if not parts.scheme and not parts.netloc:
+                return location  # relative — already ours
+            if parts.scheme.lower() not in ("http", "https"):
+                return location
+            if (parts.hostname or "").lower() not in runtime._LOOPBACK_HOSTS:
+                return location
+            # `.port` is lazily parsed, so a non-numeric authority raises HERE
+            # rather than at `urlparse` — the same seam `valid_target` guards.
+            port = parts.port or (443 if parts.scheme.lower() == "https" else 80)
+        except ValueError:
+            return location  # unparseable: forward as-is rather than invent a target
+        if port != self.upstream_port:
+            return location
+        rest = parts.path or "/"
+        if parts.query:
+            rest += "?" + parts.query
+        if parts.fragment:
+            rest += "#" + parts.fragment
+        return f"http://127.0.0.1:{self.proxy_port}{rest}"
+
+    def _relay_ws(self) -> None:
+        runtime = self.runtime
+        try:
+            upstream = runtime.socket.create_connection(
+                (self.upstream_host, self.upstream_port),
+                timeout=10,
+            )
+        except OSError:
+            self.send_error(502, "dev server unreachable")
+            return
+
+        lines = [f"{self.command} {self.path} HTTP/1.1"]
+        for key, value in self.headers.items():
+            if key.lower() in runtime._CREDENTIAL_REQUEST_HEADERS:
+                continue
+            lines.append(f"{key}: {self._upstream() if key.lower() == 'host' else value}")
+        try:
+            upstream.sendall(("\r\n".join(lines) + "\r\n\r\n").encode("latin-1", "replace"))
+        except OSError:
+            upstream.close()
+            return
+
+        self.close_connection = True
+        downstream = self.connection
+
+        head = b""
+        upstream.settimeout(runtime._RELAY_TIMEOUT)
+        try:
+            while b"\r\n\r\n" not in head and len(head) < 65536:
+                part = upstream.recv(4096)
+                if not part:
+                    break
+                head += part
+        except OSError:
+            upstream.close()
+            return
+        raw_head, separator, rest = head.partition(b"\r\n\r\n")
+        if not separator:
+            upstream.close()
+            self.send_error(502, "malformed upstream handshake")
+            return
+        head_lines = raw_head.split(b"\r\n")
+        sanitized = [head_lines[0]]
+        for header_line in head_lines[1:]:
+            name, _, _value = header_line.partition(b":")
+            if (
+                name.strip().lower().decode("latin-1", "replace")
+                in runtime._CREDENTIAL_RESPONSE_HEADERS
+            ):
+                continue
+            sanitized.append(header_line)
+        try:
+            downstream.sendall(b"\r\n".join(sanitized) + b"\r\n\r\n")
+            if rest:
+                downstream.sendall(rest)
+        except OSError:
+            upstream.close()
+            return
+
+        upstream.settimeout(None)
+        downstream.settimeout(None)
+        selector = runtime.selectors.DefaultSelector()
+        selector.register(upstream, runtime.selectors.EVENT_READ, downstream)
+        selector.register(downstream, runtime.selectors.EVENT_READ, upstream)
+        try:
+            while True:
+                events = selector.select(timeout=runtime._WS_IDLE)
+                if not events:
+                    return
+                for selector_key, _mask in events:
+                    src_sock = cast(Any, selector_key.fileobj)
+                    dst_sock = cast(Any, selector_key.data)
+                    try:
+                        chunk = src_sock.recv(65536)
+                    except OSError:
+                        return
+                    if not chunk:
+                        return
+                    try:
+                        dst_sock.sendall(chunk)
+                    except OSError:
+                        return
+        finally:
+            selector.close()
+            try:
+                upstream.close()
+            except OSError:
+                pass
+
+
+def start_inject_proxy(runtime: Any, dev_url: str) -> tuple[object | None, str]:
+    """Front ``dev_url`` with an overlay-injecting loopback proxy."""
+
+    parsed = runtime.urlparse(dev_url)
+    host = parsed.hostname or "127.0.0.1"
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        return None, ""
+    bound = cast(
+        type[DevProxyHandlerBase],
+        type(
+            "_BoundDevProxy",
+            (runtime._DevProxyHandler,),
+            {"upstream_host": host, "upstream_port": port},
+        ),
+    )
+    try:
+        server = runtime.ThreadingHTTPServer(("127.0.0.1", 0), bound)
+    except OSError:
+        return None, ""
+    server.daemon_threads = True
+    bound.proxy_port = server.server_address[1]
+    runtime.threading.Thread(
+        target=server.serve_forever,
+        daemon=True,
+        name="kiro-dev-proxy",
+    ).start()
+    return server, f"http://127.0.0.1:{server.server_address[1]}/"
+
+
+def stop_inject_proxy(runtime: Any, record: dict[str, Any]) -> None:
+    """Close a project's injection proxy and invalidate its cached URL."""
+
+    server = record.get("proxy")
+    if server is None:
+        return
+    try:
+        server.shutdown()
+        server.server_close()
+    except Exception:  # noqa: BLE001
+        pass
+    record["proxy"] = None
+    record["proxyUrl"] = ""
+    record["proxyFor"] = ""
+
+
+def front_with_proxy(runtime: Any, project_id: str, dev_url: str) -> str:
+    """Reuse or create the credential-stripping proxy for a dev server."""
+
+    record = runtime._DEV_PROCS.get(project_id)
+    if record is not None and record.get("proxy") is not None and record.get("proxyFor") == dev_url:
+        cached = str(record.get("proxyUrl") or "")
+        if cached:
+            return cached
+    server, url = runtime._start_inject_proxy(dev_url)
+    if not url:
+        return ""
+    if record is not None:
+        runtime._stop_inject_proxy(record)
+        record["proxy"] = server
+        record["proxyUrl"] = url
+        record["proxyFor"] = dev_url
+    else:
+        runtime._DEV_PROCS[project_id] = {
+            "proc": None,
+            "pgid": None,
+            "url": dev_url,
+            "proxy": server,
+            "proxyUrl": url,
+            "proxyFor": dev_url,
+            "adopted": True,
+        }
+    return url
+
+
+__all__ = [
+    "CHILD_ENV_STRIP",
+    "CHILD_ENV_STRIP_PREFIXES",
+    "DEV_SCRIPTS",
+    "LOCKFILES",
+    "NODE_BIN_DIRS",
+    "NVM_GLOB",
+    "PROC_TREE_MAX_DEPTH",
+    "DevProxyHandlerBase",
+    "auto_dev_server",
+    "child_env",
+    "classify_project",
+    "cwd_for_pids",
+    "detect_dev_servers",
+    "dev_command",
+    "dev_proc_alive",
+    "front_with_proxy",
+    "in_proc_tree",
+    "loopback_listeners",
+    "node_bin_dirs",
+    "pkg_scripts",
+    "resolve_bin",
+    "serves_html",
+    "start_inject_proxy",
+    "stop_all_dev_procs",
+    "stop_dev_proc",
+    "stop_inject_proxy",
+]

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/http_api.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/http_api.py
@@ -1,0 +1,1049 @@
+"""HTTP API adapter for the Design Tweak backend.
+
+The concrete server module binds :attr:`Handler.runtime` on a subclass.  Every
+mutable value and collaborator is resolved through that facade at call time,
+making the server namespace authoritative while keeping transport concerns out
+of the composition root.
+"""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler
+from typing import Any
+
+#: Product half of the HTTP ``Server:`` header. A wire identifier rather than
+#: prose, so it keeps the joined spelling; one definition so the unbound default
+#: and the bound value cannot drift apart.
+_SERVER_TOKEN = "KiroCrew-SelectToEdit/"  # brand-ok: Server-header token
+
+
+class IncompleteBody(ValueError):
+    """The client sent fewer bytes than its Content-Length promised."""
+
+
+class Handler(BaseHTTPRequestHandler):
+    """Design Tweak's authenticated JSON API.
+
+    A bound subclass must set ``runtime`` and implement ``_h_pick_folder``.  The
+    native picker remains in ``server.py`` so the audited subprocess sink stays
+    composition-root owned.
+    """
+
+    runtime: Any = None
+    server_version = _SERVER_TOKEN + "unbound"
+    timeout = 30
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if cls.runtime is not None:
+            cls.server_version = _SERVER_TOKEN + cls.runtime.VERSION
+            cls.timeout = cls.runtime._CLIENT_READ_TIMEOUT
+
+    def log_message(self, *args: Any) -> None:
+        """Silence the default stderr access log."""
+
+    def _route(self) -> tuple[str, dict[str, list[str]]]:
+        rt = self.runtime
+        url = rt.urlparse(self.path)
+        route = url.path.rstrip("/") or "/"
+        if route.startswith("/api/"):
+            route = route[4:] or "/"
+        elif route == "/api":
+            route = "/"
+        return route, rt.parse_qs(url.query)
+
+    def _read_raw_body(self) -> bytes:
+        """Read and cache one correctly framed, size-bounded request body."""
+
+        rt = self.runtime
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length <= 0:
+            return b""
+        if length > rt.MAX_BODY_BYTES:
+            raise ValueError("payload too large")
+        body = self.rfile.read(length)
+        if len(body) != length:
+            # Missing bytes could otherwise become the next keep-alive request.
+            self.close_connection = True
+            raise rt._IncompleteBody("request body shorter than Content-Length")
+        return body
+
+    def _authorized(self, method: str, body: bytes) -> bool:
+        """Verify gateway HMAC before dispatch, except for liveness probes."""
+
+        rt = self.runtime
+        route = rt.urlparse(self.path).path.rstrip("/")
+        if route in ("", "/health", "/api", "/api/health"):
+            return True
+        if rt.verify_proxy_request(
+            self.headers.get("X-KiroCrew-Proxy", ""),
+            method=method,
+            target=self.path,
+            body=body,
+        ):
+            return True
+        # Query strings can contain project paths, so audit only the route path.
+        rt.sel().log_api_access(
+            caller=rt.APP_NAME,
+            operation="proxy_auth_failed",
+            outcome="denied",
+            source="builtin-app",
+            resources=rt.urlparse(self.path).path,
+        )
+        self._json(
+            401,
+            {
+                "error": "invalid or missing proxy signature",
+                "code": "invalid_proxy_signature",
+            },
+        )
+        return False
+
+    def do_GET(self) -> None:  # noqa: N802
+        rt = self.runtime
+        if not self._authorized("GET", b""):
+            return
+        try:
+            route, query = self._route()
+            if route in ("/", "/health"):
+                return self._json(
+                    200,
+                    {
+                        "status": "ok",
+                        "app": rt.APP_NAME,
+                        "version": rt.VERSION,
+                        "pending": len(rt._pending_files()),
+                        "dataDir": str(rt.DATA_DIR),
+                    },
+                )
+            if route == "/queue":
+                pending = []
+                for path in rt._pending_files():
+                    request = rt._read_request(path)
+                    if request is not None:
+                        pending.append(rt._summarize(request))
+                pending.sort(key=lambda request: request.get("number") or 0)
+                return self._json(200, {"pending": pending})
+            if route == "/latest":
+                files = rt._pending_files()
+                if not files:
+                    return self._json(200, {})
+                newest, newest_number = None, -1
+                for path in files:
+                    request = rt._read_request(path)
+                    if request and (request.get("number") or 0) > newest_number:
+                        newest = request
+                        newest_number = request.get("number") or 0
+                # `/latest` returns the full record, so free-text threads need the
+                # same output-redaction floor as the summary paths.
+                if newest is not None:
+                    newest = {
+                        **newest,
+                        "thread": rt._redact_thread(newest.get("thread")),
+                        "comments": [
+                            {**comment, "thread": rt._redact_thread(comment.get("thread"))}
+                            for comment in (newest.get("comments") or [])
+                        ],
+                    }
+                return self._json(200, newest or {})
+            if route == "/projects":
+                return self._h_projects_list()
+            if route == "/detect-dev-server":
+                return self._h_detect_dev_server(query)
+            if route == "/history":
+                history = []
+                for path in sorted(rt.HANDLED_DIR.glob("*.json"), reverse=True)[:50]:
+                    request = rt._read_request(path)
+                    if request is not None:
+                        history.append(rt._summarize(request))
+                return self._json(200, {"history": history})
+            if route == "/proxy-inject.js":
+                return self._h_inject()
+            if route == "/proxy" or route.startswith("/proxy/"):
+                # Project-controlled content must never run on dashboard origin.
+                return self._json(
+                    410,
+                    {
+                        "error": "the dashboard-origin preview route was removed for "
+                        "security; previews are served from an ephemeral loopback "
+                        "server instead (see /projects → previewUrl)"
+                    },
+                )
+            return self._json(404, {"error": f"GET {route} not found"})
+        except Exception as exc:  # noqa: BLE001
+            return self._json(500, {"error": str(exc)})
+
+    def do_POST(self) -> None:  # noqa: N802
+        rt = self.runtime
+        try:
+            body = self._read_raw_body()
+        except rt._IncompleteBody as exc:
+            return self._json(400, {"error": str(exc), "code": "incomplete_body"})
+        except ValueError as exc:
+            return self._json(413, {"error": str(exc)})
+        except OSError:
+            self.close_connection = True
+            return self._json(
+                408,
+                {"error": "request body timed out", "code": "body_timeout"},
+            )
+        if not self._authorized("POST", body):
+            return
+        self._cached_body = body
+        try:
+            route, query = self._route()
+            if route == "/submit":
+                return self._h_submit()
+            if route == "/clear":
+                return self._h_clear(query)
+            if route == "/delete":
+                return self._h_delete(query)
+            if route in ("/source", "/target"):
+                return self._h_set_source()
+            if route == "/projects":
+                return self._h_projects_add()
+            if route == "/projects/select":
+                return self._h_projects_select()
+            if route == "/projects/remove":
+                return self._h_projects_remove()
+            if route == "/projects/preview-url":
+                return self._h_projects_preview_url()
+            if route == "/dev-server/start":
+                return self._h_dev_server_start(query)
+            if route == "/dev-server/stop":
+                return self._h_dev_server_stop(query)
+            if route == "/pick-folder":
+                return self._h_pick_folder()
+            if route == "/send":
+                return self._h_send(query)
+            if route == "/delivered":
+                return self._h_delivered(query)
+            if route == "/delete-comment":
+                return self._h_delete_comment(query)
+            if route == "/thread":
+                return self._h_thread(query)
+            return self._json(404, {"error": f"POST {route} not found"})
+        except Exception as exc:  # noqa: BLE001
+            return self._json(500, {"error": str(exc)})
+
+    def _read_body(self) -> dict[str, Any]:
+        rt = self.runtime
+        raw = getattr(self, "_cached_body", b"")
+        if not raw:
+            return {}
+        data = rt.json.loads(raw.decode("utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("payload must be a JSON object")
+        return data
+
+    def _h_submit(self) -> None:
+        """Append a captured comment to the project's single open draft."""
+
+        rt = self.runtime
+        payload = self._read_body()
+        if payload.get("type") != "visual_edit_request":
+            return self._json(400, {"error": "type must be 'visual_edit_request'"})
+        selection = payload.get("selection") or {}
+        elements = selection.get("elements") if isinstance(selection, dict) else None
+        if not isinstance(elements, list) or not elements:
+            return self._json(
+                400,
+                {
+                    "error": "selection.elements is required",
+                    "code": "selection_required",
+                },
+            )
+        if not all(isinstance(element, dict) for element in elements):
+            return self._json(
+                400,
+                {
+                    "error": "selection.elements must contain only objects",
+                    "code": "selection_malformed",
+                },
+            )
+        # Reject shapes that would make every later queue summary unreadable.
+        for element in elements:
+            if not all(
+                isinstance(element[key], str)
+                for key in ("tag", "id")
+                if element.get(key) is not None
+            ):
+                return self._json(
+                    400,
+                    {
+                        "error": "selection.elements[].tag and .id must be strings",
+                        "code": "selection_malformed",
+                    },
+                )
+            classes = element.get("classes")
+            if classes is not None and (
+                not isinstance(classes, list)
+                or not all(isinstance(value, str) for value in classes)
+            ):
+                return self._json(
+                    400,
+                    {
+                        "error": "selection.elements[].classes must be a list of strings",
+                        "code": "selection_malformed",
+                    },
+                )
+
+        preview_url = str(payload.get("previewUrl", ""))
+        project_id, project_root, source_file = rt._resolve_project(payload)
+        rt._sanitize_selection_sources(selection, project_root)
+
+        def transaction() -> tuple[int, dict[str, Any]]:
+            # Find/create, number, append, and publish are one transaction.  A
+            # split lets two handler threads lose a comment or duplicate a draft.
+            path = rt._open_draft_file(project_id)
+            if path is None:
+                request_id = rt._new_id()
+                request: dict[str, Any] = {
+                    "type": "visual_edit_batch",
+                    "id": request_id,
+                    "number": rt._next_number(project_id),
+                    "state": "draft",
+                    "projectId": project_id,
+                    "projectRoot": project_root,
+                    "createdAt": rt._now_iso(),
+                    "sentAt": "",
+                    "thread": [],
+                    "comments": [],
+                }
+                path = rt._request_file(rt.QUEUE_DIR, request_id)
+            else:
+                existing = rt._read_request(path)
+                if existing is None:
+                    return 500, {"error": "draft request unreadable"}
+                request = existing
+
+            comments: list[dict[str, Any]] = request.setdefault("comments", [])
+            if len(comments) >= rt.MAX_DRAFT_COMMENTS:
+                return 429, {
+                    "error": (
+                        f"this request already holds {rt.MAX_DRAFT_COMMENTS} comments — "
+                        "send or clear it before adding more"
+                    ),
+                    "code": "draft_comment_limit",
+                }
+
+            # Lookup ids are always server-minted strings, never payload values.
+            comment_id = rt._new_id()
+            created_at = payload.get("createdAt") or rt._now_iso()
+            follow_up_to = str(payload.get("followUpTo", "") or "")
+            if follow_up_to and not rt._ID_RE.match(follow_up_to):
+                follow_up_to = ""
+            comment = {
+                "cid": comment_id,
+                "index": len(comments) + 1,
+                "status": "new",
+                "comment": str(payload.get("comment", "")),
+                "createdAt": created_at,
+                "selection": selection,
+                "previewUrl": preview_url,
+                "projectId": project_id,
+                "sourceFile": source_file,
+                "followUpTo": follow_up_to,
+                "thread": [
+                    {
+                        "role": "user",
+                        "text": str(payload.get("comment", "")),
+                        "ts": created_at,
+                    }
+                ],
+            }
+            if rt._TARGET and not project_root:
+                comment["devServer"] = rt._TARGET
+            comments.append(comment)
+            rt._write_request(path, request)
+            return 200, {
+                "ok": True,
+                "id": request["id"],
+                "number": request["number"],
+                "state": request["state"],
+                "cid": comment_id,
+                "index": comment["index"],
+                "label": f"{request['number']}.{comment['index']}",
+                "commentCount": len(comments),
+                "savedTo": str(path),
+            }
+
+        with rt._QUEUE_LOCK:
+            try:
+                code, response = transaction()
+            except rt._RecordTooLarge as exc:
+                code = 413
+                response = {"error": str(exc), "code": "record_too_large"}
+        return self._json(code, response)
+
+    def _h_send(self, query: dict[str, list[str]]) -> None:
+        """Atomically seal a draft and return the authoritative delivery snapshot."""
+
+        rt = self.runtime
+        request_id = (query.get("id") or [""])[0]
+        if not request_id or not rt._ID_RE.match(request_id):
+            return self._json(400, {"error": "valid id required"})
+        path = rt._request_file(rt.QUEUE_DIR, request_id)
+
+        def transaction() -> tuple[int, dict[str, Any]]:
+            if not path.is_file():
+                return 404, {"error": "not found"}
+            request = rt._read_request(path)
+            if request is None:
+                return 500, {"error": "request unreadable"}
+            comments = request.get("comments") or []
+            if not comments:
+                return 400, {"error": "request has no comments"}
+            if not rt._is_draft(request):
+                return 200, {
+                    "ok": True,
+                    "already": True,
+                    "request": rt._summarize(request),
+                }
+            request["state"] = "sent"
+            request["sentAt"] = rt._now_iso()
+            for comment in comments:
+                if comment.get("status") == "new":
+                    comment["status"] = "sent"
+            rt._write_request(path, request)
+            return 200, {"ok": True, "request": rt._summarize(request)}
+
+        with rt._QUEUE_LOCK:
+            try:
+                code, response = transaction()
+            except rt._RecordTooLarge as exc:
+                code = 413
+                response = {"error": str(exc), "code": "record_too_large"}
+        return self._json(code, response)
+
+    def _h_delivered(self, query: dict[str, list[str]]) -> None:
+        """Idempotently acknowledge that a sealed prompt reached the agent."""
+
+        rt = self.runtime
+        request_id = (query.get("id") or [""])[0]
+        if not request_id or not rt._ID_RE.match(request_id):
+            return self._json(
+                400,
+                {"error": "valid id required", "code": "id_required"},
+            )
+        path = rt._request_file(rt.QUEUE_DIR, request_id)
+
+        def transaction() -> tuple[int, dict[str, Any]]:
+            if not path.is_file():
+                return 404, {"error": "not found", "code": "not_found"}
+            request = rt._read_request(path)
+            if request is None:
+                return 500, {"error": "request unreadable", "code": "unreadable"}
+            if rt._is_draft(request):
+                return 409, {
+                    "error": "request is still a draft — nothing was dispatched",
+                    "code": "not_sealed",
+                }
+            if not request.get("deliveredAt"):
+                request["deliveredAt"] = rt._now_iso()
+                rt._write_request(path, request)
+            return 200, {"ok": True, "request": rt._summarize(request)}
+
+        with rt._QUEUE_LOCK:
+            try:
+                code, response = transaction()
+            except rt._RecordTooLarge as exc:
+                code = 413
+                response = {"error": str(exc), "code": "record_too_large"}
+        return self._json(code, response)
+
+    def _h_delete_comment(self, query: dict[str, list[str]]) -> None:
+        """Delete one draft comment; sent batches are immutable."""
+
+        rt = self.runtime
+        request_id = (query.get("id") or [""])[0]
+        comment_id = (query.get("cid") or [""])[0]
+        if (
+            not request_id
+            or not rt._ID_RE.match(request_id)
+            or not comment_id
+            or not rt._ID_RE.match(comment_id)
+        ):
+            return self._json(400, {"error": "valid id and cid required"})
+        path = rt._request_file(rt.QUEUE_DIR, request_id)
+
+        def transaction() -> tuple[int, dict[str, Any]]:
+            if not path.is_file():
+                return 404, {"error": "not found"}
+            request = rt._read_request(path)
+            if request is None:
+                return 500, {"error": "request unreadable"}
+            if not rt._is_draft(request):
+                return 409, {"error": "request already sent — cannot remove comments"}
+            comments = request.get("comments") or []
+            kept = [comment for comment in comments if comment.get("cid") != comment_id]
+            if len(kept) == len(comments):
+                return 404, {"error": "comment not found"}
+            for index, comment in enumerate(kept, start=1):
+                comment["index"] = index
+            request["comments"] = kept
+            if not kept:
+                try:
+                    path.unlink()
+                except OSError as exc:
+                    return 500, {"error": str(exc)}
+                return 200, {"ok": True, "id": request_id, "removedRequest": True}
+            rt._write_request(path, request)
+            return 200, {
+                "ok": True,
+                "id": request_id,
+                "cid": comment_id,
+                "request": rt._summarize(request),
+            }
+
+        with rt._QUEUE_LOCK:
+            try:
+                code, response = transaction()
+            except rt._RecordTooLarge as exc:
+                code = 413
+                response = {"error": str(exc), "code": "record_too_large"}
+        return self._json(code, response)
+
+    def _h_clear(self, query: dict[str, list[str]]) -> None:
+        rt = self.runtime
+        request_id = (query.get("id") or [""])[0]
+        if not request_id or not rt._ID_RE.match(request_id):
+            return self._json(400, {"error": "valid id required"})
+        source = rt._request_file(rt.QUEUE_DIR, request_id)
+        destination = rt._request_file(rt.HANDLED_DIR, request_id)
+
+        def transaction() -> tuple[int, dict[str, Any]]:
+            # Serialize the rename with writers so a stale append cannot resurrect
+            # an archived request in queue/.
+            if not source.exists():
+                return 404, {"error": "not found"}
+            try:
+                source.replace(destination)
+            except OSError as exc:
+                return 500, {"error": str(exc)}
+            return 200, {"ok": True, "id": request_id}
+
+        with rt._QUEUE_LOCK:
+            try:
+                code, response = transaction()
+            except rt._RecordTooLarge as exc:
+                code = 413
+                response = {"error": str(exc), "code": "record_too_large"}
+        return self._json(code, response)
+
+    def _h_delete(self, query: dict[str, list[str]]) -> None:
+        rt = self.runtime
+        request_id = (query.get("id") or [""])[0]
+        if not request_id or not rt._ID_RE.match(request_id):
+            return self._json(400, {"error": "valid id required"})
+
+        def transaction() -> tuple[int, dict[str, Any]] | None:
+            removed = False
+            for directory in (rt.QUEUE_DIR, rt.HANDLED_DIR):
+                path = rt._request_file(directory, request_id)
+                if path.exists():
+                    try:
+                        path.unlink()
+                        removed = True
+                    except OSError as exc:
+                        return 500, {"error": str(exc)}
+            if not removed:
+                return 404, {"error": "not found"}
+            return None
+
+        # Serialize unlink with writers so a stale append cannot recreate it.
+        with rt._QUEUE_LOCK:
+            failed = transaction()
+        if failed is not None:
+            return self._json(*failed)
+        return self._json(200, {"ok": True, "id": request_id, "deleted": True})
+
+    def _h_projects_list(self) -> None:
+        rt = self.runtime
+        active = rt._active_project()
+        serving = bool(rt._ROOT and active and str(rt.Path(active["path"]).resolve()) == rt._ROOT)
+        projects = []
+        for project in rt._CFG["projects"]:
+            row = dict(project)
+            root = rt._valid_root(project["path"])
+            row.update(
+                rt._classify_project(root)
+                if root
+                else {
+                    "needsDevServer": False,
+                    "devCommand": "",
+                    "unbundledEntry": "",
+                    "hasEntry": False,
+                }
+            )
+            row["devRunning"] = rt._dev_proc_alive(project["id"])
+            live = rt._DEV_PROCS.get(project["id"]) or {}
+            if live.get("proxyUrl"):
+                row["previewUrl"] = live["proxyUrl"]
+                row["devUrl"] = live.get("url", "")
+            elif rt._valid_target(str(row.get("previewUrl") or "").strip()):
+                # Persisted upstream URLs must be re-framed through the injecting
+                # proxy.  A bind failure may never fall back to the bare URL.
+                dev_url = str(row["previewUrl"]).strip()
+                row["previewUrl"] = rt._front_with_proxy(project["id"], dev_url)
+                row["devUrl"] = dev_url
+            elif root is not None and not row.get("previewUrl"):
+                static_url = rt._static_preview_url(project["id"])
+                if static_url:
+                    row["previewUrl"] = static_url
+                    row["previewMode"] = "static"
+            elif row.get("previewUrl"):
+                # Never return a persisted value that no longer proves loopback.
+                row["previewUrl"] = ""
+            projects.append(row)
+        return self._json(
+            200,
+            {
+                "projects": projects,
+                "activeId": rt._CFG["activeId"],
+                "serving": serving,
+                "version": rt.VERSION,
+            },
+        )
+
+    def _h_dev_server_start(self, query: dict[str, list[str]]) -> None:
+        rt = self.runtime
+        project_id = (query.get("id") or [""])[0]
+        project = next(
+            (item for item in rt._CFG["projects"] if item["id"] == project_id),
+            None,
+        )
+        if project is None:
+            return self._json(404, {"error": "project not found"})
+        root = rt._valid_root(project["path"])
+        if root is None:
+            return self._json(
+                400,
+                {"error": f"folder no longer readable: {project['path']}"},
+            )
+
+        adopted = rt._auto_dev_server(root)
+        if adopted:
+            framed = rt._front_with_proxy(project_id, adopted)
+            return self._json(
+                200,
+                {
+                    "ok": True,
+                    "url": framed,
+                    "devUrl": adopted,
+                    "adopted": True,
+                    "injected": bool(framed) and framed != adopted,
+                    "project": project,
+                },
+            )
+
+        result = rt._start_dev_proc(project_id, root)
+        if not result.get("ok"):
+            # Starting is a probe-like operation; its error text is the answer.
+            return self._json(200, result)
+        return self._json(200, {**result, "project": project})
+
+    def _h_dev_server_stop(self, query: dict[str, list[str]]) -> None:
+        rt = self.runtime
+        project_id = (query.get("id") or [""])[0]
+        project = next(
+            (item for item in rt._CFG["projects"] if item["id"] == project_id),
+            None,
+        )
+        if project is None:
+            return self._json(404, {"error": "project not found"})
+
+        # Process teardown can wait for TERM/KILL escalation, so it must precede
+        # and remain outside the registry lock.
+        stopped = rt._stop_dev_proc(project_id)
+        with rt._QUEUE_LOCK:
+            live = next(
+                (item for item in rt._CFG["projects"] if item["id"] == project_id),
+                None,
+            )
+            if live is not None:
+                live.pop("previewUrl", None)
+                rt._save_cfg(rt._CFG)
+                project = live
+        return self._json(
+            200,
+            {"ok": True, "stopped": stopped, "project": project},
+        )
+
+    def _h_projects_add(self) -> None:
+        rt = self.runtime
+        data = self._read_body()
+        raw = str(data.get("path", "")).strip()
+        root = rt._valid_root(raw)
+        if root is None:
+            return self._json(400, {"error": f"not a readable folder: {raw}"})
+        preview_url = str(data.get("previewUrl", "") or "").strip().rstrip("/")
+        if preview_url and not rt._valid_target(preview_url):
+            return self._json(
+                400,
+                {
+                    "error": "dev server URL must be http://localhost:PORT or "
+                    "http://127.0.0.1:PORT"
+                },
+            )
+
+        def existing_project() -> dict[str, Any] | None:
+            for item in rt._CFG["projects"]:
+                if str(rt.Path(item["path"]).resolve()) == str(root):
+                    return item
+            return None
+
+        # Scan/update is a single registry transaction.
+        with rt._QUEUE_LOCK:
+            project = existing_project()
+            if project is not None:
+                if preview_url and project.get("previewUrl", "") != preview_url:
+                    project["previewUrl"] = preview_url
+                    rt._save_cfg(rt._CFG)
+                    return self._json(
+                        200,
+                        {
+                            "ok": True,
+                            "project": project,
+                            "existing": True,
+                            "updated": "previewUrl",
+                        },
+                    )
+                return self._json(
+                    200,
+                    {"ok": True, "project": project, "existing": True},
+                )
+
+        project = {
+            "id": rt.uuid.uuid4().hex[:8],
+            "path": str(root),
+            "name": root.name,
+        }
+        # Discovery invokes lsof/probes and must stay outside the registry lock.
+        detected = []
+        if preview_url:
+            project["previewUrl"] = preview_url
+        else:
+            detected = rt._detect_dev_servers(root)
+            html = [candidate for candidate in detected if candidate["servesHtml"]]
+            if len(html) == 1:
+                project["previewUrl"] = html[0]["url"]
+
+        with rt._QUEUE_LOCK:
+            duplicate = existing_project()
+            if duplicate is not None:
+                return self._json(
+                    200,
+                    {"ok": True, "project": duplicate, "existing": True},
+                )
+            rt._CFG["projects"].append(project)
+            rt._save_cfg(rt._CFG)
+        return self._json(
+            200,
+            {
+                "ok": True,
+                "project": project,
+                "detected": detected,
+                "autoDetected": bool(not preview_url and project.get("previewUrl")),
+            },
+        )
+
+    def _h_detect_dev_server(self, query: dict[str, list[str]]) -> None:
+        rt = self.runtime
+        project_id = (query.get("id") or [""])[0]
+        raw = (query.get("path") or [""])[0]
+        if project_id:
+            project = next(
+                (item for item in rt._CFG["projects"] if item["id"] == project_id),
+                None,
+            )
+            if project is None:
+                return self._json(404, {"error": "project not found"})
+            raw = project["path"]
+        root = rt._valid_root(raw)
+        if root is None:
+            return self._json(400, {"error": f"not a readable folder: {raw}"})
+        candidates = rt._detect_dev_servers(root)
+        html = [candidate for candidate in candidates if candidate["servesHtml"]]
+        return self._json(
+            200,
+            {
+                "ok": True,
+                "root": str(root),
+                "candidates": candidates,
+                "suggested": html[0]["url"] if len(html) == 1 else "",
+            },
+        )
+
+    def _h_projects_preview_url(self) -> None:
+        rt = self.runtime
+        data = self._read_body()
+        project_id = str(data.get("id", ""))
+        url = str(data.get("previewUrl", "") or "").strip().rstrip("/")
+        if url and not rt._valid_target(url):
+            return self._json(
+                400,
+                {
+                    "error": "dev server URL must be http://localhost:PORT or "
+                    "http://127.0.0.1:PORT"
+                },
+            )
+        with rt._QUEUE_LOCK:
+            project = next(
+                (item for item in rt._CFG["projects"] if item["id"] == project_id),
+                None,
+            )
+            if project is None:
+                return self._json(404, {"error": "project not found"})
+            if url:
+                project["previewUrl"] = url
+            else:
+                project.pop("previewUrl", None)
+            rt._save_cfg(rt._CFG)
+        return self._json(200, {"ok": True, "project": project})
+
+    def _h_projects_select(self) -> None:
+        rt = self.runtime
+        data = self._read_body()
+        project_id = str(data.get("id", ""))
+        with rt._QUEUE_LOCK:
+            project = next(
+                (item for item in rt._CFG["projects"] if item["id"] == project_id),
+                None,
+            )
+            if project is None:
+                return self._json(404, {"error": "project not found"})
+            root = rt._valid_root(project["path"])
+            if root is None:
+                return self._json(
+                    400,
+                    {"error": f"folder no longer readable: {project['path']}"},
+                )
+            rt._ROOT = str(root)
+            rt._TARGET = ""
+            rt._CFG["activeId"] = project_id
+            rt._save_cfg(rt._CFG)
+        return self._json(200, {"ok": True, "project": project})
+
+    def _h_projects_remove(self) -> None:
+        rt = self.runtime
+        data = self._read_body()
+        project_id = str(data.get("id", ""))
+        _QUEUE_LOCK = rt._QUEUE_LOCK
+        with _QUEUE_LOCK:
+            project = next(
+                (item for item in rt._CFG["projects"] if item["id"] == project_id),
+                None,
+            )
+            if project is None:
+                return self._json(404, {"error": "project not found"})
+            rt._CFG["projects"] = [item for item in rt._CFG["projects"] if item["id"] != project_id]
+            if rt._CFG.get("activeId") == project_id:
+                rt._CFG["activeId"] = ""
+                rt._ROOT = ""
+            rt._save_cfg(rt._CFG)
+
+        # Teardown can wait on processes and accept loops; do it after releasing
+        # the registry lock, before forgetting the final resource handles.
+        _stop_dev_proc = rt._stop_dev_proc
+        _stop_static_preview = rt._stop_static_preview
+        _stop_dev_proc(project_id)
+        _stop_static_preview(project_id)
+        return self._json(200, {"ok": True, "id": project_id})
+
+    def _h_pick_folder(self) -> None:
+        """Native picker seam implemented by the bound ``server.Handler``."""
+
+        raise NotImplementedError("the bound handler must provide the native picker")
+
+    def _h_thread(self, query: dict[str, list[str]]) -> None:
+        """Append progress to one comment thread or the request-level thread."""
+
+        rt = self.runtime
+        request_id = (query.get("id") or [""])[0]
+        comment_id = (query.get("cid") or [""])[0]
+        if not request_id or not rt._ID_RE.match(request_id):
+            return self._json(400, {"error": "valid id required"})
+        if comment_id and not rt._ID_RE.match(comment_id):
+            return self._json(400, {"error": "invalid cid"})
+        data = self._read_body()
+        # Redact before persistence.  Security-policy ordering remains owned by
+        # server and is reached through this single late-bound seam.
+        text = rt._redact_incoming_thread_text(str(data.get("text", "")).strip())
+        role = str(data.get("role", "agent")).strip() or "agent"
+        if role not in ("agent", "user", "system"):
+            role = "agent"
+        new_status = str(data.get("status", "")).strip()
+        if not text and not new_status:
+            return self._json(400, {"error": "text or status required"})
+
+        def transaction() -> tuple[int, dict[str, Any]]:
+            path = rt._find_request(request_id)
+            if path is None:
+                return 404, {"error": "not found"}
+            request = rt._read_request(path)
+            if request is None:
+                return 500, {"error": "request unreadable"}
+
+            entry = {"role": role, "text": text, "ts": rt._now_iso()}
+            if comment_id:
+                target = next(
+                    (
+                        comment
+                        for comment in (request.get("comments") or [])
+                        if comment.get("cid") == comment_id
+                    ),
+                    None,
+                )
+                if target is None:
+                    return 404, {"error": f"comment {comment_id} not in request {request_id}"}
+                thread = target.get("thread")
+                if not isinstance(thread, list):
+                    thread = []
+                if text:
+                    if len(thread) >= rt.MAX_THREAD_ENTRIES:
+                        return 429, {
+                            "error": (
+                                f"comment {comment_id} already holds "
+                                f"{rt.MAX_THREAD_ENTRIES} thread entries — the "
+                                "conversation is full"
+                            ),
+                            "code": "thread_entry_limit",
+                        }
+                    thread.append(entry)
+                target["thread"] = thread
+                if new_status in rt._COMMENT_STATUSES:
+                    target["status"] = new_status
+            else:
+                thread = request.get("thread")
+                if not isinstance(thread, list):
+                    thread = []
+                if text:
+                    if len(thread) >= rt.MAX_THREAD_ENTRIES:
+                        return 429, {
+                            "error": (
+                                f"request {request_id} already holds "
+                                f"{rt.MAX_THREAD_ENTRIES} thread entries — the "
+                                "conversation is full"
+                            ),
+                            "code": "thread_entry_limit",
+                        }
+                    thread.append(entry)
+                request["thread"] = thread
+                if new_status == "done":
+                    for comment in request.get("comments") or []:
+                        comment["status"] = "done"
+
+            agent_activity = role in ("agent", "system")
+            worked = any(
+                comment.get("status") != "new" for comment in (request.get("comments") or [])
+            )
+            if request.get("state") not in ("draft", "sent") or (
+                request.get("state") == "draft" and (worked or agent_activity)
+            ):
+                request["state"] = "sent"
+                if not request.get("sentAt"):
+                    request["sentAt"] = rt._now_iso()
+
+            try:
+                rt._write_request(path, request)
+            except OSError as exc:
+                return 500, {"error": str(exc)}
+            return 200, {
+                "ok": True,
+                "id": request_id,
+                "cid": comment_id,
+                "status": rt._request_status(request),
+                "request": rt._summarize(request),
+            }
+
+        with rt._QUEUE_LOCK:
+            try:
+                code, response = transaction()
+            except rt._RecordTooLarge as exc:
+                code = 413
+                response = {"error": str(exc), "code": "record_too_large"}
+        return self._json(code, response)
+
+    def _h_set_source(self) -> None:
+        """Set a legacy folder or loopback dev-server preview source."""
+
+        rt = self.runtime
+        data = self._read_body()
+        value = str(data.get("value", data.get("url", ""))).strip()
+        if not value:
+            rt._ROOT = ""
+            rt._TARGET = ""
+            return self._json(
+                200,
+                {"ok": True, "mode": "cleared", "proxyUrl": rt.PROXY_PUBLIC_BASE},
+            )
+        if value.lower().startswith(("http://", "https://")):
+            if not rt._valid_target(value):
+                return self._json(
+                    400,
+                    {"error": "URL must be http://localhost:PORT or " "http://127.0.0.1:PORT"},
+                )
+            rt._TARGET = value.rstrip("/")
+            rt._ROOT = ""
+            return self._json(
+                200,
+                {
+                    "ok": True,
+                    "mode": "url",
+                    "target": rt._TARGET,
+                    "proxyUrl": rt.PROXY_PUBLIC_BASE,
+                },
+            )
+        root = rt._valid_root(value)
+        if root is None:
+            return self._json(400, {"error": f"not a readable folder: {value}"})
+        rt._ROOT = str(root)
+        rt._TARGET = ""
+        return self._json(
+            200,
+            {
+                "ok": True,
+                "mode": "folder",
+                "root": rt._ROOT,
+                "proxyUrl": rt.PROXY_PUBLIC_BASE,
+            },
+        )
+
+    def _h_inject(self) -> None:
+        rt = self.runtime
+        try:
+            javascript = rt.INJECT_FILE.read_bytes()
+        except OSError:
+            return self._send_raw(
+                404,
+                "application/javascript",
+                b"// overlay not found",
+            )
+        return self._send_raw(
+            200,
+            "application/javascript; charset=utf-8",
+            javascript,
+        )
+
+    def _send_raw(self, code: int, content_type: str, body: bytes) -> None:
+        rt = self.runtime
+        self.send_response(code)
+        self.send_header("Content-Type", rt._header_value(content_type))
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, code: int, payload: Any) -> None:
+        rt = self.runtime
+        body = rt.json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+__all__ = ["Handler", "IncompleteBody"]

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/preview_files.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/preview_files.py
@@ -1,0 +1,722 @@
+"""File-backed preview serving for the Design Tweak backend.
+
+``server`` is the composition root and security-policy owner.  Helpers receive
+that module as ``runtime`` and resolve mutable state and compatibility seams at
+call time, making the server namespace the authoritative runtime boundary.
+"""
+
+from __future__ import annotations
+
+import re
+from http.server import BaseHTTPRequestHandler
+from typing import Any
+
+from kiro_crew.security import DENIED_ROOT_PARTS
+
+Response = tuple[int, str, bytes]
+
+# Ceiling on ONE statically-served preview file. Generous for real web assets
+# (bundles, fonts, images) while bounding the buffer: the static response reads
+# the whole file into memory, so without this a large asset sitting in the
+# previewed project is enough to exhaust the backend. Distinct from
+# `MAX_BODY_BYTES`, which caps an inbound request body rather than an outbound
+# file.
+MAX_STATIC_BYTES = 64 * 1024 * 1024
+CLIENT_READ_TIMEOUT = 30
+OVERLAY_PATH = "/__kiro_select_to_edit__.js"
+
+# A closed map keeps attacker-influenced path text out of response headers and
+# makes unknown extensions inert and deterministic across hosts.
+CTYPE_OVERRIDES = {
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".xhtml": "application/xhtml+xml",
+    ".css": "text/css",
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".cjs": "text/javascript",
+    ".json": "application/json",
+    ".map": "application/json",
+    ".webmanifest": "application/manifest+json",
+    ".xml": "text/xml",
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".csv": "text/csv",
+    ".wasm": "application/wasm",
+    ".pdf": "application/pdf",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".avif": "image/avif",
+    ".bmp": "image/bmp",
+    ".ico": "image/x-icon",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".otf": "font/otf",
+    ".eot": "application/vnd.ms-fontobject",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".ogg": "audio/ogg",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+}
+CTYPE_DEFAULT = "application/octet-stream"
+
+# An upstream header only selects a literal from this map.  It never reaches a
+# response-header sink verbatim, which prevents response splitting.
+PROXY_CTYPES: dict[str, str] = {
+    "text/html": "text/html; charset=utf-8",
+    "application/xhtml+xml": "text/html; charset=utf-8",
+    "text/css": "text/css; charset=utf-8",
+    "text/javascript": "text/javascript; charset=utf-8",
+    "application/javascript": "text/javascript; charset=utf-8",
+    "application/json": "application/json; charset=utf-8",
+    "application/manifest+json": "application/manifest+json",
+    "text/plain": "text/plain; charset=utf-8",
+    "text/markdown": "text/markdown; charset=utf-8",
+    "text/xml": "text/xml; charset=utf-8",
+    "application/xml": "application/xml; charset=utf-8",
+    "image/svg+xml": "image/svg+xml",
+    "image/png": "image/png",
+    "image/jpeg": "image/jpeg",
+    "image/gif": "image/gif",
+    "image/webp": "image/webp",
+    "image/avif": "image/avif",
+    "image/x-icon": "image/x-icon",
+    "image/vnd.microsoft.icon": "image/x-icon",
+    "font/woff": "font/woff",
+    "font/woff2": "font/woff2",
+    "font/ttf": "font/ttf",
+    "font/otf": "font/otf",
+    "application/wasm": "application/wasm",
+    "audio/mpeg": "audio/mpeg",
+    "video/mp4": "video/mp4",
+    "video/webm": "video/webm",
+    "application/octet-stream": "application/octet-stream",
+}
+
+ENTRY_CANDIDATES = (
+    "index.html",
+    "index.htm",
+    "public/index.html",
+    "dist/index.html",
+    "build/index.html",
+    "out/index.html",
+    "app/index.html",
+    "src/index.html",
+    "site/index.html",
+    "www/index.html",
+    "docs/index.html",
+    "demo/index.html",
+    "example/index.html",
+    "examples/index.html",
+)
+
+# These trees cannot hold a preview entry and can make a diagnostic scan
+# needlessly traverse thousands of files.
+SCAN_SKIP_DIRS = {
+    "node_modules",
+    ".git",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".cache",
+    ".turbo",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "coverage",
+    "htmlcov",
+    ".pytest_cache",
+    "target",
+    "vendor",
+    ".idea",
+    ".vscode",
+}
+
+SCRIPT_TAG_RE = re.compile(r"<script\b([^>]*)>", re.IGNORECASE)
+ATTR_TYPE_MODULE_RE = re.compile(r"""\btype\s*=\s*["']module["']""", re.IGNORECASE)
+ATTR_SRC_RE = re.compile(r"""\bsrc\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+UNBUNDLED_EXTS = (".ts", ".tsx", ".jsx")
+
+# Containment alone intentionally does not authorize credential and VCS
+# material that happens to live inside a registered project root.
+PROJECT_SECRET_NAMES: frozenset[str] = frozenset(
+    {
+        ".npmrc",
+        ".netrc",
+        ".pypirc",
+        ".git-credentials",
+        ".htpasswd",
+        ".app_secret",
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+        "credentials",
+        "secring.gpg",
+    }
+)
+# Whole directories, matched on any path component. `.docker` holds
+# `config.json`, whose `auths` entries are registry credentials. Derived from the
+# shared credential denylist so an entry added there propagates to this
+# static-file-serving guard automatically; the extras are VCS metadata and
+# credential dirs specific to what a previewed project tree may contain.
+PROJECT_SECRET_DIRS: frozenset[str] = DENIED_ROOT_PARTS | frozenset(
+    {".git", ".hg", ".svn", ".gpg", ".azure"}
+)
+PROJECT_SECRET_SUFFIXES: tuple[str, ...] = (
+    ".pem",
+    ".key",
+    ".p8",
+    ".p12",
+    ".pfx",
+    ".jks",
+    ".keystore",
+)
+
+# Filename classifiers cannot cover arbitrary private-key names, so the bytes
+# also carry a cheap, first-line PEM backstop.
+PEM_PRIVATE_KEY_RE = re.compile(rb"^-{5}BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-{5}")
+PEM_MARKER_RE = re.compile(r"-{5}(?:BEGIN|END)[A-Z0-9 ]*PRIVATE KEY-{5}")
+PEM_BODY_RE = re.compile(r"[A-Za-z0-9+/=]{16,}")
+
+
+def guess_ctype(runtime: Any, path: Any) -> str:
+    """Return a literal content type for a file served from disk."""
+
+    return runtime._CTYPE_OVERRIDES.get(path.suffix.lower(), runtime._CTYPE_DEFAULT)
+
+
+def safe_upstream_ctype(runtime: Any, raw: str | None, path: str) -> str:
+    """Return a response-safe content type selected by an upstream reply."""
+
+    media = (raw or "").split(";", 1)[0].strip().lower()
+    mapped = runtime._PROXY_CTYPES.get(media)
+    if mapped:
+        return mapped
+    ext = runtime.os.path.splitext(runtime.urlparse(path).path)[1].lower()
+    return runtime._CTYPE_OVERRIDES.get(ext, runtime._CTYPE_DEFAULT)
+
+
+def unbundled_entry(runtime: Any, body: bytes) -> str:
+    """Return the first TS/JSX module script, or ``""`` for static HTML."""
+
+    try:
+        text = body.decode("utf-8", "replace")
+    except (UnicodeDecodeError, AttributeError):
+        return ""
+    for match in runtime._SCRIPT_TAG_RE.finditer(text):
+        attrs = match.group(1)
+        if not runtime._ATTR_TYPE_MODULE_RE.search(attrs):
+            continue
+        source_match = runtime._ATTR_SRC_RE.search(attrs)
+        if not source_match:
+            continue
+        source = source_match.group(1)
+        bare = source.split("?", 1)[0].split("#", 1)[0].lower()
+        if bare.endswith(runtime._UNBUNDLED_EXTS):
+            return source
+    return ""
+
+
+def find_entry(runtime: Any, folder: Any, root: Any | None = None) -> Any | None:
+    """Return the first safe entry HTML below ``folder``, if one exists."""
+
+    project_root = root if root is not None else folder
+    for relative in runtime._ENTRY_CANDIDATES:
+        # Re-contain each candidate because a directory request screens the
+        # directory before entry selection, while the selected file may be a
+        # symlink to a secret or to a path outside that directory.
+        try:
+            candidate = runtime._contained(folder, relative)
+        except runtime._PathEscape:
+            continue
+        if not candidate.is_file():
+            continue
+        if (
+            runtime.is_sensitive_path(str(candidate))
+            or runtime._is_project_secret(project_root, candidate)
+            or runtime._is_kirocrew_internal(candidate)
+        ):
+            continue
+        return candidate
+    return None
+
+
+def scan_html(runtime: Any, root: Any, limit: int = 40, max_depth: int = 3) -> list[str]:
+    """Return a shallow, root-relative list of previewable HTML files."""
+
+    found: list[str] = []
+
+    def walk(directory: Any, depth: int) -> None:
+        if len(found) >= limit or depth > max_depth:
+            return
+        try:
+            entries = sorted(
+                directory.iterdir(), key=lambda entry: (entry.is_dir(), entry.name.lower())
+            )
+        except OSError:
+            return
+        for entry in entries:
+            if len(found) >= limit:
+                return
+            # Check before ``is_dir()``, which follows links.  Diagnostic names
+            # are visible to the preview page, so even listing a linked private
+            # directory would disclose information.
+            if entry.is_symlink():
+                continue
+            name = entry.name
+            if entry.is_dir():
+                if name.startswith(".") or name in runtime._SCAN_SKIP_DIRS:
+                    continue
+                walk(entry, depth + 1)
+            elif entry.suffix.lower() in (".html", ".htm"):
+                try:
+                    found.append(entry.relative_to(root).as_posix())
+                except ValueError:
+                    continue
+
+    walk(root, 0)
+    return found
+
+
+def rewrite_html(runtime: Any, body: bytes, base: str | None, script: str) -> bytes:
+    """Inject the Select-to-Edit overlay and an optional base URL."""
+
+    del runtime  # The uniform signature lets the composition root delegate directly.
+    try:
+        document = body.decode("utf-8", "replace")
+    except (UnicodeDecodeError, AttributeError):
+        return body
+    inject_tag = f'<script src="{script}"></script>'
+    if base is not None:
+        base_tag = f'<base href="{base}">'
+        lowered = document.lower()
+        head = lowered.find("<head")
+        if head != -1:
+            end = lowered.find(">", head)
+            if end != -1:
+                document = document[: end + 1] + base_tag + document[end + 1 :]
+        else:
+            document = base_tag + document
+    body_end = document.lower().rfind("</body>")
+    if body_end != -1:
+        document = document[:body_end] + inject_tag + document[body_end:]
+    else:
+        document += inject_tag
+    return document.encode("utf-8")
+
+
+def needs_dev_server_body(runtime: Any, root: Any, page: Any, entry: str) -> bytes:
+    """Explain why a bundler template cannot render as static HTML."""
+
+    built = [name for name in ("dist", "build", "out", ".output/public") if (root / name).is_dir()]
+    built_hint = (
+        (
+            "<p>This project has a <code>"
+            + "</code>, <code>".join(built)
+            + "</code> folder — if that is a finished build, register THAT folder "
+            "instead and it will preview from disk.</p>"
+        )
+        if built
+        else ""
+    )
+    page_display = runtime._html.escape(page.name)
+    entry_display = runtime._html.escape(entry)
+    body = (
+        f"<h3>{page_display} needs a dev server</h3>"
+        f"<p>Its only script is <code>{entry_display}</code> — TypeScript/JSX, which "
+        "the browser cannot run. A bundler has to transform it, so serving these "
+        "files from disk renders an empty page.</p>"
+        "<p><b>Start this project's dev server</b> (<code>npm run dev</code>), then "
+        "press <b>Dev server</b> in the bar below the preview. Design Tweak will "
+        "frame it directly, hot reload keeps working, and select-to-edit still "
+        "works.</p>"
+        f"{built_hint}"
+    )
+    return (
+        "<!doctype html><meta charset='utf-8'>"
+        "<style>"
+        "body{font:14px/1.6 system-ui,-apple-system,sans-serif;padding:28px 32px;"
+        "color:#e6e6e6;background:#151517;max-width:56ch}"
+        "h3{margin:0 0 12px;font-size:15px;font-weight:600}"
+        "code{font:12px ui-monospace,SFMono-Regular,Menlo,monospace;"
+        "background:#26262a;padding:1px 5px;border-radius:4px}"
+        "p{margin:0 0 10px}b{color:#fff}"
+        "</style>"
+        f"{body}"
+    ).encode("utf-8")
+
+
+def no_entry_response(
+    runtime: Any, root: Any, folder: Any, base: str, missing: str = ""
+) -> Response:
+    """Return a diagnostic 404 with safe links to HTML files that exist."""
+
+    try:
+        # Re-contain both paths so every scan and stat consumes the canonical
+        # barrier's return value, regardless of what the caller supplied.
+        root = runtime._contained(root)
+        folder = runtime._contained(root, runtime.os.fspath(folder))
+    except runtime._PathEscape:
+        return 403, "text/plain", b"forbidden"
+    scan_from = folder if folder.is_dir() else root
+    candidates = runtime._scan_html(scan_from)
+    if not candidates and scan_from != root:
+        scan_from = root
+        candidates = runtime._scan_html(scan_from)
+    try:
+        prefix = scan_from.relative_to(root).as_posix()
+    except ValueError:
+        prefix = ""
+    prefix = "" if prefix in ("", ".") else prefix + "/"
+
+    if missing:
+        head = f"<code>{runtime._html.escape(missing)}</code> was not found in this project."
+    else:
+        head = (
+            "No <code>index.html</code> in " f"<code>{runtime._html.escape(str(scan_from))}</code>."
+        )
+
+    if candidates:
+        links = "".join(
+            f'<li><a href="{runtime._html.escape(base + prefix + candidate)}">'
+            f"{runtime._html.escape(prefix + candidate)}</a></li>"
+            for candidate in candidates
+        )
+        body = (
+            "<p>Design Tweak serves the folder as a static site and looks for an "
+            "entry <code>index.html</code>. These HTML files are in the project — "
+            "click one to preview it:</p>"
+            f"<ul>{links}</ul>"
+            "<p class='hint'>If the right entry point isn't listed, register the "
+            "<em>subfolder</em> that contains it (<code>+ load new app</code>), or point "
+            "Design Tweak at a running dev server URL for framework projects.</p>"
+        )
+    else:
+        body = (
+            "<p>No HTML files were found here, so there is nothing to serve "
+            "statically. This usually means the project is a framework app "
+            "(React / Vite / Next) that needs its dev server, or the previewable "
+            "site lives in a subfolder that wasn't registered.</p>"
+            "<p class='hint'>Fix it by either registering the subfolder that "
+            "contains <code>index.html</code>, running the project's build "
+            "(<code>npm run build</code>) and registering <code>dist/</code>, or "
+            "starting <code>npm run dev</code> and pointing Design Tweak at "
+            "<code>http://localhost:PORT</code>.</p>"
+        )
+
+    document = (
+        "<!doctype html><meta charset='utf-8'>"
+        "<style>"
+        "body{font:14px/1.6 system-ui,-apple-system,sans-serif;padding:28px 32px;"
+        "color:#e6e6e6;background:#151517}"
+        "h3{margin:0 0 12px;font-size:15px;font-weight:600}"
+        "code{font:12px ui-monospace,SFMono-Regular,Menlo,monospace;"
+        "background:#26262a;padding:1px 5px;border-radius:4px}"
+        "ul{margin:12px 0;padding-left:20px}li{margin:3px 0}"
+        "a{color:#7cc4ff}.hint{color:#9a9aa2;font-size:13px}"
+        "</style>"
+        f"<h3>{head}</h3>{body}"
+    )
+    return 404, "text/html; charset=utf-8", document.encode("utf-8")
+
+
+def contains_credential(runtime: Any, data: bytes) -> bool:
+    """Return whether textual file content carries a recognizable credential."""
+
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        # Images, fonts, and wasm have no text credentials to scan and must not
+        # become false positives merely because they are arbitrary bytes.
+        return False
+    for pattern in runtime.get_credential_patterns():
+        for match in pattern.finditer(text):
+            hit = match.group()
+            if "PRIVATE KEY" in hit and not runtime._PEM_BODY_RE.search(
+                runtime._PEM_MARKER_RE.sub("", hit)
+            ):
+                # Documentation often quotes a PEM marker without carrying key
+                # material; require an armoured body before refusing that case.
+                continue
+            return True
+    return False
+
+
+def is_project_secret(runtime: Any, root: Any, target: Any) -> bool:
+    """Return whether ``target`` is credential material inside ``root``."""
+
+    try:
+        relative_parts = target.relative_to(root).parts
+    except ValueError:
+        # The canonical containment barrier normally makes this unreachable;
+        # refuse an unrelatable path instead of guessing.
+        return True
+    for part in relative_parts:
+        lowered = part.lower()
+        if lowered in runtime._PROJECT_SECRET_DIRS or lowered in runtime._PROJECT_SECRET_NAMES:
+            return True
+        # The prefix covers .env variants and direnv's .envrc family.  A web
+        # preview does not need those dotfiles, while serving one can expose a
+        # live key to same-origin project JavaScript.
+        if lowered.startswith(".env"):
+            return True
+        if lowered.endswith(runtime._PROJECT_SECRET_SUFFIXES):
+            return True
+    return False
+
+
+def read_static_file(runtime: Any, root: Any, target: Any) -> Response:
+    """Read one contained file with size and descriptor-bound no-link checks."""
+
+    # This server buffers the whole response, so the advisory stat prevents an
+    # ordinary large project asset from exhausting the backend before the open.
+    try:
+        size = target.stat().st_size
+    except OSError as exc:
+        return 500, "text/plain", str(exc).encode()
+    if size > runtime.MAX_STATIC_BYTES:
+        message = (
+            f"file is {size} bytes, over the " f"{runtime.MAX_STATIC_BYTES}-byte preview limit"
+        )
+        return 413, "text/plain", message.encode()
+
+    # The stat checks a name, not the inode ultimately read.  The no-link helper
+    # opens first, validates the descriptor's real path against the approved
+    # root, and reapplies the byte ceiling to the bytes it actually serves.
+    data = runtime.safe_read_file_bytes_nolink(
+        str(target),
+        within_root=str(root),
+        max_bytes=runtime.MAX_STATIC_BYTES,
+    )
+    if data is None:
+        return 403, "text/plain", b"forbidden"
+    return 200, "", data
+
+
+def static_response(
+    runtime: Any, root_string: str, relative: str, base: str, script: str
+) -> Response:
+    """Build a contained, credential-screened static preview response."""
+
+    relative = relative.lstrip("/")
+    try:
+        # One canonical barrier normalizes the root and proves the request path
+        # is inside it; every filesystem operation consumes these return values.
+        root = runtime._contained(root_string)
+        target = runtime._contained(root, relative)
+    except runtime._PathEscape:
+        return 403, "text/plain", b"forbidden"
+
+    # A registered root can legitimately contain sensitive home directories or
+    # project-local credentials.  Containment therefore needs all three policy
+    # classifiers before a directory lookup, stat, or read is authorized.
+    if runtime.is_sensitive_path(str(target)):
+        return 403, "text/plain", b"forbidden"
+    if runtime._is_project_secret(root, target):
+        return 403, "text/plain", b"forbidden"
+    if runtime._is_kirocrew_internal(target):
+        return 403, "text/plain", b"forbidden"
+
+    if target.is_dir():
+        entry = runtime._find_entry(target, root)
+        if entry is None:
+            return runtime._no_entry_response(root, target, base)
+        target = entry
+    if not target.is_file():
+        return runtime._no_entry_response(root, target, base, missing=relative)
+
+    status, content_type, data = read_static_file(runtime, root, target)
+    if status != 200:
+        return status, content_type, data
+
+    # Name-based secret rules cannot cover arbitrary private-key filenames or
+    # credentials embedded in ordinary config, script, and fixture files.
+    if runtime._PEM_PRIVATE_KEY_RE.match(data.lstrip()[:64]):
+        return 403, "text/plain", b"forbidden"
+    if runtime._contains_credential(data):
+        return 403, "text/plain", b"forbidden"
+
+    content_type = runtime._guess_ctype(target)
+    if "text/html" in content_type:
+        entry = runtime._unbundled_entry(data)
+        if entry:
+            # The file exists and the explanation is the successful preview;
+            # returning 4xx would replace it with the panel's generic error UI.
+            return (
+                200,
+                "text/html; charset=utf-8",
+                runtime._needs_dev_server_body(root, target, entry),
+            )
+        try:
+            subdirectory = target.parent.relative_to(root).as_posix()
+        except ValueError:
+            subdirectory = "."
+        html_base = base if subdirectory in ("", ".") else base + subdirectory + "/"
+        return (
+            200,
+            "text/html; charset=utf-8",
+            runtime._rewrite_html(data, html_base, script=script),
+        )
+    return 200, content_type, data
+
+
+class StaticInjectHandlerBase(BaseHTTPRequestHandler):
+    """Read-only file preview handler bound to a server runtime by a subclass."""
+
+    runtime: Any
+    protocol_version = "HTTP/1.1"
+    timeout = CLIENT_READ_TIMEOUT
+
+    def log_message(self, *args: Any) -> None:
+        """Suppress the standard-library request log."""
+
+    def _refuse(self, status: int, message: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(message)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(message)
+
+    def _send(self, status: int, content_type: str, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        # No CORS header is intentional: the preview must not become a
+        # cross-origin file API for an unrelated page.
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _dispatch(self) -> None:
+        runtime = self.runtime
+        path = runtime.urlparse(self.path).path
+        if path == runtime._OVERLAY_PATH:
+            try:
+                javascript = runtime.INJECT_FILE.read_bytes()
+            except OSError:
+                javascript = b"// overlay not found"
+            return self._send(200, "application/javascript; charset=utf-8", javascript)
+
+        relative = runtime.unquote(path).lstrip("/")
+        first, _, rest = relative.partition("/")
+        # The bound id makes one listener answer for exactly one project.  A URL
+        # path cannot cross into another project's browser-storage origin.
+        bound_id: str = getattr(self.server, "kiro_project_id", "")
+        if first != bound_id:
+            return self._refuse(404, b"unknown project")
+        project = next((item for item in runtime._CFG["projects"] if item["id"] == first), None)
+        if project is None:
+            return self._refuse(404, b"unknown project")
+        root = runtime._valid_root(project["path"])
+        if root is None:
+            return self._refuse(404, b"project folder no longer readable")
+        status, content_type, body = runtime._static_response(
+            str(root), rest, f"/{first}/", script=runtime._OVERLAY_PATH
+        )
+        return self._send(status, content_type, body)
+
+    do_GET = _dispatch
+    do_HEAD = _dispatch
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._refuse(405, b"read-only preview server")
+
+    do_PUT = do_POST
+    do_PATCH = do_POST
+    do_DELETE = do_POST
+    do_OPTIONS = do_POST
+
+
+def static_preview_base(runtime: Any, project_id: str) -> str:
+    """Return the dedicated static-preview base URL, starting it on demand."""
+
+    # Every project needs its own loopback port because browser storage is
+    # scoped by scheme, host, and port, not by the URL path's project id.
+    record = runtime._STATIC_SRV.get(project_id)
+    if record and record.get("url"):
+        return str(record["url"])
+    try:
+        server = runtime.ThreadingHTTPServer(("127.0.0.1", 0), runtime._StaticInjectHandler)
+    except OSError:
+        return ""
+    server.daemon_threads = True
+    setattr(server, "kiro_project_id", project_id)
+    runtime.threading.Thread(
+        target=server.serve_forever,
+        daemon=True,
+        name=f"kiro-static-preview-{project_id}",
+    ).start()
+    url = f"http://127.0.0.1:{server.server_address[1]}/"
+    runtime._STATIC_SRV[project_id] = {"srv": server, "url": url}
+    return url
+
+
+def stop_static_preview(runtime: Any, project_id: str) -> None:
+    """Shut down and forget one project's dedicated static listener."""
+
+    # Pop first so a failed shutdown cannot leave a dead cache hit behind.
+    record = runtime._STATIC_SRV.pop(project_id, None)
+    if record is None:
+        return
+    server = record.get("srv")
+    if server is None:
+        return
+    try:
+        server.shutdown()
+        server.server_close()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def static_preview_url(runtime: Any, project_id: str) -> str:
+    """Return the iframe URL for a project's file-backed preview."""
+
+    base = runtime._static_preview_base(project_id)
+    return f"{base}{project_id}/" if base else ""
+
+
+__all__ = [
+    "ATTR_SRC_RE",
+    "ATTR_TYPE_MODULE_RE",
+    "CLIENT_READ_TIMEOUT",
+    "CTYPE_DEFAULT",
+    "CTYPE_OVERRIDES",
+    "ENTRY_CANDIDATES",
+    "MAX_STATIC_BYTES",
+    "OVERLAY_PATH",
+    "PEM_BODY_RE",
+    "PEM_MARKER_RE",
+    "PEM_PRIVATE_KEY_RE",
+    "PROJECT_SECRET_DIRS",
+    "PROJECT_SECRET_NAMES",
+    "PROJECT_SECRET_SUFFIXES",
+    "PROXY_CTYPES",
+    "SCAN_SKIP_DIRS",
+    "SCRIPT_TAG_RE",
+    "StaticInjectHandlerBase",
+    "UNBUNDLED_EXTS",
+    "contains_credential",
+    "find_entry",
+    "guess_ctype",
+    "is_project_secret",
+    "needs_dev_server_body",
+    "no_entry_response",
+    "rewrite_html",
+    "safe_upstream_ctype",
+    "scan_html",
+    "static_preview_base",
+    "static_preview_url",
+    "static_response",
+    "stop_static_preview",
+    "unbundled_entry",
+]

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/request_state.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/request_state.py
@@ -1,0 +1,519 @@
+"""Durable request and project state for the Design Tweak backend.
+
+``server`` is the composition root and security-policy owner.  Functions that
+depend on its mutable state or compatibility seams receive that module as
+``runtime`` and resolve collaborators through it at call time, making the
+server namespace the authoritative runtime boundary.
+
+Queue mutations are whole-record read-modify-write transactions.  Their caller
+must hold ``runtime._QUEUE_LOCK`` from the first read through the final write or
+rename.  Socket I/O, subprocess work, and response writes must remain outside
+that critical section.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+COMMENT_STATUSES = ("new", "sent", "done")
+REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class PathEscape(ValueError):
+    """A candidate path escaped the directory that must contain it."""
+
+
+class RecordTooLarge(ValueError):
+    """A queue record would serialize past the reader's byte ceiling."""
+
+
+def load_config(runtime: Any) -> JsonObject:
+    """Load the registry from ``runtime.CONFIG_FILE``, tolerating bad state."""
+
+    try:
+        config = runtime.json.loads(runtime.CONFIG_FILE.read_text("utf-8"))
+        if isinstance(config, dict):
+            config.setdefault("projects", [])
+            config.setdefault("activeId", "")
+            config.setdefault("counter", 0)
+            return config
+    except (OSError, ValueError):
+        pass
+    return {"projects": [], "activeId": "", "counter": 0}
+
+
+def save_config(runtime: Any, config: JsonObject) -> None:
+    """Atomically persist the project registry without the queue-record cap."""
+
+    runtime._atomic_write_json(runtime.CONFIG_FILE, config)
+
+
+def active_project(runtime: Any) -> JsonObject | None:
+    """Return the configured active project, if it still exists."""
+
+    for project in runtime._CFG["projects"]:
+        if project["id"] == runtime._CFG["activeId"]:
+            return project
+    return None
+
+
+def next_request_number(runtime: Any, project_id: str = "") -> int:
+    """Return the next project-local request number.
+
+    Scoped numbering is derived from queue and history files so there is only
+    one source of truth.  Unscoped legacy callers retain the global counter.
+    The caller must hold ``runtime._QUEUE_LOCK`` while using this value to create
+    and publish a request.
+    """
+
+    if not project_id:
+        runtime._CFG["counter"] = int(runtime._CFG.get("counter", 0)) + 1
+        runtime._save_cfg(runtime._CFG)
+        return runtime._CFG["counter"]
+
+    highest = 0
+    for directory in (runtime.QUEUE_DIR, runtime.HANDLED_DIR):
+        for path in directory.glob("*.json"):
+            request = runtime._read_request(path)
+            if not request or request.get("projectId") != project_id:
+                continue
+            try:
+                highest = max(highest, int(request.get("number") or 0))
+            except (TypeError, ValueError):
+                continue
+    return highest + 1
+
+
+def new_request_id() -> str:
+    """Mint a filesystem-safe, time-sortable request or comment id."""
+
+    return f"{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}"
+
+
+def utc_now_iso() -> str:
+    """Return the persisted timestamp format used by request records."""
+
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def pending_files(runtime: Any) -> list[Path]:
+    """Return pending request paths in stable filename order."""
+
+    return sorted(runtime.QUEUE_DIR.glob("*.json"))
+
+
+def contain_path(base: Path | str, candidate: str = "") -> Path:
+    """Resolve ``candidate`` and return it only when it remains under ``base``.
+
+    Both sides are realpath-normalized so traversal and symlink escapes collapse
+    before the comparison.  The separator check rejects sibling-prefix paths.
+    Callers must use the returned path rather than reopening the input path.
+    """
+
+    base_real = os.path.realpath(base)
+    candidate_real = os.path.realpath(os.path.join(base_real, candidate))
+    if not candidate_real.startswith(base_real):
+        raise PathEscape(f"{candidate_real!r} is outside {base_real!r}")
+    if candidate_real != base_real and not candidate_real[len(base_real) :].startswith(os.sep):
+        raise PathEscape(f"{candidate_real!r} is a sibling of {base_real!r}, not inside it")
+    return Path(candidate_real)
+
+
+def request_file(runtime: Any, base: Path, request_id: str) -> Path:
+    """Return the contained JSON path for a syntactically safe request id."""
+
+    if not request_id or not runtime._ID_RE.match(request_id):
+        raise runtime._PathEscape(f"invalid request id: {request_id!r}")
+    return runtime._contained(base, f"{request_id}.json")
+
+
+def is_kirocrew_internal(runtime: Any, target: Path) -> bool:
+    """Return whether ``target`` resolves within a private Kiro Crew tree."""
+
+    real = runtime.os.path.realpath(target)
+    for base in runtime._KIROCREW_INTERNAL_DIRS:
+        if real == base or real.startswith(base + runtime.os.sep):
+            return True
+    return False
+
+
+def valid_target(runtime: Any, url: str) -> bool:
+    """Accept only an HTTP URL targeting a dialable loopback port."""
+
+    try:
+        parsed = runtime.urlparse(url)
+        if parsed.scheme != "http":
+            return False
+        if (parsed.hostname or "").lower() not in runtime._LOOPBACK_HOSTS:
+            return False
+        port = parsed.port
+    except ValueError:
+        return False
+    return port is None or 1 <= port <= 65535
+
+
+def valid_root(runtime: Any, path: str) -> Path | None:
+    """Resolve an existing project root after server-owned policy checks."""
+
+    try:
+        real = runtime.os.path.realpath(runtime.os.path.expanduser(path))
+    except (ValueError, OSError):
+        return None
+    if set(runtime.Path(real).parts) & runtime._DENIED_ROOT_PARTS:
+        return None
+    if runtime.is_sensitive_path(real):
+        return None
+    if runtime.path_contains_sensitive(real):
+        return None
+    resolved = runtime.Path(real)
+    if not resolved.is_dir():
+        return None
+    return resolved
+
+
+def request_status(request: JsonObject) -> str:
+    """Derive request status from authoritative per-comment statuses."""
+
+    comments = request.get("comments") or []
+    if not comments:
+        return "draft"
+    if all(comment.get("status") == "done" for comment in comments):
+        return "done"
+    if request.get("state") != "draft" or any(
+        comment.get("status") != "new" for comment in comments
+    ):
+        return "sent"
+    return "draft"
+
+
+def is_draft(runtime: Any, request: JsonObject) -> bool:
+    """Return whether a request remains open for new comments."""
+
+    return runtime._request_status(request) == "draft"
+
+
+def element_name(element: JsonObject) -> str:
+    """Build a tolerant human-readable label for a captured element."""
+
+    name = str(element.get("tag") or "")
+    element_id = element.get("id")
+    classes = element.get("classes")
+    if element_id:
+        name += f"#{element_id}"
+    elif isinstance(classes, (list, tuple)):
+        names = [value for value in classes[:2] if isinstance(value, str)]
+        if names:
+            name += "." + ".".join(names)
+    return name
+
+
+def redact_thread(runtime: Any, thread: object) -> list[JsonObject]:
+    """Return a read-tolerant thread, redacted as a floor under the ingest pass.
+
+    ``/thread`` already redacts before writing, so nothing new should reach disk
+    unredacted — but ingest is not the only writer. The delivery model hands the
+    agent the queue JSON directly (that is how a request reaches it), so an entry
+    written into the file rather than posted to ``/thread``, or one persisted
+    before the ingest pass existed, would otherwise render verbatim in the panel.
+    Redaction is an always-on floor in this repo, so it belongs on both edges.
+    """
+
+    if not isinstance(thread, list):
+        return []
+    result: list[JsonObject] = []
+    for entry in thread:
+        if not isinstance(entry, dict):
+            # Tolerate a malformed file rather than 500 the read path: a 500 here
+            # is unrecoverable without deleting the queue file by hand.
+            continue
+        result.append({**entry, "text": runtime._redact_text(entry.get("text", ""))})
+    return result
+
+
+def summarize_comment(runtime: Any, comment: JsonObject) -> JsonObject:
+    """Return the panel-facing shape of one comment."""
+
+    selection = comment.get("selection") or {}
+    # Keep only dict elements. ``/submit`` rejects a malformed selection at the
+    # boundary, but a queue file written before that guard existed would still
+    # crash ``element_name`` here, and this read path must stay recoverable.
+    raw_elements = selection.get("elements") or []
+    elements = [element for element in raw_elements if isinstance(element, dict)]
+    element = elements[0] if elements else {}
+    return {
+        "cid": comment.get("cid", ""),
+        "index": comment.get("index", 0),
+        "status": comment.get("status", "new"),
+        # Redacted on the way OUT for the same reason as ``thread`` below: the
+        # delivery model hands the agent the queue JSON directly, so a comment
+        # rewritten in the FILE rather than posted through ``/submit`` (which
+        # redacts on ingest) would otherwise render verbatim in the panel.
+        "comment": runtime._redact_text(comment.get("comment", "")),
+        "createdAt": comment.get("createdAt", ""),
+        "element": runtime._el_name(element),
+        "locator": element.get("locator", ""),
+        # Fallback anchors, so a pin survives its element being deleted (parent) or
+        # not existing yet (point). The overlay tries them in that order.
+        "parentLocator": element.get("parentLocator", ""),
+        "point": element.get("point") or {},
+        "count": len(elements),
+        "mode": selection.get("mode", "single"),
+        "previewUrl": comment.get("previewUrl", ""),
+        "projectId": comment.get("projectId", ""),
+        "sourceFile": comment.get("sourceFile", ""),
+        # Where the agent should edit, and how much to trust it:
+        # data-kiro-source → "high", React Fiber → "medium", neither → "low".
+        # Independent of how the page was served, so a dev-server project gets
+        # BETTER targeting than a proxied static folder, not worse.
+        "source": element.get("source") or {},
+        "followUpTo": comment.get("followUpTo", ""),
+        "thread": runtime._redact_thread(comment.get("thread")),
+    }
+
+
+def summarize_request(runtime: Any, request: JsonObject) -> JsonObject:
+    """Return request metadata and its panel-facing comment summaries."""
+
+    comments = request.get("comments") or []
+    return {
+        "id": request.get("id", ""),
+        "number": request.get("number", 0),
+        "state": request.get("state", "draft"),
+        "status": runtime._request_status(request),
+        "createdAt": request.get("createdAt", ""),
+        "sentAt": request.get("sentAt", ""),
+        # Set only once the panel confirms the prompt actually reached the agent.
+        # Sealed-but-not-acknowledged is the stranded state the retry bar exists for.
+        "deliveredAt": request.get("deliveredAt", ""),
+        "projectId": request.get("projectId", ""),
+        "projectRoot": request.get("projectRoot", ""),
+        "thread": runtime._redact_thread(request.get("thread")),
+        "doneCount": sum(1 for comment in comments if comment.get("status") == "done"),
+        "comments": [runtime._summarize_comment(comment) for comment in comments],
+    }
+
+
+def project_for_preview(runtime: Any, preview_url: str) -> tuple[JsonObject | None, str]:
+    """Resolve a project and relative file from an owned static preview URL."""
+
+    url = str(preview_url)
+    relative = ""
+    matched = False
+    for project_id, record in runtime._STATIC_SRV.items():
+        base = record.get("url") or ""
+        if base and url.startswith(f"{base}{project_id}/"):
+            relative = url[len(base) :]
+            matched = True
+            break
+    if not matched:
+        marker = "/api/proxy/"
+        marker_at = url.find(marker)
+        if marker_at == -1:
+            return None, ""
+        relative = url[marker_at + len(marker) :]
+
+    relative = relative.split("?")[0].split("#")[0]
+    project_id = relative.split("/", 1)[0] if relative else ""
+    rest = relative.split("/", 1)[1] if "/" in relative else ""
+    project = next(
+        (item for item in runtime._CFG["projects"] if item["id"] == project_id),
+        None,
+    )
+    return project, rest
+
+
+def project_by_id(runtime: Any, project_id: str) -> JsonObject | None:
+    """Look up a registered project by id."""
+
+    if not project_id:
+        return None
+    return next(
+        (project for project in runtime._CFG["projects"] if project["id"] == project_id),
+        None,
+    )
+
+
+def resolve_project(runtime: Any, payload: JsonObject) -> tuple[str, str, str]:
+    """Resolve ``(project id, project root, contained source file)`` for a capture."""
+
+    preview_url = str(payload.get("previewUrl", ""))
+    explicit_id = str(payload.get("projectId", "") or "")
+    project = runtime._project_by_id(explicit_id)
+    served_relative = ""
+
+    if project is not None:
+        url_project, served_relative = runtime._proj_for_preview(preview_url)
+        if url_project is not None and url_project["id"] != project["id"]:
+            served_relative = ""
+    else:
+        project, served_relative = runtime._proj_for_preview(preview_url)
+
+    if project is not None:
+        root = project["path"]
+        return project["id"], root, runtime._contained_source(root, served_relative)
+    if runtime._ROOT:
+        return (
+            explicit_id,
+            runtime._ROOT,
+            runtime._contained_source(runtime._ROOT, served_relative),
+        )
+    return explicit_id, "", ""
+
+
+def contained_source(runtime: Any, root: str, relative: str) -> str:
+    """Return a contained source path, or an empty string on escape/route input."""
+
+    if not relative:
+        return ""
+    try:
+        return str(runtime._contained(root, relative))
+    except runtime._PathEscape:
+        return ""
+
+
+def sanitize_selection_sources(runtime: Any, selection: Any, root: str) -> None:
+    """Contain preview-controlled element source paths in place, failing closed."""
+
+    if not isinstance(selection, dict):
+        return
+    for element in selection.get("elements") or []:
+        if not isinstance(element, dict):
+            continue
+        source = element.get("source")
+        if not isinstance(source, dict) or not source.get("file"):
+            continue
+        safe = runtime._contained_source(root, str(source["file"])) if root else ""
+        if safe:
+            source["file"] = safe
+        else:
+            source["file"] = ""
+            source["confidence"] = "low"
+
+
+def read_request(runtime: Any, path: Path) -> JsonObject | None:
+    """Read one contained, size-bounded queue record.
+
+    The size check must precede ``read_text``.  Queue files are writable outside
+    this process, and a single oversized file must not poison queue listing.
+    """
+
+    try:
+        contained = runtime._contained(runtime.DATA_DIR, runtime.os.fspath(path))
+        if contained.stat().st_size > runtime.MAX_RECORD_BYTES:
+            return None
+        request = runtime.json.loads(contained.read_text("utf-8"))
+        return request if isinstance(request, dict) else None
+    except (runtime._PathEscape, OSError, ValueError):
+        return None
+
+
+def atomic_write_json(
+    runtime: Any,
+    path: Path,
+    payload: JsonObject,
+    *,
+    max_bytes: int | None = None,
+) -> None:
+    """Publish complete durable JSON with a same-directory atomic replacement."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = runtime.json.dumps(payload, indent=2).encode("utf-8")
+    if max_bytes is not None and len(data) > max_bytes:
+        raise runtime._RecordTooLarge(
+            f"record would be {len(data)} bytes, over the {max_bytes}-byte limit"
+        )
+
+    descriptor, temporary = runtime.tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        try:
+            written = 0
+            while written < len(data):
+                count = runtime.os.write(descriptor, data[written:])
+                if count <= 0:  # pragma: no cover - os.write normally raises
+                    raise OSError(f"short write to {temporary}: {written}/{len(data)} bytes")
+                written += count
+            runtime.os.fsync(descriptor)
+        finally:
+            runtime.os.close(descriptor)
+        runtime.os.replace(temporary, path)
+    finally:
+        if runtime.os.path.exists(temporary):
+            runtime.os.unlink(temporary)
+
+
+def write_request(runtime: Any, path: Path, request: JsonObject) -> None:
+    """Atomically write a contained request using the shared read/write ceiling."""
+
+    contained = runtime._contained(runtime.DATA_DIR, runtime.os.fspath(path))
+    runtime._atomic_write_json(
+        contained,
+        request,
+        max_bytes=runtime.MAX_RECORD_BYTES,
+    )
+
+
+def find_request(runtime: Any, request_id: str) -> Path | None:
+    """Locate a request in queue first, then handled history."""
+
+    for directory in (runtime.QUEUE_DIR, runtime.HANDLED_DIR):
+        try:
+            path = runtime._request_file(directory, request_id)
+        except runtime._PathEscape:
+            return None
+        if path.is_file():
+            return path
+    return None
+
+
+def open_draft_file(runtime: Any, project_id: str) -> Path | None:
+    """Return the project's single open draft, based on derived status."""
+
+    for path in runtime._pending_files():
+        request = runtime._read_request(path)
+        if request and request.get("projectId") == project_id and runtime._is_draft(request):
+            return path
+    return None
+
+
+__all__ = [
+    "COMMENT_STATUSES",
+    "JsonObject",
+    "PathEscape",
+    "RecordTooLarge",
+    "REQUEST_ID_RE",
+    "active_project",
+    "atomic_write_json",
+    "contain_path",
+    "contained_source",
+    "element_name",
+    "find_request",
+    "is_draft",
+    "is_kirocrew_internal",
+    "load_config",
+    "new_request_id",
+    "next_request_number",
+    "open_draft_file",
+    "pending_files",
+    "project_by_id",
+    "project_for_preview",
+    "read_request",
+    "redact_thread",
+    "request_file",
+    "request_status",
+    "resolve_project",
+    "sanitize_selection_sources",
+    "save_config",
+    "summarize_comment",
+    "summarize_request",
+    "utc_now_iso",
+    "valid_root",
+    "valid_target",
+    "write_request",
+]

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -1,29 +1,8 @@
-"""Select-to-Edit backend for Kiro Crew.
+"""Composition root for the Design Tweak backend.
 
-A small stdlib-only HTTP server that receives `visual_edit_request` payloads
-from the dashboard app page and persists them to a queue directory that the
-`visual-edit` skill instructs the agent to read.
-
-Bound to localhost; Kiro Crew proxies `/apps/design-tweak/api/*` to
-this process (stripping the prefix, so the server sees `/api/<path>` or `/<path>`).
-
-Every proxied request carries the gateway's `X-KiroCrew-Proxy` HMAC, verified
-before dispatch (see `kiro_crew.apps.proxy_auth`); only `/health` is left
-unauthenticated because the gateway's liveness probe hits the backend directly.
-
-Endpoints (as seen after proxy prefix strip):
-  GET  /health              → {"status","app","version","pending"}
-  POST /submit              → body = visual_edit_request; persists → {"ok","id","savedTo"}
-  GET  /queue               → {"pending":[{id,createdAt,comment,mode,count,previewUrl}]}
-  GET  /latest              → newest pending request (full payload) or {}
-  POST /clear?id=<id>       → move request to handled/ → {"ok","id"}
-  POST /delivered?id=<id>   → ack that a sealed request's prompt reached the agent
-  POST /thread?id=<id>      → append {role,text,status?} to a request thread
-
-Delivery model: this process cannot call the agent directly (separate process).
-Instead it writes the structured payload to the app data queue dir; the bundled
-`visual-edit` skill teaches the agent to read + act on it. This is the spec's
-sanctioned "well-known file the agent watches" fallback.
+The boundary modules own durable state, preview serving, dev-server plumbing,
+and HTTP dispatch.  This module owns process creation, security-policy calls,
+mutable runtime state, compatibility names, and process lifecycle.
 """
 
 from __future__ import annotations
@@ -51,8 +30,14 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qs, unquote, urlparse
 
+from kiro_crew.apps.builtins.design_tweak.backend import (
+    dev_preview,
+    http_api,
+    preview_files,
+    request_state,
+)
 from kiro_crew.apps.proxy_auth import verify_proxy_request
-from kiro_crew.hooks import safe_read_file_bytes_nolink
+from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes_nolink
 from kiro_crew.platform_compat import (
     CREATE_NEW_PROCESS_GROUP,
     IS_POSIX,
@@ -71,18 +56,74 @@ from kiro_crew.security import (
     redact_exfiltration_urls,
 )
 from kiro_crew.sel import sel
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+# These names are intentionally present on the runtime module.  Boundary
+# implementations resolve them late through the server-owned network,
+# filesystem, clock, and platform seams.
+_RUNTIME_COMPAT_IMPORTS = (
+    BaseHTTPRequestHandler,
+    FileTooLargeError,
+    SIGKILL,
+    SIGTERM,
+    _html,
+    cast,
+    get_credential_patterns,
+    get_ppid,
+    glob,
+    http.client,
+    is_sensitive_path,
+    kill_process_tree,
+    parse_qs,
+    path_contains_sensitive,
+    safe_read_file_bytes_nolink,
+    selectors,
+    sel,
+    shutil,
+    socket,
+    tempfile,
+    unquote,
+    urllib.error,
+    urllib.request,
+    urlparse,
+    uuid,
+    verify_proxy_request,
+)
+
+
+class _RuntimeFacade:
+    """Globals-backed runtime for detached module execution."""
+
+    def __getattr__(self, name: str) -> Any:
+        # A module object answers a missing name with AttributeError, and the
+        # facade has to match: a bare ``globals()[name]`` raises KeyError, which
+        # `getattr(runtime, name, default)` does not catch, so a probe with a
+        # default would propagate instead of taking the default.
+        try:
+            return globals()[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        globals()[name] = value
+
+
+# Normal imports use the real module object, so replacing ``server.<name>`` is
+# immediately visible across every boundary.  Detached execution without a
+# sys.modules entry uses the facade for the same live get/set semantics.
+runtime: Any
+if __name__ in _sys.modules:
+    runtime = _sys.modules[__name__]
+else:  # pragma: no cover - detached execution is exercised separately
+    runtime = _RuntimeFacade()
 
 
 def _manifest_version() -> str:
-    """Read the version from app.json rather than duplicating it here.
+    """Read the backend version from its app manifest."""
 
-    A hardcoded constant drifts silently — this one sat at 0.6.0 while the
-    manifest said 0.7.1, so /health reported a version that had not been real for
-    two releases, which is worse than reporting nothing.
-    """
     try:
-        p = Path(__file__).resolve().parent.parent / "app.json"
-        return str(json.loads(p.read_text("utf-8")).get("version", "")) or "0.0.0"
+        path = Path(__file__).resolve().parent.parent / "app.json"
+        return str(json.loads(path.read_text("utf-8")).get("version", "")) or "0.0.0"
     except (OSError, ValueError):
         return "0.0.0"
 
@@ -91,41 +132,28 @@ VERSION = _manifest_version()
 PORT = int(os.environ.get("PORT", 9110))
 APP_NAME = os.environ.get("KIROCREW_APP_NAME") or "design-tweak"
 
-# Public (browser-facing) proxy paths — resolved through the gateway proxy.
 PROXY_PUBLIC_BASE = f"/apps/{APP_NAME}/api/proxy/"
 INJECT_PUBLIC = f"/apps/{APP_NAME}/api/proxy-inject.js"
-# The drop-in overlay lives at <app>/inject/select-to-edit.js
 INJECT_FILE = Path(__file__).resolve().parent.parent / "inject" / "select-to-edit.js"
 
-# Source of the previewed app. Exactly one of these is active at a time:
-#   _ROOT   — an absolute folder path served directly by this backend (preferred).
-#   _TARGET — a localhost dev-server URL reverse-proxied (for Vite/HMR projects).
-# Both are localhost/local-filesystem only (no SSRF, no arbitrary FS escape).
+# Exactly one legacy source is active: a local folder or an allow-listed
+# loopback dev URL.  Registered projects carry their own live preview state.
 _ROOT = ""
 _TARGET = ""
 
-# Resolve the app data dir. The host injects KIROCREW_APP_DATA_DIR for builtin
-# app backends; fall back to the platform-standard location under
-# $KIROCREW_HOME/apps/<name>/data (KIROCREW_HOME defaults to ~/.kiro/crew, the
-# data home nested under kiro-cli's ~/.kiro/ — NOT the pre-move ~/.kirocrew).
-_DATA_ENV = os.environ.get("KIROCREW_APP_DATA_DIR") or os.environ.get("KIROCREW_APP_DATA") or ""
+_DATA_ENV = os.environ.get("KIROCREW_APP_DATA_DIR") or os.environ.get("KIROCREW_APP_DATA", "")
 if _DATA_ENV:
     DATA_DIR = Path(_DATA_ENV).expanduser().resolve()
 else:
     _home = os.environ.get("KIROCREW_HOME")
-    _base = (
-        Path(_home).expanduser() if _home else (Path(os.path.expanduser("~")) / ".kiro" / "crew")
-    )
+    _base = Path(_home).expanduser() if _home else Path(os.path.expanduser("~")) / ".kiro" / "crew"
     DATA_DIR = (_base / "apps" / APP_NAME / "data").resolve()
 
 QUEUE_DIR = DATA_DIR / "queue"
 HANDLED_DIR = DATA_DIR / "handled"
-# Deliberately NOT created here: this runs at IMPORT time, before a test's
-# isolation fixture (`isolated_queue`) has a chance to monkeypatch these paths
-# to a private tmp tree, so importing the module for any reason -- including
-# bare pytest collection -- created real directories under the operator's own
-# $KIROCREW_HOME. Creation is deferred to `main()`, the actual process entry
-# point, which is never reached by an import alone.
+CONFIG_FILE = DATA_DIR / "config.json"
+# Directory creation stays in main(); imports are side-effect-free and never
+# touch the operator's real data home.
 
 # Directory trees this preview server must NEVER serve out of, whatever the user
 # registered as a project root.
@@ -155,8 +183,8 @@ _CREW_HOME = (
     Path(_CREW_HOME_ENV).expanduser() if _CREW_HOME_ENV else Path(_HOME_REAL) / ".kiro" / "crew"
 )
 _KIROCREW_INTERNAL_DIRS: tuple[str, ...] = tuple(
-    os.path.realpath(p)
-    for p in (
+    os.path.realpath(path)
+    for path in (
         os.path.join(_HOME_REAL, ".kiro"),  # kiro-cli's dir; crew home nests inside
         os.path.join(_HOME_REAL, ".kirocrew"),  # pre-move legacy data home
         str(_CREW_HOME),  # a relocated crew home (KIROCREW_HOME)
@@ -164,27 +192,8 @@ _KIROCREW_INTERNAL_DIRS: tuple[str, ...] = tuple(
     )
 )
 
-
-def _is_kirocrew_internal(target: Path) -> bool:
-    """Whether *target* resolves inside one of Kiro Crew's own directory trees.
-
-    Separator-aware so a sibling like `~/.kiro-backup` is not caught by a bare
-    prefix test, matching `_contained`'s reasoning.
-    """
-    real = os.path.realpath(target)
-    for base in _KIROCREW_INTERNAL_DIRS:
-        if real == base or real.startswith(base + os.sep):
-            return True
-    return False
-
-
 MAX_BODY_BYTES = 2 * 1024 * 1024  # 2 MB cap on a single payload
-# Ceiling on ONE statically-served preview file. Generous for real web assets
-# (bundles, fonts, images) while bounding the buffer: `_static_response` reads the
-# whole file into memory, so without this a large asset sitting in the previewed
-# project is enough to exhaust the backend. Distinct from MAX_BODY_BYTES, which
-# caps an inbound request body rather than an outbound file.
-MAX_STATIC_BYTES = 64 * 1024 * 1024  # 64 MB
+MAX_STATIC_BYTES = preview_files.MAX_STATIC_BYTES
 # Ceiling on comments in ONE draft request. Generous for the intended use (a
 # batch of visual edits is a handful, not hundreds) and low enough that a
 # previewed page looping on `submitComment` cannot grow the queue file without
@@ -206,14 +215,12 @@ MAX_THREAD_ENTRIES = 500
 # them would let a change to the inbound cap move this ceiling by accident.
 MAX_RECORD_BYTES = 2 * 1024 * 1024
 
+_RecordTooLarge = request_state.RecordTooLarge
+_PathEscape = request_state.PathEscape
+_IncompleteBody = http_api.IncompleteBody
+_ID_RE = request_state.REQUEST_ID_RE
+_COMMENT_STATUSES = request_state.COMMENT_STATUSES
 
-class _RecordTooLarge(ValueError):
-    """A queue record would serialize past what its reader accepts."""
-
-
-_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")  # queue file id safety
-
-# The only hosts this backend will ever fetch from (dev-server reverse proxy).
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1"})
 # Credential dirs a previewed "project" folder may never be, shared with
 # design_critique's local-target guard via kiro_crew.security. The shared
@@ -221,1045 +228,49 @@ _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1"})
 # root; these are the plain dot-dirs it does not need to know about.
 _DENIED_ROOT_PARTS = DENIED_ROOT_PARTS
 
-_PICK_LOCK = threading.Lock()  # one native folder picker at a time
-
-# Serializes every read-modify-write transaction against the queue on disk.
-#
-# WHY THIS EXISTS. The backend is a `ThreadingHTTPServer`, so two dashboard tabs
-# submitting at the same moment are two handler threads. Without this lock they
-# each `_read_request` the same draft, append their own comment to the copy they
-# read, and `_write_request` it back -- last writer wins and the other comment is
-# silently gone. The queue file is the whole record, so that is data loss, not a
-# stale read. The same shape applies to every other queue mutation (seal-on-send,
-# delete-comment, /thread append, clear, delete).
-#
-# Held across READ THROUGH WRITE as ONE critical section -- locking only the write
-# is the identical bug, because the lost update happens in the gap between the
-# read and the write.
-#
-# An RLock, not a Lock, for two reasons:
-#   1. Re-entrancy. A queue transaction legitimately nests helpers that are
-#      themselves whole-queue operations (`_h_submit` needs `_open_draft_file`
-#      AND `_next_number`, both of which scan every request file). RLock lets a
-#      helper take the lock defensively without deadlocking a caller that
-#      already holds it, so a future edit cannot introduce a silent self-
-#      deadlock.
-#   2. Deadlock-freedom is structural, not conventional. Deadlock needs either a
-#      non-reentrant self-acquire (RLock rules that out) or two locks taken in
-#      inconsistent order. There is exactly ONE lock on this path, and the only
-#      other lock in the module (`_PICK_LOCK`) is taken solely by
-#      `_h_pick_folder`, which never touches the queue -- so no thread ever holds
-#      one while wanting the other and no cycle can form.
-#
-# Critical sections stay tight: each transaction computes its `(code, payload)`
-# and the HTTP response is written AFTER the lock is released, so a client that
-# stalls reading its socket can never pin the queue. No subprocess, no network
-# I/O, and no sleeping inside.
+# One native picker may own the foreground dialog.  Queue and registry
+# read-modify-write transactions share one reentrant lock; process/network work
+# remains outside it.
+_PICK_LOCK = threading.Lock()
 _QUEUE_LOCK = threading.RLock()
 
+_CTYPE_OVERRIDES = preview_files.CTYPE_OVERRIDES
+_CTYPE_DEFAULT = preview_files.CTYPE_DEFAULT
+_PROXY_CTYPES = preview_files.PROXY_CTYPES
+_ENTRY_CANDIDATES = preview_files.ENTRY_CANDIDATES
+_SCAN_SKIP_DIRS = preview_files.SCAN_SKIP_DIRS
+_SCRIPT_TAG_RE = preview_files.SCRIPT_TAG_RE
+_ATTR_TYPE_MODULE_RE = preview_files.ATTR_TYPE_MODULE_RE
+_ATTR_SRC_RE = preview_files.ATTR_SRC_RE
+_UNBUNDLED_EXTS = preview_files.UNBUNDLED_EXTS
+_PROJECT_SECRET_NAMES = preview_files.PROJECT_SECRET_NAMES
+_PROJECT_SECRET_DIRS = preview_files.PROJECT_SECRET_DIRS
+_PROJECT_SECRET_SUFFIXES = preview_files.PROJECT_SECRET_SUFFIXES
+_PEM_PRIVATE_KEY_RE = preview_files.PEM_PRIVATE_KEY_RE
+_PEM_MARKER_RE = preview_files.PEM_MARKER_RE
+_PEM_BODY_RE = preview_files.PEM_BODY_RE
+# Each loaded server-module instance owns its listener handles; detached or
+# reloaded instances never share them.
+_STATIC_SRV: dict[str, dict[str, Any]] = {}
+
+_NODE_BIN_DIRS = dev_preview.NODE_BIN_DIRS
+_NVM_GLOB = dev_preview.NVM_GLOB
+_CHILD_ENV_STRIP = dev_preview.CHILD_ENV_STRIP
+_CHILD_ENV_STRIP_PREFIXES = dev_preview.CHILD_ENV_STRIP_PREFIXES
+_LOCKFILES = dev_preview.LOCKFILES
+_DEV_SCRIPTS = dev_preview.DEV_SCRIPTS
+_PROC_TREE_MAX_DEPTH = dev_preview.PROC_TREE_MAX_DEPTH
 
-# ---------------------------------------------------------------------------
-# Path containment. THE single barrier every filesystem operation below goes
-# through — see `_contained`.
-# ---------------------------------------------------------------------------
-class _PathEscape(ValueError):
-    """A joined path landed outside the base directory it had to stay inside."""
-
-
-def _contained(base: Path | str, candidate: str = "") -> Path:
-    """Join *candidate* under *base* and return it only if it stays inside.
-
-    This is the ONE path sanitizer in this module. It normalises **both** sides
-    with ``os.path.realpath`` — which collapses ``..`` segments and resolves
-    symlinks — and then requires the result to be *base* itself or a descendant
-    of it. Anything else raises `_PathEscape`, so the RETURN VALUE is always
-    contained; callers must use the returned path and never the one they passed
-    in. An absolute *candidate* is handled too: ``os.path.join`` lets it win,
-    and the containment check then rejects it.
-
-    Both checks are load-bearing:
-
-    * ``cand.startswith(base_real)`` on the normalised candidate is the
-      normalise-then-check shape that static analysis models as a containment
-      barrier. The equally strong ``Path(...).resolve()`` + ``relative_to()``
-      form this replaced is *not* modelled, which is why every read/write/stat
-      downstream of it showed up as a `py/path-injection` finding.
-    * the separator test then closes the sibling-prefix hole a bare prefix
-      check leaves open: ``/srv/app-evil`` starts with ``/srv/app`` but is not
-      inside it.
-    """
-    base_real = os.path.realpath(base)
-    cand = os.path.realpath(os.path.join(base_real, candidate))
-    if not cand.startswith(base_real):
-        raise _PathEscape(f"{cand!r} is outside {base_real!r}")
-    if cand != base_real and not cand[len(base_real) :].startswith(os.sep):
-        raise _PathEscape(f"{cand!r} is a sibling of {base_real!r}, not inside it")
-    return Path(cand)
-
-
-def _request_file(base: Path, rid: str) -> Path:
-    """`<base>/<rid>.json`, contained. Raises `_PathEscape` on an unusable id.
-
-    Two barriers, not one: `_ID_RE` rejects anything but an id-shaped token, and
-    `_contained` then proves the join stayed in *base* even if that pattern is
-    ever loosened.
-    """
-    if not rid or not _ID_RE.match(rid):
-        raise _PathEscape(f"invalid request id: {rid!r}")
-    return _contained(base, f"{rid}.json")
-
-
-# ---------------------------------------------------------------------------
-# Persistent config: registered projects, active project, request counter.
-# ---------------------------------------------------------------------------
-CONFIG_FILE = DATA_DIR / "config.json"
-
-
-def _load_cfg() -> dict:
-    try:
-        cfg = json.loads(CONFIG_FILE.read_text("utf-8"))
-        if isinstance(cfg, dict):
-            cfg.setdefault("projects", [])
-            cfg.setdefault("activeId", "")
-            cfg.setdefault("counter", 0)
-            return cfg
-    except (OSError, ValueError):
-        pass
-    return {"projects": [], "activeId": "", "counter": 0}
-
-
-def _save_cfg(cfg: dict) -> None:
-    # Atomic for the same reason as the queue files: a truncated config would
-    # lose every registered project.
-    _atomic_write_json(CONFIG_FILE, cfg)
-
-
-_CFG = _load_cfg()
-
-
-def _active_project() -> dict | None:
-    for p in _CFG["projects"]:
-        if p["id"] == _CFG["activeId"]:
-            return p
-    return None
-
-
-def _next_number(project_id: str = "") -> int:
-    """The next request number **within one project**.
-
-    Numbering is per-app so each web app reads as its own sequence: app B's first
-    request is "Request 1", not "Request 7" because six unrelated requests were
-    filed against app A. Derived by scanning, not stored — a stored per-project
-    counter would be a second source of truth to keep in sync, and the request
-    files already know their own numbers.
-
-    Falls back to the legacy global counter when there is no project id, so
-    pre-0.9 requests and any unscoped caller keep working.
-    """
-    if not project_id:
-        _CFG["counter"] = int(_CFG.get("counter", 0)) + 1
-        _save_cfg(_CFG)
-        return _CFG["counter"]
-    highest = 0
-    for d in (QUEUE_DIR, HANDLED_DIR):
-        for fp in d.glob("*.json"):
-            req = _read_request(fp)
-            if not req or req.get("projectId") != project_id:
-                continue
-            try:
-                highest = max(highest, int(req.get("number") or 0))
-            except (TypeError, ValueError):
-                continue
-    return highest + 1
-
-
-def _new_id() -> str:
-    return f"{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}"
-
-
-def _now_iso() -> str:
-    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-
-
-def _pending_files() -> list[Path]:
-    return sorted(QUEUE_DIR.glob("*.json"))
-
-
-def _el_name(el: dict) -> str:
-    """Human-readable element label, e.g. 'nav#site-header' or 'div.card.grid'.
-
-    Total by construction: every field is coerced rather than trusted. This runs
-    on the READ side, summarising a record that is already on disk, so it has to
-    survive input the write side never sanctioned -- a queue file written by an
-    older build, or hand-edited. A `TypeError` here is not a bad label, it is a
-    permanently 500-ing `/queue`: the poll cannot skip the offending record, so
-    the whole request list stays unreadable until someone deletes the file by
-    hand. `_h_submit` rejects these shapes at the boundary now, and that guard is
-    the one that gives a caller a real error; this is the containment that keeps
-    one bad record from taking the list down with it.
-    """
-    name = str(el.get("tag") or "")
-    el_id = el.get("id")
-    classes = el.get("classes")
-    if el_id:
-        name += f"#{el_id}"
-    elif isinstance(classes, (list, tuple)):
-        # Only string entries can be joined; a non-string would raise, and a
-        # coerced one would print as `.42`, so drop them instead.
-        names = [c for c in classes[:2] if isinstance(c, str)]
-        if names:
-            name += "." + ".".join(names)
-    return name
-
-
-# ---------------------------------------------------------------------------
-# Request / comment model.
-#
-# A queue file is ONE REQUEST that contains MANY COMMENTS as sub-items:
-#
-#   { type, id, number, state: "draft"|"sent", projectId, projectRoot,
-#     createdAt, sentAt, thread: [...],                     # request-level notes
-#     comments: [ { cid, index, status, comment, createdAt,
-#                   selection, previewUrl, sourceFile,
-#                   followUpTo, thread: [...] } ] }
-#
-# Lifecycle (seal-on-send): comments land in the project's single OPEN DRAFT.
-# Sending seals that draft (state -> "sent") and it never accepts comments
-# again, so the next comment always opens a fresh draft — even while the
-# previous batch is still being worked.
-# ---------------------------------------------------------------------------
-_COMMENT_STATUSES = ("new", "sent", "done")
-
-
-def _request_status(req: dict) -> str:
-    """Roll a request's comment statuses up into one request-level status.
-
-    Comment statuses are AUTHORITATIVE; `state` is only a hint about whether the
-    batch was formally sealed. This asymmetry matters: an agent that writes an
-    unexpected `state` (or an old file with none) must never make a request that
-    is plainly in flight read as an unsent draft. So "draft" is returned only
-    when nothing has happened yet — explicit draft state AND every comment new.
-    """
-    comments = req.get("comments") or []
-    if not comments:
-        return "draft"
-    if all(c.get("status") == "done" for c in comments):
-        return "done"
-    if req.get("state") != "draft" or any(c.get("status") != "new" for c in comments):
-        return "sent"
-    return "draft"
-
-
-def _is_draft(req: dict) -> bool:
-    """True only for a request that is still open for new comments."""
-    return _request_status(req) == "draft"
-
-
-def _redact_text(value: object) -> str:
-    """Redact one user-visible string on the way OUT.
-
-    URLs before credentials, matching the ingest call site and every other one:
-    `redact_exfiltration_urls` keys off the host, so a credential-first pass would
-    rewrite the token inside a URL and leave the exfiltration host standing.
-
-    The order is the whole reason this is a function rather than two inline calls
-    at each site -- it was already duplicated, and a second copy is how the two
-    edges drift.
-    """
-    text, _ = redact_exfiltration_urls(str(value or ""))
-    text, _ = redact_credentials(text)
-    return text
-
-
-def _redact_thread(thread: object) -> list[dict]:
-    """Redact thread text on the way OUT, as a floor under the ingest pass.
-
-    `_h_thread` already redacts before writing, so nothing new should reach disk
-    unredacted — but ingest is not the only writer. The delivery model hands the
-    agent the queue JSON directly (that is how a request reaches it), so an entry
-    written into the file rather than posted to `/thread`, or one persisted before
-    the ingest pass existed, would otherwise be rendered verbatim in the panel.
-    Redaction is an always-on floor in this repo, so it belongs on both edges.
-
-    The same reasoning covers the comment TEXT, which reaches the panel through
-    `_summarize_comment` -- see `_redact_text`.
-    """
-    if not isinstance(thread, list):
-        return []
-    out: list[dict] = []
-    for entry in thread:
-        if not isinstance(entry, dict):
-            continue  # tolerate a malformed file rather than 500 the read path
-        out.append({**entry, "text": _redact_text(entry.get("text", ""))})
-    return out
-
-
-def _summarize_comment(c: dict) -> dict:
-    sel = c.get("selection") or {}
-    # Keep only dict elements. `_h_submit` rejects a malformed selection at the
-    # boundary, but a queue file written before that guard existed would still
-    # crash `_el_name` here — and a 500 from this read path is unrecoverable
-    # without deleting the file by hand, so the read stays tolerant.
-    raw_elements = sel.get("elements") or []
-    elements = [e for e in raw_elements if isinstance(e, dict)]
-    el = elements[0] if elements else {}
-    return {
-        "cid": c.get("cid", ""),
-        "index": c.get("index", 0),
-        "status": c.get("status", "new"),
-        # Redacted on the way OUT for the same reason as `thread` below: the
-        # delivery model hands the agent the queue JSON directly, so a comment
-        # rewritten in the FILE (rather than posted through `/submit`, which
-        # redacts on ingest) would otherwise render verbatim in the panel.
-        "comment": _redact_text(c.get("comment", "")),
-        "createdAt": c.get("createdAt", ""),
-        "element": _el_name(el),
-        "locator": el.get("locator", ""),
-        # Fallback anchors, so a pin survives its element being deleted (parent) or
-        # not existing yet (point). The overlay tries them in that order.
-        "parentLocator": el.get("parentLocator", ""),
-        "point": el.get("point") or {},
-        "count": len(elements),
-        "mode": sel.get("mode", "single"),
-        "previewUrl": c.get("previewUrl", ""),
-        "projectId": c.get("projectId", ""),
-        "sourceFile": c.get("sourceFile", ""),
-        # Where the agent should edit, and how much to trust it:
-        # data-kiro-source → "high", React Fiber → "medium", neither → "low".
-        # Independent of how the page was served, so a dev-server project gets
-        # BETTER targeting than a proxied static folder, not worse.
-        "source": el.get("source") or {},
-        "followUpTo": c.get("followUpTo", ""),
-        "thread": _redact_thread(c.get("thread")),
-    }
-
-
-def _summarize(req: dict) -> dict:
-    """Panel-facing shape of a request: metadata + its comments as sub-items."""
-    comments = req.get("comments") or []
-    return {
-        "id": req.get("id", ""),
-        "number": req.get("number", 0),
-        "state": req.get("state", "draft"),
-        "status": _request_status(req),
-        "createdAt": req.get("createdAt", ""),
-        "sentAt": req.get("sentAt", ""),
-        # Set only once the panel confirms the prompt actually reached the agent.
-        # Sealed-but-not-acknowledged is the stranded state the retry bar exists
-        # for — see `_h_delivered`.
-        "deliveredAt": req.get("deliveredAt", ""),
-        "projectId": req.get("projectId", ""),
-        "projectRoot": req.get("projectRoot", ""),
-        "thread": _redact_thread(req.get("thread")),
-        "doneCount": sum(1 for c in comments if c.get("status") == "done"),
-        "comments": [_summarize_comment(c) for c in comments],
-    }
-
-
-def _proj_for_preview(preview_url: str) -> tuple[dict | None, str]:
-    """Resolve (project, path-within-project) from a preview URL.
-
-    Static previews are served from a PER-PROJECT loopback origin as
-    `<project's own static base><projectId>/<rel>` (see `_static_preview_base`
-    — each project gets its own ephemeral port so two projects never share a
-    browser-storage origin), so the project id and the served file both fall
-    out of the path. Returns `(None, "")` for any URL that isn't ours —
-    notably a dev-server URL like `http://localhost:5173/pricing`, where the path
-    is a ROUTE, not a file. Use `_resolve_project` instead of calling this
-    directly: identity should come from an explicit id, with this as the fallback
-    for older payloads.
-
-    The static origin is matched as an EXACT prefix against each project's OWN
-    recorded base — never by pattern-matching `/<seg>/<rest>` on some single
-    shared origin, because a dev-server URL has the identical shape and only
-    the origin distinguishes them, and there is no longer one shared origin to
-    compare against. Only ALREADY-RUNNING per-project servers are checked
-    (matching one never starts a new listener): a URL naming a project whose
-    listener has since stopped falls through to the legacy `/api/proxy/`
-    marker check below, exactly as an unrecognized URL always has.
-    """
-    url = str(preview_url)
-    rel = ""
-    matched = False
-    for pid, rec in _STATIC_SRV.items():
-        base = rec.get("url") or ""
-        if base and url.startswith(f"{base}{pid}/"):
-            rel = url[len(base) :]
-            matched = True
-            break
-    if not matched:
-        # The gateway-proxied `/apps/<app>/api/proxy/<id>/<rel>` route is gone, but
-        # comments captured before its removal still carry those URLs on disk.
-        marker = "/api/proxy/"
-        i = url.find(marker)
-        if i == -1:
-            return None, ""
-        rel = url[i + len(marker) :]
-    rel = rel.split("?")[0].split("#")[0]
-    seg = rel.split("/", 1)[0] if rel else ""
-    rest = rel.split("/", 1)[1] if "/" in rel else ""
-    proj = next((p for p in _CFG["projects"] if p["id"] == seg), None)
-    return proj, rest
-
-
-def _project_by_id(project_id: str) -> dict | None:
-    if not project_id:
-        return None
-    return next((p for p in _CFG["projects"] if p["id"] == project_id), None)
-
-
-def _resolve_project(payload: dict) -> tuple[str, str, str]:
-    """Identify the project a captured comment belongs to.
-
-    Returns `(projectId, projectRoot, sourceFile)`.
-
-    Identity comes from an EXPLICIT `projectId` on the payload — the panel knows
-    which project it is previewing, so it says so. The URL is only parsed as a
-    fallback for payloads written before that field existed. This matters beyond
-    tidiness: pattern-matching `/api/proxy/<id>/` only works for content this
-    backend proxies, so a project previewed straight from its dev server would
-    otherwise resolve to no project at all — losing its pins, its per-comment
-    threads, and its grouping.
-
-    `sourceFile` is only meaningful when the URL names a served FILE. A
-    dev-server route (`/pricing`) is not a path on disk, so it is left empty and
-    the agent relies on the per-element `source` block (`data-kiro-source` →
-    high confidence, React Fiber → medium) instead.
-    """
-    preview_url = str(payload.get("previewUrl", ""))
-    explicit = str(payload.get("projectId", "") or "")
-
-    proj = _project_by_id(explicit)
-    served_rel = ""
-    if proj is not None:
-        # Trust the id; still read the served path off the URL when it IS ours,
-        # so proxied projects keep exact per-page source files.
-        url_proj, served_rel = _proj_for_preview(preview_url)
-        if url_proj is not None and url_proj["id"] != proj["id"]:
-            served_rel = ""  # URL disagrees with the id — don't guess a file
-    else:
-        proj, served_rel = _proj_for_preview(preview_url)
-
-    if proj is not None:
-        root = proj["path"]
-        return proj["id"], root, _contained_source(root, served_rel)
-    if _ROOT:
-        return explicit, _ROOT, _contained_source(_ROOT, served_rel)
-    return explicit, "", ""
-
-
-def _contained_source(root: str, rel: str) -> str:
-    """`<root>/<rel>` as a string, or `""` if it would escape *root*.
-
-    `rel` is PREVIEW-CONTROLLED: it is sliced out of the `previewUrl` the page
-    reports, so it can carry `..` segments. Joining it to *root* unchecked
-    produced a `sourceFile` that the visual-edit prompt then hands the agent as
-    "the exact source file to edit" — pointing it at a path outside the project
-    the user actually registered. Nothing in this backend OPENS the value, so
-    the barrier protects the agent's edit target rather than a read here.
-
-    Empty in, empty out: no `rel` means the URL named a route, not a file, and
-    the agent falls back to the per-element `source` block.
-    """
-    if not rel:
-        return ""
-    try:
-        return str(_contained(root, rel))
-    except _PathEscape:
-        return ""
-
-
-def _sanitize_selection_sources(sel_obj: Any, root: str) -> None:
-    """Contain every per-element `source.file` in a selection, in place.
-
-    The `source` block is produced INSIDE the previewed page — from a
-    `data-kiro-source` attribute or a React Fiber `_debugSource` — so its
-    `file` is preview-controlled in exactly the way `previewUrl` is. It is
-    surfaced to the agent as "where the agent should edit", so a page that
-    names `../../../../etc/hosts` (or any absolute path) would aim the edit
-    outside the project the user registered.
-
-    A path that escapes is cleared rather than dropped, and its confidence
-    falls to `low` — the same shape `resolveSource()` emits when it finds
-    nothing, so the agent locates the element by locator instead of trusting a
-    file. Clearing only `file` would leave an incoherent `high`-confidence
-    hint with no path.
-
-    Absolute paths are handled by `_contained`: `os.path.join` lets an absolute
-    candidate win, and the containment check then accepts it only if it is
-    genuinely inside *root*. That keeps the normal React-Fiber case (absolute
-    paths under the project) working.
-
-    With no known root there is nothing to contain against, so every hint is
-    cleared — fail closed.
-    """
-    if not isinstance(sel_obj, dict):
-        return
-    for el in sel_obj.get("elements") or []:
-        if not isinstance(el, dict):
-            continue
-        src = el.get("source")
-        if not isinstance(src, dict) or not src.get("file"):
-            continue
-        safe = _contained_source(root, str(src["file"])) if root else ""
-        if not safe:
-            src["file"] = ""
-            src["confidence"] = "low"
-        else:
-            src["file"] = safe
-
-
-def _read_request(fp: Path) -> dict | None:
-    # Re-contain at entry so the read consumes the RETURN of the barrier even
-    # when a caller built the path itself (idempotent for the glob/`_request_file`
-    # callers; makes the containment legible at the sink).
-    try:
-        fp = _contained(DATA_DIR, os.fspath(fp))
-        # Bound the read before it happens. A file in the queue dir is not
-        # necessarily one this backend wrote through the size-capped API: the
-        # bundled skill hands the agent this exact path, so anything with the
-        # user's filesystem access is a writer here. `json.loads` on an oversized
-        # file pulls the whole thing into memory and takes the backend down, and
-        # `/queue` reads EVERY pending file, so one bad record poisons the route
-        # rather than just itself. Treat over-limit as unreadable, which is the
-        # same disposition this already gives malformed JSON.
-        if fp.stat().st_size > MAX_RECORD_BYTES:
-            return None
-        req = json.loads(fp.read_text("utf-8"))
-        return req if isinstance(req, dict) else None
-    except (_PathEscape, OSError, ValueError):
-        return None
-
-
-def _atomic_write_json(path: Path, payload: dict, *, max_bytes: int | None = None) -> None:
-    """Write JSON so an interrupted write can never leave a truncated file.
-
-    An in-place `write_text` truncates the target first, so a SIGTERM partway
-    through (the app being disabled mid-submit is the realistic case) leaves
-    invalid JSON on disk. `_read_request` treats unparseable JSON as absent, so
-    the user's queued request would silently disappear rather than fail loudly.
-    Writing to a unique temp file in the SAME directory and `os.replace`-ing it
-    over the target makes the swap atomic on POSIX and Windows alike, so a reader
-    sees either the old contents or the new ones and never a half-written file.
-    Mirrors `code_review_sage/sage_lib/learning.py::_atomic_write`.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    data = json.dumps(payload, indent=2).encode("utf-8")
-    if max_bytes is not None and len(data) > max_bytes:
-        # Refuse BEFORE the temp file exists, so the caller's rejection leaves the
-        # previous record exactly as it was. Checking the serialized bytes here
-        # rather than in the caller is what keeps the bound honest: this is the
-        # only place that knows what will actually be written.
-        raise _RecordTooLarge(
-            f"record would be {len(data)} bytes, over the {max_bytes}-byte limit"
-        )
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-    try:
-        try:
-            # os.write is NOT guaranteed to write everything in one call — on a
-            # nearly-full disk (or a signal) it returns a short count. Publishing
-            # that with os.replace would swap a TRUNCATED file over good state,
-            # which `_read_request` then treats as absent. Loop to completion and
-            # fsync, so the rename only ever publishes a whole, durable file.
-            written = 0
-            while written < len(data):
-                n = os.write(fd, data[written:])
-                if n <= 0:  # pragma: no cover - defensive; os.write raises instead
-                    raise OSError(f"short write to {tmp}: {written}/{len(data)} bytes")
-                written += n
-            os.fsync(fd)
-        finally:
-            os.close(fd)  # close even if the write raised
-        os.replace(tmp, path)
-    finally:
-        if os.path.exists(tmp):
-            os.unlink(tmp)
-
-
-def _write_request(fp: Path, req: dict) -> None:
-    # Same re-containment as `_read_request`: the write only ever touches a path
-    # the barrier returned.
-    fp = _contained(DATA_DIR, os.fspath(fp))
-    # Bounded at the chokepoint rather than per route, because every mutating
-    # route funnels through here — `/submit`, `/thread`, seal-on-send,
-    # delete-comment and delivered can each be the append that crosses the line,
-    # and a guard on only one of them would leave the others able to write a
-    # record `_read_request` then reports as absent.
-    _atomic_write_json(fp, req, max_bytes=MAX_RECORD_BYTES)
-
-
-def _find_request(rid: str) -> Path | None:
-    """Locate a request file by id, queue/ first then handled/."""
-    for d in (QUEUE_DIR, HANDLED_DIR):
-        try:
-            fp = _request_file(d, rid)
-        except _PathEscape:
-            return None
-        if fp.is_file():
-            return fp
-    return None
-
-
-def _open_draft_file(project_id: str) -> Path | None:
-    """The project's single open draft, if one exists.
-
-    Uses the derived status, not raw `state`, so a request whose comments are
-    already being worked can never quietly collect new comments.
-    """
-    for fp in _pending_files():
-        req = _read_request(fp)
-        if req and req.get("projectId") == project_id and _is_draft(req):
-            return fp
-    return None
-
-
-def _valid_target(url: str) -> bool:
-    """Only allow http://localhost[:port] or http://127.0.0.1[:port] (SSRF guard).
-
-    The PORT is validated here too, not just the host. ``urlsplit`` parses
-    ``http://localhost:notaport`` without complaint and resolves ``.hostname``
-    fine -- ``.port`` is a lazily-parsed property, so the ValueError only surfaces
-    at the first reader. Letting such a URL through the barrier persists it onto
-    the project, and every later ``.port`` read (``_start_inject_proxy`` on the
-    ``/projects`` poll) then raises: one bad input becomes a permanent
-    self-inflicted 500 on project loading.
-    """
-    try:
-        u = urlparse(url)
-        if u.scheme != "http":
-            return False
-        if (u.hostname or "").lower() not in _LOOPBACK_HOSTS:
-            return False
-        port = u.port  # raises ValueError on a non-numeric or out-of-range port
-    except ValueError:
-        return False
-    # `.port` already rejects >65535; port 0 parses but is not a dialable port.
-    return port is None or 1 <= port <= 65535
-
-
-def _valid_root(path: str):
-    """Resolve a folder path to serve. Returns a normalised Path or None if it is
-    not an existing directory or is a sensitive credential location.
-
-    `os.path.realpath` rather than `Path.resolve()`: both collapse `..` and
-    symlinks, but realpath is a *pure* normalisation while `resolve()` also
-    counts as a filesystem access — so the old form was itself a path-injection
-    sink on top of the ones it fed.
-
-    Sensitivity is delegated to the shared `is_sensitive_path()` floor, not just
-    a local dot-dir denylist: the preview servers will serve ANY file under the
-    chosen folder, so picking `~/.kiro/crew` as a "project" would have exposed
-    the governance trust root and this backend's own `.app_secret`.
-    """
-
-    try:
-        real = os.path.realpath(os.path.expanduser(path))
-    except (ValueError, OSError):
-        return None
-    if set(Path(real).parts) & _DENIED_ROOT_PARTS:
-        return None
-    if is_sensitive_path(real):
-        return None
-    # The reverse direction matters just as much here, because the preview
-    # servers serve ANY file under the chosen folder: a root that merely
-    # CONTAINS a credential store — `$HOME` itself, or any parent of `~/.ssh` —
-    # turns that store into a fetchable URL for the previewed page's own script,
-    # even though the root is not itself a sensitive path.
-    if path_contains_sensitive(real):
-        return None
-    p = Path(real)
-    # The `py/path-injection` finding on the next line is the FEATURE, and it is
-    # NOT suppressed in code: GitHub's default-setup code scanning does not honour
-    # `lgtm`-style inline markers, so a marker here would only mislead. It is
-    # dismissed on GitHub with this rationale — an authenticated operator names a
-    # folder on their own machine to preview it. The value is realpath-normalised
-    # above (no traversal survives), screened against `_DENIED_ROOT_PARTS` and the
-    # `is_sensitive_path()` floor, and there is no enclosing base to contain an
-    # arbitrary user-chosen directory within.
-    if not p.is_dir():
-        return None
-    return p
-
-
-# Boot-time restore: resume serving the active project across restarts.
-_boot_active = _active_project()
-if _boot_active:
-    _boot_root = _valid_root(_boot_active.get("path", ""))
-    if _boot_root is not None:
-        _ROOT = str(_boot_root)
-
-
-# Extension → Content-Type for every file this backend serves FROM DISK.
-#
-# This map is closed and every value is a LITERAL, which is load-bearing twice:
-#
-#   * Security: the requested path is attacker-influenced, so deriving a header
-#     value from it — as `mimetypes.guess_type(path)` did — put a tainted string
-#     one step from `send_header`. That is `py/http-response-splitting`, and no
-#     sanitiser call satisfies it because the analysis does not recognise one. A
-#     dict lookup that can only ever return a constant breaks the flow outright
-#     instead of trying to clean it.
-#   * Behaviour: an unmapped extension now serves as `application/octet-stream`
-#     rather than whatever the host's `/etc/mime.types` happened to say, so the
-#     result no longer varies by machine and never sniffs a script type for a
-#     file we do not recognise. `_header_value()` stays at the sink as defence in
-#     depth for the proxied path, which does forward an upstream-selected value.
-_CTYPE_OVERRIDES = {
-    # markup + code
-    ".html": "text/html",
-    ".htm": "text/html",
-    ".xhtml": "application/xhtml+xml",
-    ".css": "text/css",
-    ".js": "text/javascript",
-    ".mjs": "text/javascript",
-    ".cjs": "text/javascript",
-    ".json": "application/json",
-    ".map": "application/json",
-    ".webmanifest": "application/manifest+json",
-    ".xml": "text/xml",
-    ".txt": "text/plain",
-    ".md": "text/markdown",
-    ".csv": "text/csv",
-    ".wasm": "application/wasm",
-    ".pdf": "application/pdf",
-    # images
-    ".svg": "image/svg+xml",
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".avif": "image/avif",
-    ".bmp": "image/bmp",
-    ".ico": "image/x-icon",
-    # fonts
-    ".woff": "font/woff",
-    ".woff2": "font/woff2",
-    ".ttf": "font/ttf",
-    ".otf": "font/otf",
-    ".eot": "application/vnd.ms-fontobject",
-    # media
-    ".mp3": "audio/mpeg",
-    ".wav": "audio/wav",
-    ".ogg": "audio/ogg",
-    ".mp4": "video/mp4",
-    ".webm": "video/webm",
-    ".mov": "video/quicktime",
-}
-
-# What an extension we do not know is served as. Deliberately inert.
-_CTYPE_DEFAULT = "application/octet-stream"
-
-
-def _guess_ctype(p: Path) -> str:
-    """Content-Type for a file served from disk — always a constant.
-
-    A closed lookup, never a computation over the path (see `_CTYPE_OVERRIDES`).
-    Only the file's extension is read, and only to pick a key.
-    """
-    return _CTYPE_OVERRIDES.get(p.suffix.lower(), _CTYPE_DEFAULT)
-
-
-# Content types this backend will echo back for a proxied dev-server response.
-# The upstream is the user's own dev server, but it is still an unaudited process
-# whose headers land in OUR response, so its `Content-Type` is not forwarded
-# verbatim — it only SELECTS a value from this table. Every value here is a
-# literal, so a CR/LF (or a whole second header) smuggled into the upstream
-# header can never reach `send_header` — that was `py/http-response-splitting`.
-_PROXY_CTYPES: dict[str, str] = {
-    "text/html": "text/html; charset=utf-8",
-    "application/xhtml+xml": "text/html; charset=utf-8",
-    "text/css": "text/css; charset=utf-8",
-    "text/javascript": "text/javascript; charset=utf-8",
-    "application/javascript": "text/javascript; charset=utf-8",
-    "application/json": "application/json; charset=utf-8",
-    "application/manifest+json": "application/manifest+json",
-    "text/plain": "text/plain; charset=utf-8",
-    "text/markdown": "text/markdown; charset=utf-8",
-    "text/xml": "text/xml; charset=utf-8",
-    "application/xml": "application/xml; charset=utf-8",
-    "image/svg+xml": "image/svg+xml",
-    "image/png": "image/png",
-    "image/jpeg": "image/jpeg",
-    "image/gif": "image/gif",
-    "image/webp": "image/webp",
-    "image/avif": "image/avif",
-    "image/x-icon": "image/x-icon",
-    "image/vnd.microsoft.icon": "image/x-icon",
-    "font/woff": "font/woff",
-    "font/woff2": "font/woff2",
-    "font/ttf": "font/ttf",
-    "font/otf": "font/otf",
-    "application/wasm": "application/wasm",
-    "audio/mpeg": "audio/mpeg",
-    "video/mp4": "video/mp4",
-    "video/webm": "video/webm",
-    "application/octet-stream": "application/octet-stream",
-}
-
-
-def _safe_upstream_ctype(raw: str | None, path: str) -> str:
-    """A `Content-Type` safe to put in our own response for a proxied reply.
-
-    Kept for the PROXIED path only, which is the one case where the value has to
-    reflect something a foreign process said. The return is always one of the
-    literals in `_PROXY_CTYPES` or `_CTYPE_OVERRIDES` (keyed by the requested
-    extension when the upstream media type is unrecognised) — never a substring of
-    *raw* — so nothing the dev server sends can be spliced into our header block.
-    Files served from disk do not come through here: they use `_guess_ctype`.
-    """
-    media = (raw or "").split(";", 1)[0].strip().lower()
-    mapped = _PROXY_CTYPES.get(media)
-    if mapped:
-        return mapped
-    ext = os.path.splitext(urlparse(path).path)[1].lower()
-    return _CTYPE_OVERRIDES.get(ext, _CTYPE_DEFAULT)
-
-
-# A header NAME must be a bare RFC 7230 token — anything else is dropped rather
-# than forwarded, so a malformed name cannot open a new header line of its own.
 _HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
-
-
-def _header_value(value: str) -> str:
-    """A response-header value stripped of anything that could split the response.
-
-    Both places this backend writes a forwarded header value go through here, so
-    the CR/LF/control strip lives in one spot — belt to `_safe_upstream_ctype`'s
-    braces, and it also covers any header added here later.
-    """
-    cleaned = "".join(ch for ch in value if ch.isprintable() and ch not in "\r\n")
-    return cleaned[:256]
-
-
-# ---------------------------------------------------------------------------
-# Dev-server detection.
-#
-# A project registered as a folder may also be served by a dev server the user
-# already has running. Rather than guessing from a list of popular ports — which
-# picks the wrong server the moment two are up — identify it: every loopback
-# listener has a PID, every PID has a working directory, and the one whose
-# working directory sits inside the project folder IS that project's dev server.
-#
-# `lsof` is the only portable way to get that mapping without elevated
-# privileges, and the two invocations below work identically on macOS and Linux.
-# Detection is always best-effort: if lsof is missing or slow, callers fall back
-# to the manual URL field.
-# ---------------------------------------------------------------------------
-_LSOF_TIMEOUT = 4  # generous: lsof on a busy machine can take ~1s
-_PROBE_TIMEOUT = 1.5  # per-candidate HTTP probe
-
-
-def _lsof_fields(args: list[str]) -> list[dict]:
-    """Run lsof in field mode and return one dict per record.
-
-    Field output is a flat stream of `p<pid>` / `f<fd>` / `n<name>` lines where
-    the pid line begins a new process block, so `p` is carried forward.
-
-    The binary is resolved from the fixed system directories rather than `PATH`:
-    a gateway's `PATH` can lead with agent-writable dirs, so a bare `lsof` argv
-    would let a planted shim run with our environment. `None` means unavailable,
-    and the caller degrades to "no listeners found" rather than guessing.
-    """
-    lsof = trusted_system_bin("lsof")
-    if not lsof:
-        return []
-    try:
-        r = subprocess.run([lsof, *args], capture_output=True, text=True, timeout=_LSOF_TIMEOUT)
-    except (OSError, subprocess.SubprocessError):
-        return []
-    out: list[dict] = []
-    pid = ""
-    for line in r.stdout.splitlines():
-        if not line:
-            continue
-        tag, val = line[0], line[1:]
-        if tag == "p":
-            pid = val
-        elif tag == "n":
-            out.append({"pid": pid, "name": val})
-    return out
-
-
-def _loopback_listeners() -> dict[int, int]:
-    """{port: pid} for TCP listeners bound to loopback (or all interfaces)."""
-    found: dict[int, int] = {}
-    for rec in _lsof_fields(["-nP", "-iTCP", "-sTCP:LISTEN", "-Fpn"]):
-        name = rec["name"]
-        if ":" not in name:
-            continue
-        host, _, port_s = name.rpartition(":")
-        host = host.strip("[]")
-        # `*` means all interfaces, which includes loopback.
-        if host not in ("127.0.0.1", "localhost", "::1", "*", ""):
-            continue
-        try:
-            port = int(port_s)
-            found[port] = int(rec["pid"])
-        except ValueError:
-            continue
-    return found
-
-
-def _cwd_for_pids(pids: list[int]) -> dict[int, str]:
-    """{pid: working directory} — one lsof call for the whole set."""
-    if not pids:
-        return {}
-    joined = ",".join(str(p) for p in dict.fromkeys(pids))
-    out: dict[int, str] = {}
-    for rec in _lsof_fields(["-a", "-p", joined, "-d", "cwd", "-Fn"]):
-        try:
-            out[int(rec["pid"])] = rec["name"]
-        except ValueError:
-            continue
-    return out
-
-
-def _serves_html(port: int) -> bool:
-    """Does this port answer with an HTML page?
-
-    Discriminates a dev server from the API server / test runner / language
-    server that may also be running out of the same folder. Deliberately lenient
-    about status: a dev server can answer `/` with a 404 and still be the right
-    target, so only the content type has to look like a page.
-    """
-    url = f"http://127.0.0.1:{port}/"
-    try:
-        req = urllib.request.Request(url, headers={"User-Agent": "DesignTweak-Detect"})
-        # The url is a literal f-string: scheme and host are constants and `port`
-        # is an int parsed out of lsof output, so no scheme (`file://`) or host
-        # can be substituted. `# noqa: S310` covers flake8-bandit only.
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-        with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT) as resp:  # noqa: S310
-            return "text/html" in (resp.headers.get("Content-Type") or "").lower()
-    except urllib.error.HTTPError as exc:
-        return "text/html" in (exc.headers.get("Content-Type") or "").lower()
-    except (urllib.error.URLError, OSError, ValueError):
-        return False
-
-
-def _detect_dev_servers(root: Path, probe: bool = True) -> list[dict]:
-    """Dev servers plausibly serving `root`, best match first.
-
-    A candidate matches when the listening process's working directory is inside
-    the project folder — which also covers a monorepo whose server runs from
-    `<root>/apps/web`. Depth 0 (cwd IS the root) sorts first, since a server
-    started in the project root is the more likely target than one nested in it.
-    """
-    listeners = _loopback_listeners()
-    cwds = _cwd_for_pids(list(listeners.values()))
-
-    out: list[dict] = []
-    for port, pid in listeners.items():
-        cwd = cwds.get(pid, "")
-        if not cwd:
-            continue
-        try:
-            depth = len(Path(cwd).resolve().relative_to(root).parts)
-        except ValueError:
-            continue  # cwd is not inside the project
-        out.append(
-            {
-                "port": port,
-                "pid": pid,
-                "cwd": cwd,
-                "depth": depth,
-                "url": f"http://localhost:{port}",
-                "servesHtml": _serves_html(port) if probe else None,
-            }
-        )
-    # HTML-serving first, then shallowest cwd, then lowest port for stability.
-    out.sort(key=lambda c: (c["servesHtml"] is False, c["depth"], c["port"]))
-    return out
-
-
-def _auto_dev_server(root: Path) -> str:
-    """The one unambiguous dev-server URL for `root`, or "".
-
-    Returns a URL only when exactly ONE candidate serves HTML. With none there is
-    nothing to attach; with several, guessing would silently point the preview at
-    the wrong server, so the caller surfaces the list instead.
-    """
-    html = [c for c in _detect_dev_servers(root) if c["servesHtml"]]
-    return html[0]["url"] if len(html) == 1 else ""
-
-
-# ---------------------------------------------------------------------------
-# Dev-server processes we started.
-#
-# Spawned in their own process group so the whole tree can be signalled at once:
-# `npm run dev` forks the real server as a child, so killing only the npm pid
-# leaves an orphan holding the port. The isolation flag is platform-specific
-# (`start_new_session` is POSIX-only, `CREATE_NEW_PROCESS_GROUP` is the Windows
-# equivalent), and the teardown goes through `kill_process_tree` so Windows uses
-# `taskkill /T` instead of the non-existent `os.killpg`. Registered with atexit
-# so a gateway shutdown does not leak them either.
-# ---------------------------------------------------------------------------
-_DEV_PROCS: dict[str, dict] = {}  # projectId -> {proc, pgid, url, log}
-_START_TIMEOUT = 45  # cold Vite/Next can take a while
+_LSOF_TIMEOUT = 4
+_PROBE_TIMEOUT = 1.5
+_START_TIMEOUT = 45
 _STOP_GRACE = 3
+_RELAY_TIMEOUT = 30
+_WS_IDLE = 3600
+_CLIENT_READ_TIMEOUT = preview_files.CLIENT_READ_TIMEOUT
+_OVERLAY_PATH = preview_files.OVERLAY_PATH
 
-
-def _stop_dev_proc(project_id: str) -> bool:
-    """Signal the whole process tree, escalating only if it ignores SIGTERM."""
-
-    rec = _DEV_PROCS.pop(project_id, None)
-    if not rec:
-        return False
-    _stop_inject_proxy(rec)
-    proc = rec.get("proc")
-    if proc is None:  # adopted server: proxy was ours, process is not
-        return True
-    try:
-        kill_process_tree(proc.pid, SIGTERM)
-        try:
-            proc.wait(timeout=_STOP_GRACE)
-        except Exception:  # noqa: BLE001
-            kill_process_tree(proc.pid, SIGKILL)
-    except (ProcessLookupError, PermissionError, ValueError, OSError):
-        pass  # already gone
-    return True
-
-
-def _stop_all_dev_procs() -> None:
-    for pid in list(_DEV_PROCS):
-        _stop_dev_proc(pid)
-
-
-atexit.register(_stop_all_dev_procs)
-
-
-def _dev_proc_alive(project_id: str) -> bool:
-    rec = _DEV_PROCS.get(project_id)
-    if not rec:
-        return False
-    proc = rec.get("proc")
-    if proc is None:  # adopted: the user's server, our proxy
-        return bool(rec.get("proxy"))
-    return proc.poll() is None
-
-
-# ---------------------------------------------------------------------------
-# Injecting reverse proxy for dev servers
-#
-# The overlay is what makes select-to-edit work, and it is injected by THIS
-# backend when it serves a folder from disk. Point the iframe straight at a dev
-# server and the overlay never loads — Vite serves its own index.html, and no
-# amount of postMessage plumbing helps because there is nothing in the page to
-# talk to. Framing the dev server directly preserved hot reload and silently
-# dropped the app's entire reason for existing.
-#
-# So a dev server is framed THROUGH a proxy that injects the overlay. Two
-# decisions make this robust rather than a URL-rewriting game:
-#
-#   • It listens on its OWN port and maps paths 1:1. A dev server's HTML refers
-#     to root-absolute URLs (/src/main.tsx, /@vite/client) and its client builds
-#     more at runtime; behind a /proxy/<id>/ path prefix every one of them would
-#     miss. Identity mapping means nothing needs rewriting but the script tag.
-#   • WebSocket upgrades are relayed as raw bytes, so hot reload keeps working.
-#     Once the handshake is done a WS connection is just a byte stream — we never
-#     parse a frame, and the accept key is computed by the dev server, not us.
-# ---------------------------------------------------------------------------
 _HOP_BY_HOP = {
     "connection",
     "keep-alive",
@@ -1270,621 +281,382 @@ _HOP_BY_HOP = {
     "transfer-encoding",
     "upgrade",
 }
-# Request headers that carry the BROWSER's credentials for the dashboard origin.
-# They are stripped before relaying to the project's dev server (see
-# `_relay_http`), and also from the WebSocket handshake replay.
 _CREDENTIAL_REQUEST_HEADERS = {"cookie", "authorization"}
-# Response headers the previewed project must never be able to set on OUR
-# response. Cookies ignore ports, and this proxy shares 127.0.0.1 with the
-# dashboard, so an upstream Set-Cookie could overwrite the dashboard session.
 _CREDENTIAL_RESPONSE_HEADERS = {"set-cookie", "set-cookie2"}
-# Served by the proxy itself, so the overlay needs no cross-origin fetch and no
-# knowledge of which port this backend is on.
-_OVERLAY_PATH = "/__kiro_select_to_edit__.js"
-_WS_IDLE = 3600  # a quiet HMR socket is normal; don't tear it down
 
-# Wall clock a single client read may block for. Without this every handler here
-# inherits `socketserver`'s default of NO socket timeout, so a client that sends a
-# permitted `Content-Length` and then no body parks its handler thread forever —
-# and `ThreadingHTTPServer` gives one thread and one descriptor per connection, so
-# repeating that pre-auth exhausts both. The WebSocket relay is unaffected: it
-# pumps through `selectors.select()` and only `recv`s a socket already reported
-# readable, and it carries its own `_WS_IDLE` cap for a legitimately quiet socket.
-_CLIENT_READ_TIMEOUT = 30
-
-
-class _IncompleteBody(ValueError):
-    """A client declared a `Content-Length` it never delivered."""
-
-
-_RELAY_TIMEOUT = 30
-
-
-class _DevProxyHandler(BaseHTTPRequestHandler):
-    """Byte-transparent reverse proxy, except HTML gains the overlay script."""
-
-    protocol_version = "HTTP/1.1"
-    timeout = _CLIENT_READ_TIMEOUT  # see `_CLIENT_READ_TIMEOUT`
-    upstream_host = "127.0.0.1"
-    upstream_port = 0
-    # This proxy's OWN bound port, stamped on the per-proxy subclass once the
-    # socket has one (it is ephemeral, so it cannot be known at class-creation
-    # time). Used to keep an upstream redirect on this origin — see
-    # `_keep_redirect_local`. Read from the subclass rather than
-    # `self.server.server_address`, which is typed too loosely to index.
-    proxy_port = 0
-
-    def log_message(self, *args) -> None:
-        pass
-
-    def _upstream(self) -> str:
-        return f"{self.upstream_host}:{self.upstream_port}"
-
-    def _dispatch(self) -> None:
-        if self.path.split("?", 1)[0] == _OVERLAY_PATH:
-            return self._serve_overlay()
-        if "websocket" in self.headers.get("Upgrade", "").lower():
-            return self._relay_ws()
-        return self._relay_http()
-
-    do_GET = _dispatch
-    do_POST = _dispatch
-    do_HEAD = _dispatch
-    do_PUT = _dispatch
-    do_PATCH = _dispatch
-    do_DELETE = _dispatch
-    do_OPTIONS = _dispatch
-
-    def _serve_overlay(self) -> None:
-        try:
-            js = INJECT_FILE.read_bytes()
-        except OSError:
-            js = b"// overlay not found"
-        self.send_response(200)
-        self.send_header("Content-Type", "application/javascript; charset=utf-8")
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("Content-Length", str(len(js)))
-        self.end_headers()
-        self.wfile.write(js)
-
-    def _relay_http(self) -> None:
-
-        # Both directions are buffered whole (the HTML rewrite needs the full
-        # body), so both need a ceiling: without one, a preview request or a
-        # dev-server response larger than available memory takes the backend
-        # down. The request side reuses MAX_BODY_BYTES (inbound payload cap) and
-        # the response side MAX_STATIC_BYTES (one served asset), matching what
-        # the non-proxy paths already enforce.
-        body = b""
-        length = self.headers.get("Content-Length")
-        if length:
-            try:
-                size = int(length)
-            except ValueError:
-                size = -1
-            if size > MAX_BODY_BYTES:
-                # The unread body stays in the socket, so this connection can no
-                # longer be framed — close rather than desync the next request.
-                self.close_connection = True
-                self.send_error(413, f"request body over the {MAX_BODY_BYTES}-byte proxy limit")
-                return
-            if size > 0:
-                try:
-                    body = self.rfile.read(size)
-                except OSError:
-                    # Timed out mid-body (see `_CLIENT_READ_TIMEOUT`). Forwarding a
-                    # truncated body would make the dev server act on a partial
-                    # request, so refuse and close.
-                    self.close_connection = True
-                    self.send_error(408, "request body timed out")
-                    return
-                if len(body) != size:
-                    self.close_connection = True
-                    self.send_error(400, "request body shorter than Content-Length")
-                    return
-
-        headers = {}
-        for key, value in self.headers.items():
-            low = key.lower()
-            # Accept-Encoding is dropped so the upstream answers in identity
-            # encoding — otherwise the HTML would arrive gzipped and the overlay
-            # tag could not be inserted without decompressing it first.
-            if low in _HOP_BY_HOP or low in ("accept-encoding", "host"):
-                continue
-            # Never forward the browser's credentials to the project's dev
-            # server. This proxy advertises itself as http://127.0.0.1:<port>,
-            # and cookies are host-scoped but PORT-agnostic — so when the
-            # dashboard is served from 127.0.0.1 too, the browser attaches the
-            # dashboard's SameSite=Lax auth cookie to these requests, and
-            # relaying it verbatim would hand a usable session token to an
-            # arbitrary `npm run dev` process. The upstream is the user's own
-            # project and needs no dashboard credential to serve its assets.
-            if low in _CREDENTIAL_REQUEST_HEADERS:
-                continue
-            headers[key] = value
-        headers["Host"] = self._upstream()
-
-        try:
-            conn = http.client.HTTPConnection(
-                self.upstream_host, self.upstream_port, timeout=_RELAY_TIMEOUT
-            )
-            conn.request(self.command, self.path, body=body or None, headers=headers)
-            resp = conn.getresponse()
-            # Read one byte past the cap so an oversized body is detectable
-            # without buffering all of it.
-            payload = resp.read(MAX_STATIC_BYTES + 1)
-        except (OSError, http.client.HTTPException) as exc:
-            self.send_error(502, f"dev server unreachable: {exc}")
-            return
-
-        if len(payload) > MAX_STATIC_BYTES:
-            conn.close()
-            self.send_error(
-                502, f"dev server response over the {MAX_STATIC_BYTES}-byte preview limit"
-            )
-            return
-
-        if "text/html" in (resp.getheader("Content-Type") or "").lower():
-            payload = _rewrite_html(payload, base=None, script=_OVERLAY_PATH)
-
-        self.send_response(resp.status)
-        for key, value in resp.getheaders():
-            if key.lower() in _HOP_BY_HOP or key.lower() == "content-length":
-                continue
-            # Never let the dev server set cookies on OUR response. Cookies are
-            # host-scoped but PORT-agnostic, and this proxy shares 127.0.0.1 with
-            # the dashboard — so an upstream `Set-Cookie` naming the gateway's own
-            # cookie would REPLACE the dashboard's session in the browser, logging
-            # the user out or pinning them to an attacker-chosen value. This is the
-            # response-side mirror of the request-side `_CREDENTIAL_REQUEST_HEADERS`
-            # strip: the previewed project has no business touching dashboard state
-            # in either direction.
-            if key.lower() in _CREDENTIAL_RESPONSE_HEADERS:
-                continue
-            # Upstream is the project's own dev server, but its headers land in
-            # OUR response: a folded or CR/LF-bearing value forwarded verbatim
-            # would let it append headers or a second body (response splitting).
-            if not _HEADER_NAME_RE.match(key):
-                continue
-            # The upstream is the project's own dev server but still an unaudited
-            # process, so its media type SELECTS one of our literals instead of
-            # being echoed -- which is what `_PROXY_CTYPES` and
-            # `_safe_upstream_ctype` are for. Forwarding it verbatim lost the
-            # charset normalisation: an upstream `text/html; charset=iso-8859-1`
-            # reached the browser as sent.
-            if key.lower() == "content-type":
-                value = _safe_upstream_ctype(value, self.path)
-            # A redirect naming the dev server's OWN origin would take the iframe
-            # off this proxy and onto the bare upstream port — and because cookies
-            # are host-scoped but PORT-agnostic, the browser would then attach the
-            # dashboard's session cookie to the project's `npm run dev` process.
-            # The request-side strip cannot help: that navigation never passes
-            # through here. So keep the redirect INSIDE the proxy by re-pointing
-            # it at our own origin, which preserves the redirect's behaviour while
-            # keeping the cookie boundary intact.
-            if key.lower() == "location":
-                value = self._keep_redirect_local(value)
-            self.send_header(key, _header_value(value))
-        self.send_header("Content-Length", str(len(payload)))
-        self.end_headers()
-        if self.command != "HEAD":
-            self.wfile.write(payload)
-        conn.close()
-
-    def _keep_redirect_local(self, location: str) -> str:
-        """Re-point an upstream redirect that names the dev server at THIS proxy.
-
-        Only a `Location` whose host is loopback AND whose port is the upstream's
-        is rewritten — that is the one case where following it would move the
-        iframe from the proxy's port to the dev server's while staying on the same
-        cookie host. A redirect that is already relative needs nothing (it resolves
-        against our origin), and an off-host absolute redirect is left alone: the
-        dashboard cookie is scoped to this host, so it cannot ride along.
-
-        Path, query and fragment are preserved verbatim; only the authority moves.
-        """
-        try:
-            parts = urlparse(location)
-            if not parts.scheme and not parts.netloc:
-                return location  # relative — already ours
-            if parts.scheme.lower() not in ("http", "https"):
-                return location
-            if (parts.hostname or "").lower() not in _LOOPBACK_HOSTS:
-                return location
-            # `.port` is lazily parsed, so a non-numeric authority raises HERE
-            # rather than at `urlparse` — the same seam `_valid_target` guards.
-            port = parts.port or (443 if parts.scheme.lower() == "https" else 80)
-        except ValueError:
-            return location  # unparseable: forward as-is rather than invent a target
-        if port != self.upstream_port:
-            return location
-        rest = parts.path or "/"
-        if parts.query:
-            rest += "?" + parts.query
-        if parts.fragment:
-            rest += "#" + parts.fragment
-        return f"http://127.0.0.1:{self.proxy_port}{rest}"
-
-    def _relay_ws(self) -> None:
-
-        try:
-            up = socket.create_connection((self.upstream_host, self.upstream_port), timeout=10)
-        except OSError:
-            self.send_error(502, "dev server unreachable")
-            return
-
-        # Replay the handshake verbatim; the upstream's 101 comes back sanitized
-        # below, so we never compute Sec-WebSocket-Accept ourselves.
-        lines = [f"{self.command} {self.path} HTTP/1.1"]
-        for key, value in self.headers.items():
-            if key.lower() in _CREDENTIAL_REQUEST_HEADERS:
-                continue  # same reason as _relay_http: never leak dashboard creds
-            lines.append(f"{key}: {self._upstream() if key.lower() == 'host' else value}")
-        try:
-            up.sendall(("\r\n".join(lines) + "\r\n\r\n").encode("latin-1", "replace"))
-        except OSError:
-            up.close()
-            return
-
-        self.close_connection = True
-        down = self.connection
-
-        # Read the upstream handshake BEFORE any byte pumping. `_relay_http`
-        # already strips `_CREDENTIAL_RESPONSE_HEADERS` from ordinary responses,
-        # but a 101 used to go straight into the pump below and bypass that
-        # filter entirely. Same root cause as the request side: cookies ignore
-        # ports and this proxy shares 127.0.0.1 with the dashboard, so an
-        # upstream `Set-Cookie` naming the gateway's cookie would replace the
-        # user's dashboard session. Bounded read — a dev server that never
-        # terminates its header block must not hang us or grow this unboundedly.
-        head = b""
-        up.settimeout(_RELAY_TIMEOUT)
-        try:
-            while b"\r\n\r\n" not in head and len(head) < 65536:
-                part = up.recv(4096)
-                if not part:
-                    break
-                head += part
-        except OSError:
-            up.close()
-            return
-        raw_head, sep, rest = head.partition(b"\r\n\r\n")
-        if not sep:
-            up.close()
-            self.send_error(502, "malformed upstream handshake")
-            return
-        head_lines = raw_head.split(b"\r\n")
-        sanitized = [head_lines[0]]  # status line verbatim — we never recompute Accept
-        for header_line in head_lines[1:]:
-            name, _, _value = header_line.partition(b":")
-            if name.strip().lower().decode("latin-1", "replace") in _CREDENTIAL_RESPONSE_HEADERS:
-                continue
-            sanitized.append(header_line)
-        try:
-            down.sendall(b"\r\n".join(sanitized) + b"\r\n\r\n")
-            if rest:
-                down.sendall(rest)  # frames that arrived in the same read
-        except OSError:
-            up.close()
-            return
-
-        up.settimeout(None)
-        down.settimeout(None)
-        sel = selectors.DefaultSelector()
-        sel.register(up, selectors.EVENT_READ, down)
-        sel.register(down, selectors.EVENT_READ, up)
-        try:
-            while True:
-                events = sel.select(timeout=_WS_IDLE)
-                if not events:
-                    return  # idle past the cap
-                for sel_key, _mask in events:
-                    src_sock = cast(socket.socket, sel_key.fileobj)
-                    dst_sock = cast(socket.socket, sel_key.data)
-                    try:
-                        chunk = src_sock.recv(65536)
-                    except OSError:
-                        return
-                    if not chunk:
-                        return  # either side hung up
-                    try:
-                        dst_sock.sendall(chunk)
-                    except OSError:
-                        return
-        finally:
-            sel.close()
-            try:
-                up.close()
-            except OSError:
-                pass
-
-
-def _start_inject_proxy(dev_url: str) -> tuple[object | None, str]:
-    """Front `dev_url` with an overlay-injecting proxy. Returns (server, url)."""
-    parsed = urlparse(dev_url)
-    host = parsed.hostname or "127.0.0.1"
-    # Second `.port` reader after `_valid_target`. Guarded independently because a
-    # URL can reach here from `_auto_dev_server` / `_start_dev_proc` as well as
-    # from a persisted, allow-listed one -- and an unguarded ValueError here is
-    # what turned a malformed persisted port into a permanent `/projects` 500.
-    # Failing to (None, "") makes the caller frame the bare URL instead.
-    try:
-        port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    except ValueError:
-        return None, ""
-    bound = cast(
-        "type[_DevProxyHandler]",
-        type("_BoundDevProxy", (_DevProxyHandler,), {"upstream_host": host, "upstream_port": port}),
-    )
-    try:
-        srv = ThreadingHTTPServer(("127.0.0.1", 0), bound)
-    except OSError:
-        return None, ""
-    srv.daemon_threads = True
-    # The bound port only exists after the socket is bound, so stamp it on this
-    # proxy's own handler subclass now. Per-proxy, never shared.
-    bound.proxy_port = srv.server_address[1]
-    threading.Thread(target=srv.serve_forever, daemon=True, name="kiro-dev-proxy").start()
-    return srv, f"http://127.0.0.1:{srv.server_address[1]}/"
+# Owned processes and adopted-server proxies share this table.  ``proc is None``
+# means the listener belongs to the user and only our proxy may be stopped.
+_DEV_PROCS: dict[str, dict[str, Any]] = {}
 
 
 # ---------------------------------------------------------------------------
-# Static preview server (loopback, ephemeral, unauthenticated by design).
-#
-# WHY THIS EXISTS — it is a security boundary, not a convenience.
-#
-# The preview iframe used to be pointed at `/apps/design-tweak/api/proxy/<id>/`,
-# which is served from the DASHBOARD's own origin. The frame needs
-# `allow-scripts` (prototypes are JavaScript) and `allow-same-origin` (real
-# projects use localStorage / cookies / same-origin fetch, and every asset the
-# page loads must be reachable) — but those two together, on our OWN origin,
-# cancel the sandbox: arbitrary previewed project HTML (or a third-party snippet
-# pasted into a mockup) would run first-party and could call the authenticated
-# dashboard API and read the parent DOM.
-#
-# Dropping `allow-same-origin` is NOT the fix. It gives the frame an opaque
-# origin, whose "site for cookies" is null, so the browser treats every
-# subresource request as cross-site and withholds the dashboard's SameSite=Lax
-# auth cookie. Measured in Chromium: the frame's own navigation still gets the
-# cookie, but the overlay script, CSS, images and `fetch()` all lose it, and
-# `localStorage` throws SecurityError. The gateway would 401 the overlay itself,
-# so select-to-edit would not merely degrade — it would not load.
-#
-# So the frame keeps the permissive sandbox and instead stops sharing our origin:
-# the project is served from 127.0.0.1 on an ephemeral port, exactly like the
-# dev-server path already is. `allow-same-origin` then grants the project only
-# ITS OWN origin, which is what a dev server would have given it anyway.
-#
-# Consequences that are deliberate:
-#   * This listener is UNAUTHENTICATED. It is the same exposure `npm run dev`
-#     already accepts: loopback-only bind, an OS-assigned random port, and it
-#     serves nothing but the folders the user explicitly registered, each behind
-#     the `_contained` barrier.
-#   * It reads no request credentials and forwards nothing anywhere — there is no
-#     upstream. Unlike `_DevProxyHandler` there is no relay to strip headers on.
-#   * The port is never persisted; it dies with this backend and is resolved live
-#     in `_h_projects_list`, so a stale port can never be framed.
+# Durable state compatibility surface
 # ---------------------------------------------------------------------------
-class _StaticInjectHandler(BaseHTTPRequestHandler):
-    """Serve any registered project folder from loopback, overlay injected.
 
-    Paths are `/<projectId>/<rest>`, mapping 1:1 onto the registered folder, so
-    one listener covers every project and a newly registered folder needs no
-    restart. Read-only: anything but GET/HEAD is refused.
+
+def _is_kirocrew_internal(target: Path) -> bool:
+    return request_state.is_kirocrew_internal(runtime, target)
+
+
+def _contained(base: Path | str, candidate: str = "") -> Path:
+    return request_state.contain_path(base, candidate)
+
+
+def _request_file(base: Path, rid: str) -> Path:
+    return request_state.request_file(runtime, base, rid)
+
+
+def _atomic_write_json(
+    path: Path,
+    payload: dict,
+    *,
+    max_bytes: int | None = None,
+) -> None:
+    return request_state.atomic_write_json(runtime, path, payload, max_bytes=max_bytes)
+
+
+def _load_cfg() -> dict:
+    return request_state.load_config(runtime)
+
+
+def _save_cfg(cfg: dict) -> None:
+    return request_state.save_config(runtime, cfg)
+
+
+_CFG = _load_cfg()
+
+
+def _active_project() -> dict | None:
+    return request_state.active_project(runtime)
+
+
+def _next_number(project_id: str = "") -> int:
+    return request_state.next_request_number(runtime, project_id)
+
+
+def _new_id() -> str:
+    return request_state.new_request_id()
+
+
+def _now_iso() -> str:
+    return request_state.utc_now_iso()
+
+
+def _pending_files() -> list[Path]:
+    return request_state.pending_files(runtime)
+
+
+def _el_name(el: dict) -> str:
+    return request_state.element_name(el)
+
+
+def _request_status(req: dict) -> str:
+    return request_state.request_status(req)
+
+
+def _is_draft(req: dict) -> bool:
+    return request_state.is_draft(runtime, req)
+
+
+def _redact_text(value: object) -> str:
+    """Apply the redaction floor to one string, URLs before credentials.
+
+    The order is load-bearing: `redact_exfiltration_urls` keys off the URL's
+    host, so a credential-first pass would rewrite a token inside a URL to
+    `[REDACTED: credential]` and leave the exfiltration host itself standing.
+    That is why both edges route through this one function rather than inlining
+    the pair — a second copy of the order is how the two edges drift.
     """
 
-    protocol_version = "HTTP/1.1"
-    timeout = _CLIENT_READ_TIMEOUT  # see `_CLIENT_READ_TIMEOUT`
-
-    def log_message(self, *args) -> None:
-        pass
-
-    def _refuse(self, status: int, msg: bytes) -> None:
-        self.send_response(status)
-        self.send_header("Content-Type", "text/plain; charset=utf-8")
-        self.send_header("Content-Length", str(len(msg)))
-        self.end_headers()
-        if self.command != "HEAD":
-            self.wfile.write(msg)
-
-    def _send(self, status: int, ctype: str, body: bytes) -> None:
-        self.send_response(status)
-        self.send_header("Content-Type", ctype)
-        self.send_header("Cache-Control", "no-store")
-        # The previewed project is NOT allowed to become a cross-origin API for
-        # some other page: no CORS headers are emitted, so only the frame itself
-        # (same origin as this server) can read these bodies.
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        if self.command != "HEAD":
-            self.wfile.write(body)
-
-    def _dispatch(self) -> None:
-        path = urlparse(self.path).path
-        if path == _OVERLAY_PATH:
-            try:
-                js = INJECT_FILE.read_bytes()
-            except OSError:
-                js = b"// overlay not found"
-            return self._send(200, "application/javascript; charset=utf-8", js)
-        rel = unquote(path).lstrip("/")
-        first, _, rest = rel.partition("/")
-        # This listener is dedicated to exactly ONE project (bound at server
-        # creation, see `_static_preview_base`) — it does not consult the full
-        # `_CFG["projects"]` list. Two projects previewed from disk therefore
-        # never share a listener, and so never share the browser-storage
-        # origin (scheme+host+port) that listener answers on: cross-project
-        # localStorage/cookie access is impossible because there is no
-        # same-origin path between them, not merely an unenforced convention.
-        bound_id: str = getattr(self.server, "kiro_project_id", "")
-        if first != bound_id:
-            return self._refuse(404, b"unknown project")
-        proj = next((p for p in _CFG["projects"] if p["id"] == first), None)
-        if proj is None:
-            return self._refuse(404, b"unknown project")
-        root = _valid_root(proj["path"])
-        if root is None:
-            return self._refuse(404, b"project folder no longer readable")
-        # `base` is this server's own 1:1 prefix for the project, so a nested
-        # entry's <base href> and the diagnostic 404's links stay correct.
-        status, ctype, body = _static_response(str(root), rest, f"/{first}/", script=_OVERLAY_PATH)
-        return self._send(status, ctype, body)
-
-    do_GET = _dispatch
-    do_HEAD = _dispatch
-
-    def do_POST(self) -> None:  # noqa: N802
-        self._refuse(405, b"read-only preview server")
-
-    do_PUT = do_POST
-    do_PATCH = do_POST
-    do_DELETE = do_POST
-    do_OPTIONS = do_POST
+    text, _ = redact_exfiltration_urls(str(value or ""))
+    text, _ = redact_credentials(text)
+    return text
 
 
-# One live static preview server PER PROJECT, keyed by project id:
-# `{project_id: {"srv": ThreadingHTTPServer, "url": str}}`. Each project gets
-# its own ephemeral loopback port — and therefore its own browser-storage
-# origin — rather than sharing one listener differentiated only by URL path.
-# A shared listener put every previewed project's localStorage/cookies on the
-# SAME origin (scheme+host+port; the path prefix plays no part in same-origin
-# checks), so switching the panel from project A to project B on that one
-# listener handed B's page A's storage. See the design_tweak security-review
-# thread for the reachable vector.
-_STATIC_SRV: dict[str, dict] = {}
+def _redact_incoming_thread_text(value: object) -> str:
+    """Redact agent-authored thread text before it reaches durable storage.
+
+    Named separately from `_redact_text` because it guards the opposite edge:
+    the panel renders this text later, so a leaked credential must not exist on
+    disk in the first place. It is applied per-field, not to the whole payload —
+    `role` and `status` are allow-listed to fixed vocabularies and `ts` is
+    generated server-side, so none of them can persist an arbitrary string.
+    """
+
+    return _redact_text(value)
+
+
+def _redact_thread(thread: object) -> list[dict]:
+    return request_state.redact_thread(runtime, thread)
+
+
+def _summarize_comment(comment: dict) -> dict:
+    return request_state.summarize_comment(runtime, comment)
+
+
+def _summarize(request: dict) -> dict:
+    return request_state.summarize_request(runtime, request)
+
+
+def _proj_for_preview(preview_url: str) -> tuple[dict | None, str]:
+    return request_state.project_for_preview(runtime, preview_url)
+
+
+def _project_by_id(project_id: str) -> dict | None:
+    return request_state.project_by_id(runtime, project_id)
+
+
+def _resolve_project(payload: dict) -> tuple[str, str, str]:
+    return request_state.resolve_project(runtime, payload)
+
+
+def _contained_source(root: str, rel: str) -> str:
+    return request_state.contained_source(runtime, root, rel)
+
+
+def _sanitize_selection_sources(sel_obj: Any, root: str) -> None:
+    return request_state.sanitize_selection_sources(runtime, sel_obj, root)
+
+
+def _read_request(fp: Path) -> dict | None:
+    """Read only after the MAX_RECORD_BYTES st_size gate, before read_text."""
+
+    return request_state.read_request(runtime, fp)
+
+
+def _write_request(fp: Path, req: dict) -> None:
+    """Publish through the shared chokepoint with max_bytes=MAX_RECORD_BYTES."""
+
+    return request_state.write_request(runtime, fp, req)
+
+
+def _find_request(rid: str) -> Path | None:
+    return request_state.find_request(runtime, rid)
+
+
+def _open_draft_file(project_id: str) -> Path | None:
+    return request_state.open_draft_file(runtime, project_id)
+
+
+def _valid_target(url: str) -> bool:
+    return request_state.valid_target(runtime, url)
+
+
+def _valid_root(path: str) -> Path | None:
+    return request_state.valid_root(runtime, path)
+
+
+# Resume the active, still-readable project without creating any directory.
+_boot_active = _active_project()
+if _boot_active:
+    _boot_root = _valid_root(_boot_active.get("path", ""))
+    if _boot_root is not None:
+        _ROOT = str(_boot_root)
+
+
+# ---------------------------------------------------------------------------
+# File preview compatibility surface
+# ---------------------------------------------------------------------------
+
+
+def _guess_ctype(p: Path) -> str:
+    return preview_files.guess_ctype(runtime, p)
+
+
+def _safe_upstream_ctype(raw: str | None, path: str) -> str:
+    return preview_files.safe_upstream_ctype(runtime, raw, path)
+
+
+def _header_value(value: str) -> str:
+    """Strip controls and bound a value before a response-header sink."""
+
+    cleaned = "".join(ch for ch in value if ch.isprintable() and ch not in "\r\n")
+    return cleaned[:256]
+
+
+def _unbundled_entry(html: bytes) -> str:
+    return preview_files.unbundled_entry(runtime, html)
+
+
+def _find_entry(folder: Path, root: Path | None = None) -> Path | None:
+    return preview_files.find_entry(runtime, folder, root)
+
+
+def _scan_html(root: Path, limit: int = 40, max_depth: int = 3) -> list[str]:
+    return preview_files.scan_html(runtime, root, limit, max_depth)
+
+
+def _rewrite_html(
+    body: bytes,
+    base: str | None = PROXY_PUBLIC_BASE,
+    script: str = INJECT_PUBLIC,
+) -> bytes:
+    return preview_files.rewrite_html(runtime, body, base, script)
+
+
+def _needs_dev_server_body(root: Path, page: Path, entry: str) -> bytes:
+    return preview_files.needs_dev_server_body(runtime, root, page, entry)
+
+
+def _no_entry_response(
+    root: Path,
+    folder: Path,
+    base: str,
+    missing: str = "",
+) -> tuple[int, str, bytes]:
+    return preview_files.no_entry_response(runtime, root, folder, base, missing)
+
+
+def _contains_credential(data: bytes) -> bool:
+    return preview_files.contains_credential(runtime, data)
+
+
+def _is_project_secret(root: Path, target: Path) -> bool:
+    return preview_files.is_project_secret(runtime, root, target)
+
+
+def _static_response(
+    root_str: str,
+    rel: str,
+    base: str,
+    script: str = INJECT_PUBLIC,
+) -> tuple[int, str, bytes]:
+    """Serve only after containment and the _is_kirocrew_internal policy floor."""
+
+    return preview_files.static_response(runtime, root_str, rel, base, script)
 
 
 def _static_preview_base(project_id: str) -> str:
-    """Base URL of *project_id*'s dedicated loopback static server.
-
-    Starts that project's own listener on demand. Returns "" if it cannot
-    bind. There is deliberately NO fallback: the panel renders its "preview
-    not reachable" state instead. The gateway-proxied route this used to fall
-    back to served project files from the DASHBOARD's origin, which let a
-    hostile previewed page escape the iframe sandbox, so it has been deleted
-    (it answers 410). Do not reintroduce a same-origin fallback.
-    """
-    rec = _STATIC_SRV.get(project_id)
-    if rec and rec.get("url"):
-        return str(rec["url"])
-    try:
-        srv = ThreadingHTTPServer(("127.0.0.1", 0), _StaticInjectHandler)
-    except OSError:
-        return ""
-    srv.daemon_threads = True
-    # Bind the project this listener is dedicated to onto the server instance
-    # itself — `_StaticInjectHandler._dispatch` reads it back via `self.server`
-    # so the SAME handler class stays generic while each instance answers for
-    # exactly one project.
-    srv.kiro_project_id = project_id  # type: ignore[attr-defined]
-    threading.Thread(
-        target=srv.serve_forever, daemon=True, name=f"kiro-static-preview-{project_id}"
-    ).start()
-    url = f"http://127.0.0.1:{srv.server_address[1]}/"
-    _STATIC_SRV[project_id] = {"srv": srv, "url": url}
-    return url
+    return preview_files.static_preview_base(runtime, project_id)
 
 
 def _stop_static_preview(project_id: str) -> None:
-    """Shut down and forget *project_id*'s dedicated static listener.
-
-    Each project gets its OWN listener (a shared one would put two projects on
-    one browser-storage origin), so the registry entry is the only handle to it.
-    Dropping the project without this leaves the thread and the bound port alive
-    with nothing able to reach them, and `daemon_threads` only helps at process
-    exit — a long-lived gateway accumulates one orphan per remove.
-    """
-    rec = _STATIC_SRV.pop(project_id, None)
-    if rec is None:
-        return
-    srv = rec.get("srv")
-    if srv is None:
-        return
-    try:
-        srv.shutdown()
-        srv.server_close()
-    except Exception:  # noqa: BLE001
-        pass
+    return preview_files.stop_static_preview(runtime, project_id)
 
 
 def _static_preview_url(project_id: str) -> str:
-    """URL the iframe should use to preview `project_id` from disk ("" if none)."""
-    base = _static_preview_base(project_id)
-    return f"{base}{project_id}/" if base else ""
+    return preview_files.static_preview_url(runtime, project_id)
+
+
+class _StaticInjectHandler(preview_files.StaticInjectHandlerBase):
+    runtime = runtime
+    timeout = _CLIENT_READ_TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# Dev-server discovery, lifecycle, and proxy compatibility surface
+# ---------------------------------------------------------------------------
+
+
+def _lsof_fields(args: list[str]) -> list[dict]:
+    """Run the trusted system lsof binary and parse its field records."""
+
+    lsof = trusted_system_bin("lsof")
+    if not lsof:
+        return []
+    try:
+        result = subprocess.run(
+            [lsof, *args],
+            capture_output=True,
+            timeout=_LSOF_TIMEOUT,
+            **UTF8_TEXT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    out: list[dict] = []
+    pid = ""
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        tag, value = line[0], line[1:]
+        if tag == "p":
+            pid = value
+        elif tag == "n":
+            out.append({"pid": pid, "name": value})
+    return out
+
+
+def _loopback_listeners() -> dict[int, int]:
+    return dev_preview.loopback_listeners(runtime)
+
+
+def _cwd_for_pids(pids: list[int]) -> dict[int, str]:
+    return dev_preview.cwd_for_pids(runtime, pids)
+
+
+def _serves_html(port: int) -> bool:
+    return dev_preview.serves_html(runtime, port)
+
+
+def _detect_dev_servers(root: Path, probe: bool = True) -> list[dict]:
+    return dev_preview.detect_dev_servers(runtime, root, probe)
+
+
+def _auto_dev_server(root: Path) -> str:
+    return dev_preview.auto_dev_server(runtime, root)
+
+
+def _node_bin_dirs() -> list[Path]:
+    return dev_preview.node_bin_dirs(runtime)
+
+
+def _resolve_bin(name: str) -> Path | None:
+    return dev_preview.resolve_bin(runtime, name)
+
+
+def _child_env(bin_dir: Path) -> dict:
+    return dev_preview.child_env(runtime, bin_dir)
+
+
+def _pkg_scripts(root: Path) -> dict:
+    return dev_preview.pkg_scripts(runtime, root)
+
+
+def _dev_command(root: Path) -> list[str]:
+    return dev_preview.dev_command(runtime, root)
+
+
+def _classify_project(root: Path) -> dict:
+    return dev_preview.classify_project(runtime, root)
 
 
 def _stop_inject_proxy(rec: dict) -> None:
-    srv = rec.get("proxy")
-    if srv is None:
-        return
-    try:
-        srv.shutdown()
-        srv.server_close()
-    except Exception:  # noqa: BLE001
-        pass
-    rec["proxy"] = None
-    # Keep "proxyUrl is set" ⟺ "proxy is live": a dead listener's URL must never
-    # be reused as a cache hit below, nor framed by `_h_projects_list`.
-    rec["proxyUrl"] = ""
-    rec["proxyFor"] = ""
+    return dev_preview.stop_inject_proxy(runtime, rec)
+
+
+def _start_inject_proxy(dev_url: str) -> tuple[object | None, str]:
+    return dev_preview.start_inject_proxy(runtime, dev_url)
 
 
 def _front_with_proxy(project_id: str, dev_url: str) -> str:
-    """Attach an injecting proxy to a running dev server; return the URL to frame.
+    # The boundary's bind-failure result is `return ""`; never expose upstream.
+    return dev_preview.front_with_proxy(runtime, project_id, dev_url)
 
-    Idempotent: if this project already has a LIVE proxy fronting this same
-    `dev_url`, that proxy is reused instead of being rebuilt. `_h_projects_list`
-    calls this on every poll for a project whose dev URL is persisted, so a
-    start-unconditionally version would leak a listener per request and hand the
-    iframe a fresh origin each time (losing the preview's localStorage and
-    scroll position on every refresh).
 
-    Returns `""` when the proxy cannot be started, which the panel renders as the
-    unreachable state. Framing the BARE dev server instead is not an acceptable
-    degradation, even though it is also loopback: cookies are host-scoped but
-    **port-agnostic**, so `127.0.0.1:<dev-port>` receives the dashboard's own
-    session cookie. Stripping `Cookie`/`Authorization` is one of the reasons this
-    proxy exists, so falling back past it would hand the previewed project's code
-    the credential the proxy was built to withhold — trading a fixed
-    credential-exposure bug for a missing overlay. A preview that says it is
-    unreachable is better than one that leaks.
-    """
-    rec = _DEV_PROCS.get(project_id)
-    if rec is not None and rec.get("proxy") is not None and rec.get("proxyFor") == dev_url:
-        cached = str(rec.get("proxyUrl") or "")
-        if cached:
-            return cached
-    srv, url = _start_inject_proxy(dev_url)
-    if not url:
-        return ""
-    if rec is not None:
-        _stop_inject_proxy(rec)
-        rec["proxy"] = srv
-        rec["proxyUrl"] = url
-        rec["proxyFor"] = dev_url
-    else:
-        _DEV_PROCS[project_id] = {
-            "proc": None,
-            "pgid": None,
-            "url": dev_url,
-            "proxy": srv,
-            "proxyUrl": url,
-            "proxyFor": dev_url,
-            "adopted": True,
-        }
-    return url
+def _stop_dev_proc(project_id: str) -> bool:
+    return dev_preview.stop_dev_proc(runtime, project_id)
+
+
+def _stop_all_dev_procs() -> None:
+    return dev_preview.stop_all_dev_procs(runtime)
+
+
+def _dev_proc_alive(project_id: str) -> bool:
+    return dev_preview.dev_proc_alive(runtime, project_id)
+
+
+def _in_proc_tree(pid: int, root_pid: int, pgid: int | None) -> bool:
+    return dev_preview.in_proc_tree(runtime, pid, root_pid, pgid)
+
+
+class _DevProxyHandler(dev_preview.DevProxyHandlerBase):
+    runtime = runtime
+    timeout = _CLIENT_READ_TIMEOUT
 
 
 def _start_dev_proc(project_id: str, root: Path) -> dict:
-    """Start the project's dev server and wait until it is listening.
+    """Start an owned project dev server and discover the port it selected."""
 
-    Returns `{"ok": True, "url": …}` or `{"ok": False, "error": …, "log": …}`.
-
-    The port is NOT chosen here — the dev tool picks its own, and we then find it
-    by matching a listening port back to a process rooted in this folder. That
-    avoids a per-framework table of port flags, and it is also what makes the
-    result honest: we report the port something is actually listening on.
-    """
     if _dev_proc_alive(project_id):
         rec = _DEV_PROCS[project_id]
         return {
@@ -1893,7 +665,7 @@ def _start_dev_proc(project_id: str, root: Path) -> dict:
             "devUrl": rec["url"],
             "already": True,
         }
-    _stop_dev_proc(project_id)  # clear a dead record
+    _stop_dev_proc(project_id)
 
     cmd = _dev_command(root)
     if not cmd:
@@ -1904,12 +676,11 @@ def _start_dev_proc(project_id: str, root: Path) -> dict:
             + ").",
         }
 
-    # Resolve the package manager absolutely — the gateway hands this backend a
-    # minimal PATH, so spawning by bare name fails with ENOENT even though the
-    # same command works in a terminal.
+    # Resolve the executable before spawn; the backend deliberately does not
+    # trust an agent-writable PATH for this process boundary.
     binary = _resolve_bin(cmd[0])
     if binary is None:
-        looked = ", ".join(str(d) for d in _node_bin_dirs()[:4])
+        looked = ", ".join(str(directory) for directory in _node_bin_dirs()[:4])
         return {
             "ok": False,
             "error": f"Could not find `{cmd[0]}`. Design Tweak's backend does not inherit "
@@ -1935,18 +706,15 @@ def _start_dev_proc(project_id: str, root: Path) -> dict:
             cwd=str(root),
             stdout=handle,
             stderr=subprocess.STDOUT,
-            env=_child_env(binary.parent),  # node must be on PATH for npm's own child
-            # Own process group → killable as a tree. `start_new_session` is a
-            # POSIX-only setsid() and raises on Windows; the Windows equivalent
-            # is the creation flag, which is 0 on POSIX.
+            env=_child_env(binary.parent),
+            # npm-style launchers fork the listener, so each owned process gets a
+            # platform-appropriate group/tree that cleanup can terminate.
             start_new_session=IS_POSIX,
             creationflags=CREATE_NEW_PROCESS_GROUP,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return {"ok": False, "error": f"could not start `{' '.join(cmd)}`: {exc}"}
 
-    # POSIX-only: there is no process-group id on Windows, where descendants are
-    # matched by walking the parent chain instead (see `_in_proc_tree`).
     pgid = None
     if IS_POSIX:
         try:
@@ -1963,12 +731,9 @@ def _start_dev_proc(project_id: str, root: Path) -> dict:
         "proxyFor": "",
     }
 
-    # Poll for the port it chose. Probing is skipped while polling: an HTTP request
-    # per candidate per tick is wasteful, and a dev server that is listening but
-    # still compiling would fail the HTML check and look like a miss.
     deadline = time.time() + _START_TIMEOUT
     while time.time() < deadline:
-        if proc.poll() is not None:  # exited — surface its own output
+        if proc.poll() is not None:
             tail = ""
             try:
                 tail = log.read_text("utf-8", errors="replace")[-800:]
@@ -1980,20 +745,16 @@ def _start_dev_proc(project_id: str, root: Path) -> dict:
                 "error": f"`{' '.join(cmd)}` exited ({proc.returncode}).",
                 "log": tail,
             }
-        for cand in _detect_dev_servers(root, probe=False):
-            if cand["pid"] == proc.pid or _in_proc_tree(cand["pid"], proc.pid, pgid):
-                _DEV_PROCS[project_id]["url"] = cand["url"]
-                # Frame the PROXY, not the dev server: the proxy is what injects
-                # the select-to-edit overlay.
-                framed = _front_with_proxy(project_id, cand["url"])
+        for candidate in _detect_dev_servers(root, probe=False):
+            if candidate["pid"] == proc.pid or _in_proc_tree(candidate["pid"], proc.pid, pgid):
+                _DEV_PROCS[project_id]["url"] = candidate["url"]
+                framed = _front_with_proxy(project_id, candidate["url"])
                 return {
                     "ok": True,
                     "url": framed,
-                    "devUrl": cand["url"],
-                    "port": cand["port"],
-                    # Empty `framed` means the proxy could not bind, so nothing is
-                    # framed at all — that is not "injected".
-                    "injected": bool(framed) and framed != cand["url"],
+                    "devUrl": candidate["url"],
+                    "port": candidate["port"],
+                    "injected": bool(framed) and framed != candidate["url"],
                 }
         time.sleep(0.4)
 
@@ -2004,1739 +765,11 @@ def _start_dev_proc(project_id: str, root: Path) -> dict:
     }
 
 
-# Depth cap on the Windows parent-chain walk in `_in_proc_tree`: a real chain is
-# npm → node → (maybe) a wrapper, and the cap keeps a corrupt/cyclic parent map
-# from spinning even though `seen` already breaks true cycles.
-_PROC_TREE_MAX_DEPTH = 16
-
-
-def _in_proc_tree(pid: int, root_pid: int, pgid: int | None) -> bool:
-    """Does `pid` belong to the tree we started? The listener is usually npm's CHILD.
-
-    POSIX matches on the process group, which catches a grandchild even when the
-    intermediate `npm` has already exited. Windows has no process group to read,
-    so the parent chain is walked instead — bounded because a real chain here is
-    two or three links and `get_ppid` returns 0 at the root.
-    """
-    if pgid is not None:
-        try:
-            return os.getpgid(pid) == pgid
-        except OSError:
-            return False
-    seen: set[int] = set()
-    cur = pid
-    for _ in range(_PROC_TREE_MAX_DEPTH):
-        if cur == root_pid:
-            return True
-        if cur <= 0 or cur in seen:
-            return False
-        seen.add(cur)
-        cur = get_ppid(cur)
-    return False
-
-
-#
-# Not every project folder has index.html at its top level: a repo may keep the
-# static site in public/ or dist/, or nest the app in a subfolder (mono-repos).
-# Rather than 404 on the folder request, look for the most likely entry file,
-# and if there is none, render a page that lists the HTML files we DID find so
-# the user can pick one instead of staring at a dead iframe.
-# ---------------------------------------------------------------------------
-_ENTRY_CANDIDATES = (
-    "index.html",
-    "index.htm",
-    "public/index.html",
-    "dist/index.html",
-    "build/index.html",
-    "out/index.html",
-    "app/index.html",
-    "src/index.html",
-    "site/index.html",
-    "www/index.html",
-    "docs/index.html",
-    "demo/index.html",
-    "example/index.html",
-    "examples/index.html",
-)
-
-# Directories that never contain the previewable entry point but do contain
-# thousands of files — skipping them keeps the HTML scan fast.
-_SCAN_SKIP_DIRS = {
-    "node_modules",
-    ".git",
-    ".next",
-    ".nuxt",
-    ".svelte-kit",
-    ".cache",
-    ".turbo",
-    "__pycache__",
-    ".venv",
-    "venv",
-    "coverage",
-    "htmlcov",
-    ".pytest_cache",
-    "target",
-    "vendor",
-    ".idea",
-    ".vscode",
-}
-
-# A module script pointing at TypeScript/JSX is a BUNDLER TEMPLATE, not a page.
-# Browsers cannot execute .ts/.tsx/.jsx, so serving such an index.html statically
-# yields HTTP 200, valid HTML, and a completely blank render — the worst kind of
-# failure, because every layer reports success. Detect it and say so instead.
-#
-# Attributes are checked independently of order: `<script type="module" src=…>`
-# and `<script src=… type="module">` are both valid HTML and both appear in real
-# templates, so a single ordered pattern silently misses half of them.
-_SCRIPT_TAG_RE = re.compile(r"<script\b([^>]*)>", re.IGNORECASE)
-_ATTR_TYPE_MODULE_RE = re.compile(r"""\btype\s*=\s*["']module["']""", re.IGNORECASE)
-_ATTR_SRC_RE = re.compile(r"""\bsrc\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
-_UNBUNDLED_EXTS = (".ts", ".tsx", ".jsx")
-
-
-def _unbundled_entry(html: bytes) -> str:
-    """The first TS/JSX module script in this page, or "" if it can stand alone."""
-    try:
-        text = html.decode("utf-8", "replace")
-    except (UnicodeDecodeError, AttributeError):
-        return ""
-    for m in _SCRIPT_TAG_RE.finditer(text):
-        attrs = m.group(1)
-        if not _ATTR_TYPE_MODULE_RE.search(attrs):
-            continue
-        src_m = _ATTR_SRC_RE.search(attrs)
-        if not src_m:
-            continue  # inline module — nothing to fetch
-        src = src_m.group(1)
-        bare = src.split("?")[0].split("#")[0].lower()
-        if bare.endswith(_UNBUNDLED_EXTS):
-            return src
-    return ""
-
-
-# Where Node toolchains actually live. The gateway spawns this backend with a
-# minimal PATH — typically /usr/bin:/bin:/usr/sbin:/sbin — so `npm` is NOT
-# resolvable by name even though it works fine in the user's terminal. Two things
-# follow: the binary has to be found absolutely, AND the child's PATH has to
-# include its directory, because `npm run dev` shells out to `node` itself.
-_NODE_BIN_DIRS = (
-    "/opt/homebrew/bin",  # homebrew, Apple silicon
-    "/usr/local/bin",  # homebrew (Intel) / manual installs
-    "/opt/local/bin",  # MacPorts
-    "/usr/bin",
-    "~/.volta/bin",
-    "~/.bun/bin",
-    "~/.asdf/shims",
-    "~/.local/share/fnm/aliases/default/bin",
-    "~/Library/pnpm",
-)
-# nvm keeps a directory per version; prefer the newest.
-_NVM_GLOB = "~/.nvm/versions/node/*/bin"
-
-
-def _node_bin_dirs() -> list[Path]:
-    dirs = [Path(d).expanduser() for d in _NODE_BIN_DIRS]
-    try:
-
-        nvm = sorted(glob.glob(os.path.expanduser(_NVM_GLOB)), reverse=True)
-        dirs = [Path(p) for p in nvm] + dirs
-    except OSError:
-        pass
-    return [d for d in dirs if d.is_dir()]
-
-
-def _resolve_bin(name: str) -> Path | None:
-    """Absolute path to a package-manager binary, or None.
-
-    `shutil.which` is tried first so a properly-configured PATH wins; the
-    directory scan is the fallback for the gateway's stripped environment.
-    """
-
-    found = shutil.which(name)
-    if found:
-        return Path(found)
-    for d in _node_bin_dirs():
-        cand = d / name
-        if cand.is_file() and os.access(cand, os.X_OK):
-            return cand
-    return None
-
-
-# Environment this backend holds that the user's dev script must NEVER see.
-# `KIROCREW_PROXY_SECRET` is the whole of this backend's authentication: the
-# gateway HMACs every proxied request with it (`kiro_crew.apps.proxy_auth`), and
-# `_authorized()` refuses anything unsigned. Handing it to a project's `npm run
-# dev` — arbitrary code from a folder the operator merely pointed at — would let
-# that code forge signed calls straight to our loopback socket and bypass the
-# gateway's token auth and per-app scope entirely.
-#
-# `PORT` is stripped because `minimal_env()` sets it to THIS backend's port
-# (`apps/backend.py`); a dev server that honours `PORT` (Next, CRA, many Node
-# servers do) would try to bind a socket we already hold and die on EADDRINUSE.
-#
-# `SSH_AUTH_SOCK` / `GIT_SSH_COMMAND` / `GIT_SSH` are stripped because the dev
-# script is untrusted project code, not Kiro Crew's own: an inherited SSH agent
-# socket or SSH override command lets it authenticate to a remote (`git push`,
-# a bare `ssh`) AS the operator, with no confinement of its own — the same
-# credential class `sandbox._SENSITIVE_ENV_PREFIXES` strips for the sandboxed
-# agent spawn path, kept here as its own narrow entry rather than an import
-# across modules for a single-purpose backend that otherwise has none.
-_CHILD_ENV_STRIP = (
-    "KIROCREW_PROXY_SECRET",
-    "PORT",
-    "NODE_OPTIONS",
-    "SSH_AUTH_SOCK",
-    "GIT_SSH_COMMAND",
-    "GIT_SSH",
-)
-# Prefixes covering every capability/identity var the host may inject
-# (`KIROCREW_HOME`, `KIROCREW_APP_*`, operator-declared `KIROCREW_DEVFLEET_BIN_*`,
-# `KIROCREW_PROJECT_DIR`, …). None of them are the child's business, and a
-# forward-compatible prefix strip means a var added upstream later cannot leak
-# through this seam by default.
-_CHILD_ENV_STRIP_PREFIXES = ("KIROCREW_", "KIRO_CREW_")
-
-
-def _child_env(bin_dir: Path) -> dict:
-    """Environment for the dev server: ours, minus our secrets, toolchain on PATH.
-
-    The child is UNTRUSTED code (the project's own dev script), so this is a
-    deny-by-prefix strip rather than a hand-maintained blocklist — see
-    `_CHILD_ENV_STRIP` for why `KIROCREW_PROXY_SECRET` and `PORT` in particular
-    are disqualifying.
-    """
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if k not in _CHILD_ENV_STRIP and not k.startswith(_CHILD_ENV_STRIP_PREFIXES)
-    }
-    extra = [str(bin_dir)] + [str(d) for d in _node_bin_dirs()]
-    seen, parts = set(), []
-    for p in extra + os.environ.get("PATH", "").split(os.pathsep):
-        if p and p not in seen:
-            seen.add(p)
-            parts.append(p)
-    env["PATH"] = os.pathsep.join(parts)
-    return env
-
-
-def _pkg_scripts(root: Path) -> dict:
-    try:
-        data = json.loads((root / "package.json").read_text("utf-8"))
-        s = data.get("scripts")
-        return s if isinstance(s, dict) else {}
-    except (OSError, ValueError):
-        return {}
-
-
-# Lockfile → the package manager that project expects. Order matters: a repo can
-# carry more than one, and the more specific manager wins over npm's default.
-_LOCKFILES = (
-    ("pnpm-lock.yaml", "pnpm"),
-    ("bun.lockb", "bun"),
-    ("yarn.lock", "yarn"),
-    ("package-lock.json", "npm"),
-)
-# Script names that mean "run the dev server", best first.
-_DEV_SCRIPTS = ("dev", "start:dev", "dev:web", "serve", "start")
-
-
-def _dev_command(root: Path) -> list[str]:
-    """The command that starts this project's dev server, or [] if none is obvious.
-
-    Deliberately does NOT pass a port: the flag differs per framework (`--port` for
-    Vite, `-p` for Next, …) and guessing wrong just fails. Let the tool choose its
-    own port and find it afterwards with `_detect_dev_servers`.
-    """
-    scripts = _pkg_scripts(root)
-    script = next((s for s in _DEV_SCRIPTS if s in scripts), "")
-    if not script:
-        return []
-    pm = next((m for f, m in _LOCKFILES if (root / f).is_file()), "npm")
-    return [pm, "run", script] if pm != "bun" else ["bun", "run", script]
-
-
-def _classify_project(root: Path) -> dict:
-    """Can this folder be previewed from disk, or does it need a dev server?
-
-    The distinction is not "does it have an index.html" — a Vite project has one,
-    and serving it statically yields a blank page because its only script is
-    TypeScript. So: resolve the entry, and if that entry is a bundler template,
-    the folder needs its dev server.
-    """
-    entry = _find_entry(root)
-    unbundled = ""
-    if entry is not None:
-        try:
-            unbundled = _unbundled_entry(entry.read_bytes())
-        except OSError:
-            unbundled = ""
-    cmd = _dev_command(root)
-    needs = bool(unbundled) or (entry is None and bool(cmd))
-    return {
-        "needsDevServer": needs,
-        "devCommand": " ".join(cmd),
-        # Named so the panel can explain WHY rather than just asserting it.
-        "unbundledEntry": unbundled,
-        "hasEntry": entry is not None,
-    }
-
-
-def _find_entry(folder: Path, root: Path | None = None):
-    """Best-guess entry HTML inside `folder`. Returns a Path or None.
-
-    Every candidate is screened by the SAME three secret barriers the direct-file
-    path uses. That is load-bearing rather than belt-and-braces: `_static_response`
-    runs those checks on the requested path, which for a directory request is the
-    DIRECTORY, and then calls this to pick an entry afterwards. A project
-    containing `index.html -> .env` therefore passed the checks on the folder and
-    got the symlink's target served — the candidate itself was never screened.
-    `_contained` already resolves the link, so screening its return value closes
-    it. `root` defaults to `folder` when a caller has no separate project root.
-    """
-    base = root if root is not None else folder
-    for rel in _ENTRY_CANDIDATES:
-        # Re-contain per candidate so the stat consumes the barrier's return
-        # value regardless of what the caller passed as `folder`.
-        try:
-            p = _contained(folder, rel)
-        except _PathEscape:
-            continue
-        if not p.is_file():
-            continue
-        if is_sensitive_path(str(p)) or _is_project_secret(base, p) or _is_kirocrew_internal(p):
-            continue
-        return p
-    return None
-
-
-def _scan_html(root: Path, limit: int = 40, max_depth: int = 3) -> list[str]:
-    """Shallow scan for .html/.htm files, returned as root-relative POSIX paths.
-
-    Feeds the diagnostic 404 page, so every name it collects is DISCLOSED to the
-    previewed page. Symlinks are skipped outright — not followed, and not listed:
-    `e.is_dir()` follows the link, so a project containing `docs -> ~/.ssh` would
-    otherwise have this walk enumerate a protected directory and print the
-    filenames it found there. Only filenames leak, never contents, but the
-    directory listing is exactly what the sensitive-path floor exists to withhold.
-
-    Skipping rather than resolving-and-containing is deliberate: a legitimate
-    preview never needs a symlinked entry page, so refusing the whole class is
-    cheaper than proving each target safe.
-    """
-    found: list[str] = []
-
-    def walk(d: Path, depth: int) -> None:
-        if len(found) >= limit or depth > max_depth:
-            return
-        try:
-            entries = sorted(d.iterdir(), key=lambda e: (e.is_dir(), e.name.lower()))
-        except OSError:
-            return
-        for e in entries:
-            if len(found) >= limit:
-                return
-            # Before `is_dir()`, which would follow the link.
-            if e.is_symlink():
-                continue
-            name = e.name
-            if e.is_dir():
-                if name.startswith(".") or name in _SCAN_SKIP_DIRS:
-                    continue
-                walk(e, depth + 1)
-            elif e.suffix.lower() in (".html", ".htm"):
-                try:
-                    found.append(e.relative_to(root).as_posix())
-                except ValueError:
-                    continue
-
-    walk(root, 0)
-    return found
-
-
-def _rewrite_html(
-    body: bytes, base: str | None = PROXY_PUBLIC_BASE, script: str = INJECT_PUBLIC
-) -> bytes:
-    """Inject the Select-to-Edit overlay, and optionally a <base> tag.
-
-    `base=None` is for the dev-server proxy, which maps paths 1:1 and so needs no
-    <base> — adding one there would repoint every relative URL and break the page.
-    """
-    try:
-        html = body.decode("utf-8", "replace")
-    except (UnicodeDecodeError, AttributeError):
-        return body
-    inject_tag = f'<script src="{script}"></script>'
-    if base is not None:
-        base_tag = f'<base href="{base}">'
-        low = html.lower()
-        head = low.find("<head")
-        if head != -1:
-            end = low.find(">", head)
-            if end != -1:
-                html = html[: end + 1] + base_tag + html[end + 1 :]
-        else:
-            html = base_tag + html
-    bidx = html.lower().rfind("</body>")
-    if bidx != -1:
-        html = html[:bidx] + inject_tag + html[bidx:]
-    else:
-        html = html + inject_tag
-    return html.encode("utf-8")
-
-
-# ---------------------------------------------------------------------------
-# Static serving, as pure response builders.
-#
-# `_StaticInjectHandler` — the ephemeral loopback server the PREVIEW IFRAME is
-# pointed at (see `_static_preview_base`) — is now the ONLY caller. The former
-# gateway-proxied `/apps/<app>/api/proxy/…` route was deleted: serving
-# project-controlled content from the dashboard's own origin let a hostile
-# previewed page escape the iframe sandbox. Keep these as pure builders anyway —
-# entry-point resolution, the containment barrier, the bundler-template
-# explanation and the diagnostic 404 are worth stating once, and the loopback
-# server for dev projects (`_DevProxyHandler`) shares the same rules.
-# Each returns `(status, content_type, body)` and touches no request state.
-# ---------------------------------------------------------------------------
-def _needs_dev_server_body(root: Path, page: Path, entry: str) -> bytes:
-    """The page is a bundler template — explain that, don't render a blank.
-
-    `<script type="module" src="…/main.tsx">` needs Vite (or equivalent) to
-    transform it. Served from disk the browser gets TypeScript, refuses to
-    execute it, and leaves an empty `#root`: HTTP 200, valid HTML, nothing on
-    screen. Silent success is the worst outcome here, so say what is wrong and
-    name the two ways out.
-    """
-    built = [d for d in ("dist", "build", "out", ".output/public") if (root / d).is_dir()]
-    built_hint = (
-        (
-            "<p>This project has a <code>"
-            + "</code>, <code>".join(built)
-            + "</code> folder — if that is a finished build, register THAT folder "
-            "instead and it will preview from disk.</p>"
-        )
-        if built
-        else ""
-    )
-    page_disp = _html.escape(page.name)
-    entry_disp = _html.escape(entry)
-    body = (
-        f"<h3>{page_disp} needs a dev server</h3>"
-        f"<p>Its only script is <code>{entry_disp}</code> — TypeScript/JSX, which "
-        "the browser cannot run. A bundler has to transform it, so serving these "
-        "files from disk renders an empty page.</p>"
-        "<p><b>Start this project's dev server</b> (<code>npm run dev</code>), then "
-        "press <b>Dev server</b> in the bar below the preview. Design Tweak will "
-        "frame it directly, hot reload keeps working, and select-to-edit still "
-        "works.</p>"
-        f"{built_hint}"
-    )
-    return (
-        "<!doctype html><meta charset='utf-8'>"
-        "<style>"
-        "body{font:14px/1.6 system-ui,-apple-system,sans-serif;padding:28px 32px;"
-        "color:#e6e6e6;background:#151517;max-width:56ch}"
-        "h3{margin:0 0 12px;font-size:15px;font-weight:600}"
-        "code{font:12px ui-monospace,SFMono-Regular,Menlo,monospace;"
-        "background:#26262a;padding:1px 5px;border-radius:4px}"
-        "p{margin:0 0 10px}b{color:#fff}"
-        "</style>"
-        f"{body}"
-    ).encode("utf-8")
-
-
-def _no_entry_response(
-    root: Path, folder: Path, base: str, missing: str = ""
-) -> tuple[int, str, bytes]:
-    """404 page that explains WHY nothing rendered and offers what we found.
-
-    Replaces a bare "Not found in project folder." — the common cause is a
-    project with no top-level index.html (site lives in public/ or dist/, or
-    the app is nested in a subfolder, or it isn't a static site at all).
-    """
-    try:
-        # Re-contain both at entry so the scan/stat below consume the barrier's
-        # return value regardless of what the caller passed in.
-        root = _contained(root)
-        folder = _contained(root, os.fspath(folder))
-    except _PathEscape:
-        return 403, "text/plain", b"forbidden"
-    scan_from = folder if folder.is_dir() else root
-    candidates = _scan_html(scan_from)
-    if not candidates and scan_from != root:
-        # An empty subfolder tells the user nothing — widen to the project root
-        # so the suggestions are actually actionable.
-        scan_from = root
-        candidates = _scan_html(scan_from)
-    try:
-        prefix = scan_from.relative_to(root).as_posix()
-    except ValueError:
-        prefix = ""
-    prefix = "" if prefix in ("", ".") else prefix + "/"
-
-    if missing:
-        head = f"<code>{_html.escape(missing)}</code> was not found in this project."
-    else:
-        head = f"No <code>index.html</code> in <code>{_html.escape(str(scan_from))}</code>."
-
-    if candidates:
-        links = "".join(
-            f'<li><a href="{_html.escape(base + prefix + c)}">{_html.escape(prefix + c)}</a></li>'
-            for c in candidates
-        )
-        body = (
-            "<p>Design Tweak serves the folder as a static site and looks for an "
-            "entry <code>index.html</code>. These HTML files are in the project — "
-            "click one to preview it:</p>"
-            f"<ul>{links}</ul>"
-            "<p class='hint'>If the right entry point isn't listed, register the "
-            "<em>subfolder</em> that contains it (<code>+ load new app</code>), or point "
-            "Design Tweak at a running dev server URL for framework projects.</p>"
-        )
-    else:
-        body = (
-            "<p>No HTML files were found here, so there is nothing to serve "
-            "statically. This usually means the project is a framework app "
-            "(React / Vite / Next) that needs its dev server, or the previewable "
-            "site lives in a subfolder that wasn't registered.</p>"
-            "<p class='hint'>Fix it by either registering the subfolder that "
-            "contains <code>index.html</code>, running the project's build "
-            "(<code>npm run build</code>) and registering <code>dist/</code>, or "
-            "starting <code>npm run dev</code> and pointing Design Tweak at "
-            "<code>http://localhost:PORT</code>.</p>"
-        )
-
-    page = (
-        "<!doctype html><meta charset='utf-8'>"
-        "<style>"
-        "body{font:14px/1.6 system-ui,-apple-system,sans-serif;padding:28px 32px;"
-        "color:#e6e6e6;background:#151517}"
-        "h3{margin:0 0 12px;font-size:15px;font-weight:600}"
-        "code{font:12px ui-monospace,SFMono-Regular,Menlo,monospace;"
-        "background:#26262a;padding:1px 5px;border-radius:4px}"
-        "ul{margin:12px 0;padding-left:20px}li{margin:3px 0}"
-        "a{color:#7cc4ff}.hint{color:#9a9aa2;font-size:13px}"
-        "</style>"
-        f"<h3>{head}</h3>{body}"
-    )
-    return 404, "text/html; charset=utf-8", page.encode("utf-8")
-
-
-# Names that must never be served out of a previewed project, even though they
-# sit INSIDE the registered root and so pass containment. `is_sensitive_path`
-# is HOME-relative and does not cover a project's own copy of any of these.
-#
-# Scoped deliberately to credential and VCS material, not to "files a site does
-# not need": over-blocking a static preview turns into a support burden, and the
-# threat being closed is same-origin read-back of a secret, not directory
-# listing. `.git` is included because `.git/config` carries remote URLs that can
-# embed a token, and every real dev server refuses it too.
-_PROJECT_SECRET_NAMES: frozenset[str] = frozenset(
-    {
-        ".npmrc",
-        ".netrc",
-        ".pypirc",
-        ".git-credentials",
-        ".htpasswd",
-        # Kiro Crew's per-app proxy-auth HMAC credential. Also covered by
-        # `_is_kirocrew_internal` at its real home; listed here as well so a copy
-        # that ends up inside a project tree is refused too.
-        ".app_secret",
-        "id_rsa",
-        "id_dsa",
-        "id_ecdsa",
-        "id_ed25519",
-        "credentials",
-        "secring.gpg",
-    }
-)
-# Whole directories, matched on any path component. `.docker` holds
-# `config.json`, whose `auths` entries are registry credentials. Derived from the
-# shared credential denylist so an entry added there propagates to this
-# static-file-serving guard automatically; the extras are VCS metadata and
-# credential dirs specific to what a previewed project tree may contain.
-_PROJECT_SECRET_DIRS: frozenset[str] = DENIED_ROOT_PARTS | frozenset(
-    {".git", ".hg", ".svn", ".gpg", ".azure"}
-)
-# Private-key / keystore material by extension. `.key` is the conventional TLS
-# private-key name (`server.key`); it is also Apple Keynote's extension, which is
-# an acceptable false positive for a WEB preview — a Keynote document is not a
-# servable web asset.
-_PROJECT_SECRET_SUFFIXES: tuple[str, ...] = (
-    ".pem",
-    ".key",
-    ".p8",
-    ".p12",
-    ".pfx",
-    ".jks",
-    ".keystore",
-)
-
-# A PEM private-key header, matched against CONTENT rather than a filename.
-#
-# The extension list above is an enumeration, and an enumeration is only ever as
-# good as the next filename someone picks (`privkey`, `id_deploy`, `server.key.bak`).
-# This closes the class instead: whatever it is called, a file whose bytes open with
-# a PEM private-key armour is refused. Cheap — the bytes are already in hand — and
-# it only inspects the first line, so it cannot be fooled by a key mentioned later
-# in an ordinary document.
-_PEM_PRIVATE_KEY_RE = re.compile(rb"^-{5}BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-{5}")
-
-# A PEM marker line on its own is a LABEL, not key material.
-_PEM_MARKER_RE = re.compile(r"-{5}(?:BEGIN|END)[A-Z0-9 ]*PRIVATE KEY-{5}")
-# 16+ base64-alphabet chars: enough to be an armoured key body rather than a word.
-_PEM_BODY_RE = re.compile(r"[A-Za-z0-9+/=]{16,}")
-
-
-def _contains_credential(data: bytes) -> bool:
-    """True when *data* is text carrying a recognizable credential.
-
-    Deliberately uses ONLY the labelled / vendor-prefixed pattern set from
-    ``get_credential_patterns()`` — the same set deploy-web's pre-publish content
-    scan reuses — and NOT the full ``redact_credentials()`` pipeline.
-
-    That pipeline adds two further passes: a base64-chunk decode and an
-    entropy-gated hunt for bare 40-char AWS secrets. ``security`` documents the
-    latter as "the HIGHEST false-positive-risk redaction rule in the module", and
-    both slide windows across every long base64-alphabet run. Running them per
-    request over every served asset costs real CPU on the preview hot path, and a
-    false positive here does not degrade quietly: the asset 403s and the user's
-    preview renders blank or broken, on a surface whose entire job is faithful
-    rendering. The labelled classes are the ones that actually appear checked into
-    a project file, which is the reachable case.
-
-    Binary assets (images, fonts, wasm) carry no scannable text; a strict UTF-8
-    decode failure is the discriminator, and they are passed through.
-    """
-    try:
-        text = data.decode("utf-8")
-    except UnicodeDecodeError:
-        return False
-    for pattern in get_credential_patterns():
-        for match in pattern.finditer(text):
-            hit = match.group()
-            if "PRIVATE KEY" in hit:
-                # The PEM branch also matches a header with no body, so prose that
-                # quotes the marker — a docs page explaining key rotation — would
-                # otherwise 403 and blank a legitimate page while leaking nothing.
-                # Require actual armoured body before refusing. A file that IS a
-                # key is caught by the first-line check regardless of its name.
-                if not _PEM_BODY_RE.search(_PEM_MARKER_RE.sub("", hit)):
-                    continue
-            return True
-    return False
-
-
-def _is_project_secret(root: Path, target: Path) -> bool:
-    """Whether *target* is credential material inside the previewed project.
-
-    Matched on the path RELATIVE to *root* so the project's own `.env` is caught
-    wherever the project happens to live. `target` is already the return value of
-    `_contained(root, ...)`, so it is guaranteed to be inside *root* and this
-    only has to classify, not re-validate.
-
-    `.env` is matched as a PREFIX (`.env`, `.env.local`, `.env.production`)
-    because the framework convention is a suffixed family, and blocking only the
-    bare name would serve `.env.production` — the one most likely to hold a live
-    key.
-    """
-    try:
-        rel_parts = target.relative_to(root).parts
-    except ValueError:  # pragma: no cover — `target` came from `_contained(root)`
-        return True  # unrelatable to the root: refuse rather than guess
-    for part in rel_parts:
-        low = part.lower()
-        if low in _PROJECT_SECRET_DIRS or low in _PROJECT_SECRET_NAMES:
-            return True
-        # Any dotfile whose name starts `.env` — `.env`, `.env.local`,
-        # `.env.production`, and direnv's `.envrc` / `.envrc.local`. Matched as a
-        # bare prefix rather than `.env` + `.env.`: requiring the dot let
-        # `.envrc` through, and `.envrc` routinely holds `export AWS_SECRET…`,
-        # which the PEM content backstop below cannot recognise because it is
-        # shell, not armoured key material. A non-secret dotfile caught by this
-        # (`.env.example`) is not a servable web asset, so the over-match costs
-        # nothing.
-        if low.startswith(".env"):
-            return True
-        if low.endswith(_PROJECT_SECRET_SUFFIXES):
-            return True
-    return False
-
-
-def _static_response(
-    root_str: str, rel: str, base: str, script: str = INJECT_PUBLIC
-) -> tuple[int, str, bytes]:
-    """Serve one file from a project folder, contained and overlay-injected.
-
-    `base` is the public URL prefix the served folder is reachable at — it
-    becomes the `<base href>` for an entry that lives in a subdirectory, and it
-    prefixes the links on the diagnostic 404. `script` is the overlay's URL from
-    the FRAMED page's point of view, which differs per server.
-    """
-    rel = rel.lstrip("/")
-    try:
-        # ONE barrier for both values: `_contained(root_str)` normalises the
-        # project root, `_contained(root, rel)` proves the requested file is
-        # inside it. Everything below consumes these RETURN values, so no
-        # request-supplied path reaches a stat or a read.
-        root = _contained(root_str)
-        target = _contained(root, rel)
-    except _PathEscape:
-        return 403, "text/plain", b"forbidden"
-    # Containment is NOT sufficient: `_valid_root()` screens only the REGISTERED
-    # folder, so a root that is an ancestor of a credential directory (registering
-    # `~` is a natural pick when a site lives at `~/index.html`) leaves every
-    # secret under it "contained" and therefore servable. This server is
-    # deliberately unauthenticated, so screen the REQUESTED path too — the
-    # sibling `file_explorer` builtin checks the requested path for the same
-    # reason, not just its allowed roots.
-    if is_sensitive_path(str(target)):
-        return 403, "text/plain", b"forbidden"
-    # `is_sensitive_path` is HOME-relative: it covers `~/.aws`, `~/.npmrc` and
-    # Kiro Crew's own data home, but NOT a credential file sitting inside the
-    # previewed project itself. A web project's `.env` is exactly that, and it is
-    # the common case rather than a contrived one -- `create-vite` writes one, and
-    # it routinely holds a real API key.
-    #
-    # This matters because a real dev server REFUSES to serve `.env` while this
-    # static server would hand over any contained byte. The preview is same-origin
-    # with the project's own scripts, so `fetch('/.env')` from the page (or from
-    # any third-party script it loads) would read it back. Screen the project-
-    # relative path too.
-    if _is_project_secret(root, target):
-        return 403, "text/plain", b"forbidden"
-    # Kiro Crew's own trees are refused outright, whatever the project root is.
-    # This is the barrier that actually holds: the checks above are a HOME-relative
-    # leaf list and a project-relative name list, and neither knows about
-    # `<crew home>/apps/<app>/.app_secret` or `<crew home>/history/*.jsonl`.
-    if _is_kirocrew_internal(target):
-        return 403, "text/plain", b"forbidden"
-    if target.is_dir():
-        # Pass the project ROOT: `_find_entry` screens each candidate with
-        # `_is_project_secret`, which is relative to the project, not to whatever
-        # subdirectory was requested.
-        entry = _find_entry(target, root)
-        if entry is None:
-            return _no_entry_response(root, target, base)
-        target = entry
-    if not target.is_file():
-        return _no_entry_response(root, target, base, missing=rel)
-    # Size-check BEFORE reading. This server buffers the whole file (there is no
-    # streaming path), so a large asset in the previewed project — a video, a
-    # design source file, an archive — would be materialised in memory in one go
-    # and can take the backend process down. The project is the user's own, so
-    # this is an accident waiting to happen rather than an attack; either way the
-    # ceiling is what keeps a preview from killing the app.
-    try:
-        size = target.stat().st_size
-    except OSError as exc:
-        return 500, "text/plain", str(exc).encode()
-    if size > MAX_STATIC_BYTES:
-        msg = f"file is {size} bytes, over the {MAX_STATIC_BYTES}-byte preview limit"
-        return 413, "text/plain", msg.encode()
-    # The size check above is advisory — it stats a NAME, so it cannot bind the
-    # bytes that get read. `_contained` proved an ancestor at walk time, and
-    # `O_NOFOLLOW` alone would only guard the final component, so a nested
-    # directory swapped for a symlink between the walk and the open would escape
-    # the approved tree. This helper opens first and validates the DESCRIPTOR's
-    # real path against the root, so the inode checked is the inode served, and
-    # it re-applies the byte ceiling as the authority rather than the hint.
-    data = safe_read_file_bytes_nolink(
-        str(target), within_root=str(root), max_bytes=MAX_STATIC_BYTES
-    )
-    if data is None:
-        return 403, "text/plain", b"forbidden"    # Content-based backstop for the private-key class: refuse whatever the file is
-    # named if its bytes actually open with PEM private-key armour. The filename
-    # lists above cannot enumerate every name a project might use.
-    if _PEM_PRIVATE_KEY_RE.match(data.lstrip()[:64]):
-        return 403, "text/plain", b"forbidden"
-    # Same reasoning, widened past private keys: a checked-in credential can sit in
-    # any ordinary project file (`config.js`, a JSON fixture, a committed sample),
-    # and the previewed page's OWN JavaScript is same-origin with this server, so it
-    # can fetch any file under the root — a pasted third-party prototype included.
-    # A name-based list cannot cover that, so gate on content.
-    if _contains_credential(data):
-        return 403, "text/plain", b"forbidden"
-    ctype = _guess_ctype(target)
-    if "text/html" in ctype:
-        # A bundler template cannot render statically — bail out with an
-        # explanation rather than a page guaranteed to come up blank.
-        entry = _unbundled_entry(data)
-        if entry:
-            # 200, not an error: the file was found and read fine. The page IS
-            # the answer, and a 4xx here would trip the panel's error handling.
-            return 200, "text/html; charset=utf-8", _needs_dev_server_body(root, target, entry)
-        # <base> must point at the SERVED FILE's own directory, not the project
-        # root — otherwise an index.html living in public/ or app/ resolves its
-        # relative assets one level too high and renders blank.
-        try:
-            sub_dir = target.parent.relative_to(root).as_posix()
-        except ValueError:
-            sub_dir = "."
-        html_base = base if sub_dir in ("", ".") else base + sub_dir + "/"
-        return (
-            200,
-            "text/html; charset=utf-8",
-            _rewrite_html(data, html_base, script=script),
-        )
-    return 200, ctype, data
-
-
-class Handler(BaseHTTPRequestHandler):
-    server_version = "KiroCrew-SelectToEdit/" + VERSION  # brand-ok: Server-header token
-    timeout = _CLIENT_READ_TIMEOUT  # see `_CLIENT_READ_TIMEOUT`
-
-    def log_message(self, *args) -> None:  # silence default logging
-        pass
-
-    # ---- routing ----
-    def _route(self) -> tuple[str, dict]:
-        url = urlparse(self.path)
-        route = url.path.rstrip("/") or "/"
-        if route.startswith("/api/"):
-            route = route[4:] or "/"
-        elif route == "/api":
-            route = "/"
-        return route, parse_qs(url.query)
-
-    def _read_raw_body(self) -> bytes:
-        """Read the request body once, enforcing the size cap.
-
-        The bytes are cached on the handler so the HMAC gate and the JSON
-        parser (`_read_body`) both see the same payload without re-reading the
-        socket.
-        """
-        length = int(self.headers.get("Content-Length", 0) or 0)
-        if length <= 0:
-            return b""
-        if length > MAX_BODY_BYTES:
-            raise ValueError("payload too large")
-        # A short read means the client promised bytes it never sent (or stalled
-        # past `timeout`). Treat the request as unframeable rather than acting on
-        # a truncated payload, and close: the missing bytes would otherwise be
-        # read as the head of the next request on a keep-alive connection.
-        body = self.rfile.read(length)
-        if len(body) != length:
-            self.close_connection = True
-            raise _IncompleteBody("request body shorter than Content-Length")
-        return body
-
-    def _authorized(self, method: str, body: bytes) -> bool:
-        """Verify the gateway's X-KiroCrew-Proxy HMAC before dispatch (CWE-306).
-
-        `/health` (and its aliases) stay unauthenticated because the gateway's
-        own liveness probe hits the backend directly, unsigned.
-        """
-        route = urlparse(self.path).path.rstrip("/")
-        if route in ("", "/health", "/api", "/api/health"):
-            return True
-        if verify_proxy_request(
-            self.headers.get("X-KiroCrew-Proxy", ""),
-            method=method,
-            target=self.path,
-            body=body,
-        ):
-            return True
-        # Audit the denial before answering, following the file-explorer and
-        # md-notebook builtins' `proxy_auth_failed` convention — an unsigned
-        # local process probing this backend is exactly what the SEL trail
-        # exists to record, and a permission denial that leaves no record is
-        # indistinguishable from one that never happened.
-        #
-        # Called directly rather than off-loop: this is a ThreadingHTTPServer,
-        # so the handler already owns a worker thread and there is no event loop
-        # for a blocking SEL write to stall (md-notebook needs
-        # `asyncio.to_thread` only because it runs on aiohttp).
-        #
-        # Log the path WITHOUT the query string — it can carry a project path.
-        sel().log_api_access(
-            caller=APP_NAME,
-            operation="proxy_auth_failed",
-            outcome="denied",
-            source="builtin-app",
-            resources=urlparse(self.path).path,
-        )
-        self._json(
-            401,
-            {"error": "invalid or missing proxy signature", "code": "invalid_proxy_signature"},
-        )
-        return False
-
-    def do_GET(self) -> None:  # noqa: N802
-        if not self._authorized("GET", b""):
-            return
-        try:
-            route, qs = self._route()
-            if route in ("/", "/health"):
-                return self._json(
-                    200,
-                    {
-                        "status": "ok",
-                        "app": APP_NAME,
-                        "version": VERSION,
-                        "pending": len(_pending_files()),
-                        "dataDir": str(DATA_DIR),
-                    },
-                )
-            if route == "/queue":
-                # Requests, oldest first — each carries its comments as sub-items.
-                pending = []
-                for fp in _pending_files():
-                    req = _read_request(fp)
-                    if req is not None:
-                        pending.append(_summarize(req))
-                pending.sort(key=lambda r: r.get("number") or 0)
-                return self._json(200, {"pending": pending})
-            if route == "/latest":
-                # The newest request, full payload — what the agent reads to work
-                # a batch it was just handed.
-                files = _pending_files()
-                if not files:
-                    return self._json(200, {})
-                newest, newest_num = None, -1
-                for fp in files:
-                    req = _read_request(fp)
-                    if req and (req.get("number") or 0) > newest_num:
-                        newest, newest_num = req, req.get("number") or 0
-                # This is the one read path that hands the request's raw dict
-                # straight to a caller rather than routing through _summarize()'s
-                # panel-facing shape, so it must apply the SAME redaction floor
-                # _summarize()/_summarize_comment() apply on their own thread
-                # fields — otherwise agent-written credential text in the queue
-                # JSON reaches this authenticated GET verbatim. Every other field
-                # is passed through unchanged: the agent needs the full payload
-                # (selection elements, locators, source hints), only the request
-                # and comment threads carry free-text an agent could have pasted
-                # a secret into.
-                if newest is not None:
-                    newest = {
-                        **newest,
-                        "thread": _redact_thread(newest.get("thread")),
-                        "comments": [
-                            {**c, "thread": _redact_thread(c.get("thread"))}
-                            for c in (newest.get("comments") or [])
-                        ],
-                    }
-                return self._json(200, newest or {})
-            if route == "/projects":
-                return self._h_projects_list()
-            if route == "/detect-dev-server":
-                return self._h_detect_dev_server(qs)
-            if route == "/history":
-                done = []
-                for fp in sorted(HANDLED_DIR.glob("*.json"), reverse=True)[:50]:
-                    req = _read_request(fp)
-                    if req is not None:
-                        done.append(_summarize(req))
-                return self._json(200, {"history": done})
-            if route == "/proxy-inject.js":
-                return self._h_inject()
-            if route == "/proxy" or route.startswith("/proxy/"):
-                # REMOVED DELIBERATELY — do not restore. See the note above
-                # `_static_preview_base`. This route served project-controlled
-                # content from the DASHBOARD's origin, and the preview iframe runs
-                # with `allow-same-origin`. A hostile previewed page could read the
-                # dashboard origin off `document.referrer` and navigate itself
-                # here; because the document it then loaded was its OWN html on
-                # our origin, its script ran first-party and could reach the
-                # authenticated API and the parent DOM. Navigating to any OTHER
-                # dashboard URL gains nothing (navigation replaces the document
-                # with ours), so THIS route was the whole bridge.
-                return self._json(
-                    410,
-                    {
-                        "error": "the dashboard-origin preview route was removed for "
-                        "security; previews are served from an ephemeral loopback "
-                        "server instead (see /projects → previewUrl)"
-                    },
-                )
-            return self._json(404, {"error": f"GET {route} not found"})
-        except Exception as exc:  # noqa: BLE001
-            return self._json(500, {"error": str(exc)})
-
-    def do_POST(self) -> None:  # noqa: N802
-        try:
-            body = self._read_raw_body()
-        except _IncompleteBody as exc:
-            return self._json(400, {"error": str(exc), "code": "incomplete_body"})
-        except ValueError as exc:
-            return self._json(413, {"error": str(exc)})
-        except OSError:
-            # Read timed out (see `_CLIENT_READ_TIMEOUT`). The socket state is
-            # indeterminate, so close instead of framing another request on it.
-            self.close_connection = True
-            return self._json(408, {"error": "request body timed out", "code": "body_timeout"})
-        if not self._authorized("POST", body):
-            return
-        self._cached_body = body
-        try:
-            route, qs = self._route()
-            if route == "/submit":
-                return self._h_submit()
-            if route == "/clear":
-                return self._h_clear(qs)
-            if route == "/delete":
-                return self._h_delete(qs)
-            if route in ("/source", "/target"):
-                return self._h_set_source()
-            if route == "/projects":
-                return self._h_projects_add()
-            if route == "/projects/select":
-                return self._h_projects_select()
-            if route == "/projects/remove":
-                return self._h_projects_remove()
-            if route == "/projects/preview-url":
-                return self._h_projects_preview_url()
-            if route == "/dev-server/start":
-                return self._h_dev_server_start(qs)
-            if route == "/dev-server/stop":
-                return self._h_dev_server_stop(qs)
-            if route == "/pick-folder":
-                return self._h_pick_folder()
-            if route == "/send":
-                return self._h_send(qs)
-            if route == "/delivered":
-                return self._h_delivered(qs)
-            if route == "/delete-comment":
-                return self._h_delete_comment(qs)
-            if route == "/thread":
-                return self._h_thread(qs)
-            return self._json(404, {"error": f"POST {route} not found"})
-        except Exception as exc:  # noqa: BLE001
-            return self._json(500, {"error": str(exc)})
-
-    # ---- handlers ----
-    def _read_body(self) -> dict:
-        # The raw bytes were already read (and size-capped) by _read_raw_body in
-        # do_POST, then HMAC-verified. Parse that cached copy.
-        raw = getattr(self, "_cached_body", b"")
-        if not raw:
-            return {}
-        data = json.loads(raw.decode("utf-8"))
-        if not isinstance(data, dict):
-            raise ValueError("payload must be a JSON object")
-        return data
-
-    def _h_submit(self) -> None:
-        """Append a captured comment to the project's OPEN DRAFT request.
-
-        Creates the draft if there isn't one. Never dispatches — sending is an
-        explicit, separate step (POST /send) so a batch of comments goes to the
-        agent as a single request.
-        """
-        payload = self._read_body()
-        if payload.get("type") != "visual_edit_request":
-            return self._json(400, {"error": "type must be 'visual_edit_request'"})
-        sel = payload.get("selection") or {}
-        elements = sel.get("elements") if isinstance(sel, dict) else None
-        # Every element must be a DICT, not merely present. `_el_name` does
-        # `el.get("tag")`, so a string element raises AttributeError when
-        # `/queue` summarises the request — and because the bad selection was
-        # already persisted by then, that endpoint keeps returning 500 on every
-        # later poll until someone deletes the queue file by hand. The preview
-        # page controls this payload, so it is a one-request self-inflicted
-        # outage. Reject it at the boundary instead.
-        if not isinstance(elements, list) or not elements:
-            return self._json(
-                400,
-                {"error": "selection.elements is required", "code": "selection_required"},
-            )
-        if not all(isinstance(el, dict) for el in elements):
-            return self._json(
-                400,
-                {
-                    "error": "selection.elements must contain only objects",
-                    "code": "selection_malformed",
-                },
-            )
-        # A dict is not enough: the FIELD TYPES are what `_el_name` consumes. A
-        # non-string `tag` (`{"tag": 42, "id": "x"}`) used to raise `TypeError`
-        # on `str + str`, and `classes` holding non-strings broke the `.join`.
-        # Same outage shape as above and for the same reason -- the record is
-        # persisted before anything reads it back -- so it is refused here, where
-        # the caller still gets an error it can act on. `_el_name` is separately
-        # total, which contains records this guard never saw (an older build's
-        # queue file); this check is what makes a malformed submit visible rather
-        # than silently relabelled.
-        for el in elements:
-            if not all(
-                isinstance(el[k], str) for k in ("tag", "id") if el.get(k) is not None
-            ):
-                return self._json(
-                    400,
-                    {
-                        "error": "selection.elements[].tag and .id must be strings",
-                        "code": "selection_malformed",
-                    },
-                )
-            classes = el.get("classes")
-            if classes is not None and (
-                not isinstance(classes, list)
-                or not all(isinstance(c, str) for c in classes)
-            ):
-                return self._json(
-                    400,
-                    {
-                        "error": "selection.elements[].classes must be a list of strings",
-                        "code": "selection_malformed",
-                    },
-                )
-
-        preview_url = str(payload.get("previewUrl", ""))
-        project_id, project_root, source_file = _resolve_project(payload)
-        # The selection is persisted verbatim below and its per-element `source`
-        # block is handed to the agent as an edit target, so contain those paths
-        # before they are stored — same barrier `sourceFile` goes through.
-        _sanitize_selection_sources(sel, project_root)
-
-        def _txn() -> tuple[int, dict]:
-            # Find-or-open the draft, number it, append, write — ONE transaction.
-            # Splitting it would let two tabs each see "no open draft" and both
-            # create a request with the same number, or (the reported bug) each
-            # append to its own copy of the same draft and lose one comment.
-            fp = _open_draft_file(project_id)
-            if fp is None:
-                rid = _new_id()
-                req: dict[str, Any] = {
-                    "type": "visual_edit_batch",
-                    "id": rid,
-                    "number": _next_number(project_id),
-                    "state": "draft",
-                    "projectId": project_id,
-                    "projectRoot": project_root,
-                    "createdAt": _now_iso(),
-                    "sentAt": "",
-                    "thread": [],
-                    "comments": [],
-                }
-                fp = _request_file(QUEUE_DIR, rid)
-            else:
-                existing = _read_request(fp)
-                if existing is None:
-                    return 500, {"error": "draft request unreadable"}
-                req = existing
-
-            comments: list[dict[str, Any]] = req.setdefault("comments", [])
-            # A capture originates from a gesture INSIDE the previewed page, so a
-            # hostile project could post them in a loop. The draft is reviewable
-            # and nothing reaches the agent without a separate Send, so the real
-            # exposure is unbounded growth of the user's own queue file rather
-            # than an agent action. Cap the draft instead of demanding a
-            # parent-side gesture, which is the interaction this product IS.
-            if len(comments) >= MAX_DRAFT_COMMENTS:
-                return 429, {
-                    "error": (
-                        f"this request already holds {MAX_DRAFT_COMMENTS} comments — "
-                        "send or clear it before adding more"
-                    ),
-                    "code": "draft_comment_limit",
-                }
-            # Always minted here, never taken from the payload. The id is the
-            # lookup key for `/delete-comment` and `/thread`, and both read it
-            # from the query string — i.e. always as a `str`. A caller-supplied
-            # `cid` could arrive as a JSON number, pass a `str()`-ed format check,
-            # and persist as an int that neither lookup can ever match again,
-            # leaving a comment that cannot be deleted or replied to. A duplicate
-            # of an existing id has the mirror-image problem: one delete would
-            # take both comments. The response below hands the id back, so no
-            # caller needs to choose one.
-            cid = _new_id()
-            created = payload.get("createdAt") or _now_iso()
-
-            # A follow-up references an earlier comment (possibly in an already-sent
-            # request); it still ships in THIS batch, just linked to its origin.
-            follow_up_to = str(payload.get("followUpTo", "") or "")
-            if follow_up_to and not _ID_RE.match(follow_up_to):
-                follow_up_to = ""
-
-            comment = {
-                "cid": cid,
-                "index": len(comments) + 1,
-                "status": "new",
-                "comment": str(payload.get("comment", "")),
-                "createdAt": created,
-                "selection": sel,
-                "previewUrl": preview_url,
-                # Stored per comment as well as on the request: the panel matches
-                # pins to the previewed project by this id, and matching on the id
-                # (rather than on the shape of previewUrl) is what lets a project
-                # previewed straight from its dev server keep its pins.
-                "projectId": project_id,
-                "sourceFile": source_file,
-                "followUpTo": follow_up_to,
-                # The user's own comment seeds the thread so the in-preview bubble
-                # reads as a conversation from the first frame.
-                "thread": [
-                    {"role": "user", "text": str(payload.get("comment", "")), "ts": created}
-                ],
-            }
-            if _TARGET and not project_root:
-                comment["devServer"] = _TARGET
-            comments.append(comment)
-            _write_request(fp, req)
-
-            return 200, {
-                "ok": True,
-                "id": req["id"],
-                "number": req["number"],
-                "state": req["state"],
-                "cid": cid,
-                "index": comment["index"],
-                "label": f"{req['number']}.{comment['index']}",
-                "commentCount": len(comments),
-                "savedTo": str(fp),
-            }
-
-        with _QUEUE_LOCK:
-            try:
-                code, body = _txn()
-            except _RecordTooLarge as exc:
-                # The append was refused and the prior record is intact, so this
-                # is a full draft rather than lost work — say which.
-                code, body = 413, {"error": str(exc), "code": "record_too_large"}
-        return self._json(code, body)
-
-    def _h_send(self, qs: dict) -> None:
-        """Seal a draft request and mark every comment as sent (seal-on-send).
-
-        After this the request never accepts new comments, so the next captured
-        comment opens a fresh draft even while this batch is still in flight.
-        """
-        rid = (qs.get("id") or [""])[0]
-        if not rid or not _ID_RE.match(rid):
-            return self._json(400, {"error": "valid id required"})
-        fp = _request_file(QUEUE_DIR, rid)
-
-        def _txn() -> tuple[int, dict]:
-            if not fp.is_file():
-                return 404, {"error": "not found"}
-            req = _read_request(fp)
-            if req is None:
-                return 500, {"error": "request unreadable"}
-            comments = req.get("comments") or []
-            if not comments:
-                return 400, {"error": "request has no comments"}
-            if not _is_draft(req):
-                return 200, {"ok": True, "already": True, "request": _summarize(req)}
-            req["state"] = "sent"
-            req["sentAt"] = _now_iso()
-            for c in comments:
-                if c.get("status") == "new":
-                    c["status"] = "sent"
-            _write_request(fp, req)
-            return 200, {"ok": True, "request": _summarize(req)}
-
-        with _QUEUE_LOCK:
-            try:
-                code, body = _txn()
-            except _RecordTooLarge as exc:
-                # The append was refused and the prior record is intact, so this
-                # is a full draft rather than lost work — say which.
-                code, body = 413, {"error": str(exc), "code": "record_too_large"}
-        return self._json(code, body)
-
-    def _h_delivered(self, qs: dict) -> None:
-        """Acknowledge that a sealed request's prompt actually reached the agent.
-
-        `/send` seals the batch server-side, but the prompt is dispatched by the
-        panel afterwards. Those are two steps, so a tab closed (or crashed)
-        between them left the request sealed with nothing in flight: the send bar
-        is gone once a request is no longer a draft, so the work was stranded
-        with no way to retry it. Sealing after dispatch instead would reopen the
-        window where a second tab joins the draft mid-prompt, so the fix is a
-        separate acknowledgement rather than a reorder.
-
-        Idempotent: re-acknowledging keeps the FIRST timestamp, so a duplicate
-        call cannot make a delivered request look newer than it is.
-        """
-        rid = (qs.get("id") or [""])[0]
-        if not rid or not _ID_RE.match(rid):
-            return self._json(400, {"error": "valid id required", "code": "id_required"})
-        fp = _request_file(QUEUE_DIR, rid)
-
-        def _txn() -> tuple[int, dict]:
-            if not fp.is_file():
-                return 404, {"error": "not found", "code": "not_found"}
-            req = _read_request(fp)
-            if req is None:
-                return 500, {"error": "request unreadable", "code": "unreadable"}
-            # A draft was never dispatched, so acknowledging one would mark work
-            # delivered that no agent has seen — and would suppress the retry bar
-            # for the very state it is meant to cover.
-            if _is_draft(req):
-                return 409, {
-                    "error": "request is still a draft — nothing was dispatched",
-                    "code": "not_sealed",
-                }
-            if not req.get("deliveredAt"):
-                req["deliveredAt"] = _now_iso()
-                _write_request(fp, req)
-            return 200, {"ok": True, "request": _summarize(req)}
-
-        with _QUEUE_LOCK:
-            try:
-                code, body = _txn()
-            except _RecordTooLarge as exc:
-                # The append was refused and the prior record is intact, so this
-                # is a full draft rather than lost work — say which.
-                code, body = 413, {"error": str(exc), "code": "record_too_large"}
-        return self._json(code, body)
-
-    def _h_delete_comment(self, qs: dict) -> None:
-        """Drop a single comment from a DRAFT request (undo a mis-click).
-
-        Refused once the request is sent — the agent already has that batch.
-        """
-        rid = (qs.get("id") or [""])[0]
-        cid = (qs.get("cid") or [""])[0]
-        if not rid or not _ID_RE.match(rid) or not cid or not _ID_RE.match(cid):
-            return self._json(400, {"error": "valid id and cid required"})
-        fp = _request_file(QUEUE_DIR, rid)
-
-        def _txn() -> tuple[int, dict]:
-            if not fp.is_file():
-                return 404, {"error": "not found"}
-            req = _read_request(fp)
-            if req is None:
-                return 500, {"error": "request unreadable"}
-            if not _is_draft(req):
-                return 409, {"error": "request already sent — cannot remove comments"}
-            comments = req.get("comments") or []
-            kept = [c for c in comments if c.get("cid") != cid]
-            if len(kept) == len(comments):
-                return 404, {"error": "comment not found"}
-            for n, c in enumerate(kept, start=1):
-                c["index"] = n  # keep sub-numbering contiguous (3.1, 3.2, …)
-            req["comments"] = kept
-            # An emptied draft is noise in the rail — drop the request with it.
-            if not kept:
-                try:
-                    fp.unlink()
-                except OSError as exc:
-                    return 500, {"error": str(exc)}
-                return 200, {"ok": True, "id": rid, "removedRequest": True}
-            _write_request(fp, req)
-            return 200, {"ok": True, "id": rid, "cid": cid, "request": _summarize(req)}
-
-        with _QUEUE_LOCK:
-            try:
-                code, body = _txn()
-            except _RecordTooLarge as exc:
-                # The append was refused and the prior record is intact, so this
-                # is a full draft rather than lost work — say which.
-                code, body = 413, {"error": str(exc), "code": "record_too_large"}
-        return self._json(code, body)
-
-    def _h_clear(self, qs: dict) -> None:
-        rid = (qs.get("id") or [""])[0]
-        if not rid or not _ID_RE.match(rid):
-            return self._json(400, {"error": "valid id required"})
-        src = _request_file(QUEUE_DIR, rid)
-        dst = _request_file(HANDLED_DIR, rid)
-
-        def _txn() -> tuple[int, dict]:
-            # Archiving is a rename, not a read-modify-write, but it still has to
-            # be serialized: a `/thread` append that read this path before the
-            # move would otherwise write the file back into queue/, resurrecting
-            # a request the user just cleared.
-            if not src.exists():
-                return 404, {"error": "not found"}
-            try:
-                src.replace(dst)
-            except OSError as exc:
-                return 500, {"error": str(exc)}
-            return 200, {"ok": True, "id": rid}
-
-        with _QUEUE_LOCK:
-            try:
-                code, body = _txn()
-            except _RecordTooLarge as exc:
-                # The append was refused and the prior record is intact, so this
-                # is a full draft rather than lost work — say which.
-                code, body = 413, {"error": str(exc), "code": "record_too_large"}
-        return self._json(code, body)
-
-    def _h_delete(self, qs: dict) -> None:
-        """Permanently delete a request (from queue/ or handled/). Unlike /clear
-        (which archives to handled/), this removes the file entirely."""
-        rid = (qs.get("id") or [""])[0]
-        if not rid or not _ID_RE.match(rid):
-            return self._json(400, {"error": "valid id required"})
-
-        def _txn() -> tuple[int, dict] | None:
-            # Same serialization reason as `_h_clear`: without the lock a
-            # concurrent write can recreate the file right after the unlink.
-            removed = False
-            for d in (QUEUE_DIR, HANDLED_DIR):
-                fp = _request_file(d, rid)
-                if fp.exists():
-                    try:
-                        fp.unlink()
-                        removed = True
-                    except OSError as exc:
-                        return 500, {"error": str(exc)}
-            if not removed:
-                return 404, {"error": "not found"}
-            return None  # deleted — caller emits the shared success response
-
-        with _QUEUE_LOCK:
-            failed = _txn()
-        if failed is not None:
-            return self._json(*failed)
-        return self._json(200, {"ok": True, "id": rid, "deleted": True})
-
-    # ---- project registry handlers ----
-    def _h_projects_list(self) -> None:
-        active = _active_project()
-        serving = bool(_ROOT and active and str(Path(active["path"]).resolve()) == _ROOT)
-        # Classification is computed per request, never stored: a folder becomes
-        # static the moment its build lands in dist/, and a stale flag would keep
-        # showing "needs a dev server" for something that now previews fine.
-        out = []
-        for p in _CFG["projects"]:
-            row = dict(p)
-            root = _valid_root(p["path"])
-            row.update(
-                _classify_project(root)
-                if root
-                else {
-                    "needsDevServer": False,
-                    "devCommand": "",
-                    "unbundledEntry": "",
-                    "hasEntry": False,
-                }
-            )
-            row["devRunning"] = _dev_proc_alive(p["id"])
-            # The injecting proxy's port is ephemeral: it lives and dies with this
-            # backend, so it is resolved live here rather than persisted. A saved
-            # port would be guaranteed dead after a restart.
-            live = _DEV_PROCS.get(p["id"]) or {}
-            if live.get("proxyUrl"):
-                row["previewUrl"] = live["proxyUrl"]
-                row["devUrl"] = live.get("url", "")
-            elif _valid_target(str(row.get("previewUrl") or "").strip()):
-                # A PERSISTED dev URL has to be framed through the injecting proxy
-                # too. Returned bare it still renders — which is exactly why this
-                # was invisible — but the proxy is the only thing that injects the
-                # select-to-edit overlay, so the feature silently does nothing on
-                # precisely the framework projects that need a dev server. Matches
-                # what `_start_dev_proc` and the adopt path in
-                # `_h_dev_server_start` already do for a freshly-started server.
-                #
-                # `_front_with_proxy` reuses this project's live proxy, so polling
-                # this endpoint does not spawn a listener per request, and it
-                # returns the bare URL unchanged if the proxy cannot bind.
-                #
-                # The loopback allow-list is re-asserted here rather than trusted
-                # from `_h_projects_add` / `_h_projects_preview_url`: this value is
-                # read back off disk and is about to become a proxy upstream. A
-                # value that FAILS it is cleared in the `else` below — never handed
-                # back bare.
-                dev_url = str(row["previewUrl"]).strip()
-                row["previewUrl"] = _front_with_proxy(p["id"], dev_url)
-                row["devUrl"] = dev_url
-            elif root is not None and not row.get("previewUrl"):
-                # Static preview: framed from the app's OWN loopback server, never
-                # from the dashboard origin (see `_StaticInjectHandler`). Same
-                # ephemeral-by-design reasoning as the dev proxy above, so it is
-                # resolved live here too. If it cannot bind we leave previewUrl
-                # empty and the panel falls back to the gateway-proxied route.
-                static_url = _static_preview_url(p["id"])
-                if static_url:
-                    row["previewUrl"] = static_url
-                    row["previewMode"] = "static"
-            elif row.get("previewUrl"):
-                # A NON-EMPTY previewUrl that failed `_valid_target` reaches here:
-                # it is not live-proxied, not re-provable as a loopback dev URL,
-                # and the static branch above only fires when the value is empty.
-                # Handing it back would frame it DIRECTLY — bypassing the proxy
-                # that strips `Cookie`/`Authorization` — so the dashboard's
-                # host-scoped session cookie would reach whatever it names. Clear
-                # it and let the panel render the unreachable state, matching what
-                # `_front_with_proxy` does when the proxy cannot bind.
-                #
-                # Reachable from a value persisted by an older build, or one whose
-                # host/scheme stopped qualifying (e.g. `https://127.0.0.1:5173` —
-                # the allow-list is http-only), so validating only on write is not
-                # enough.
-                row["previewUrl"] = ""
-            out.append(row)
-        return self._json(
-            200,
-            {
-                "projects": out,
-                "activeId": _CFG["activeId"],
-                "serving": serving,
-                "version": VERSION,
-            },
-        )
-
-    def _h_dev_server_start(self, qs: dict) -> None:
-        """Start the project's own dev server and point the preview at it."""
-        pid = (qs.get("id") or [""])[0]
-        proj = next((p for p in _CFG["projects"] if p["id"] == pid), None)
-        if proj is None:
-            return self._json(404, {"error": "project not found"})
-        root = _valid_root(proj["path"])
-        if root is None:
-            return self._json(400, {"error": f"folder no longer readable: {proj['path']}"})
-
-        # Already running elsewhere (started by hand in a terminal)? Adopt it
-        # rather than starting a second one on another port.
-        adopted = _auto_dev_server(root)
-        if adopted:
-            # Front it with the injecting proxy as well — a server the user started
-            # serves its own HTML, so without this the overlay never loads and
-            # select-to-edit is missing on exactly the projects that need it most.
-            framed = _front_with_proxy(pid, adopted)
-            # NOT persisted: the proxy port dies with this backend, so a saved URL
-            # is guaranteed dead after a restart. _h_projects_list resolves the live
-            # one per request instead.
-            return self._json(
-                200,
-                {
-                    "ok": True,
-                    "url": framed,
-                    "devUrl": adopted,
-                    "adopted": True,
-                    "injected": bool(framed) and framed != adopted,
-                    "project": proj,
-                },
-            )
-
-        res = _start_dev_proc(pid, root)
-        if not res.get("ok"):
-            return self._json(200, res)  # 200: the error text IS the answer
-        # Likewise not persisted — see above.
-        return self._json(200, {**res, "project": proj})
-
-    def _h_dev_server_stop(self, qs: dict) -> None:
-        """Stop a dev server WE started and revert the preview to serving from disk.
-
-        A server the user started themselves is left running — Design Tweak did not
-        start it, so killing it would be a surprise. Its URL is just forgotten.
-        """
-        pid = (qs.get("id") or [""])[0]
-        proj = next((p for p in _CFG["projects"] if p["id"] == pid), None)
-        if proj is None:
-            return self._json(404, {"error": "project not found"})
-        # `_stop_dev_proc` stays OUTSIDE the lock ON PURPOSE: it escalates
-        # SIGTERM -> SIGKILL and WAITS on the child, so holding `_QUEUE_LOCK`
-        # across it would stall every queue operation for the length of that
-        # teardown.
-        stopped = _stop_dev_proc(pid)
-        # The registry write, however, has to be serialized like every other one
-        # in this file. `_save_cfg` is a whole-file atomic replace, so two
-        # concurrent replacements do not interleave -- the loser is simply
-        # overwritten, and a project added or removed in the racing request
-        # disappears on the next load. This was the only `_save_cfg(_CFG)` call
-        # site not under the lock.
-        with _QUEUE_LOCK:  # read-modify-write over the shared registry
-            # Re-resolve inside the lock. `proj` was found before the teardown,
-            # which is a long window: a concurrent remove may have dropped it,
-            # and mutating that detached dict would save a registry the project
-            # is no longer part of.
-            live = next((p for p in _CFG["projects"] if p["id"] == pid), None)
-            if live is not None:
-                live.pop("previewUrl", None)
-                _save_cfg(_CFG)
-                proj = live
-        return self._json(200, {"ok": True, "stopped": stopped, "project": proj})
-
-    def _h_projects_add(self) -> None:
-        data = self._read_body()
-        raw = str(data.get("path", "")).strip()
-        root = _valid_root(raw)
-        if root is None:
-            return self._json(400, {"error": f"not a readable folder: {raw}"})
-        # Optional dev-server URL. A project is always identified by its FOLDER —
-        # that is where the agent edits — and the URL only changes how it is
-        # previewed: framed directly instead of proxied from disk. Framework
-        # projects need that because this backend cannot proxy a WebSocket, so
-        # HMR dies behind the proxy.
-        preview_url = str(data.get("previewUrl", "") or "").strip().rstrip("/")
-        if preview_url and not _valid_target(preview_url):
-            return self._json(
-                400,
-                {
-                    "error": "dev server URL must be http://localhost:PORT or http://127.0.0.1:PORT",
-                },
-            )
-
-        def _existing() -> dict | None:
-            for p in _CFG["projects"]:
-                if str(Path(p["path"]).resolve()) == str(root):
-                    return p
-            return None
-
-        # Scan-then-append is a read-modify-write over the shared registry, and
-        # this is a ThreadingHTTPServer: without the lock two concurrent adds of
-        # the same folder both miss the dedupe and both append it.
-        with _QUEUE_LOCK:
-            p = _existing()
-            if p is not None:
-                if preview_url and p.get("previewUrl", "") != preview_url:
-                    p["previewUrl"] = preview_url
-                    _save_cfg(_CFG)
-                    return self._json(
-                        200, {"ok": True, "project": p, "existing": True, "updated": "previewUrl"}
-                    )
-                return self._json(200, {"ok": True, "project": p, "existing": True})
-
-        proj = {"id": uuid.uuid4().hex[:8], "path": str(root), "name": root.name}
-
-        # No URL typed? Look for a dev server already serving this folder. Only
-        # an UNAMBIGUOUS match is attached (exactly one candidate serving HTML) —
-        # with several running, silently picking one would point the preview at
-        # the wrong app, so they are returned for the user to choose instead.
-        #
-        # Deliberately OUTSIDE the lock: `_detect_dev_servers` shells out to
-        # `lsof`, and holding the registry lock across that would serialize every
-        # queue transaction behind a subprocess. The re-check below closes the
-        # window this opens.
-        detected = []
-        if preview_url:
-            proj["previewUrl"] = preview_url
-        else:
-            detected = _detect_dev_servers(root)
-            auto = [c for c in detected if c["servesHtml"]]
-            if len(auto) == 1:
-                proj["previewUrl"] = auto[0]["url"]
-
-        with _QUEUE_LOCK:
-            # Re-check: another request may have registered this same folder while
-            # detection was running above.
-            p = _existing()
-            if p is not None:
-                return self._json(200, {"ok": True, "project": p, "existing": True})
-            _CFG["projects"].append(proj)
-            _save_cfg(_CFG)
-        return self._json(
-            200,
-            {
-                "ok": True,
-                "project": proj,
-                "detected": detected,
-                "autoDetected": bool(not preview_url and proj.get("previewUrl")),
-            },
-        )
-
-    def _h_detect_dev_server(self, qs: dict) -> None:
-        """Dev servers plausibly serving a project — for the UI's Detect button.
-
-        Takes either `?id=<projectId>` or `?path=<folder>` so it works before a
-        project is registered as well as after.
-        """
-        pid = (qs.get("id") or [""])[0]
-        raw = (qs.get("path") or [""])[0]
-        if pid:
-            proj = next((p for p in _CFG["projects"] if p["id"] == pid), None)
-            if proj is None:
-                return self._json(404, {"error": "project not found"})
-            raw = proj["path"]
-        root = _valid_root(raw)
-        if root is None:
-            return self._json(400, {"error": f"not a readable folder: {raw}"})
-        candidates = _detect_dev_servers(root)
-        html = [c for c in candidates if c["servesHtml"]]
-        return self._json(
-            200,
-            {
-                "ok": True,
-                "root": str(root),
-                "candidates": candidates,
-                # Only offered when unambiguous, matching add-time behaviour.
-                "suggested": html[0]["url"] if len(html) == 1 else "",
-            },
-        )
-
-    def _h_projects_preview_url(self) -> None:
-        """Set or clear a registered project's dev-server URL.
-
-        Sending an empty `previewUrl` reverts the project to proxied-from-disk,
-        which is the right move when the dev server is not running: the static
-        proxy still renders something, where a dead URL frames an error page.
-        """
-        data = self._read_body()
-        pid = str(data.get("id", ""))
-        url = str(data.get("previewUrl", "") or "").strip().rstrip("/")
-        if url and not _valid_target(url):
-            return self._json(
-                400,
-                {
-                    "error": "dev server URL must be http://localhost:PORT or http://127.0.0.1:PORT",
-                },
-            )
-        with _QUEUE_LOCK:  # read-modify-write over the shared registry
-            proj = next((p for p in _CFG["projects"] if p["id"] == pid), None)
-            if proj is None:
-                return self._json(404, {"error": "project not found"})
-            if url:
-                proj["previewUrl"] = url
-            else:
-                proj.pop("previewUrl", None)
-            _save_cfg(_CFG)
-        return self._json(200, {"ok": True, "project": proj})
-
-    def _h_projects_select(self) -> None:
-        """Connect a registered project: make it the active served root.
-
-        Under `_QUEUE_LOCK` for the same reason as the queue transactions: this
-        is a ThreadingHTTPServer, so a concurrent `remove` could drop the project
-        from the registry between the lookup and the write below, leaving a
-        removed project as `activeId` with `_ROOT` still serving it.
-        """
-        data = self._read_body()
-        pid = str(data.get("id", ""))
-        global _ROOT, _TARGET
-        with _QUEUE_LOCK:
-            proj = next((p for p in _CFG["projects"] if p["id"] == pid), None)
-            if proj is None:
-                return self._json(404, {"error": "project not found"})
-            root = _valid_root(proj["path"])
-            if root is None:
-                return self._json(400, {"error": f"folder no longer readable: {proj['path']}"})
-            _ROOT = str(root)
-            _TARGET = ""
-            _CFG["activeId"] = pid
-            _save_cfg(_CFG)
-        return self._json(200, {"ok": True, "project": proj})
-
-    def _h_projects_remove(self) -> None:
-        """Remove a project from the registry (does not touch the folder on disk).
-
-        Same lock, same reason: read-modify-write over the shared registry.
-        """
-        data = self._read_body()
-        pid = str(data.get("id", ""))
-        global _ROOT
-        with _QUEUE_LOCK:
-            proj = next((p for p in _CFG["projects"] if p["id"] == pid), None)
-            if proj is None:
-                return self._json(404, {"error": "project not found"})
-            _CFG["projects"] = [p for p in _CFG["projects"] if p["id"] != pid]
-            if _CFG.get("activeId") == pid:
-                _CFG["activeId"] = ""
-                _ROOT = ""
-            _save_cfg(_CFG)
-        # Release the project's RUNNING resources, not just its registry row.
-        # Deliberately outside `_QUEUE_LOCK`: `_stop_dev_proc` escalates
-        # SIGTERM→SIGKILL and waits, and `shutdown()` blocks on the accept loop,
-        # so holding the registry lock across either would stall every other
-        # queue and registry operation for the duration of a process kill.
-        # Without this the row disappears while the child dev server, its
-        # injecting proxy and the project's static listener keep running with no
-        # handle left to reach them, so repeated add/preview/remove accumulates
-        # processes, threads and bound ports until something fails to start.
-        _stop_dev_proc(pid)
-        _stop_static_preview(pid)
-        return self._json(200, {"ok": True, "id": pid})
+class Handler(http_api.Handler):
+    runtime = runtime
 
     def _h_pick_folder(self) -> None:
-        """Open the native macOS folder chooser (osascript) and return the
-        picked absolute path. The backend runs on the user's Mac, so the
-        dialog appears locally — the browser never needs the path."""
+        """Open the trusted macOS native folder picker."""
 
         if _sys.platform != "darwin":
             return self._json(501, {"error": "native picker is macOS-only"})
@@ -3747,18 +780,20 @@ class Handler(BaseHTTPRequestHandler):
                 'tell application "System Events" to activate\n'
                 'POSIX path of (choose folder with prompt "Select a web app folder for Design Tweak")'
             )
-            # Pinned to the system directories, not `PATH` — see `_lsof_fields`.
             osascript = trusted_system_bin("osascript")
             if not osascript:
                 return self._json(
                     501,
-                    {"error": "native picker is unavailable", "code": "picker_unavailable"},
+                    {
+                        "error": "native picker is unavailable",
+                        "code": "picker_unavailable",
+                    },
                 )
-            r = subprocess.run(
+            result = subprocess.run(
                 [osascript, "-e", script],
                 capture_output=True,
-                text=True,
                 timeout=180,
+                **UTF8_TEXT,
             )
         except subprocess.TimeoutExpired:
             return self._json(408, {"error": "picker timed out"})
@@ -3766,225 +801,23 @@ class Handler(BaseHTTPRequestHandler):
             return self._json(500, {"error": str(exc)})
         finally:
             _PICK_LOCK.release()
-        if r.returncode != 0:
-            err = (r.stderr or "").strip()
-            if "-128" in err or "canceled" in err.lower():
+        if result.returncode != 0:
+            error = (result.stderr or "").strip()
+            if "-128" in error or "canceled" in error.lower():
                 return self._json(200, {"ok": False, "canceled": True})
-            return self._json(500, {"error": err[-200:] or "picker failed"})
-        path = r.stdout.strip().rstrip("/")
+            return self._json(500, {"error": error[-200:] or "picker failed"})
+        path = result.stdout.strip().rstrip("/")
         if not path:
             return self._json(200, {"ok": False, "canceled": True})
         return self._json(200, {"ok": True, "path": path})
 
-    def _h_thread(self, qs: dict) -> None:
-        """Append a progress note to a COMMENT's thread (or the request's).
 
-        `POST /thread?id=<requestId>&cid=<commentId>` targets one comment — this
-        is what the agent uses while working a batch, so each comment's bubble
-        tracks its own progress. Omitting `cid` appends a request-level note.
-
-        Body: {"role": "agent"|"user"|"system", "text": "...", "status": "done"?}
-        `status` applies to the addressed comment. The request's own status is
-        always derived from its comments, never stored.
-        """
-        rid = (qs.get("id") or [""])[0]
-        cid = (qs.get("cid") or [""])[0]
-        if not rid or not _ID_RE.match(rid):
-            return self._json(400, {"error": "valid id required"})
-        if cid and not _ID_RE.match(cid):
-            return self._json(400, {"error": "invalid cid"})
-        data = self._read_body()
-        # `text` is AGENT-authored: it is persisted into the queue JSON and later
-        # rendered in the panel, so it goes through the repo's mandatory output
-        # redaction before it is stored, not on the way out — a leaked credential
-        # must not exist on disk in the first place.
-        #
-        # URLs first, then credentials — the same order as every other call site
-        # (`dashboard/handlers/artifacts.py::_serialize`,
-        # `apps/builtins/workflows/server.py::_redact_obj`). The order is
-        # load-bearing: `redact_exfiltration_urls` keys off the URL's host, so
-        # running the credential pass first would rewrite a token inside a URL to
-        # `[REDACTED: credential]` and leave the exfiltration host itself intact.
-        # Applied per-field, not to the whole payload: `role` and `status` below
-        # are allow-listed to fixed vocabularies, so neither can persist an
-        # arbitrary string, and `ts` is generated here.
-        text, _ = redact_exfiltration_urls(str(data.get("text", "")).strip())
-        text, _ = redact_credentials(text)
-        role = str(data.get("role", "agent")).strip() or "agent"
-        if role not in ("agent", "user", "system"):
-            role = "agent"
-        new_status = str(data.get("status", "")).strip()
-        if not text and not new_status:
-            return self._json(400, {"error": "text or status required"})
-
-        def _txn() -> tuple[int, dict]:
-            fp = _find_request(rid)
-            if fp is None:
-                return 404, {"error": "not found"}
-            req = _read_request(fp)
-            if req is None:
-                return 500, {"error": "request unreadable"}
-
-            entry = {"role": role, "text": text, "ts": _now_iso()}
-            if cid:
-                target = next((c for c in (req.get("comments") or []) if c.get("cid") == cid), None)
-                if target is None:
-                    return 404, {"error": f"comment {cid} not in request {rid}"}
-                thread = target.get("thread")
-                if not isinstance(thread, list):
-                    thread = []
-                if text:
-                    if len(thread) >= MAX_THREAD_ENTRIES:
-                        return 429, {
-                            "error": (
-                                f"comment {cid} already holds {MAX_THREAD_ENTRIES} thread "
-                                "entries — the conversation is full"
-                            ),
-                            "code": "thread_entry_limit",
-                        }
-                    thread.append(entry)
-                target["thread"] = thread
-                if new_status in _COMMENT_STATUSES:
-                    target["status"] = new_status
-            else:
-                thread = req.get("thread")
-                if not isinstance(thread, list):
-                    thread = []
-                if text:
-                    if len(thread) >= MAX_THREAD_ENTRIES:
-                        return 429, {
-                            "error": (
-                                f"request {rid} already holds {MAX_THREAD_ENTRIES} thread "
-                                "entries — the conversation is full"
-                            ),
-                            "code": "thread_entry_limit",
-                        }
-                    thread.append(entry)
-                req["thread"] = thread
-                # A request-level `done` fans out to every comment, so an agent that
-                # reports once for the whole batch still resolves the sub-items.
-                if new_status == "done":
-                    for c in req.get("comments") or []:
-                        c["status"] = "done"
-
-            # Any agent activity means this batch is in flight — normalise `state` so
-            # it can never contradict the comments. Two drifts to close: an agent
-            # writing its own `state` value (which used to make a worked request read
-            # back as an unsent draft), and an agent reporting progress on a request
-            # that was never formally sealed. A bare progress note is enough evidence:
-            # the agent only ever sees a request that was handed to it.
-            agent_activity = role in ("agent", "system")
-            worked = any(c.get("status") != "new" for c in (req.get("comments") or []))
-            if req.get("state") not in ("draft", "sent") or (
-                req.get("state") == "draft" and (worked or agent_activity)
-            ):
-                req["state"] = "sent"
-                if not req.get("sentAt"):
-                    req["sentAt"] = _now_iso()
-
-            try:
-                _write_request(fp, req)
-            except OSError as exc:
-                return 500, {"error": str(exc)}
-            return 200, {
-                "ok": True,
-                "id": rid,
-                "cid": cid,
-                "status": _request_status(req),
-                "request": _summarize(req),
-            }
-
-        with _QUEUE_LOCK:
-            try:
-                code, body = _txn()
-            except _RecordTooLarge as exc:
-                # The append was refused and the prior record is intact, so this
-                # is a full draft rather than lost work — say which.
-                code, body = 413, {"error": str(exc), "code": "record_too_large"}
-        return self._json(code, body)
-
-    # ---- source + proxy handlers ----
-    def _h_set_source(self) -> None:
-        """Set the previewed app source: a folder path (served directly) or a
-        localhost dev-server URL (reverse-proxied). Empty value clears."""
-        data = self._read_body()
-        val = str(data.get("value", data.get("url", ""))).strip()
-        global _ROOT, _TARGET
-        if not val:
-            _ROOT = ""
-            _TARGET = ""
-            return self._json(200, {"ok": True, "mode": "cleared", "proxyUrl": PROXY_PUBLIC_BASE})
-        if val.lower().startswith(("http://", "https://")):
-            if not _valid_target(val):
-                return self._json(
-                    400,
-                    {
-                        "error": "URL must be http://localhost:PORT or http://127.0.0.1:PORT",
-                    },
-                )
-            _TARGET = val.rstrip("/")
-            _ROOT = ""
-            return self._json(
-                200,
-                {
-                    "ok": True,
-                    "mode": "url",
-                    "target": _TARGET,
-                    "proxyUrl": PROXY_PUBLIC_BASE,
-                },
-            )
-        root = _valid_root(val)
-        if root is None:
-            return self._json(400, {"error": f"not a readable folder: {val}"})
-        _ROOT = str(root)
-        _TARGET = ""
-        return self._json(
-            200,
-            {
-                "ok": True,
-                "mode": "folder",
-                "root": _ROOT,
-                "proxyUrl": PROXY_PUBLIC_BASE,
-            },
-        )
-
-    def _h_inject(self) -> None:
-        try:
-            js = INJECT_FILE.read_bytes()
-        except OSError:
-            return self._send_raw(404, "application/javascript", b"// overlay not found")
-        return self._send_raw(200, "application/javascript; charset=utf-8", js)
-
-    def _send_raw(self, code: int, ctype: str, body: bytes) -> None:
-        self.send_response(code)
-        # Every caller passes either a string literal or a `_guess_ctype` constant
-        # (closed extension map — no value is derived from the request path). The
-        # proxied reply does not come through here: it applies
-        # `_safe_upstream_ctype` at its own `send_header` in `_DevProxyHandler`.
-        # `_header_value` stays as defence in depth at the sink: a single CR/LF
-        # reaching send_header would let a caller append headers or a second
-        # response body (response splitting).
-        self.send_header("Content-Type", _header_value(ctype))
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Cache-Control", "no-store")
-        self.end_headers()
-        self.wfile.write(body)
-
-    # ---- helpers ----
-    def _json(self, code: int, payload) -> None:
-        body = json.dumps(payload).encode("utf-8")
-        self.send_response(code)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Cache-Control", "no-store")
-        self.end_headers()
-        self.wfile.write(body)
+atexit.register(_stop_all_dev_procs)
 
 
 def main() -> int:
-    # Created here, not at import time (see the QUEUE_DIR/HANDLED_DIR comment
-    # above): this is the real process entry point, reached only when the
-    # gateway actually starts this backend -- never by an import alone.
+    """Create data directories and run the loopback HTTP server."""
+
     QUEUE_DIR.mkdir(parents=True, exist_ok=True)
     HANDLED_DIR.mkdir(parents=True, exist_ok=True)
     server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1466,7 +1466,15 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # app's own queue JSON (`/thread`). Because the stored copy is already
         # scrubbed, every later read of it — the panel's own `/queue`, and the
         # thread rendered beside a pin — serves clean data, so there is no
-        # separate egress boundary to register.
+        # separate egress boundary to register. Three modules of this backend
+        # match the call-site scan and the boundary between them adds no new
+        # transport or audience: `server.py` owns the redactor pair itself and
+        # the app's whole security-policy surface, `request_state.py` applies it
+        # while BUILDING the panel-facing request and comment shapes, and
+        # `http_api.py` runs the ingest pass and re-applies the same floor on
+        # the read path it serves.
+        "apps/builtins/design_tweak/backend/http_api.py",
+        "apps/builtins/design_tweak/backend/request_state.py",
         "apps/builtins/design_tweak/backend/server.py",
         "sync_bridge.py",
         "suggestions.py",

--- a/test/test_design_tweak_devproc.py
+++ b/test/test_design_tweak_devproc.py
@@ -189,6 +189,36 @@ class TestPkgScripts:
         )
         assert server._pkg_scripts(tmp_path) == {}
 
+    def test_uses_hardened_reader_with_project_root_and_cap(self, tmp_path, monkeypatch):
+        """User-selected package metadata stays inside the guarded read boundary."""
+        seen = {}
+
+        def guarded_read(raw, within_root=None, *, max_bytes=None):
+            seen.update(raw=raw, within_root=within_root, max_bytes=max_bytes)
+            return b'{"scripts":{"dev":"vite"}}'
+
+        monkeypatch.setattr(server, "safe_read_file_bytes_nolink", guarded_read)
+
+        assert server._pkg_scripts(tmp_path) == {"dev": "vite"}
+        assert Path(seen["raw"]) == tmp_path / "package.json"
+        assert seen["within_root"] == str(tmp_path)
+        assert seen["max_bytes"] == server.MAX_BODY_BYTES
+
+    def test_rejected_or_oversized_package_metadata_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        """A rejected inode or oversized package file cannot influence commands."""
+        monkeypatch.setattr(
+            server, "safe_read_file_bytes_nolink", lambda *args, **kwargs: None
+        )
+        assert server._pkg_scripts(tmp_path) == {}
+
+        def oversized(*args, **kwargs):
+            raise server.FileTooLargeError("too large")
+
+        monkeypatch.setattr(server, "safe_read_file_bytes_nolink", oversized)
+        assert server._pkg_scripts(tmp_path) == {}
+
 
 # ---------------------------------------------------------------------------
 # _node_bin_dirs tests
@@ -622,3 +652,41 @@ class TestClassifyProject:
         result = server._classify_project(tmp_path)
         assert result["needsDevServer"] is True
         assert result["hasEntry"] is False
+
+    def test_entry_scan_uses_hardened_reader_with_project_root_and_cap(
+        self, tmp_path, monkeypatch
+    ):
+        """Classification cannot follow an entry inode outside the selected project."""
+        entry = tmp_path / "index.html"
+        entry.write_text(
+            '<script type="module" src="/src/main.tsx"></script>', encoding="utf-8"
+        )
+        seen = []
+
+        def guarded_read(raw, within_root=None, *, max_bytes=None):
+            seen.append(
+                {"raw": raw, "within_root": within_root, "max_bytes": max_bytes}
+            )
+            return entry.read_bytes()
+
+        monkeypatch.setattr(server, "safe_read_file_bytes_nolink", guarded_read)
+
+        result = server._classify_project(tmp_path)
+        assert result["unbundledEntry"] == "/src/main.tsx"
+        entry_read = next(call for call in seen if Path(call["raw"]) == entry)
+        assert entry_read["within_root"] == str(tmp_path)
+        assert entry_read["max_bytes"] == server.MAX_STATIC_BYTES
+
+    def test_rejected_or_oversized_entry_scan_fails_closed(self, tmp_path, monkeypatch):
+        """Rejected entry content never reaches the HTML classifier."""
+        (tmp_path / "index.html").write_text("<html></html>", encoding="utf-8")
+        monkeypatch.setattr(
+            server, "safe_read_file_bytes_nolink", lambda *args, **kwargs: None
+        )
+        assert server._classify_project(tmp_path)["unbundledEntry"] == ""
+
+        def oversized(*args, **kwargs):
+            raise server.FileTooLargeError("too large")
+
+        monkeypatch.setattr(server, "safe_read_file_bytes_nolink", oversized)
+        assert server._classify_project(tmp_path)["unbundledEntry"] == ""

--- a/test/test_design_tweak_project_routes.py
+++ b/test/test_design_tweak_project_routes.py
@@ -94,6 +94,162 @@ def _post(path: str, body: dict | None = None) -> tuple[server.Handler, _Recorde
 
 
 # ---------------------------------------------------------------------------
+# HTTP composition root -- routing, authorization, and error framing
+# ---------------------------------------------------------------------------
+
+_POST_DISPATCH_CASES = (
+    ("/submit", "_h_submit", False),
+    ("/clear", "_h_clear", True),
+    ("/delete", "_h_delete", True),
+    ("/source", "_h_set_source", False),
+    ("/target", "_h_set_source", False),
+    ("/projects", "_h_projects_add", False),
+    ("/projects/select", "_h_projects_select", False),
+    ("/projects/remove", "_h_projects_remove", False),
+    ("/projects/preview-url", "_h_projects_preview_url", False),
+    ("/dev-server/start", "_h_dev_server_start", True),
+    ("/dev-server/stop", "_h_dev_server_stop", True),
+    ("/pick-folder", "_h_pick_folder", False),
+    ("/send", "_h_send", True),
+    ("/delivered", "_h_delivered", True),
+    ("/delete-comment", "_h_delete_comment", True),
+    ("/thread", "_h_thread", True),
+)
+
+
+class TestHttpCompositionContract:
+    """Pin the thin HTTP adapter before its responsibilities are extracted."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected_route", "expected_query"),
+        [
+            ("/api", "/", {}),
+            ("/api/", "/", {}),
+            (
+                "/api/projects/?id=request%201&tag=first&tag=second",
+                "/projects",
+                {"id": ["request 1"], "tag": ["first", "second"]},
+            ),
+            (
+                "/projects/?id=request%201&tag=first&tag=second",
+                "/projects",
+                {"id": ["request 1"], "tag": ["first", "second"]},
+            ),
+        ],
+    )
+    def test_route_normalizes_api_prefix_trailing_slash_and_query(
+        self, path, expected_route, expected_query
+    ):
+        handler, _response = _get(path)
+
+        assert handler._route() == (expected_route, expected_query)
+
+    @pytest.mark.parametrize(
+        ("route", "expected_handler", "takes_query"),
+        _POST_DISPATCH_CASES,
+    )
+    def test_every_post_route_dispatches_to_its_owned_handler(
+        self, route, expected_handler, takes_query, monkeypatch
+    ):
+        path = f"/api{route}/?id=request%201&cid=comment-1"
+        handler, response = _post(path)
+        calls = []
+
+        # Stub every dispatch target so a wrong branch is observable without
+        # letting the real handler touch queue state, processes, or native UI.
+        for handler_name, handler_takes_query in {
+            name: has_query for _route, name, has_query in _POST_DISPATCH_CASES
+        }.items():
+            if handler_takes_query:
+
+                def _record_query(query, *, name=handler_name):
+                    calls.append((name, query))
+
+                monkeypatch.setattr(handler, handler_name, _record_query)
+            else:
+
+                def _record_no_query(*, name=handler_name):
+                    calls.append((name, None))
+
+                monkeypatch.setattr(handler, handler_name, _record_no_query)
+
+        server.Handler.do_POST(handler)
+
+        expected_query = {
+            "id": ["request 1"],
+            "cid": ["comment-1"],
+        }
+        assert response.code is None
+        assert calls == [(expected_handler, expected_query if takes_query else None)]
+
+    def test_post_body_is_read_once_then_authorized_before_dispatch(self, monkeypatch):
+        body = {"type": "visual_edit_request", "comment": "one read"}
+        raw = json.dumps(body).encode()
+        handler, response = _post("/api/submit/", body)
+        events = []
+
+        class _ReadProbe(io.BytesIO):
+            def read(self, size=-1):
+                value = super().read(size)
+                events.append(("read", value))
+                return value
+
+        handler.rfile = _ReadProbe(raw)
+
+        def _authorize(method, authorized_body):
+            events.append(("authorize", method, authorized_body))
+            return True
+
+        monkeypatch.setattr(handler, "_authorized", _authorize)
+        monkeypatch.setattr(
+            handler,
+            "_h_submit",
+            lambda: events.append(("dispatch", handler._cached_body)),
+        )
+
+        server.Handler.do_POST(handler)
+
+        assert response.code is None
+        assert events == [
+            ("read", raw),
+            ("authorize", "POST", raw),
+            ("dispatch", raw),
+        ]
+
+    @pytest.mark.parametrize(
+        ("method", "path", "expected_payload"),
+        [
+            ("GET", "/api/missing/", {"error": "GET /missing not found"}),
+            ("POST", "/api/missing/", {"error": "POST /missing not found"}),
+        ],
+    )
+    def test_unknown_route_keeps_the_existing_404_json(
+        self, method, path, expected_payload
+    ):
+        handler, response = _make_handler(method, path)
+
+        getattr(server.Handler, f"do_{method}")(handler)
+
+        assert response.code == 404
+        assert response.payload == expected_payload
+
+    def test_unexpected_post_handler_error_keeps_the_existing_500_json(
+        self, monkeypatch
+    ):
+        handler, response = _post("/api/submit/")
+
+        def _explode():
+            raise RuntimeError("handler exploded")
+
+        monkeypatch.setattr(handler, "_h_submit", _explode)
+
+        server.Handler.do_POST(handler)
+
+        assert response.code == 500
+        assert response.payload == {"error": "handler exploded"}
+
+
+# ---------------------------------------------------------------------------
 # /projects (GET) — project listing
 # ---------------------------------------------------------------------------
 

--- a/test/test_design_tweak_queue_routes.py
+++ b/test/test_design_tweak_queue_routes.py
@@ -885,6 +885,211 @@ class TestSubmitFollowUp:
         assert saved["comments"][-1]["cid"] == cid
 
 
+class TestPersistedRequestLifecycle:
+    """Pin the complete persisted state machine, not only its individual cuts."""
+
+    def test_submit_through_history_preserves_order_and_opens_the_next_draft(
+        self, isolated_queue, tmp_path, monkeypatch
+    ):
+        project_root = (tmp_path / "project").resolve()
+        project_root.mkdir()
+        monkeypatch.setattr(
+            server,
+            "_CFG",
+            {
+                "projects": [
+                    {"id": "project-one", "path": str(project_root), "name": "project"}
+                ],
+                "activeId": "project-one",
+            },
+        )
+
+        ids = iter(("req-one", "comment-one", "req-two", "comment-two"))
+        expected_times = [
+            "2026-08-01T00:00:00+00:00",  # first request created
+            "2026-08-01T00:00:02+00:00",  # first request sealed
+            "2026-08-01T00:00:03+00:00",  # second request created
+            "2026-08-01T00:00:05+00:00",  # first request delivered
+            "2026-08-01T00:00:06+00:00",  # done note appended
+        ]
+        times = iter(expected_times)
+        time_calls = []
+
+        def _fixed_now():
+            value = next(times)
+            time_calls.append(value)
+            return value
+
+        monkeypatch.setattr(server, "_new_id", lambda: next(ids))
+        monkeypatch.setattr(server, "_now_iso", _fixed_now)
+
+        def _request(method: str, path: str, body: dict | None = None) -> _Response:
+            handler, response = _make_handler(method, path, body)
+            handler._authorized = lambda *_args: True
+            getattr(server.Handler, f"do_{method}")(handler)
+            return response
+
+        first_comment = "Make the save button primary"
+        first_comment_created = "2026-08-01T00:00:01+00:00"
+        submit = _request(
+            "POST",
+            "/api/submit/",
+            {
+                "type": "visual_edit_request",
+                "selection": {
+                    "mode": "single",
+                    "elements": [{"tag": "button", "id": "save", "locator": "#save"}],
+                },
+                "comment": first_comment,
+                "createdAt": first_comment_created,
+                "projectId": "project-one",
+            },
+        )
+        first_queue_file = server._request_file(isolated_queue, "req-one")
+        assert submit.code == 200
+        assert submit.payload == {
+            "ok": True,
+            "id": "req-one",
+            "number": 1,
+            "state": "draft",
+            "cid": "comment-one",
+            "index": 1,
+            "label": "1.1",
+            "commentCount": 1,
+            "savedTo": str(first_queue_file),
+        }
+        assert first_queue_file.is_file()
+
+        sealed = _request("POST", "/api/send/?id=req-one")
+        assert sealed.code == 200
+        assert sealed.payload["ok"] is True
+        assert {
+            key: sealed.payload["request"][key]
+            for key in ("id", "number", "state", "status", "sentAt", "deliveredAt")
+        } == {
+            "id": "req-one",
+            "number": 1,
+            "state": "sent",
+            "status": "sent",
+            "sentAt": "2026-08-01T00:00:02+00:00",
+            "deliveredAt": "",
+        }
+
+        # The sealed request deliberately remains in queue while the next
+        # capture arrives. That is what proves seal-on-send, rather than archive,
+        # is the boundary that opens a new draft.
+        second_comment_created = "2026-08-01T00:00:04+00:00"
+        second = _request(
+            "POST",
+            "/api/submit/",
+            {
+                "type": "visual_edit_request",
+                "selection": {"elements": [{"tag": "nav", "id": "primary"}]},
+                "comment": "Tighten the navigation spacing",
+                "createdAt": second_comment_created,
+                "projectId": "project-one",
+            },
+        )
+        second_queue_file = server._request_file(isolated_queue, "req-two")
+        assert second.code == 200
+        assert second.payload == {
+            "ok": True,
+            "id": "req-two",
+            "number": 2,
+            "state": "draft",
+            "cid": "comment-two",
+            "index": 1,
+            "label": "2.1",
+            "commentCount": 1,
+            "savedTo": str(second_queue_file),
+        }
+        assert first_queue_file.is_file()
+        assert second_queue_file.is_file()
+
+        delivered = _request("POST", "/api/delivered/?id=req-one")
+        assert delivered.code == 200
+        assert delivered.payload["ok"] is True
+        assert delivered.payload["request"]["deliveredAt"] == "2026-08-01T00:00:05+00:00"
+
+        done = _request(
+            "POST",
+            "/api/thread/?id=req-one&cid=comment-one",
+            {"role": "agent", "text": "Applied the change", "status": "done"},
+        )
+        assert done.code == 200
+        assert {
+            key: done.payload[key] for key in ("ok", "id", "cid", "status")
+        } == {
+            "ok": True,
+            "id": "req-one",
+            "cid": "comment-one",
+            "status": "done",
+        }
+        assert done.payload["request"]["doneCount"] == 1
+        assert done.payload["request"]["comments"][0]["status"] == "done"
+
+        archived = _request("POST", "/api/clear/?id=req-one")
+        handled_file = server._request_file(server.HANDLED_DIR, "req-one")
+        assert archived.code == 200
+        assert archived.payload == {"ok": True, "id": "req-one"}
+        assert not first_queue_file.exists()
+        assert handled_file.is_file()
+        assert second_queue_file.is_file(), "archiving one request must not move the next draft"
+
+        history = _request("GET", "/api/history/")
+        assert history.code == 200
+        assert history.payload == {
+            "history": [
+                {
+                    "id": "req-one",
+                    "number": 1,
+                    "state": "sent",
+                    "status": "done",
+                    "createdAt": "2026-08-01T00:00:00+00:00",
+                    "sentAt": "2026-08-01T00:00:02+00:00",
+                    "deliveredAt": "2026-08-01T00:00:05+00:00",
+                    "projectId": "project-one",
+                    "projectRoot": str(project_root),
+                    "thread": [],
+                    "doneCount": 1,
+                    "comments": [
+                        {
+                            "cid": "comment-one",
+                            "index": 1,
+                            "status": "done",
+                            "comment": first_comment,
+                            "createdAt": first_comment_created,
+                            "element": "button#save",
+                            "locator": "#save",
+                            "parentLocator": "",
+                            "point": {},
+                            "count": 1,
+                            "mode": "single",
+                            "previewUrl": "",
+                            "projectId": "project-one",
+                            "sourceFile": "",
+                            "source": {},
+                            "followUpTo": "",
+                            "thread": [
+                                {
+                                    "role": "user",
+                                    "text": first_comment,
+                                    "ts": first_comment_created,
+                                },
+                                {
+                                    "role": "agent",
+                                    "text": "Applied the change",
+                                    "ts": "2026-08-01T00:00:06+00:00",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        assert time_calls == expected_times
+
+
 class TestThreadEntryCap:
     """A full thread must refuse further appends rather than grow without bound.
 


### PR DESCRIPTION
## Problem / Motivation

The Design Tweak backend server had grown to roughly 4,000 lines and combined durable request state, static preview serving, development-server lifecycle, WebSocket relay plumbing, and HTTP routing in one module. The requested maintenance work is to establish reviewable boundaries without changing its routes, payloads, relay ordering, or lifecycle contracts.

## Why it matters

Those responsibilities carry security- and process-sensitive invariants. Keeping them in one file made route changes difficult to review, encouraged broad test fixtures, and obscured which component owned filesystem containment, credential handling, child processes, and shutdown.

## What changed (motivation → approach → change)

- Kept server.py as the composition root, mutable-runtime owner, compatibility facade, security-policy boundary, and the only owner of real subprocess creation.
- Extracted durable config, request, comment, queue, project-resolution, containment, and atomic-I/O behavior into request_state.py.
- Extracted no-link static preview reads, entry selection, MIME/HTML handling, credential barriers, and static listener ownership into preview_files.py.
- Extracted Node toolchain discovery, dev-process lifecycle, HTTP proxying, and WebSocket relay behavior into dev_preview.py.
- Extracted exact GET/POST dispatch and handler implementations into http_api.py while preserving route aliases, read-once authentication order, JSON shapes, and status codes.
- Routed project package and entry classification reads through the hardened no-link reader with root pinning and explicit size ceilings after local security review identified the migrated direct reads.
- Added route-contract, persisted queue-lifecycle, and guarded project-classification regression coverage.
- Reclassified the backend's redactor call sites in `security_posture.py`: the split spread them across `server.py`, `request_state.py`, and `http_api.py`, so all three are now named in `NON_EGRESS_REDACTION_MODULES` with the reason. The classification is unchanged — the split adds no new transport or audience — and the omission-detecting drift guard passes again.
- Pinned UTF-8 decoding on the two relocated `subprocess.run` calls (`lsof`, `osascript`) via `**UTF8_TEXT`, and pruned the server's now-empty entry from the shared subprocess-encoding baseline.
- Removed only the now-clean Design Tweak server entry from the shared Black baseline after the canonical checker proved it graduated.
- No frontend, dependency, lockfile, public protocol, or App Kit specification changes.

## Tests

- Design Tweak direct suite: 575 collected; 562 passed, 13 skipped, 0 failed.
- Guarded-read focused verification: 52 passed, 3 skipped; the original blocking security finding is closed with no new blocking regression.
- Security posture checks: spawn audit 12 passed; related security classes 117 passed, 8 platform skips.
- Canonical Black gate: passed with 0 new offenders and 0 graduated entries. isort, flake8, subprocess-encoding, and mypy also passed; mypy reported 0 issues across 1,241 source files.
- Frontend build: passed. The exact localeFormatting Vitest node passed 7 of 7 on the same blob as origin/main. Its scan reports an inherited advisory baseline graduation of 19 calls under a ceiling of 25.
- The broader shared Windows frontend run was non-green only on unchanged frontend/time-sensitive guards and unavailable Electron subproject packages: 1,724 Vitest file passes with 9 failing files, and 1,430 Electron test passes with 17 environment failures. This branch has no frontend diff; these are recorded as inherited/environmental evidence, not product regressions.

## Manual verification

- Verified normal import and detached module execution, complete compatibility-name inventory, absence of circular server imports, exactly three real subprocess sites, and the existing two-stage outbound redaction order.
- N/A — this is a behavior-preserving backend refactor with direct route, persistence, process, relay, and security coverage; there is no rendered UI delta.

## Related Issues

no linked issue: behavior-preserving backend maintenance was requested directly.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — public behavior and the existing App Kit specification remain accurate)
- [x] No secrets, credentials, or internal references in the diff

