### PR TITLE
fix(jobs): let a requested cancel survive a fresh read of the run

### DIFF
--- a/src/kiro_crew/apps/job_routes.py
+++ b/src/kiro_crew/apps/job_routes.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from functools import wraps
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, TypeVar
 
 from aiohttp import web
 
@@ -47,6 +47,10 @@ logger = logging.getLogger(__name__)
 # request arrives the dashboard package is long since loaded.
 
 Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
+
+#: What one store read returns, so ``_read_with_cancelling`` can pair a single
+#: record and a list of them with the same snapshot without losing the type.
+_T = TypeVar("_T")
 
 #: Mounted under each app's own namespace.
 _PREFIX = "/api/apps/{app}/_jobs"
@@ -88,24 +92,61 @@ def _safe(text: str) -> str:
         return text[:500]
 
 
-def _public_view(run: JobRun) -> dict[str, Any]:
+def _public_view(run: JobRun, cancelling: frozenset[str]) -> dict[str, Any]:
     """The record as the browser sees it.
 
     ``origin`` and ``pid`` are host facts with no client meaning, so they are
     withheld. Everything else the record holds is served: P1's record has no
     caller- or runner-supplied payload to decide about, which is why there is no
     per-field withholding rule here any more.
+
+    ``cancelling`` is the one field NOT read off the record. It says a cancel has
+    been asked for and the worker has not reached the checkpoint where it records
+    the outcome, and it comes from the SDK's live table via ``cancelling_ids``
+    because ``cancel`` deliberately writes nothing -- see that method for why
+    persisting it would break the single-writer rule. ``cancelling`` is a
+    REQUIRED argument rather than a defaulted one so that a future caller cannot
+    quietly serve ``false`` by forgetting to pass it; a missing argument is a
+    type error at the call site instead of a wrong answer in the response.
+
+    A terminal run is never ``cancelling``. The worker writes the record before
+    ``_execute`` drops the live entry, so a read landing between those two would
+    otherwise report ``status: cancelled`` and ``cancelling: true`` together --
+    the cancel both finished and still pending. Once the status carries the
+    answer there is nothing left to be pending.
     """
     return {
         "run_id": run.run_id,
         "kind": run.kind,
         "status": run.status,
         "cancellable": run.cancellable,
+        "cancelling": not run.is_terminal and run.run_id in cancelling,
         "created_at": run.created_at,
         "updated_at": run.updated_at,
         "finished_at": run.finished_at,
         "error": run.error,
     }
+
+
+def _read_with_cancelling(sdk: JobSDK, read: Callable[[], _T]) -> tuple[_T, frozenset[str]]:
+    """Run one store read and take the cancelling snapshot, in ONE off-loop hop.
+
+    Off the loop because ``cancelling_ids`` takes the SDK's lock and ``_persist``
+    holds that same lock across a disk write, so acquiring it on the loop could
+    park the gateway for the length of that write. The store read is already
+    off-loop work for the same reason, so pairing them adds no hop.
+
+    ONE snapshot per response, not one per row: a list endpoint would otherwise
+    render each row against a different instant, so two rows could disagree about
+    a cancel that landed while the page was being built.
+
+    The record is read BEFORE the snapshot, deliberately. A cancel arriving
+    between the two is then reported (a ``running`` record against a snapshot
+    that has it) rather than missed, which is the direction that serves the user
+    who just pressed the button. The reverse order would answer "not cancelling"
+    about a cancel that was already in.
+    """
+    return read(), sdk.cancelling_ids()
 
 
 def _enabled_and_permitted(app_name: str) -> tuple[bool, bool]:
@@ -253,19 +294,21 @@ async def _handle_start(request: web.Request, app_name: str, sdk: JobSDK) -> web
         # aiohttp's default handler as a bare 500 carrying no machine-readable
         # code, which no client can switch on.
         return web.json_response({"error": _safe(str(exc)), "code": "job_start_failed"}, status=503)
-    run = await asyncio.to_thread(sdk.get, run_id)
+    run, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
     if run is None:
         return web.json_response(
             {"error": "the run record could not be read back", "code": "run_unreadable"},
             status=500,
         )
-    return web.json_response({"run": _public_view(run)})
+    return web.json_response({"run": _public_view(run, cancelling)})
 
 
 async def _handle_active(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
     kind = request.query.get("kind", "")
-    runs = await asyncio.to_thread(sdk.list_active, kind)
-    return web.json_response({"runs": [_public_view(r) for r in runs]})
+    runs, cancelling = await asyncio.to_thread(
+        _read_with_cancelling, sdk, lambda: sdk.list_active(kind)
+    )
+    return web.json_response({"runs": [_public_view(r, cancelling) for r in runs]})
 
 
 async def _handle_recent(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
@@ -278,21 +321,23 @@ async def _handle_recent(request: web.Request, app_name: str, sdk: JobSDK) -> we
             {"error": "limit must be an integer", "code": "invalid_limit"}, status=400
         )
     limit = max(1, min(limit, _RECENT_MAX))
-    runs = await asyncio.to_thread(sdk.list_recent, kind, limit)
-    return web.json_response({"runs": [_public_view(r) for r in runs]})
+    runs, cancelling = await asyncio.to_thread(
+        _read_with_cancelling, sdk, lambda: sdk.list_recent(kind, limit)
+    )
+    return web.json_response({"runs": [_public_view(r, cancelling) for r in runs]})
 
 
 async def _handle_get(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
     run_id = request.match_info.get("run_id", "")
-    run = await asyncio.to_thread(sdk.get, run_id)
+    run, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
     if run is None:
         return web.json_response({"error": "no such run", "code": "job_not_found"}, status=404)
-    return web.json_response({"run": _public_view(run)})
+    return web.json_response({"run": _public_view(run, cancelling)})
 
 
 async def _handle_cancel(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
     run_id = request.match_info.get("run_id", "")
-    run = await asyncio.to_thread(sdk.get, run_id)
+    run, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
     if run is None:
         return web.json_response({"error": "no such run", "code": "job_not_found"}, status=404)
     accepted = await sdk.cancel_async(run_id)
@@ -304,12 +349,17 @@ async def _handle_cancel(request: web.Request, app_name: str, sdk: JobSDK) -> we
             {
                 "error": "this run cannot be cancelled",
                 "code": "job_not_cancellable",
-                "run": _public_view(run),
+                "run": _public_view(run, cancelling),
             },
             status=409,
         )
-    fresh = await asyncio.to_thread(sdk.get, run_id)
-    return web.json_response({"cancelling": True, "run": _public_view(fresh or run)})
+    # Re-read AFTER the cancel, so the snapshot carries the request this call just
+    # made. ``cancelling: True`` at the top level is what this CALL did; the
+    # field inside ``run`` is what any later read of the record will now also
+    # report, and the two legitimately differ once a fast worker has already
+    # reached its checkpoint and recorded ``cancelled``.
+    fresh, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
+    return web.json_response({"cancelling": True, "run": _public_view(fresh or run, cancelling)})
 
 
 # ── Registration ──

--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -39,7 +39,10 @@ its own file and writers never share a path: ``start`` writes the initial record
 BEFORE handing off, the worker thread is the sole writer from then on, and
 ``cancel`` writes nothing at all (it sets an in-memory event; the worker records
 the outcome at its next checkpoint). Reconciliation writes only records from a
-process that is already gone.
+process that is already gone. A requested cancel still has to be visible to a
+reader before that checkpoint arrives, so it is DERIVED on read from the live
+table -- ``cancelling_ids`` -- rather than written down. Reading it costs nothing
+the rule protects; writing it would cost the rule.
 
 **Claiming a run and LAUNCHING it are separate, and the interval between them is
 named.** That interval contains a disk write, so it is not instantaneous, and the
@@ -762,6 +765,38 @@ class JobSDK:
         """Loop-native :meth:`cancel`. Present so an on-loop caller does not
         have to know which methods happen to touch the disk."""
         return await asyncio.to_thread(self.cancel, run_id)
+
+    def cancelling_ids(self) -> frozenset[str]:
+        """Run ids whose cancel has been asked for and not yet recorded.
+
+        The read side of :meth:`cancel`'s "writes nothing". A requested cancel
+        has to outlive the tab that asked -- that is the whole point of the SDK --
+        but persisting it from ``cancel`` would make a second writer on that
+        run's file, and one-writer-per-run is what keeps ``atomic_write``'s
+        crash-safety from silently dropping the loser of a concurrent update. So
+        the fact is DERIVED from the live table on read instead, the same way
+        :meth:`reconcile` already derives liveness from it. Nothing new is
+        written and the single-writer rule is untouched.
+
+        The window this covers is the gap between the request and the worker's
+        next checkpoint, which for a runner that checkpoints minutes apart is
+        minutes. It closes on its own: the worker records ``cancelled`` and
+        ``_execute`` drops the entry, after which this returns nothing for that
+        run and the status carries the answer.
+
+        Deliberately NOT durable across a restart. A restarted gateway has no
+        live table, and ``reconcile`` has already resolved the run to
+        ``interrupted`` -- there is no pending cancel left to report.
+
+        Call OFF the event loop. ``_persist`` holds this same lock across a disk
+        write, so taking it on the loop can park the gateway for the length of
+        that write. One acquisition serves a whole response, so a list endpoint
+        renders every row from ONE snapshot rather than from N of them.
+        """
+        with self._lock:
+            return frozenset(
+                run_id for run_id, live in self._live.items() if live.handle.cancelled.is_set()
+            )
 
     # ── Reconciliation ──
 

--- a/test/test_job_routes.py
+++ b/test/test_job_routes.py
@@ -474,6 +474,134 @@ async def test_cancel_live_cancellable_run_is_200_cancelling(
 
 
 # ---------------------------------------------------------------------------
+# 9b: a requested cancel survives a fresh read (issue #7589)
+# ---------------------------------------------------------------------------
+
+
+def _parked_cancellable(sdk: JobSDK, kind: str = "slow") -> tuple[threading.Event, threading.Event]:
+    """Register a cancellable runner whose next checkpoint is far away.
+
+    It does NOT poll ``handle.cancelled`` until the returned ``release`` is set,
+    which holds the request window open deterministically. Racing a runner that
+    exits the moment it is cancelled is what would make these flaky, and the
+    window is the whole subject: for a runner that checkpoints minutes apart it
+    is minutes long.
+    """
+    started = threading.Event()
+    release = threading.Event()
+
+    def _runner(handle: Any, **params: Any) -> None:
+        started.set()
+        release.wait(timeout=_DEADLINE)
+
+    sdk.register(kind, _runner, cancellable=True)
+    return started, release
+
+
+@pytest.mark.asyncio
+async def test_requested_cancel_is_visible_to_a_later_read_of_the_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """A GET after the cancel — a reload, a second tab, a fresh mount.
+
+    Holding the cancel response was previously the ONLY way to know a cancel had
+    been asked for: ``_public_view`` served no such field, so any client that
+    re-read the run saw ``running`` and no evidence the button had worked.
+    """
+    _setup_guards(tmp_path, monkeypatch)
+    started, release = _parked_cancellable(sdk)
+    rid = sdk.start("slow")
+    try:
+        assert started.wait(timeout=_DEADLINE), "runner never started"
+        _wait_status(sdk, rid, js.RUNNING)
+        async with TestClient(TestServer(_make_app())) as client:
+            assert (await client.post(f"{_base()}/{rid}/cancel")).status == 200
+            # A brand-new read, holding nothing from the cancel call.
+            resp = await client.get(f"{_base()}/{rid}")
+            assert resp.status == 200
+            run = (await resp.json())["run"]
+        assert run["cancelling"] is True
+        # Still running: the worker has not reached its checkpoint. Both facts
+        # are served together, which is what lets a UI say "cancelling…".
+        assert run["status"] == js.RUNNING
+    finally:
+        release.set()
+    assert _wait_terminal(sdk, rid).status == js.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_requested_cancel_is_visible_in_the_active_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """``active`` is what a fresh mount adopts, so it must carry the request too."""
+    _setup_guards(tmp_path, monkeypatch)
+    started, release = _parked_cancellable(sdk)
+    rid = sdk.start("slow")
+    try:
+        assert started.wait(timeout=_DEADLINE), "runner never started"
+        _wait_status(sdk, rid, js.RUNNING)
+        async with TestClient(TestServer(_make_app())) as client:
+            assert (await client.post(f"{_base()}/{rid}/cancel")).status == 200
+            resp = await client.get(f"{_base()}/active")
+            assert resp.status == 200
+            runs = (await resp.json())["runs"]
+        adopted = [r for r in runs if r["run_id"] == rid]
+        assert len(adopted) == 1
+        assert adopted[0]["cancelling"] is True
+    finally:
+        release.set()
+    assert _wait_terminal(sdk, rid).status == js.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_a_run_nobody_cancelled_reads_not_cancelling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """The flag is derived, not decoration: an untouched run must read false."""
+    _setup_guards(tmp_path, monkeypatch)
+    started, release = _parked_cancellable(sdk)
+    rid = sdk.start("slow")
+    try:
+        assert started.wait(timeout=_DEADLINE), "runner never started"
+        _wait_status(sdk, rid, js.RUNNING)
+        async with TestClient(TestServer(_make_app())) as client:
+            run = (await (await client.get(f"{_base()}/{rid}")).json())["run"]
+        assert run["cancelling"] is False
+        assert run["status"] == js.RUNNING
+    finally:
+        release.set()
+    _wait_terminal(sdk, rid)
+
+
+@pytest.mark.asyncio
+async def test_a_recorded_cancel_is_no_longer_cancelling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """Once the status carries the answer, nothing is pending.
+
+    Without the terminal guard a read landing between the worker's write and the
+    live entry being dropped would serve ``status: cancelled`` and
+    ``cancelling: true`` together — the same cancel both finished and still
+    outstanding.
+    """
+    _setup_guards(tmp_path, monkeypatch)
+    started, release = _parked_cancellable(sdk)
+    rid = sdk.start("slow")
+    try:
+        assert started.wait(timeout=_DEADLINE), "runner never started"
+        _wait_status(sdk, rid, js.RUNNING)
+        async with TestClient(TestServer(_make_app())) as client:
+            assert (await client.post(f"{_base()}/{rid}/cancel")).status == 200
+            release.set()
+            assert _wait_terminal(sdk, rid).status == js.CANCELLED
+            run = (await (await client.get(f"{_base()}/{rid}")).json())["run"]
+        assert run["status"] == js.CANCELLED
+        assert run["cancelling"] is False
+    finally:
+        release.set()
+
+
+# ---------------------------------------------------------------------------
 # 10: restricted session refused on a mutation
 # ---------------------------------------------------------------------------
 

--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -277,6 +277,80 @@ class TestCancellation:
 
 
 # ---------------------------------------------------------------------------
+# 5b. cancelling_ids — the read side of "cancel writes nothing"
+# ---------------------------------------------------------------------------
+
+
+class TestCancellingIds:
+    """A requested cancel must be readable before the worker records it.
+
+    ``cancel`` writes nothing on purpose, so the request used to exist only in
+    the response to the cancel call itself. These pin the derived read that makes
+    it survive a fresh read of the record instead.
+    """
+
+    def test_request_is_reported_until_the_worker_records_it(self, sdk: JobSDK) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def runner(h, **kw):
+            # A checkpoint deliberately far away: this runner does not poll
+            # ``h.cancelled`` until the test lets it. That holds the request
+            # window open deterministically rather than racing a worker that
+            # would settle before the assertion runs.
+            started.set()
+            release.wait(5.0)
+            return {}
+
+        sdk.register("slow", runner, cancellable=True)
+        run_id = sdk.start("slow")
+        try:
+            assert started.wait(5.0)
+            # Nothing has been asked for yet.
+            assert sdk.cancelling_ids() == frozenset()
+            assert sdk.cancel(run_id) is True
+            # Requested, and readable while the RECORD still says running --
+            # which is exactly what a fresh mount has to be able to see.
+            assert run_id in sdk.cancelling_ids()
+            record = sdk.get(run_id)
+            assert record is not None and record.status == RUNNING
+        finally:
+            # In FINALLY: an assertion failing above must not park this worker
+            # for the rest of the session.
+            release.set()
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == CANCELLED
+        # The worker recorded the outcome and the live entry is gone, so the
+        # status now carries the answer and nothing is pending.
+        assert sdk.cancelling_ids() == frozenset()
+
+    def test_a_refused_cancel_reports_nothing(self, sdk: JobSDK) -> None:
+        """The snapshot follows the ACCEPTED request, not the attempt.
+
+        A live run that was never declared cancellable refuses ``cancel``, so no
+        event is set and nothing may claim a cancel is under way.
+        """
+        started = threading.Event()
+        release = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            release.wait(5.0)
+            return {}
+
+        sdk.register("plain", runner)  # cancellable=False, the default
+        run_id = sdk.start("plain")
+        try:
+            assert started.wait(5.0)
+            assert sdk.cancel(run_id) is False
+            assert sdk.cancelling_ids() == frozenset()
+        finally:
+            release.set()
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+
+
+# ---------------------------------------------------------------------------
 # 6. dedupe_key
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the problem?

`JobSDK.cancel` sets an in-memory `threading.Event` on the live handle and
writes nothing (`src/kiro_crew/apps/job_sdk.py`). `_public_view` served no field
for that request (`src/kiro_crew/apps/job_routes.py`), so the ONLY report of a
requested cancel was the body of the cancel call itself: `_handle_cancel`'s
`{"cancelling": true, ...}`.

Every later read said nothing. `GET /_jobs/{run_id}` and `GET /_jobs/active`
both returned the run's status unchanged - still `running` - until the worker
reached its next checkpoint. For a runner that checkpoints minutes apart, that
window is minutes.

## Why this issue matters to the user

Surviving navigation is the Job SDK's entire thesis. Its own module docstring
says the SDK exists because "a task of mine is running" had no server-side
representation: the fact lived in the React component that started it, so
navigating away destroyed the fact while the work kept going.

`cancelling` was the one fact still living only in that component. A UI could
show "cancelling..." for exactly as long as the tab that asked stayed mounted. A
reload, a navigation away and back, a second tab, or the fresh mount the SDK was
built to serve all saw `running` and no evidence the button had worked - so the
user's own action was the one thing the durable record could not tell them about.

## How our fix solves it

The obvious fix is the wrong one, and that is the whole shape of this change.
Writing `cancel_requested_at` from `cancel()` would make it a **second writer**
on that run's file. One-writer-per-run is load-bearing rather than incidental:
`atomic_write` gives crash-safety but not mutual exclusion, so two writers on
one path silently drop the loser's update. That would be a worse bug than the
one being fixed.

So the fact is **derived on read** instead of written down:

- `JobSDK.cancelling_ids()` returns the run ids whose handle has its `cancelled`
  event set, read from the live table under the SDK's own lock. This is the same
  table `reconcile` already derives liveness from - no new state, no new writer,
  single-writer rule untouched.
- `_public_view` serves `cancelling: bool` from that snapshot, so every read path
  (`start`, `active`, `recent`, `{run_id}`, `cancel`) carries it.

Chained from symptom to cause: the symptom is a re-read that shows `running`; the
cause is that the request was never *readable* anywhere but the cancel response;
the constraint is that it must not become *writable*; the remedy is a read-side
derivation from the process that already holds the fact.

Three details the chain forced:

- **A terminal run is never `cancelling`.** The worker writes the record and then
  `_execute` drops the live entry, so a read landing between those two would
  otherwise serve `status: cancelled` together with `cancelling: true` - the same
  cancel both finished and still outstanding.
- **The snapshot is taken off the event loop.** `_persist` holds that same lock
  across a disk write, so acquiring it on the loop could park the gateway for the
  length of that write. `_read_with_cancelling` pairs the snapshot with the store
  read that was already off-loop work, so no hop is added.
- **One snapshot per response, taken after the record read.** One per row would
  let two rows of a list disagree about a cancel that landed mid-render; taking
  it after the record means a cancel arriving during the request is reported
  rather than missed.

`cancelling` is a **required** argument to `_public_view`, not a defaulted one:
a future call site that forgets it is a type error rather than a response that
quietly says `false`.

Not durable across a restart, deliberately - a restarted gateway has no live
table and `reconcile` has already resolved the run to `interrupted`, so there is
no pending cancel left to report.

## What tests we did

Six new tests, all verified **red on base** (`KeyError: 'cancelling'` on the
routes; `AttributeError: 'JobSDK' object has no attribute 'cancelling_ids'` on
the SDK) by reverting only the two source files and re-running:

| Test | What it pins |
| --- | --- |
| `test_requested_cancel_is_visible_to_a_later_read_of_the_run` | a fresh `GET {run_id}` after the cancel reports `cancelling: true` AND `status: running` - the reload / second-tab case |
| `test_requested_cancel_is_visible_in_the_active_list` | `GET /active`, the list a fresh mount adopts, carries it too |
| `test_a_run_nobody_cancelled_reads_not_cancelling` | the flag is derived, not decoration - an untouched run reads `false` |
| `test_a_recorded_cancel_is_no_longer_cancelling` | once the status carries the answer, `cancelling` is `false` (the terminal guard) |
| `TestCancellingIds::test_request_is_reported_until_the_worker_records_it` | SDK level: visible while the record still says `running`, gone once the worker records `CANCELLED` |
| `TestCancellingIds::test_a_refused_cancel_reports_nothing` | the snapshot follows the ACCEPTED request, not the attempt (live but not declared cancellable) |

The route tests use a runner whose next checkpoint is deliberately far away -
it does not poll `handle.cancelled` until the test releases it - so the window
under test is held open rather than raced. Each release happens in a `finally`,
so an assertion failure cannot park a worker for the rest of the session.

Gates run locally: `test_job_routes.py` + `test_job_sdk.py` **114 passed**,
`flake8` clean, `mypy` clean on both changed modules, `black --check` clean on
all four files, and `scripts/check_black_formatting.py` passes in scope.

## Any other suggestions on the work

- **A frontend consumer is still needed to make this visible to a human.** P1
  ships with no `_jobs` consumer (`grep` finds none under `website/src`), so this
  makes the fact *available*; the "cancelling..." pill is the consumer's job.
  Code Review Sage already renders exactly that shape from its own
  `cancel_requested_at`, which is the pattern to copy.
- **`docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md` was
  deliberately not touched.** It is the pre-#6682 problem statement and still
  says the App SDK "has no job service" - already stale from that merge, not
  from this change, and correcting it belongs with whoever owns that spec rather
  than in a bug fix's diff. The authoritative field list is the `_public_view`
  docstring, which this change updates, along with the module docstring's
  one-writer-per-run section so it names the derived read.
- **Worth noting for P2:** if a progress channel returns, the worker stops being
  the sole writer and this derivation's terminal guard is one of the places that
  will need re-reading against the new write pattern.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a mutation handler reports state it just changed with a response key
that the same resource's READ serializer does not carry. The acknowledgement
then lives only in the caller that made the call, so any client that re-reads
instead of holding that response cannot see the change. Here it was
`_handle_cancel` returning `cancelling: true` while `_public_view` had no such
field.

Detectable signature, cheap enough for a reviewer to run: a key that appears in
a mutation response body and in no read serializer for the same resource. It is
a review-prompt rather than a semgrep rule because deciding "same resource"
needs the route family, which the AST does not carry. The narrower half IS
mechanizable and worth filing separately if the class recurs: within one routes
module, flag a response literal key that no `_public_view`-style function emits.

Generalizes in this repo rather than being one file's accident: the SAME question
has three different answers on main today. Code Review Sage persists it
(`cancel_requested_at` on the run record, which it can afford because it owns
both writers). Dev Fleet overlays it at request time
(`_with_live_run_pointers`). The Job SDK did neither, which is the defect. Any
new durable-run surface faces the same fork, and the constraint that picks the
answer is who is allowed to write the record -- worth asking at review time
rather than after the fact.

Closes #7589

