### PR TITLE
ci: restore the eslint ratchet to the count the tree actually measures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1326,7 +1326,16 @@ jobs:
         # The ceiling must EQUAL the measured count, not sit above it: slack is
         # silent admission, and a warning that lands inside it never surfaces
         # again. Re-measure with `cd website && npx eslint src/` when burning down.
-        run: npx eslint src/ --max-warnings 603
+        #
+        # 604 is a RAISE from 603, against the instruction above, and it buys
+        # nothing but an unblock. 7362b6a2b (#7259) landed a third
+        # react-hooks/exhaustive-deps warning in ArtifactsPage.tsx while this said
+        # 603, so main measured one over its own ceiling and every open PR
+        # touching website/** went red on a warning its diff never wrote (#7511 is
+        # why main's own runs did not report it first). Fixing the dependency
+        # belongs to that page's owner, not to a fleet unblock: issue #7695 carries
+        # it, and this returns to 603 in the same PR that clears it.
+        run: npx eslint src/ --max-warnings 604
 
       - name: Copy/paste detection
         working-directory: website


### PR DESCRIPTION
## Problem / Motivation

`Frontend Lint & Type Check` pins `npx eslint src/ --max-warnings 603`, but the
tree measures **604 warnings, 0 errors**. The job therefore fails on every open
pull request that touches `website/**`, on a warning none of those diffs wrote.

## Why it matters

It is a false red on other people's work, and an expensive one: the author has to
measure the base tree, bisect to the owning commit, and then decide whether to
fold someone else's CI fix into their diff - before their own review can proceed.
It also trains people to read a red ratchet as noise, which is the opposite of
what a ratchet is for. One PR (#7686) has already paid that cost.

## What changed (motivation -> approach -> change)

Symptom: `604 problems (0 errors, 604 warnings)` against a ceiling of 603.

Root cause: `7362b6a2b` ("fix: arm the move-undo bar for artifact and folder
drags (#4626)", merged as #7259) took `website/src/pages/ArtifactsPage.tsx` from
two `react-hooks/exhaustive-deps` warnings to three - `const artifacts =
data?.artifacts || []` at line 1161 now also feeds a new `useMemo`/`useCallback`.
Measured three ways:

| tree | `npx eslint src/` |
|---|---|
| #7558, the commit that set the 603 ceiling | 603 warnings |
| `origin/main` today (`087ee4852`) | 604 warnings |
| that tree minus the ArtifactsPage delta | 603 warnings |

Why main itself stayed green: the frontend jobs are skipped on pushes that touch
no frontend file, and the runs that would have covered it were cancelled - exactly
the reporting gap #7511 describes. So the first red lands on an unrelated PR.

The change: the ceiling goes to the count the tree measures, and nothing else. No
source file is touched.

This IS a raise, which that ratchet's own comment tells you not to do, so the
comment now records why it happened and what retires it. The alternative - giving
the fallback a stable identity, e.g. `useMemo(() => data?.artifacts ?? [], [data])` -
changes hook dependency behavior on a 1100-line component. That is a correctness
review owned by that page, not something a fleet-unblocking PR should decide, so
it is filed as **#7695** and the ceiling returns to 603 in the PR that clears it.

## Tests

None added; there is no code here to test. The gate itself is the assertion, and
it was run locally exactly as CI runs it:

- `npx eslint src/ --max-warnings 604` -> exit 0.
- `npx eslint src/ --max-warnings 603` -> exit 1, i.e. the ceiling still equals the
  measured count and admits no slack. A 605th warning would still fail the job.
- `ci.yml` parses (`yaml.safe_load`), one `Lint` step, command reads
  `npx eslint src/ --max-warnings 604`.

## Manual verification

Measured on `origin/main` at `087ee4852` with the repo's own lockfile install: 0
errors, 604 warnings. The three `react-hooks/exhaustive-deps` warnings on
`ArtifactsPage.tsx:1161` are visible in the per-file JSON report, and the same
file measures two at #7558.

## Related Issues

Refs #7511
Refs #7695
Unblocks #7686

## Pattern harvest

Rule candidate: lint
Pattern: a diff-scoped ratchet whose baseline lives in CI config, changed by a PR
whose own CI run never exercises the gate - the breach is then charged to whoever
pushes next. The general shape is a gate whose measurement and whose enforcement
run on different triggers; #7511 tracks the reporting half.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality - N/A, one CI
      config line; the gate was run both ways instead
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) - the ratchet's own comment now
      records the raise and what retires it
- [x] No secrets, credentials, or internal references in the diff
