### PR TITLE
fix(aws-control): never publish backup state over a read that failed

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
@@ -89,6 +89,55 @@ def write_state(state: dict[str, Any]) -> None:
     atomic_write(path, json.dumps(state, indent=1))
 
 
+class _StateUnreadable(OSError):
+    """The state document exists but could not be read.
+
+    A distinct type so :func:`_record_run` can say WHICH half of its
+    read-modify-write failed. Both halves reach it as an ``OSError`` and the two
+    are not interchangeable to whoever reads the log: "could not be read" sends
+    that reader to check permissions and file handles, which is the wrong place
+    to look when the truth is that the read was fine and ``write_state`` hit a
+    full disk.
+
+    It stays an ``OSError`` SUBCLASS deliberately. The other caller of
+    :func:`_locked_state_update` -- :func:`set_nightly`, which lets the error
+    reach its handler -- keeps behaving exactly as before this split, so nothing
+    outside this module has to learn the new type to stay correct.
+    """
+
+
+def _read_state_for_update() -> dict[str, Any]:
+    """The state document a read-modify-write is allowed to publish over.
+
+    :func:`read_state` is a DISPLAY read: every failure collapses to ``{}`` so a
+    render never crashes on a state file it could not load. That reading is
+    wrong as the BASE of a mutation, because :func:`_locked_state_update` writes
+    the whole document back -- an empty base there does not mean "no fields to
+    carry forward", it means "replace every account's nightly toggle and run
+    history with this one field". The sidecar lock does not help: it serializes
+    writers, and the loss happens inside it.
+
+    Only the missing file is a failure where ``{}`` is the truth (nothing has
+    been written yet). An unreadable one -- a transient EACCES/EIO, a scanner
+    holding the handle on Windows -- is state we still have, so the error is
+    allowed to propagate and the mutation is abandoned rather than published
+    over state nobody read.
+
+    Corruption keeps its existing repair-on-write behaviour, which is a
+    deliberate decision documented on :func:`_account_state`: a document that
+    parsed to nothing usable carries nothing to lose.
+    """
+    try:
+        data = json.loads(_state_path().read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    except OSError as exc:
+        raise _StateUnreadable(
+            exc.errno, exc.strerror or "state file could not be read", exc.filename
+        ) from exc
+    return data if isinstance(data, dict) else {}
+
+
 def _locked_state_update(mutate) -> Any:
     """Read-modify-write the state file under the sidecar lock.
 
@@ -96,12 +145,16 @@ def _locked_state_update(mutate) -> Any:
     nightly loop); an unlocked read-modify-write would let the later atomic
     write silently discard the earlier run record. Same sidecar-lock shape
     as the share ledger.
+
+    Raises ``OSError`` when the existing state could not be read; see
+    :func:`_read_state_for_update` for why that is not collapsed to an empty
+    document here.
     """
     lock_path = _state_path().with_suffix(".lock")
     _state_path().parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
-            state = read_state()
+            state = _read_state_for_update()
             result = mutate(state)
             write_state(state)
     return result
@@ -125,7 +178,132 @@ def _account_state(state: dict[str, Any], account: str) -> dict[str, Any]:
     return entry
 
 
+#: Runs whose archive reached the bucket but whose state write did not land,
+#: held for the life of THIS process. :func:`last_runs` merges them in, and that
+#: is the whole point: it is what stops :func:`due_for_nightly` re-firing the
+#: unattended loop on a stamp that was never persisted. See :func:`_record_run`.
+#:
+#: Keyed by the state FILE as well as the account and kind. An entry is a claim
+#: about one state document -- "this file is missing a run it should have" -- so it
+#: must never answer for a different one. Production resolves a single fixed path
+#: (``app_data_dir`` is ``app_dir(name) / "data"``, and nothing repoints it), so
+#: this is not guarding a live scenario; what it buys is that the tests are
+#: hermetic by construction instead of through a reset hook every future test has
+#: to remember to call. :func:`_state_key` resolves the element without raising.
+#:
+#: Bounded by the accounts the owner has actually connected times the two backup
+#: kinds, and an entry is dropped as soon as one write for that key succeeds.
+_unpersisted_runs: dict[tuple[str, str, str], dict[str, Any]] = {}
+_unpersisted_lock = threading.Lock()
+
+
+def _state_key() -> str:
+    """The state-file element of a :data:`_unpersisted_runs` key, without raising.
+
+    :func:`_state_path` is NOT a pure path join. It goes through
+    :func:`app_data_dir`, whose last statement is
+    ``mkdir(parents=True, exist_ok=True)``, so merely resolving the path raises
+    ``OSError`` on a read-only filesystem, on EACCES/ENOSPC, or when a parent
+    path is a file. Those are precisely the conditions this overlay exists to
+    survive, which makes an unguarded key derivation self-defeating:
+    :func:`_record_run` derives the key from INSIDE its own except handler, where
+    an exception would 500 a request whose archive is already in the bucket --
+    the exact defect this change exists to remove, reintroduced one layer in.
+    The read is already guarded (:func:`read_state` swallows ``OSError``), so
+    without this the failure is absorbed once and then raised by the very next
+    statement.
+
+    A failure returns a SENTINEL rather than skipping the work. Skipping would
+    drop the held record in exactly the case the hold exists for. One sentinel is
+    consistent for the life of the process, so the overlay still answers
+    :func:`last_runs`, the completed upload still reports, and no caller raises.
+
+    All three key sites go through here rather than each guarding itself: one
+    place to reason about, and one place a future edit cannot forget.
+    """
+    try:
+        return str(_state_path())
+    except OSError:
+        return ""
+
+
+def _remember_unpersisted(account: str, kind: str, record: dict[str, Any]) -> None:
+    with _unpersisted_lock:
+        _unpersisted_runs[(_state_key(), account, kind)] = record
+
+
+def _forget_unpersisted(account: str, kind: str, persisted_at: str) -> None:
+    """Drop the held entry once a write for the same key has persisted.
+
+    Conditional, not unconditional, and the condition is the point. This runs
+    AFTER the sidecar lock is released, so another run for the same key can fail
+    its write and cache a NEWER record inside the window between this run's write
+    and this pop; an unconditional pop would evict that record, and the panel
+    would then report the older archive as the last run while the newer upload
+    has no record anywhere.
+
+    Taking the sidecar lock for the pop would not fix it. The matching
+    :func:`_remember_unpersisted` also runs outside that lock, and more
+    fundamentally two gateway processes hold SEPARATE in-memory caches, so no
+    file lock can serialize one process's pop against the other's cache. The
+    invariant that holds in both cases is monotonic: never evict a record
+    STRICTLY NEWER than the one just persisted.
+
+    An EQUAL stamp evicts. Two back-to-back runs can stamp identically where the
+    clock is coarse -- Windows granularity is far above a microsecond -- and
+    keeping the held record on a tie makes it immortal for the life of the
+    process, since no later write can ever compare greater. A tie means the two
+    records are simultaneous and the persisted one is on disk, so retaining the
+    held copy buys nothing. A stamp that is missing or not a string cannot be
+    ordered and is unusable, so it is dropped.
+    """
+    key = (_state_key(), account, kind)
+    with _unpersisted_lock:
+        held = _unpersisted_runs.get(key)
+        if held is None:
+            return
+        held_at = held.get("at")
+        if not isinstance(held_at, str) or held_at <= persisted_at:
+            _unpersisted_runs.pop(key, None)
+
+
+def _merge_unpersisted(account: str, runs: dict[str, Any]) -> dict[str, Any]:
+    """Overlay this process's unpersisted runs onto what the state file holds.
+
+    Newest wins, rather than memory always winning: a second gateway process on
+    the same data home can persist a NEWER run while this one still remembers a
+    write that failed, and the sidecar lock exists precisely because that other
+    process can exist. Both stamps come from the same UTC
+    ``isoformat(timespec="microseconds")`` call, so comparing the strings orders
+    them -- and microseconds rather than seconds is what makes that comparison
+    able to separate two uploads that finished in the same second. A persisted
+    stamp that is not a string is unusable and loses.
+    """
+    path = _state_key()
+    with _unpersisted_lock:
+        remembered = {
+            kind: record
+            for (state_path, acct, kind), record in _unpersisted_runs.items()
+            if state_path == path and acct == account
+        }
+    for kind, record in remembered.items():
+        persisted = runs.get(kind)
+        persisted_at = persisted.get("at") if isinstance(persisted, dict) else None
+        if not isinstance(persisted_at, str) or persisted_at < str(record.get("at", "")):
+            runs[kind] = record
+    return runs
+
+
 def _record_run(account: str, kind: str, key: str, size: int) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "key": key,
+        "bytes": size,
+        # Provisional. The authoritative stamp is taken inside `mutate`, under the
+        # sidecar lock -- see there. This value survives only on the path where the
+        # READ fails, because `mutate` never runs then.
+        "at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="microseconds"),
+    }
+
     def mutate(state: dict[str, Any]) -> dict[str, Any]:
         entry = _account_state(state, account)
         runs = entry.setdefault("runs", {})
@@ -133,14 +311,61 @@ def _record_run(account: str, kind: str, key: str, size: int) -> dict[str, Any]:
             # A corrupted non-dict `runs` must not crash AFTER the archive
             # already uploaded (500 + no ledger entry + duplicate on retry).
             runs = entry["runs"] = {}
-        runs[kind] = {
-            "key": key,
-            "bytes": size,
-            "at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
-        }
+        # Stamp HERE, not where `record` was built. `mutate` runs inside the
+        # sidecar lock, so a stamp taken here is ordered by the same lock that
+        # orders the writes; a stamp taken before the lock is not. Two runs can
+        # stamp in one order and acquire the lock in the other -- a manual run
+        # racing the nightly loop -- and then the older-stamped record writes
+        # LAST and the ledger reports the wrong archive as the last run.
+        #
+        # This is load-bearing for more than the ledger: everything that compares
+        # these stamps (the overlay's newest-wins in `_merge_unpersisted`, the
+        # monotonic eviction in `_forget_unpersisted`) is only sound if stamp
+        # order matches WRITE order, which is exactly what generating it in here
+        # buys. Microsecond precision alone does not: it separates two stamps
+        # without telling you which write landed first.
+        record["at"] = dt.datetime.now(dt.timezone.utc).isoformat(timespec="microseconds")
+        runs[kind] = record
         return runs[kind]
 
-    return _locked_state_update(mutate)
+    try:
+        recorded = _locked_state_update(mutate)
+    except OSError as exc:
+        # Two things are true here and only one of them was handled before.
+        #
+        # (1) The archive is ALREADY in the bucket, so raising would 500 a
+        # request whose upload succeeded and send the operator back to the button
+        # for a duplicate -- the same harm the corrupted-`runs` branch above
+        # avoids. So this still does not raise.
+        #
+        # (2) Not raising is not the end of it. `due_for_nightly` decides
+        # due-ness from the PERSISTED stamp and `hooks._run_once` calls it on
+        # every wake, so a write that never landed leaves the loop permanently
+        # due: it re-uploads, unattended and billable, on every wake for as long
+        # as this process lives, behind one log line nobody reads. Holding the
+        # run in process-local memory -- which `last_runs` merges in -- bounds
+        # that to at most one extra upload per gateway restart.
+        #
+        # Which half failed decides the wording, because both arrive as OSError
+        # and they send a reader to different places: `_StateUnreadable` means
+        # the existing document could not be read and was deliberately not
+        # published over, while a plain OSError means the read was fine and
+        # `write_state` failed (ENOSPC, EROFS, EIO). Reporting a full disk as
+        # "could not be read" points at permissions instead.
+        stage = "could not be read" if isinstance(exc, _StateUnreadable) else "could not be written"
+        _remember_unpersisted(account, kind, record)
+        logger.error(
+            "aws-control: %s backup for %s uploaded, but its state file %s, so the run is "
+            "not on disk; holding it in memory for this process so the nightly loop does "
+            "not re-upload the same archive: %s",
+            kind,
+            account,
+            stage,
+            exc,
+        )
+        return record
+    _forget_unpersisted(account, kind, record["at"])
+    return recorded
 
 
 def _stamp() -> str:
@@ -535,6 +760,20 @@ def _account_view(account: str) -> dict[str, Any]:
 
 
 def nightly_enabled(account: str) -> bool:
+    """Whether the owner has authorized unattended uploads for this account.
+
+    Reads through :func:`read_state`, so an unreadable state file answers False.
+    That is FAIL-CLOSED, and it is the opposite of what :func:`last_runs` does
+    with a run it could not persist -- the asymmetry is deliberate, because the
+    two answers cost different things when they are wrong.
+
+    This bit AUTHORIZES spending the owner's money without them present. Read it
+    optimistically and a corrupt or unreadable file becomes a reason to start
+    uploading; refuse, and a transient failure costs one skipped nightly window
+    that the next wake picks up. The run record is the mirror image: it is a
+    record of something that ALREADY happened and is already paid for, so
+    dropping it does not prevent a charge, it causes one.
+    """
     return bool(_account_view(account).get("nightly"))
 
 
@@ -546,8 +785,16 @@ def set_nightly(account: str, enabled: bool) -> None:
 
 
 def last_runs(account: str) -> dict[str, Any]:
+    """The last run per kind, including runs this process could not persist.
+
+    The merge is not cosmetic. A run whose state write failed really did upload,
+    and :func:`due_for_nightly` reads its answer from here -- so without the
+    overlay the nightly loop treats the account as never backed up and uploads
+    again on every wake. See :data:`_unpersisted_runs`.
+    """
     runs = _account_view(account).get("runs", {})
-    return runs if isinstance(runs, dict) else {}
+    runs = dict(runs) if isinstance(runs, dict) else {}
+    return _merge_unpersisted(account, runs)
 
 
 def due_for_nightly(account: str, now: Optional[dt.datetime] = None) -> bool:

--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -1306,7 +1306,24 @@ async def _handle_backup_nightly(request: web.Request) -> web.Response:
         return _bad_request("enabled must be a boolean", "invalid_enabled")
     enabled = raw
     account, _profile, _region = target
-    await asyncio.to_thread(backup_mod.set_nightly, account, enabled)
+    try:
+        await asyncio.to_thread(backup_mod.set_nightly, account, enabled)
+    except OSError:
+        # `set_nightly` now propagates rather than publishing over state it could
+        # not read, so this toggle can genuinely fail to persist. It must fail
+        # LOUDLY -- reporting a setting the next read contradicts is worse than an
+        # error -- but as a structured failure, because every non-2xx this app
+        # returns carries a machine-readable `code` the console switches on.
+        #
+        # The message is FIXED rather than the OSError's own text: that text
+        # renders the absolute path of the state file, and there is no reason to
+        # disclose a local filesystem path in a response body when the log below
+        # already carries it for whoever is actually debugging.
+        logger.exception("aws-control: the nightly toggle could not be persisted")
+        return web.json_response(
+            {"error": "the nightly setting could not be saved", "code": "state_persist_failed"},
+            status=500,
+        )
     return web.json_response({"nightly": enabled})
 
 

--- a/test/test_aws_control_backup.py
+++ b/test/test_aws_control_backup.py
@@ -18,8 +18,11 @@ the authorization so no network or live STS is ever reached.
 from __future__ import annotations
 
 import datetime as dt
+import errno
 import json
+import logging
 import tarfile
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -456,6 +459,402 @@ class TestDueForNightlyBadStamp:
 # ---------------------------------------------------------------------------
 # costs — cache read and freshness branches
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# The state file is a WHOLE document: a read that failed must not be published
+# ---------------------------------------------------------------------------
+
+
+OTHER_ACCOUNT = "444455556666"
+
+
+class TestUnreadableStateIsNotOverwritten:
+    """``_locked_state_update`` rewrites the ENTIRE state document.
+
+    ``read_state`` is a display read and collapses every failure to ``{}``. Used
+    as the base of a read-modify-write, that empty dict is not "no fields to
+    carry forward" -- it is an instruction to replace every account's nightly
+    toggle and run history with whatever this one mutation writes. A missing
+    file is the only failure where ``{}`` is true. The sidecar lock does not
+    help: it serializes writers, and this loss happens inside the lock.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_state(self, tmp_path, monkeypatch):
+        self.state_file = tmp_path / "backup.json"
+        # Captured BEFORE the failure is injected, so assertions can read the
+        # file the code under test could not.
+        self.real_read_text = Path.read_text
+        monkeypatch.setattr(backup, "_state_path", lambda: self.state_file)
+        yield
+
+    def _on_disk(self) -> dict:
+        return json.loads(self.real_read_text(self.state_file, encoding="utf-8"))
+
+    def _guarded_read(self):
+        """A ``Path.read_text`` that fails for the state file only -- a transient
+        EACCES, e.g. a Windows scanner holding the handle between the open and
+        the read."""
+        real = self.real_read_text
+        target = self.state_file
+
+        def guarded(path_self, *args, **kwargs):
+            if Path(path_self) == target:
+                raise PermissionError(13, "Permission denied")
+            return real(path_self, *args, **kwargs)
+
+        return guarded
+
+    def _break_reads(self, monkeypatch):
+        monkeypatch.setattr(Path, "read_text", self._guarded_read())
+
+    def test_a_transient_read_failure_does_not_wipe_the_other_account(self, monkeypatch):
+        backup.set_nightly(ACCOUNT, True)
+        assert self._on_disk()["accounts"][ACCOUNT]["nightly"] is True
+        # Captured through read_bytes, which `_break_reads` does not patch, so the
+        # comparison below is against the real pre-failure bytes.
+        before = self.state_file.read_bytes()
+
+        self._break_reads(monkeypatch)
+        with pytest.raises(OSError):
+            backup.set_nightly(OTHER_ACCOUNT, True)
+
+        # The strongest form of the invariant: the file was not rewritten AT ALL.
+        # `_locked_state_update` rewrites the whole document from whatever the
+        # in-lock read returned, so a lenient read that collapses OSError to `{}`
+        # publishes an empty base over live state. Byte equality rules out a
+        # partial write and a dropped run record too, not just a surviving flag.
+        assert self.state_file.read_bytes() == before
+        # And the same harm in human terms: the first account's authorization to
+        # run unattended paid uploads is still on disk.
+        assert self._on_disk()["accounts"][ACCOUNT]["nightly"] is True
+
+    def test_a_missing_file_is_still_a_first_write(self):
+        # The one failure where an empty base IS the truth -- this must keep
+        # working, so the guard above cannot be "refuse whenever the read fails".
+        assert not self.state_file.exists()
+        backup.set_nightly(ACCOUNT, True)
+        assert self._on_disk()["accounts"][ACCOUNT]["nightly"] is True
+
+    def test_a_corrupt_file_still_repairs_on_write(self):
+        # Deliberate existing behaviour (see `_account_state`): a corrupted
+        # document is replaced by the mutation rather than crashing it. Pinned
+        # here so the unreadable-file guard is not mistaken for a licence to
+        # start failing on corruption too.
+        self.state_file.write_text("{not json", encoding="utf-8")
+        backup.set_nightly(ACCOUNT, True)
+        assert self._on_disk()["accounts"][ACCOUNT]["nightly"] is True
+
+    def test_a_completed_run_reports_itself_without_publishing_over_unread_state(self, monkeypatch):
+        # `_record_run` runs AFTER the archive is already in the bucket. Raising
+        # would 500 a request whose upload succeeded and send the operator back
+        # to the button for a duplicate -- the same harm the corrupt-`runs`
+        # branch avoids. It must neither raise nor destroy the other account.
+        backup.set_nightly(ACCOUNT, True)
+        self._break_reads(monkeypatch)
+
+        record = backup._record_run(OTHER_ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        assert record["key"] == "snapshots/x.tar.gz"
+        assert record["bytes"] == 7
+        assert self._on_disk()["accounts"][ACCOUNT]["nightly"] is True
+
+    def test_the_log_names_the_read_when_the_read_is_what_failed(self, caplog):
+        backup.set_nightly(ACCOUNT, True)
+        with (
+            caplog.at_level(logging.ERROR),
+            mock.patch.object(Path, "read_text", self._guarded_read()),
+        ):
+            backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        assert "could not be read" in caplog.text
+        assert "could not be written" not in caplog.text
+
+    def test_a_run_lost_to_a_transient_read_failure_does_not_re_upload(self):
+        # A PERSISTING read failure needs no guard: `due_for_nightly` asks
+        # `nightly_enabled` first, which reads through `read_state`, so an
+        # unreadable file collapses authorization to False and the loop goes
+        # quiet by itself. The repeat belongs to a read failure that CLEARS --
+        # authorization comes back on the next wake, the stamp is still missing,
+        # and the loop would upload the same archive again.
+        backup.set_nightly(ACCOUNT, True)
+        with mock.patch.object(Path, "read_text", self._guarded_read()):
+            assert backup.due_for_nightly(ACCOUNT) is False  # quiet while unreadable
+            backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        # Reads work again: authorization is back, the stamp never landed.
+        assert backup.nightly_enabled(ACCOUNT) is True
+        assert backup.KIND_SNAPSHOT not in self._on_disk()["accounts"][ACCOUNT].get("runs", {})
+        assert backup.due_for_nightly(ACCOUNT) is False
+
+
+class TestALostRunWriteDoesNotReUploadForever:
+    """A run whose state WRITE failed must not leave the nightly loop due.
+
+    ``_record_run`` deliberately does not raise: the archive is already in the
+    bucket, so a 500 would send the operator back to the button for a duplicate
+    upload. On its own, though, not raising is a worse bug than the one it
+    avoids. ``due_for_nightly`` reads due-ness from the PERSISTED stamp and
+    ``hooks._run_once`` calls it on every wake, so a write that never landed
+    leaves the loop permanently due -- it re-uploads, unattended and billable, on
+    every wake, behind one log line nobody reads.
+
+    Holding the run in process-local memory bounds that to at most one extra
+    upload per gateway restart, which is honest: the archive really is in the
+    bucket, and this process really did put it there.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_state(self, tmp_path, monkeypatch):
+        self.state_file = tmp_path / "backup.json"
+        monkeypatch.setattr(backup, "_state_path", lambda: self.state_file)
+        yield
+
+    def _on_disk(self) -> dict:
+        return json.loads(self.state_file.read_text(encoding="utf-8"))
+
+    def _full_disk(self):
+        """The read succeeds and the WRITE fails. This is the case the single
+        ``except OSError`` swallowed while its log line blamed the read."""
+
+        def raiser(_state):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        return mock.patch.object(backup, "write_state", raiser)
+
+    def test_a_lost_write_does_not_leave_the_nightly_loop_due(self):
+        backup.set_nightly(ACCOUNT, True)
+        with self._full_disk():
+            backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        # Nothing reached disk -- the stamp the loop reads is genuinely absent.
+        assert backup.KIND_SNAPSHOT not in self._on_disk()["accounts"][ACCOUNT].get("runs", {})
+        # And yet the loop must not re-upload an archive that is already there.
+        assert backup.due_for_nightly(ACCOUNT) is False
+
+    def test_the_completed_run_still_reports_itself_to_the_caller(self):
+        backup.set_nightly(ACCOUNT, True)
+        with self._full_disk():
+            record = backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        # No raise: the upload succeeded, so the handler must not 500 the
+        # operator into pressing the button again for a duplicate.
+        assert record["key"] == "snapshots/x.tar.gz"
+        assert record["bytes"] == 7
+
+    def test_the_held_run_is_what_the_panel_reads_too(self):
+        # `due_for_nightly` reads through `last_runs`, so that is where the
+        # overlay lands -- and showing it is truthful, not a white lie: the
+        # archive is in the bucket.
+        backup.set_nightly(ACCOUNT, True)
+        with self._full_disk():
+            backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        assert backup.last_runs(ACCOUNT)[backup.KIND_SNAPSHOT]["key"] == "snapshots/x.tar.gz"
+
+    def test_the_log_names_the_write_not_the_read(self, caplog):
+        backup.set_nightly(ACCOUNT, True)
+        with caplog.at_level(logging.ERROR), self._full_disk():
+            backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        # The old line said the state file "could not be read", which sends
+        # whoever reads it to check permissions on what is really a full disk.
+        assert "could not be written" in caplog.text
+        assert "could not be read" not in caplog.text
+
+    def test_a_later_successful_write_takes_over_from_memory(self):
+        # The memory entry is a stopgap, not a second source of truth: once a
+        # write lands, disk answers and the entry is dropped.
+        backup.set_nightly(ACCOUNT, True)
+        with self._full_disk():
+            backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/lost.tar.gz", 7)
+        assert backup.last_runs(ACCOUNT)[backup.KIND_SNAPSHOT]["key"] == "snapshots/lost.tar.gz"
+
+        backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/kept.tar.gz", 9)
+
+        runs = self._on_disk()["accounts"][ACCOUNT]["runs"]
+        assert runs[backup.KIND_SNAPSHOT]["key"] == "snapshots/kept.tar.gz"
+        assert backup.last_runs(ACCOUNT)[backup.KIND_SNAPSHOT]["key"] == "snapshots/kept.tar.gz"
+        assert (str(self.state_file), ACCOUNT, backup.KIND_SNAPSHOT) not in backup._unpersisted_runs
+
+    def test_an_entry_never_answers_for_a_different_state_document(self, tmp_path, monkeypatch):
+        # The memory key carries the state FILE, so a held run is a claim about
+        # one document only. A relocated data home reads its own truth -- and
+        # this is also what keeps the tests hermetic with no reset hook.
+        backup.set_nightly(ACCOUNT, True)
+        with self._full_disk():
+            backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+        assert backup.last_runs(ACCOUNT)[backup.KIND_SNAPSHOT]["key"] == "snapshots/x.tar.gz"
+
+        elsewhere = tmp_path / "moved" / "backup.json"
+        monkeypatch.setattr(backup, "_state_path", lambda: elsewhere)
+        assert backup.last_runs(ACCOUNT) == {}
+
+    def test_a_persisting_run_does_not_evict_a_newer_held_run(self):
+        # The pop happens after the sidecar lock is released, so a run that
+        # failed its write can cache a NEWER record in the window between another
+        # run's write and that pop. An unconditional pop would evict it and the
+        # panel would report the older archive while the newer upload has no
+        # record anywhere. Two gateway processes hold separate caches, so no file
+        # lock can close this -- only monotonic eviction can.
+        backup.set_nightly(ACCOUNT, True)
+        newer = {
+            "key": "snapshots/newer.tar.gz",
+            "bytes": 11,
+            "at": dt.datetime(2099, 1, 1, tzinfo=dt.timezone.utc).isoformat(
+                timespec="microseconds"
+            ),
+        }
+        backup._remember_unpersisted(ACCOUNT, backup.KIND_SNAPSHOT, newer)
+
+        # This one persists, and its stamp is older than the held record's.
+        backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/older.tar.gz", 7)
+
+        assert backup.last_runs(ACCOUNT)[backup.KIND_SNAPSHOT]["key"] == "snapshots/newer.tar.gz"
+
+    def test_a_stale_held_run_is_still_evicted(self):
+        # The counterpart: monotonic must not become "never evict", or the entry
+        # would outlive the write that supersedes it.
+        backup.set_nightly(ACCOUNT, True)
+        stale = {
+            "key": "snapshots/stale.tar.gz",
+            "bytes": 3,
+            "at": dt.datetime(2000, 1, 1, tzinfo=dt.timezone.utc).isoformat(
+                timespec="microseconds"
+            ),
+        }
+        backup._remember_unpersisted(ACCOUNT, backup.KIND_SNAPSHOT, stale)
+
+        backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/fresh.tar.gz", 7)
+
+        assert backup.last_runs(ACCOUNT)[backup.KIND_SNAPSHOT]["key"] == "snapshots/fresh.tar.gz"
+        assert (str(self.state_file), ACCOUNT, backup.KIND_SNAPSHOT) not in backup._unpersisted_runs
+
+    def test_the_run_is_stamped_inside_the_lock_not_before(self):
+        # Two concurrent runs can stamp in one order and acquire the sidecar lock
+        # in the other, so a stamp taken BEFORE the lock does not order the
+        # writes: the older-stamped record can write last and the ledger then
+        # names the wrong archive. It also undermines everything that compares
+        # these stamps -- the overlay's newest-wins and the monotonic eviction --
+        # both of which assume stamp order equals write order.
+        #
+        # Asserted without threads: delay the locked section, capture a moment
+        # from inside it, and require the record's stamp to be no earlier. A
+        # stamp taken before the lock is necessarily earlier than that moment.
+        backup.set_nightly(ACCOUNT, True)
+        observed = {}
+        real_read = backup._read_state_for_update
+
+        def slow_read():
+            time.sleep(0.01)
+            observed["inside"] = dt.datetime.now(dt.timezone.utc).isoformat(timespec="microseconds")
+            return real_read()
+
+        with mock.patch.object(backup, "_read_state_for_update", slow_read):
+            record = backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        assert record["at"] >= observed["inside"]
+        # And the stamp that reached disk is that same authoritative one.
+        on_disk = self._on_disk()["accounts"][ACCOUNT]["runs"][backup.KIND_SNAPSHOT]
+        assert on_disk["at"] == record["at"]
+
+    def test_a_failed_read_keeps_the_provisional_stamp(self):
+        # `mutate` never runs when the read fails, so the pre-lock stamp is all
+        # there is. It must still be a usable timestamp: the held record is
+        # ordered against the persisted one, and `due_for_nightly` parses it.
+        backup.set_nightly(ACCOUNT, True)
+        real_read = backup._read_state_for_update
+
+        def broken_read():
+            raise backup._StateUnreadable(13, "Permission denied")
+
+        with mock.patch.object(backup, "_read_state_for_update", broken_read):
+            record = backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+        assert dt.datetime.fromisoformat(record["at"]).tzinfo is not None
+        assert backup.due_for_nightly(ACCOUNT) is False
+        assert real_read is backup._read_state_for_update  # patch scoped, not leaked
+
+    def test_an_unresolvable_data_dir_neither_raises_nor_loses_the_run(self):
+        # `_state_path()` is not a pure path join: it goes through `app_data_dir`,
+        # whose last statement is mkdir(parents=True, exist_ok=True), so resolving
+        # it RAISES on a read-only filesystem or EACCES. That is the same broken
+        # filesystem this overlay exists to survive, and the read is already
+        # guarded (`read_state` swallows OSError) -- so an unguarded key
+        # derivation absorbs the failure once and then raises on the very next
+        # statement, from inside `_record_run`'s own except handler.
+        #
+        # What the redness means when this fails: a backup that finished uploading
+        # reports as a failure because the machine's app-data directory went
+        # read-only, which is the defect this PR exists to remove.
+        def unresolvable():
+            raise OSError(errno.EROFS, "Read-only file system")
+
+        with mock.patch.object(backup, "_state_path", unresolvable):
+            record = backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/x.tar.gz", 7)
+
+            # The completed upload still reports to its caller.
+            assert record["key"] == "snapshots/x.tar.gz"
+            assert record["bytes"] == 7
+
+            # And the status read returns rather than raising -- the sentinel key
+            # is consistent within the process, so the overlay still answers.
+            runs = backup.last_runs(ACCOUNT)
+            assert runs[backup.KIND_SNAPSHOT]["key"] == "snapshots/x.tar.gz"
+
+    def test_a_held_run_with_an_equal_stamp_is_evicted(self):
+        # Windows clock granularity is far above a microsecond, so two
+        # back-to-back runs can stamp IDENTICALLY -- this is what reddened
+        # `test_a_later_successful_write_takes_over_from_memory` on the Windows
+        # shard while it passed on Linux. On a tie the entry must go: the two
+        # records are simultaneous and the persisted one is on disk, and keeping
+        # the held copy would make it immortal for the life of the process
+        # because no later write can ever compare greater. Only a STRICTLY newer
+        # held record is protected. Asserted directly rather than through the
+        # clock, so it pins the rule on every platform.
+        stamp = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc).isoformat(timespec="microseconds")
+        backup._remember_unpersisted(
+            ACCOUNT,
+            backup.KIND_SNAPSHOT,
+            {"key": "snapshots/tie.tar.gz", "bytes": 5, "at": stamp},
+        )
+
+        backup._forget_unpersisted(ACCOUNT, backup.KIND_SNAPSHOT, stamp)
+
+        assert (backup._state_key(), ACCOUNT, backup.KIND_SNAPSHOT) not in backup._unpersisted_runs
+
+    def test_two_runs_in_the_same_second_are_distinguishable(self):
+        # `_stamp` already carries entropy because a manual run can race the
+        # nightly loop into the same second. The run record has to be orderable
+        # at that resolution too, or the overlay cannot tell which of two uploads
+        # is the later one: at `timespec="seconds"` these compare EQUAL.
+        backup.set_nightly(ACCOUNT, True)
+        first = backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/a.tar.gz", 1)
+        second = backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/b.tar.gz", 2)
+
+        assert first["at"] != second["at"]
+        assert first["at"] < second["at"]
+        # And it still parses as a timestamp, which `due_for_nightly` relies on.
+        assert dt.datetime.fromisoformat(second["at"]).tzinfo is not None
+
+    def test_the_later_of_two_same_second_runs_wins_the_overlay(self):
+        # The concrete harm from an unorderable stamp: the first upload persists,
+        # the second fails its write in the same second, and the panel reports
+        # the first archive as the last run.
+        backup.set_nightly(ACCOUNT, True)
+        persisted = backup._record_run(ACCOUNT, backup.KIND_SNAPSHOT, "snapshots/first.tar.gz", 1)
+        held = {
+            "key": "snapshots/second.tar.gz",
+            "bytes": 2,
+            # One microsecond later: same second, genuinely newer.
+            "at": (
+                dt.datetime.fromisoformat(persisted["at"]) + dt.timedelta(microseconds=1)
+            ).isoformat(timespec="microseconds"),
+        }
+        backup._remember_unpersisted(ACCOUNT, backup.KIND_SNAPSHOT, held)
+
+        assert backup.last_runs(ACCOUNT)[backup.KIND_SNAPSHOT]["key"] == "snapshots/second.tar.gz"
 
 
 class TestCostsCacheBranches:

--- a/test/test_aws_control_routes.py
+++ b/test/test_aws_control_routes.py
@@ -2116,6 +2116,35 @@ class TestBackupEndpoints:
             assert _payload(resp)["code"] == "invalid_enabled"
             set_nightly.assert_not_called()
 
+    def test_a_toggle_that_could_not_persist_fails_with_a_structured_error(self):
+        # `set_nightly` now propagates rather than publishing over state it could
+        # not read, so this endpoint has a reachable failure. It must fail loudly
+        # -- reporting a setting the next read contradicts is worse than an error
+        # -- but with the machine-readable `code` every non-2xx here carries.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        req = _request("POST", f"/backup/{ACCOUNT}/nightly", match_info={"account": ACCOUNT})
+        req.json = AsyncMock(return_value={"enabled": True})  # type: ignore[method-assign]
+        boom = OSError(28, "No space left on device", "/home/someone/.kirocrew/backup.json")
+        with (
+            p1,
+            p2,
+            p3,
+            mock.patch.object(routes_mod.backup_mod, "set_nightly", side_effect=boom),
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/backup/{account}/nightly")](req)  # type: ignore[operator]
+            )
+        body = _payload(resp)
+        assert resp.status == 500
+        assert body["code"] == "state_persist_failed"
+        # The response must not report the toggle as applied...
+        assert "nightly" not in body
+        # ...and must not echo the OSError's rendering, which carries the
+        # absolute path of the state file. The log has it; a response body does
+        # not need to disclose the local filesystem layout.
+        assert ".kirocrew" not in body["error"]
+
     def test_a_real_false_still_disables_nightly(self):
         # The validation must not break the ordinary off path.
         handlers = _registered()


### PR DESCRIPTION
## Problem / Motivation

**One invariant, broken in two directions: never report or persist an outcome the
storage did not actually produce.**

Both defects here are failures of that single rule on the same file, and they arrive
from opposite sides of it. The read half publishes over data the storage never handed
back. The write half reports success the storage never accepted. Reading them as two
unrelated bugs that happen to share a module misses that fixing one is what exposed
the other:

- **The read half (1)** is the headline. A failed in-lock read collapses to `{}`, and
  the whole document is rewritten from it -- so an outcome the storage did not produce
  (an empty state) is persisted over good data.
- **The write half (2)** was introduced by this PR's own first revision while fixing
  the read half, and is fixed here too. The handler added to absorb the newly
  propagating read failure also absorbed the write failure, so a run that never
  persisted was reported as recorded -- an outcome the storage did not accept.

### 1. One transient read error silently wipes every account's backup configuration

`backup.json` is a single document holding, per account, the `nightly` toggle
that authorizes unattended uploads plus the last-run record for each backup
kind. `_locked_state_update` is a read-modify-write that writes the **whole
document** back, and its base came from `read_state`:

```python
def read_state() -> dict[str, Any]:
    try:
        data = json.loads(_state_path().read_text(encoding="utf-8"))
        return data if isinstance(data, dict) else {}
    except (FileNotFoundError, OSError, json.JSONDecodeError):
        return {}
```

That `{}` is right for a *display* read -- a render must not crash on a state
file it could not load. As the base of a mutation it means something else
entirely: not "no fields to carry forward", but "replace every account's nightly
toggle and run history with this one field".

So if the read raises `PermissionError`/`EIO` -- a scanner holding the handle on
Windows, a momentary EACCES -- while the nightly loop records a run for account
B, account A's `nightly: true` and every run record on the file are gone. A's
unattended backups stop, permanently and silently: `due_for_nightly` reads the
same file back and now says `nightly` is off.

The sidecar lock does not help. It serializes writers correctly; the loss
happens *inside* it, because the damage is in the read, not in the interleaving.

### 2. Swallowing the resulting write failure makes the nightly loop re-upload forever

Fixing (1) means `_locked_state_update` can now raise, so `_record_run` gained an
`except OSError` -- it runs after the archive is already in the bucket, and a 500
there sends the operator back to the button for a duplicate upload. But that
handler spans read, mutate **and** `write_state`, so it also swallows a write
failure (ENOSPC, EROFS, EIO) and returns the record as though it had persisted.

That is worse than the bug it avoids. `due_for_nightly` decides due-ness from the
**persisted** stamp, and `hooks._run_once` calls it on every wake. A write that
never landed leaves the loop permanently due, so it re-uploads the same archive
on every wake -- unattended and billable -- behind one log line nobody reads.

One precision that matters, because it narrows the claim: this does **not** fire
whenever the disk misbehaves. A *persisting* read failure needs no guard, since
`due_for_nightly` asks `nightly_enabled` first, which reads through `read_state`,
so authorization collapses to False and the loop goes quiet by itself. The
repeat belongs to the **write** failure, and to a **transient** read failure that
clears before the next wake, where authorization returns while the stamp is still
missing.

## Why it matters

- **Silent, permanent, and self-concealing (1).** Nothing raises, nothing logs,
  and the panel afterwards shows exactly what the file says -- an account with
  backups switched off looks like an account whose owner switched them off.
- **It hits the accounts that were not part of the request (1).** The mutation
  that triggers it succeeds and looks correct; the accounts destroyed are the
  bystanders.
- **It removes a durable-data protection, not a convenience (1).** What stops is
  the nightly snapshot of memory, workspace, config, crons and sessions. The
  operator finds out when they need a restore.
- **It spends the owner's money unattended (2).** Each wake re-uploads a snapshot
  the bucket already holds, paying PUT and storage every time. On a versioned
  bucket every repeat is retained as another version, so the cost compounds.
- The window is not exotic on the platform this product ships on: a brief
  unreadable moment on a small JSON file under an on-access scanner is the
  ordinary Windows failure this repo already carries retry helpers for
  elsewhere.

## What changed (motivation -> approach -> change)

**Symptom:** a mutation for one account empties the other accounts' state; and a
backup whose record fails to persist is re-uploaded on every wake.

**Root cause:** one read function served two callers with incompatible failure
contracts. For the display caller, "unreadable" and "absent" may both degrade to
empty. For the read-modify-write caller they must not: only *absent* means the
document is empty, and *unreadable* means the document still exists and must not
be overwritten unread. The second defect is the same class one layer up -- a
handler whose scope is wider than the failure it was written for.

**Change** -- `backup.py` and `routes.py`:

1. **`_read_state_for_update()`** -- the read a whole-document rewrite is allowed
   to stand on. `FileNotFoundError` -> `{}` (the genuine first write).
   `json.JSONDecodeError` -> `{}`, preserving the **existing, deliberate**
   repair-on-write behaviour documented on `_account_state` (a document that
   parsed to nothing usable carries nothing to lose). Every other `OSError`
   propagates, so the mutation is abandoned and the file is left as it is.
   `_locked_state_update` now uses it; `read_state` is untouched and stays the
   display read.

2. **`_record_run` handles that `OSError` rather than raising it**, because the
   archive is already in the bucket and a 500 would mint a duplicate upload --
   the same harm the corrupted-`runs` branch immediately above it exists to
   avoid.

3. **The completed run is held in process-local `_unpersisted_runs`, which
   `last_runs` merges in.** This is what stops defect (2): `due_for_nightly`
   reads its answer through `last_runs`, so a run whose write failed still counts
   as having happened and the loop does not re-fire inside the window. Worst case
   degrades from "re-upload every wake, forever" to "at most one extra upload per
   gateway restart" -- bounded, and honest, since the archive really is in the
   bucket. The entry is dropped as soon as a write for that key lands, so it is a
   stopgap and not a second source of truth.

   The entry is keyed by the state **file** as well as account and kind: it is a
   claim about one document, so it must never answer for a different one.
   Eviction is **monotonic** -- only a record strictly older than the stamp just
   persisted is dropped -- because the pop happens after the sidecar lock is
   released, and because two gateway processes hold separate in-memory caches, so
   no file lock can serialize one process's pop against the other's cache. The
   run stamp is written with `timespec="microseconds"` rather than seconds, so two
   uploads finishing in the same second are orderable; at second precision they
   compare equal and the overlay cannot tell which upload is later.

4. **`nightly_enabled` is deliberately left fail-closed**, and the asymmetry with
   (3) is argued in its docstring so it is not read as an inconsistency. That bit
   authorizes spending money with nobody present: read it optimistically and an
   unreadable file becomes a reason to start uploading, while refusing costs one
   skipped window the next wake picks up. The run record is the mirror image -- a
   record of something already paid for, so dropping it does not prevent a charge,
   it causes one.

5. **`_read_state_for_update` raises `_StateUnreadable`, an `OSError` subclass**,
   so the log names which half failed. Reporting a full disk as "could not be
   read" sends the reader to check permissions. Keeping it an `OSError` subclass
   means `set_nightly` behaves exactly as before the split.

6. **`routes.py::_handle_backup_nightly` maps the newly reachable `OSError` to a
   structured error** -- `{"error": ..., "code": "state_persist_failed"}` at 500 --
   rather than a bare 500 with no machine-readable `code`. The message is fixed
   rather than the `OSError`'s own text, which renders the absolute path of the
   state file; the log carries that for whoever is debugging.

`set_nightly` deliberately does **not** get (2)'s treatment: there the write *is*
the whole operation, and answering `{"nightly": true}` for a toggle that was
never persisted is the lie this change exists to remove. It surfaces the error,
which is what (6) then renders.

The two sibling instances of the same lenient-read-into-rewrite shape --
`shares.py::_load` and `library.py::read_ledger` -- were called out as out of
scope here and have since been fixed and merged as #7620, and this branch is
rebased onto a `main` that contains them.

## Tests

Green CI proves nothing regressed. What follows is the evidence that the fix does
its job, stated as the mechanism rather than as a count: for each fix, deleting it
makes a specific test fail, and that failure is the defect returning.

**The load-bearing one.** `test_a_lost_write_does_not_leave_the_nightly_loop_due`
asserts that a write failure returns the record **without raising** and leaves
`due_for_nightly` **False**. Delete the in-memory hold and this test fails, and
that failure *is* the nightly loop resuming its re-uploads. It is the workability
claim for defect (2) in one assertion.

Every mechanism was mutation-verified by reverting it and confirming which test
reddens. The table covers both halves of the invariant: rows 1-6 and 9 are the write
half, row 10 is the read half, rows 7-8 and 11-12 are the ordering and
exception-safety machinery the write half needs to be correct.

| reverted mechanism | tests that go red |
|---|---|
| the in-memory hold in `_record_run` | lost-write-not-due, transient-read-not-re-upload, panel-reads-held-run |
| the `last_runs` overlay | those three, plus the takeover test |
| the read/write log-wording split | write-wording test (read-wording still passes) |
| `_forget_unpersisted` | takeover test |
| the state path in the memory key | scoping test, and the takeover test (the pop key stops matching) |
| the `_StateUnreadable` wrap | read-wording test |
| non-monotonic (unconditional) eviction | `test_a_persisting_run_does_not_evict_a_newer_held_run` |
| the stamp reverted to `timespec="seconds"` | `test_two_runs_in_the_same_second_are_distinguishable` |
| the `except OSError` in `_handle_backup_nightly` | structured-error test |
| the lenient `read_state()` restored inside the lock | `test_a_transient_read_failure_does_not_wipe_the_other_account` |
| the stamp moved back outside the lock | `test_the_run_is_stamped_inside_the_lock_not_before` |
| the `OSError` guard dropped from `_state_key()` | `test_an_unresolvable_data_dir_neither_raises_nor_loses_the_run` |
| eviction narrowed back to strictly-older | `test_a_held_run_with_an_equal_stamp_is_evicted` |

**Two honest gaps in that table**, stated here rather than left for a reviewer to
find, because a table that looks uniformly green is worth less than one with its
limits named.

First, `test_the_later_of_two_same_second_runs_wins_the_overlay` does **not** red
under the seconds mutant. Any stamp derived from the persisted one is orderable by
construction, so only two real `_record_run` calls inside one second exercise the
equality. The precision fix is pinned by
`test_two_runs_in_the_same_second_are_distinguishable` alone; the other test pins the
overlay's ordering, not the precision.

Second, the byte-identical assertion in
`test_a_transient_read_failure_does_not_wipe_the_other_account` is not what the
lenient-read mutant catches. That mutant reds earlier, at
`DID NOT RAISE <class 'OSError'>`, before the byte comparison is reached. The byte
assertion is therefore a stronger *statement* of the invariant -- the file was not
rewritten at all, which also rules out a partial write and a dropped run record --
rather than the thing this mutant exercises. Its value is catching a future change
that raises but writes anyway.

For the read half, the negative controls remain the point: a missing file is still a
first write, and a corrupt file still repairs on write. They fail if the guard is
over-broad ("refuse whenever the read fails"), so the fix cannot quietly grow into
refusing on corruption too. Only the state path is made unreadable (a
`Path.read_text` guard matching the state file exactly), and the assertions read the
file through a reference captured *before* the failure is injected, so they observe
the real durable state.

`259 passed` across `test_aws_control_backup.py`, `test_aws_control_routes.py` and
`test_aws_control_app.py`. `black`, `isort`, `flake8` and `mypy` clean on the
changed files -- mypy caught a real error before CI did, where `record` inferred as
`dict[str, object]` from its mixed value types so `record["at"]` was not a `str` at
the new call site.

Two of these fixes were found by CI on a platform the local runs cannot reproduce,
both from clock resolution: `timespec="seconds"` made same-second uploads unorderable
in the merge rule, and the Windows shard then showed that two back-to-back runs can
stamp identically, which the strictly-older eviction rule refused to evict. Recorded
because it is the argument for not trusting a local-only green on this file.

## Manual verification

N/A -- unit coverage sufficient: both failures are filesystem errors on a specific
path, which the tests inject at exactly the call the production code makes, and
the assertions are on the real on-disk bytes afterwards.

## Related Issues

None -- found by audit of the `aws_control` backend's persistence paths. Sibling
instances fixed separately in #7620.

## Pattern harvest

Rule candidate: review-prompt

Pattern: "a lenient read used as the base of a whole-document rewrite". A reader
that degrades every failure to an empty value is correct for rendering and
destructive for a read-modify-write, because there `{}` is not an absence of
input -- it is an instruction to delete everything the caller did not re-supply.
The two callers need different failure contracts even when they want the same
happy path, and a lock around the write does not protect against it.

Second rule candidate, from this PR's own second revision: "an `except` added to
absorb one newly-propagating failure will also absorb every sibling failure in the
same block". Widening a try to cover a read also covered the write, and swallowing
a write is not the same kind of loss -- here it converted a status gap into
repeated unattended billable uploads, because a scheduler decided due-ness from
the state the swallowed write was supposed to record.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text -- it will be added here once Legal provides it. -->

