### PR TITLE
fix(knowledge): guard the store's connection accessor against on-loop use

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -357,6 +357,26 @@ Both entity extraction (`EntityExtractor`) and internal-URL fetch (`agent_fetch.
 
 **Citation enrichment** — `_attach_source_locations` batch-fetches `source_locations` (adds `section_title`, `chunk_range`, `anchor`); `_attach_citation_sources` adds `source_type`/`source_name`/`source_uri` plus the most specific per-document locator: `file_path` for folder/vault sources (from `folder_file_state`), `artifact_slug`/`artifact_name` for the aggregate artifact source (deep-links `/artifacts/<slug>`). Missing/unmapped sources degrade cleanly (extra keys simply absent).
 
+### On-loop connection guard (`on_loop_db.py`)
+
+`KnowledgeStore.db` is the single accessor every query in the store funnels through, so it carries the runtime half of the off-loop discipline (#7078, remedy A of #3057). `OnLoopDBGuard.check()` runs at the top of the property, before the cached-connection fast path — a second query on an already-open connection must not escape it:
+
+- **Off the loop** (worker thread, `executors.py` lane, CLI, cron, subagent) — no-op. This is the sanctioned path.
+- **On the loop, strict** — raises `OnLoopStoreError`, so an un-offloaded call-site fails a test instead of shipping.
+- **On the loop, otherwise** — a throttled WARNING with `stack_info` (once per 60s per guard) and the call proceeds. Production deliberately does not raise: that would convert a slow query into a failed request.
+
+This complements `scripts/check_sync_io_in_async.py` rather than duplicating it. The gate rejects a blocking call written *lexically* inside an `async def`; it cannot see an `async def` that reaches the store through a plain synchronous helper one frame down (`store.get_item(...)`), and no name-based AST scan can without whole-program type inference. The guard fires for every caller regardless of stack depth. `test_knowledge_store_onloop_db.py::test_static_gate_is_blind_to_that_same_call` asserts the blind spot against the real gate, so if a future gate learns to see the interprocedural form the overlap gets re-judged deliberately instead of silently.
+
+**Strictness** comes from `strict_enabled()`, the single parser of the truthy/falsy rules, which takes the env var name as a parameter — because "strict" means "this surface is fully offloaded, so enforce it", a property of a *surface* rather than of the process. Two surfaces can sit at different stages of the same cleanup, so each gets its own switch:
+
+| Surface | Switch | Dev mode arms strict? |
+|---|---|---|
+| `history.py` session mutations | `KIROCREW_STRICT_ON_LOOP_PERSIST` | yes |
+| auto_research campaigns DB | `KIROCREW_STRICT_ON_LOOP_PERSIST` (shared default) | yes |
+| knowledge store | `KIROCREW_STRICT_ON_LOOP_STORE` | **no** |
+
+The knowledge store's two narrowings exist for one reason and are both temporary: it still carries the 85 recorded on-loop callers in `.github/sync-io-in-async-baseline.txt` that #7019 owns. The separate switch is load-bearing because `KIROCREW_STRICT_ON_LOOP_PERSIST` is **already exported** into the e2e gateway by `setup.py`'s `test_e2e` and `.github/workflows/ci.yml`, scoped when written to history's clean surface — on that switch the on-loop `/api/knowledge/stats` and `/api/knowledge/namespaces` handlers would raise and 500 the e2e run. Excluding the dev-mode arm matters for the same backlog: raising on tracked work reports it as a regression, and the developer's rational response (unsetting `KIROCREW_DEV_MODE`) would silence `history.py`'s guard too. When #7019 empties that baseline, both arguments go and this store joins the shared switch — `test_knowledge_store_onloop_db.py::TestSharedSwitchCannotArmThisStore` asserts the CI export against the real workflow file, so that flip has to be deliberate.
+
 ### `local_knowledge_search` MCP tool (`mcp_core.py`)
 
 The LLM reaches retrieval through the `kirocrew-core` MCP tool `local_knowledge_search`:
@@ -419,6 +439,7 @@ Returns the item count per source **under the active filters**:
 - **LLM-derived text is redacted before storage and before return** — ingestion redacts extracted text (`ingestion._redact`), and `local_knowledge_search` redacts its assembled output.
 - **FTS query input is parameterized** — user query tokens are always double-quoted literals; the user never injects FTS5 operators.
 - **Embedding-dimension mismatches are skipped, not scored** — vector search excludes incomparable-dimension items so a model swap cannot fill the top-K with all-zero ghosts.
+- **Taking `store.db` on the event loop is a diagnosable event, not a silent one** — the accessor is guarded (`on_loop_db.OnLoopDBGuard`): strict raises `OnLoopStoreError`, production logs a throttled WARNING with a stack and proceeds. This is what covers callers the lexical `check_sync_io_in_async` gate cannot see, so the two must both stay — neither alone closes #3057.
 - **The self-heal rebuild path never touches SQLite on the event loop** — `_maybe_reembed_stale`'s stale COUNT, `rebuild_embeddings`' total COUNT / page SELECTs / batch progress commits, and the success-path job finalize all run via `asyncio.to_thread` (`store.db` is a per-thread connection, so each worker thread uses its own connection to the same WAL db). On a large KB (observed: ~1.3GB after an embedder-sig change) an inline COUNT can stall past the 25s loop-watchdog threshold and crash-loop the gateway. The one deliberate exception is the CancelledError finalize in `_run_reembed_job`, which stays inline so cancellation cannot pre-empt the single-flight finalize. When the stale count exceeds `_LARGE_REBUILD_WARN_THRESHOLD` the watcher logs a prominent WARNING before starting the full re-embed.
 - **`__none__` is a shared wire contract** — the no-source sentinel is defined as `_NO_SOURCE` in `dashboard/handlers/knowledge.py` and mirrored as `NO_SOURCE` in `website/src/pages/knowledge/SourceGroup.tsx`. Both sides must change together; it is effectively un-renameable once shipped.
 - **A source-scoped `total` is scoped, never global** — `/items?source_id=` reports the count for that source alone, because the per-source pager computes its page count from it.

--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -42,9 +42,9 @@ from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
 )
-from kiro_crew.history import on_loop_persist_strict
 from kiro_crew.knowledge.llm_pool import LLMPool
 from kiro_crew.llm_helpers import _extract_json_of_type
+from kiro_crew.on_loop_db import OnLoopDBGuard
 from kiro_crew.platform_compat import is_link_or_junction, unlink_link_or_junction
 
 try:
@@ -203,48 +203,24 @@ def _safe_campaign_dir(campaign_id: str) -> Path | None:
 # --- Database ---
 
 
-class OnLoopDBError(RuntimeError):
-    """A campaigns-DB connection was opened on the event loop under strict mode."""
-
-
-_ON_LOOP_DB_WARN_INTERVAL_S = 60.0
-_on_loop_db_warn_last = 0.0
-
-
-def _check_on_loop_db_discipline() -> None:
-    """Enforce (strict) or diagnose (production) an on-loop ``_get_db`` entry.
-
-    Called at the top of :func:`_get_db`. No running event loop means the
-    caller is already off-loop (worker thread / executor / CLI) — the common,
-    correct case — and this is a no-op.
-    """
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return  # off-loop: the sanctioned path — nothing to flag
-    if on_loop_persist_strict():
-        raise OnLoopDBError(
-            "auto_research campaigns DB opened on the event loop; the 30s "
-            "busy timeout means one lock wait can stall the loop past the "
-            "watchdog budget and kill the gateway. Offload the DB section "
-            "(asyncio.to_thread / run_in_executor) like the surrounding "
-            "handlers do."
-        )
-    global _on_loop_db_warn_last
-    now = time.monotonic()
-    if now - _on_loop_db_warn_last >= _ON_LOOP_DB_WARN_INTERVAL_S:
-        _on_loop_db_warn_last = now
-        logger.warning(
-            "auto_research: _get_db() ran ON the event loop without "
-            "offloading; a contended write here blocks every task (including "
-            "the watchdog heartbeat) for up to 30s. Route it through "
-            "asyncio.to_thread / run_in_executor.",
-            stack_info=True,
-        )
+# The campaigns DB carries a 30s busy timeout, so one on-loop lock wait can
+# outlast the 25s loop-stall watchdog budget and kill the gateway. #7039
+# offloaded all six call sites and added this guard; it now uses the shared
+# implementation in ``kiro_crew.on_loop_db``. Defaults are deliberate: this
+# surface IS fully offloaded, so it stays on the shared
+# ``KIROCREW_STRICT_ON_LOOP_PERSIST`` switch (which the e2e harness exports) and
+# keeps the dev-mode arm, where a raise means genuinely new drift.
+_ON_LOOP_DB_GUARD = OnLoopDBGuard(
+    label="auto_research campaigns DB",
+    remedy=(
+        "Offload the DB section (asyncio.to_thread / run_in_executor) like the "
+        "surrounding handlers do."
+    ),
+)
 
 
 def _get_db() -> sqlite3.Connection:
-    _check_on_loop_db_discipline()
+    _ON_LOOP_DB_GUARD.check()
     dbp = db_path()
     dbp.parent.mkdir(parents=True, exist_ok=True)
     # Explicit 30s busy timeout (vs the 5s driver default). The research worker

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -16,7 +16,40 @@ try:
 except ImportError:
     import sqlite3
 
+from kiro_crew.on_loop_db import STORE_STRICT_ENV, OnLoopDBGuard
+
 logger = logging.getLogger(__name__)
+
+# Every query in this module funnels through the ``db`` property, so one check
+# there covers every caller at any stack depth -- including the ones a lexical
+# ``async def`` scan cannot see, which is why this guard exists (#7078, the
+# interprocedural half of #3057).
+#
+# Both narrowings below are temporary and exist for the same reason: this store
+# still has 85 recorded on-loop callers -- the whole of
+# ``.github/sync-io-in-async-baseline.txt``, all of it knowledge paths, owned by
+# the cleanup at #7019.
+#
+# * ``strict_env=STORE_STRICT_ENV`` keeps this store off the SHARED
+#   ``KIROCREW_STRICT_ON_LOOP_PERSIST`` switch, which ``setup.py``'s ``test_e2e``
+#   and ``ci.yml`` already export into the e2e gateway for history's clean
+#   surface. On the shared flag, the on-loop ``/api/knowledge/stats`` and
+#   ``/api/knowledge/namespaces`` handlers would raise and 500 the e2e run.
+# * ``dev_mode_arms_strict=False`` keeps a developer gateway from raising on that
+#   same backlog, which would report tracked work as a regression and push the
+#   developer to unset ``KIROCREW_DEV_MODE`` -- silencing history.py's guard too.
+#
+# When #7019 empties that baseline, delete both arguments and this store joins
+# the shared switch.
+_ON_LOOP_DB_GUARD = OnLoopDBGuard(
+    label="knowledge store",
+    remedy=(
+        "Offload the call (await asyncio.to_thread(...), or a named lane from "
+        "kiro_crew.executors) so the busy wait runs off the loop."
+    ),
+    strict_env=STORE_STRICT_ENV,
+    dev_mode_arms_strict=False,
+)
 
 
 class KnowledgeBundleError(ValueError):
@@ -285,6 +318,7 @@ class KnowledgeStore:
     @property
     def db(self) -> sqlite3.Connection:
         """The calling thread's connection, created lazily on first use."""
+        _ON_LOOP_DB_GUARD.check()
         conn = getattr(self._thread_local, "conn", None)
         if conn is None:
             conn = self._connect()

--- a/src/kiro_crew/on_loop_db.py
+++ b/src/kiro_crew/on_loop_db.py
@@ -1,0 +1,190 @@
+"""Reusable runtime guard for on-loop SQLite access in the store layer.
+
+The gateway runs one asyncio event loop. A blocking SQLite call made ON that
+loop stalls every session's turn while it waits, and a stall held past
+``dashboard.loop_stall_exit_after_secs`` (25s) makes the watchdog kill the
+process and drop every in-flight turn in every channel (#1572, #3057).
+
+``scripts/check_sync_io_in_async.py`` catches that defect only where it is
+written *lexically* inside an ``async def``. It cannot see the same call one
+frame down -- an ``async def`` that calls a plain synchronous helper which runs
+the query -- and no name-based AST scan can, without whole-program type
+inference. Closing that interprocedural half is what #3057 called remedy A: put
+the check at the store's connection accessor, where it fires for every caller
+regardless of how deep in the stack the call sits.
+
+Adopting the guard in a store is two lines: build one module-level
+:class:`OnLoopDBGuard` and call :meth:`OnLoopDBGuard.check` at the top of the
+connection accessor.
+
+``history.py`` keeps its own guard rather than adopting this one. Its
+:class:`~kiro_crew.history.OnLoopPersistError` subclasses ``AssertionError`` and
+it carries a ``ContextVar`` opt-out for the tests that drive its low-level
+``_locked`` primitive on purpose -- semantics this module does not reproduce and
+that PR must not change.
+
+A NOTE ON THE STRICTNESS SWITCH, because it is the subtle part. "Strict" means
+"this surface is fully offloaded, so enforce it". That is a property of a
+SURFACE, not of the process, and two surfaces can be at different stages of the
+same cleanup. ``KIROCREW_STRICT_ON_LOOP_PERSIST`` is already exported into the
+e2e gateway by ``setup.py``'s ``test_e2e`` and ``.github/workflows/ci.yml``,
+scoped when it was added to history's clean surface. A store still carrying
+known un-offloaded on-loop callers must therefore NOT be armed by that flag, or
+arming history's discipline reds an unrelated gate. Hence ``strict_env``: one
+parser, one spelling of the truthy/falsy rules, one switch per surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+
+from kiro_crew.constants import ENV_TRUTHY
+
+logger = logging.getLogger(__name__)
+
+#: The shared switch, read by ``history.py``'s own guard and the default here.
+#: Already exported by the e2e harness, so it means "history's surface is
+#: offloaded" and nothing more.
+STRICT_ENV = "KIROCREW_STRICT_ON_LOOP_PERSIST"
+
+#: The store layer's switch. Separate from :data:`STRICT_ENV` so a store with a
+#: tracked offload backlog is not armed by the flag CI already exports for
+#: history. Export this to make an on-loop store take raise instead of ship.
+STORE_STRICT_ENV = "KIROCREW_STRICT_ON_LOOP_STORE"
+
+#: Turning strict on for a developer gateway run.
+DEV_MODE_ENV = "KIROCREW_DEV_MODE"
+
+#: An explicit falsy value force-disables strict even under dev mode, so the
+#: production warn-and-proceed path stays reachable for testing. Mirrors
+#: ``history._ON_LOOP_FALSY``.
+_ENV_FALSY = frozenset({"0", "false", "no", "off"})
+
+#: Throttle window for the production diagnostic, so a mis-wired hot path
+#: cannot flood the log while the warning still fires once per window.
+DEFAULT_WARN_INTERVAL_S = 60.0
+
+
+class OnLoopStoreError(RuntimeError):
+    """A store connection was taken on the event loop under strict mode.
+
+    Raised by :meth:`OnLoopDBGuard.check`. Not an ``AssertionError`` (unlike
+    ``history.OnLoopPersistError``) so that running under ``python -O`` cannot
+    change whether the discipline is enforced.
+    """
+
+
+def strict_enabled(*, strict_env: str = STRICT_ENV, include_dev_mode: bool = True) -> bool:
+    """Whether an on-loop store entry should RAISE rather than warn-and-proceed.
+
+    Resolution order, matching ``history._on_loop_persist_strict()`` exactly
+    when both keyword arguments are left at their defaults:
+
+    1. a truthy *strict_env* -> strict (the explicit opt-in);
+    2. an explicitly falsy value -> NOT strict, even under dev mode (this is
+       what keeps the production path testable);
+    3. otherwise, a truthy ``KIROCREW_DEV_MODE`` -> strict, but only when the
+       caller opted into that branch via *include_dev_mode*.
+
+    It is deliberately NOT auto-on under bare pytest: the suite's own async
+    harness reaches several stores directly on the loop as a convenience rather
+    than as a production path, so auto-strict would flag harness code instead of
+    real drift.
+    """
+    raw = os.environ.get(strict_env, "").strip().lower()
+    if raw in ENV_TRUTHY:
+        return True
+    if raw in _ENV_FALSY:
+        return False
+    return include_dev_mode and os.environ.get(DEV_MODE_ENV, "").strip().lower() in ENV_TRUTHY
+
+
+class OnLoopDBGuard:
+    """One store's on-loop entry guard.
+
+    Each guard keeps its OWN throttle clock, so a chatty store cannot mute the
+    diagnostic for an unrelated one -- the reason this is an instance rather
+    than the module-level globals the pattern's first copies used.
+    """
+
+    __slots__ = ("_label", "_remedy", "_strict_env", "_include_dev_mode", "_warn_last")
+
+    def __init__(
+        self,
+        *,
+        label: str,
+        remedy: str,
+        strict_env: str = STRICT_ENV,
+        dev_mode_arms_strict: bool = True,
+    ) -> None:
+        """
+        :param label: what was opened, for the message ("knowledge store").
+        :param remedy: how the caller should have done it -- named concretely,
+            because the message is the only thing the person who hits this
+            reads.
+        :param strict_env: the env var that arms the raise for THIS surface.
+            Defaults to the shared :data:`STRICT_ENV`. A store with known
+            un-offloaded on-loop callers passes :data:`STORE_STRICT_ENV` (or its
+            own name) so that arming another surface's discipline does not raise
+            on its tracked backlog -- see the module docstring.
+        :param dev_mode_arms_strict: whether ``KIROCREW_DEV_MODE`` alone turns
+            this guard strict. Default True, matching ``history.py``. A store
+            with a known backlog passes False for the same reason: raising on
+            tracked work reports it as if it were a regression, and the
+            developer's rational response is to stop exporting
+            ``KIROCREW_DEV_MODE`` -- which silences every OTHER surface's guard
+            too. Flip it back to True once that backlog is empty.
+        """
+        self._label = label
+        self._remedy = remedy
+        self._strict_env = strict_env
+        self._include_dev_mode = dev_mode_arms_strict
+        # None (not 0.0) means "never warned". A 0.0 sentinel compares against
+        # time.monotonic(), which on a freshly-booted host is a small number, so
+        # the very first warning could fall inside the throttle window and be
+        # swallowed -- exactly the diagnostic that matters most.
+        self._warn_last: float | None = None
+
+    @property
+    def strict(self) -> bool:
+        """Whether this guard is currently in raising mode."""
+        return strict_enabled(strict_env=self._strict_env, include_dev_mode=self._include_dev_mode)
+
+    def check(self) -> None:
+        """Enforce (strict) or diagnose (production) an on-loop connection take.
+
+        No running event loop means the caller is already off-loop (worker
+        thread, executor lane, CLI, cron, subagent) -- the common and correct
+        case -- and this is a no-op.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return  # off-loop: the sanctioned path -- nothing to flag
+        if self.strict:
+            raise OnLoopStoreError(
+                f"{self._label} connection taken on the event loop; a contended "
+                f"query here blocks every task (including the watchdog "
+                f"heartbeat) for the connection's whole busy timeout, and a "
+                f"stall past 25s makes the watchdog kill the gateway. "
+                f"{self._remedy}"
+            )
+        now = time.monotonic()
+        last = self._warn_last
+        if last is None or now - last >= DEFAULT_WARN_INTERVAL_S:
+            self._warn_last = now
+            logger.warning(
+                "%s: connection taken ON the event loop without offloading; a "
+                "contended query here blocks every task (including the watchdog "
+                "heartbeat) for the connection's whole busy timeout. %s",
+                self._label,
+                self._remedy,
+                stack_info=True,
+            )
+
+    def reset_throttle(self) -> None:
+        """Re-open the throttle window. For tests asserting the warn path."""
+        self._warn_last = None

--- a/test/test_auto_research_onloop_db.py
+++ b/test/test_auto_research_onloop_db.py
@@ -33,13 +33,13 @@ from aiohttp.test_utils import TestClient, TestServer
 from kiro_crew.apps.builtins.auto_research import handlers as h
 from kiro_crew.apps.builtins.auto_research.handlers import (
     CampaignStatus,
-    OnLoopDBError,
     _get_db,
     create_campaign,
     get_campaign,
     register_routes,
     update_campaign_status,
 )
+from kiro_crew.on_loop_db import OnLoopDBGuard, OnLoopStoreError
 
 
 @pytest.fixture(autouse=True)
@@ -64,7 +64,7 @@ class TestOnLoopGuard:
     @pytest.mark.asyncio
     async def test_on_loop_get_db_raises_under_strict(self, monkeypatch):
         monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
-        with pytest.raises(OnLoopDBError):
+        with pytest.raises(OnLoopStoreError):
             _get_db()
 
     def test_off_loop_get_db_allowed_under_strict(self, monkeypatch):
@@ -82,8 +82,8 @@ class TestOnLoopGuard:
         """Strict off (production): the on-loop entry proceeds but logs loudly,
         so a mis-wired call-site is never silent."""
         monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
-        monkeypatch.setattr(h, "_on_loop_db_warn_last", 0.0)  # reset throttle window
-        with caplog.at_level("WARNING", logger=h.logger.name):
+        h._ON_LOOP_DB_GUARD.reset_throttle()  # reset throttle window
+        with caplog.at_level("WARNING", logger="kiro_crew.on_loop_db"):
             conn = _get_db()
             conn.close()
         assert any("event loop" in r.message for r in caplog.records)
@@ -91,8 +91,8 @@ class TestOnLoopGuard:
     @pytest.mark.asyncio
     async def test_on_loop_warning_is_throttled(self, monkeypatch, caplog):
         monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
-        monkeypatch.setattr(h, "_on_loop_db_warn_last", 0.0)
-        with caplog.at_level("WARNING", logger=h.logger.name):
+        h._ON_LOOP_DB_GUARD.reset_throttle()
+        with caplog.at_level("WARNING", logger="kiro_crew.on_loop_db"):
             for _ in range(3):
                 conn = _get_db()
                 conn.close()
@@ -103,12 +103,12 @@ class TestOnLoopGuard:
         silently disarms every other protection here — pin the call."""
         tree = ast.parse(inspect.getsource(h._get_db))
         fn = tree.body[0]
-        calls = [
-            n.func.id
+        attrs = [
+            n.func.attr
             for n in ast.walk(fn)
-            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
         ]
-        assert "_check_on_loop_db_discipline" in calls
+        assert "check" in attrs
 
 
 # Functions that open (or transitively open) the campaigns DB. A direct call
@@ -663,6 +663,16 @@ class TestWarnThrottleClock:
     def test_throttle_uses_monotonic_clock(self):
         """The warn throttle must use time.monotonic (wall-clock jumps must not
         re-open or permanently close the throttle window)."""
-        src = inspect.getsource(h._check_on_loop_db_discipline)
+        src = inspect.getsource(OnLoopDBGuard.check)
         assert "time.monotonic()" in src
         assert time.monotonic  # imported and real
+
+    def test_this_surface_stays_on_the_shared_switch(self):
+        """#7039 offloaded all six call sites here, so this surface keeps the
+        shared ``KIROCREW_STRICT_ON_LOOP_PERSIST`` switch and the dev-mode arm --
+        a raise means genuinely new drift. The knowledge store deliberately
+        differs (its offload backlog is #7019); pin that this one does not."""
+        from kiro_crew.on_loop_db import STRICT_ENV
+
+        assert h._ON_LOOP_DB_GUARD._strict_env == STRICT_ENV
+        assert h._ON_LOOP_DB_GUARD._include_dev_mode is True

--- a/test/test_knowledge_store_onloop_db.py
+++ b/test/test_knowledge_store_onloop_db.py
@@ -1,0 +1,345 @@
+"""Off-loop DB discipline for the knowledge store (#7078, remedy A of #3057).
+
+``scripts/check_sync_io_in_async.py`` rejects a blocking DB call written
+*lexically* inside an ``async def``. It cannot see the same call one frame down:
+an ``async def`` that calls a plain synchronous store method which runs the
+query. That interprocedural half is what this guard closes, by checking at the
+one accessor every query funnels through -- ``KnowledgeStore.db``.
+
+These tests pin the discipline from four directions:
+
+1. the runtime chokepoint itself (strict raise / production warn / off-loop
+   no-op / throttled warning),
+2. the *interprocedural* catch, together with proof that the static gate is
+   blind to the very same call -- the two are complementary, not redundant,
+3. the deliberate departure from ``history.py``: ``KIROCREW_DEV_MODE`` alone
+   must NOT arm this store's raise while #7019's 85 recorded on-loop callers
+   are outstanding,
+4. a mutation guard, so deleting the check from the accessor fails loudly
+   instead of silently disarming everything above.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib.util
+import inspect
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import on_loop_db
+from kiro_crew.knowledge.store import _ON_LOOP_DB_GUARD, KnowledgeStore
+from kiro_crew.on_loop_db import (
+    STORE_STRICT_ENV,
+    STRICT_ENV,
+    OnLoopDBGuard,
+    OnLoopStoreError,
+    strict_enabled,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> KnowledgeStore:
+    """A store built OFF the loop.
+
+    ``__init__`` runs the schema init, the migrations and the graph load through
+    ``self.db``, so building one on the loop is itself an on-loop take. Every
+    test here builds it off-loop and then exercises the accessor deliberately.
+    """
+    return KnowledgeStore(str(tmp_path / "knowledge.db"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_throttle():
+    """The guard is module-level, so its throttle clock leaks between tests."""
+    _ON_LOOP_DB_GUARD.reset_throttle()
+    yield
+    _ON_LOOP_DB_GUARD.reset_throttle()
+
+
+class TestOnLoopGuard:
+    """The runtime chokepoint: ``KnowledgeStore.db`` flags on-loop entry."""
+
+    @pytest.mark.asyncio
+    async def test_on_loop_db_raises_under_strict(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_STORE", "1")
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        with pytest.raises(OnLoopStoreError):
+            st.db  # noqa: B018 - taking the connection is the operation under test
+
+    def test_off_loop_db_allowed_under_strict(self, store, monkeypatch):
+        """No running loop (worker thread / executor lane / CLI / cron) is the
+        sanctioned path -- strict mode must not flag it."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_STORE", "1")
+        assert store.db.execute("SELECT 1").fetchone()[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_offloaded_call_is_allowed_under_strict(self, tmp_path, monkeypatch):
+        """The remedy the message names must actually satisfy the guard."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_STORE", "1")
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        got = await asyncio.to_thread(lambda: st.db.execute("SELECT 1").fetchone()[0])
+        assert got == 1
+
+    @pytest.mark.asyncio
+    async def test_on_loop_db_warns_in_production_mode(self, tmp_path, monkeypatch, caplog):
+        """Strict off (production): the take proceeds but logs loudly, so a
+        mis-wired call-site is never silent. Production must not start raising --
+        that would turn a slow query into a failed request."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_STORE", "0")
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        with caplog.at_level("WARNING", logger="kiro_crew.on_loop_db"):
+            assert st.db.execute("SELECT 1").fetchone()[0] == 1
+        assert any("event loop" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_on_loop_warning_is_throttled(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_STORE", "0")
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        with caplog.at_level("WARNING", logger="kiro_crew.on_loop_db"):
+            for _ in range(3):
+                st.db.execute("SELECT 1").fetchone()
+        assert sum("event loop" in r.message for r in caplog.records) == 1
+
+    def test_first_warning_is_never_swallowed_by_the_throttle(self, caplog, monkeypatch):
+        """A 0.0 "last warned" sentinel compares against ``time.monotonic()``,
+        which is small on a freshly-booted host -- so the FIRST warning, the one
+        that matters most, could fall inside the throttle window and vanish. The
+        guard uses a None sentinel; pin it with a huge window.
+        """
+        monkeypatch.setattr(on_loop_db, "DEFAULT_WARN_INTERVAL_S", 1e9)
+        guard = OnLoopDBGuard(label="probe store", remedy="offload it")
+
+        async def _take() -> None:
+            guard.check()
+
+        with caplog.at_level("WARNING", logger="kiro_crew.on_loop_db"):
+            asyncio.run(_take())
+        assert any("probe store" in r.message for r in caplog.records)
+
+
+class TestInterproceduralCatch:
+    """The half the static gate cannot see -- the reason this guard exists."""
+
+    # An async frame reaching the store through a plain SYNC store method. No
+    # DB-named call appears lexically inside the ``async def``.
+    _INTERPROCEDURAL_SRC = (
+        "async def handler(store, item_id):\n" "    return store.get_item(item_id)\n"
+    )
+
+    @pytest.mark.asyncio
+    async def test_sync_helper_one_frame_down_is_caught(self, tmp_path, monkeypatch):
+        """``get_item`` is a plain ``def`` that runs ``self.db.execute(...)``.
+        Called from an ``async def`` it runs the busy wait on the loop, and the
+        runtime guard is what notices."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_STORE", "1")
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+
+        async def handler():
+            return st.get_item("does-not-exist")
+
+        with pytest.raises(OnLoopStoreError):
+            await handler()
+
+    def test_static_gate_is_blind_to_that_same_call(self):
+        """Complementarity, asserted against the real gate rather than claimed:
+        the gate reports NOTHING for the interprocedural form, so the runtime
+        guard is not redundant with it. If a future gate learns to see this,
+        this test fails and the overlap can be re-judged deliberately."""
+        spec = importlib.util.spec_from_file_location(
+            "_sync_io_gate", REPO_ROOT / "scripts" / "check_sync_io_in_async.py"
+        )
+        assert spec and spec.loader
+        gate = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(gate)
+
+        # Coherence check: the detector does fire on the LEXICAL form, so a zero
+        # below is a real blind spot and not a mis-wired probe.
+        lexical = gate._violations_in_source(
+            "async def handler(store):\n    return store.db.execute('SELECT 1').fetchone()\n"
+        )
+        assert lexical, "probe is mis-wired: the gate did not flag the lexical form"
+
+        interprocedural = gate._violations_in_source(self._INTERPROCEDURAL_SRC)
+        assert interprocedural == [], (
+            "the static gate now sees the interprocedural form; re-judge whether "
+            f"the runtime guard still adds coverage. found: {interprocedural}"
+        )
+
+
+class TestDevModeDeparture:
+    """This store deliberately does NOT let ``KIROCREW_DEV_MODE`` alone raise.
+
+    ``history.py``'s guard can arm that branch because every session mutator was
+    already offloaded when it landed, so a raise there means genuinely new
+    drift. This store still has 85 recorded on-loop callers (the whole of
+    ``.github/sync-io-in-async-baseline.txt``), owned by #7019. Raising on a
+    tracked backlog reports it as a regression, and the developer's rational
+    response -- unset ``KIROCREW_DEV_MODE`` -- would silence history.py's guard
+    too. Pinned so flipping it later is a conscious edit with a failing test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_alone_warns_but_does_not_raise(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.delenv("KIROCREW_STRICT_ON_LOOP_STORE", raising=False)
+        monkeypatch.setenv("KIROCREW_DEV_MODE", "1")
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        with caplog.at_level("WARNING", logger="kiro_crew.on_loop_db"):
+            assert st.db.execute("SELECT 1").fetchone()[0] == 1  # must NOT raise
+        assert any("event loop" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_explicit_opt_in_still_raises_under_dev_mode(self, tmp_path, monkeypatch):
+        """The escape from the departure: a CI job or a discipline test that
+        wants the hard failure exports the explicit flag."""
+        monkeypatch.setenv("KIROCREW_DEV_MODE", "1")
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_STORE", "1")
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        with pytest.raises(OnLoopStoreError):
+            st.db  # noqa: B018
+
+    def test_store_guard_opts_out_of_the_dev_mode_arm(self):
+        """Pin the wiring, not just the behaviour: the store's guard instance
+        must be the one that excludes dev mode."""
+        assert _ON_LOOP_DB_GUARD._include_dev_mode is False
+
+
+class TestSharedSwitchCannotArmThisStore:
+    """Regression: the shared switch is ALREADY exported in CI.
+
+    ``setup.py``'s ``test_e2e`` and ``.github/workflows/ci.yml`` both export
+    ``KIROCREW_STRICT_ON_LOOP_PERSIST=1`` into the e2e gateway, scoped when they
+    were written to history's fully-offloaded surface. If this store read that
+    same switch, the on-loop ``/api/knowledge/stats`` and
+    ``/api/knowledge/namespaces`` handlers would raise and 500 the e2e run --
+    a green-looking flag arming a raise on the backlog #7019 owns. The store
+    therefore reads its OWN switch. Pinned here because the failure only shows
+    up in an expensive end-to-end job.
+    """
+
+    def test_store_reads_its_own_switch(self):
+        assert _ON_LOOP_DB_GUARD._strict_env == STORE_STRICT_ENV
+        assert STORE_STRICT_ENV != STRICT_ENV
+
+    @pytest.mark.asyncio
+    async def test_ci_shared_flag_alone_does_not_raise(self, tmp_path, monkeypatch):
+        """The exact e2e environment: shared flag on, store flag absent."""
+        monkeypatch.setenv(STRICT_ENV, "1")
+        monkeypatch.delenv(STORE_STRICT_ENV, raising=False)
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        assert st.db.execute("SELECT 1").fetchone()[0] == 1  # must NOT raise
+
+    @pytest.mark.asyncio
+    async def test_the_e2e_handler_shapes_survive_the_shared_flag(self, tmp_path, monkeypatch):
+        """Both shapes the e2e Playwright run exercises against /knowledge: the
+        interprocedural one (``get_stats`` -> ``self.db``) and the direct one
+        (``store.db.execute``) that the namespaces handler uses."""
+        monkeypatch.setenv(STRICT_ENV, "1")
+        monkeypatch.delenv(STORE_STRICT_ENV, raising=False)
+        st = await asyncio.to_thread(KnowledgeStore, str(tmp_path / "k.db"))
+        assert isinstance(st.get_stats(), dict)
+        st.db.execute(
+            "SELECT namespace, COUNT(*) FROM items WHERE status = 'active' GROUP BY namespace"
+        ).fetchall()
+
+    def test_ci_exports_the_shared_flag_not_the_store_flag(self):
+        """The premise above, asserted against the real CI config rather than
+        assumed. If CI later exports the store switch too, this fails and the
+        narrowing must be re-judged (that is the #7019 completion signal)."""
+        ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        setup_py = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
+        assert STRICT_ENV in ci and STRICT_ENV in setup_py, (
+            "the shared switch is no longer exported by CI; this store's "
+            "narrowing was justified by that export"
+        )
+        assert STORE_STRICT_ENV not in ci and STORE_STRICT_ENV not in setup_py, (
+            "CI now exports the store switch -- the knowledge store's on-loop "
+            "callers must be offloaded (#7019) before that can hold"
+        )
+
+
+class TestGuardIsWired:
+    def test_db_property_enters_the_guard(self):
+        """Mutation guard: removing the check from the accessor silently disarms
+        every other protection here -- pin the call."""
+        src = textwrap.dedent(inspect.getsource(KnowledgeStore.db.fget))
+        tree = ast.parse(src)
+        attrs = [
+            n.func.attr
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        ]
+        assert "check" in attrs, "KnowledgeStore.db no longer calls the on-loop guard"
+
+    def test_guard_check_precedes_the_connection(self):
+        """The check must run BEFORE the cached-connection fast path, or a
+        second on-loop query on an already-open connection escapes it."""
+        src = inspect.getsource(KnowledgeStore.db.fget)
+        assert src.index("_ON_LOOP_DB_GUARD.check()") < src.index("_thread_local")
+
+    def test_throttle_uses_monotonic_clock(self):
+        """Wall-clock jumps must not re-open or permanently close the window."""
+        src = inspect.getsource(OnLoopDBGuard.check)
+        assert "time.monotonic()" in src
+        assert time.monotonic  # imported and real
+
+
+class TestStrictSwitchDoesNotDrift:
+    """``on_loop_db.strict_enabled`` re-derives the switch instead of calling
+    ``history.on_loop_persist_strict()``, because history's version hardcodes the
+    dev-mode arm and this store needs that arm excludable. Two readers of one
+    env var can drift apart, so pin that they agree wherever they overlap.
+    """
+
+    CASES = [
+        {},
+        {"KIROCREW_STRICT_ON_LOOP_PERSIST": "1"},
+        {"KIROCREW_STRICT_ON_LOOP_PERSIST": "true"},
+        {"KIROCREW_STRICT_ON_LOOP_PERSIST": "0"},
+        {"KIROCREW_STRICT_ON_LOOP_PERSIST": "off"},
+        {"KIROCREW_DEV_MODE": "1"},
+        {"KIROCREW_DEV_MODE": "yes"},
+        {"KIROCREW_DEV_MODE": "0"},
+        # explicit falsy must force-disable even under dev mode, in both readers
+        {"KIROCREW_DEV_MODE": "1", "KIROCREW_STRICT_ON_LOOP_PERSIST": "0"},
+        {"KIROCREW_DEV_MODE": "1", "KIROCREW_STRICT_ON_LOOP_PERSIST": "1"},
+        # an unrecognised value is neither truthy nor falsy in either reader
+        {"KIROCREW_STRICT_ON_LOOP_PERSIST": "maybe"},
+        {"KIROCREW_DEV_MODE": "1", "KIROCREW_STRICT_ON_LOOP_PERSIST": "maybe"},
+    ]
+
+    def test_agrees_with_history_when_dev_mode_is_armed(self, monkeypatch):
+        from kiro_crew.history import on_loop_persist_strict
+
+        for env in self.CASES:
+            for var in ("KIROCREW_STRICT_ON_LOOP_PERSIST", "KIROCREW_DEV_MODE"):
+                monkeypatch.delenv(var, raising=False)
+            for key, value in env.items():
+                monkeypatch.setenv(key, value)
+            assert (
+                strict_enabled(include_dev_mode=True) == on_loop_persist_strict()
+            ), f"strict switch drifted from history.py for {env}"
+
+    def test_excluding_dev_mode_differs_only_on_the_dev_mode_arm(self, monkeypatch):
+        """The narrowing must be exactly the dev-mode arm and nothing else: for
+        every case where the explicit flag decides, both forms must agree."""
+        for env in self.CASES:
+            for var in ("KIROCREW_STRICT_ON_LOOP_PERSIST", "KIROCREW_DEV_MODE"):
+                monkeypatch.delenv(var, raising=False)
+            for key, value in env.items():
+                monkeypatch.setenv(key, value)
+            explicit = env.get("KIROCREW_STRICT_ON_LOOP_PERSIST", "").strip().lower()
+            if explicit in {"1", "true", "yes", "on", "0", "false", "no", "off"}:
+                assert strict_enabled(include_dev_mode=False) == strict_enabled(
+                    include_dev_mode=True
+                ), f"narrowing changed an explicitly-decided case: {env}"
+            else:
+                assert (
+                    strict_enabled(include_dev_mode=False) is False
+                ), f"narrowed form must never raise without the explicit flag: {env}"


### PR DESCRIPTION
## Problem / Motivation

The CI ratchet from #3057 (PR #6997) rejects blocking SQLite calls written
*lexically* inside an `async def`. It cannot see the same defect one frame down:
an `async def` that calls a plain synchronous helper which runs the query. No
name-based AST scan can, without whole-program type inference.

`dashboard/handlers/knowledge.py` shows both halves side by side. The gate sees
`store.db.execute(...)` on line 176 and counts it. Further down, at line 458,
`store.get_item(item_id)` is invisible to it: `get_item` is a plain `def` whose
body runs `self.db.execute(...)` (`knowledge/store.py:751`), so the blocking wait
happens on the loop with nothing in the `async def` for a lexical scan to match.

That interprocedural half is what #3057 called remedy A, and #7078 tracks it
because #3057 closed with the ratchet PR and would otherwise have left it
untracked.

The population is not theoretical, and it was measured rather than assumed. An
AST census of calls to the 34 synchronous `KnowledgeStore` methods that reach
`self.db`, counting only call sites whose nearest enclosing function is an
`async def` and excluding anything wrapped in `asyncio.to_thread`, finds **35
on-loop sites the lexical gate cannot see**:

| Sites | File | Gate status |
|------:|------|-------------|
| 19 | `dashboard/handlers/knowledge.py` | baselined |
| 8 | `knowledge/ingestion.py` | baselined |
| 3 | `knowledge/artifact_ingest.py` | **not in the baseline** |
| 3 | `knowledge/watcher.py` | baselined |
| 1 | `knowledge/agent_source.py` | **not in the baseline** |
| 1 | `knowledge/sync.py` | baselined |

The last column is the part worth pausing on. Four of those sites live in two
files the ratchet has never listed, so the gate reports them as clean today:
`artifact_ingest.py:396` calls `kstore.release_stale_claim(...)` inside `async def
ingest_artifact`, and `agent_source.py:340` calls `store.release_stale_claim(...)`
inside `async def _add_agent_document`. Both were confirmed by hand, and neither
file appears in `.github/sync-io-in-async-baseline.txt`. One receiver-name
collision (`_rt().stats.get_stats()` in the Mochi app, whose receiver is not a
`KnowledgeStore`) was found and excluded from the count.

## Why it matters

The user-visible failure is the one both halves exist for: a blocking call on the
gateway's single event loop, held past `dashboard.loop_stall_exit_after_secs`
(25s), makes the watchdog kill the process and drop every in-flight turn in every
channel (#1572). The ratchet stops new *direct* instances; nothing stopped a new
helper-mediated one.

The gap is not hypothetical. `DashboardState.knowledge_store`
(`dashboard/state.py:5379`) is a lazy synchronous property, so the first access
from any async handler constructs the store on the loop, running schema init,
migrations and the graph load there. Nothing in that `async def` is a DB call by
name, so the gate has never had anything to report.

## What changed

Every query in the store funnels through one accessor, the `db` property
(`knowledge/store.py:285`, 176 internal uses). Checking there fires for every
caller regardless of stack depth, which is precisely what the lexical gate cannot
do. So:

- **`src/kiro_crew/on_loop_db.py` (new)**: `OnLoopDBGuard.check()`. Off-loop is a
  no-op (the sanctioned path); on-loop raises `OnLoopStoreError` under strict, and
  otherwise logs a throttled WARNING with `stack_info` and proceeds. Production
  deliberately does not raise, matching `history.py`; a raise there would convert
  a slow query into a failed request.
- **`knowledge/store.py`**: two lines. One module-level guard, and `check()` at
  the top of the `db` property, BEFORE the cached-connection fast path, so a
  second on-loop query on an already-open connection cannot escape it.

Guarding `_connect()` instead was rejected: it runs once per thread and would miss
every query after the first, which is the whole population.

This is the pattern's third instance (`history.py`, then auto_research via #7039),
so it is factored into `on_loop_db.py` and **auto_research is migrated onto it in
this PR** -- a net deletion of ~35 lines there, and the module ships with two real
consumers rather than one plus a promise. `history.py` keeps its own guard: its
`OnLoopPersistError` subclasses `AssertionError` and it carries a `ContextVar`
opt-out for the tests that drive its low-level `_locked` primitive on purpose,
semantics this module does not reproduce and that PR should not change.

Scope stayed at this one class on evidence, not by omission. Six sibling stores
were surveyed; the full table is in a PR comment below. The discriminator is
uniform: every other store already offloads, so a guard on it would have no live
call site to protect. `VectorMemoryStore.db` also has no single funnel method (a
bare property plus ~30 direct `.execute` sites), and the auth, usage-api,
kiro-cli and personal_shopper stores open short-lived or read-only connections
with no owned accessor.

**The decision the issue asked for, and a correction.** #7078 asked whether strict
mode is on in CI. The first revision of this PR answered "one knob, opt-in only"
and that was **wrong on a fact**: `KIROCREW_STRICT_ON_LOOP_PERSIST` is not
hypothetical, it is *already* exported into the e2e gateway by `setup.py`'s
`test_e2e` and `.github/workflows/ci.yml:1971`, scoped when written to history's
clean surface. Reading that switch here would have made the on-loop
`/api/knowledge/stats` and `/api/knowledge/namespaces` handlers raise and 500 the
e2e run. Caught in review by Opus and Design Review, verified, and fixed.

The corrected model: "strict" means "this surface is fully offloaded, so enforce
it", which is a property of a *surface*, not of the process. `strict_enabled()`
stays the single parser of the truthy/falsy rules and takes the env var name as a
parameter, so each surface gets its own switch:

| Surface | Switch | Dev mode arms strict? |
|---|---|---|
| `history.py` session mutations | `KIROCREW_STRICT_ON_LOOP_PERSIST` | yes |
| auto_research campaigns DB | `KIROCREW_STRICT_ON_LOOP_PERSIST` (shared default) | yes |
| knowledge store | `KIROCREW_STRICT_ON_LOOP_STORE` | **no** |

This is not a new convention: `cron.py:470` already carries a per-surface
`KIROCREW_STRICT_LOOP_SAFETY` for the cron store's loop-safety guard, documented
as mirroring `KIROCREW_STRICT_ON_LOOP_PERSIST`. Both of the knowledge store's
narrowings exist for the same reason and are both temporary -- the 85 recorded
on-loop callers #7019 owns. When that baseline empties, both arguments go and this
store joins the shared switch.

Production behaviour is unchanged: warn-and-proceed, per the issue's item 3.

## Tests

`test/test_knowledge_store_onloop_db.py` (20 tests, 6 groups):

- **`TestOnLoopGuard`**: strict raises on-loop; off-loop is allowed under strict;
  the offload the error message recommends actually satisfies the guard;
  production warns and proceeds; the warning is throttled to one per window; and
  the first warning is never swallowed by the throttle. That last one is a real
  bug avoided: a `0.0` "last warned" sentinel compares against
  `time.monotonic()`, which is small on a freshly-booted host, so the most
  important diagnostic could vanish. The guard uses a `None` sentinel instead.
- **`TestInterproceduralCatch`**: the reason the PR exists. An `async def` calling
  `store.get_item(...)` raises under strict. Its sibling test asserts the
  complementarity against the REAL gate rather than claiming it:
  `_violations_in_source` flags the lexical form (proving the probe is wired) and
  returns empty for the interprocedural form. If a future gate learns to see it,
  that test fails and the overlap gets re-judged deliberately.
- **`TestDevModeDeparture`**: `KIROCREW_DEV_MODE` alone warns and does not raise;
  the explicit flag still raises under dev mode; and the wiring itself is pinned.
- **`TestGuardIsWired`**: AST mutation guard that the accessor calls the check;
  that the check precedes the connection lookup; and that the throttle uses a
  monotonic clock.
- **`TestSharedSwitchCannotArmThisStore`**: the regression for the review finding
  above. It asserts the store reads its own switch; that the exact e2e environment
  (shared flag on, store flag absent) does not raise; that both handler shapes the
  Playwright run exercises survive it -- the interprocedural `get_stats()` and the
  direct `store.db.execute` the namespaces handler uses; and, against the real
  `ci.yml` and `setup.py`, that CI exports the shared switch and not the store one.
  That last assertion is the #7019 completion signal: when CI does export the store
  switch, it fails and the narrowing must be re-judged.
- **`TestStrictSwitchDoesNotDrift`**: `strict_enabled` is the only parser of the
  env pair, but it is a second reader alongside `history.on_loop_persist_strict()`
  (delegating would drag history's heavy import graph into every store import). One
  test asserts they agree across 12 env combinations -- truthy spellings, explicit
  falsy, dev mode, unrecognised values -- on the shared switch with the dev-mode arm
  included; a second asserts the narrowing differs on exactly that arm.

Verification run, not just written:

- 114 pass across the three affected files (`pytest -n 2`): 20 new store-guard
  tests, 27 auto_research tests after the migration, 67 history tests confirming
  the shared switch's semantics are untouched.
- Teeth proven by mutation: removing only `_ON_LOOP_DB_GUARD.check()` from the
  accessor reddens 8 of the store-guard tests. On base the module does not exist at
  all, so the suite cannot import it.
- No regressions: 207 pass across `test_knowledge.py`,
  `test_knowledge_cross_thread.py`, `test_knowledge_delete_off_loop.py` and
  `test_knowledge_ingest_scan_off_loop.py`, the existing off-loop and
  thread-local-connection suites.
- `check_sync_io_in_async.py` passes on the real diff scope (3 changed files); the
  85 baselined calls still resolve, since they are in warn mode.
- `black --check`, `isort --check-only` and `flake8` clean on both new files.
  `knowledge/store.py` is in `.github/black-baseline.txt` and already fails black
  on base, so it was deliberately not reformatted; the diff there is 28 added
  lines, no deletions.

## Manual verification

N/A, unit coverage is sufficient. The guard has no UI surface, and all three of
its arms (raise, warn, off-loop no-op) plus the interprocedural catch are
exercised directly by the tests above, including against the real static gate.

## Related Issues

Closes #7078
Refs #3057, #7019, #1572, #7055, PR #6997, PR #7039

## Pattern harvest

Rule candidate: review-prompt

Pattern: a static gate that matches call NAMES inside `async def` cannot see the
same call behind a synchronous helper, so it must be paired with a runtime check
at the resource's own accessor, the one place every caller funnels through. Worth
asking of any future "we added a CI gate for blocking I/O" change: which frame
does it see, and what guards the frame below it.
