### PR TITLE
fix(session-storage): catch a mid-staging resume that only reads the transcript

### DIFF
--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -98,25 +98,49 @@ the legacy stem fails instead of agreeing with itself.
 
 The freshness floor narrows the window but does not establish ownership, so the report exposes `reclaim_blocked_reason` for a client to explain rather than offering an action that `move_to_trash()` must refuse. Tests that inspect this host state isolate `KIROCREW_POD_ROOT` with the homes.
 
-### The index is re-read after the scan, inside the lock
+### The index is re-read after the scan, and again per session
 
 Scanning a six-figure store is the slow part of a reclaim, so an index read *before*
 it is already stale by the time anything moves. `move_to_trash` therefore re-reads
-through a `refresh` callable **after** the scan and immediately before the move loop,
-making the authority check the freshest view available. The two active sets are
-**unioned**, so a re-read can only ever add protection, and a re-read that fails
-refuses the operation rather than proceeding on the stale view.
+through a `refresh` callable **after** the scan, and then again before **every**
+session the move loop reaches. The two active sets are **unioned**, so a re-read can
+only ever add protection.
 
-The move loop then closes part of what the re-read cannot, for a resume that
-**writes**. Every source file is stat'd there anyway, to record its size in the
-manifest, and that same stat carries an mtime. A candidate qualified by being
-untouched for `MIN_RECLAIM_AGE_DAYS`, so a source whose mtime is newer than the
-instant the reclaim began has been written to since every read that certified it —
-which an idle session's file cannot be. The whole session is left in place, whatever
-already moved for it is rolled back, and it is named in `TrashBatch.revived` so the
-caller can report it. This costs no extra syscall: the detection rides on a stat the
-loop already performs. A resume that only READS is invisible to it — see Known
-Limitations.
+The loop needs both signals it has, because they catch different resumes.
+
+A resume that **writes** is caught by mtime. Every source file is stat'd there anyway,
+to record its size in the manifest, and that same stat carries an mtime. A candidate
+qualified by being untouched for `MIN_RECLAIM_AGE_DAYS`, so a source whose mtime is
+newer than the instant the reclaim began has been written to since every read that
+certified it — which an idle session's file cannot be. This costs no extra syscall:
+the detection rides on a stat the loop already performs.
+
+A resume that only **reads** writes nothing, so mtime has nothing to see: the resume
+reads the old transcript to rebuild history and records the turn that follows under a
+newly mapped sid, leaving every file's mtime days old. That resume is visible in the
+index instead — it is mapped — which is why the re-read runs at the same per-session
+cadence rather than once before the loop.
+
+Either way the whole session is left in place, whatever already moved for it is rolled
+back, and it is named in `TrashBatch.revived` so the caller can report it. A session
+the re-read catches has nothing staged yet, so there is nothing to roll back.
+
+The per-session re-read has to be affordable, and that is the caller's half of the
+contract: `refresh` may be called once per selected session, and returning the **same
+object** as last time says "nothing has moved", which the loop recognises by identity
+and does not re-derive sets for. `_build_index` costs a file read plus a full json
+parse — about 0.26 ms even against a 100-entry map — so a rebuild per session would be
+~56 s at that floor and hours against a realistic map, at the `_MAX_SELECTION` cap.
+The dashboard's refresher therefore rebuilds only when `session_map.json`'s
+`(st_ino, st_mtime_ns, st_size)` moves; every mapping write lands via `mkstemp` plus
+`os.replace`, so the inode changes on every write and an unmoved token cannot hide
+one. A caller that returns a fresh index every call is correct, only slower.
+
+A re-read that fails **before** anything moves refuses the operation rather than
+proceeding on the stale view. One that fails **during** the loop is logged once and
+the last view read is kept: every re-read only widens the live sets, so a lost one
+costs the extra protection it would have added, not the protection already read, and
+abandoning a batch that has already moved files would be the worse trade.
 
 Naming a session in `revived` is a claim -- "this one was left where it was" -- so it
 is only made when the rollback actually completed. Putting a file back is
@@ -134,12 +158,12 @@ it would miss a session resumed during the scan or between the index re-read and
 loop, which is most of the elapsed time. Taking it early adds no false positives,
 because a candidate has to be untouched for `MIN_RECLAIM_AGE_DAYS` to qualify at all.
 
-Detection, not prevention: a session revived *after* its last file was stat'd and
-moved is still staged. For a resume that writes, the window is therefore the gap
-between one file's stat and its rename rather than the whole loop. For a resume that
-only reads it is still the whole loop, because there is no write for the stat to see.
-Either way what lands in that gap lands in the trash — fully restorable, with
-destruction still needing a second explicit `empty`.
+Detection, not prevention. For a resume that writes, the window is the gap between one
+file's stat and its rename. For a resume that only reads, it is the gap between the
+re-read that precedes its session and that session's files moving, plus however long
+the map write takes to become visible in the file this reads — bounded by
+`SessionMap._FLUSH_DEBOUNCE_SECS`. Either way what lands in that gap lands in the
+trash — fully restorable, with destruction still needing a second explicit `empty`.
 
 ## What is reclaimable
 
@@ -890,14 +914,14 @@ That is the conservative direction (never a wrong move), but a client cannot
 distinguish it from a malformed request without reading the code, and retrying is
 the only recovery.
 
-A session that goes live *later still* — after the `refresh`, while the move loop is
-running — is not all-or-nothing, provided the resume writes. The loop's mtime check
-leaves that one session in place and the rest of the batch proceeds, and the handler
-folds each such uid into the same `refused` list under `in_use`. The mechanism differs
-from the pre-pass (caught by a stat during the move rather than by the index before
-it) but the reason a reader needs is identical, so it carries no new code. A resume
-that only reads writes nothing for that stat to catch, so it is staged instead of
-refused — the gap recorded in Known Limitations.
+A session that goes live *later still* — after the first `refresh`, while the move loop
+is running — is not all-or-nothing. The loop leaves that one session in place and the
+rest of the batch proceeds, and the handler folds each such uid into the same `refused`
+list under `in_use`. A resume that writes is caught by the loop's mtime check; one that
+only reads is caught by the per-session index re-read, which is why that re-read runs
+inside the loop. The mechanism differs from the pre-pass (caught during the move rather
+than by the index before it) but the reason a reader needs is identical, so it carries
+no new code.
 
 **The guarantee is not weakened.** `move_to_trash()` still re-reads the session map
 inside the mutation lock and still unions the active sets, so the pre-pass can only
@@ -960,33 +984,20 @@ instead of the trash over-deleting. `TestEmptyTrash` and
 
 ## Known Limitations
 
-- **A much smaller residual race remains for a resume that writes.** The authority
-  check is re-read after the scan and inside the reclaim lock, and the move loop then
-  rejects any source whose mtime is newer than the batch's validation instant, so a
-  session resumed *during* the loop is left in place and reported rather than staged.
-  What is left is detection, not prevention: the session map's writer still does not
-  take the reclaim lock, so a session revived between one file's stat and its rename
-  is staged anyway. That gap is microseconds rather than the whole loop, and it stays
-  restorable — nothing is destroyed without a second explicit action. Removing it
-  entirely still requires the session/slot code and this module to share one lock,
-  which is a wider change than this surface.
-- **A resume that only READS the transcript is not detected at all, and its window is
-  the whole loop.** The bullet above describes a resume that writes; the mtime check
-  has nothing to see when the resume writes nothing. The sequence: a retired session's files
-  are certified reclaimable, the session is resumed, the resume reads the old transcript
-  to rebuild history, and the turn that follows is recorded under a newly mapped SID
-  without rewriting that old transcript. Every one of the session's files therefore
-  still carries its original mtime, all of them pass the validation-instant check, and
-  the live slot's durable history is staged out from under it. Detection would need the
-  index re-read to happen inside the loop rather than once before it, and the naive form
-  of that is not affordable: `refresh` is `_build_index`, which costs a file read plus a
-  full json parse — about 0.26 ms even against a 100-entry map — so at the
-  `_MAX_SELECTION` cap of 200,000 units it is ~56 s at that floor and hours against a
-  realistic map, and it would take `SessionMap._MAP_LOCK` once per unit while the
-  reclaim lock is held. Making it affordable means the caller memoizing its own index on
-  a change token, which is a contract change to `refresh` rather than an adjustment to
-  the loop. Like the write-shaped gap this stays restorable: the history lands in the
-  trash, and destruction still needs a second explicit `empty`.
+- **A much smaller residual race remains, and it is now bounded for both shapes of
+  resume.** The authority check is re-read after the scan and again before every
+  session the move loop reaches, and the loop also rejects any source whose mtime is
+  newer than the batch's validation instant, so a session resumed *during* the loop is
+  left in place and reported rather than staged — whether the resume writes or only
+  reads. What is left is detection, not prevention, because the session map's writer
+  still does not take the reclaim lock. Two gaps survive that. A resume that writes can
+  land between one file's stat and its rename, which is microseconds. A resume that
+  only reads becomes visible when its mapping reaches `session_map.json`, and
+  `SessionMap` defers that write by `_FLUSH_DEBOUNCE_SECS` while the refresher reads the
+  file rather than the live in-process map, so that gap is bounded by the debounce
+  rather than by the loop. Both stay restorable — nothing is destroyed without a second
+  explicit action. Removing either entirely still requires the session/slot code and
+  this module to share one lock, which is a wider change than this surface.
 - Reclaiming is offered both by age (`cleanup`) and by explicit selection
   (`trash`). Neither can take a session the map still lists, so targeting one large
   conversation only works if that conversation is unmapped.

--- a/src/kiro_crew/dashboard/handlers/session_storage.py
+++ b/src/kiro_crew/dashboard/handlers/session_storage.py
@@ -26,12 +26,13 @@ from typing import Any
 
 from aiohttp import web
 
+from kiro_crew.config.paths import config_dir
 from kiro_crew.dashboard.handlers._shared import _is_restricted_session, _read_session_key
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import transcript_stems
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.session_digest import digest
-from kiro_crew.session_map import SessionMap
+from kiro_crew.session_map import SESSION_MAP_FILENAME, SessionMap
 from kiro_crew.session_storage import (
     BUCKET_DAYS,
     MIN_RECLAIM_AGE_DAYS,
@@ -106,6 +107,70 @@ def _build_index(state: DashboardState | None = None) -> SessionIndex:
         active_sids=frozenset(mapping.values()),
         live_sids=live_sids,
     )
+
+
+def _map_token() -> tuple[int, int, int] | None:
+    """Identity of the session map file, or ``None`` when it cannot be read.
+
+    ``(st_ino, st_mtime_ns, st_size)``. Every mapping write lands through
+    ``mkstemp`` plus ``os.replace`` (``SessionMap._write``), so the inode changes
+    on every write — a token that has not moved means no mapping has been written,
+    which mtime alone could not establish at this resolution.
+    """
+    try:
+        st = (config_dir() / SESSION_MAP_FILENAME).stat()
+    except OSError:
+        return None
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+class _MapBackedRefresh:
+    """A ``refresh`` for :func:`move_to_trash` that is cheap to call repeatedly.
+
+    ``move_to_trash`` calls ``refresh`` once per selected session, because the
+    index is the only place a resume that merely READS an old transcript shows up
+    (#7118): such a resume writes nothing, so the mtime guard inside the move loop
+    cannot see it, and the session's history would be staged out from under a live
+    slot.
+
+    Rebuilding per session cannot be paid for directly. :func:`_build_index` reads
+    and parses the whole session map — about 0.26 ms even for a 100-entry map,
+    because the floor is one file read plus one json parse — and the selection is
+    capped at :data:`_MAX_SELECTION`, so a naive per-session rebuild costs at least
+    ~56 s, and hours against a five-figure map.
+
+    So the rebuild is gated on the map file's identity, and the SAME object is
+    returned while that has not moved. ``move_to_trash`` recognises an unchanged
+    index by identity and skips re-deriving its sets, so an unmoved map costs one
+    stat (~2 us) — under a second for the whole cap.
+
+    Fails toward rebuilding rather than skipping: a token that could not be read is
+    ``None``, which never compares equal, so an unreadable map pays a real re-read.
+
+    RESIDUAL: ``SessionMap`` defers its write by ``_FLUSH_DEBOUNCE_SECS`` and this
+    reads the FILE, not the live in-process map, so a resume is invisible here for
+    up to that long. Bounded at ~50 ms instead of the whole move loop; closing it
+    outright needs the resume and reclaim paths to share a lock, which is the
+    change ``docs/system-specs/modules/session-storage.md`` already names.
+    """
+
+    def __init__(self) -> None:
+        self._token: tuple[int, int, int] | None = None
+        self._index: SessionIndex | None = None
+
+    def __call__(self) -> SessionIndex:
+        # Read the token BEFORE the rebuild, and store that one. A write landing
+        # while the rebuild is in flight then leaves a token the next call sees as
+        # moved, so it rebuilds again. Reading it afterwards would stamp the
+        # rebuilt index with a token that already includes the write it missed.
+        token = _map_token()
+        if self._index is not None and token is not None and token == self._token:
+            return self._index
+        # Deliberately without *state*: the running-session signal only LABELS a
+        # refusal, and this index is used to widen refusals, never to explain them.
+        self._index = _build_index()
+        self._token = token
+        return self._index
 
 
 def _deny(operation: str, request: web.Request) -> web.Response:
@@ -289,8 +354,11 @@ async def api_session_storage_cleanup(request: web.Request) -> web.Response:
             reason=REASON_POLICY,
             index=index,
             # Re-read the map inside the lock: the scan above can take long enough
-            # for a session to be resumed and mapped in the meantime.
-            refresh=_build_index,
+            # for a session to be resumed and mapped in the meantime, and so can
+            # the move loop, which calls this once per session. One instance per
+            # request — a shared one would serve a later request an index built
+            # before it started.
+            refresh=_MapBackedRefresh(),
         )
     except SessionStorageError as exc:
         return _refused(exc, "cleanup_refused")
@@ -966,7 +1034,11 @@ async def api_session_inventory_trash(request: web.Request) -> web.Response:
             eligible,
             reason=REASON_MANUAL,
             index=index,
-            refresh=_build_index,
+            # Called once per selected session, so it is gated on the map file's
+            # identity rather than rebuilding every time. One instance per request:
+            # a shared one would serve a later request an index built before it
+            # started.
+            refresh=_MapBackedRefresh(),
         )
     except SessionStorageError as exc:
         # Audited before returning. A refusal from inside the move is the same

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -1633,18 +1633,26 @@ def move_to_trash(
     :data:`MIN_RECLAIM_AGE_DAYS`: a mapped session is resumable, and a fresh one
     may be running under a subsystem that never registered it.
 
-    *refresh* re-reads the caller's index INSIDE the lock, immediately before
-    anything moves. Scanning a large store takes long enough that a session can be
-    resumed and mapped while the selection is being computed, and the stale index
-    would then treat it as retired. The two active sets are UNIONED, never
-    replaced, so a re-read can only ever add protection.
+    *refresh* re-reads the caller's index INSIDE the lock: once immediately before
+    anything moves, and again before every session the loop reaches. Scanning a
+    large store takes long enough that a session can be resumed and mapped while
+    the selection is being computed, and the move loop after that is not instant
+    either. The active sets are UNIONED, never replaced, so a re-read can only ever
+    add protection.
 
-    That re-read still describes one instant, and the move loop after it is not
-    instant. A session resumed anywhere in that stretch is caught in the loop
-    instead: each file is already stat'd for the manifest, so a source modified
-    since the reclaim began marks its session as revived and leaves it in place.
-    The returned batch names those sessions in ``revived`` — they were asked for
-    and not taken.
+    Called up to once per selected session, so it must be CHEAP when nothing has
+    changed. Return the same :class:`SessionIndex` object as last time to say
+    "nothing has moved" — an identical object is recognised by identity and costs
+    one comparison. Returning a freshly built index every call is correct but pays
+    for a full re-read per session, which at a six-figure selection is minutes.
+
+    Two shapes of mid-staging resume are caught, and both are needed. A resume
+    that WRITES is caught by mtime: each file is already stat'd for the manifest,
+    so a source modified since the reclaim began fails the check before it moves.
+    A resume that only READS an old transcript writes nothing, so it is invisible
+    to mtime and is caught by the re-read instead — it is mapped. Either way the
+    session is left in place and named in the returned batch's ``revived``: it was
+    asked for and not taken.
 
     Serialized against other mutations, because two interleaved reclaims can put
     one half of a session in each batch and leave neither able to restore it.
@@ -1678,11 +1686,13 @@ def _move_to_trash_locked(
     would connect to this action.
 
     Every such check runs before the move loop, so each describes the instant it
-    ran. The loop closes the remaining window itself, against an instant taken
-    before any of them: a source file whose mtime is newer than that has been
-    written to since the reads that certified it, which an idle session's file
-    cannot be, so the whole session is left in place and named in
-    ``TrashBatch.revived``.
+    ran. The loop closes the remaining window itself, with two per-session signals.
+    A source file whose mtime is newer than an instant taken before any of those
+    checks has been written to since the reads that certified it, which an idle
+    session's file cannot be. And a session the re-read now reports as mapped is
+    one the product can resume, however old its files are — the case mtime cannot
+    see, because a resume that only reads a transcript writes nothing. Either way
+    the whole session is left in place and named in ``TrashBatch.revived``.
 
     Each session is recorded as it lands, so an interruption leaves a manifest
     describing exactly what moved — a partial batch stays restorable instead of
@@ -1718,9 +1728,14 @@ def _move_to_trash_locked(
     # The authority check runs AFTER the scan, not before it. Enumerating a
     # six-figure store is the slow part of this function, so an index read before
     # it is already stale by the time anything moves — a session continued in that
-    # interval would look retired. Re-reading here makes the last thing before the
-    # move loop the freshest view available, and the sets are UNIONED so a re-read
-    # can only ever add protection.
+    # interval would look retired. Re-reading here is what the checks below get to
+    # judge against, and the sets are UNIONED so a re-read can only ever add
+    # protection. It is not the last word: the move loop re-reads per session, for
+    # the stretch this one cannot describe.
+    #
+    # *seen* keeps the index this returned, so the loop can tell an unchanged view
+    # apart from a new one by identity and skip re-deriving the sets for it.
+    seen: SessionIndex | None = None
     if refresh is not None:
         try:
             latest = refresh()
@@ -1729,6 +1744,7 @@ def _move_to_trash_locked(
             raise SessionStorageError(
                 "could not confirm which sessions are live; nothing was moved"
             )
+        seen = latest
         live_sids = index.active_sids | latest.active_sids
         live_stems = index.active_stems | latest.active_stems
     else:
@@ -1795,6 +1811,7 @@ def _move_to_trash_locked(
     moved_bytes = 0
     moved_sessions = 0
     revived: list[str] = []
+    refresh_failed = False
     staged_dirs: set[Path] = set()
     cli_files = _cli_index()
     with (target / MANIFEST_NAME).open("w", encoding="utf-8") as manifest:
@@ -1802,6 +1819,51 @@ def _move_to_trash_locked(
         for uid in requested:
             unit = by_uid.get(uid)
             if unit is None:
+                continue
+            if refresh is not None:
+                # Re-read before EVERY unit, not once before the loop. The mtime
+                # check below is the only other per-unit signal and it sees writes
+                # only, so a resume that merely READS an old transcript to rebuild
+                # history — recording the turn that follows under a newly mapped
+                # sid — leaves every mtime days old and slips past it (#7118). The
+                # index is where that resume IS visible, so it has to be consulted
+                # at the same cadence.
+                #
+                # Affordable because an unchanged view costs one identity
+                # comparison: *refresh* may return the same object it returned last
+                # time to say "nothing has moved", and the dashboard's does exactly
+                # that behind a stat of the session map. A caller that returns a
+                # fresh index every time is not wrong, only slower — the sets are
+                # re-derived and the answer is identical.
+                try:
+                    latest = refresh()
+                except Exception:
+                    # Degraded, not fatal. Every re-read only ever WIDENS the live
+                    # sets, so losing one leaves the guard exactly as strong as the
+                    # pre-loop read already made it — it cannot make a session
+                    # reclaimable that the checks before this loop protected. A
+                    # batch part-way through has already moved files, and
+                    # abandoning it over the loss of an additive signal would be
+                    # the worse trade. A refresh broken from the start still fails
+                    # closed: the pre-loop call above raises.
+                    if not refresh_failed:
+                        refresh_failed = True
+                        logger.warning(
+                            "could not re-read the session index while staging; "
+                            "continuing with the last view read",
+                            exc_info=True,
+                        )
+                else:
+                    if latest is not seen:
+                        seen = latest
+                        live_sids = live_sids | latest.active_sids
+                        live_stems = live_stems | latest.active_stems
+            if is_live(uid):
+                # Mapped since the checks that certified it. Nothing of this
+                # session has moved yet, so there is nothing to roll back — it is
+                # simply not taken, and reported the same way a write-shaped
+                # revival is.
+                revived.append(uid)
                 continue
             files: list[dict[str, Any]] = []
             done: list[tuple[Path, Path]] = []

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -474,6 +474,202 @@ class TestASessionResumedWhileStagingIsLeftAlone:
         assert batch.revived == ()
 
 
+class TestAReadOnlyResumeIsCaughtByTheIndexReRead:
+    """mtime sees writes, so a resume that only READS needs a second signal.
+
+    Resuming a session reads its old transcript to rebuild history and records the
+    turn that follows under a newly mapped sid, without rewriting that transcript.
+    Every file therefore keeps the mtime that qualified it and passes the check
+    above — so the loop consults the index too, at the same per-session cadence,
+    where the resume IS visible: it is mapped.
+    """
+
+    def test_a_resume_that_only_reads_the_transcript_is_left_in_place(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The case the mtime guard cannot see: nothing is written at all."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=400)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-2", size=16, age_days=400)
+
+        pairs = {"aaaa1111": "dashboard_chat-1", "bbbb2222": "dashboard_chat-2"}
+        retired = _index(pairs)
+        resumed = {"yet": False}
+        real = session_storage._move_file
+
+        def _resume_the_second_session(src: Path, dst: Path) -> None:
+            # Mapped part-way through the batch, and nothing written: no utime, no
+            # append, no recreated origin. This is the whole point of the case.
+            real(src, dst)
+            resumed["yet"] = True
+
+        monkeypatch.setattr(session_storage, "_move_file", _resume_the_second_session)
+
+        def _refresh() -> SessionIndex:
+            return retired if not resumed["yet"] else _index(pairs, active={"bbbb2222"})
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222"],
+            reason="manual",
+            index=retired,
+            now=_NOW,
+            refresh=_refresh,
+        )
+
+        assert batch.revived == ("bbbb2222",)
+        assert batch.sessions == 1
+        # Left in place means every half, and nothing of it staged: the loop reaches
+        # this session before touching any of its files, so there is no rollback.
+        assert (kiro_home / "sessions" / "cli" / "bbbb2222.jsonl").is_file()
+        assert (kiro_home / "sessions" / "cli" / "bbbb2222.json").is_file()
+        assert (crew_home / "sessions" / "dashboard_chat-2.jsonl").is_file()
+        staged = list((crew_home / "sessions" / "trash").rglob("*bbbb2222*"))
+        assert staged == [], f"a session left in place has files in the batch: {staged}"
+
+    def test_the_index_is_consulted_before_every_session(self, stores: tuple[Path, Path]) -> None:
+        """Once before the loop is not enough — that is the gap being closed.
+
+        Pinned as a count rather than a behaviour because the behaviour it buys is
+        already covered above; what a future change could quietly drop is the
+        CADENCE, and then only a batch resumed at exactly the wrong moment would
+        notice.
+        """
+        crew_home, kiro_home = stores
+        for sid, stem in (("aaaa1111", "1"), ("bbbb2222", "2"), ("cccc3333", "3")):
+            _cli_half(kiro_home, sid, log_bytes=16, age_days=400)
+            _transcript(crew_home, f"dashboard_chat-{stem}", size=16, age_days=400)
+
+        retired = _index(
+            {
+                "aaaa1111": "dashboard_chat-1",
+                "bbbb2222": "dashboard_chat-2",
+                "cccc3333": "dashboard_chat-3",
+            }
+        )
+        calls = {"n": 0}
+
+        def _refresh() -> SessionIndex:
+            calls["n"] += 1
+            return retired
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222", "cccc3333"],
+            reason="manual",
+            index=retired,
+            now=_NOW,
+            refresh=_refresh,
+        )
+
+        assert batch.sessions == 3
+        # One before the authority checks, then one per session reached.
+        assert calls["n"] == 4
+
+    def test_an_unchanged_index_is_not_re_derived(self, stores: tuple[Path, Path]) -> None:
+        """The per-session re-read has to be affordable at the selection cap.
+
+        ``active_stems`` rebuilds a frozenset over the whole map every time it is
+        read, so re-deriving it per session is what would make a six-figure
+        selection unpayable. A caller says "nothing has moved" by returning the same
+        object, and that must cost one identity comparison rather than a rebuild.
+        """
+        crew_home, kiro_home = stores
+        for sid, stem in (("aaaa1111", "1"), ("bbbb2222", "2"), ("cccc3333", "3")):
+            _cli_half(kiro_home, sid, log_bytes=16, age_days=400)
+            _transcript(crew_home, f"dashboard_chat-{stem}", size=16, age_days=400)
+
+        derived: list[str] = []
+
+        class _CountingIndex(SessionIndex):
+            """Records every read of the set the union would rebuild."""
+
+            @property
+            def active_stems(self) -> frozenset[str]:
+                derived.append("active_stems")
+                return super().active_stems
+
+        retired = _CountingIndex(
+            stem_to_sid={
+                "dashboard_chat-1": "aaaa1111",
+                "dashboard_chat-2": "bbbb2222",
+                "dashboard_chat-3": "cccc3333",
+            }
+        )
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222", "cccc3333"],
+            reason="manual",
+            index=_index(
+                {
+                    "aaaa1111": "dashboard_chat-1",
+                    "bbbb2222": "dashboard_chat-2",
+                    "cccc3333": "dashboard_chat-3",
+                }
+            ),
+            now=_NOW,
+            refresh=lambda: retired,
+        )
+
+        assert batch.sessions == 3
+        # Once, for the union before the authority checks. Three more would mean
+        # every session paid for a rebuild of a set that had not changed.
+        assert derived == ["active_stems"]
+
+    def test_a_re_read_that_starts_failing_keeps_the_view_it_last_read(
+        self, stores: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A lost re-read costs extra protection, not the protection already read.
+
+        Every re-read only widens the live sets, so failing to take one leaves the
+        guard exactly as strong as the last successful read made it. Abandoning a
+        batch that has already moved files would be the worse trade — and a refresh
+        broken from the start still fails closed, before anything moves.
+        """
+        crew_home, kiro_home = stores
+        for sid, stem in (("aaaa1111", "1"), ("bbbb2222", "2"), ("cccc3333", "3")):
+            _cli_half(kiro_home, sid, log_bytes=16, age_days=400)
+            _transcript(crew_home, f"dashboard_chat-{stem}", size=16, age_days=400)
+
+        pairs = {
+            "aaaa1111": "dashboard_chat-1",
+            "bbbb2222": "dashboard_chat-2",
+            "cccc3333": "dashboard_chat-3",
+        }
+        calls = {"n": 0}
+
+        def _refresh() -> SessionIndex:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Before the authority checks: reports every session retired, so
+                # the batch is allowed to start.
+                return _index(pairs)
+            if calls["n"] == 2:
+                # Reached the first session, and the third has just been resumed.
+                return _index(pairs, active={"cccc3333"})
+            raise OSError("the map went away")
+
+        with caplog.at_level(logging.WARNING, logger=session_storage.__name__):
+            batch = session_storage.move_to_trash(
+                ["aaaa1111", "bbbb2222", "cccc3333"],
+                reason="manual",
+                index=_index(pairs),
+                now=_NOW,
+                refresh=_refresh,
+            )
+
+        # The two the failing re-reads could not speak for still moved.
+        assert batch.sessions == 2
+        # And the one the last GOOD read named is still protected, which is the
+        # difference between retaining the view and discarding it.
+        assert batch.revived == ("cccc3333",)
+        assert (kiro_home / "sessions" / "cli" / "cccc3333.jsonl").is_file()
+        warnings = [r for r in caplog.records if "could not re-read" in r.getMessage()]
+        # Once for the batch, not once per session: at the selection cap a
+        # per-session line is six figures of identical warnings.
+        assert len(warnings) == 1
+
+
 class TestRestoreIsAllOrNothing:
     def test_restores_every_half(self, stores: tuple[Path, Path]) -> None:
         crew_home, kiro_home = stores

--- a/test/test_session_storage_api.py
+++ b/test/test_session_storage_api.py
@@ -1071,6 +1071,116 @@ class TestIndexConstruction:
         assert index.active_stems == frozenset(index.stem_to_sid)
 
 
+class TestTheReclaimRefreshIsCheapToCallPerSession:
+    """``move_to_trash`` calls ``refresh`` once per selected session (#7118).
+
+    It has to, because a resume that only READS an old transcript writes nothing
+    and is invisible to the mtime guard inside the move loop — the index is where
+    it shows up. Rebuilding the index that often is what has to be made affordable:
+    the rebuild reads and parses the whole session map, and the selection is capped
+    at six figures.
+    """
+
+    def _write_map(self, payload: dict[str, str]) -> Path:
+        """Land a session map the way ``SessionMap`` does: replace, never edit.
+
+        The token includes ``st_ino`` precisely because every real write arrives
+        through ``os.replace``, so an in-place rewrite is not the case under test.
+        """
+        target = handler.config_dir() / handler.SESSION_MAP_FILENAME
+        tmp = target.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, target)
+        return target
+
+    def test_the_same_index_is_returned_while_the_map_has_not_moved(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """One stat, not one parse — and the SAME object, which is the signal.
+
+        ``move_to_trash`` reads an unchanged index by identity, so returning an
+        equal-but-new object would still pay for re-deriving its sets per session.
+        """
+        self._write_map({"dashboard:chat-1": "aaaa1111"})
+        built = []
+
+        def _spy() -> handler.SessionIndex:
+            built.append(1)
+            return handler.SessionIndex()
+
+        refresh = handler._MapBackedRefresh()
+        with patch.object(handler, "_build_index", _spy):
+            first = refresh()
+            second = refresh()
+            third = refresh()
+
+        assert first is second is third
+        assert len(built) == 1
+
+    def test_a_mapping_write_forces_a_rebuild(self, stores: tuple[Path, Path]) -> None:
+        """A resume maps the session, which replaces the file. That must be seen."""
+        self._write_map({"dashboard:chat-1": "aaaa1111"})
+
+        def _spy() -> handler.SessionIndex:
+            return handler.SessionIndex()
+
+        refresh = handler._MapBackedRefresh()
+        with patch.object(handler, "_build_index", _spy):
+            before = refresh()
+            self._write_map({"dashboard:chat-1": "aaaa1111", "dashboard:chat-2": "bbbb2222"})
+            after = refresh()
+
+        assert before is not after
+
+    def test_an_unreadable_map_is_never_treated_as_unchanged(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """Fails toward rebuilding: a missing map costs a re-read, not a skip.
+
+        Skipping on an unreadable token would turn "I cannot tell" into "nothing
+        has changed", which is exactly the wrong direction for a guard.
+        """
+        assert not (handler.config_dir() / handler.SESSION_MAP_FILENAME).exists()
+        built = []
+
+        def _spy() -> handler.SessionIndex:
+            built.append(1)
+            return handler.SessionIndex()
+
+        refresh = handler._MapBackedRefresh()
+        with patch.object(handler, "_build_index", _spy):
+            first = refresh()
+            second = refresh()
+
+        assert first is not second
+        assert len(built) == 2
+
+    def test_a_write_landing_during_a_rebuild_is_not_missed(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """The token is read BEFORE the rebuild, and that one is stored.
+
+        Stamping the rebuilt index with a token read afterwards would record a write
+        the rebuild had already raced past, and the next call would report the map
+        unchanged — losing the very resume this exists to catch.
+        """
+        self._write_map({"dashboard:chat-1": "aaaa1111"})
+        raced = {"yet": False}
+
+        def _spy_that_races() -> handler.SessionIndex:
+            if not raced["yet"]:
+                raced["yet"] = True
+                self._write_map({"dashboard:chat-2": "bbbb2222"})
+            return handler.SessionIndex()
+
+        refresh = handler._MapBackedRefresh()
+        with patch.object(handler, "_build_index", _spy_that_races):
+            first = refresh()
+            second = refresh()
+
+        assert first is not second
+
+
 class TestWhyAReclaimIsRefused:
     """A refusal must name the real reason.
 


### PR DESCRIPTION
## Problem / Motivation

`move_to_trash`'s revival guard (added in #7081) decides whether a session was
resumed mid-staging by comparing each source file's mtime against the instant the
reclaim began. That catches a resume that WRITES. It does not catch a resume that
only READS.

The uncovered sequence:

1. A retired session's files are certified reclaimable: unmapped by both index
   reads, untouched for `MIN_RECLAIM_AGE_DAYS`.
2. The session is resumed. The resume reads the old transcript to rebuild history.
3. The turn that follows is recorded under a newly mapped sid, without rewriting
   that old transcript.
4. Every one of the session's files therefore still carries its days-old mtime,
   all of them pass `mtime > validated_at`, and the whole session is staged.

The live slot then keeps running with its durable history in the trash.

## Why it matters

A user resumes a chat and finds its history gone, with nothing in the transcript
explaining why. #7081 narrowed the window this happens in; the remaining case is
the one where the resume is a pure read, and its window is the whole move loop
rather than microseconds.

It is a continuity failure rather than data loss: restore puts the history back,
and emptying the trash needs a separate deliberate action. Same severity class as
the defect #7081 fixed.

## What changed (motivation -> approach -> change)

**The index is the only place a read-only resume is visible**, because such a
resume is mapped even though it wrote nothing. So `refresh` is now called before
EVERY session the move loop reaches, not once before the loop. A session the
re-read reports as mapped is left in place and named in `TrashBatch.revived`, the
same way a write-shaped revival already was. Nothing of it has moved when the
check fires, so there is no rollback. The mtime check stays: it costs no syscall
(the stat is already taken for the manifest) and it catches the write-shaped
resume inside a session's own file walk, which the re-read cannot.

**Making that cadence affordable is the whole design problem, and it is measured.**
`_build_index` reads and parses the whole session map, so there is a per-call floor
of about 0.26 ms however small the map, and the selection is capped at
`_MAX_SELECTION = 200_000`:

| map entries | `_build_index()` | union sets | per unit | x 200,000 units |
|---|---|---|---|---|
| 100 | 0.260 ms | 0.022 ms | 0.282 ms | **56 s** |
| 1,000 | 2.017 ms | 0.238 ms | 2.255 ms | **451 s** |
| 10,000 | 21.74 ms | 4.91 ms | 26.65 ms | **1.5 h** |
| 100,000 | 306.8 ms | 88.0 ms | 394.8 ms | **21.9 h** |

`os.stat()` on the map file, for comparison: 2.0 us. It is not the six-figure
store that makes a naive per-session rebuild expensive, it is the six-figure
selection: 56 s even against a 100-entry map.

So the cheapness is where the knowledge is. `refresh` may return the SAME
`SessionIndex` object it returned last time to say "nothing has moved", which the
loop recognises by identity and does not re-derive sets for. The dashboard's
refresher (`_MapBackedRefresh`) rebuilds only when `session_map.json`'s
`(st_ino, st_mtime_ns, st_size)` moves. Every mapping write lands through
`mkstemp` plus `os.replace`, so the inode changes on every write and an unmoved
token cannot hide one. Per-session cost at the cap: one stat, 0.4 s total. The
token is read BEFORE the rebuild and that one is stored, so a write landing during
a rebuild is seen by the next call rather than stamped as already-included. An
unreadable token is `None`, which never compares equal, so it costs a real re-read
rather than a skipped one. No signature change, and a caller that returns a fresh
index every call (every existing test) still gets a real re-read per session.

**A re-read that fails mid-loop degrades rather than aborting.** It is logged once
per batch and the last view read is kept. Every re-read only ever widens the live
sets, so losing one costs the extra protection it would have added, not the
protection already read; abandoning a batch that has already moved files would be
the worse trade. A refresh broken from the start still fails closed, before
anything moves, through the existing pre-loop raise.

**Two candidate shapes the issue named were rejected, and why.** Shape 1 (naive
per-unit rebuild) is the table above. Shape 2 (one refresh after the loop, then
roll back what is now live) costs one extra map read, but the unwind is the
problem: manifest entries are written as each session lands specifically so an
interruption leaves a manifest describing exactly what moved, so removing an entry
means either rewriting the manifest, which gives that invariant up, or a tombstone
every one of `_read_manifest`, `_summarize_manifest`, `_restore_locked`,
`_manifest_rels`, `_listed_bytes`, `staged_targets` and `_empty_trash_locked` has
to honour. The shape shipped here keeps the append-as-it-lands invariant untouched.

`docs/system-specs/modules/session-storage.md` moves with the code: the section is
retitled, the two-signal loop is described, the corrected Known Limitations entry
that #7282 added for this gap is replaced by the bounded residual that survives it,
and the handler section stops saying a read-only resume is staged instead of
refused.

## Tests

Targeted files only (`test_session_storage.py`, `test_session_storage_api.py`):
284 passed. `test_session_map_locking.py` (the locking ratchet over this tree): 16
passed. black, ruff and mypy clean on the four changed Python files.

Red on base, with the exact assertions:

- `test_a_resume_that_only_reads_the_transcript_is_left_in_place` -
  `assert () == ('bbbb2222',)`. The resume writes nothing at all: no append, no
  utime, no recreated origin. Also asserts every half is still in place and the
  batch holds no file of it.
- `test_the_index_is_consulted_before_every_session` - `assert 1 == 4`. Pins the
  cadence, which is what a future change could quietly drop.
- `test_a_re_read_that_starts_failing_keeps_the_view_it_last_read` -
  `assert 3 == 2`. The last good view still protects the session it named, the rest
  of the batch still moves, and the warning is logged once rather than per session.

`test_an_unchanged_index_is_not_re_derived` passes on base too, because base calls
`refresh` once - it is a cost ratchet, not a repro. Mutation-verified it has teeth:
replacing the identity check with an unconditional re-derivation turns it red
(`assert ['active_stems', ...] == ['active_stems']`).

Four tests cover the refresher itself: same object while the map has not moved
(one build for three calls), a rebuild after a mapping write, a rebuild when the
map is unreadable, and a write landing during a rebuild not being missed.

## Manual verification

Not applicable - no user-visible surface changes. The behaviour is a refusal path
inside a reclaim, exercised by the tests above.

## Related Issues

Closes #7118
Refs #7081, #7282

## Pattern harvest

Rule candidate: review-prompt
Pattern: a guard infers "was this resumed" from a file's mtime, so a resume that
only READS the file is invisible to it.

The mtime proxy is the whole defect. It answers "was this written since we
certified it", which is a strictly narrower question than "is this live", and the
gap is exactly the read-only user. A review prompt can ask it directly: when a
staleness or liveness check reads an mtime, what does a reader of that file look
like to the check? Not a semgrep candidate - `mtime > stamp` is a correct and
common comparison, and only the surrounding claim makes it wrong here.

Three further observations from the fix, none of them rule-shaped on their own:

- A per-item check that is prohibitive at scale is often prohibitive only in its
  naive form. Measure the floor, not the ceiling: the first row of the table (a
  100-entry map) settles the design, because n is what multiplies it.
- Push the cheapness to whoever owns the change signal. This module already takes
  liveness from its caller by design, so a caller-memoized refresh is idiomatic
  here where a module that secretly stats the caller's backing file would not be.
- A monotonic signal (these sets are only ever unioned) can degrade safely on
  failure. That is what makes "log once and keep the last view" defensible instead
  of a swallowed error.
