### PR TITLE
fix(voice): quote the codesign team id, and say a retired STT provider once (#7331)

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -4668,6 +4668,16 @@ _VALID_STT_MODELS = tuple(m.name for m in _STT_CATALOG)
 _VALID_CHANNEL_PREFIXES = ("C", "D", "G")
 
 
+# Provider values already warned about in this process. The gateway loads config
+# repeatedly, so an unusable stored provider is per-install information, not
+# per-load: without this the retirement notice repeats several times a second for
+# the whole session, which is how it was reported. Keyed on ``repr`` rather than
+# the value itself because this arrives from ``config.json`` and may be
+# unhashable (a list or dict), which must not raise on the degrade path. Exposed
+# for tests to reset.
+_WARNED_STT_PROVIDERS: set[str] = set()
+
+
 def _validated_stt_provider(value: object) -> str:
     """Return *value* if it is selectable, else degrade to ``local`` with a reason.
 
@@ -4678,6 +4688,10 @@ def _validated_stt_provider(value: object) -> str:
     """
     if value in _VALID_STT_PROVIDERS:
         return str(value)
+    seen = repr(value)
+    if seen in _WARNED_STT_PROVIDERS:
+        return STT_PROVIDER_LOCAL
+    _WARNED_STT_PROVIDERS.add(seen)
     if value in _RETIRED_STT_PROVIDERS:
         logger.warning(
             "STT provider %r is retired; using %r instead. It needed a separate "

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -173,8 +173,15 @@ _MAX_SIGNED_FFMPEG_BYTES = 192 * 1024 * 1024
 # ties the chain to Apple's root, so only a certificate Apple issued to THIS team
 # satisfies the requirement -- a self-signed or ad-hoc replacement does not.
 _MACOS_SIGNING_TEAM_ID = "94KV3E626L"
+# The team identifier MUST stay quoted. In the requirement language a bare token
+# beginning with a digit is not a valid identifier, so an unquoted 94KV3E626L is
+# a SYNTAX ERROR rather than a comparison: codesign exits non-zero without ever
+# evaluating the signature, which this function cannot tell apart from a genuine
+# authenticity failure. That made every signed macOS release refuse its own
+# decoder -- the digest anchor cannot cover a signed artifact by construction,
+# so with the signature anchor unparseable both anchors were unreachable.
 _MACOS_FFMPEG_REQUIREMENT = (
-    f"anchor apple generic and certificate leaf[subject.OU] = {_MACOS_SIGNING_TEAM_ID}"
+    f'anchor apple generic and certificate leaf[subject.OU] = "{_MACOS_SIGNING_TEAM_ID}"'
 )
 
 

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -2350,6 +2350,13 @@ class TestSttRetiredProviders:
     provider" without the name is unactionable.
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_warn_once(self):
+        """The degrade log is once-per-value-per-process, so tests must not inherit it."""
+        loader_module._WARNED_STT_PROVIDERS.clear()
+        yield
+        loader_module._WARNED_STT_PROVIDERS.clear()
+
     @pytest.mark.parametrize("retired", loader_module._RETIRED_STT_PROVIDERS)
     def test_retired_provider_degrades_to_local(self, retired: str, caplog) -> None:
         with caplog.at_level(logging.WARNING, logger="kiro_crew.config.loader"):
@@ -2396,6 +2403,31 @@ class TestSttRetiredProviders:
         assert "whispr" in caplog.text
         for selectable in loader_module._VALID_STT_PROVIDERS:
             assert selectable in caplog.text
+
+    def test_the_same_unusable_provider_is_only_said_once(self, caplog) -> None:
+        """A stored retired name must not narrate itself on every config load.
+
+        The gateway loads config repeatedly -- several times a second under normal
+        dashboard traffic -- and this degrade sits on that path, so without
+        deduplication one stale ``config.json`` value fills the log for the whole
+        session and buries everything else. The retirement is per-install
+        information: saying it once is what makes it readable.
+        """
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.config.loader"):
+            for _ in range(25):
+                assert _validated_stt_provider("whisper") == STT_PROVIDER_LOCAL
+        assert caplog.text.count("retired") == 1
+
+    def test_each_distinct_unusable_provider_still_gets_its_own_line(self, caplog) -> None:
+        """Deduplication is per VALUE, not a single global latch -- otherwise the
+        first bad value would silence the explanation for every later one."""
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.config.loader"):
+            assert _validated_stt_provider("whisper") == STT_PROVIDER_LOCAL
+            assert _validated_stt_provider("parakeet") == STT_PROVIDER_LOCAL
+            assert _validated_stt_provider("whispr") == STT_PROVIDER_LOCAL
+        assert "whisper" in caplog.text
+        assert "parakeet" in caplog.text
+        assert "whispr" in caplog.text
 
     def test_a_non_string_provider_degrades_rather_than_raising(self, tmp_path: Path) -> None:
         """The membership tests take an ``object``, so a hand-edited number or a

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -13,6 +13,7 @@ import asyncio
 import importlib.machinery
 import importlib.util
 import os
+import subprocess
 import sys
 import threading
 import types
@@ -26,6 +27,7 @@ import pytest
 from kiro_crew import platform_compat as _pc
 from kiro_crew import stt, transcribe
 from kiro_crew.config.loader import SttConfig
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 from kiro_crew.transcribe import (
     _ProfileCredentialResolver,
     availability_detail,
@@ -1379,8 +1381,49 @@ class TestBundledFfmpeg:
         replacement cannot satisfy it."""
         assert transcribe._MACOS_SIGNING_TEAM_ID == "94KV3E626L"
         assert transcribe._MACOS_FFMPEG_REQUIREMENT == (
-            "anchor apple generic and certificate leaf[subject.OU] = 94KV3E626L"
+            'anchor apple generic and certificate leaf[subject.OU] = "94KV3E626L"'
         )
+
+    def test_codesign_requirement_quotes_the_team_identifier(self):
+        """The team id must be a QUOTED string constant, not a bare token.
+
+        A requirement-language identifier cannot begin with a digit, so an
+        unquoted 94KV3E626L does not parse as a comparison operand at all --
+        codesign rejects the whole requirement and exits non-zero before it looks
+        at any signature. :func:`_macos_developer_id_authentic` only sees that
+        exit status, so the malformed constant is indistinguishable there from an
+        inauthentic binary, and every signed release refused its own decoder.
+        Asserting the exact string above cannot catch this on its own: the old
+        assertion pinned the unparseable form and passed.
+        """
+        assert f'"{transcribe._MACOS_SIGNING_TEAM_ID}"' in transcribe._MACOS_FFMPEG_REQUIREMENT
+
+    @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="codesign is macOS-only")
+    def test_codesign_accepts_the_requirement_as_parseable(self):
+        """Let codesign itself judge the syntax -- the only oracle that counts.
+
+        Run against a binary the OS signs (never our team), so a PARSEABLE
+        requirement is simply unsatisfied while an unparseable one reports a
+        syntax error. Only the latter is asserted against: this test is about the
+        requirement compiling, not about /bin/ls being authentic.
+        """
+        result = subprocess.run(
+            [
+                "/usr/bin/codesign",
+                "--verify",
+                "--strict",
+                "-R",
+                f"={transcribe._MACOS_FFMPEG_REQUIREMENT}",
+                "--",
+                "/bin/ls",
+            ],
+            check=False,
+            capture_output=True,
+            timeout=120,
+            **UTF8_TEXT,
+        )
+        assert "syntax error" not in result.stderr.lower()
+        assert "invalid or corrupted code requirement" not in result.stderr.lower()
 
     def test_codesign_is_invoked_by_absolute_path_with_requirement_source_text(
         self, monkeypatch, tmp_path


### PR DESCRIPTION
Cherry-picks #7331 onto `release/0.5.0`.

Source commit on `main`: `98f9ad3fbe05c35029e919ed84757f3ff2858d33`. Picked with `-x`, zero conflicts; the resulting diff is content-identical to the source commit (only hunk line offsets differ, since the release branch's files are shorter).

## Why it belongs on the release branch

`_MACOS_FFMPEG_REQUIREMENT` interpolated the signing team identifier unquoted. A requirement-language identifier cannot begin with a digit, so `codesign` rejected the whole requirement before it looked at any signature — and `_macos_developer_id_authentic` only observes the exit status, so a malformed constant of ours was indistinguishable from an inauthentic binary. The digest anchor cannot cover a signed artifact by construction, so with the signature anchor unparseable both anchors were unreachable and voice transcode refused to start on every signed macOS release. The release branch carries the same signed-decoder path (`60f6df6a1`), so it has the same defect.

The second half stops a retired STT provider name from re-emitting the same warning on every config load.

## Verification on this branch

- `pytest test/test_transcribe.py test/test_config_loader.py`: 625 passed, 2 skipped
- `flake8` on the four changed files: clean
- `mypy --platform linux` on the two changed source files: clean

No version or changelog change is included.