### PR TITLE
test(irq): replace real sleeps with a stepped fake clock (#7598)

### DIFF
--- a/test/test_irq.py
+++ b/test/test_irq.py
@@ -37,18 +37,56 @@ from kiro_crew.irq import (
 )
 
 #: Grace floor used by tests that need a window to close. Paired with
-#: :func:`_settle`, which pushes wall-clock past it.
+#: :func:`_settle`, which steps the fake clock past it.
 _COALESCE = 0.01
 
 
+class _FakeClock:
+    """A wall clock that moves only when a test advances it.
+
+    Installed over the ``time`` name that :mod:`kiro_crew.irq` reads (see
+    :func:`_deterministic_clock`), so every interval the kernel measures is
+    exact by construction. The assertions this protects are the ones that
+    need an interval to stay SHORT -- two back-to-back ``_verdict()`` calls
+    asserting a floor has NOT closed yet had only ``_COALESCE`` (10 ms) of
+    real wall clock between them, which a loaded CI runner can overshoot.
+    With a clock that nothing but an explicit :meth:`advance` moves, no
+    scheduling stall can age a window between two calls.
+    """
+
+    def __init__(self, start: float) -> None:
+        self._now = start
+
+    def time(self) -> float:
+        return self._now
+
+    def advance(self, secs: float) -> None:
+        self._now += secs
+
+    def reset(self, start: float) -> None:
+        self._now = start
+
+    def __getattr__(self, name: str) -> object:
+        raise AttributeError(
+            f"_FakeClock does not fake time.{name}; kiro_crew.irq grew a clock "
+            "read beyond time.time(). Cover it here (see _deterministic_clock)."
+        )
+
+
+#: The clock every test in this module runs on; re-seeded per test by the
+#: autouse :func:`_deterministic_clock` fixture. Nothing outside a test body
+#: may read or cache it -- the per-test reset is what keeps tests independent.
+_clock = _FakeClock(0.0)
+
+
 def _settle() -> None:
-    """Advance wall clock past ``_COALESCE`` so an OPEN window may now fire.
+    """Advance the clock past ``_COALESCE`` so an OPEN window may now fire.
 
     A window cannot open and fire within one tick -- ``elapsed`` is zero at
     the moment it opens -- so every coalesced wake costs at least one extra
     tick. See ``test_coalesced_wake_always_costs_an_extra_tick``.
     """
-    time.sleep(_COALESCE * 3)
+    _clock.advance(_COALESCE * 3)
 
 
 @pytest.fixture(autouse=True)
@@ -56,6 +94,22 @@ def _isolated_home(tmp_path, monkeypatch):
     """Point the kernel's state directory at a private tmp home."""
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_clock(monkeypatch):
+    """Give ``kiro_crew.irq`` a clock that only this module can move.
+
+    The patch targets the module attribute ``kiro_crew.irq.time`` -- the name
+    the kernel's ``time.time()`` reads resolve -- never the stdlib module
+    object, so the fake is scoped to the kernel and nothing else in the
+    process sees it. Seeding from the real clock keeps the absolute values
+    plausible; determinism comes from the clock being frozen BETWEEN explicit
+    advances, not from the seed.
+    """
+    _clock.reset(time.time())
+    monkeypatch.setattr("kiro_crew.irq.time", _clock)
+    return _clock
 
 
 def _ctx(message: str = "{}", job_id: str = "job-1") -> types.SimpleNamespace:
@@ -385,7 +439,7 @@ def test_an_entry_left_by_a_partial_fire_still_reaches_the_cap():
                 "epoch": "e1",
                 # What a partial fire leaves: the sticky half already delivered,
                 # one epoch-scoped survivor carrying the age it earned.
-                "coalescing": {key: {"brief": "a red", "opened_at": time.time() - 600}},
+                "coalescing": {key: {"brief": "a red", "opened_at": _clock.time() - 600}},
             }
         ),
         encoding="utf-8",
@@ -767,7 +821,9 @@ def test_a_sticky_key_is_dropped_once_past_the_realert_window():
         ]
     )
     assert isinstance(_verdict(probe, coalesce_secs=0, realert_secs=0.01), Report)
-    time.sleep(0.05)
+    # Crosses the 0.01s re-alert window -- an irq-measured interval, so it is a
+    # clock advance, not a real sleep.
+    _clock.advance(0.05)
     assert isinstance(_verdict(probe, coalesce_secs=0, realert_secs=0.01), Skip)
     state = load_state(state_path("test-kind", "sub-1", "job-1"))
     assert not [k for k in state.get("alerted", {}) if "comment:1" in k]
@@ -806,7 +862,7 @@ def test_state_written_before_the_sentinels_existed_costs_no_extra_wake():
     path = state_path("test-kind", "sub-1", "job-1")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        json.dumps({"epoch": "e1", "alerted": {"red:a": time.time()}}), encoding="utf-8"
+        json.dumps({"epoch": "e1", "alerted": {"red:a": _clock.time()}}), encoding="utf-8"
     )
     probe = ScriptedProbe([Tick(epoch="e1", observations=[_wake("red:a")])])
     assert isinstance(_verdict(probe, coalesce_secs=0), Skip)
@@ -1160,7 +1216,7 @@ def test_a_window_written_before_per_entry_ages_keeps_the_age_it_had():
             {
                 "epoch": "e1",
                 "coalescing": {key: "said"},
-                "coalesce_started_at": time.time() - 600,
+                "coalesce_started_at": _clock.time() - 600,
             }
         ),
         encoding="utf-8",


### PR DESCRIPTION
## Problem / Motivation

`test/test_irq.py::test_an_entry_joining_after_a_partial_fire_serves_its_own_floor` fails intermittently on loaded CI runners (observed on PR #7300, `Backend Tests (3.12, 2)`, as a bare `AssertionError: assert False`; the rerun of the same commit passed). The file measures its coalescing floor in real wall clock: `_COALESCE = 0.01` with `_settle()` sleeping `_COALESCE * 3`. Two assertions require the opposite of settling -- that a floor has NOT yet expired -- and their entire budget is the gap between two back-to-back `_verdict()` calls. Any scheduling stall >= 10 ms there (4 xdist workers, ~19.8k items, memory-bounded box) lets the joining entry's own floor close, so it Reports instead of Skips.

Closes #7598

## Why it matters

The flake reddens whichever `Backend Tests` shard carries the test plus the downstream `Coverage Gate`, taxing every PR on the repo with rerun round-trips. And the test guards a recently fixed behaviour (#7431: a coalescing entry gets its own floor, not the window's age), so it must stay -- deleting/skipping/flaky-marking it would unguard that fix.

## What changed (motivation -> approach -> change)

Symptom: assertions about intervals staying SHORT race real scheduling. Root cause: the kernel reads `time.time()` while the test controls elapsed time only by sleeping, so the clock keeps moving between the test's own statements. Change: give the test module full ownership of the clock the kernel reads.

- A `_FakeClock` (`time()` / `advance()` / `reset()`) is installed by an autouse fixture over the module attribute `kiro_crew.irq.time` -- the name the kernel's clock reads resolve -- via `monkeypatch.setattr`, never the stdlib module object, so the fake is scoped to the kernel and invisible to everything else in the process.
- `_settle()` now advances the fake clock by `_COALESCE * 3` instead of sleeping; every existing call site keeps its exact meaning at zero wall cost.
- The three pre-aged state stamps (`opened_at`/`alerted`/`coalesce_started_at`) derive from the fake clock, and the one `time.sleep(0.05)` crossing a `realert_secs=0.01` window (a kernel-measured interval) becomes a clock advance. No other real-time dependency exists in the file; `test_future_timestamp_reads_as_stale_...` uses the absolute literal `2**40` and is unaffected.
- The two "has not waited" assertions are now exact BY CONSTRUCTION: a clock that moves only when the test moves it cannot be aged by a scheduling stall between two `_verdict()` calls. That construction -- not a reproduced flake -- is the proof of the fix (the reporter could not reproduce locally and said so; a workstation has more headroom than a loaded CI box).
- `_FakeClock.__getattr__` raises a directive error if `kiro_crew.irq` ever grows a clock read beyond `time.time()` (e.g. `monotonic`), so the failure names this fixture instead of reading as harness breakage.

Deliberately NOT done: no injectable-clock parameter in `src/kiro_crew/irq.py`. The test-side seam is sufficient, a production seam widens the blast radius, and PR #7584 (open) is concurrently editing that file -- a production change here invites a real conflict. Also not done: raising `_COALESCE` (only widens the window a stall must beat, keeping the assertion probabilistic while slowing the suite).

Relationship to PR #7609: opened concurrently for the same issue by a kiro-agent session under the same login, it threads a `clock` callable through `run()` in `src/kiro_crew/irq.py` (+9/-2 production lines overlapping the region #7584 edits) and converts 2 of the 4 real-clock uses in the test file. This PR is the zero-production-surface alternative: no `irq.py` change, no #7584 conflict, all 4 real-clock uses converted, and the mutation check below. One of the two should merge; maintainer's call.

## Tests

All 60 tests in `test/test_irq.py` pass, now in ~5s wall (previously each `_settle()` burned 30 ms of real sleep). Full suite: 78786 passed; the 96 failures + 2 errors are host-environment issues byte-identical to a pristine-main control run at the same base (fail-set diff empty in both directions).

Mutation check (proving the converted test still guards #7431): temporarily reverting the joining-entry behaviour in `src/kiro_crew/irq.py` -- handing a joining entry the window's oldest `opened_at` instead of its own -- makes `test_an_entry_joining_after_a_partial_fire_serves_its_own_floor` FAIL under the fake clock with exactly "a joining entry must not inherit the window's age"; restoring the file returns it to green. A determinism conversion that still catches the guarded defect is a determinism fix, not a defanged test.

Pre-push review: GPT 5.6 Sol PASS (0 findings); Opus 5 PASS (0 blocking, 4 Low advisories -- 3 adopted: stale clock-read-count docstring, `__getattr__` directive guard, shared-global invariant comment; 1 was explicitly no-action-needed).

## Manual verification

N/A -- unit coverage sufficient: the change is confined to one test module and the mutation check exercises the kernel path the tests guard.

## Pattern harvest

Class: a test asserting an interval stays SHORT under a real clock is a latent flake on any loaded runner -- `_settle()`-style helpers make the window-CLOSED direction safe, but nothing protects the window-STILL-OPEN direction. Reusable shape: install a stepped fake clock over the clock name as the module under test resolves it (`monkeypatch.setattr("pkg.mod.time", fake)`), convert sleeps to advances, and mutation-check that the converted test still fails when the guarded behaviour is reverted. Candidates elsewhere would grep for `time.sleep` adjacent to assertions that something has NOT happened; this PR deliberately stops at `test_irq.py` per the issue scope.