### PR TITLE
fix(system): make the session trash write path crash-durable

### DIFF
--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -310,9 +310,88 @@ reversible move into data loss.
 
 On a default install both stores sit under `~/.kiro`, so staging is a
 same-filesystem `os.rename`: instant regardless of size, and instantly reversible.
-A data home mounted apart from the kiro-cli store falls back to `shutil.move`,
-which copies — correct, but slow and needing the space twice while it runs.
+A data home mounted apart from the kiro-cli store falls back to a copy — correct,
+but slow and needing the space twice while it runs.
 `StorageReport.trash_same_filesystem` reports which case applies.
+
+**The cross-filesystem copy is atomic and durable, in that order.**
+`_copy_across_filesystems()` copies into an `INCOMING_PREFIX` name beside the
+destination, carries the source's metadata onto it, `fsync`s it, publishes it with
+`replace_with_retry`, `fsync`s the destination's directory, and unlinks the source.
+Nothing there is cosmetic: copying straight to the final name (what `shutil.move`
+does) spends the whole copy with a partial file under the name the manifest will
+record; `copystat` runs BEFORE the file `fsync` because it writes the inode and the
+`fsync` is what forces the inode out, so the other order can publish the bytes under
+the temp's own `0600` and creation time — and this module ages sessions by their mtime;
+and unlinking before the destination `fsync` can return to a durable absence of the
+source with the destination's bytes still in the page cache.
+
+**Nothing that can raise runs after the unlink.** The staging loop reads an exception
+from the mover as "this file did not move" — it rolls the session back and omits the
+file from the manifest — so raising after the file HAS moved produces a half-staged
+session nothing records, which is the split the rollback exists to prevent. The source
+directory still wants syncing, because copy-then-unlink is TWO operations (unlike the
+same-filesystem rename, which is one, so forcing the destination side forces the
+removal with it) and a crash between them can leave BOTH names: a live session the user
+was told had been reclaimed beside a staged copy the manifest records as trashed. So
+the loop collects the drained directories and `_sync_batch()` syncs them once, after
+the batch is fully recorded, `best_effort` — a non-durable source entry can only
+resurrect a duplicate, never lose a copy. `test_nothing_that_can_raise_runs_after_a_file_has_moved`
+and `test_the_drained_source_directories_are_synced_once_per_batch` pin both halves.
+
+Because an exception out of a mover MEANS "nothing of this move survives", the failing
+DESTINATION SYNC withdraws the publication before re-raising — safe there because the
+source has not been touched yet, so removing the destination provably restores the state
+the call started in. The `src.unlink()` that follows is deliberately NOT treated that way,
+and the difference is the point. A filesystem can report a failure for an unlink that DID
+commit (a network filesystem losing the reply to a completed operation), and the source
+name existing afterwards does not prove the ORIGINAL still does: a concurrent append
+recreates that name with a new, empty file, at which point the destination holds the only
+copy of the history. Nothing observable at that instant separates "the unlink failed" from
+"the unlink succeeded and something recreated the name", so the destination is kept and
+the exception propagates untouched. The leftover is then a file no manifest entry names,
+which `_unlisted_files()` refuses to delete and which blocks emptying that batch until an
+operator clears it — a worse report than the truth, but recoverable, which bytes nobody
+can get back are not. `test_the_mover_keeps_the_copy_when_the_unlink_fails` and
+`test_the_exclusive_mover_keeps_the_copy_when_the_unlink_fails` pin it on each mover, and
+`test_a_failed_unlink_keeps_the_published_copy` pins the end-to-end case where the name is
+recreated.
+
+Only a COPY can dereference a symlink: `os.rename` moves the link itself and `os.link`
+links to the link, so neither mover's fast path can leak through one. Their copy fallbacks
+read through `_open_source_no_follow()`, which sets `O_NOFOLLOW` and refuses a link in the
+source's final component rather than reading what it points at — in both directions,
+because a session file swapped for a link to a credential store would copy the SECRET's
+bytes into an agent-readable trash, and a link planted in the trash would copy arbitrary
+bytes back out over a restored origin. Staging does not hand it a link today, since every
+enumeration scan uses `is_file(follow_symlinks=False)`, so this is hardening rather than a
+reachable hole being closed: it makes the copy safe on its own terms instead of by
+inheritance from a filter several hundred lines away.
+`test_the_copy_helper_refuses_a_symlink_instead_of_reading_its_target` pins it at the copy
+and `test_a_planted_source_symlink_never_reaches_the_trash` pins the end-to-end outcome.
+The final component is what a swap replaces; a symlinked PARENT directory is still
+traversed, which needs an `openat` walk down the chain and is its own change.
+
+The incoming name is naming only: `_unlisted_files()` deliberately does NOT exempt it,
+because a name says nothing about who wrote it and this module's threat model already
+assumes a batch can be planted in. So a crash mid-copy leaves debris that blocks
+emptying that batch until an operator clears it — the same posture main already has for
+an interrupted cross-filesystem move, whose partial file is equally unlisted.
+`TestCrossFilesystemStaging` fails if the copy publishes under the final name, skips
+any of the syncs, or if the scan starts passing over the incoming prefix.
+
+**`fsync_dir()` is quiet only where a directory sync cannot be expressed.** Windows
+has no directory descriptor to open and some network mounts reject `fsync` on a
+directory, so those return without complaint; every other errno is raised. The
+distinction is load-bearing rather than fussy, because each caller's next step is to
+destroy the only other copy — a swallowed `EIO` would hand it a false "durable" just
+before the unlink. `best_effort=True` downgrades even that to a warning, and is for
+callers whose operation is ALREADY COMMITTED (the drained source directories above; the
+vault's key and store writes, where a raise would report a stored secret as never
+written and drop it from a migration's rollback set). It is a keyword rather than a
+bare `except OSError` per call site so the decision is visible and still logged.
+`TestFsyncDirDiscriminates` fails if a device error is logged away by default or if a
+platform without directory descriptors starts raising.
 
 **Staging does not free space.** The bytes stay on disk until the trash is
 emptied. `StorageReport.trash_bytes` and the payload's `trash.still_on_disk` exist
@@ -321,9 +400,9 @@ its own payload.
 
 ### Manifests
 
-Every new batch starts an append-only `manifest.jsonl`: a header line followed by one entry per staged session recording each file's relative staged path, original path, and size. `_append_entry()` flushes each entry, but it does not `fsync`, so the implementation does not promise device-persistent durability across a power loss. `_manifest_records()` retains every valid record it can read and ignores a trailing malformed record, while `_unlisted_files()` prevents deletion of files that no retained manifest entry names. `TestTrashAccounting::test_a_truncated_final_line_does_not_lose_the_batch` pins that recovery posture.
+Every new batch starts an append-only `manifest.jsonl`: a header line followed by one entry per staged session recording each file's relative staged path, original path, and size. `_append_entry()` flushes each entry, and `_sync_batch()` `fsync`s the manifest and then EVERY staged directory level, deepest first, at each point `_move_to_trash_locked()` can leave a batch on disk. That is what makes a move that RETURNED durable: the moves are renames whose metadata the filesystem commits on its own schedule, so without it a power loss could come back to the sessions' only copies under an empty manifest — and a batch with no readable manifest is omitted from `list_trash()`, out of reach of restore and of empty alike. Every level, not just each file's own parent, because `mkdir(parents=True)` also creates the intermediates and a directory's name lives in its PARENT's entries — a session with archive segments but no transcript never otherwise records `crew` at all, and on the FIRST batch a machine ever stages the same call creates `trash/` and `trash/sessions/`, whose own entries `_fsync_tree()` walks down from the data home. A fresh chain is ALSO synced at the moment it is created, before any file is renamed into it: the same-filesystem move is a rename, which gives up the file's only other name in the same atomic step that creates the new one, so a rename that reaches disk while the `mkdir` that created its parent does not would leave no name resolving to the file at all. That sync costs one call per new directory rather than one per file, so the per-file path stays a bare rename; if it fails the session is rolled back and left in place, exactly as for a file that would not move, rather than abandoning a batch whose manifest has not been forced out. A failing sync RAISES: the batch is the only copy, so reporting a durable batch that is not one is worse than reporting a failure for work that partly happened. The single exception is the "resumed while being staged" path, which is already raising an error that names the session and locates its fragment; there a sync failure is logged so that pointer is not replaced by an `OSError`. None of this makes a crash mid-move consistent; a batch interrupted halfway still holds files its manifest never named, which is what `_unlisted_files()` is for. `_manifest_records()` retains every valid record it can read and ignores a trailing malformed record, while `_unlisted_files()` prevents deletion of files that no retained manifest entry names. `TestTrashAccounting::test_a_truncated_final_line_does_not_lose_the_batch` pins that recovery posture, and `TestStagedBatchDurability` fails if a returned move left the manifest or any staged directory level unsynced.
 
-A partial restore is the exception to append-only growth: `_rewrite_manifest()` writes a temporary replacement and uses `os.replace`. That gives readers the old or replacement pathname during the running filesystem operation, not a power-loss durability guarantee. A batch with no readable manifest is omitted from `list_trash()`: its files could not be put back, so offering it as restorable would be a false promise.
+A partial restore is the exception to append-only growth: `_rewrite_manifest()` writes the replacement through `atomic_write(..., fsync=True)` and then `fsync`s the batch directory, so both the new content and the rename that gave it the manifest's name are durable before the call returns. Without the directory half a power loss could return the pre-restore manifest, whose entries name files restore has already moved back into live storage. A batch with no readable manifest is omitted from `list_trash()`: its files could not be put back, so offering it as restorable would be a false promise.
 
 **A manifest that is a link stops the empty before anything is removed**
 (`SKIP_UNREADABLE`), and the check runs BEFORE the manifest is read and before the
@@ -751,7 +830,15 @@ so undoing a deletion would destroy the newer data it exists to protect.
 `_move_file_exclusive()` creates the destination exclusively (`os.link`, falling back
 to `O_CREAT | O_EXCL` across filesystems), making the check and the write one atomic
 step. A lost race rolls the session back and **retains** its manifest entry, because
-restoring the rest would splice two generations of one session together.
+restoring the rest would splice two generations of one session together. On the copy
+branch the destination is `fsync`ed and its directory `fsync`ed **before** the source
+is unlinked, and the source's directory `fsync`ed after: that unlink is the moment the
+copy stops being a second copy, buffered bytes on the far side of it are a session a
+power loss can erase from both places at once, and a non-durable unlink can instead
+leave both names — a session restored into live storage while its staged copy is still
+in the batch under its manifest entry.
+`test_a_cross_filesystem_restore_syncs_before_it_unlinks_the_source`
+fails if either sync moves after the unlink.
 
 `_rollback()` uses the same exclusive move. A rollback runs *after* something already
 failed, so the origin may have been recreated in the meantime, and a plain rename

--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -302,6 +302,113 @@ def replace_with_retry(src: Path | str, dst: Path | str) -> None:
     os.replace(str(src), str(dst))
 
 
+#: ``fsync`` on a directory that the platform or filesystem simply cannot express.
+#: Every other errno is a real failure and is raised, because a caller whose next
+#: step destroys the only other copy must not read "could not sync" as "synced".
+_DIR_SYNC_UNSUPPORTED = frozenset(
+    code
+    for code in (
+        getattr(errno, name, None)
+        for name in ("EINVAL", "ENOTSUP", "EOPNOTSUPP", "EPERM", "EACCES", "EBADF", "ENOSYS")
+    )
+    if code is not None
+)
+
+
+def _close_quietly(fd: int, path: Path | str) -> None:
+    """Close a directory descriptor, logging rather than raising.
+
+    POSIX releases the descriptor even when ``close`` reports an error, so there is no
+    leak to recover from — only a diagnostic, and one that is never the most useful
+    thing the caller could be told.
+    """
+    try:
+        os.close(fd)
+    except OSError:
+        logger.warning("could not close the directory descriptor for %s", path, exc_info=True)
+
+
+def fsync_dir(path: Path | str, *, best_effort: bool = False) -> None:
+    """Force a directory's own entries out, so a create or rename survives a crash.
+
+    The half that :func:`atomic_write`'s ``fsync=True`` does not cover. Syncing the
+    file descriptor forces the DATA; the name that reaches it lives in the parent
+    directory, and until that directory is synced a power-off can return from
+    ``os.replace`` and still come back to the old entry, with the new file's name
+    recorded nowhere. Any writer whose next step destroys the only other copy —
+    unlinking the source of a move, emptying a staging area — has to sync the
+    directory too, or its "the replacement is safely in place" is not yet true.
+
+    Deliberately NOT a ``sync_dir=`` option on :func:`atomic_write`: that would
+    change the durability cost of every existing caller. This is opt-in, so the
+    callers that need the guarantee pay for it and the rest are untouched.
+
+    **Quiet where a directory sync cannot be expressed, and only there.** Windows has
+    no directory descriptor to open, and some filesystems (network mounts in
+    particular) reject ``fsync`` on a directory; there the atomic rename plus the
+    file ``fsync`` are the guarantee available, and raising would turn a completed
+    write into a reported failure. But an ``EIO`` is not that case — it says the
+    device did not take the write — so it is raised. Swallowing it would hand the
+    caller a false "durable" just before it unlinks the only other copy, which is the
+    data loss this helper exists to prevent.
+
+    ``best_effort=True`` downgrades even that to a warning, and exists for one shape
+    of caller: one whose operation is ALREADY COMMITTED, where the sync only firms up
+    a step that has happened. Raising at such a point does not protect anything — it
+    reports completed work as failed, and a caller that then treats the work as
+    un-done is the worse outcome. It is a keyword rather than a bare
+    ``except OSError`` at the call site so the decision is visible, single-pathed, and
+    still logged.
+    """
+    try:
+        dir_fd = os.open(str(path), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        if platform_compat.IS_WINDOWS:
+            # The platform case: no directory descriptors at all.
+            return
+        if best_effort:
+            logger.warning("could not open %s to sync it; its entries may not be durable", path)
+            return
+        raise
+    try:
+        os.fsync(dir_fd)
+    except OSError as exc:
+        # The fsync error is the informative one, so the close is quiet on every
+        # failing path here: raising a close error on top would mask the reason.
+        _close_quietly(dir_fd, path)
+        if exc.errno in _DIR_SYNC_UNSUPPORTED:
+            logger.debug(
+                "this filesystem does not support syncing the directory %s (%s)",
+                path,
+                errno.errorcode.get(exc.errno or 0, exc.errno),
+            )
+            return
+        if best_effort:
+            logger.warning(
+                "could not sync the directory %s; its entries may not be durable",
+                path,
+                exc_info=True,
+            )
+            return
+        raise
+    # The sync reported success — but ``close`` can report a write error the kernel
+    # deferred, which for a caller whose next step is to unlink the only other copy
+    # is the same signal as a failed fsync. So it is checked, and it honours
+    # best_effort for the same reason the fsync above does: a caller past its point of
+    # no return cannot act on it. Not in a ``finally``: that would let a close error
+    # replace an in-flight fsync error with a less informative one.
+    try:
+        os.close(dir_fd)
+    except OSError:
+        if not best_effort:
+            raise
+        logger.warning(
+            "could not close the descriptor for %s; its entries may not be durable",
+            path,
+            exc_info=True,
+        )
+
+
 def read_bytes_with_retry(path: Path | str) -> bytes:
     """``Path.read_bytes()``, retrying the Windows sharing-violation window.
 

--- a/src/kiro_crew/secrets/vault.py
+++ b/src/kiro_crew/secrets/vault.py
@@ -25,26 +25,8 @@ from typing import Iterator, Optional
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from kiro_crew.atomic_write import atomic_write
+from kiro_crew.atomic_write import atomic_write, fsync_dir
 from kiro_crew.platform_compat import file_lock, restrict_to_owner
-
-
-def _fsync_dir(path: Path) -> None:
-    """Fsync a directory so a rename/create is durable across power loss.
-
-    No-op where directory fds cannot be opened for fsync (e.g. Windows),
-    where the atomic rename + file fsync already provide the guarantee.
-    """
-    try:
-        dir_fd = os.open(str(path), os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(dir_fd)
-    except OSError:
-        pass
-    finally:
-        os.close(dir_fd)
 
 
 class SecretValue:
@@ -322,7 +304,11 @@ class SecretVault:
                 pass
             raise
         os.close(fd)
-        _fsync_dir(self._config_dir)
+        # best_effort: the key file is created, written and fsynced by this point, and
+        # the failure cleanup above has already been left behind. Raising here would
+        # report a key that IS on disk as never created, and the caller's recovery for
+        # that is to mint a second one over it.
+        fsync_dir(self._config_dir, best_effort=True)
         return key
 
     # ── Crypto helpers ──
@@ -463,4 +449,10 @@ class SecretVault:
                 fsync=True,
                 restrict_to_owner=True,
             )
-            _fsync_dir(self._config_dir)
+            # best_effort, and it is this call site's own decision, not a weakening of
+            # the helper: atomic_write has already COMMITTED the entry. A raise here
+            # would abort set_if_absent before it returns its fingerprint, so a
+            # migration would omit an entry that is on disk from its rollback set and
+            # let it shadow the plaintext it was migrating away from. The directory
+            # entry is the least of what is at stake once the value is stored.
+            fsync_dir(self._config_dir, best_effort=True)

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -71,6 +71,7 @@ import os
 import re
 import shutil
 import stat
+import tempfile
 import threading
 import time
 import uuid
@@ -81,7 +82,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import IO, Any
 
 from kiro_crew import hooks, pinned_fs, platform_compat
-from kiro_crew.atomic_write import atomic_write
+from kiro_crew.atomic_write import atomic_write, fsync_dir, replace_with_retry
 from kiro_crew.config.paths import (
     CONFIG_DIR_LEAF,
     KIRO_BASE_DIR_NAME,
@@ -109,6 +110,15 @@ STAGE_CREW_LEAF = "crew"
 
 MANIFEST_NAME = "manifest.jsonl"
 MANIFEST_SCHEMA = 1
+
+# Prefix for a cross-filesystem copy still in flight, so an operator who finds one
+# after a crash can see what it is. Naming only — :func:`_unlisted_files` deliberately
+# does NOT exempt it, because a name says nothing about who wrote it.
+INCOMING_PREFIX = ".kc-incoming-"
+
+# Absent on Windows, where creating a symlink needs privilege this threat model does not
+# hand out; ``| 0`` then leaves the open unchanged rather than failing at import.
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 # Age buckets (in days) the report splits reclaimable sessions into. The
 # boundaries are what make a threshold choice legible: the reclaimable total is
@@ -1133,6 +1143,85 @@ def _batch_dir(batch_id: str) -> Path:
     return path
 
 
+def _open_source_no_follow(src: Path) -> IO[bytes]:
+    """Open *src* for reading, refusing to traverse a symlink in its final component.
+
+    Both movers' COPY fallbacks read through this; their fast paths neither need it nor
+    have the hole. ``os.rename`` moves a symlink rather than what it points at, and
+    ``os.link`` links to the link itself — only a copy dereferences. Without this the
+    same mover would mean two different things depending on whether source and
+    destination happen to share a filesystem, and the cross-device meaning is the
+    dangerous one in both directions: an indexed session file swapped for a link to a
+    credential store would have the SECRET's bytes copied into a trash the agent can
+    read, and a link planted in the trash would have arbitrary bytes copied back out
+    over a restored origin. This module's threat model already assumes planted files,
+    so it has to assume planted links too.
+
+    Refused rather than followed, and not recreated as a link either: a symlink in the
+    session store is anomalous, the staging loop already knows how to leave a session
+    alone when one of its files will not move, and failing closed is the direction that
+    cannot leak.
+
+    The guard covers the FINAL component, which is what the swap it defends against
+    replaces. A symlinked parent directory is still traversed; closing that needs an
+    ``openat`` walk down the chain and is its own change.
+    """
+    # O_NOFOLLOW is POSIX and absent on Windows, where creating a symlink needs
+    # privilege this model does not hand out. Degrade rather than fail to import.
+    return open(src, "rb", opener=lambda path, flags: os.open(path, flags | _O_NOFOLLOW))
+
+
+def _publish_then_drop(src: Path, dst: Path) -> None:
+    """Make a just-created *dst* durable, then remove *src*. Both movers end here.
+
+    One code path for both of :func:`_move_file_exclusive`'s branches, because they have
+    the same shape and the same hazard: a hard link and a copy both leave TWO directory
+    entries for one file, and removing the source is a SECOND metadata operation. Unlike
+    a same-filesystem rename — one atomic operation, where forcing the destination side
+    forces the removal with it — nothing orders these two for us. If the unlink reaches
+    disk and the new name does not, the inode has no name left at all and the session is
+    gone, which is why the destination is synced BEFORE the source is dropped rather than
+    alongside it.
+
+    A failing destination sync ATTEMPTS to withdraw *dst* — the unlink is suppressed so
+    that it cannot displace the sync error, which is the one that says what went wrong.
+    That withdrawal is safe because the SOURCE has not been touched at that point, so
+    removing *dst* provably restores the state the call started in. The unlink below is
+    different: once it has been attempted, no observation available here proves whether
+    the original survived, so nothing is withdrawn there. This function's callers read an
+    exception as "the origin was not taken", which the sync case honours exactly. The
+    unlink case can leave *dst* behind, and that leftover is deliberate: it is a file no
+    manifest entry names, so :func:`_unlisted_files` refuses to delete it and the batch
+    cannot be emptied until an operator clears it. That is a worse report than the truth
+    but a recoverable one, and it is chosen over withdrawing a copy that may be the last
+    one. Only the calling move created *dst*, so keeping it costs nothing that predates
+    the call either.
+
+    The source-side sync is ``best_effort`` and runs after the unlink, where nothing may
+    raise: the move is complete by then, so an exception could only mislabel finished work
+    as failed, and a source entry that is not yet durable can at worst resurrect a
+    duplicate — never lose the copy now at *dst*.
+    """
+    try:
+        fsync_dir(dst.parent)
+    except OSError:
+        with suppress(OSError):
+            dst.unlink()
+        raise
+    # Propagates untouched on failure, leaving *dst* where it is. Withdrawing it would
+    # be guessing: a filesystem can report a failure for an unlink that DID commit (a
+    # network filesystem losing the reply to a completed operation), and the source name
+    # existing afterwards does not prove the original still does — a concurrent append
+    # recreates that name with a NEW, empty file, at which point *dst* holds the only
+    # copy of the history and deleting it destroys exactly what this module exists to
+    # keep. Nothing available here separates those cases, so the leftover is accepted:
+    # it stays in the batch as a file no manifest entry names, which _unlisted_files()
+    # refuses to delete, and it blocks emptying that batch until an operator clears it.
+    # A wedge an operator can undo beats bytes nobody can get back.
+    src.unlink()
+    fsync_dir(src.parent, best_effort=True)
+
+
 def _move_file_exclusive(src: Path, dst: Path) -> bool:
     """Move *src* to *dst*, never replacing an existing *dst*. False if occupied.
 
@@ -1141,6 +1230,9 @@ def _move_file_exclusive(src: Path, dst: Path) -> bool:
     destination silently, so undoing a deletion would destroy the newer data it was
     meant to protect. Creating the destination exclusively makes the check and the
     write one atomic step, so a lost race is reported rather than acted on.
+
+    Both branches finish through :func:`_publish_then_drop`, which is where the
+    durability ordering lives.
     """
     try:
         os.link(src, dst)
@@ -1154,16 +1246,26 @@ def _move_file_exclusive(src: Path, dst: Path) -> bool:
         except FileExistsError:
             return False
         try:
-            with os.fdopen(fd, "wb") as out, open(src, "rb") as handle:
+            with os.fdopen(fd, "wb") as out, _open_source_no_follow(src) as handle:
                 shutil.copyfileobj(handle, out)
-            shutil.copystat(src, dst)
+                # Before the unlink, not after: this is the moment the copy stops
+                # being a second copy. Buffered bytes live in this process and then
+                # in the page cache, so without forcing them out a power-off between
+                # the last write and the unlink reaching disk comes back to an
+                # empty-or-partial destination and no source — the one outcome a MOVE
+                # of the only copy must never produce.
+                #
+                # copystat first so the fsync forces the metadata with the bytes.
+                out.flush()
+                shutil.copystat(src, dst)
+                os.fsync(out.fileno())
         except OSError:
             with suppress(OSError):
                 dst.unlink()
             raise
-        src.unlink()
+        _publish_then_drop(src, dst)
         return True
-    src.unlink()
+    _publish_then_drop(src, dst)
     return True
 
 
@@ -1172,15 +1274,89 @@ def _move_file(src: Path, dst: Path) -> None:
 
     A rename is atomic and instant, which is what makes a trash usable at tens of
     gigabytes. It only works within one filesystem, so a data home mounted apart
-    from the kiro-cli store falls back to :func:`shutil.move` — correct, but it
-    copies, so it is slow and needs the space twice while it runs.
+    from the kiro-cli store falls back to a copy — slow, and it needs the space
+    twice while it runs.
+
+    That fallback is NOT ``shutil.move``. ``shutil.move`` copies straight to the
+    final name and then unlinks the source, so it spends the whole copy with a
+    partial file sitting under the name the manifest will record: an exit there
+    leaves a staged file that looks complete and silently is not. Copy into a
+    private incoming name instead, force the bytes out, and publish with a rename —
+    then the destination name only ever exists whole, and the source is not
+    unlinked until it is durable.
     """
     try:
         os.rename(src, dst)
+        return
     except OSError as exc:
         if getattr(exc, "errno", None) != getattr(os, "EXDEV", 18):
             raise
-        shutil.move(str(src), str(dst))
+    _copy_across_filesystems(src, dst)
+
+
+def _copy_across_filesystems(src: Path, dst: Path) -> None:
+    """Copy *src* to *dst* durably and atomically, then remove *src*.
+
+    The incoming file is created in ``dst.parent`` because the publishing step is a
+    rename, and a rename is only atomic within one filesystem — the destination's
+    own directory is the only place that is guaranteed to be. It carries
+    :data:`INCOMING_PREFIX` so an operator who finds one after a crash can see what it
+    is. That is ALL the prefix does: :func:`_unlisted_files` deliberately exempts
+    nothing by name, so an interrupted copy stays protected as unlisted data rather
+    than being deleted as scratch. Erring that way is the safe direction — a name says
+    nothing about who wrote it, and this module already assumes planted files — at the
+    documented cost that such a leftover blocks its batch from being emptied until an
+    operator removes it.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(dst.parent), prefix=INCOMING_PREFIX)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as out, _open_source_no_follow(src) as handle:
+            shutil.copyfileobj(handle, out)
+            out.flush()
+            # On the temp, not on dst: dst does not exist yet, and the point is that
+            # the name appears already carrying the source's mode and timestamps. The
+            # mtime in particular is what the rest of this module ages sessions by.
+            #
+            # BEFORE the fsync, because copystat writes the inode and the fsync is
+            # what forces the inode out. After it, a power loss could publish the
+            # bytes under the temp's own 0600 and its creation time instead.
+            shutil.copystat(src, tmp)
+            os.fsync(out.fileno())
+        replace_with_retry(tmp, dst)
+    except BaseException:
+        # BaseException, matching atomic_write: a Ctrl-C mid-copy must not leave the
+        # incoming file behind either. The exception itself propagates untouched.
+        with suppress(OSError):
+            tmp.unlink()
+        raise
+    # Publish, then make the publication durable, and only then drop the source.
+    # Reversing the last two would be the same lost-only-copy window the exclusive
+    # mover guards against.
+    #
+    # A failing sync takes the published name back out. The caller reads an exception
+    # as "this file did not move", and it is only entitled to read it that way if
+    # nothing of the move survives: leaving dst behind would put a file in the batch
+    # that no manifest entry names, which blocks emptying that batch for good. The
+    # source has not been touched yet, so unlinking dst restores the state this call
+    # started in exactly.
+    try:
+        fsync_dir(dst.parent)
+    except OSError:
+        with suppress(OSError):
+            dst.unlink()
+        raise
+    # Propagates untouched on failure, leaving *dst* in the batch: see
+    # :func:`_publish_then_drop` for why withdrawing it would be a guess that can
+    # destroy the only remaining copy.
+    src.unlink()
+    # Nothing raising may follow the unlink. The move is COMPLETE here, and this
+    # function's caller reads an exception as "this file did not move" — it rolls the
+    # session back and omits the file from the manifest, which for a file that HAS
+    # moved is a half-staged session that nothing records: the exact split the loop's
+    # rollback exists to prevent. The source directory still wants syncing (see
+    # :func:`_sync_batch`, which does it once per batch), so the caller collects it
+    # rather than paying a per-file sync here.
 
 
 def _file_stamp(path: Path) -> tuple[int, float]:
@@ -1321,6 +1497,15 @@ def _unlisted_files(batch: Path) -> list[Path]:
 
     An unreadable manifest yields every file, which is the safe direction: without
     the manifest nothing in the batch is accounted for.
+
+    There is deliberately NO exemption for the incoming name
+    :func:`_copy_across_filesystems` writes, even though a crash can leave one here and
+    a caller then cannot empty the batch until an operator removes it. A name is not
+    proof of who wrote it: everything else in this module's threat model assumes a
+    batch can be planted in (a linked manifest, a file substituted at the manifest's
+    name), so anything that may rename a file inside a batch could pick that prefix and
+    have this scan pass over a staged file the manifest never approved for deletion.
+    Blocking a deletion that should proceed is recoverable; letting one through is not.
 
     A scan that cannot be completed RAISES rather than returning a short list. This
     function exists to block deletions, so an empty result must mean "there is
@@ -1892,6 +2077,83 @@ def _rewrite_manifest(batch: Path, header: dict[str, Any], entries: list[dict[st
     header_line = json.dumps(header) + "\n"
     entry_lines = "".join(json.dumps(entry) + "\n" for entry in entries)
     atomic_write(batch / MANIFEST_NAME, header_line + entry_lines, fsync=True)
+    # ``fsync=True`` made the new CONTENT durable; this makes the rename that gave
+    # it the manifest's name durable. Without it a power-off just after this returns
+    # can come back to the pre-restore manifest, which lists files restore has
+    # already moved back out — an entry that now names live session data.
+    fsync_dir(batch)
+
+
+def _levels_between(root: Path, leaf: Path) -> list[Path]:
+    """Every directory from *root*'s first child down to *leaf*, shallowest first.
+
+    ``mkdir(parents=True)`` creates intermediates, and a directory's own NAME lives in
+    its PARENT's entries — so syncing only the leaf leaves the entries that reach it
+    unrecorded. ``relative_to`` bounds the walk: a leaf outside *root* raises here
+    rather than climbing past it.
+    """
+    levels: list[Path] = []
+    level = root
+    for part in leaf.relative_to(root).parts:
+        level = level / part
+        levels.append(level)
+    return levels
+
+
+def _fsync_tree(root: Path, leaf: Path) -> None:
+    """Sync *root* and every level down to *leaf*, deepest first."""
+    for level in reversed(_levels_between(root, leaf)):
+        fsync_dir(level)
+    fsync_dir(root)
+
+
+def _sync_batch(
+    target: Path,
+    staged_dirs: set[Path],
+    manifest: IO[str],
+    source_dirs: set[Path] | None = None,
+) -> None:
+    """Force a staged batch out to disk: the manifest's bytes, then every name.
+
+    Called at each point :func:`_move_to_trash_locked` can leave a batch on disk,
+    because until this runs the batch is only durable by luck. The moves themselves
+    are renames, whose metadata a journalling filesystem commits on its own
+    schedule; the manifest is buffered text. So a power-off just after the move
+    reported success can come back to a batch holding the sessions' only copies with
+    an empty manifest — and a batch with no readable manifest is one
+    :func:`list_trash` omits, which puts those files out of reach of restore AND of
+    empty. That is the loss this whole layer exists to prevent, arrived at by
+    reporting success too early.
+
+    Order matters. The manifest's CONTENT first, because it is what makes the moves
+    reversible; then the directories that hold the staged names, deepest first, so a
+    child's entries are durable before the entry naming that child is.
+
+    A failing sync RAISES rather than being logged away. The files have already moved,
+    so raising costs the caller a reported failure for work that partly happened —
+    but the alternative is reporting a durable batch that is not one, and the batch is
+    the only copy. Each caller decides what to do with it; nothing is swallowed here.
+
+    *source_dirs* — the live-store directories the batch drained — are the exception,
+    on both counts. They are synced ONCE here rather than per file, because the
+    same-filesystem path is a bare ``os.rename`` and a sync per staged file is exactly
+    the cost that would stop a trash working at tens of gigabytes; and they are synced
+    ``best_effort`` because a source entry that is not yet durable can only resurrect
+    a name whose staged copy is intact — a duplicate the user thought they reclaimed,
+    never a lost session. Raising for that after the batch is fully recorded would
+    report a completed move as failed.
+
+    This does not make a crash MID-move consistent — a batch interrupted halfway
+    still holds files its manifest never named, which is what :func:`_unlisted_files`
+    exists to protect. It makes a move that RETURNED durable.
+    """
+    manifest.flush()
+    os.fsync(manifest.fileno())
+    for staged in sorted(staged_dirs, key=lambda path: len(path.parts), reverse=True):
+        fsync_dir(staged)
+    fsync_dir(target)
+    for source in sorted(source_dirs or (), key=lambda path: len(path.parts), reverse=True):
+        fsync_dir(source, best_effort=True)
 
 
 def _entry_bytes(entry: dict[str, Any]) -> int:
@@ -2105,6 +2367,17 @@ def _move_to_trash_locked(
     # ancestor reaching a different directory - however convincingly it is dressed up - is
     # refused rather than emptied.
     created_identity = _identity_of(target)
+    # And the entry itself has to exist ON DISK before anything is moved in: the batch
+    # directory is about to become the only home of these files, so a crash with the
+    # mkdir still in the page cache would come back to no batch directory at all — and
+    # the files were renamed INTO it, so they would be gone with it.
+    #
+    # Every level down from the data home, not just target.parent: on the FIRST batch
+    # this machine ever stages, parents=True creates `trash/` and `trash/sessions/`
+    # too, and an unsynced `trash/sessions` entry takes the batch inside it. Bounded
+    # by relative_to, which raises rather than climbing past the data home if the
+    # trash root is ever moved out from under it (_batch_dir already refuses that).
+    _fsync_tree(data_home(), target.parent)
     archives = _archive_index()
 
     moved_bytes = 0
@@ -2112,6 +2385,7 @@ def _move_to_trash_locked(
     revived: list[str] = []
     refresh_failed = False
     staged_dirs: set[Path] = set()
+    source_dirs: set[Path] = set()
     cli_files = _cli_index()
     with (target / MANIFEST_NAME).open("w", encoding="utf-8") as manifest:
         _write_header(manifest, batch_id, clock, reason)
@@ -2198,13 +2472,46 @@ def _move_to_trash_locked(
                 dst = target / rel
                 if dst.parent not in staged_dirs:
                     dst.parent.mkdir(parents=True, exist_ok=True)
-                    staged_dirs.add(dst.parent)
+                    # Before anything moves INTO it, not with the batch at the end.
+                    # The same-filesystem move is a rename, which removes the file's
+                    # only other name in the same atomic step that creates this one:
+                    # if the rename reaches disk while the mkdir that created its
+                    # parent does not, the file has no reachable name left. Syncing
+                    # the chain here orders the two — the directory that will hold
+                    # the file is durable before the source entry can be given up.
+                    #
+                    # Cheap in the way the per-file case would not be: once per new
+                    # directory, not once per file, so the hot path stays a bare
+                    # rename (see :func:`_sync_batch` for the end-of-batch sync that
+                    # forces the entries those renames then add).
+                    try:
+                        _fsync_tree(target, dst.parent)
+                    except OSError:
+                        # Same treatment as a file that would not move: nothing of
+                        # this session has entered this directory yet, so rolling it
+                        # back and leaving the rest of the batch to be recorded and
+                        # synced properly is strictly better than abandoning a batch
+                        # whose manifest has not been forced out.
+                        logger.warning(
+                            "could not sync the staging directory %s", dst.parent, exc_info=True
+                        )
+                        failed = True
+                        break
+                    # Recorded only once the chain is durable. On the failure above
+                    # nothing was staged under it, so there is nothing for the
+                    # end-of-batch sync to force; a later session needing the same
+                    # directory re-runs the mkdir and retries the sync.
+                    staged_dirs.update(_levels_between(target, dst.parent))
                 try:
                     _move_file(src, dst)
                 except OSError:
                     logger.warning("could not move %s into the trash", src, exc_info=True)
                     failed = True
                     break
+                # The live-store directory this file just left. Synced once at the end
+                # rather than per file, because the same-filesystem path is a bare
+                # rename and this is the hot path (see :func:`_sync_batch`).
+                source_dirs.add(src.parent)
                 done.append((dst, src))
                 files.append({"rel": rel, "origin": str(src), "bytes": size})
             if woke:
@@ -2240,6 +2547,27 @@ def _move_to_trash_locked(
                     # place" would be false, so raise instead — matching how this
                     # module already treats a file it could not put back — and name
                     # the batch so the fragment can be found.
+                    #
+                    # The message promises the fragment "can be restored", and that
+                    # is only true of a manifest that reached disk: sync before
+                    # raising, because nothing after this point will.
+                    #
+                    # A sync failure here is logged rather than raised — the one place
+                    # in this module where that is right. This path is ALREADY
+                    # failing, with an error that names which session was resumed and
+                    # where its fragment is; replacing that with an OSError would cost
+                    # the operator the only pointer to the fragment in exchange for
+                    # information the log line already carries.
+                    try:
+                        _sync_batch(target, staged_dirs, manifest, source_dirs)
+                    except OSError:
+                        logger.warning(
+                            "could not sync %s while recording the stranded half of %r; "
+                            "the fragment is on disk but may not survive a power loss",
+                            target,
+                            uid,
+                            exc_info=True,
+                        )
                     raise SessionStorageError(
                         f"session {uid!r} was resumed while being staged and could "
                         f"not be fully put back; what is still staged is recorded in "
@@ -2275,6 +2603,9 @@ def _move_to_trash_locked(
                     continue
                 moved_sessions += 1
                 moved_bytes += sum(int(record["bytes"]) for record in files)
+        # Inside the handle's scope, so the manifest can still be synced through the
+        # descriptor that wrote it. Closing only flushes to the OS.
+        _sync_batch(target, staged_dirs, manifest, source_dirs)
 
     if revived:
         # Reported, not just skipped: the endpoint's own rule is that doing less

--- a/test/test_trash_write_durability.py
+++ b/test/test_trash_write_durability.py
@@ -1,0 +1,1158 @@
+"""Crash-durability of the session trash WRITE path.
+
+A staged batch is the only copy — ``move_to_trash`` MOVES files — so every step
+that publishes a name or drops a source has to be ordered against the disk, not
+just against the process. These tests pin that ordering the only way it can be
+pinned without pulling the power: by making the sync fail and asserting the
+source is still there, and by watching which descriptors and directories are
+synced before the call returns.
+
+Kept apart from ``test_session_storage.py`` because the invariant is different:
+that file protects "both halves move together", this one protects "what a
+returned move claims is on disk really is".
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import json
+import os
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kiro_crew import atomic_write as atomic_write_mod
+from kiro_crew import session_storage
+from kiro_crew.atomic_write import fsync_dir
+from kiro_crew.session_storage import INCOMING_PREFIX, MANIFEST_NAME, SessionIndex
+
+_NOW = 1_700_000_000.0
+_DAY = 86400.0
+
+#: Windows has no directory descriptor to open, so ``fsync_dir`` returns at its
+#: documented no-op before reaching the ``fsync`` or the ``close`` these tests drive.
+#: The behaviour under test genuinely does not exist there, so asserting it would only
+#: assert the no-op.
+_POSIX_DIR_FDS = pytest.mark.skipif(
+    os.name == "nt", reason="directory descriptors do not exist on Windows"
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_scan_cache() -> None:
+    session_storage.invalidate_scan_cache()
+
+
+@pytest.fixture()
+def stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Point both stores at temp dirs; return (crew data home, kiro home)."""
+    crew_home = tmp_path / "crew"
+    kiro_home = crew_home / "kiro"
+    (crew_home / "sessions" / "archive").mkdir(parents=True)
+    (kiro_home / "sessions" / "cli").mkdir(parents=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+    monkeypatch.setenv("KIRO_HOME", str(kiro_home))
+    return crew_home, kiro_home
+
+
+def _cli_half(kiro_home: Path, sid: str, *, log_bytes: int, age_days: float) -> None:
+    root = kiro_home / "sessions" / "cli"
+    mtime = _NOW - age_days * _DAY
+    for suffix, payload in ((".json", b"{}"), (".jsonl", b"c" * log_bytes)):
+        path = root / f"{sid}{suffix}"
+        path.write_bytes(payload)
+        os.utime(path, (mtime, mtime))
+
+
+def _transcript(crew_home: Path, stem: str, *, size: int, age_days: float) -> Path:
+    path = crew_home / "sessions" / f"{stem}.jsonl"
+    path.write_bytes(b"t" * size)
+    mtime = _NOW - age_days * _DAY
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def _index(pairs: dict[str, str] | None = None) -> SessionIndex:
+    return SessionIndex(
+        stem_to_sid={stem: sid for sid, stem in (pairs or {}).items()},
+        active_sids=frozenset(),
+    )
+
+
+def _force_cross_filesystem(monkeypatch: pytest.MonkeyPatch, *, under: Path) -> None:
+    """Make ``os.rename`` report EXDEV for destinations under *under*.
+
+    The real condition — a data home mounted apart from the kiro-cli store — cannot
+    be created in a unit test, and it is the ONLY path on which the copy fallback
+    runs, so the tests below would silently exercise nothing without this.
+    """
+    real_rename = os.rename
+
+    def _rename(src: Any, dst: Any, **kwargs: Any) -> None:
+        try:
+            crosses = Path(dst).is_relative_to(under)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            crosses = False
+        if crosses:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_rename(src, dst, **kwargs)
+
+    monkeypatch.setattr(session_storage.os, "rename", _rename)
+
+
+def _is_dir_fd(fd: int) -> bool:
+    """Whether *fd* is a directory descriptor, without raising on a closed one."""
+    try:
+        return stat.S_ISDIR(os.fstat(fd).st_mode)
+    except OSError:  # pragma: no cover - defensive
+        return False
+
+
+@contextlib.contextmanager
+def _dir_fd_faults(
+    target: Path,
+    *,
+    fsync_error: int | None = None,
+    close_error: int | None = None,
+) -> Iterator[list[int]]:
+    """Fail ``fsync``/``close`` for the descriptor opened on *target*, for THIS call only.
+
+    Scoped by TIME, deliberately, and that is the third shape this took. ``os.close`` is a
+    process-wide name, so a fault that outlives the call under test reaches pytest's own
+    machinery: failing "any directory descriptor" broke the stdlib ``rmtree`` behind
+    ``tmp_path`` cleanup, and narrowing to "the descriptor we opened on this path" still
+    broke teardown, because that cleanup opens the very directory the test targeted, by
+    the same path string. No predicate over descriptors separates the call from the
+    teardown -- only keeping the patch installed for the duration of the call does.
+    Restoring on exit means nothing after ``fsync_dir`` returns sees these wrappers.
+
+    Yields the list of OUR descriptors that were closed, for tests that count them.
+    """
+    real_open, real_close, real_fsync = os.open, os.close, os.fsync
+    ours: set[int] = set()
+    closed: list[int] = []
+    wanted = str(target)
+
+    def _open(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        fd = real_open(path, flags, *args, **kwargs)
+        if str(path) == wanted and _is_dir_fd(fd):
+            ours.add(fd)
+        return fd
+
+    def _fsync(fd: int) -> None:
+        if fd in ours and fsync_error is not None:
+            raise OSError(fsync_error, "injected")
+        real_fsync(fd)
+
+    def _close(fd: int) -> None:
+        mine = fd in ours
+        ours.discard(fd)
+        if mine:
+            closed.append(fd)
+        real_close(fd)
+        if mine and close_error is not None:
+            raise OSError(close_error, "injected")
+
+    os.open, os.fsync, os.close = _open, _fsync, _close  # type: ignore[assignment]
+    try:
+        yield closed
+    finally:
+        os.open, os.fsync, os.close = real_open, real_fsync, real_close  # type: ignore[assignment]
+
+
+def _incoming_files(root: Path) -> list[Path]:
+    return [path for path in root.rglob(f"{INCOMING_PREFIX}*")]
+
+
+class TestCrossFilesystemStaging:
+    """The EXDEV fallback: atomic publish, durable bytes, source dropped last."""
+
+    def test_the_source_survives_a_copy_whose_sync_fails(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The proof that the fsync precedes the unlink, without cutting power.
+
+        If the sync ran after the source was dropped — or never ran, which is what
+        ``shutil.move`` does — a failing sync would leave the source gone. It is
+        still here, so the durability step is on the near side of the unlink.
+        """
+        crew_home, _ = stores
+        transcript = _transcript(crew_home, "dashboard_chat-1", size=64, age_days=400)
+        original = transcript.read_bytes()
+        dst_dir = crew_home / "elsewhere"
+        dst_dir.mkdir()
+        _force_cross_filesystem(monkeypatch, under=dst_dir)
+        # The FILE sync only. Failing every descriptor would prove nothing about it: the
+        # directory sync that follows also raises, and its own failure path withdraws the
+        # publication and keeps the source -- the same observable outcome, reached without
+        # the fsync under test ever running.
+        real_fsync = os.fsync
+
+        def _fail_on_files(fd: int) -> None:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                real_fsync(fd)
+                return
+            raise OSError(errno.EIO, "no")
+
+        monkeypatch.setattr(session_storage.os, "fsync", _fail_on_files)
+
+        with pytest.raises(OSError):
+            session_storage._move_file(transcript, dst_dir / "dashboard_chat-1.jsonl")
+
+        assert transcript.exists()
+        assert transcript.read_bytes() == original
+        assert not (dst_dir / "dashboard_chat-1.jsonl").exists()
+        assert _incoming_files(dst_dir) == []
+
+    def test_an_interrupted_copy_never_appears_under_the_final_name(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A copy straight to the final name is the silent-corruption case.
+
+        ``shutil.move`` writes the destination in place, so an exit mid-copy leaves
+        a short file under the name the manifest records — complete-looking and not.
+        """
+        crew_home, _ = stores
+        transcript = _transcript(crew_home, "dashboard_chat-1", size=4096, age_days=400)
+        dst_dir = crew_home / "elsewhere"
+        dst_dir.mkdir()
+        dst = dst_dir / "dashboard_chat-1.jsonl"
+        _force_cross_filesystem(monkeypatch, under=dst_dir)
+
+        def _half_then_die(src: Any, out: Any, length: int = 0) -> None:
+            out.write(src.read(16))
+            raise OSError(errno.EIO, "device fell over")
+
+        monkeypatch.setattr(session_storage.shutil, "copyfileobj", _half_then_die)
+
+        with pytest.raises(OSError):
+            session_storage._move_file(transcript, dst)
+
+        assert not dst.exists(), "a partial copy was published under the final name"
+        assert transcript.exists()
+        assert _incoming_files(dst_dir) == []
+
+    def test_the_published_name_and_its_directory_are_durable_before_the_unlink(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bytes are not enough: the NAME reaching them has to be durable too.
+
+        The source is what stops providing that name, so the directory sync has to
+        happen while the source is still there.
+        """
+        crew_home, _ = stores
+        transcript = _transcript(crew_home, "dashboard_chat-1", size=64, age_days=400)
+        dst_dir = crew_home / "elsewhere"
+        dst_dir.mkdir()
+        dst = dst_dir / "dashboard_chat-1.jsonl"
+        _force_cross_filesystem(monkeypatch, under=dst_dir)
+
+        seen: list[tuple[str, bool]] = []
+        real_fsync_dir = session_storage.fsync_dir
+
+        def _spy(path: Path | str, *, best_effort: bool = False) -> None:
+            seen.append((str(path), transcript.exists()))
+            real_fsync_dir(path, best_effort=best_effort)
+
+        monkeypatch.setattr(session_storage, "fsync_dir", _spy)
+
+        session_storage._move_file(transcript, dst)
+
+        assert dst.read_bytes() == b"t" * 64
+        assert not transcript.exists()
+        assert (
+            str(dst_dir),
+            True,
+        ) in seen, "the destination directory was not synced while the source still existed"
+
+    def test_a_cross_filesystem_restore_syncs_before_it_unlinks_the_source(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exclusive mover carries the same rule on its copy branch.
+
+        Restore and rollback run through it, and there the destination is live
+        session storage — so a lost copy is a session the user asked to get back.
+        """
+        crew_home, _ = stores
+        staged = crew_home / "staged.jsonl"
+        staged.write_bytes(b"s" * 32)
+        origin = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+        monkeypatch.setattr(
+            session_storage.os,
+            "link",
+            lambda src, dst: (_ for _ in ()).throw(OSError(errno.EXDEV, "no links")),
+        )
+        # The FILE sync only, for the same reason as the staging mover's test: a blanket
+        # failure would be satisfied by the directory sync's own rollback path.
+        real_fsync = os.fsync
+
+        def _fail_on_files(fd: int) -> None:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                real_fsync(fd)
+                return
+            raise OSError(errno.EIO, "no")
+
+        monkeypatch.setattr(session_storage.os, "fsync", _fail_on_files)
+
+        with pytest.raises(OSError):
+            session_storage._move_file_exclusive(staged, origin)
+
+        assert staged.exists(), "the staged copy was dropped before it was durable"
+        assert not origin.exists()
+
+    def test_the_hard_link_restore_syncs_before_it_unlinks_the_source(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fast path has the same two-operation hazard as the copy branch.
+
+        A hard link plus an unlink leaves two directory entries for one file and then
+        removes one, and nothing orders those two operations -- unlike a same-filesystem
+        rename, which is one. If the unlink reaches disk and the new name does not, the
+        inode has no name left at all. So the destination is synced while the source is
+        still there.
+        """
+        crew_home, _ = stores
+        staged = crew_home / "staged.jsonl"
+        staged.write_bytes(b"s" * 32)
+        origin = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+
+        seen: list[tuple[str, bool]] = []
+        real_fsync_dir = session_storage.fsync_dir
+
+        def _spy(path: Path | str, *, best_effort: bool = False) -> None:
+            seen.append((str(path), staged.exists()))
+            real_fsync_dir(path, best_effort=best_effort)
+
+        monkeypatch.setattr(session_storage, "fsync_dir", _spy)
+
+        assert session_storage._move_file_exclusive(staged, origin) is True
+
+        assert origin.read_bytes() == b"s" * 32
+        assert not staged.exists()
+        assert (
+            str(origin.parent),
+            True,
+        ) in seen, "the restored name was not synced while the staged copy still existed"
+
+    @pytest.mark.skipif(
+        not hasattr(os, "O_NOFOLLOW"), reason="no O_NOFOLLOW: symlink swap needs privilege"
+    )
+    def test_the_copy_helper_refuses_a_symlink_instead_of_reading_its_target(
+        self, tmp_path: Path
+    ) -> None:
+        """The copy fallback's own guarantee, independent of who calls it.
+
+        Staging never hands it a symlink today -- both enumeration scans use
+        ``is_file(follow_symlinks=False)`` -- so this pins the property AT the copy
+        rather than relying on a filter several hundred lines away staying that way.
+        """
+        secret = tmp_path / "credentials"
+        secret.write_bytes(b"SECRET-DO-NOT-COPY")
+        link = tmp_path / "session.jsonl"
+        link.symlink_to(secret)
+
+        with pytest.raises(OSError) as caught:
+            session_storage._open_source_no_follow(link).close()
+
+        assert caught.value.errno in (errno.ELOOP, errno.EMLINK), caught.value
+        # And a regular file still opens, or the guard would break every copy.
+        plain = tmp_path / "plain.jsonl"
+        plain.write_bytes(b"ok")
+        with session_storage._open_source_no_follow(plain) as handle:
+            assert handle.read() == b"ok"
+
+    @pytest.mark.skipif(
+        not hasattr(os, "O_NOFOLLOW"), reason="no O_NOFOLLOW: symlink swap needs privilege"
+    )
+    def test_a_planted_source_symlink_never_reaches_the_trash(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """End to end: a session file swapped for a link to a secret leaks nothing.
+
+        Enumeration is what stops it -- the link is not staged at all -- and the rest of
+        the session still moves. Asserting the leak AND the omission together is what
+        makes this fail if either line of defence is removed.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        secret = tmp_path / "credentials"
+        secret.write_bytes(b"SECRET-DO-NOT-COPY")
+        # Aged too: the staging gate that compares mtimes reads THROUGH a link, so a
+        # freshly written target would skip the session for an unrelated reason.
+        aged = _NOW - 400 * _DAY
+        os.utime(secret, (aged, aged))
+        planted = kiro_home / "sessions" / "cli" / "aaaa1111.jsonl"
+        planted.unlink()
+        planted.symlink_to(secret)
+        os.utime(planted, (aged, aged), follow_symlinks=False)
+        _force_cross_filesystem(monkeypatch, under=session_storage.trash_root())
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        staged = list(session_storage._batch_dir(batch.batch_id).rglob("*"))
+        leaked = [p for p in staged if p.is_file() and b"SECRET" in p.read_bytes()]
+        assert leaked == [], f"the link target's bytes were copied into the trash: {leaked}"
+        assert not any(
+            p.name == "aaaa1111.jsonl" for p in staged
+        ), "the planted link was staged rather than passed over"
+        assert secret.read_bytes() == b"SECRET-DO-NOT-COPY", "the secret itself was disturbed"
+        assert planted.is_symlink(), "the planted link was consumed"
+
+    def test_a_failed_unlink_keeps_the_published_copy(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Withdrawing the destination here would be a guess that can destroy the last copy.
+
+        A filesystem can report failure for an unlink that DID commit, and the name
+        existing afterwards does not prove the ORIGINAL does -- a concurrent append
+        recreates it as a new, empty file. So the published copy stays, protected by the
+        unlisted-file guard, and the batch is left un-emptiable until an operator clears
+        it. See ``test_the_kept_copy_is_protected_from_emptying``.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        source = _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        _force_cross_filesystem(monkeypatch, under=session_storage.trash_root())
+        real_unlink = Path.unlink
+
+        def _unlink(self: Path, missing_ok: bool = False) -> None:
+            if self == source:
+                # Commits, then reports failure -- and a concurrent append puts a NEW
+                # file back at the same name, which is what defeats an existence check.
+                real_unlink(self, missing_ok=missing_ok)
+                self.write_bytes(b"fresh")
+                raise OSError(errno.EIO, "reply lost")
+            real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _unlink)
+
+        with pytest.raises(session_storage.SessionStorageError):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )
+
+        kept = [
+            path
+            for path in session_storage.trash_root().rglob("*")
+            if path.is_file() and path.read_bytes() == b"t" * 32
+        ]
+        assert kept, (
+            "the historical bytes were deleted by the recovery path; the recreated "
+            "source only holds b'fresh'"
+        )
+
+    def test_the_exclusive_mover_keeps_the_copy_when_the_unlink_fails(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Same rule on the restore direction's publish-then-drop tail."""
+        src = tmp_path / "staged.jsonl"
+        src.write_bytes(b"history")
+        dst = tmp_path / "restored.jsonl"
+        dst.write_bytes(b"history")
+        real_unlink = Path.unlink
+
+        def _unlink(self: Path, missing_ok: bool = False) -> None:
+            if self == src:
+                raise OSError(errno.EIO, "reply lost")
+            real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _unlink)
+
+        with pytest.raises(OSError):
+            session_storage._publish_then_drop(src, dst)
+
+        assert dst.exists(), "the exclusive mover withdrew a copy it could not prove redundant"
+
+    def test_the_mover_keeps_the_copy_when_the_unlink_fails(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Pinned on the mover itself, which is where the decision lives.
+
+        Whatever the caller then does with the leftover, the mover must not be the thing
+        that destroys a copy it cannot prove is redundant.
+        """
+        src = tmp_path / "origin.jsonl"
+        src.write_bytes(b"history")
+        dst_dir = tmp_path / "batch"
+        dst_dir.mkdir()
+        dst = dst_dir / "origin.jsonl"
+        real_unlink = Path.unlink
+
+        def _unlink(self: Path, missing_ok: bool = False) -> None:
+            if self == src:
+                raise OSError(errno.EIO, "reply lost")
+            real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _unlink)
+
+        with pytest.raises(OSError):
+            session_storage._copy_across_filesystems(src, dst)
+
+        assert dst.exists(), "the mover withdrew a copy it could not prove was redundant"
+        assert dst.read_bytes() == b"history"
+
+    def test_a_failed_sync_on_the_hard_link_path_withdraws_the_destination(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reporting "origin not taken" while the origin holds a file is unrecoverable.
+
+        The manifest entry is kept and every later restore finds the origin occupied.
+        """
+        crew_home, _ = stores
+        staged = crew_home / "staged.jsonl"
+        staged.write_bytes(b"s" * 32)
+        origin = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+        monkeypatch.setattr(
+            session_storage,
+            "fsync_dir",
+            lambda path, **kw: (_ for _ in ()).throw(OSError(errno.EIO, "device")),
+        )
+
+        with pytest.raises(OSError):
+            session_storage._move_file_exclusive(staged, origin)
+
+        assert staged.exists(), "the staged copy was dropped after a failed sync"
+        assert not origin.exists(), "a published destination outlived a failed sync"
+
+    def test_the_copy_branch_still_refuses_an_occupied_destination(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The added syncs must not cost the no-clobber guarantee."""
+        crew_home, _ = stores
+        staged = crew_home / "staged.jsonl"
+        staged.write_bytes(b"s" * 32)
+        origin = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+        origin.write_bytes(b"newer")
+        monkeypatch.setattr(
+            session_storage.os,
+            "link",
+            lambda src, dst: (_ for _ in ()).throw(OSError(errno.EXDEV, "no links")),
+        )
+
+        assert session_storage._move_file_exclusive(staged, origin) is False
+        assert origin.read_bytes() == b"newer"
+        assert staged.exists()
+
+    def test_an_incoming_file_a_crash_left_behind_is_still_protected(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """The deletion guard exempts NOTHING by name, this prefix included.
+
+        A name says nothing about who wrote it. Everything else in this module's threat
+        model assumes a batch can be planted in — a linked manifest, a file substituted
+        at the manifest's own name — so an exemption keyed on a prefix would let
+        anything able to rename a file inside a batch put a staged file beyond this
+        scan's reach. The cost is that a crash's debris blocks emptying that batch until
+        an operator clears it; blocking a deletion that should proceed is recoverable,
+        and letting one through is not.
+        """
+        crew_home, _ = stores
+        batch = crew_home / "trash" / "sessions" / "20260101T000000-abcd1234"
+        (batch / "crew").mkdir(parents=True)
+        (batch / MANIFEST_NAME).write_text(
+            json.dumps({"schema": 1, "batch_id": "x", "created_at": 0, "reason": "manual"})
+            + "\n"
+            + json.dumps(
+                {"uid": "a", "files": [{"rel": "crew/a.jsonl", "origin": "/x/a.jsonl", "bytes": 1}]}
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (batch / "crew" / "a.jsonl").write_bytes(b"a")
+        leftover = batch / "crew" / f"{INCOMING_PREFIX}deadbeef"
+        leftover.write_bytes(b"half a copy")
+
+        assert session_storage._unlisted_files(batch) == [leftover]
+
+    def test_a_file_no_entry_names_is_still_reported(self, stores: tuple[Path, Path]) -> None:
+        """The carve-out is one prefix wide, not a hole in the scan."""
+        crew_home, _ = stores
+        batch = crew_home / "trash" / "sessions" / "20260101T000000-abcd1234"
+        (batch / "crew").mkdir(parents=True)
+        (batch / MANIFEST_NAME).write_text(
+            json.dumps({"schema": 1, "batch_id": "x", "created_at": 0, "reason": "manual"}) + "\n",
+            encoding="utf-8",
+        )
+        stranded = batch / "crew" / "b.jsonl"
+        stranded.write_bytes(b"b")
+
+        assert session_storage._unlisted_files(batch) == [stranded]
+
+    def test_a_cross_filesystem_batch_is_complete_and_emptiable(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End to end on the copy path: every byte staged, and the batch still empties."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=128, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=64, age_days=400)
+        _force_cross_filesystem(monkeypatch, under=session_storage.trash_root())
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        assert batch.sessions == 1
+        staged = session_storage._batch_dir(batch.batch_id)
+        assert (staged / "crew" / "dashboard_chat-1.jsonl").read_bytes() == b"t" * 64
+        assert (staged / "cli" / "aaaa1111.jsonl").read_bytes() == b"c" * 128
+        assert _incoming_files(staged) == []
+        assert session_storage._unlisted_files(staged) == []
+
+
+class TestStagedBatchDurability:
+    """What a returned ``move_to_trash`` has actually put on disk."""
+
+    def _record_fsync(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[list[tuple[int, int]], list[str]]:
+        """Collect (st_dev, st_ino) of every synced descriptor and every synced dir."""
+        synced: list[tuple[int, int]] = []
+        dirs: list[str] = []
+        real_fsync = os.fsync
+        real_fsync_dir = session_storage.fsync_dir
+
+        def _fsync(fd: int) -> None:
+            info = os.fstat(fd)
+            synced.append((info.st_dev, info.st_ino))
+            real_fsync(fd)
+
+        def _dir(path: Path | str, *, best_effort: bool = False) -> None:
+            dirs.append(str(path))
+            real_fsync_dir(path, best_effort=best_effort)
+
+        monkeypatch.setattr(session_storage.os, "fsync", _fsync)
+        monkeypatch.setattr(session_storage, "fsync_dir", _dir)
+        return synced, dirs
+
+    def test_the_manifest_is_synced_before_the_move_returns(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without this the files can be staged under a manifest that never landed.
+
+        A batch with no readable manifest is omitted from ``list_trash``, so those
+        files are then reachable by neither restore nor empty — the exact loss this
+        layer exists to prevent, produced by reporting success too early.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        synced, _dirs = self._record_fsync(monkeypatch)
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        manifest = session_storage._batch_dir(batch.batch_id) / MANIFEST_NAME
+        info = manifest.stat()
+        assert (info.st_dev, info.st_ino) in synced, "the manifest descriptor was never synced"
+
+    def test_every_directory_holding_a_staged_name_is_synced(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A staged file's name lives in its own parent, not in the batch root.
+
+        Deepest first, so a child's entries are durable before the entry that names
+        the child.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        _dirs_synced, dirs = self._record_fsync(monkeypatch)
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        staged = session_storage._batch_dir(batch.batch_id)
+        assert str(staged / "cli") in dirs
+        assert str(staged / "crew") in dirs
+        assert str(staged) in dirs
+        # LAST occurrence, not first: a fresh staging directory is also synced on
+        # creation, before anything is renamed into it, so the batch root's first
+        # sync legitimately precedes a subdirectory that did not exist yet. The
+        # ordering this test is about is the end-of-batch sweep, which is the run
+        # these last indices fall in.
+        last = {path: index for index, path in enumerate(dirs)}
+        assert (
+            last[str(staged / "crew")] < last[str(staged)]
+        ), "the batch directory was synced before the subdirectory it names"
+
+    def test_the_batch_directory_exists_on_disk_before_anything_moves_into_it(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The files are renamed INTO it, so a lost mkdir loses them with it."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        order: list[str] = []
+        real_fsync_dir = session_storage.fsync_dir
+        real_move = session_storage._move_file
+
+        def _dir(path: Path | str, *, best_effort: bool = False) -> None:
+            order.append(f"sync:{path}")
+            real_fsync_dir(path, best_effort=best_effort)
+
+        def _move(src: Path, dst: Path) -> None:
+            order.append("move")
+            real_move(src, dst)
+
+        monkeypatch.setattr(session_storage, "fsync_dir", _dir)
+        monkeypatch.setattr(session_storage, "_move_file", _move)
+
+        session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        root = str(session_storage.trash_root())
+        assert f"sync:{root}" in order
+        assert order.index(f"sync:{root}") < order.index(
+            "move"
+        ), "files were staged before the batch directory's own entry was durable"
+
+    def test_a_staging_subdirectory_is_durable_before_a_file_is_renamed_into_it(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The rename that fills a fresh directory also gives up the file's only other name.
+
+        Syncing the chain with the batch at the end is too late: if the rename reaches
+        disk and the mkdir that created its parent does not, neither name resolves.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        order: list[str] = []
+        real_fsync_dir = session_storage.fsync_dir
+        real_move = session_storage._move_file
+
+        def _dir(path: Path | str, *, best_effort: bool = False) -> None:
+            order.append(f"sync:{path}")
+            real_fsync_dir(path, best_effort=best_effort)
+
+        def _move(src: Path, dst: Path) -> None:
+            order.append(f"move:{dst}")
+            real_move(src, dst)
+
+        monkeypatch.setattr(session_storage, "fsync_dir", _dir)
+        monkeypatch.setattr(session_storage, "_move_file", _move)
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        staged = session_storage._batch_dir(batch.batch_id)
+        moves = [step for step in order if step.startswith("move:")]
+        assert moves, "nothing was staged, so this test would pass vacuously"
+        for step in moves:
+            parent = Path(step.removeprefix("move:")).parent
+            assert parent != staged, "expected a subdirectory, not the batch root"
+            sync = f"sync:{parent}"
+            assert sync in order, f"{parent} was never synced"
+            assert order.index(sync) < order.index(step), (
+                f"{parent} still held no durable entry of its own when a file was "
+                f"renamed into it"
+            )
+
+    def test_a_failed_staging_directory_sync_puts_the_session_back(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing has entered the directory yet, so this rolls back rather than raising.
+
+        Propagating would abandon a batch whose manifest has not been forced out. The
+        session is left where it was, exactly as for a file that would not move.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        source = _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        real_tree = session_storage._fsync_tree
+        leaves: list[Path] = []
+
+        def _tree(root: Path, leaf: Path) -> None:
+            leaves.append(leaf)
+            if len(leaves) == 1:
+                # The pre-loop sync of the trash root's own ancestors, which has to
+                # keep working or the batch never gets far enough to stage anything.
+                real_tree(root, leaf)
+                return
+            raise OSError(errno.EIO, "device is gone")
+
+        monkeypatch.setattr(session_storage, "_fsync_tree", _tree)
+
+        # Not a zero-session success: this module already refuses to report a batch
+        # in which nothing moved, which is the honest answer here too.
+        with pytest.raises(session_storage.SessionStorageError):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )
+
+        assert len(leaves) > 1, "the staging-directory sync never ran"
+        assert source.exists(), "the session was not put back"
+
+    def test_an_intermediate_directory_mkdir_created_is_synced_too(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A session with archive segments and no transcript never touches ``crew``.
+
+        ``mkdir(parents=True)`` creates ``crew`` on the way to ``crew/archive``, and a
+        directory's own name lives in its parent's entries — so syncing only the leaf
+        leaves the entry that reaches the staged segments unrecorded.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        segment = crew_home / "sessions" / "archive" / "dashboard_chat-1__20260730-211852.jsonl"
+        segment.write_bytes(b"a" * 48)
+        mtime = _NOW - 400 * _DAY
+        os.utime(segment, (mtime, mtime))
+        _dirs_synced, dirs = self._record_fsync(monkeypatch)
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        staged = session_storage._batch_dir(batch.batch_id)
+        assert (staged / "crew" / "archive" / segment.name).exists()
+        assert str(staged / "crew" / "archive") in dirs
+        assert (
+            str(staged / "crew") in dirs
+        ), "the intermediate directory mkdir(parents=True) created was never synced"
+
+    def test_the_drained_source_directories_are_synced_once_per_batch(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Copy-then-unlink is two operations, so a crash can leave BOTH names.
+
+        That is a live session the user was told had been reclaimed, sitting beside a
+        staged copy the manifest records as trashed. Synced once at the end rather than
+        per file: the same-filesystem path is a bare rename and this is the hot path.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        _dirs_synced, dirs = self._record_fsync(monkeypatch)
+
+        session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        assert str(crew_home / "sessions") in dirs
+        assert str(kiro_home / "sessions" / "cli") in dirs
+        assert (
+            dirs.count(str(crew_home / "sessions")) == 1
+        ), "the source directory was synced per file instead of once per batch"
+
+    def test_nothing_that_can_raise_runs_after_a_file_has_moved(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completed move must never reach the caller as a failure.
+
+        The staging loop reads an exception from the mover as "this file did not
+        move": it rolls the session back and omits the file from the manifest. For a
+        file that HAS moved that leaves a half-staged session nothing records -- the
+        exact split the rollback exists to prevent. So a failing source-directory sync
+        may not be raised from inside the mover.
+        """
+        crew_home, _ = stores
+        transcript = _transcript(crew_home, "dashboard_chat-1", size=64, age_days=400)
+        dst_dir = crew_home / "elsewhere"
+        dst_dir.mkdir()
+        dst = dst_dir / "dashboard_chat-1.jsonl"
+        _force_cross_filesystem(monkeypatch, under=dst_dir)
+        real_fsync_dir = session_storage.fsync_dir
+
+        def _fail_once_the_source_is_gone(path: Path | str, *, best_effort: bool = False) -> None:
+            if not transcript.exists():
+                raise OSError(errno.EIO, "device")
+            real_fsync_dir(path, best_effort=best_effort)
+
+        monkeypatch.setattr(session_storage, "fsync_dir", _fail_once_the_source_is_gone)
+
+        session_storage._move_file(transcript, dst)
+
+        assert dst.read_bytes() == b"t" * 64
+        assert not transcript.exists()
+
+    def test_the_metadata_is_carried_before_the_sync_that_forces_it(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``copystat`` writes the inode; the file ``fsync`` is what forces it out.
+
+        After the sync, a power loss could publish the bytes under the temp's own 0600
+        and its creation time -- and this module ages sessions by their mtime.
+        """
+        crew_home, _ = stores
+        transcript = _transcript(crew_home, "dashboard_chat-1", size=64, age_days=400)
+        dst_dir = crew_home / "elsewhere"
+        dst_dir.mkdir()
+        _force_cross_filesystem(monkeypatch, under=dst_dir)
+
+        order: list[str] = []
+        real_copystat = session_storage.shutil.copystat
+        real_fsync = os.fsync
+
+        def _copystat(src: Any, dst: Any, **kwargs: Any) -> None:
+            order.append("copystat")
+            real_copystat(src, dst, **kwargs)
+
+        def _fsync(fd: int) -> None:
+            if not stat.S_ISDIR(os.fstat(fd).st_mode):
+                order.append("fsync")
+            real_fsync(fd)
+
+        monkeypatch.setattr(session_storage.shutil, "copystat", _copystat)
+        monkeypatch.setattr(session_storage.os, "fsync", _fsync)
+
+        session_storage._move_file(transcript, dst_dir / "dashboard_chat-1.jsonl")
+
+        assert order == ["copystat", "fsync"], f"metadata was carried after the sync: {order}"
+        assert (dst_dir / "dashboard_chat-1.jsonl").stat().st_mtime == pytest.approx(
+            _NOW - 400 * _DAY, abs=1
+        )
+
+    def test_the_first_batch_ever_syncs_the_trash_directories_it_created(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mkdir(parents=True)`` creates ``trash/`` and ``trash/sessions/`` too.
+
+        An unsynced ``trash/sessions`` entry takes the batch inside it, and the batch
+        holds the only copies.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        root = session_storage.trash_root()
+        assert not root.exists(), "this test only means anything on a first-ever batch"
+        _dirs_synced, dirs = self._record_fsync(monkeypatch)
+
+        session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        assert str(root) in dirs
+        assert str(root.parent) in dirs, "the trash directory's own parent was never synced"
+        assert str(session_storage.data_home()) in dirs
+
+
+class TestRestoredManifestDurability:
+    def test_rewriting_a_manifest_syncs_the_directory_that_names_it(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``fsync=True`` covers the content; the rename needs the directory.
+
+        Otherwise a power loss can return the pre-restore manifest, whose entries
+        name files restore has already moved back into live storage.
+        """
+        crew_home, _ = stores
+        batch = crew_home / "trash" / "sessions" / "20260101T000000-abcd1234"
+        batch.mkdir(parents=True)
+        dirs: list[str] = []
+        real_fsync_dir = session_storage.fsync_dir
+
+        def _dir(path: Path | str, *, best_effort: bool = False) -> None:
+            dirs.append(str(path))
+            real_fsync_dir(path, best_effort=best_effort)
+
+        monkeypatch.setattr(session_storage, "fsync_dir", _dir)
+
+        session_storage._rewrite_manifest(batch, {"schema": 1}, [{"uid": "a", "files": []}])
+
+        assert str(batch) in dirs
+        assert (batch / MANIFEST_NAME).read_text(encoding="utf-8").count("\n") == 2
+
+
+class TestFsyncDirDiscriminates:
+    """Quiet where a directory sync cannot be expressed; loud where the device failed.
+
+    Both halves are load-bearing. Callers unlink the only other copy right after
+    calling this, so a swallowed ``EIO`` hands them a false "durable"; but Windows and
+    some network mounts cannot sync a directory at all, and raising there would fail
+    every write on those platforms.
+    """
+
+    def test_a_platform_without_directory_descriptors_is_a_no_op(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows has no directory descriptor to open, and that is not an error."""
+        monkeypatch.setattr(atomic_write_mod.platform_compat, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            os, "open", lambda *a, **k: (_ for _ in ()).throw(PermissionError("no dir fds"))
+        )
+
+        fsync_dir(tmp_path)
+
+    def test_a_directory_that_cannot_be_opened_on_posix_is_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On a platform that HAS directory fds, failing to open one is an anomaly."""
+        monkeypatch.setattr(atomic_write_mod.platform_compat, "IS_WINDOWS", False)
+        monkeypatch.setattr(
+            os, "open", lambda *a, **k: (_ for _ in ()).throw(OSError(errno.EIO, "device"))
+        )
+
+        with pytest.raises(OSError):
+            fsync_dir(tmp_path)
+
+    def test_the_injection_does_not_outlive_the_call(self, tmp_path: Path) -> None:
+        """The property three rounds of teardown errors were missing.
+
+        Both earlier attempts left the fault installed for the whole test and tried to
+        pick out the right descriptor; pytest's own cleanup went through the wrapper
+        anyway. Restoring on exit is what makes that impossible, so it is pinned here
+        rather than left to the next reader to rediscover.
+        """
+        before = (os.open, os.fsync, os.close)
+
+        with _dir_fd_faults(tmp_path, close_error=errno.EIO):
+            assert os.close is not before[2], "the fault was never installed"
+
+        assert (os.open, os.fsync, os.close) == before, "the fault outlived its call"
+
+    @_POSIX_DIR_FDS
+    def test_a_filesystem_that_refuses_the_sync_is_quiet_and_closes_the_descriptor(
+        self, tmp_path: Path
+    ) -> None:
+        """Some network mounts reject fsync on a directory; the fd is still ours."""
+        with _dir_fd_faults(tmp_path, fsync_error=errno.EINVAL) as closed:
+            fsync_dir(tmp_path)
+
+        assert len(closed) == 1
+
+    @_POSIX_DIR_FDS
+    def test_a_device_error_is_raised_not_logged_away(self, tmp_path: Path) -> None:
+        """The finding that matters: EIO means the write did not land.
+
+        A caller about to unlink the only other copy has to hear it.
+        """
+        with _dir_fd_faults(tmp_path, fsync_error=errno.EIO):
+            with pytest.raises(OSError):
+                fsync_dir(tmp_path)
+
+    @_POSIX_DIR_FDS
+    def test_a_deferred_write_error_reported_by_close_is_raised(self, tmp_path: Path) -> None:
+        """``close`` can report a write error the kernel deferred past the ``fsync``.
+
+        For a caller whose next step is to unlink the only other copy that is the same
+        signal as a failed sync, so by default it is not swallowed.
+        """
+        with _dir_fd_faults(tmp_path, close_error=errno.EIO):
+            with pytest.raises(OSError):
+                fsync_dir(tmp_path)
+
+    @_POSIX_DIR_FDS
+    def test_best_effort_survives_a_close_error_too(self, tmp_path: Path) -> None:
+        """Otherwise ``best_effort`` would still raise past its caller's commit point.
+
+        A restore that has already unlinked its staged source cannot act on this, and a
+        raise there would leave the batch holding a stale manifest entry.
+        """
+        with _dir_fd_faults(tmp_path, close_error=errno.EIO):
+            fsync_dir(tmp_path, best_effort=True)
+
+    @_POSIX_DIR_FDS
+    def test_a_close_error_does_not_mask_the_sync_error(self, tmp_path: Path) -> None:
+        """The sync error names the real problem; the close error would replace it."""
+        with _dir_fd_faults(tmp_path, fsync_error=errno.EIO, close_error=errno.EBADF):
+            with pytest.raises(OSError) as caught:
+                fsync_dir(tmp_path)
+
+        assert caught.value.errno == errno.EIO, "the close error masked the sync error"
+
+    @_POSIX_DIR_FDS
+    def test_a_failed_directory_sync_keeps_the_source(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End to end: the raise has to reach the mover before it drops the source."""
+        crew_home, _ = stores
+        transcript = _transcript(crew_home, "dashboard_chat-1", size=64, age_days=400)
+        dst_dir = crew_home / "elsewhere"
+        dst_dir.mkdir()
+        _force_cross_filesystem(monkeypatch, under=dst_dir)
+        real_fsync = os.fsync
+
+        def _fail_on_directories(fd: int) -> None:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                raise OSError(errno.EIO, "device")
+            real_fsync(fd)
+
+        monkeypatch.setattr(session_storage.os, "fsync", _fail_on_directories)
+        dst = dst_dir / "dashboard_chat-1.jsonl"
+
+        with pytest.raises(OSError):
+            session_storage._move_file(transcript, dst)
+
+        assert transcript.exists(), "the source was dropped after a failed directory sync"
+        # And the publication is withdrawn. The caller reads the exception as "this file
+        # did not move" and rolls the session back WITHOUT this file, so a surviving dst
+        # would sit in the batch named by no manifest entry -- which blocks emptying that
+        # batch for good.
+        assert not dst.exists(), "a published destination outlived a failed sync"
+        assert _incoming_files(dst_dir) == []
+
+    def test_a_failed_manifest_sync_is_not_reported_as_a_completed_move(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A batch whose manifest never reached the device is not a moved batch.
+
+        The failure is restricted to non-directory descriptors on purpose. Failing
+        every ``fsync`` would prove nothing about the manifest: the directory syncs
+        that follow raise on ``EIO`` too, so the test would still see an exception
+        with the manifest's own sync swallowed.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=32, age_days=400)
+        real_fsync = os.fsync
+
+        def _fail_on_files(fd: int) -> None:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                real_fsync(fd)
+                return
+            raise OSError(errno.EIO, "device")
+
+        monkeypatch.setattr(session_storage.os, "fsync", _fail_on_files)
+
+        with pytest.raises(OSError):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )


### PR DESCRIPTION
## What is the problem?

`move_to_trash` MOVES a session's files, so a staged batch holds the only copy of
that transcript. Three steps on that write path reported success before the disk
agreed, and a power loss in any of the windows could destroy a session:

**The cross-filesystem fallback was `shutil.move`.** On a data home mounted apart
from the kiro-cli store, `_move_file` fell back to `shutil.move(str(src), str(dst))`
-- which copies straight to the final name and then unlinks the source. Two defects
in one call: for the whole duration of the copy a short file sits under the name the
manifest is about to record, so an exit there leaves a staged file that looks
complete and is not; and the source is unlinked with the destination's bytes still in
the page cache, so a power loss between the last write and the unlink reaching disk
comes back to a durable absence of the source and an empty destination.
`_move_file_exclusive`'s copy branch -- the path restore and rollback take -- had the
same missing `fsync` before its `src.unlink()`.

**The staged manifest was never synced at all.** The batch manifest is written
through a buffered text handle whose `with` block only flushes to the OS. Meanwhile
the files reach the batch by `os.rename`, whose metadata a journalling filesystem
commits on its own schedule. So `move_to_trash` could return successfully and a power
loss come back to a batch holding the sessions' only copies under an empty manifest --
and a batch with no readable manifest is one `list_trash()` omits, which puts those
files out of reach of restore AND of empty. This gap is not in the issue's list; it
was found while confirming the three that are, and it is the most severe of the four.

**Two renames and a `mkdir` skipped the directory `fsync`.** `_rewrite_manifest`
already syncs its content (`atomic_write(..., fsync=True)`) but not the directory that
gives that content the manifest's name, so a power loss can return the pre-restore
manifest -- whose entries name files restore has already moved back into live storage.
The batch `mkdir` had the same gap, and the files are renamed INTO that directory, so
a lost `mkdir` loses them with it.

Sub-claim (b) from the issue -- inverted `truncate`/`seek` in the manifest rollback,
and text-mode `tell()` returning an opaque cookie on Windows -- **is dropped, and this
PR does not touch that code.** Both the triage and the claimant withdrew it, and a
probe confirms it firsthand on CPython 3.12: `truncate(mark); seek(mark)` and
`seek(mark); truncate()` produce byte-identical files, and a write-only text handle's
`tell()` returned 7 after writing 7 UTF-8 bytes of 6 characters -- a true byte offset,
not a cookie.

## Why this issue matters to the user

This layer's whole purpose is that reclaiming disk space is reversible. A user who
stages 40 GB of old sessions and loses power gets, on the paths above, a batch the
Trash screen does not list -- the sessions are gone from live storage and unreachable
in the trash, with nothing on screen to say so. The cross-filesystem case is not
exotic: it is any container-mounted or separately-mounted data home, which is exactly
the deployment where the copy fallback runs on every single staged file.

## How our fix solves it

The chain runs symptom -> root cause in each case.

- **A lost session on a cross-FS move** <- the copy published under the final name and
  dropped the source before the bytes were durable. `_move_file`'s EXDEV branch now
  calls a new `_copy_across_filesystems`: copy into an `INCOMING_PREFIX` name beside
  the destination, `fsync` it, `copystat` onto the temp so the published name arrives
  already carrying the source's mode and mtime, publish with `replace_with_retry`
  (which also picks up the Windows sharing-violation retry the old `os.replace` lacked),
  `fsync` the destination's directory, and only then `unlink` the source. Every failure
  path reclaims the temp under `except BaseException`, matching `atomic_write`.
- **The same loss on restore/rollback** <- `_move_file_exclusive`'s copy branch had no
  `fsync`. It now `fsync`s the file and its directory before `src.unlink()`. Its
  no-clobber contract is untouched: still `os.link` first, still `O_CREAT | O_EXCL` on
  the fallback, no rename anywhere near it (a rename would replace, which is the data
  loss that branch exists to prevent).
- **A batch that survives with an empty manifest** <- nothing ever forced the manifest
  out. New `_sync_batch()` `fsync`s the manifest descriptor, then the staged
  directories deepest-first (a staged file's name lives in its own parent, and a
  child's entries must be durable before the entry naming that child), then the batch.
  It is called at both points `_move_to_trash_locked` can leave a batch on disk --
  including before the "resumed while being staged" raise, whose message promises the
  fragment "can be restored", which is only true of a manifest that reached disk.
- **A stale manifest after a partial restore** <- the rename was not durable.
  `_rewrite_manifest` now `fsync`s the batch directory after `atomic_write`.
- **A batch directory that may not exist after a crash** <- `fsync_dir(target.parent)`
  after the `mkdir`, before anything moves in.

Two supporting pieces. `atomic_write.py` gains a public `fsync_dir()` -- deliberately
NOT a `sync_dir=` option on `atomic_write`, which would change the durability cost of
its ~30 existing callers; this is opt-in, so only the callers that need the guarantee
pay. It replaces the private `_fsync_dir` in `secrets/vault.py` (identical body,
net -18 lines there) rather than becoming a second copy that drifts.

**Round 2 -- three blocking findings from GPT, all real, all fixed forward (no
override used).** They share one root cause, which is recorded under Pattern harvest:
a *failed* sync was being treated as a successful one.

- **A swallowed sync error is a false "durable".** `fsync_dir` had
  `except OSError: log`, and `_sync_batch` wrapped the manifest sync the same way -- so
  an `EIO` was suppressed and the source unlinked anyway. `fsync_dir` now returns
  quietly ONLY where a directory sync cannot be expressed (Windows has no directory
  descriptor; `EINVAL`/`ENOTSUP`/`EPERM`/`EACCES`/`EBADF`/`ENOSYS` from the `fsync`
  itself) and raises everything else; `_sync_batch` no longer catches at all. The one
  exception is the "resumed while being staged" path, which is already raising an error
  that names the session and locates its fragment -- replacing that with an `OSError`
  would cost the operator the only pointer to the fragment, so there it is logged, and
  that is stated at the call site.
- **Intermediate directories were never synced.** `staged_dirs` recorded only each
  file's own parent, but `mkdir(parents=True)` also creates the levels above it, and a
  directory's name lives in its PARENT's entries. A session with archive segments and
  no transcript therefore never recorded `crew` at all, so the entry reaching the
  staged segments was left unsynced. Every level from the batch down is now recorded
  (bounded by `relative_to`, so a destination outside the batch raises rather than
  climbing past it).
- **The unlink itself was not durable.** Copy-then-unlink is two operations, unlike the
  same-filesystem rename, so a crash after the unlink can come back to BOTH names: a
  live session the user was told had been reclaimed, beside a staged copy the manifest
  records as trashed. `fsync_dir(src.parent)` after the unlink, in
  `_copy_across_filesystems` and in `_move_file_exclusive`'s copy branch -- GPT named
  the first; the second is the identical mechanism and was fixed with it rather than
  left as an asymmetry.

And the interaction the triage predicted: an interrupted copy leaves an incoming file
inside a batch, and `_unlisted_files()` treats anything the manifest does not name as the
only copy of a session and blocks every deletion path. I first exempted the prefix; round
5 removed that exemption as unsound (see below), so the incoming name is naming only --
the guard exempts nothing. The prefix cannot collide with a staged name, which is always
`<store leaf>/<real session filename>`, at least one directory deep.

**Round 3 -- four more blocking findings from GPT, all real, all fixed forward (still
no override).** Two were defects in round 2's own fixes, which is the honest record:

- **Metadata was carried after the sync that forces it.** `copystat` writes the inode
  and the file `fsync` is what flushes the inode, so running it afterwards could
  publish the bytes under the temp's own `0600` and creation time -- and this module
  ages sessions by their mtime. `copystat` now precedes the `fsync` in both copy
  branches.
- **Round 2's post-unlink source sync put a COMPLETED move on the failure path.** The
  staging loop reads an exception from the mover as "this file did not move": it rolls
  the session back and omits the file from the manifest. For a file that has already
  moved, that is a half-staged session nothing records -- precisely the split the
  rollback exists to prevent. Nothing that can raise now follows the unlink. The source
  directories are collected instead and synced once in `_sync_batch`, after the batch is
  fully recorded and `best_effort` -- which also answers the cost objection, since the
  same-filesystem path is a bare rename and a sync per staged file is what would stop a
  trash working at tens of gigabytes. On that rename path no per-file source sync was
  added and none is needed: a rename is one atomic operation, so forcing the destination
  directory forces the source-side removal in the same transaction, unlike
  copy-then-unlink, which is two.
- **The trash's own directories were unsynced on a first-ever batch.**
  `mkdir(parents=True)` creates `trash/` and `trash/sessions/` too, and an unsynced
  `trash/sessions` entry takes the batch inside it. New `_fsync_tree()` walks down from
  the data home.
- **The stricter `fsync_dir` regressed the vault.** Raising after `atomic_write` has
  committed means `set_if_absent` never returns its fingerprint, so a migration omits a
  stored entry from its rollback set and lets it shadow the plaintext it was migrating
  from. Both vault sites are now explicitly `best_effort=True` -- a new keyword on
  `fsync_dir` rather than a hand-rolled `except OSError` per call site, so the decision
  is visible, single-pathed, still logged, and does not reintroduce the very pattern
  harvested below. It is for callers whose operation is ALREADY COMMITTED, where raising
  cannot protect anything and only reports finished work as failed.

**Round 4 -- one blocking finding, real, fixed forward.** `best_effort=True` still
raised, because `os.close(dir_fd)` sat in a `finally` and `close` can report a write
error the kernel deferred past the `fsync`. So a restore that had already unlinked its
staged source could still see an exception and leave the batch holding a stale manifest
entry -- the flag's whole purpose defeated by the one line it did not cover. The close
now honours `best_effort`, and it moved out of the `finally` for a second reason the
finding did not name: from there a close error would REPLACE an in-flight sync error
with a less informative one, so on every failing path the close is now quiet and only
the success path can surface it. By default a deferred error still raises, since for a
caller about to unlink the only other copy it means exactly what a failed sync means.

**Round 5 -- one blocking finding, real, and it retracts a claim made earlier in this
PR.** The `INCOMING_PREFIX` exemption in `_unlisted_files()` is gone. I had argued it
was "safe by construction" because the mover unlinks the source only after publishing,
so an unpublished incoming file always still has its source. That reasoning covers files
MY code wrote and nothing else: a name is not proof of provenance, and everything else
in this module's threat model already assumes a batch can be planted in (a linked
manifest, a file substituted at the manifest's own name are both handled explicitly). So
anything able to rename a file inside a batch could pick that prefix and put a staged
file beyond the deletion guard's reach.

Removing it costs the operability it bought: a crash mid-copy now leaves debris that
blocks emptying that batch until an operator clears it. That is not a regression --
`main` behaves the same way today for an interrupted cross-filesystem move, whose
partial file is equally unlisted -- so the durability fix stands on its own and the
wedge stays a pre-existing, separately-fixable problem (see the last item under Other
suggestions). Blocking a deletion that should proceed is recoverable; letting one
through is not. The prefix survives as naming only, so an operator who finds one knows
what it is.

The advisory in the same round (a comment claiming the vault key is "renamed" when it is
created with `O_CREAT | O_EXCL` directly) was correct and is fixed.

**Round 6 -- one blocking finding, real, fixed forward; plus a rebase onto current main.**
GPT found that a failing `fsync_dir(dst.parent)` left the published destination behind
while the caller was told the move failed. The staging loop then rolls the session back
WITHOUT that file, so a surviving `dst` sits in the batch named by no manifest entry --
the wedge class again. Both movers now withdraw the publication before re-raising, which
restores the exact state the call started in (the source is still untouched at that
point, and only this call created `dst`).

The three teardown errors on the Linux shard took a THIRD attempt, and the first two were
the wrong kind of fix. Both narrowed the PREDICATE -- fail any directory descriptor, then
fail only the descriptor we opened on this path -- and pytest's own `tmp_path` cleanup
defeated each, because the stdlib `rmtree` behind it opens and closes directory
descriptors of its own, on the very directory the test targeted. The traceback settled it:
`real_close(fd)` was itself raising `EBADF` during teardown, i.e. the wrapper was still
installed. No predicate over descriptors separates the call from the teardown, so the
third fix changes the AXIS to time: `_dir_fd_faults` is a context manager that restores
`os.open`/`os.fsync`/`os.close` on exit, and a test now pins that the injection cannot
outlive its call.

Re-running the earlier mutation harnesses on the rebased head caught a second-order
regression the green suite hid: the new `dst` rollback made two existing tests unable to
distinguish the FILE `fsync`, because they failed every descriptor and the directory
sync's own rollback path produced the identical observable state. Both are now scoped to
non-directory descriptors and redden again.

**Round 7 -- one blocking finding, real, and it retracts residual 2 below.** GPT found
the `os.link` fast path in `_move_file_exclusive` unlinks the source with no directory
sync. I had listed exactly this as a deliberately-deferred residual, arguing both names
reference one intact inode -- which is wrong about the failure mode: if the unlink reaches
disk and the new link does not, the inode has NO name left and the session is gone. A hard
link plus an unlink is two metadata operations, the same structure I had already accepted
for the copy branch; only a same-filesystem rename is one operation whose destination sync
carries the removal with it. Both branches now finish through one shared
`_publish_then_drop`, so the ordering cannot drift between them.

**What this does not claim.** It makes a move that RETURNED durable. It does not make
a crash MID-move consistent: a batch interrupted halfway still holds files its
manifest never named, which is what `_unlisted_files()` exists to protect.

## What tests we did

**Round 7 -- one blocking finding, real, fixed forward.**
GPT found the gap this change had left one level down from a fix it already made. Round 3
added a `_fsync_tree()` for the trash ancestors on a machine's first-ever batch, on the
reasoning that a directory's own entry is not durable until its parent is synced; the
staging subtree created inside each batch got no such treatment, and was left to the
end-of-batch sweep. That window is a loss, not a delay: the same-filesystem move is a
rename, which gives up the file's only other name in the same atomic step that creates the
new one, so a rename reaching disk while the `mkdir` that created its parent does not
leaves NO name resolving to the file. A fresh chain is now synced at creation, before
anything is renamed into it.

This is not the per-file durability listed below as a deliberate residual: it is one call
per new DIRECTORY, so the per-file path stays a bare rename. A failure rolls the session
back and leaves it in place -- the treatment a file that would not move already gets --
rather than propagating out of a batch whose manifest has not been forced out yet.

Re-running the harnesses caught a second-order effect for the third time in this change,
and in the more interesting direction: mutation `d2` ("record only the leaf staged
directory") stopped reddening, because with the chain now durable at creation and renames
only ever altering the leaf's entries, leaf-only recording is genuinely
behaviour-preserving. The guarantee moved rather than disappeared, so `d2` is retired with
that reasoning written down and the new creation-time sync is pinned in its place.

**Rounds 8 and 10 -- the same three lines, twice, in opposite directions. The second
answer is the one in the diff, and the reasoning is worth stating because the reviewer
took both positions.**
Round 8's finding: a bare `src.unlink()` after the destination is published means a
sharing violation or permission error leaves `dst` in the batch while the caller is told
the file did not move -- a file no manifest entry names, which blocks emptying that batch.
The suggested fix was to remove `dst` before re-raising. I did not take it as written,
because a filesystem can report failure for an unlink that DID commit, and there `dst`
holds the only copy; I made the withdrawal conditional on the source name still existing.

Round 10's finding, on that conditional: a surviving NAME does not prove the surviving
FILE is the original. A concurrent append recreates the transcript at the same path as a
new, empty file, the existence check says "the source survived", and the withdrawal then
deletes the only copy of the history. That is correct, and it is the more serious of the
two errors -- my guard turned a recoverable wedge into unrecoverable loss under a race.

So the destination is now kept on ANY unlink error and the exception propagates untouched.
Nothing observable at that instant distinguishes "the unlink failed" from "the unlink
succeeded and something recreated the name", and when the candidate outcomes are "an
operator must clear a leftover" and "bytes nobody can get back", the ordering is not close.
The leftover is protected by the same `_unlisted_files()` guard as any other unnamed file
in a batch, so it is residual 3 below rather than a new category.

I considered a third option -- capture the source's `(st_dev, st_ino)` before the unlink
and withdraw only on an exact identity match afterwards -- and rejected it. It is strictly
more precise, and this module does compare inode identity elsewhere. But its safety rests
on an inode-reuse argument across a race I cannot exercise in a test, and the failure mode
if that argument is wrong is silent permanent data loss. Three rounds on these three lines
is enough evidence that the subtle answer keeps being wrong here; the provable one is worth
an operator's cleanup.

**Round 9 -- one blocking finding, hardening rather than a vulnerability fix, and the
difference matters.**
GPT found that the cross-filesystem copy opened the source with plain `open()`, which
follows symlinks: a session file swapped for a link to a credential store would have the
SECRET's bytes copied into a trash the agent can read. Only a copy can do that -- the
rename path moves the link itself and the restore path's `os.link` links to the link -- so
the two branches of one mover disagreed about what a symlink means, and the cross-device
branch had the dangerous meaning. Both copy fallbacks now read through a shared
`_open_source_no_follow()`.

The finding is NOT reachable as described, and it took three wrong tests to establish
that. The first passed because the mtime gate reads THROUGH the link, saw a
freshly-written target and skipped the session; the second because the planted link never
reached the copy at all. Probing instead of guessing a fourth time showed why: every
enumeration scan uses `entry.is_file(follow_symlinks=False)`, so a symlink never becomes a
staging candidate. The guard is kept anyway, because it makes the copy safe on its OWN
terms rather than by inheritance from a filter several hundred lines away, and because a
mover whose two branches disagree about symlinks is a defect independent of whether
anything currently exploits it. The two tests pin what is actually true -- one on the
helper directly, one end-to-end asserting both that nothing leaked AND that the link was
passed over -- and the mutation that removes the upstream filter shows the layers are
independent: the copy guard still keeps the bytes out.

`_O_NOFOLLOW` is `getattr(os, "O_NOFOLLOW", 0)`, so Windows -- which has no such flag, and
where creating a symlink needs privilege this model does not hand out -- still imports and
opens normally.

New `test/test_trash_write_durability.py`, 36 tests. The ordering is pinned without
cutting power: make the `fsync` fail and assert the source is still there -- if the
sync ran after the unlink, or never ran, the source would be gone.

- **29 targeted mutations, all reddened against the final head.** Every fix was
  reverted individually and the matching test re-run: `_move_file` back to
  `shutil.move` (3 tests red), each new `fsync` dropped, the `INCOMING_PREFIX`
  carve-out dropped, the `_sync_batch` call dropped (2), the post-`mkdir` sync dropped,
  the `_rewrite_manifest` directory sync dropped, `fsync_dir` back to swallowing every
  errno (2), `_sync_batch` back to logging a
  failed manifest sync away, `copystat` moved back after the `fsync`, the source sync
  put back inside the mover, the source-directory collection removed, and `_fsync_tree`
  reduced to the batch's own parent; and for round 4, the descriptor close put back in a
  `finally` that ignores `best_effort`, and allowed to mask the sync error.
- **One test was vacuous and the mutation caught it.** The manifest-sync test first
  failed `os.fsync` for every descriptor, so `move_to_trash` still raised with the
  manifest's own sync swallowed -- the raise came from a directory sync instead. It now
  restricts the failure to non-directory descriptors, and the mutation reddens.
- **Coverage:** a partial copy never appears under the final name; metadata is carried
  before the sync that forces it (asserted on the published mtime, not just call
  order); nothing that can raise runs after a file has moved; the destination directory
  is synced while the source still exists; an intermediate directory
  `mkdir(parents=True)` created is synced, and so are the trash directories a
  first-ever batch creates; the drained source directories are synced once per batch,
  not per file; the exclusive mover still refuses an occupied destination; an incoming
  leftover is protected exactly like any other unlisted file; a
  cross-FS batch is byte-complete end to end; the manifest descriptor is among those
  synced before `move_to_trash` returns; `fsync_dir` is quiet on a platform without
  directory descriptors and on a refusing filesystem, and raises on `EIO`.
- **Regression:** 479 passed across `test_session_storage.py`,
  `test_session_storage_api.py`, `test_secrets_vault.py`, `test_secrets_migrate.py`,
  `test_secrets_handler.py`, the six `test_atomic_write_*` suites and the new file.
  `ruff`, `black` and `mypy` clean on all four changed files (the two remaining `mypy`
  errors are pre-existing in `transcribe.py`, untouched here).
- **Six tests are POSIX-only.** Windows has no directory descriptor to open, so
  `fsync_dir` returns at its documented no-op before reaching the `fsync` or `close`
  those tests drive -- the Windows shard proved it by failing five of them with DID
  NOT RAISE. They now carry a `skipif`, verified by flipping the condition (20 pass,
  6 skip). The production no-op is the intended Windows behaviour and is unchanged.
- **Claim (b) probe:** byte-identical output from both `truncate`/`seek` orders, and
  `tell()` == 7 for 7 UTF-8 bytes.

## Any other suggestions on the work

Three residuals I deliberately did not fold in, each a separate change:

1. **`_move_file_exclusive`'s copy branch is durable but still not atomic.** It writes
   the destination under its final name, so a crash mid-copy leaves a partial file
   there. It is not a loss -- the batch copy is intact because the source is not
   unlinked -- and the next restore attempt hits `FileExistsError` and reports the
   origin occupied, which is the safe direction. But it is a confusing permanent block
   by a garbage file. Fixing it properly needs a no-clobber atomic publish, and
   `os.link` is unavailable there by definition (that branch runs *because* `os.link`
   failed), so it wants its own design.
2. **Per-FILE durability inside the staging loop is still absent** by design: an `fsync`
   per file would defeat the point of a trash that stays usable at tens of gigabytes.
   Round 7 added the per-DIRECTORY sync, which is a different cost -- once per new
   directory, so the per-file path is still a bare rename -- and it closes the case
   where a file could end up with no reachable name at all. What remains open is
   narrower and not a loss: a crash mid-batch can leave files staged that the manifest
   does not yet name, which is what `_unlisted_files()` already guards. If mid-crash
   batch consistency is wanted later, the shape is a durable intent record, not more
   `fsync`s.
3. **An interrupted cross-filesystem copy leaves debris that blocks emptying its
   batch.** Pre-existing on `main` for the same interruption, and round 5 established
   that a name-based exemption cannot fix it safely. The shape that could is a durable
   record of what THIS batch's mover created -- provenance rather than a naming
   convention -- which is its own change and wants its own issue.

`_move_file`'s same-filesystem path -- the default install -- is unchanged: still a bare
`os.rename`, still instant.

## Pattern harvest

Rule candidate: semgrep
Pattern: `os.fsync` whose `OSError` is swallowed without discriminating on `errno`

The generalizable defect in this PR is not the missing syncs -- it is that a *failed*
sync was treated as a successful one. It appeared three times in this one change:
`secrets/vault.py`'s `_fsync_dir` had `except OSError: pass` (inherited, now deleted),
and my own first draft repeated it in the new `fsync_dir` and in `_sync_batch`. All
three read as reasonable, because a directory sync genuinely cannot be expressed on
Windows or on some network mounts -- so the swallow looks like portability rather than
a suppressed device error. GPT caught all three; the shape a rule should demand is that
any `except OSError` around an `os.fsync` either re-raises or tests `exc.errno` against
an explicit unsupported-set, never a bare `pass`/`log`. That is syntactic and
low-noise: a legitimate swallow has to name the errnos it tolerates.

Deliberately NOT harvested: "flag `shutil.move`". The repository has 23 call sites and
most are correct -- moving an extracted archive into a staging dir, where the source is
reproducible. What made it wrong *here* is that the source was the only copy of user
data, which is a semantic property no pattern can see. That half stays a review
question ("is the source of this move the only copy?"), not a rule.

Closes #6291
