### PR TITLE
fix(dashboard): pin expected_history_key at the remaining tags/folders forced saves (#7519)

### DIFF
--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -8,13 +8,14 @@ import logging
 import os
 import unicodedata
 import uuid
+import weakref
 from typing import Any
 
 from aiohttp import web
 
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_tags import tags_write_lock, validate_folder_tag_ids
-from kiro_crew.dashboard.chat_utils import effective_session_key
+from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
 from kiro_crew.dashboard.create_rate_limit import FOLDER_CREATE, allow_create
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.dashboard.token_auth import caller_names_a_missing_slot, derive_caller_app
@@ -915,8 +916,29 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
     for slot in state._slots.values():
         if slot.folder_id == fid:
             unfiled.append((slot, slot.folder_id))
+            # Pin the write to the transcript this iteration's membership
+            # check covered: the save awaits inside the loop, so a rebind can
+            # land mid-persist and the save would otherwise resolve its
+            # target from the moved routing at write time. No await between
+            # this capture and the unfile below.
+            authorized_history_key = slot_history_key(slot)
             slot.folder_id = ""
-            await save_slot_off_loop(state, slot, force=True)
+            if not await save_slot_off_loop(
+                state, slot, force=True, expected_history_key=authorized_history_key
+            ):
+                # Refused without writing (session permanently deleted or
+                # rebound mid-persist). The in-memory unfile stands — the
+                # folder is being removed — so mark dirty and let the
+                # periodic flush persist wherever the slot now routes; a
+                # dangling folder_id left on the old transcript is ignored
+                # on the next load.
+                slot._dirty = True
+                logger.warning(
+                    "folder delete: unfile save refused for %s "
+                    "(session deleted or rebound); marked dirty for "
+                    "periodic-flush retry",
+                    getattr(slot, "key", "?"),
+                )
 
     async def _restore_unfiled() -> None:
         for slot, previous in unfiled:
@@ -927,9 +949,18 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
             # slot back into the folder this request was trying to delete.
             if slot.folder_id:
                 continue
+            # Same pin as the unfile: no await between this capture and the
+            # restore below, so the rollback write cannot land on a
+            # transcript this slot was rebound to mid-restore.
+            authorized_history_key = slot_history_key(slot)
             slot.folder_id = previous
             try:
-                await save_slot_off_loop(state, slot, force=True)
+                applied = await save_slot_off_loop(
+                    state,
+                    slot,
+                    force=True,
+                    expected_history_key=authorized_history_key,
+                )
             except Exception:
                 # Best-effort restore; a slot left unfiled renders at the top
                 # level, which the sidebar handles, so keep restoring the rest.
@@ -939,6 +970,18 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
                     previous,
                     exc_info=True,
                 )
+            else:
+                if not applied:
+                    # Refused without writing (session deleted or rebound).
+                    # Keep the restored live field and mark dirty so the
+                    # periodic flush persists it wherever the slot now routes.
+                    slot._dirty = True
+                    logger.warning(
+                        "folder delete rollback: restore save refused for %s "
+                        "(session deleted or rebound); marked dirty for "
+                        "periodic-flush retry",
+                        getattr(slot, "key", "?"),
+                    )
         state.push_slots_update()
 
     def _remove(folders: list[dict[str, Any]]) -> tuple[bool, None]:
@@ -994,6 +1037,33 @@ def _effective_request_app(state: DashboardState, request: web.Request) -> str:
     return app_name
 
 
+# Per-STATE metadata-write transaction lock for the slot metadata PATCH
+# endpoints (folder / pin / mode), same rationale as the autocompact txn lock:
+# with awaits inside a mutate/save/rollback span, a second concurrent request
+# would otherwise capture the first one's value as its rollback snapshot, and
+# value-based rollback cannot tell "my write survived" from "someone else
+# wrote the same value" — so a refused request could erase an equal,
+# acknowledged concurrent commit. Under the lock exactly one request is inside
+# the span, so a rollback can only undo its own write.
+#
+# Keyed by the STATE, not the transcript: a transcript-keyed lock changes
+# identity when the slot is rebound mid-request (review-caught), so a second
+# request entering after the rebind would acquire a DIFFERENT lock and the
+# spans would interleave anyway. The state key is stable across rebinds and
+# covers alias slots resolving onto one file too — the same identity
+# chat_tags._TAGS_WRITE_LOCKS uses for the tags writers. These are rare,
+# human-driven sidebar operations, so one lock per state does not contend.
+_SLOT_META_TXN_LOCKS: "weakref.WeakKeyDictionary[Any, LoopBoundLock]" = weakref.WeakKeyDictionary()
+
+
+def _slot_meta_txn_lock(state: Any) -> LoopBoundLock:
+    lock = _SLOT_META_TXN_LOCKS.get(state)
+    if lock is None:
+        lock = LoopBoundLock()
+        _SLOT_META_TXN_LOCKS[state] = lock
+    return lock
+
+
 async def api_chat_slot_folder(request: web.Request) -> web.Response:
     """PATCH /api/chat/slots/{slot}/folder — assign slot to a folder."""
 
@@ -1024,6 +1094,14 @@ async def api_chat_slot_folder(request: web.Request) -> web.Response:
             ),
         )
         return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+    # Capture the transcript key the ownership decision above just covered,
+    # BEFORE the body-parse await: ``linked_session_key`` is rebound on
+    # already-live slots with no ``running`` gate (cron completions, workflow
+    # injections), so a slow caller can be authorized against its own session
+    # and land on somebody else's conversation. The re-check below and the
+    # save's expected_history_key pin together keep this request's write on
+    # the transcript it was authorized against.
+    authorized_history_key = slot_history_key(slot)
     try:
         body = await request.json()
     except Exception:
@@ -1031,21 +1109,75 @@ async def api_chat_slot_folder(request: web.Request) -> web.Response:
     folder_id = str(body.get("folder_id") or "")
     if folder_id and not any(f["id"] == folder_id for f in state._folders):
         return web.json_response({"error": "folder not found"}, status=400)
-    previous = slot.folder_id
-    if folder_id != slot.folder_id:
-        slot._folder_changed = True  # re-inject [FOLDER] breadcrumb on next turn
-    slot.folder_id = folder_id
-    # The check above reads the store unlocked, so a delete can land between it
-    # and here. _unhide_folder re-checks existence under the store lock, which
-    # is the only place the answer cannot go stale — reject rather than persist a
-    # placement into a folder that no longer exists.
-    if not await _unhide_folder(state, folder_id):
-        slot.folder_id = previous
-        slot._folder_changed = False
-        return web.json_response(
-            {"error": "folder not found", "code": "folder_not_found"}, status=400
-        )
-    await save_slot_off_loop(state, slot, force=True)
+    # Serialize the whole re-check/mutate/persist/rollback span under the
+    # state-wide metadata txn lock (rebind-stable; see _slot_meta_txn_lock):
+    # with awaits inside the span, a second concurrent request would capture
+    # this one's value as its rollback snapshot, and value-based rollback
+    # cannot tell "my write survived" from "someone else wrote the same
+    # value". Under the lock a rollback can only undo its own write; the
+    # compare-and-set below stays as defense for the non-endpoint writers
+    # (the folder-delete unfile loop) that do not take this lock.
+    async with _slot_meta_txn_lock(state):
+        # Re-authorize after the awaits above (body parse, lock acquisition):
+        # same slot OBJECT still registered under the name, routing still on
+        # the transcript captured before the first await. No await between
+        # this check and the mutation below; the _unhide_folder and persist
+        # awaits after it are covered by the save's pin.
+        if state._slots.get(name) is not slot or slot_history_key(slot) != authorized_history_key:
+            source, caller = _audit_origin(request)
+            sel().log_api_access(
+                caller=caller,
+                operation="chat.slot_folder",
+                outcome="denied",
+                source=source,
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"}, status=409
+            )
+        previous = slot.folder_id
+        previous_changed = slot._folder_changed
+        if folder_id != slot.folder_id:
+            slot._folder_changed = True  # re-inject [FOLDER] breadcrumb on next turn
+        slot.folder_id = folder_id
+        # The check above reads the store unlocked, so a delete can land between it
+        # and here. _unhide_folder re-checks existence under the store lock, which
+        # is the only place the answer cannot go stale — reject rather than persist a
+        # placement into a folder that no longer exists.
+        if not await _unhide_folder(state, folder_id):
+            slot.folder_id = previous
+            slot._folder_changed = previous_changed
+            return web.json_response(
+                {"error": "folder not found", "code": "folder_not_found"}, status=400
+            )
+        if not await save_slot_off_loop(
+            state, slot, force=True, expected_history_key=authorized_history_key
+        ):
+            # Refused without writing: the session was permanently deleted or
+            # rebound mid-persist. Roll back the live fields — but only while
+            # they still hold THIS request's value: a non-endpoint writer may
+            # have committed a newer placement that an unconditional restore
+            # would erase (the same guard _restore_unfiled applies).
+            if slot.folder_id == folder_id:
+                slot.folder_id = previous
+                slot._folder_changed = previous_changed
+            # The UNPINNED periodic flush may have persisted the provisional
+            # value while this save awaited (review-caught): mark dirty so the
+            # next flush reconverges the durable record to the live state.
+            slot._dirty = True
+            source, caller = _audit_origin(request)
+            sel().log_api_access(
+                caller=caller,
+                operation="chat.slot_folder",
+                outcome="denied",
+                source=source,
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"}, status=409
+            )
     state.push_slots_update()
     source, caller = _audit_origin(request)
     sel().log_api_access(
@@ -1066,12 +1198,62 @@ async def api_chat_slot_pin(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found"}, status=404)
+    # Capture the transcript key the lookup above just covered, BEFORE the
+    # body-parse await — the same rebind window api_chat_slot_folder
+    # documents. The re-check below and the save's expected_history_key pin
+    # together keep this request's write on the transcript it was authorized
+    # against.
+    authorized_history_key = slot_history_key(slot)
     try:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
-    slot.pinned = bool(body.get("pinned", False))
-    await save_slot_off_loop(state, slot, force=True)
+    # Serialize the re-check/mutate/persist/rollback span under the
+    # state-wide metadata txn lock — same rationale as api_chat_slot_folder.
+    async with _slot_meta_txn_lock(state):
+        # Re-authorize after the awaits above (body parse, lock acquisition):
+        # same slot OBJECT still registered under the name, routing still on
+        # the transcript captured before the first await. No await between
+        # this check and the save dispatch.
+        if state._slots.get(name) is not slot or slot_history_key(slot) != authorized_history_key:
+            sel().log_api_access(
+                caller="dashboard",
+                operation="chat.slot_pin",
+                outcome="denied",
+                source="dashboard",
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"}, status=409
+            )
+        prior_pinned = slot.pinned
+        new_pinned = bool(body.get("pinned", False))
+        slot.pinned = new_pinned
+        if not await save_slot_off_loop(
+            state, slot, force=True, expected_history_key=authorized_history_key
+        ):
+            # Refused without writing: the session was permanently deleted or
+            # rebound mid-persist. Roll back the live field — but only while
+            # it still holds THIS request's value, so a non-endpoint writer's
+            # newer commit is not erased.
+            if slot.pinned == new_pinned:
+                slot.pinned = prior_pinned
+            # The UNPINNED periodic flush may have persisted the provisional
+            # value while this save awaited (review-caught): mark dirty so the
+            # next flush reconverges the durable record to the live state.
+            slot._dirty = True
+            sel().log_api_access(
+                caller="dashboard",
+                operation="chat.slot_pin",
+                outcome="denied",
+                source="dashboard",
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"}, status=409
+            )
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard",
@@ -1094,6 +1276,12 @@ async def api_chat_slot_mode(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found"}, status=404)
+    # Capture the transcript key the lookup above just covered, BEFORE the
+    # body-parse and busy-check awaits — the same rebind window
+    # api_chat_slot_folder documents. The re-check before the mutation and
+    # the save's expected_history_key pin together keep this request's write
+    # on the transcript it was authorized against.
+    authorized_history_key = slot_history_key(slot)
     # App ownership (App Kit §5.2) — the same deny-by-default rule api_chat_send
     # and api_chat_slot_create apply, and it matters HERE because the mode
     # decides which execution model a session runs under: an app holding
@@ -1153,55 +1341,106 @@ async def api_chat_slot_mode(request: web.Request) -> web.Response:
             {"error": "this session name cannot run crew mode", "code": "crew_unsupported_slot"},
             status=400,
         )
-    # Work in SUBAGENTS keeps `slot.running` false the whole time, so that flag
-    # alone lets the mode flip mid-flight and interleave two execution models in
-    # one session. Two separate questions are needed, because the risk is not
-    # symmetric:
-    #  * ANY direction — a plain-chat subagent may be running on this slot right
-    #    now, and its completion follows the default `_run_chat` path, so
-    #    ENTERING crew mode has to be refused for that too, not just leaving it.
-    #    (Gating the whole check on `slot.mode == "crew"` missed exactly this.)
-    #  * LEAVING crew — the orchestrator may still hold crew topics or a live
-    #    queue, which only it can answer for.
-    busy = False
-    subs = getattr(state, "subagents", None)
-    if subs is not None:
-        try:
-            # The key the SPAWN ran under, which for a channel-linked slot is the
-            # channel session, not `dashboard:<tab>` — `has_pending_work_for`
-            # matches `parent_session_key` exactly, so deriving it differently
-            # here reports "idle" while that slot's subagents are still running
-            # and flips the execution model out from under them.
-            busy = bool(subs.has_pending_work_for(effective_session_key(slot)))
-        except Exception:
-            busy = True  # fail closed: refuse rather than risk the flip
-    if not busy and slot.mode == "crew":
-        # isinstance, not `is not None` — matching gateway.py's own check on this
-        # attribute. A stand-in object passes an identity check and then answers
-        # `has_live_work` with something truthy, refusing a switch that is fine.
-        crew = getattr(state, "crew", None)
-        if isinstance(crew, CrewOrchestrator):
+    # Serialize the busy-check/re-check/mutate/persist/rollback span under
+    # the state-wide metadata txn lock — same rationale as
+    # api_chat_slot_folder. The busy guard runs INSIDE the lock: waiting on a
+    # concurrent metadata save can take long enough for a turn to start, so a
+    # guard evaluated before the acquisition would be stale by the time the
+    # mutation runs (review-caught).
+    async with _slot_meta_txn_lock(state):
+        # Re-authorize after the awaits above (body parse, lock acquisition):
+        # same slot OBJECT still registered under the name, routing still on
+        # the transcript captured before the first await.
+        if state._slots.get(name) is not slot or slot_history_key(slot) != authorized_history_key:
+            sel().log_api_access(
+                caller="dashboard",
+                operation="chat.slot_mode",
+                outcome="denied",
+                source="dashboard",
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"}, status=409
+            )
+        # Work in SUBAGENTS keeps `slot.running` false the whole time, so that
+        # flag alone lets the mode flip mid-flight and interleave two execution
+        # models in one session. Two separate questions are needed, because the
+        # risk is not symmetric:
+        #  * ANY direction — a plain-chat subagent may be running on this slot
+        #    right now, and its completion follows the default `_run_chat`
+        #    path, so ENTERING crew mode has to be refused for that too, not
+        #    just leaving it. (Gating the whole check on `slot.mode == "crew"`
+        #    missed exactly this.)
+        #  * LEAVING crew — the orchestrator may still hold crew topics or a
+        #    live queue, which only it can answer for.
+        busy = False
+        subs = getattr(state, "subagents", None)
+        if subs is not None:
             try:
-                busy = bool(await crew.has_live_work(name))
+                # The key the SPAWN ran under, which for a channel-linked slot
+                # is the channel session, not `dashboard:<tab>` —
+                # `has_pending_work_for` matches `parent_session_key` exactly,
+                # so deriving it differently here reports "idle" while that
+                # slot's subagents are still running and flips the execution
+                # model out from under them.
+                busy = bool(subs.has_pending_work_for(effective_session_key(slot)))
             except Exception:
-                busy = True
-    if slot.running or busy:
-        sel().log_api_access(
-            caller="dashboard",
-            operation="chat.slot_mode",
-            outcome="denied",
-            source="dashboard",
-            resources=name,
-        )
-        return web.json_response(
-            {"error": "cannot switch mode while session is running"}, status=409
-        )
-    slot.mode = mode
-    # Clear orchestrator auto-run flag when leaving orchestrator mode to
-    # prevent stale "Go All" state from triggering on re-entry.
-    if mode != "orchestrator" and getattr(slot, "_auto_run", False):
-        slot._auto_run = False
-    await save_slot_off_loop(state, slot, force=True)
+                busy = True  # fail closed: refuse rather than risk the flip
+        if not busy and slot.mode == "crew":
+            # isinstance, not `is not None` — matching gateway.py's own check
+            # on this attribute. A stand-in object passes an identity check and
+            # then answers `has_live_work` with something truthy, refusing a
+            # switch that is fine.
+            crew = getattr(state, "crew", None)
+            if isinstance(crew, CrewOrchestrator):
+                try:
+                    busy = bool(await crew.has_live_work(name))
+                except Exception:
+                    busy = True
+        if slot.running or busy:
+            sel().log_api_access(
+                caller="dashboard",
+                operation="chat.slot_mode",
+                outcome="denied",
+                source="dashboard",
+                resources=name,
+            )
+            return web.json_response(
+                {"error": "cannot switch mode while session is running"}, status=409
+            )
+        prior_mode = slot.mode
+        prior_auto_run = getattr(slot, "_auto_run", False)
+        slot.mode = mode
+        # Clear orchestrator auto-run flag when leaving orchestrator mode to
+        # prevent stale "Go All" state from triggering on re-entry.
+        if mode != "orchestrator" and getattr(slot, "_auto_run", False):
+            slot._auto_run = False
+        if not await save_slot_off_loop(
+            state, slot, force=True, expected_history_key=authorized_history_key
+        ):
+            # Refused without writing: the session was permanently deleted or
+            # rebound mid-persist. Roll back the live fields — but only while
+            # the mode still holds THIS request's value, so a non-endpoint
+            # writer's newer commit is not erased.
+            if slot.mode == mode:
+                slot.mode = prior_mode
+                slot._auto_run = prior_auto_run
+            # The UNPINNED periodic flush may have persisted the provisional
+            # value while this save awaited (review-caught): mark dirty so the
+            # next flush reconverges the durable record to the live state.
+            slot._dirty = True
+            sel().log_api_access(
+                caller="dashboard",
+                operation="chat.slot_mode",
+                outcome="denied",
+                source="dashboard",
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"}, status=409
+            )
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard",

--- a/src/kiro_crew/dashboard/chat_tags.py
+++ b/src/kiro_crew/dashboard/chat_tags.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, TypeVar
 from aiohttp import web
 
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+from kiro_crew.dashboard.chat_utils import slot_history_key
 from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.loop_lock import LoopBoundLock
@@ -407,9 +408,21 @@ async def api_chat_tag_delete(request: web.Request) -> web.Response:
         # the next load; mark the slot dirty so the periodic flush retries.
         for slot in state._slots.values():
             if tid in slot.tags:
+                # Pin the write to the transcript this iteration's membership
+                # check covered: the save awaits inside the loop, so a rebind
+                # can land mid-persist and the save would otherwise resolve
+                # its target from the moved routing at write time. No await
+                # between this capture and the strip below.
+                authorized_history_key = slot_history_key(slot)
                 slot.tags = [t for t in slot.tags if t != tid]
                 try:
-                    await save_slot_off_loop(state, slot, force=True, best_effort=False)
+                    applied = await save_slot_off_loop(
+                        state,
+                        slot,
+                        force=True,
+                        best_effort=False,
+                        expected_history_key=authorized_history_key,
+                    )
                 except Exception:
                     slot._dirty = True
                     logger.warning(
@@ -418,6 +431,21 @@ async def api_chat_tag_delete(request: web.Request) -> web.Response:
                         getattr(slot, "key", "?"),
                         exc_info=True,
                     )
+                else:
+                    if not applied:
+                        # Refused without writing (session permanently deleted
+                        # or rebound mid-persist). The in-memory strip stands —
+                        # the id is already gone from the vocabulary — so mark
+                        # dirty and let the periodic flush persist wherever the
+                        # slot now routes; a dangling id left on the old
+                        # transcript is pruned on the next load.
+                        slot._dirty = True
+                        logger.warning(
+                            "tag delete: slot strip save refused for %s "
+                            "(session deleted or rebound); marked dirty for "
+                            "periodic-flush retry",
+                            getattr(slot, "key", "?"),
+                        )
 
         # ── Best-effort cleanup: strip the deleted id from folders ───────
         # A folder can carry tags (copied onto new chats filed into it); the
@@ -488,6 +516,14 @@ async def api_chat_slot_tags(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+    # Capture the transcript key the lookup above just covered, BEFORE the
+    # body-parse and lock awaits: ``linked_session_key`` is rebound on
+    # already-live slots with no ``running`` gate (cron completions, workflow
+    # injections), so a slow caller can be authorized against its own session
+    # and land on somebody else's conversation. The re-check below and the
+    # save's expected_history_key pin together keep this request's write on
+    # the transcript it was authorized against.
+    authorized_history_key = slot_history_key(slot)
     body, body_err = await read_bounded_json(request)
     if body_err is not None:
         return body_err
@@ -504,8 +540,54 @@ async def api_chat_slot_tags(request: web.Request) -> web.Response:
         for tid in raw_ids:
             if isinstance(tid, str) and tid in valid_ids and tid not in new_tags:
                 new_tags.append(tid)
+        # Re-authorize after the awaits above (body parse, lock acquisition):
+        # the same slot OBJECT must still be registered under the name, and
+        # its routing must still resolve to the transcript captured before
+        # the first await — a rebind in either window means this request's
+        # authorization no longer covers the write target.
+        if state._slots.get(name) is not slot or slot_history_key(slot) != authorized_history_key:
+            sel().log_api_access(
+                caller="dashboard",
+                operation="chat.slot_tags",
+                outcome="denied",
+                source="dashboard",
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"},
+                status=409,
+            )
+        prior_tags = slot.tags
         slot.tags = new_tags
-        await save_slot_off_loop(state, slot, force=True)
+        if not await save_slot_off_loop(
+            state, slot, force=True, expected_history_key=authorized_history_key
+        ):
+            # Refused without writing: the session was permanently deleted or
+            # rebound mid-persist. Roll back the live field — but only while
+            # it still holds THIS request's value: the write span awaits, so
+            # a concurrent writer may have committed a newer value that an
+            # unconditional restore would erase (the same guard
+            # _restore_unfiled applies to its rollback).
+            if slot.tags == new_tags:
+                slot.tags = prior_tags
+            # The UNPINNED periodic flush may have persisted the provisional
+            # value to the slot's current transcript while this save awaited
+            # (review-caught): mark dirty so the next flush reconverges the
+            # durable record to the rolled-back live state.
+            slot._dirty = True
+            sel().log_api_access(
+                caller="dashboard",
+                operation="chat.slot_tags",
+                outcome="denied",
+                source="dashboard",
+                resources=name,
+                error="session was deleted or rebound",
+            )
+            return web.json_response(
+                {"error": "session was deleted or rebound", "code": "session_gone"},
+                status=409,
+            )
 
     state.push_slots_update()
     sel().log_api_access(
@@ -832,55 +914,89 @@ async def api_chat_slot_drop(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+    # Capture the transcript key the lookup above just covered, BEFORE the
+    # body-parse await — the same rebind window PUT /tags documents. The
+    # re-check below and the save's expected_history_key pin together keep
+    # this request's write on the transcript it was authorized against.
+    authorized_history_key = slot_history_key(slot)
     body, body_err = await read_bounded_json(request)
     if body_err is not None:
         return body_err
     assert body is not None  # read_bounded_json returns (dict, None) on success
     column_id = str(body.get("column_id") or "")
-    column = next((c for c in state._tag_boards if c.get("id") == column_id), None)
-    if not column:
-        return web.json_response(
-            {"error": "column not found", "code": "column_not_found"}, status=404
-        )
-    tag_index = {t["id"]: t for t in state._tags}
-    if column.get("source") == "state":
-        # A state lane's membership is derived from the session's own runtime
-        # state, so there is nothing to write that would move the card there —
-        # only the agent reaching that state moves it. Refuse rather than
-        # silently reassigning tags the lane does not filter by.
+
+    def _rejected(reason: str) -> web.Response:
         sel().log_api_access(
             caller="dashboard",
             operation="chat.slot_drop",
             outcome="rejected",
             source="dashboard",
             resources=f"{name}->{column_id}",
-            error="column is a derived state lane",
+            error=reason,
         )
-        return web.json_response(
-            {"ok": False, "reason": "column is a derived state lane", "tags": slot.tags}
-        )
-    col_tags = [tag_index[t] for t in column.get("tag_ids") or [] if t in tag_index]
-    status_tags = [t for t in col_tags if t.get("status")]
-    if len(status_tags) != 1:
-        # Column doesn't carry exactly one status tag — there's no
-        # unambiguous status to assign on drop, so this is a visual no-op
-        # (covers both the unfiltered and the multi-status filter cases).
-        # Audit the rejected drop so the SEL trail captures every attempt.
-        sel().log_api_access(
-            caller="dashboard",
-            operation="chat.slot_drop",
-            outcome="rejected",
-            source="dashboard",
-            resources=f"{name}->{column_id}",
-            error="column is not a status lane",
-        )
-        return web.json_response(
-            {"ok": False, "reason": "column is not a status lane", "tags": slot.tags}
-        )
-    target_id = status_tags[0]["id"]
-    kept = [t for t in slot.tags if t in tag_index and not tag_index[t].get("status")]
-    slot.tags = kept + [target_id]
-    await save_slot_off_loop(state, slot, force=True)
+        return web.json_response({"ok": False, "reason": reason, "tags": slot.tags})
+
+    # Serialize the whole resolve/re-check/mutate/persist/rollback span under
+    # the same lock every other tags writer holds (PUT /tags, the tag-delete
+    # strip, auto-tag). Two reasons, both review-caught: (1) with awaits
+    # inside the span, a second concurrent writer would capture this one's
+    # value as its rollback snapshot, and value-based rollback cannot tell
+    # "my write survived" from "someone else wrote the same value" — a
+    # refused drop could then erase an equal, acknowledged concurrent commit;
+    # (2) the column and tag vocabulary must be RESOLVED under the lock too,
+    # or a tag deletion completing while this request waits on the lock is
+    # resurrected — the stale target id would be re-added and persisted onto
+    # the slot after the vocabulary commit removed it.
+    async with _tags_write_lock(state):
+        column = next((c for c in state._tag_boards if c.get("id") == column_id), None)
+        if not column:
+            return web.json_response(
+                {"error": "column not found", "code": "column_not_found"}, status=404
+            )
+        tag_index = {t["id"]: t for t in state._tags}
+        if column.get("source") == "state":
+            # A state lane's membership is derived from the session's own
+            # runtime state, so there is nothing to write that would move the
+            # card there — only the agent reaching that state moves it. Refuse
+            # rather than silently reassigning tags the lane does not filter by.
+            return _rejected("column is a derived state lane")
+        col_tags = [tag_index[t] for t in column.get("tag_ids") or [] if t in tag_index]
+        status_tags = [t for t in col_tags if t.get("status")]
+        if len(status_tags) != 1:
+            # Column doesn't carry exactly one LIVE status tag — there's no
+            # unambiguous status to assign on drop, so this is a visual no-op
+            # (covers the unfiltered, multi-status, and target-tag-deleted
+            # cases alike; tag_index was built under the lock, so a tag
+            # deleted while this request waited is already absent here).
+            return _rejected("column is not a status lane")
+        target_id = status_tags[0]["id"]
+        # Re-authorize after the awaits above (body parse, lock acquisition):
+        # same slot OBJECT still registered under the name, routing still on
+        # the transcript captured before the first await. No await between
+        # this check and the save dispatch; the persist window itself is
+        # covered by the save's pin.
+        if state._slots.get(name) is not slot or slot_history_key(slot) != authorized_history_key:
+            return _rejected("session was deleted or rebound")
+        kept = [t for t in slot.tags if t in tag_index and not tag_index[t].get("status")]
+        prior_tags = slot.tags
+        written_tags = kept + [target_id]
+        slot.tags = written_tags
+        if not await save_slot_off_loop(
+            state, slot, force=True, expected_history_key=authorized_history_key
+        ):
+            # Refused without writing: the session was permanently deleted or
+            # rebound mid-persist. Roll back the live field — but only while
+            # it still holds THIS request's value, so a non-endpoint writer's
+            # newer commit is not erased — and report the drop as rejected,
+            # matching this endpoint's rejection shape (the card stays where
+            # it was).
+            if slot.tags == written_tags:
+                slot.tags = prior_tags
+            # The UNPINNED periodic flush may have persisted the provisional
+            # value while this save awaited (review-caught): mark dirty so the
+            # next flush reconverges the durable record to the live state.
+            slot._dirty = True
+            return _rejected("session was deleted or rebound")
     state.push_slots_update()
     sel().log_api_access(
         caller="dashboard",

--- a/test/test_chat_tags.py
+++ b/test/test_chat_tags.py
@@ -334,8 +334,9 @@ class TestTagVocabulary:
         app = _make_tags_app(state)
         call_order: list[str] = []
 
-        async def _tracking_save(st, slot, *, force=False, best_effort=True):
+        async def _tracking_save(st, slot, **kwargs):
             call_order.append("save_slot")
+            return True  # a committed save — None would read as the refusal
 
         original_write = __import__(
             "kiro_crew.dashboard.chat_tags", fromlist=["_write_tags_snapshot"]
@@ -416,6 +417,7 @@ class TestTagVocabulary:
                 saves.append(slot_arg.key)
                 if slot_arg.key == "s1":
                     raise IOError("disk full")
+                return True  # a committed save — None would read as the refusal
 
             with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", _partial_failing_save):
                 resp = await client.delete(f"/api/chat/tags/{tag['id']}")

--- a/test/test_forced_save_history_key_pin.py
+++ b/test/test_forced_save_history_key_pin.py
@@ -1,0 +1,381 @@
+"""expected_history_key pin at the tags/folders forced-save call sites (#7519).
+
+``save_slot_off_loop`` / ``_save_slot_to_history`` resolve their target
+transcript from live routing at write time, so a ``linked_session_key`` rebind
+during the persist await can redirect a durable write to a transcript the
+caller never authorized against. PR #7346 added the ``expected_history_key``
+refuse-if-moved pin (save returns ``False``, writing nothing, when the live
+key has moved off the pinned one) and wired it at the autocompact endpoint;
+these tests pin the REMAINING forced-save sites the same way, mirroring
+``test_session_autocompact_override.TestExpectedHistoryKeyPin``:
+
+- ``chat_tags``: the tag-delete slot strip, PUT slot tags, and the drag-drop
+  status reassign.
+- ``chat_folders``: the folder-delete unfile loop and its restore rollback,
+  PATCH slot folder, PATCH slot pin, and PATCH slot mode.
+
+Two layers:
+
+- Real-save tests drive an endpoint through the REAL save with the routing
+  rebound mid-persist, asserting the refusal propagates (409, rollback) and
+  that neither the pinned nor the foreign transcript received the write.
+- Disposition tests stub the save to refuse (``False``) and assert each call
+  site's documented handling: the direct mutation endpoints roll back and
+  return 409 ``session_gone`` (the autocompact disposition); the drag-drop
+  endpoint answers in its own rejection shape (``ok: False`` + reason); the
+  best-effort cleanup loops mark the slot dirty and keep going. Every stubbed
+  call also proves the pin was captured from the PRE-rebind routing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_folder_app, _make_state, _make_tags_app
+
+from kiro_crew.dashboard.chat import api_chat_slot_mode
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop as _real_save
+from kiro_crew.dashboard.chat_tags import tags_write_lock
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+_FOREIGN_KEY = "channel:foreign:123"
+
+
+def _rebinding_save(slot: _ChatSlot):
+    """A save double that rebinds *slot* then delegates to the REAL save.
+
+    Simulates the rebind window the pin exists for: the routing moves after
+    the caller captured its authorized key but before the save's own routing
+    snapshot, so the real refusal path (not a stub) produces the ``False``.
+    """
+
+    async def _save(state, target, *args, **kwargs):
+        target.linked_session_key = _FOREIGN_KEY
+        return await _real_save(state, target, *args, **kwargs)
+
+    return _save
+
+
+def _make_mode_app(state: DashboardState) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+    app.router.add_patch("/api/chat/slots/{slot}/mode", api_chat_slot_mode)
+    return app
+
+
+class TestRealSaveRefusalThroughEndpoints:
+    """The rebind refusal, end to end through the real save."""
+
+    @pytest.mark.asyncio
+    async def test_slot_tags_put_refuses_409_and_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Spike"})).json()
+            slot = state.get_or_create_slot("s1")
+            slot.append("user", "hello")
+            slot.drain()
+            pinned = slot_history_key(slot)
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", _rebinding_save(slot)):
+                resp = await client.put("/api/chat/slots/s1/tags", json={"tags": [tag["id"]]})
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "session_gone"
+            # Live field rolled back — the acknowledged state never diverges
+            # from what the caller was told.
+            assert slot.tags == []
+            # Nothing was written to either transcript.
+            assert not (state.conversation_log._read_metadata(pinned) or {}).get("tags")
+            foreign_meta = state.conversation_log._read_metadata(_FOREIGN_KEY)
+            assert not (foreign_meta or {}).get("tags")
+
+    @pytest.mark.asyncio
+    async def test_slot_folder_patch_refuses_409_and_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_folder_app(state)
+        async with TestClient(TestServer(app)) as client:
+            folder = await (await client.post("/api/chat/folders", json={"name": "F"})).json()
+            slot = state.get_or_create_slot("s1")
+            slot.append("user", "hello")
+            slot.drain()
+            pinned = slot_history_key(slot)
+            with patch(
+                "kiro_crew.dashboard.chat_folders.save_slot_off_loop", _rebinding_save(slot)
+            ):
+                resp = await client.patch(
+                    "/api/chat/slots/s1/folder", json={"folder_id": folder["id"]}
+                )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "session_gone"
+            assert slot.folder_id == ""
+            assert slot._folder_changed is False
+            assert not (state.conversation_log._read_metadata(pinned) or {}).get("folder_id")
+            foreign_meta = state.conversation_log._read_metadata(_FOREIGN_KEY)
+            assert not (foreign_meta or {}).get("folder_id")
+
+
+class TestRefusalDispositionPerSite:
+    """Each site's handling of a refused save, with the pin capture proven."""
+
+    @pytest.mark.asyncio
+    async def test_slot_pin_rolls_back_and_409(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_folder_app(state)
+        refusing = AsyncMock(return_value=False)
+        async with TestClient(TestServer(app)) as client:
+            slot = state.get_or_create_slot("s1")
+            pinned = slot_history_key(slot)
+            with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", refusing):
+                resp = await client.patch("/api/chat/slots/s1/pin", json={"pinned": True})
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "session_gone"
+            assert slot.pinned is False
+            assert refusing.await_args.kwargs["expected_history_key"] == pinned
+
+    @pytest.mark.asyncio
+    async def test_slot_mode_rolls_back_both_fields_and_409(self):
+        slot = _ChatSlot("test")
+        slot.mode = "orchestrator"
+        slot._auto_run = True
+        state = MagicMock(spec=DashboardState)
+        state._slots = {slot.key: slot}
+        state.push_slots_update = MagicMock()
+        pinned = slot_history_key(slot)
+        refusing = AsyncMock(return_value=False)
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", refusing):
+            async with TestClient(TestServer(_make_mode_app(state))) as client:
+                resp = await client.patch("/api/chat/slots/test/mode", json={"mode": ""})
+                assert resp.status == 409
+                assert (await resp.json())["code"] == "session_gone"
+        # Both live fields restored: the mode AND the auto-run flag the
+        # transition cleared on the way through.
+        assert slot.mode == "orchestrator"
+        assert slot._auto_run is True
+        assert refusing.await_args.kwargs["expected_history_key"] == pinned
+
+    @pytest.mark.asyncio
+    async def test_slot_drop_answers_in_rejection_shape(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        refusing = AsyncMock(return_value=False)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (
+                await client.post("/api/chat/tags", json={"name": "Doing", "status": True})
+            ).json()
+            col = await (
+                await client.post(
+                    "/api/chat/tag-columns", json={"tag_ids": [tag["id"]], "mode": "any"}
+                )
+            ).json()
+            slot = state.get_or_create_slot("s1")
+            pinned = slot_history_key(slot)
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", refusing):
+                resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": col["id"]})
+            # This endpoint reports rejections as ok:False in a 200 body (the
+            # card stays put); the refusal takes the same shape, with the
+            # rolled-back tag list so the client renders the true state.
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["ok"] is False
+            assert body["reason"] == "session was deleted or rebound"
+            assert body["tags"] == []
+            assert slot.tags == []
+            assert refusing.await_args.kwargs["expected_history_key"] == pinned
+
+    @pytest.mark.asyncio
+    async def test_tag_delete_strip_marks_dirty_and_delete_succeeds(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        refusing = AsyncMock(return_value=False)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Del"})).json()
+            slot = state.get_or_create_slot("s1")
+            slot.tags = [tag["id"]]
+            pinned = slot_history_key(slot)
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", refusing):
+                resp = await client.delete(f"/api/chat/tags/{tag['id']}")
+            # The vocabulary commit already made the deletion durable; the
+            # refused strip is best-effort cleanup, so the delete still
+            # succeeds and the slot is marked dirty for the flush to retry.
+            assert resp.status == 200
+            assert all(t["id"] != tag["id"] for t in state._tags)
+            assert slot.tags == []
+            assert slot._dirty is True
+            assert refusing.await_args.kwargs["expected_history_key"] == pinned
+
+    @pytest.mark.asyncio
+    async def test_folder_delete_unfile_marks_dirty_and_delete_succeeds(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_folder_app(state)
+        refusing = AsyncMock(return_value=False)
+        async with TestClient(TestServer(app)) as client:
+            folder = await (await client.post("/api/chat/folders", json={"name": "F"})).json()
+            slot = state.get_or_create_slot("s1")
+            slot.folder_id = folder["id"]
+            pinned = slot_history_key(slot)
+            with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", refusing):
+                resp = await client.delete(f"/api/chat/folders/{folder['id']}")
+            # The unfile stands in memory (the folder is gone); the refused
+            # persist marks the slot dirty so the flush re-persists wherever
+            # the slot now routes.
+            assert resp.status == 200
+            assert slot.folder_id == ""
+            assert slot._dirty is True
+            assert refusing.await_args.kwargs["expected_history_key"] == pinned
+
+    @pytest.mark.asyncio
+    async def test_restore_unfiled_refusal_marks_dirty_and_keeps_restored_field(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_folder_app(state)
+        refusing = AsyncMock(return_value=False)
+        async with TestClient(TestServer(app)) as client:
+            folder = await (await client.post("/api/chat/folders", json={"name": "F"})).json()
+            slot = state.get_or_create_slot("s1")
+            slot.folder_id = folder["id"]
+            # Force the folder-store commit to fail so the rollback runs and
+            # its restore save is also refused.
+            with (
+                patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", refusing),
+                patch.object(state, "mutate_folders", AsyncMock(side_effect=OSError("disk full"))),
+            ):
+                resp = await client.delete(f"/api/chat/folders/{folder['id']}")
+            # The commit failure propagates (the delete did NOT land)…
+            assert resp.status == 500
+            # …and the rollback restored the live field despite its own save
+            # being refused, leaving the slot dirty for the flush to retry.
+            assert slot.folder_id == folder["id"]
+            assert slot._dirty is True
+            # Both the unfile and the restore were pinned.
+            assert refusing.await_count == 2
+            for call in refusing.await_args_list:
+                assert call.kwargs["expected_history_key"] == slot_history_key(slot)
+
+
+class TestRefusalRollbackHardening:
+    """The reviewer-caught refinements: the rollback must not clobber state
+    it does not own — a pending breadcrumb latch from an EARLIER successful
+    move, or a CONCURRENT writer's acknowledged commit — and a rebind during
+    an await before the mutation must be refused before anything mutates.
+    """
+
+    @pytest.mark.asyncio
+    async def test_folder_refusal_preserves_pending_breadcrumb_latch(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_folder_app(state)
+        refusing = AsyncMock(return_value=False)
+        async with TestClient(TestServer(app)) as client:
+            folder = await (await client.post("/api/chat/folders", json={"name": "F"})).json()
+            slot = state.get_or_create_slot("s1")
+            # An earlier successful move armed the latch; the session has not
+            # taken its next turn yet, so the breadcrumb re-injection is
+            # still pending and must survive this request's refusal.
+            slot._folder_changed = True
+            with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", refusing):
+                resp = await client.patch(
+                    "/api/chat/slots/s1/folder", json={"folder_id": folder["id"]}
+                )
+            assert resp.status == 409
+            assert slot._folder_changed is True
+
+    @pytest.mark.asyncio
+    async def test_mode_refusal_does_not_clobber_concurrent_writer(self):
+        slot = _ChatSlot("test")
+        assert slot.mode == ""
+        state = MagicMock(spec=DashboardState)
+        state._slots = {slot.key: slot}
+        state.push_slots_update = MagicMock()
+
+        async def _concurrent_writer_wins(st, target, *args, **kwargs):
+            # While THIS request's save awaits, a concurrent writer commits
+            # and is acknowledged; then this save is refused. The stale
+            # rollback must not erase the newer value.
+            target.mode = "crew"
+            return False
+
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", _concurrent_writer_wins):
+            async with TestClient(TestServer(_make_mode_app(state))) as client:
+                resp = await client.patch(
+                    "/api/chat/slots/test/mode", json={"mode": "orchestrator"}
+                )
+                assert resp.status == 409
+        assert slot.mode == "crew"
+
+    @pytest.mark.asyncio
+    async def test_tags_rebind_while_waiting_on_lock_is_refused_before_mutation(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        recording = AsyncMock(return_value=True)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "T"})).json()
+            slot = state.get_or_create_slot("s1")
+            lock = tags_write_lock(state)
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", recording):
+                # Hold the tags write lock so the PUT parks on a REAL await
+                # window, rebind the slot while it waits, then release. The
+                # post-await re-check must refuse before any mutation.
+                await lock.acquire()
+                try:
+                    put = asyncio.ensure_future(
+                        client.put("/api/chat/slots/s1/tags", json={"tags": [tag["id"]]})
+                    )
+                    await asyncio.sleep(0.05)  # let the PUT reach the lock
+                    slot.linked_session_key = _FOREIGN_KEY
+                finally:
+                    lock.release()
+                resp = await put
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "session_gone"
+            assert slot.tags == []
+            recording.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_drop_does_not_resurrect_a_deleted_target_tag(self, tmp_path, monkeypatch):
+        """The column and vocabulary are resolved UNDER the tags lock.
+
+        A tag deletion completing while the drop waits on the lock removes the
+        target from the vocabulary; resolving before the lock would re-add and
+        persist the stale id onto the slot after the vocabulary commit removed
+        it. Resolved under the lock, the dead target reads as "not a status
+        lane" and the drop is a rejected no-op.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        recording = AsyncMock(return_value=True)
+        async with TestClient(TestServer(app)) as client:
+            # The column still references the tag id, but the vocabulary no
+            # longer carries it — the state a tag delete leaves for a drop
+            # that lost the lock race.
+            state._tags = []
+            state._tag_boards = [
+                {"id": "col1", "name": "Doing", "tag_ids": ["ghost"], "mode": "any", "order": 0}
+            ]
+            slot = state.get_or_create_slot("s1")
+            slot.tags = ["keep-me"]
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", recording):
+                resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": "col1"})
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["ok"] is False
+            assert body["reason"] == "column is not a status lane"
+            assert slot.tags == ["keep-me"]
+            recording.assert_not_awaited()


### PR DESCRIPTION
## Problem / Motivation

`save_slot_off_loop` / `_save_slot_to_history` resolve their target transcript from live routing (`linked_session_key`) at write time. A rebind during the persist await -- a cron completion or workflow injection rebinds already-live slots with no `running` gate -- can therefore redirect a durable write to a transcript the caller never authorized against. PR #7346 added the `expected_history_key` refuse-if-moved pin (the save returns `False`, writing nothing, when the live key has moved off the pinned one) but wired it only at the autocompact endpoint. The remaining forced-save sites in the tags/folders handlers shared the same rebind window and were still unpinned.

## Why it matters

A user action aimed at one conversation (tagging it, filing it, pinning it, switching its mode, deleting a tag or folder) could durably mutate a *different* conversation's transcript metadata if the slot rebinds mid-request. That is a cross-session write-integrity hole: the caller's authorization covered one transcript and the bytes landed on another, with no error and no audit trail.

## What changed (motivation -> approach -> change)

Thread the pin through the 8 remaining forced-save sites, following the autocompact precedent:

- `chat_tags.py`: the tag-delete slot strip loop, `PUT /slots/{slot}/tags`, and the drag-drop status reassign (`POST /slots/{slot}/drop`).
- `chat_folders.py`: the folder-delete unfile loop and its `_restore_unfiled` rollback, `PATCH /slots/{slot}/folder`, `PATCH /slots/{slot}/pin`, and `PATCH /slots/{slot}/mode`.

The five request endpoints capture the authorized key **before their first await** and re-check it (plus slot **object identity**, mirroring `_reauthorize_after_await`) after the last await before mutating, so a rebind during body parsing, lock waits, or the mode endpoint's busy probes is refused before anything mutates. The persist window itself is covered by the save's pin.

Refusal handling matches each caller's existing convention rather than one uniform policy:

- Direct mutation endpoints (tags PUT, folder, pin, mode) roll back the live field and return `409 session_gone` -- the autocompact disposition.
- The drag-drop endpoint answers in its own rejection shape (`ok: false` + reason, SEL `rejected`), so the card stays put.
- The best-effort cleanup loops (tag-delete strip, folder-delete unfile, restore rollback) mark the slot dirty for the periodic flush and keep going, matching their existing failure tolerance.

Hardenings from review: each endpoint's re-check/mutate/persist/rollback span is **serialized** -- folder/pin/mode under a new per-transcript `_slot_meta_txn_lock` (the autocompact txn-lock shape), and the drag-drop reassign under the module's existing `tags_write_lock` that every other `slot.tags` writer already holds -- so a rollback can only ever undo its own write (value-based rollback cannot tell "my write survived" from "someone else wrote the same value"). Rollbacks additionally stay **compare-and-set** as defense for the non-endpoint writers that do not take these locks (the folder-delete unfile loop), and the folder endpoint restores the **prior** `_folder_changed` breadcrumb latch instead of clearing it (a pending re-injection from an earlier successful move survives a later refusal).

Reviewed and deliberately NOT changed:

- A rebind landing *after* the save's routing snapshot leaves the durable write correctly on the authorized transcript; the slot's own metadata then follows the slot to its new home on later flushes. That is the ordinary data model for slot-owned meta keys (autocompact's post-save check protected its SessionManager live-map seeding, which has no analogue here).
- The `_unhide_folder` write is not compensated on the new 409 path: re-hiding could erase a concurrent legitimate unhide, and a visible empty folder is benign and user-correctable.
- Same-class `force=True` sites outside this issue's tags/folders scope (slot-recreate in `chat_handlers.py`, `chat_auto_tag.py`, `crew_chat.py`) are left for a follow-up issue.

## Tests

- New `test/test_forced_save_history_key_pin.py` (11 tests): two real-save tests drive endpoints through the real `_save_slot_to_history` with routing rebound mid-persist (409, rollback, nothing written to either transcript -- mutation-sensitive: an unpinned save reddens the foreign-meta assertion); per-site disposition tests for all 8 sites assert the refusal handling and that the pin kwarg equals the pre-request key; hardening tests cover the preserved breadcrumb latch, the concurrent-writer-wins rollback guard, and a real lock-window rebind refused by the post-await re-check before any mutation.
- Two existing test stubs that returned `None` (now falsy at the new refusal branches) return `True`, restoring their documented fidelity.
- Ran: the new file (11 passed) plus the 10 related suites (300 passed); `isort`, `flake8`, the baselined black gate, and full `mypy` (1,243 files) all clean.

## Manual verification

Not applicable -- backend-only; behavior on the success path is byte-identical at every site (verified in review), and the refusal paths are only reachable through the mid-request rebind race, which the real-save tests exercise deterministically.

## Screenshots / video

Not applicable (no UI change).

## Related Issues

Closes #7519

## Pattern harvest

Rule candidate: a mutate/save/rollback span with awaits inside must be serialized per resource (txn lock), with compare-and-set rollback as the fallback where a writer cannot take the lock: value-based restore cannot tell "my write survived" from "someone else committed after me", so an unconditional restore erases a concurrent writer's acknowledged commit. The same class produced `_autocompact_txn_lock` and the guarded rollback in `_restore_unfiled`; candidate for the recurring-defect list if it recurs once more.

## Checklist

- [x] Tests added/updated for the change
- [x] Local gates run (isort / flake8 / mypy / pytest)
- [x] Docs updated where behavior they document changed (no spec documents these endpoints' persist semantics; the pin's contract lives in `chat_persistence.py` docstrings from #7346)

## Contribution License Agreement

By submitting this pull request, I confirm my contribution is made under the terms of the project's license.
