### PR TITLE
fix(aws-control): never publish the share or library ledger over a failed read

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/library.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/library.py
@@ -79,11 +79,39 @@ def _ledger_path() -> Path:
 
 
 def read_ledger() -> dict[str, Any]:
+    """The push ledger, or ``{}`` when there is nothing readable.
+
+    A DISPLAY read: the Library list must keep rendering local artifacts on a
+    ledger it could not load. See :func:`_read_ledger_for_update` for why the
+    single writer may not stand on the same answer.
+    """
     try:
         data = json.loads(_ledger_path().read_text(encoding="utf-8"))
         return data if isinstance(data, dict) else {}
     except (FileNotFoundError, OSError, json.JSONDecodeError):
         return {}
+
+
+def _read_ledger_for_update() -> dict[str, Any]:
+    """The ledger :func:`_update_ledger` is allowed to publish over.
+
+    The write rewrites the WHOLE document, so an empty base there does not mean
+    "no records to carry forward" -- it means "drop every other account's push
+    state, and every other slug's record for this one". Only a missing file
+    makes that true; an unreadable one (a transient EACCES/EIO, a scanner
+    holding the handle on Windows) is state we still have. Losing it is not
+    cosmetic: the console then reports pushed artifacts as never pushed, which
+    offers a re-push (a duplicate billable upload) and leaves the real cloud
+    copies with no record to remove them by.
+
+    Corruption keeps reading as empty, matching the display read and the
+    per-account tolerance :func:`_update_ledger` already applies.
+    """
+    try:
+        data = json.loads(_ledger_path().read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def _write_ledger(ledger: dict[str, Any]) -> None:
@@ -108,6 +136,10 @@ def _update_ledger(account: str, mutate: Callable[[dict[str, Any]], bool]) -> bo
     did, so a reconcile that finds nothing stale costs no disk write on a
     surface that renders on every page load.
 
+    Raises ``OSError`` when the existing ledger could not be read; see
+    :func:`_read_ledger_for_update` for why that is not collapsed to an empty
+    document here.
+
     The lock is held for a read plus an atomic rename and nothing else. Callers
     that also touch S3 do that OUTSIDE this block on purpose:
     :func:`platform_compat.file_lock` documents every in-tree critical section
@@ -119,7 +151,7 @@ def _update_ledger(account: str, mutate: Callable[[dict[str, Any]], bool]) -> bo
     _ledger_path().parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
-            ledger = read_ledger()
+            ledger = _read_ledger_for_update()
             slugs = ledger.get(account)
             if not isinstance(slugs, dict):
                 slugs = {}

--- a/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
@@ -44,11 +44,39 @@ def _now() -> dt.datetime:
 
 
 def _load() -> list[dict[str, Any]]:
+    """Every recorded share, or ``[]`` when there is nothing readable.
+
+    A DISPLAY read: :func:`list_shares` must render on a store it could not
+    load rather than failing the Access section. See :func:`_load_for_update`
+    for why a mutation may not stand on the same answer.
+    """
     try:
         data = json.loads(_store_path().read_text(encoding="utf-8"))
         return data if isinstance(data, list) else []
     except (FileNotFoundError, OSError, json.JSONDecodeError):
         return []
+
+
+def _load_for_update() -> list[dict[str, Any]]:
+    """The ledger a read-modify-write is allowed to publish over.
+
+    Both mutations below rewrite the WHOLE file from what they read, so an
+    empty base is not "nothing to carry forward" -- it is "forget every share
+    already recorded". Only a missing file makes that true. An unreadable one
+    (a transient EACCES/EIO, a scanner holding the handle on Windows) is a
+    ledger we still have, and this one is the only local record of live
+    PRESIGNED URLs: they are bearer grants that cannot be revoked, so a
+    truncated ledger under-reports access that is still working. The error
+    propagates and the mutation is abandoned instead.
+
+    A corrupt document keeps reading as empty, matching the display read: it
+    parsed to nothing usable, so there is nothing to lose by replacing it.
+    """
+    try:
+        data = json.loads(_store_path().read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+    return data if isinstance(data, list) else []
 
 
 def _save(entries: list[dict[str, Any]]) -> None:
@@ -90,7 +118,7 @@ def record_share(
     _store_path().parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
-            entries = _prune(_load())
+            entries = _prune(_load_for_update())
             entries.append(entry)
             _save(entries[-_MAX_SHARES:])
     return entry
@@ -110,7 +138,7 @@ def forget_share(share_id: str) -> Optional[dict[str, Any]]:
     _store_path().parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
-            entries = _prune(_load())
+            entries = _prune(_load_for_update())
             kept = [e for e in entries if e.get("id") != share_id]
             removed = next((e for e in entries if e.get("id") == share_id), None)
             _save(kept)

--- a/test/test_aws_control_app.py
+++ b/test/test_aws_control_app.py
@@ -746,6 +746,77 @@ class TestShares:
         assert record["id"] in raw
         assert shares.list_shares(ACCOUNT)[0]["key"] == "a.txt"
 
+    def test_a_read_that_failed_never_truncates_the_share_ledger(self, tmp_path, monkeypatch):
+        # `_load` collapses every failure to []. As the base of `record_share`'s
+        # whole-file rewrite that empty list means "forget every share already
+        # recorded" -- and this ledger is the only local record of live presigned
+        # URLs, which are unrevokable bearer grants. Under-reporting them is the
+        # security-visible half of the loss.
+        import contextlib
+        from pathlib import Path
+
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        kept = shares.record_share(
+            account=ACCOUNT, section="drive", key="live.txt", expires_secs=3600
+        )
+        store = tmp_path / "shares.json"
+        real_read_text = Path.read_text
+        broken = {"on": True}
+
+        def guarded(path_self, *args, **kwargs):
+            if broken["on"] and Path(path_self) == store:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", guarded)
+        with contextlib.suppress(OSError):
+            shares.record_share(
+                account=ACCOUNT, section="drive", key="second.txt", expires_secs=3600
+            )
+        with contextlib.suppress(OSError):
+            shares.forget_share(kept["id"])
+
+        # The durable harm, asserted directly: the live bearer grant recorded
+        # before the failure must still be in the ledger.
+        broken["on"] = False
+        assert [e["key"] for e in shares.list_shares(ACCOUNT)] == ["live.txt"]
+
+    def test_an_unreadable_share_store_refuses_the_mutation(self, tmp_path, monkeypatch):
+        # A mint that cannot be recorded must not answer as though it were.
+        from pathlib import Path
+
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        shares.record_share(account=ACCOUNT, section="drive", key="live.txt", expires_secs=3600)
+        store = tmp_path / "shares.json"
+        real_read_text = Path.read_text
+
+        def guarded(path_self, *args, **kwargs):
+            if Path(path_self) == store:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", guarded)
+        with pytest.raises(OSError):
+            shares.record_share(account=ACCOUNT, section="drive", key="x.txt", expires_secs=3600)
+
+    def test_a_missing_share_store_is_still_a_first_write(self, tmp_path):
+        # Absent is the one failure where [] is the truth.
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        assert not (tmp_path / "shares.json").exists()
+        shares.record_share(account=ACCOUNT, section="drive", key="first.txt", expires_secs=3600)
+        assert [e["key"] for e in shares.list_shares(ACCOUNT)] == ["first.txt"]
+
+    def test_a_corrupt_share_store_still_repairs_on_write(self, tmp_path):
+        # Existing tolerance, pinned alongside the new guard.
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        (tmp_path / "shares.json").write_text("[not json", encoding="utf-8")
+        shares.record_share(account=ACCOUNT, section="drive", key="after.txt", expires_secs=3600)
+        assert [e["key"] for e in shares.list_shares(ACCOUNT)] == ["after.txt"]
+
     def test_expired_shares_are_pruned_and_forget_removes(self):
         from kiro_crew.apps.builtins.aws_control.backend import shares
 

--- a/test/test_aws_control_library.py
+++ b/test/test_aws_control_library.py
@@ -14,9 +14,11 @@ Comments explain WHY each case matters, matching the sibling file's style.
 
 from __future__ import annotations
 
+import contextlib
 import datetime as dt
 import json
 import time
+from pathlib import Path
 from types import SimpleNamespace as NS
 from unittest import mock
 
@@ -33,6 +35,14 @@ def _ledger_at(monkeypatch, tmp_path):
     path = tmp_path / "library.json"
     monkeypatch.setattr(library, "_ledger_path", lambda: path)
     return path
+
+
+def _adds_a_record(slugs):
+    """A mutation that really changes something -- `_update_ledger` skips the
+    write when the callback reports no change, so a falsy edit would never
+    reach the rewrite these tests are about."""
+    slugs["new"] = {"version": 1}
+    return True
 
 
 # --------------------------------------------------------------------------
@@ -396,6 +406,64 @@ class TestUpdateLedger:
         ledger = library.read_ledger()
         assert ledger[other] == {"kept": {"version": 7}}
         assert ledger[ACCOUNT] == {}
+
+    def test_a_read_that_failed_is_never_published_over(self, tmp_path, monkeypatch):
+        # `read_ledger` is a DISPLAY read: it collapses every failure to {} so a
+        # render never crashes. As the base of this whole-document rewrite that
+        # empty dict is not "nothing to carry forward", it is "delete every other
+        # account's push state". A transient EACCES (a scanner holding the handle)
+        # must abandon the mutation, not publish over state nobody read.
+        path = _ledger_at(monkeypatch, tmp_path)
+        other = "999988887777"
+        path.write_text(json.dumps({other: {"kept": {"version": 7}}}), encoding="utf-8")
+        real_read_text = Path.read_text
+        broken = {"on": True}
+
+        def guarded(path_self, *args, **kwargs):
+            if broken["on"] and Path(path_self) == path:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", guarded)
+        with contextlib.suppress(OSError):
+            library._update_ledger(ACCOUNT, _adds_a_record)
+
+        # The durable harm, asserted directly: the OTHER account's push state
+        # must still be on disk, whatever this mutation did or did not do.
+        broken["on"] = False
+        assert library.read_ledger() == {other: {"kept": {"version": 7}}}
+
+    def test_an_unreadable_ledger_refuses_the_mutation(self, tmp_path, monkeypatch):
+        # The caller must be told, rather than being handed a silent no-op that
+        # reads as success.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(json.dumps({ACCOUNT: {"kept": {"version": 7}}}), encoding="utf-8")
+        real_read_text = Path.read_text
+
+        def guarded(path_self, *args, **kwargs):
+            if Path(path_self) == path:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", guarded)
+        with pytest.raises(OSError):
+            library._update_ledger(ACCOUNT, _adds_a_record)
+
+    def test_a_missing_ledger_is_still_a_first_write(self, tmp_path, monkeypatch):
+        # Absent is the one failure where {} is the truth. The guard above must
+        # not turn the very first push into an error.
+        path = _ledger_at(monkeypatch, tmp_path)
+        assert not path.exists()
+        assert library._update_ledger(ACCOUNT, _adds_a_record) is True
+        assert library.read_ledger()[ACCOUNT] == {"new": {"version": 1}}
+
+    def test_a_corrupt_ledger_still_repairs_on_write(self, tmp_path, monkeypatch):
+        # Existing tolerance, pinned so the unreadable-file guard is not mistaken
+        # for a licence to start failing on corruption too.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text("{not json", encoding="utf-8")
+        assert library._update_ledger(ACCOUNT, _adds_a_record) is True
+        assert library.read_ledger()[ACCOUNT] == {"new": {"version": 1}}
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

The AWS Control app keeps two JSON ledgers, and a single transient read failure
empties either one.

Both `shares._load` and `library.read_ledger` swallow every failure:

```python
    except (FileNotFoundError, OSError, json.JSONDecodeError):
        return []   # / {}
```

That is right for the readers they were written for — `list_shares` and the
Library list must keep rendering on a file they could not load. But both are
also the base of a **whole-file rewrite**:

```python
# shares.record_share
entries = _prune(_load())
entries.append(entry)
_save(entries[-_MAX_SHARES:])          # rewrites the entire file

# library._update_ledger  (the ONE writer)
ledger = read_ledger()
...
_write_ledger(ledger)                  # rewrites the entire document
```

In that position the empty value is not "nothing to carry forward" — it is an
instruction to delete everything the caller did not re-supply. A `PermissionError`
or `EIO` on the read (a scanner holding the handle on Windows, a momentary
EACCES) therefore means:

- **`shares.json`** — minting the next share **forgets every share already
  recorded**, and `forget_share` republishes that truncation.
- **`library.json`** — recording one push **drops every other account's push
  state**, and every other slug's record for the account being written.

The sidecar `file_lock` around each is doing its job; the loss happens *inside*
it, because the damage is in the read, not in the interleaving.

## Why it matters

The two losses are different, and neither is cosmetic:

- **The share ledger is a security-visibility record.** A presigned URL is
  self-contained: once minted, S3 honours it until it expires and there is
  nothing to revoke. The module docstring says so, and says the ledger exists
  precisely so the Access section can answer "what was shared, and when does it
  stop working". Truncating it makes the console **under-report live bearer
  grants that are still working** — the operator sees one share and there are
  six. This is the one place that answer is kept.

- **The push ledger gates a paid, irreversible action.** Emptied, the Library
  reports pushed artifacts as never pushed. That offers a re-push (a duplicate
  billable S3 upload) and leaves the real cloud copies with no record to remove
  them by — the "filled it, cannot empty it" gap the same module already calls
  out and works to avoid elsewhere.

Both are silent and self-concealing: nothing raises, nothing logs, and the panel
afterwards faithfully renders what the file now says.

## What changed (motivation → approach → change)

**Symptom:** one unlucky read empties a ledger; the mutation that triggered it
looks like it succeeded.

**Root cause:** one read function serving two callers with incompatible failure
contracts. A render may degrade "unreadable" to "empty". A read-modify-write may
not, because for it only *absent* means the document is empty — *unreadable*
means the document still exists and must not be overwritten unread.

**Change** — two files, one added function each, and the two call sites that
consume them:

- `shares.py`: **`_load_for_update()`**, used by `record_share` and
  `forget_share`. `_load` is untouched and stays the display read for
  `list_shares`.
- `library.py`: **`_read_ledger_for_update()`**, used by `_update_ledger`.
  `read_ledger` is untouched and stays the display read (it is also public and
  called from `routes.py` and `list_pushable`).

In both, `FileNotFoundError` → empty (the genuine first write) and every other
`OSError` propagates, so the mutation is abandoned and the file is left alone.

`json.JSONDecodeError` deliberately keeps reading as empty in both. That is
existing, intentional behaviour — a document that parsed to nothing usable
carries nothing to lose, and `_update_ledger` already applies the same tolerance
to a corrupted per-account entry. Changing it would be a separate decision, and
the tests below pin it so this guard is not mistaken for a licence to start
failing on corruption too.

Callers see the error rather than a silent no-op, which is the point: a mint
that could not be recorded, or a push whose record did not land, must not answer
as though it had. This mirrors the `backup.json` fix in #7618 — the same shape,
which that PR's *Pattern harvest* names as the remaining instances. The
consequences differ enough (bearer-grant visibility; duplicate paid uploads) to
be reviewed on their own, and the file sets do not overlap, so the two land
independently.

## Tests

Eight cases, in each module's existing home
(`test_aws_control_library.py::TestUpdateLedger`, `test_aws_control_app.py::TestShares`).
Only the ledger path is made unreadable, via a `Path.read_text` guard matching
that exact file and a flag the test clears afterwards — so the assertions
observe the real durable bytes.

Per ledger:

| test | invariant |
|---|---|
| `..._a_read_that_failed_is_never_published_over` / `..._never_truncates_the_share_ledger` | the records written before the failure are **still on disk** |
| `..._refuses_the_mutation` | the caller is told, rather than handed a silent no-op |
| `..._is_still_a_first_write` | absent ≠ unreadable — the first write still works |
| `..._still_repairs_on_write` | corruption keeps its existing repair behaviour |

The last two are the guard's negative controls: they fail if the fix is
over-broad.

Red-before on this branch's parent (`3a5824d20`), production change reverted —
the first two state the loss directly rather than only reporting a missing
raise:

```
FAILED test_aws_control_app.py::TestShares::test_a_read_that_failed_never_truncates_the_share_ledger
        - AssertionError: assert [] == ['live.txt']
FAILED test_aws_control_library.py::TestUpdateLedger::test_a_read_that_failed_is_never_published_over
        - AssertionError: assert {'123456789012': {'new': {'version': 1}}}
                              == {'999988887777': {'kept': {'version': 7}}}
FAILED ...::TestShares::test_an_unreadable_share_store_refuses_the_mutation - DID NOT RAISE
FAILED ...::TestUpdateLedger::test_an_unreadable_ledger_refuses_the_mutation - DID NOT RAISE
4 failed, 9 passed
```

`[] == ['live.txt']` is the live presigned-share record gone; the dict comparison
is the other account's entry replaced outright.

After the fix:

```
test_aws_control_library.py test_aws_control_app.py     152 passed, 7 skipped, 2 failed
test_aws_control_routes.py test_aws_control_backup.py
test_aws_control_hooks.py  test_aws_control_storage.py  201 passed, 4 skipped
```

Both failures are `test_restore_refuses_a_symlinked_*`, failing in the test's own
`(staging / "a.tar.gz").symlink_to(target)` with `OSError: [WinError 1314] A
required privilege is not held by the client` — the local Windows host cannot
create symlinks. No production code is reached, and this diff touches no symlink
path. Inherited environment limitation, not diff-owned.

`black --check` clean on all four files. `ruff check` reports the identical 17
findings before and after (`SIM117` ×13, plus one each of
`I001`/`RUF100`/`UP035`/`UP045`, all pre-existing) — no new finding. `mypy` clean
on both changed modules.

## Manual verification

N/A — unit coverage sufficient: the failure is a filesystem error on a specific
path, injected at exactly the call the production code makes, with the assertion
taken from the real on-disk bytes afterwards.

## Related Issues

None. Found by audit of the `aws_control` backend's persistence paths; these are
the two instances #7618 names as out of its scope.

## Pattern harvest

Rule candidate: review-prompt

Pattern: "a lenient read used as the base of a whole-document rewrite". A reader
that degrades every failure to an empty value is correct for rendering and
destructive for a read-modify-write, because there the empty value is not an
absence of input — it is an instruction to delete everything the caller did not
re-supply. The two callers need different failure contracts even when they share
a happy path, and a lock around the write does not protect against it. Worth a
review prompt wherever a `read_*()` helper feeds a function that serialises the
whole document back.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
