### PR TITLE
fix: resolve kiro-cli via resolve_kiro_cli() in auto-update paths

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -884,14 +884,29 @@ Each step checks if the tool is already installed and skips if present.
    edits in another terminal to rescue them is the natural response to the
    prompt, and is exactly what would otherwise be reset away). Only `HEAD` can
    move in that window, so the re-check needs no second fetch.
-2. Rebuilds the dashboard via `build_frontend_sync()` (npm; non-fatal on failure).
+2. Updates the optional Kiro CLI backend with one `<kiro-cli> update`, skipped
+   when no install is found and best-effort when one is (a timeout warns and the
+   update continues). The path comes from the same candidate discovery the ACP
+   launch resolves through — `kiro_cli.resolve_kiro_cli()`, which covers the
+   supported fixed install locations as well as the inherited `PATH` — so an
+   install the invoking shell's `PATH` does not name is updated instead of
+   silently skipped, and the step can only ever target the binary the agent
+   itself runs rather than a second copy of it. The gateway's unattended
+   auto-apply resolves through the same function, off the event loop. Neither
+   site narrows the search: a narrower one would update an install the agent
+   does not launch, leaving the launched one permanently stale. The residual is
+   the resolver's, not either call site's — the search order includes
+   user-writable install directories, which is where Kiro CLI's own installer
+   puts it, and the ACP session spawn carries that residual first and far more
+   often.
+3. Rebuilds the dashboard via `build_frontend_sync()` (npm; non-fatal on failure).
    Non-fatal also means non-destructive: `npm ci` deletes `node_modules` before it
    installs, so the tree is moved aside and restored unless the install succeeds
    (`node_modules_txn.NodeModulesBackup`). A failed install therefore costs the
    rebuild, not the dependency tree -- which matters because the registry needed
    to rebuild one is usually what was unavailable. The gateway's unattended
    auto-apply takes the async sibling and is protected the same way.
-3. Reinstalls backend via `pip install -e .`
+4. Reinstalls backend via `pip install -e .`
 
 ## Client Port Resolution
 

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -52,6 +52,7 @@ from kiro_crew.git_divergence import (
 from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import HookManager, hooks_config_from_config_dict
 from kiro_crew.instances import run_marker
+from kiro_crew.kiro_cli import resolve_kiro_cli
 from kiro_crew.learn import LessonStore
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.memory import MemoryStore
@@ -1367,12 +1368,18 @@ def _update(force: bool = False) -> None:
         print(f"  ❌ git reset failed:\n{result.stderr.strip()}")
         sys.exit(1)
 
-    # Update the optional kiro-cli backend if present.
-    if shutil.which("kiro-cli"):
+    # Update the optional kiro-cli backend if present. `resolve_kiro_cli` is the
+    # resolver the agent's own spawn goes through, so an install reachable only
+    # through a fixed known_kiro_cli_dirs() entry rather than the inherited PATH
+    # is still found, and the absolute path spawns the same binary the agent
+    # runs. This path is synchronous, so the resolution's stat walk blocks
+    # nothing but the CLI verb the operator invoked.
+    kiro_cli_bin = resolve_kiro_cli()
+    if kiro_cli_bin:
         print("  🔄 kiro-cli update")
         try:
             subprocess.run(
-                ["kiro-cli", "update"],
+                [kiro_cli_bin, "update"],
                 stdin=subprocess.DEVNULL,
                 capture_output=True,
                 timeout=120,

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -167,6 +167,7 @@ from kiro_crew.heartbeat import (
 )
 from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import HookManager, HooksConfig, hooks_config_from_config_dict
+from kiro_crew.kiro_cli import resolve_kiro_cli
 from kiro_crew.learn import LessonStore
 from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
@@ -9622,11 +9623,23 @@ class GatewayOrchestrator:
             logger.info("Auto-update: reset to origin/%s, rebuilding", branch)
 
             # Update the optional kiro-cli backend if present.
-            if shutil.which("kiro-cli"):
+            # `resolve_kiro_cli` is the resolver the agent's own spawn goes
+            # through, so an install reachable only through a fixed
+            # known_kiro_cli_dirs() entry rather than the inherited PATH is
+            # still found, and the absolute path spawns the same binary the
+            # agent runs.
+            #
+            # Offloaded: the resolution stats every fixed candidate dir plus
+            # every augmented-PATH entry, and the augmented PATH globs each
+            # mise/asdf/nvm/fnm version root on a cold cache — an unbounded
+            # filesystem walk that ON THE EVENT LOOP would stall every chat
+            # and the heartbeat (`no-blocking-call-on-event-loop`).
+            kiro_cli_bin = await asyncio.to_thread(resolve_kiro_cli)
+            if kiro_cli_bin:
                 kiro_update: asyncio.subprocess.Process | None = None
                 try:
                     kiro_update = await asyncio.create_subprocess_exec(
-                        "kiro-cli",
+                        kiro_cli_bin,
                         "update",
                         stdout=asyncio.subprocess.DEVNULL,
                         stderr=asyncio.subprocess.DEVNULL,

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -1193,7 +1193,9 @@ class TestUpdateGitPath:
     ) -> None:
         stub = _GitStub()
         monkeypatch.setattr(subprocess, "run", stub)
-        monkeypatch.setattr(cli_server.shutil, "which", lambda name: "/usr/bin/kiro-cli")
+        # resolve_kiro_cli() returns an absolute path (a fixed-dir install need
+        # not be on PATH); the spawn must use that path, not the bare name.
+        monkeypatch.setattr(cli_server, "resolve_kiro_cli", lambda: "/opt/kiro/bin/kiro-cli")
         built: list[Path] = []
         monkeypatch.setattr(cli_server, "build_frontend_sync", lambda p: built.append(p))
         cli_server._update()
@@ -1201,8 +1203,38 @@ class TestUpdateGitPath:
         assert "Kiro Crew updated!" in out
         assert "Agent config refreshed" in out
         assert built == [git_checkout]
-        assert ["kiro-cli", "update"] in stub.calls
+        assert ["/opt/kiro/bin/kiro-cli", "update"] in stub.calls
         assert any("setup" in c for c in stub.calls)
+
+    def test_fixed_dir_only_kiro_cli_is_updated_not_skipped(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        """A kiro-cli reachable only via a fixed known dir (absent from PATH)
+        must still be updated.
+
+        ``resolve_kiro_cli()`` finds such an install via a fixed
+        ``known_kiro_cli_dirs()`` entry, so gating on PATH alone would skip it
+        silently. The spawn uses the absolute path the resolver returns.
+        """
+        stub = _GitStub()
+        monkeypatch.setattr(subprocess, "run", stub)
+        # No PATH-resolvable kiro-cli, but resolve_kiro_cli() finds a fixed-dir
+        # install and returns its absolute path.
+        monkeypatch.setattr(cli_server.shutil, "which", lambda name: None)
+        monkeypatch.setattr(cli_server, "resolve_kiro_cli", lambda: "/opt/kiro/bin/kiro-cli")
+        cli_server._update()
+        assert "Kiro Crew updated!" in capsys.readouterr().out
+        assert ["/opt/kiro/bin/kiro-cli", "update"] in stub.calls
+
+    def test_no_kiro_cli_skips_the_backend_update(self, monkeypatch, git_checkout, capsys) -> None:
+        """When resolve_kiro_cli() returns None the backend update is skipped
+        (best-effort no-op), preserving the current behavior."""
+        stub = _GitStub()
+        monkeypatch.setattr(subprocess, "run", stub)
+        monkeypatch.setattr(cli_server, "resolve_kiro_cli", lambda: None)
+        cli_server._update()
+        assert "Kiro Crew updated!" in capsys.readouterr().out
+        assert not any("kiro-cli" in str(c[0]) for c in stub.calls)
 
     def test_agent_config_refresh_failure_only_warns(
         self, monkeypatch, git_checkout, capsys
@@ -1246,7 +1278,7 @@ class TestUpdateSubprocessHardening:
 
         monkeypatch.setattr(subprocess, "run", _run)
         # A findable kiro-cli makes the sixth (best-effort) site reachable.
-        monkeypatch.setattr(cli_server.shutil, "which", lambda name: "/usr/bin/kiro-cli")
+        monkeypatch.setattr(cli_server, "resolve_kiro_cli", lambda: "/opt/kiro/bin/kiro-cli")
         cli_server._update()
         assert "Kiro Crew updated!" in capsys.readouterr().out
 
@@ -1256,7 +1288,7 @@ class TestUpdateSubprocessHardening:
             ["git", "diff"],
             ["git", "status"],
             ["git", "reset"],
-            ["kiro-cli", "update"],
+            ["/opt/kiro/bin/kiro-cli", "update"],
         ]
         for prefix in six:
             matching = [kw for argv, kw in recorded if argv[: len(prefix)] == prefix]
@@ -1311,8 +1343,10 @@ class TestUpdateSubprocessHardening:
         """The backend update's result is not inspected today, so its timeout
         warns and the update continues — the #5637 handler shape."""
         stub = _GitStub()
-        monkeypatch.setattr(subprocess, "run", self._timeout_on(["kiro-cli", "update"], stub))
-        monkeypatch.setattr(cli_server.shutil, "which", lambda name: "/usr/bin/kiro-cli")
+        monkeypatch.setattr(
+            subprocess, "run", self._timeout_on(["/opt/kiro/bin/kiro-cli", "update"], stub)
+        )
+        monkeypatch.setattr(cli_server, "resolve_kiro_cli", lambda: "/opt/kiro/bin/kiro-cli")
         cli_server._update()
         out = capsys.readouterr().out
         assert "kiro-cli update timed out" in out

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -3435,7 +3435,10 @@ class TestAutoApplyUpdateVenvPath:
                         ):
                             with patch("kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock):
                                 with patch("os.execv", side_effect=OSError("test")):
-                                    with patch("shutil.which", return_value=None):
+                                    with patch(
+                                        "kiro_crew.slack.gateway.resolve_kiro_cli",
+                                        return_value=None,
+                                    ):
                                         await orch._auto_apply_update()
 
         # The install runs through the shared entry point, which picks a reinstall
@@ -3471,7 +3474,7 @@ class TestAutoApplyUpdateVenvPath:
 
         async def _fake_exec(*args, **kwargs):
             argv = [a for a in args if isinstance(a, str)]
-            if argv and argv[0] == "kiro-cli":
+            if argv and argv[0] == "/opt/kiro/bin/kiro-cli":
                 proc = AsyncMock()
                 proc.kill = MagicMock()
                 proc.returncode = None
@@ -3490,6 +3493,15 @@ class TestAutoApplyUpdateVenvPath:
         async def _fake_kill_and_reap(proc):
             killed.append(proc)
 
+        # The coroutine under test runs on this thread, so anything recorded
+        # as a different thread was genuinely offloaded off the event loop.
+        loop_thread = threading.current_thread()
+        resolve_threads: list = []
+
+        def _fake_resolve():
+            resolve_threads.append(threading.current_thread())
+            return "/opt/kiro/bin/kiro-cli"
+
         with patch("kiro_crew.env.is_toolbox_install", return_value=False):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
                 with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
@@ -3504,9 +3516,13 @@ class TestAutoApplyUpdateVenvPath:
                                 new_callable=AsyncMock,
                             ) as mock_build:
                                 with patch("os.execv", side_effect=OSError("test")):
-                                    # Truthy: the optional kiro-cli step runs.
+                                    # A resolved absolute path makes the
+                                    # optional kiro-cli step run; a fixed-dir
+                                    # install off PATH must not be silently
+                                    # skipped.
                                     with patch(
-                                        "shutil.which", return_value="/usr/bin/kiro-cli"
+                                        "kiro_crew.slack.gateway.resolve_kiro_cli",
+                                        side_effect=_fake_resolve,
                                     ):
                                         # The gateway resolves _kill_and_reap
                                         # function-locally on every call, so
@@ -3524,6 +3540,14 @@ class TestAutoApplyUpdateVenvPath:
         # frontend build and the dependency install exactly as before.
         mock_build.assert_awaited_once()
         assert mock_install.call_count == 1
+        # The resolution stats every candidate dir and globs the tool-manager
+        # version roots, so it must run in a worker thread: on the loop it
+        # would stall every chat and the heartbeat, and past
+        # `dashboard.loop_stall_exit_after_secs` the watchdog kills the
+        # gateway. Asserting the thread pins the offload deterministically,
+        # where a duration assertion would be timing-dependent.
+        assert resolve_threads, "resolve_kiro_cli was never called"
+        assert resolve_threads[0] is not loop_thread
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -859,6 +859,29 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_doctor.py::_linger_enabled",
         "cli_server.py::_logs_cmd",
         "cli_server.py::_spawn_detached_gateway",
+        # `kirocrew update`: git fetch/diff/status/reset against our own
+        # checkout, plus one optional `<kiro-cli> update`. Operator-invoked on a
+        # TTY, no shell, stdin=DEVNULL and a bounded timeout on every call, and
+        # no agent-supplied value reaches any argv.
+        #
+        # The kiro-cli step is the one spawn here whose argv[0] is not a literal:
+        # it is `kiro_cli.resolve_kiro_cli()`'s answer, the SAME resolver
+        # `acp/client.py::_resolve_kiro_bin` launches the agent through. That is
+        # what bounds it — the step can only ever name the binary the agent
+        # itself runs, never a second one, and it cannot gain an argument. A
+        # narrower lookup (a bare name, or `PATH` alone) would not bound it more
+        # tightly; it would update an install the agent does not launch and leave
+        # the launched one stale. `test_kiro_cli_update_spawns_resolve_through_
+        # the_shared_resolver` pins both halves.
+        #
+        # RESIDUAL, and it belongs to the resolver rather than to either call
+        # site: the candidate order includes user-writable install directories
+        # (Kiro CLI's own installer targets `~/.local/bin`), which are fenced
+        # from an agent write by neither `security._SENSITIVE_HOME_DIRS` nor
+        # `_WRITE_PROTECTED_HOME_PATHS`. The ACP session spawn resolves the same
+        # way and reaches the same candidate first and far more often, so the
+        # residual is closed on the WRITE side and at the resolver, not by
+        # narrowing a maintenance spawn.
         "cli_server.py::_update",
         # The agent-only config refresh extracted from _update: a fixed argv
         # (`<this interpreter> -m kiro_crew setup --agent-only`) built from
@@ -1159,6 +1182,14 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "session_pid.py::_our_orphan_pids",
         "session_pid.py::find_orphan_mcp_candidates",
         "session_pid.py::kill_orphan_mcps",
+        # The unattended sibling of `cli_server.py::_update` — same steps, same
+        # bounds, same reasoning for the optional `<kiro-cli> update` argv (see
+        # that entry). Being unattended is why `git` here is resolved OFF `PATH`
+        # through `platform_compat.trusted_git_bin()` and a refusal aborts the
+        # whole apply: on this path what git reports decides which code gets
+        # installed and re-executed. `PATH` is therefore the LESS trusted input
+        # on this function, which is also why the kiro-cli step does not gate on
+        # it.
         "slack/gateway.py::_auto_apply_update",
         # Wheel/cli.sh auto-update: runs the signed installer command
         # (composed locally from a validated channel name and https-pinned
@@ -1532,6 +1563,138 @@ def test_agent_influenced_sites_are_routed():
         assert key not in unrouted, (
             f"{key} must route its spawn through sandboxed_spawn_argv "
             "(security-review 92e24570) but is no longer sandbox-wrapped."
+        )
+
+
+# Every site that execs the user's Kiro CLI, and the resolver all of them must
+# share. ``acp/client.py::_resolve_kiro_bin`` is the agent's own session spawn
+# and is listed so "the same resolver" is pinned rather than assumed.
+_KIRO_CLI_RESOLVER = "resolve_kiro_cli"
+# Spelled literally, like every other token this AST audit matches on; the
+# owning constant is ``kiro_cli.KIRO_CLI_NAME``.
+_KIRO_CLI_NAME = "kiro-cli"
+_KIRO_CLI_EXEC_SITES = (
+    ("cli_server.py", "_update"),
+    ("slack/gateway.py", "_auto_apply_update"),
+    ("acp/client.py", "_resolve_kiro_bin"),
+)
+# The subcommand that identifies the maintenance spawn inside the two update
+# functions. Its argv[0] is the assertion's subject.
+_KIRO_CLI_UPDATE_SUBCOMMAND = "update"
+
+
+def _named_function(rel: str, name: str) -> ast.AST:
+    """Return the ``def``/``async def`` node called *name* in *rel*."""
+    tree = ast.parse((_SRC_ROOT / rel).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{rel} no longer defines {name}() — update this audit.")
+
+
+def _spawn_argv_nodes(scope: ast.AST) -> list[list[ast.expr]]:
+    """Return one argv element list per spawn call inside *scope*.
+
+    ``subprocess.run([prog, *args])`` passes a list literal; the asyncio spawns
+    pass the elements positionally. Both are flattened to the same shape so a
+    caller can reason about argv[0] without knowing which API a site used.
+    """
+    argvs: list[list[ast.expr]] = []
+    for node in ast.walk(scope):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in _SPAWN_ATTRS:
+            continue
+        base = node.func.value
+        base_name = (
+            base.id
+            if isinstance(base, ast.Name)
+            else base.attr if isinstance(base, ast.Attribute) else ""
+        )
+        if base_name not in _SPAWN_BASES or not node.args:
+            continue
+        first = node.args[0]
+        argvs.append(list(first.elts) if isinstance(first, ast.List) else list(node.args))
+    return argvs
+
+
+def test_kiro_cli_update_spawns_resolve_through_the_shared_resolver():
+    """Every site that execs the user's Kiro CLI must resolve it the same way.
+
+    The optional ``<kiro-cli> update`` step and the agent's own session spawn
+    have to name the SAME executable. Two failures follow from letting them
+    diverge, and only one is visible: gating the update on the inherited
+    ``PATH`` skips an install reachable only through a fixed
+    ``kiro_cli.known_kiro_cli_dirs()`` entry, and — worse, because nothing
+    reports it — a lookup that resolves differently from the launch path updates
+    an install the agent never runs, leaving the launched one stale forever.
+
+    One resolver is what makes those one question instead of three, so this pins
+    that every site goes through ``kiro_cli.resolve_kiro_cli`` and that the two
+    update sites spawn ITS answer as argv[0] — never a bare name, never
+    ``shutil.which``, and never a second lookup of their own. That is also the
+    whole basis of both sites' ``BENIGN_SPAWNS`` justification: the resolved
+    path is the only non-literal argv element, so no agent-supplied value can
+    reach the argv, and the step cannot name a binary the session spawn would
+    not name.
+    """
+    for rel, func in _KIRO_CLI_EXEC_SITES:
+        node = _named_function(rel, func)
+        body = ast.unparse(node)
+        assert _KIRO_CLI_RESOLVER in body, (
+            f"{rel}::{func} no longer resolves the Kiro CLI through "
+            f"kiro_cli.{_KIRO_CLI_RESOLVER}(). Every site that execs the user's "
+            "CLI shares that resolver so the update target and the launch target "
+            "cannot drift apart."
+        )
+        assert f"which({_KIRO_CLI_NAME!r})" not in body, (
+            f"{rel}::{func} gates on shutil.which({_KIRO_CLI_NAME!r}), which sees "
+            "only the inherited PATH and skips an install reachable through a "
+            f"fixed known_kiro_cli_dirs() entry. Use kiro_cli.{_KIRO_CLI_RESOLVER}()."
+        )
+
+    for rel, func in _KIRO_CLI_EXEC_SITES[:2]:
+        node = _named_function(rel, func)
+        # The resolver's answer must reach the spawn through a local name, so
+        # find what that name is bound to before inspecting the argv.
+        resolved_names = {
+            target.id
+            for assign in ast.walk(node)
+            if isinstance(assign, ast.Assign)
+            for target in assign.targets
+            if isinstance(target, ast.Name) and _KIRO_CLI_RESOLVER in ast.unparse(assign.value)
+        }
+        assert resolved_names, (
+            f"{rel}::{func} calls {_KIRO_CLI_RESOLVER}() without binding its result, "
+            "so the spawn below cannot be using it."
+        )
+        update_argvs = [
+            argv
+            for argv in _spawn_argv_nodes(node)
+            if any(
+                isinstance(element, ast.Constant) and element.value == _KIRO_CLI_UPDATE_SUBCOMMAND
+                for element in argv
+            )
+        ]
+        assert len(update_argvs) == 1, (
+            f"expected exactly one {_KIRO_CLI_NAME} maintenance spawn in {rel}::{func}, "
+            f"found {len(update_argvs)}"
+        )
+        argv = update_argvs[0]
+        program = argv[0]
+        assert isinstance(program, ast.Name) and program.id in resolved_names, (
+            f"{rel}::{func} spawns {ast.unparse(program)!r} rather than the name bound "
+            f"from {_KIRO_CLI_RESOLVER}(). A bare {_KIRO_CLI_NAME!r} resolves through the "
+            "child's PATH, which on a gateway can lead with an agent-writable "
+            "directory — the same hazard trusted_git_bin() exists to avoid on this "
+            "very path."
+        )
+        assert [element.value for element in argv[1:] if isinstance(element, ast.Constant)] == [
+            _KIRO_CLI_UPDATE_SUBCOMMAND
+        ], (
+            f"{rel}::{func}'s {_KIRO_CLI_NAME} argv gained an element beyond the fixed "
+            f"{_KIRO_CLI_UPDATE_SUBCOMMAND!r} subcommand. Its BENIGN_SPAWNS entry rests "
+            "on the resolved path being the only non-literal argv element."
         )
 
 


### PR DESCRIPTION
Fixes #7704.

## Problem

Two auto-update steps gated on `shutil.which("kiro-cli")` and then spawned the bare name, so they resolved only through the process's inherited `PATH`:

- `src/kiro_crew/cli_server.py` (CLI-side auto-update)
- `src/kiro_crew/slack/gateway.py` (gateway auto-update)

Because the spawn was `which`-guarded, a working install reachable only through a fixed `known_kiro_cli_dirs()` entry was **silently skipped** by `kiro-cli update`. Same root cause as #7674 (bare-name resolution instead of `resolve_kiro_cli()`); deliberately left out of PR #7692's scope (diagnostics-only).

## Fix

Both sites now resolve via the existing `resolve_kiro_cli()` helper (`kiro_cli.py`): skip when it returns `None` (unchanged best-effort no-op), otherwise spawn the returned absolute path. Same containment posture as before (update remains best-effort).

- `cli_server.py`: added `from kiro_crew.kiro_cli import resolve_kiro_cli`; replaced the `shutil.which` gate with `resolve_kiro_cli()` and spawn `[kiro_cli_bin, "update"]`.
- `slack/gateway.py`: same import; replaced the gate and spawn the resolved path. `shutil` remains used elsewhere in both files.
- `slack/gateway.py` also moves the resolution **off the event loop** — `kiro_cli_bin = await asyncio.to_thread(resolve_kiro_cli)`. This is a timing change shipped deliberately with the fix, not a drive-by: `resolve_kiro_cli()` stats every fixed candidate directory and every inherited-`PATH` entry and reaches `env.augmented_path()`, which globs every mise/asdf/nvm/fnm version root, whereas the `shutil.which` it replaces walked `os.environ["PATH"]` only. Resolving on the loop would therefore newly stall chat and heartbeat on the first cold call. `cli_server.py::_update` stays synchronous — it is a CLI verb with no event loop, so the stat walk blocks nothing but the command the operator invoked. `test/test_slack_gateway.py::TestAutoApplyUpdateVenvPath::test_kiro_cli_update_timeout_kills_child_and_stays_nonfatal` asserts the resolver does not run on the thread running the coroutine.

`resolve_kiro_cli()` is a strict superset of the old `shutil.which` gate: it honours `KIROCREW_KIRO_BIN`, then the fixed known directories, then the inherited `PATH`, and returns `None` when nothing is executable. Where a host has copies both on `PATH` and in a fixed directory, update now targets the fixed-directory copy — which is the binary the agent spawn itself resolves (`acp/client.py`), so the updater and the agent now agree on which binary they are talking about.

## Scope: the sibling bare-name sites are deliberately not in this PR

Four other call sites still resolve the bare name. None of them is on an auto-update path, none is made worse by this change, and each needs its own reasoning — so they are left for a follow-up rather than folded in here:

- `slack/gateway.py::_warn_if_kiro_cli_outdated` — the boot version probe. Not the one-line swap it looks like: it is a declared `test_spawn_audit.py` sandbox exemption annotated "fixed argv", it carries a documented never-raises contract, and seven existing tests in `test/test_slack_gateway_more_coverage.py` patch `asyncio.create_subprocess_exec` and would need the resolver patched too. It was already probing a binary the agent may not be running, both before and after this PR.
- `diagnostics.py::_kiro_cli_version` — reports `unavailable` for a fixed-directory install. A `kirocrew doctor` surface this PR does not touch.
- `cli_setup.py` — its message reads "kiro-cli not found on PATH", so `PATH` is the intended semantics; changing the probe without rewriting the advice would make the advice wrong.
- `cli_doctor.py` — already imports `resolve_kiro_cli` and uses it elsewhere; the remaining sites need a per-site read.

## Tests

Updated existing auto-update tests to patch `resolve_kiro_cli` and assert on the resolved absolute path. Added regression tests:
- `test_fixed_dir_only_kiro_cli_is_updated_not_skipped` — resolvable via a fixed directory while absent from `PATH`; the update must run and must spawn the absolute path.
- `test_no_kiro_cli_skips_the_backend_update` — `None` resolves to a skip, preserving the best-effort no-op.

Also updated `test/test_slack_gateway.py` to patch `resolve_kiro_cli` instead of `shutil.which`.

## Verification

Run against this branch rebased on `main`:

- `isort --check-only`, `flake8`, `mypy --platform linux src/kiro_crew` — clean.
- `scripts/check_black_formatting.py`, `check_subprocess_encoding.py`, `check_agent_sdk_boundary.py`, `check_sync_io_in_async.py`, `check_lockdown_before_publish.py` — all pass. (The earlier `Backend Lint & Type Check (3.10)` red was this gate: `test_cli_server_more_coverage.py` was not black-formatted. Fixed.)
- `test_cli_server_more_coverage.py`, `test_slack_gateway.py`, `test_slack_gateway_more_coverage.py`, `test_spawn_audit.py`, `test_security_posture.py`, `test_kiro_prerequisite.py` — 683 passed.

The earlier `Backend Tests (3.10, 4)` red was `test_subagent_state_write_serialization.py::TestOnLoopCallerDoesNotWait::test_a_coroutine_does_not_wait_on_a_held_lock` failing a timed threshold by 0.08s (`0.58s` against `< 0.5`) on a shared runner. That file is not in this diff and the test passes on both `main` and this branch locally; `Coverage Gate` failed closed on that shard (`backend-test=failure -- failing closed`), so it is the same failure reported twice.

## Pattern harvest

Rule candidate: semgrep

Pattern: a hardcoded `kiro-cli` path or a bare `"kiro-cli"` argv name on a spawn
path, where the repo already owns a resolver (`resolve_kiro_cli()`). Every such
call site silently diverges from the resolver's search order, so an operator whose
binary lives outside the assumed location gets a working agent everywhere except
the one path that hardcoded it. Review prompt: when a binary has a named resolver,
grep for every other spelling of that binary before adding a call site.


## The spawn-audit record for these two sites, and the residual

Both changed functions sit in `test/test_spawn_audit.py`'s `BENIGN_SPAWNS`, on the
module docstring's stated basis that a self-update spawn is a "fixed argv against our
own install". That basis moves the moment `argv[0]` becomes a resolved path, so each
entry now carries its own justification naming what actually bounds it — one resolver,
shared with the ACP session spawn (`acp/client.py::_resolve_kiro_bin`), so the
maintenance step can only ever name the binary the agent itself runs, and no
agent-supplied value reaches the argv.

`test_kiro_cli_update_spawns_resolve_through_the_shared_resolver` pins that invariant
across all three sites, so the update target and the launch target cannot drift apart
and no site can reintroduce a bare name or a `shutil.which` gate. Confirmed to bite by
mutating production code on each of its four branches.

`docs/system-specs/modules/cli.md` § Update Command documents the previously unlisted
kiro-cli step and how its path is resolved.

The residual is stated in both places rather than left implicit: the candidate order
includes user-writable install directories — `~/.local/bin` is where Kiro CLI's own
installer puts the binary — and `security.is_sensitive_path` / `is_sensitive_write_path`
both answer `False` for it, so an auto-approved agent write there is not refused. That
residual belongs to the resolver and to the write side, not to a maintenance spawn: the
ACP session spawn resolves through the same function, reaches the same candidate ahead
of every `PATH` entry, and runs at every session start.

Closing it is a keystone decision with no cheap form, which is why it is filed for its
own PR rather than carried here. `_WRITE_PROTECTED_HOME_PATHS` alone would not close it:
that list is enforced at the file-edit gate only, so an entry there leaves
`cp payload ~/.local/bin/kiro-cli` permitted. The path-shaped alternative in the
sensitive-command regex — the mechanism that actually refuses a write under
`.kiro/agents` — is verb-independent, so applying its shape to a general-purpose user
bin directory would also refuse routine reads and listings there. And kiro-cli is a
multi-call binary that execs sibling executables resolved relative to its own path, so a
leaf-only fence on the `kiro-cli` name is insufficient in any case.

One property of this diff belongs in the same record rather than only in a review
thread: on Linux the ACP session spawn runs inside the namespace sandbox (the
`is_kiro_cli` delegation is gated to darwin and win32), while both update sites are
unrouted `BENIGN_SPAWNS` entries. So on a host where `~/.local/bin` is not on the
invoking `PATH`, this change adds one execution of that candidate outside the
credential-hiding sandbox. Routing the maintenance spawn is not the remedy available
here — the audit already records that a self-update spawn cannot run confined because
the installer must write its own install directory, and any routed spawn must
additionally carry a kernel RLIMIT ceiling, which is not something to put on a
downloader on an untested assumption. It is part of the same escalation.

