### PR TITLE
fix(update): fail closed when approval nonce persists

### DIFF
--- a/docs/request-for-change/rfc-update-architecture.md
+++ b/docs/request-for-change/rfc-update-architecture.md
@@ -49,7 +49,11 @@ Update button arms a pending request (`POST /api/update/arm`; single-use
 nonce, TTL 10 min, written owner-only to the data home and never returned to
 the SPA), and `kirocrew update approve` on the gateway host presents the
 nonce back (`POST /api/update/approve`, loopback + unix-socket preferred),
-upon which the gateway runs the shadow apply itself and restarts. The full
+upon which the gateway removes the nonce before accepting the approval, fails
+closed if that removal does not succeed, and serializes that read-validate-remove
+against a concurrent re-arm so the request it removes is always the request it
+validated, then runs the shadow apply itself and
+restarts. The full
 drain lease (§5) and hash-pinned dependency constraints remain open. pipx
 installs keep the installer re-run.
 

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1655,6 +1655,9 @@ def _update_approve() -> None:
     from kiro_crew.platform.update_stepup import read_pending
 
     print("👻 Approving the pending in-app update…\n")
+    # Default read: never writes. This runs in the CLI process, outside the
+    # gateway's nonce mutex — expiry cleanup here could race a gateway
+    # re-arm and delete a fresh request. Cleanup is the gateway's job.
     pending = read_pending()
     if pending is None:
         print("❌ No armed update request (it may have expired).")

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -2322,7 +2322,9 @@ async def api_update_arm_status(request: web.Request) -> web.Response:
     """GET /api/update/arm — the armed request, SPA-safe projection."""
     from kiro_crew.platform import update_stepup
 
-    pending = await asyncio.to_thread(update_stepup.read_pending)
+    # clear_expired=True: this runs inside the gateway, where the expiry
+    # cleanup is serialized against arm under the module mutex.
+    pending = await asyncio.to_thread(lambda: update_stepup.read_pending(clear_expired=True))
     if pending is None:
         return web.json_response({"armed": False})
     return web.json_response(update_stepup.public_view(pending))

--- a/src/kiro_crew/platform/update_stepup.py
+++ b/src/kiro_crew/platform/update_stepup.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import secrets
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -57,6 +58,18 @@ PENDING_TTL_SECS = 600
 #: exists to keep apart. The gateway writes it directly (keystone readers
 #: never route through is_sensitive_path), so arming is unaffected.
 _PENDING_FILENAME = "pending-update-approval.json"
+
+#: Serializes every read-validate-remove of the nonce file against arm's
+#: atomic swap. Arm and approve run as concurrent executor threads in ONE
+#: gateway process (see arm's temp-name comment), so without this an approve
+#: that validated request A could unlink a request B that arm swapped in
+#: between the read and the unlink — accepting A while silently destroying B.
+#: The approval/consumption write plane lives entirely in the gateway, so an
+#: in-process lock closes it. One reader lives elsewhere: `kirocrew update
+#: approve` calls read_pending() from its own CLI process, outside this lock.
+#: Reading never writes by default (clear_expired=False), so that caller
+#: cannot write at all — the lock covers every writer that exists.
+_PENDING_MUTEX = threading.RLock()
 
 
 class StepUpError(Exception):
@@ -127,7 +140,8 @@ def arm(version: str, channel: str, *, source: str = "dashboard") -> PendingUpda
                     }
                 )
             )
-        os.replace(tmp, path)
+        with _PENDING_MUTEX:
+            os.replace(tmp, path)
     except OSError as exc:
         try:
             tmp.unlink(missing_ok=True)
@@ -144,58 +158,87 @@ def arm(version: str, channel: str, *, source: str = "dashboard") -> PendingUpda
     return pending
 
 
-def read_pending() -> PendingUpdate | None:
+def read_pending(*, clear_expired: bool = False) -> PendingUpdate | None:
     """The current armed request, or ``None`` when absent, expired or unreadable.
 
-    An expired file is removed on read so a stale arm cannot sit on disk as a
-    standing invitation. Unreadable/malformed files also read as ``None`` —
+    Reading never writes by default. Removing an expired file on read is safe
+    only from INSIDE the gateway process — under the module mutex, serialized
+    against arm — so it is an explicit opt-in (``clear_expired=True``) for
+    gateway callers, never a behavior another process inherits silently: an
+    out-of-process unlink (the ``kirocrew update approve`` CLI) could delete
+    a fresh request it never read. An expired file that lingers grants
+    nothing — every reader checks expiry — and the next arm replaces it.
+    Unreadable/malformed files also read as ``None`` —
     an approval must never be minted from a file this module cannot vouch for.
     """
     path = pending_path()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return None
-    try:
-        pending = PendingUpdate(
-            request_id=str(raw["request_id"]),
-            nonce=str(raw["nonce"]),
-            version=str(raw["version"]),
-            channel=str(raw["channel"]),
-            created_at=float(raw["created_at"]),
-        )
-    except (KeyError, TypeError, ValueError):
-        return None
-    if pending.expired:
-        clear_pending()
-        return None
-    return pending
+    with _PENDING_MUTEX:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        try:
+            pending = PendingUpdate(
+                request_id=str(raw["request_id"]),
+                nonce=str(raw["nonce"]),
+                version=str(raw["version"]),
+                channel=str(raw["channel"]),
+                created_at=float(raw["created_at"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+        if pending.expired:
+            if clear_expired:
+                # Still under the mutex: the file this removes is the expired
+                # one just read, never a fresh request a concurrent arm
+                # swapped in.
+                clear_pending()
+            return None
+        return pending
 
 
 def consume(nonce: str) -> PendingUpdate:
     """Validate *nonce* against the armed request and consume it (single-use).
 
-    The comparison is constant-time. The file is removed BEFORE this returns,
-    so a second approve with the same nonce fails whatever the first one went
-    on to do — single-use means the apply gets at most one trigger.
+    The comparison is constant-time. The read, the validation and the removal
+    happen as ONE critical section under the module mutex, so a concurrent
+    arm cannot swap a fresh request in between the read and the unlink — the
+    request this removes is the request it validated. The file is removed
+    BEFORE this returns, so a second approve with the same nonce fails
+    whatever the first one went on to do — single-use means the apply gets at
+    most one trigger.
     """
-    pending = read_pending()
-    if pending is None:
-        raise StepUpError(
-            "no armed update request (it may have expired) — arm one from the "
-            "dashboard's About panel first"
-        )
-    if not nonce or not hmac.compare_digest(pending.nonce, nonce):
-        raise StepUpError("approval nonce does not match the armed request")
-    clear_pending()
-    return pending
+    with _PENDING_MUTEX:
+        pending = read_pending(clear_expired=True)
+        if pending is None:
+            raise StepUpError(
+                "no armed update request (it may have expired) — arm one from the "
+                "dashboard's About panel first"
+            )
+        if not nonce or not hmac.compare_digest(pending.nonce, nonce):
+            raise StepUpError("approval nonce does not match the armed request")
+        _consume_pending_file()
+        return pending
+
+
+def _consume_pending_file() -> None:
+    """Remove the nonce for a successful approval, failing closed on error.
+
+    Called only from consume(), which already holds ``_PENDING_MUTEX`` around
+    its whole read-validate-remove section — no re-acquisition here.
+    """
+    try:
+        pending_path().unlink()
+    except OSError as exc:
+        raise StepUpError(f"could not consume the pending update request: {exc}") from exc
 
 
 def clear_pending() -> None:
-    try:
-        pending_path().unlink(missing_ok=True)
-    except OSError:
-        pass
+    with _PENDING_MUTEX:
+        try:
+            pending_path().unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def public_view(pending: PendingUpdate) -> dict[str, object]:

--- a/test/test_update_stepup.py
+++ b/test/test_update_stepup.py
@@ -9,7 +9,9 @@ here, plus TTL expiry, single-use consumption, and the endpoint refusals.
 from __future__ import annotations
 
 import json
+import threading
 import time
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -96,6 +98,76 @@ class TestStepUpModule:
         with pytest.raises(update_stepup.StepUpError, match="no armed update request"):
             update_stepup.consume(pending.nonce)
 
+    def test_consume_refuses_when_the_nonce_cannot_be_removed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pending = update_stepup.arm("9.9.9", "stable")
+        path = update_stepup.pending_path()
+        original_unlink = Path.unlink
+
+        def refuse_nonce_unlink(target: Path, *args, **kwargs) -> None:
+            if target == path:
+                raise PermissionError("nonce file is locked")
+            original_unlink(target, *args, **kwargs)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(Path, "unlink", refuse_nonce_unlink)
+            with pytest.raises(update_stepup.StepUpError, match="could not consume"):
+                update_stepup.consume(pending.nonce)
+
+        still_pending = update_stepup.read_pending()
+        assert still_pending is not None
+        assert still_pending.nonce == pending.nonce
+        update_stepup.clear_pending()
+
+    def test_in_flight_consume_cannot_unlink_a_concurrent_rearm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A consume that validated request A must never remove a request B
+        that a concurrent arm swapped in between the read and the unlink —
+        arm and approve run as executor threads in one process, so the
+        window is real. The mutex serializes them: the re-arm lands only
+        after the consume's critical section, and its nonce survives."""
+        first = update_stepup.arm("9.9.9", "stable")
+        in_window = threading.Event()
+        original_consume = update_stepup._consume_pending_file
+
+        def paused_consume() -> None:
+            in_window.set()
+            # Without the mutex this sleep is exactly the race window: the
+            # re-arm thread swaps its fresh request in, and the unlink
+            # below destroys it while the stale approval is accepted.
+            time.sleep(0.3)
+            original_consume()
+
+        rearmed: list[update_stepup.PendingUpdate] = []
+
+        def rearm() -> None:
+            # A False return means consume() raised before opening the
+            # window: do NOT arm — past teardown that write would land in
+            # the operator's real data home, not the test's.
+            if in_window.wait(timeout=5):
+                rearmed.append(update_stepup.arm("9.9.10", "stable"))
+
+        rearm_thread = threading.Thread(target=rearm)
+        with monkeypatch.context() as patch:
+            patch.setattr(update_stepup, "_consume_pending_file", paused_consume)
+            rearm_thread.start()
+            try:
+                consumed = update_stepup.consume(first.nonce)
+            finally:
+                # Always release and reap the worker INSIDE the fixture's
+                # scope, even when consume() raises — a leaked thread would
+                # outlive the isolated KIROCREW_HOME.
+                in_window.set()
+                rearm_thread.join(timeout=5)
+        assert not rearm_thread.is_alive()
+        assert consumed.request_id == first.request_id
+        still_pending = update_stepup.read_pending()
+        assert still_pending is not None
+        assert still_pending.request_id == rearmed[0].request_id
+        update_stepup.clear_pending()
+
     def test_wrong_nonce_refused_and_not_consumed(self) -> None:
         pending = update_stepup.arm("9.9.9", "stable")
         try:
@@ -114,8 +186,25 @@ class TestStepUpModule:
         monkeypatch.setattr(
             time, "time", lambda: pending.created_at + update_stepup.PENDING_TTL_SECS + 1
         )
-        assert update_stepup.read_pending() is None
+        assert update_stepup.read_pending(clear_expired=True) is None
         assert not update_stepup.pending_path().exists()
+
+    def test_cross_process_reader_never_deletes_the_file(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A DEFAULT read never writes. A reader outside the gateway (the
+        `kirocrew update approve` CLI) uses the default: its unlink cannot be
+        serialized against a gateway re-arm, so an expired read must report
+        absent WITHOUT touching the file — otherwise it could delete a fresh
+        request it never read (GPT review finding, head 82cd360d3). Cleanup
+        is the explicit clear_expired=True opt-in for gateway callers."""
+        pending = update_stepup.arm("9.9.9", "stable")
+        monkeypatch.setattr(
+            time, "time", lambda: pending.created_at + update_stepup.PENDING_TTL_SECS + 1
+        )
+        assert update_stepup.read_pending() is None
+        assert update_stepup.pending_path().exists()
+        update_stepup.clear_pending()
 
     def test_malformed_file_reads_as_absent(self) -> None:
         path = update_stepup.pending_path()


### PR DESCRIPTION
## Problem / Motivation

The host-local update approval nonce is documented as single-use, but `consume()` delegated deletion to a best-effort cleanup helper. If unlinking the nonce file failed, the helper swallowed the error and `consume()` still returned the approved request, leaving the same nonce on disk and replayable.

## Why it matters

The nonce is the authority boundary between dashboard arming and host-local approval. Accepting an approval without durably consuming that nonce breaks the at-most-once guarantee precisely when the filesystem reports that it could not enforce it.

## What changed (motivation → approach → change)

Approval consumption now uses a strict removal path that raises `StepUpError` on any unlink failure. General cleanup remains best-effort, so expired-state cleanup keeps its existing behavior while the security-sensitive transition fails closed. The update architecture RFC now states that removal must succeed before approval is accepted.

Review hardening: consume() runs its read → validate → remove as one critical section under a new module mutex (`_PENDING_MUTEX`), and arm()'s atomic swap, the expiry cleanup, and clear_pending() take the same lock. This closes a window the GPT review lane flagged: an approve that validated request A could unlink a fresh request B a concurrent arm swapped in — accepting the stale approval while silently destroying the new one. Reading never writes by default: `read_pending()` removes an expired file only on the explicit `clear_expired=True` opt-in, which only gateway callers use (under the mutex, serialized against arm). The one out-of-process reader (`kirocrew update approve`) uses the no-write default, so the lock covers every writer that exists. A stale file that lingers grants nothing (every reader checks expiry) and the next arm replaces it.

## Tests

- Added a deterministic test that forces the nonce unlink to raise `PermissionError`, verifies approval is rejected, and verifies the request remains pending.
- Red-before: the new test failed with `DID NOT RAISE StepUpError` on current `main`.
- Added a two-thread regression test for the serialization: a consume paused inside its read-validate-remove window while a second thread re-arms. Red-before: without the mutex it fails with the re-armed request destroyed (verified by mutation probe); with the mutex the re-armed nonce survives.
- Added a cross-process-reader test: a default `read_pending()` on an expired file reports absent and leaves the file untouched; cleanup happens only via the explicit `clear_expired=True` gateway opt-in.
- `test/test_update_stepup.py`: 28 passed.
- isort, flake8, and mypy (`src/kiro_crew/`) pass on the final tree.

## Manual verification

N/A — the unit test directly controls the filesystem failure at the consumption boundary and the existing endpoint tests cover `StepUpError` response handling.

## Related Issues

no linked issue: found through direct source inspection; no matching open issue or pull request.

## Pattern harvest

Rule candidate: review-prompt
Pattern: single-use credentials must fail closed unless durable consumption succeeds.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


