### PR TITLE
fix(ledger): report the history a bounded write discards

### DIFF
--- a/docs/system-specs/features/session-work-ledger.md
+++ b/docs/system-specs/features/session-work-ledger.md
@@ -45,6 +45,10 @@ Every accepted record advances `last_progress_at`. Changing `phase` requires a n
 
 `session_ledger._serialize_bounded()` evicts oldest history before an accepted state file can exceed the reader ceiling. `test_writer_guarantees_the_read_ceiling_for_legitimate_records` ensures a valid record remains readable, and `test_oversized_unknown_fields_are_dropped_not_self_corrupting` ensures oversized forward-compatible fields do not destroy known state.
 
+Each eviction discards data that never reaches disk, so it cannot be recovered from the stored file the way a read-side clamp can. `_serialize_bounded()` therefore logs one warning per over-budget serialization naming the ledger, the evicted `events`/`tried` counts, and any unknown fields dropped - including on the refusal path, which raises with the in-memory record already stripped. The line describes the document the call built rather than a durable write, because `atomic_write` runs afterwards and may still fail. A document that fits logs nothing. `TestBoundedWriteIsLoudAboutLoss` pins the counts, the named ledger, the refusal report, the failed-write case leaving the stored file intact, and the silence.
+
+`record()` returns the same dict `_serialize_bounded()` evicts from, so a caller's post-write view is the document on disk rather than the pre-eviction one. `test_record_returns_exactly_what_landed_on_disk` pins that equality across an eviction; serializing a copy instead would report entries the write dropped.
+
 Writes use the bounded exclusive lock in `session_ledger._locked()`. Contention raises `OSError` rather than allowing an unserialized write or indefinitely blocking a worker; `test_record_fails_closed_on_held_lock` enforces this. Reads are lock-free because `atomic_write` exposes either the previous or complete replacement document, so the state and event tail come from one transaction.
 
 ## 4. MCP surface and authorization

--- a/src/kiro_crew/session_ledger.py
+++ b/src/kiro_crew/session_ledger.py
@@ -381,11 +381,16 @@ def record(
             state["events"] = events[-_MAX_EVENTS:]
         state["last_progress_at"] = now
         state["schema"] = SCHEMA_VERSION
-        atomic_write(dir_path / _STATE_FILE, _serialize_bounded(state) + "\n", mode=0o600)
+        blob = _serialize_bounded(state, source=dir_path.name)
+        atomic_write(dir_path / _STATE_FILE, blob + "\n", mode=0o600)
+        # ``_serialize_bounded`` evicted from THIS dict, so the caller's
+        # post-write view is the document that just landed on disk. Do not
+        # serialize a copy here: that would return the pre-eviction lists
+        # while disk held the evicted ones (#6290).
         return state
 
 
-def _serialize_bounded(state: dict[str, Any]) -> str:
+def _serialize_bounded(state: dict[str, Any], source: str = "") -> str:
     """Serialize the state document, guaranteeing it fits the read ceiling.
 
     The reader treats a file past ``_MAX_STATE_BYTES`` as damage and reads it
@@ -400,33 +405,77 @@ def _serialize_bounded(state: dict[str, Any]) -> str:
     the oldest tried entries, are evicted until it fits. History ages out;
     the current state (goal/phase/next/artifacts) is never dropped and cannot
     exceed the ceiling on its own.
+
+    Every one of those evictions DISCARDS data that never reaches disk, so
+    unlike the read side there is no original file left to recover it from —
+    the loss is permanent the moment the write lands. The reader already WARNs
+    when the ceiling makes it discard a whole file; discarding history to stay
+    under that same ceiling is the same loss in a smaller quantity and is
+    reported the same way: one line per over-budget serialization, naming what
+    went and how much, and nothing at all when the document fits. The line
+    describes the document this call built, not a durable write — the caller's
+    ``atomic_write`` runs afterwards and may still fail.
+
+    Mutates *state* in place while evicting, and ``record`` returns that same
+    dict — deliberately, so a caller's post-write view is the document on
+    disk. See the note at the ``return`` in ``record``.
     """
     budget = _MAX_STATE_BYTES - 4096  # headroom so the reader's check never ties
-    while True:
-        blob = json.dumps(state, ensure_ascii=False)
-        if len(blob.encode("utf-8")) <= budget:
-            return blob
-        if state["events"]:
-            state["events"] = state["events"][1:]
-        elif state["tried"]:
-            state["tried"] = state["tried"][1:]
-        else:
-            # History is gone and the document still does not fit. The known
-            # fields are all clamped well under the budget, so the excess can
-            # only live in UNKNOWN fields carried forward by ``_coerce_state``
-            # (a newer writer's data, or a corrupt/hostile file that parsed).
-            # Preserving unknown fields is best-effort forward compatibility;
-            # preserving THE LEDGER is the contract — a document past the
-            # reader's ceiling is discarded wholesale on the next read, which
-            # loses the known state too. Drop the extras and retry once.
-            extras = [k for k in state if k not in _empty_state()]
-            if extras:
-                for k in extras:
-                    state.pop(k, None)
-                continue
-            # Unreachable with the field clamps; refuse rather than write a
-            # document the reader is guaranteed to discard.
-            raise ValueError("record too large to store")
+    evicted_events = 0
+    evicted_tried = 0
+    dropped_extras: list[str] = []
+    try:
+        while True:
+            blob = json.dumps(state, ensure_ascii=False)
+            if len(blob.encode("utf-8")) <= budget:
+                return blob
+            if state["events"]:
+                state["events"] = state["events"][1:]
+                evicted_events += 1
+            elif state["tried"]:
+                state["tried"] = state["tried"][1:]
+                evicted_tried += 1
+            else:
+                # History is gone and the document still does not fit. The known
+                # fields are all clamped well under the budget, so the excess can
+                # only live in UNKNOWN fields carried forward by ``_coerce_state``
+                # (a newer writer's data, or a corrupt/hostile file that parsed).
+                # Preserving unknown fields is best-effort forward compatibility;
+                # preserving THE LEDGER is the contract — a document past the
+                # reader's ceiling is discarded wholesale on the next read, which
+                # loses the known state too. Drop the extras and retry once.
+                extras = [k for k in state if k not in _empty_state()]
+                if extras:
+                    for k in extras:
+                        state.pop(k, None)
+                    dropped_extras.extend(extras)
+                    continue
+                # Unreachable with the field clamps; refuse rather than write a
+                # document the reader is guaranteed to discard.
+                raise ValueError("record too large to store")
+    finally:
+        # In ``finally`` so the refusal path reports too: it raises with the
+        # in-memory record already gutted, which is exactly when an operator
+        # most needs to know what this call threw away.
+        losses: list[str] = []
+        if evicted_events:
+            losses.append(f"oldest events[] evicted x{evicted_events}")
+        if evicted_tried:
+            losses.append(f"oldest tried[] evicted x{evicted_tried}")
+        if dropped_extras:
+            losses.append("unknown fields dropped: " + ", ".join(sorted(dropped_extras)))
+        if losses:
+            # Describes the DOCUMENT being serialized, not a completed write:
+            # ``atomic_write`` runs after this and can still fail (ENOSPC),
+            # leaving the previous file intact, and the refusal path above
+            # never writes at all. Either way this call's in-memory record has
+            # already lost the entries named here.
+            logger.warning(
+                "ledger state exceeded the %d-byte serialization budget%s; discarded: %s",
+                budget,
+                f" ({source})" if source else "",
+                "; ".join(losses),
+            )
 
 
 def purge(slot_key: str) -> None:

--- a/test/test_session_ledger.py
+++ b/test/test_session_ledger.py
@@ -12,6 +12,7 @@ purge.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -243,6 +244,183 @@ def test_coerce_preserves_unknown_fields():
     assert state["goal"] == "g"
     assert state["future_field"] == {"a": 1}
     assert state["tried"] == []
+
+
+# -- the bounded write reports what it discards -----------------------------
+
+
+def test_record_returns_exactly_what_landed_on_disk(monkeypatch):
+    """``record``'s return value is the authoritative post-write view.
+
+    The dashboard handler puts it straight into ``{"ok": True, "state": ...}``
+    and the MCP tool reports it as "what is now recorded", so it must not
+    describe entries the write budget evicted. ``_serialize_bounded`` evicts
+    from the very dict ``record`` returns, which is what keeps the two equal;
+    serializing a copy instead would return the pre-eviction lists while disk
+    held the evicted ones. Pinned so that aliasing is not "cleaned up" later.
+    """
+    key = "chat-62-90a"
+    sl.record(key, goal="keep me", event="seed", event_kind="progress")
+    for i in range(4):
+        sl.record(key, tried_approach=f"a{i}", tried_rejected_because="x" * 400)
+        sl.record(key, event=f"e{i}" + "y" * 400, event_kind="progress")
+    path = sl.ledger_dir(key) / sl._STATE_FILE
+    before = json.loads(path.read_text(encoding="utf-8"))
+
+    # Squeeze the ceiling so the budget lands just UNDER the current document:
+    # the next write must evict, while the read that precedes it still passes
+    # the same ceiling's file-size guard. Derived from the real size so a
+    # timestamp-width change cannot silently turn this into a no-op.
+    size = path.stat().st_size
+    monkeypatch.setattr(sl, "_MAX_STATE_BYTES", size + 4096 - 200)
+    returned = sl.record(key, next_step="advance")
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+
+    kept = len(returned["events"]) + len(returned["tried"])
+    assert kept < len(before["events"]) + len(before["tried"]), "no eviction happened"
+    assert returned["events"] or returned["tried"], "eviction emptied the history entirely"
+    assert returned == on_disk, "the caller's post-write view diverged from disk"
+    assert returned["goal"] == "keep me"
+
+
+class TestBoundedWriteIsLoudAboutLoss:
+    """``_serialize_bounded`` drops history to keep the document readable.
+
+    That data never reaches disk, so — unlike the read side, where the
+    original file survives until a write-back — the loss is unrecoverable the
+    moment the write lands. ``_read_state_unlocked`` already WARNs when the
+    same ceiling makes it discard a whole file; these pin that the partial
+    discard is reported too, that the counts are named, that a refused write
+    still reports, and that a document which fits stays silent.
+    """
+
+    def _warnings(self, caplog: pytest.LogCaptureFixture) -> list[str]:
+        return [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and "serialization budget" in r.getMessage()
+        ]
+
+    def _over_budget_state(self, extra_events: int = 6) -> dict[str, Any]:
+        state = sl._empty_state()
+        state["goal"] = "survives"
+        state["events"] = [
+            {"ts": "t", "kind": "progress", "text": "e" * 200} for _ in range(extra_events)
+        ]
+        state["tried"] = [
+            {"approach": "a" * 200, "rejected_because": "r" * 200, "at": "t"} for _ in range(3)
+        ]
+        return state
+
+    def test_a_record_that_fits_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The control that makes this safe to ship: no discard, no line.
+        Without it every ledger write would emit a WARNING."""
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_ledger"):
+            sl.record("chat-62-fits", goal="small", event="tiny", event_kind="note")
+        assert self._warnings(caplog) == []
+
+    def test_evicted_history_is_counted(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sl, "_MAX_STATE_BYTES", 4096 + 600)
+        state = self._over_budget_state()
+        before_events, before_tried = len(state["events"]), len(state["tried"])
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_ledger"):
+            blob = sl._serialize_bounded(state, source="chat-62-abcd1234")
+        found = self._warnings(caplog)
+        assert len(found) == 1, f"the discard was silent (warnings: {found})"
+        msg = found[0]
+        evicted_events = before_events - len(state["events"])
+        assert evicted_events > 0, "fixture did not cross the budget"
+        assert f"oldest events[] evicted x{evicted_events}" in msg
+        assert "chat-62-abcd1234" in msg, "the line must name which ledger lost data"
+        # Reporting the loss changes nothing about what is kept or written.
+        assert len(blob.encode("utf-8")) <= sl._MAX_STATE_BYTES - 4096
+        assert json.loads(blob) == state
+        assert json.loads(blob)["goal"] == "survives"
+        if len(state["tried"]) < before_tried:
+            assert f"oldest tried[] evicted x{before_tried - len(state['tried'])}" in msg
+
+    def test_dropped_unknown_fields_are_named(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Forward-compat baggage from a newer writer is dropped wholesale.
+        That is the widest discard this function makes and was the quietest."""
+        monkeypatch.setattr(sl, "_MAX_STATE_BYTES", 4096 + 600)
+        state = sl._empty_state()
+        state["goal"] = "survives"
+        state["future_blob"] = "z" * 4000
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_ledger"):
+            blob = sl._serialize_bounded(state, source="chat-62-ffff0000")
+        found = self._warnings(caplog)
+        assert len(found) == 1, f"the discard was silent (warnings: {found})"
+        assert "unknown fields dropped: future_blob" in found[0]
+        assert json.loads(blob)["goal"] == "survives"
+        assert "future_blob" not in json.loads(blob)
+
+    def test_a_refused_write_reports_what_it_gutted(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refusal raises with the in-memory record already stripped —
+        the moment an operator most needs to know what went."""
+        monkeypatch.setattr(sl, "_MAX_STATE_BYTES", 4096 + 10)
+        state = self._over_budget_state(extra_events=2)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_ledger"):
+            with pytest.raises(ValueError, match="too large"):
+                sl._serialize_bounded(state, source="chat-62-dead0000")
+        found = self._warnings(caplog)
+        assert len(found) == 1, f"the refusal was silent (warnings: {found})"
+        assert "oldest events[] evicted x2" in found[0]
+
+    def test_a_failed_write_still_reports_but_leaves_the_stored_file_intact(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Why the line describes the DOCUMENT, not a durable write.
+
+        ``atomic_write`` runs after the serializer and can fail (ENOSPC),
+        leaving the previous state file whole — so nothing was durably lost,
+        even though this call's in-memory record was already stripped. A
+        message claiming a write discarded data would be false here.
+        """
+        key = "chat-62-enospc"
+        sl.record(key, goal="on disk")
+        for i in range(5):
+            sl.record(key, event=f"e{i}" + "y" * 300, event_kind="progress")
+        path = sl.ledger_dir(key) / sl._STATE_FILE
+        before = path.read_text(encoding="utf-8")
+
+        def _boom(*a: Any, **kw: Any) -> None:
+            raise OSError(28, "No space left on device")
+
+        # Gentle squeeze: one evicted event is enough to fit, so serialization
+        # SUCCEEDS and the failing write is genuinely reached.
+        monkeypatch.setattr(sl, "_MAX_STATE_BYTES", path.stat().st_size + 4096 - 200)
+        monkeypatch.setattr(sl, "atomic_write", _boom)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_ledger"):
+            with pytest.raises(OSError):
+                sl.record(key, next_step="never lands")
+        found = self._warnings(caplog)
+        assert len(found) == 1, f"the discard was silent (warnings: {found})"
+        assert "oldest events[] evicted x" in found[0]
+        assert "write" not in found[0], "must not claim a write that did not happen"
+        assert path.read_text(encoding="utf-8") == before, "the stored file must be untouched"
+
+    def test_the_eviction_branch_needs_both_lists_at_scale(self) -> None:
+        """Why these tests squeeze the budget instead of using real bounds.
+
+        A full astral-script EVENT tail is ~806 KB — under the 995,904-byte
+        budget on its own, so ``test_writer_guarantees_the_read_ceiling_...``
+        never actually reaches the eviction branch. Crossing it at production
+        bounds needs ``events`` AND ``tried`` both loaded (~1.87 MB), which
+        costs 150 locked read-modify-write cycles over a multi-megabyte
+        document. Pinned as arithmetic so the reason stays visible.
+        """
+        four_byte = 4  # astral-plane char in UTF-8
+        events = sl._MAX_EVENTS * sl._MAX_TEXT * four_byte
+        tried = sl._MAX_TRIED * 2 * sl._MAX_TEXT * four_byte
+        budget = sl._MAX_STATE_BYTES - 4096
+        assert events < budget, "events alone would cross the budget; revisit the fast tests"
+        assert events + tried > budget, "the eviction branch would be unreachable"
 
 
 def test_purge_removes_dir_and_tolerates_bad_keys():


### PR DESCRIPTION
## What is the problem?

`session_ledger._serialize_bounded()` keeps the state document under the ceiling its own reader enforces by evicting the oldest `events`, then the oldest `tried` entries, then unknown forward-compat fields wholesale. It does all of that **silently** - there is no log line anywhere on the write path.

The issue that prompted this reports a different defect: that `record()` returns a dict the serializer mutated, so the caller sees *fewer* entries than are on disk. **That claim is inverted and I did not implement its proposed fix.** The eviction loop re-serializes after every eviction and returns the blob built from the fully-evicted dict, so the returned dict already equals the bytes written. Applying the proposed `_serialize_bounded(dict(state))` would *create* the divergence it claims to remove, returning the pre-eviction lists while disk held the evicted ones. Mutation-verified below.

The genuine residual is the silence, and the missing test coverage underneath it. Two coverage facts I measured rather than assumed:

- `test_writer_guarantees_the_read_ceiling_for_legitimate_records` never reaches the eviction branch. A full astral-script event tail is ~806 KB, under the 995,904-byte budget on its own; crossing it needs `events` **and** `tried` both at maxima (~1.87 MB). Running that test with the new warning in place emits zero lines, confirming it.
- So on `main` the `events`/`tried` eviction branch has no coverage at all. Only the extras-drop branch does, via `test_oversized_unknown_fields_are_dropped_not_self_corrupting`.

## Why this issue matters to the user

A read-side clamp is recoverable: the original file is still on disk until something writes back. A write-side eviction is not. The dropped entries never reach disk, so once the write lands the loss is permanent, and nothing tells the operator it happened. A long-horizon session whose `tried`/`events` history is being quietly truncated by the write budget looks identical to one that simply has less history, and the ledger exists precisely so that history survives compaction.

This is also an asymmetry on `main` today, independent of any other PR: `_read_state_unlocked()` already logs `WARNING "ledger state file over size ceiling; treating as absent"` when that same ceiling makes it discard a whole file. The writer discarding history to stay under it says nothing.

## How our fix solves it

Symptom: a session's ledger history shrinks with no explanation. Cause: `_serialize_bounded()` evicts to satisfy `_MAX_STATE_BYTES` and reports nothing. Fix: tally what each eviction drops and emit one line per over-budget serialization.

- `_serialize_bounded()` counts evicted `events`, evicted `tried`, and dropped unknown keys, then logs a single `WARNING` naming the budget, the ledger directory, and each loss with its count. A document that fits logs nothing, so this is not per-write noise.
- The tally is emitted from a `finally`, so the `ValueError("record too large to store")` refusal path reports too. That path raises with the in-memory record already stripped of its history, which is the moment the operator most needs to know what the call threw away.
- The line describes **the document the call built, not a durable write**. `atomic_write` runs after the serializer and can fail (ENOSPC), leaving the previous state file whole; the refusal path never writes at all. Claiming a write discarded data would be false in both cases. This wording was tightened in response to GPT's advisory finding on the first revision, and is now pinned by a test.
- `record()` passes `source=dir_path.name` so the line names *which* ledger lost data, mirroring the read-side `_coerce_state(raw, source=...)` shape in open PR #6017.
- Zero behaviour change: what is kept, what is written, and what is returned are all byte-identical to before. This is observability only.
- The aliasing the issue asked to remove is instead **documented and pinned**: a comment at `record()`'s `return` states why a copy must not be serialized there, and a test enforces the equality.

## What tests we did

`test/test_session_ledger.py`, targeted file only - 52 passed. `black`, `isort`, `flake8`, `mypy` clean on both changed files.

New: `TestBoundedWriteIsLoudAboutLoss` (eviction counted and ledger named; unknown fields named; refusal path still reports; a failed write still reports while leaving the stored file intact; a record that fits logs nothing; plus the budget arithmetic documenting why the fast tests squeeze the ceiling instead of using production bounds) and `test_record_returns_exactly_what_landed_on_disk`.

Verified red, not just green. Three mutations, each isolating one property:

| Run | Result |
|---|---|
| Fix applied (baseline) | 7 passed |
| Source reverted to `origin/main`, tests kept | 3 failed, 3 passed |
| **Mutation A** - `logger.warning` suppressed, signature kept | the 4 loud tests fail, nothing else |
| **Mutation B** - the issue's proposed `_serialize_bounded(dict(state))` | only `test_record_returns_exactly_what_landed_on_disk` fails |
| **Mutation C** - message reworded back to claim a completed write | only `test_a_failed_write_still_reports_but_leaves_the_stored_file_intact` fails |

Mutation A matters because the base-revert reds fail on the added `source` parameter, which would prove nothing about the warning; suppressing only the log call reddens the same tests, so the loud assertions are load-bearing. Mutation B is the evidence for rejecting the issue's proposed fix. Mutation C proves the ENOSPC test pins the wording rather than merely passing alongside it.

The eviction tests squeeze `_MAX_STATE_BYTES` via `monkeypatch` rather than building a 1.87 MB document. `test_record_returns_exactly_what_landed_on_disk` and the ENOSPC test both derive their squeezed ceiling from the real file size, so a timestamp-width change cannot silently turn either into a no-op.

## Any other suggestions on the work?

1. **The issue should not be closed as not-a-bug, but its Proposed fix section should be struck.** A comment on #6290 records the disposition; this PR keeps the correct behaviour and pins it so the shallow copy cannot be reintroduced as a cleanup.
2. **The eviction loop is O(n) re-serializations of the whole document under the exclusive lock** - up to 150 iterations (`_MAX_EVENTS` + `_MAX_TRIED`), each a full `json.dumps` of an up-to-1.8 MB dict, each dropping exactly one entry. With `_LOCK_TIMEOUT_SECS = 5.0`, a slow eviction can push a concurrent writer past its deadline into a refused write (`OSError`, surfaced as 503 by the dashboard handler). Deliberately out of scope here; a size-guided bulk trim would collapse it to a couple of passes. Happy to file it separately.
3. **Overlap with #6017 is by construction, not accident.** That PR makes the read side loud; this one makes the write side loud, in a different function (`_serialize_bounded` vs `_coerce_state`). If #6017 lands first, the rebase should fold this PR's inline summary rendering into its `_lost_summary()` helper - I kept the rendering local rather than pre-adopting a helper that does not exist on `main`.
4. `_serialize_bounded()` evaluates `_empty_state()` once per key inside the extras comprehension. Untouched to keep this diff observability-only.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a bound-enforcing path discards caller data with no diagnostic - and on a write path that discard is unrecoverable, because the dropped bytes never reach disk for anything to read back.

This is the second instance in this one module: open PR #6017 fixes the read-side clamps and this fixes the write-side evictions, in a file whose own reader already warned about the whole-file case. The generalizable review question is not "is the bound correct" but "when this bound sheds data, can an operator find out - and is there still a copy anywhere". A `semgrep` rule is not the right vehicle: the shape (a re-serialize-and-trim loop with no logging in the enclosing function) is too fuzzy to match without heavy false positives, whereas a reviewer prompted to ask it will catch the whole class.

Closes #6290
