### PR TITLE
fix(chat): remove only the complete generated suffix on a ChatPane chip un-toggle

### DIFF
--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -863,23 +863,23 @@ export default function ChatPane({
             // text so it no longer matches, leave the text alone — the chip
             // still un-highlights for consistency).
             if (followUpPickedRef.current.has(o)) {
+              const pickedSuffix = Array.from(followUpPickedRef.current).join(', ')
               const next = new Set(followUpPickedRef.current); next.delete(o)
+              const remainingSuffix = Array.from(next).join(', ')
               followUpPickedRef.current = next
               setInput(prev => {
-                // Order matters: try leading ", o" first so "opt, opt" + remove
-                // last "opt" doesn't match "opt, " and splice the wrong one.
-                // lastIndexOf, not indexOf: the handler appends options at the
-                // END, so the last occurrence is the one it created — a draft
-                // merely containing ", o" as a substring (draft "Please, Google"
-                // + option "Go") must not be spliced mid-word.
-                const leading = ', ' + o
-                let idx = prev.lastIndexOf(leading)
-                if (idx >= 0) return prev.slice(0, idx) + prev.slice(idx + leading.length)
-                const trailing = o + ', '
-                idx = prev.indexOf(trailing)
-                if (idx >= 0) return prev.slice(0, idx) + prev.slice(idx + trailing.length)
-                if (prev === o) return ''
-                return prev  // user edited — leave text, still unmark below
+                // Same removal ChatPage does (#6092 review). The picked options
+                // are appended as ONE ordered suffix, so the only text this
+                // handler may take back is that whole structure, still intact at
+                // the end. A last-occurrence search for ", o" instead reaches
+                // into the draft once the user has deleted the appended tail by
+                // hand: draft "Discuss, Alpha home" + a still-lit "Alpha" chip
+                // loses the user's own ", Alpha".
+                if (prev === pickedSuffix) return remainingSuffix
+                const delimitedSuffix = ', ' + pickedSuffix
+                if (!prev.endsWith(delimitedSuffix)) return prev  // user edited — leave text, still unmark below
+                const draft = prev.slice(0, -delimitedSuffix.length)
+                return remainingSuffix ? draft + ', ' + remainingSuffix : draft
               })
               setFollowUpPicked(next)
             } else {

--- a/website/src/test/ChatPane.followUpOptions.test.tsx
+++ b/website/src/test/ChatPane.followUpOptions.test.tsx
@@ -206,6 +206,25 @@ describe('ChatPane follow-up options (issue #5870)', () => {
     expect(composer().value).toBe('Please, Alphabet')
   })
 
+  it('leaves earlier draft text alone when the user already deleted the appended option', async () => {
+    // ChatPage removes only the COMPLETE generated suffix (#6092 review). The
+    // pane must hold the same invariant: once the user has deleted the
+    // appended ", Alpha" by hand, unselecting the still-lit chip has nothing of
+    // its own left to remove, and a last-occurrence search would fall back onto
+    // the ", Alpha" the user typed — silently editing their draft.
+    await renderPane('pane-8')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Alpha' })).toBeTruthy())
+    fireEvent.change(composer(), { target: { value: 'Discuss, Alpha home' } })
+    vi.useFakeTimers()
+    await act(async () => { clickOption('Alpha') })
+    expect(composer().value).toBe('Discuss, Alpha home, Alpha')
+
+    // The chip stays lit; the user removes its generated tail themselves.
+    fireEvent.change(composer(), { target: { value: 'Discuss, Alpha home' } })
+    await act(async () => { clickOption('Alpha') })
+    expect(composer().value).toBe('Discuss, Alpha home')
+  })
+
   it('offers no pills while the pane is busy, and offers them once busy clears', async () => {
     // selectComposerBusy reads the dashboard slot's subagents_running flag —
     // the same composer-busy rule that queues sends — so the derive gate must


### PR DESCRIPTION
## Problem / Motivation

In a grid pane, un-toggling a still-lit follow-up chip can delete text the user
typed themselves.

`ChatPane`'s toggle removed the **last occurrence** of `", " + option` anywhere
in the composer. That is correct only while the text the handler appended is
still present. Once the user has deleted that appended tail by hand — a normal
thing to do, and the chip stays lit because nothing tells it otherwise — the
search falls back onto the next-most-recent match, which is the user's own
draft:

| step | composer |
|---|---|
| user types | `Discuss, Alpha home` |
| clicks the `Alpha` chip | `Discuss, Alpha home, Alpha` |
| user deletes the appended `, Alpha` by hand | `Discuss, Alpha home` |
| clicks `Alpha` again to un-toggle | **`Discuss home`** ← their `, Alpha` is gone |

`ChatPage` had exactly this defect and was rewritten for it; the review of #6092
counted `ChatPane` as the unfixed sibling, still on the `lastIndexOf` splice.

## Why it matters

It is silent, unprompted destruction of unsent user input, in the one widget
whose entire contract is "if the user edited the text so it no longer matches,
leave the text alone" — a promise both files' own comments make. Nothing warns,
nothing undoes it, and the deleted span is exactly the kind of short phrase that
is easy not to notice before pressing Enter.

It is also a divergence between two panes that are meant to behave identically:
the same click on the same draft produces different text in the main chat and in
a grid pane.

## What changed (motivation → approach → change)

**Symptom:** un-toggling a chip removes a matching substring of the user's draft.

**Root cause:** the removal was defined by *pattern* (`lastIndexOf(', ' + o)`),
not by *provenance*. A substring search cannot distinguish text this handler
generated from identical text the user typed, so once the generated copy is gone
it happily takes theirs.

**Change:** adopt `ChatPage`'s removal, which is defined by provenance instead.
The picked options are appended as one ordered suffix, so the only text the
handler may take back is that whole structure, still intact at the end:

- `prev === pickedSuffix` → the composer is nothing but the suffix; replace it
  with the remaining options.
- `prev.endsWith(', ' + pickedSuffix)` → strip exactly that tail and re-append
  what is left picked.
- otherwise → the user edited it; return `prev` untouched (the chip still
  un-highlights, as before).

`website/src/components/ChatPane.tsx` only — a 14-line block swapped for the
12-line one `ChatPage.tsx:8331-8344` already runs. No new helper, no shared
extraction: the two blocks are now textually parallel, which is what makes the
next drift visible in review.

Behavioural delta beyond the bug: a draft the user has appended to *after* the
generated suffix (`Alpha, Beta and hurry`) now keeps its text on un-toggle
instead of being spliced. That is the stated contract, and it is what
`ChatPage` already does.

## Tests

`website/src/test/ChatPane.followUpOptions.test.tsx` — one added case,
`leaves earlier draft text alone when the user already deleted the appended
option`, mirroring the `ChatPage` test of the same name. It drives the table
above through the real component and asserts the composer still reads
`Discuss, Alpha home`.

Red-before on this branch's parent (`3a5824d20`), with the fix reverted:

```
AssertionError: expected 'Discuss home' to be 'Discuss, Alpha home'
Expected: "Discuss, Alpha home"
Received: "Discuss home"
 Tests  1 failed | 32 passed (33)
```

After the fix, and including the sibling suite that pins the behaviour being
ported from:

```
npx vitest run src/test/ChatPane.followUpOptions.test.tsx src/test/ChatPage.followUpToggle.test.tsx
 Test Files  2 passed (2)
      Tests  47 passed (47)
```

The pre-existing `unselecting an option splices its own appended text, never a
matching substring of the draft` case (draft `Please, Alphabet`) and the
multi-option accumulate/remove cases stay green — they are the regression
control for the case this change does *not* alter.

`npx tsc --noEmit` clean; `npx eslint` clean on both touched files.

## Manual verification

N/A — unit coverage sufficient: the added test drives the real `ChatPane`
through React Testing Library and asserts on the live composer value, so it
exercises the same code path a click does.

## Related Issues

Residual named by the review of #6092 (`ChatPane.tsx` counted as the unfixed
sibling of the `ChatPage.tsx` rewrite). No separate issue.

## Pattern harvest

Rule candidate: review-prompt

Pattern: "text removal identified by substring match rather than by provenance"
— when a handler appends generated text into a field a user also edits, the
undo must be defined by the exact structure it generated (anchored at a known
end, matched whole), never by searching for a pattern that the user's own input
can also satisfy. `indexOf` → `lastIndexOf` looks like the fix and is only a
narrower guess; the generated span has to be identified, not searched for.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
