### PR TITLE
fix(sandbox): retry a spawn whose launcher interpreter is mid-rebuild

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -36,7 +36,7 @@
 1 src/kiro_crew/cli_perf.py
 2 src/kiro_crew/cli_setup.py
 1 src/kiro_crew/cloud/aws.py
-4 src/kiro_crew/cron_script.py
+2 src/kiro_crew/cron_script.py
 1 src/kiro_crew/dashboard/handlers/knowledge.py
 1 src/kiro_crew/dashboard/handlers/terminal.py
 1 src/kiro_crew/dashboard/handlers_system.py

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -1814,7 +1814,13 @@ class CronService:
                     "job_id": job_id,
                     "session_key": session_key,
                     "elapsed": int(elapsed),
-                    "killed_subprocess": killed_proc,
+                    # Named for what the return now MEANS, not for what it used
+                    # to. kill_running_process returns True either because it
+                    # signalled a live child OR because it recorded the cancel
+                    # against a spawn still in flight, where there is no child to
+                    # signal yet. Auditing that second case as
+                    # "killed_subprocess" asserted a kill that never happened.
+                    "cancellation_accepted": killed_proc,
                 },
             )
         except Exception:

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -717,13 +717,100 @@ def _secret_env_precheck(
 _PROCS_LOCK = threading.Lock()
 _RUNNING_PROCS: dict[str, subprocess.Popen] = {}
 _CANCELLED_PROC_JOBS: set[str] = set()
+#: Jobs whose sandboxed child is being SPAWNED right now but is not yet in
+#: ``_RUNNING_PROCS``. Without this, ``kill_running_process`` sees no registered
+#: child, returns False and records NOTHING -- so a cancel arriving inside
+#: ``popen_limited``'s interpreter-ENOENT backoff is discarded rather than
+#: delayed, and the retry then runs work the user cancelled while the run still
+#: reports ``ok``. Membership makes that window cancellable.
+_SPAWNING_JOBS: set[str] = set()
 
 _KILL_ESCALATION_GRACE_SECS = 5.0
 
 
-def _register_proc(job_id: str, proc: subprocess.Popen) -> None:
+def _begin_spawn(job_id: str | None) -> bool:
+    """Claim the spawn slot for *job_id*. False means REFUSED, do not proceed.
+
+    Refused when this job is already spawning or already registered, because
+    every cancellation surface here is keyed on the job id ALONE:
+    ``kill_running_process`` takes only a job id, and ``_RUNNING_PROCS`` holds one
+    child per job. Two concurrent runs of one job therefore make "cancel this
+    job" ambiguous by construction, and the flag is consumed by whichever run
+    finishes its spawn first -- so a cancel aimed at a run still in its ENOENT
+    backoff could be eaten by a rerun that was never cancelled. That rerun then
+    kills its own child and reports cancelled, while the run the user actually
+    cancelled sees no flag and executes.
+
+    Refusing the overlap makes the per-job cancellation contract well defined.
+    It also closes a pre-existing hazard: a second concurrent run used to
+    overwrite the ``_RUNNING_PROCS`` entry, orphaning the first child from
+    cancellation entirely.
+
+    An unidentified run (``job_id is None``) is never registered or cancellable,
+    so it is always allowed and claims nothing.
+    """
+    if job_id is None:
+        return True
     with _PROCS_LOCK:
+        if job_id in _SPAWNING_JOBS or job_id in _RUNNING_PROCS:
+            return False
+        _SPAWNING_JOBS.add(job_id)
+        return True
+
+
+def _finish_spawn(job_id: str | None, proc: subprocess.Popen) -> bool:
+    """Atomically move *job_id* from spawning to registered.
+
+    Both mutations happen under a single hold of ``_PROCS_LOCK``, so
+    ``kill_running_process`` -- which takes the same lock -- can never observe a
+    moment where the job is NEITHER spawning nor registered. Doing this as two
+    separate calls left exactly that gap, and a cancel landing in it was dropped.
+
+    Returns True when a cancel was recorded while the spawn was in flight. The
+    child launched regardless (the cancel raced the successful ``Popen``), so
+    nothing else will ever signal it and the caller MUST kill it. The flag is
+    CONSUMED here: leaving it set would make ``_unregister_proc`` attribute this
+    cancellation to a later run of the same job.
+    """
+    if job_id is None:
+        return False
+    with _PROCS_LOCK:
+        _SPAWNING_JOBS.discard(job_id)
+        if job_id in _CANCELLED_PROC_JOBS:
+            _CANCELLED_PROC_JOBS.discard(job_id)
+            return True
         _RUNNING_PROCS[job_id] = proc
+        return False
+
+
+def _abandon_spawn(job_id: str | None) -> bool:
+    """Clear spawn state after a spawn that produced NO child.
+
+    Returns True when a cancel had been recorded, so the caller reports the run
+    cancelled instead of raising. Either way the cancellation flag is cleared:
+    there is no child for it to signal, and leaving it set would make the NEXT
+    run of the same job report itself cancelled.
+    """
+    if job_id is None:
+        return False
+    with _PROCS_LOCK:
+        _SPAWNING_JOBS.discard(job_id)
+        cancelled = job_id in _CANCELLED_PROC_JOBS
+        _CANCELLED_PROC_JOBS.discard(job_id)
+        return cancelled
+
+
+def _spawn_cancelled(job_id: str | None) -> bool:
+    """True when a cancel landed while this job's spawn was in flight.
+
+    A PEEK, not a take, because this is the ``abort_retry`` hook: it may be
+    consulted several times across the backoff. The flag is consumed by
+    :func:`_finish_spawn` or :func:`_abandon_spawn`, whichever ends the spawn.
+    """
+    if job_id is None:
+        return False
+    with _PROCS_LOCK:
+        return job_id in _CANCELLED_PROC_JOBS
 
 
 def _unregister_proc(job_id: str, proc: subprocess.Popen) -> bool:
@@ -777,6 +864,14 @@ def kill_running_process(job_id: str) -> bool:
     with _PROCS_LOCK:
         maybe_proc = _RUNNING_PROCS.get(job_id)
         if maybe_proc is None or maybe_proc.poll() is not None:
+            # No live child to signal. If a spawn is in flight the cancellation
+            # must still be RECORDED, or it is lost: the spawn's retry backoff
+            # would finish, launch the command, and the run would report ok
+            # having done the work the caller cancelled. The spawner consults
+            # this flag before spawning and the run is reported cancelled.
+            if job_id in _SPAWNING_JOBS:
+                _CANCELLED_PROC_JOBS.add(job_id)
+                return True
             return False
         proc: subprocess.Popen = maybe_proc
         _CANCELLED_PROC_JOBS.add(job_id)
@@ -1686,16 +1781,67 @@ def run_script_sandboxed(
         clean_env.update(prevalidated_gh_env())
 
         sandboxed_argv = cgroup_scope_argv(sandboxed_argv)  # cgroup DoS ceiling
-        proc = popen_limited(
-            sandboxed_argv,
-            stdin=subprocess.PIPE if stdin_payload is not None else None,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=clean_env,
-            start_new_session=True,
-        )
-        _register_proc(job_id, proc)
+        # The spawn-in-flight window makes popen_limited's interpreter-ENOENT
+        # backoff cancellable: without it a cancel arriving mid-backoff is
+        # recorded nowhere, and the retry runs the cancelled job anyway.
+        #
+        # A refusal means this job is already spawning or running. Return WITHOUT
+        # touching any spawn or cancellation state: that state belongs to the
+        # other run, and clearing it here is exactly how a rerun used to eat the
+        # cancel aimed at a run still in its backoff.
+        #
+        # Status is "skipped", NOT "error". This is a second overlap guard behind
+        # the scheduler's own (which logs "previous execution still running,
+        # skipping" and returns silently), covering the tail where a claimed
+        # worker outlives its deadline: the first guard clears while the child
+        # runs on. Beyond that tail it earns its place for a different reason --
+        # it is what keeps the job-keyed cancel flag unambiguous. Every
+        # cancellation surface here takes a job id ALONE, so two concurrent runs
+        # of one job make "cancel this job" undecidable however the scheduler
+        # arrived at them; refusing the overlap is what gives _CANCELLED_PROC_JOBS
+        # a single owner. An overlapping wake is not a job defect, so it must not
+        # count a failure strike toward auto-pause -- inflating strikes for a
+        # transient condition is the harm this change exists to reduce.
+        if not _begin_spawn(job_id):
+            return {
+                "status": "skipped",
+                "error": "Another run of this job is already starting or running",
+            }
+        try:
+            proc = popen_limited(
+                sandboxed_argv,
+                stdin=subprocess.PIPE if stdin_payload is not None else None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=clean_env,
+                start_new_session=True,
+                abort_retry=lambda: _spawn_cancelled(job_id),
+                # Locale decoding, declared deliberate. A cron runs an ARBITRARY
+                # command, so its output is in the host's encoding, not
+                # necessarily UTF-8. Forcing encoding="utf-8" with
+                # errors="replace" turned every non-UTF-8 byte into U+FFFD
+                # BEFORE the output was persisted and delivered -- irreversible
+                # corruption of the very thing the user asked to see. Locale
+                # decoding is what their shell does, and it is what this call
+                # did before the encoding gate was satisfied by pinning it.
+                text=True,  # subprocess-encoding: locale
+            )
+        except Exception:
+            # No child exists, so a cancel recorded against this spawn can never
+            # be signalled -- clear it here rather than let it leak into the next
+            # run of this job. Covers abort_retry's deliberate re-raise and a
+            # genuinely broken install alike.
+            if _abandon_spawn(job_id):
+                return {"status": "cancelled", "error": "Cancelled by user"}
+            raise
+        if _finish_spawn(job_id, proc):
+            # The cancel raced the successful spawn, so the child is live and was
+            # never registered: this is the only place that can still stop it.
+            # Reporting "cancelled" without this kill would claim the work was
+            # stopped while it ran on and mutated state.
+            _kill_proc_group(proc)
+            _drain_after_kill(proc, job_id)
+            return {"status": "cancelled", "error": "Cancelled by user"}
         try:
             try:
                 stdout, stderr = proc.communicate(
@@ -1909,21 +2055,37 @@ def run_command_sandboxed(
             "remove it from the cron store.",
             "exit_code": -1,
         }
-    shell = _resolve_command_shell()
-    if shell is None:
+    # Claimed BEFORE the shell probe, not merely before the spawn. Resolving the
+    # shell (_resolve_command_shell -> _shell_is_posix_strict -> run_limited)
+    # carries run_limited's own interpreter-ENOENT backoff, so on a cold
+    # _POSIX_STRICT_CACHE it can sleep for seconds while this job is registered
+    # NOWHERE. A cancel landing in that window found the job in neither
+    # _SPAWNING_JOBS nor _RUNNING_PROCS, so kill_running_process returned False
+    # and DISCARDED it -- and this function then launched the very command the
+    # user cancelled, side effects and all. Holding the claim across the probe
+    # makes such a cancel RECORDED; the pre-spawn check below turns it into a
+    # launch that never happens.
+    #
+    # The secret-grant refusal above stays AHEAD of the claim: it fails closed
+    # without doing any work, so it must not take a slot it would only release.
+    #
+    # A refusal returns WITHOUT touching spawn or cancellation state -- that state
+    # belongs to the run already in flight -- and reports "skipped" rather than
+    # "error" so an overlapping wake costs no auto-pause strike. See the script
+    # path for the full rationale.
+    if not _begin_spawn(job_id):
         return {
-            "status": "error",
-            "output": (
-                "❌ No POSIX shell available to run this command cron. Command "
-                "crons execute with `sh -c` under POSIX-sh semantics (what the "
-                "storage-time vet gate assumes); Windows ships no such shell "
-                "(Git for Windows's sh.exe is bash and would widen the language "
-                "past the vet). Use a script cron or an LLM `message` cron on "
-                "this platform, or run the gateway under POSIX."
-            ),
+            "status": "skipped",
+            "output": "⏭️ Another run of this job is already starting or running",
             "exit_code": -1,
         }
-    argv = [shell, "-c", command]
+    # True while the claim is still ours to release. _finish_spawn and
+    # _abandon_spawn each end the spawn and clear it; the finally below covers
+    # every OTHER exit, all of which now happen with the claim held. Without that
+    # release an early return -- no POSIX shell, wrap_argv fail-closing, any
+    # raised error -- would leak the claim and _begin_spawn would then refuse
+    # every future wake of this job for the life of the process.
+    spawn_claimed = True
     # mode="cc" (not "standard"): the command string is fully model-supplied via
     # cron_add and executes outside the kiro-cli ACP permission/hook flow, so this
     # is a low-trust exec path. "cc" hides the credential dirs/files (.aws, .kube,
@@ -1942,20 +2104,87 @@ def run_command_sandboxed(
     # instead of a job it could mark failed, so the remedy never reached the user.
     sandbox_cleanup: str | None = None
     try:
+        # Inside the claim (see above) AND inside the try: the probe can raise on
+        # a host with no OS sandbox backend, and that has to reach the handlers
+        # below as a job the scheduler can mark failed.
+        shell = _resolve_command_shell()
+        if shell is None:
+            return {
+                "status": "error",
+                "output": (
+                    "❌ No POSIX shell available to run this command cron. Command "
+                    "crons execute with `sh -c` under POSIX-sh semantics (what the "
+                    "storage-time vet gate assumes); Windows ships no such shell "
+                    "(Git for Windows's sh.exe is bash and would widen the language "
+                    "past the vet). Use a script cron or an LLM `message` cron on "
+                    "this platform, or run the gateway under POSIX."
+                ),
+                "exit_code": -1,
+            }
+        argv = [shell, "-c", command]
         sandboxed_argv, sandbox_cleanup = wrap_argv(argv, mode="cc")
         sandboxed_argv = cgroup_scope_argv(sandboxed_argv)  # cgroup DoS ceiling
         clean_env = _clean_cron_env()
-        proc = popen_limited(
-            sandboxed_argv,
-            stdin=None,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=clean_env,
-            start_new_session=True,
-        )
-        if job_id:
-            _register_proc(job_id, proc)
+        if _spawn_cancelled(job_id):
+            # Cancelled while the probe above sat in its interpreter-ENOENT
+            # backoff. Report it WITHOUT spawning: not launching is the entire
+            # point, and a spawn-then-kill would still have run the command for
+            # however long the signal took to land -- long enough to delete a
+            # file or push a commit. No child exists, so the flag is consumed
+            # here rather than left to leak into this job's next run.
+            spawn_claimed = False
+            _abandon_spawn(job_id)
+            return {
+                "status": "cancelled",
+                "output": "Cancelled by user",
+                "exit_code": -1,
+            }
+        try:
+            proc = popen_limited(
+                sandboxed_argv,
+                stdin=None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=clean_env,
+                start_new_session=True,
+                abort_retry=lambda: _spawn_cancelled(job_id),
+                # Locale decoding, declared deliberate. A cron runs an ARBITRARY
+                # command, so its output is in the host's encoding, not
+                # necessarily UTF-8. Forcing encoding="utf-8" with
+                # errors="replace" turned every non-UTF-8 byte into U+FFFD
+                # BEFORE the output was persisted and delivered -- irreversible
+                # corruption of the very thing the user asked to see. Locale
+                # decoding is what their shell does, and it is what this call
+                # did before the encoding gate was satisfied by pinning it.
+                text=True,  # subprocess-encoding: locale
+            )
+        except Exception:
+            # See the script path: no child exists, so clear any recorded cancel
+            # rather than let it leak into this job's next run.
+            spawn_claimed = False
+            if _abandon_spawn(job_id):
+                return {
+                    "status": "cancelled",
+                    "output": "Cancelled by user",
+                    "exit_code": -1,
+                }
+            raise
+        spawn_claimed = False
+        if _finish_spawn(job_id, proc):
+            # Cancel raced the successful spawn; the child is live and
+            # unregistered, so kill it rather than report a stop that never
+            # happened.
+            _kill_proc_group(proc)
+            _drain_after_kill(proc, job_id)
+            # Same shape as the post-communicate cancellation below: a cancelled
+            # command cron reports the CHILD's returncode (the signal that
+            # stopped it), not a synthetic -1. Reporting -1 here diverged from
+            # that contract for the raced-cancel case alone.
+            return {
+                "status": "cancelled",
+                "output": "Cancelled by user",
+                "exit_code": proc.returncode,
+            }
         cancelled = False
         try:
             try:
@@ -2003,5 +2232,10 @@ def run_command_sandboxed(
     except Exception as exc:
         return {"status": "error", "output": f"❌ Command failed: {exc}", "exit_code": -1}
     finally:
+        if spawn_claimed:
+            # Left this function without ever reaching _finish_spawn or
+            # _abandon_spawn -- an early return or a raised error. Release the
+            # claim, or _begin_spawn refuses every future wake of this job.
+            _abandon_spawn(job_id)
         if sandbox_cleanup:
             Path(sandbox_cleanup).unlink(missing_ok=True)

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -8477,6 +8477,21 @@ async def create_subprocess_limited(
     ``PATH`` after the shim has entered that directory. ``PATH=.:/usr/bin`` --
     or the same directory spelled absolutely -- would otherwise exec a binary
     out of the agent's own workspace, ahead of the sandbox meant to contain it.
+
+    A spawn landing while the launcher interpreter's install tree is being
+    rebuilt is retried, on the same budget and by the same discriminator as
+    :func:`popen_limited` -- this wrapper puts the same ``sys.executable`` at
+    the head of the spawned argv, so it was exposed to the identical blip. The
+    backoff uses ``asyncio.sleep``: a blocking sleep would freeze the event loop
+    for up to ~3.75s, which is precisely the hazard this wrapper exists to
+    avoid. Only the shim-prefixed spawn is retried -- the no-shim fallback below
+    execs the caller's own ``argv[0]``, so an ENOENT there is the caller's own
+    missing binary and must still surface on the first attempt.
+
+    There is deliberately no ``abort_retry`` hook here, unlike
+    :func:`popen_limited`: no caller mediates this wrapper's cancellation
+    through a registry keyed on the live child, so the lost-cancel window that
+    hook exists to close has no consumer. Add one when a caller needs it.
     """
     if "preexec_fn" in kwargs:
         raise TypeError(
@@ -8564,6 +8579,23 @@ async def create_subprocess_limited(
         # NFS/autofs entry would otherwise freeze the gateway -- and the search it
         # replaces used to happen in the child, never in this process.
         resolved = await asyncio.to_thread(_resolve_spawn_target, argv, search_env, search_cwd)
+    for delay in _INTERPRETER_ENOENT_DELAYS:
+        try:
+            return await asyncio.create_subprocess_exec(
+                *prefix, resolved, *argv[1:], preexec_fn=None, **kwargs
+            )
+        except FileNotFoundError as exc:
+            # ``prefix`` IS the head of the argv actually spawned, and prefix[0]
+            # is this process's own sys.executable -- the only shape the
+            # discriminator accepts.
+            if not _retry_interpreter_enoent(exc, prefix, delay):
+                raise
+            # asyncio.sleep, NOT time.sleep: a blocking sleep here would freeze
+            # the event loop for up to ~3.75s, which is the hazard this wrapper
+            # exists to avoid.
+            await asyncio.sleep(delay)
+    # Budget spent. Deliberately unguarded, exactly as in popen_limited: a
+    # genuinely broken install reports the error it reports today, ~4s later.
     return await asyncio.create_subprocess_exec(
         *prefix, resolved, *argv[1:], preexec_fn=None, **kwargs
     )
@@ -8640,11 +8672,36 @@ def run_limited(
     ``-c`` string, and both exceptions render ``cmd`` into their message, so
     reporting the spawned argv would put the whole shim in every failure log
     line.
+
+    A spawn landing while the launcher interpreter's install tree is being
+    rebuilt is retried, on the same budget and by the same discriminator as
+    :func:`popen_limited` -- this wrapper puts the same ``sys.executable`` at
+    ``cmd[0]``, so it was exposed to the identical blip. The retry sits INSIDE
+    the ``cmd``-rewriting handler so a ``CalledProcessError`` or
+    ``TimeoutExpired`` still reports the caller's own argv.
+
+    There is deliberately no ``abort_retry`` hook here, unlike
+    :func:`popen_limited`: this wrapper never hands back a handle, so no
+    cancellation registry can be keyed on the child and the lost-cancel hazard
+    that hook exists to close cannot arise. Add one when a caller needs it.
     """
     cmd, preexec = _prepare_limited_spawn(argv, profile, kwargs, "run_limited")
     reported = list(argv)
     try:
-        result = subprocess.run(cmd, preexec_fn=preexec, **kwargs)
+        for delay in _INTERPRETER_ENOENT_DELAYS:
+            try:
+                result = subprocess.run(cmd, preexec_fn=preexec, **kwargs)
+                break
+            except FileNotFoundError as exc:
+                if not _retry_interpreter_enoent(exc, cmd, delay):
+                    raise
+                time.sleep(delay)
+        else:
+            # Budget spent. Deliberately unguarded, exactly as in
+            # popen_limited: whatever this raises reaches the caller unchanged,
+            # so a genuinely broken install still reports the error it reports
+            # today -- just ~4s later.
+            result = subprocess.run(cmd, preexec_fn=preexec, **kwargs)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
         exc.cmd = reported
         raise
@@ -8652,10 +8709,83 @@ def run_limited(
     return result
 
 
+#: Backoff between spawn attempts when the launcher interpreter is transiently
+#: absent. Five attempts, ~3.75s of waiting in total.
+#:
+#: ``sys.executable`` is often a symlink into a managed install tree, and
+#: rebuilding that tree DELETES and re-creates its entries -- including the
+#: interpreter :func:`wrap_argv` prepends to EVERY sandboxed argv. The tree is
+#: whole again in about a second, so a spawn landing inside that window dies with
+#: ENOENT on an interpreter that both existed before it and exists after it. The
+#: caller cannot tell that apart from a broken install: a cron records a hard
+#: failure (and counts a strike toward auto-pause) for a condition that already
+#: healed itself, and several crons sharing one tick fail together. Any packaging
+#: that relinks an interpreter in place reaches this -- an environment rebuild, a
+#: toolchain reinstall, a swapped container layer.
+_INTERPRETER_ENOENT_DELAYS: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0)
+
+
+def _is_transient_interpreter_enoent(exc: OSError, cmd: "Sequence[str]") -> bool:
+    """True when ``exc`` is ENOENT for the interpreter WE prepended to ``cmd``.
+
+    Deliberately narrow, because ENOENT from ``Popen`` is ambiguous: it is raised
+    for a missing ``cwd`` and for a missing program alike, and a genuinely absent
+    user binary MUST still fail on the first attempt rather than after a delay.
+    So the only retryable shape is an ENOENT whose ``filename`` IS ``cmd[0]`` and
+    whose ``cmd[0]`` is this process's own ``sys.executable``. A missing-``cwd``
+    ENOENT names the directory and a missing user binary names that binary, so
+    both fall through untouched.
+
+    ``filename`` being populated is not guaranteed, so when it is absent fall
+    back to a live check that the interpreter really is gone from disk -- an
+    observation, rather than an assumption that this ENOENT must be ours.
+    """
+    if not cmd or cmd[0] != sys.executable:
+        return False
+    if exc.filename is not None:
+        return exc.filename == cmd[0]
+    return not os.path.exists(sys.executable)
+
+
+def _retry_interpreter_enoent(exc: OSError, cmd: "Sequence[str]", delay: float) -> bool:
+    """Decide whether *exc* is a retryable interpreter blip, and log it if so.
+
+    The single shared implementation behind all three spawn wrappers
+    (:func:`run_limited`, :func:`popen_limited`,
+    :func:`create_subprocess_limited`), which all put ``sys.executable`` at
+    ``cmd[0]`` via :func:`spawn_shim_argv` and are therefore exposed to the same
+    transient ENOENT. Returning ``False`` means the caller must re-raise
+    untouched.
+
+    What is deliberately NOT shared is the spawn itself, and the WAIT. The spawn
+    stays lexically inside each wrapper because both spawn audits key on
+    ``<relpath>::<enclosing function>``: hoisting any of the three into a common
+    helper would migrate its audit key, stranding the existing ``_SYNC_ALLOWED``
+    and ``BENIGN_SPAWNS`` entries as stale while the relocated call read as a
+    brand-new unrouted spawn. The wait is per-flavour because the async wrapper
+    must ``await asyncio.sleep`` -- a ``time.sleep`` there would block the event
+    loop for up to ~3.75s, which is the very hazard the async wrapper exists to
+    avoid. So each caller keeps its own two lines (wait, then re-check abort) and
+    shares the DECISION, which is where the subtlety actually lives.
+    """
+    if not _is_transient_interpreter_enoent(exc, cmd):
+        return False
+    # Log every retry: a silently-absorbed spawn failure would hide an install
+    # tree that has genuinely stopped converging.
+    logger.warning(
+        "sandbox launcher interpreter %r is absent; retrying spawn in "
+        "%.2fs (its install tree is probably mid-rebuild)",
+        cmd[0],
+        delay,
+    )
+    return True
+
+
 def popen_limited(
     argv: "Sequence[str]",
     *,
     profile: str = RLIMIT_PROFILE_TOOL,
+    abort_retry: "Callable[[], bool] | None" = None,
     **kwargs: "Any",
 ) -> "subprocess.Popen[Any]":
     """``subprocess.Popen`` with resource limits applied AFTER ``exec``.
@@ -8673,8 +8803,47 @@ def popen_limited(
     ``TimeoutExpired`` from ``self.args``, so leaving the shim there would put
     ~8 KB of shim source into the timeout message. Nothing in CPython reads
     ``self.args`` functionally -- only ``__repr__`` and that exception.
+
+    A spawn that lands while the launcher interpreter's install tree is being
+    rebuilt is retried rather than surfaced -- see
+    :data:`_INTERPRETER_ENOENT_DELAYS`. The retry loop is INLINE rather than
+    extracted into a helper on purpose: both spawn audits key on
+    ``<relpath>::<enclosing function>``, so moving this ``Popen`` into its own
+    function would migrate its key, stranding the ``popen_limited`` entries in
+    ``_SYNC_ALLOWED`` and ``BENIGN_SPAWNS`` as stale while the relocated call read
+    as a brand-new unrouted spawn.
+
+    ``abort_retry`` is consulted after each backoff, and matters only to a caller
+    whose cancellation is mediated by a REGISTRY keyed on the live child -- for
+    those, the backoff is a window in which a cancel is silently LOST rather than
+    merely delayed, because the canceller finds no registered child and records
+    nothing, and the retry then launches work the caller already cancelled.
+    Returning ``True`` re-raises the ENOENT instead of spawning, so the caller's
+    own cancellation path reports the run rather than running it. A caller that
+    holds the ``Popen`` handle itself and polls a stop flag (such as
+    ``auto_improvement.spine.agent_runner``, which calls ``_terminate_group`` on
+    the handle) loses nothing by omitting it: the stop is observed after the
+    spawn returns and the child is signalled then.
     """
     cmd, preexec = _prepare_limited_spawn(argv, profile, kwargs, "popen_limited")
-    proc = subprocess.Popen(cmd, preexec_fn=preexec, **kwargs)
+    for delay in _INTERPRETER_ENOENT_DELAYS:
+        try:
+            proc = subprocess.Popen(cmd, preexec_fn=preexec, **kwargs)
+            break
+        except FileNotFoundError as exc:
+            if not _retry_interpreter_enoent(exc, cmd, delay):
+                raise
+            time.sleep(delay)
+            # Checked AFTER the sleep, because that is when a cancellation
+            # racing the backoff will have landed. Spawning now would run work
+            # the caller has already cancelled, and the exit status would not
+            # say so.
+            if abort_retry is not None and abort_retry():
+                raise
+    else:
+        # Budget spent. Deliberately unguarded: whatever this raises reaches the
+        # caller unchanged, so a genuinely broken install still reports exactly
+        # the error it reports today -- just ~4s later.
+        proc = subprocess.Popen(cmd, preexec_fn=preexec, **kwargs)
     proc.args = list(argv)
     return proc

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -3690,6 +3690,32 @@ class GatewayOrchestrator:
                         # User-initiated cancel: CronService.cancel() owns the
                         # bookkeeping/history — no failure counting, no delivery.
                         return None
+                    if result.get("status") == "skipped":
+                        # Overlapping wake refused because this job is already
+                        # spawning or running. Not a job defect, so no failure
+                        # counting and no delivery -- counting it would strike a
+                        # job for a transient scheduling overlap.
+                        #
+                        # But returning None alone is NOT neutral: _execute treats
+                        # any non-"error" last_status as success, so it would set
+                        # last_status="ok" AND call record_success(), fabricating a
+                        # run that never happened and refilling the auto-pause
+                        # budget. The cancelled branch above escapes that only
+                        # because _execute additionally checks self._cancelled_jobs
+                        # membership, and a refused overlap is not in that set.
+                        #
+                        # So use the established deliberately-neutral shape of the
+                        # starvation and fire-time-denial paths: last_status="error"
+                        # to skip the success branch, run_never_started=True as the
+                        # retention marker, and DELIBERATELY NOT record_failure() --
+                        # a strike is only ever counted by that explicit call, never
+                        # by last_status, so this spends no budget and refills none.
+                        logger.info("Cron '%s': overlapping run refused, skipping", job.name)
+                        job.clear_carried_result()
+                        job.last_status = "error"
+                        job.last_error = "Another run of this job was already starting or running"
+                        job.run_never_started = True
+                        return None
                     output = result.get("output", "")
                     if not output.strip():
                         if result.get("status") == "ok":
@@ -4025,6 +4051,20 @@ class GatewayOrchestrator:
                     if status == "cancelled":
                         # User-initiated cancel: CronService.cancel() owns the
                         # bookkeeping/history — no failure counting, no delivery.
+                        return None
+                    if status == "skipped":
+                        # Overlapping wake refused because this job is already
+                        # spawning or running -- no failure counting, no delivery.
+                        # See the command path for why returning None alone would
+                        # be recorded as a SUCCESS: last_status="error" skips
+                        # _execute's success branch, run_never_started=True is the
+                        # retention marker, and record_failure() is deliberately
+                        # NOT called so the overlap costs no auto-pause strike.
+                        logger.info("Cron '%s': overlapping run refused, skipping", job.name)
+                        job.clear_carried_result()
+                        job.last_status = "error"
+                        job.last_error = "Another run of this job was already starting or running"
+                        job.run_never_started = True
                         return None
                     if status == "ok":
                         job.clear_carried_result()

--- a/test/test_cron_script_more_coverage.py
+++ b/test/test_cron_script_more_coverage.py
@@ -1287,9 +1287,20 @@ class TestRunCommandSandboxed:
         assert killed == [command_run.proc]
         assert cron_script._RUNNING_PROCS == {}
 
-    def test_cancellation_is_reported_over_the_output(self, command_run):
-        command_run.proc = _FakeProc(comm_results=[("ignored", "")], returncode=-15)
-        cron_script._CANCELLED_PROC_JOBS.add("job-c")
+    def test_cancellation_is_reported_over_the_output(self, command_run, monkeypatch):
+        # The cancel lands DURING the spawn, which is the only way this path is
+        # reachable now that a cancel recorded BEFORE the spawn returns without
+        # launching at all. Pre-seeding the flag instead exercised a state
+        # production cannot produce: _begin_spawn is reached only when the job is
+        # in neither registry, and every helper clears the flag on the way out.
+        proc = _FakeProc(comm_results=[("ignored", "")], returncode=-15)
+        command_run.proc = proc
+
+        def _popen_then_cancel(argv, **kw):
+            cron_script._CANCELLED_PROC_JOBS.add("job-c")
+            return proc
+
+        monkeypatch.setattr(cron_script, "popen_limited", _popen_then_cancel)
 
         result = run_command_sandboxed("sleep 100", job_id="job-c")
 

--- a/test/test_sandbox_interpreter_enoent_retry.py
+++ b/test/test_sandbox_interpreter_enoent_retry.py
@@ -1,0 +1,1248 @@
+"""Tests for kiro_crew.sandbox — launcher-interpreter ENOENT spawn retry.
+
+``sys.executable`` is often a symlink into a managed install tree, and rebuilding
+that tree deletes and re-creates its entries, including the interpreter
+``wrap_argv`` prepends to every sandboxed argv. A spawn landing in that ~1s
+window used to die with a bare ENOENT that the caller could not distinguish from
+a broken install.
+
+These tests pin BOTH directions: the transient shape is retried, and every
+other ENOENT shape still fails on the first attempt. They also pin the
+``abort_retry`` contract on ``popen_limited`` -- the ONLY wrapper carrying that
+hook, because it is the only one with consumers -- because its backoff is
+otherwise a window in which a cancellation is lost rather than delayed.
+
+The retry lives INLINE in each of the three wrappers rather than in a shared
+helper, because both spawn audits key on ``<relpath>::<enclosing function>`` --
+so these tests drive the wrappers themselves and would fail if any spawn were
+extracted.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import pathlib
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import kiro_crew.sandbox as sandbox_mod
+from kiro_crew import platform_compat as pc
+from kiro_crew.sandbox import _INTERPRETER_ENOENT_DELAYS, _is_transient_interpreter_enoent
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+#: The argv ``_prepare_limited_spawn`` is stubbed to return: a launcher argv
+#: whose argv[0] is this process's own interpreter, i.e. the shape wrap_argv
+#: produces and the only shape the retry accepts.
+_LAUNCHER_CMD = [sys.executable, "-I", "/tmp/launcher.py"]
+
+
+def _enoent(filename: str | None) -> FileNotFoundError:
+    """A FileNotFoundError shaped like the one Popen raises."""
+    exc = FileNotFoundError(2, "No such file or directory")
+    exc.filename = filename
+    return exc
+
+
+def _prepared(cmd: list[str] | None = None):
+    """Patch ``_prepare_limited_spawn`` so tests reach the spawn deterministically."""
+    return patch.object(
+        sandbox_mod,
+        "_prepare_limited_spawn",
+        return_value=(list(cmd if cmd is not None else _LAUNCHER_CMD), None),
+    )
+
+
+class TestIsTransientInterpreterEnoent:
+    def test_enoent_naming_our_own_interpreter_is_transient(self):
+        assert _is_transient_interpreter_enoent(_enoent(sys.executable), _LAUNCHER_CMD)
+
+    def test_enoent_naming_a_different_path_is_not_transient(self):
+        """A missing cwd names the DIRECTORY, not argv[0] — must not retry."""
+        assert not _is_transient_interpreter_enoent(_enoent("/nonexistent/workdir"), _LAUNCHER_CMD)
+
+    def test_enoent_for_a_user_binary_is_not_transient(self):
+        """argv[0] is not our interpreter, so this is a real missing program."""
+        assert not _is_transient_interpreter_enoent(
+            _enoent("/usr/bin/definitely-not-installed"),
+            ["/usr/bin/definitely-not-installed", "--version"],
+        )
+
+    def test_empty_cmd_is_not_transient(self):
+        assert not _is_transient_interpreter_enoent(_enoent(None), [])
+
+    def test_missing_filename_falls_back_to_a_live_existence_check(self):
+        """With no filename, decide by observation — not by assumption."""
+        # The interpreter running this test plainly exists, so an ENOENT that
+        # names nothing is NOT attributable to a farm rebuild.
+        assert not _is_transient_interpreter_enoent(_enoent(None), _LAUNCHER_CMD)
+        with patch.object(sandbox_mod.os.path, "exists", return_value=False):
+            assert _is_transient_interpreter_enoent(_enoent(None), _LAUNCHER_CMD)
+
+
+class TestPopenLimitedToleratesAnAbsentInterpreter:
+    def test_retries_until_the_farm_comes_back(self):
+        sentinel = MagicMock(name="Popen")
+        # Absent for the first two attempts, then the farm is whole again.
+        attempts = [_enoent(sys.executable), _enoent(sys.executable), sentinel]
+
+        def fake_popen(*_args, **_kwargs):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+        slept: list[float] = []
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "Popen", side_effect=fake_popen),
+            patch.object(sandbox_mod.time, "sleep", side_effect=slept.append),
+        ):
+            got = sandbox_mod.popen_limited(["/bin/echo", "hi"])
+
+        assert got is sentinel
+        # Proves the retry path ran rather than the first attempt succeeding.
+        assert slept == list(_INTERPRETER_ENOENT_DELAYS[:2])
+        # The caller still sees its OWN argv, not the launcher's.
+        assert got.args == ["/bin/echo", "hi"]
+
+    def test_a_permanently_absent_interpreter_still_raises(self):
+        """Negative control: exhausting the budget re-raises, unchanged."""
+        final = _enoent(sys.executable)
+        raised = [_enoent(sys.executable)] * len(_INTERPRETER_ENOENT_DELAYS) + [final]
+
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "Popen", side_effect=raised) as popen,
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            with pytest.raises(FileNotFoundError) as caught:
+                sandbox_mod.popen_limited(["/bin/echo", "hi"])
+
+        assert caught.value is final
+        assert popen.call_count == len(_INTERPRETER_ENOENT_DELAYS) + 1
+
+    def test_a_non_transient_enoent_is_not_retried(self):
+        """A missing cwd must fail on attempt ONE, with no delay."""
+        with (
+            _prepared(),
+            patch.object(
+                sandbox_mod.subprocess,
+                "Popen",
+                side_effect=_enoent("/nonexistent/workdir"),
+            ) as popen,
+            patch.object(sandbox_mod.time, "sleep") as sleep,
+        ):
+            with pytest.raises(FileNotFoundError):
+                sandbox_mod.popen_limited(["/bin/echo", "hi"])
+
+        assert popen.call_count == 1
+        sleep.assert_not_called()
+
+    def test_a_non_enoent_oserror_is_not_retried(self):
+        with (
+            _prepared(),
+            patch.object(
+                sandbox_mod.subprocess, "Popen", side_effect=PermissionError(13, "nope")
+            ) as popen,
+            patch.object(sandbox_mod.time, "sleep") as sleep,
+        ):
+            with pytest.raises(PermissionError):
+                sandbox_mod.popen_limited(["/bin/echo", "hi"])
+
+        assert popen.call_count == 1
+        sleep.assert_not_called()
+
+    def test_a_user_binary_enoent_is_not_retried(self):
+        """argv[0] not being our interpreter must fail immediately."""
+        missing = "/usr/bin/definitely-not-installed"
+        with (
+            _prepared([missing, "--version"]),
+            patch.object(sandbox_mod.subprocess, "Popen", side_effect=_enoent(missing)) as popen,
+            patch.object(sandbox_mod.time, "sleep") as sleep,
+        ):
+            with pytest.raises(FileNotFoundError):
+                sandbox_mod.popen_limited([missing, "--version"])
+
+        assert popen.call_count == 1
+        sleep.assert_not_called()
+
+
+class TestTheSpawnStaysInsidePopenLimited:
+    """The spawn audits key on the ENCLOSING FUNCTION, so its location is load-bearing.
+
+    ``_SYNC_ALLOWED`` and ``BENIGN_SPAWNS`` both name ``sandbox.py::popen_limited``.
+    Extracting this ``Popen`` into a helper migrates its audit key: the entries go
+    stale and the relocated call reads as a new unrouted, preexec_fn-forking spawn.
+    """
+
+    def test_popen_limited_itself_contains_the_spawn_call(self):
+        import ast
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(sandbox_mod.popen_limited)))
+        spawns = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and ast.unparse(node.func).endswith("subprocess.Popen")
+        ]
+        assert spawns, (
+            "popen_limited no longer contains its own subprocess.Popen call — the "
+            "spawn audits key on the enclosing function, so extracting it strands "
+            "the sandbox.py::popen_limited entries in _SYNC_ALLOWED and "
+            "BENIGN_SPAWNS and reports the relocated call as a new spawn."
+        )
+        assert all(
+            any(kw.arg == "preexec_fn" for kw in node.keywords) for node in spawns
+        ), "every spawn in popen_limited must still carry preexec_fn"
+
+
+class TestAbortRetryClosesTheCancellationWindow:
+    """The backoff must not become a window where a cancellation is LOST.
+
+    ``kill_running_process`` keys on a REGISTERED child. During the backoff none
+    exists, so without a recorded intent the cancel is discarded and the retry
+    runs the cancelled work while the run still reports success.
+    """
+
+    def test_abort_retry_stops_the_spawn_instead_of_launching_it(self):
+        calls: list[int] = []
+
+        def fake_popen(*_args, **_kwargs):
+            calls.append(1)
+            raise _enoent(sys.executable)
+
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "Popen", side_effect=fake_popen),
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            with pytest.raises(FileNotFoundError):
+                sandbox_mod.popen_limited(["/bin/echo", "hi"], abort_retry=lambda: True)
+
+        # Exactly ONE attempt: the abort is consulted after the first backoff, so
+        # no further spawn is attempted and nothing is launched.
+        assert calls == [1]
+
+    def test_without_abort_retry_the_budget_is_still_spent(self):
+        """Negative control: the abort is what shortens it, not the ENOENT."""
+        attempts = [_enoent(sys.executable)] * len(_INTERPRETER_ENOENT_DELAYS)
+        attempts.append(MagicMock(name="Popen"))
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "Popen", side_effect=attempts),
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            sandbox_mod.popen_limited(["/bin/echo", "hi"])
+
+    def test_a_false_abort_retry_does_not_stop_the_retry(self):
+        sentinel = MagicMock(name="Popen")
+        attempts = [_enoent(sys.executable), sentinel]
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "Popen", side_effect=attempts),
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            got = sandbox_mod.popen_limited(["/bin/echo", "hi"], abort_retry=lambda: False)
+        assert got is sentinel
+
+
+class TestSpawnToRegisteredIsAtomic:
+    """A cancel must never fall between "spawning" and "registered".
+
+    ``_finish_spawn`` performs both mutations under one hold of ``_PROCS_LOCK``,
+    so ``kill_running_process`` cannot observe a job that is neither. The earlier
+    two-call shape (clear the spawning mark, then register) left that gap.
+    """
+
+    def _clear(self, cron):
+        with cron._PROCS_LOCK:
+            cron._SPAWNING_JOBS.clear()
+            cron._CANCELLED_PROC_JOBS.clear()
+            cron._RUNNING_PROCS.clear()
+
+    def test_finish_spawn_registers_and_clears_the_spawning_mark(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._clear(cron)
+        proc = MagicMock(name="Popen")
+        cron._begin_spawn("job-a")
+        assert cron._finish_spawn("job-a", proc) is False
+        with cron._PROCS_LOCK:
+            assert "job-a" not in cron._SPAWNING_JOBS
+            assert cron._RUNNING_PROCS["job-a"] is proc
+        self._clear(cron)
+
+    def test_a_cancel_during_the_spawn_is_reported_and_the_child_not_registered(self):
+        """The raced-cancel case: caller must kill, so we must NOT register."""
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._clear(cron)
+        proc = MagicMock(name="Popen")
+        cron._begin_spawn("job-b")
+        with cron._PROCS_LOCK:
+            cron._CANCELLED_PROC_JOBS.add("job-b")
+        assert cron._finish_spawn("job-b", proc) is True
+        with cron._PROCS_LOCK:
+            assert "job-b" not in cron._RUNNING_PROCS
+            # Consumed, so a later run of the same job is not told it was cancelled.
+            assert "job-b" not in cron._CANCELLED_PROC_JOBS
+            assert "job-b" not in cron._SPAWNING_JOBS
+        self._clear(cron)
+
+    def test_kill_during_the_spawn_window_records_the_cancel(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._clear(cron)
+        cron._begin_spawn("job-c")
+        # No registered child, but a spawn is in flight: the cancel must stick.
+        assert cron.kill_running_process("job-c") is True
+        assert cron._spawn_cancelled("job-c") is True
+        self._clear(cron)
+
+    def test_kill_with_no_spawn_and_no_child_still_records_nothing(self):
+        """Negative control: the window is what makes it recordable."""
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._clear(cron)
+        assert cron.kill_running_process("job-d") is False
+        assert cron._spawn_cancelled("job-d") is False
+        self._clear(cron)
+
+    def test_abandon_spawn_clears_the_flag_so_it_cannot_leak(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._clear(cron)
+        cron._begin_spawn("job-e")
+        with cron._PROCS_LOCK:
+            cron._CANCELLED_PROC_JOBS.add("job-e")
+        assert cron._abandon_spawn("job-e") is True
+        with cron._PROCS_LOCK:
+            assert "job-e" not in cron._CANCELLED_PROC_JOBS
+            assert "job-e" not in cron._SPAWNING_JOBS
+        # Second call sees nothing left to report.
+        assert cron._abandon_spawn("job-e") is False
+        self._clear(cron)
+
+
+class TestCommandCronSpawnFailureIsCancellable:
+    """The spawn-failure branch must CONSUME a recorded cancel, not drop it.
+
+    Exercises ``run_command_sandboxed``'s ``_abandon_spawn`` arm end to end: no
+    child was produced, so the recorded cancel can never be signalled and must be
+    reported and cleared instead of leaking into this job's next run.
+    """
+
+    @pytest.fixture
+    def cron(self, monkeypatch):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        monkeypatch.setattr(cron, "_resolve_command_shell", lambda: "/bin/sh")
+        monkeypatch.setattr(cron, "wrap_argv", lambda argv, **k: (list(argv), None))
+        monkeypatch.setattr(cron, "cgroup_scope_argv", lambda argv: list(argv))
+
+        def _reset():
+            with cron._PROCS_LOCK:
+                cron._SPAWNING_JOBS.clear()
+                cron._CANCELLED_PROC_JOBS.clear()
+                cron._RUNNING_PROCS.clear()
+
+        _reset()
+        yield cron
+        _reset()
+
+    @staticmethod
+    def _raising_spawn(*_args, **_kwargs):
+        # Stands in for abort_retry's deliberate re-raise, and for a genuinely
+        # absent interpreter -- the branch treats them the same.
+        raise _enoent(sys.executable)
+
+    def test_a_cancel_recorded_during_a_failed_spawn_reports_cancelled(self, cron, monkeypatch):
+        monkeypatch.setattr(cron, "popen_limited", self._raising_spawn)
+        with cron._PROCS_LOCK:
+            cron._CANCELLED_PROC_JOBS.add("job-x")
+
+        result = cron.run_command_sandboxed("sleep 100", job_id="job-x")
+
+        assert result["status"] == "cancelled"
+        # No child exists, so there is no signal to report -- unlike the
+        # raced-cancel case, which reports the child's returncode.
+        assert result["exit_code"] == -1
+        with cron._PROCS_LOCK:
+            assert "job-x" not in cron._CANCELLED_PROC_JOBS
+            assert "job-x" not in cron._SPAWNING_JOBS
+
+    def test_a_failed_spawn_without_a_cancel_is_still_an_error(self, cron, monkeypatch):
+        """Negative control: the recorded cancel is what changes the outcome.
+
+        Without one the exception propagates to the function's own handler and
+        the run is reported as an error, exactly as before this change.
+        """
+        monkeypatch.setattr(cron, "popen_limited", self._raising_spawn)
+
+        result = cron.run_command_sandboxed("sleep 100", job_id="job-y")
+
+        assert result["status"] == "error"
+        with cron._PROCS_LOCK:
+            assert "job-y" not in cron._SPAWNING_JOBS
+
+
+class TestOverlappingRunCannotEatTheCancel:
+    """A rerun must not consume the cancel aimed at a run still in its backoff.
+
+    Every cancellation surface is keyed on the job id alone -- ``_RUNNING_PROCS``
+    holds one child per job and ``kill_running_process`` takes only an id -- so two
+    concurrent runs of one job make "cancel this job" ambiguous, and whichever
+    finishes its spawn first consumes the flag. ``_begin_spawn`` therefore refuses
+    the overlap.
+    """
+
+    def _reset(self, cron):
+        with cron._PROCS_LOCK:
+            cron._SPAWNING_JOBS.clear()
+            cron._CANCELLED_PROC_JOBS.clear()
+            cron._RUNNING_PROCS.clear()
+
+    def test_a_second_run_is_refused_while_the_first_is_spawning(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._reset(cron)
+        assert cron._begin_spawn("job-a") is True
+        # Run B for the SAME job, while A is still in its ENOENT backoff.
+        assert cron._begin_spawn("job-a") is False
+        self._reset(cron)
+
+    def test_a_second_run_is_refused_while_the_first_is_registered(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._reset(cron)
+        assert cron._begin_spawn("job-b") is True
+        assert cron._finish_spawn("job-b", MagicMock(name="Popen")) is False
+        # Now registered rather than spawning -- still an overlap.
+        assert cron._begin_spawn("job-b") is False
+        self._reset(cron)
+
+    def test_the_refused_rerun_cannot_consume_the_pending_cancel(self):
+        """The race itself: the flag must still be there for the cancelled run."""
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._reset(cron)
+        # Run A claims the slot and is cancelled mid-backoff.
+        assert cron._begin_spawn("job-c") is True
+        assert cron.kill_running_process("job-c") is True
+        assert cron._spawn_cancelled("job-c") is True
+        # A rerun is refused, so it never reaches _finish_spawn/_abandon_spawn and
+        # cannot discard the flag. Before the refusal, B's _finish_spawn ate it and
+        # A's abort_retry peek then returned False, letting A run the cancelled work.
+        assert cron._begin_spawn("job-c") is False
+        assert cron._spawn_cancelled("job-c") is True
+        self._reset(cron)
+
+    def test_a_distinct_job_is_not_refused(self):
+        """Negative control: the refusal is per job, not a global lock."""
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._reset(cron)
+        assert cron._begin_spawn("job-d") is True
+        assert cron._begin_spawn("job-e") is True
+        self._reset(cron)
+
+    def test_an_unidentified_run_is_always_allowed_and_claims_nothing(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._reset(cron)
+        assert cron._begin_spawn(None) is True
+        assert cron._begin_spawn(None) is True
+        with cron._PROCS_LOCK:
+            assert cron._SPAWNING_JOBS == set()
+        self._reset(cron)
+
+    def test_the_slot_is_reusable_once_the_run_ends(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        self._reset(cron)
+        assert cron._begin_spawn("job-f") is True
+        assert cron._abandon_spawn("job-f") is False
+        # Slot released, so the next run may claim it.
+        assert cron._begin_spawn("job-f") is True
+        self._reset(cron)
+
+
+class TestCommandOutputUsesLocaleDecoding:
+    """A cron's output must not be UTF-8-decoded with replacement.
+
+    A command cron runs an ARBITRARY command, so its output carries the host's
+    encoding. ``encoding="utf-8", errors="replace"`` turns every non-UTF-8 byte
+    into U+FFFD before the output is persisted and delivered -- the original byte
+    is gone, so this is irreversible corruption of the thing the user asked to
+    see, not a display quirk.
+    """
+
+    @pytest.fixture
+    def cron(self, monkeypatch):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        monkeypatch.setattr(cron, "_resolve_command_shell", lambda: "/bin/sh")
+        monkeypatch.setattr(cron, "wrap_argv", lambda argv, **k: (list(argv), None))
+        monkeypatch.setattr(cron, "cgroup_scope_argv", lambda argv: list(argv))
+
+        def _reset():
+            with cron._PROCS_LOCK:
+                cron._SPAWNING_JOBS.clear()
+                cron._CANCELLED_PROC_JOBS.clear()
+                cron._RUNNING_PROCS.clear()
+
+        _reset()
+        yield cron
+        _reset()
+
+    def test_the_command_spawn_does_not_force_utf8_replacement(self, cron, monkeypatch):
+        """Fails on the pinned form, which passed encoding/errors explicitly."""
+        seen: dict[str, object] = {}
+
+        def _capture(_argv, **kwargs):
+            seen.update(kwargs)
+            raise RuntimeError("stop after capturing kwargs")
+
+        monkeypatch.setattr(cron, "popen_limited", _capture)
+        cron.run_command_sandboxed("echo hi", job_id="job-enc")
+
+        assert seen, "popen_limited was never reached, so nothing was asserted"
+        assert seen.get("text") is True
+        # The defect, stated as the assertion: forcing either of these is what
+        # replaced non-UTF-8 bytes with U+FFFD.
+        assert "encoding" not in seen
+        assert "errors" not in seen
+
+    def test_forcing_utf8_replacement_really_does_destroy_the_bytes(self):
+        """The mechanism, with a positive control, so the risk is not theoretical.
+
+        These bytes are valid in a single-byte locale and invalid as UTF-8.
+        """
+        raw = b"caf\xe9\n"
+        forced = raw.decode("utf-8", errors="replace")
+        locale_like = raw.decode("latin-1")
+        assert "\ufffd" in forced  # what the pinned form delivered
+        assert "\ufffd" not in locale_like  # what locale decoding delivers
+        assert locale_like.strip() == "café"
+        # And it is not recoverable: the replacement character does not carry the
+        # original byte, so nothing downstream can undo it.
+        assert forced.strip().encode("utf-8") != raw.strip()
+
+    def test_neither_cron_spawn_pins_an_encoding(self):
+        """Source-level guard: re-pinning either site fails here, at source."""
+        cron = importlib.import_module("kiro_crew.cron_script")
+        source = pathlib.Path(cron.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        cron_spawns = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "popen_limited"
+            and any(kw.arg == "abort_retry" for kw in node.keywords)
+        ]
+        assert len(cron_spawns) == 2, f"expected both cron spawns, saw {len(cron_spawns)}"
+        for node in cron_spawns:
+            kwargs = {kw.arg for kw in node.keywords if kw.arg}
+            assert "encoding" not in kwargs
+            assert "errors" not in kwargs
+            assert "text" in kwargs
+
+
+class TestAnOverlappingWakeCostsNoFailureStrike:
+    """A refused overlap must not be counted as a job failure.
+
+    The consumer records a strike toward auto-pause for any status that is not
+    ``ok`` and not intercepted earlier, so returning ``error`` here would inflate
+    strikes for a transient scheduling overlap -- the same harm this change
+    exists to reduce. ``skipped`` matches the scheduler's own pre-existing
+    overlap guard, which logs "previous execution still running, skipping" and
+    returns without counting anything.
+    """
+
+    @pytest.fixture
+    def cron(self, monkeypatch):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        monkeypatch.setattr(cron, "_resolve_command_shell", lambda: "/bin/sh")
+        monkeypatch.setattr(cron, "wrap_argv", lambda argv, **k: (list(argv), None))
+        monkeypatch.setattr(cron, "cgroup_scope_argv", lambda argv: list(argv))
+
+        def _reset():
+            with cron._PROCS_LOCK:
+                cron._SPAWNING_JOBS.clear()
+                cron._CANCELLED_PROC_JOBS.clear()
+                cron._RUNNING_PROCS.clear()
+
+        _reset()
+        yield cron
+        _reset()
+
+    def test_a_refused_command_overlap_reports_skipped_not_error(self, cron):
+        # A run of this job is already in flight.
+        assert cron._begin_spawn("job-ovl") is True
+
+        result = cron.run_command_sandboxed("echo hi", job_id="job-ovl")
+
+        # "error" here would reach record_failure() and strike toward auto-pause.
+        assert result["status"] == "skipped"
+        assert result["status"] != "error"
+
+    def test_the_refusal_does_not_disturb_the_other_run(self, cron):
+        assert cron._begin_spawn("job-ovl2") is True
+        with cron._PROCS_LOCK:
+            cron._CANCELLED_PROC_JOBS.add("job-ovl2")
+
+        cron.run_command_sandboxed("echo hi", job_id="job-ovl2")
+
+        # Still claimed, and the other run's cancel is still pending for it.
+        with cron._PROCS_LOCK:
+            assert "job-ovl2" in cron._SPAWNING_JOBS
+            assert "job-ovl2" in cron._CANCELLED_PROC_JOBS
+
+    def test_the_consumer_treats_skipped_as_non_counting(self):
+        """The status is inert unless the consumer honours it -- pin that too."""
+        gateway = pathlib.Path(
+            importlib.import_module("kiro_crew.slack.gateway").__file__
+        ).read_text(encoding="utf-8")
+        # Both cron dispatch paths must intercept it before the strike branch.
+        assert gateway.count('== "skipped"') == 2
+
+
+class TestARefusedOverlapIsNotPersistedAsASuccessfulRun:
+    """A refused overlap must record "did not run" -- not a fabricated success.
+
+    ``CronService._execute`` treats ANY non-``"error"`` ``last_status`` as success:
+    it sets ``last_status="ok"`` and calls ``record_success()``, which also resets
+    the auto-pause budget. So a dispatch branch that merely returns ``None``
+    without setting ``last_status`` persists a run that never happened. The
+    ``cancelled`` branch escapes this only via ``_execute``'s separate
+    ``self._cancelled_jobs`` membership check, which a refused overlap is not in.
+
+    These tests assert the disposition the starvation and fire-time-denial paths
+    already use: ``last_status="error"`` (skips the success branch) plus
+    ``run_never_started=True`` (retention marker), with ``record_failure()``
+    deliberately NOT called so no strike is spent.
+    """
+
+    def _dispatch_source(self) -> str:
+        return pathlib.Path(importlib.import_module("kiro_crew.slack.gateway").__file__).read_text(
+            encoding="utf-8"
+        )
+
+    def _skipped_branches(self, source: str) -> list[str]:
+        """The CODE of each `status == "skipped"` branch, up to its return.
+
+        Comment lines are stripped: these branches deliberately explain in prose
+        why ``record_failure`` is not called, and a substring check against the
+        raw text would match that explanation instead of a real call.
+        """
+        out: list[str] = []
+        lines = source.splitlines()
+        for i, line in enumerate(lines):
+            if '== "skipped"' not in line:
+                continue
+            body: list[str] = []
+            for nxt in lines[i + 1 : i + 40]:
+                if not nxt.strip().startswith("#"):
+                    body.append(nxt)
+                if nxt.strip() == "return None":
+                    break
+            out.append("\n".join(body))
+        return out
+
+    def test_both_dispatch_paths_intercept_the_skipped_status(self):
+        branches = self._skipped_branches(self._dispatch_source())
+        assert len(branches) == 2, f"expected both cron dispatch paths, saw {len(branches)}"
+
+    def test_neither_branch_leaves_last_status_unset(self):
+        """The defect: an unset last_status is what _execute reads as success."""
+        for body in self._skipped_branches(self._dispatch_source()):
+            assert 'job.last_status = "error"' in body
+
+    def test_both_branches_mark_the_run_as_never_started(self):
+        for body in self._skipped_branches(self._dispatch_source()):
+            assert "job.run_never_started = True" in body
+
+    def test_neither_branch_counts_a_failure_strike(self):
+        """Negative control: the fix must not swing the other way into a strike.
+
+        A strike comes only from an explicit record_failure(); last_status alone
+        never counts one. An overlap is a scheduling condition, so it must spend
+        no auto-pause budget -- the same reasoning the starvation path documents.
+        """
+        for body in self._skipped_branches(self._dispatch_source()):
+            assert "record_failure" not in body
+
+    def test_neither_branch_records_a_success(self):
+        for body in self._skipped_branches(self._dispatch_source()):
+            assert "record_success" not in body
+
+    def test_execute_really_does_treat_a_non_error_status_as_success(self):
+        """Positive control: proves the hazard these tests guard is real.
+
+        If this ever stops holding, the assertions above are guarding nothing.
+        """
+        cron_src = pathlib.Path(importlib.import_module("kiro_crew.cron").__file__).read_text(
+            encoding="utf-8"
+        )
+        assert 'if job.last_status != "error":' in cron_src
+        assert "job.record_success()" in cron_src
+
+
+class TestRunLimitedToleratesAnAbsentInterpreter:
+    """``run_limited`` shares the exposure: same `_prepare_limited_spawn` prefix.
+
+    Same shape as the ``popen_limited`` tests above, because the contract is the
+    same one -- only the ``subprocess`` entry point differs.
+    """
+
+    def test_retries_until_the_tree_comes_back(self):
+        done = MagicMock(name="CompletedProcess")
+        attempts = [_enoent(sys.executable), _enoent(sys.executable), done]
+
+        def fake_run(*_args, **_kwargs):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+        slept: list[float] = []
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "run", side_effect=fake_run),
+            patch.object(sandbox_mod.time, "sleep", side_effect=slept.append),
+        ):
+            got = sandbox_mod.run_limited(["/bin/echo", "hi"])
+
+        assert got is done
+        assert slept == list(_INTERPRETER_ENOENT_DELAYS[:2])
+        # The caller still sees its OWN argv, not the launcher's.
+        assert got.args == ["/bin/echo", "hi"]
+
+    def test_a_permanently_absent_interpreter_still_raises(self):
+        """Negative control: the final attempt is unguarded, so it re-raises."""
+        final = _enoent(sys.executable)
+        raised = [_enoent(sys.executable)] * len(_INTERPRETER_ENOENT_DELAYS) + [final]
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "run", side_effect=raised) as run,
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            with pytest.raises(FileNotFoundError) as caught:
+                sandbox_mod.run_limited(["/bin/echo", "hi"])
+
+        assert caught.value is final
+        assert run.call_count == len(_INTERPRETER_ENOENT_DELAYS) + 1
+
+    def test_a_non_transient_enoent_is_not_retried(self):
+        with (
+            _prepared(),
+            patch.object(
+                sandbox_mod.subprocess, "run", side_effect=_enoent("/nonexistent/workdir")
+            ) as run,
+            patch.object(sandbox_mod.time, "sleep") as sleep,
+        ):
+            with pytest.raises(FileNotFoundError):
+                sandbox_mod.run_limited(["/bin/echo", "hi"])
+
+        assert run.call_count == 1
+        sleep.assert_not_called()
+
+    def test_a_user_binary_enoent_is_not_retried(self):
+        missing = "/usr/bin/definitely-not-installed"
+        with (
+            _prepared([missing, "--version"]),
+            patch.object(sandbox_mod.subprocess, "run", side_effect=_enoent(missing)) as run,
+            patch.object(sandbox_mod.time, "sleep") as sleep,
+        ):
+            with pytest.raises(FileNotFoundError):
+                sandbox_mod.run_limited([missing, "--version"])
+
+        assert run.call_count == 1
+        sleep.assert_not_called()
+
+    def test_a_called_process_error_still_reports_the_callers_argv(self):
+        """The retry nests INSIDE the cmd-rewriting handler, so this still holds."""
+        exc = subprocess.CalledProcessError(1, _LAUNCHER_CMD)
+        with (
+            _prepared(),
+            patch.object(sandbox_mod.subprocess, "run", side_effect=exc),
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            with pytest.raises(subprocess.CalledProcessError) as caught:
+                sandbox_mod.run_limited(["/bin/echo", "hi"])
+
+        assert caught.value.cmd == ["/bin/echo", "hi"]
+
+
+class TestCreateSubprocessLimitedToleratesAnAbsentInterpreter:
+    """The async wrapper must ride out the blip WITHOUT blocking the loop."""
+
+    def _shimmed(self):
+        """Force the shim-prefixed branch with an interpreter-headed prefix."""
+        return patch.object(
+            sandbox_mod,
+            "spawn_shim_argv",
+            return_value=(sys.executable, "-I", "-S", "-c", "pass"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_retries_until_the_tree_comes_back(self):
+        proc = MagicMock(name="Process")
+        attempts = [_enoent(sys.executable), _enoent(sys.executable), proc]
+
+        async def fake_exec(*_args, **_kwargs):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+        slept: list[float] = []
+
+        async def fake_sleep(d):
+            slept.append(d)
+
+        with (
+            self._shimmed(),
+            patch.object(sandbox_mod.asyncio, "create_subprocess_exec", side_effect=fake_exec),
+            patch.object(sandbox_mod.asyncio, "sleep", side_effect=fake_sleep),
+        ):
+            got = await sandbox_mod.create_subprocess_limited("/bin/echo", "hi")
+
+        assert got is proc
+        assert slept == list(_INTERPRETER_ENOENT_DELAYS[:2])
+
+    @pytest.mark.asyncio
+    async def test_the_backoff_never_blocks_the_event_loop(self):
+        """time.sleep here would freeze the gateway for ~3.75s -- the core hazard."""
+        attempts = [_enoent(sys.executable), MagicMock(name="Process")]
+
+        async def fake_exec(*_args, **_kwargs):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+        async def fake_sleep(_d):
+            return None
+
+        with (
+            self._shimmed(),
+            patch.object(sandbox_mod.asyncio, "create_subprocess_exec", side_effect=fake_exec),
+            patch.object(sandbox_mod.asyncio, "sleep", side_effect=fake_sleep),
+            patch.object(sandbox_mod.time, "sleep") as blocking,
+        ):
+            await sandbox_mod.create_subprocess_limited("/bin/echo", "hi")
+
+        blocking.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_permanently_absent_interpreter_still_raises(self):
+        final = _enoent(sys.executable)
+        raised = [_enoent(sys.executable)] * len(_INTERPRETER_ENOENT_DELAYS) + [final]
+        calls = {"n": 0}
+
+        async def fake_exec(*_args, **_kwargs):
+            exc = raised[calls["n"]]
+            calls["n"] += 1
+            raise exc
+
+        async def fake_sleep(_d):
+            return None
+
+        with (
+            self._shimmed(),
+            patch.object(sandbox_mod.asyncio, "create_subprocess_exec", side_effect=fake_exec),
+            patch.object(sandbox_mod.asyncio, "sleep", side_effect=fake_sleep),
+        ):
+            with pytest.raises(FileNotFoundError) as caught:
+                await sandbox_mod.create_subprocess_limited("/bin/echo", "hi")
+
+        assert caught.value is final
+        assert calls["n"] == len(_INTERPRETER_ENOENT_DELAYS) + 1
+
+    @pytest.mark.asyncio
+    async def test_a_user_binary_enoent_is_not_retried(self):
+        missing = "/usr/bin/definitely-not-installed"
+        calls = {"n": 0}
+
+        async def fake_exec(*_args, **_kwargs):
+            calls["n"] += 1
+            raise _enoent(missing)
+
+        async def fake_sleep(_d):
+            return None
+
+        with (
+            self._shimmed(),
+            patch.object(sandbox_mod.asyncio, "create_subprocess_exec", side_effect=fake_exec),
+            patch.object(sandbox_mod.asyncio, "sleep", side_effect=fake_sleep) as slept,
+        ):
+            with pytest.raises(FileNotFoundError):
+                await sandbox_mod.create_subprocess_limited(missing, "--version")
+
+        assert calls["n"] == 1
+        slept.assert_not_called()
+
+
+class TestAllThreeWrappersShareOneDiscriminator:
+    """The decision is factored; the three spawns are deliberately NOT."""
+
+    def _source(self) -> str:
+        return pathlib.Path(sandbox_mod.__file__).read_text(encoding="utf-8")
+
+    def test_every_wrapper_routes_through_the_shared_helper(self):
+        src = self._source()
+        # One definition, three call sites -- not three copies of the predicate.
+        assert src.count("def _retry_interpreter_enoent(") == 1
+        assert src.count("_retry_interpreter_enoent(exc,") == 3
+
+    def test_no_wrapper_reimplements_the_predicate_inline(self):
+        """Negative control: a fourth copy of the predicate would fail this."""
+        src = self._source()
+        # Only the shared helper and its own definition may name the predicate.
+        assert src.count("_is_transient_interpreter_enoent(") == 2
+
+    def test_each_spawn_still_lives_in_its_own_wrapper(self):
+        """The audits key on the enclosing function, so this is load-bearing."""
+        tree = ast.parse(self._source())
+        wanted = {
+            "run_limited": "run",
+            "popen_limited": "Popen",
+            "create_subprocess_limited": "create_subprocess_exec",
+        }
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            attr = wanted.get(node.name)
+            if attr is None:
+                continue
+            found = [
+                n
+                for n in ast.walk(node)
+                if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and n.func.attr == attr
+            ]
+            assert found, f"{node.name} must spawn via {attr} in its own body"
+            wanted.pop(node.name)
+        assert not wanted, f"wrappers not found: {sorted(wanted)}"
+
+    def test_the_async_wrapper_uses_an_async_sleep(self):
+        """A blocking sleep in the async wrapper would freeze the loop."""
+        tree = ast.parse(self._source())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "create_subprocess_limited":
+                calls = [
+                    n
+                    for n in ast.walk(node)
+                    if isinstance(n, ast.Call)
+                    and isinstance(n.func, ast.Attribute)
+                    and n.func.attr == "sleep"
+                ]
+                names = {n.func.value.id for n in calls if isinstance(n.func.value, ast.Name)}
+                assert "asyncio" in names
+                assert "time" not in names
+                return
+        raise AssertionError("create_subprocess_limited not found")
+
+    def test_abort_retry_exists_only_on_the_wrapper_with_consumers(self):
+        """Subtraction guard: the hook belongs to ``popen_limited`` alone.
+
+        It was briefly carried onto both siblings "for symmetry" and had ZERO
+        callers there. Only ``popen_limited`` has consumers -- the two cron spawn
+        sites -- so a parameter on either sibling is inherited provenance rather
+        than a requirement. This fails if one is reintroduced without a caller.
+        """
+        tree = ast.parse(self._source())
+        expected = {
+            "popen_limited": True,
+            "run_limited": False,
+            "create_subprocess_limited": False,
+        }
+        seen: dict[str, bool] = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name in expected:
+                seen[node.name] = "abort_retry" in {a.arg for a in node.args.kwonlyargs}
+        assert seen == expected, f"abort_retry placement changed: {seen}"
+
+
+class TestTheStrictShellProbeNoLongerLatchesOnABlip:
+    """Extending the retry to ``run_limited`` cures a latch, not just a spawn.
+
+    ``cron_script._shell_is_posix_strict`` probes a candidate shell through
+    ``run_limited`` and catches ``(OSError, SubprocessError,
+    SandboxUnavailableError)`` into ``result = False``, which it then CACHES in
+    ``_POSIX_STRICT_CACHE`` for the process lifetime. ``FileNotFoundError`` is an
+    ``OSError``, so before the retry reached ``run_limited`` a ~1s interpreter
+    blip made the probe answer "this shell expands braces" -- permanently, for
+    every later caller, long after the tree healed.
+
+    The retry now absorbs that blip inside ``run_limited``, so it never reaches
+    the except clause and never latches. The BROADER design (caching a failure
+    permanently) is unchanged and still deferred -- a tree down longer than the
+    ~3.75s budget still latches.
+    """
+
+    def test_a_transient_blip_no_longer_caches_a_wrong_answer(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+        shell = "/bin/dash"
+        cron._POSIX_STRICT_CACHE.pop(shell, None)
+
+        good = MagicMock(returncode=0, stdout="x.{a,a}\n")
+        attempts = [_enoent(sys.executable), good]
+
+        def fake_run(*_args, **_kwargs):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+        with (
+            _prepared(),
+            patch.object(cron, "wrap_argv", return_value=([shell, "-c", "echo x.{a,a}"], None)),
+            patch.object(cron, "cgroup_scope_argv", side_effect=lambda a: a),
+            patch.object(cron, "_clean_cron_env", return_value={}),
+            patch.object(sandbox_mod.subprocess, "run", side_effect=fake_run),
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            got = cron._shell_is_posix_strict(shell)
+
+        # Pre-fix this was False, and the False was cached for the process life.
+        assert got is True
+        assert cron._POSIX_STRICT_CACHE[shell] is True
+        cron._POSIX_STRICT_CACHE.pop(shell, None)
+
+    def test_with_no_retry_budget_the_latch_reappears(self):
+        """Negative control: proves the test above detects the defect.
+
+        Emptying the delay budget makes the loop body never run, so the
+        unguarded final attempt raises immediately -- which is exactly the
+        pre-fix shape. The wrong answer is cached, as it used to be.
+        """
+        cron = importlib.import_module("kiro_crew.cron_script")
+        shell = "/bin/dash"
+        cron._POSIX_STRICT_CACHE.pop(shell, None)
+
+        with (
+            _prepared(),
+            patch.object(cron, "wrap_argv", return_value=([shell, "-c", "echo x.{a,a}"], None)),
+            patch.object(cron, "cgroup_scope_argv", side_effect=lambda a: a),
+            patch.object(cron, "_clean_cron_env", return_value={}),
+            patch.object(sandbox_mod, "_INTERPRETER_ENOENT_DELAYS", ()),
+            patch.object(sandbox_mod.subprocess, "run", side_effect=_enoent(sys.executable)),
+            patch.object(sandbox_mod.time, "sleep"),
+        ):
+            got = cron._shell_is_posix_strict(shell)
+
+        assert got is False
+        assert cron._POSIX_STRICT_CACHE[shell] is False
+        cron._POSIX_STRICT_CACHE.pop(shell, None)
+
+
+class TestACancelDuringTheShellProbeIsNotLost:
+    """The probe's backoff was a window with no owner, so a cancel vanished.
+
+    ``run_command_sandboxed`` resolves its shell before it spawns, and that
+    resolution runs ``_shell_is_posix_strict`` through ``run_limited`` -- which
+    now carries the interpreter-ENOENT backoff. On a cold ``_POSIX_STRICT_CACHE``
+    the function could therefore sleep for seconds while the job was in NEITHER
+    ``_SPAWNING_JOBS`` nor ``_RUNNING_PROCS``, and ``kill_running_process`` has no
+    third place to record against: it returned ``False`` and the cancellation was
+    DISCARDED rather than delayed. The probe then finished and the command the
+    user cancelled was launched, side effects and all.
+
+    The claim is now taken before the probe, so such a cancel is recorded, and a
+    pre-spawn check turns it into a launch that never happens. A spawn-then-kill
+    would not do: the command would still run for as long as the signal took.
+    """
+
+    @pytest.fixture
+    def cron(self):
+        cron = importlib.import_module("kiro_crew.cron_script")
+
+        def _reset():
+            with cron._PROCS_LOCK:
+                cron._SPAWNING_JOBS.clear()
+                cron._CANCELLED_PROC_JOBS.clear()
+                cron._RUNNING_PROCS.clear()
+            cron._POSIX_STRICT_CACHE.pop("/bin/dash", None)
+
+        _reset()
+        yield cron
+        _reset()
+
+    @staticmethod
+    def _probe_blip(cron, on_backoff):
+        """Patches making the FIRST probe attempt blip, calling *on_backoff*.
+
+        The cancel is delivered from inside the patched sleep, which is exactly
+        where a real one lands: mid-backoff, with the spawn not yet made.
+        """
+        good = MagicMock(returncode=0, stdout="x.{a,a}\n")
+        attempts: list = [_enoent(sys.executable), good]
+
+        def fake_run(*_a, **_k):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+        return (
+            _prepared(),
+            patch.object(cron, "_resolve_command_shell", wraps=cron._resolve_command_shell),
+            patch.object(cron, "wrap_argv", side_effect=lambda argv, **k: (list(argv), None)),
+            patch.object(cron, "cgroup_scope_argv", side_effect=lambda a: list(a)),
+            patch.object(cron, "_clean_cron_env", return_value={}),
+            patch.object(cron.os.path, "isfile", return_value=True),
+            patch.object(sandbox_mod.subprocess, "run", side_effect=fake_run),
+            patch.object(sandbox_mod.time, "sleep", side_effect=lambda _d: on_backoff()),
+        )
+
+    @pytest.mark.skipif(
+        not pc.IS_POSIX,
+        reason=(
+            "_resolve_command_shell returns None unconditionally on Windows, so "
+            "_shell_is_posix_strict -- and the backoff window this closes -- is "
+            "unreachable there. Command crons are unavailable on Windows by "
+            "design; script crons are the supported path."
+        ),
+    )
+    def test_the_cancelled_command_is_never_launched(self, cron):
+        accepted: list[bool] = []
+        popen = MagicMock(name="popen_limited")
+
+        with patch.object(cron, "popen_limited", popen):
+            with _ExitStack(
+                *self._probe_blip(
+                    cron, lambda: accepted.append(cron.kill_running_process("job-probe"))
+                )
+            ):
+                result = cron.run_command_sandboxed("rm -rf ./data", job_id="job-probe")
+
+        # The cancel had somewhere to land: pre-fix this was False -- discarded.
+        assert accepted == [True]
+        # And the command never ran. This is the assertion that fails pre-fix.
+        assert popen.call_count == 0
+        assert result["status"] == "cancelled"
+
+    @pytest.mark.skipif(
+        not pc.IS_POSIX,
+        reason="Same reason as the test above: no POSIX shell resolves on Windows.",
+    )
+    def test_a_cancel_for_a_different_job_still_lets_this_one_run(self, cron):
+        """Control: proves the assertions above key on THIS job's cancellation.
+
+        Same blip, same backoff, same patches -- only the cancelled id differs.
+        The command must still be launched, so a test that passed because
+        ``popen_limited`` was simply unreachable would fail here.
+        """
+        popen = MagicMock(name="popen_limited")
+        popen.return_value.communicate.return_value = ("", "")
+        popen.return_value.returncode = 0
+
+        with patch.object(cron, "popen_limited", popen):
+            with _ExitStack(
+                *self._probe_blip(cron, lambda: cron.kill_running_process("some-other-job"))
+            ):
+                result = cron.run_command_sandboxed("echo hi", job_id="job-probe2")
+
+        assert popen.call_count == 1
+        assert result["status"] != "cancelled"
+
+    def test_the_claim_is_released_when_no_shell_resolves(self, cron):
+        """The claim now spans early returns, so every one of them must free it.
+
+        A leaked claim is worse than the bug it guards: ``_begin_spawn`` would
+        refuse every later wake of this job for the life of the process.
+        """
+        with patch.object(cron, "_resolve_command_shell", return_value=None):
+            result = cron.run_command_sandboxed("echo hi", job_id="job-noshell")
+
+        assert result["status"] == "error"
+        with cron._PROCS_LOCK:
+            assert "job-noshell" not in cron._SPAWNING_JOBS
+
+    def test_the_claim_is_released_when_the_sandbox_refuses(self, cron):
+        with (
+            patch.object(cron, "_resolve_command_shell", return_value="/bin/sh"),
+            patch.object(cron, "wrap_argv", side_effect=RuntimeError("no backend")),
+        ):
+            result = cron.run_command_sandboxed("echo hi", job_id="job-nosbx")
+
+        assert result["status"] == "error"
+        with cron._PROCS_LOCK:
+            assert "job-nosbx" not in cron._SPAWNING_JOBS
+
+
+class TestSpawnOnlyCancellationIsReportedHonestly:
+    """``kill_running_process`` returning True without a kill has two readers.
+
+    It now returns True either because it signalled a live child OR because it
+    recorded the cancel against a spawn still in flight. The control-flow reader
+    is fine with that -- but it is only fine because of a guard, and the audit
+    reader was asserting a kill that never happened.
+    """
+
+    @staticmethod
+    def _cron_source() -> str:
+        return pathlib.Path(importlib.import_module("kiro_crew.cron").__file__).read_text(
+            encoding="utf-8"
+        )
+
+    def test_the_control_flow_reader_is_gated_on_the_job_being_an_agent_job(self):
+        """A spawn-only True must not be able to suppress an agent-session reset.
+
+        It cannot, because the branch also requires ``is_agent_job`` -- and only
+        ``run_script_sandboxed`` / ``run_command_sandboxed`` ever claim a spawn,
+        so an agent job is never in ``_SPAWNING_JOBS`` to begin with. Pin the
+        guard: dropping it would make the two facts silently interact.
+        """
+        assert "if self._sessions and is_agent_job and not killed_proc:" in self._cron_source()
+
+        cron_script = importlib.import_module("kiro_crew.cron_script")
+        claimers = {
+            node.name
+            for node in ast.walk(
+                ast.parse(pathlib.Path(cron_script.__file__).read_text(encoding="utf-8"))
+            )
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Name)
+                and c.func.id == "_begin_spawn"
+                for c in ast.walk(node)
+            )
+        }
+        assert claimers == {"run_script_sandboxed", "run_command_sandboxed"}
+
+    def test_the_audit_reader_no_longer_claims_a_kill_that_did_not_happen(self):
+        source = self._cron_source()
+        assert '"cancellation_accepted": killed_proc,' in source
+        # The old KEY is gone from the metadata dict. Prose naming it is fine --
+        # the comment at that seam explains why the rename happened.
+        assert '"killed_subprocess": killed_proc' not in source
+
+
+class _ExitStack:
+    """Minimal nested-context helper (contextlib.ExitStack without the import)."""
+
+    def __init__(self, *managers):
+        self._managers = managers
+        self._entered: list = []
+
+    def __enter__(self):
+        for manager in self._managers:
+            manager.__enter__()
+            self._entered.append(manager)
+        return self
+
+    def __exit__(self, *exc_info):
+        for manager in reversed(self._entered):
+            manager.__exit__(*exc_info)
+        return False
+
+
+def test_real_spawn_still_works_end_to_end():
+    """Guards against the retry wrapper breaking the ordinary success path."""
+    proc = sandbox_mod.popen_limited(
+        [sys.executable, "-c", "print('ok')"],
+        stdout=subprocess.PIPE,
+        **UTF8_TEXT,
+    )
+    out, _ = proc.communicate(timeout=60)
+    assert out.strip() == "ok"
+    assert proc.returncode == 0


### PR DESCRIPTION
## Problem / Motivation

`wrap_argv` prepends `sys.executable` to **every** sandboxed argv, so that interpreter
path is on the critical path of every sandboxed spawn. When it is a symlink into a
directory tree that can be rebuilt underneath a live process, the path can vanish for
about a second and then come back.

Rebuilding a managed install tree deletes and re-creates its entries, including the
interpreter symlink itself. A spawn landing inside that window dies with ENOENT on a path
that both existed before it and exists after it. Any packaging that relinks an
interpreter in place reaches this: an environment rebuild, a toolchain reinstall, a
swapped container layer.

Observed symptom: three scheduled script jobs sharing one 900-second tick all fired
inside a single rebuild window. Two died with `FileNotFoundError: [Errno 2] No such file
or directory` naming the interpreter, and each recorded a hard job failure plus a strike
toward auto-pause — for a condition that had already healed by the time anyone looked.

## Why it matters

The caller cannot distinguish this from a broken install, so a self-healing one-second
blip is recorded as a real failure. Cron auto-pause is latching and only clears on a
later success, so transient strikes accumulate against jobs that are fine. Because the
window hits every sandboxed spawn at once, jobs sharing a tick fail together, which
reads like a systemic outage rather than a moment of filesystem churn.

## What changed (motivation → approach → change)

Root cause is a spawn against a path that is briefly absent, so the fix is to retry that
one spawn rather than to surface it.

**1. The retry itself (`sandbox.py`).** `popen_limited` retries on a 0.25 / 0.5 / 1.0 /
2.0 s backoff (5 attempts, ~3.75 s total). The loop is **inline** in `popen_limited`
rather than extracted into a helper, and deliberately so: both spawn audits key on
`<relpath>::<enclosing function>`, so moving the `Popen` into its own function migrates
its audit key — stranding the `popen_limited` entries in `_SYNC_ALLOWED` and
`BENIGN_SPAWNS` as stale while the relocated call reads as a brand-new unrouted spawn.
An extraction was tried first and broke four guard tests at once;
`TestTheSpawnStaysInsidePopenLimited` now asserts the shape by AST so the regression
fails at source.

The gate is narrow, because ENOENT from `Popen` is ambiguous — it is also raised for a
missing `cwd`, and a genuinely absent user binary must still fail on the first attempt.
`_is_transient_interpreter_enoent` therefore accepts only an ENOENT whose `filename`
**is** `cmd[0]` **and** whose `cmd[0]` is this process's own `sys.executable`. A
missing-`cwd` ENOENT names the directory and a missing user binary names that binary, so
both fall through untouched. `filename` being populated is not guaranteed by every
platform, so when it is absent the fallback is a live check that the interpreter really
is gone from disk — an observation rather than an assumption that this ENOENT must be
ours.

Two deliberate properties:

- **The final attempt is unguarded.** Whatever it raises reaches the caller unchanged, so
  a permanently broken install still reports exactly the error it reports today, ~4 s
  later. The retry cannot convert a real failure into a different one.
- **Every retry logs a warning.** An install tree that has genuinely stopped converging
  stays visible instead of being silently absorbed.

**2. The backoff had to be made cancellable (`cron_script.py`).** A retry that waits
seconds is a window in which a cancellation was previously *lost*, not delayed:
`kill_running_process` keys on a **registered** child, and during the backoff none
exists, so it returned `False` and recorded nothing — the retry then launched the work
and the run reported `ok`. This rider is the larger half of the diff and is listed
explicitly because it is not implied by "retry a spawn":

- `_SPAWNING_JOBS` marks a job whose spawn is in flight, so `kill_running_process` can
  **record** a cancel in that window instead of dropping it. That is a semantic change:
  it now returns `True` for a job that is only spawning (one consumer, `cron.py`).
- `popen_limited` gained an `abort_retry` hook, consulted after each backoff, which
  re-raises instead of spawning when a cancel has landed. It is wired at the two cron
  spawn sites. It matters only where cancellation is mediated by a registry keyed on the
  live child; a caller holding the `Popen` handle and polling a stop flag (such as
  `auto_improvement.spine.agent_runner`, which calls `_terminate_group` on the handle)
  loses nothing by omitting it, and the docstring says so.
- `_finish_spawn` moves a job from spawning to registered under a **single** hold of
  `_PROCS_LOCK`, so a cancel can never fall between the two states. When a cancel raced
  the successful `Popen`, the child is live and unregistered, so the caller kills it and
  reports `cancelled` — reporting a stop that did not happen would be worse than the
  original bug. `_abandon_spawn` clears the flag when a spawn produced no child, so it
  cannot leak into that job's next run.

**3. Cron output keeps locale decoding, now declared deliberate.** Relocating the two
`popen_limited` calls into their `try:` blocks made the repo's `subprocess-encoding` gate
count them as newly added lines. An earlier revision satisfied that by pinning them with
`**UTF8_TEXT` (`text=True, encoding="utf-8", errors="replace"`) — **that was wrong and has
been reverted.** A cron runs an arbitrary command, so its output carries the host's
encoding; forcing UTF-8 with `errors="replace"` turned every non-UTF-8 byte into U+FFFD
*before* the output was persisted and delivered, which is irreversible corruption of the
thing the user asked to see. Both calls therefore read `text=True,
# subprocess-encoding: locale` — the gate's own opt-out marker for deliberate locale
decoding — and `TestCommandOutputUsesLocaleDecoding` asserts that neither call pins
`encoding` or `errors`. **Runtime decoding behaviour is unchanged from the base.**

Either remedy takes those two calls out of the gate's violation set, so its per-file count
drops the same way, and the gate is a ratchet: the one-line count for `cron_script.py` in
`.github/subprocess-encoding-baseline.txt` must move `4 -> 2` or the gate fails with
"1 entry to prune". That is the only `.github/**` path this PR touches, and it is why the
`Fork workflow-change guard` lane is red: it needs the `allow-fork-workflow-change` label
from a maintainer, and no push can clear it.

**4. An overlapping wake of the same job is refused.** `_begin_spawn` returns false when the
job is already spawning or registered, and the caller returns without touching the other
run's state. This is required by items 2 and 3 rather than optional: every cancellation
surface here is keyed on the job id alone (`kill_running_process` takes only an id,
`_RUNNING_PROCS` holds one child per job), so two concurrent runs make "cancel this job"
ambiguous and whichever finishes its spawn first consumes the flag — a cancel aimed at a run
still in its backoff could be eaten by a rerun that was never cancelled. It also backstops a
documented pre-existing gap: when a deadline fires with a worker already claimed, the
scheduler's own overlap guard clears while the child runs on.

The refusal reports `status: "skipped"`, **not** `"error"`, and both cron dispatch paths
intercept it before the strike branch. An overlapping wake is a scheduling condition, not a
job defect, so counting it toward auto-pause would inflate strikes for exactly the transient
class this change exists to stop striking. That matches the disposition of the scheduler's
own pre-existing guard, which logs "previous execution still running, skipping" and returns
without counting anything.

**5. A raced-cancel command run reports the child's returncode, not `-1`.** When a cancel
races a successful spawn the child is killed and the run reported cancelled; it now carries
`proc.returncode` (the signal that stopped it), matching the existing post-`communicate`
cancellation contract rather than inventing a synthetic value. The spawn-failed case still
reports `-1`, because no child exists and there is no signal to report.

Scope — now **all three** spawn wrappers, not one. The named cause is `wrap_argv` prepending
`sys.executable` to every sandboxed argv, and `spawn_shim_argv` puts it at `cmd[0]` for
`popen_limited`, `run_limited` (17 call sites, 15 files) and `create_subprocess_limited`
(41 call sites, 26 files) alike — so the exposure was identical and a point fix on one of
three was not honest to the root cause. All three now retry on the same budget, through **one**
shared discriminator (`_retry_interpreter_enoent`): one definition, three call sites, no
copies. The async wrapper backs off with `asyncio.sleep`, never `time.sleep` — blocking the
event loop for up to ~3.75s is the exact hazard that wrapper exists to avoid. The final
attempt stays unguarded in every wrapper, so a genuinely broken install reports its original
error, just ~4s later. `abort_retry` stays on `popen_limited` **alone** — it is the only
wrapper with consumers (the two cron spawn sites), and a sibling backoff is therefore **not**
cancellable: neither sibling hands back a handle a cancellation registry could key on, so the
lost-cancel window the hook closes has no consumer there. An AST test pins that placement.

What deliberately did **not** move: the three `subprocess` calls themselves stay lexically
inside their own wrappers. Both spawn audits key on `<relpath>::<enclosing function>`, so
hoisting any of them into a shared helper would migrate its audit key — stranding the
`_SYNC_ALLOWED` and `BENIGN_SPAWNS` entries as stale while the relocated call read as a
brand-new unrouted spawn. An AST test pins each spawn to its own wrapper, and another pins the
async wrapper to an async sleep.

This also **cures**, rather than defers, the `_shell_is_posix_strict` latch flagged in review:
that probe runs through `run_limited` and catches `OSError` into `result = False`, which it
caches in `_POSIX_STRICT_CACHE` for the process lifetime — so a ~1s blip used to make every
later caller believe the shell expands braces. `FileNotFoundError` is an `OSError`, so the
retry now absorbs the blip before it reaches that clause. A test pins it, with a negative
control (empty delay budget) proving the latch reappears without the retry.

Two deferrals remain, and no tracking issue is filed for them — deliberately, since filing on
the upstream repo would notify its watchers and that is not mine to do; they are recorded here
instead. First, the broader `_POSIX_STRICT_CACHE` design still caches a *permanent* failure, so
a tree down longer than the ~3.75s budget still latches; only the transient blip is covered.
Second, a child that starts and *then* fails its own imports mid-rebuild (a transient
`ModuleNotFoundError` for a `kiro_crew` submodule) is a different phase this does not address.

## Tests

New file `test/test_sandbox_interpreter_enoent_retry.py`, **56 tests** in fourteen classes
plus one end-to-end case:

- `TestIsTransientInterpreterEnoent` — the discriminator, both directions: our own
  interpreter retries; a missing `cwd`, a missing user binary, and a non-ENOENT `OSError`
  do not.
- `TestPopenLimitedToleratesAnAbsentInterpreter` — the budget is spent and then the final
  unguarded attempt raises; a mid-budget success returns that handle.
- `TestTheSpawnStaysInsidePopenLimited` — AST assertion that the `Popen` call is
  lexically inside `popen_limited`, pinning the audit-key constraint above.
- `TestAbortRetryClosesTheCancellationWindow` — an aborting hook stops after one attempt;
  a `False` hook does not shorten the retry (negative control).
- `TestSpawnToRegisteredIsAtomic` — `_finish_spawn` registers and clears atomically; a
  raced cancel is reported and the child deliberately left unregistered so the caller
  kills it; a kill inside the spawn window records the cancel, and one outside it records
  nothing (negative control); `_abandon_spawn` cannot leak a flag.
- `TestCommandCronSpawnFailureIsCancellable` — the spawn-failure arm consumes a recorded
  cancel and reports cancelled; without one the run is still an error (negative control).
- `TestOverlappingRunCannotEatTheCancel` — a second run is refused while the first is
  spawning and while it is registered; a refused rerun leaves the pending cancel intact; a
  distinct job is not refused, so this is not a global lock (negative control); the slot is
  reusable once the run ends.
- `TestCommandOutputUsesLocaleDecoding` — the command spawn passes neither `encoding` nor
  `errors`; forcing UTF-8 with replacement really does destroy the bytes irrecoverably
  (mechanism, with a positive control); and an AST guard fails at source if either cron
  spawn is re-pinned.
- `TestAnOverlappingWakeCostsNoFailureStrike` — a refused overlap reports `skipped` rather
  than `error`, leaves the other run's claim and pending cancel untouched, and both
  dispatch paths intercept the status before the strike branch.
- `TestARefusedOverlapIsNotPersistedAsASuccessfulRun` — the refusal sets `last_status`
  and `run_never_started` so `_execute` cannot write a fabricated `ok` and reset the
  auto-pause budget; it calls neither `record_failure` nor `record_success` (negative
  control); and a positive control asserts `_execute` really does treat a non-`error`
  status as success, so the other assertions cannot pass vacuously.
- `TestRunLimitedToleratesAnAbsentInterpreter` — the sibling sync wrapper, same shape as
  the `popen_limited` class: retries mid-budget, re-raises when the budget is spent, does
  not retry a missing `cwd` or a missing user binary, and still
  reports the caller's own argv in a `CalledProcessError` (the retry nests inside that
  handler). No `abort_retry` case — the hook is not on this wrapper.
- `TestCreateSubprocessLimitedToleratesAnAbsentInterpreter` — the async wrapper: retries
  mid-budget, re-raises when spent, does not retry a user-binary ENOENT,
  and **never** calls `time.sleep` (asserted directly), because blocking the
  loop is the hazard this wrapper exists to avoid. No `abort_retry` case here either.
- `TestAllThreeWrappersShareOneDiscriminator` — one `_retry_interpreter_enoent` definition
  with three call sites and no inline re-implementation of the predicate (negative
  control); an AST assertion that each of the three spawns still lives in its own wrapper,
  pinning the audit-key constraint; an AST assertion that the async wrapper sleeps with
  `asyncio`, not `time`; and `test_abort_retry_exists_only_on_the_wrapper_with_consumers`,
  which pins the hook to `popen_limited` and asserts its **absence** on both siblings, so a
  zero-consumer parameter cannot creep back.
- `TestTheStrictShellProbeNoLongerLatchesOnABlip` — a transient blip during the
  `_shell_is_posix_strict` probe no longer caches a wrong `False` for the process lifetime,
  with a negative control (empty delay budget) that reproduces the latch.

Gate results on the current head:

- `mypy src/kiro_crew/` with the repo's pinned `mypy==1.14.1`: `Success: no issues found
  in 1261 source files`. An earlier revision failed this lane on
  `cron_script.py` (`discard` given `str | None`); a single-file mypy run had reported
  clean, so the whole-package command is what catches it.
- `flake8 src/kiro_crew test conftest.py xdist_budget.py`: 0 findings from this change.
- `scripts/check_black_formatting.py`, `scripts/check_subprocess_encoding.py`,
  `scripts/check_sync_io_in_async.py`, `scripts/scrub-lint.sh`: all pass with the change
  in diff scope. The diff-scoped gates must be run with the upstream base ref; scoped
  against a fork `main` that is behind, the encoding gate reported a pass it should not
  have.
- 479 passed / 2 skipped across the new file plus `test_spawn_preexec_guard.py`,
  `test_spawn_audit.py`, `test_cron_script.py`, `test_cron_script_more_coverage.py` and
  `test_sandbox_argv.py`; **3329 passed** across every `test/*sandbox*`, `test/*spawn*` and
  `test/*cron*` file, which is the scope covering all three wrappers and the
  `slack/gateway.py` dispatch change. The 16 spawn-audit tests pass unchanged, confirming no
  audit key moved.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** no user-visible surface changes — this touches subprocess spawn
wrappers and cron spawn bookkeeping, and adds a unit test file.

## Related Issues

N/A — no tracking issue; found while diagnosing scheduled-job failures.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a retry that waits is a cancellation window. Adding a backoff to a spawn whose
cancellation is mediated by a registry keyed on the *live child* converts "cancel
arrives slightly late" into "cancel is discarded", because during the backoff there is no
child to look up and the canceller records nothing. Widening a retry therefore requires
auditing the cancel path, not just the failure path — and the two state changes
(no-longer-spawning, now-registered) must happen under one lock hold or the same cancel
falls through the gap between them.




