### PR TITLE
fix(babysit): refuse a non-boolean wake_on_green instead of coercing it

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py
@@ -322,11 +322,21 @@ class PrWatchProbe(Probe):
             raise ValueError("pr_watch coalesce_secs must be a finite number")
         if coalesce < 0:
             raise ValueError("pr_watch coalesce_secs must not be negative")
+        # The cron message is JSON, so {"wake_on_green": "false"} arrives as a
+        # string. bool("false") is True, so coercing would silently INVERT an
+        # explicit disable and wake the operator they told it not to. Any
+        # non-empty string does this. bool is a subclass of int, so validate
+        # against bool explicitly and refuse everything else -- a nonsense flag
+        # is a permanently-invalid config, terminal (ValueError -> Done) like
+        # every other malformed field here.
+        raw_wake = params.get("wake_on_green", True)
+        if not isinstance(raw_wake, bool):
+            raise ValueError("pr_watch wake_on_green must be true or false")
 
         self.repo = repo
         self.pr = pr
         self.known_reds = {sanitize_label(x) for x in raw_reds or [] if isinstance(x, str)}
-        self.wake_on_green = bool(params.get("wake_on_green", True))
+        self.wake_on_green = raw_wake
         self.note = str(params.get("note") or "")[:500]
         self.coalesce_secs = coalesce
         return ("gh-pr", f"{repo}#{pr}")

--- a/test/test_babysit_pr_watch.py
+++ b/test/test_babysit_pr_watch.py
@@ -507,6 +507,53 @@ def test_malformed_known_reds_parameter_is_terminal(monkeypatch, module):
         _tick(module, _msg(known_reds=1))
 
 
+@pytest.mark.parametrize("spelling", ["false", "no", "0", "off"])
+def test_string_wake_on_green_is_refused_not_coerced(monkeypatch, module, spelling):
+    """The cron message is JSON, so a caller can write a string. bool("false")
+    is True, so coercing would INVERT an explicit disable and wake the operator
+    they told it not to. Every non-boolean spelling must stop the watch with a
+    terminal Done instead of running forever with the opposite behaviour."""
+    _wire(monkeypatch, module, _payload([_check("CI", "SUCCESS")]))
+    with pytest.raises(Done, match="wake_on_green"):
+        _tick(module, _msg(wake_on_green=spelling))
+
+
+def test_string_wake_on_green_does_not_coerce_to_a_wake(monkeypatch, module):
+    """The all-green PR a coerced ``"false"`` string would wake on: assert the
+    terminal Done fires instead of the review-ready Report that a truthy
+    coercion (``bool("false")`` is True) would have produced."""
+    # Same rollup as test_cancelled_runs_are_noise_not_failures: with a real
+    # ``wake_on_green=True`` this fires the "all checks green" ready wake.
+    checks = [_check("GPT Review", "CANCELLED"), _check("CI", "SUCCESS")]
+    _wire(monkeypatch, module, _payload(checks))
+    with pytest.raises(Done, match="wake_on_green"):
+        _tick(module, _msg(wake_on_green="false"))
+
+
+def test_real_boolean_true_wake_on_green_still_wakes(monkeypatch, module):
+    """The narrow fix keeps a real ``true`` working: it still fires the wake."""
+    checks = [_check("GPT Review", "CANCELLED"), _check("CI", "SUCCESS")]
+    _wire(monkeypatch, module, _payload(checks))
+    with pytest.raises(Report, match="all checks green"):
+        _tick(module, _msg(wake_on_green=True))
+
+
+def test_real_boolean_false_wake_on_green_stays_quiet(monkeypatch, module):
+    """The narrow fix keeps a real ``false`` working: the all-green PR stays quiet."""
+    checks = [_check("GPT Review", "CANCELLED"), _check("CI", "SUCCESS")]
+    _wire(monkeypatch, module, _payload(checks))
+    with pytest.raises(Skip):
+        _tick(module, _msg(wake_on_green=False))
+
+
+def test_absent_wake_on_green_defaults_to_waking(monkeypatch, module):
+    """An absent key keeps the documented default of True and still wakes."""
+    checks = [_check("GPT Review", "CANCELLED"), _check("CI", "SUCCESS")]
+    _wire(monkeypatch, module, _payload(checks))
+    with pytest.raises(Report, match="all checks green"):
+        _tick(module, _msg())
+
+
 def test_boolean_and_nonpositive_pr_numbers_are_terminal(monkeypatch, module):
     _wire(monkeypatch, module, _payload([]))
     with pytest.raises(Done, match="positive int"):


### PR DESCRIPTION
Fixes #7644.

## Problem
The gh-pr watch probe read its `wake_on_green` switch as:
```python
self.wake_on_green = bool(params.get("wake_on_green", True))
```
The cron message is JSON, so a caller can write `{"wake_on_green": "false"}` (a string). `bool("false")` is `True`, so an explicit disable silently inverts to ENABLED and the watch wakes the operator on all-green anyway. Any non-empty string (`"no"`, `"0"`, `"off"`) has the same effect.

## Fix
In `PrWatchProbe.identity()` (`src/kiro_crew/builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py`), replaced the coercion with explicit validation that mirrors the existing malformed-parameter discipline already used for `repo`, `pr`, and `coalesce_secs`:
```python
raw_wake = params.get("wake_on_green", True)
if not isinstance(raw_wake, bool):
    raise ValueError("pr_watch wake_on_green must be true or false")
...
self.wake_on_green = raw_wake
```
A non-boolean now raises `ValueError`, which the wrapper converts into a terminal `Done` (the watch says so once and stops) rather than running forever with the opposite of the requested behaviour. Because `bool` is a subclass of `int`, the guard uses an explicit `isinstance(..., bool)` check. The absent-key default remains `True`.

## Tests
Added to `test/test_babysit_pr_watch.py` alongside the existing malformed-parameter cases:
- `test_string_wake_on_green_is_refused_not_coerced` — parametrized over `"false"`, `"no"`, `"0"`, `"off"`; each asserts terminal `Done`.
- `test_string_wake_on_green_does_not_coerce_to_a_wake` — on an all-green rollup, asserts `Done` fires instead of the review-ready `Report` a truthy coercion would have produced.
- `test_real_boolean_true_wake_on_green_still_wakes`, `test_real_boolean_false_wake_on_green_stays_quiet`, `test_absent_wake_on_green_defaults_to_waking` — confirm real booleans and the default still behave.

## Verification
Ran the target module offline against the sandbox Python: **70 passed**. Falsification check: with the source fix reverted (test change only), the 5 new string-rejection tests fail against the old `bool(...)` coercion; with the fix restored they pass.

The documented full-suite entry (`make backend && make test`) requires building the dev venv from PyPI, which is unavailable under the sandbox's repository-access-only network mode, so full-suite CI verification should run in the pipeline.

## Scope note
Targets `pr_watch.py` on `main` as directed. The relocation into `kiro_crew.probes.gh_pr` (PR #7634) is not yet merged; when it lands, the byte-identical expression at `probes/gh_pr.py:329` will need the same guard carried across, or this change rebased onto the relocated path.

## Pattern harvest

Rule candidate: semgrep

Pattern: `bool(params.get("flag", default))` over a value parsed from JSON. Every
non-empty string coerces to True, so `"false"`, `"no"`, `"0"` and `"off"` all invert
an explicit disable into enabled. Prefer an `isinstance(x, bool)` guard that refuses
the value over a coercion that silently means the opposite of what was sent.
