### PR TITLE
fix(channels): persist a durable row id for channel-born transcript rows

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -53,7 +53,7 @@ from kiro_crew.dashboard.slot_queue_repository import SlotQueueRepository
 from kiro_crew.dashboard.slot_registry import SlotRegistry
 from kiro_crew.dashboard.system_notices import is_system_notice
 from kiro_crew.dashboard.websocket_hub import WebSocketHub
-from kiro_crew.history import latest_transcript_ts, monotonic_transcript_ts
+from kiro_crew.history import latest_transcript_ts, mint_row_mid, monotonic_transcript_ts
 from kiro_crew.knowledge.store import KnowledgeStore
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.messaging.link import (
@@ -3897,7 +3897,7 @@ class _ChatSlot:
             existing = msg.get("meta")
             msg["meta"] = {
                 **(existing if isinstance(existing, dict) else {}),
-                "mid": f"m-{uuid.uuid4().hex[:16]}",
+                "mid": mint_row_mid(),
             }
         self.messages.append(msg)
         self.invalidate_source_links()

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.state import row_mid
 from kiro_crew.discord.attachments import (
     append_attachment_context,
     process_discord_attachments,
@@ -56,6 +57,7 @@ from kiro_crew.discord.session_resume import (
 )
 from kiro_crew.discord.transport import DISCORD_CAPABILITIES
 from kiro_crew.executors import run_in_embed_pool
+from kiro_crew.history import mint_row_mid
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.attachments import IngestLimits
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
@@ -750,15 +752,15 @@ class DiscordDispatcher:
                 # Loop-side: put the turn in the live dashboard window FIRST so
                 # the dashboard's own save serializes it in chronological
                 # position instead of appending it to the foreign tail.
-                mirrored = self._mirror_turn_to_live_slot(session_key, text, accumulated)
+                mirror_mids = self._mirror_turn_to_live_slot(session_key, text, accumulated)
                 await asyncio.to_thread(
                     self._persist_turn,
                     session_key,
                     text,
                     accumulated,
                     is_new_own_session,
-                    mirrored,
                     agent=agent,
+                    mirror_mids=mirror_mids,
                 )
             except Exception:
                 logger.warning(
@@ -1530,7 +1532,9 @@ class DiscordDispatcher:
             persisted_probe=_probe_persisted_session,
         )
 
-    def _mirror_turn_to_live_slot(self, session_key: str, user_text: str, reply_text: str) -> bool:
+    def _mirror_turn_to_live_slot(
+        self, session_key: str, user_text: str, reply_text: str
+    ) -> tuple[str, str] | None:
         """Land a resumed turn in the live dashboard window. Loop-side only.
 
         A disk-only append is not enough. The dashboard save writes
@@ -1541,21 +1545,30 @@ class DiscordDispatcher:
         so ordering is preserved. Mirrors ``dashboard/cron_inject.py``, which
         appends to the slot and persists idempotently for the same reason.
 
-        Returns True when the in-memory slot took the turn, so the disk write
-        can use the idempotent append and not duplicate it.
+        Returns the ``(user_mid, assistant_mid)`` the slot minted when the
+        in-memory window took the turn, else ``None``. The caller hands those to
+        the durable write so both copies of one row share ONE identity -- the
+        dual-writer shape ``cron_inject`` uses (``row_mid(slot.append(...))`` ->
+        ``append_if_absent(..., mid=...)``). Minting a SECOND id there instead
+        would defeat the idempotency check the mirrored write exists for:
+        ``append_if_absent`` only skips a body-equal row carrying the SAME mid,
+        so an unrelated id can never match the copy the slot save already landed
+        and the turn would be persisted twice. An empty string stands for a row
+        the slot did not mint an id for (a reply that was not written).
         """
         slot = self._live_dashboard_slot(session_key)
         if slot is None:
-            return False
+            return None
         try:
-            slot.append("user", user_text, "msg msg-u")
+            user_mid = row_mid(slot.append("user", user_text, "msg msg-u")) or ""
+            assistant_mid = ""
             if reply_text:
-                slot.append("assistant", reply_text, "msg msg-a")
+                assistant_mid = row_mid(slot.append("assistant", reply_text, "msg msg-a")) or ""
         except Exception:
             logger.debug(
                 "discord: could not mirror turn into live slot %s", session_key, exc_info=True
             )
-            return False
+            return None
         state = getattr(self._session_resume, "dashboard_state", None)
         push = getattr(state, "push_slots_update", None)
         if callable(push):
@@ -1563,7 +1576,7 @@ class DiscordDispatcher:
                 push()
             except Exception:
                 logger.debug("discord: slots push after resumed turn failed", exc_info=True)
-        return True
+        return (user_mid, assistant_mid)
 
     def _persist_turn(
         self,
@@ -1571,25 +1584,44 @@ class DiscordDispatcher:
         user_text: str,
         reply_text: str,
         is_new: bool,
-        mirrored: bool = False,
         agent: str | None = None,
+        mirror_mids: tuple[str, str] | None = None,
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart).
 
-        When the turn already went into a live dashboard slot (*mirrored*), the
-        disk write must be idempotent: that slot's own save re-serializes its
-        window, so a plain append would persist the same message twice.
+        *mirror_mids* is what ``_mirror_turn_to_live_slot`` returned: the ids the
+        live dashboard window minted for this turn's rows, or ``None`` when there
+        was no live slot to mirror into. It carries BOTH facts, so there is no
+        separate ``mirrored`` flag -- the presence of the tuple IS the flag, and a
+        second parameter encoding the same thing could only ever disagree with it.
+
+        With a live slot the disk write must be idempotent: that slot's own save
+        re-serializes its window, so a plain append would persist the same message
+        twice. The write goes under the SAME ids the window rows carry -- the
+        dual-writer shape ``cron_inject`` uses -- because ``append_if_absent``
+        skips only a body-equal row carrying the same mid. A fresh id there would
+        never match the slot save's copy and the turn would land on disk twice.
+
+        With no live slot nothing has the row yet, so it is a plain append under a
+        newly minted id.
         """
         if self.conv_log is None:
             return
-        if mirrored:
-            self.conv_log.append_if_absent(session_key, "user", user_text, agent=agent)
+        if mirror_mids is not None:
+            user_mid, assistant_mid = mirror_mids
+            self.conv_log.append_if_absent(
+                session_key, "user", user_text, agent=agent, mid=user_mid
+            )
             if reply_text:
-                self.conv_log.append_if_absent(session_key, "assistant", reply_text, agent=agent)
+                self.conv_log.append_if_absent(
+                    session_key, "assistant", reply_text, agent=agent, mid=assistant_mid
+                )
         else:
-            self.conv_log.append(session_key, "user", user_text, agent=agent)
+            self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
             if reply_text:
-                self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+                self.conv_log.append(
+                    session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+                )
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Discord"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/feishu/transport_dispatch.py
+++ b/src/kiro_crew/feishu/transport_dispatch.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew.feishu.client import CHAT_GROUP
 from kiro_crew.feishu.renderer import FeishuRenderer
 from kiro_crew.feishu.transport import FEISHU_CAPABILITIES
+from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.conversation import ConversationState
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
@@ -336,9 +337,11 @@ class FeishuDispatcher:
         """
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text, agent=agent)
+        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+            self.conv_log.append(
+                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+            )
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Feishu"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -17,6 +17,7 @@ import os
 import re
 import threading
 import time as _time
+import uuid
 from collections.abc import Callable, Container, Iterator
 from collections.abc import Set as AbstractSet
 from datetime import datetime, timedelta
@@ -861,6 +862,35 @@ def metadata_now_iso() -> str:
     it speak the same, unambiguous format.
     """
     return datetime.now().astimezone().isoformat()
+
+
+def mint_row_mid() -> str:
+    """Mint a durable per-row delivery identity for a transcript row.
+
+    The ONE place the ``meta.mid`` format is spelled. ``_ChatSlot.append`` mints
+    the id for a row that enters a dashboard window, and the dashboard
+    dual-writers (``cron_inject``, ``workflow_inject``, ``crew_chat``) read it back
+    off that append to stamp their durable copy (``row_mid``). A writer with no
+    slot to mint from -- a channel dispatcher persisting a turn it ran on its own
+    session -- has to mint the id itself, and it must produce the SAME shape,
+    because the readers match on the value, not on who wrote it.
+
+    Why a channel row needs one AT WRITE TIME: the dashboard's merge keys on
+    ``meta.mid`` and nothing else. ``isRedeliveredMessage`` drops a redelivered row
+    by it, ``olderHeadAbovePage`` cuts the retained scrollback head at it, and
+    ``rowIdentities``/``tailNotInPage`` decide by it which prior rows a page already
+    carries -- and every one of those DECLINES rather than guesses when the id is
+    absent or has changed. A row persisted without one is re-minted by each surface
+    that materializes it (``channel_slots._rebuild_window`` /
+    ``refresh_channel_window``), so one logical row carries a different identity on
+    every pass, silently degrading all three at once.
+
+    Random rather than a per-key counter, for the reason ``_ChatSlot.append``
+    gives: a counter rebased after a restore can reissue an id a restored row
+    already holds, and a colliding id makes a client DROP a real message. A
+    random id has no such failure mode.
+    """
+    return f"m-{uuid.uuid4().hex[:16]}"
 
 
 def monotonic_transcript_ts(previous: str | None, now: datetime) -> str:

--- a/src/kiro_crew/imessage/transport_dispatch.py
+++ b/src/kiro_crew/imessage/transport_dispatch.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.history import mint_row_mid
 from kiro_crew.imessage.client import redact_handle
 from kiro_crew.imessage.commands import HELP_TEXT, ConversationState, parse_command
 from kiro_crew.imessage.renderer import IMessageRenderer
@@ -287,9 +288,11 @@ class IMessageDispatcher:
         """
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text, agent=agent)
+        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+            self.conv_log.append(
+                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+            )
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "iMessage"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/teams/transport_dispatch.py
+++ b/src/kiro_crew/teams/transport_dispatch.py
@@ -36,6 +36,7 @@ import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
+from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.attachments import IngestLimits
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.commands import (
@@ -1047,9 +1048,11 @@ class TeamsDispatcher:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text, agent=agent)
+        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+            self.conv_log.append(
+                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+            )
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Teams"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -36,6 +36,7 @@ from kiro_crew.acp.client import AcpError
 from kiro_crew.agent_discovery import list_agents
 from kiro_crew.config.loader import ACTIVATION_MENTION, ACTIVATION_OFF
 from kiro_crew.executors import run_in_embed_pool
+from kiro_crew.history import mint_row_mid
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging import auto_title, privacy_mode
 from kiro_crew.messaging.attachments import IngestLimits, append_attachment_context
@@ -2667,9 +2668,11 @@ class TelegramDispatcher:
         # drained queue and the steered continuation alike.
         if privacy_mode.is_restricted(session_key):
             return
-        self.conv_log.append(session_key, "user", user_text, agent=agent)
+        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+            self.conv_log.append(
+                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+            )
         if is_new and not auto_title.is_titled(session_key):
             # Skipped when auto-title has CLAIMED this session, because the two
             # writers race and the loser is always the generated one: the fallback

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -53,7 +53,7 @@ import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
-from kiro_crew.history import transcript_stem
+from kiro_crew.history import mint_row_mid, transcript_stem
 from kiro_crew.messaging.approval import PendingApprovals, SessionApprovalDecider
 from kiro_crew.messaging.attachments import append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
@@ -1513,9 +1513,11 @@ class WebexDispatcher:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text, agent=agent)
+        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+            self.conv_log.append(
+                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+            )
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Webex"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/wecom/transport_dispatch.py
+++ b/src/kiro_crew/wecom/transport_dispatch.py
@@ -30,6 +30,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.attachments import append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.dispatch import (
@@ -376,9 +377,11 @@ class WeComDispatcher:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text, agent=agent)
+        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+            self.conv_log.append(
+                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+            )
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "WeCom"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/weixin/transport_dispatch.py
+++ b/src/kiro_crew/weixin/transport_dispatch.py
@@ -34,6 +34,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.attachments import append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.dispatch import (
@@ -436,12 +437,22 @@ class WeixinDispatcher:
         is_new: bool,
         agent: str | None = None,
     ) -> None:
-        """Record the turn to conversation_log (dashboard visibility + restart)."""
+        """Record the turn to conversation_log (dashboard visibility + restart).
+
+        Each row is stamped with a durable ``mid``. A channel turn runs on the
+        dispatcher's own session, so unlike the dashboard dual-writers there is no
+        ``_ChatSlot.append`` to mint the id and hand it back -- this writer is the
+        first and only place the row exists, so it mints its own. See
+        :func:`kiro_crew.history.mint_row_mid` for why the identity has to be
+        durable rather than re-derived per materialization.
+        """
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text, agent=agent)
+        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
+            self.conv_log.append(
+                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
+            )
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "WeChat"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/whatsapp/transport_dispatch.py
+++ b/src/kiro_crew/whatsapp/transport_dispatch.py
@@ -14,6 +14,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.approval import (
     TextReplyApprovalDecider,
     deliver_verdict,
@@ -494,9 +495,9 @@ class WhatsAppDispatcher:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text)
+        self.conv_log.append(session_key, "user", user_text, mid=mint_row_mid())
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text)
+            self.conv_log.append(session_key, "assistant", reply_text, mid=mint_row_mid())
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "WhatsApp"
             self.conv_log.set_title(session_key, title)

--- a/test/test_channel_row_identity.py
+++ b/test/test_channel_row_identity.py
@@ -1,0 +1,339 @@
+"""A channel-born transcript row carries a durable delivery identity (#5981).
+
+The dashboard's merge keys on ``meta.mid`` and nothing else: ``isRedeliveredMessage``
+drops a redelivered row by it, ``olderHeadAbovePage`` cuts the retained scrollback
+head at it, and ``rowIdentities``/``tailNotInPage`` decide by it which prior rows a
+page already carries. Every one of those DECLINES rather than guesses when the id is
+absent or has changed -- so a row whose identity is not stable degrades all three at
+once, and the same reply can render more than once in the dashboard's view.
+
+Channel dispatchers persisted their rows with no ``mid``, so the row reached disk
+with no ``meta``; each surface that materialized it
+(``channel_slots._rebuild_window`` / ``refresh_channel_window``) then minted a FRESH
+id, giving one logical row a different identity on every pass. The dispatcher is the
+first and only place the row exists -- a channel turn runs on its own session, so
+unlike the dashboard dual-writers there is no ``_ChatSlot.append`` to mint the id and
+hand it back -- so it now mints its own.
+
+Discord's ``mirrored`` branch is the one exception and is pinned separately below: it
+DOES have a slot, so it must thread that slot's id into the durable write rather than
+mint a second one. ``append_if_absent`` skips only a body-equal row carrying the SAME
+mid, so an unrelated id can never match the copy the slot save landed and the turn
+would be persisted twice -- a durable duplicate, worse than the display one this
+change fixes.
+
+Structured after ``test_channel_persist_agent_metadata.py`` (#2890, the same "every
+channel omitted a kwarg on its persist writes" shape): the unbound ``_persist_turn``
+is called with a minimal stand-in so no channel client has to be constructed.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import channel_slots
+from kiro_crew.dashboard.state import row_mid
+from kiro_crew.history import ConversationLog
+
+#: Every dispatcher sharing the two-append ``_persist_turn`` shape. Slack is absent
+#: deliberately: its persist is a different topology (three write branches, off-loop
+#: stamping) and is not covered by this change.
+_CHANNELS = [
+    ("weixin", "kiro_crew.weixin.transport_dispatch"),
+    ("telegram", "kiro_crew.telegram.transport_dispatch"),
+    ("discord", "kiro_crew.discord.transport_dispatch"),
+    ("feishu", "kiro_crew.feishu.transport_dispatch"),
+    ("imessage", "kiro_crew.imessage.transport_dispatch"),
+    ("teams", "kiro_crew.teams.transport_dispatch"),
+    ("webex", "kiro_crew.webex.transport_dispatch"),
+    ("wecom", "kiro_crew.wecom.transport_dispatch"),
+    ("whatsapp", "kiro_crew.whatsapp.transport_dispatch"),
+]
+
+
+@pytest.fixture
+def dashboard_state(tmp_path):
+    """DashboardState with mocked services and a real (empty) ConversationLog.
+
+    ``channel_key_for_stem`` is pinned to the empty-session-map answer, mirroring
+    ``test_channel_slots.py``: ``sessions`` is a MagicMock whose auto-created
+    attributes are truthy, so without the pin a slot could silently bind to a Mock.
+    """
+    state = _make_state(tmp_path)
+    state.sessions.channel_key_for_stem = lambda stem: ""
+    return state
+
+
+def _dispatcher_class(module):
+    """The class in *module* that defines ``_persist_turn``."""
+    for obj in vars(module).values():
+        if isinstance(obj, type) and "_persist_turn" in vars(obj):
+            return obj
+    raise AssertionError(f"no _persist_turn owner in {module.__name__}")
+
+
+def _persist(cls, host, key, user_text, reply_text, is_new):
+    """Call ``_persist_turn`` across the two signatures in play.
+
+    WhatsApp's takes no ``agent`` (it predates #2890's fix), so keywords alone
+    cannot cover both shapes.
+    """
+    try:
+        cls._persist_turn(host, key, user_text, reply_text, is_new, agent="kirocrew-research")
+    except TypeError:
+        cls._persist_turn(host, key, user_text, reply_text, is_new)
+
+
+def _rows_on_disk(log: ConversationLog, key: str) -> list[dict]:
+    """The raw JSONL message rows for *key*.
+
+    Read straight off the file rather than through a reader helper: what is being
+    pinned is what is DURABLE, and a reader that re-derived an id would hide the
+    very regression this file exists to catch.
+    """
+    rows: list[dict] = []
+    for line in log._path(key).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if isinstance(row, dict) and row.get("role"):
+            rows.append(row)
+    return rows
+
+
+class TestMintRowMid:
+    """The id format has ONE definition, shared with ``_ChatSlot.append``.
+
+    ``mint_row_mid`` is imported inside each test on purpose: the rest of this file
+    must still COLLECT against a tree without the helper, so the behavioural tests
+    below fail on their assertions (the real regression) rather than the whole
+    module erroring out on an ImportError.
+    """
+
+    def test_mints_the_shape_every_reader_matches(self) -> None:
+        from kiro_crew.history import mint_row_mid
+
+        mid = mint_row_mid()
+        assert mid.startswith("m-")
+        # "m-" + 16 hex: the same width _ChatSlot.append stamps. Readers match the
+        # VALUE, so a second spelling would be invisible to all of them.
+        assert len(mid) == 18
+        assert all(c in "0123456789abcdef" for c in mid[2:])
+
+    def test_ids_are_distinct(self) -> None:
+        from kiro_crew.history import mint_row_mid
+
+        # A collision makes a client DROP a real message, so distinctness is the
+        # property that matters, not merely the format.
+        assert len({mint_row_mid() for _ in range(512)}) == 512
+
+
+@pytest.mark.parametrize("channel,mod_name", _CHANNELS)
+def test_persist_turn_stamps_a_durable_mid_on_both_rows(channel, mod_name, tmp_path) -> None:
+    """RED before the fix: each dispatcher forwarded no ``mid``, so disk had no meta."""
+    module = __import__(mod_name, fromlist=["_"])
+    log = ConversationLog(base_dir=tmp_path)
+    host = SimpleNamespace(conv_log=log)
+    key = f"{channel}:row-identity-test"
+
+    _persist(_dispatcher_class(module), host, key, "hello", "world", True)
+
+    rows = _rows_on_disk(log, key)
+    assert [r["role"] for r in rows] == [
+        "user",
+        "assistant",
+    ], f"{channel}: _persist_turn should write exactly the turn's two rows"
+    mids = [row_mid(r) for r in rows]
+    assert all(isinstance(m, str) and m for m in mids), (
+        f"{channel}: a channel row reached disk with no meta.mid -- every later "
+        f"materialization mints a fresh one, so the row has no stable identity and "
+        f"the dashboard cannot recognise a redelivery of it"
+    )
+    assert mids[0] != mids[1], f"{channel}: the two rows of one turn must not share an id"
+
+
+@pytest.mark.parametrize("channel,mod_name", _CHANNELS)
+def test_persist_turn_ids_are_unique_across_turns(channel, mod_name, tmp_path) -> None:
+    """A reused id makes a client DROP a real row, the opposite failure to a duplicate."""
+    module = __import__(mod_name, fromlist=["_"])
+    cls = _dispatcher_class(module)
+    log = ConversationLog(base_dir=tmp_path)
+    host = SimpleNamespace(conv_log=log)
+    key = f"{channel}:row-identity-unique"
+
+    _persist(cls, host, key, "first", "one", True)
+    _persist(cls, host, key, "second", "two", False)
+
+    mids = [row_mid(r) for r in _rows_on_disk(log, key)]
+    assert len(mids) == 4
+    assert len(set(mids)) == 4, f"{channel}: every persisted row needs its own id"
+
+
+@pytest.mark.parametrize("channel,mod_name", _CHANNELS)
+def test_persist_turn_still_writes_an_empty_reply(channel, mod_name, tmp_path) -> None:
+    """The reply guard is unchanged: an empty reply persists the user row only."""
+    module = __import__(mod_name, fromlist=["_"])
+    log = ConversationLog(base_dir=tmp_path)
+    host = SimpleNamespace(conv_log=log)
+    key = f"{channel}:row-identity-noreply"
+
+    _persist(_dispatcher_class(module), host, key, "hello", "", False)
+
+    rows = _rows_on_disk(log, key)
+    assert [r["role"] for r in rows] == ["user"]
+    assert row_mid(rows[0])
+
+
+class TestDiscordMirroredBranchStaysIdempotent:
+    """The mirrored write must NOT mint a second identity for a row it already has.
+
+    ``append_if_absent`` skips only a body-equal row carrying the SAME ``meta.mid``
+    (``history.py``'s own contract). The mirrored branch runs after
+    ``_mirror_turn_to_live_slot`` put the row in a live slot, whose save writes that
+    window row under the slot-minted id. Minting a fresh id for the durable copy
+    means the check can never match, so the turn lands on disk TWICE under two
+    unrelated ids -- a durable duplicate no mid-keyed sweep can collapse.
+
+    ``mirror_mids`` carries both facts: the ids, and (by being present at all)
+    whether there was a slot to mirror into. There is deliberately no second
+    ``mirrored`` flag for the two to disagree about.
+    """
+
+    @staticmethod
+    def _discord_cls():
+        module = __import__("kiro_crew.discord.transport_dispatch", fromlist=["_"])
+        return _dispatcher_class(module)
+
+    def test_mirrored_write_reuses_the_slot_minted_ids(self, tmp_path) -> None:
+        cls = self._discord_cls()
+        log = ConversationLog(base_dir=tmp_path)
+        host = SimpleNamespace(conv_log=log)
+        key = "discord:mirrored-threaded"
+
+        cls._persist_turn(
+            host,
+            key,
+            "hello",
+            "world",
+            False,
+            agent=None,
+            mirror_mids=("m-1111111111111111", "m-2222222222222222"),
+        )
+
+        assert [row_mid(r) for r in _rows_on_disk(log, key)] == [
+            "m-1111111111111111",
+            "m-2222222222222222",
+        ], "the durable copy must carry the id the slot already stamped on its window row"
+
+    def test_mirrored_write_is_a_no_op_when_the_slot_save_landed_it(self, tmp_path) -> None:
+        """The race the branch exists for: same row, same id, must not double-write."""
+        cls = self._discord_cls()
+        log = ConversationLog(base_dir=tmp_path)
+        host = SimpleNamespace(conv_log=log)
+        key = "discord:mirrored-after-save"
+
+        # The slot save got there first, under the slot's own id.
+        log.append(key, "user", "hello", mid="m-1111111111111111")
+        log.append(key, "assistant", "world", mid="m-2222222222222222")
+
+        cls._persist_turn(
+            host,
+            key,
+            "hello",
+            "world",
+            False,
+            agent=None,
+            mirror_mids=("m-1111111111111111", "m-2222222222222222"),
+        )
+
+        rows = _rows_on_disk(log, key)
+        assert len(rows) == 2, (
+            "the mirrored write duplicated a row the slot save already persisted -- "
+            "a fresh mid defeats append_if_absent's same-mid skip"
+        )
+
+    def test_no_live_slot_means_a_plain_append_under_a_fresh_id(self, tmp_path) -> None:
+        """``mirror_mids=None`` is "there was no slot", so nothing holds the row yet."""
+        cls = self._discord_cls()
+        log = ConversationLog(base_dir=tmp_path)
+        host = SimpleNamespace(conv_log=log)
+        key = "discord:unmirrored"
+
+        cls._persist_turn(host, key, "hello", "world", False, agent=None, mirror_mids=None)
+
+        mids = [row_mid(r) for r in _rows_on_disk(log, key)]
+        assert all(isinstance(m, str) and m for m in mids)
+        assert len(set(mids)) == 2
+
+
+class TestIdentitySurvivesMaterialization:
+    """The load-bearing half: a persisted id is PRESERVED, not re-minted.
+
+    This is the property the frontend merge depends on. A row whose id changes
+    between two materializations is, to every consumer of ``meta.mid``, two rows.
+    """
+
+    @staticmethod
+    def _surface(state, messages, *, user: str):
+        return channel_slots.surface_channel_session(
+            state,
+            {"key": f"weixin_kirocrew-research_direct_{user}", "title": "t", "modified": 0.0},
+            {},
+            [dict(r) for r in messages],
+            session_key=f"weixin:kirocrew-research:direct:{user}",
+        )
+
+    @staticmethod
+    def _transcript(*, with_ids: bool) -> list[dict]:
+        rows: list[dict] = [
+            {"role": "user", "content": "hi", "ts": "2026-09-01T00:00:00+00:00"},
+            {"role": "assistant", "content": "hello", "ts": "2026-09-01T00:00:01+00:00"},
+        ]
+        if with_ids:
+            rows[0]["meta"] = {"mid": "m-aaaaaaaaaaaaaaaa"}
+            rows[1]["meta"] = {"mid": "m-bbbbbbbbbbbbbbbb"}
+        return rows
+
+    def test_window_carries_the_persisted_ids(self, dashboard_state) -> None:
+        """What the fix buys: the window's identity IS the transcript's identity."""
+        slot = self._surface(dashboard_state, self._transcript(with_ids=True), user="u1")
+        assert slot is not None
+        assert [row_mid(m) for m in slot.messages] == [
+            "m-aaaaaaaaaaaaaaaa",
+            "m-bbbbbbbbbbbbbbbb",
+        ], "a materialized channel row must keep its persisted id rather than re-mint"
+
+    def test_two_materializations_of_a_persisted_transcript_agree(self, dashboard_state) -> None:
+        """Two independent windows over one transcript resolve to the SAME ids."""
+        messages = self._transcript(with_ids=True)
+        first = self._surface(dashboard_state, messages, user="u1")
+        second = self._surface(dashboard_state, messages, user="u2")
+        assert first is not None and second is not None
+        assert [row_mid(m) for m in first.messages] == [row_mid(m) for m in second.messages]
+
+    def test_an_id_less_transcript_is_re_minted_per_materialization(self, dashboard_state) -> None:
+        """Why the fix has to live in the WRITER, not in a downstream dedup.
+
+        Re-minting for an id-less row is deliberate and stays: a window row must be
+        addressable. But it means two materializations of an id-less transcript
+        disagree on identity, and no ``mid``-keyed consumer downstream can collapse
+        them. Only the writer can supply an id that is stable by construction.
+        Rows written before this change stay in exactly this state -- nothing is
+        retro-migrated, which is the contract ``TestAppendMid`` pins in
+        ``test_history.py``.
+        """
+        bare = self._transcript(with_ids=False)
+        first = self._surface(dashboard_state, bare, user="u3")
+        second = self._surface(dashboard_state, bare, user="u4")
+        assert first is not None and second is not None
+        first_mids = [row_mid(m) for m in first.messages]
+        second_mids = [row_mid(m) for m in second.messages]
+        assert all(isinstance(m, str) and m for m in first_mids)
+        assert first_mids != second_mids, (
+            "an id-less transcript is re-minted per materialization -- the exact "
+            "instability the write-time fix removes"
+        )

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -324,7 +324,9 @@ class _ConversationLog:
             rows = [row for row in rows if row.get("role") in roles]
         return rows[-max_messages:]
 
-    def append(self, key: str, role: str, content: str, agent: str | None = None) -> None:
+    def append(
+        self, key: str, role: str, content: str, agent: str | None = None, mid: str | None = None
+    ) -> None:
         self.messages.setdefault(key, []).append({"role": role, "content": content})
 
     def set_title(self, key: str, title: str) -> None:

--- a/test/test_feishu_dispatch.py
+++ b/test/test_feishu_dispatch.py
@@ -194,7 +194,7 @@ class FakeConvLog:
         self.agents: list[str | None] = []
         self.titles: dict[str, str] = {}
 
-    def append(self, key, role, text, *, agent=None) -> None:
+    def append(self, key, role, text, *, agent=None, mid=None) -> None:
         self.appended.append((key, role, text))
         self.agents.append(agent)
 

--- a/test/test_teams_dispatch.py
+++ b/test/test_teams_dispatch.py
@@ -212,7 +212,7 @@ class FakeConvLog:
         self.appended: list[tuple[str, str, str]] = []
         self.titles: dict[str, str] = {}
 
-    def append(self, key, role, text, agent=None) -> None:
+    def append(self, key, role, text, agent=None, mid=None) -> None:
         self.appended.append((key, role, text))
 
     def set_title(self, key, title) -> None:

--- a/test/test_webex_dispatch.py
+++ b/test/test_webex_dispatch.py
@@ -243,7 +243,7 @@ class FakeConvLog:
         self.appended: list[tuple[str, str, str]] = []
         self.titles: dict[str, str] = {}
 
-    def append(self, key, role, text, agent=None) -> None:
+    def append(self, key, role, text, agent=None, mid=None) -> None:
         self.appended.append((key, role, text))
 
     def set_title(self, key, title) -> None:

--- a/test/test_wecom_dispatch.py
+++ b/test/test_wecom_dispatch.py
@@ -230,7 +230,7 @@ class FakeConvLog:
         self.appended: list[tuple[str, str, str]] = []
         self.titles: dict[str, str] = {}
 
-    def append(self, key, role, text, agent=None) -> None:
+    def append(self, key, role, text, agent=None, mid=None) -> None:
         self.appended.append((key, role, text))
 
     def set_title(self, key, title) -> None:

--- a/test/test_weixin_dispatch.py
+++ b/test/test_weixin_dispatch.py
@@ -615,7 +615,7 @@ def test_delivery_failure_is_not_recorded_as_success(tmp_path):
             raise RuntimeError("ilink send timeout")
 
     class Log:
-        def append(self, key, role, text, agent=None):
+        def append(self, key, role, text, agent=None, mid=None):
             rows.append((role, text))
 
         def set_title(self, key, title):
@@ -639,7 +639,7 @@ def test_persist_turn_writes_user_and_assistant_rows(tmp_path):
             self.rows: list[tuple[str, str]] = []
             self.title = ""
 
-        def append(self, key, role, text, agent=None):
+        def append(self, key, role, text, agent=None, mid=None):
             self.rows.append((role, text))
 
         def set_title(self, key, title):

--- a/test/test_whatsapp_dispatch.py
+++ b/test/test_whatsapp_dispatch.py
@@ -423,7 +423,7 @@ def test_persist_turn_writes_user_and_assistant_rows():
             self.rows: list[tuple[str, str]] = []
             self.title = ""
 
-        def append(self, key, role, text):
+        def append(self, key, role, text, mid=None):
             self.rows.append((role, text))
 
         def set_title(self, key, title):


### PR DESCRIPTION
## What is the problem?

Viewing a channel-born session (Weixin/iLink) in the dashboard renders the assistant's reply several times - reported as 5x on one turn - while the on-disk transcript holds exactly one copy of the message.

A channel dispatcher persists its rows through `ConversationLog.append` **without a `mid`**, so the JSONL row gets no `meta` at all. `_ChatSlot.append` mints a `meta.mid` for any row that lacks one, and `channel_slots._rebuild_window` / `refresh_channel_window` both materialize the disk tail through that append - so **the same logical row gets a fresh identity on every materialization**, and the identity the dashboard was handed a moment ago is not the identity it is handed next time.

That matters because the dashboard's merge keys on `meta.mid` and nothing else, and each consumer is deliberately written to *decline rather than guess* when the id is absent or has changed:

- `isRedeliveredMessage` (`chatSlice.ts:90`) returns `false` for a missing mid, so a redelivered channel row is never recognised as one.
- `olderHeadAbovePage` (`chatSlice.ts:1374`) locates the retained scrollback head by `page[0].meta.mid`; a changed mid makes `findIndex` return `-1`.
- `rowIdentities` (`chatSlice.ts:1265`) derives identity from `meta.mid`/`meta.sendId` only, so a row with neither yields an **empty** identity array - and `tailNotInPage` (`:1280`) therefore treats it as "not present in the page" and always retains it.

With `cutIdx < 0` permanent for a channel session, the warm-cache merge runs in its degraded branch, where `priorEndsBeforePage` unions `[...prior, ...tailNotInPage(warmed, prior)]` - appending a copy the pane already holds, once per pass.

## Why this issue matters to the user

The dashboard's view of a Weixin/Telegram/Discord conversation is visibly wrong: a reply is repeated several times, so the history reads as though the agent answered over and over. Because the duplication is display-side, nothing in the transcript looks broken and there is no obvious recovery - and since the identity is re-minted on every window rebuild, re-opening the tab can produce a different wrong answer rather than a fixed one. The same root cause also degrades scrollback retention in the other direction: a declined cut can drop history the pane had already paged in.

## How our fix solves it

The identity has to come from the writer, because only the writer sees the row once.

A channel turn runs on the dispatcher's own session, so unlike the dashboard dual-writers (`cron_inject`, `workflow_inject`, `crew_chat`, which read the id back off `slot.append` and pass it to `append_if_absent`) there is normally no slot to mint from. The dispatcher is the first and only place the row exists, so it now mints its own id and persists it.

- **`history.py`** gains `mint_row_mid()`, the single definition of the `meta.mid` format. `_ChatSlot.append` now calls it instead of spelling `f"m-{uuid4().hex[:16]}"` inline, so the format cannot drift between the two mint sites. `ConversationLog.append` already accepted `mid` and already wrote it as `meta.mid`; no storage change was needed, and its id-less contract (`TestAppendMid`) is untouched.
- **Nine dispatchers** that share the two-append `_persist_turn` shape now pass `mid=mint_row_mid()` on each row: weixin, telegram, discord, feishu, imessage, teams, webex, wecom, whatsapp.
- **Discord's `mirrored` branch is the one exception**, because it DOES have a live slot. `_mirror_turn_to_live_slot` now returns the `(user_mid, assistant_mid)` the slot minted and `_persist_turn` threads them into `append_if_absent`, so both copies of one row share ONE identity. Minting a second id there would defeat that call's same-mid skip - `append_if_absent` only skips a body-equal row carrying the *same* mid - and persist the turn twice on disk. An earlier revision of this PR had exactly that bug; it is fixed and pinned by four tests.

Chaining it back to the symptom: the row now reaches disk with `meta.mid`; `_rebuild_window`/`refresh_channel_window` pass that `meta` straight into `slot.append`, which preserves a caller-supplied mid rather than minting; so every materialization resolves to the *same* identity, `isRedeliveredMessage` can recognise a redelivery, `olderHeadAbovePage` can find its cut, and the union branch that was appending a duplicate is no longer reached.

Two deliberate exclusions. **Slack** stays out: its persist is a different topology (three write branches, off-loop `to_thread` stamping, an options-turn path) and folding it in would mean reworking that path rather than adding a kwarg. And the other half of the producer analysis on #5981 - removing manual `broadcast_ws("chat_message", ...)` frames that follow a `slot.append` - is **not** here: I traced each candidate site (`chat_orchestrator.py` 238/809/847/1022/1068, `chat_handlers.py` 617/778, `workflow_inject.py:173`, `crew_chat.py:1164`, `slack/handler.py:2538`, `slack/gateway.py` 5902/6821, `handlers/files.py:326`) and none is reachable from a channel-born turn - a weixin turn never enters the dashboard orchestrator, and the weixin package contains no `broadcast_ws`/`slot.append` call site at all.

## What tests we did

New `test/test_channel_row_identity.py` - 36 tests, **33 red on pristine base** (`origin/main` `1ee69f225`), verified in a detached base worktree:

- `test_persist_turn_stamps_a_durable_mid_on_both_rows` - parametrized over all 9 channels, drives the real unbound `_persist_turn` against a real `ConversationLog` and asserts `meta.mid` on the **raw JSONL** (read off the file, not through a reader that could re-derive an id).
- `test_persist_turn_ids_are_unique_across_turns` - 4 rows over 2 turns, 4 distinct ids. A reused id makes a client *drop* a real row, the opposite failure to a duplicate.
- `test_persist_turn_still_writes_an_empty_reply` - the empty-reply guard is unchanged.
- `TestDiscordMirroredBranchStaysIdempotent` - 4 tests on the exception path, including the real race (slot save lands the row, then the mirror retries it) which was red under the previous head.
- `TestMintRowMid` - format and distinctness over 512 mints. Imported inside each test on purpose, so the rest of the module still *collects* on a tree without the helper and the behavioural tests fail on their assertions rather than the file erroring out on an ImportError.
- `TestIdentitySurvivesMaterialization` - 3 characterization tests that **pass on base**: `channel_slots` already preserves a persisted mid and already re-mints an absent one. They are what make the fix load-bearing rather than incidental, and they pin the re-mint behaviour that must stay for legacy rows.

Structured after `test_channel_persist_agent_metadata.py` (#2890), which locks the same "every channel omitted a kwarg on its persist writes" shape.

Eight existing `conv_log` test doubles were widened to accept `mid`, matching the real signature (weixin, whatsapp, discord_sessions, webex, wecom, feishu, teams dispatch tests). Enumerated in one pass rather than discovered per CI round.

2893 passed across every affected channel suite plus `channel_slots`, `history` (`TestAppendMid` intact), `cron_history`, `chat_row_identity` and the discord suite. flake8, isort, black clean on all 19 changed files. Inherited, reproduces on pristine base: `test_weixin_qr.py` fails 2 with `ModuleNotFoundError: No module named 'qrcode'` (missing optional dep in my environment, unrelated to this diff).

## Pattern harvest

Rule candidate: semgrep (or a review checklist item)

Pattern: a dual-writer that mints a fresh identity for its durable copy instead of reusing the one its in-memory copy already carries

The generalizable defect is not "channels forgot a kwarg" - it is that a row's identity must be minted once per *row*, not once per *write*. Two shapes are worth catching mechanically:

1. A call to `ConversationLog.append_if_absent(..., mid=<freshly minted>)`. That call's skip is defined as "body-equal AND same mid", so a fresh id makes it structurally unable to skip and converts an idempotent write into an unconditional one. Any `mid=` argument there that is not derived from a prior `slot.append` return (`row_mid(...)`) or a stored value is a bug. This is exactly what GPT caught on head `d08ede5fd`, and it is the second time this class has appeared: `chat_runner.py:9287`'s comment already warns about the sibling case (append plus a manual re-broadcast).
2. A persist site that writes a row a live slot also holds, without threading the slot's `meta.mid`. The correct shape is documented three times in-tree (`cron_inject.py:136-167`, `workflow_inject.py:167-198`, `crew_chat.py:1163-1184`) - `window_mid = row_mid(slot.append(...))` then `append_if_absent(..., mid=window_mid)` - which is a strong signal it should be a lint rule or a small shared helper rather than a pattern each writer re-derives.

Not generalizable: the specific list of nine dispatchers is not a reusable rule. That breadth is a consequence of the same `_persist_turn` shape having been copied per channel, which #2890 already hit for the `agent` kwarg - the durable lesson there is that a per-channel copy of one persist routine will keep needing the same fix N times, and is a refactor candidate in its own right.

## Any other suggestions on the work?

- **This is the backend half of #5981.** [PR #5982](https://github.com/kirodotdev/KiroCrew/pull/5982) (@isotope14) is the frontend `deduplicateByMid` sweep, currently held by a First Principles BLOCK whose confirmed half is that the sweep cannot reach the producer. The two are complementary: with ids now stable, a future duplicate of a channel row becomes a *same-mid* duplicate, which is exactly what that sweep collapses. Nothing here conflicts with it, and the diffs share no file.
- **Defaulting the mint inside `ConversationLog.append` is a real improvement, deliberately not taken here.** It would need no call-site edits and would cover Slack, WhatsApp and eval at once. I implemented it in full before reverting: it breaks `test_history.py::TestAppendMid`, which explicitly pins that an id-less append must not grow a `meta` field. Forking a documented identity contract belongs in its own change where that can be argued on its merits, not folded into a bug fix. Recorded as a follow-up.
- **Existing transcripts are not backfilled.** Rows already on disk stay id-less and keep being re-minted per materialization, so the duplication is still observable on conversations that predate this fix. That is intentional (no retro-migration, per the same `TestAppendMid` contract) and worth an explicit decision rather than a silent migration.
- **Slack's `_persist_turn` still has the gap** and deserves its own change, sized for its three-branch write path.
- **The evidence gap named on #5981 is now closed by construction rather than by observation.** Nobody ever captured whether the five rendered rows carried mids. If a duplicate is seen again after this lands, the discriminator is whether the copies now share a mid; if they do, the producer is a second delivery rather than an identity churn, and #5982's sweep is the right place for it.

Closes #5981
