### PR TITLE
feat(security): allowlist the Figma MCP OAuth authorization endpoint

### DIFF
--- a/src/kiro_crew/security/exfil.py
+++ b/src/kiro_crew/security/exfil.py
@@ -285,7 +285,7 @@ _OAUTH_AUTHORIZATION_ENDPOINTS: frozenset[tuple[str, str]] = frozenset(
         ("gitlab.com", "/oauth/authorize"),
         ("mcp.auth.mail.superhuman.com", "/oauth2/authorize"),
         ("mcp.linear.app", "/authorize"),
-        # Maintainer-verified 2026-09-01 via RFC 8414 metadata at
+        # Maintainer-verified via RFC 8414 metadata at
         # https://mcp.miro.com/.well-known/oauth-authorization-server
         # (authorization_endpoint: https://mcp.miro.com/authorize), matching the
         # reporter's independent RFC 8414 read in issue #7578. Not (yet) a
@@ -294,6 +294,14 @@ _OAUTH_AUTHORIZATION_ENDPOINTS: frozenset[tuple[str, str]] = frozenset(
         ("mcp.miro.com", "/authorize"),
         ("mcp.notion.com", "/authorize"),
         ("vercel.com", "/oauth/authorize"),
+        # Figma's MCP authorization server (issuer https://api.figma.com) hosts
+        # its consent page on www.figma.com. Independently corroborated by the
+        # maintainer's operator via RFC 9728 protected-resource discovery on
+        # https://mcp.figma.com/mcp (authorization_servers -> api.figma.com)
+        # and its RFC 8414 metadata, which advertises
+        # authorization_endpoint https://www.figma.com/oauth/mcp — the consent
+        # host is the main web property by the provider's own design.
+        ("www.figma.com", "/oauth/mcp"),
     }
 )
 

--- a/test/oauth_url_corpus.py
+++ b/test/oauth_url_corpus.py
@@ -182,6 +182,20 @@ LEGIT_OAUTH_URLS: list[tuple[str, str]] = [
         "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
         "&code_challenge_method=S256",
     ),
+    # Figma MCP consent page (issuer api.figma.com, consent on www.figma.com;
+    # RFC 8414 metadata via RFC 9728 discovery on mcp.figma.com/mcp).
+    # developers.figma.com/docs/figma-mcp-server/
+    (
+        "figma-mcp",
+        "https://www.figma.com/oauth/mcp"
+        "?client_id=fig_abcDEF1234567890"
+        "&redirect_uri=http%3A%2F%2F127.0.0.1%3A55089%2Fcallback"
+        "&response_type=code"
+        "&scope=mcp%3Aconnect"
+        "&state=af0ifjsldkjZx9yW8vU"
+        "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        "&code_challenge_method=S256",
+    ),
 ]
 
 # Consent URLs that the ACP banner-safety gate


### PR DESCRIPTION
## Problem / Motivation

Reconnecting the **Figma** MCP server fails at the OAuth consent banner with:

```
<server> authentication failed: URL contained credential or exfiltration pattern
```

Root cause: `oauth_url_contains_credential()` only waives the generic credential/exfiltration heuristics for the high-entropy OAuth `state`/PKCE values when the consent URL's exact `(host, path)` is in the code-owned allowlist `_OAUTH_AUTHORIZATION_ENDPOINTS` (now in `src/kiro_crew/security/exfil.py`). Figma is absent, so its normal consent URL fails closed — the exact regression class the gate's own comment documents: *"A launch provider missing from this set cannot be connected at all."*

> This PR originally also covered **Miro**. That entry landed on `main` separately via #7739, so the Miro hunks were dropped during rebase and this PR is now **Figma-only**.

## Why it matters

Figma is a shipped/common MCP integration. Until this lands, every user has to hand-edit the operator keystone `oauth_endpoints.json` to connect it (undocumented; see #7578). Adding it to the builtin set makes it work out of the box.

## What changed (motivation → approach → change)

The Figma MCP consent URL is rejected by the banner gate. The fix adds one `(host, path)` pair to the code-owned allowlist.

The pair comes from Figma's own RFC 8414 metadata, reached via RFC 9728 protected-resource discovery on its MCP url: `www.figma.com` + `/oauth/mcp` (issuer `https://api.figma.com`; the consent page is hosted on `www.figma.com`, discovered from `https://mcp.figma.com/mcp`).

The diff also trims the date from the neighboring Miro comment in `exfil.py`: main outgrew the comment-history baseline for this file after #7739 landed (tracked in #9384/#9385), so any PR touching it failed the `Backend Lint & Type Check` gate. Dropping the one dated narration span returns the file to its baselined count; the verification claim itself stays.

A matching `figma-mcp` entry in the `LEGIT_OAUTH_URLS` corpus (a real consent-URL shape with fake identifiers) locks in that the banner-safety contract accepts it under default config, mirroring the pattern established for Superhuman in #5967.

## Tests

- `test/oauth_url_corpus.py` gains the `figma-mcp` entry; the existing parametrized contract tests (`test_corpus_url_not_flagged_as_credential`, `test_corpus_url_renders_banner` in `test/test_mcp_oauth_banner.py`) now cover it: the URL passes `oauth_url_contains_credential` and renders a live auth banner, not a rejection.
- `test/test_security.py` + `test/test_mcp_oauth_banner.py`: 1066 passed locally.
- `flake8` / `isort` / `black` / `mypy` clean on the changed files.

## Manual verification

N/A — unit coverage sufficient: the corpus contract test exercises the exact accept/reject decision the banner takes on this URL shape.

## Screenshots / video

N/A — backend-only diff, no user-visible UI change.

## Related Issues

Refs #7578 (opaque error / undocumented allowlist) — not closed by this PR: its asks (name the offending host in the error, RFC 8414 auto-discovery) are broader and remain valuable.

no linked issue: this is the per-provider unbreak step following the #5967 pattern; the broader tracking issue #7578 stays open by design.

## Pattern harvest

Not generalizable: one-off data addition to a code-owned allowlist; the recurring class (each new provider needs a code change) is already tracked as #7578.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
