### PR TITLE
docs(security): drop an unsupported claim about the agent backend

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -611,7 +611,7 @@ than an automatic readiness failure.
 
 ### Denied Commands (`security.py` + `hooks.py`)
 
-First-class `DeniedCommandRule` records in `BUILTIN_DENIED_RULES` (`security.py`) — each a stable `id`, a Python regex `pattern`, a `category`, and a human `description` — blocking destructive and credential-exfiltrating operations. They are enforced **only** at Kiro Crew's own `hooks.py` PreToolUse gate (`HookManager.on_tool_call` → `PolicyAuthority.is_denied`), never by kiro-cli. They are no longer a raw `deniedCommands` array injected into a kiro agent JSON, so there is no `execute_bash`/`shell` tool-settings copy and no project-dir `agents/defaults.json` override for them. Built-ins are **default-ON but user-DISABLEABLE** from Settings → Security (see "Denied-command rules, opt-out state, and read-only auto-approve" below). ada credential patterns are NOT in Kiro Crew's denied commands — kiro-cli has its own built-in deny list for `ada credentials` that cannot be overridden via agent config.
+First-class `DeniedCommandRule` records in `BUILTIN_DENIED_RULES` (`security.py`) — each a stable `id`, a Python regex `pattern`, a `category`, and a human `description` — blocking destructive and credential-exfiltrating operations. They are enforced **only** at Kiro Crew's own `hooks.py` PreToolUse gate (`HookManager.on_tool_call` → `PolicyAuthority.is_denied`), never by kiro-cli. They are no longer a raw `deniedCommands` array injected into a kiro agent JSON, so there is no `execute_bash`/`shell` tool-settings copy and no project-dir `agents/defaults.json` override for them. Built-ins are **default-ON but user-DISABLEABLE** from Settings → Security (see "Denied-command rules, opt-out state, and read-only auto-approve" below). Patterns for deployment-specific credential-vending CLIs are NOT in this catalog — a composed edition contributes those itself, either as an un-weakenable `SecurityOverlay` pattern or as a user-disableable rule through the `denied_rules` seam.
 
 **Credential exfiltration blocks**:
 - `.*echo.*\$AWS_SECRET.*`, `.*echo.*\$AWS_ACCESS.*`, `.*echo.*\$AWS_SESSION.*` — env var echo
@@ -623,9 +623,9 @@ First-class `DeniedCommandRule` records in `BUILTIN_DENIED_RULES` (`security.py`
 - `aws s3 cp .* s3://.*`, `aws s3 mv .* s3://.*`, `aws s3 sync .* s3://.*` — file upload exfiltration
 - `.*cat.*/\.aws/.*`, `.*cat.*/\.ssh/.*`, etc. — direct credential file reads
 
-**Allowed operations** (system prompt explicitly permits):
-- `ada credentials update` — blocked by kiro-cli's built-in deny list (not KiroCrew). Users must run ada in their own terminal; `credential_process` in `~/.aws/config` handles automatic refresh for AWS CLI commands
-- `ada profile add/list/print/delete` — also blocked by kiro-cli
+**Allowed operations** (not denied by this catalog):
+- `ada credentials update` — NOT denied by this catalog. A composed edition may deny the credential-*vending* form through its own `SecurityOverlay`; where it does, the supported pattern is to run the vending command in your own terminal once and let `credential_process` in `~/.aws/config` refresh automatically for AWS CLI calls
+- `ada profile add/list/print/delete` — NOT denied by this catalog either
 - `aws sts assume-role` — cross-account access
 - AWS CLI commands (`describe-*`, `list-*`, `get-*`, `filter-*`, `s3 cp`, `s3 ls`, etc.) — work via `credential_process`
 


### PR DESCRIPTION
## What

`docs/system-specs/modules/security.md` claimed the agent backend ships its own
built-in deny list for a credential-vending CLI, non-overridable through agent
config, and listed two of that CLI's subcommand groups as blocked by it. Neither
holds. This drops the claim and replaces it with what is verifiable from this
repository.

Docs only — no behavior change.

## Why it matters

The claim sent readers to the wrong owner. Someone whose workflow was refused was
told the block lived upstream in the backend, where there is nothing to change,
rather than in a composed edition's own `SecurityOverlay`, which is where the
pattern actually comes from and where narrowing or removing it is a one-line
decision. I lost real time to this before checking the binary.

## Evidence

- A string scan of the shipped backend binary finds no entries for that CLI's
  credential or profile verbs. The only hits for the auth helper it mentions are
  the backend's own sign-in client (`no ... cookie found: run <helper> to refresh`)
  plus one `which`-style probe in a diagnostics path — not a deny list.
- The profile-listing subcommand exits 0 and prints normally inside a session where
  the credential-update form is refused. If the backend denied the profile verbs,
  as the second bullet asserted, that could not happen.
- The refusal of the update form comes from a composed edition's
  `SecurityOverlay.extra_deny_patterns`, which is documented in this same file as
  the un-weakenable floor.

Scope note on the evidence: I scanned one platform build of one version. That is
enough to disprove "there is a built-in deny list for these verbs", which is what
the doc asserted, and it is deliberately not used to assert the opposite. The
replacement text says nothing about the backend's internals in either direction —
it only states what this repository's catalog does and does not carry.

## Changes

- The catalog paragraph now says patterns for a deployment-specific
  credential-vending CLI are not in the built-in catalog, and that a composed
  edition contributes those itself — as an un-weakenable overlay pattern, or as a
  user-disableable rule through the `denied_rules` seam.
- The two bullets now say those commands are not denied by this catalog, and that
  where an edition does deny the vending form, the supported pattern is to run it
  in your own terminal once and let `credential_process` refresh automatically for
  AWS CLI calls.
- Fixed the enclosing header, which read **Allowed operations** above bullets that
  described those operations as blocked.

## Verification

`./scripts/docs-lint.sh` passes. `grep` confirms no occurrence of either claim
remains under `docs/`. One commit, no `CHANGELOG.md` touch.
