### PR TITLE
refactor: share credential dot-dir denylist across design apps (#6613)

### DIFF
--- a/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
@@ -43,7 +43,11 @@ import kiro_crew
 from kiro_crew import link_unfurl, platform_compat, sandbox
 from kiro_crew.apps.manager import is_app_enabled
 from kiro_crew.config.paths import config_dir
-from kiro_crew.security import is_sensitive_path, path_contains_sensitive
+from kiro_crew.security import (
+    DENIED_ROOT_PARTS,
+    is_sensitive_path,
+    path_contains_sensitive,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +65,11 @@ _SCRIPTS_DIR = _SKILL_DIR / "scripts"
 # A route path or discovery id can be anything; collapse to a safe filename stem.
 _UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
 
-# Credential dot-dirs a local target may never be, mirroring design_tweak's
-# local-path guard. The is_sensitive_path floor covers the crew home + governance
-# trust root; these are the plain dot-dirs it does not enumerate.
-_DENIED_ROOT_PARTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
+# Credential dot-dirs a local target may never be, shared with design_tweak's
+# local-path guard via kiro_crew.security. The is_sensitive_path floor covers the
+# crew home + governance trust root; these are the plain dot-dirs it does not
+# enumerate.
+_DENIED_ROOT_PARTS = DENIED_ROOT_PARTS
 
 # Discover/capture scripts emit a small JSON manifest; this per-pipe cap guards a
 # runaway child (a pathological repo / huge render) from buffering into an OOM.

--- a/src/kiro_crew/apps/builtins/design_critique/skills/design-critique/scripts/ssrf-guard.mjs
+++ b/src/kiro_crew/apps/builtins/design_critique/skills/design-critique/scripts/ssrf-guard.mjs
@@ -152,4 +152,3 @@ export async function installSsrfGuard(target, allowOrigin = null) {
   }
 }
 
-export const _test = { ipDisallowed, isLoopbackIp, hostVerdict }

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -63,6 +63,7 @@ from kiro_crew.platform_compat import (
     trusted_system_bin,
 )
 from kiro_crew.security import (
+    DENIED_ROOT_PARTS,
     get_credential_patterns,
     is_sensitive_path,
     path_contains_sensitive,
@@ -214,10 +215,11 @@ _ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")  # queue file id safety
 
 # The only hosts this backend will ever fetch from (dev-server reverse proxy).
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1"})
-# Credential dirs a previewed "project" folder may never be. The shared
+# Credential dirs a previewed "project" folder may never be, shared with
+# design_critique's local-target guard via kiro_crew.security. The shared
 # `is_sensitive_path()` floor covers the crew home and the governance trust
 # root; these are the plain dot-dirs it does not need to know about.
-_DENIED_ROOT_PARTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
+_DENIED_ROOT_PARTS = DENIED_ROOT_PARTS
 
 _PICK_LOCK = threading.Lock()  # one native folder picker at a time
 
@@ -2550,9 +2552,12 @@ _PROJECT_SECRET_NAMES: frozenset[str] = frozenset(
     }
 )
 # Whole directories, matched on any path component. `.docker` holds
-# `config.json`, whose `auths` entries are registry credentials.
-_PROJECT_SECRET_DIRS: frozenset[str] = frozenset(
-    {".git", ".hg", ".svn", ".ssh", ".aws", ".gnupg", ".gpg", ".azure", ".kube", ".docker"}
+# `config.json`, whose `auths` entries are registry credentials. Derived from the
+# shared credential denylist so an entry added there propagates to this
+# static-file-serving guard automatically; the extras are VCS metadata and
+# credential dirs specific to what a previewed project tree may contain.
+_PROJECT_SECRET_DIRS: frozenset[str] = DENIED_ROOT_PARTS | frozenset(
+    {".git", ".hg", ".svn", ".gpg", ".azure"}
 )
 # Private-key / keystore material by extension. `.key` is the conventional TLS
 # private-key name (`server.key`); it is also Apple Keynote's extension, which is

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -6941,6 +6941,18 @@ def _is_keystone_publish_artifact(path_str: str, base_dir: str | None = None) ->
     return False
 
 
+# Credential dot-dirs denied as a path COMPONENT anywhere in an app-picked local
+# folder. This broadens the `is_sensitive_path()` floor below, which resolves its
+# entries relative to $HOME and pins `.kube`/`.docker` to single leaf files
+# (`config`, `config.json`): membership here denies these directory names at any
+# depth and covers those two dirs whole. `path_contains_sensitive()` supplies the
+# complementary ancestor/root protection. Owned here so every consumer
+# (design_critique's local-target guard, design_tweak's project-folder guard)
+# screens against the same set — a credential directory added for one app is
+# automatically denied by the others.
+DENIED_ROOT_PARTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
+
+
 def is_sensitive_path(path_str: str, base_dir: str | None = None) -> bool:
     """Return True if the path points to a read+write-sensitive location.
 

--- a/test/test_denied_root_parts_shared.py
+++ b/test/test_denied_root_parts_shared.py
@@ -1,0 +1,48 @@
+"""Pins the credential dot-dir denylist to ONE shared owner (#6613).
+
+`design_critique` (local render target) and `design_tweak` (previewed project
+folder) each screen operator-picked paths against a set of credential dot-dirs
+that the `is_sensitive_path()` floor does not enumerate. That set is owned by
+:data:`kiro_crew.security.DENIED_ROOT_PARTS`; both apps must consume the SAME
+object — identity, not equality — so a credential directory added for one app
+can never silently miss the other.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.apps.builtins.design_critique.backend import routes
+from kiro_crew.apps.builtins.design_tweak.backend import server
+from kiro_crew.security import DENIED_ROOT_PARTS
+
+
+class TestDeniedRootPartsSharedOwner:
+    def test_design_critique_consumes_the_shared_object(self):
+        # `is`, not `==`: a byte-identical local copy would pass equality while
+        # re-creating exactly the drift this refactor removes.
+        assert routes._DENIED_ROOT_PARTS is DENIED_ROOT_PARTS
+
+    def test_design_tweak_consumes_the_shared_object(self):
+        assert server._DENIED_ROOT_PARTS is DENIED_ROOT_PARTS
+
+    def test_project_secret_dirs_derives_from_the_shared_set(self):
+        # The static-file-serving guard is a strict superset: every shared entry
+        # plus the preview-specific extras. Pinning the exact membership keeps
+        # this refactor behavior-preserving; the subset assertion keeps a future
+        # DENIED_ROOT_PARTS addition from silently missing this guard.
+        assert DENIED_ROOT_PARTS <= server._PROJECT_SECRET_DIRS
+        assert server._PROJECT_SECRET_DIRS == DENIED_ROOT_PARTS | {
+            ".git",
+            ".hg",
+            ".svn",
+            ".gpg",
+            ".azure",
+        }
+
+    def test_owner_is_an_immutable_frozenset_of_dot_dirs(self):
+        # The guard's semantics depend on immutability (no consumer can mutate
+        # the shared set) and on every entry being a dot-dir path *part*.
+        assert isinstance(DENIED_ROOT_PARTS, frozenset)
+        assert DENIED_ROOT_PARTS  # never empty — an empty set silently disables the guard
+        for part in DENIED_ROOT_PARTS:
+            assert part.startswith("."), part
+            assert "/" not in part and "\\" not in part, part


### PR DESCRIPTION
## Summary

Two behavior-preserving cleanups deferred from PR #6401's First Principles review. Closes #6613

**1. Dedup the credential dot-dir denylist into one shared owner.**
`design_critique/backend/routes.py` and `design_tweak/backend/server.py` each defined a local `_DENIED_ROOT_PARTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})`. The set now lives in `kiro_crew.security.DENIED_ROOT_PARTS` (beside the `is_sensitive_path()` floor it complements); both apps import the same object, aliased to their existing private name so every use site is unchanged. `design_tweak`'s `_PROJECT_SECRET_DIRS` (static-file-serving guard) is now derived from the shared set plus its preview-specific extras, so a credential directory added to the shared set propagates to all three guards automatically.

**2. Delete the unused `_test` export from `ssrf-guard.mjs`.**
Verified zero importers repo-wide (the two importers of the module consume only `installSsrfGuard`); the three helpers it re-exported remain module-internal and in use. Per the issue, NO JS unit tests are added here — #6578 tracks the JS/Python SSRF-table divergence separately.

## Testing

- New `test/test_denied_root_parts_shared.py`: pins `is`-identity for both app consumers (a byte-identical local copy would pass equality while re-creating the drift this removes), pins `_PROJECT_SECRET_DIRS` exact membership + superset relation, and asserts the owner is a non-empty frozenset of dot-dir path parts.
- Local gates green: isort, flake8, mypy, diff-scoped black gate, new test file 4/4.
- `test_design_tweak_backend.py` + `test_design_tweak_project_routes.py`: 333 passed / 21 failed — the 21 reds are byte-identical on a pristine main worktree (host-env, pre-existing).
- Pre-push dual blind review (GPT gpt-5.6-sol + Opus claude-opus-5): both PASS; both advisories adopted (derive `_PROJECT_SECRET_DIRS` from the shared set; correct the overstated floor-coverage comment on the new constant).

## Screenshots

No UI change (backend constants + comment-only edits and an unused-export deletion).
