### PR TITLE
fix(chat): close a trigger picker the composer no longer owns

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1584,7 +1584,14 @@ function ChatInput({
   // Reset manual height when input is cleared (new message sent)
   const prevValueRef = useRef(value)
   useEffect(() => {
-    if (prevValueRef.current && !value) resetHeight()
+    if (prevValueRef.current && !value) {
+      resetHeight()
+      // Picker open state is derived only in the textarea's own onChange, so the
+      // parent-driven send-clear would otherwise leave a stale menu open.
+      setSlashMenuOpen(false)
+      setFilePickerOpen(false); setFileQuery('')
+      setSkillPickerOpen(false); setSkillQuery('')
+    }
     // Exit history mode when value diverges from the recalled message
     // (user edited it, or the send pipeline cleared it).
     if (historyIdxRef.current !== -1 && value !== sentMessages?.[historyIdxRef.current]) {
@@ -1593,6 +1600,14 @@ function ChatInput({
     }
     prevValueRef.current = value
   }, [value, resetHeight, sentMessages])
+
+  // ChatInput is one instance shared by every slot, so a switch would carry the
+  // previous tab's menu over; an unsent draft never hits the clear above.
+  useEffect(() => {
+    setSlashMenuOpen(false)
+    setFilePickerOpen(false); setFileQuery('')
+    setSkillPickerOpen(false); setSkillQuery('')
+  }, [slotId])
 
   // Record undo snapshots as the controlled value changes.
   useEffect(() => {

--- a/website/src/test/ChatInput.pickerReset.test.tsx
+++ b/website/src/test/ChatInput.pickerReset.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useState } from 'react'
+import { screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import { SlotProvider } from '../providers/SlotContext'
+
+/* ── A trigger picker must not survive a value change the composer did not
+ *    originate: a parent-driven clear (send) or a slot switch. ── */
+const mockApi = vi.hoisted(() => ({
+  skills: vi.fn(),
+  skillTrust: vi.fn(),
+  grantSkillTrust: vi.fn(),
+  fileSearch: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import ChatInput from '../components/ChatInput'
+
+const SKILLS = [
+  { key: 'peer-review-walk', name: 'peer-review-walk', description: 'Walk peer CRs', source: 'kirocrew' },
+  { key: 'grill', name: 'grill', description: 'Questioning', source: 'kirocrew' },
+]
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  localStorage.clear()
+  mockApi.skills.mockResolvedValue(SKILLS)
+  mockApi.skillTrust.mockResolvedValue({ project: '/work/p', project_key: '/work/p' })
+  mockApi.grantSkillTrust.mockResolvedValue({ trusted: true })
+  mockApi.fileSearch.mockResolvedValue({ results: [] })
+})
+
+/** Clears the draft the way send does: set it to '' with no DOM change event.
+ *  `slot` feeds the seam ChatInput actually reads (useSlotId), not a prop. */
+function Host({ slot = 'chat-1' }: { slot?: string }) {
+  const [val, setVal] = useState('')
+  return (
+    <SlotProvider slotId={slot}>
+      <button onClick={() => setVal('')}>parent-clear</button>
+      <ChatInput value={val} onChange={setVal} onSend={vi.fn()} />
+    </SlotProvider>
+  )
+}
+
+function typeInto(value: string) {
+  fireEvent.change(screen.getByLabelText('Message input'), { target: { value } })
+}
+
+/** Scoped to the menu: the composer mirrors the draft into a PasteHighlightLayer,
+ *  so a bare getByText also matches the typed text. */
+function row(name: string) {
+  return within(screen.getByRole('listbox')).getByText(name)
+}
+
+describe('ChatInput — trigger pickers close on a non-user value change', () => {
+  it('closes the skill picker when the parent clears the draft (send)', async () => {
+    renderWithProviders(<Host />)
+    typeInto('$peer')
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    await waitFor(() => expect(row('$peer-review-walk')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('parent-clear'))
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+  })
+
+  it('closes the skill picker when the slot changes', async () => {
+    const { rerender } = renderWithProviders(<Host slot="chat-1" />)
+    typeInto('$peer')
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+
+    // Same ChatInput instance, different slot — a tab switch.
+    rerender(<Host slot="chat-2" />)
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+  })
+
+  it('NEGATIVE CONTROL: keeps the picker open while a token is still under the caret', async () => {
+    renderWithProviders(<Host />)
+    typeInto('$peer')
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+
+    // A keystroke must never close the menu.
+    typeInto('$peer-review')
+    typeInto('$peer-review-walk')
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(row('$peer-review-walk')).toBeInTheDocument()
+  })
+
+  it('NEGATIVE CONTROL: keeps the picker open when the parent never applies onChange', async () => {
+    // With a no-op onChange `value` stays '', so a close derived from value
+    // CONTENT would shut the menu on the keystroke that opened it.
+    renderWithProviders(
+      <SlotProvider slotId="chat-1">
+        <ChatInput value="" onChange={vi.fn()} onSend={vi.fn()} />
+      </SlotProvider>,
+    )
+    typeInto('hello $peer')
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    await waitFor(() => expect(row('$peer-review-walk')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The `$skill` / `@file` / `/command` picker stays open after the message is sent, and then paints over other chat tabs — reading as **"Loading skills…"** in a chat the user never typed a `$` in.

Two independent defects, both in `website/src/components/ChatInput.tsx`:

**1 — never closed on send.** `slashMenuOpen` / `filePickerOpen` / `skillPickerOpen` are derived *only* inside the textarea's own `onChange`. The send pipeline clears the draft from the **parent** (`value` is a prop), which runs no `onChange` at all, so the menu survives holding the query that was just sent.

**2 — not per-tab.** `<ChatInput>` is rendered with no per-slot `key` (`ChatPage.tsx`), there is no route key on `ChatPage`, and nothing resets on the slot. The picker state is one instance's, shared by every tab.

## Why it matters

The combination is what produces the confusing surface. `SkillPickerMenu`'s query key is `['skills', slotKey, project, agent]`, so the still-open menu re-fetches under each tab's own key as the user switches: already-cached tabs render rows, uncached ones sit at the loading copy. The user sees a skill menu — sometimes mid-load — attached to composers they never typed in, with no way to dismiss it except typing a closing character.

## What changed

Close the pickers on the **transition to an empty value** — the existing send-clear signal, folded in alongside `resetHeight` — and on a slot change.

Keyed on the transition, not on whether `value` still contains a token. A content test also fires whenever the parent has not yet applied our `onChange`, which closes the picker on the very keystroke that opened it; an earlier draft of this change did exactly that and broke three existing suites that mount `ChatInput` with a no-op `onChange`. Two negative controls now pin that distinction.

**Known residual, narrowed after merge:** picker open state is re-derived only from the textarea's own `onChange`, so a programmatic value replacement that neither empties the value nor changes slot would leave a stale query. No reachable browser path was identified: paste and the prompt-optimizer write-back both insert via `execCommand('insertText')`, which fires that `onChange` and re-derives the pickers, and ↑/↓ history recall cannot fire while a picker is open because the picker owns those keys. What remains is the `execCommand`-unavailable fallback (jsdom/tests), which reconciles straight through the controlled value and skips the derivation. The enumeration covered this component's own writers, not every caller in `ChatPage`.

Enter being inert while "Loading skills…" is up is a **separate** issue in `SkillPickerMenu` (its release gate requires a settled query, so the menu swallows Enter for up to `SKILLS_TIMEOUT_MS`), tracked separately.

## Pattern harvest

Rule candidate: review-prompt / agents-md — "derive state from the dependency, not from the event that usually changes it".

Pattern: state derived as a side effect of ONE input handler, while the state's real dependency is a **prop** that other routes also write. `skillPickerOpen` / `filePickerOpen` / `slashMenuOpen` were computed only inside the textarea's `onChange`, so every non-typed route to `value` — the send-clear, a slot draft restore, ↑ history recall, a follow-up insert — skipped the derivation entirely. A shared un-keyed component instance then made that stale state visible in tabs which never triggered it, which is why the symptom looked like a cross-tab bug rather than a missing reset.

Generalizable form: when a handler derives state from a prop, the derivation belongs on the prop's change — or the handler must be the prop's only writer, which a controlled input never is. Grep-able shape: a `set*Open(...)` (or any derived-state setter) called from inside an `onChange`/`onInput` handler whose own `value` arrives as a prop.

The trap worth recording, because the obvious fix is the wrong one: re-deriving from `value` **content** ("does it still hold a token?") fires whenever the parent has not yet applied `onChange`, closing the picker on the very keystroke that opened it. That is not hypothetical — it broke three existing suites that mount `ChatInput` with a no-op `onChange`. Both negative controls in this PR exist to pin the distinction so the transition test is not later "simplified" into a content test.

## Tests

New `website/src/test/ChatInput.pickerReset.test.tsx` — 2 regression tests + 2 negative controls:

- closes the skill picker when the parent clears the draft (send)
- closes the skill picker when the slot changes
- NEGATIVE CONTROL: keeps the picker open while a token is still under the caret
- NEGATIVE CONTROL: keeps the picker open when the parent never applies `onChange`

Both regression tests were confirmed to **fail on an unmodified base** (the picker stays open); both negative controls pass on base, so they are not what is under test.

Gates: `website` **1735 files / 27306 tests pass**, `tsc -b` clean, `eslint` 0 errors. Backend cross-surface guards were not runnable in this worktree (no venv) — the diff is one `.tsx` file adding no strings or i18n keys. The electron test half cannot run in this sandbox (`node_modules/electron` absent); the diff touches no electron code.

