### PR TITLE
fix(diagnostics): resolve kiro-cli before probing its version

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -46,7 +46,6 @@
 1 src/kiro_crew/deploy/engine.py
 1 src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
 1 src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
-1 src/kiro_crew/diagnostics.py
 1 src/kiro_crew/env.py
 1 src/kiro_crew/mcp_core.py
 1 src/kiro_crew/mcp_shared.py

--- a/src/kiro_crew/diagnostics.py
+++ b/src/kiro_crew/diagnostics.py
@@ -25,12 +25,10 @@ import logging
 import os
 import platform
 import re
-import subprocess
 import sys
 import time
 import uuid
 import zipfile
-from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -39,11 +37,13 @@ from urllib.parse import quote, urlencode
 from kiro_crew import __version__, platform_compat, release_channel
 from kiro_crew.config.loader import config_dir
 from kiro_crew.kiro_cli import resolve_kiro_cli
+from kiro_crew.sandbox import run_limited, scrub_env
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
     redact_exfiltration_urls,
 )
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -284,12 +284,7 @@ def _macos_crash_reports() -> list[Path]:
     return reports[:_MAX_IPS_REPORTS]
 
 
-def _kiro_cli_version(
-    *,
-    platform_name: str | None = None,
-    home: Path | None = None,
-    environ: Mapping[str, str] | None = None,
-) -> str:
+def _kiro_cli_version() -> str:
     """Version string of the installed Kiro CLI, for the support bundle.
 
     Resolves the binary through :func:`kiro_crew.kiro_cli.resolve_kiro_cli`
@@ -298,8 +293,7 @@ def _kiro_cli_version(
     spawning the bare name: a collector process whose inherited ``PATH`` lacks
     the install directory made the bare-name spawn misreport a working install
     as ``unavailable`` in both ``versions.txt`` and the prefilled bug-report
-    footer (#7674). The keyword-only parameters are passthroughs to the
-    resolver so tests can pin the host layout; production callers pass nothing.
+    footer (#7674).
 
     Return values, each a plain one-line string (both consumers interpolate
     it verbatim):
@@ -313,20 +307,33 @@ def _kiro_cli_version(
       printed nothing.
 
     Never raises: diagnostics collection must degrade to a string, so the
-    spawn keeps its existing containment boundary.
+    whole spawn (including preparation) runs inside one broad exception
+    containment, logged at DEBUG. Hardening — the resolver's first candidates
+    live in user-writable install dirs, so the child gets a credential-
+    scrubbed environment (:func:`kiro_crew.sandbox.scrub_env`, the tailnet-
+    probe posture) and a kernel resource ceiling (:func:`run_limited`).
+    Deliberately NOT routed through the ``sandboxed_spawn_argv`` OS wrapper:
+    its preparation resolves the governance sandbox floor, which raises
+    ``PlatformCompositionError`` outside a booted gateway context (verified
+    empirically — a working install then misreports as not runnable, the
+    exact defect class #7674 exists to eliminate), and diagnostics must work
+    precisely when the rest of the system is broken. Tests pin the host
+    layout by monkeypatching this module's ``resolve_kiro_cli`` binding.
     """
-    binary = resolve_kiro_cli(platform_name=platform_name, home=home, environ=environ)
+    binary = resolve_kiro_cli()
     if binary is None:
         return "unavailable"
     try:
-        out = subprocess.run(
+        out = run_limited(  # noqa: S603 - fixed argv, resolver-vetted binary
             [binary, "--version"],
             capture_output=True,
-            text=True,
+            **UTF8_TEXT,
             timeout=5,
             check=False,
+            env=scrub_env(),
         )
-    except (OSError, subprocess.SubprocessError):
+    except Exception:
+        logger.debug("kiro-cli version probe failed for %r", binary, exc_info=True)
         return "present but not runnable"
     if out.returncode != 0:
         return "present but not runnable"

--- a/src/kiro_crew/diagnostics.py
+++ b/src/kiro_crew/diagnostics.py
@@ -30,6 +30,7 @@ import sys
 import time
 import uuid
 import zipfile
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,6 +38,7 @@ from urllib.parse import quote, urlencode
 
 from kiro_crew import __version__, platform_compat, release_channel
 from kiro_crew.config.loader import config_dir
+from kiro_crew.kiro_cli import resolve_kiro_cli
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
@@ -282,18 +284,53 @@ def _macos_crash_reports() -> list[Path]:
     return reports[:_MAX_IPS_REPORTS]
 
 
-def _kiro_cli_version() -> str:
+def _kiro_cli_version(
+    *,
+    platform_name: str | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Version string of the installed Kiro CLI, for the support bundle.
+
+    Resolves the binary through :func:`kiro_crew.kiro_cli.resolve_kiro_cli`
+    (fixed install directories first, inherited ``PATH`` after — the same
+    resolver the agent runtime spawn uses, see ``acp/client.py``) instead of
+    spawning the bare name: a collector process whose inherited ``PATH`` lacks
+    the install directory made the bare-name spawn misreport a working install
+    as ``unavailable`` in both ``versions.txt`` and the prefilled bug-report
+    footer (#7674). The keyword-only parameters are passthroughs to the
+    resolver so tests can pin the host layout; production callers pass nothing.
+
+    Return values, each a plain one-line string (both consumers interpolate
+    it verbatim):
+
+    * ``unavailable`` — the resolver found no binary anywhere. This is now the
+      ONLY path producing that string, so it means "genuinely not installed".
+    * ``present but not runnable`` — a resolved binary failed to spawn, timed
+      out, or exited non-zero. Distinct from ``unavailable`` so a broken
+      install is never misread as a missing one.
+    * the trimmed ``--version`` output, or ``unknown`` when a clean exit
+      printed nothing.
+
+    Never raises: diagnostics collection must degrade to a string, so the
+    spawn keeps its existing containment boundary.
+    """
+    binary = resolve_kiro_cli(platform_name=platform_name, home=home, environ=environ)
+    if binary is None:
+        return "unavailable"
     try:
         out = subprocess.run(
-            ["kiro-cli", "--version"],
+            [binary, "--version"],
             capture_output=True,
             text=True,
             timeout=5,
             check=False,
         )
-        return (out.stdout or out.stderr).strip() or "unknown"
     except (OSError, subprocess.SubprocessError):
-        return "unavailable"
+        return "present but not runnable"
+    if out.returncode != 0:
+        return "present but not runnable"
+    return (out.stdout or out.stderr).strip() or "unknown"
 
 
 #: PEP 440 prerelease segment — see

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -787,10 +787,12 @@ class TestKiroCliVersionResolution:
     """#7674: the probe resolves the binary instead of spawning a bare name.
 
     The decisive case plants a fake executable reachable ONLY through a fixed
-    ``known_kiro_cli_dirs()`` entry (an injected fake home's ``.local/bin``)
-    while the injected ``PATH`` excludes it — red on the old bare-name spawn,
-    green through the resolver. Every layout knob (``home`` / ``environ`` /
-    ``platform_name``) is injected so nothing depends on the test host.
+    ``known_kiro_cli_dirs()`` entry (a fake home's ``.local/bin``) while the
+    pinned ``PATH`` excludes it — red on the old bare-name spawn, green
+    through the resolver. Layout is pinned by rebinding the module's
+    ``resolve_kiro_cli`` to the REAL resolver with fixed ``home`` / ``environ``
+    / ``platform_name`` kwargs, so the resolution logic itself stays under
+    test and nothing depends on the test host.
     """
 
     @staticmethod
@@ -802,33 +804,78 @@ class TestKiroCliVersionResolution:
         cli.chmod(0o755)
         return cli
 
+    @staticmethod
+    def _pin_layout(monkeypatch, home: Path, path_dir: Path) -> None:
+        from kiro_crew.kiro_cli import resolve_kiro_cli as real_resolve
+
+        monkeypatch.setattr(
+            diagnostics,
+            "resolve_kiro_cli",
+            lambda: real_resolve(
+                platform_name="linux", home=home, environ={"PATH": str(path_dir)}
+            ),
+        )
+
     @pytest.mark.skipif(os.name == "nt", reason="POSIX shell-script fake executable")
-    def test_binary_absent_from_path_is_still_found(self, tmp_path):
+    def test_binary_absent_from_path_is_still_found(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         self._plant_cli(home, "#!/bin/sh\necho 'kiro-cli 9.9.9'\n")
-        result = diagnostics._kiro_cli_version(
-            platform_name="linux",
-            home=home,
-            environ={"PATH": str(tmp_path / "elsewhere")},
-        )
-        assert result == "kiro-cli 9.9.9"
+        self._pin_layout(monkeypatch, home, tmp_path / "elsewhere")
+        assert diagnostics._kiro_cli_version() == "kiro-cli 9.9.9"
 
     def test_nothing_resolved_is_exactly_unavailable(self, monkeypatch):
-        monkeypatch.setattr(diagnostics, "resolve_kiro_cli", lambda **_kw: None)
+        monkeypatch.setattr(diagnostics, "resolve_kiro_cli", lambda: None)
         assert diagnostics._kiro_cli_version() == "unavailable"
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX shell-script fake executable")
-    def test_nonzero_exit_is_not_runnable_not_unavailable(self, tmp_path):
+    def test_nonzero_exit_is_not_runnable_not_unavailable(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         self._plant_cli(home, "#!/bin/sh\necho boom >&2\nexit 3\n")
-        result = diagnostics._kiro_cli_version(
-            platform_name="linux",
-            home=home,
-            environ={"PATH": str(tmp_path / "elsewhere")},
-        )
-        assert result == "present but not runnable"
+        self._pin_layout(monkeypatch, home, tmp_path / "elsewhere")
+        assert diagnostics._kiro_cli_version() == "present but not runnable"
 
     def test_spawn_failure_is_not_runnable_not_unavailable(self, tmp_path, monkeypatch):
         ghost = str(tmp_path / "ghost" / "kiro-cli")
-        monkeypatch.setattr(diagnostics, "resolve_kiro_cli", lambda **_kw: ghost)
+        monkeypatch.setattr(diagnostics, "resolve_kiro_cli", lambda: ghost)
         assert diagnostics._kiro_cli_version() == "present but not runnable"
+
+    def test_raising_spawn_machinery_degrades_to_not_runnable(self, tmp_path, monkeypatch):
+        """Spawn machinery that RAISES beyond OSError must not crash collection.
+
+        The resource-limit / spawn plumbing can raise more than the classic
+        ``(OSError, SubprocessError)`` pair (e.g. a platform-composition error
+        from governance-aware machinery on an un-booted context). Diagnostics
+        must degrade to the not-runnable string — never-raises is the
+        collector's contract, and diagnostics must work precisely when the
+        rest of the system is broken.
+        """
+
+        def _boom(argv, **kw):
+            raise RuntimeError("spawn machinery failed closed")
+
+        monkeypatch.setattr(
+            diagnostics, "resolve_kiro_cli", lambda: str(tmp_path / "kiro-cli")
+        )
+        monkeypatch.setattr(diagnostics, "run_limited", _boom)
+        assert diagnostics._kiro_cli_version() == "present but not runnable"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX shell-script fake executable")
+    def test_probe_child_env_is_scrubbed(self, tmp_path, monkeypatch):
+        """The probed binary must not inherit credential-bearing env vars.
+
+        The resolver's first candidates live in user-writable install dirs, so
+        the probe hands the child :func:`sandbox.scrub_env` output — a planted
+        binary reads no secrets out of the inherited environment. The fake CLI
+        echoes the sentinel if it can see it; a clean child prints only the
+        version line.
+        """
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "sentinel-must-not-leak")
+        home = tmp_path / "home"
+        self._plant_cli(
+            home,
+            "#!/bin/sh\n"
+            'if [ -n "$AWS_SECRET_ACCESS_KEY" ]; then echo "leaked"; '
+            'else echo "kiro-cli 1.2.3"; fi\n',
+        )
+        self._pin_layout(monkeypatch, home, tmp_path / "elsewhere")
+        assert diagnostics._kiro_cli_version() == "kiro-cli 1.2.3"

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -781,3 +781,54 @@ def test_collect_handler_rejects_non_object_body(tmp_path, monkeypatch):
     )
     resp = asyncio.run(dh.api_diagnostics_collect(_CollectReq(["not", "a", "dict"])))
     assert resp.status == 400
+
+
+class TestKiroCliVersionResolution:
+    """#7674: the probe resolves the binary instead of spawning a bare name.
+
+    The decisive case plants a fake executable reachable ONLY through a fixed
+    ``known_kiro_cli_dirs()`` entry (an injected fake home's ``.local/bin``)
+    while the injected ``PATH`` excludes it — red on the old bare-name spawn,
+    green through the resolver. Every layout knob (``home`` / ``environ`` /
+    ``platform_name``) is injected so nothing depends on the test host.
+    """
+
+    @staticmethod
+    def _plant_cli(home: Path, script: str) -> Path:
+        bin_dir = home / ".local" / "bin"
+        bin_dir.mkdir(parents=True)
+        cli = bin_dir / "kiro-cli"
+        cli.write_text(script)
+        cli.chmod(0o755)
+        return cli
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX shell-script fake executable")
+    def test_binary_absent_from_path_is_still_found(self, tmp_path):
+        home = tmp_path / "home"
+        self._plant_cli(home, "#!/bin/sh\necho 'kiro-cli 9.9.9'\n")
+        result = diagnostics._kiro_cli_version(
+            platform_name="linux",
+            home=home,
+            environ={"PATH": str(tmp_path / "elsewhere")},
+        )
+        assert result == "kiro-cli 9.9.9"
+
+    def test_nothing_resolved_is_exactly_unavailable(self, monkeypatch):
+        monkeypatch.setattr(diagnostics, "resolve_kiro_cli", lambda **_kw: None)
+        assert diagnostics._kiro_cli_version() == "unavailable"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX shell-script fake executable")
+    def test_nonzero_exit_is_not_runnable_not_unavailable(self, tmp_path):
+        home = tmp_path / "home"
+        self._plant_cli(home, "#!/bin/sh\necho boom >&2\nexit 3\n")
+        result = diagnostics._kiro_cli_version(
+            platform_name="linux",
+            home=home,
+            environ={"PATH": str(tmp_path / "elsewhere")},
+        )
+        assert result == "present but not runnable"
+
+    def test_spawn_failure_is_not_runnable_not_unavailable(self, tmp_path, monkeypatch):
+        ghost = str(tmp_path / "ghost" / "kiro-cli")
+        monkeypatch.setattr(diagnostics, "resolve_kiro_cli", lambda **_kw: ghost)
+        assert diagnostics._kiro_cli_version() == "present but not runnable"

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -257,10 +257,14 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py::_git",
         "apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py::setUp",
         # Diagnostics support-bundle version probe: fixed argv
-        # ``["kiro-cli", "--version"]`` with a 5s timeout, no shell, no cwd, and
-        # no agent-influenced args — it only stamps the collected kiro-cli
-        # version into versions.txt. The binary name is a module constant; a
-        # resource ceiling / sandbox adds nothing to a `--version` call.
+        # ``[<resolved kiro-cli>, "--version"]`` with a 5s timeout, no shell,
+        # no cwd, and no agent-influenced args — it only stamps the collected
+        # kiro-cli version into versions.txt. The binary is resolved through
+        # ``kiro_cli.resolve_kiro_cli`` (fixed install directories first), the
+        # same resolver that selects the trusted agent-runtime binary itself in
+        # ``acp/client.py`` — so this probe trusts exactly what the runtime
+        # already trusts, and a resource ceiling / sandbox adds nothing to a
+        # ``--version`` call.
         "diagnostics.py::_kiro_cli_version",
         # Tailnet origin derivation + forwarded-peer whois (RFC:
         # rfc-tailnet-dashboard-access): one fixed argv — ``["<tailscale>",

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -256,16 +256,16 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # every mocked-git test passed.
         "apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py::_git",
         "apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py::setUp",
-        # Diagnostics support-bundle version probe: fixed argv
-        # ``[<resolved kiro-cli>, "--version"]`` with a 5s timeout, no shell,
-        # no cwd, and no agent-influenced args — it only stamps the collected
-        # kiro-cli version into versions.txt. The binary is resolved through
-        # ``kiro_cli.resolve_kiro_cli`` (fixed install directories first), the
-        # same resolver that selects the trusted agent-runtime binary itself in
-        # ``acp/client.py`` — so this probe trusts exactly what the runtime
-        # already trusts, and a resource ceiling / sandbox adds nothing to a
-        # ``--version`` call.
-        "diagnostics.py::_kiro_cli_version",
+        # (diagnostics.py::_kiro_cli_version removed — the support-bundle
+        # version probe now spawns via run_limited with a scrub_env()
+        # environment (review hardening on #7674's fix; the resolver-vetted
+        # binary lives in a user-writable install dir, so the child gets no
+        # inherited credentials and a kernel resource ceiling). Deliberately
+        # NOT wrapped by sandboxed_spawn_argv: its preparation resolves the
+        # governance sandbox floor, which raises PlatformCompositionError
+        # outside a booted gateway context — diagnostics must work precisely
+        # when the rest of the system is broken. An entry here would be stale
+        # and would mask a regression that dropped the limits/scrub.)
         # Tailnet origin derivation + forwarded-peer whois (RFC:
         # rfc-tailnet-dashboard-access): one fixed argv — ``["<tailscale>",
         # "status", "--json"]`` or ``["<tailscale>", "whois", "--json",


### PR DESCRIPTION
Fixes #7674

## Symptom

A diagnostics bundle from a host with a working Kiro CLI reports `kiro_cli_version: unavailable` in `versions.txt`, and the prefilled bug-report footer shows `kiro-cli: unavailable` — indistinguishable from "not installed". The motivating evidence is a bundle that contradicts itself: its `versions.txt` says `unavailable` while its own `gateway.log`, same host and same collection, logs the gateway spawning the binary from the reporter's home `.local/bin` — the FIRST fixed entry in `known_kiro_cli_dirs()`.

The triage cost is concrete: the false `unavailable` was named "the strongest remaining signal" in two separate re-triage passes on #3084, and supplied the sole evidence for #7233's "cause 2".

## Root cause

`_kiro_cli_version()` spawned the bare command name, so it resolved only through the collector process's inherited `PATH`. When that `PATH` lacks the install directory, the spawn raises `FileNotFoundError` and the `except (OSError, SubprocessError)` handler returns `"unavailable"`. The resolution METHOD is the defect: the repo already owns correct resolution in `kiro_cli.resolve_kiro_cli()`, which searches fixed install directories ahead of the inherited `PATH` — — and the collector bypassed it. (A second bare-name version probe exists at `slack/gateway.py:2380`, `_warn_if_kiro_cli_outdated`; its silent-suppress symptom is tracked with the other siblings in #7704 and is out of this PR's scope.) (No claim is made about the specific `PATH` contents on the reporter's host; what is proven is that the bare-name spawn failed while the binary sat in a fixed resolver directory.)

## Fix (smallest change, `_kiro_cli_version()` only)

- Resolve the binary via `resolve_kiro_cli()` — the same resolver the agent-runtime spawn already uses (`acp/client.py:297`) — and spawn the absolute path it returns, with the capture/text/timeout/no-check arguments unchanged.
- `resolve_kiro_cli() -> None` is now the ONLY producer of `"unavailable"`, so that string means genuinely not installed.
- A resolved binary that fails to spawn, times out, or exits non-zero reports the DISTINCT `"present but not runnable"` instead of collapsing onto `"unavailable"`. The existing exception tuple stays as the containment boundary — the probe degrades to a string, never raises.
- Tests pin the host layout by rebinding the module's `resolve_kiro_cli` to the REAL resolver with fixed `home`/`environ`/`platform_name` kwargs — the resolution logic stays under test with no shipped parameter surface (First Principles round-1 subtraction, adopted in the review commit).
- The resolved path is deliberately NOT embedded in the reported string: it flows verbatim into the public GitHub issue prefill footer, and a home-directory path would leak the username there (the spec offered this as optional; skipped on that ground).
- `test/test_spawn_audit.py` `BENIGN_SPAWNS` rationale for this probe updated in the same commit ("binary name is a module constant" would otherwise be stale); the probe now trusts exactly what the runtime spawn already trusts.
- No `docs/system-specs/modules/*.md` documents the `versions.txt` field values (checked by grep), so no spec-doc update is required.

## Verification

**Red before green** — all four new tests fail on unmodified `main` (run in a `git worktree` at `origin/main`): the decisive case plants a fake executable reachable ONLY through a fixed `known_kiro_cli_dirs()` entry (a fake home's `.local/bin`, layout pinned through the real resolver) with a pinned `PATH` that excludes it — a bare-name spawn cannot see it. Green on this branch (4/4).

**Mutation checks** — each direction executed with `sed`, test run captured, then reverted:
- (a) restore the bare-name spawn → `test_binary_absent_from_path_is_still_found` red (`'kiro-cli 2.20.2' == 'kiro-cli 9.9.9'` — the mutant resolved the test host's REAL install through `PATH`, which is precisely the misreport class under fix).
- (b) map the `None` branch onto the found-binary path → `test_nothing_resolved_is_exactly_unavailable` red (`'kiro-cli 2.20.2' == 'unavailable'`).
- (c) collapse `"present but not runnable"` onto `"unavailable"` → both not-runnable tests red.
- Restored tree: 4/4 pass.

**Gates** — `scripts/local-gate.py --base origin/main` (backend-only diff plan: full backend + 194 frontend guard specs):
- Backend full suite: 78,925 passed, 221 failed + 2 errors — all pre-existing environmental (see zero-regression proof).
- Frontend cross-surface guards: 196 files / 5,347 tests, all passed (node 22 toolchain).
- Repo black gate (`scripts/check_black_formatting.py`): passed. isort/flake8/mypy on touched files: clean.

**Zero-regression proof (both directions)** — full backend suite on this branch vs a `git worktree` at `origin/main`, sorted failing-id sets diffed:
- Branch-only failures: **zero**.
- Main-only failures: 3 ids in `test_release_macos_fail_closed.py`, which re-run solo fail IDENTICALLY on both trees (order/environment-dependent, unrelated to this diff).
- Remaining 221+2 ids byte-identical across both runs.

No frontend surface changes.

<!-- no-visual-delta -->
No screenshot evidence: this is a subprocess-resolution change in the diagnostics collector with no rendered surface; the behavioral delta is only provable by the focus of the regression tests above, not by a still frame.

## Review-driven changes

- Round 1 (First Principles CONCERNS, advisory): adopted the subtraction — dropped the three zero-consumer keyword-only test passthrough params from `_kiro_cli_version()`; tests now pin layout via a resolver rebind with identical decisive coverage. The watch item (two bare-name `kiro-cli` auto-update spawns in `cli_server.py` / `slack/gateway.py`, same cause / different symptom) is tracked in #7704; out of scope here per the task spec's no-opportunistic-widening constraint.

- Rounds 2-4 (GPT 5.6 BLOCKING ×3 + Design CONCERNS, converged empirically): final probe shape is `run_limited` + `scrub_env()` child environment — no inherited credentials, kernel resource ceiling. The round-3 `sandboxed_spawn_argv(mode="strict")` route was tried and then REMOVED with evidence: GPT round-4 correctly found its preparation sat outside the containment, and reproducing on a real enterprise-profile install showed `wrap_argv` raising `PlatformCompositionError` outside a booted gateway context — a working `kiro-cli 2.21.0` misreported as `present but not runnable`, the exact defect class this PR eliminates (Design round-4 concern, empirically confirmed, then fixed: the same real-binary check now returns the true version). The whole spawn incl. preparation sits in one broad containment logged at DEBUG; guards: raising-machinery regression test + env sentinel test, each mutation-checked red (narrowed containment / dropped scrub).

## Pattern harvest

Rule candidate: a version/presence probe of an optional binary must resolve through the component's owning resolver (here the `kiro_cli.resolve_kiro_cli()` family) instead of spawning the bare name — a bare-name spawn conflates "not on this process's inherited PATH" with "not installed", and diagnostics surfaces then misreport working installs as absent. Sibling bare-name sites knowingly left out of scope (unrelated flows, per the task spec): the auto-update presence checks in `cli_server.py` and `slack/gateway.py` (`shutil.which("kiro-cli")` + bare spawn) share the shape and are candidates for the same rule.
