### PR TITLE
fix(acp): recognise every deny-shaped permission option so a user denial stays per-tool

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -565,11 +565,16 @@ def reject_option_id(params: dict) -> str | None:
     """The least-destructive reject optionId a permission request advertises.
 
     Used when auto-answering a ``session/request_permission`` for a session
-    this client never registered (a backend-internal subagent). Prefer the
-    request's own ``reject_once``-kind option; fall back to a legacy id that
-    names reject. ``None`` means the caller must answer with the ``cancelled``
-    outcome instead — kiro-cli maps that to cancelling the child's turn, which
-    is strictly worse than a per-tool reject, so this is the last resort.
+    this client never registered (a backend-internal subagent), and by
+    :meth:`AcpClient.reject_tool` for a user's explicit deny. Prefer the
+    request's own ``reject_once``-kind option; fall back to a ``behavior``
+    that names deny, then to a legacy id that names reject. ``None`` means
+    the caller must answer with the ``cancelled`` outcome instead — kiro-cli
+    maps that to cancelling the TURN, which auto-denies every later tool call
+    in it without prompting (#7681), so recognition here is deliberately
+    broad: any deny-shaped option beats the cancelled fallback. What it must
+    never do is pick an ALLOW option, so every branch matches deny-naming
+    values exactly rather than by substring.
     """
     raw = params.get("options")
     if not isinstance(raw, list):
@@ -580,11 +585,35 @@ def reject_option_id(params: dict) -> str | None:
             opt_id = opt.get("optionId") or opt.get("id")
             if opt.get("kind") == want_kind and isinstance(opt_id, str) and opt_id:
                 return opt_id
-    # Legacy kiro payloads omit `kind` — match well-known reject ids only, so
-    # an allow option can never be picked by accident.
+    # Adapters that speak `behavior` instead of `kind`: an exact deny/reject
+    # behavior is unambiguous whatever the id is called. Same vocabulary as
+    # build_permission_event's branch (_DENY_BEHAVIORS) by construction.
+    # An option carrying a VALID spec `kind` is classified by that kind alone:
+    # a contradictory {kind:"allow_once", behavior:"deny"} must never be
+    # selected as a reject — answering with an allow optionId APPROVES the
+    # tool, the exact inversion this function exists to prevent.
     for opt in options:
         opt_id = opt.get("optionId") or opt.get("id")
-        if isinstance(opt_id, str) and opt_id in ("reject_once", "reject_always", "reject"):
+        if opt.get("kind") in _SPEC_OPTION_KINDS:
+            continue
+        behavior = opt.get("behavior")
+        if (
+            isinstance(behavior, str)
+            and behavior.lower() in _DENY_BEHAVIORS
+            and isinstance(opt_id, str)
+            and opt_id
+        ):
+            return opt_id
+    # Legacy payloads omit `kind` and `behavior` — match well-known deny ids
+    # only (exact, lowercased), so an allow option can never be picked by
+    # accident. Derived from _LEGACY_OPTION_KIND so this list and the event
+    # builder's classification cannot drift apart. Same kind-wins precedence
+    # as the behavior branch above.
+    for opt in options:
+        opt_id = opt.get("optionId") or opt.get("id")
+        if opt.get("kind") in _SPEC_OPTION_KINDS:
+            continue
+        if isinstance(opt_id, str) and opt_id.lower() in _DENY_OPTION_IDS:
             return opt_id
     return None
 
@@ -603,7 +632,36 @@ _LEGACY_OPTION_KIND: dict[str, str] = {
     OPTION_ALLOW_ALWAYS: "allow_always",
     "reject_once": "reject_once",
     "reject_always": "reject_always",
+    # Deny-naming ids without a `kind`: recognising them is what keeps a user
+    # denial on the per-tool reject path. Missing them meant reject_tool fell
+    # back to the `cancelled` outcome, which kiro-cli treats as cancelling the
+    # TURN — every later tool call in it was auto-denied unprompted (#7681).
+    "reject": "reject_once",
+    "deny": "reject_once",
+    "deny_once": "reject_once",
+    "decline": "reject_once",
+    "deny_always": "reject_always",
 }
+
+#: The four ACP-spec permission-option kinds. An option carrying one of these
+#: is classified by its kind ALONE — later deny-recognition branches
+#: (behavior, legacy id) must not override it, or a contradictory
+#: {kind:"allow_once", behavior:"deny"} could be answered as a reject with an
+#: ALLOW optionId, approving the tool the caller meant to deny.
+_SPEC_OPTION_KINDS = frozenset({"allow_once", "allow_always", "reject_once", "reject_always"})
+
+#: `behavior` values that mark an option as a deny, for adapters that speak
+#: behavior instead of kind (behavior:"deny" appears as the selection RESULT in
+#: claude-agent-acp; recognising it on an advertised option is defensive).
+#: Exact-match only — an allow option must never be classified as a reject.
+_DENY_BEHAVIORS = frozenset({"deny", "reject"})
+
+#: Deny-naming option ids, DERIVED from the one table above so the auto-answer
+#: path (`reject_option_id`) and the event builder (`build_permission_event`)
+#: cannot drift on the vocabulary a second time (#7681 was exactly that drift).
+_DENY_OPTION_IDS: frozenset[str] = frozenset(
+    k for k, v in _LEGACY_OPTION_KIND.items() if v in ("reject_once", "reject_always")
+)
 
 
 def build_permission_event(
@@ -671,6 +729,14 @@ def build_permission_event(
         options.append({"id": opt_id, "label": opt_label})
         if not opt_kind:
             opt_kind = _LEGACY_OPTION_KIND.get(opt_id.lower(), "")
+        if not opt_kind:
+            # Adapters that speak `behavior` instead of `kind`: an exact deny
+            # behavior classifies the option as a per-tool reject whatever the
+            # id is called, keeping a user denial off the turn-cancelling
+            # `cancelled` fallback (#7681).
+            behavior = o.get("behavior")
+            if isinstance(behavior, str) and behavior.lower() in _DENY_BEHAVIORS:
+                opt_kind = "reject_once"
         if opt_kind:
             kind_to_id.setdefault(opt_kind, opt_id)
     if not options:
@@ -685,8 +751,11 @@ def build_permission_event(
     # reject option (for a clean reject) was advertised. claude-agent-acp offers
     # a {kind:"reject_once", optionId:"reject"} whose selection yields
     # behavior:"deny" — far better than a "cancelled" outcome, which the adapter
-    # turns into a cryptic "Tool use aborted". kiro-cli advertises no reject
-    # option, so reject_tool falls back to "cancelled" (a clean rejection there).
+    # turns into a cryptic "Tool use aborted". A payload advertising no
+    # deny-shaped option at all leaves reject_tool on the "cancelled" fallback,
+    # which kiro-cli maps to cancelling the TURN — auto-denying every later
+    # tool call in it (#7681); that is why recognition above is deliberately
+    # broad and why both fallback sites log a warning.
     any_allow = kind_to_id.get("allow_once") or kind_to_id.get("allow_always")
     any_reject = kind_to_id.get("reject_once") or kind_to_id.get("reject_always")
     recorded: dict[str, str] | None = None

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -5112,6 +5112,17 @@ class AcpClient:
                 request_id, {"outcome": {"outcome": OUTCOME_SELECTED, "optionId": reject_id}}
             )
         else:
+            # Last resort, and not a per-tool signal: kiro-cli maps a
+            # `cancelled` outcome to cancelling the TURN, so every later tool
+            # call in it resolves as denied without prompting (#7681). Say so
+            # where an operator will find it — the silent cascade is the bug
+            # report's whole complaint.
+            logger.warning(
+                "reject_tool: no deny option advertised for req=%s; answering "
+                "'cancelled', which the backend may treat as cancelling the "
+                "remainder of the turn's tool calls",
+                request_id,
+            )
             await self._send_response(request_id, {"outcome": {"outcome": OUTCOME_CANCELLED}})
 
     async def send_command(self, command: str, args: dict | None = None) -> str:

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -1177,8 +1177,9 @@ class AcpSessionHandle:
         advertised (claude-agent-acp offers ``reject`` → behavior:"deny",
         surfacing a clear "permission denied" rather than the cryptic "Tool use
         aborted" the adapter throws on a ``cancelled`` outcome). Falls back to
-        ``cancelled`` when no reject option was advertised (kiro-cli), which kiro
-        handles as an ordinary rejection.
+        ``cancelled`` when no deny-shaped option was advertised — NOT a per-tool
+        signal: kiro-cli maps it to cancelling the TURN, auto-denying every
+        later tool call in it without prompting (#7681).
         """
         recorded = self._permission_options.pop(request_id, None)
         # Answered (see approve_tool) — a rejection ends the human wait too.
@@ -1190,6 +1191,15 @@ class AcpSessionHandle:
                 {"outcome": {"outcome": OUTCOME_SELECTED, "optionId": reject_id}},
             )
         else:
+            # Same last-resort warning as AcpClient.reject_tool — this is the
+            # second of the two ``cancelled`` fallback sites, and the silent
+            # cascade is the bug report's whole complaint (#7681).
+            logger.warning(
+                "reject_tool: no deny option advertised for req=%s; answering "
+                "'cancelled', which the backend may treat as cancelling the "
+                "remainder of the turn's tool calls",
+                request_id,
+            )
             await self._runtime.send_response(
                 request_id,
                 {"outcome": {"outcome": OUTCOME_CANCELLED}},

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -5833,6 +5833,159 @@ class TestBuildPermissionEvent:
         client._build_permission_event(msg)
         assert client._permission_options[22].get("reject") == "reject_once"
 
+    def test_plain_reject_id_without_kind_recorded(self):
+        """#7681: a deny-naming id with NO kind (plain "reject"/"deny") must be
+        classified as a per-tool reject. Missing it sent reject_tool down the
+        ``cancelled`` fallback, which the backend treats as cancelling the
+        TURN — every later tool call was auto-denied without prompting."""
+        client = AcpClient()
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        for req_id, opt_id in ((24, "reject"), (25, "deny"), (26, "Deny_Once")):
+            msg = JsonRpcMessage(
+                id=req_id,
+                method="session/requestPermission",
+                params={
+                    "toolCall": {"title": "shell"},
+                    "options": [
+                        {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+                        {"optionId": opt_id, "name": "Deny"},
+                    ],
+                },
+            )
+            client._build_permission_event(msg)
+            assert client._permission_options[req_id].get("reject") == opt_id, opt_id
+
+    def test_every_deny_vocabulary_value_round_trips(self):
+        """Every id in the shared deny table and every deny behavior must be
+        recognized by BOTH classification sites — the event builder (recorded
+        reject option) and the auto-answer path (reject_option_id). Driven by
+        the table itself so a vocabulary addition cannot ship untested."""
+        from kiro_crew.acp._dispatch import (
+            _DENY_BEHAVIORS,
+            _DENY_OPTION_IDS,
+            reject_option_id,
+        )
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        assert _DENY_OPTION_IDS, "derived deny-id table must not be empty"
+        client = AcpClient()
+        req_id = 9000
+        for opt_id in sorted(_DENY_OPTION_IDS):
+            params = {
+                "toolCall": {"title": "shell"},
+                "options": [
+                    {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+                    {"optionId": opt_id, "name": "Deny"},
+                ],
+            }
+            # Site 1: auto-answer path picks the deny id.
+            assert reject_option_id(params) == opt_id, opt_id
+            # Site 2: event builder records it as the reject option.
+            req_id += 1
+            client._build_permission_event(
+                JsonRpcMessage(id=req_id, method="session/requestPermission", params=params)
+            )
+            assert client._permission_options[req_id].get("reject") == opt_id, opt_id
+        for behavior in sorted(_DENY_BEHAVIORS):
+            params = {
+                "toolCall": {"title": "shell"},
+                "options": [
+                    {"optionId": "yes", "name": "Allow", "behavior": "allow"},
+                    {"optionId": "custom-no", "name": "Deny", "behavior": behavior},
+                ],
+            }
+            assert reject_option_id(params) == "custom-no", behavior
+            req_id += 1
+            client._build_permission_event(
+                JsonRpcMessage(id=req_id, method="session/requestPermission", params=params)
+            )
+            assert client._permission_options[req_id].get("reject") == "custom-no", behavior
+
+    def test_contradictory_kind_wins_over_deny_metadata(self):
+        """A valid spec `kind` classifies the option ALONE: an option carrying
+        {kind:"allow_once"} with a contradictory deny behavior or deny-naming
+        id must never be selected as the reject — answering with an allow
+        optionId would APPROVE the tool the caller meant to deny."""
+        from kiro_crew.acp._dispatch import reject_option_id
+
+        # behavior:"deny" on an allow-kind option: not a reject candidate.
+        params = {
+            "options": [
+                {"optionId": "yes", "name": "Allow", "kind": "allow_once", "behavior": "deny"},
+            ]
+        }
+        assert reject_option_id(params) is None
+        # deny-naming id on an allow-kind option: not a reject candidate.
+        params = {
+            "options": [
+                {"optionId": "deny", "name": "Allow", "kind": "allow_always"},
+            ]
+        }
+        assert reject_option_id(params) is None
+        # A genuine reject option alongside the contradictory one still wins.
+        params = {
+            "options": [
+                {"optionId": "yes", "name": "Allow", "kind": "allow_once", "behavior": "deny"},
+                {"optionId": "no", "name": "Deny", "behavior": "deny"},
+            ]
+        }
+        assert reject_option_id(params) == "no"
+
+    def test_deny_behavior_without_kind_recorded(self):
+        """#7681: an option that speaks ``behavior: "deny"`` instead of
+        ``kind`` is a per-tool reject whatever its id is called. An allow
+        behavior must never be classified as a reject."""
+        client = AcpClient()
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        msg = JsonRpcMessage(
+            id=27,
+            method="session/requestPermission",
+            params={
+                "toolCall": {"title": "shell"},
+                "options": [
+                    {"optionId": "yes", "name": "Allow", "behavior": "allow"},
+                    {"optionId": "no", "name": "Deny", "behavior": "deny"},
+                ],
+            },
+        )
+        client._build_permission_event(msg)
+        assert client._permission_options[27].get("reject") == "no"
+        # The allow-behavior option was NOT misread as a reject.
+        assert client._permission_options[27].get("reject") != "yes"
+
+    @pytest.mark.asyncio
+    async def test_reject_with_advertised_deny_never_answers_cancelled(self):
+        """#7681 end-to-end pin: when ANY deny-shaped option was advertised,
+        reject_tool answers a per-tool ``selected`` reject — never the
+        turn-cancelling ``cancelled`` outcome."""
+        client = AcpClient()
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        msg = JsonRpcMessage(
+            id=28,
+            method="session/requestPermission",
+            params={
+                "toolCall": {"title": "shell"},
+                "options": [
+                    {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+                    {"optionId": "deny", "name": "Deny"},
+                ],
+            },
+        )
+        client._build_permission_event(msg)
+        sent: list[dict] = []
+
+        async def _capture(request_id, payload):
+            sent.append(payload)
+
+        client._send_response = _capture  # type: ignore[method-assign]
+        await client.reject_tool(28)
+        assert len(sent) == 1
+        assert sent[0]["outcome"]["outcome"] != "cancelled"
+        assert sent[0]["outcome"] == {"outcome": "selected", "optionId": "deny"}
+
     def test_unknown_legacy_id_not_classified(self):
         """Unknown legacy ids do not get a synthesized kind."""
         client = AcpClient()


### PR DESCRIPTION
## Problem / Motivation

Denying one tool call cascades: every subsequent tool call in the same turn is auto-resolved as "User denied tool execution" without the user ever being prompted (#7681). The reporter's repro is a single legitimate deny followed by the agent revising its approach — whose new, different tool call is then silently rejected.

## Why it matters

A deny is the user's highest-signal steering input, and today it costs them the rest of the turn: the agent's corrected follow-up work is blocked by a denial the user never issued, and nothing on screen explains why. It teaches users that denying anything wedges the agent.

## What changed (motivation → approach → change)

Observed symptom: one deny becomes a rest-of-turn deny → root cause: the deny path answers ACP `session/request_permission` with the advertised per-tool reject option **only when it recognises one**; otherwise it falls back to the `cancelled` outcome, which kiro-cli maps to cancelling the **turn** — and recognition was too narrow, so real payloads kept taking the fallback. Options were classified only by `kind` (`reject_once`/`reject_always`) or an id allowlist that omitted plain `reject`/`deny` spellings, and adapters that speak `behavior: "deny"` instead of `kind` were never consulted → change, at both classification sites (`_dispatch.py`'s recorded-options builder, which serves the user-deny path, and `reject_option_id`, which serves the auto-answer paths):

- Extend the legacy id table with every deny-naming id (`reject`, `deny`, `deny_once`, `deny_always`, `decline`), exact-match and lowercased so an allow option can never be picked by accident.
- Classify an option with an exact `behavior` of `deny`/`reject` as a per-tool reject whatever its id is called.
- When the `cancelled` fallback is genuinely unavoidable (no deny-shaped option at all), log a warning naming the turn-scoped consequence, so the cascade is attributable instead of silent.

The fallback semantics themselves are untouched — for a payload with truly no deny option, `cancelled` remains the only ACP-conformant answer; making the backend prompt per-tool in that case is upstream (kiro-cli) work.

## Tests

- `test_plain_reject_id_without_kind_recorded` — plain `reject`/`deny`/`Deny_Once` ids (no `kind`) classify as per-tool rejects.
- `test_deny_behavior_without_kind_recorded` — `behavior: "deny"` classifies as a reject; `behavior: "allow"` is never misread as one.
- `test_reject_with_advertised_deny_never_answers_cancelled` — end-to-end pin: with any deny-shaped option advertised, `reject_tool` answers `selected` with that option, never `cancelled`.
- Full `test_acp_client.py` + `test_acp_runtime.py` pass (846 passed; the two `spawn_passes_installed_path_through_exact_wrappers` failures are pre-existing at the base commit — verified by stashing this diff).

## Manual verification

N/A — unit coverage sufficient: the defect and fix are entirely in the option-classification and response-selection logic, both pinned end-to-end by the new tests; no UI or rendering changes.

## Related Issues

Fixes #7681

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a graceful fallback whose semantics are coarser than the primary path (per-tool → per-turn) silently escalates blast radius when the primary path's recognition is too narrow — when adding vocabulary-gated dispatch, log the fallback and test that known vocabularies never reach it"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
