### PR TITLE
fix(skills): resolve the full block-scalar grammar and real chomping

### DIFF
--- a/src/kiro_crew/dashboard/handlers/skill_budget.py
+++ b/src/kiro_crew/dashboard/handlers/skill_budget.py
@@ -126,7 +126,7 @@ def _compute_budget(
             logger.warning("skill-budget: unreadable frontmatter for %s", key, exc_info=True)
             meta = {}
 
-        is_always = meta.get("always", "").lower() == "true"
+        is_always = meta.get("always", "").strip().lower() == "true"
 
         # Deliveries: own key + aliases
         deliveries: int | None = None

--- a/src/kiro_crew/frontmatter.py
+++ b/src/kiro_crew/frontmatter.py
@@ -23,20 +23,40 @@ import: the skill editor's frontmatter splicer
 (``website/src/components/SkillForm.tsx``) MIRRORS :data:`SKILL_LOADER`'s
 grammar in TypeScript, because it must never write a value this reader would
 decode differently than it wrote it. ``readerCannotDecode`` and
-``backendReadsValue`` there encode this dialect's two quirks that matter to a
-writer -- quote characters are stripped off both ends rather than unquoted,
-and nothing is unescaped -- and its refusal rules are derived from them. That
+``backendReadsValue`` there encode this dialect's quirks that matter to a
+writer -- quote characters are stripped off both ends rather than unquoted, and
+nothing is unescaped -- and its refusal rules are derived from them. That
 mirror was measured against this module, not inferred, but nothing in the
 build enforces it: change the quote handling, the block-scalar folding, or the
 unescaping here and the editor will keep writing for the old dialect, which is
 silent corruption of a user's skill file. Update that file in the same change,
-and see https://github.com/kirodotdev/KiroCrew/issues/7097 for the shared
-fixture corpus that would turn this comment into a failing test.
+and see ``test_frontmatter.py``'s corpus test for the pin that now fails when
+a repo-tracked SKILL.md starts reading differently.
 
-This is deliberately NOT a YAML parser and must not grow into one: values are
-single-line strings apart from the minimal block-scalar folding below, and no
-YAML library is involved. Swapping the parsing technology would change every
-caller's accepted-input surface at once and needs its own review.
+BLOCK SCALARS follow YAML: the full header grammar (explicit indentation
+indicator, either modifier ordering, a trailing comment) is resolved by
+:func:`parse_block_scalar_header`, and :func:`fold_block_scalar` honours real
+chomping. That half of the dialect IS a YAML subset and is pinned differentially
+against ``yaml`` in the tests.
+
+PLAIN SCALARS are deliberately NOT YAML, and this is not a gap waiting to be
+closed. This reader splits a field on its first colon and keeps the remainder
+verbatim, so it accepts a value a YAML parser REFUSES OUTRIGHT -- an unquoted
+``": "`` inside the text::
+
+    description: Three capture backends: playwright-cli (the session ...)
+
+A YAML parser rejects that document whole ("mapping values are not allowed
+here"), not just the field. Two skills this repo SHIPS are written that way and
+are read correctly only because of it:
+
+- ``builtin_skills/kirocrew-dev/prepare-pr/SKILL.md``
+- ``builtin_skills/web-verify/SKILL.md``
+
+So the two accepted-input surfaces CROSS rather than nest, and swapping this
+scanner for a YAML parse is not a strict improvement: measured over the 56
+fenced repo-tracked SKILL.md files it would break those two outright. The
+quoting and unescaping rows of #7097 are tracked separately in #7063.
 """
 
 from __future__ import annotations
@@ -45,21 +65,50 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
-# YAML block-scalar indicators recognized as frontmatter values: folded (>) or
-# literal (|), each with an optional chomping modifier. Explicit indentation
-# indicators (e.g. ">2") are not supported by this minimal parser.
-BLOCK_SCALAR_INDICATORS = frozenset({">", "|", ">-", "|-", ">+", "|+"})
+# Any valid YAML block-scalar HEADER, matched everywhere one is recognized.
+#
+# There used to be a second recognizer beside this one -- a frozenset of the six
+# BARE indicators (``>``, ``|``, ``>-``, ``|-``, ``>+``, ``|+``) -- and the module
+# disagreed with itself about what a block scalar is: the read path tested set
+# membership, the write path matched this regex, and the onboarding activation gate
+# imported the set. Widening one recognizer and not the others is what turned that
+# gate fail-OPEN (see ``_column0_activation_declared``). One matcher now, so a
+# change to the grammar reaches every caller at once.
+#
+# The two halves of the alternation are YAML's two orderings of the optional
+# indentation indicator and chomping modifier (``|2-`` and ``|-2``), and the
+# second matches empty, which is the bare ``|`` case. A trailing ``# comment``
+# is allowed because YAML allows one there: it belongs to the header line, not
+# to the value.
+_BLOCK_SCALAR_HEADER_RE = re.compile(
+    r"^(?P<style>[|>])"
+    r"(?:(?P<indent_first>[0-9])(?P<chomp_last>[+-]?)"
+    r"|(?P<chomp_first>[+-]?)(?P<indent_last>[0-9]?))"
+    r"(?:[ \t]+#.*)?$"
+)
 
-# Any valid YAML block-scalar HEADER, including the explicit-indentation forms
-# (``|2``, ``>2-``, ...) this module's READER still does not fold — see the
-# limitation noted above. Used only on the WRITE path, to decide whether an
-# indented tail belongs to the value being replaced. Without this, an explicit-
-# indent scalar's `#`-shaped continuation line is mistaken for a real YAML
-# comment (the ordinary rule a plain scalar's tail follows) and left orphaned
-# in the document by a rewrite of an unrelated line above it — not invalid
-# YAML, since a lone indented `#` still parses as a floating comment, but the
-# author's content silently detaches from the field it was written under.
-_BLOCK_SCALAR_HEADER_RE = re.compile(r"^[|>](?:[0-9][+-]?|[+-]?[0-9]?)$")
+
+def parse_block_scalar_header(value: str) -> tuple[str, int | None] | None:
+    """Split a block-scalar header into ``(style_with_chomp, explicit_indent)``.
+
+    Returns ``None`` when *value* is not a block-scalar header, so a caller can
+    treat it as an ordinary plain scalar. ``explicit_indent`` is the declared
+    indentation indicator, or ``None`` when the header omits it and the content
+    indentation is inferred from the first non-blank line.
+
+    An explicit ``0`` is refused (``None``): YAML forbids it, and accepting it
+    would hand :func:`fold_block_scalar` a zero-width indent that silently
+    turns the whole block into content.
+    """
+    match = _BLOCK_SCALAR_HEADER_RE.match(value)
+    if match is None:
+        return None
+    digits = match.group("indent_first") or match.group("indent_last") or ""
+    if digits == "0":
+        return None
+    chomp = match.group("chomp_first") or match.group("chomp_last") or ""
+    return match.group("style") + chomp, (int(digits) if digits else None)
+
 
 # Fence extraction for the "column0_fence" dialect: the opener must be exactly
 # ``---`` at position 0 followed by a newline; the closer is the next line
@@ -123,9 +172,9 @@ class FrontmatterDialect:
     # True: the first occurrence of a duplicate key wins (single-value lookup
     # semantics). False: the last occurrence wins (dict-overwrite semantics).
     first_key_wins: bool = False
-    # Resolve a bare block-scalar indicator value (see
-    # BLOCK_SCALAR_INDICATORS) from the blank-or-indented lines that follow
-    # it, via fold_block_scalar. Dialects without this store the indicator
+    # Resolve a block-scalar header value (see
+    # :func:`parse_block_scalar_header`) from the blank-or-indented lines that
+    # follow it, via fold_block_scalar. Dialects without this store the header
     # character verbatim and leave the continuation lines to the indent
     # policy.
     resolve_block_scalars: bool = False
@@ -191,35 +240,95 @@ SKILL_UPDATE = FrontmatterDialect(
 )
 
 
-def fold_block_scalar(indicator: str, block: list[str]) -> str:
+def fold_block_scalar(
+    indicator: str,
+    block: list[str],
+    *,
+    indent: int | None = None,
+) -> str:
     """Resolve a YAML block scalar's indented lines into a single value.
 
-    ``indicator`` is one of ``BLOCK_SCALAR_INDICATORS``; ``block`` holds the
-    raw continuation lines (still carrying their indentation). Literal (``|``)
-    scalars keep one line per newline. Folded (``>``) scalars fold a single
-    break between plain lines to a space and keep blank lines as newlines
-    (k blanks -> k newlines plain-to-plain, k+1 next to a more-indented line,
-    where the separator break stays literal), and never fold a break adjacent
-    to a more-indented line, so nested indentation survives. Indentation is
-    stripped relative to the first non-blank line, and the result is trimmed,
-    so the chomping modifier (``-``/``+``) has no residual effect on the
-    stored value.
+    ``indicator`` is a block-scalar header's style and chomping modifier (``|``,
+    ``>-``, ``|+``, ...); ``block`` holds the raw continuation lines, still
+    carrying their indentation. ``indent`` is the header's explicit indentation
+    indicator when it declared one, and ``None`` when the content indentation is
+    inferred from the first non-blank line.
+
+    Literal (``|``) scalars keep one line per newline. Folded (``>``) scalars
+    fold a single break between plain lines to a space and keep blank lines as
+    newlines (k blanks -> k newlines plain-to-plain, k+1 next to a more-indented
+    line, where the separator break stays literal), and never fold a break
+    adjacent to a more-indented line, so nested indentation survives.
+
+    Chomping follows YAML, and is the reason this function does not trim its
+    result: ``-`` (strip) drops every trailing break, ``+`` (keep) preserves all
+    of them, and the default (clip) keeps exactly one. A LEADING break is
+    content under all three -- no chomping mode removes it -- so it is preserved
+    too. The previous ``.strip()`` did both, which is what made agreement with a
+    YAML parser depend on a block's content rather than on its header, and
+    therefore what forced the skill editor to simulate this function and compare
+    instead of reading the header. See #7097.
+
+    Note that EVERY line the frontmatter fence hands over is newline-terminated in
+    the document: the fence's closing ``---`` sits on its own line, so the newline
+    the extractor drops before it is the last content line's own terminator. The
+    break count therefore always includes it. Feeding a YAML parser the captured
+    text WITHOUT that newline is what makes the two look like they disagree here --
+    reconstitute it and they do not.
     """
-    # Trim trailing blank lines without mutating the caller's list and
-    # without per-iteration copies (a pathological blank run stays linear).
-    end = len(block)
-    while end and not block[end - 1].strip():
-        end -= 1
-    if not end:
-        return ""
-    block = block[:end]
-    first = next(ln for ln in block if ln.strip())
-    indent = len(first) - len(first.lstrip())
+    style = indicator[:1]
+    chomp = indicator[1:2] if indicator[1:2] in ("+", "-") else ""
+    all_breaks = "\n" * len(block) if chomp == "+" else ""
+    if indent is None:
+        # Without an explicit indicator the block's indentation IS its first content
+        # line's, so a block with no content line has no indent to derive from and
+        # every line really is a break. Measured against the parser: ``|+`` over one
+        # blank line is one break, over two is two.
+        #
+        # Indentation in YAML is SPACES, never tabs, so "is this line content?" is
+        # decided with ``lstrip(" ")`` rather than ``strip()``: under ``|`` a line of two
+        # spaces then a tab is two columns of indent followed by a TAB OF CONTENT, and
+        # a parser reads ``"\t"``. Judging it with ``strip()`` counted the tab as
+        # indentation, found no content line at all, and returned "" for the scalar.
+        first = next((ln for ln in block if ln.lstrip(" ")), None)
+        if first is None:
+            return all_breaks
+        indent = len(first) - len(first.lstrip(" "))
     dedented = [
         ln[indent:] if ln[:indent].isspace() or not ln.strip() else ln.lstrip() for ln in block
     ]
-    if indicator.startswith("|"):
-        return "\n".join(dedented).strip()
+    if not any(dedented):
+        # An EXPLICIT indicator can still leave nothing behind, and deciding that
+        # BEFORE the dedent is what erased authored whitespace: under ``|2-`` a line of
+        # three spaces is one space of CONTENT, not an empty line, because the header
+        # -- not the content -- fixes where the block starts. Judged on the raw line it
+        # looked blank and the whole scalar came back "". This is the same
+        # whitespace-is-content rule the trailing-break classifier below already
+        # applies; this early exit simply predates it.
+        return all_breaks
+    # Classify the trailing breaks AFTER dedenting, not before. A line holding only
+    # whitespace is not necessarily blank: whitespace BEYOND the block's indent is
+    # content, so ``|-`` over ``  body`` then three spaces is ``body\n `` to a YAML
+    # parser and was ``body`` here -- authored content silently dropped. Judged on the
+    # raw line, ``"   ".strip()`` is empty and the line looks like a break; judged after
+    # dedent it is the one-space content line it actually is. A whitespace-only line at
+    # or inside the indent still dedents to ``""`` and is still a break.
+    end = len(dedented)
+    while end and not dedented[end - 1]:
+        end -= 1
+    # The +1 is the last line's own terminator, per the note above.
+    trailing_breaks = len(dedented) - end + 1
+    content = dedented[:end]
+    if chomp == "-":
+        suffix = ""
+    elif chomp == "+":
+        suffix = "\n" * trailing_breaks
+    else:
+        # Clip keeps exactly one break, and there is always one to keep: the
+        # count includes the last line's own terminator, so it is never zero.
+        suffix = "\n"
+    if style == "|":
+        return "\n".join(content) + suffix
     # Folded: a single line break between two plain lines becomes a space;
     # blank lines are preserved as line breaks (k blanks -> k newlines); and
     # breaks adjacent to a more-indented line are kept, so indented structure
@@ -227,12 +336,17 @@ def fold_block_scalar(indicator: str, block: list[str]) -> str:
     parts: list[str] = []
     pending_blanks = 0
     prev_more_indented = False
-    for ln in dedented:
-        if not ln.strip():
+    started = False
+    for ln in content:
+        # Judged on the DEDENTED line, an empty string is a blank and a whitespace-only
+        # line is not: the whitespace it still holds sits beyond the block's indent, so
+        # it is content, and a more-indented line at that. Testing ``.strip()`` here
+        # folded such a line away entirely.
+        if not ln:
             pending_blanks += 1
             continue
         more_indented = ln[:1].isspace()
-        if parts:
+        if started:
             if pending_blanks:
                 # The separator break folds to nothing between plain lines,
                 # but stays literal next to a more-indented line: k blanks
@@ -243,10 +357,22 @@ def fold_block_scalar(indicator: str, block: list[str]) -> str:
                 parts.append("\n")
             else:
                 parts.append(" ")
-        parts.append(ln.rstrip() if more_indented else ln.strip())
+        elif pending_blanks:
+            # Leading blank lines are content, not a separator: they precede the
+            # first line rather than joining two, so they are emitted verbatim.
+            parts.append("\n" * pending_blanks)
+        # The dedent above already removed the block's indentation, so a plain line
+        # arrives flush and a more-indented one keeps only its extra depth -- there is
+        # nothing left to trim on the left. Nothing is trimmed on the RIGHT either: a
+        # folded scalar's trailing spaces are content, and the break folds to a space
+        # AFTER them, so ``>`` over ``a  `` then ``b`` is ``a   b`` to a YAML parser.
+        # Stripping here silently deleted whatever the author wrote at the end of every
+        # folded line.
+        parts.append(ln)
         prev_more_indented = more_indented
         pending_blanks = 0
-    return "".join(parts)
+        started = True
+    return "".join(parts) + suffix
 
 
 def parse_frontmatter(text: str, dialect: FrontmatterDialect) -> dict[str, str]:
@@ -484,12 +610,27 @@ def set_frontmatter_fields(
         # to the document rather than to this field.
         continuation: list[str] = []
         if is_field:
-            is_block = dialect.resolve_block_scalars and bool(
-                _BLOCK_SCALAR_HEADER_RE.match(line.partition(":")[2].strip())
+            header = (
+                parse_block_scalar_header(line.partition(":")[2].strip())
+                if dialect.resolve_block_scalars
+                else None
             )
+            is_block = header is not None
+            # The declared indentation indicator when the header carries one, so the
+            # walk's boundary below matches the read path's for the same document.
+            block_indent = header[1] if header is not None else None
+            blank_floor = 0
             while index < len(lines):
                 nxt = lines[index]
-                blank = not nxt.strip()
+                # Judged on the CR-STRIPPED line, and in SPACES for a block scalar, so
+                # this walk keeps agreeing with the read path: there, a line of spaces then
+                # a tab is a content line whose content is the tab, and a CRLF blank line
+                # is still a blank. If only one of the two paths counted the tab as
+                # indentation, or saw ``"\r"`` as content, they would disagree about where
+                # the block ends and a rewrite of an unrelated field would move the
+                # author's lines.
+                probe = nxt.rstrip("\r")
+                blank = not probe.strip() if not is_block else not probe.lstrip(" ")
                 if blank and not is_block:
                     # A blank line does NOT end a plain multi-line scalar: YAML keeps
                     # folding while an indented line follows, so `a\n\n  b` is one
@@ -517,6 +658,30 @@ def set_frontmatter_fields(
                 # of each line rather than just its indentation.
                 if not is_block and nxt.lstrip().startswith("#"):
                     break
+                # Inside a block scalar, "indented" is not enough: the scalar ends at
+                # the first non-blank line indented LESS than its content, so a
+                # less-indented line is not the field's to consume. Without this the
+                # walk stayed on the READ path's old rule and swallowed a
+                # less-indented trailing comment when the block's own field was
+                # replaced — the same silent note deletion the rule above prevents for
+                # a plain value. The boundary is the declared indent when the header
+                # gives one, and otherwise the first content line's own indent -- with a
+                # leading all-space line's own depth as a floor on that, because YAML
+                # detects the indent from the leading blanks too and ends the scalar
+                # rather than accept a shallower content line. Kept identical to the read
+                # path's walk: if only one of them applied the floor they would disagree
+                # about where the block ends, and rewriting the field would delete a line
+                # the reader had left in the surrounding document.
+                if is_block and not blank:
+                    nxt_indent = len(probe) - len(probe.lstrip(" "))
+                    if block_indent is None:
+                        if nxt_indent < blank_floor:
+                            break
+                        block_indent = nxt_indent
+                    if nxt_indent < block_indent:
+                        break
+                elif is_block and block_indent is None:
+                    blank_floor = max(blank_floor, len(probe))
                 # Strip the CR here too: these lines are re-joined with the
                 # document's newline, so a retained CR would be written back
                 # doubled.
@@ -636,19 +801,63 @@ def _parse_block_lines(lines: list[str], dialect: FrontmatterDialect) -> dict[st
         key, _, raw = line.partition(":")
         key = key.strip()
         value = raw.strip()
-        if dialect.resolve_block_scalars and value in BLOCK_SCALAR_INDICATORS:
-            # Blank or indented lines up to the next column-0 line are the
-            # scalar's content; trailing blanks between fields are trimmed by
-            # the folder. Under a reject_indented dialect (every preset that
-            # resolves scalars) consuming them hides no key — those lines
-            # could not have been fields anyway. A custom dialect combining
-            # resolution with accept_indented trades indented-key visibility
-            # for scalar content, which is what the indicator means in YAML.
+        header = parse_block_scalar_header(value) if dialect.resolve_block_scalars else None
+        if header is not None:
+            style_chomp, explicit_indent = header
+            # Blank or indented lines are the scalar's content, but only DOWN TO the
+            # block's indentation: YAML ends a block scalar at the first non-blank line
+            # indented less than its content, so a less-indented ``#`` line is a comment
+            # in the surrounding document, not part of the value. Collecting purely on
+            # "is it indented" absorbed one -- ``|- `` + ``  body`` + `` # note`` read
+            # back as ``body\n# note`` -- and the explicit-indicator support added here
+            # would have widened that to every declared-indent block. The boundary is
+            # the declared indent when the header gives one, and otherwise the first
+            # non-blank line's own indent, which is what the folder infers too.
+            #
+            # Trailing blank lines are still collected: they are the block's trailing
+            # breaks, and chomping is what decides their fate.
+            #
+            # "Blank" and "indented" are both judged in SPACES, never tabs, because that
+            # is what YAML counts as indentation. A line of two spaces then a tab is a
+            # content line whose content is the tab, so it is what fixes the block's
+            # indent; judging it with ``strip()`` made it look blank, let a following
+            # more-indented line set a deeper boundary, and silently truncated the
+            # scalar at the next line that sat at the real indent.
             block: list[str] = []
-            while i < len(lines) and (not lines[i].strip() or lines[i][:1].isspace()):
-                block.append(lines[i])
+            content_indent = explicit_indent
+            # Leading BLANK lines take part in detecting the block's indentation: YAML
+            # sets the content indent from the first non-empty line, but a leading
+            # all-space line may not be deeper than that line, and a parser resolves the
+            # conflict by ending the scalar rather than by taking the shallower line as
+            # content. So a blank line's own depth is a floor. Without it, `description:
+            # |` over three spaces then ` # note` read the note as CONTENT where a parser
+            # reads an empty scalar and a document comment -- and the write path then
+            # replaced the note away with the field.
+            blank_floor = 0
+            while i < len(lines):
+                # Drop the trailing CR before classifying. A CRLF document's blank line is
+                # ``"\r"``, which is not empty once "blank" is judged in SPACES, so it
+                # counted as a content line at indent 0 and ENDED the scalar -- truncating
+                # a steering description at its first interior blank, or losing it whole
+                # when the blank came first. Stripping it also puts the value where a YAML
+                # parser puts it: line breaks are normalised, so a CRLF document resolves
+                # to exactly what its LF twin does, with no stray CR left inside.
+                nxt = lines[i].rstrip("\r")
+                if nxt.lstrip(" "):
+                    nxt_indent = len(nxt) - len(nxt.lstrip(" "))
+                    if nxt_indent == 0:
+                        break
+                    if content_indent is None:
+                        if nxt_indent < blank_floor:
+                            break
+                        content_indent = nxt_indent
+                    if nxt_indent < content_indent:
+                        break
+                elif content_indent is None:
+                    blank_floor = max(blank_floor, len(nxt))
+                block.append(nxt)
                 i += 1
-            value = fold_block_scalar(value, block)
+            value = fold_block_scalar(style_chomp, block, indent=explicit_indent)
         else:
             if dialect.strip_inline_comments:
                 value, _ = split_inline_comment(value)

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -39,7 +39,7 @@ from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.embeddings import make_sync_embed_fn
-from kiro_crew.frontmatter import BLOCK_SCALAR_INDICATORS, ONBOARDING_IMPORT, split_frontmatter
+from kiro_crew.frontmatter import ONBOARDING_IMPORT, parse_block_scalar_header, split_frontmatter
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes_nolink
 from kiro_crew.learn import _MAX_LESSONS_TOTAL, Lesson, LessonStore
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -2046,8 +2046,19 @@ def _column0_activation_declared(text: str) -> bool:
     key rules therefore match the loader exactly: the frontmatter closes at the
     first line that STARTS with ``---`` (the loader's ``\\n---`` regex), and
     only column-0 keys count. A column-0 ``always`` activates on a truthy plain
-    value or a bare block-scalar indicator (fail-closed: this parser cannot see
-    the continuation lines the loader resolves); a column-0 ``triggers`` key
+    value or ANY block-scalar header the loader can resolve (fail-closed: this
+    parser cannot see the continuation lines the loader resolves, so it assumes
+    the worst). That set is read from
+    :func:`~kiro_crew.frontmatter.parse_block_scalar_header` rather than
+    re-listed here, because the gate is fail-closed only while its detected set
+    is a SUPERSET of what the loader resolves. It once held its own list of six
+    bare indicators, and widening the loader to the full header grammar without
+    it turned this screen fail-OPEN: ``always: |2-`` over a ``true``
+    continuation was not detected, was installed verbatim, and then read as
+    ``always == "true"`` -- external content self-activating into every session,
+    the exact hazard ``automatic_activation_excluded`` exists to reject. One
+    matcher means widening the loader can only ever make this stricter.
+    A column-0 ``triggers`` key
     activates by presence. ANY activating declaration rejects — stricter than
     the loader's last-wins on duplicate keys, which only ever diverges in the
     conservative direction.
@@ -2065,8 +2076,13 @@ def _column0_activation_declared(text: str) -> bool:
             return True
         if key != "always":
             continue
-        value = raw.strip().strip("\"'").casefold()
-        if value in {"1", "true", "yes"} or value in BLOCK_SCALAR_INDICATORS:
+        # Strip whitespace AFTER removing the quotes as well as before. The loader
+        # unquotes with ``str.strip("\"'")`` and its consumers then compare
+        # ``.strip().lower() == "true"``, so ``always: " true "`` activates a skill --
+        # while stripping only on the outside leaves ``" true "`` -> `` true ``, which
+        # matches no truthy word here and let that spelling through the screen.
+        value = raw.strip().strip("\"'").strip().casefold()
+        if value in {"1", "true", "yes"} or parse_block_scalar_header(value) is not None:
             return True
     return False
 

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -1671,7 +1671,7 @@ class SkillsLoader:
                     "description": description,
                     "path": str(skill_file),
                     "dir": str(skill_file.parent),
-                    "always": meta.get("always", "").lower() == "true",
+                    "always": meta.get("always", "").strip().lower() == "true",
                     "repo_scope": repo_scope,
                     # Project paths cannot safely offer a live pointer to the
                     # agent, so report the effective forced-body behavior.
@@ -1923,12 +1923,15 @@ class SkillsLoader:
                     "description": meta.get("description", name),
                     "path": str(skill_file),
                     "dir": str(skill_file.parent),
-                    "always": meta.get("always", "").lower() == "true",
+                    "always": meta.get("always", "").strip().lower() == "true",
                     # Carried so a caller assembling context can drop a
                     # repo-scoped skill from the INDEX, not just from the
                     # injected body: a summary line the agent is told to read
-                    # advertises the skill just as effectively.
-                    "repo_scope": meta.get("repo_scope", ""),
+                    # advertises the skill just as effectively. Stripped because
+                    # the consumer guards on this value's truthiness before
+                    # calling the gate, so it has to agree with the other two
+                    # gate call sites about what counts as "no scope at all".
+                    "repo_scope": meta.get("repo_scope", "").strip(),
                     # Mirrors split_triggered: confined project rows always use
                     # the body; only an explicit `false` on an unconfined skill
                     # opts out. A malformed value therefore reads as injecting.
@@ -2825,7 +2828,7 @@ class SkillsLoader:
             # recorded rather than reading it unconfined for a ranking signal.
             meta = self._cached_frontmatter(Path(s["path"]), within=s.get("confine_root"))
             hits, anchor = self._auto_activity(key, s["path"], meta)
-            pinned = str(meta.get("pinned", "")).lower() == "true"
+            pinned = str(meta.get("pinned", "")).strip().lower() == "true"
             slug = key.split("/")[-1]
             exempt_row = (
                 pinned
@@ -3989,8 +3992,16 @@ class SkillsLoader:
         result: list[str] = []
         for name, skill_file, _within in self._iter_visible(project_dir):
             meta = self._cached_frontmatter(skill_file, within=_within)
-            if meta.get("always", "").lower() == "true":
-                scope = meta.get("repo_scope", "")
+            if meta.get("always", "").strip().lower() == "true":
+                # Stripped so a whitespace-only value means "no scope" here exactly as it
+                # does at the other two gate call sites. The guard below tests this
+                # value's TRUTHINESS, and `repo_scope: |` over a blank line now resolves
+                # to a break rather than to "" -- truthy, so the gate would be handed
+                # whitespace and refuse it, suppressing a skill its author never scoped.
+                # A trailing break on a real path is NOT the concern:
+                # `project_scope_satisfied` strips its own fragment, so `src/x\n` was
+                # always gated as `src/x`.
+                scope = meta.get("repo_scope", "").strip()
                 if scope and not self._repo_scope_satisfied(scope, project_dir):
                     continue
                 result.append(name)
@@ -4028,15 +4039,17 @@ class SkillsLoader:
         negated_skills: list[str] = []
         for name, skill_file, _within in self._iter_visible(project_dir):
             meta = self._cached_frontmatter(skill_file, within=_within)
-            if meta.get("always", "").lower() == "true":
+            if meta.get("always", "").strip().lower() == "true":
                 continue
             triggers = meta.get("triggers", "")
             if not triggers:
                 continue
             # Repo-scoped skills are mechanically suppressed outside their
             # repo — word-overlap can fire on ordinary user phrasing, and a
-            # prose scope guard alone is probabilistic.
-            scope = meta.get("repo_scope", "")
+            # prose scope guard alone is probabilistic. Stripped so a
+            # whitespace-only value reads as "no scope" at every gate call site
+            # (see the always-on lister for why the truthiness test needs it).
+            scope = meta.get("repo_scope", "").strip()
             if scope and not self._repo_scope_satisfied(scope, project_dir):
                 continue
 

--- a/test/test_frontmatter.py
+++ b/test/test_frontmatter.py
@@ -15,9 +15,12 @@ in ``test_skill_discover.py``).
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
+import yaml
+from yaml_helpers import load_with
 
 from kiro_crew import history
 from kiro_crew.frontmatter import (
@@ -29,6 +32,7 @@ from kiro_crew.frontmatter import (
     _render_frontmatter_value,
     fold_block_scalar,
     frontmatter_value,
+    parse_block_scalar_header,
     parse_frontmatter,
     set_frontmatter_fields,
     split_frontmatter,
@@ -36,6 +40,30 @@ from kiro_crew.frontmatter import (
 )
 from kiro_crew.onboarding_import import _column0_activation_declared, _frontmatter
 from kiro_crew.skills import SkillsLoader
+
+
+class _StringScalarLoader(yaml.SafeLoader):
+    """The YAML oracle for the block-scalar tests: every scalar stays a ``str``.
+
+    The obvious spelling is ``BaseLoader``, which resolves nothing implicitly and is
+    what this reader's ``dict[str, str]`` contract needs -- ``always: true`` must read
+    the STRING ``"true"``, not ``True``, or the oracle would disagree with the reader
+    about a value neither of them mis-parsed. But BaseLoader is a SIBLING of
+    ``SafeLoader``, not a subclass, so ``load_with`` refuses it, and this repo forbids
+    ``yaml.load`` call sites outright (``test_yaml_safe_loading.py``): safety has to be
+    legible at the call site rather than hidden in a ``Loader=`` argument.
+
+    Emptying the implicit-resolver table gives the same behaviour from a safe base:
+    with no implicit resolver to match, every plain scalar falls through to
+    ``DEFAULT_SCALAR_TAG`` (``str``), while collections still resolve normally.
+    Measured equal to BaseLoader over 348 documents, including the shapes that make
+    the difference (``true``, ``yes``, ``123``, ``1.5``, ``null``, ``~``, a date, a
+    flow sequence and a flow mapping).
+    """
+
+
+_StringScalarLoader.yaml_implicit_resolvers = {}
+
 
 # Inputs chosen to hit every axis the four grammars disagree on: opener
 # strictness, closer form, indent policy, quote stripping, duplicate-key
@@ -88,19 +116,19 @@ CORPUS: dict[str, str] = {
 # SKILL_LOADER dialect is exercised on normalized text, like the real caller.
 SKILL_LOADER_EXPECTED: dict[str, dict[str, str]] = {
     "bare_open_fence": {},
-    "block_scalar_blank_fold": {"description": "para one\npara two"},
+    "block_scalar_blank_fold": {"description": "para one\npara two\n"},
     "block_scalar_chomped": {"description": "folded text", "name": "x"},
-    "block_scalar_folded": {"description": "first line second line"},
-    "block_scalar_junk_keys": {"description": "Steps: do x\nmore: prose"},
-    "block_scalar_literal": {"description": "line one\nline two"},
-    "block_scalar_quoted_inside": {"k": '"quoted"'},
+    "block_scalar_folded": {"description": "first line second line\n"},
+    "block_scalar_junk_keys": {"description": "Steps: do x\nmore: prose\n"},
+    "block_scalar_literal": {"description": "line one\nline two\n"},
+    "block_scalar_quoted_inside": {"k": '"quoted"\n'},
     "body_padding": {"k": "v"},
     "closer_indented": {},
     "closer_trailing_junk": {"name": "x"},
     "colon_in_value": {"url": "http://example.com:8080"},
     "crlf": {"name": "x"},
     "duplicate_keys": {"k": "second"},
-    "duplicate_plain_then_scalar": {"k": "from scalar"},
+    "duplicate_plain_then_scalar": {"k": "from scalar\n"},
     "duplicate_scalar_then_plain": {"k": "plain"},
     "empty_block": {},
     "empty_text": {},
@@ -170,12 +198,12 @@ ONBOARDING_EXPECTED: dict[str, tuple[dict[str, str], str]] = {
 # ``_frontmatter_value``.
 HISTORY_EXPECTED: dict[str, dict[str, str]] = {
     "bare_open_fence": {},
-    "block_scalar_blank_fold": {"description": "para one\npara two"},
+    "block_scalar_blank_fold": {"description": "para one\npara two\n"},
     "block_scalar_chomped": {"description": "folded text", "name": "x"},
-    "block_scalar_folded": {"description": "first line second line"},
-    "block_scalar_junk_keys": {"description": "Steps: do x\nmore: prose"},
-    "block_scalar_literal": {"description": "line one\nline two"},
-    "block_scalar_quoted_inside": {"k": '"quoted"'},
+    "block_scalar_folded": {"description": "first line second line\n"},
+    "block_scalar_junk_keys": {"description": "Steps: do x\nmore: prose\n"},
+    "block_scalar_literal": {"description": "line one\nline two\n"},
+    "block_scalar_quoted_inside": {"k": '"quoted"\n'},
     "body_padding": {"k": "v"},
     "closer_indented": {},
     "closer_trailing_junk": {"name": "x"},
@@ -187,7 +215,7 @@ HISTORY_EXPECTED: dict[str, dict[str, str]] = {
     # never even read — the lookup result is identical), and a resolved
     # scalar survives a later plain duplicate.
     "duplicate_plain_then_scalar": {"k": "plain"},
-    "duplicate_scalar_then_plain": {"k": "from scalar"},
+    "duplicate_scalar_then_plain": {"k": "from scalar\n"},
     "empty_block": {},
     "empty_text": {},
     "empty_value": {},
@@ -308,51 +336,744 @@ class TestTheLiteralFoldTheSkillEditorSimulates:
     field whose value this reader and a real YAML parser disagree about -- adopting one
     reading and saving it would silently redefine the file for the code that loads skills.
     Rather than predict agreement from the block-scalar indicator, which was wrong three
-    times, it SIMULATES this function for the bare ``|`` family and compares; a folded or
-    explicit-indicator form is refused outright, so no simulation of the folded rules
-    exists to keep in step.
+    times, it SIMULATES this function for the ``|`` family and compares.
 
     So this is the backend half of a cross-language invariant, and its scope is every step
-    that simulation mirrors -- trailing-blank trim, dedent relative to the first non-blank
-    line, join, and the final ``.strip()`` -- not the chomping axis alone. A dedent change
+    that simulation mirrors -- trailing-blank counting, dedent relative to the first
+    non-blank line, join, and chomping -- not the chomping axis alone. A dedent change
     would otherwise leave both this file and the TypeScript tests green (those expectations
     are hardcoded) while the two readers drifted apart, reopening exactly the silent
     corruption the editor's refusal was written to prevent. If any assertion below fails,
     ``backendFoldsLiteral`` has to change with it. See #1825 and #7097.
 
-    Note for anyone editing :func:`fold_block_scalar`: the trailing-blank trim is applied
-    at TWO points -- the ``while`` loop that shortens ``block``, and the final ``.strip()``
-    on the literal branch -- so disabling either one alone leaves the observable result
-    unchanged and these tests still pass. That is measured, not assumed. They assert the
-    CONTRACT, so they go red when the output actually changes, which needs both to go.
+    What CHANGED in #7097: the fold used to end in ``.strip()``, which ate a leading
+    newline and every trailing one. No YAML chomping mode does either, so agreement with a
+    parser depended on a block's CONTENT rather than on its header. It no longer does --
+    the cases below are the ones that used to diverge, and they now agree, which is why
+    :class:`TestBlockScalarsAgreeWithARealYamlParser` can assert agreement wholesale.
     """
 
     # The bodies the TypeScript simulation test drives through `canEditStructured`, with
     # the value measured from this reader. Held here so a fold change reds the backend
     # too, instead of only the hardcoded frontend expectations that mirror it.
+    #
+    # Each ends in a newline because a block scalar inside a fence always does: the
+    # closing ``---`` is its own line, so the last content line carries a real
+    # terminating break and clip chomping keeps exactly one.
     LITERAL_FOLDS = (
-        ("plain two lines", ["  one", "  two"], "one\ntwo"),
-        ("interior blank", ["  one", "", "  two"], "one\n\ntwo"),
-        ("deeper indent inside", ["  one", "    nested", "  two"], "one\n  nested\ntwo"),
-        ("leading blank", ["", "  true"], "true"),
+        ("plain two lines", ["  one", "  two"], "one\ntwo\n"),
+        ("interior blank", ["  one", "", "  two"], "one\n\ntwo\n"),
+        ("deeper indent inside", ["  one", "    nested", "  two"], "one\n  nested\ntwo\n"),
+        ("leading blank", ["", "  true"], "\ntrue\n"),
     )
 
     def test_the_literal_fold_the_simulation_mirrors(self):
         for label, body, expected in self.LITERAL_FOLDS:
             assert fold_block_scalar("|", body) == expected, label
 
-    def test_a_leading_blank_line_is_lost_where_a_parser_keeps_it(self):
-        # The crux of simulate-don't-predict: `.strip()` eats a LEADING newline, which no
-        # YAML chomping mode does, so `|` agrees on some content and not on other content.
-        assert fold_block_scalar("|", ["", "  true"]) == "true"
-        assert fold_block_scalar("|", ["  true"]) == "true"
+    def test_a_leading_blank_line_survives_the_way_a_parser_keeps_it(self):
+        # Was `test_a_leading_blank_line_is_lost_where_a_parser_keeps_it`, asserting the
+        # loss. A leading break is CONTENT under every chomping mode, so keeping it is
+        # what removes the content-dependence from the editor's comparison.
+        assert fold_block_scalar("|", ["", "  true"]) == "\ntrue\n"
+        assert fold_block_scalar("|", ["  true"]) == "true\n"
+        # Strip chomping is how a caller asks for neither break.
+        assert fold_block_scalar("|-", ["", "  true"]) == "\ntrue"
 
-    def test_the_keep_forms_discard_what_keep_chomping_preserves(self):
-        # `|+`/`>+` tell YAML to KEEP the trailing blank lines. This reader strips them,
-        # so the two readings differ. A bare `|+` is caught by comparing; `>+` never
-        # reaches a comparison because every folded form is refused.
+    def test_the_keep_forms_preserve_what_keep_chomping_preserves(self):
+        # `|+`/`>+` tell YAML to KEEP the trailing blank lines, and now so does this
+        # reader. Was `test_the_keep_forms_discard_what_keep_chomping_preserves`.
         for indicator in ("|+", ">+"):
-            assert fold_block_scalar(indicator, ["  true", "", ""]) == "true", indicator
+            assert fold_block_scalar(indicator, ["  true", "", ""]) == "true\n\n\n", indicator
+
+    def test_strip_and_clip_chomping_differ_from_keep(self):
+        # The three modes are distinguishable on the same body, which is what makes the
+        # modifier meaningful rather than decorative. Clip keeps exactly one break.
+        assert fold_block_scalar("|-", ["  true", "", ""]) == "true"
+        assert fold_block_scalar("|", ["  true", "", ""]) == "true\n"
+        assert fold_block_scalar("|+", ["  true", "", ""]) == "true\n\n\n"
+
+    def test_a_block_with_no_content_line_charges_no_break_for_the_header(self):
+        # An all-blank block's FIRST blank is the newline that ended the header line, not
+        # a content break -- so keep-chomping preserves one fewer than the break count.
+        # Measured against the parser; getting this wrong is a silent off-by-one that
+        # only shows up on an empty managed field.
+        assert fold_block_scalar("|+", []) == ""
+        assert fold_block_scalar("|+", [""]) == "\n"
+        assert fold_block_scalar("|", [""]) == ""
+        assert fold_block_scalar("|-", [""]) == ""
+
+
+class TestTheBlockScalarHeaderGrammar:
+    """The full YAML header grammar is resolved, on the read path as well as the write one.
+
+    Before #7097 the read path matched only the six BARE indicators while the write path
+    already matched the explicit-indentation forms. A ``description: |2-`` was therefore
+    stored as the literal text ``"|2-"`` -- the header mistaken for the value -- while a
+    rewrite of an unrelated line above it correctly treated the indented tail as that
+    field's content. One matcher now serves both.
+    """
+
+    def test_an_explicit_indentation_indicator_is_resolved(self) -> None:
+        text = "---\nname: s\ndescription: |2-\n  body text\n---\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["description"] == "body text"
+
+    def test_an_explicit_indicator_preserves_leading_whitespace(self) -> None:
+        # The reason the indicator exists, and the construct the skill editor
+        # deliberately degrades a managed value to avoid: with the indentation DECLARED,
+        # a first line indented past it keeps that extra space as content. Inferring the
+        # indent from the first non-blank line cannot express this at all.
+        text = "---\nname: s\ndescription: |2-\n    indented first\n  flush second\n---\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["description"] == "  indented first\nflush second"
+
+    def test_either_modifier_ordering_is_accepted(self) -> None:
+        for header in ("|2-", "|-2"):
+            text = f"---\nname: s\ndescription: {header}\n    indented\n---\n"
+            assert parse_frontmatter(text, SKILL_LOADER)["description"] == "  indented", header
+
+    def test_a_comment_may_share_the_header_line(self) -> None:
+        # YAML allows a comment on the header line; it belongs to the header, not to the
+        # value. This reader used to store `"|- # note"` as the whole value.
+        text = "---\nname: s\ndescription: |- # note\n  body text\n---\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["description"] == "body text"
+
+    def test_a_zero_indicator_is_not_a_block_scalar(self) -> None:
+        # YAML forbids an indentation indicator of 0. Accepting it would hand the folder a
+        # zero-width indent and turn the whole block into content, so it stays a plain
+        # value -- the pre-existing behaviour for anything unrecognized.
+        text = "---\nname: s\ndescription: |0\n  body\n---\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["description"] == "|0"
+
+    def test_a_hash_without_leading_space_is_not_a_comment(self) -> None:
+        # `|-#note` is not a header-plus-comment to YAML, so it is not one here either.
+        text = "---\nname: s\ndescription: |-#note\n  body\n---\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["description"] == "|-#note"
+
+    def test_the_header_parser_reports_style_chomp_and_indent(self) -> None:
+        assert parse_block_scalar_header("|") == ("|", None)
+        assert parse_block_scalar_header(">-") == (">-", None)
+        assert parse_block_scalar_header("|2-") == ("|-", 2)
+        assert parse_block_scalar_header("|-2") == ("|-", 2)
+        assert parse_block_scalar_header(">+3") == (">+", 3)
+        assert parse_block_scalar_header("|2 # note") == ("|", 2)
+        assert parse_block_scalar_header("plain value") is None
+        assert parse_block_scalar_header("|0") is None
+
+    def test_read_and_write_share_one_header_grammar(self) -> None:
+        # The convergence, stated as behaviour: rewriting an unrelated field must consume
+        # the explicit-indicator scalar's tail with its key, leaving no orphan, and the
+        # rewritten document must read back with both fields intact.
+        text = "---\nname: s\ndescription: |2-\n  body text\nrepo_scope: x\n---\nbody\n"
+        out = set_frontmatter_fields(text, {"name": "renamed"}, SKILL_LOADER)
+        fields = parse_frontmatter(out, SKILL_LOADER)
+        assert fields["name"] == "renamed"
+        assert fields["description"] == "body text"
+        assert fields["repo_scope"] == "x"
+
+    def test_replacing_the_scalar_itself_leaves_no_orphaned_tail(self) -> None:
+        text = "---\nname: s\ndescription: |2-\n  body text\n---\nbody\n"
+        out = set_frontmatter_fields(text, {"description": "plain now"}, SKILL_LOADER)
+        assert parse_frontmatter(out, SKILL_LOADER)["description"] == "plain now"
+        assert "body text" not in out
+
+    def test_the_write_walk_stops_at_the_same_boundary_the_read_does(self) -> None:
+        # Raised and self-dropped by Opus on b1c0c5c8c as unreachable; fixed anyway,
+        # because it is an asymmetry THIS change introduced. Tightening the read path's
+        # collection without the write path's left the writer consuming a less-indented
+        # trailing comment as though it were block content, so REPLACING the block's own
+        # field deleted the author's note -- exactly the silent loss the walk's plain-value
+        # rule already guards against. Reachable through the one production caller
+        # (steering's mode edit) even though such a document is contrived.
+        for header in ("|-", "|2-"):
+            text = f"---\nname: s\ndescription: {header}\n  body\n # note\nrepo_scope: x\n---\nBODY\n"
+            out = set_frontmatter_fields(text, {"description": "replaced"}, SKILL_LOADER)
+            assert "# note" in out, header
+            assert parse_frontmatter(out, SKILL_LOADER)["description"] == "replaced", header
+            assert parse_frontmatter(out, SKILL_LOADER)["repo_scope"] == "x", header
+        # A comment indented INSIDE the block is still the field's content and still goes
+        # with it, so the boundary did not become "never consume a comment".
+        text = "---\nname: s\ndescription: |-\n  body\n   # inside\nrepo_scope: x\n---\nBODY\n"
+        out = set_frontmatter_fields(text, {"description": "replaced"}, SKILL_LOADER)
+        assert "# inside" not in out
+
+    def test_onboarding_import_does_not_resolve_block_scalars(self) -> None:
+        # ONBOARDING_IMPORT does not resolve block scalars, so its collapsed map still
+        # stores the header verbatim. What must NOT happen is the activation GATE going
+        # fail-open with it -- see
+        # TestTheActivationGateCoversEverythingTheLoaderResolves.
+        text = "---\nalways: |2-\n  true\n---\n"
+        assert parse_frontmatter(text, ONBOARDING_IMPORT)["always"] == "|2-"
+
+    def test_a_less_indented_comment_is_not_absorbed_into_the_value(self) -> None:
+        # YAML ends a block scalar at the first non-blank line indented less than its
+        # content, so a less-indented `#` line is a comment in the surrounding document.
+        # Collecting purely on "is it indented" absorbed it -- this read back as
+        # `body\n# note`, which is a value the file does not contain. Pre-existing for a
+        # bare indicator, and the explicit-indicator support would have widened it.
+        for header in ("|-", "|2-", ">-", ">2-"):
+            text = f"---\nd: {header}\n  body\n # note\n---\nbody\n"
+            assert parse_frontmatter(text, SKILL_LOADER)["d"] == "body", header
+
+    def test_a_comment_indented_past_the_content_is_still_content(self) -> None:
+        # The boundary is the indent, not the `#`: a MORE-indented `#` line is inside the
+        # block and stays part of the value, which is what YAML does.
+        text = "---\nd: |-\n  body\n   # note\n---\nbody\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["d"] == "body\n # note"
+
+
+class TestBlockScalarsAgreeWithARealYamlParser:
+    """Differential pin: for BLOCK SCALARS this reader now agrees with ``yaml``.
+
+    Hand-written expectations pin what someone believed; this pins the language. The
+    oracle is ``yaml.BaseLoader`` rather than ``safe_load`` because BaseLoader leaves
+    every scalar a ``str``, which is this module's contract -- ``always: true`` must stay
+    the string ``"true"``, not become ``True``.
+
+    The oracle is fed ``block + "\\n"``, not ``block``. The fence extractor drops the
+    newline before the closing ``---``, but that newline is the last content line's own
+    terminator in the document, so a parser given the captured text verbatim is being
+    asked about a DIFFERENT document -- one line short of a break. Getting this wrong is
+    what made PyYAML and the editor's JavaScript parser look like they disagreed about a
+    clip-chomped scalar at the end of a block; reconstituted, they agree.
+
+    Scope is deliberate. Only the block-scalar half is asserted to agree, because the
+    plain-scalar half deliberately does NOT (see the module docstring: an unquoted
+    ``": "`` inside a value is read here and REFUSED by YAML, and two shipped builtin
+    skills depend on that). Asserting agreement wholesale would be asserting the parser
+    swap this issue measured and rejected.
+    """
+
+    BODIES = (
+        ["  one"],
+        ["  one", "  two"],
+        ["  one", "", "  two"],
+        ["  one", "    nested", "  two"],
+        ["", "  one"],
+        ["", "", "  one"],
+        ["  one", ""],
+        ["  one", "", ""],
+        ["  one", "", "", ""],
+        ["  one", "  two", ""],
+        ["    deep", "  shallow"],
+        ["  a", "", "    ind", "", "  b"],
+        # WHITESPACE-ONLY lines, which are not interchangeable with empty ones: after
+        # dedent, whitespace beyond the block's indent is CONTENT. Judging a trailing
+        # line blank on its raw text dropped it (``|-`` over ``  body`` then three
+        # spaces read ``body`` where a parser reads ``body\n ``). The matrix originally
+        # used only empty strings, which is why it missed that -- these rows are the
+        # gap closing.
+        ["  one", "   "],
+        ["  one", "  "],
+        ["  one", " "],
+        ["  one", "   ", "   "],
+        ["  one", "   ", ""],
+        ["  one", "", "   "],
+        ["   ", "  one"],
+        ["  one", "   ", "  two"],
+        ["\t"],
+        # Content lines with TRAILING whitespace, which is a third distinct case again:
+        # a folded scalar's trailing spaces are content and the break folds to a space
+        # AFTER them, so `>` over `a  ` then `b` is `a   b`. The earlier body set had
+        # whitespace-only lines but never a content line followed by spaces, so it could
+        # not express that -- and `parts.append(ln.strip())` was deleting the author's
+        # trailing text on every folded line.
+        ["  one  "],
+        ["  one  ", "  two"],
+        ["  one", "  two  "],
+        ["  one  ", "  two  "],
+        ["    deep  ", "  shallow  "],
+        ["  one  ", "", "  two  "],
+        ["  one  ", "   "],
+        ["  a  ", "    ind  ", "  b  "],
+        [],
+        [""],
+        ["", ""],
+    )
+    # The hand-written bodies above are REGRESSION rows: each group was added after a
+    # reviewer found a line shape the set could not express. That happened three rounds
+    # running -- whitespace-only trailing lines, then content followed by trailing
+    # spaces, then whitespace-only lines extending PAST an explicit indent -- because a
+    # hand-enumerated list only covers the shapes someone already thought of, and "0
+    # divergences" says nothing about the ones it never emits.
+    #
+    # So the space is now GENERATED from the line kinds that actually behave
+    # differently, and every 1- and 2-line combination of them is checked. New shapes
+    # come from naming a kind here, not from waiting for a reviewer to find one.
+    LINE_KINDS = (
+        "",  # empty
+        " ",  # whitespace, short of the indent
+        "  ",  # whitespace, exactly the indent
+        "   ",  # whitespace, PAST the indent -- content, not a blank line
+        "  \t",  # a tab past the indent -- indentation is spaces, so the tab is content
+        "\t",  # a bare tab, at column 0
+        " # note",  # SHALLOW content, indented 1 -- deeper than the key, shallower than
+        # a typical body line. Pairs with the whitespace-only kinds to express the shape
+        # that made the reader consume a document comment: a leading all-space line takes
+        # part in detecting the indent, so a shallower line after it ENDS the scalar.
+        " shallow",  # the same depth without the comment marker
+        "  one",  # plain content
+        "  one  ",  # content with authored trailing whitespace
+        "    deep",  # more-indented content
+        "    deep  ",  # more-indented, with trailing whitespace
+    )
+    # Some defects need THREE lines to show: a tab-content first line, then a
+    # more-indented line, then a line back at the real indent. Judging the first line
+    # blank let the second set a deeper boundary and truncated the scalar at the third,
+    # and no 1- or 2-line body can express that. The full 10^3 space costs ~30s, so the
+    # triples run over the kinds that actually discriminate.
+    TRIPLE_KINDS = ("", "   ", "  \t", "  one", "    deep")
+
+    @classmethod
+    def generated_bodies(cls) -> list[list[str]]:
+        bodies: list[list[str]] = [[a] for a in cls.LINE_KINDS]
+        bodies += [[a, b] for a in cls.LINE_KINDS for b in cls.LINE_KINDS]
+        bodies += [
+            [a, b, c]
+            for a in cls.TRIPLE_KINDS
+            for b in cls.TRIPLE_KINDS
+            for c in cls.TRIPLE_KINDS
+        ]
+        return bodies
+
+    HEADERS = ("|", "|-", "|+", ">", ">-", ">+", "|2", "|2-", "|2+", ">2", ">2-", "|-2")
+    # Where the scalar SITS matters as much as its header, and missing this cost a real
+    # bug. The fence strips the newline before ``---``, so a scalar that runs to the end of
+    # the block ends without a break -- but one followed by another field ends on a real
+    # one, and clip chomping keeps it. Reading both positions the same way made
+    # ``description: |`` followed by ``name: x`` return ``one`` where a parser returns
+    # ``one\n``.
+    TAILS = ((), ("zz: tail",))
+
+    def test_every_header_and_body_combination_agrees(self) -> None:
+        checked = 0
+        bodies = [*self.BODIES, *self.generated_bodies()]
+        for tail in self.TAILS:
+            for header in self.HEADERS:
+                for body in bodies:
+                    block = "\n".join([f"d: {header}", *body, *tail])
+                    try:
+                        expected = load_with(_StringScalarLoader, block + "\n")
+                    except yaml.YAMLError:
+                        # A shape YAML itself refuses (e.g. an explicit indent wider than
+                        # the content) has no oracle to compare against.
+                        continue
+                    if not isinstance(expected, dict) or "d" not in expected:
+                        continue
+                    want = expected["d"] or ""
+                    got = parse_frontmatter(f"---\n{block}\n---\nbody\n", SKILL_LOADER).get("d")
+                    assert got == want, (
+                        f"{header} {body!r} tail={tail!r}: yaml={want!r} reader={got!r}"
+                    )
+                    checked += 1
+        # Guard against the loop silently checking nothing if the oracle starts refusing
+        # everything -- a green test that asserts nothing is worse than a red one. 5928
+        # of 7512 combinations have an oracle to compare against; the rest are shapes
+        # YAML itself refuses.
+        assert checked > 5800, checked
+
+    def test_a_folded_scalar_keeps_the_trailing_whitespace_its_author_wrote(self) -> None:
+        # GPT 5.6 review, head 8dcd6ef26. A folded scalar's trailing spaces are CONTENT,
+        # and the line break folds to a space AFTER them, so `>` over `a  ` then `b` is
+        # `a   b` -- three spaces, not one. The fold was calling `.strip()` on each line,
+        # which deleted the author's trailing text outright.
+        assert fold_block_scalar(">", ["  a  ", "  b"]) == "a   b\n"
+        assert fold_block_scalar(">", ["  a  "]) == "a  \n"
+        assert fold_block_scalar(">-", ["  a  "]) == "a  "
+        # A more-indented line keeps both its extra indent AND its trailing spaces.
+        assert fold_block_scalar(">", ["  a", "    b  "]) == "a\n  b  \n"
+        # The literal family always kept them; assert it so the two stay in step.
+        assert fold_block_scalar("|", ["  a  ", "  b"]) == "a  \nb\n"
+
+    def test_an_explicit_indent_makes_a_whitespace_only_block_content(self) -> None:
+        # GPT 5.6 review, head c24bf7f53. Under an explicit indicator the HEADER fixes
+        # where content starts, so `|2-` over a line of three spaces is one space of
+        # CONTENT -- not an empty block. The emptiness check ran BEFORE the dedent, so
+        # the line looked blank on its raw text and the whole scalar came back "".
+        assert fold_block_scalar("|-", ["   "], indent=2) == " "
+        assert fold_block_scalar("|", ["   "], indent=2) == " \n"
+        assert fold_block_scalar("|+", ["   "], indent=2) == " \n"
+        assert fold_block_scalar("|-", ["   "], indent=1) == "  "
+        assert fold_block_scalar(">-", ["   "], indent=2) == " "
+        assert fold_block_scalar("|-", ["   ", "   "], indent=2) == " \n "
+        # Within or short of the declared indent there really is nothing left.
+        assert fold_block_scalar("|-", ["  "], indent=2) == ""
+        assert fold_block_scalar("|-", [" "], indent=2) == ""
+        assert fold_block_scalar("|-", ["   "], indent=4) == ""
+        # Without an indicator the indent comes from the content, so these stay empty.
+        assert fold_block_scalar("|-", ["   "]) == ""
+        assert fold_block_scalar("|+", ["", ""]) == "\n\n"
+
+    def test_indentation_is_counted_in_spaces_so_a_tab_is_content(self) -> None:
+        # YAML indentation is spaces, never tabs, so under `|` a line of two spaces then
+        # a tab is two columns of indent followed by a TAB OF CONTENT. Judging it with
+        # `strip()` counted the tab as indentation and found no content line at all.
+        assert fold_block_scalar("|", ["  \t"]) == "\t\n"
+        assert fold_block_scalar("|-", ["  \t"]) == "\t"
+        # The same misjudgement truncated a scalar through the COLLECTION boundary: the
+        # tab line looked blank, the more-indented line then set a deeper boundary, and
+        # the line back at the real indent was read as outside the block. This shape
+        # needs all three lines, which is why the generated matrix runs triples.
+        text = "---\nd: |\n  \t\n    deep\n  one\nzz: tail\n---\nbody\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["d"] == "\t\n  deep\none\n"
+
+    def test_a_rewrite_leaves_a_tab_indented_block_alone(self) -> None:
+        # The write path's boundary walk has to agree with the read path's about where
+        # that block ends, or replacing an unrelated field moves the author's lines.
+        text = "---\nname: before\nd: |\n  \t\n    deep\n  one\nzz: tail\n---\nbody\n"
+        out = set_frontmatter_fields(text, {"name": "after"}, SKILL_LOADER)
+        assert "d: |\n  \t\n    deep\n  one\nzz: tail" in out
+        assert parse_frontmatter(out, SKILL_LOADER)["d"] == "\t\n  deep\none\n"
+
+    def test_whitespace_beyond_the_indent_is_content_not_a_trailing_break(self) -> None:
+        # GPT 5.6 review, head b1c0c5c8c. A line holding only whitespace looks blank
+        # (`"   ".strip()` is empty) but the whitespace past the block's indent is
+        # CONTENT, so it is not a trailing break and chomping must not eat it. Classified
+        # on the raw line this returned `body`; classified after dedent it is `body\n `.
+        assert fold_block_scalar("|-", ["  body", "   "]) == "body\n "
+        assert fold_block_scalar("|", ["  body", "   "]) == "body\n \n"
+        assert fold_block_scalar("|+", ["  body", "   "]) == "body\n \n"
+        assert fold_block_scalar(">-", ["  body", "   "]) == "body\n "
+        # At or inside the indent there is nothing left after dedent, so it IS a break.
+        assert fold_block_scalar("|-", ["  body", "  "]) == "body"
+        assert fold_block_scalar("|-", ["  body", " "]) == "body"
+        # And the same distinction through the public reader, with an explicit indicator.
+        text = "---\nd: |2-\n  body\n   \n---\nBODY\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["d"] == "body\n "
+
+    def test_a_scalar_reads_the_same_wherever_it_sits_in_the_block(self) -> None:
+        # The bug the TAILS axis caught, pinned on its own so a regression names itself
+        # rather than surfacing as one row of a 300-case loop. Reading the two positions
+        # differently made a clip-chomped scalar followed by a field return `one` while
+        # the same scalar at the end of the block returned `one\n` -- a value that
+        # depended on which field came next.
+        followed = "---\nname: s\ndescription: |\n  one\nrepo_scope: x\n---\nbody\n"
+        at_end = "---\nname: s\ndescription: |\n  one\n---\nbody\n"
+        assert parse_frontmatter(followed, SKILL_LOADER)["description"] == "one\n"
+        assert parse_frontmatter(at_end, SKILL_LOADER)["description"] == "one\n"
+        # Strip chomping is the spelling that asks for no trailing break, in BOTH
+        # positions -- the modifier decides this, never the field's position.
+        for text in (followed.replace("|", "|-"), at_end.replace("|", "|-")):
+            assert parse_frontmatter(text, SKILL_LOADER)["description"] == "one"
+
+    def test_a_comment_on_the_header_line_agrees(self) -> None:
+        for header in ("|- # note", "| # note", ">- # note", "|2- # note"):
+            block = "\n".join([f"d: {header}", "  one", "  two"])
+            want = load_with(_StringScalarLoader, block + "\n")["d"]
+            got = parse_frontmatter(f"---\n{block}\n---\nbody\n", SKILL_LOADER).get("d")
+            assert got == want, f"{header}: yaml={want!r} reader={got!r}"
+
+
+class TestTheRepoSkillFileCorpus:
+    """Read every repo-tracked SKILL.md both ways. The corpus pin #7097 asked for.
+
+    The module docstring's cross-language warning used to end "nothing in the build
+    enforces it". This is the enforcement: a change to the reader that moves what a
+    SHIPPED skill file means fails here, naming the file.
+    """
+
+    # Skill files whose frontmatter is NOT valid YAML, and which are read correctly only
+    # because SKILL_LOADER is wider than YAML on plain scalars. Both carry an unquoted
+    # ``": "`` inside `description`, which a YAML parser rejects document-wide with
+    # "mapping values are not allowed here".
+    #
+    # This set is asserted EXACTLY, in both directions. A new entry means someone shipped
+    # a skill that a real YAML parse cannot read -- fine today, but it is the evidence
+    # that decides whether the parser swap in #7097 is ever affordable, so it must be
+    # visible rather than absorbed. A removed entry means the file was quoted and the set
+    # needs updating with it.
+    NOT_VALID_YAML = frozenset(
+        {
+            "src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md",
+            "src/kiro_crew/builtin_skills/web-verify/SKILL.md",
+        }
+    )
+
+    @staticmethod
+    def _repo_root() -> Path:
+        return Path(__file__).resolve().parent.parent
+
+    @classmethod
+    def _skill_files(cls) -> list[tuple[str, str]]:
+        root = cls._repo_root()
+        out: list[tuple[str, str]] = []
+        for path in sorted(root.rglob("SKILL.md")):
+            rel = path.relative_to(root).as_posix()
+            if any(part in ("node_modules", ".git", "dist", "build") for part in path.parts):
+                continue
+            out.append((rel, path.read_text(encoding="utf-8")))
+        return out
+
+    @staticmethod
+    def _fence_block(text: str) -> str | None:
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        return None if match is None else match.group(1)
+
+    def test_the_corpus_is_actually_populated(self) -> None:
+        # Every assertion below is vacuous if the glob stops finding files.
+        files = self._skill_files()
+        assert len(files) > 40, len(files)
+        assert sum(1 for _, text in files if self._fence_block(text) is not None) > 40
+
+    def test_the_named_files_are_the_only_ones_not_valid_yaml(self) -> None:
+        offenders = set()
+        for rel, text in self._skill_files():
+            block = self._fence_block(text)
+            if block is None:
+                continue
+            try:
+                load_with(_StringScalarLoader, block + "\n")
+            except yaml.YAMLError:
+                offenders.add(rel)
+        assert offenders == set(self.NOT_VALID_YAML), (
+            "the set of shipped skill files a YAML parser cannot read has changed; "
+            f"unexpected={sorted(offenders - set(self.NOT_VALID_YAML))} "
+            f"fixed={sorted(set(self.NOT_VALID_YAML) - offenders)}"
+        )
+
+    def test_every_shipped_block_scalar_reads_the_same_both_ways(self) -> None:
+        for rel, text in self._skill_files():
+            block = self._fence_block(text)
+            if block is None or rel in self.NOT_VALID_YAML:
+                continue
+            parsed = load_with(_StringScalarLoader, block + "\n")
+            if not isinstance(parsed, dict):
+                continue
+            fields = parse_frontmatter(text, SKILL_LOADER)
+            for line in block.split("\n"):
+                if ":" not in line or line[:1].isspace():
+                    continue
+                key, _, raw = line.partition(":")
+                key = key.strip()
+                if parse_block_scalar_header(raw.strip()) is None:
+                    continue
+                assert fields[key] == parsed[key], f"{rel}::{key}"
+
+
+class TestChompingCannotFlipAnActivationFlag:
+    """Real chomping must not silently change whether a skill is always-on.
+
+    ``always`` and ``pinned`` are decided by an EXACT string comparison against
+    ``"true"`` (``skills.py``, ``skill_budget.py``). Before #7097 the fold ended in
+    ``.strip()``, so ``always: |+`` followed by trailing blank lines read ``"true"`` and
+    the skill was always-on. Honouring keep-chomping makes that same field read
+    ``"true\\n\\n"``, which is not equal to ``"true"`` -- so without normalising at the
+    comparison the flag would flip from on to OFF on a file nobody edited.
+
+    The repo already stripped at five of those comparisons (``inject_on_trigger`` in three
+    places, ``pinned`` in two) and not at six others -- ``pinned`` was read BOTH ways in
+    the same module. This pins the whole class as normalised, so the reader can stay
+    YAML-correct without the activation semantics riding on a trailing newline.
+
+    ``repo_scope`` belongs to the same class and was missed on the first sweep, which
+    stopped at the boolean flags. Its harm is narrower than a flag's, though, and worth
+    stating precisely: ``project_scope_satisfied`` strips its own fragment, so a real path
+    carrying a trailing break was always gated correctly. What breaks is the
+    WHITESPACE-ONLY value -- ``repo_scope: |`` over a blank line resolves to a break, which
+    is truthy, and each of the three gate call sites guards on that truthiness. An
+    unstripped site therefore hands the gate whitespace and it refuses, suppressing a skill
+    nobody scoped.
+    """
+
+    FLAG_BODIES = (
+        ("keep chomped with trailing blanks", "|+", ["  true", "", ""]),
+        ("clip chomped with a trailing blank", "|", ["  true", ""]),
+        ("leading blank line", "|", ["", "  true"]),
+        ("plain literal", "|", ["  true"]),
+        ("strip chomped", "|-", ["  true", "", ""]),
+    )
+
+    def test_every_block_scalar_spelling_of_true_still_reads_as_always_on(self) -> None:
+        for label, header, body in self.FLAG_BODIES:
+            text = "\n".join(["---", "name: s", f"always: {header}", *body, "---", "", "# Body"])
+            value = parse_frontmatter(text, SKILL_LOADER)["always"]
+            assert value.strip().lower() == "true", f"{label}: {value!r}"
+
+    def test_a_crlf_document_resolves_exactly_like_its_lf_twin(self) -> None:
+        # GPT 5.6 review, head ac5b7940e. Judging "blank" in SPACES made a CRLF blank line
+        # -- which is "\r", not "" -- look like a content line at indent 0, so it ENDED the
+        # scalar: a steering description was truncated at its first interior blank, and lost
+        # whole when the blank came first. YAML normalises line breaks, so the contract is
+        # equality with the LF twin, which also removes the stray CR base left in the value.
+        for header, body in (
+            ("|", ["  one", "", "  two"]),
+            ("|", ["", "  one"]),
+            ("|-", ["  one", "", "  two"]),
+            ("|+", ["  one", ""]),
+            (">", ["  one", "", "  two"]),
+            ("|2", ["  one", "", "  two"]),
+        ):
+            frag = "\n".join(["name: s", f"description: {header}", *body, "mode: always"])
+            lf = f"---\n{frag}\n---\n\nBody\n"
+            crlf = lf.replace("\n", "\r\n")
+            want = parse_frontmatter(lf, STEERING_LOADER)["description"]
+            got = parse_frontmatter(crlf, STEERING_LOADER)["description"]
+            assert got == want, (header, body, got, want)
+            assert "\r" not in got, (header, body, got)
+        # And the value is what a parser gives, not merely self-consistent.
+        crlf = "---\r\nname: s\r\ndescription: |\r\n  one\r\n\r\n  two\r\nmode: always\r\n---\r\n"
+        assert parse_frontmatter(crlf, STEERING_LOADER)["description"] == "one\n\ntwo\n"
+
+    def test_a_leading_blank_line_sets_the_block_boundary(self) -> None:
+        # GPT 5.6 review, head a337c8182. A leading all-space line takes part in detecting
+        # the block's indent, so a SHALLOWER line after it ends the scalar instead of
+        # becoming its first content line. Without that floor, `description: |` over three
+        # spaces then ` # note` read the note as content where a parser reads an empty
+        # scalar plus a document comment -- and rewriting the field then deleted the note.
+        doc = "---\nname: s\ndescription: |\n   \n # outer comment\nrepo_scope: x\n---\n\n# B\n"
+        assert parse_frontmatter(doc, SKILL_LOADER)["description"] == ""
+        # The note is the surrounding document's, so a rewrite of ANY field must keep it.
+        for target in ("description", "name", "repo_scope"):
+            out = set_frontmatter_fields(doc, {target: "AFTER"}, SKILL_UPDATE)
+            assert " # outer comment" in out, (target, out)
+        # Contrast, and the reason this is a floor and not a blanket refusal: with NO
+        # leading blank the comment IS the first content line, so it is scalar content and
+        # a parser agrees. Consuming it there is correct.
+        no_blank = "---\nname: s\ndescription: |\n # outer comment\nrepo_scope: x\n---\n\n# B\n"
+        assert parse_frontmatter(no_blank, SKILL_LOADER)["description"] == "# outer comment\n"
+        # An explicit indicator fixes the indent itself, so the floor must not override it.
+        explicit = "---\nname: s\ndescription: |2\n   \n # note\nrepo_scope: x\n---\n\n# B\n"
+        assert parse_frontmatter(explicit, SKILL_LOADER)["description"] == " \n"
+
+    def test_a_block_scalar_repo_scope_still_gates_to_the_same_path(self) -> None:
+        # First Principles review, heads e5c989b4a and e847966a7. `repo_scope` reaches a
+        # gate at three call sites, each guarded on the value's TRUTHINESS, so all three
+        # have to agree about what counts as "no scope at all". `repo_scope: |` over a
+        # blank line resolves to a break rather than to "", which is truthy -- so an
+        # unstripped site hands the gate whitespace and it refuses, suppressing a skill
+        # nobody scoped, while a stripped site reads it as unscoped and shows it.
+        #
+        # A trailing break on a REAL path is deliberately not the claim here:
+        # `project_scope_satisfied` strips its own fragment, so `src/x\n` was always gated
+        # as `src/x`. Only the whitespace-only case was ever a defect.
+        for label, header, body in (
+            ("keep chomped", "|+", ["  src/kiro_crew", "", ""]),
+            ("clip chomped", "|", ["  src/kiro_crew", ""]),
+            ("plain literal", "|", ["  src/kiro_crew"]),
+            ("strip chomped", "|-", ["  src/kiro_crew"]),
+            ("folded", ">", ["  src/kiro_crew"]),
+        ):
+            text = "\n".join(["---", "name: s", f"repo_scope: {header}", *body, "---", "", "# B"])
+            value = parse_frontmatter(text, SKILL_LOADER)["repo_scope"]
+            assert value.strip() == "src/kiro_crew", f"{label}: {value!r}"
+        # Not vacuous: at least one spelling really does carry the break, so the
+        # normalisation is doing work rather than restating the parser.
+        carried = parse_frontmatter(
+            "---\nname: s\nrepo_scope: |\n  src/kiro_crew\n---\n\n# B\n", SKILL_LOADER
+        )["repo_scope"]
+        assert carried == "src/kiro_crew\n", carried
+        # The whitespace-only value: truthy as parsed, falsy once normalised, which is
+        # what makes the three gate sites agree. Measured spellings -- keep-chomping and
+        # an explicit indent both survive as breaks, and so does a tab past the indent.
+        # A plain `|` over spaces is NOT one of these: with the indent taken from the
+        # content, a whitespace-only block has no content line and resolves to "".
+        for label, frag in (
+            ("keep chomped blank", "repo_scope: |+\n\n"),
+            ("explicit indent, spaces", "repo_scope: |2\n   \n"),
+            ("explicit indent, stripped", "repo_scope: |2-\n   \n"),
+            ("folded keep chomped", "repo_scope: >+\n\n"),
+            ("tab past the indent", "repo_scope: |\n  \t\n"),
+        ):
+            blank = parse_frontmatter(f"---\nname: s\n{frag}---\n\n# B\n", SKILL_LOADER)[
+                "repo_scope"
+            ]
+            assert blank, f"{label}: must be truthy as parsed, else no inconsistency"
+            assert not blank.strip(), f"{label}: {blank!r}"
+        # And the falsy-as-parsed spelling, for contrast.
+        assert (
+            parse_frontmatter("---\nname: s\nrepo_scope: |\n   \n---\n\n# B\n", SKILL_LOADER)[
+                "repo_scope"
+            ]
+            == ""
+        )
+
+    def test_every_repo_scope_gate_site_normalises(self) -> None:
+        # The defect was a PARTIAL sweep: two of the three call sites stripped and the
+        # third consumed an unstripped row, so one document was scoped at one site and
+        # unscoped at another. Pin every site that feeds the gate as normalised.
+        src = (Path(__file__).resolve().parents[1] / "src/kiro_crew/skills.py").read_text()
+        reads = re.findall(r'"repo_scope":\s*meta\.get\("repo_scope"[^\n]*', src)
+        reads += re.findall(r'scope\s*=\s*meta\.get\("repo_scope"[^\n]*', src)
+        assert reads, "no repo_scope reads found -- the pattern moved, update this test"
+        for read in reads:
+            assert ".strip()" in read, read
+        # And the gate is only ever called with a value that came through one of those.
+        calls = re.findall(r"self\._repo_scope_satisfied\(([^,]+),", src)
+        assert len(calls) >= 3, calls
+        for call in calls:
+            assert call.strip() in {"scope", 'str(s["repo_scope"])'}, call
+
+    def test_the_raw_value_really_does_carry_the_breaks(self) -> None:
+        # Guard the test above against becoming vacuous: it only proves anything while at
+        # least one spelling genuinely carries a trailing break that the comparison has to
+        # absorb. If chomping were reverted this assertion fails, not the one above.
+        text = "\n".join(["---", "name: s", "always: |+", "  true", "", "", "---", "", "# Body"])
+        assert parse_frontmatter(text, SKILL_LOADER)["always"] == "true\n\n\n"
+
+
+class TestTheActivationGateCoversEverythingTheLoaderResolves:
+    """The onboarding import screen must not go fail-OPEN when the loader widens.
+
+    ``_column0_activation_declared`` decides whether an IMPORTED (untrusted) skill
+    package declares itself always-on, and refuses it if so. It cannot see the
+    continuation lines the loader resolves, so it treats any block-scalar header as
+    activating and assumes the worst. That is fail-closed only while its detected set is
+    a SUPERSET of what the loader can resolve.
+
+    It used to hold its own list of six bare indicators. Widening the loader to the full
+    header grammar without it inverted the gate: ``always: |2-`` over a ``true``
+    continuation was NOT detected, was installed verbatim, and was then read by
+    ``SkillsLoader`` as ``always == "true"`` -- external content self-activating into
+    every session, the exact hazard ``automatic_activation_excluded`` exists to reject.
+    Both sides now read the grammar from ``parse_block_scalar_header``.
+    """
+
+    SPELLINGS = ("|", "|-", "|+", ">", ">-", ">+", "|2-", "|-2", "|2", "|- # note", "| # note")
+
+    def test_every_header_the_loader_resolves_is_detected_by_the_gate(self) -> None:
+        for spelling in self.SPELLINGS:
+            text = f"---\nname: s\nalways: {spelling}\n  true\n---\nbody\n"
+            resolved = parse_frontmatter(text, SKILL_LOADER).get("always", "")
+            activates = resolved.strip().lower() == "true"
+            declared = _column0_activation_declared(text)
+            # The invariant is one-directional: the gate may be stricter than the loader,
+            # never looser. An undetected activation is the fail-open case.
+            assert not (activates and not declared), (
+                f"always: {spelling} activates (loader reads {resolved!r}) "
+                f"but the import gate did not detect it"
+            )
+
+    def test_the_gate_is_a_superset_not_an_equality(self) -> None:
+        # Being STRICTER is fine and expected: a header whose continuation is not `true`
+        # does not activate, yet the gate still refuses it, because it cannot see the
+        # continuation. That asymmetry is the fail-closed design, not a bug.
+        text = "---\nname: s\nalways: |-\n  false\n---\nbody\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["always"] == "false"
+        assert _column0_activation_declared(text) is True
+
+    def test_a_plain_truthy_value_is_still_detected(self) -> None:
+        for value in ("true", "TRUE", "yes", "1", '"true"'):
+            text = f"---\nname: s\nalways: {value}\n---\nbody\n"
+            assert _column0_activation_declared(text) is True, value
+
+    def test_a_padded_quoted_value_is_detected(self) -> None:
+        # GPT 5.6 review, head 8dcd6ef26. The gate stripped whitespace only OUTSIDE the
+        # quotes, so `always: " true "` unquoted to `` true `` and matched no truthy
+        # word -- while the loader's consumers compare `.strip().lower() == "true"` and
+        # DO activate it. An imported skill spelled that way self-activated past the
+        # screen. Whitespace is now stripped after the quotes come off too.
+        for value in ('" true "', "' true '", '"  TRUE  "', '"\ttrue\t"'):
+            text = f"---\nname: s\nalways: {value}\n---\nbody\n"
+            resolved = parse_frontmatter(text, SKILL_LOADER)["always"]
+            assert resolved.strip().lower() == "true", value
+            assert _column0_activation_declared(text) is True, value
+
+    def test_a_non_header_value_is_not_treated_as_one(self) -> None:
+        # The gate must not start refusing ordinary values just because it now reads a
+        # wider grammar: an explicit `0` indicator is invalid YAML and a plain word is
+        # not a header.
+        for value in ("false", "no", "0", "|0", "maybe", "pipe | in prose"):
+            text = f"---\nname: s\nalways: {value}\n---\nbody\n"
+            assert _column0_activation_declared(text) is False, value
 
 
 class TestDialectContracts:
@@ -384,15 +1105,17 @@ class TestDialectContracts:
 
     def test_block_scalar_resolution_is_per_dialect(self) -> None:
         text = "---\nk: |\n  content\n---\n"
-        assert parse_frontmatter(text, SKILL_LOADER)["k"] == "content"
-        assert parse_frontmatter(text, SKILL_UPDATE)["k"] == "content"
+        # Clip chomping keeps the last line's own terminating break; see
+        # :func:`fold_block_scalar`.
+        assert parse_frontmatter(text, SKILL_LOADER)["k"] == "content\n"
+        assert parse_frontmatter(text, SKILL_UPDATE)["k"] == "content\n"
         assert parse_frontmatter(text, ONBOARDING_IMPORT)["k"] == "|"
 
     def test_quote_strip_never_applies_to_a_resolved_scalar(self) -> None:
         # SKILL_LOADER strips quotes from plain values but a resolved block
         # scalar keeps its content verbatim, quotes included.
         text = '---\nk: |\n  "quoted"\n---\n'
-        assert parse_frontmatter(text, SKILL_LOADER)["k"] == '"quoted"'
+        assert parse_frontmatter(text, SKILL_LOADER)["k"] == '"quoted"\n'
 
     def test_split_returns_text_unchanged_without_block(self) -> None:
         for dialect in (SKILL_LOADER, ONBOARDING_IMPORT, SKILL_UPDATE):

--- a/test/test_skill_update_flow.py
+++ b/test/test_skill_update_flow.py
@@ -816,7 +816,11 @@ def test_frontmatter_value_resolves_block_scalars():
         "  a, b\n"
         "---\n\n## Steps\n"
     )
-    assert H._frontmatter_value(body, "description") == "Retry a deploy after checking the logs."
+    assert (
+        H._frontmatter_value(body, "description") == "Retry a deploy after checking the logs.\n"
+    )
+    # `triggers` uses `|-`, whose strip chomping drops the trailing break, so it is
+    # unaffected by #7097 -- the pair keeps the two modes visibly distinct here.
     assert H._frontmatter_value(body, "triggers") == "a, b"
     # An empty block resolves to "" rather than the indicator character.
     assert H._frontmatter_value("---\ndescription: >\nname: x\n---\nbody", "description") == ""

--- a/test/test_skills_frontmatter.py
+++ b/test/test_skills_frontmatter.py
@@ -59,7 +59,7 @@ class TestFoldedBlockScalar:
             )
         )
         assert meta["description"] == (
-            "Render rich HTML inline via mcwidget tags with theme-aware styling."
+            "Render rich HTML inline via mcwidget tags with theme-aware styling.\n"
         )
         # Surrounding keys still parse normally.
         assert meta["name"] == "my-skill"
@@ -72,23 +72,26 @@ class TestFoldedBlockScalar:
         assert meta["description"] == "first line second line"
 
     def test_folded_with_chomping_keep(self, tmp_path):
+        # Keep preserves the trailing break that strip drops -- the two spellings above
+        # and below used to return the SAME string, which is what made the chomping
+        # modifier decorative. See #7097.
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: >+\n  first line\n  second line")
         )
-        assert meta["description"] == "first line second line"
+        assert meta["description"] == "first line second line\n"
 
     def test_folded_blank_line_is_paragraph_break(self, tmp_path):
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: >\n  para one\n\n  para two")
         )
-        assert meta["description"] == "para one\npara two"
+        assert meta["description"] == "para one\npara two\n"
 
     def test_folded_preserves_consecutive_blank_count(self, tmp_path):
         # k blank lines fold to k newlines, not to a single separator.
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: >\n  para one\n\n\n  para two")
         )
-        assert meta["description"] == "para one\n\npara two"
+        assert meta["description"] == "para one\n\npara two\n"
 
     def test_folded_keeps_more_indented_line_breaks(self, tmp_path):
         # Breaks adjacent to a more-indented line are not folded, so nested
@@ -103,7 +106,7 @@ class TestFoldedBlockScalar:
                 "  outro line",
             )
         )
-        assert meta["description"] == "intro line\n  - item one\n  - item two\noutro line"
+        assert meta["description"] == "intro line\n  - item one\n  - item two\noutro line\n"
 
     def test_folded_blank_next_to_more_indented_keeps_separator_break(self, tmp_path):
         # Between plain lines the separator break folds away (k blanks -> k
@@ -120,13 +123,13 @@ class TestFoldedBlockScalar:
                 "  plain outro",
             )
         )
-        assert meta["description"] == "plain intro\n\n  indented detail\n\nplain outro"
+        assert meta["description"] == "plain intro\n\n  indented detail\n\nplain outro\n"
 
     def test_folded_at_end_of_frontmatter(self, tmp_path):
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "name: my-skill\ndescription: >\n  trailing block value")
         )
-        assert meta["description"] == "trailing block value"
+        assert meta["description"] == "trailing block value\n"
 
     def test_empty_folded_block_is_empty_string(self, tmp_path):
         # An indicator with no continuation lines resolves to "", never ">".
@@ -140,7 +143,7 @@ class TestLiteralBlockScalar:
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: |\n  line one\n  line two")
         )
-        assert meta["description"] == "line one\nline two"
+        assert meta["description"] == "line one\nline two\n"
 
     def test_literal_with_chomping_strip(self, tmp_path):
         meta = SkillsLoader._parse_frontmatter(
@@ -149,24 +152,30 @@ class TestLiteralBlockScalar:
         assert meta["description"] == "line one\nline two"
 
     def test_literal_with_chomping_keep(self, tmp_path):
+        # As with the folded pair, keep preserves the trailing break strip drops. The two
+        # used to return the same string, which is what made the modifier decorative.
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: |+\n  line one\n  line two")
         )
-        assert meta["description"] == "line one\nline two"
+        assert meta["description"] == "line one\nline two\n"
 
     def test_literal_keeps_relative_indentation(self, tmp_path):
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: |\n  outer\n    nested detail")
         )
-        assert meta["description"] == "outer\n  nested detail"
+        assert meta["description"] == "outer\n  nested detail\n"
 
     def test_literal_leading_blank_line_keeps_relative_indentation(self, tmp_path):
         # Indent is derived from the first NON-BLANK line, so a blank line
         # right after the indicator must not flatten nested indentation.
+        #
+        # The leading break itself is now PRESERVED (#7097): no YAML chomping mode
+        # removes a leading break, and the fold's old trailing `.strip()` was what
+        # dropped it. The indentation claim this test exists for is unaffected.
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: |\n\n  outer\n    nested detail")
         )
-        assert meta["description"] == "outer\n  nested detail"
+        assert meta["description"] == "\nouter\n  nested detail\n"
 
 
 class TestBlockScalarBoundaries:
@@ -179,7 +188,7 @@ class TestBlockScalarBoundaries:
                 "description: >\n  Steps: do x then y\nname: my-skill",
             )
         )
-        assert meta["description"] == "Steps: do x then y"
+        assert meta["description"] == "Steps: do x then y\n"
         assert "Steps" not in meta
         assert meta["name"] == "my-skill"
 
@@ -190,7 +199,7 @@ class TestBlockScalarBoundaries:
                 "description: >\n  the description\nalways: true\ntriggers: a, b",
             )
         )
-        assert meta["description"] == "the description"
+        assert meta["description"] == "the description\n"
         assert meta["always"] == "true"
         assert meta["triggers"] == "a, b"
 
@@ -198,7 +207,7 @@ class TestBlockScalarBoundaries:
         meta = SkillsLoader._parse_frontmatter(
             _write(tmp_path, "description: >\n  the description\n\nname: my-skill")
         )
-        assert meta["description"] == "the description"
+        assert meta["description"] == "the description\n"
         assert meta["name"] == "my-skill"
 
     def test_indicator_like_prose_value_kept_verbatim(self, tmp_path):

--- a/website/src/components/SkillForm.tsx
+++ b/website/src/components/SkillForm.tsx
@@ -108,27 +108,77 @@ function everyTopKeyAtColumnZero(block: string, doc: Document.Parsed): boolean {
 /** Reproduce the reader's fold for a BARE LITERAL block scalar, from the source lines
  *  after its header.
  *
- *  Mirrors `fold_block_scalar` in `src/kiro_crew/frontmatter.py` for the `|` family only:
- *  it drops trailing blank lines, dedents by the first non-blank line's indent, joins with
- *  newlines and strips. The strip is the part no YAML chomping mode performs, and it is
- *  why comparing beats predicting -- a leading blank line survives in the parser and not
- *  here, and nothing about the indicator says so. */
-function backendFoldsLiteral(block: string, headerEnd: number): string {
+ *  Mirrors `fold_block_scalar` in `src/kiro_crew/frontmatter.py` for the `|` family: it
+ *  separates the trailing blank lines from the content, dedents by the first non-blank
+ *  line's indent, joins with newlines, and applies the header's chomping modifier --
+ *  `-` drops every trailing break, `+` keeps them all, and the default keeps exactly one.
+ *
+ *  It no longer trims. Until #7097 the backend fold ended in `.strip()`, which removed a
+ *  LEADING break and every trailing one -- neither of which any chomping mode does -- so
+ *  whether the two readers agreed depended on the block's CONTENT. They now agree on the
+ *  whole `|` family, which is why the comparison below stops refusing the leading-blank
+ *  and keep-chomped shapes. The comparison itself stays: it is what catches the next
+ *  drift, and a dedent rule is still not derivable from the indicator. */
+function backendFoldsLiteral(block: string, headerEnd: number, header: string): string {
   const rest = block.slice(headerEnd + 1).split('\n')
   const body: string[] = []
+  /* The same boundary the reader's own walk uses, judged in SPACES because that is what
+     YAML counts as indentation: a line with content at column 0 ends the scalar (so a
+     bare tab ends it, having no space indent at all), and so does a content line
+     indented LESS than the block's. Breaking only on "non-blank and unindented" let this
+     mirror keep lines the reader stops at, and it then predicted a value the reader
+     never returns. */
+  let contentIndent: number | null = null
+  /* A leading all-space line's own depth is a floor on the detected indent, because YAML
+     detects from the leading blanks too and ends the scalar rather than accept a
+     shallower content line after them. The reader applies the same floor; without it this
+     mirror kept lines the reader leaves in the surrounding document. */
+  let blankFloor = 0
   for (const line of rest) {
-    // The scalar ends at the first non-blank line that is not indented.
-    if (line.trim() !== '' && !/^\s/.test(line)) break
+    const stripped = line.replace(/^ +/, '')
+    if (stripped !== '') {
+      const lineIndent = line.length - stripped.length
+      if (lineIndent === 0) break
+      if (contentIndent === null) {
+        if (lineIndent < blankFloor) break
+        contentIndent = lineIndent
+      }
+      if (lineIndent < contentIndent) break
+    } else if (contentIndent === null) {
+      blankFloor = Math.max(blankFloor, line.length)
+    }
     body.push(line)
   }
   let end = body.length
   while (end && body[end - 1].trim() === '') end -= 1
-  if (!end) return ''
-  const kept = body.slice(0, end)
-  const first = kept.find(l => l.trim() !== '') ?? ''
-  const indent = first.length - first.replace(/^\s+/, '').length
-  const dedented = kept.map(l => (l.slice(0, indent).trim() === '' ? l.slice(indent) : l.replace(/^\s+/, '')))
-  return dedented.join('\n').trim()
+  const chomp = header.slice(1, 2)
+  /* The +1 is the last line's OWN terminating newline. Every line inside the fence has
+     one, including the last: the closing `---` is on its own line. Omitting it made a
+     clip-chomped scalar read one break short of what both parsers give. So a block that
+     is nothing but breaks has exactly as many as it has lines. */
+  const allBreaks = chomp === '+' ? '\n'.repeat(body.length) : ''
+  /* Indentation is SPACES, never tabs, so under `|` a line of two spaces then a tab is
+     two columns of indent followed by a TAB OF CONTENT -- which is how the backend
+     counts it. Matching on \s treated the tab as indentation, found no content line at
+     all, and made this mirror disagree with the reader it exists to predict. */
+  const first = body.find(l => l.replace(/^ +/, '') !== '')
+  if (first === undefined) return allBreaks
+  const indent = first.length - first.replace(/^ +/, '').length
+  const dedented = body.map(l =>
+    /^ *$/.test(l.slice(0, indent)) || l.trim() === '' ? l.slice(indent) : l.replace(/^\s+/, ''),
+  )
+  if (!dedented.some(l => l !== '')) return allBreaks
+  /* Classify the trailing breaks AFTER dedenting, as the backend does: whitespace
+     BEYOND the block's indent is content, so a trailing line of three spaces under a
+     two-space block is a one-space content line and not a break at all. Judging the raw
+     lines dropped it and reported a divergence against a reader that had kept it. */
+  end = dedented.length
+  while (end && dedented[end - 1] === '') end -= 1
+  const trailingBreaks = dedented.length - end + 1
+  /* Clip keeps exactly one break, and there is always one to keep: the count includes
+     the last line's own terminator, so it is never zero. */
+  const suffix = chomp === '-' ? '' : chomp === '+' ? '\n'.repeat(trailingBreaks) : '\n'
+  return dedented.slice(0, end).join('\n') + suffix
 }
 
 /** What the BACKEND reader would take a managed field's value to be, from its own
@@ -150,18 +200,23 @@ function backendReadsValue(block: string, pair: Pair<unknown, unknown>): string 
   if (colon === -1) return null
   const rhs = line.slice(colon + 1).trim()
   /* Block scalars. Three attempts at deciding agreement from the INDICATOR were all
-     wrong -- six (the reader's resolvable set), then four, then the realisation that the
-     reader's fold ends in `.strip()`, which eats LEADING whitespace too, so
-     `always: |-` with a blank first line reads `true` on the backend and
-     newline-then-true in the parser. Agreement depends on the CONTENT.
-     So stop predicting and SIMULATE, exactly as the single-line branch below does.
-     For a bare LITERAL indicator the reader's fold is short enough to reproduce
-     faithfully: drop trailing blank lines, dedent by the first non-blank line's indent,
-     join with newlines, strip. Verified against the real `fold_block_scalar`.
-     A FOLDED (`>`) form is NOT reproduced -- its blank-line and indentation folding rules
-     are intricate, and duplicating them is the cross-language coupling this change exists
-     to avoid -- so it falls through and is refused, as does an explicit indicator. */
-  if (/^\|[+-]?$/.test(rhs)) return backendFoldsLiteral(block, lineEnd)
+     wrong, and the reason has now been removed at the source: until #7097 the reader's
+     fold ended in `.strip()`, so `always: |-` with a blank first line read `true` on the
+     backend and newline-then-true in the parser, and agreement depended on the CONTENT.
+     The backend fold now follows YAML chomping and keeps a leading break, so the `|`
+     family agrees outright.
+     The SIMULATION stays anyway, exactly as the single-line branch below does: it is what
+     catches the next drift between the two implementations, and the dedent rule still is
+     not derivable from the indicator.
+     A FOLDED (`>`) form is still NOT reproduced -- its blank-line and indentation folding
+     rules are intricate, and duplicating them is the cross-language coupling #7187 chose
+     to avoid -- so it falls through and is refused. An EXPLICIT indicator (`|2-`) is now
+     resolved by the backend, but stays refused here for the same reason: relaxing that is
+     a capability change, not a correctness one, and refusing it merely declines an edit
+     the reader could have taken. Every remaining gap between this mirror and the backend
+     is in that safe direction -- it can only refuse a block both sides agree on, never
+     accept one they read differently. */
+  if (/^\|[+-]?$/.test(rhs)) return backendFoldsLiteral(block, lineEnd, rhs)
   return rhs.replace(/^["']+/, '').replace(/["']+$/, '')
 }
 
@@ -191,7 +246,15 @@ function backendDisagreesOnManagedField(block: string, doc: Document.Parsed): bo
     if (typeof (pair.value as { comment?: unknown }).comment === 'string') continue
     const backend = backendReadsValue(block, pair)
     if (backend === null) continue
-    if (backend !== scalarText(pair.value)) return true
+    /* Compare the two in the SAME space. `scalarText` drops one trailing newline from a
+       block node, because that break is the block's own terminator and the form's text
+       field does not show it -- re-emitting as `|` puts it back. Since #7097 the backend
+       fold keeps that break too (it is what a YAML parser returns), so comparing the raw
+       fold against the stripped parser text would report a disagreement on every block
+       scalar in the file and refuse them all. Normalise the backend side identically. */
+    const isBlockNode = pair.value.type === 'BLOCK_LITERAL' || pair.value.type === 'BLOCK_FOLDED'
+    const backendText = isBlockNode ? backend.replace(/\n$/, '') : backend
+    if (backendText !== scalarText(pair.value)) return true
   }
   return false
 }
@@ -440,16 +503,24 @@ function managedText(key: string, data: SkillFormData): string {
  *  which case the field is copied verbatim rather than re-rendered.
  *
  *  `always` needs its own comparison, and it must be an INVERSION rather than a
- *  list of false-like spellings. The form reads the flag as `meta.always ===
- *  'true'`, so the field is unchanged exactly when the checkbox still agrees with
- *  that same test applied to the original text. Enumerating `''` and `'false'`
- *  missed every other non-`true` spelling -- `always: yes` and `always: no` parse
- *  as STRINGS under the YAML 1.2 core schema, `always: 0` as a number -- and each
- *  one was silently deleted on an unrelated edit. Enumerating shapes is the exact
- *  mistake this whole change exists to stop making. */
+ *  list of false-like spellings. The form reads the flag as
+ *  `meta.always.trim().toLowerCase() === 'true'`, so the field is unchanged
+ *  exactly when the checkbox still agrees with that same test applied to the
+ *  original text. Enumerating `''` and `'false'` missed every other non-`true`
+ *  spelling -- `always: yes` and `always: no` parse as STRINGS under the YAML 1.2
+ *  core schema, `always: 0` as a number -- and each one was silently deleted on an
+ *  unrelated edit. Enumerating shapes is the exact mistake this whole change
+ *  exists to stop making.
+ *
+ *  The normalisation is load-bearing and must stay in step with the backend, which
+ *  reads this flag as `meta.get("always", "").strip().lower() == "true"`. Since
+ *  #7097 the reader honours YAML chomping, so `always: |+` followed by blank lines
+ *  legitimately reads `true\n\n`; and `always: "TRUE"` reaches here uppercased.
+ *  Without `.trim().toLowerCase()` on BOTH sides the form would show such a skill
+ *  as off while the loader treated it as on. */
 function managedUnchanged(key: string, data: SkillFormData, original: Record<string, string>): boolean {
   const was = original[key] ?? ''
-  if (key === 'always') return data.always === (was === 'true')
+  if (key === 'always') return data.always === (was.trim().toLowerCase() === 'true')
   return managedText(key, data) === was
 }
 
@@ -787,7 +858,12 @@ export function parseSkillContent(raw: string, key: string): SkillFormData {
     description: meta.description || '',
     triggers: meta.triggers || '',
     tags: meta.tags || '',
-    always: meta.always === 'true',
+    // `.trim().toLowerCase()` keeps this in step with the backend's
+    // `meta.get("always", "").strip().lower() == "true"`: a chomping-preserved
+    // trailing newline must not read as "not always-on" here while the loader
+    // reads it as on, and neither must `always: "TRUE"`, which the loader
+    // activates. See `managedUnchanged`, which inverts this exact test.
+    always: (meta.always ?? '').trim().toLowerCase() === 'true',
     body: split.body,
   }
 

--- a/website/src/test/SkillFormFrontmatter.test.tsx
+++ b/website/src/test/SkillFormFrontmatter.test.tsx
@@ -835,11 +835,15 @@ describe('structured editor preserves unmodelled frontmatter', () => {
   })
 
   it('declines an existing block scalar with an explicit indentation indicator', () => {
-    /* GPT round 24, read side. `SKILL_LOADER` resolves only the six BARE indicators
-       (`>` `|` `>-` `|-` `>+` `|+`, its own BLOCK_SCALAR_INDICATORS); given `|2-` it
-       takes the header itself as the value. The YAML parser decodes the body, so the
-       two disagree about what this file already means, and the divergence rule was
-       skipping every block scalar rather than just the ones both sides resolve. */
+    /* GPT round 24, read side. The ORIGINAL reason was that `SKILL_LOADER` resolved only
+       the six BARE indicators, so given `|2-` it took the header itself as the value while
+       the YAML parser decoded the body -- the two disagreed about what the file already
+       meant. #7097 fixed that: the backend now resolves the full header grammar and agrees
+       with the parser here.
+       The refusal REMAINS, for a narrower reason: this file does not simulate the explicit
+       indent, so it has no value to compare and must not guess. That only declines an edit
+       the backend could have taken -- conservative, never corrupting -- and relaxing it is
+       a capability change belonging with the folded-family work #7187 deferred. */
     const raw = ['---', 'name: s', 'description: |2-', '  body text', 'repo_scope: x', '---', '', '# Body'].join('\n')
     expect(canEditStructured(raw)).toBe(false)
     expect(assembleSkillContent(parseSkillContent(raw, 's'))).toBe(raw)
@@ -851,20 +855,37 @@ describe('structured editor preserves unmodelled frontmatter', () => {
        the real Python reader, so this test fails if either side drifts. Reached through
        the public behaviour: a field whose simulated backend value MATCHES the parser's is
        editable, one that differs is refused. */
-    const editable: [string, string[]][] = [
-      ['plain two lines', ['  one', '  two']],
-      ['interior blank', ['  one', '', '  two']],
-      ['deeper indent inside', ['  one', '    nested', '  two']],
-    ]
-    for (const [label, body] of editable) {
-      const raw = ['---', 'name: s', 'description: |', ...body, 'repo_scope: x', '---', '', '# Body'].join('\n')
-      expect(canEditStructured(raw), label).toBe(true)
-    }
-    /* These the reader collapses to something the parser does not: a leading blank line
-       survives in YAML and not in the reader, and keep-chomped trailing blanks likewise. */
-    const refused: [string, string, string[]][] = [
+    const editable: [string, string, string[]][] = [
+      ['plain two lines', '|', ['  one', '  two']],
+      ['interior blank', '|', ['  one', '', '  two']],
+      ['deeper indent inside', '|', ['  one', '    nested', '  two']],
+      /* These two used to be refused: the reader collapsed them to something the parser
+         did not, because its fold ended in `.strip()`. #7097 made it honour chomping and
+         keep a leading break, so both sides now agree and the capability comes back. */
       ['leading blank', '|', ['', '  true']],
       ['keep chomp trailing blanks', '|+', ['  true', '', '']],
+      ['clip chomp trailing blank', '|', ['  one', '']],
+      /* Whitespace shapes, each of which used to make the simulation disagree with the
+         reader and so refuse an edit the backend could take. A trailing line of three
+         spaces is a one-space CONTENT line once dedented, not a break; a content line
+         keeps the spaces its author typed at the end; and indentation is counted in
+         SPACES, so two spaces then a tab is a tab of content -- which also means a bare
+         tab line ends the block, exactly as the reader's own walk decides. */
+      ['whitespace-only trailing line', '|', ['  one', '   ']],
+      ['content with trailing spaces', '|', ['  one  ', '  two  ']],
+      ['tab past the indent', '|', ['  \t']],
+      ['tab then deeper then flush', '|', ['  \t', '    deep', '  one']],
+      ['trailing whitespace and a blank', '|-', ['  one  ', '   ', '']],
+    ]
+    for (const [label, ind, body] of editable) {
+      const raw = ['---', 'name: s', `description: ${ind}`, ...body, 'repo_scope: x', '---', '', '# Body'].join('\n')
+      expect(canEditStructured(raw), label).toBe(true)
+    }
+    /* Still refused, and for a reason the simulation cannot remove: the FOLDED family's
+       rules are not reproduced here at all, so there is no simulated value to compare. */
+    const refused: [string, string, string[]][] = [
+      ['folded', '>', ['  one', '  two']],
+      ['folded keep chomp', '>+', ['  one', '', '']],
     ]
     for (const [label, ind, body] of refused) {
       const raw = ['---', 'name: s', `description: ${ind}`, ...body, 'repo_scope: x', '---', '', '# Body'].join('\n')
@@ -874,12 +895,15 @@ describe('structured editor preserves unmodelled frontmatter', () => {
 
   it('compares block scalars instead of trusting their indicator', () => {
     /* GPT rounds 24-26 walked this boundary three times: six indicators exempt, then
-       four, then the realisation that agreement depends on the CONTENT -- the reader's
-       fold ends in `.strip()`, which eats LEADING whitespace, something no YAML chomping
-       mode does. So nothing is exempt by indicator any more. A bare LITERAL scalar is
-       SIMULATED and compared, which keeps it editable when the two readings match; a
-       FOLDED or explicit-indicator form is refused, because reproducing those rules to
-       compare is the coupling this change avoids. */
+       four, then the realisation that agreement depended on the CONTENT -- the reader's
+       fold ended in `.strip()`, which ate LEADING whitespace, something no YAML chomping
+       mode does. #7097 removed that step, so the `|` family now agrees outright; the
+       SIMULATION stays because it is what catches the next drift, and because the dedent
+       rule still is not derivable from the indicator. A bare LITERAL scalar is SIMULATED
+       and compared, which keeps it editable when the two readings match; a FOLDED form is
+       refused because reproducing those rules to compare is the coupling #7187 avoided,
+       and an explicit indicator is refused for the same reason even though the backend
+       now resolves it -- refusing merely declines an edit, it cannot corrupt. */
     const literal = ['---', 'name: s', 'description: |', '  body text', 'repo_scope: x', '---', '', '# Body'].join('\n')
     expect(canEditStructured(literal), 'plain literal agrees').toBe(true)
     for (const ind of ['>', '>-', '>+', '|2-']) {
@@ -889,22 +913,52 @@ describe('structured editor preserves unmodelled frontmatter', () => {
     }
   })
 
-  it('declines a block scalar whose blank first line the reader eats', () => {
+  it('edits a block scalar whose blank first line the reader used to eat', () => {
     /* The case that ended the indicator approach: `|-` is a STRIP form, so nothing about
-       the indicator hints at a problem -- the divergence comes from where the content
-       sits. On `always` it is the undisableable-skill case again. */
+       the indicator hinted at a problem -- the divergence came from where the content
+       sat, because the reader's fold ended in `.strip()`. #7097 removed that step, so a
+       leading break now survives on BOTH sides and the field is editable. The comparison
+       is what proves it, not the indicator. */
     const raw = ['---', 'name: s', 'always: |-', '', '  true', 'repo_scope: x', '---', '', '# Body'].join('\n')
-    expect(canEditStructured(raw)).toBe(false)
-    expect(parseSkillContent(raw, 's').raw).toBeDefined()
+    expect(canEditStructured(raw)).toBe(true)
+    /* And the flag still reads as ON: the value is `\ntrue`, which only equals `true`
+       once trimmed -- the same normalisation the loader applies. Getting this wrong shows
+       the skill as off in the form while the loader keeps injecting it. */
+    expect(parseSkillContent(raw, 's').always).toBe(true)
   })
 
-  it('does not let a keep-chomped always become undisableable', () => {
-    /* The form would read `true\n\n` (not "true") and treat the field as already false,
-       so `managedUnchanged` would keep the original bytes and the backend would go on
-       reading true -- the skill could not be turned off. */
+  it('keeps a keep-chomped always disableable', () => {
+    /* Was 'does not let a keep-chomped always become undisableable', which refused the
+       block because the reader dropped the trailing breaks and the parser kept them. Both
+       now read `true\n\n`, so the field is editable -- and the round trip below is the
+       part that matters: turning the checkbox OFF must actually reach the file, not be
+       swallowed by `managedUnchanged` comparing an untrimmed `true\n\n` against `true`. */
     const raw = ['---', 'name: s', 'always: |+', '  true', '', '', 'repo_scope: x', '---', '', '# Body'].join('\n')
-    expect(canEditStructured(raw)).toBe(false)
-    expect(parseSkillContent(raw, 's').raw).toBeDefined()
+    expect(canEditStructured(raw)).toBe(true)
+    const data = parseSkillContent(raw, 's')
+    expect(data.always).toBe(true)
+    const off = assembleSkillContent({ ...data, always: false })
+    expect(off).not.toBe(raw)
+    expect(parseSkillContent(off, 's').always).toBe(false)
+  })
+
+  it('reads an uppercase always the way the loader does', () => {
+    /* GPT 5.6 review, head 9cc2cfa32. The loader reads this flag as
+       `.strip().lower() == "true"`, so `always: "TRUE"` activates the skill. The form
+       compared case-sensitively, so it showed the same skill as OFF -- the checkbox
+       disagreeing with the loader about whether the skill injects. Pre-existing in the
+       case dimension; fixed here because this PR is what makes the two comparisons
+       claim to agree. */
+    for (const spelling of ['"TRUE"', 'True', '  true  ']) {
+      const raw = ['---', 'name: s', `always: ${spelling}`, 'repo_scope: x', '---', '', '# Body'].join('\n')
+      expect(parseSkillContent(raw, 's').always, spelling).toBe(true)
+    }
+    /* ...and a genuinely false-like value still reads as off, so the normalisation did
+       not turn the comparison into "any non-empty value activates". */
+    for (const spelling of ['false', 'FALSE', 'no', '0', '']) {
+      const raw = ['---', 'name: s', `always: ${spelling}`, 'repo_scope: x', '---', '', '# Body'].join('\n')
+      expect(parseSkillContent(raw, 's').always, spelling).toBe(false)
+    }
   })
 
   it('leaves a skill with no frontmatter alone', () => {


### PR DESCRIPTION
## Problem / Motivation

`SKILL_LOADER` in `src/kiro_crew/frontmatter.py` reads block scalars with a
hand-rolled scanner that implements less of YAML than the files on disk use. Two
separate defects, both silent:

| frontmatter | reader returned | correct |
|---|---|---|
| `description: \|2-` + indented body | `\|2-` (the header) | the body |
| `description: \|- # note` + body | `\|- # note` (the header) | the body |
| `description: \|` + `  one` | `one` | `one\n` (clip keeps one break) |
| `description: \|+` + body + blanks | body, blanks dropped | blanks kept |
| a leading blank line inside a block | dropped | kept (no chomping mode drops it) |

The first two are a matcher gap: the READ path tested membership of a six-element
frozenset of bare indicators, while the WRITE path in the same module already
matched the full header grammar with `_BLOCK_SCALAR_HEADER_RE`. So one half of the
module understood `|2-` and the other did not.

The rest is one line: `fold_block_scalar` ended in `.strip()`, which removes a
LEADING break and every trailing one. No YAML chomping mode does either.

A third defect surfaced while reviewing this PR and is fixed here because it is the
same collection loop: the reader took ANY indented line as scalar content, so a
less-indented `#` line -- a comment in the surrounding document to YAML -- was
absorbed into the value (`|-` + `  body` + ` # note` read back as `body\n# note`).
That was already wrong on base for a bare indicator; supporting explicit indents
would have widened it.

**This PR does NOT give `SKILL_LOADER` a real YAML parse**, which is what #7097
originally asked for. I measured the corpus the issue asked for first, and it
disqualifies that fix: see the comment on the issue
(https://github.com/kirodotdev/KiroCrew/issues/7097#issuecomment-5495175682). Over
the 56 fenced repo-tracked SKILL.md files, 2 make a YAML parser RAISE outright,
and both are skills this repo ships:

- `src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md`
- `src/kiro_crew/builtin_skills/web-verify/SKILL.md`

Both carry an unquoted `": "` inside `description` (`... Three capture backends:
playwright-cli ...`), which YAML rejects DOCUMENT-wide with "mapping values are not
allowed here". The scanner splits on the first colon and reads them correctly. So
the two accepted-input surfaces CROSS rather than nest, and the swap is not a
strict improvement. The quoting and unescaping rows of #7097 are #7063's scope and
are deliberately untouched here.

## Why it matters

Every row above is a value the agent is handed that is not what the file says. The
`|2-` and `|- # note` rows are the worst: the value becomes the literal string
`"|2-"`, so a skill's entire description is replaced by two characters of YAML
syntax.

It also pushed cost outward. `website/src/components/SkillForm.tsx` mirrors this
reader in TypeScript and refuses to edit a field the two readers disagree about.
Because `.strip()` made agreement depend on a block's CONTENT rather than its
header, that mirror could not decide from the indicator -- three attempts tried and
each was wrong -- and a leading-space first line was deliberately degraded in the
editor because no YAML form of it survived the reader.

There was also a live activation hazard. `always` and `pinned` are decided by an
exact `meta.get(...).lower() == "true"`, so honouring keep-chomping would make
`always: |+` followed by blank lines read `"true\n\n"`, which is not `"true"` -- a
skill silently flipping from always-on to off on a file nobody edited.

## What changed (motivation -> approach -> change)

1. **One header matcher for every site that recognizes a block scalar.**
   `_BLOCK_SCALAR_HEADER_RE` now carries the full grammar (both modifier orderings,
   an optional trailing comment) and is parsed by a new
   `parse_block_scalar_header()` used by the read path, the write path, AND the
   onboarding activation gate. An explicit `0` is refused, as YAML forbids it. The
   old six-element `BLOCK_SCALAR_INDICATORS` frozenset is DELETED -- it was the
   second recognizer, and keeping it is what let the module disagree with itself.
2. **The onboarding activation gate reads that same grammar.** It is fail-closed
   only while its detected set is a SUPERSET of what the loader can resolve.
   Round 1 of this PR widened the loader while the gate kept its own list, which
   turned the gate fail-OPEN: `always: |2-` over a `true` continuation went
   undetected by `_column0_activation_declared`, was installed verbatim, and was
   then read by `SkillsLoader` as `always == "true"` -- external skill-package
   content self-activating into every session, the exact hazard
   `automatic_activation_excluded` exists to reject. Caught by Design Review, Opus
   and First Principles; measured before and after (three spellings fail-open
   before, none after) and pinned by
   `TestTheActivationGateCoversEverythingTheLoaderResolves`. An earlier revision of
   this description claimed the gate "must not move" -- that was wrong in the
   safety-relevant direction, and this is the correction.
3. **Collection stops at the block's indentation boundary, on BOTH paths.** YAML ends
   a block scalar at the first non-blank line indented less than its content, so a
   less-indented `#` line is a comment in the surrounding document. Collecting on
   "is it indented" absorbed one: `|-` + `  body` + ` # note` read back as
   `body\n# note`. Caught by GPT on the explicit-indent path; measurement showed it
   was ALREADY wrong on base for a bare indicator, and one boundary rule fixes
   both. The WRITE path needed the same rule -- tightening read alone left the writer
   treating a less-indented comment as block content, so replacing that field deleted
   the author's note (raised and self-dropped as unreachable by Opus; fixed anyway,
   because it is an asymmetry this change introduced and it does reproduce through
   steering's mode edit). A comment indented PAST the content is still content on
   both paths, as YAML has it.
4. **Trailing breaks are classified AFTER dedent.** A line holding only whitespace
   looks blank -- `"   ".strip()` is empty -- but whitespace BEYOND the block's indent
   is content, so it is not a break and chomping must not eat it: `|-` over `  body`
   then three spaces is `body\n `, not `body`. Found by GPT; the same correction was
   needed in the folded branch, which tested `.strip()` too and folded such a line
   away entirely.
5. **Explicit indentation indicators are honoured**, which is what makes a
   leading-space first line survive -- inferring the indent from the first non-blank
   line cannot express it.
6. **Real chomping.** `-` drops every trailing break, `+` keeps them all, clip keeps
   exactly one; a leading break is content and is preserved. The `.strip()` is gone.
7. **The break count includes the last line's own terminator.** The fence extractor
   drops the newline before the closing `---`, but that newline terminates the last
   content line, so every line inside a fence is newline-terminated. Missing this
   made a value depend on WHICH FIELD CAME NEXT (`one` when followed by another key,
   `one\n` at the end of the block) -- caught by the differential matrix, pinned by
   its own test, and it is also why PyYAML and the editor's JavaScript parser looked
   like they disagreed: feeding a parser the captured text verbatim asks about a
   document one break short.
8. **Activation flags normalise, case included.** The six comparisons reading
   `always` / `pinned` with a bare `.lower()` now `.strip().lower()`, matching the
   five that already stripped (`pinned` was read BOTH ways in the same module). The
   frontend's two `always` comparisons use `.trim().toLowerCase()`, so the form and
   the loader agree on `always: |+` with trailing blanks AND on `always: "TRUE"`
   (the case half was pre-existing; it is fixed here because this PR is what makes
   the two comparisons claim to agree).
9. **The TypeScript mirror moves with the fold**, as `test_frontmatter.py`'s own
   docstring requires. It no longer trims, counts the terminator, and compares in
   the same normalised space as `scalarText` (which drops one trailing break for a
   block node). Consequence: the leading-blank and keep-chomped shapes it used to
   refuse are editable again, because both sides genuinely agree now. A FOLDED form
   and an explicit indicator stay refused -- that is #7187's deliberate trade, and
   refusing only declines an edit, it cannot corrupt.
10. **The corpus test #7097 asked for**, over every repo-tracked SKILL.md, asserting
    the not-valid-YAML set EXACTLY in both directions so a third such skill is
    visible rather than absorbed.

## Tests

- **Differential vs PyYAML, 544 cases, 0 divergences.** 13 headers x 25 bodies x 2
  positions (end-of-block and followed-by-a-field). The oracle is
  `yaml.BaseLoader`, not `safe_load`, so every scalar stays a `str` and
  `always: true` keeps reading `"true"`. Scoped to block scalars on purpose:
  asserting agreement wholesale would assert the parser swap the corpus rejected.
  The body set includes WHITESPACE-ONLY lines, which are not interchangeable with
  empty ones -- the first version of this matrix used only empty strings and so could
  not express the case GPT found, which is why those rows carry a comment saying so.
  The floor assertion is 450 checked cases, so they cannot quietly disappear.
- **Red on base: 9 of 10 new expectations.** Verified by loading `origin/main`'s
  `frontmatter.py` as a module and running the new expectations against it -- base
  returns `'|2-'` and `'|- # note'` as values. The tenth (`|-` strip with trailing
  blanks) already passed on base, since `.strip()` and strip-chomping agree there.
- **Chomping gets its own test**, as asked. Two of them: the three modes are
  distinguishable on one body, and `TestChompingCannotFlipAnActivationFlag` pins
  that every block-scalar spelling of `true` still reads as always-on, with a
  guard assertion so it cannot go vacuous if chomping were reverted.
- **The fail-open gate is measured, not argued.** Before: `always: |2-`, `|-2` and
  `|- # note` each activate the skill (loader reads `true`) while
  `_column0_activation_declared` returns False. After: all detected.
  `TestTheActivationGateCoversEverythingTheLoaderResolves` asserts the invariant
  one-directionally over eleven header spellings (the gate may be stricter, never
  looser), plus that it stays stricter where it should be and does not start
  refusing ordinary values (`false`, `no`, `0`, `|0`, `maybe`).
- **The indentation boundary** has its own tests for all four indicator families on
  the read path, one asserting a comment indented PAST the content is still content
  (the boundary is the indent, not the `#`), and one on the WRITE path asserting a
  replaced block-scalar field leaves the author's less-indented comment behind.
- **Named blast radius.** Exactly ONE repo-tracked SKILL.md uses a block scalar --
  `skills/goal-loop/SKILL.md` (`description: |`) -- and it gains exactly one
  trailing newline (562 -> 563 chars, measured base vs new). Eight snapshot-corpus
  rows move for the same reason; `block_scalar_chomped` (`>-`) does not, which is
  the case that proves the modifier is now load-bearing. NOTE: this corrects the
  "3 affected files" figure from my earlier issue comment -- those three were
  installed-only skills, measured against an oracle missing the terminating break.
- Suites: `test_frontmatter.py`, `test_skills.py`, `test_skills_frontmatter.py`,
  `test_skill_discover.py`, `test_skill_update_flow.py`, `test_onboarding_import.py`,
  `test_onboarding_import_coverage.py`, `test_skill_budget.py`,
  `test_skill_listing_cost.py`, `test_history.py`, `test_check_feed_advance.py`,
  `test_pod_e2e_video_guard.py`, `test_vector_memory.py`,
  `test_ai_review_workflows.py` -- 1887 passed. Frontend
  `SkillFormFrontmatter.test.tsx` + `SkillsTab.test.tsx` -- 121 passed.
- Gates: flake8, isort, mypy, `scripts/check_black_formatting.py`, `tsc --noEmit`,
  eslint on changed files -- all clean.

## Manual verification

Measured on this machine over 274 markdown files (repo builtins, apps, and two
installed-skill trees, 170 with a column-0 fence) comparing the reader against a
real YAML parse field by field. Results are in the issue comment linked above; the
repo-scoped slice of it is now the corpus test rather than a one-off script.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** nothing rendered changes -- no component, layout, style, copy
or state was touched, and no locale string was added; the only user-facing
consequence is that a narrow class of skill files (a block-scalar `description` or
`always` with a leading blank line or keep-chomping) now opens in the EXISTING
structured editor instead of the EXISTING raw editor, both pixel-identical to their
current selves, and which one is selected is asserted by
`SkillFormFrontmatter.test.tsx` rather than by pixels.

## Related Issues

Closes #7097

Refs #7063 -- the quoting and unescaping rows. Left alone deliberately: decoding
`"a\tb"` requires parsing the quoted scalar properly, which IS #7063's change, and
that issue is claimed by another owner.

Refs #7187 -- its `backendFoldsLiteral` mirror moves here. The block-scalar decline
STRING it deferred (and its twelve locale catalogs) is still deferred; this PR
shrinks the refusal class instead of rewording it.

## Pattern harvest

Rule candidate: semgrep
Pattern: a frontmatter/metadata value read into an exact string comparison
(`meta.get(...).lower() == "true"`) without `.strip()`. This repo held BOTH
spellings -- five comparisons stripped, six did not, and `pinned` was read both ways
in the same module -- so any reader change that alters trailing whitespace flips a
behaviour flag at exactly the six unstripped sites. Mechanically detectable, and it
was a latent bug before this PR rather than one this PR introduced.

Second candidate, and the one that actually bit: one module recognising one grammar
with TWO different matchers. The read path tested membership of a six-element
frozenset while the write path, forty lines away, matched the full header regex, and
a fail-closed security gate in another module imported the frozenset. Widening one
recognizer and not the others is what turned that gate fail-OPEN. Rule candidate:
`Not generalizable` is the wrong answer here -- the smell is a hand-maintained set of
literals sitting beside a regex for the same construct, and the fix is to delete the
set. Corollary worth stating because three reviewers had to find it for me: when a
gate is fail-closed BECAUSE its detected set covers a parser's, widening the parser
is a change to the gate, whether or not you touch its file.

Not generalizable: the trailing-`.strip()` in `fold_block_scalar` itself -- that was
one wrong line in one folder, and the corpus test is the guard, not a pattern.

Measure before adopting an issue's prescribed fix. #7097 asked for a real YAML
parse and the request looked obviously right; running its own suggested corpus
first showed the reader is deliberately WIDER than YAML in a way two shipped files
depend on, which inverted the fix. The corpus is now a test, so the next person
does not have to rediscover it.

Two parsers disagreeing is a sign the INPUT is wrong. PyYAML and the JavaScript
`yaml` library returned different values for the same block, which looked like a
library quirk to route around; both were right, and the captured text was missing
the newline that the closing `---` implies. Reconstituting it made them agree and
exposed a real bug -- a value that changed depending on which field followed it.
