### PR TITLE
refactor(acp): define the capability sets in the acp_backends leaf

### DIFF
--- a/docs/system-specs/features/agent-host-contract.md
+++ b/docs/system-specs/features/agent-host-contract.md
@@ -104,7 +104,7 @@ replays full history.
 |---|---|---|---|
 | Sign-in | `kiro-cli login`; SSO `--use-device-flow --license pro` (`kiro_prerequisite.py:80,90`) | same | brings its own: a credential-refresh **command** named inside its own `settings.json`, plus a provider-routing env var on the child (companion) |
 | Credential store | projected, never copied: identity tables plus `migrations` rows plus selected `state` rows (`kiro_prerequisite.py:182-200`) | same store | its own; that refresh command is copied **verbatim** into the isolated seed at `0o600`. Dropping it breaks auth outright, so the seed cannot simply be emptied (companion) |
-| Recyclable on a host logout | yes | yes (`ACP_BACKENDS_KIRO_IDENTITY_STORE`, `acp/types.py:182-196`) | **no** — a live CC child must survive `kiro-cli logout` |
+| Recyclable on a host logout | yes | yes (`ACP_BACKENDS_KIRO_IDENTITY_STORE`, `acp_backends.py:303-316`) | **no** — a live CC child must survive `kiro-cli logout` |
 | Entitlement discovery | account API | account API | runtime, from the advertised model set at session init; the registry is filtered down to it (`dashboard/handlers/agents.py:1151-1160`) |
 | Readiness probe | `--version` then `whoami`, inside the OS sandbox (`kiro_prerequisite.py:4-7`) | same | binary resolution only, but for **both** components and through the spawn's own resolvers, so the answer cannot disagree with what a spawn does (`agent_sdk/backend_install.py`, `agent_sdk/drivers/acp.py`) |
 

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -7,7 +7,8 @@ import re as _re
 from dataclasses import dataclass, field
 from typing import Any
 
-# Backend identifiers + the selectable registry live in the leaf module
+# Backend identifiers, the capability sets and the selectable registry live in the
+# leaf module
 # ``kiro_crew.acp_backends`` (it imports nothing from this package, which is what
 # lets the config loader and the dashboard read them). Re-exported here so every
 # existing ``from kiro_crew.acp.types import ACP_BACKEND_*`` call site is
@@ -16,7 +17,12 @@ from kiro_crew.acp_backends import (  # noqa: F401 - re-exported for existing im
     ACP_BACKEND_CLAUDE,
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
+    ACP_BACKENDS_ACP_RUNTIME,
+    ACP_BACKENDS_INTERNAL_SANDBOX,
+    ACP_BACKENDS_KIRO_IDENTITY_STORE,
     ACP_BACKENDS_KNOWN,
+    ACP_BACKENDS_SESSION_SHARING,
+    ACP_BACKENDS_STEER,
     selectable_backends,
 )
 
@@ -132,71 +138,14 @@ ACP_CLIENT_CAPABILITIES: dict = {
 # extends (``register_selectable_backend``). A frozen ``ACP_BACKENDS_SELECTABLE``
 # snapshot here would be read before boot registration and silently miss it.
 
-# ── Capability membership (harness-parity H6, H7) ──
-# Every capability a backend may claim is an OPT-IN set here, never a negation at
-# the call site. ``not is_claude_backend`` reads correctly with two backends and
-# then silently hands the capability to the third, so a harness that has never
-# demonstrated the capability inherits it — and the operator who never opted into
-# that harness is the one who finds out. Adding a member is a deliberate edit
-# with evidence; inheriting a default is not a decision. See
-# docs/system-specs/modules/harness-parity.md.
+# ── Capability membership ──
+# The five ``ACP_BACKENDS_*`` capability sets are DEFINED in the leaf module
+# ``kiro_crew.acp_backends`` and re-exported by the import above, so
+# ``from kiro_crew.acp.types import ACP_BACKENDS_STEER`` still resolves. They moved
+# for the same reason the backend identifiers did: a consumer outside this package
+# must be able to ask a capability question without importing ``kiro_crew.acp``,
+# whose ``__init__`` pulls in the client and runtime.
 
-# Backends whose single process can host N concurrent ACP sessions (AcpRuntime
-# demux) AND can persist a SHARED subagent session across teardown. KAS runs on
-# AcpRuntime (multi-session), but its teardown maps to _kiro/session/delete,
-# which removes the persisted session — so a shared subagent would strand
-# spawn_continue (conversation_gone). KAS therefore opts in only once a
-# keep-aware teardown lands (native subagent work); until then its subagents get
-# dedicated sessions. claude-agent-acp runs through AcpClient (one process per
-# session) and is not a member.
-ACP_BACKENDS_SESSION_SHARING = frozenset({ACP_BACKEND_KIRO})
-
-# Backends implementing the ``_session/steer`` extension (mid-turn steer).
-ACP_BACKENDS_STEER = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
-
-# Backends carrying their OWN internal OS sandbox, which on macOS cannot nest
-# inside Kiro Crew's seatbelt (kernel EPERM) — so ``sandbox.wrap_argv`` skips
-# Crew's own layer for them. This is the one membership test that fails OPEN:
-# claiming it for a harness with no internal sandbox hands isolation to a layer
-# that never starts and leaves the agent process unconfined. Only kiro-cli
-# qualifies; a Node or Python harness does not, however it is spawned.
-#
-# KAS is NOT a member even though Crew now spawns it as ``kiro-cli acp
-# --agent-engine v3`` and the process on the end of the argv IS kiro-cli. The
-# relay spawns the KAS server without an ``--sandbox`` argument, and KAS's
-# sandbox factory resolves an absent config to its no-op backend, so no OS
-# sandbox starts inside — adding KAS here would skip Crew's seatbelt in favour of
-# a layer that does not exist. See :mod:`kiro_crew.acp.kas_transport`.
-ACP_BACKENDS_INTERNAL_SANDBOX = frozenset({ACP_BACKEND_KIRO})
-
-# Backends served by AcpRuntime + AcpSessionHandle — the kiro-agent family
-# (kiro-cli and KAS) whose single process hosts N sessions via demux.
-# claude-agent-acp runs one AcpClient per session and is NOT a
-# member. Membership drives the shared runtime start path and the kiro-family
-# spawn conventions: members read the cli.json effort/tool-search overlay and
-# receive effort at spawn, whereas claude applies it via a live push after the
-# session is ready. Stated as opt-in membership (harness-parity H5/H6) so the
-# four sites that mean "kiro or kas" say so positively rather than as
-# ``not is_claude_backend`` — an inference that silently captures every harness
-# added later. This is a SUPERSET of ACP_BACKENDS_SESSION_SHARING: running on
-# AcpRuntime is necessary for session sharing but not sufficient (KAS runs here
-# yet is excluded from sharing until keep-aware teardown lands).
-ACP_BACKENDS_ACP_RUNTIME = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
-
-# Backends whose sign-in lives in kiro-cli's OWN identity store, so an external
-# ``kiro-cli logout`` (or a switch to another account) invalidates a process that
-# is already running. Membership is what authorizes retiring a live session's
-# child when that store starts naming a different account: a harness
-# authenticated some other way must not be recycled on a store it never reads.
-# KAS is a member: it is spawned as ``kiro-cli acp --agent-engine v3
-# --auth-method cli`` (see :mod:`kiro_crew.acp.kas_transport`), and that
-# ``--auth-method cli`` is precisely the demonstration this set waits for — the
-# relay resolves every access token from kiro-cli's own store, so a logout that
-# invalidates the kiro backend invalidates a running KAS relay identically.
-# Excluding it would let a KAS session keep serving turns on the previous
-# account's credentials. Positive membership rather than "not claude"
-# (harness-parity H5).
-ACP_BACKENDS_KIRO_IDENTITY_STORE = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
 
 # ── Provider labels ──
 # The backend identity key persisted in the session map. It indexes three

--- a/src/kiro_crew/acp_backends.py
+++ b/src/kiro_crew/acp_backends.py
@@ -247,3 +247,70 @@ def resolve_selected_backend(value: object) -> str:
             ", ".join(repr(b) for b in sorted(selectable)),
         )
     return ACP_BACKEND_KIRO
+
+
+# ── Capability membership (harness-parity H6, H7) ──
+# Every capability a backend may claim is an OPT-IN set here, never a negation at
+# the call site. ``not is_claude_backend`` reads correctly with two backends and
+# then silently hands the capability to the third, so a harness that has never
+# demonstrated the capability inherits it — and the operator who never opted into
+# that harness is the one who finds out. Adding a member is a deliberate edit
+# with evidence; inheriting a default is not a decision. See
+# docs/system-specs/modules/harness-parity.md.
+
+# Backends whose single process can host N concurrent ACP sessions (AcpRuntime
+# demux) AND can persist a SHARED subagent session across teardown. KAS runs on
+# AcpRuntime (multi-session), but its teardown maps to _kiro/session/delete,
+# which removes the persisted session — so a shared subagent would strand
+# spawn_continue (conversation_gone). KAS therefore opts in only once a
+# keep-aware teardown lands (native subagent work); until then its subagents get
+# dedicated sessions. claude-agent-acp runs through AcpClient (one process per
+# session) and is not a member.
+ACP_BACKENDS_SESSION_SHARING = frozenset({ACP_BACKEND_KIRO})
+
+# Backends implementing the ``_session/steer`` extension (mid-turn steer).
+ACP_BACKENDS_STEER = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+
+# Backends carrying their OWN internal OS sandbox, which on macOS cannot nest
+# inside Kiro Crew's seatbelt (kernel EPERM) — so ``sandbox.wrap_argv`` skips
+# Crew's own layer for them. This is the one membership test that fails OPEN:
+# claiming it for a harness with no internal sandbox hands isolation to a layer
+# that never starts and leaves the agent process unconfined. Only kiro-cli
+# qualifies; a Node or Python harness does not, however it is spawned.
+#
+# KAS is NOT a member even though Crew now spawns it as ``kiro-cli acp
+# --agent-engine v3`` and the process on the end of the argv IS kiro-cli. The
+# relay spawns the KAS server without an ``--sandbox`` argument, and KAS's
+# sandbox factory resolves an absent config to its no-op backend, so no OS
+# sandbox starts inside — adding KAS here would skip Crew's seatbelt in favour of
+# a layer that does not exist. See :mod:`kiro_crew.acp.kas_transport`.
+ACP_BACKENDS_INTERNAL_SANDBOX = frozenset({ACP_BACKEND_KIRO})
+
+# Backends served by AcpRuntime + AcpSessionHandle — the kiro-agent family
+# (kiro-cli and KAS) whose single process hosts N sessions via demux.
+# claude-agent-acp runs one AcpClient per session and is NOT a
+# member. Membership drives the shared runtime start path and the kiro-family
+# spawn conventions: members read the cli.json effort/tool-search overlay and
+# receive effort at spawn, whereas claude applies it via a live push after the
+# session is ready. Stated as opt-in membership (harness-parity H5/H6) so the
+# four sites that mean "kiro or kas" say so positively rather than as
+# ``not is_claude_backend`` — an inference that silently captures every harness
+# added later. This is a SUPERSET of ACP_BACKENDS_SESSION_SHARING: running on
+# AcpRuntime is necessary for session sharing but not sufficient (KAS runs here
+# yet is excluded from sharing until keep-aware teardown lands).
+ACP_BACKENDS_ACP_RUNTIME = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+
+# Backends whose sign-in lives in kiro-cli's OWN identity store, so an external
+# ``kiro-cli logout`` (or a switch to another account) invalidates a process that
+# is already running. Membership is what authorizes retiring a live session's
+# child when that store starts naming a different account: a harness
+# authenticated some other way must not be recycled on a store it never reads.
+# KAS is a member: it is spawned as ``kiro-cli acp --agent-engine v3
+# --auth-method cli`` (see :mod:`kiro_crew.acp.kas_transport`), and that
+# ``--auth-method cli`` is precisely the demonstration this set waits for — the
+# relay resolves every access token from kiro-cli's own store, so a logout that
+# invalidates the kiro backend invalidates a running KAS relay identically.
+# Excluding it would let a KAS session keep serving turns on the previous
+# account's credentials. Positive membership rather than "not claude"
+# (harness-parity H5).
+ACP_BACKENDS_KIRO_IDENTITY_STORE = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})

--- a/test/test_acp_capability_sets_leaf.py
+++ b/test/test_acp_capability_sets_leaf.py
@@ -1,0 +1,138 @@
+"""The capability sets must be askable without importing ``kiro_crew.acp``.
+
+They used to be defined in ``kiro_crew.acp.types``. Importing anything under
+``kiro_crew.acp`` executes that package's ``__init__`` (client + runtime), and
+``kiro_crew.acp`` is a FORBIDDEN_ROOT for the agent-SDK boundary gate -- so every
+consumer outside the ACP layer that asked a capability question had to add a
+forbidden edge, against a baseline that may only shrink. Onboarding a new harness
+means teaching outside consumers (readiness, prerequisite, MCP wiring) to ask these
+sets, so that cost was about to be paid repeatedly.
+
+Definitions now live in the leaf ``kiro_crew.acp_backends`` and are re-exported from
+``acp.types`` for existing importers. These tests pin both halves: the leaf stays
+reachable without the ACP package, and the re-export keeps working.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.acp_backends import (
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
+    ACP_BACKENDS_ACP_RUNTIME,
+    ACP_BACKENDS_INTERNAL_SANDBOX,
+    ACP_BACKENDS_KIRO_IDENTITY_STORE,
+    ACP_BACKENDS_SESSION_SHARING,
+    ACP_BACKENDS_STEER,
+)
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+CAPABILITY_SETS = (
+    "ACP_BACKENDS_ACP_RUNTIME",
+    "ACP_BACKENDS_INTERNAL_SANDBOX",
+    "ACP_BACKENDS_KIRO_IDENTITY_STORE",
+    "ACP_BACKENDS_SESSION_SHARING",
+    "ACP_BACKENDS_STEER",
+)
+
+
+@pytest.mark.parametrize("name", CAPABILITY_SETS)
+def test_defined_in_the_leaf_not_in_the_acp_package(name: str) -> None:
+    """The definition must sit in ``acp_backends``, never back in ``acp.types``.
+
+    A future edit that moves one back would compile and pass every other test while
+    silently re-imposing a forbidden edge on each consumer that reads it.
+    """
+    leaf = (SRC / "acp_backends.py").read_text(encoding="utf-8")
+    types_mod = (SRC / "acp" / "types.py").read_text(encoding="utf-8")
+
+    assert f"\n{name} = frozenset(" in leaf, f"{name} is not defined in acp_backends.py"
+    assert f"\n{name} = frozenset(" not in types_mod, (
+        f"{name} is defined in acp/types.py again; define it in the leaf "
+        f"acp_backends.py so a consumer can read it without importing kiro_crew.acp"
+    )
+
+
+@pytest.mark.parametrize("name", CAPABILITY_SETS)
+def test_the_re_export_is_the_same_object(name: str) -> None:
+    """Existing ``from kiro_crew.acp.types import ...`` call sites keep working.
+
+    Identity, not equality: a copy would drift the moment one side is edited.
+    """
+    import kiro_crew.acp_backends as leaf
+    from kiro_crew.acp import types as acp_types
+
+    assert getattr(acp_types, name) is getattr(leaf, name), (
+        f"acp.types.{name} is a different object than acp_backends.{name}; "
+        f"re-export it rather than redefining it"
+    )
+
+
+def test_reading_a_capability_set_does_not_load_the_acp_package() -> None:
+    """The whole point of the move, and the reason it needs a test.
+
+    The boundary gate counts import edges; it cannot see that this one is now
+    avoidable. If the sets drifted back behind ``kiro_crew.acp``, every consumer
+    would silently start paying that package again -- and the gate would stay green
+    because those consumers are already in its baseline.
+
+    Runs in a subprocess: by the time this test executes, the suite has imported
+    most of the package already, so an in-process ``sys.modules`` check proves
+    nothing.
+    """
+    probe = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(SRC.parent)!r})\n"
+        "from kiro_crew.acp_backends import ACP_BACKENDS_STEER, ACP_BACKENDS_ACP_RUNTIME\n"
+        "assert isinstance(ACP_BACKENDS_STEER, frozenset)\n"
+        "print(repr({'acp': 'kiro_crew.acp' in sys.modules,\n"
+        "            'providers': 'kiro_crew.providers' in sys.modules}))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        cwd=str(SRC.parent.parent),
+        **UTF8_TEXT,
+    )
+    assert result.returncode == 0, f"probe failed: {result.stderr[-2000:]}"
+    loaded = ast.literal_eval(result.stdout.strip().splitlines()[-1])
+
+    assert loaded["acp"] is False, (
+        "reading a capability set loaded kiro_crew.acp; the sets must stay in the "
+        "leaf so an outside consumer can ask without a forbidden-root import"
+    )
+    assert loaded["providers"] is False, "reading a capability set loaded kiro_crew.providers"
+
+
+def test_membership_is_unchanged_by_the_move() -> None:
+    """Pin the actual members, so the move cannot quietly grant a capability.
+
+    Opting a harness in is a deliberate edit with evidence (harness-parity H5/H6);
+    a relocation is not the place for it.
+    """
+    assert ACP_BACKENDS_SESSION_SHARING == frozenset({ACP_BACKEND_KIRO})
+    assert ACP_BACKENDS_INTERNAL_SANDBOX == frozenset({ACP_BACKEND_KIRO})
+    assert ACP_BACKENDS_STEER == frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+    assert ACP_BACKENDS_ACP_RUNTIME == frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+    assert ACP_BACKENDS_KIRO_IDENTITY_STORE == frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+
+
+def test_acp_runtime_is_a_superset_of_session_sharing() -> None:
+    """The documented relationship between the two sets, asserted rather than described.
+
+    Running on AcpRuntime is necessary for session sharing but not sufficient: KAS
+    runs there yet is excluded from sharing until keep-aware teardown lands. A future
+    edit that adds a harness to sharing without adding it to the runtime set would
+    describe a backend that multiplexes sessions without a multiplexer.
+    """
+    assert ACP_BACKENDS_SESSION_SHARING <= ACP_BACKENDS_ACP_RUNTIME
+    assert ACP_BACKEND_KAS in ACP_BACKENDS_ACP_RUNTIME
+    assert ACP_BACKEND_KAS not in ACP_BACKENDS_SESSION_SHARING


### PR DESCRIPTION
## Problem / Motivation

The five ACP capability frozensets — `ACP_BACKENDS_SESSION_SHARING`, `ACP_BACKENDS_STEER`, `ACP_BACKENDS_INTERNAL_SANDBOX`, `ACP_BACKENDS_ACP_RUNTIME`, `ACP_BACKENDS_KIRO_IDENTITY_STORE` — were defined in `src/kiro_crew/acp/types.py`.

`kiro_crew.acp` is a `FORBIDDEN_ROOT` for the agent-SDK boundary gate, and importing anything under it executes that package's `__init__` (ACP client + runtime). So a consumer **outside** the ACP layer could not ask "does the selected harness support X?" without adding a forbidden import edge, to a baseline the gate only ever lets shrink.

This is not hypothetical. [#6777](https://github.com/kirodotdev/KiroCrew/pull/6777) (OpenCode harness) adds exactly that edge to `dashboard/kiro_readiness.py`:

```python
from kiro_crew.acp.types import ACP_BACKENDS_KIRO_IDENTITY_STORE

async def selected_backend_uses_kiro_identity() -> bool:
    backend = getattr(cfg.agent, "acp_backend", ACP_BACKEND_KIRO)
    return backend in ACP_BACKENDS_KIRO_IDENTITY_STORE
```

That is the *correct* pattern — ask a capability set, never branch on harness identity — and today it costs a forbidden edge to write.

## Why it matters

Onboarding a harness is precisely the act of teaching outside consumers to ask these sets. The two live onboarding PRs each touch ~10 files outside `acp/` and `providers/`: readiness (`kiro_readiness.py`, `kiro_prerequisite.py`), MCP wiring (`mcp_gateway/session_servers.py`, +112 in #6777), agent config (`dashboard/handlers/agents.py`, +213), and `cli_doctor.py`. Every one of those that asks a capability question pays the same edge.

So the cost is per-consumer per-harness, and it is charged against a shrink-only ratchet — which means the gate and the correct pattern are in direct conflict until the definitions move.

## What changed (motivation → approach → change)

**Approach.** The precedent already exists in the destination file. `acp_backends.py` is a documented **leaf** — it imports nothing from `kiro_crew.acp`, `kiro_crew.config` or `kiro_crew.platform`, which is what lets the config loader and the dashboard read it — and it already hosts the backend id constants for exactly this reason, with `acp.types` re-exporting them so no call site changed. Its own comment says so:

> ``acp.types`` re-exports these, so every existing call site keeps importing them from there; this module is only where they are DEFINED.

The capability sets are the same kind of thing with the same consumers, so they get the same treatment.

**Change.** The definitions move to `src/kiro_crew/acp_backends.py` and are added to the existing `from kiro_crew.acp_backends import (...)` re-export block in `acp/types.py`. Every prior `from kiro_crew.acp.types import ACP_BACKENDS_*` keeps resolving, to the *same object* rather than a copy.

The 65 lines of membership prose moved **verbatim** with the definitions rather than being retyped. That prose is the harness-parity evidence record — why KAS is in `ACP_BACKENDS_KIRO_IDENTITY_STORE` but not in `ACP_BACKENDS_SESSION_SHARING`, and why `ACP_BACKENDS_INTERNAL_SANDBOX` deliberately fails **open** — and separating it from what it explains would be the real loss here, not the line move.

**Membership is unchanged.** Opting a harness into a capability is a deliberate edit with evidence (harness-parity H5/H6); a relocation is not the place for it. The five sets are byte-identical and pinned by a test.

**Not changed:** `docs/system-specs/modules/harness-parity.md` and the H6/H7 rule text still name `acp/types.py`. Those references still resolve through the re-export, so repointing them would be churn beyond this PR's purpose.

## Tests

`test/test_acp_capability_sets_leaf.py`, 13 tests:

- **`test_defined_in_the_leaf_not_in_the_acp_package`** (×5) — the ratchet. A future edit moving one back would compile and pass everything else while silently re-imposing the forbidden edge on every consumer that reads it.
- **`test_the_re_export_is_the_same_object`** (×5) — identity, not equality: a copy would drift the moment either side is edited.
- **`test_reading_a_capability_set_does_not_load_the_acp_package`** — subprocess probe asserting neither `kiro_crew.acp` nor `kiro_crew.providers` loads. **The boundary gate cannot catch this regression**: the consumers who would start paying that import are already in its baseline, so it would stay green.
- **`test_membership_is_unchanged_by_the_move`** — pins all five memberships explicitly.
- **`test_acp_runtime_is_a_superset_of_session_sharing`** — asserts the relationship the prose describes, so adding a harness to sharing without adding it to the runtime set fails rather than describing a backend that multiplexes sessions with no multiplexer.

Mutation-verified: re-defining `ACP_BACKENDS_STEER` in `acp/types.py` fails both the ratchet and the identity test, and passes once reverted.

## Manual verification

N/A — pure relocation with no user-visible surface; equivalence is asserted directly.

Beyond the test suite I verified two things before committing: both import paths yield **the same** frozenset objects, and the five definitions parsed out of `origin/main`'s `acp/types.py` are identical to the five now in `acp_backends.py`.

Gates green on this head: `agent-sdk-boundary`, `harness-parity`, `docs-lint` (including the citation check), black, isort, flake8, mypy, `subprocess-encoding`, `sync-io-in-async`, brand, changelog, `focus-cue`, `testpaths-coverage`, `vendor-manifest`, `scrub-lint`. 1357 tests pass across the ACP-backend, harness-parity, agent-SDK, KAS and governance surfaces.

## Related Issues

no linked issue: this is the next step of the in-flight `agent_sdk` boundary consolidation (RFC landed in #6939, continued in #7303 and #7523) rather than a discrete tracked issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
