### PR TITLE
feat(design-critique): reuse discovery probe PNGs in /render

### DIFF
--- a/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import ipaddress
 import json
 import logging
@@ -34,7 +35,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
 from aiohttp import web
@@ -136,6 +137,270 @@ def _finish_job(job_id: str, *, result: Any = None, error: str | None = None) ->
             rec["result"] = result
 
 
+# ── discovery-probe PNG cache ──
+#
+# The discover probe (capture-build.mjs over the first <=20 routes) is the slowest
+# step of a critique, and its PNGs cover most of what /render is then asked to
+# capture — so re-capturing a picked route the probe already rendered doubles
+# exactly the latency the probe was meant to remove. The probe PNGs are therefore
+# retained past discover with a handle-keyed route->PNG map recorded here, and
+# /render reuses one for any picked route the probe covered, shelling out only for
+# the rest.
+#
+# Guarded by its own lock, mirroring the _JOBS registry. Each entry is:
+#   {"dir": <retained probe dir>, "routes": {<route>: <abs png path>},
+#    "created_at": <time.time()>, "build_dir": <abs build output served>,
+#    "served_signature": <_served_signature() digest>}
+_PROBE_CACHE: dict[str, dict[str, Any]] = {}
+_PROBE_CACHE_LOCK = threading.Lock()
+# Ordering stamp of the newest discovery known to have STARTED for each handle, as a
+# strictly increasing monotonic_ns value. This is what makes a cache write ordered:
+# a write is installed only if no newer discovery of the same handle has begun, so an
+# older capture can never land on top of a newer one.
+#
+# It has to live outside the cache entry, because every discovery evicts the handle's
+# entry before it captures — so a stamp kept in the entry would be gone by the time a
+# slower, older discovery tried to write, which is precisely when it is needed. The
+# stamp is therefore a HIGH-WATER MARK that eviction RAISES rather than clears.
+#
+# Only stable "local:<path>" handles can genuinely interleave (a repo handle is a
+# fresh clone id per discovery), but the guard is unconditional: the cost is one int,
+# and a rule that holds for one kind of handle only is a rule nobody can rely on.
+# Bounded by _sweep_clones, which drops stamps no live discovery could still be using.
+_PROBE_STARTS: dict[str, int] = {}
+# How long a cached probe may still be REUSED — deliberately much shorter than the
+# retained dir's own lifetime, which is _CLONE_TTL_SEC and belongs to _sweep_clones.
+# _served_signature proves the served build output has not changed, but a built SPA
+# can fetch live data at runtime, and no filesystem token can see that. Sizing the
+# reuse window to the interactive discover -> pick -> render flow bounds how stale a
+# reused capture can be; past it the pick is captured fresh, which is cheap insurance
+# exactly when the gap has grown big enough to matter. So an entry can be too old to
+# reuse while its dir is still on disk — that ordering is the point.
+_PROBE_REUSE_TTL_SEC = 10 * 60
+
+
+def _probe_put(
+    handle: str,
+    claim: int,
+    dir_path: str,
+    routes: dict[str, str],
+    build_dir: str,
+    served_signature: str,
+) -> None:
+    # Store a retained probe under its discovery handle. A falsy handle (a failed
+    # clone returns "") has no /render counterpart to key against, so skip it.
+    if not handle:
+        return
+    # `claim` is the stamp _probe_claim handed this discovery. A newer discovery of the
+    # same handle having started since means THIS capture is the older of the two, and
+    # last-writer-wins would let it replace the newer one — including replacing a map
+    # that correctly withheld a route the newer probe found behind a login gate, whose
+    # staleness token still matches because an auth state is not served bytes. So the
+    # write is dropped and this discovery's own dir goes with it: nothing may reuse a
+    # capture that lost the ordering.
+    with _PROBE_CACHE_LOCK:
+        superseded = claim < _PROBE_STARTS.get(handle, 0)
+        prev = None if superseded else _PROBE_CACHE.get(handle)
+        if not superseded:
+            _PROBE_CACHE[handle] = {
+                "dir": dir_path,
+                "routes": dict(routes),
+                "created_at": time.time(),
+                "build_dir": build_dir,
+                "served_signature": served_signature,
+            }
+    # rmtree is blocking IO; this runs inside the discover to_thread worker, so it stays
+    # off the event loop. The `prev` drop is belt-and-braces: reaching it requires the
+    # slot to be occupied while this discovery holds the newest claim, which the
+    # superseded check above already refuses to any other writer. It is kept so that
+    # _probe_put orphans no directory on its own, without depending on that argument.
+    if superseded:
+        shutil.rmtree(dir_path, ignore_errors=True)
+    elif prev is not None and prev.get("dir") and prev["dir"] != dir_path:
+        shutil.rmtree(prev["dir"], ignore_errors=True)
+
+
+def _probe_claim(handle: str) -> int:
+    """Register a starting discovery for ``handle`` and evict what it supersedes.
+
+    Returns the ordering stamp the caller MUST hand back to ``_probe_put``; a write
+    carrying a stamp older than the newest claim is refused.
+
+    Eviction is the point of calling this first: a prior entry must not survive as a
+    fallback, or /render would serve the earlier capture for a project whose discovery
+    just failed — a gate appeared on every screen, the probe timed out, the build output
+    went away. The old token can still match in those cases, so nothing downstream would
+    notice. rmtree is blocking IO, so callers on the event loop must reach this through
+    ``asyncio.to_thread``.
+    """
+    if not handle:
+        return 0
+    stamp = time.monotonic_ns()
+    with _PROBE_CACHE_LOCK:
+        # monotonic_ns is non-decreasing rather than strictly increasing, and two claims
+        # taken inside one clock tick would compare equal — which _probe_put reads as
+        # "not superseded". Force the map strictly upward so ties resolve to the later
+        # claimant.
+        prior = _PROBE_STARTS.get(handle, 0)
+        if stamp <= prior:
+            stamp = prior + 1
+        _PROBE_STARTS[handle] = stamp
+        rec = _PROBE_CACHE.pop(handle, None)
+    if rec is not None and rec.get("dir"):
+        shutil.rmtree(rec["dir"], ignore_errors=True)
+    return stamp
+
+
+def _probe_get(handle: str) -> dict[str, Any] | None:
+    # Return a shallow copy of a still-reusable entry, or None. Copying under the
+    # lock keeps a caller from mutating the shared record or racing a sweep. The
+    # cutoff is _PROBE_REUSE_TTL_SEC, not the dir's longer _CLONE_TTL_SEC lifetime:
+    # an entry whose dir is still on disk can already be too old to reuse.
+    if not handle:
+        return None
+    now = time.time()
+    with _PROBE_CACHE_LOCK:
+        rec = _PROBE_CACHE.get(handle)
+        if rec is None:
+            return None
+        if now - rec.get("created_at", now) > _PROBE_REUSE_TTL_SEC:
+            return None
+        return {
+            "dir": rec["dir"],
+            "routes": dict(rec["routes"]),
+            "created_at": rec["created_at"],
+            "build_dir": rec["build_dir"],
+            "served_signature": rec["served_signature"],
+        }
+
+
+# Files under a build output that one staleness token will stat. A build tree is
+# normally hundreds to a couple of thousand files, and one bounded walk of it is far
+# cheaper than the browser capture the reuse skips. A tree bigger than this yields NO
+# token at all rather than a partial one, so reuse is refused and the pick falls back
+# to a fresh capture.
+_SIGNATURE_MAX_FILES = 20_000
+
+
+class _ServedToken(NamedTuple):
+    """What one walk of a build output yields.
+
+    ``digest`` is the staleness token compared across /discover and /render.
+
+    ``newest_mtime_ns`` is only used at discover, to detect a build that landed while
+    the probe was capturing: the token is necessarily taken AFTER the capture (the
+    manifest is what names the build dir), so without this the digest would describe
+    post-build bytes while the PNGs depict pre-build ones, and /render would match and
+    serve them. It is a high-water mark over both files AND directories — a deletion
+    leaves no file behind to carry a recent mtime, so files alone would miss one.
+    """
+
+    digest: str
+    newest_mtime_ns: int
+
+
+def _served_signature(build_dir: Path) -> _ServedToken | None:
+    """Staleness token for the bytes a reused capture actually depicts.
+
+    capture-build.mjs never builds anything: it serves the already-built output it
+    finds under the project dir, so a reused PNG depicts ``build_dir``'s contents,
+    NOT the project root's. Signing the project root would miss the case this guard
+    exists for, because a directory's own st_mtime moves only when its direct
+    entries change and an ordinary rebuild writes underneath an already-existing
+    ``dist/``.
+
+    The token digests every file the static server will actually serve — each one's
+    relative path, size and ``st_mtime_ns`` — so an ordinary write moves it, including
+    an in-place overwrite of a nested file under an unchanged name. The walk is sorted,
+    so the token describes the tree rather than the order the filesystem happened to
+    enumerate it in.
+
+    It is metadata, not content: a rewrite that keeps a file's byte count identical AND
+    restores its original ``st_mtime_ns`` (a deliberate ``utime``, or an archive
+    extracted with preserved timestamps) is not detected. Hashing the bytes instead
+    would mean reading the whole build output on every /render, which can cost more
+    than the capture the reuse saves, and the reuse window (``_PROBE_REUSE_TTL_SEC``)
+    already bounds how long such a rewrite could matter. Size-and-mtime is the same
+    token build tools themselves rely on.
+
+    "Will actually serve" is capture-build.mjs's own index, and the two enumerations
+    have to agree: signing something the server never serves yields false mismatches
+    and needless re-captures, while MISSING something it does serve lets a stale PNG
+    through. That script indexes with a readdir Dirent test that counts neither a
+    symlinked directory nor a symlinked file as one, and skips dot-entries, so none
+    of those is ever reachable over the preview server — and none is signed here.
+
+    Returns ``None`` whenever the served set cannot be read in full: missing,
+    unreadable, or larger than ``_SIGNATURE_MAX_FILES``. A caller MUST treat ``None``
+    as "unknown" rather than "unchanged" and refuse reuse — a token over part of a
+    tree is no evidence about the rest.
+
+    This walks and stats a caller-supplied path that may be a stale NFS/UNC mount,
+    so callers on the event loop MUST reach it through ``asyncio.to_thread``.
+    """
+
+    def _fail(exc: OSError) -> None:
+        # os.walk swallows errors by default, which would silently yield a token over
+        # the part of the tree it could read. Turn any of them into "no token".
+        raise exc
+
+    digest = hashlib.blake2b(digest_size=16)
+    newest = 0
+    seen = 0
+    try:
+        for root, dirs, files in os.walk(build_dir, onerror=_fail):
+            # Prune in place so the walk itself skips what the server will not serve.
+            dirs[:] = sorted(
+                d
+                for d in dirs
+                if not d.startswith(".") and not os.path.islink(os.path.join(root, d))
+            )
+            # Each directory's own mtime feeds ``newest_mtime_ns`` but NOT the digest.
+            # It has to feed the former because a DELETION leaves no file behind to
+            # carry a recent mtime, so a served file removed while the probe was
+            # capturing would otherwise not raise the high-water mark and the
+            # mid-capture check would miss it. It stays out of the digest because the
+            # digest describes the served bytes, and a directory's mtime also moves for
+            # changes that leave those bytes identical.
+            newest = max(newest, os.stat(root).st_mtime_ns)
+            rel_root = os.path.relpath(root, build_dir)
+            for name in sorted(files):
+                path = os.path.join(root, name)
+                if name.startswith(".") or os.path.islink(path):
+                    continue
+                seen += 1
+                if seen > _SIGNATURE_MAX_FILES:
+                    return None
+                st = os.stat(path)
+                newest = max(newest, st.st_mtime_ns)
+                entry = f"{rel_root}/{name}\0{st.st_size}\0{st.st_mtime_ns}\0"
+                digest.update(entry.encode("utf-8", "surrogateescape"))
+    except OSError:
+        return None
+    return _ServedToken(digest.hexdigest(), newest)
+
+
+def _probe_build_dir(reported: Any, directory: Path) -> Path | None:
+    # The build output capture-build.mjs reports it served, as an absolute path
+    # inside the project dir. It is only ever stat()ed — never served, never handed
+    # to the client — but keep it under the directory the handler already validated:
+    # a token taken over some unrelated tree would stand still and permit reuse of a
+    # stale PNG for the whole TTL. None (no reuse) for anything that fails to match.
+    if not isinstance(reported, str) or not reported:
+        return None
+    candidate = Path(reported)
+    if not candidate.is_absolute():
+        return None
+    # capture-build.mjs resolves a relative project path against ITS cwd, which it
+    # inherits from the gateway, so anchor the containment check the same way.
+    # Comparing an absolute manifest path against a relative `directory` would never
+    # match and would silently disable reuse for every relative local target.
+    # abspath, not resolve: lexical, so no filesystem IO on a path that may be a
+    # stale mount.
+    base = Path(os.path.abspath(directory))
+    return candidate if candidate.is_relative_to(base) else None
+
+
 def _start_job(work: Callable[[], Awaitable[dict[str, Any]]]) -> str:
     """Run ``work`` in a detached task and return a job id to poll for its result."""
     job_id = uuid.uuid4().hex
@@ -192,12 +457,37 @@ def _sweep_clones() -> None:
     uploads = _uploads_dir()
     if uploads.exists():
         victims += [c for c in uploads.iterdir() if c.is_dir() and c.name.startswith("dc-probe-")]
+    removed: list[str] = []
     for child in victims:
         try:
             if now - child.stat().st_mtime > _CLONE_TTL_SEC:
                 shutil.rmtree(child, ignore_errors=True)
+                removed.append(str(child))
         except OSError:
             continue
+    cutoff_ns = time.monotonic_ns() - int(_CLONE_TTL_SEC * 1_000_000_000)
+    with _PROBE_CACHE_LOCK:
+        # A retained probe dir (dc-probe-*) is swept above on the same TTL, but its
+        # _PROBE_CACHE entry would otherwise outlive the dir and hand /render a
+        # route->png path for a directory that no longer exists. Purge any cache entry
+        # whose retained dir was just removed, so the cache never serves a missing PNG.
+        if removed:
+            stale_handles = [
+                h
+                for h, rec in _PROBE_CACHE.items()
+                # Equality is exhaustive: a record's dir is always the dc-probe-*
+                # dir _probe_put was handed, a direct child of uploads, and every
+                # sweep victim is a top-level dir under the same parent.
+                if rec.get("dir") in removed
+            ]
+            for h in stale_handles:
+                _PROBE_CACHE.pop(h, None)
+        # Ordering stamps are not tied to a dir, so they need their own bound or the map
+        # would grow one entry per repo discovery forever (each is a fresh clone id).
+        # _CLONE_TTL_SEC (3600s) is over three times _DISCOVER_TIMEOUT + _CAPTURE_TIMEOUT
+        # (1080s), so a dropped stamp cannot belong to a discovery still able to write.
+        for h in [h for h, stamp in _PROBE_STARTS.items() if stamp < cutoff_ns]:
+            _PROBE_STARTS.pop(h, None)
 
 
 def _tool(name: str) -> str | None:
@@ -515,6 +805,18 @@ async def _handle_method(request: web.Request) -> web.Response:
 
 async def _discover_from_dir(directory: Path, handle: str) -> dict[str, Any]:
     """Run discover-routes + a capture probe against a local/cloned directory."""
+    # Re-discovering a handle supersedes whatever was cached under it, so claim it FIRST
+    # — which evicts the prior entry and stamps this discovery's place in the order —
+    # and let a successful probe install the replacement. Claiming on the way out instead
+    # would be skipped by every path that does not reach the end: a timeout, a node/git
+    # failure, an early return, an exception the job wrapper catches. A stale entry
+    # surviving any of those is invisible downstream, because its token can still match
+    # and /render would serve the earlier capture for a project whose discovery just
+    # failed. The stamp is what stops the reverse hazard: this discovery may be the
+    # slower of two on the same handle, and _probe_put refuses a write that a newer
+    # claim has already superseded. A repo handle is a fresh clone id, so nothing is
+    # evicted there — the stamp is still taken, so the rule needs no per-kind exception.
+    claim = await asyncio.to_thread(_probe_claim, handle)
     node = await asyncio.to_thread(_node)
     if node is None:
         return {
@@ -550,6 +852,9 @@ async def _discover_from_dir(directory: Path, handle: str) -> dict[str, Any]:
         probe_out = probe_base / f"dc-probe-{uuid.uuid4().hex[:12]}"
         await asyncio.to_thread(probe_out.mkdir, parents=True, exist_ok=True)
         csv = ",".join(str(r.get("path", "")) for r in routes[:20] if r.get("path"))
+        # Read before the capture starts: any served file written at or after this
+        # instant means the build output changed while the probe was screenshotting it.
+        probe_started_ns = time.time_ns()
         prc, pout, perr = await _run(
             [
                 node,
@@ -565,8 +870,40 @@ async def _discover_from_dir(directory: Path, handle: str) -> dict[str, Any]:
             probe = json.loads(pout)
         except ValueError:
             probe = {}
+        route_png_map: dict[str, str] = {}
         for s in probe.get("screens") or []:
-            seeable[str(s.get("route"))] = True
+            route = str(s.get("route"))
+            seeable[route] = True
+            # Cache the route->PNG path so /render can reuse this capture instead
+            # of re-rendering the same route. Only screens with both a route and a
+            # path are usable; the path is absolute, inside probe_out.
+            #
+            # A screen the probe caught under a login / consent / onboarding overlay is
+            # NOT cached. /render raises its own gate warning from the capture it runs,
+            # and a fully-covered render runs no capture at all — so reusing a gate
+            # screenshot would hand the critic a picture of the wall with that warning
+            # silently missing. Leaving the route uncovered restores both. This keys on
+            # the per-screen `overlay` rather than the manifest's `blockedBy` summary,
+            # which the script only sets when one overlay covers >=60% of screens: a
+            # single gated route has an overlay but no blockedBy, and would slip past.
+            #
+            # `fullPageCoverage` is what makes reuse LOSSLESS rather than merely fast.
+            # /render captures with --full and the probe without it, so a probe PNG of a
+            # page taller than the viewport holds strictly less than the render it would
+            # replace, and the critic would judge a page whose lower half it cannot see.
+            # The script sets this flag only when the page's scroll height fit the
+            # viewport, i.e. when the two capture modes produce the same pixels. A route
+            # that overflowed is simply left uncovered and /render captures it fresh with
+            # --full, exactly as it did before any reuse existed. Absent (an older
+            # manifest) is falsy, so reuse fails closed toward capturing.
+            png = s.get("path")
+            if (
+                s.get("route") is not None
+                and png
+                and not s.get("overlay")
+                and s.get("fullPageCoverage")
+            ):
+                route_png_map[route] = str(png)
         if probe.get("blockedBy"):
             b = probe["blockedBy"]
             cannot_see.append(
@@ -574,10 +911,60 @@ async def _discover_from_dir(directory: Path, handle: str) -> dict[str, Any]:
             )
         if probe.get("buildDir") is None and probe.get("notes"):
             cannot_see.extend(str(n) for n in probe["notes"])
-        # The probe images are throwaway (only the manifest is used); drop the dir
-        # now rather than wait for the TTL sweep — off the event loop, since a
-        # recursive delete is blocking IO.
-        await asyncio.to_thread(shutil.rmtree, probe_out, ignore_errors=True)
+        # When the probe produced at least one usable screen AND a staleness token
+        # over the build output it served, RETAIN the dir and cache its route->PNG
+        # map keyed by `handle` so /render can reuse those PNGs instead of
+        # re-capturing (see _PROBE_CACHE). The retained dir is a dc-probe-* dir, so
+        # _sweep_clones TTL-sweeps it (and purges the matching cache entry) on the
+        # ~1h _CLONE_TTL_SEC window; its fresh mkdir mtime starts that clock.
+        #
+        # The probe deliberately stays WITHOUT --full while /render runs WITH it. The
+        # reason is blast radius, not screenshot cost: this ONE subprocess renders up to
+        # 20 routes of an unknown project under a single shared _CAPTURE_TIMEOUT, and a
+        # full-page screenshot of an unknown page is unbounded (a long or virtualised
+        # list can make it enormous or very slow). One pathological route would then
+        # exhaust the shared budget, the manifest would not parse, and EVERY route would
+        # come back canSee=False — losing all of discovery to improve a subset of
+        # renders. /render's --full runs on the two or three routes the user picked, with
+        # the same budget and far more headroom per route, which is why the flag belongs
+        # there and not here.
+        #
+        # That asymmetry does NOT reach a critique, because only screens the script
+        # certified as `fullPageCoverage` enter route_png_map above: reuse is confined to
+        # pages that fit the viewport, where a --full capture would have produced the
+        # same pixels. So a covered pick is a substitution of equals, and a page too tall
+        # to reuse losslessly is re-captured with --full instead of being silently
+        # truncated. Making the probe itself pass --full would buy the same fidelity at
+        # exactly the blast radius above.
+        build_dir = _probe_build_dir(probe.get("buildDir"), directory)
+        token = (
+            await asyncio.to_thread(_served_signature, build_dir)
+            if route_png_map and build_dir is not None
+            else None
+        )
+        if token is not None and token.newest_mtime_ns >= probe_started_ns:
+            # A build landed while the probe was capturing. The token has to be taken
+            # after the capture (the manifest is what names the build dir), so it
+            # describes the NEW bytes while the PNGs depict the old ones — and /render
+            # would find it matching and serve them. Refuse to cache instead.
+            token = None
+        if build_dir is not None and token is not None:
+            await asyncio.to_thread(
+                _probe_put,
+                handle,
+                claim,
+                str(probe_out),
+                route_png_map,
+                str(build_dir),
+                token.digest,
+            )
+        else:
+            # No usable screen, no readable build output to take a staleness token
+            # over, or a capture the token cannot vouch for: either way there is
+            # nothing that can be reused safely, so drop the dir now (off the event
+            # loop — a recursive delete is blocking IO) rather than leak it to the
+            # TTL sweep.
+            await asyncio.to_thread(shutil.rmtree, probe_out, ignore_errors=True)
 
     screens = []
     for i, r in enumerate(routes):
@@ -854,30 +1241,83 @@ async def _handle_discover(request: web.Request) -> web.Response:
 # ── POST /render ──
 
 
+def _adopt_reused(reused: dict[str, str], out_dir: Path) -> dict[str, str]:
+    """Copy each reused probe PNG into ``out_dir``; return ref -> the copy's path.
+
+    A returned screen path is kept FOREVER by a saved critique's history entry, which
+    is why the TTL sweep exempts dc-render-*. A probe PNG has the opposite lifetime:
+    its dc-probe-* dir is swept on _CLONE_TTL_SEC and is deleted outright when the
+    same local project is re-discovered. Handing the probe path straight to the
+    client would therefore make saved critiques lose their screenshots, so the bytes
+    are adopted into the render dir and only the copy is ever returned. The copy
+    costs milliseconds; the capture subprocess is still skipped.
+
+    A copy that fails (the probe dir was swept, or rmtree'd by a concurrent local
+    re-discovery, between the handler's exists() check and here) is omitted from the
+    result. The caller must then treat that ref as UNCOVERED and capture it fresh:
+    an omission means "nothing has rendered this pick yet", never "this pick cannot
+    be seen". Only the source's basename is used, so a manifest path cannot place the
+    copy outside ``out_dir``.
+    """
+    copies: dict[str, str] = {}
+    for i, (ref, src) in enumerate(reused.items()):
+        dest = out_dir / f"reused-{i}-{Path(src).name}"
+        try:
+            shutil.copyfile(src, dest)
+        except OSError:
+            continue
+        copies[ref] = str(dest)
+    return copies
+
+
 async def _render_capture_job(
     kind: str,
-    cmd: list[str],
+    cmd: list[str] | None,
     out_dir: Path,
     refs: list[str],
     labels: list[str],
+    adopted: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Run the capture subprocess (detached) and shape its output for the client.
 
     The synchronous validation and the SSRF/handle checks already ran in the
     handler; this only executes the vetted command and parses it, so a client
     disconnect cannot cancel the capture.
+
+    ``adopted`` maps a pick's ref -> the copy of a probe PNG the handler already
+    adopted into ``out_dir`` (see _adopt_reused). Those (repo/local) refs are absent
+    from ``cmd``'s route list, and are merged in at the pick's original step order —
+    so /render pays the capture cost only for the routes the probe did not cover. A
+    ref the handler failed to adopt is in ``cmd``'s route list instead, never here.
+    ``cmd`` is None when every pick is already adopted: there is then no capture to
+    run at all.
     """
+    adopted_paths = adopted or {}
     screens: list[dict[str, Any]] = []
     could_not_see: list[str] = []
     try:
-        rc, out, cerr = await _run(cmd, _CAPTURE_TIMEOUT, env=await asyncio.to_thread(_script_env))
+        out = ""
+        if cmd is not None:
+            rc, out, cerr = await _run(
+                cmd, _CAPTURE_TIMEOUT, env=await asyncio.to_thread(_script_env)
+            )
         if kind in ("repo", "local"):
-            try:
-                cap = json.loads(out)
-            except ValueError as exc:
-                raise RuntimeError("could not render the selected screens") from exc
+            cap: dict[str, Any] = {}
+            if cmd is not None:
+                try:
+                    cap = json.loads(out)
+                except ValueError as exc:
+                    raise RuntimeError("could not render the selected screens") from exc
             by_route = {str(s.get("route")): s for s in (cap.get("screens") or [])}
             for i, ref in enumerate(refs):
+                # A covered pick is served from its adopted copy (viewport, not
+                # --full) at its original step; the rest are mapped by route from the
+                # fresh capture, and anything neither adopted nor captured is not
+                # seeable.
+                copy = adopted_paths.get(ref)
+                if copy:
+                    screens.append({"step": i + 1, "label": labels[i], "path": copy})
+                    continue
                 s = by_route.get(ref)
                 if s and s.get("path"):
                     screens.append({"step": i + 1, "label": labels[i], "path": s["path"]})
@@ -908,10 +1348,11 @@ async def _render_capture_job(
                     could_not_see.append(str(rec.get("label") or rec.get("route") or "a page"))
         return {"screens": screens, "couldNotSee": could_not_see}
     finally:
-        # A dc-render-* dir is referenced by history ONLY when a screen succeeded.
-        # On any no-screen exit (failed capture, empty result) nothing references
-        # it and the TTL sweep skips dc-render-*, so drop it here to keep repeated
-        # failures from exhausting upload storage.
+        # A dc-render-* dir is referenced by history ONLY when a screen succeeded —
+        # every returned path lives in out_dir, adopted copies included. On any
+        # no-screen exit (failed capture, empty result) nothing references it and the
+        # TTL sweep skips dc-render-*, so drop it here to keep repeated failures from
+        # exhausting upload storage.
         if not screens:
             await asyncio.to_thread(shutil.rmtree, out_dir, ignore_errors=True)
 
@@ -987,18 +1428,82 @@ async def _handle_render(request: web.Request) -> web.Response:
                 "the discovered project is no longer available; run discovery again",
                 "handle_expired",
             )
-        csv = ",".join(r for r in refs if r)
+
+        # Reuse the discovery probe's PNGs where we can. The probe cached a
+        # route->PNG map at /discover; reuse a cached PNG for any picked route it
+        # captured (whose file still exists) — but only when the build output the
+        # probe served still carries the token recorded then, so a rebuild between
+        # /discover and /render is re-captured rather than served a stale image.
+        # Reused PNG paths come from the probe dir the server created under uploads,
+        # so they need no extra path validation beyond the exists() check. Every
+        # filesystem touch goes through asyncio.to_thread, like the rest of this
+        # handler, so a stale NFS/UNC mount cannot freeze the gateway loop. This
+        # lookup runs AFTER all the synchronous validations above (NUL,
+        # field-length, handle containment / sensitive dir, exists), never before.
+        #
+        # The key is derived from the target that was just VALIDATED, never from the
+        # raw handle. A local render takes `directory` from `value` whenever the
+        # handle is not a "local:<path>" one, so keying off the handle there would
+        # read a different project's entry and hand back its screenshots. A repo
+        # render derives `directory` from the handle itself and containment-checks
+        # it, so for repos the handle IS the target. /discover records local entries
+        # under exactly this "local:<expanded path>" spelling.
+        cache_key = handle if kind == "repo" else f"local:{directory}"
+        reused: dict[str, str] = {}
+        cached = _probe_get(cache_key)
+        if cached is not None:
+            token = await asyncio.to_thread(_served_signature, Path(cached["build_dir"]))
+            # A missing token means "unknown", not "unchanged", so it must not satisfy
+            # the match: a build output that no longer stats is no evidence it stands
+            # still. Only the digest is compared — newest_mtime_ns is a discover-time
+            # concern. The stored side is never None: _probe_put is only reached with a
+            # real digest.
+            if token is not None and cached["served_signature"] == token.digest:
+                cached_routes = cached["routes"]
+                for ref in refs:
+                    if not ref:
+                        continue
+                    png = cached_routes.get(ref)
+                    if png and await asyncio.to_thread(os.path.exists, png):
+                        reused[ref] = png
+
+        # An out dir is created either way: the reused PNGs are adopted into it so
+        # every path this render hands the client (and history keeps) lives in the
+        # never-swept dc-render-* dir.
         uploads_base = await asyncio.to_thread(_uploads_dir)
         out_dir = uploads_base / f"dc-render-{uuid.uuid4().hex[:12]}"
         await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
-        cmd = [
-            node,
-            str(_SCRIPTS_DIR / "capture-build.mjs"),
-            str(directory),
-            f"--routes={csv}",
-            f"--out={out_dir}",
-            "--full",
-        ]
+
+        # Adopt BEFORE deciding what is uncovered, so a copy that fails falls back to a
+        # fresh capture instead of losing the pick. The probe dir can be swept or
+        # rmtree'd by a concurrent local re-discovery in the window after the
+        # os.path.exists check above, and a pick whose adoption fails is simply a pick
+        # nothing has yet rendered — the same situation as one the probe never covered.
+        # Treating it as "could not see" instead would make a render that always
+        # worked before return zero screens. A copy is milliseconds and goes through
+        # to_thread like every other filesystem touch here.
+        copies = await asyncio.to_thread(_adopt_reused, reused, out_dir)
+        uncovered = [r for r in refs if r and r not in copies]
+
+        # A capture command is built only when something is actually uncovered; None
+        # means every pick is already adopted in out_dir, so no node subprocess runs.
+        capture_cmd: list[str] | None = None
+        if uncovered:
+            capture_cmd = [
+                node,
+                str(_SCRIPTS_DIR / "capture-build.mjs"),
+                str(directory),
+                f"--routes={','.join(uncovered)}",
+                f"--out={out_dir}",
+                "--full",
+            ]
+        return web.json_response(
+            {
+                "job": _start_job(
+                    lambda: _render_capture_job(kind, capture_cmd, out_dir, refs, labels, copies)
+                )
+            }
+        )
     elif kind == "url":
         base = value or (handle[len("url:") :] if handle.startswith("url:") else "")
         routes = [r for r in refs if r]

--- a/src/kiro_crew/apps/builtins/design_critique/skills/design-critique/scripts/capture-build.mjs
+++ b/src/kiro_crew/apps/builtins/design_critique/skills/design-critique/scripts/capture-build.mjs
@@ -81,6 +81,14 @@ function findBuild(root, notes) {
  * user input left to get wrong, and CodeQL's "uncontrolled data in a path
  * expression" no longer has a flow to report because every path handed to fs
  * originates from our own readdir walk.
+ *
+ * WHAT THIS ENUMERATES IS A CONTRACT with routes.py's `_served_signature`, which
+ * takes the staleness token that decides whether a probe screenshot may be reused
+ * for a later render. That token signs exactly the set indexed here — the Dirent
+ * test below counts neither a symlinked directory nor a symlinked file, and
+ * dot-entries are skipped. Widening this walk without widening that one leaves a
+ * served file unsigned, so a change to it would not move the token and a stale
+ * screenshot would be reused. Change both together.
  */
 function indexBuildFiles(rootDir) {
   const root = resolve(rootDir)
@@ -180,6 +188,31 @@ function findOverlay(page) {
   }).catch(() => null)
 }
 
+/**
+ * Whether the page's scrollable height already fits the viewport, so a viewport
+ * screenshot holds the same pixels a fullPage one would.
+ *
+ * THIS IS A CONTRACT with routes.py, which reuses a probe PNG for a later /render
+ * only when the screen record says the PNG covers the whole page. Playwright's
+ * `fullPage` extends a capture along the HEIGHT only — width stays the viewport
+ * width either way — so height is the only axis on which the two modes differ.
+ *
+ * An unreadable page (detached frame, hostile script) counts as NOT fitting: the
+ * caller then re-captures with --full rather than assuming an equivalence it could
+ * not confirm. Erring this way costs one screenshot; erring the other way silently
+ * drops everything below the fold from a critique.
+ */
+function pageFitsViewport(page) {
+  return page.evaluate(() => {
+    // The scrolling box is documentElement in standards mode, but a page can put
+    // overflow on body instead; take the taller so neither is missed.
+    const h = Math.max(document.documentElement?.scrollHeight || 0, document.body?.scrollHeight || 0)
+    // scrollHeight is a rounded integer while innerHeight can be fractional under a
+    // non-integral devicePixelRatio, so allow one pixel of rounding slack.
+    return h > 0 && h <= innerHeight + 1
+  }).catch(() => false)
+}
+
 const sig = (o) => (o && o.text ? o.text.slice(0, 60).toLowerCase() : '')
 
 async function main() {
@@ -250,12 +283,21 @@ async function main() {
         await page.waitForTimeout(350)
         chars = await page.evaluate(() => (document.body?.innerText || '').replace(/\s+/g, ' ').trim().length).catch(() => 0)
         const overlay = await findOverlay(page)
+        // Measure before the screenshot but after the settle above, so lazy content
+        // that changes the page height is already in.
+        const fits = await pageFitsViewport(page)
         const safe = route.replace(/[^\w.-]+/g, '_').replace(/^_+|_+$/g, '') || 'index'
         const outPath = join(outDir, `build-${safe}-${Date.now()}.png`)
         await page.screenshot({ path: outPath, fullPage: opt.full })
         // Same rule as render.mjs: a blank page is NOT a seen screen.
         if (chars < 8) skipped.push({ route, why: 'rendered blank (' + chars + ' chars) — not counted as seen' })
-        else screens.push({ route, path: outPath, chars, overlay: overlay || null })
+        // `fullPageCoverage` describes the PNG, not the page: a --full capture always
+        // covers it, and a viewport capture does when the page fits. routes.py reuses
+        // a probe PNG only when this is true.
+        else screens.push({
+          route, path: outPath, chars, overlay: overlay || null,
+          fullPageCoverage: opt.full || fits,
+        })
       } catch (err) {
         skipped.push({ route, why: (err && err.message ? err.message : String(err)).slice(0, 120) })
       } finally {

--- a/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
+import time
 from pathlib import Path
 from typing import Any
 
@@ -91,8 +93,6 @@ def test_resolve_vetted_loopback_only_for_typed_loopback(monkeypatch) -> None:  
 
 
 def test_sweep_removes_probe_and_clones_keeps_render(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
-    import time
-
     monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
     aged = time.time() - routes._CLONE_TTL_SEC - 60
     for name in ("dc-probe-old", "dc-clones/repo-old", "dc-render-old"):
@@ -263,6 +263,38 @@ async def _drain(job_id: str) -> dict[str, Any] | None:
             return rec
         await asyncio.sleep(0.005)
     return routes._get_job(job_id)
+
+
+def _bump(path: Path, seconds: float = 10.0) -> None:
+    # Move a path's mtime forward by an explicit amount instead of relying on the
+    # wall clock: two writes in quick succession can land on the same timestamp on a
+    # filesystem with coarse mtime granularity, which would make any assertion about
+    # a changed mtime timing-dependent.
+    stamp = os.stat(path).st_mtime + seconds
+    os.utime(path, (stamp, stamp))
+
+
+def _reset_probe_cache(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # Isolate BOTH module-level probe maps so a test neither leaks entries nor inherits
+    # another test's ordering stamp — a leftover stamp for a shared handle would make
+    # _probe_put refuse a later test's write, which is order-dependent and invisible.
+    monkeypatch.setattr(routes, "_PROBE_CACHE", {})
+    monkeypatch.setattr(routes, "_PROBE_STARTS", {})
+
+
+def _cache_probe(handle: str, probe_dir: Path, proj: Path, route_pngs: dict[str, str]) -> Path:
+    # Cache a retained probe the way /discover does, and return the build dir the
+    # capture served. The staleness token is taken over THAT dir, not over the
+    # project root, because the build output is what a reused PNG depicts.
+    build = proj / "dist"
+    build.mkdir(parents=True, exist_ok=True)
+    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+    token = routes._served_signature(build)
+    assert token is not None
+    routes._probe_put(
+        handle, routes._probe_claim(handle), str(probe_dir), route_pngs, str(build), token.digest
+    )
+    return build
 
 
 @pytest.mark.asyncio
@@ -968,3 +1000,1233 @@ async def test_job_status_error_returns_message() -> None:
     assert isinstance(resp.body, bytes)
     body = json.loads(resp.body)
     assert body["status"] == "error" and "kaboom" in body["error"]
+
+
+# ── probe-PNG cache: reuse the discovery capture in /render ──
+
+
+def test_probe_put_get_round_trip(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Isolate the module-level cache so the test does not leak entries.
+    _reset_probe_cache(monkeypatch)
+    pdir = tmp_path / "dc-probe-abc"
+    pdir.mkdir()
+    claim = routes._probe_claim("clone1")
+    routes._probe_put("clone1", claim, str(pdir), {"/": "/x/home.png"}, "/proj/dist", "sig-a")
+    rec = routes._probe_get("clone1")
+    assert rec is not None
+    assert rec["dir"] == str(pdir)
+    assert rec["routes"] == {"/": "/x/home.png"}
+    assert rec["build_dir"] == "/proj/dist"
+    assert rec["served_signature"] == "sig-a"
+    # A shallow copy is returned: mutating it must not corrupt the stored record.
+    rec["routes"]["/"] = "tampered"
+    again = routes._probe_get("clone1")
+    assert again is not None and again["routes"]["/"] == "/x/home.png"
+    # Unknown handle -> None; a falsy handle is never stored.
+    assert routes._probe_get("nope") is None
+    routes._probe_put("", 0, str(pdir), {"/": "/x/home.png"}, "/proj/dist", "sig-a")
+    assert routes._probe_get("") is None
+
+
+def test_probe_put_overwrite_drops_prior_dir(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A stable "local:<path>" handle re-discovered before TTL overwrites its entry.
+    # The prior retained probe dir must be removed on overwrite so it is not
+    # orphaned until the sweep, while the NEW dir is kept intact.
+    _reset_probe_cache(monkeypatch)
+    first = tmp_path / "dc-probe-first"
+    first.mkdir()
+    second = tmp_path / "dc-probe-second"
+    second.mkdir()
+    handle = "local:/some/project"
+    # One claim shared by both writes, so this exercises _probe_put's own overwrite
+    # path rather than the eviction _probe_claim would otherwise have done first: a
+    # write carrying the CURRENT claim is not superseded and must install.
+    claim = routes._probe_claim(handle)
+    routes._probe_put(handle, claim, str(first), {"/": "/x/a.png"}, "/proj/dist", "sig-1")
+    routes._probe_put(handle, claim, str(second), {"/": "/x/b.png"}, "/proj/dist", "sig-2")
+    # Prior dir gone, new dir retained, cache points at the new record.
+    assert not first.exists()
+    assert second.exists()
+    rec = routes._probe_get(handle)
+    assert rec is not None and rec["dir"] == str(second)
+
+    # Re-storing the SAME dir (unchanged) must NOT delete it (no self-destruct).
+    routes._probe_put(handle, claim, str(second), {"/": "/x/b.png"}, "/proj/dist", "sig-3")
+    assert second.exists()
+    kept = routes._probe_get(handle)
+    assert kept is not None and kept["served_signature"] == "sig-3"
+
+
+def test_probe_get_expired_returns_none(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    _reset_probe_cache(monkeypatch)
+    routes._probe_put(
+        "clone1",
+        routes._probe_claim("clone1"),
+        str(tmp_path),
+        {"/": "/x/home.png"},
+        str(tmp_path),
+        "sig-a",
+    )
+    # The reuse window is the cutoff, not the retained dir's longer _CLONE_TTL_SEC
+    # lifetime: an entry whose dir is still on disk can already be too old to reuse.
+    # Age it just past the reuse window but well inside the dir's TTL, and _probe_get
+    # must still refuse it.
+    assert routes._PROBE_REUSE_TTL_SEC < routes._CLONE_TTL_SEC
+    routes._PROBE_CACHE["clone1"]["created_at"] = time.time() - routes._PROBE_REUSE_TTL_SEC - 60
+    assert routes._probe_get("clone1") is None
+
+
+def _build_tree(build: Path) -> None:
+    (build / "assets").mkdir(parents=True)
+    (build / "index.html").write_text("<html>v1</html>", encoding="utf-8")
+    (build / "assets" / "app.js").write_text("v1", encoding="utf-8")
+
+
+def test_served_signature_none_on_missing_and_moves_on_a_rebuild(tmp_path) -> None:
+    # The token must cover the BUILD OUTPUT, because that is what a reused PNG
+    # depicts: a rebuild rewrites index.html under an existing dist/, which leaves
+    # the project root's own st_mtime untouched.
+    assert routes._served_signature(tmp_path / "does-not-exist") is None
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    _build_tree(build)
+    sig = routes._served_signature(build)
+    assert sig is not None and isinstance(sig.digest, str)
+
+    root_before = os.stat(proj).st_mtime_ns
+    (build / "index.html").write_text("<html>v2</html>", encoding="utf-8")
+    _bump(build / "index.html")
+    assert os.stat(proj).st_mtime_ns == root_before
+    assert routes._served_signature(build) != sig
+
+
+def test_served_signature_moves_on_a_nested_in_place_overwrite(tmp_path) -> None:
+    # The hard case: a nested file overwritten under an UNCHANGED name. Neither the
+    # build dir's own mtime nor its direct entries' mtimes move (asserted), so a
+    # token that read only the top level would call this tree unchanged and /render
+    # would adopt the pre-edit PNG. The digest covers every file, so it moves.
+    build = tmp_path / "dist"
+    _build_tree(build)
+    sig = routes._served_signature(build)
+    top_before = [os.stat(build).st_mtime_ns, os.stat(build / "assets").st_mtime_ns]
+
+    (build / "assets" / "app.js").write_text("v2-different-length", encoding="utf-8")
+    _bump(build / "assets" / "app.js")
+    assert [os.stat(build).st_mtime_ns, os.stat(build / "assets").st_mtime_ns] == top_before
+    assert routes._served_signature(build) != sig
+
+
+def test_served_signature_moves_when_a_file_is_added_or_removed(tmp_path) -> None:
+    build = tmp_path / "dist"
+    _build_tree(build)
+    sig = routes._served_signature(build)
+    assert sig is not None
+    (build / "assets" / "extra.js").write_text("x", encoding="utf-8")
+    added = routes._served_signature(build)
+    assert added is not None and added.digest != sig.digest
+    (build / "assets" / "extra.js").unlink()
+    # Removing it again restores the original DIGEST: it describes the tree, not the
+    # history of edits to it. The digest is the only field asserted, for two reasons: it
+    # is the only one /render compares, and newest_mtime_ns is a high-water mark that
+    # also reads directory mtimes — so whether creating and removing extra.js leaves
+    # assets/'s own mtime raised depends on the filesystem's timestamp granularity
+    # versus how fast the test ran, which is not a property to assert either way.
+    back = routes._served_signature(build)
+    assert back is not None and back.digest == sig.digest
+
+
+def test_served_signature_refuses_a_tree_it_cannot_read_in_full(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A token over PART of a tree is no evidence about the rest, so an over-bound
+    # tree yields None (reuse refused) rather than a partial digest.
+    monkeypatch.setattr(routes, "_SIGNATURE_MAX_FILES", 2)
+    build = tmp_path / "dist"
+    build.mkdir()
+    for i in range(3):
+        (build / f"f{i}.js").write_text("x", encoding="utf-8")
+    assert routes._served_signature(build) is None
+    monkeypatch.setattr(routes, "_SIGNATURE_MAX_FILES", 3)
+    assert routes._served_signature(build) is not None
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="platform has no symlink")
+def test_served_signature_ignores_what_the_server_will_not_serve(tmp_path) -> None:
+    # capture-build.mjs's file index counts neither a symlinked dir nor a symlinked
+    # file as one, and skips dot-entries, so none of them is reachable over the
+    # preview server. The token must agree: signing them would only cause needless
+    # re-captures when something the critic never saw changed.
+    build = tmp_path / "dist"
+    _build_tree(build)
+    sig = routes._served_signature(build)
+    assert sig is not None
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "extra.js").write_text("x", encoding="utf-8")
+    try:
+        (build / "linked").symlink_to(outside, target_is_directory=True)
+        (build / "linked.js").symlink_to(outside / "extra.js")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted here")
+    (build / ".vite-manifest").write_text("x", encoding="utf-8")
+    (build / ".cache").mkdir()
+    (build / ".cache" / "x.js").write_text("x", encoding="utf-8")
+    # The DIGEST is what /render compares, and it is the only field that can hold still
+    # here: creating these entries moves dist/'s own mtime, and newest_mtime_ns reads
+    # directory mtimes on purpose so a deletion cannot hide from the discover-time
+    # mid-capture check.
+    unserved = routes._served_signature(build)
+    assert unserved is not None and unserved.digest == sig.digest
+
+    # And a change behind the symlink is likewise invisible, because the server would
+    # never have served it either.
+    (outside / "extra.js").write_text("changed-and-longer", encoding="utf-8")
+    _bump(outside / "extra.js")
+    behind = routes._served_signature(build)
+    assert behind is not None and behind.digest == sig.digest
+
+
+def test_probe_build_dir_rejects_a_path_outside_the_project(tmp_path) -> None:
+    # A manifest path is only ever stat()ed, but a token taken over an unrelated
+    # tree would stand still and permit reuse of a stale PNG for the whole TTL.
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    assert routes._probe_build_dir(str(proj / "dist"), proj) == proj / "dist"
+    assert routes._probe_build_dir(str(proj), proj) == proj
+    assert routes._probe_build_dir(str(tmp_path / "elsewhere"), proj) is None
+    assert routes._probe_build_dir("dist", proj) is None
+    assert routes._probe_build_dir(None, proj) is None
+    assert routes._probe_build_dir("", proj) is None
+    assert routes._probe_build_dir(123, proj) is None
+
+
+def test_probe_build_dir_matches_a_relative_project_dir(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # capture-build.mjs resolves a relative project path against the cwd it inherits
+    # from the gateway and reports an ABSOLUTE buildDir. Comparing that against the
+    # relative path as given would never match and would silently disable reuse.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "proj" / "dist").mkdir(parents=True)
+    # Derive from the real cwd, not from tmp_path: on macOS tmp_path sits under a
+    # symlinked /tmp, so the two spellings differ and a lexical check would not match.
+    reported = str(Path(os.getcwd()) / "proj" / "dist")
+    assert routes._probe_build_dir(reported, Path("proj")) == Path(reported)
+    assert routes._probe_build_dir(reported, Path("other")) is None
+
+
+def test_sweep_purges_probe_cache_entry_when_dir_swept(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    aged = time.time() - routes._CLONE_TTL_SEC - 60
+    probe_dir = tmp_path / "dc-probe-old"
+    probe_dir.mkdir()
+    os.utime(probe_dir, (aged, aged))
+    # A cache entry pointing at the soon-to-be-swept dir must be purged too, so the
+    # cache never hands /render a path for a directory that no longer exists.
+    routes._probe_put(
+        "clone-old",
+        routes._probe_claim("clone-old"),
+        str(probe_dir),
+        {"/": str(probe_dir / "home.png")},
+        str(tmp_path),
+        "sig-a",
+    )
+    routes._sweep_clones()
+    assert not probe_dir.exists()
+    assert routes._probe_get("clone-old") is None
+
+
+@pytest.mark.asyncio
+async def test_render_all_covered_skips_capture_subprocess(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # When the probe covered every pick, /render must NOT spawn the capture
+    # subprocess and must return the reused PNG paths in pick order.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "dc-clones" / "clone42"
+    proj.mkdir(parents=True)
+    probe_dir = tmp_path / "dc-probe-x"
+    probe_dir.mkdir()
+    home_png = probe_dir / "home.png"
+    about_png = probe_dir / "about.png"
+    home_png.write_bytes(b"home-bytes")
+    about_png.write_bytes(b"about-bytes")
+
+    called = {"run": 0}
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        called["run"] += 1
+        return (0, "{}", "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    # Cache keyed by the repo handle (clone id), token taken over the build output.
+    _cache_probe(
+        "clone42",
+        probe_dir,
+        proj.resolve(),
+        {"/": str(home_png), "/about": str(about_png)},
+    )
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "repo",
+                "handle": "clone42",
+                "picks": [
+                    {"ref": "/", "label": "Home"},
+                    {"ref": "/about", "label": "About"},
+                ],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    screens = rec["result"]["screens"]
+    assert [s["step"] for s in screens] == [1, 2]
+    # The capture subprocess was never invoked.
+    assert called["run"] == 0
+    # Every returned path is an ADOPTED COPY inside the never-swept dc-render-* dir,
+    # never the probe path itself: history keeps these paths forever while the
+    # dc-probe-* dir is TTL-swept, so serving the probe path would lose the images.
+    paths = [Path(s["path"]) for s in screens]
+    assert [p.parent.name.startswith("dc-render-") for p in paths] == [True, True]
+    assert {p.parent for p in paths} == {paths[0].parent}
+    assert str(home_png) not in [str(p) for p in paths]
+    # The copies carry the probe's bytes, in pick order.
+    assert [p.read_bytes() for p in paths] == [b"home-bytes", b"about-bytes"]
+    # Deleting the probe dir (a sweep, or a local re-discovery overwrite) leaves the
+    # saved critique's screenshots intact.
+    shutil.rmtree(probe_dir)
+    assert all(p.exists() for p in paths)
+
+
+@pytest.mark.asyncio
+async def test_render_mixed_reuse_captures_only_uncovered(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # One pick covered by the probe, one not: the capture --routes CSV must contain
+    # ONLY the uncovered ref, and the result merges reused + fresh in pick order.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "dc-clones" / "clone7"
+    proj.mkdir(parents=True)
+    probe_dir = tmp_path / "dc-probe-y"
+    probe_dir.mkdir()
+    home_png = probe_dir / "home.png"
+    home_png.write_bytes(b"home-bytes")
+
+    seen_cmds: list[list[str]] = []
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        seen_cmds.append(cmd)
+        # The fresh capture renders the uncovered route /about.
+        return (0, json.dumps({"screens": [{"route": "/about", "path": "/x/about.png"}]}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    _cache_probe("clone7", probe_dir, proj.resolve(), {"/": str(home_png)})
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "repo",
+                "handle": "clone7",
+                "picks": [
+                    {"ref": "/", "label": "Home"},
+                    {"ref": "/about", "label": "About"},
+                ],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    # The single capture call requested ONLY the uncovered ref.
+    assert len(seen_cmds) == 1
+    routes_flag = next(a for a in seen_cmds[0] if a.startswith("--routes="))
+    assert routes_flag == "--routes=/about"
+    # Reused (step 1) then fresh (step 2), in original pick order. The reused screen
+    # is served from the copy adopted into the same dc-render-* dir as the fresh
+    # capture, carrying the probe's bytes — never from the probe path itself.
+    screens = rec["result"]["screens"]
+    assert screens[1] == {"step": 2, "label": "About", "path": "/x/about.png"}
+    assert screens[0]["step"] == 1 and screens[0]["label"] == "Home"
+    adopted = Path(screens[0]["path"])
+    assert adopted.parent.name.startswith("dc-render-")
+    assert adopted.read_bytes() == b"home-bytes"
+    assert str(adopted) != str(home_png)
+
+
+@pytest.mark.asyncio
+async def test_render_covered_png_deleted_falls_back_to_fresh(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The cache holds a route->png for a pick, but the PNG was deleted from disk
+    # between /discover and /render (e.g. swept). That pick must be treated as
+    # UNCOVERED — it lands in the fresh capture --routes CSV — rather than reused.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "dc-clones" / "clone-gone"
+    proj.mkdir(parents=True)
+    probe_dir = tmp_path / "dc-probe-gone"
+    probe_dir.mkdir()
+    # The cached PNG for "/" is recorded but NEVER written to disk (deleted/missing).
+    home_png = probe_dir / "home.png"
+
+    seen_cmds: list[list[str]] = []
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        seen_cmds.append(cmd)
+        return (0, json.dumps({"screens": [{"route": "/", "path": "/x/home-fresh.png"}]}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    _cache_probe("clone-gone", probe_dir, proj.resolve(), {"/": str(home_png)})
+    # Precondition: the cache references a path that does not exist on disk.
+    assert not home_png.exists()
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "repo",
+                "handle": "clone-gone",
+                "picks": [{"ref": "/", "label": "Home"}],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    # The pick was NOT reused: the capture subprocess ran with the pick in --routes.
+    assert len(seen_cmds) == 1
+    routes_flag = next(a for a in seen_cmds[0] if a.startswith("--routes="))
+    assert routes_flag == "--routes=/"
+    # The result serves the FRESH capture, not the missing probe PNG.
+    paths = [s["path"] for s in rec["result"]["screens"]]
+    assert paths == ["/x/home-fresh.png"]
+    assert str(home_png) not in paths
+
+
+def test_adopt_reused_copies_into_out_dir_and_omits_failures(tmp_path) -> None:
+    # The adopted copy always lands INSIDE out_dir (only the source basename is
+    # used, so a manifest path cannot escape it) and carries the source bytes.
+    probe_dir = tmp_path / "dc-probe-a"
+    probe_dir.mkdir()
+    out_dir = tmp_path / "dc-render-a"
+    out_dir.mkdir()
+    good = probe_dir / "build-home-1.png"
+    good.write_bytes(b"good")
+    escape = probe_dir / "esc.png"
+    escape.write_bytes(b"esc")
+
+    copies = routes._adopt_reused(
+        {
+            "/": str(good),
+            "/esc": f"{probe_dir}/../dc-probe-a/esc.png",
+            "/missing": str(probe_dir / "not-there.png"),
+        },
+        out_dir,
+    )
+    # A source that cannot be copied is OMITTED rather than yielding a path to nothing.
+    # The handler reads that omission as "this ref is uncovered" and captures it fresh
+    # (see test_render_failed_adoption_falls_back_to_a_fresh_capture).
+    assert "/missing" not in copies
+    for ref in ("/", "/esc"):
+        dest = Path(copies[ref])
+        assert dest.parent == out_dir
+        assert dest.exists()
+    assert Path(copies["/"]).read_bytes() == b"good"
+
+
+@pytest.mark.asyncio
+async def test_render_failed_adoption_falls_back_to_a_fresh_capture(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Every pick was covered, so on the happy path no capture runs — but the probe dir
+    # vanishes before the copy (a sweep, or a concurrent local re-discovery). A pick
+    # whose adoption failed is one nothing has rendered yet, so it must be DEMOTED to
+    # uncovered and captured fresh. Reporting "could not see" instead would turn a
+    # render that always worked before into zero screens.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "dc-clones" / "clone-race"
+    proj.mkdir(parents=True)
+    probe_dir = tmp_path / "dc-probe-race"
+    probe_dir.mkdir()
+    home_png = probe_dir / "home.png"
+    home_png.write_bytes(b"x")
+
+    seen_cmds: list[list[str]] = []
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        seen_cmds.append(cmd)
+        return (0, json.dumps({"screens": [{"route": "/", "path": "/x/home-fresh.png"}]}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+
+    real_adopt = routes._adopt_reused
+
+    def racing_adopt(reused, out_dir):  # type: ignore[no-untyped-def]
+        # Stand in for the probe dir being removed between the handler's exists()
+        # check and the copy: every copy fails, so nothing is adopted.
+        shutil.rmtree(probe_dir, ignore_errors=True)
+        return real_adopt(reused, out_dir)
+
+    monkeypatch.setattr(routes, "_adopt_reused", racing_adopt)
+    _cache_probe("clone-race", probe_dir, proj.resolve(), {"/": str(home_png)})
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "repo",
+                "handle": "clone-race",
+                "picks": [{"ref": "/", "label": "Home"}],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    # The un-adoptable pick was captured fresh rather than reported unseeable.
+    assert len(seen_cmds) == 1
+    assert next(a for a in seen_cmds[0] if a.startswith("--routes=")) == "--routes=/"
+    assert [s["path"] for s in rec["result"]["screens"]] == ["/x/home-fresh.png"]
+    assert rec["result"]["couldNotSee"] == []
+
+
+@pytest.mark.asyncio
+async def test_render_local_does_not_read_a_foreign_handles_cache(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A local render takes `directory` from `value` when the handle is not a
+    # "local:<path>" one, so the cache lookup must key off the VALIDATED target. Key
+    # it off the raw handle and a local render for project B reads repo-A's entry and
+    # hands back A's screenshots as B's screens.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    other = tmp_path / "dc-clones" / "clone-a"
+    other.mkdir(parents=True)
+    target = tmp_path / "project-b"
+    target.mkdir()
+    probe_dir = tmp_path / "dc-probe-a"
+    probe_dir.mkdir()
+    foreign_png = probe_dir / "home.png"
+    foreign_png.write_bytes(b"project-a-bytes")
+
+    seen_cmds: list[list[str]] = []
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        seen_cmds.append(cmd)
+        return (0, json.dumps({"screens": [{"route": "/", "path": "/x/b-fresh.png"}]}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    # Repo A's probe is cached under its clone id, exactly as /discover records it.
+    _cache_probe("clone-a", probe_dir, other.resolve(), {"/": str(foreign_png)})
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "local",
+                "value": str(target),
+                "handle": "clone-a",
+                "picks": [{"ref": "/", "label": "Home"}],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    # The pick went to a fresh capture of project B; none of A's bytes came back.
+    assert len(seen_cmds) == 1
+    assert str(target) in seen_cmds[0]
+    paths = [s["path"] for s in rec["result"]["screens"]]
+    assert paths == ["/x/b-fresh.png"]
+    assert str(foreign_png) not in paths
+    assert not any((p / "reused-0-home.png").exists() for p in tmp_path.glob("dc-render-*"))
+
+
+@pytest.mark.asyncio
+async def test_render_local_reuses_its_own_cache_entry(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The other side of the key derivation: a local render whose validated target IS
+    # the discovered project must still find its entry, whether the client echoes the
+    # "local:<path>" handle back or sends only `value`.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    target = tmp_path / "project-b"
+    target.mkdir()
+    probe_dir = tmp_path / "dc-probe-b"
+    probe_dir.mkdir()
+    home_png = probe_dir / "home.png"
+    home_png.write_bytes(b"project-b-bytes")
+
+    called = {"run": 0}
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        called["run"] += 1
+        return (0, "{}", "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    _cache_probe(f"local:{target}", probe_dir, target, {"/": str(home_png)})
+
+    for handle in (f"local:{target}", ""):
+        resp = await routes._handle_render(
+            _Req(
+                {
+                    "kind": "local",
+                    "value": str(target),
+                    "handle": handle,
+                    "picks": [{"ref": "/", "label": "Home"}],
+                }
+            )  # type: ignore[arg-type]
+        )
+        assert resp.status == 200
+        assert isinstance(resp.body, bytes)
+        rec = await _drain(json.loads(resp.body)["job"])
+        assert rec is not None and rec["status"] == "done"
+        paths = [s["path"] for s in rec["result"]["screens"]]
+        assert len(paths) == 1
+        assert Path(paths[0]).read_bytes() == b"project-b-bytes"
+        assert Path(paths[0]).parent.name.startswith("dc-render-")
+    assert called["run"] == 0
+
+
+@pytest.mark.asyncio
+async def test_render_past_the_reuse_window_recaptures(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A build-output token cannot see data a built SPA fetches at runtime, so the
+    # reuse window — not the retained dir's lifetime — is what bounds how stale a
+    # reused capture can be. An entry aged past it must be re-captured even though its
+    # dir, its PNG and its signature are all still perfectly valid.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "dc-clones" / "clone-aged"
+    proj.mkdir(parents=True)
+    probe_dir = tmp_path / "dc-probe-aged"
+    probe_dir.mkdir()
+    home_png = probe_dir / "home.png"
+    home_png.write_bytes(b"stale-bytes")
+
+    seen_cmds: list[list[str]] = []
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        seen_cmds.append(cmd)
+        return (0, json.dumps({"screens": [{"route": "/", "path": "/x/home-fresh.png"}]}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    _cache_probe("clone-aged", probe_dir, proj.resolve(), {"/": str(home_png)})
+    aged_by = routes._PROBE_REUSE_TTL_SEC + 60
+    # The age used here must land strictly INSIDE the dir's _CLONE_TTL_SEC lifetime,
+    # or the test would pass just as well with the two windows collapsed into one.
+    assert aged_by < routes._CLONE_TTL_SEC
+    routes._PROBE_CACHE["clone-aged"]["created_at"] = time.time() - aged_by
+    assert home_png.exists()
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "repo",
+                "handle": "clone-aged",
+                "picks": [{"ref": "/", "label": "Home"}],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    assert len(seen_cmds) == 1
+    assert next(a for a in seen_cmds[0] if a.startswith("--routes=")) == "--routes=/"
+    assert [s["path"] for s in rec["result"]["screens"]] == ["/x/home-fresh.png"]
+
+
+@pytest.mark.asyncio
+async def test_render_unknown_signature_is_not_a_match(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # An unreadable build output yields no token, and "unknown" is not "unchanged":
+    # a build dir deleted between /discover and /render is no evidence the bytes the
+    # probe captured still stand, so reuse must be refused rather than permitted.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "dc-clones" / "clone-unknown"
+    proj.mkdir(parents=True)
+    probe_dir = tmp_path / "dc-probe-unknown"
+    probe_dir.mkdir()
+    home_png = probe_dir / "home.png"
+    home_png.write_bytes(b"x")
+
+    seen_cmds: list[list[str]] = []
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        seen_cmds.append(cmd)
+        return (0, json.dumps({"screens": [{"route": "/", "path": "/x/home-fresh.png"}]}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    build = _cache_probe("clone-unknown", probe_dir, proj.resolve(), {"/": str(home_png)})
+    shutil.rmtree(build)
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "repo",
+                "handle": "clone-unknown",
+                "picks": [{"ref": "/", "label": "Home"}],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    # Reuse was refused: the pick went to a fresh capture.
+    assert len(seen_cmds) == 1
+    assert next(a for a in seen_cmds[0] if a.startswith("--routes=")) == "--routes=/"
+    assert [s["path"] for s in rec["result"]["screens"]] == ["/x/home-fresh.png"]
+
+
+@pytest.mark.asyncio
+async def test_render_staleness_mismatch_recaptures_all(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # An IN-PLACE rebuild between /discover and /render must bypass reuse so ALL
+    # picks are re-captured. This is the case the guard exists for and the one a
+    # token over the project root would miss: a rebuild writes underneath an
+    # already-existing dist/, which leaves the root's own st_mtime untouched (the
+    # test asserts that below), so only a token over the build output catches it.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "dc-clones" / "clone9"
+    proj.mkdir(parents=True)
+    probe_dir = tmp_path / "dc-probe-z"
+    probe_dir.mkdir()
+    home_png = probe_dir / "home.png"
+    home_png.write_bytes(b"x")
+
+    seen_cmds: list[list[str]] = []
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        seen_cmds.append(cmd)
+        return (
+            0,
+            json.dumps(
+                {
+                    "screens": [
+                        {"route": "/", "path": "/x/home-fresh.png"},
+                        {"route": "/about", "path": "/x/about.png"},
+                    ]
+                }
+            ),
+            "",
+        )
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    build = _cache_probe("clone9", probe_dir, proj.resolve(), {"/": str(home_png)})
+    # Rebuild in place: index.html is rewritten, and nothing is added to or removed
+    # from the project root, so the root's own mtime does not move.
+    root_mtime = os.stat(proj).st_mtime_ns
+    (build / "index.html").write_text("<html>v2</html>", encoding="utf-8")
+    _bump(build / "index.html")
+    assert os.stat(proj).st_mtime_ns == root_mtime
+
+    resp = await routes._handle_render(
+        _Req(
+            {
+                "kind": "repo",
+                "handle": "clone9",
+                "picks": [
+                    {"ref": "/", "label": "Home"},
+                    {"ref": "/about", "label": "About"},
+                ],
+            }
+        )  # type: ignore[arg-type]
+    )
+    assert resp.status == 200
+    assert isinstance(resp.body, bytes)
+    rec = await _drain(json.loads(resp.body)["job"])
+    assert rec is not None and rec["status"] == "done"
+    # All picks re-captured (the CSV contains both refs); no probe PNG reused.
+    assert len(seen_cmds) == 1
+    routes_flag = next(a for a in seen_cmds[0] if a.startswith("--routes="))
+    assert routes_flag == "--routes=/,/about"
+    paths = [s["path"] for s in rec["result"]["screens"]]
+    assert paths == ["/x/home-fresh.png", "/x/about.png"]
+    assert str(home_png) not in paths
+
+
+@pytest.mark.asyncio
+async def test_discover_from_dir_retains_probe_and_caches(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A probe that produced a usable screen must RETAIN its dir and cache the
+    # route->PNG map keyed by the handle.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    build.mkdir(parents=True)
+    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (0, json.dumps({"framework": "", "routes": [{"path": "/"}]}), "")
+        # Probe manifest: the captured PNG path lives inside the probe --out dir, and
+        # buildDir names the already-built output the capture served. fullPageCoverage
+        # marks the page as having fit the viewport, so the PNG is reusable.
+        out_dir = next(a[len("--out=") :] for a in cmd if a.startswith("--out="))
+        png = os.path.join(out_dir, "build-home.png")
+        return (
+            0,
+            json.dumps(
+                {
+                    "buildDir": str(build),
+                    "screens": [{"route": "/", "path": png, "fullPageCoverage": True}],
+                }
+            ),
+            "",
+        )
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    out = await routes._discover_from_dir(proj, handle="clone-keep")
+    assert out["handle"] == "clone-keep"
+    rec = routes._probe_get("clone-keep")
+    assert rec is not None
+    assert "/" in rec["routes"]
+    # The token is recorded over the build output, so /render compares the bytes the
+    # reused PNG actually depicts rather than the project root's directory entry.
+    assert rec["build_dir"] == str(build)
+    fresh = routes._served_signature(build)
+    assert fresh is not None and rec["served_signature"] == fresh.digest
+    # The retained probe dir still exists on disk and is a dc-probe-* dir.
+    assert Path(rec["dir"]).exists()
+    assert "dc-probe-" in Path(rec["dir"]).name
+
+
+def test_probe_claim_drops_the_entry_and_its_dir(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    _reset_probe_cache(monkeypatch)
+    pdir = tmp_path / "dc-probe-e"
+    pdir.mkdir()
+    routes._probe_put(
+        "h", routes._probe_claim("h"), str(pdir), {"/": "/x/a.png"}, "/proj/dist", "sig-a"
+    )
+    routes._probe_claim("h")
+    assert routes._probe_get("h") is None
+    assert not pdir.exists()
+    # Claiming an unknown handle is a no-op eviction, not an error; a falsy handle has
+    # no /render counterpart and yields the sentinel claim.
+    routes._probe_claim("nope")
+    assert routes._probe_claim("") == 0
+
+
+def test_probe_claim_stamps_strictly_increase_per_handle(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # monotonic_ns is only non-decreasing, so two claims inside one clock tick would
+    # compare equal and _probe_put would read the older one as "not superseded". Seeding
+    # a stamp above any real reading forces that tie-break branch deterministically,
+    # without patching the clock the rest of the process shares.
+    _reset_probe_cache(monkeypatch)
+    seeded = 2**62
+    routes._PROBE_STARTS["h"] = seeded
+    assert routes._probe_claim("h") == seeded + 1
+    assert routes._probe_claim("h") == seeded + 2
+
+
+def test_probe_put_refuses_a_write_a_newer_discovery_superseded(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Two discoveries of the same stable "local:<path>" handle interleave and finish out
+    # of order. The OLDER capture must not land on top of the newer one: its route map
+    # can differ in ways a staleness token cannot see (the newer probe may have withheld
+    # a route it found behind a login gate, and an auth state is not served bytes), so
+    # last-writer-wins would hand /render a screenshot the newer discovery rejected.
+    _reset_probe_cache(monkeypatch)
+    handle = "local:/some/project"
+    old_dir = tmp_path / "dc-probe-old"
+    old_dir.mkdir()
+    new_dir = tmp_path / "dc-probe-new"
+    new_dir.mkdir()
+
+    old_claim = routes._probe_claim(handle)
+    new_claim = routes._probe_claim(handle)
+    # The newer discovery finishes first.
+    routes._probe_put(handle, new_claim, str(new_dir), {"/": "/x/new.png"}, "/proj/dist", "sig-new")
+    # Then the older one finishes and tries to write.
+    routes._probe_put(handle, old_claim, str(old_dir), {"/": "/x/old.png"}, "/proj/dist", "sig-old")
+
+    rec = routes._probe_get(handle)
+    assert rec is not None
+    assert rec["dir"] == str(new_dir)
+    assert rec["routes"] == {"/": "/x/new.png"}
+    assert rec["served_signature"] == "sig-new"
+    # The newer dir survives; the refused write drops its OWN dir rather than leaking it
+    # to the TTL sweep, since nothing may reuse a capture that lost the ordering.
+    assert new_dir.exists()
+    assert not old_dir.exists()
+
+    # And the guard is not one-shot: the newest claim can still write afterwards.
+    newer_dir = tmp_path / "dc-probe-newer"
+    newer_dir.mkdir()
+    routes._probe_put(
+        handle, routes._probe_claim(handle), str(newer_dir), {"/": "/x/n.png"}, "/p/dist", "sig-n"
+    )
+    latest = routes._probe_get(handle)
+    assert latest is not None and latest["dir"] == str(newer_dir)
+
+
+def test_sweep_bounds_the_ordering_stamp_map(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A stamp is not tied to a retained dir, so without its own bound the map would grow
+    # one entry per repo discovery forever (each is a fresh clone id).
+    _reset_probe_cache(monkeypatch)
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    fresh = routes._probe_claim("clone-fresh")
+    routes._PROBE_STARTS["clone-ancient"] = fresh - int((routes._CLONE_TTL_SEC + 60) * 1e9)
+    routes._sweep_clones()
+    assert "clone-fresh" in routes._PROBE_STARTS
+    assert "clone-ancient" not in routes._PROBE_STARTS
+
+
+@pytest.mark.asyncio
+async def test_rediscovery_with_nothing_reusable_evicts_the_prior_entry(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A stable "local:<path>" handle is re-discovered in place. If THIS discovery finds
+    # nothing reusable — every screen now behind a gate, the probe timed out, the build
+    # output gone — the earlier entry must not survive as a fallback, or /render would
+    # serve the older capture for a project whose discovery just failed. The prior
+    # token can still match, so nothing downstream would notice.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    build.mkdir(parents=True)
+    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+    old_probe = tmp_path / "dc-probe-old"
+    old_probe.mkdir()
+    old_png = old_probe / "home.png"
+    old_png.write_bytes(b"stale")
+    handle = f"local:{proj}"
+    _cache_probe(handle, old_probe, proj, {"/": str(old_png)})
+    assert routes._probe_get(handle) is not None
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (0, json.dumps({"framework": "", "routes": [{"path": "/"}]}), "")
+        # Re-discovery renders nothing usable this time — the build output is intact,
+        # so the OLD entry's token would still match if it survived.
+        return (0, json.dumps({"buildDir": str(build), "screens": []}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    await routes._discover_from_dir(proj, handle=handle)
+    assert routes._probe_get(handle) is None
+    assert not old_probe.exists()
+    assert not any(p.name.startswith("dc-probe-") for p in tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_rediscovery_evicts_even_when_it_never_reaches_the_probe(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The eviction runs FIRST, so it cannot be skipped by a discovery that dies before
+    # any store: a node/git failure, a timeout, an exception the job wrapper catches.
+    # A stale entry surviving one of those is invisible downstream, because its token
+    # can still match and /render would serve the earlier capture.
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    build.mkdir(parents=True)
+    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+    handle = f"local:{proj}"
+
+    for break_it in ("no-node", "raises"):
+        old_probe = tmp_path / f"dc-probe-{break_it}"
+        old_probe.mkdir()
+        _cache_probe(handle, old_probe, proj, {"/": str(old_probe / "home.png")})
+        assert routes._probe_get(handle) is not None
+
+        if break_it == "no-node":
+            monkeypatch.setattr(routes, "_node", lambda: None)
+            await routes._discover_from_dir(proj, handle=handle)
+        else:
+            monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+
+            async def boom(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+                raise RuntimeError("discovery died")
+
+            monkeypatch.setattr(routes, "_run", boom)
+            with pytest.raises(RuntimeError):
+                await routes._discover_from_dir(proj, handle=handle)
+
+        assert routes._probe_get(handle) is None, break_it
+        assert not old_probe.exists(), break_it
+
+
+@pytest.mark.asyncio
+async def test_rediscovery_with_no_routes_evicts_the_prior_entry(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The same must hold when discover-routes itself returns nothing, which skips the
+    # probe block entirely — the eviction is a single exit precisely so this path cannot
+    # forget it.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    old_probe = tmp_path / "dc-probe-old"
+    old_probe.mkdir()
+    handle = f"local:{proj}"
+    _cache_probe(handle, old_probe, proj, {"/": str(old_probe / "home.png")})
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        return (0, json.dumps({"framework": "", "routes": []}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    await routes._discover_from_dir(proj, handle=handle)
+    assert routes._probe_get(handle) is None
+    assert not old_probe.exists()
+
+
+@pytest.mark.asyncio
+async def test_discover_does_not_cache_when_a_file_is_deleted_mid_capture(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A DELETION leaves no file behind to carry a recent mtime, so a high-water mark
+    # over files alone would miss a served file removed while the probe was capturing —
+    # and /render would then reuse a PNG depicting content that is gone. The mark has to
+    # read directory mtimes too. Only the directory's mtime is moved here, so the test
+    # fails if that stat is dropped.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    (build / "assets").mkdir(parents=True)
+    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+    (build / "assets" / "legacy.js").write_text("old", encoding="utf-8")
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (0, json.dumps({"framework": "", "routes": [{"path": "/"}]}), "")
+        out_dir = next(a[len("--out=") :] for a in cmd if a.startswith("--out="))
+        # Stand in for a build's cleanup step removing a served file mid-capture. No
+        # remaining file's mtime moves; _bump makes the directory's move
+        # deterministically rather than relying on the filesystem's mtime granularity.
+        (build / "assets" / "legacy.js").unlink()
+        _bump(build / "assets", 60.0)
+        return (
+            0,
+            json.dumps(
+                {
+                    "buildDir": str(build),
+                    "screens": [{"route": "/", "path": os.path.join(out_dir, "home.png")}],
+                }
+            ),
+            "",
+        )
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    out = await routes._discover_from_dir(proj, handle="clone-deleting-build")
+    assert out["screens"][0]["canSee"] is True
+    assert routes._probe_get("clone-deleting-build") is None
+    assert not any(p.name.startswith("dc-probe-") for p in tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_discover_does_not_cache_when_a_build_lands_mid_capture(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The token can only be taken AFTER the capture, because the manifest is what names
+    # the build dir. So a build finishing while the probe screenshots would leave the
+    # token describing the NEW bytes and the PNGs depicting the old ones — and /render
+    # would find the token matching and serve them. Nothing may be cached in that case.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    build.mkdir(parents=True)
+    (build / "index.html").write_text("<html>v1</html>", encoding="utf-8")
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (0, json.dumps({"framework": "", "routes": [{"path": "/"}]}), "")
+        out_dir = next(a[len("--out=") :] for a in cmd if a.startswith("--out="))
+        # Stand in for `vite build` completing while the probe is screenshotting: the
+        # served bytes are rewritten after the capture started. _bump makes the mtime
+        # move deterministically rather than relying on the clock's granularity.
+        (build / "index.html").write_text("<html>v2</html>", encoding="utf-8")
+        _bump(build / "index.html", 60.0)
+        return (
+            0,
+            json.dumps(
+                {
+                    "buildDir": str(build),
+                    "screens": [{"route": "/", "path": os.path.join(out_dir, "home.png")}],
+                }
+            ),
+            "",
+        )
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    out = await routes._discover_from_dir(proj, handle="clone-racing-build")
+    # Discovery itself still succeeds and the route is still seeable.
+    assert out["screens"][0]["canSee"] is True
+    # Nothing cached, and no probe dir left for the sweep.
+    assert routes._probe_get("clone-racing-build") is None
+    assert not any(p.name.startswith("dc-probe-") for p in tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_discover_does_not_cache_a_gated_screen(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A screen captured under a login / consent overlay must NOT be cached for reuse.
+    # /render raises its gate warning from the capture it runs, and a fully-covered
+    # render runs no capture — so reusing a gate screenshot would show the critic the
+    # wall with the warning silently missing. The clean route still caches, and the
+    # check keys on the per-screen `overlay`, not the `blockedBy` summary (absent here,
+    # since the script only sets that when one overlay covers most screens).
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    build.mkdir(parents=True)
+    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (
+                0,
+                json.dumps({"framework": "", "routes": [{"path": "/"}, {"path": "/app"}]}),
+                "",
+            )
+        out_dir = next(a[len("--out=") :] for a in cmd if a.startswith("--out="))
+        return (
+            0,
+            json.dumps(
+                {
+                    "buildDir": str(build),
+                    "blockedBy": None,
+                    "screens": [
+                        {
+                            "route": "/",
+                            "path": os.path.join(out_dir, "home.png"),
+                            "fullPageCoverage": True,
+                        },
+                        {
+                            "route": "/app",
+                            "path": os.path.join(out_dir, "app.png"),
+                            "fullPageCoverage": True,
+                            "overlay": {"text": "Sign in to continue", "area": 0.8},
+                        },
+                    ],
+                }
+            ),
+            "",
+        )
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    out = await routes._discover_from_dir(proj, handle="clone-gated")
+    # Discovery still reports BOTH routes as seeable — the gated one did render.
+    assert {s["ref"]: s["canSee"] for s in out["screens"]} == {"/": True, "/app": True}
+    rec = routes._probe_get("clone-gated")
+    assert rec is not None
+    # ...but only the clean route is offered for reuse.
+    assert list(rec["routes"]) == ["/"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flag", [False, None])
+async def test_discover_does_not_cache_a_screen_taller_than_the_viewport(monkeypatch, tmp_path, flag) -> None:  # type: ignore[no-untyped-def]
+    # The probe captures WITHOUT --full and /render captures WITH it, so a probe PNG of
+    # a page taller than the viewport holds strictly less than the render it would
+    # replace. Reuse is therefore confined to screens capture-build.mjs certified as
+    # fullPageCoverage; an overflowing route is left uncovered and /render captures it
+    # fresh. `None` stands for a manifest that predates the flag: absent must read as
+    # "cannot vouch", never as permission to reuse.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    build = proj / "dist"
+    build.mkdir(parents=True)
+    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (
+                0,
+                json.dumps({"framework": "", "routes": [{"path": "/"}, {"path": "/tall"}]}),
+                "",
+            )
+        out_dir = next(a[len("--out=") :] for a in cmd if a.startswith("--out="))
+        tall: dict[str, object] = {
+            "route": "/tall",
+            "path": os.path.join(out_dir, "tall.png"),
+        }
+        if flag is not None:
+            tall["fullPageCoverage"] = flag
+        return (
+            0,
+            json.dumps(
+                {
+                    "buildDir": str(build),
+                    "screens": [
+                        {
+                            "route": "/",
+                            "path": os.path.join(out_dir, "home.png"),
+                            "fullPageCoverage": True,
+                        },
+                        tall,
+                    ],
+                }
+            ),
+            "",
+        )
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    out = await routes._discover_from_dir(proj, handle="clone-tall")
+    # The tall route still RENDERED, so discovery reports it as seeable; only its
+    # reusability is withheld.
+    assert {s["ref"]: s["canSee"] for s in out["screens"]} == {"/": True, "/tall": True}
+    rec = routes._probe_get("clone-tall")
+    assert rec is not None
+    assert list(rec["routes"]) == ["/"]
+
+
+@pytest.mark.asyncio
+async def test_discover_from_dir_drops_probe_when_build_dir_is_foreign(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A manifest naming a build dir OUTSIDE the project must cache nothing: a token
+    # taken over an unrelated tree would stand still and permit reuse of a stale PNG
+    # for the whole TTL. The probe dir is dropped rather than leaked to the sweep.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    foreign = tmp_path / "elsewhere"
+    foreign.mkdir()
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (0, json.dumps({"framework": "", "routes": [{"path": "/"}]}), "")
+        out_dir = next(a[len("--out=") :] for a in cmd if a.startswith("--out="))
+        png = os.path.join(out_dir, "build-home.png")
+        return (
+            0,
+            json.dumps({"buildDir": str(foreign), "screens": [{"route": "/", "path": png}]}),
+            "",
+        )
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    out = await routes._discover_from_dir(proj, handle="clone-foreign")
+    # Discovery still succeeds and the route is still reported seeable — only the
+    # reuse cache is withheld.
+    assert out["screens"][0]["canSee"] is True
+    assert routes._probe_get("clone-foreign") is None
+    assert not any(p.name.startswith("dc-probe-") for p in tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_discover_from_dir_drops_empty_probe(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A probe with no usable screen must delete its dir immediately and cache nothing.
+    monkeypatch.setattr(routes, "_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(routes, "_uploads_dir", lambda: tmp_path)
+    _reset_probe_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+
+    async def fake_run(cmd, timeout, env=None):  # type: ignore[no-untyped-def]
+        if any("discover-routes" in c for c in cmd):
+            return (0, json.dumps({"framework": "", "routes": [{"path": "/"}]}), "")
+        # No screens -> nothing usable to retain.
+        return (0, json.dumps({"screens": []}), "")
+
+    monkeypatch.setattr(routes, "_run", fake_run)
+    await routes._discover_from_dir(proj, handle="clone-empty")
+    assert routes._probe_get("clone-empty") is None
+    # No retained dc-probe-* dir was left behind.
+    assert not any(p.name.startswith("dc-probe-") for p in tmp_path.iterdir())


### PR DESCRIPTION
Closes #6416.

## Summary
The design-critique backend captures screens twice per critique: `/discover` runs `capture-build.mjs` as a probe over the first ≤20 routes to decide `canSee`, then deletes the probe PNGs; `/render` re-captures the user's picks. Capture is the slowest step, so a critique pays that cost twice.

This change retains the probe dir when it produced usable screens, caches a route→PNG map, and makes `/render` reuse a probe capture for any picked route the probe already covered — capturing only the uncovered picks, and skipping the capture subprocess entirely when every pick is covered.

## Implementation (`src/kiro_crew/apps/builtins/design_critique/backend/routes.py`)
- A `_PROBE_CACHE` guarded by `_PROBE_CACHE_LOCK` (TTL = `_CLONE_TTL_SEC`), mirroring the existing `_JOBS` registry pattern, with `_probe_put` / `_probe_get` helpers.
- **The freshness token is taken over the build output, not the project root** (`_served_signature`). `capture-build.mjs` never builds — it serves whatever already exists under a `dist/` / `storybook-static/` — so what a reused PNG depicts is that directory's contents. A project root's own `st_mtime` moves only when its *direct* entries change, and a rebuild writes underneath an already-existing `dist/`, so a root-mtime token would miss the one case the guard exists for. The token digests **every file the preview server will actually serve** (relative path, size, `st_mtime_ns`, walked in sorted order), so any change to the served bytes moves it — including an in-place overwrite of a nested file under an unchanged name.
- **"Will actually serve" is `capture-build.mjs`'s own index**, and the two enumerations have to agree: its readdir `Dirent` test counts neither a symlinked directory nor a symlinked file as one, and it skips dot-entries, so none of those is reachable over the server and none is signed here. Signing what is not served yields needless re-captures; missing something that *is* served would let a stale PNG through.
- **A served set that cannot be read in full yields no token at all, rather than a partial one:** missing, unreadable, or over `_SIGNATURE_MAX_FILES`. No token ⇒ no reuse, because a token over part of a tree is no evidence about the rest. One bounded walk is far cheaper than the browser capture the reuse skips. The token is *metadata, not content*: a rewrite that keeps a file's byte count identical **and** restores its original mtime is not detected. Hashing the bytes would mean reading the whole build output on every `/render` — which can cost more than the capture the reuse saves — and the reuse window already bounds how long such a rewrite could matter.
- **A build that lands mid-capture caches nothing.** The token can only be taken *after* the capture, since the manifest is what names the build dir — so a build finishing while the probe screenshots would leave the token describing the new bytes and the PNGs depicting the old ones, and `/render` would find it matching and serve them. Discover records the wall clock before the capture starts and refuses to cache if anything under the build dir was written at or after that instant. The high-water mark reads **directory** mtimes as well as file mtimes: a deletion leaves no file behind to carry a recent one, so a served file removed mid-capture would otherwise escape the check and `/render` would reuse a PNG depicting content that is gone. Directory mtimes stay out of the digest itself, which describes the served bytes.
- **A screen the probe caught under a login / consent / onboarding overlay is not cached for reuse.** `/render` raises its gate warning from the capture it runs, and a fully-covered render runs no capture, so reusing a gate screenshot would show the critic the wall with that warning silently missing. Leaving the route uncovered restores both. The check reads the per-screen `overlay`, not the manifest's `blockedBy` summary — the script only sets `blockedBy` when one overlay covers ≥60% of screens, so a single gated route would slip past it. Discovery still reports the route as seeable; only reuse is withheld.
- **Reuse is confined to screens a viewport capture already covered in full** (`fullPageCoverage`). This is what makes reuse lossless rather than merely fast; see the section below.
- **The reuse window is separated from the retained dir's lifetime** (`_PROBE_REUSE_TTL_SEC`, 10 min, vs the dir's `_CLONE_TTL_SEC`, ~1h). A filesystem token cannot see everything a capture depends on — a built SPA may fetch live data at runtime — so the window, not the dir's TTL, is what bounds how stale a reused capture can be. It is sized to the interactive discover → pick → render flow; past it the pick is captured fresh, which is cheap insurance exactly when the gap has grown big enough to matter. The dir keeps the longer lifetime so `_sweep_clones` stays the single owner of removing it.
- **The cache key comes from the target `/render` just validated, never from the raw handle.** A local render takes its `directory` from `value` whenever the handle is not a `local:<path>` one, so keying off the handle would read a *different* project's entry and hand back its screenshots as this one's screens. A repo render derives `directory` from the handle and containment-checks it, so there the handle *is* the target.
- `_probe_build_dir` requires the manifest's `buildDir` to be an absolute path inside the validated project dir, anchored the way the script resolves a relative path (`abspath`, lexical, no IO). So a manifest can neither aim the token at an unrelated tree that would stand still nor silently disable reuse for a relative local target.
- `_discover_from_dir` retains the `dc-probe-*` dir and caches its route→PNG map (keyed by the discovery handle: clone id for repos, `local:<path>` for locals) when the probe produced at least one usable screen **and** a build output it could take a token over; it deletes the dir immediately otherwise.
- **Re-discovering a handle CLAIMS it FIRST** (`_probe_claim`) — evicting the prior entry and its dir, and stamping this discovery's place in the order — and a successful probe installs the replacement. A stable `local:<path>` is re-discovered in place, so leaving the older entry as a fallback would let `/render` serve the earlier capture for a project whose discovery just failed — and the old token can still match, so nothing downstream would notice. Evicting on the way out instead would be skipped by every path that does not reach the end: no routes, no usable screen, no readable build output, a token the capture cannot vouch for, a timeout, a missing `node`, an exception the job wrapper catches.
- **Cache writes are ORDERED by that claim stamp, so an older capture can never land on top of a newer one.** Two discoveries of the same stable `local:<path>` handle can interleave and finish out of order; under last-writer-wins the slower-but-older one replaces the newer entry — including replacing a route map that correctly withheld a route the newer probe found behind a login gate, which no staleness token can catch because an auth state is not served bytes. A write carrying a superseded stamp is dropped and its own probe dir goes with it, rather than leaking to the sweep. The stamp (`_PROBE_STARTS`) is a high-water mark held OUTSIDE the cache entry, because every discovery evicts that entry before it captures — a stamp kept inside it would be gone at exactly the moment the older writer needs refusing. `monotonic_ns` is only non-decreasing, so the map is forced strictly upward and a tie resolves to the later claimant. `_sweep_clones` bounds the map on the same `_CLONE_TTL_SEC`, which is over three times `_DISCOVER_TIMEOUT + _CAPTURE_TIMEOUT` (3600 s vs 1080 s), so a dropped stamp cannot belong to a discovery still able to write.
- `_sweep_clones` purges `_PROBE_CACHE` entries whose retained dir it just swept, so a cache entry can never outlive its dir. `_probe_put` also drops any dir it replaces, so it orphans nothing on its own. That branch is belt-and-braces rather than load-bearing: reaching it needs the slot occupied while this discovery holds the newest claim, which the ordering check above already refuses to every other writer.
- **A reused PNG is adopted into the render's `dc-render-*` dir and only the copy is returned** (`_adopt_reused`). A returned screen path is kept forever by a saved critique's history entry, which is why the TTL sweep exempts `dc-render-*`; a `dc-probe-*` dir has the opposite lifetime, so handing back the probe path would make saved critiques lose their screenshots. The copy costs milliseconds and the capture subprocess is still skipped. Only the source basename is used, so a manifest path cannot place a copy outside the out dir. **Adoption runs in the handler, before the uncovered list is computed**, so a pick whose copy fails is *demoted to uncovered* and captured fresh: the probe dir can be swept (or `rmtree`d by a concurrent local re-discovery) in the window after the `exists()` check, and a pick nothing has rendered yet is the same situation as one the probe never covered. Reporting “could not see” instead would turn a render that always worked into zero screens.
- `_handle_render` (repo/local paths only; the SSRF-sensitive `url` path is untouched) reuses a cached probe PNG for any picked route whose file still exists AND whose build output still carries the token recorded at discover, builds the `--routes` CSV from only the uncovered picks, and passes `None` for the capture command when every pick is covered. Uncovered picks (routes beyond the probe's first-20 window, no probe image, a page taller than the probe viewport, a since-deleted PNG, or a changed/unreadable build output) fall back to a fresh `--full` capture. The reuse lookup runs strictly after all existing validations (NUL, field-length, repo handle containment, sensitive-dir, exists), and every one of its filesystem touches goes through `asyncio.to_thread` like the rest of the handler, so a stale NFS/UNC mount cannot stall the gateway loop.
- `_render_capture_job` takes a `reused` map and merges adopted + freshly captured screens in original pick order; its `dc-render-*` cleanup keys on whether any screen succeeded, since every returned path now lives in the out dir.
- **`capture-build.mjs` gains one measurement and one manifest field.** After the same settle the overlay check uses, it compares the page's scroll height against the viewport and records `fullPageCoverage` per screen — true when a `--full` capture would have produced the same pixels (and trivially true when `--full` was passed). An unreadable page counts as *not* covering, so the caller re-captures rather than assume an equivalence it could not confirm. It also gains a comment recording that its file index is a CONTRACT with `_served_signature`: the drift direction that matters is "widened there, unsigned here" — a served file the token does not sign would let a stale PNG through — and the note sits at the walk an editor would widen, which is the one place that coupling can be seen before it breaks.

## Tests (`tests/test_backend_routes.py`)
Cache-primitive round-trip; expiry at the *reuse* window while the dir's TTL still has hours left. `_served_signature` assertions compare the **digest**, which is the only field `/render` compares: `newest_mtime_ns` is a high-water mark that deliberately reads directory mtimes, so whether an add-then-remove leaves it raised depends on the filesystem's timestamp granularity versus how fast the test ran — asserting the whole token made those two tests fail on every CI platform while passing locally. Covered: an in-place rebuild that leaves the project root's `st_mtime_ns` untouched (the case a root-mtime token would miss), a **nested** in-place overwrite that leaves the build dir's and `assets/`'s own mtimes untouched, add/remove of a nested file, refusal over the file bound, and indifference to exactly what the server will not serve (symlinked dir, symlinked file, dot-entries, and a change made *behind* the symlink). `_probe_build_dir` containment plus a relative project dir; sweep cache-purge; `_adopt_reused` containment and copy-failure omission. `/render` flow: all-covered (asserts the capture subprocess never runs, that every returned path is an adopted copy under `dc-render-*`, and that deleting the probe dir afterwards leaves the screenshots intact), mixed reuse (asserts the `--routes` CSV holds only the uncovered ref, plus merge order and the adopted copy's bytes), a local render with a foreign repo handle (must capture fresh and return none of the other project's bytes) and with its own handle or none at all (must reuse), rebuild mismatch (re-captures all), an entry aged past the reuse window (re-captures even though dir, PNG and signature are all still valid), unreadable build output (reuse refused), covered-PNG-deleted fallback, a failed adoption demoted to a fresh capture rather than to “could not see”, probe-put overwrite drops the prior dir, and `_discover_from_dir` retain / drop-on-empty / drop-on-foreign-`buildDir` / withhold-a-gated-screen-while-still-reporting-it-seeable / withhold-everything-when-a-build-lands-mid-capture / evict-a-prior-entry-on-re-discovery (the nothing-usable path, the no-routes path, and two paths that never reach the probe at all: a missing `node` and a raising `_run`), withhold-everything-when-a-served-file-is-deleted-mid-capture (only the directory's mtime moves there, so it pins the directory stat), plus `_probe_claim` directly. Ordering: an older discovery's write is refused after a newer claim (the newer entry survives, the refused write's own dir is removed, and the newest claim can still write afterwards — checked against a build with the guard disabled, where it fails), claim stamps strictly increase within one clock tick, and the sweep bounds the stamp map. Fidelity: a screen the script did not certify as `fullPageCoverage` is withheld from reuse while discovery still reports it seeable — parametrised over an explicit `false` and an absent field, and failing on a build with the gate disabled.

Every regression test written for a reviewer-reported defect was checked against the pre-fix code and fails there.

## Fidelity: the probe keeps its viewport capture, and reuse stays lossless
`/render` captures with `--full` and the probe without it, so an earlier draft of this change handed the critic a viewport PNG wherever a pick was covered — losing anything below the fold on what is, since picks are drawn from discovered routes, the *common* path. Three review lanes flagged that, and they were right: reuse is only legitimate if it is a substitution of equals.

**The probe still runs without `--full`, and the reason is blast radius, not screenshot cost.** `--full` is a single `fullPage:` toggle, and the page load (`networkidle` + settle) that dominates a capture is identical either way. What differs is exposure: the probe is **one** subprocess rendering up to 20 routes of an *unknown* project under a single shared `_CAPTURE_TIMEOUT`, and a full-page screenshot of an unknown page is unbounded — a long or virtualised list can make it enormous or very slow. One pathological route would exhaust that shared budget; the manifest would then fail to parse and **every** route would come back `canSee: false`, losing all of discovery to improve a subset of renders. `/render`'s `--full` runs on the two or three routes the user actually picked, with the same budget and far more headroom per route, which is why the flag belongs there.

**So the asymmetry is resolved at the reuse gate instead of at the flag.** `capture-build.mjs` reports, per screen, whether the page's scroll height fit the viewport — i.e. whether a `--full` capture of it would have produced the same pixels. Only those screens enter the reuse map. Playwright's `fullPage` extends a capture along the height only (width is the viewport width either way), so height is the only axis on which the two modes can differ, which is what makes the check sufficient rather than approximate.

The consequences:
- A covered pick is equivalent to the render it replaces. Nothing below the fold is lost, so there is no silent quality trade to disclose and no need for a `viewport: true` marker on the screen record — which would also have been a client-visible API addition.
- A page too tall to reuse losslessly is left uncovered and captured fresh with `--full`, exactly as before any reuse existed. The feature is now "reuse when it is free *and* lossless" rather than "reuse always" — smaller, and honest.
- A manifest with the field absent (an older script) reads as falsy, so reuse fails closed toward capturing.

GPT 5.6's prescribed remedy was to cache only probe captures "made with full-page semantics", i.e. to pass `--full` on the probe. I rejected that literal form — it buys the same fidelity at exactly the blast radius above — and implemented what the finding actually requires: cache only captures that *have* full-page coverage, which a viewport capture of a page that fits already does.

Reusing "only for thumbnails" is *not* a viable third option: the critic is the only consumer of these PNGs, so it reduces to capturing twice, which is the duplicate this change removes.

## Testing
- `isort`, `flake8`, `mypy --platform linux src/kiro_crew` (1266 files, clean), `scripts/check_black_formatting.py`, `check_subprocess_encoding`, `check_agent_sdk_boundary`, `check_sync_io_in_async`, `check_lockdown_before_publish`, `check_harness_parity`, `check_brand_name`, `check_changelog_history`, `docs-lint`: all exit 0.
- `pytest test/test_security_posture.py src/kiro_crew/apps/builtins/design_critique/tests/`: 163 passed.
- Inclusive-language scan of this PR's added lines: no error-severity terms.

