### PR TITLE
feat(themes): let installed packs select loader symbols

### DIFF
--- a/docs/system-specs/modules/themes.md
+++ b/docs/system-specs/modules/themes.md
@@ -32,6 +32,15 @@ a pack may ship. Validation is tier-scaled to payload trust.
 | **L1 Branded** | 1 | + `branding/` (logo, favicon, wordmark), `styles/fonts/`, scoped `overrides.css` |
 | **L2 Experience** | 2 | + `overlays/` + `topbar/` sandboxed HTML, `audio/`, `persona.md` |
 
+Level-1 and Level-2 manifests may also declare `loaderIcons`: 4–8 distinct
+names from the bundled stock-symbol allowlist (`cloud`, `flower`, `heart`,
+`moon`, `sparkles`, `star`, `sun`, `zap`). The backend validates and surfaces
+the names in the theme asset descriptor; the frontend maps them to bundled
+Lucide components and reuses the existing carousel. No component code, SVG, or
+asset path crosses the manifest boundary. Missing declarations preserve the
+Kiro ghost poses, and trusted compiled themes retain the broader
+`registerThemeBranding()` component seam.
+
 Constants (`dashboard/theme_validate.py`): `_THEME_MAX_LEVEL=2`,
 `_THEME_MAX_FONTS=6`, `_THEME_MAX_OVERLAYS=5`, `_THEME_PERSONA_MAX_CHARS=2000`,
 plus per-file byte caps (`_THEME_FILE_CAPS`) and per-level entry-count + total

--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -37,6 +37,7 @@ a level-0 pack shipping a font is refused.
   "emoji": "🎨",
   "level": 1,
   "formatVersion": 1,
+  "loaderIcons": ["star", "sparkles", "moon", "cloud"],
   "fonts": [
     { "family": "My Sans", "file": "my-sans-400.woff2", "weight": 400, "role": "sans" },
     { "family": "My Sans", "file": "my-sans-500.woff2", "weight": 500, "role": "sans" },
@@ -45,6 +46,12 @@ a level-0 pack shipping a font is refused.
   ]
 }
 ```
+
+`loaderIcons` is optional and requires Level 1 or 2. Supply 4–8 distinct names
+from: `cloud`, `flower`, `heart`, `moon`, `sparkles`, `star`, `sun`, `zap`.
+Kiro Crew maps these names to bundled Lucide symbols and keeps the stock
+cross-fading carousel; packs cannot inject loader code or SVG through this field.
+Omit it to retain the default Kiro ghost poses.
 
 ## Fonts — the role system (the ONLY supported route)
 

--- a/src/kiro_crew/dashboard/theme_validate.py
+++ b/src/kiro_crew/dashboard/theme_validate.py
@@ -277,6 +277,13 @@ _THEME_FONT_PIN_SELECTORS = frozenset({"body", "html", "*", ":root"})
 _THEME_MAX_OVERLAYS = 5
 _THEME_PERSONA_MAX_CHARS = 2000
 _THEME_BOTNAME_MAX = 48  # branding bot-name display cap (plain text)
+# Installed themes may select only these bundled Lucide symbols. Names cross the
+# manifest/API boundary; executable components and arbitrary SVG never do.
+_THEME_LOADER_ICONS = frozenset(
+    {"cloud", "flower", "heart", "moon", "sparkles", "star", "sun", "zap"}
+)
+_THEME_LOADER_ICONS_MIN = 4
+_THEME_LOADER_ICONS_MAX = len(_THEME_LOADER_ICONS)
 # Per-file size caps by category (bytes), §4.1.
 _THEME_FILE_CAPS = {
     "manifest": 16 * 1024,
@@ -1104,6 +1111,30 @@ def _validate_audio_manifest(theme_dir: Path) -> tuple[dict[str, Any] | None, st
     return out, None
 
 
+def _validate_loader_icons(manifest: dict[str, Any], level: int) -> str | None:
+    """Validate optional stock loader artwork selected by an installed theme."""
+    if "loaderIcons" not in manifest:
+        return None
+    icons = manifest["loaderIcons"]
+    if level < 1:
+        return "theme.json 'loaderIcons' requires level 1"
+    if not isinstance(icons, list):
+        return "theme.json 'loaderIcons' must be an array of stock symbol names"
+    if not (_THEME_LOADER_ICONS_MIN <= len(icons) <= _THEME_LOADER_ICONS_MAX):
+        return (
+            "theme.json 'loaderIcons' must contain "
+            f"{_THEME_LOADER_ICONS_MIN}..{_THEME_LOADER_ICONS_MAX} symbols"
+        )
+    if any(not isinstance(icon, str) for icon in icons):
+        return "theme.json 'loaderIcons' entries must be strings"
+    unknown = sorted(set(icons) - _THEME_LOADER_ICONS)
+    if unknown:
+        return f"theme.json 'loaderIcons' contains unknown symbol: {unknown[0]!r}"
+    if len(set(icons)) != len(icons):
+        return "theme.json 'loaderIcons' entries must be unique"
+    return None
+
+
 def _validate_theme_dir(
     path: Path, *, installing: bool = False
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -1168,6 +1199,9 @@ def _validate_theme_dir(
     emoji = manifest.get("emoji", _THEME_DEFAULT_EMOJI)
     if not isinstance(emoji, str):
         return None, "theme.json 'emoji' must be a string"
+    loader_err = _validate_loader_icons(manifest, level)
+    if loader_err:
+        return None, loader_err
 
     # Font role: reject an unrecognised value at INSTALL time only. The read
     # path (`_theme_asset_descriptor`, which this function also feeds when an
@@ -1425,6 +1459,15 @@ def _theme_asset_descriptor(
 
     if (theme_dir / "styles" / "overrides.css").is_file():
         desc["hasOverrides"] = True
+
+    loader_icons = manifest.get("loaderIcons")
+    if isinstance(loader_icons, list):
+        resolved_loader_icons = [
+            icon for icon in loader_icons
+            if isinstance(icon, str) and icon in _THEME_LOADER_ICONS
+        ]
+        if len(resolved_loader_icons) >= _THEME_LOADER_ICONS_MIN:
+            desc["loaderIcons"] = resolved_loader_icons[:_THEME_LOADER_ICONS_MAX]
 
     if level >= 2:
         overlays_dir = theme_dir / "overlays"

--- a/test/test_dashboard_themes_coverage.py
+++ b/test/test_dashboard_themes_coverage.py
@@ -1171,15 +1171,19 @@ class TestApiThemeDetailGet:
     async def test_installed_pack_detail_carries_level_and_assets(
         self, themes_dir: Path
     ) -> None:
-        _make_pack(themes_dir / "lcars")
+        pack = _make_pack(themes_dir / "lcars", level=1)
+        manifest_path = pack / "theme.json"
+        manifest = json.loads(manifest_path.read_text("utf-8"))
+        manifest["loaderIcons"] = ["star", "sparkles", "moon", "cloud"]
+        _write_json(manifest_path, manifest)
         resp = await th.api_theme_detail(_detail("GET", "lcars"))
         assert resp.status == 200
         payload = _body(resp)
         assert payload["slug"] == "lcars"
         assert payload["source"] == "installed"
-        assert payload["level"] == 0
+        assert payload["level"] == 1
         assert payload["dark"]["--bg"] == "#000000"
-        assert "assets" in payload
+        assert payload["assets"]["loaderIcons"] == manifest["loaderIcons"]
 
     @pytest.mark.asyncio
     async def test_invalid_installed_pack_is_500(self, themes_dir: Path) -> None:

--- a/test/test_theme_install.py
+++ b/test/test_theme_install.py
@@ -26,6 +26,7 @@ structure/security logic lives, so no aiohttp app is needed. Covers:
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -38,6 +39,8 @@ from kiro_crew.dashboard.handlers.themes import (
     _copy_installed_theme,
 )
 from kiro_crew.dashboard.theme_validate import (
+    _THEME_LOADER_ICONS,
+    _THEME_LOADER_ICONS_MAX,
     _THEME_MAX_FONTS,
     _THEME_OVERLAY_DEFAULT_POSITION,
     _THEME_OVERLAY_DEFAULT_ZINDEX,
@@ -234,6 +237,47 @@ class TestValidateThemeDir:
         summary, err = _validate_theme_dir(_make_theme(tmp_path / "ok", level=2))
         assert err is None, err
         assert summary is not None and summary["level"] == 2
+
+    def test_level_one_loader_icons_are_accepted_and_described(self, tmp_path: Path) -> None:
+        d = _make_theme(tmp_path, level=1)
+        manifest = json.loads((d / "theme.json").read_text("utf-8"))
+        manifest["loaderIcons"] = ["star", "sparkles", "moon", "cloud"]
+        _write(d / "theme.json", manifest)
+        summary, err = _validate_theme_dir(d, installing=True)
+        assert err is None, err
+        assert summary is not None
+        descriptor = _theme_asset_descriptor(d, manifest, 1)
+        assert descriptor["loaderIcons"] == manifest["loaderIcons"]
+
+    @pytest.mark.parametrize(
+        ("level", "icons", "message"),
+        [
+            (0, ["star", "sparkles", "moon", "cloud"], "requires level 1"),
+            (1, None, "must be an array"),
+            (1, "star", "must be an array"),
+            (1, ["star", "moon", "cloud"], "must contain"),
+            (1, ["star", "sparkles", "moon", "unknown"], "unknown symbol"),
+            (1, ["star", "sparkles", "moon", "star"], "must be unique"),
+        ],
+    )
+    def test_invalid_loader_icons_are_rejected(
+        self, tmp_path: Path, level: int, icons: object, message: str
+    ) -> None:
+        d = _make_theme(tmp_path, level=level)
+        manifest = json.loads((d / "theme.json").read_text("utf-8"))
+        manifest["loaderIcons"] = icons
+        _write(d / "theme.json", manifest)
+        summary, err = _validate_theme_dir(d, installing=True)
+        assert summary is None
+        assert err is not None and message in err
+
+    def test_backend_loader_icon_allowlist_matches_frontend(self) -> None:
+        frontend = (
+            Path(__file__).parents[1] / "website" / "src" / "themeLoaderIcons.ts"
+        ).read_text("utf-8")
+        declared = set(re.findall(r"^  ([a-z]+): [A-Z]", frontend, re.MULTILINE))
+        assert declared == _THEME_LOADER_ICONS
+        assert _THEME_LOADER_ICONS_MAX == len(declared)
 
     def test_l2_overlay_asset_rejected(self, tmp_path: Path) -> None:
         d = _make_theme(tmp_path)  # declares level 0 but ships an overlay

--- a/website/docs/theming-contract.md
+++ b/website/docs/theming-contract.md
@@ -203,19 +203,32 @@ refuses the pack with an explainable error, and the runtime scoper is the positi
 allowlist that is the actual enforced boundary. A rule that slips past the former
 still gets dropped by the latter.
 
-## Chat loader (compiled seam, not an installed pack)
+## Chat loader
 
-The loading indicator in the chat footer (shown while a turn is running) is
-theme-owned, but it is a **compiled seam, not a manifest capability**. It is
-declared in code through `registerThemeBranding()` (`src/themeBranding.tsx`),
-which runs at module load from the composition root (`src/extensions.ts`), so it
-is available to themes **bundled in the build**: the core's own themes and a
-downstream edition's. An *installed* `theme.json` pack cannot ship executable
-registration, so it cannot set a loader; a pack that needs one has to land as a
-compiled theme instead. (A pack can still restyle whatever loader is active via
-CSS; see the colour note below.)
+The loading indicator in the chat footer (shown while a turn is running) supports
+both installed packs and compiled themes.
 
-Two levels, pick one:
+### Installed packs: stock symbols
+
+A Level-1 or Level-2 pack may select 4–8 distinct bundled symbols in
+`theme.json`. The names are a closed allowlist; packs never ship executable
+components or inline SVG through this field.
+
+```json
+"loaderIcons": ["star", "sparkles", "moon", "cloud"]
+```
+
+Allowed names: `cloud`, `flower`, `heart`, `moon`, `sparkles`, `star`, `sun`,
+`zap`. The existing four-slot carousel supplies the cross-fade, cascade timing,
+and reduced-motion behavior. An absent declaration preserves the default Kiro
+ghost poses. Invalid names, duplicates, fewer than four entries, or declarations
+on a Level-0 pack are rejected during install.
+
+### Compiled themes: component seam
+
+Themes bundled into the build may still register arbitrary trusted artwork or a
+whole custom loader through `registerThemeBranding()` (`src/themeBranding.tsx`),
+which runs at module load from the composition root (`src/extensions.ts`):
 
 ```tsx
 import { registerThemeBranding } from '@/themeBranding'

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -27,6 +27,7 @@ import {
 } from './themeCss'
 
 import { i18nT } from '../i18n/t'
+import type { ThemeLoaderIconName } from '../themeLoaderIcons'
 
 export type ModePreference = 'dark' | 'light' | 'system'
 export type ResolvedMode = 'dark' | 'light'
@@ -126,6 +127,8 @@ export interface ThemeAssets {
   branding?: ThemeBranding
   fonts?: ThemeFontFace[]
   hasOverrides?: boolean
+  /** Stock symbol names for the chat loader's existing carousel. */
+  loaderIcons?: ThemeLoaderIconName[]
   // L2 assets: overlays, topbar, audio, persona.
   overlays?: ThemeOverlayDecl[]
   topbar?: ThemeTopbar
@@ -513,6 +516,11 @@ export function useTheme(): ThemeContextValue {
     throw new Error('useTheme must be used within <ThemeProvider>')
   }
   return ctx
+}
+
+/** Read theme state when available without requiring standalone consumers to mount the provider. */
+export function useOptionalTheme(): ThemeContextValue | null {
+  return useContext(ThemeContext)
 }
 
 /**

--- a/website/src/pages/chat/ChatFooter.tsx
+++ b/website/src/pages/chat/ChatFooter.tsx
@@ -5,6 +5,8 @@ import { motion } from 'framer-motion'
 import { i18nT } from '../../i18n/t'
 import { GHOST_POSE_ICONS } from '../../components/GhostPoses'
 import { getThemeBranding } from '../../themeBranding'
+import { resolveThemeLoaderIcons } from '../../themeLoaderIcons'
+import { useOptionalTheme } from '../../hooks/useTheme'
 import ErrorBoundary from '../../components/ErrorBoundary'
 import { useLanguageGeneration } from '../../i18n/useLanguageGeneration'
 type StopState = 'idle' | 'soft_pending' | 'killing'
@@ -89,22 +91,25 @@ function useThemeSlug(): string {
   return slug
 }
 
-/** Resolve what the footer should show while a turn runs. A theme may replace the
- *  whole loader, or just the artwork the default carousel cycles through:
- *    1. `loader`      — the theme's own component, rendered instead of everything
- *    2. `loaderIcons` — the stock carousel, cycling the theme's artwork
- *    3. the default pool (the mascot poses)
- *  An empty registered pool is ignored rather than rendering nothing. */
-export function resolveLoader(slug: string):
+/** Resolve what the footer should show while a turn runs. A compiled theme may
+ *  replace the whole loader; compiled and installed themes may select artwork:
+ *    1. `loader`               — trusted compiled component
+ *    2. manifest `loaderIcons` — stock symbols selected by an installed pack
+ *    3. compiled `loaderIcons` — trusted compiled artwork
+ *    4. the default pool (the mascot poses)
+ *  Invalid or empty pools are ignored rather than rendering nothing. */
+export function resolveLoader(slug: string, manifestIcons?: readonly string[]):
   | { kind: 'custom'; Component: ComponentType }
   | { kind: 'icons'; icons: ComponentType[] } {
   const branding = getThemeBranding(slug)
   if (branding?.loader) return { kind: 'custom', Component: branding.loader }
-  return { kind: 'icons', icons: resolveLoaderIcons(slug) }
+  return { kind: 'icons', icons: resolveLoaderIcons(slug, manifestIcons) }
 }
 
 /** The icon pool for the default carousel under a given theme. */
-export function resolveLoaderIcons(slug: string): ComponentType[] {
+export function resolveLoaderIcons(slug: string, manifestIcons?: readonly string[]): ComponentType[] {
+  const installed = resolveThemeLoaderIcons(manifestIcons)
+  if (installed.length > 0) return installed
   const registered = getThemeBranding(slug)?.loaderIcons
   if (registered && registered.length > 0) return registered
   return DEFAULT_ICONS
@@ -214,7 +219,12 @@ export function useStreamIdle(tick: number, active: boolean, ms: number = STREAM
 
 const ChatFooter = memo(function ChatFooter({ running, stopping, state, lastRole, regenerating, stopState, streamTick = 0 }: { running: boolean; stopping: boolean; state: string; lastRole: string; regenerating?: boolean; stopState?: StopState; streamTick?: number }) {
   useLanguageGeneration() // memo() bails out of the provider-level repaint; subscribe directly
-  const loader = resolveLoader(useThemeSlug())
+  const slug = useThemeSlug()
+  const themeState = useOptionalTheme()
+  const installedTheme = slug.startsWith('custom-')
+    ? themeState?.customThemeDataMap.get(slug.slice('custom-'.length))
+    : undefined
+  const loader = resolveLoader(slug, installedTheme?.assets?.loaderIcons)
   // Text is only ACTIVELY streaming while the slot says so AND chunks keep
   // arriving. `lastRole` alone cannot tell the two apart: the trailing
   // 'streaming' message is deliberately left unfinalized across a whole tool

--- a/website/src/test/ChatFooter.test.tsx
+++ b/website/src/test/ChatFooter.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act } from '@testing-library/react'
 import ChatFooter, { pickDistinct, resolveLoader, resolveLoaderIcons, SwapCarousel, STREAM_IDLE_MS } from '../pages/chat/ChatFooter'
 import { GHOST_POSE_ICONS, GHOST_POSE_URLS } from '../components/GhostPoses'
 import { registerThemeBranding } from '../themeBranding'
+import { THEME_LOADER_ICONS } from '../themeLoaderIcons'
 
 const base = { running: false, stopping: false, state: '', lastRole: '', avatar: '/logo.png', botName: 'KiroCrew' }
 
@@ -158,6 +159,27 @@ describe('loader — theme seam', () => {
     const icons = [Mark, Mark, Mark, Mark, Mark]
     registerThemeBranding({ 'seam-loader-theme': { loaderIcons: icons } })
     expect(resolveLoaderIcons('seam-loader-theme')).toBe(icons)
+  })
+
+  it('resolves stock symbols selected by an installed theme manifest', () => {
+    const names = ['star', 'sparkles', 'moon', 'cloud'] as const
+    expect(resolveLoaderIcons('custom-pearce-crt', names)).toEqual(
+      names.map(name => THEME_LOADER_ICONS[name]),
+    )
+  })
+
+  it.each([
+    ['unknown symbol', ['star', 'sparkles', 'moon', 'unknown']],
+    ['too few symbols', ['star', 'sparkles', 'moon']],
+    ['duplicate symbols', ['star', 'sparkles', 'moon', 'star']],
+  ])('falls back safely for manifest pools with %s', (_case, names) => {
+    expect(resolveLoaderIcons('custom-broken', names)).toBe(GHOST_POSE_ICONS)
+  })
+
+  it('keeps a trusted compiled custom loader ahead of manifest symbols', () => {
+    registerThemeBranding({ 'seam-manifest-precedence': { loader: CustomLoader } })
+    const got = resolveLoader('seam-manifest-precedence', ['star', 'sparkles', 'moon', 'cloud'])
+    expect(got.kind).toBe('custom')
   })
 
   it('renders a registered theme’s icons in the footer', () => {

--- a/website/src/themeLoaderIcons.ts
+++ b/website/src/themeLoaderIcons.ts
@@ -1,0 +1,46 @@
+import {
+  Cloud,
+  Flower2,
+  Heart,
+  Moon,
+  Sparkles,
+  Star,
+  Sun,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react'
+
+/**
+ * Stock artwork an installed theme may request for the chat loader.
+ *
+ * Theme manifests carry names, never components or SVG markup. Keeping this a
+ * closed map preserves the installed-theme trust boundary while letting packs
+ * reuse Kiro Crew's existing carousel animation.
+ */
+export const THEME_LOADER_ICONS = {
+  cloud: Cloud,
+  flower: Flower2,
+  heart: Heart,
+  moon: Moon,
+  sparkles: Sparkles,
+  star: Star,
+  sun: Sun,
+  zap: Zap,
+} satisfies Record<string, LucideIcon>
+
+export type ThemeLoaderIconName = keyof typeof THEME_LOADER_ICONS
+
+const MIN_THEME_LOADER_ICONS = 4
+const MAX_THEME_LOADER_ICONS = Object.keys(THEME_LOADER_ICONS).length
+
+/** Resolve a complete validated manifest pool, or fail closed to the caller's default. */
+export function resolveThemeLoaderIcons(names?: readonly string[]): LucideIcon[] {
+  if (
+    !names
+    || names.length < MIN_THEME_LOADER_ICONS
+    || names.length > MAX_THEME_LOADER_ICONS
+    || new Set(names).size !== names.length
+  ) return []
+  const icons = names.map(name => THEME_LOADER_ICONS[name as ThemeLoaderIconName])
+  return icons.every((icon): icon is LucideIcon => !!icon) ? icons : []
+}


### PR DESCRIPTION
## Problem / Motivation

Compiled themes can customize the chat loading indicator through `registerThemeBranding()`, but installed `theme.json` packs cannot use that TypeScript registration seam.

An installed theme can configure most of the dashboard experience while still being forced to inherit the default Kiro ghost poses. Theme authors currently have no safe, portable way to keep the existing carousel and change only its symbols.

## Why it matters

Installed themes are the user-facing distribution format. They can be installed from a local folder or GitHub without rebuilding Kiro Crew.

Loader customization should work in that format without allowing theme packs to inject React components, SVG markup, or executable code.

## What changed (motivation → approach → change)

The existing carousel already handles animation, icon sizing, distinct sampling, pool changes, and reduced motion. This change keeps that implementation and adds a declarative installed-pack input.

Level 1 and Level 2 manifests may now declare:

```json
"loaderIcons": ["star", "sparkles", "moon", "cloud"]
```

The backend:

- accepts 4 to 8 unique names from a closed stock-symbol allowlist;
- rejects the field on Level 0 packs;
- rejects unknown names, duplicates, non-string values, and invalid list sizes;
- includes validated names in the installed theme asset descriptor.

The frontend:

- maps manifest names to bundled Lucide components;
- passes the active installed theme's symbols into the existing carousel;
- keeps trusted compiled `loader` components at the highest precedence;
- fails closed to compiled artwork or Kiro ghost poses for malformed descriptors;
- keeps `ChatFooter` usable outside `ThemeProvider` for isolated tests.

The branch now builds on upstream #7722, which owns the `ArtifactsPage` memoization cleanup that restored the frontend lint warning budget, and #7761, which repaired the inherited redactor-census baseline.

The authoring skill, frontend contract, and themes system specification document the new field and trust boundary.

## Tests

Backend coverage verifies valid Level 1 declarations, Level 0 rejection, type and size bounds, unknown-name and duplicate rejection, backend/frontend allowlist parity, and propagation through `GET /api/themes/{slug}`.

Frontend coverage verifies stock-symbol resolution, malformed-descriptor fallback, compiled custom-loader precedence, and existing carousel/turn-state behavior.

Validation completed locally:

- 78,809 backend tests passed in the full profile run; remaining local failures reproduce host/upstream baseline conditions involving `/local/home` ownership, sensitive-path classification, long Unix-socket paths, and unrelated existing tests
- full website coverage suite passed
- 46 ChatFooter tests passed
- exact CI frontend lint passed with 597 warnings against the 603-warning ceiling
- the formerly failing redactor-census regression and both session-control tests from the Windows flake pass on current main
- TypeScript, ESLint, isort, flake8, mypy, production build, docs lint, brand, formatting, subprocess-encoding, i18n, and theme contract gates passed
- local and server GPT/Opus review found no feature defects on predecessor heads; `git range-diff` confirms current commit `e83a4e24a92bfaa4eb6351e3204d150cd042b0ec` is feature-patch-equivalent to `1bf22c2132bbc1c272a9fd9974cd3666ad7bf4ee` and builds on current main

## Manual verification

Verified through the real Settings flow in an isolated Kiro Crew pod:

1. Installed a Level 1 theme from a local folder.
2. Confirmed the installer accepted and selected it.
3. Started a real agent turn that remained active for five seconds.
4. Confirmed the footer rendered moon, zap, flower, and heart symbols with no ghost-pose artwork.
5. Removed the pod and verified zero residual pod state.

## Screenshots / video

![Installed theme symbols in the running chat loader](https://github.com/Pearcekieser/KiroCrew/raw/6ee12459c5f7c7ec462638f586bd6e9f9cb35d92/loader-symbols.png)

[Watch the real-turn loader recording](https://github.com/Pearcekieser/KiroCrew/raw/6ee12459c5f7c7ec462638f586bd6e9f9cb35d92/loader-symbols.webm)

Evidence was captured from the isolated worktree pod with a real server and agent turn, then published on an immutable evidence-only ref. No fixture or binary evidence is included in the feature commit.

## Related Issues

Related prior work: #894, #952, #5549.

Fixes #7632

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff