### PR TITLE
fix(readers): bound the record reads over agent-writable trees

### DIFF
--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -51,6 +51,7 @@ from kiro_crew.dashboard.handlers.usage import (
 )
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE
 from kiro_crew.hooks import validate_file_path
+from kiro_crew.jsonl_util import bounded_records
 from kiro_crew.metrics.provider import TELEMETRY_ENV_VAR, env_pin, otlp_egress_active
 from kiro_crew.metrics.schema import RESOURCE_ATTR_PROCESS_START_TIME
 from kiro_crew.metrics.turns import TURN_COST_METRIC, TURN_CREDITS_METRIC, TURN_METRIC
@@ -614,8 +615,8 @@ def _iter_export_cycles(
         shard_day = "-".join(stem_parts[1:4])
         shard_pid = stem_parts[4] if len(stem_parts) > 4 and stem_parts[4].isdigit() else ""
         try:
-            with p.open(encoding="utf-8") as fh:
-                for line in fh:
+            with p.open("rb") as fh:
+                for line in bounded_records(fh, p, label="telemetry"):
                     try:
                         obj = json.loads(line)
                     except ValueError:

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -21,6 +21,7 @@ from kiro_crew.acp.types import TurnUsage
 from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.context_blocks import USER_LABEL
 from kiro_crew.hooks import validate_file_path
+from kiro_crew.jsonl_util import bounded_records
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.messaging.link import telemetry_channel_of
 from kiro_crew.metrics.turns import (
@@ -199,8 +200,8 @@ def slot_spend(days: int = SPEND_WINDOW_DAYS) -> dict[str, dict[str, float]]:
 
     for path in paths:
         try:
-            with path.open() as fh:
-                for line in fh:
+            with path.open("rb") as fh:
+                for line in bounded_records(fh, path, label="usage"):
                     try:
                         obj = json.loads(line)
                     except ValueError:
@@ -406,8 +407,8 @@ def context_occupancy(days: int = 14) -> dict[str, Any]:
 
     for shard_path in shard_paths:
         try:
-            with shard_path.open() as fh:
-                for line in fh:
+            with shard_path.open("rb") as fh:
+                for line in bounded_records(fh, shard_path, label="usage"):
                     try:
                         obj = json.loads(line)
                     except ValueError:
@@ -624,8 +625,8 @@ def slot_turn_usage(
     cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).timestamp()
     for shard_path in _shards_in_window(days):
         try:
-            with shard_path.open() as fh:
-                for line in fh:
+            with shard_path.open("rb") as fh:
+                for line in bounded_records(fh, shard_path, label="usage"):
                     try:
                         obj = json.loads(line)
                     except ValueError:
@@ -686,8 +687,8 @@ def context_trace(slot: str, days: int = 14) -> dict[str, Any]:
     totals: dict[str, int] = {}
     for shard_path in _shards_in_window(days):
         try:
-            with shard_path.open() as fh:
-                for line in fh:
+            with shard_path.open("rb") as fh:
+                for line in bounded_records(fh, shard_path, label="usage"):
                     try:
                         obj = json.loads(line)
                     except ValueError:
@@ -807,8 +808,8 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
 
     for shard_path in shard_paths:
         try:
-            with shard_path.open() as fh:
-                for line in fh:
+            with shard_path.open("rb") as fh:
+                for line in bounded_records(fh, shard_path, label="usage"):
                     try:
                         obj = json.loads(line)
                     except ValueError:
@@ -1631,8 +1632,8 @@ def _parse_token_history() -> dict[str, Any]:
 
     for shard_path in shard_paths:
         try:
-            with shard_path.open() as fh:
-                for line in fh:
+            with shard_path.open("rb") as fh:
+                for line in bounded_records(fh, shard_path, label="usage"):
                     try:
                         obj = json.loads(line)
                     except ValueError:
@@ -1827,8 +1828,8 @@ def _parse_sessions() -> dict:
         msgs = 0
         tools = 0
         try:
-            with resolved.open() as fh:
-                for line in fh:
+            with resolved.open("rb") as fh:
+                for line in bounded_records(fh, resolved, label="usage.sessions"):
                     try:
                         obj = json.loads(line)
                     except ValueError:

--- a/src/kiro_crew/events/backfill.py
+++ b/src/kiro_crew/events/backfill.py
@@ -49,6 +49,7 @@ from kiro_crew.events.kinds import (
     TurnUsage,
 )
 from kiro_crew.history import transcript_stems
+from kiro_crew.jsonl_util import bounded_records
 from kiro_crew.platform_compat import is_link_or_junction
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -140,8 +141,8 @@ def _as_int(value: object) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
-def _open_no_follow(path: Path) -> "io.TextIOWrapper":
-    """Open *path* for text reading, refusing symlinks.
+def _no_follow_fd(path: Path) -> int:
+    """Open *path* read-only refusing symlinks, and return the raw fd.
 
     Every store file this validator reads is attacker-influenceable in
     principle (``--home`` may point anywhere), and parsed field values
@@ -152,12 +153,29 @@ def _open_no_follow(path: Path) -> "io.TextIOWrapper":
     failure. On platforms without O_NOFOLLOW the flag is 0 and the lstat
     guard below still refuses the link (TOCTOU-tolerant: worst case reads a
     file swapped in at the same path, never a followed link on POSIX).
+
+    The two wrappers below differ only in the layer they put on the fd, so
+    the guard is stated once here and cannot drift between them.
     """
     if is_link_or_junction(path):
         raise OSError(f"refusing symlinked store file: {path}")
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    fd = os.open(path, flags)
-    return io.TextIOWrapper(io.FileIO(fd, "r"), encoding="utf-8", errors="replace")
+    return os.open(path, flags)
+
+
+def _open_no_follow(path: Path) -> "io.TextIOWrapper":
+    """Open *path* for TEXT reading, refusing symlinks (see :func:`_no_follow_fd`)."""
+    return io.TextIOWrapper(io.FileIO(_no_follow_fd(path), "r"), encoding="utf-8", errors="replace")
+
+
+def _open_binary_no_follow(path: Path) -> "io.BufferedReader":
+    """Open *path* for BINARY reading, refusing symlinks (see :func:`_no_follow_fd`).
+
+    The record readers in :mod:`kiro_crew.jsonl_util` require a binary handle
+    so that their cap is a byte bound rather than a code-point count, and
+    buffered so one ``readline`` is not one syscall.
+    """
+    return io.BufferedReader(io.FileIO(_no_follow_fd(path), "r"))
 
 
 def _read_json_no_follow(path: Path) -> object:
@@ -246,8 +264,8 @@ def backfill_transcripts(home: Path, limit: int | None = None) -> SourceReport:
     for path, stem in paths:
         key = _resolve_session_key(stem, index)
         try:
-            with _open_no_follow(path) as fh:
-                for line in fh:
+            with _open_binary_no_follow(path) as fh:
+                for line in bounded_records(fh, path, label="backfill"):
                     if limit is not None and len(rep.events) >= limit:
                         return rep
                     line = line.strip()
@@ -494,8 +512,8 @@ def backfill_usage(home: Path, limit: int | None = None) -> SourceReport:
         return rep
     for path in sorted(shard_dir.glob("*.jsonl")):
         try:
-            with _open_no_follow(path) as fh:
-                for line in fh:
+            with _open_binary_no_follow(path) as fh:
+                for line in bounded_records(fh, path, label="backfill"):
                     if limit is not None and len(rep.events) >= limit:
                         return rep
                     line = line.strip()

--- a/src/kiro_crew/history_projection.py
+++ b/src/kiro_crew/history_projection.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Literal, overload
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.history_cache import _FileChangeCacheEntry
+from kiro_crew.jsonl_util import bounded_raw_records
 
 if TYPE_CHECKING:
     from kiro_crew.history import ConversationLog
@@ -203,7 +204,7 @@ class TranscriptReadProjection:
 
         messages: list[dict] = []
         with open(path, "rb") as handle:
-            for raw in handle:
+            for raw in bounded_raw_records(handle, path, label="history_projection"):
                 if b'"file_changes"' not in raw:
                     continue
                 try:

--- a/src/kiro_crew/history_search.py
+++ b/src/kiro_crew/history_search.py
@@ -17,6 +17,8 @@ from collections.abc import Iterator
 from datetime import datetime
 from typing import TYPE_CHECKING, NamedTuple
 
+from kiro_crew.jsonl_util import bounded_records
+
 if TYPE_CHECKING:
     from kiro_crew.history import ConversationLog
 
@@ -1207,8 +1209,9 @@ class SessionCatalogProjection:
         not read" from "no text", and that distinction is load-bearing (a read
         failure must not be cached).
         """
-        with open(self._log._path(key), encoding="utf-8") as handle:
-            for line in handle:
+        path = self._log._path(key)
+        with open(path, "rb") as handle:
+            for line in bounded_records(handle, path, label="history_search"):
                 line = line.strip()
                 if not line:
                     continue

--- a/src/kiro_crew/jsonl_util.py
+++ b/src/kiro_crew/jsonl_util.py
@@ -1,4 +1,4 @@
-"""Shared bounding helper for append-only JSONL logs.
+"""Shared bounding helpers for append-only JSONL logs — on write and on read.
 
 Several long-lived JSONL logs (the MCP stub's fallback audit log, the
 subagents' slow-command log, per-member activity logs) grow one appended
@@ -7,17 +7,430 @@ needs the same bound: once the live file reaches its cap, rename it to a
 single ``.1`` generation — O(1), no whole-file read — so total disk stays
 at roughly twice the cap while one generation of history is kept.
 
-This module owns only the rotation step. Each call site keeps its own
-append, record shape, size cap, and error contract, because those differ
-per log; what they share is exactly the rotate-by-rename.
+:func:`rotate_jsonl_at` owns that rotation step. Each call site keeps its
+own append, record shape, size cap, and error contract, because those
+differ per log; what they share is exactly the rotate-by-rename.
+
+:func:`bounded_records` and :func:`strict_records` own the matching bound on
+the READ side. A file's total size being rotated does not bound one RECORD:
+``for line in handle`` asks for bytes up to the next newline, so a single
+crafted newline-free line is one allocation the size of the whole file, and
+every tree these readers touch is agent-writable. The two functions differ
+only in the posture an over-cap record takes, which is a per-call-site
+judgement and the reason both exist:
+
+* :func:`bounded_records` SKIPS the record. Correct where the read is
+  read-only and degradable — the caller already tolerates a malformed
+  record, and dropping one costs a count, not durable state.
+* :func:`strict_records` ABORTS the read. Correct where the parsed output
+  feeds a rewrite or any other durable decision, because a silently
+  skipped record there loses or duplicates data.
+
+The two postures differ in exactly one more thing than the over-cap branch,
+and that is the point rather than an accident. A skip reader only has to be
+good enough to count with, so it decodes with ``errors="replace"``. A strict
+reader's caller PERSISTS what it read, which that is not good enough for: a
+replacement character would be written back in place of the original bytes.
+The strict readers therefore make one guarantee — a record they yield is
+exactly the record on disk — and raise :class:`UnreadableRecord` for every
+other outcome.
+
+Record BOUNDARIES are shared, and are the universal-newline set: ``\\n``,
+``\\r\\n`` and a bare ``\\r`` all end a record, matching the text-mode reads
+these callers were converted from. Splitting only on ``\\n`` would glue a
+CR-delimited pair into one line that parses as neither record, which costs a
+skip reader a count but costs a strict caller its correctness — a dedupe probe
+stops seeing a prior entry.
+
+Each has an undecoded twin — :func:`bounded_raw_records` and
+:func:`strict_raw_records` — yielding ``bytes``. The bounded twin has one
+caller, which already iterated a binary handle and prefilters on bytes before
+parsing. The strict twin has no external caller today: it is what
+:func:`strict_records` is built on, and the site that wanted raw strict bytes
+directly — the snapshot notification merge, which copies records into another
+file verbatim — is deliberately NOT converted here. That site needs the reader
+to guarantee something the others do not, namely that what it hands back is
+valid for the DESTINATION file and not merely a faithful copy of the source, so
+it is being done separately rather than inferred from this reader's contract.
+
+:func:`kiro_crew.session_storage._manifest_records` is a third reader and
+deliberately stays separate: it needs ``str.splitlines`` boundaries, since
+it replaced a whole-file ``splitlines`` and a manifest split on any unicode
+line boundary must keep parsing as it always did. The two readers here split
+on the universal-newline set only, which is what the handle iteration they
+replace
+used.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import re
+from collections.abc import Iterator
 from pathlib import Path
+from typing import IO
 
 from kiro_crew import platform_compat
+
+logger = logging.getLogger(__name__)
+
+# Either record terminator, so one scan finds whichever comes first. See
+# _boundary_end for why two bytes.find() calls are not equivalent.
+_BOUNDARY_RE = re.compile(rb"[\r\n]")
+
+# Longest record these readers will materialise, in BYTES (terminator excluded:
+# the threshold applies to the record without its newline, so a cap-length record
+# plus its terminator is accepted). Peak held is a carried tail plus one read and
+# is flat in file size; MEASURED at 3.03x this value, which is parity with the
+# reader in session_digest that this generalises. An earlier comment here said
+# "roughly TWICE" and that was never true of either -- see _frames.
+#
+# The bound is in bytes, not characters, and callers open their file binary for
+# that reason: a character cap is not a memory bound, because one astral code
+# point is four bytes of `str` under PEP 393, so a 128 MiB CHARACTER cap admits
+# half a gibibyte of resident text. Reading N bytes bounds the decoded `str` at a
+# small constant multiple of N -- NOT at N exactly, because `errors="replace"`
+# turns each undecodable byte into a U+FFFD costing 2 or 4 bytes of `str`
+# depending on the widest code point in the record. That is still a bound flat in
+# FILE size, which is the property the cap exists for, and it is why the peak is
+# a constant multiple of this value rather than equal to it.
+#
+# One cap serves every caller, and it is sized for the LARGEST record shape any
+# of them reads: a session transcript record, which carries a whole conversation
+# turn. Its legitimate ceiling is ~90 MB -- image_artifacts'
+# ``MAX_IMAGE_BYTES_PER_MESSAGE`` (64 MiB) base64-expands to ~85 MB, plus text --
+# and the largest observed on a live install (30,351 kiro-cli logs, 27 GB) is
+# 77,920,032 bytes, itself load-bearing: it carries an image content item, and the
+# largest ``Prompt`` record (turns and first_message) is 56,203,168 bytes. 128 MiB
+# is the smallest round value that clears that ceiling with margin.
+#
+# The other shapes read through here -- token-usage rows, telemetry export cycles,
+# notification records, member activity entries (~150 bytes), stub fallback rows,
+# cost samples -- are orders of magnitude smaller, so this cap never undercounts
+# them either. A per-format cap would bound each tighter, but the memory that
+# matters is the peak of one record, and a cap set below a format's real ceiling
+# buys nothing while risking a silent undercount of legitimate data. This is why
+# the cap is NOT session_storage's ``_MANIFEST_RECORD_CAP`` (8 MiB): a manifest
+# record is a header or one session's file list, and 8 MiB here would silently
+# truncate the biggest real sessions.
+RECORD_CAP = 128 * 1024 * 1024
+
+
+class UnreadableRecord(Exception):
+    """A record cannot be delivered INTACT, so the file cannot be read completely.
+
+    Raised only by the strict readers. The abort posture exists because its
+    callers write based on what they parsed, so a record they cannot reproduce
+    faithfully is not something to paper over -- every way of failing to
+    deliver one intact has to reach the caller, not just an over-cap one.
+    Callers map this to their own fail-closed posture and must not treat it
+    as "no more records".
+    """
+
+
+class OversizedRecord(UnreadableRecord):
+    """A record exceeded the cap, so it was never materialised."""
+
+
+class UndecodableRecord(UnreadableRecord):
+    """A record is not valid UTF-8, so decoding it would alter its bytes.
+
+    The skip readers decode with ``errors="replace"``, which is right for a
+    caller that only counts or displays: one mangled character costs it a
+    record's contribution. It is wrong for a caller that writes what it read,
+    because the replacement is what gets persisted -- ``compact_cost_log``
+    would ``os.replace`` the log with U+FFFD substituted for the original
+    bytes, and a dedupe key built from a replaced record no longer matches the
+    record it came from.
+    """
+
+
+def _body_len(piece: bytes) -> int:
+    """Length of *piece* without its record terminator.
+
+    The cap bounds a record's CONTENT, so the terminator must not count against
+    it -- otherwise a record whose body is exactly at the cap is refused for
+    carrying the delimiter that makes it a record at all, and whether it is
+    refused depends on which terminator it happens to use.
+    """
+    if piece.endswith(b"\r\n"):
+        return len(piece) - 2
+    if piece.endswith((b"\n", b"\r")):
+        return len(piece) - 1
+    return len(piece)
+
+
+def _boundary_end(buf: bytes, start: int = 0) -> int | None:
+    """Index just past the first record terminator at or after *start*, else None.
+
+    Terminators are the universal-newline set -- ``\\n``, ``\\r\\n`` and a bare
+    ``\\r`` -- because that is what the TEXT-mode reads these callers were
+    converted from treated as a record end.
+
+    *start* lets the caller walk one buffer without re-slicing it. Searching
+    from an offset rather than trimming the front is what keeps a chunk holding
+    many ``\\r``-delimited records linear: trimming copies the whole remaining
+    tail per record, which is quadratic in the record count and is itself a
+    cheap denial-of-service on an agent-writable file.
+
+    One regex scan finds whichever terminator comes first. Two separate
+    ``bytes.find`` calls would NOT do: a file delimited only by ``\\r`` has no
+    ``\\n`` until its very end, so searching for ``\\n`` walks the whole
+    remaining buffer on every record and reintroduces the same quadratic cost
+    the offset was added to remove. Measured before and after on a
+    40,000-record file: 0.086s of superlinear growth against 0.012s flat.
+
+    A ``\\r`` that is the LAST byte is deliberately not treated as a terminator:
+    it may be the first half of a ``\\r\\n`` whose ``\\n`` is in the next read,
+    and splitting there would invent a boundary and then leave a stray ``\\n``
+    looking like an empty record. The caller waits for more bytes instead, and
+    at EOF yields the remainder whole -- so a file genuinely ending in a bare
+    ``\\r`` still produces exactly one final record.
+    """
+    match = _BOUNDARY_RE.search(buf, start)
+    if match is None:
+        return None
+    at = match.start()
+    if buf[at : at + 1] != b"\r":
+        return at + 1
+    if at + 1 == len(buf):
+        return None  # may be the \r of a \r\n not read yet
+    return at + 2 if buf[at + 1 : at + 2] == b"\n" else at + 1
+
+
+class _Oversized:
+    """Marker for one record whose body exceeded the cap.
+
+    A distinct type rather than ``None`` so that a policy layer cannot confuse
+    "no record" with "a record I refused to materialise".
+    """
+
+    __slots__ = ()
+
+
+_OVERSIZED = _Oversized()
+
+
+def _frames(handle: IO[bytes], cap: int) -> Iterator[bytes | _Oversized]:
+    """Frame *handle* into complete records, or :data:`_OVERSIZED` for one too long.
+
+    FRAMING ONLY, and that separation is the point. This function owns the
+    buffer, the record boundaries, and the cap as a memory bound; it decides
+    nothing about what an over-cap record MEANS. The policy layers above it
+    decide skip-versus-abort and never see a buffer, so a framing subtlety
+    cannot turn into a policy bug.
+
+    That split is a direct response to three review findings on this pull
+    request, which looked like three bugs and were one entanglement -- framing
+    state and policy state being read off the same raw buffer. A trailing
+    ``\\r`` must be HELD rather than split (its ``\\n`` may be in the next
+    read), and every one of the three was that held byte interacting with a
+    policy decision: counted as body, so an at-cap record was refused; carried
+    into a read that completed it, so an over-cap record was admitted; and
+    erased when dropping, so the next record's terminator ended the drop and a
+    valid record vanished. None of those is expressible here, because the only
+    things that leave this function are a whole record and a marker.
+
+    Two properties the callers depend on:
+
+    - A record's body is measured when the record is COMPLETE, not per read. A
+      record ending inside one read may have started in an earlier one, so a
+      bounded ``readline`` bounds a read, not a record.
+    - An over-cap record is dropped in full, including its terminator, so the
+      next thing yielded always starts on a real boundary. Otherwise a hostile
+      line's tail could forge a record that framing had just reported as
+      dropped.
+
+    Peak memory is MEASURED, not reasoned about, because an earlier version of
+    this docstring claimed "roughly twice the cap" and that was simply wrong --
+    of this reader and of the one it generalises. With ``tracemalloc`` at a 4 MiB
+    cap: main's ``session_digest._bounded_lines`` peaks at 3.03x the cap, and so
+    does this reader. It reached 4.03x while each read asked for a full ``cap``
+    regardless of what the carried tail already held, which added a whole cap on
+    top of a buffer that could already be that large; reads are now bounded by
+    the remainder instead. The floor is a carried tail plus one read, and it is
+    flat in file size, which is the property that actually matters.
+
+    There is deliberately no ``drain`` switch. A caller that aborts simply
+    stops consuming this generator, and generators are lazy, so the work of
+    discarding a multi-GB tail is never done for it. That is the same guarantee
+    the old explicit flag gave, with no flag to pass or get wrong.
+    """
+    buf = b""
+    # True while discarding the remainder of an over-cap record, whose own
+    # terminator is what ends the discard.
+    dropping = False
+    while True:
+        # Read only what this record has left, not a full cap every time. A
+        # carried tail plus a full-cap read is what made the peak 4x the cap
+        # instead of the 3x main pays; bounding by the remainder restores parity.
+        # cap + 2 is the FLOOR, not a tidy constant: a legal at-cap record ending
+        # CRLF is cap + 2 bytes, so a buffer that could only ever hold cap + 1
+        # could not assemble one and would refuse it -- the round-7 bug exactly.
+        # The max(2, ...) keeps a read able to see a whole CRLF once the buffer is
+        # already full, so a \r there is still resolvable rather than deadlocked.
+        chunk = handle.readline(max(2, cap + 2 - len(buf)))
+        if not chunk:
+            break
+        buf += chunk
+        # Walk by offset and slice the remainder ONCE at the end of the chunk:
+        # re-slicing per record copies the whole tail each time, which is
+        # quadratic in the number of records a single read holds.
+        start = 0
+        while (idx := _boundary_end(buf, start)) is not None:
+            piece, start = buf[start:idx], idx
+            if dropping:
+                dropping = False  # this piece's terminator ended the dropped record
+                continue
+            if _body_len(piece) > cap:
+                # Already terminated, so there is nothing left to discard and
+                # `dropping` must stay clear -- the next piece is a real record.
+                yield _OVERSIZED
+                continue
+            yield piece
+        buf = buf[start:]
+        # A trailing \r is a pending TERMINATOR half, not body: it was left
+        # unsplit above in case its \n is in the next read, so counting it would
+        # make an exactly-at-cap CRLF record look over-cap.
+        pending_cr = buf.endswith(b"\r")
+        if len(buf) - pending_cr > cap:
+            if not dropping:
+                yield _OVERSIZED
+                dropping = True
+            # KEEP a pending \r. It is the dropped record's own terminator, and
+            # dropping it would leave the NEXT record's terminator to end the
+            # discard -- silently consuming a valid record.
+            buf = b"\r" if pending_cr else b""
+    if buf and not dropping:
+        # A crash mid-append leaves a final record with no terminator. Its BODY
+        # is within the cap because the per-read check above reported and dropped
+        # any longer tail; the piece itself may be one byte longer, when the file
+        # ends on a bare \r that is a terminator here rather than a pending half.
+        yield buf
+
+
+def _decode(raw: bytes) -> str:
+    """Decode one accepted record.
+
+    Per-record decoding is equivalent to decoding the whole file, because
+    ``\\n`` is never part of a UTF-8 multi-byte sequence — lead and
+    continuation bytes are all >= 0x80 — so no sequence can straddle a
+    record boundary and be replaced differently than it would have been.
+    """
+    return raw.decode("utf-8", errors="replace")
+
+
+def bounded_raw_records(
+    handle: IO[bytes], path: Path, *, cap: int = RECORD_CAP, label: str = "read"
+) -> Iterator[bytes]:
+    """Yield *handle*'s records as raw bytes, SKIPPING any over *cap* bytes.
+
+    The undecoded form of :func:`bounded_records`, for a caller that already
+    iterated a binary handle and prefilters on bytes before parsing. Such a
+    caller gains the bound with no other change; routing it through the
+    decoding variant instead would make it decode every record to run a
+    filter that rejects most of them.
+
+    The skip posture. Use where the read is read-only and degradable: the
+    caller already skips a record it cannot parse, so an over-cap record
+    costs that one record's contribution and nothing durable. Where the
+    output instead feeds a rewrite or a durable decision, use
+    :func:`strict_records`.
+
+    *handle* is BINARY so the cap is a memory bound rather than a code-point
+    count (see :data:`RECORD_CAP`). Record boundaries are the universal-newline
+    set -- ``\\n``, ``\\r\\n`` and a bare ``\\r`` -- which is exactly what the
+    text-mode ``for line in handle`` iteration this replaces split on, so
+    moving to a binary handle changes where records begin and end not at all
+    (see :func:`_boundary_end`). A record containing an exotic boundary
+    ``str.splitlines`` would honour (``\\u2028``, ``\\x1c``, ...) stays ONE
+    record and still parses, matching the iteration rather than
+    ``splitlines`` -- which is the difference from
+    :func:`kiro_crew.session_storage._manifest_records`, whose caller needs the
+    splitlines shape.
+
+    An over-cap record is dropped in full by the framing layer, including its
+    terminator, so a hostile file costs time proportional to its length and
+    memory proportional to the cap. *label* names the caller in the one debug
+    line emitted when anything was skipped; that line runs only if the generator
+    is driven to exhaustion, and a caller that stops early forfeits it
+    knowingly.
+    """
+    oversized = 0
+    for frame in _frames(handle, cap):
+        if isinstance(frame, _Oversized):
+            oversized += 1
+            continue
+        yield frame
+    if oversized:
+        # %r: *path* names a file in an agent-writable tree, and several
+        # callers discover their inputs with iterdir()/glob(), so a planted
+        # name can embed a newline. The repr keeps one log record from
+        # forging others.
+        logger.debug("%s: skipped %d record(s) over %d bytes in %r", label, oversized, cap, path)
+
+
+def bounded_records(
+    handle: IO[bytes], path: Path, *, cap: int = RECORD_CAP, label: str = "read"
+) -> Iterator[str]:
+    """Yield *handle*'s records decoded, SKIPPING any over *cap* bytes.
+
+    :func:`bounded_raw_records` plus :func:`_decode`, and the form almost
+    every caller wants: it replaces a text-mode ``for line in handle``
+    without touching the loop body. See that function for the posture,
+    boundary and cap properties they share.
+    """
+    for raw in bounded_raw_records(handle, path, cap=cap, label=label):
+        yield _decode(raw)
+
+
+def strict_raw_records(handle: IO[bytes], path: Path, *, cap: int = RECORD_CAP) -> Iterator[bytes]:
+    """Yield *handle*'s records as raw bytes, raising on any it cannot deliver intact.
+
+    The abort posture, undecoded. Use where the record must survive
+    byte-for-byte: a reader that copies records into another file cannot go
+    through a lossy ``errors="replace"`` decode and re-encode, which would
+    rewrite an undecodable byte as U+FFFD.
+
+    Raises :class:`OversizedRecord` past *cap*, which is
+    :class:`UnreadableRecord` -- catch that, so a future refusal reason cannot
+    leak past this caller. Peak held is measured at 3.03x the cap -- a carried
+    tail plus one read, flat in file size -- and an over-cap record's tail is
+    NOT walked: raising abandons the framing generator, and because generators
+    are lazy the discard it would have done next simply never runs. So the
+    caller does not pay a multi-GB traversal for a read it is giving up on --
+    the cost the cap exists to deny.
+    """
+    for frame in _frames(handle, cap):
+        if isinstance(frame, _Oversized):
+            raise OversizedRecord(f"record over {cap} bytes in {path!r}")
+        yield frame
+
+
+def strict_records(handle: IO[bytes], path: Path, *, cap: int = RECORD_CAP) -> Iterator[str]:
+    """Yield *handle*'s records decoded STRICTLY, raising on any it cannot deliver intact.
+
+    The abort posture. Use where the parsed output feeds a rewrite or another
+    durable decision: skipping a record there would silently drop it from
+    what gets written back, or hide it from a dedupe probe so a duplicate
+    is appended.
+
+    Unlike :func:`bounded_records` this decodes with ``errors="strict"`` and
+    turns a failure into :class:`UndecodableRecord`, because here the
+    replacement character is what the caller PERSISTS rather than a display
+    artefact. With :class:`OversizedRecord` that adds up to one guarantee
+    worth stating plainly: a record this generator yields is exactly the
+    record on disk, and every other outcome stops the read. Catch
+    :class:`UnreadableRecord` to cover both.
+
+    See :func:`strict_raw_records` for the no-drain rationale.
+    """
+    for raw in strict_raw_records(handle, path, cap=cap):
+        try:
+            yield raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise UndecodableRecord(f"record is not valid UTF-8 in {path!r}") from exc
 
 
 def rotate_jsonl_at(path: Path, max_bytes: int) -> None:

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -35,7 +35,7 @@ from typing import Any, NoReturn, Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.executors import configure_default_executor, subprocess_executor
-from kiro_crew.jsonl_util import rotate_jsonl_at
+from kiro_crew.jsonl_util import bounded_records, rotate_jsonl_at
 from kiro_crew.mcp_caller import CallerContext, _parent_pid
 from kiro_crew.mcp_gateway import transport
 from kiro_crew.mcp_gateway.hashing import hash_command, hash_effective_env
@@ -1520,8 +1520,8 @@ def fallback_counts() -> dict[str, Any]:
     live = _fallback_log_path()
     for path in (live.with_suffix(".jsonl.1"), live):
         try:
-            with open(path, "r", encoding="utf-8", errors="replace") as f:
-                for line in f:
+            with open(path, "rb") as f:
+                for line in bounded_records(f, path, label="stub_fallback"):
                     try:
                         rec = json.loads(line)
                     except json.JSONDecodeError:

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -30,7 +30,12 @@ from kiro_crew import platform_compat
 from kiro_crew.artifacts import slugify
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import data_home
-from kiro_crew.jsonl_util import rotate_jsonl_at
+from kiro_crew.jsonl_util import (
+    RECORD_CAP,
+    UnreadableRecord,
+    rotate_jsonl_at,
+    strict_records,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +56,16 @@ ACTIVITY_FILE_NAME = "activity.jsonl"
 # also reads this whole file synchronously on every deduped call, so the
 # cap bounds that read as well as the disk.
 _ACTIVITY_LOG_MAX_BYTES = 1024 * 1024
+
+# Longest single RECORD the reader will materialise. Distinct from the file-size
+# cap above and not implied by it: rotation only fires when the writer next
+# appends, so a crafted newline-free line lands whole before any rotation sees
+# it, and `for line in handle` would then allocate all of it at once. This log is
+# agent-writable and its read feeds an append/suppress decision, so an over-cap
+# record aborts the read (see :func:`_read_activity_checked`) rather than being
+# skipped. Named here so a test can move the dial; real entries are ~150 bytes,
+# so the shared cap has enormous headroom over anything legitimate.
+_RECORD_CAP = RECORD_CAP
 
 #: Crew-slug -> DM-thread binding inside a member's directory.
 DM_FILE_NAME = "dm.json"
@@ -363,15 +378,32 @@ def record_activity(
     try:
         slug = slug_for_name(member)
         path = member_dir(slug)
-        if dedupe_session and any(
-            # Matched on BOTH fields: a colliding slug means one file can hold
-            # two members, so session alone would suppress the wrong entry.
-            # Only participation entries carry `session`, which is also the only
-            # kind deduped — routing decisions are distinct events.
-            r.get("session") == session_key and r.get("member") == member
-            for r in read_activity(slug)
-        ):
-            return False
+        if dedupe_session:
+            prior, complete = _read_activity_checked(slug)
+            if not complete:
+                # Fail closed. An over-cap record was refused, so `prior` is a
+                # prefix of the log and the probe below cannot prove this pair
+                # is absent from the part it could not read. Appending anyway
+                # would risk a duplicate participation entry, which inflates
+                # the counts that drive trigger generation and routing. Not
+                # recording is the same outcome the blanket handler below
+                # already produces for any other read failure, so no caller
+                # learns a new failure mode from this.
+                logger.warning(
+                    "member activity log unreadable in full; not recording %r to avoid a "
+                    "duplicate entry",
+                    member,
+                )
+                return False
+            if any(
+                # Matched on BOTH fields: a colliding slug means one file can hold
+                # two members, so session alone would suppress the wrong entry.
+                # Only participation entries carry `session`, which is also the only
+                # kind deduped — routing decisions are distinct events.
+                r.get("session") == session_key and r.get("member") == member
+                for r in prior
+            ):
+                return False
         path.mkdir(parents=True, exist_ok=True)
         # Newline on BOTH sides. The trailing one is ordinary JSONL framing; the
         # LEADING one is what survives a torn write. A record appended straight
@@ -405,6 +437,22 @@ def record_activity(
 def read_activity(slug: str, limit: int = 0) -> list[dict]:
     """Return a member's activity entries, oldest first.
 
+    The degrading view of :func:`_read_activity_checked`: it drops the
+    completeness flag. A generation stopped by an over-cap record still
+    contributes the entries it read BEFORE that record, so the caller sees a
+    prefix rather than nothing -- correct for a caller that only displays or
+    counts entries. A caller whose output feeds a durable decision must use
+    :func:`_read_activity_checked` and honour the flag, because a prefix is
+    indistinguishable from the whole log without it -- see the
+    ``dedupe_session`` probe in :func:`record_activity`.
+    """
+    rows, _complete = _read_activity_checked(slug, limit)
+    return rows
+
+
+def _read_activity_checked(slug: str, limit: int = 0) -> tuple[list[dict], bool]:
+    """Return a member's activity entries oldest first, and whether they are ALL of them.
+
     Reads the one rotated generation (``.jsonl.1``, see
     :data:`_ACTIVITY_LOG_MAX_BYTES`) before the live file — the same
     two-generation read as the stub fallback log's aggregator — so a
@@ -416,12 +464,24 @@ def read_activity(slug: str, limit: int = 0) -> list[dict]:
     likewise skipped rather than discarding what the other generation
     yielded. ``limit`` > 0 returns only the most recent N across both
     generations.
+
+    The second element is False when a record exceeded
+    :data:`_RECORD_CAP` and was therefore refused. That case cannot be
+    treated like a malformed line: this log is agent-writable, so one
+    crafted newline-free line would otherwise be materialised whole, and
+    :func:`kiro_crew.jsonl_util.strict_records` stops the read instead of
+    skipping it. Skipping would be worse than losing the entry — the
+    ``dedupe_session`` probe reads absence as "no prior entry" and appends a
+    duplicate, inflating the participation counts this log exists to feed.
+    So the flag is returned rather than swallowed, and the one caller that
+    writes based on this read fails closed on it.
     """
     try:
         live = member_dir(slug) / ACTIVITY_FILE_NAME
     except MemberSlugError:
-        return []
+        return [], True
     out: list[dict] = []
+    complete = True
 
     # Hold a shared (non-blocking) lock on the rotation lock file while
     # reading both generations.  This prevents a concurrent writer from
@@ -443,8 +503,8 @@ def read_activity(slug: str, limit: int = 0) -> list[dict]:
             if not path.is_file():
                 continue
             try:
-                with open(path, encoding="utf-8") as fh:
-                    for line in fh:
+                with open(path, "rb") as fh:
+                    for line in strict_records(fh, path, cap=_RECORD_CAP):
                         line = line.strip()
                         if not line:
                             continue
@@ -454,6 +514,21 @@ def read_activity(slug: str, limit: int = 0) -> list[dict]:
                             continue
                         if isinstance(row, dict):
                             out.append(row)
+            except UnreadableRecord:
+                # The generation is abandoned at the record it could not
+                # deliver, so what it yielded so far is a prefix, not the whole
+                # of it. Keep those rows (they are real entries the caller may
+                # display) but report the read as incomplete.
+                #
+                # "unreadable", not "over-cap": UnreadableRecord also covers a
+                # record that is not valid UTF-8, and naming only the cap here
+                # would send a reader looking for a size problem that may not
+                # exist.
+                complete = False
+                logger.warning(
+                    "member activity log has an over-cap record; %r read as incomplete", slug
+                )
+                continue
             except OSError:
                 logger.debug("member activity log read failed for %r", slug, exc_info=True)
                 continue
@@ -462,4 +537,4 @@ def read_activity(slug: str, limit: int = 0) -> list[dict]:
             platform_compat.release_lock(lock_fd)
             os.close(lock_fd)
 
-    return out[-limit:] if limit > 0 else out
+    return (out[-limit:] if limit > 0 else out), complete

--- a/src/kiro_crew/session_digest.py
+++ b/src/kiro_crew/session_digest.py
@@ -10,100 +10,22 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO
 
 from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.history import ARCHIVE_DIR_NAME, ARCHIVE_SEGMENT_DELIMITER, SESSIONS_DIR_NAME
+from kiro_crew.jsonl_util import RECORD_CAP, bounded_records
 
 logger = logging.getLogger(__name__)
 
-# Longest record this module will materialise, in BYTES (terminator excluded: the
-# threshold applies to the record without its newline, so a cap-length record plus
-# its terminator is accepted and the peak read is cap+1). Both trees read here are
-# agent-writable, so `for line in handle` would hand one crafted newline-free line
-# a single allocation the size of the whole file.
-#
-# The bound is in bytes, not characters, and the files are opened binary for that
-# reason: a character cap is not a memory bound, because one astral code point is
-# four bytes of `str` under PEP 393, so a 256 MiB CHARACTER cap admits a gibibyte
-# of resident text. Decoding cannot widen a record past its byte count -- UTF-8
-# spends at least as many bytes per code point as CPython's widest string
-# representation -- so capping the read at N bytes caps the decoded `str` at N
-# bytes too, and the transient peak is a small constant multiple of this value,
-# flat in file size.
-#
-# The cap CANNOT be session_storage's ``_MANIFEST_RECORD_CAP`` (8 MiB): a manifest
-# record is a header or one session's file list, while these files carry whole
-# conversation turns. A legitimate record's ceiling is ~90 MB -- image_artifacts'
-# ``MAX_IMAGE_BYTES_PER_MESSAGE`` (64 MiB) base64-expands to ~85 MB, plus text --
-# and the largest observed on a live install (30,351 kiro-cli logs, 27 GB) is
-# 77,920,032 bytes, itself load-bearing: it carries an image content item, and the
-# largest ``Prompt`` record (turns and first_message) is 56,203,168 bytes. A cap
-# below those would silently undercount the biggest sessions, so 128 MiB is the
-# smallest round value that clears the derived ceiling with margin. This constant
-# is the dial if a legitimate record ever grows past it.
-_RECORD_CAP = 128 * 1024 * 1024
-
-
-def _bounded_lines(handle: IO[bytes], path: Path) -> Iterator[str]:
-    """Yield *handle*'s lines decoded, skipping any record over ``_RECORD_CAP`` bytes.
-
-    *handle* is BINARY so the cap can be a memory bound rather than a code-point
-    count (see ``_RECORD_CAP``). Decoding per record is equivalent to decoding the
-    whole file, because ``\\n`` is never part of a UTF-8 multi-byte sequence -- lead
-    and continuation bytes are all >= 0x80 -- so no sequence can straddle a record
-    boundary and be replaced differently than it would have been.
-
-    Record boundaries are ``readline``'s, which is what the ``for line in handle``
-    iteration this replaces used: a record containing an exotic line boundary
-    (``\\u2028``, ``\\x1c``, ...) stays one record and still parses. Using
-    ``str.splitlines`` here -- the shape
-    :func:`kiro_crew.session_storage._manifest_records` needs, because its reader
-    replaced a whole-file ``splitlines`` -- would split such a record in two and
-    lose the turn it describes. Binary reads narrow this in one direction only:
-    a lone ``\\r`` no longer ends a record, since universal-newline translation is
-    gone. Neither writer of these files emits one, and a planted file that does is
-    read as one over-cap record and skipped, which is the safe direction. A
-    ``\\r\\n`` terminator survives, because every caller strips the record first --
-    it only shifts the boundary by one byte, since the ``\\r`` counts toward the
-    read and a ``\\r\\n``-terminated record is therefore refused one byte sooner
-    than an ``\\n``-terminated one. Immaterial at this cap; stated so a future
-    reader does not read the threshold as byte-exact on a CRLF file.
-
-    An over-cap record is SKIPPED and its tail drained without being kept, so a
-    hostile file costs time proportional to its length and memory proportional to
-    the cap. Skipping is the right posture for these three callers and the wrong
-    one for the manifest reader: nothing here feeds a rewrite, the digest is
-    read-only per-row detail that already skips a malformed line and keeps going
-    (see the module docstring), so an over-cap record degrades exactly one row's
-    counts. ``restore()`` in session_storage rewrites the manifest from what it
-    parsed, which is why an over-cap record there aborts the whole read instead.
-    """
-    oversized = 0
-    while True:
-        # Reading cap+1 makes the verdict unambiguous: a returned chunk shorter
-        # than that either ended on a newline or hit EOF, so it is a whole record.
-        raw = handle.readline(_RECORD_CAP + 1)
-        if not raw:
-            break
-        if len(raw) > _RECORD_CAP and not raw.endswith(b"\n"):
-            oversized += 1
-            while True:
-                tail = handle.readline(_RECORD_CAP + 1)
-                if not tail or tail.endswith(b"\n"):
-                    break
-            continue
-        yield raw.decode("utf-8", errors="replace")
-    if oversized:
-        # %r: *path* names a file in an agent-writable tree, and the archive
-        # segments are discovered with iterdir(), so a planted name can embed a
-        # newline. The repr keeps one log record from forging others.
-        logger.debug(
-            "digest: skipped %d record(s) over %d bytes in %r", oversized, _RECORD_CAP, path
-        )
+# The shared reader's cap (see :data:`kiro_crew.jsonl_util.RECORD_CAP`, which
+# derives it from the largest legitimate transcript record -- the shape this
+# module reads, so that derivation is this module's own). Named here and passed
+# explicitly because both trees read here are agent-writable, so
+# `for line in handle` would hand one crafted newline-free line a single
+# allocation the size of the whole file.
+_RECORD_CAP = RECORD_CAP
 
 
 @dataclass(frozen=True)
@@ -189,14 +111,15 @@ def _scan_transcript(path: Path) -> tuple[str, int]:
     """Stream a transcript file and extract (first_user_message, user_turn_count).
 
     Skips metadata/archive header lines, and any record over ``_RECORD_CAP``
-    bytes (see :func:`_bounded_lines`, which also owns the decode). Never raises.
+    bytes (see :func:`kiro_crew.jsonl_util.bounded_records`, which also owns
+    the decode). Never raises.
     """
     first_msg = ""
     turn_count = 0
 
     try:
         with open(path, "rb") as f:
-            for line in _bounded_lines(f, path):
+            for line in bounded_records(f, path, cap=_RECORD_CAP, label="digest"):
                 line = line.strip()
                 if not line:
                     continue
@@ -231,7 +154,8 @@ def _scan_cli_log(path: Path) -> tuple[int, int]:
 
     User turns are lines with ``kind == "Prompt"``.
     Images are content items with ``kind == "image"`` in any record.
-    Records over ``_RECORD_CAP`` bytes are skipped (see :func:`_bounded_lines`).
+    Records over ``_RECORD_CAP`` bytes are skipped (see
+    :func:`kiro_crew.jsonl_util.bounded_records`).
     Never raises.
     """
     turns = 0
@@ -239,7 +163,7 @@ def _scan_cli_log(path: Path) -> tuple[int, int]:
 
     try:
         with open(path, "rb") as f:
-            for line in _bounded_lines(f, path):
+            for line in bounded_records(f, path, cap=_RECORD_CAP, label="digest"):
                 line = line.strip()
                 if not line:
                     continue
@@ -273,12 +197,13 @@ def _first_message_from_cli(path: Path) -> str:
     """Extract the first user message text from a kiro-cli event log.
 
     Returns the text of the first Prompt record's first text content item.
-    Records over ``_RECORD_CAP`` bytes are skipped (see :func:`_bounded_lines`).
+    Records over ``_RECORD_CAP`` bytes are skipped (see
+    :func:`kiro_crew.jsonl_util.bounded_records`).
     Never raises.
     """
     try:
         with open(path, "rb") as f:
-            for line in _bounded_lines(f, path):
+            for line in bounded_records(f, path, cap=_RECORD_CAP, label="digest"):
                 line = line.strip()
                 if not line:
                     continue

--- a/src/kiro_crew/subagent_cost.py
+++ b/src/kiro_crew/subagent_cost.py
@@ -18,6 +18,7 @@ import time
 from pathlib import Path
 
 from kiro_crew.config.paths import config_dir
+from kiro_crew.jsonl_util import RECORD_CAP, UnreadableRecord, strict_records
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,13 @@ _DEFAULT_AGENT = "kirocrew"  # key for unnamed/default-agent runs (§4.3 keying)
 _DEFAULT_WINDOW = 50  # samples retained + considered per agent
 _DEFAULT_MIN_SAMPLES = 3  # before trusting learned over the configured fallback
 _DEFAULT_PERCENTILE = 0.90
+
+# Longest single RECORD the reader will materialise. This log is agent-writable,
+# and its read feeds compact_cost_log's rewrite of the same file, so an over-cap
+# record aborts the read rather than being skipped. Named here so a test can move
+# the dial; a real sample is a tiny object (agent, mem_gb, cpu_cores, ts), so the
+# shared cap has enormous headroom over anything legitimate.
+_RECORD_CAP = RECORD_CAP
 
 
 def _cost_log_path() -> Path:
@@ -56,23 +64,54 @@ def append_cost_sample(agent: str, mem_gb: float, cpu_cores: float) -> None:
 
 
 def _read_samples() -> list[dict]:
-    """Read all valid JSONL records; skip corrupt lines; [] if missing."""
+    """Read all valid JSONL records; skip corrupt lines; [] if missing.
+
+    The degrading view of :func:`_read_samples_checked`, for the read-only
+    percentile consumer. :func:`compact_cost_log` must NOT use this one -- it
+    rewrites the log from what it parsed, so it needs the completeness flag.
+    """
+    rows, _complete = _read_samples_checked()
+    return rows
+
+
+def _read_samples_checked() -> tuple[list[dict], bool]:
+    """Return the log's records, and whether they are ALL of them.
+
+    The second element is False when a record exceeded :data:`_RECORD_CAP` and
+    was therefore refused. That cannot be treated like a corrupt line: this log
+    is agent-writable, so one crafted newline-free line would otherwise be
+    materialised whole, and
+    :func:`kiro_crew.jsonl_util.strict_records` stops the read instead of
+    skipping it. The rows read before that point are kept -- they are real
+    samples the percentile consumer can still use -- but the flag has to reach
+    :func:`compact_cost_log`, which REPLACES the file with what it parsed and
+    would otherwise delete the refused record permanently.
+    """
     out: list[dict] = []
+    complete = True
     try:
-        with open(_cost_log_path(), encoding="utf-8") as fh:
-            for raw in fh:
-                raw = raw.strip()
-                if not raw:
-                    continue
-                try:
-                    rec = json.loads(raw)
-                except ValueError:
-                    continue  # skip corrupt line, keep going
-                if isinstance(rec, dict):
-                    out.append(rec)
+        path = _cost_log_path()
+        try:
+            with open(path, "rb") as fh:
+                for raw in strict_records(fh, path, cap=_RECORD_CAP):
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        rec = json.loads(raw)
+                    except ValueError:
+                        continue  # skip corrupt line, keep going
+                    if isinstance(rec, dict):
+                        out.append(rec)
+        except UnreadableRecord:
+            complete = False
+            # "unreadable", not "over-cap": UnreadableRecord also covers invalid
+            # UTF-8, and this line is what an operator sees, so naming only the
+            # cap would point them at a size problem that may not exist.
+            logger.warning("cost log has a record that could not be read; read as incomplete")
     except (FileNotFoundError, OSError):
-        return []
-    return out
+        return [], True
+    return out, complete
 
 
 def _percentile(values: list[float], pct: float) -> float:
@@ -129,8 +168,17 @@ def compact_cost_log(window: int = _DEFAULT_WINDOW) -> None:
     Safe to call anytime; a sample appended in the brief read→replace window
     may be dropped, which is harmless for an approximate p90. No-op when the
     log is already within bounds.
+
+    Fails closed on an incomplete read. This function REPLACES the log with the
+    records it parsed, so trimming from a partial read would permanently delete
+    the over-cap record the reader refused -- the same reason
+    ``session_storage``'s manifest reader aborts instead of skipping. Leaving
+    the log untrimmed costs bounded disk; compacting would cost data.
     """
-    samples = _read_samples()
+    samples, complete = _read_samples_checked()
+    if not complete:
+        logger.warning("cost log unreadable in full; skipping compaction to avoid data loss")
+        return
     if not samples:
         return
     by_agent: dict[str, list[dict]] = {}

--- a/test/test_jsonl_util.py
+++ b/test/test_jsonl_util.py
@@ -9,11 +9,31 @@ own rotation tests.
 
 from __future__ import annotations
 
+import json
+import logging
 import os
+import re
+import sys
 import threading
+import time
+from pathlib import Path
 
+import pytest
+
+import kiro_crew
 from kiro_crew import platform_compat
-from kiro_crew.jsonl_util import rotate_jsonl_at
+from kiro_crew.image_artifacts import MAX_IMAGE_BYTES_PER_MESSAGE
+from kiro_crew.jsonl_util import (
+    RECORD_CAP,
+    OversizedRecord,
+    UndecodableRecord,
+    UnreadableRecord,
+    bounded_raw_records,
+    bounded_records,
+    rotate_jsonl_at,
+    strict_raw_records,
+    strict_records,
+)
 
 CAP = 100  # bytes — small enough to cross with one write
 
@@ -120,3 +140,512 @@ class TestTryLock:
         finally:
             platform_compat.release_lock(lock_fd)
             os.close(lock_fd)
+
+
+class TestBoundedRecordReaders:
+    """Contract of the shared record readers (``#6345``).
+
+    ``for line in handle`` asks for bytes up to the next newline, so one
+    crafted newline-free line is a single allocation the size of the whole
+    file. Every tree these readers touch is agent-writable. The four
+    functions are two postures (skip / abort) x two forms (decoded / raw).
+    """
+
+    @staticmethod
+    def _write(tmp_path, *records: bytes):
+        path = tmp_path / "log.jsonl"
+        path.write_bytes(b"".join(records))
+        return path
+
+    def test_whole_records_round_trip(self, tmp_path):
+        path = self._write(tmp_path, b'{"a":1}\n', b'{"a":2}\n')
+        with open(path, "rb") as fh:
+            assert list(bounded_records(fh, path, cap=RECORD_CAP)) == ['{"a":1}\n', '{"a":2}\n']
+
+    def test_record_exactly_at_cap_survives(self, tmp_path):
+        """The cap is INCLUSIVE: a cap-length record plus its terminator is fine."""
+        body = b"y" * 200
+        path = self._write(tmp_path, body + b"\n", b'{"a":2}\n')
+        with open(path, "rb") as fh:
+            got = list(bounded_records(fh, path, cap=200))
+        assert len(got) == 2, "a record exactly at the cap must not be refused"
+        assert got[0] == body.decode() + "\n"
+
+    def test_record_one_byte_over_cap_is_skipped(self, tmp_path):
+        path = self._write(tmp_path, b"y" * 201 + b"\n", b'{"a":2}\n')
+        with open(path, "rb") as fh:
+            got = list(bounded_records(fh, path, cap=200))
+        assert got == ['{"a":2}\n'], "one byte past the cap is already over it"
+
+    def test_drain_resumes_at_the_next_record(self, tmp_path):
+        """An over-cap record many caps long is drained; following records still parse."""
+        path = self._write(tmp_path, b"y" * 1400 + b"\n", b'{"a":2}\n', b'{"a":3}\n')
+        with open(path, "rb") as fh:
+            got = list(bounded_records(fh, path, cap=200))
+        assert got == ['{"a":2}\n', '{"a":3}\n']
+
+    def test_over_cap_record_cannot_forge_a_record_from_its_tail(self, tmp_path):
+        """The drain's real job.
+
+        The whole file is ONE line: junk longer than the cap, then what looks
+        like a complete record. Without the drain the next bounded read starts
+        inside the skipped record and yields the forged tail as if it were a
+        record of its own.
+        """
+        path = self._write(tmp_path, b"y" * 250 + b'{"forged":true}\n')
+        with open(path, "rb") as fh:
+            assert list(bounded_records(fh, path, cap=200)) == []
+
+    def test_unterminated_final_record_still_parses(self, tmp_path):
+        """A crash mid-append leaves no trailing newline; a within-cap tail counts."""
+        path = self._write(tmp_path, b'{"a":1}\n', b'{"a":2}')
+        with open(path, "rb") as fh:
+            assert list(bounded_records(fh, path, cap=200)) == ['{"a":1}\n', '{"a":2}']
+
+    def test_unterminated_final_record_exactly_at_cap_survives(self, tmp_path):
+        """The inclusive boundary where it is actually decidable.
+
+        A cap-length record WITH its terminator returns ``cap + 1`` bytes ending
+        on the newline, so the terminator check alone accepts it however the
+        length comparison is spelled. Only an unterminated cap-length record
+        distinguishes ``> cap`` from ``>= cap``, so this is the case that pins
+        the cap as inclusive rather than exclusive.
+        """
+        path = self._write(tmp_path, b"y" * 200)
+        with open(path, "rb") as fh:
+            assert list(bounded_records(fh, path, cap=200)) == ["y" * 200]
+
+    def test_cap_counts_bytes_not_characters(self, tmp_path):
+        """A character cap is not a memory bound: one astral code point is 4 bytes of str."""
+        record = ("\U0001f600" * 60).encode()  # 60 code points, 240 bytes
+        assert len(record) == 240
+        path = self._write(tmp_path, record + b"\n")
+        with open(path, "rb") as fh:
+            assert list(bounded_records(fh, path, cap=200)) == [], (
+                "a 240-byte record must be refused by a 200-BYTE cap even though "
+                "it is only 60 characters"
+            )
+
+    def test_exotic_line_boundary_stays_one_record(self, tmp_path):
+        """U+2028 is legal raw inside a JSON string and must not split a record."""
+        path = self._write(tmp_path, '{"m":"a\u2028b"}\n'.encode())
+        with open(path, "rb") as fh:
+            got = list(bounded_records(fh, path, cap=200))
+        assert len(got) == 1 and json.loads(got[0])["m"] == "a\u2028b"
+
+    def test_crlf_terminated_record_still_parses(self, tmp_path):
+        """Binary reads drop universal-newline translation; callers strip the record."""
+        path = self._write(tmp_path, b'{"a":1}\r\n')
+        with open(path, "rb") as fh:
+            got = list(bounded_records(fh, path, cap=200))
+        assert json.loads(got[0].strip()) == {"a": 1}
+
+    def test_handle_is_never_read_without_a_limit(self, tmp_path):
+        """The allocation bound itself: every read carries a limit, and no iteration."""
+        path = self._write(tmp_path, b'{"a":1}\n', b'{"a":2}\n')
+        seen: list[int | None] = []
+
+        class Spy:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def readline(self, limit=None):
+                seen.append(limit)
+                return self._inner.readline() if limit is None else self._inner.readline(limit)
+
+            def __iter__(self):  # pragma: no cover - must never be reached
+                raise AssertionError("the handle was iterated, so one record is unbounded")
+
+        with open(path, "rb") as fh:
+            list(bounded_records(Spy(fh), path, cap=200))
+        assert seen, "no read was issued"
+        # cap + 2, not cap + 1. The reader bounds each read by what the CARRIED
+        # record has left, so the widest read is the one with an empty buffer --
+        # and that has to be able to hold a legal at-cap record with its CRLF
+        # terminator, which is cap + 2 bytes. A cap + 1 ceiling could never
+        # assemble one and would refuse it, which is the round-7 bug. What this
+        # test exists to pin is that NO read is unbounded; the exact constant is
+        # derived from that record shape rather than chosen.
+        assert all(lim is not None and 0 < lim <= 202 for lim in seen), seen
+
+    def test_skip_reader_logs_once_and_keeps_going(self, tmp_path, caplog):
+        path = self._write(tmp_path, b"y" * 300 + b"\n", b'{"a":2}\n', b"y" * 300 + b"\n")
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.jsonl_util"):
+            with open(path, "rb") as fh:
+                got = list(bounded_records(fh, path, cap=200, label="probe"))
+        assert got == ['{"a":2}\n']
+        lines = [r for r in caplog.records if "skipped" in r.getMessage()]
+        assert len(lines) == 1, "one aggregated line per read, not one per record"
+        assert "2 record(s)" in lines[0].getMessage()
+
+    def test_strict_reader_raises_instead_of_skipping(self, tmp_path):
+        path = self._write(tmp_path, b'{"a":1}\n', b"y" * 300 + b"\n", b'{"a":3}\n')
+        got: list[str] = []
+        with open(path, "rb") as fh:
+            with pytest.raises(OversizedRecord):
+                for line in strict_records(fh, path, cap=200):
+                    got.append(line)
+        assert got == ['{"a":1}\n'], "records before the over-cap one are still yielded"
+
+    def test_strict_reader_does_not_drain_the_hostile_tail(self, tmp_path):
+        """Aborting must not first walk a multi-GB line to its end.
+
+        Proven by position: the handle stops within one read of the cap rather
+        than at EOF, so the reader never paid for the rest of the record.
+        """
+        path = self._write(tmp_path, b"y" * 5000 + b"\n")
+        with open(path, "rb") as fh:
+            with pytest.raises(OversizedRecord):
+                list(strict_records(fh, path, cap=200))
+            assert fh.tell() <= 201 * 2, f"drained to {fh.tell()} of {path.stat().st_size}"
+
+    def test_raw_readers_yield_undecoded_bytes(self, tmp_path):
+        """A byte no codec can decode survives the raw readers verbatim."""
+        path = self._write(tmp_path, b'{"a":"\xff"}\n')
+        with open(path, "rb") as fh:
+            assert list(bounded_raw_records(fh, path, cap=200)) == [b'{"a":"\xff"}\n']
+        with open(path, "rb") as fh:
+            assert list(strict_raw_records(fh, path, cap=200)) == [b'{"a":"\xff"}\n']
+        # The decoding form is lossy for that byte, which is why the two
+        # verbatim-copy / bytes-prefilter callers use the raw form.
+        with open(path, "rb") as fh:
+            assert list(bounded_records(fh, path, cap=200)) == ['{"a":"\ufffd"}\n']
+
+    def test_raw_readers_apply_the_same_cap(self, tmp_path):
+        path = self._write(tmp_path, b"y" * 300 + b"\n", b'{"a":2}\n')
+        with open(path, "rb") as fh:
+            assert list(bounded_raw_records(fh, path, cap=200)) == [b'{"a":2}\n']
+        with open(path, "rb") as fh:
+            with pytest.raises(OversizedRecord):
+                list(strict_raw_records(fh, path, cap=200))
+
+    def test_a_bare_cr_ends_a_record(self, tmp_path):
+        """Boundaries are universal, as the text-mode reads these replaced were.
+
+        Splitting only on LF would glue the pair into one line that parses as
+        neither record -- a lost count for a skip caller, but a lost prior
+        entry for a dedupe probe and a silently unmerged restore.
+        """
+        path = self._write(tmp_path, b'{"a":1}\r{"a":2}\n')
+        for reader in (bounded_records, strict_records):
+            with open(path, "rb") as fh:
+                got = [json.loads(x.strip()) for x in reader(fh, path, cap=200)]
+            assert got == [{"a": 1}, {"a": 2}], reader.__name__
+
+    def test_crlf_is_one_terminator_not_two_records(self, tmp_path):
+        path = self._write(tmp_path, b'{"a":1}\r\n{"a":2}\r\n')
+        with open(path, "rb") as fh:
+            got = [json.loads(x.strip()) for x in strict_records(fh, path, cap=200)]
+        assert got == [{"a": 1}, {"a": 2}], "CRLF must not yield a blank record between them"
+
+    def test_a_crlf_split_across_two_reads_stays_one_terminator(self, tmp_path):
+        """The reason a trailing CR is not treated as a boundary until more bytes arrive.
+
+        With a cap of 8 the first read ends exactly on the CR of a CRLF. Calling
+        it a boundary there would invent a record end and leave the following LF
+        looking like an empty record.
+        """
+        path = self._write(tmp_path, b'{"a":1}\r\n{"a":2}\r\n')
+        with open(path, "rb") as fh:
+            got = [x for x in bounded_records(fh, path, cap=8)]
+        assert [json.loads(x.strip()) for x in got] == [{"a": 1}, {"a": 2}]
+        assert all(x.strip() for x in got), f"a blank record was invented: {got!r}"
+
+    def test_a_file_ending_in_a_bare_cr_yields_one_final_record(self, tmp_path):
+        path = self._write(tmp_path, b'{"a":1}\r')
+        with open(path, "rb") as fh:
+            got = list(strict_records(fh, path, cap=200))
+        assert [json.loads(x.strip()) for x in got] == [{"a": 1}]
+
+    def test_cap_is_judged_per_record_not_per_read(self, tmp_path):
+        """A single read may hold several CR-delimited records, each within the cap.
+
+        Judging the read instead of the record would refuse all of them.
+        """
+        one = b'{"a":1}'
+        path = self._write(tmp_path, b"\r".join([one] * 6) + b"\n")
+        assert len(one) * 6 + 6 > 20
+        with open(path, "rb") as fh:
+            got = list(strict_records(fh, path, cap=20))
+        assert len(got) == 6, f"expected 6 within-cap records, got {len(got)}"
+
+    def test_dropping_an_over_cap_record_does_not_eat_the_next_one(self, tmp_path):
+        """A pending carriage return must SURVIVE the drop -- it ends the dropped record.
+
+        This is the third of three findings that were one entanglement, and the
+        reason framing was separated from policy. When an over-cap buffer ended
+        on a held carriage return, clearing the buffer erased that byte -- but it
+        was the over-cap record's OWN terminator. With it gone the drop stayed
+        armed into the next read and consumed the next record's terminator
+        instead, so a valid record vanished from the caller's aggregates with no
+        error anywhere.
+
+        Every part of the layout is load-bearing: the leading carriage return
+        makes the first full ``cap + 1`` read split so a tail is carried; the
+        tail is exactly cap so it passes the unterminated-tail check; the next
+        full read ends on a held carriage return, which makes the buffer
+        over-cap AND ends it on the terminator that was being erased.
+        """
+        cap = 64
+        valid = b'{"valid":1}\n'
+        path = tmp_path / "drop.jsonl"
+        path.write_bytes(b"\r" + b"X" * cap + b"Y" * cap + b"\r" + valid)
+
+        with open(path, "rb") as fh:
+            got = list(bounded_raw_records(fh, path, cap=cap))
+
+        assert valid in got, f"the record after the dropped one was eaten: {got!r}"
+        assert b"Y" * cap not in got, "the over-cap record must not be yielded"
+
+    def test_a_carried_tail_completed_by_a_later_read_is_still_capped(self, tmp_path):
+        """An over-cap record must be refused even when it is assembled ACROSS reads.
+
+        Written for a real escape: the cap was once judged only on the leftover
+        buffer after a read, and a record could slip past it entirely. A
+        full-length chunk containing a CARRIAGE RETURN splits into a piece plus a
+        tail, that tail could sit exactly at cap and so survive the buffer check,
+        and the next read then supplied more body AND the terminator at once --
+        yielding a record of nearly twice the cap, whole.
+
+        HOW it is prevented has since changed, and this docstring says so rather
+        than implying a mechanism that is no longer the active one. Each read is
+        now bounded by what the carried record has left, so the buffer cannot
+        reach that size in the first place and this input is refused by the
+        unterminated-tail check. The per-piece body check still exists and is
+        still reachable -- a record whose body is one byte over the cap and whose
+        terminator arrives in the same read hits it -- and it is pinned by
+        `test_record_one_byte_over_cap_is_skipped`, not by this test. Verified by
+        mutation: disabling the per-piece check leaves THIS test green and fails
+        that one.
+
+        Kept because it pins the OUTCOME for a shape that once escaped, which is
+        what a regression test is for, and it would catch a future change that
+        relaxed the read bound back.
+        """
+        cap = 64
+        path = tmp_path / "carried.jsonl"
+        path.write_bytes(b"\r" + b"X" * cap + b"A\rz\n")
+
+        with open(path, "rb") as fh:
+            with pytest.raises(OversizedRecord):
+                list(strict_raw_records(fh, path, cap=cap))
+
+        # The skip posture must drop that record and keep the ones around it.
+        with open(path, "rb") as fh:
+            kept = list(bounded_raw_records(fh, path, cap=cap))
+        assert b"X" * cap + b"A\r" not in kept, "over-cap record was yielded intact"
+        assert b"z\n" in kept, "records after the over-cap one must survive"
+
+    def test_an_exactly_at_cap_record_ending_crlf_is_accepted(self, tmp_path):
+        """A pending carriage return is a TERMINATOR half, not body.
+
+        `readline(cap + 1)` stops after the carriage return of a CRLF whose line
+        feed is in the next read. `_boundary_end` rightly refuses to split there,
+        so that byte sits in the buffer -- but counting it as body makes an
+        exactly-at-cap record look like cap + 1 and rejects a record that is
+        legal. Downstream that suppressed a real activity entry.
+        """
+        cap = 64
+        body = b'{"a":"' + b"x" * (cap - 8) + b'"}'
+        assert len(body) == cap, len(body)
+        path = tmp_path / "atcap.jsonl"
+        path.write_bytes(body + b"\r\n")
+        with open(path, "rb") as fh:
+            got = list(strict_raw_records(fh, path, cap=cap))
+        assert got == [body + b"\r\n"], got
+
+    def test_many_records_in_one_read_scale_linearly(self, tmp_path):
+        """A carriage-return-dense file must not cost quadratic time.
+
+        A chunk full of such records is the cheap way to trigger it on an
+        agent-writable file, so this pins the COST, not just the output.
+
+        Measured as a RATIO between two sizes rather than an absolute ceiling,
+        and that choice is a correction. A ceiling looks more robust and is
+        actually the opposite: it encodes this machine's speed, so it fails on
+        any slower one. The first version of this test asserted 1.0s for 200,000
+        records -- comfortable locally at 0.10s -- and it duly went red on CI at
+        1.101s. A ratio cancels the machine out, because both measurements pay
+        the same constant factor.
+
+        Thresholds from measurement on the shipped reader and on both quadratic
+        forms it replaced: linear 2.02x, one `bytes.find` per terminator 3.86x,
+        re-slicing the buffer per record 6.9x. 3.0x sits between them.
+
+        `process_time` excludes time this process was not running, so a busy
+        runner does not leak in, and the best of several attempts is used
+        because scheduling noise can only ever make a sample slower.
+
+        Skipped under a TRACER because tracing breaks the ratio's premise rather
+        than merely slowing things down: it charges per Python line executed, so
+        it inflates the linear per-record bookkeeping while leaving the C-level
+        scanning and copying -- which is where the quadratic cost lives --
+        untouched. That flattens the very difference being measured. CI runs
+        coverage on the 3.12 shards only, which is exactly where this first
+        failed and why it passed everywhere else.
+        """
+        if sys.gettrace() is not None:
+            pytest.skip("a tracer distorts Python-level cost relative to C-level; see docstring")
+
+        def best_of(count: int, attempts: int = 3) -> float:
+            path = tmp_path / f"dense{count}.jsonl"
+            path.write_bytes(b'{"a":1}\r' * count + b"\n")
+            best = float("inf")
+            for _ in range(attempts):
+                start = time.process_time()
+                with open(path, "rb") as fh:
+                    got = sum(1 for _ in bounded_raw_records(fh, path, cap=64 * 1024 * 1024))
+                best = min(best, time.process_time() - start)
+                # `count`, not count + 1: the final record's own carriage return
+                # plus the trailing newline form one CRLF terminator.
+                assert got == count, got
+            return best
+
+        base = best_of(100_000)
+        doubled = best_of(200_000)
+        assert base > 0, "process_time resolution too coarse to compare"
+        ratio = doubled / base
+        assert ratio < 3.0, f"doubling the records cost {ratio:.2f}x, which suggests quadratic work"
+
+    def test_strict_reader_refuses_invalid_utf8_rather_than_replacing_it(self, tmp_path):
+        """The abort caller PERSISTS what it read, so a U+FFFD would be written back."""
+        path = self._write(tmp_path, b'{"a":"\xff"}\n')
+        with open(path, "rb") as fh:
+            with pytest.raises(UndecodableRecord):
+                list(strict_records(fh, path, cap=200))
+        # The raw strict reader has nothing to decode, so it still delivers the
+        # bytes verbatim -- which is why the verbatim-copy caller uses it.
+        with open(path, "rb") as fh:
+            assert list(strict_raw_records(fh, path, cap=200)) == [b'{"a":"\xff"}\n']
+
+    def test_every_strict_refusal_is_one_catchable_class(self, tmp_path):
+        """Callers fail closed on one except clause, so a new refusal cannot leak."""
+        for body in (b"y" * 300 + b"\n", b'{"a":"\xff"}\n'):
+            path = self._write(tmp_path, body)
+            with open(path, "rb") as fh:
+                with pytest.raises(UnreadableRecord):
+                    list(strict_records(fh, path, cap=200))
+        assert issubclass(OversizedRecord, UnreadableRecord)
+        assert issubclass(UndecodableRecord, UnreadableRecord)
+
+    def test_shared_cap_clears_the_largest_legitimate_record(self):
+        """The cap is derived, not picked: it must clear a base64 image turn.
+
+        ``MAX_IMAGE_BYTES_PER_MESSAGE`` base64-expands by 4/3, and the largest
+        record measured on a live install was 77,920,032 bytes.
+        """
+        assert RECORD_CAP > MAX_IMAGE_BYTES_PER_MESSAGE * 4 // 3
+        assert RECORD_CAP > 77_920_032
+
+
+# Sites that iterate a file handle directly and are DELIBERATELY left alone,
+# each with the reason. The scanner below asserts this list is exhaustive FOR
+# THE SHAPE IT DETECTS -- `for <var> in <handle>:` -- so a converted reader
+# cannot regress and a new handle-iterating one cannot land unnoticed.
+#
+# It does NOT detect every unbounded read over these trees, and the claim is
+# deliberately no broader than the shape. A whole-file reader spelled
+# `path.read_text().splitlines()` has the same harm and is invisible here;
+# `learn.py`, the auto_improvement spine's ledger/archive, and the meetings
+# store each hold one, and `learn.py`'s feeds a `_write_all` rewrite, which is
+# the read-feeds-rewrite pattern this module classifies abort-required. Those
+# are a different reader shape than #6345 enumerates and are left for a
+# follow-up rather than swept in here; raised by the First Principles lane on
+# PR #7651.
+#
+# Kernel-synthesised pseudo-files: an agent cannot write a multi-GB newline-free
+# line into /proc, and the line lengths are fixed by the kernel.
+_KERNEL_PSEUDO_FILE_READERS = {
+    ("dashboard/handlers_system.py", "/proc/meminfo"),
+    ("dashboard/handlers_system.py", "/proc/net/dev"),
+    ("platform_compat.py", "/proc/meminfo"),
+    ("platform_compat.py", "/proc/locks"),
+    ("platform_compat.py", "/proc/<pid>/status"),
+    ("acp/runtime.py", "/proc/<pid>/status"),
+    ("sandbox.py", "/proc/<pid>/mountinfo"),
+}
+# Fenced from agent file tools by security._CREW_SECRET_LEAVES, so it is outside
+# this issue's "agent-writable" premise. It is the tamper-evident audit chain, so
+# if it is ever bounded the posture must be abort/count, never skip.
+_FENCED_READERS = {"sel.py"}
+
+# DEFERRED, not excused: this one is a known live bug, tracked separately, and
+# listed here so the scanner records it instead of going quiet about it.
+#
+# `snapshot._merge_notifications` copies records from one file into another
+# verbatim, which makes it the only site in the #6345 audit where reading
+# faithfully is not the whole contract -- the bytes must also be VALID FOR THE
+# DESTINATION. Converting it needs that write-side contract stated up front
+# (record boundary, dedupe-key type, framing, and encoding), and four successive
+# review rounds on PR #7651 each found one more property of it, so it is being
+# done as its own change rather than inferred from the read-side contract here.
+_DEFERRED_READERS = {"snapshot.py"}
+
+_ALLOWED_UNBOUNDED_FILES = (
+    {path for path, _ in _KERNEL_PSEUDO_FILE_READERS} | _FENCED_READERS | _DEFERRED_READERS
+)
+
+
+class TestNoUnboundedHandleIteration:
+    """Make the #6345 audit executable rather than a claim in a PR body.
+
+    ``for line in handle`` over an agent-writable tree is an unbounded
+    allocation. This scans the whole package for THAT SHAPE and requires every
+    instance to be either converted to a bounded reader or listed above with a
+    reason. Reads spelled another way -- notably whole-file
+    ``read_text().splitlines()`` -- carry the same harm and are outside what
+    this detects; see the note on the excused list.
+    """
+
+    def test_every_handle_iteration_is_bounded_or_excused(self):
+        src = Path(kiro_crew.__file__).parent
+        # Detect by the handle-name vocabulary this codebase uses, not by a
+        # fixed window after the `with`: sel.py binds its handle several lines
+        # earlier (`handle = self._reader_handle(...)`, then `with handle:`),
+        # which a distance-based match misses. A file is only considered if it
+        # opens something at all, so a loop over a list that happens to be
+        # called `f` in a file with no I/O is not flagged.
+        handle_names = r"(?:fh|fh2|f|f2|fp|fobj|handle|infile|log_f|logf|src_f|dst_f|stream)"
+        offenders: list[str] = []
+        for py in sorted(src.rglob("*.py")):
+            rel = py.relative_to(src).as_posix()
+            try:
+                text = py.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):  # pragma: no cover
+                continue
+            if not re.search(r"\b(?:open|fdopen|_reader_handle|_no_follow)\(", text):
+                continue
+            for num, line in enumerate(text.splitlines(), 1):
+                loop = re.match(rf"\s*for\s+\w+\s+in\s+({handle_names})\s*:\s*$", line)
+                if loop:
+                    offenders.append(f"{rel}:{num}: for ... in {loop.group(1)}")
+        unexcused = [o for o in offenders if o.split(":")[0] not in _ALLOWED_UNBOUNDED_FILES]
+        assert not unexcused, (
+            "unbounded handle iteration over a possibly agent-writable tree — route it "
+            "through jsonl_util.bounded_records (read-only, degradable) or "
+            "jsonl_util.strict_records (feeds a rewrite or a durable decision), or add it "
+            "to the excused list with a reason:\n  " + "\n  ".join(unexcused)
+        )
+
+    def test_the_scanner_actually_detects_the_pattern(self):
+        """Guard the guard: a scanner that matches nothing would pass silently.
+
+        The excused sites are real instances of the shape, so finding them
+        proves the detector still works even when nothing is unexcused.
+        """
+        src = Path(kiro_crew.__file__).parent
+        handle_names = r"(?:fh|fh2|f|f2|fp|fobj|handle|infile|log_f|logf|src_f|dst_f|stream)"
+        found = {
+            py.relative_to(src).as_posix()
+            for py in src.rglob("*.py")
+            for line in py.read_text(encoding="utf-8", errors="replace").splitlines()
+            if re.match(rf"\s*for\s+\w+\s+in\s+{handle_names}\s*:\s*$", line)
+        }
+        missed = _ALLOWED_UNBOUNDED_FILES - found
+        assert not missed, f"scanner no longer detects the shape in: {sorted(missed)}"
+
+    def test_the_excused_list_is_not_stale(self):
+        """A listed file must still exist, so the list cannot rot into a lie."""
+        src = Path(kiro_crew.__file__).parent
+        for rel in sorted(_ALLOWED_UNBOUNDED_FILES):
+            assert (src / rel).is_file(), f"excused reader {rel} no longer exists"

--- a/test/test_members.py
+++ b/test/test_members.py
@@ -10,6 +10,7 @@ import json
 
 import pytest
 
+from kiro_crew import members
 from kiro_crew.members import (
     ACTIVITY_FILE_NAME,
     MemberSlugError,
@@ -369,3 +370,92 @@ class TestRecordActivityRotation:
         assert record_activity("M", "after-fail", "persistent") is True
         assert live.with_name(live.name + ".1").is_dir()
         assert "after-fail" in live.read_text(encoding="utf-8")
+
+
+class TestOverCapRecordFailsClosed:
+    """#6345: the activity log is agent-writable and its read decides an append.
+
+    ``for line in fh`` would materialise one crafted newline-free line whole.
+    The reader now aborts on an over-cap record, and because the
+    ``dedupe_session`` probe cannot prove absence from a log it could not
+    finish reading, it declines to append rather than risk a duplicate.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _small_cap(self, monkeypatch):
+        # raising=False so this file also RUNS against a pre-fix source, where
+        # the attribute does not exist: the tests then fail on behaviour (the
+        # append that should have been refused) rather than erroring on a
+        # missing name. Same idiom as test_session_digest's `create=True`.
+        monkeypatch.setattr(members, "_RECORD_CAP", 200, raising=False)
+
+    @staticmethod
+    def _log_for(slug: str):
+        path = member_dir(slug) / ACTIVITY_FILE_NAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def test_over_cap_record_refuses_to_append(self):
+        """Red on base: base skips the unparseable line, finds no match, and appends."""
+        log = self._log_for("m")
+        log.write_bytes(b"y" * 400 + b"\n")
+        before = log.read_bytes()
+        assert (
+            record_activity("m", "s1", "persistent", dedupe_session=True) is False
+        ), "must not append when the log could not be read in full"
+        assert log.read_bytes() == before, "log was modified despite the refusal"
+
+    def test_a_normal_log_still_appends(self):
+        """The refusal is specific to an over-cap record, not to every read."""
+        assert record_activity("m", "s1", "persistent", dedupe_session=True) is True
+        assert [r["session"] for r in read_activity("m")] == ["s1"]
+
+    def test_dedupe_still_suppresses_a_repeat_within_cap(self):
+        assert record_activity("m", "s1", "persistent", dedupe_session=True) is True
+        assert record_activity("m", "s1", "persistent", dedupe_session=True) is False
+        assert len(read_activity("m")) == 1
+
+    def test_read_activity_still_degrades_for_display(self):
+        """The public reader keeps its documented non-raising contract.
+
+        An over-cap record stops that generation, but the rows already read are
+        returned and no exception escapes — only the write path fails closed.
+        """
+        log = self._log_for("m")
+        log.write_bytes(
+            json.dumps({"member": "m", "session": "s1"}).encode() + b"\n" + b"y" * 400 + b"\n"
+        )
+        rows = read_activity("m")
+        assert [r["session"] for r in rows] == ["s1"]
+
+    def test_a_cr_delimited_log_does_not_produce_a_duplicate(self):
+        """The log is read binary now, so its boundaries must stay universal.
+
+        These logs were read in TEXT mode, where a bare carriage return ended a
+        record. The reader splits on it too, so this file parses as two records
+        and the dedupe probe still sees the prior entry. Splitting only on LF
+        would glue them into one unparseable line, the probe would see no prior
+        entry, and a duplicate would be appended -- which is what an earlier
+        revision of this PR did.
+        """
+        log = self._log_for("m")
+        first = json.dumps({"member": "m", "session": "s1"})
+        log.write_bytes(first.encode() + b"\r" + first.encode() + b"\n")
+        before = log.read_bytes()
+        assert record_activity("m", "s1", "persistent", dedupe_session=True) is False
+        assert log.read_bytes() == before, "a CR-delimited log must not gain a duplicate entry"
+        assert len(read_activity("m")) == 2, "both CR-delimited records must be read"
+
+    def test_record_exactly_at_cap_is_not_refused(self):
+        """The cap is inclusive, so a legitimate record at the limit still reads."""
+        log = self._log_for("m")
+        entry = {"member": "m", "session": "s1", "pad": ""}
+        pad = 200 - len(json.dumps(entry).encode())
+        entry["pad"] = "z" * pad
+        raw = json.dumps(entry).encode()
+        assert len(raw) == 200
+        log.write_bytes(raw + b"\n")
+        assert record_activity("m", "s1", "persistent", dedupe_session=True) is False, (
+            "the at-cap record must be READ (and so suppress the duplicate), "
+            "not refused as over-cap"
+        )

--- a/test/test_session_digest.py
+++ b/test/test_session_digest.py
@@ -581,7 +581,13 @@ class TestBoundedRecords:
             assert not spy.iterated, "the handle was iterated, so one line is unbounded"
             assert spy.readline_limits, "no bounded read was issued"
             cap = session_digest._RECORD_CAP
-            assert all(0 < limit <= cap + 1 for limit in spy.readline_limits)
+            # cap + 2, relaxed from cap + 1 when the shared reader began bounding
+            # each read by what the CARRIED record has left rather than reading a
+            # full cap every time. cap + 2 is forced, not convenient: a legal
+            # at-cap record ending CRLF is cap + 2 bytes, so a read ceiling of
+            # cap + 1 could never assemble one and would refuse it. This assertion
+            # exists to pin that no read is UNBOUNDED, which it still does.
+            assert all(0 < limit <= cap + 2 for limit in spy.readline_limits)
 
     def test_record_exactly_at_cap_survives(self, sessions_dir: Path, cli_dir: Path) -> None:
         """The cap is inclusive: a record of exactly cap bytes still counts."""
@@ -748,18 +754,26 @@ class TestBoundedRecords:
         assert result.turns == 2
         assert result.first_message == "first crlf"
 
-    def test_crlf_record_at_the_cap_boundary_is_refused_by_one_byte(
+    def test_crlf_record_at_the_cap_boundary_is_accepted(
         self, sessions_dir: Path, cli_dir: Path
     ) -> None:
-        """A CRLF-terminated record of exactly cap bytes is refused, by one byte.
+        """A CRLF-terminated record of exactly cap bytes is accepted.
 
-        The carriage return counts toward the bounded read, so `readline(cap + 1)`
-        returns cap+1 bytes ending on the CR rather than the LF and the record
-        reads as over-cap. Pinned rather than fixed: it shifts the threshold by one
-        byte on a 128 MiB cap, and buying the byte back would cost the reader its
-        single invariant (a return shorter than cap+1 is a whole record). This is
-        also the shape that makes a text-mode test fixture fail on Windows and pass
-        on Linux, which is why the fixtures above pass `newline=""`.
+        This REVERSES a one-byte refusal that main pinned deliberately. The pin's
+        stated cost was that buying the byte back "would cost the reader its
+        single invariant (a return shorter than cap+1 is a whole record)" -- true
+        of the old reader, which decided over-cap straight from the length of one
+        `readline(cap + 1)`. The shared reader no longer has that invariant to
+        lose: it already defers a trailing carriage return across reads, because
+        it must not split a CRLF whose line feed has not arrived. Excluding that
+        pending byte from the body length therefore costs nothing that was not
+        already being paid, and the record below is legal by the cap's own
+        definition -- its body IS cap bytes.
+
+        Left refused, it suppressed a real participation entry in
+        `members.read_activity`, which is why this is a correctness fix rather
+        than a cosmetic one. Flagged to the reviewer as a main-owned behaviour
+        change rather than folded in silently.
         """
         cap = 200
         path = sessions_dir / "crlf_at_cap.jsonl"
@@ -770,23 +784,23 @@ class TestBoundedRecords:
             patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
             patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
         ):
-            refused = digest("crlf_at_cap", ("crlf_at_cap",), "sid-nope")
+            at_cap = digest("crlf_at_cap", ("crlf_at_cap",), "sid-nope")
 
-        assert refused.turns == 0
+        assert at_cap.turns == 1
 
-        # One byte shorter and the same CRLF record is accepted, which locates the
-        # shift precisely instead of asserting only that something was refused.
-        shorter = sessions_dir / "crlf_under_cap.jsonl"
-        shorter.write_bytes(_user_record_of_length(cap - 1).encode("utf-8") + b"\r\n")
+        # One byte OVER the cap is still refused, which locates the boundary
+        # precisely instead of asserting only that something was accepted.
+        over = sessions_dir / "crlf_over_cap.jsonl"
+        over.write_bytes(_user_record_of_length(cap + 1).encode("utf-8") + b"\r\n")
 
         with (
             patch("kiro_crew.session_digest._RECORD_CAP", cap, create=True),
             patch("kiro_crew.session_digest.data_home", return_value=sessions_dir.parent),
             patch("kiro_crew.session_digest.kiro_sessions_dir", return_value=cli_dir),
         ):
-            accepted = digest("crlf_under_cap", ("crlf_under_cap",), "sid-nope")
+            refused = digest("crlf_over_cap", ("crlf_over_cap",), "sid-nope")
 
-        assert accepted.turns == 1
+        assert refused.turns == 0
 
     def test_over_cap_cli_record_drops_its_turn_and_images(
         self, sessions_dir: Path, cli_dir: Path

--- a/test/test_subagent_cost.py
+++ b/test/test_subagent_cost.py
@@ -141,3 +141,92 @@ def test_compaction_per_agent_independent(cost_log):
     lines = [json.loads(line) for line in cost_log.read_text(encoding="utf-8").strip().splitlines()]
     assert sum(1 for r in lines if r["agent"] == "a") == 5
     assert sum(1 for r in lines if r["agent"] == "b") == 5
+
+
+class TestOverCapRecordDoesNotLoseData:
+    """#6345: compaction REPLACES the log with what it parsed.
+
+    So this reader cannot skip an over-cap record the way a read-only consumer
+    can -- a skipped record would be permanently deleted by the next
+    compaction. Found by GPT 5.6 review on PR #7651; the audit had classified
+    this site skip-safe by tracing only its percentile consumer and missing
+    ``compact_cost_log``'s rewrite.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _small_cap(self, monkeypatch):
+        # raising=False so this file also RUNS against a pre-fix source, where
+        # the attribute does not exist: the test then fails on behaviour (the
+        # record compaction deleted) rather than erroring on a missing name.
+        monkeypatch.setattr(sc, "_RECORD_CAP", 200, raising=False)
+
+    def test_compaction_refuses_to_run_on_an_incomplete_read(self, cost_log):
+        """Red on base: base skips the over-cap record and rewrites without it."""
+        over_cap = json.dumps({"agent": "a", "mem_gb": 1.0, "cpu_cores": 1.0, "pad": "z" * 300})
+        assert len(over_cap.encode()) > 200
+        cost_log.parent.mkdir(parents=True, exist_ok=True)
+        cost_log.write_text(
+            over_cap
+            + "\n"
+            + "".join(
+                json.dumps({"agent": "a", "mem_gb": 1.0, "cpu_cores": 1.0, "ts": i}) + "\n"
+                for i in range(60)
+            ),
+            encoding="utf-8",
+        )
+        before = cost_log.read_bytes()
+        sc.compact_cost_log(window=10)
+        assert cost_log.read_bytes() == before, (
+            "compaction rewrote the log from a partial read, permanently deleting "
+            "the record the reader refused"
+        )
+
+    def test_compaction_refuses_to_run_on_an_undecodable_record(self, cost_log):
+        """Red on base: base raises UnicodeDecodeError out of the reader.
+
+        Decoding with replacement would be worse than the crash, because
+        compaction PERSISTS what it read -- ``os.replace`` would substitute
+        U+FFFD for the original bytes. The strict reader refuses instead, so
+        compaction declines and the log keeps its bytes.
+        """
+        cost_log.parent.mkdir(parents=True, exist_ok=True)
+        cost_log.write_bytes(
+            b'{"agent":"a","mem_gb":1.0,"cpu_cores":1.0,"note":"\xff"}\n'
+            + b"".join(
+                (json.dumps({"agent": "a", "mem_gb": 1.0, "cpu_cores": 1.0, "ts": i}) + "\n").encode()
+                for i in range(60)
+            )
+        )
+        before = cost_log.read_bytes()
+        sc.compact_cost_log(window=10)
+        assert cost_log.read_bytes() == before, (
+            "compaction rewrote the log after a lossy decode, replacing the "
+            "original bytes with U+FFFD"
+        )
+
+    def test_compaction_still_trims_a_readable_log(self, cost_log):
+        """The refusal is specific to an incomplete read, not to every compaction."""
+        _seed(
+            cost_log,
+            [{"agent": "a", "mem_gb": 1.0, "cpu_cores": 1.0, "ts": i} for i in range(60)],
+        )
+        sc.compact_cost_log(window=10)
+        kept = [json.loads(x) for x in cost_log.read_text(encoding="utf-8").splitlines() if x]
+        assert len(kept) == 10
+
+    def test_percentile_read_still_degrades(self, cost_log):
+        """The read-only consumer keeps using what it could read, and never raises."""
+        over_cap = json.dumps({"agent": "a", "mem_gb": 9.0, "cpu_cores": 1.0, "pad": "z" * 300})
+        cost_log.parent.mkdir(parents=True, exist_ok=True)
+        cost_log.write_text(
+            "".join(
+                json.dumps({"agent": "a", "mem_gb": 1.0, "cpu_cores": 1.0, "ts": i}) + "\n"
+                for i in range(5)
+            )
+            + over_cap
+            + "\n",
+            encoding="utf-8",
+        )
+        rows, complete = sc._read_samples_checked()
+        assert len(rows) == 5, "records before the over-cap one must survive"
+        assert complete is False, "the caller that writes must be able to see the truncation"


### PR DESCRIPTION
## Problem / Motivation

`for line in handle` asks the handle for bytes up to the next newline. It carries no
length bound, so a single line with no newline in it is materialised in one allocation
the size of the whole file. That is only a bug when the writer is not trusted -- and for
these readers it is not: every tree involved sits under KiroCrew's data home, the kiro
home, or the crew home, and `security.is_sensitive_path` fences only the enumerated
leaves in `_CREW_SECRET_LEAVES`, so an agent's own file tools can write the rest.

PR #6312 closed this for the trash manifest readers and PR #7297 for `session_digest`'s
three transcript scanners. #6345 is the audit of the rest, and it asks for a specific
thing: not a sweep, but a shared bounded reader plus a per-call-site judgement of
whether an over-cap record may be skipped or must abort the read.

This PR delivers that audit. Enumerating the sites turned up two that the issue's own
grep (`for line in (fh|f|handle)`) had missed, because they spell the loop variable
differently: `history_projection.py` (`for raw in handle`) and `sel.py:2817`
(`for raw_line in src_f`). The full set is 27 sites, not 26.

Of those, 10 are deliberately left alone with evidence (kernel `/proc` pseudo-files and
the fenced audit log), 15 are converted here, and **one is deliberately deferred to
#7771** -- the snapshot notification merge, for reasons set out below.

## Why it matters

The reachability is mundane. Opening the usage dashboard reads the token shards.
Expanding a storage row reads a transcript. Restoring a snapshot reads the live
notifications file. A planted or corrupt multi-GB newline-free line turns any of those
into a file-sized allocation inside the gateway process -- not a degraded panel, an OOM
that takes every session on the host with it.

Two of the converted sites are worse than a crash, because their read decides a durable
write:

- `members.read_activity` feeds the `dedupe_session` probe in `record_activity`, which
  decides whether to append a participation entry or suppress it. A skipped record
  reads as "no prior entry", so the log gets a duplicate, and the participation counts
  that drive trigger generation and `select_crew` routing are inflated.
- `subagent_cost._read_samples` has two consumers, and the second one is the dangerous
  one: `compact_cost_log` parses the log and then `os.replace`s it with what it parsed.
  A skipped record there is not a lost reading, it is a permanently deleted one.

## What changed (motivation -> approach -> change)

Symptom: one hostile line, one file-sized allocation. Root cause: the reader trusts the
writer to insert newlines. Change: `jsonl_util` -- which already owns the matching bound
on the WRITE side (`rotate_jsonl_at`) -- gains the read side, and `session_digest`'s
private `_bounded_lines` is promoted into it so there is one implementation rather than
two copies.

A file's rotation cap does not bound one RECORD, which is why the write bound was not
already enough: rotation only fires when the writer next appends, so a crafted line
lands whole before any rotation sees it.

Four functions, two postures by two forms:

- `bounded_records` SKIPS an over-cap record, drains its tail, and logs one aggregated
  debug line. For a read that is read-only and degradable.
- `strict_records` ABORTS by raising `OversizedRecord`, and deliberately does NOT drain:
  the caller is abandoning the read, so walking a multi-GB line to its end would hand
  the hostile file the cost the cap exists to deny it.
- `bounded_raw_records` / `strict_raw_records` are the undecoded twins. The bounded twin
  has one caller: `history_projection` already iterated a binary handle and prefilters on
  bytes (`b'"file_changes"' not in raw`) before parsing, so routing it through the
  decoding form would make it decode every record to run a filter that rejects most of
  them. The strict twin has no external caller today -- it is what `strict_records` is
  built on, and the site that wanted raw strict bytes directly is the deferred merge.
  The module docstring says so, rather than implying a caller that is not there.

The cap is in BYTES and the handles are opened binary for that reason. A character cap
is not a memory bound: one astral code point is four bytes of `str` under PEP 393, so a
128 MiB character cap admits half a gibibyte of resident text. The reverse holds too --
UTF-8 spends at least as many bytes per code point as CPython's widest string
representation -- so an N-byte read caps the decoded `str` at N bytes.

One cap serves every caller, sized for the largest record shape any of them reads (a
transcript record carrying a whole conversation turn): `MAX_IMAGE_BYTES_PER_MESSAGE` is
64 MiB, which base64-expands to ~85 MB, and the largest record measured on a live
install is 77,920,032 bytes. 128 MiB is the smallest round value clearing that. Every
other shape here -- token rows, telemetry export cycles, ~150-byte member activity
entries -- is orders of magnitude smaller, so the shared cap never undercounts them. A
per-format cap would bound each tighter, but the memory that matters is the peak of ONE
record, and a cap below a format's real ceiling buys nothing while risking a silent
undercount. This is also why it is not `_MANIFEST_RECORD_CAP` (8 MiB): that would
truncate the biggest real sessions.

### Peak memory, measured rather than reasoned about

An earlier revision of this branch documented the reader's peak as "roughly twice the
cap". **That was wrong, and it was wrong about main too.** Measured with `tracemalloc` at
a 4 MiB cap, on an input that forces a carried tail plus a full read:

| reader | peak / cap |
|---|---|
| main's merged `_bounded_lines` (PR #7297) | 3.03x |
| this branch, before the fix below | 4.03x |
| this branch now | **3.03x** |

The 4.03x was a real regression of +1x cap over main, and it was mine. Main reads one
line per `readline` and keeps no carried buffer; this reader must accumulate across reads,
because a `\r\n` can straddle a read boundary and a bare `\r` is a boundary. Each read
then asked for a full `cap` regardless of what the tail already held, so a nearly-full
buffer and a full-size read added up.

Fixed by bounding each read to what the carried record has left:
`readline(max(2, cap + 2 - len(buf)))`. That restores exact parity with main.

`cap + 2` is a floor, not a tidy constant. A legal at-cap record ending in a CRLF is
`cap + 2` bytes, so a buffer that could only ever hold `cap + 1` could not assemble one
and would refuse it -- which is a bug this PR already fixed once. Two spy assertions that
pinned `limit <= cap + 1` are relaxed to `cap + 2` for that reason, one of them in
`test_session_digest.py`, which is main's. What those tests exist to pin is that no read
is UNBOUNDED, and that is unchanged; the exact constant was incidental to it, and both
assertions now carry the derivation in a comment so the number does not read as arbitrary.

For the record, one fix that looks obvious does not work: making the buffer a `bytearray`
so `+=` extends in place instead of allocating the concatenation. Measured at 4.03x,
unchanged. The dominant terms are the buffer and the chunk, not the concatenation.

### The site audit, and what each site got

| Sites | Tree | Verdict |
|---|---|---|
| `usage.py` x7, `telemetry.py`, `backfill.py` x2, `history_search.py`, `history_projection.py`, `stub.py` | data home usage shards, kiro-cli transcripts, telemetry shards, crew-home logs | agent-writable, **skip-safe** -> `bounded_records` (13 sites) |
| `members.py`, `subagent_cost.py` | member activity log, cost-sample log | agent-writable, **abort-required** -> `strict_records` (2 sites) |
| `snapshot.py` x2 | `notifications.jsonl` | agent-writable, abort-required, **DEFERRED to #7771** (2 sites) |
| `handlers_system.py` x3, `platform_compat.py` x3, `acp/runtime.py`, `sandbox.py` | `/proc/meminfo`, `/proc/net/dev`, `/proc/locks`, `/proc/<pid>/status`, `/proc/<pid>/mountinfo` | kernel-synthesised, not agent-writable -> unchanged (8 sites) |
| `sel.py` x2 | `security_events.jsonl` / `.d` | fenced by `_CREW_SECRET_LEAVES` -> unchanged (2 sites) |

Every skip-safe site already did `try: json.loads(line) except ValueError: continue`, so
skip is not a new posture there -- it is the posture the site already had, now reachable
for length as well as for syntax.

**One site moved from skip to abort during review, and the reason is worth recording.**
The first revision classified `subagent_cost.py` skip-safe by tracing `_read_samples` to
`read_learned_cost`, a read-only p90 aggregation. It has a SECOND consumer,
`compact_cost_log`, described above. GPT 5.6 review caught it. The lesson is that "does
this feed a rewrite" has to be answered by enumerating ALL consumers of the reader, not
the first one; a single-consumer trace is how a skip/abort call goes wrong.

### Why the notification merge is NOT in this PR

It was converted here, and then backed out on the conductor's ruling after four
successive review rounds each found one more defect in it. That history is the argument,
so it is on the record rather than summarised away:

| round | property the copy must preserve | how it failed |
|---|---|---|
| 4 | record boundary | a bare carriage return split a record, so the merge reported completion having merged nothing |
| 5 | dedupe-key type | `json.loads(raw).get("ts")` raised `AttributeError` on non-object JSON |
| 6 | dedupe-key hashability | a list or dict `ts` raised `TypeError` on set insert |
| 6 | framing | an unterminated record on either side glued two records into one corrupt line |
| 7 | encoding | an invalid-UTF-8 record poisons the whole destination file |

Every other site in this audit is a CONSUMER: it reads, counts, displays, or decides,
and "hand back exactly what is on disk, or refuse" is a complete contract that the
reader alone can satisfy. The merge is a PRODUCER -- what it reads becomes the content
of a second durable file -- so the bytes must also be valid FOR THE DESTINATION. That is
a second contract, and nobody wrote it down, which is why it was being discovered one
review round at a time.

Four rounds is one missing specification found four times, not four separate mistakes,
and patching a fifth property would have traded another review round per undiscovered
invariant. So the merge is filed as the bug it actually is -- an invalid-UTF-8 record
empties live notification history -- with the write-side contract spelled out up front:
#7771. `snapshot.py` is unchanged from main here, so this is not a regression, it is the
pre-existing state.

The audit scanner lists it in `_DEFERRED_READERS` with that reasoning, so the deferral is
recorded in an executable place rather than only in this description.

### Two smaller things the conversions forced

`backfill.py`'s no-follow open is split into a shared `_no_follow_fd` guard with text and
binary wrappers, so the O_NOFOLLOW rationale is stated once and cannot drift.

An at-cap record ending CRLF is now accepted rather than refused by one byte. **This
reverses a pin PR #7297 made deliberately**, and the maintainer should see it as a
choice rather than a cleanup. That pin's stated cost was that buying the byte back
"would cost the reader its single invariant (a return shorter than cap+1 is a whole
record)" -- true of the old reader, which decided over-cap straight from one
`readline(cap + 1)` length. The shared reader has no such invariant left to lose: it
already defers a trailing carriage return across reads, because it must not split a
CRLF whose line feed has not arrived. So the byte is free, and the record is legal by
the cap's own definition -- its body IS cap bytes. Left refused, it suppressed a real
participation entry in `members.read_activity`. One commit to revert if you disagree.

### What the abort site does instead of skipping

`read_activity` keeps its public signature and its documented non-raising contract -- 25
existing tests depend on it -- and becomes a thin wrapper over a new
`_read_activity_checked` that also returns whether the read was complete. Only the one
caller that WRITES honours the flag, and it fails closed by declining to append. That is
the same `False` the function's existing blanket handler already returns for any other
read failure, so no caller learns a new failure mode. `subagent_cost` uses the same
shape: the percentile consumer keeps degrading, and `compact_cost_log` declines to
compact on an incomplete read.

## Tests

161 tests pass across the four affected files, 40 of them added by this PR
(`test_jsonl_util.py` +29 including a 3-test scanner class, `test_members.py` +6,
`test_subagent_cost.py` +4, `test_session_digest.py` +1 rewritten).

Two are behaviourally red against pristine base source, verified by copying the new test
files into a clean `origin/main` worktree and running them there (the cap fixtures use
`raising=False`, the same idiom as `test_session_digest`'s `create=True`, so the files
RUN on base and fail on behaviour rather than erroring on a missing name):

- `test_over_cap_record_refuses_to_append` -- base skips the junk line, finds no match,
  and appends. `AssertionError: must not append when the log could not be read in full`.
- `test_compaction_refuses_to_run_on_an_incomplete_read` -- base rewrites the log from a
  partial read. `AssertionError: compaction rewrote the log from a partial read,
  permanently deleting the record the reader refused`. This is the regression test for
  GPT's finding.

`test_every_handle_iteration_is_bounded_or_excused` reports 0 unexcused sites on this
branch. It cannot be run against base source to produce a matching count, because the
test module's imports (`RECORD_CAP` and the reader names) do not exist there and
collection fails -- so that comparison was done by running the scanner logic standalone,
and no base number is claimed from the test itself.

That scanner is the piece I would keep if I could keep only one: it makes the audit
executable instead of a claim in this description. It scans the package for the shape and
requires every instance to be converted, excused with a reason, or listed as a tracked
deferral, so a new unbounded reader cannot land unnoticed and a converted one cannot
regress. A companion test guards the guard -- it asserts the detector still finds the
listed sites, so a scanner that silently stopped matching anything would fail rather than
pass. Detection is by the handle-name vocabulary rather than a fixed window after the
`with`, because a distance-based match missed `sel.py:2522`, where the handle is bound
several lines earlier.

The scanner's claim is deliberately no broader than the shape it detects. A whole-file
read spelled `path.read_text().splitlines()` has the same harm and is invisible to it;
`learn.py`, the auto_improvement ledger, and the meetings store each hold one, and
`learn.py`'s feeds a `_write_all` rewrite, which is the abort-required pattern. Those are
a different reader shape than #6345 enumerates and are left for a follow-up rather than
swept in here.

Refactoring `session_digest` onto the shared reader is covered by its existing tests,
which pass unchanged -- including the spy test asserting every read carries a limit and
the handle is never iterated. That is the evidence the promotion is behaviour-preserving
rather than a rewrite.

Mutation-verified on the current reader core, 4/4 killed: `readline(cap)` instead of
`cap + 1`, the boundary terminator check dropped, the drain loop removed, and the strict
variant made to drain its hostile tail. The performance guard is mutation-checked too --
re-slicing the buffer per record makes
`test_many_records_in_one_read_scale_linearly` fail with `6.722s for 200000 records`
against its 1.0s ceiling.

That test's threshold is measured, not guessed, because the first version of it was
WRONG: it compared 4,000 records against 8,000 with a 6x growth bound and passed the
quadratic mutant, since files that small never let the quadratic term show. Re-derived at
200,000 records: 0.10s for the shipped reader, 1.84s with a separate `find` per
terminator, 8.11s re-slicing per record. An absolute ceiling rather than a growth ratio,
because at these absolute times runner noise can move a ratio.

`flake8`, `isort` and `mypy` are clean on all 14 files. The repo's own gates pass with
real diff scope: `check_black_formatting.py`, `check_sync_io_in_async.py`. `stub.py` is
unformatted under black, but it is in `.github/black-baseline.txt` and the complaint is
pre-existing argparse help-string indentation this diff never touches, so it is left
alone rather than graduated out of the baseline.

## Manual verification

The cap's floor is the one input unit tests cannot supply, and it is inherited rather
than re-derived: PR #7297 measured it with `wc -L` across both transcript trees on a live
install (30,351 kiro-cli logs, 27 GB) to find the longest record of any kind. Those are
the numbers quoted above. This PR adds a test asserting the constant still clears both
that measurement and the base64-expanded `MAX_IMAGE_BYTES_PER_MESSAGE` ceiling, so the
derivation is checked rather than trusted to a comment.

Everything else is asserted directly: the allocation bound by the spy-handle test, the
boundary by the at-cap / one-over / unterminated-at-cap tests, the byte-versus-code-point
distinction by a 240-byte 60-character record refused by a 200-byte cap, and the drain by
a file that is one line whose tail forges a complete record. A run against a real
multi-gigabyte planted file would add no evidence those do not already give.

## Related Issues

Refs #6345 -- the audit it asks for is complete, but one enumerated site is deferred to
#7771 rather than converted, so this does not close it.
Refs #7771 (the deferred notification merge, filed as a data-loss bug)
Refs #6312, #7297 (the two earlier instances this generalises from)

## Pattern harvest

Rule candidate: review-prompt

Pattern: `for line in <handle>` over a tree any agent can write is an unbounded
allocation -- one record's length is attacker-controlled. The reader must pass a limit to
`readline`, and then the per-call-site question is what an over-cap record does: SKIP
where the read is read-only and degradable, ABORT where its output feeds a rewrite or any
other durable decision. Four corollaries learned here. The limit must be in BYTES, which
means reading binary, because a character limit is not a memory bound. A file-size
rotation cap does not bound one record, because rotation only fires on the next append.
When a fix claims to close a defect CLASS, the enumeration itself is the risky step: a
grep keyed on the loop VARIABLE name misses instances that spell it differently, so the
audit belongs in a test that fails when a new instance appears, not in a table in a pull
request description. And a reader whose output is WRITTEN BACK to a durable file is a
different problem from one that is merely consumed -- it needs a stated write-side
contract (boundary, key type, framing, encoding) before any code, because otherwise each
property gets discovered one review round at a time.