### PR TITLE
fix(ledger): scope the bounded-lock promise to a live holder (#7645)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/session_ledger.py
+++ b/src/kiro_crew/dashboard/handlers/session_ledger.py
@@ -126,9 +126,13 @@ async def api_session_ledger_record(request: web.Request) -> web.Response:
         )
     try:
         # record() takes the per-ledger file lock (bounded acquire + disk
-        # I/O); off-loop so a wedged cross-process peer cannot freeze
-        # chat/WS/heartbeat — the bounded lock then costs at most one refused
-        # write, never a parked worker thread.
+        # I/O); off-loop so a merely-contended cross-process peer cannot
+        # freeze chat/WS/heartbeat — against a live lock HOLDER the bounded
+        # acquire costs at most one refused write. This does NOT bound a
+        # wedged filesystem/mount: the pre-lock mkdir/os.open can still stall
+        # this worker thread at the syscall (a mount-health failure mode the
+        # lock deadline cannot reach), so off-loading it keeps that stall off
+        # the event loop rather than promising it can't happen.
         state_record = await asyncio.to_thread(
             session_ledger.record,
             key,

--- a/src/kiro_crew/session_ledger.py
+++ b/src/kiro_crew/session_ledger.py
@@ -28,8 +28,14 @@ Design notes, each earned by a review finding:
   inside :func:`_store_name` — a lossy charset fold as the identity would map
   distinct channel session keys (colon-structured) onto one ledger.
 - **Bounded lock.** The per-ledger lock acquire is a bounded poll and fails
-  closed with ``OSError`` — a wedged cross-process holder costs one refused
-  write, never an executor thread parked forever.
+  closed with ``OSError`` — a *live cross-process holder* of the flock costs
+  one refused write, not an executor thread parked on it forever. The bound
+  covers only what the deadline can reach: contention for an already-created
+  lock inode. It does NOT cover a wedged filesystem/mount — the pre-lock
+  ``mkdir``/``os.open`` are ordinary path/inode syscalls that a dead NFS mount
+  or dying disk can stall unboundedly, and no in-process deadline can
+  interrupt a stalled syscall. That mount-level failure is a distinct,
+  out-of-scope failure mode, not a bound this code promises.
 - **Size ceiling before parse.** A state file past ``_MAX_STATE_BYTES`` is
   treated as corrupt/absent rather than parsed, so a hostile or damaged file
   cannot make every nudge fire allocate its size.
@@ -83,7 +89,7 @@ _MAX_EVENT_TAIL = 20
 _MAX_STATE_BYTES = 1_000_000
 
 #: Lock acquire budget. Every in-tree critical section is a sub-millisecond
-#: read + atomic rename, so this is a ceiling against a wedged cross-process
+#: read + atomic rename, so this is a ceiling against a live cross-process
 #: holder, not a normal wait. On expiry the write FAILS CLOSED with OSError.
 _LOCK_TIMEOUT_SECS = 5.0
 _LOCK_POLL_SECS = 0.05
@@ -173,20 +179,43 @@ def _clamp(value: Any, limit: int = _MAX_TEXT) -> str:
 
 @contextmanager
 def _locked(dir_path: Path) -> Iterator[None]:
-    """Bounded cross-process exclusive lock over one ledger directory.
+    """Bounded-against-a-holder exclusive lock over one ledger directory.
 
     The lock file is a dedicated inode that writes never replace (replacing
     the locked inode would let a second writer lock the NEW inode and
     interleave). The acquire is a bounded poll over
     :func:`platform_compat.try_acquire_lock` — the repo's one non-blocking
     acquire primitive, covering POSIX and Windows alike — and FAILS CLOSED
-    with ``OSError`` rather than entering the critical section unserialized
-    or parking a worker thread on a wedged holder forever.
+    with ``OSError`` rather than entering the critical section unserialized.
+
+    Scope of the bound (be precise — the docstring must not out-promise the
+    code). ``_LOCK_TIMEOUT_SECS`` bounds ONLY the ``try_acquire_lock`` poll
+    loop below: against a *live cross-process holder* of the flock, this
+    refuses with ``OSError`` instead of waiting forever. The deadline is
+    checked between sleeps rather than during one, so the refusal lands within
+    the budget plus at most one ``_LOCK_POLL_SECS`` interval — a bound, not an
+    exact wall-clock cap.
+
+    The pre-lock ``mkdir``/``os.open`` are ordinary path/inode syscalls; on a
+    wedged filesystem (hard NFS mount, dying disk) they can stall unboundedly,
+    and NO in-process deadline can interrupt them — SIGALRM is main-thread +
+    POSIX-only (this runs on an ``asyncio.to_thread`` worker), a bounded
+    dedicated-thread offload leaks an unkillable thread and a held fd on a
+    hard hang, and ``O_NONBLOCK`` does not cover path-resolution/inode stalls
+    (only FIFO/device opens). A wedged mount is therefore explicitly OUT OF
+    SCOPE of this lock's deadline, not a bound this contextmanager promises.
+
+    The deadline is established immediately before the poll it governs and is
+    NOT hoisted above ``mkdir``/``os.open`` — hoisting would spend the budget
+    on the pre-lock syscalls and leave a near-zero retry window for genuine
+    contention, which is the inversion that must not recur.
     """
     dir_path.mkdir(parents=True, exist_ok=True)
     lock_path = dir_path / _LOCK_FILE
     fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
     try:
+        # Bound only the acquire poll: set the deadline adjacent to the loop
+        # it governs, after the pre-lock syscalls (which it cannot bound).
         deadline = time.monotonic() + _LOCK_TIMEOUT_SECS
         while not try_acquire_lock(fd, exclusive=True):
             if time.monotonic() >= deadline:

--- a/test/test_session_ledger.py
+++ b/test/test_session_ledger.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -435,22 +436,41 @@ def test_purge_removes_dir_and_tolerates_bad_keys():
 
 @pytest.mark.skipif(not IS_POSIX, reason="flock-based holder simulation is POSIX-only")
 def test_record_fails_closed_on_held_lock(monkeypatch):
-    """A wedged cross-process holder costs one refused write (OSError), never
-    an unbounded wait — and removing the lock entirely would break this test,
-    because an unlocked record would succeed while the lock is held."""
+    """A live cross-process flock HOLDER costs one refused write (``OSError``),
+    and the refusal is bounded rather than an unbounded wait — removing the
+    lock entirely would break this test, because an unlocked record would
+    succeed while the lock is held.
+
+    Deliberately NOT asserted: a bound on a wedged FILESYSTEM/mount. The
+    pre-lock mkdir/os.open are ordinary syscalls that a dead mount can stall
+    unboundedly, and no in-process deadline can interrupt a stalled syscall
+    (see ``session_ledger._locked``). There is no portable way to simulate a
+    hung mkdir/os.open, and asserting a bound there would re-assert the
+    over-broad "never a parked worker thread" promise the docs do not make.
+    """
     import fcntl
 
+    timeout = 0.2
+    # Generous absolute ceiling: the claim under test is "bounded, not
+    # forever", so the margin only has to exclude an unbounded wait.
+    slack = 2.0
     key = "chat-lock-1"
     sl.record(key, goal="x")  # create the dir + lock inode
-    monkeypatch.setattr(sl, "_LOCK_TIMEOUT_SECS", 0.2)
+    monkeypatch.setattr(sl, "_LOCK_TIMEOUT_SECS", timeout)
     fd = os.open(str(sl.ledger_dir(key) / ".lock"), os.O_RDWR)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
+        start = time.monotonic()
         with pytest.raises(OSError, match="held by another process"):
             sl.record(key, goal="y")
+        elapsed = time.monotonic() - start
     finally:
         fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
+    assert elapsed < timeout + slack, (
+        f"refusal took {elapsed:.3f}s; the deadline is not governing the "
+        f"acquire poll (expected < {timeout + slack:.3f}s)"
+    )
     # Holder released: the next write goes through.
     sl.record(key, goal="z")
     assert sl.read_state(key)["goal"] == "z"


### PR DESCRIPTION
Resolves #7645.

## Problem

`session_ledger._locked` runs `dir_path.mkdir(...)` and `os.open(...)` **before** the `_LOCK_TIMEOUT_SECS` deadline is set, and that deadline only bounds the `try_acquire_lock` retry poll (`time.monotonic() >= deadline` is evaluated *between* attempts). On a wedged filesystem (hard NFS mount, dying disk) those pre-lock syscalls stall unboundedly, parking the `asyncio.to_thread` worker. This contradicted the documented promise in `dashboard/handlers/session_ledger.py` ("at most one refused write, never a parked worker thread") and the module's "Bounded lock" docstring.

## Mechanism decision

This was a design choice, not a reorder. Every candidate userspace mechanism was weighed against the actual code and confirmed unable to bound a stalled syscall:

- **SIGALRM** — main-thread + POSIX-only; this path runs on a `to_thread` worker. Unusable.
- **Bounded/cancellable dedicated-thread offload** — leaks an unkillable thread and a held fd on a hard hang; trades an unbounded park for an unbounded leak.
- **`O_NONBLOCK`/`fcntl` fail-fast** — `O_NONBLOCK` only affects FIFO/device opens, not the NFS path-resolution/inode create that actually stalls.
- A pure deadline reorder is already known to fail — it withdrew PR #6296 and regressed #6282 via the near-zero-retry inversion.

Since no in-process deadline can interrupt a wedged syscall, the resolution is to **make the guarantee honest**: scope the documented bound to a *live cross-process flock holder* (which the deadline genuinely bounds), and explicitly name the wedged-mount syscall stall as a distinct, out-of-scope failure mode. The `_locked` deadline was deliberately **not** hoisted above `mkdir`/`os.open` (that is the #6296 inversion).

## Changes

- `src/kiro_crew/session_ledger.py` — reworded the module "Bounded lock" note and the `_locked` docstring to scope the bound to a live holder and enumerate why every alternative cannot bound the mount stall. The docstring also states the bound as the timeout **plus at most one `_LOCK_POLL_SECS` interval**, since the deadline is checked between sleeps rather than during one. The `_LOCK_TIMEOUT_SECS` constant comment says "live" rather than "wedged" for the same reason, so the definition site and the docstrings agree. Execution path and `OSError` message unchanged.
- `src/kiro_crew/dashboard/handlers/session_ledger.py` — reworded the `to_thread(record, ...)` comment: bounded against a live holder; a wedged mount can still stall at the syscall, so off-loading keeps that stall off the event loop rather than promising it can't happen.
- `test/test_session_ledger.py` — extended the existing POSIX-guarded `test_record_fails_closed_on_held_lock` with an elapsed-time ceiling, so the refusal is pinned as *bounded* rather than merely raised, plus an in-code fence telling future readers not to assert a wedged-mount bound. Folded into that sibling rather than added as a second test, since setup, monkeypatch, flock hold, raises-match and post-release write were all identical.

## Testing

Full local CI-parity gate, all green:

- `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test`, `mypy src/kiro_crew/` (1245 files, no issues), `scripts/check_black_formatting.py`, `scripts/check_subprocess_encoding.py`
- `scripts/check_brand_name.py`, `scripts/check_harness_parity.py`, `scripts/check_changelog_history.py`, `scripts/docs-lint.sh`
- `pytest test/test_session_ledger.py test/test_flock_compat.py test/test_no_blocking_call_on_loop.py` — 74 passed

The timing assertion is a generous absolute ceiling (timeout + 2.0s), because the claim under test is "bounded, not forever" — a tight ratio would false-red on a shared runner. `scripts/scrub-lint.sh` reports one pre-existing hit in `test/test_atomic_write_named_duplicates.py`, which this branch does not touch and which reproduces on `main`.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a docstring or comment promising a timing bound that the code can only
enforce over part of its guarded region. The deadline governs the flock retry poll
but not the preceding `mkdir` / `os.open`, which no in-process mechanism can
interrupt on a wedged mount. Review prompt: when a comment states a timing
guarantee, check every syscall inside the guarded region, not just the retry loop.

