### PR TITLE
fix(history): skip a transcript row that decodes to a non-object

### DIFF
--- a/src/kiro_crew/history_projection.py
+++ b/src/kiro_crew/history_projection.py
@@ -26,6 +26,14 @@ if TYPE_CHECKING:
     from kiro_crew.history import ConversationLog
 
 
+#: Every reader below decodes one ``.jsonl`` line at a time and then reads a
+#: field off it. ``json.JSONDecodeError`` covers the line that will not parse;
+#: it does NOT cover a line that parses to something other than an object
+#: (``[]``, ``"text"``, ``12``, ``null``), which reaches ``.get`` and raises
+#: ``AttributeError`` -- abandoning the read, and every valid row after the bad
+#: one, on an error none of these callers expect. So a decode is followed by a
+#: shape check, exactly as ``read_file_change_messages`` already does for the
+#: same rows of the same files.
 _HISTORY_LOGGER = logging.getLogger("kiro_crew.history")
 
 
@@ -149,6 +157,8 @@ class TranscriptReadProjection:
                         try:
                             data = json.loads(line.strip())
                         except ValueError:
+                            continue
+                        if not isinstance(data, dict):
                             continue
                         if data.get(
                             "_type"
@@ -410,6 +420,8 @@ class TranscriptReadProjection:
                     data = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(data, dict):
+                    continue
                 if data.get("_type") != "metadata":
                     messages.append(data)
 
@@ -501,6 +513,8 @@ class TranscriptReadProjection:
                     data = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(data, dict):
+                    continue
                 if data.get("_type") == "metadata":
                     continue
                 if roles and data.get("role") not in roles:
@@ -563,6 +577,8 @@ class TranscriptReadProjection:
                 try:
                     data = json.loads(line)
                 except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict):
                     continue
                 if data.get("_type") == "metadata":
                     continue
@@ -802,6 +818,8 @@ class SessionMetadataProjection:
                 metadata = json.loads(lines[0])
             except json.JSONDecodeError:
                 return
+            if not isinstance(metadata, dict):
+                return
             if metadata.get("_type") != "metadata":
                 return
         else:
@@ -863,6 +881,8 @@ class SessionMetadataProjection:
             try:
                 metadata = json.loads(lines[0])
             except json.JSONDecodeError:
+                return
+            if not isinstance(metadata, dict):
                 return
             if metadata.get("_type") != "metadata" or "closed" not in metadata:
                 return

--- a/test/test_history_projection_row_shape.py
+++ b/test/test_history_projection_row_shape.py
@@ -1,0 +1,143 @@
+"""A transcript row that is valid JSON but not an object must be skipped.
+
+``history_projection`` reads ``.jsonl`` transcripts line by line, and every
+reader already guards the line that will not parse::
+
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+
+That guard does not cover a line which parses fine and decodes to something
+that is not a mapping -- ``[]``, ``"text"``, ``12``, ``null``. The very next
+statement is ``data.get(...)``, so such a row raises ``AttributeError``, which
+is not what any of these callers catch: the read is abandoned and every VALID
+row after the bad one is lost with it.
+
+The file already treats this as a real hazard. ``read_file_change_messages``
+decodes the same rows of the same files and follows its ``except ValueError``
+with ``if not isinstance(data, dict)``, and ``_read_metadata_status`` and
+``delete_session`` do the same. These tests pin the remaining readers to that
+existing in-file contract rather than introducing a new one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kiro_crew.history import ConversationLog
+
+KEY = "row-shape"
+
+#: Valid JSON, no ``.get``. ``null`` is included because ``json.loads`` turns it
+#: into ``None``, which fails in the same place for a different reason.
+NON_OBJECT_ROWS = ["[]", '"just a string"', "12", "null", '["a", "b"]']
+
+
+def _seed(tmp_path: Path, bad_row: str) -> ConversationLog:
+    """A transcript with one unusable row BETWEEN two good ones.
+
+    Between, not last: a reader that stops at the bad row still returns ``m1``,
+    so only a message written AFTER it can show that the rest of the file was
+    abandoned rather than merely truncated.
+    """
+    log = ConversationLog(base_dir=tmp_path)
+    log.append(KEY, "user", "m1")
+    path = log._path(KEY)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(bad_row + "\n")
+    log.append(KEY, "assistant", "m2")
+    return ConversationLog(base_dir=tmp_path)  # fresh: no warm cache
+
+
+class TestTranscriptReadsSkipNonObjectRows:
+    def test_read_messages_keeps_the_rows_after_it(self, tmp_path: Path) -> None:
+        for index, row in enumerate(NON_OBJECT_ROWS):
+            # One transcript per shape, in its own directory: `enumerate`, not the
+            # row text, because several of these are not legal path names.
+            log = _seed(tmp_path / f"row{index}", row)
+            assert [m["content"] for m in log._read_messages(KEY)] == ["m1", "m2"], row
+
+    def test_recent_keeps_the_rows_after_it(self, tmp_path: Path) -> None:
+        # `recent` prefers the tail reader, so this covers a different loop from
+        # the one above even though the transcript is the same.
+        log = _seed(tmp_path, "[]")
+        assert [m["content"] for m in log.recent(KEY, max_messages=10)] == ["m1", "m2"]
+
+    def test_last_message_preview_reads_past_it(self, tmp_path: Path) -> None:
+        # The preview scans BACKWARDS from the end, so the bad row sits between
+        # the newest message and the reader's starting point.
+        log = _seed(tmp_path, "[]")
+        assert log.last_message_preview(KEY) == "m2"
+
+    def test_recent_from_source_still_returns_the_session(self, tmp_path: Path) -> None:
+        # This loop reads the first five lines looking for an incognito marker.
+        # It runs inside `try: ... except OSError`, which an AttributeError walks
+        # straight out of, taking the whole cross-session view with it.
+        log = _seed(tmp_path, "[]")
+        recent = log.recent_from_source(KEY.split("-")[0], max_messages=10)
+        assert [m["content"] for m in recent] == ["m1", "m2"]
+
+
+class TestMetadataWritesRefuseANonObjectFirstLine:
+    """Line 0 is the metadata row. When it will not parse, both writers below
+    ``return`` and leave the file alone; a non-object line 0 must reach the same
+    refusal instead of raising out from under the owner lock."""
+
+    def _seed_bad_metadata(self, tmp_path: Path) -> ConversationLog:
+        log = ConversationLog(base_dir=tmp_path)
+        log.append(KEY, "user", "m1")
+        path = log._path(KEY)
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        lines[0] = "[]\n"
+        path.write_text("".join(lines), encoding="utf-8")
+        return ConversationLog(base_dir=tmp_path)
+
+    def test_update_metadata_is_a_noop(self, tmp_path: Path) -> None:
+        log = self._seed_bad_metadata(tmp_path)
+        before = log._path(KEY).read_text(encoding="utf-8")
+        log.update_metadata(KEY, {"title": "t"})
+        assert log._path(KEY).read_text(encoding="utf-8") == before
+
+    def test_clear_closed_is_a_noop(self, tmp_path: Path) -> None:
+        log = self._seed_bad_metadata(tmp_path)
+        before = log._path(KEY).read_text(encoding="utf-8")
+        log.clear_closed(KEY)
+        assert log._path(KEY).read_text(encoding="utf-8") == before
+
+
+class TestOrdinaryTranscriptsAreUnaffected:
+    """Positive control. Every assertion above is satisfied by a reader that
+    returns nothing at all, so pin that the same calls still work normally."""
+
+    def test_a_clean_transcript_reads_normally(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        log.append(KEY, "user", "m1")
+        log.append(KEY, "assistant", "m2")
+        fresh = ConversationLog(base_dir=tmp_path)
+
+        assert [m["content"] for m in fresh._read_messages(KEY)] == ["m1", "m2"]
+        assert [m["content"] for m in fresh.recent(KEY, max_messages=10)] == ["m1", "m2"]
+        assert fresh.last_message_preview(KEY) == "m2"
+
+        fresh.update_metadata(KEY, {"title": "t"})
+        assert fresh.get_metadata(KEY)["title"] == "t"
+
+    def test_an_unparseable_row_is_still_skipped(self, tmp_path: Path) -> None:
+        # The behaviour that already worked, kept under test beside the new one.
+        log = ConversationLog(base_dir=tmp_path)
+        log.append(KEY, "user", "m1")
+        with log._path(KEY).open("a", encoding="utf-8") as handle:
+            handle.write("{not json\n")
+        log.append(KEY, "assistant", "m2")
+        fresh = ConversationLog(base_dir=tmp_path)
+        assert [m["content"] for m in fresh._read_messages(KEY)] == ["m1", "m2"]
+
+
+def test_the_transcript_on_disk_really_holds_the_bad_row(tmp_path: Path) -> None:
+    """Guards the fixture itself: if `append` ever rewrote the file, the tests
+    above would pass without the row they are about ever existing."""
+    log = _seed(tmp_path, "[]")
+    rows = [json.loads(line) for line in log._path(KEY).read_text(encoding="utf-8").splitlines()]
+    assert [] in rows


### PR DESCRIPTION
## Problem / Motivation

One transcript line that is valid JSON but not an object makes the rest of that
session unreadable — and stops it being written to at all.

Every reader in `history_projection.py` decodes a `.jsonl` line and then reads a
field off it:

```python
try:
    data = json.loads(line)
except json.JSONDecodeError:
    continue
if data.get("_type") == "metadata":
    continue
```

The guard covers the line that will not parse. It does not cover a line that
parses *fine* and decodes to something other than a mapping — `[]`, `"text"`,
`12`, `null`. That value reaches `.get()` and raises `AttributeError`, which is
not what any of these callers catch (`except OSError`, `except ValueError`,
`except json.JSONDecodeError`). The read is abandoned, and every valid row
**after** the bad one is lost with it.

It is not only a read fault. `ConversationLog.append()` calls `_last_row_ts()`,
which runs the tail reader, so the same row stops new messages being recorded:

```
test/test_history_projection_row_shape.py:50: in _seed
    log.append(KEY, "assistant", "m2")
src/kiro_crew/history.py:1797: in append
src/kiro_crew/history.py:2560: in _last_row_ts
src/kiro_crew/history_projection.py:516: in _last_row_ts
src/kiro_crew/history.py:2557: in _read_tail_messages
E   AttributeError: 'list' object has no attribute 'get'
```

Six readers are affected: the full-transcript read, both tail readers, the
cross-session incognito probe, and the two metadata writers that parse line 0.

**This file already treats the hazard as real.** `read_file_change_messages`
decodes the same rows of the same files and follows its `except ValueError`
with a shape check, and `_read_metadata_status` and `delete_session` do the
same:

```python
except ValueError:
    continue
if not isinstance(data, dict) or data.get("_type") == "metadata":
    continue
meta = data.get("meta")
if not isinstance(meta, dict):
    continue
```

So this is not a new rule — it is four readers in the file holding a contract
that six siblings do not.

## Why it matters

- **The blast radius is a whole session, not a row.** The bad line is skipped by
  a reader that stops; the *good* lines after it are the loss. A user opening
  that chat sees a transcript truncated at an arbitrary point.
- **The session becomes unwritable.** Because `append` goes through the tail
  reader, the chat cannot record new messages either — the failure is not
  something the user can work around by carrying on.
- **The error is the wrong kind.** `_read_messages_locked` has a deliberate
  retry-and-re-raise contract for read faults ("re-raising so restore can
  retry"); an `AttributeError` is not the transient `OSError` that contract is
  written for, so it escapes as an unhandled fault.
- **Two of the sites raise from under the owner lock**, inside metadata writers
  whose neighbouring `except json.JSONDecodeError` branch deliberately `return`s
  and leaves the file alone. Same input class, opposite outcome.

## What changed (motivation → approach → change)

**Symptom:** a transcript read (and then `append`) dies with `AttributeError`,
losing every row after the offending line.

**Root cause:** the decode is guarded on *parseability* but the code depends on
*shape*. `json.JSONDecodeError` and "is a mapping" are different questions, and
only the first was being asked.

**Change** — one production file, `src/kiro_crew/history_projection.py`, one
guard shape, six sites, copied verbatim from the four readers in the same file
that already have it:

| reader | entry point | after the fix |
|---|---|---|
| `_read_messages_locked` | `read_messages` | row skipped, later rows still returned |
| `_read_tail_messages` | `recent`, `append` → `_last_row_ts` | row skipped |
| `last_message_info` | `last_message_preview` | row skipped |
| `recent_from_source` | cross-session recent view | row skipped |
| `_update_metadata_locked` | `update_metadata` | `return`, as the parse-failure branch beside it already does |
| `clear_closed` | `clear_closed` | `return`, likewise |

The row loops `continue`; the two line-0 metadata writers `return`, matching the
`except json.JSONDecodeError: return` immediately above them so a bad first line
is a no-op rather than a fault.

Deliberately **not** logged. The neighbouring `read_file_change_messages` skips
silently, and these are hot per-line loops — a log line per bad row would be a
different decision from the one this fix is making. A module-level comment
states the contract once, where the next reader will look.

## Tests

New file, `test/test_history_projection_row_shape.py` — a fresh surface with no
existing PR touching it. The fixture puts the bad row **between** two good
messages, because a reader that merely stopped early would still return `m1`;
only a message written after it can show the rest of the file was abandoned.

| test | invariant |
|---|---|
| `test_read_messages_keeps_the_rows_after_it` | over all five shapes: `[]`, `"just a string"`, `12`, `null`, `["a","b"]` |
| `test_recent_keeps_the_rows_after_it` | the tail reader, a different loop from the above |
| `test_last_message_preview_reads_past_it` | the backwards scan |
| `test_recent_from_source_still_returns_the_session` | the 5-line incognito probe |
| `test_update_metadata_is_a_noop` / `test_clear_closed_is_a_noop` | a non-object line 0 leaves the file byte-identical |
| `test_the_transcript_on_disk_really_holds_the_bad_row` | guards the fixture — if `append` ever rewrote the file, every test above would pass vacuously |

Two positive controls (`TestOrdinaryTranscriptsAreUnaffected`) pin that a clean
transcript still reads normally and that an *unparseable* row is still skipped —
every assertion above is also satisfied by a reader that returns nothing, so the
controls are what make the greens mean something. Both pass in the red state
too, which is the point.

Red-before on this branch's parent (`1ee69f225`), production change reverted,
test file unchanged:

```
7 failed, 2 passed
FAILED ...::test_read_messages_keeps_the_rows_after_it            - AttributeError: 'list' object has no attribute 'get'
FAILED ...::test_recent_keeps_the_rows_after_it                   - AttributeError: 'list' object has no attribute 'get'
FAILED ...::test_last_message_preview_reads_past_it               - AttributeError: 'list' object has no attribute 'get'
FAILED ...::test_recent_from_source_still_returns_the_session     - AttributeError: 'list' object has no attribute 'get'
FAILED ...::test_update_metadata_is_a_noop                        - AttributeError: 'list' object has no attribute 'get'
FAILED ...::test_clear_closed_is_a_noop                           - AttributeError: 'list' object has no attribute 'get'
FAILED ...::test_the_transcript_on_disk_really_holds_the_bad_row  - AttributeError: 'list' object has no attribute 'get'
```

The 2 that pass in the red state are exactly the two positive controls.

After the fix: `9 passed`.

Sibling suites that exercise these readers, same command:

```
test_history.py  test_history_coverage.py  test_history_atomic_rewrite.py
test_history_locking_remediation.py  test_history_cache_fill_race.py
test_history_consolidation_retry.py                    655 passed, 9 skipped

test_session_mtime_ordering.py  test_tab_id_index_rebuild.py
test_search_sessions_cost.py  test_open_slots_persistence.py
plus the new file                                      145 passed, 1 skipped
```

`black --check` clean. `ruff check` reports the identical 3 findings before and
after (`UP035`, `S112`, `BLE001` — all pre-existing, line numbers shifted by the
added comment) — no new finding. `mypy` clean on the changed module.

## Manual verification

N/A — unit coverage sufficient: the tests drive the real `ConversationLog`
against a real on-disk `.jsonl`, and the fixture-guard test proves the bad row
was actually present in the file the readers read.

## Related Issues

None. Found by audit. Same defect class as the open #7457
(`fix(secrets): fail closed on a non-object vault envelope`) — that one is a
different module and a different remedy (fail closed on a single envelope);
here the readers are per-row and the right remedy is to skip the row and keep
the session.

## Pattern harvest

Rule candidate: semgrep

Pattern: "`json.loads` guarded only by `JSONDecodeError`, then a `.get()` on the
decoded value". Parseability and shape are separate questions; JSON's top level
is legally a list, string, number, or `null`, so the decode guard says nothing
about whether `.get` exists. In a per-row loop the cost is not the bad row, it
is every good row after it. A scan for `json.loads` whose handler names only
`JSONDecodeError`/`ValueError` and whose next use of the bound name is an
attribute access, with no intervening `isinstance`, finds this mechanically —
it is how these six were found, and the same scan surfaced the already-open
#7457 as a true positive in another module.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
