### PR TITLE
fix(ci): give each AI review pass its own Bedrock session

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -278,6 +278,20 @@ jobs:
           echo "--- stage 1 candidates (never posted; kept here as tuning signal) ---"
           cat .review-candidates.md
 
+      # Re-assume the role BETWEEN the stages. The action's session lasts one
+      # hour and both stages used to share it, so a discovery stage that took
+      # most of that hour left validation to die mid-call on `401 Unauthorized:
+      # The security token included in the request is expired` -- the gate then
+      # failed closed with no verdict and no way to tell a real hang from a
+      # spent session. Each stage now starts on a fresh session, leaving the
+      # 90-minute job timeout as the only wall. Keep in sync with
+      # codex-review.yml.
+      - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        if: github.actor != 'dependabot[bot]' && steps.human_override.outputs.active != 'true'
+        with:
+          role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+          aws-region: us-west-2
+
       # ── Stage 2 of 2: VALIDATION (authoritative) ───────────────────────────
       # A fresh call with no memory of stage 1's reasoning. It re-derives input /
       # call path / observable outcome for every candidate from code it opens

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -43,12 +43,15 @@ jobs:
   codex-review:
     name: GPT 5.6 Review
     runs-on: ubuntu-latest
-    # Runaway/hang backstop only, NOT a per-review budget: the two-pass review
-    # self-terminates on its own long before this. Set generously at 90 min so
-    # it never cuts a completing review the way the old 30-min wall did, while
-    # still failing the gate closed on a true hang well under GitHub's 360-min
-    # job default. Keep in sync with claude-review.yml.
-    timeout-minutes: 90
+    # Runaway/hang backstop only, NOT a per-review budget: each pass carries its
+    # own PASS_WALL and self-terminates first. This wall MUST therefore stay
+    # above the sum of the pass walls plus setup -- otherwise it, not the named
+    # pass timeout, is what kills pass 2, and the job is cancelled with no
+    # verdict and no diagnostic. 2 x 55m + ~20m of setup/posting = 130, still
+    # well under GitHub's 360-min job default. Deliberately NOT the Opus lanes'
+    # 90 min: those drive the model through `claude-code-action`, which cannot be
+    # wrapped in `timeout`, so they have no pass walls to contain.
+    timeout-minutes: 130
     # Only run on PRs from the same repo (not forks) to prevent budget abuse,
     # prompt injection via malicious diffs, and secret exfiltration attempts.
     if: github.event.pull_request.head.repo.full_name == github.repository
@@ -355,24 +358,85 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: GPT 5.6 review (discovery + falsification)
+      - name: GPT 5.6 review (discovery pass)
+        if: github.actor != 'dependabot[bot]' && steps.human_override.outputs.active != 'true'
+        env:
+          AWS_REGION: us-east-1
+          # Bounded just under the one-hour Bedrock session so a pass that runs
+          # away dies on a named timeout instead of mid-call on an expired
+          # token, which reads as a model failure and buries the real cause.
+          PASS_WALL: 55m
+        # Pass 1 generates candidates; its output is never posted or gated
+        # directly -- the falsification pass below emits the only verdict the
+        # comment and gate consume.
+        #
+        # Actions runs this `run:` with `bash -e {0}`, so `|| rc=$?` is REQUIRED
+        # to keep a failed model call visible instead of aborting before the
+        # diagnostics. A failed pass strips the reviewed marker, so the gate
+        # fails closed rather than silently degrading coverage.
+        run: |
+          set -uo pipefail
+          # `rm -f` FIRST, never a bare `: >`: this checkout is the PR's merge
+          # ref, so a PR can commit a tracked symlink at this name and `>` would
+          # follow it and truncate the target -- including
+          # .review-base-rules/AUTOSDE.yaml, materialized into this same
+          # workspace above, which would leave the review running with no
+          # blocking rules. Removing the link first makes the write land on a
+          # fresh regular file. Same reason the codex-pass-N.md writes below are
+          # already `rm -f`-ed.
+          rm -f codex-failed-passes
+          : > codex-failed-passes
+          PROMPT=$(printf '%s\n\n%s\n' "$(cat /tmp/codex-prompt.md)" \
+            "DISCOVERY PASS: inspect the full current diff and report every candidate that meets the FINDING BAR. This is candidate generation, not the final verdict.")
+
+          rm -f codex-pass-1.md
+          rc=0
+          # Called by path, not from PATH: exporting the bin directory
+          # through $GITHUB_PATH is a run-step write to an environment
+          # file, which is an execution vector in a job holding Bedrock
+          # credentials (zizmor github-env). The path is under RUNNER_TEMP
+          # because the manifest that produced it was materialized from the
+          # BASE commit, not from this checkout -- see "Install review CLI".
+          timeout "$PASS_WALL" \
+            "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
+            --sandbox read-only \
+            --output-last-message "codex-pass-1.md" \
+            "$PROMPT" || rc=$?
+          if [ "$rc" -ne 0 ] || [ ! -s codex-pass-1.md ]; then
+            echo "::warning::GPT 5.6 review pass 1 did not complete (exit ${rc}); the verdict will fail closed."
+            printf ' 1' >> codex-failed-passes
+          fi
+
+      # Re-assume the role BETWEEN the passes. The action's session lasts one
+      # hour and both passes used to share it, so a discovery pass that took
+      # most of that hour left pass 2 to die mid-call on `401 Unauthorized: The
+      # security token included in the request is expired` -- the gate then
+      # failed closed with no verdict and no way to tell a real hang from a
+      # spent session. Each pass now starts on a fresh session, so PASS_WALL --
+      # not session expiry, and not the job wall above it -- is what bounds it.
+      - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        if: github.actor != 'dependabot[bot]' && steps.human_override.outputs.active != 'true'
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: GPT 5.6 review (falsification pass)
         if: github.actor != 'dependabot[bot]' && steps.human_override.outputs.active != 'true'
         env:
           AWS_REGION: us-east-1
           DISCOVERY_OUTPUT_MAX_BYTES: "50000"
-        # Pass 1 generates candidates. Pass 2 tries to KILL them, then emits the
-        # only verdict the comment and gate consume. Pass 1's output is never
-        # posted or gated directly.
-        #
-        # Actions runs this `run:` with `bash -e {0}`, so `|| rc=$?` is REQUIRED
-        # to keep a failed model call visible instead of aborting before the
-        # diagnostics. Any failed pass strips the reviewed marker, so the gate
-        # fails closed rather than silently degrading coverage.
+          PASS_WALL: 55m
+        # Pass 2 tries to KILL pass 1's candidates and emits the verdict. Both
+        # calls are required: if either failed, no verdict is published and the
+        # gate fails closed.
         run: |
           set -uo pipefail
           BASE_PROMPT="$(cat /tmp/codex-prompt.md)"
+          # Same PR-controlled-symlink hazard as the discovery pass: remove
+          # before truncating so `>` cannot follow a link out of this file.
+          rm -f codex-review-output.md
           : > codex-review-output.md
-          failed_passes=""
+          failed_passes="$(cat codex-failed-passes 2>/dev/null || true)"
           review_nonce="$(openssl rand -hex 16)"
 
           truncate_utf8() {
@@ -397,45 +461,30 @@ jobs:
             fi
           }
 
-          for pass in 1 2; do
-            case "$pass" in
-              1)
-                PROMPT=$(printf '%s\n\n%s\n' "$BASE_PROMPT" \
-                  "DISCOVERY PASS: inspect the full current diff and report every candidate that meets the FINDING BAR. This is candidate generation, not the final verdict.")
-                ;;
-              2)
-                discovery_one="$(bounded_output "codex-pass-1.md")"
-                PROMPT="$(
-                  printf '%s\n\n' "$BASE_PROMPT"
-                  cat .review-prompts-gpt/gpt-falsification-mandate.md
-                  printf '%s\n' \
-                    "(3) any candidate the ROUND CONVERGENCE section forbids — a variant that a recorded ruling's rationale equally covers is at most an advisory FINDING, while an independent same-class defect at a site the ruling never addressed is judged normally."
-                  cat .review-prompts-gpt/gpt-falsification-verdict.md
-                  printf '%s\n' \
-                    "DISCOVERY_1_BEGIN::${review_nonce}" \
-                    "$discovery_one" \
-                    "DISCOVERY_1_END::${review_nonce}"
-                )"
-                ;;
-            esac
+          discovery_one="$(bounded_output "codex-pass-1.md")"
+          PROMPT="$(
+            printf '%s\n\n' "$BASE_PROMPT"
+            cat .review-prompts-gpt/gpt-falsification-mandate.md
+            printf '%s\n' \
+              "(3) any candidate the ROUND CONVERGENCE section forbids — a variant that a recorded ruling's rationale equally covers is at most an advisory FINDING, while an independent same-class defect at a site the ruling never addressed is judged normally."
+            cat .review-prompts-gpt/gpt-falsification-verdict.md
+            printf '%s\n' \
+              "DISCOVERY_1_BEGIN::${review_nonce}" \
+              "$discovery_one" \
+              "DISCOVERY_1_END::${review_nonce}"
+          )"
 
-            rm -f "codex-pass-${pass}.md"
-            rc=0
-            # Called by path, not from PATH: exporting the bin directory
-            # through $GITHUB_PATH is a run-step write to an environment
-            # file, which is an execution vector in a job holding Bedrock
-            # credentials (zizmor github-env). The path is under RUNNER_TEMP
-            # because the manifest that produced it was materialized from the
-            # BASE commit, not from this checkout -- see "Install review CLI".
+          rm -f codex-pass-2.md
+          rc=0
+          timeout "$PASS_WALL" \
             "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
-              --sandbox read-only \
-              --output-last-message "codex-pass-${pass}.md" \
-              "$PROMPT" || rc=$?
-            if [ "$rc" -ne 0 ] || [ ! -s "codex-pass-${pass}.md" ]; then
-              echo "::warning::GPT 5.6 review pass ${pass} did not complete (exit ${rc}); the verdict will fail closed."
-              failed_passes="${failed_passes} ${pass}"
-            fi
-          done
+            --sandbox read-only \
+            --output-last-message "codex-pass-2.md" \
+            "$PROMPT" || rc=$?
+          if [ "$rc" -ne 0 ] || [ ! -s codex-pass-2.md ]; then
+            echo "::warning::GPT 5.6 review pass 2 did not complete (exit ${rc}); the verdict will fail closed."
+            failed_passes="${failed_passes} 2"
+          fi
 
           if [ -n "$failed_passes" ]; then
             {

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -48,7 +48,10 @@ jobs:
   fork-gpt-review:
     name: Fork GPT 5.6 Review
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Must stay above the sum of the two PASS_WALLs plus setup, or this wall --
+    # not the named pass timeout -- kills pass 2 and the job ends with no
+    # verdict. Keep in sync with codex-review.yml.
+    timeout-minutes: 130
     # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request.
     if: >-
       github.event.workflow_run.event == 'pull_request'
@@ -362,7 +365,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: GPT 5.6 review (discovery + falsification)
+      - name: GPT 5.6 review (discovery pass)
         id: review
         env:
           AWS_REGION: us-east-1
@@ -371,12 +374,16 @@ jobs:
           NONCE: ${{ steps.intent.outputs.nonce }}
           INTENT_FILE: ${{ runner.temp }}/pr-intent.txt
           INTENT_TRUNCATED: ${{ steps.intent.outputs.truncated }}
-          DISCOVERY_OUTPUT_MAX_BYTES: "50000"
-        # Pass 1 generates candidates. Pass 2 tries to KILL them, then emits the
-        # only verdict the comment and gate consume. Pass 1's output is never
-        # posted or gated directly. Mirrors codex-review.yml's two-pass design.
+          # Bounded just under the one-hour Bedrock session so a pass that runs
+          # away dies on a named timeout instead of mid-call on an expired
+          # token, which reads as a model failure and buries the real cause.
+          PASS_WALL: 55m
+        # Pass 1 generates candidates; its output is never posted or gated
+        # directly -- the falsification pass below emits the only verdict the
+        # comment and gate consume. Mirrors codex-review.yml's two-pass design.
         run: |
           set -uo pipefail
+          rm -f codex-review-output.md
           : > codex-review-output.md
           # The shared GPT prompt blocks are read from the checked-out tree,
           # which on this lane is the UNMODIFIED trusted BASE -- a fork PR
@@ -559,8 +566,58 @@ jobs:
             echo "PR_INTENT_END::${NONCE}"
           } >> /tmp/fork-codex-prompt.md
 
+          # `rm -f` FIRST, never a bare `: >`. This lane checks out the trusted
+          # base rather than the fork head, so a PR-committed symlink at this
+          # name cannot be planted here today -- but that is a property of the
+          # checkout step, not of this write, and codex-review.yml's identical
+          # write IS reachable. Keep both lanes spelled the same way so the safe
+          # form survives any future change to what this lane checks out.
+          rm -f codex-failed-passes
+          : > codex-failed-passes
+          BASE_PROMPT="$(cat /tmp/fork-codex-prompt.md)"
+          PROMPT=$(printf '%s\n\n%s\n' "$BASE_PROMPT" \
+            "DISCOVERY PASS: inspect the full current diff and report every candidate that meets the FINDING BAR. This is candidate generation, not the final verdict.")
+
+          rm -f codex-pass-1.md
           rc=0
-          failed_passes=""
+          # Called by path, not from PATH: exporting the bin directory
+          # through $GITHUB_PATH is a run-step write to an environment
+          # file, which is an execution vector in a job holding Bedrock
+          # credentials (zizmor github-env). The path is under RUNNER_TEMP
+          # because the manifest that produced it was materialized from the
+          # BASE commit, not from this checkout -- see "Install review CLI".
+          timeout "$PASS_WALL" \
+            "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
+            --sandbox read-only \
+            --output-last-message "codex-pass-1.md" \
+            "$PROMPT" || rc=$?
+          if [ "$rc" -ne 0 ] || [ ! -s codex-pass-1.md ]; then
+            echo "::warning::GPT 5.6 fork review pass 1 did not complete (exit ${rc}); the verdict will fail closed."
+            printf ' 1' >> codex-failed-passes
+          fi
+
+      # Re-assume the role BETWEEN the passes: the session lasts one hour, and a
+      # discovery pass that consumes most of it used to leave pass 2 to die
+      # mid-call on an expired security token, failing the gate closed with no
+      # verdict. Keep in sync with codex-review.yml.
+      - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: GPT 5.6 review (falsification pass)
+        env:
+          AWS_REGION: us-east-1
+          DISCOVERY_OUTPUT_MAX_BYTES: "50000"
+          PASS_WALL: 55m
+        # Pass 2 tries to KILL pass 1's candidates and emits the only verdict the
+        # comment and gate consume. Both calls are required: if either failed, no
+        # verdict is published and the gate fails closed.
+        run: |
+          set -uo pipefail
+          rm -f codex-review-output.md
+          : > codex-review-output.md
+          failed_passes="$(cat codex-failed-passes 2>/dev/null || true)"
           review_nonce="$(openssl rand -hex 16)"
 
           truncate_utf8() {
@@ -586,44 +643,28 @@ jobs:
           }
 
           BASE_PROMPT="$(cat /tmp/fork-codex-prompt.md)"
+          discovery_one="$(bounded_output "codex-pass-1.md")"
+          PROMPT="$(
+            printf '%s\n\n' "$BASE_PROMPT"
+            cat .github/review-prompts/gpt-falsification-mandate.md
+            cat .github/review-prompts/gpt-falsification-verdict.md
+            printf '%s\n' \
+              "DISCOVERY_1_BEGIN::${review_nonce}" \
+              "$discovery_one" \
+              "DISCOVERY_1_END::${review_nonce}"
+          )"
 
-          for pass in 1 2; do
-            case "$pass" in
-              1)
-                PROMPT=$(printf '%s\n\n%s\n' "$BASE_PROMPT" \
-                  "DISCOVERY PASS: inspect the full current diff and report every candidate that meets the FINDING BAR. This is candidate generation, not the final verdict.")
-                ;;
-              2)
-                discovery_one="$(bounded_output "codex-pass-1.md")"
-                PROMPT="$(
-                  printf '%s\n\n' "$BASE_PROMPT"
-                  cat .github/review-prompts/gpt-falsification-mandate.md
-                  cat .github/review-prompts/gpt-falsification-verdict.md
-                  printf '%s\n' \
-                    "DISCOVERY_1_BEGIN::${review_nonce}" \
-                    "$discovery_one" \
-                    "DISCOVERY_1_END::${review_nonce}"
-                )"
-                ;;
-            esac
-
-            rm -f "codex-pass-${pass}.md"
-            rc=0
-            # Called by path, not from PATH: exporting the bin directory
-            # through $GITHUB_PATH is a run-step write to an environment
-            # file, which is an execution vector in a job holding Bedrock
-            # credentials (zizmor github-env). The path is under RUNNER_TEMP
-            # because the manifest that produced it was materialized from the
-            # BASE commit, not from this checkout -- see "Install review CLI".
+          rm -f codex-pass-2.md
+          rc=0
+          timeout "$PASS_WALL" \
             "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
-              --sandbox read-only \
-              --output-last-message "codex-pass-${pass}.md" \
-              "$PROMPT" || rc=$?
-            if [ "$rc" -ne 0 ] || [ ! -s "codex-pass-${pass}.md" ]; then
-              echo "::warning::GPT 5.6 fork review pass ${pass} did not complete (exit ${rc}); the verdict will fail closed."
-              failed_passes="${failed_passes} ${pass}"
-            fi
-          done
+            --sandbox read-only \
+            --output-last-message "codex-pass-2.md" \
+            "$PROMPT" || rc=$?
+          if [ "$rc" -ne 0 ] || [ ! -s codex-pass-2.md ]; then
+            echo "::warning::GPT 5.6 fork review pass 2 did not complete (exit ${rc}); the verdict will fail closed."
+            failed_passes="${failed_passes} 2"
+          fi
 
           if [ -n "$failed_passes" ]; then
             {

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -364,6 +364,15 @@ jobs:
           echo "--- stage 1 candidates (never posted; kept here as tuning signal) ---"
           cat .review-candidates.md
 
+      # Re-assume the role BETWEEN the stages: the session lasts one hour, and a
+      # discovery stage that consumes most of it used to leave validation to die
+      # mid-call on an expired security token, failing the gate closed with no
+      # verdict. Keep in sync with claude-review.yml.
+      - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+          aws-region: us-west-2
+
       # ── Stage 2 of 2: VALIDATION (authoritative) ───────────────────────────
       # Fresh call, no memory of stage 1's reasoning. Re-derives input / call path
       # / observable outcome for every candidate from code it opens itself, keeps

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
@@ -795,11 +795,23 @@ def build_spliced_lane(
     prompt = substitute_sed_placeholders(prompt, workflow_text, values)
     prompt = remap_staged_paths(substitute_expressions(prompt, values), stage_dir)
 
-    pass_block = _run_block_with(scalars, "DISCOVERY PASS", contract)
-    literals = prompt_segments(pass_block, stage_dir)
-    discovery = literals_between(literals, "DISCOVERY PASS", "DISCOVERY PASS", "discovery-pass")
+    # Each pass needs its own Bedrock session, so a lane may run them as two
+    # separate steps -- locate each instruction in the `run:` block that carries
+    # it rather than assuming both share one. Both lookups resolve to the same
+    # block for a lane that still drives both passes from a single step.
+    discovery_block = _run_block_with(scalars, "DISCOVERY PASS", contract, stage_dir)
+    discovery = literals_between(
+        prompt_segments(discovery_block, stage_dir),
+        "DISCOVERY PASS",
+        "DISCOVERY PASS",
+        "discovery-pass",
+    )
+    pass_block = _run_block_with(scalars, "FALSIFICATION PASS", contract, stage_dir)
     falsification = literals_between(
-        literals, "FALSIFICATION PASS", "UNTRUSTED EVIDENCE", "falsification-pass"
+        prompt_segments(pass_block, stage_dir),
+        "FALSIFICATION PASS",
+        "UNTRUSTED EVIDENCE",
+        "falsification-pass",
     )
     markers = re.findall(r"\"([A-Z0-9_]+)::\$\{?[a-z_]+\}?\"", pass_block)
     notes: list[str] = []
@@ -931,14 +943,32 @@ def _assembly_block(scalars: list[BlockScalar], target: str, contract: str) -> s
     )
 
 
-def _run_block_with(scalars: list[BlockScalar], needle: str, contract: str) -> str:
+def _run_block_with(
+    scalars: list[BlockScalar], needle: str, contract: str, stage_dir: str
+) -> str:
+    """The `run:` block whose MODEL-FACING instructions carry ``needle``.
+
+    Matches ``needle`` in the block's own text first, then in the ``cat``-spliced
+    prompt files it pulls in, so an instruction the workflow keeps in a shared
+    prompt file is found in the step that splices it rather than only where it
+    appears inline. A block whose splices cannot be resolved is skipped, not
+    fatal: an unresolvable splice elsewhere in the job is not evidence about the
+    block being looked for.
+    """
     for scalar in scalars:
-        if scalar.key == "run" and needle in scalar.text:
+        if scalar.key != "run":
+            continue
+        if needle in scalar.text:
+            return scalar.text
+        try:
+            segments = prompt_segments(scalar.text, stage_dir)
+        except ParityError:
+            continue
+        if any(needle in segment for segment in segments):
             return scalar.text
     raise ParityError(
-        "no `run:` block in {} contains {!r} - the workflow was restructured.".format(
-            contract, needle
-        )
+        "no `run:` block in {} carries the instruction {!r}, in its own text or in "
+        "a prompt file it splices - the workflow was restructured.".format(contract, needle)
     )
 
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -289,9 +289,12 @@ class TestPrReadiness:
 
         # The three-pass recall ratchet was replaced by discovery + an
         # authoritative FALSIFICATION pass whose primary job is to KILL
-        # candidates, not extend them.
-        assert "GPT 5.6 review (discovery + falsification)" in workflow
-        assert "for pass in 1 2; do" in workflow
+        # candidates, not extend them. The two passes are separate STEPS so a
+        # fresh Bedrock session can be minted between them.
+        assert "- name: GPT 5.6 review (discovery pass)" in workflow
+        assert "- name: GPT 5.6 review (falsification pass)" in workflow
+        assert workflow.index("(discovery pass)") < workflow.index("(falsification pass)")
+        assert "for pass in 1 2; do" not in workflow
         assert "for pass in 1 2 3; do" not in workflow
         # The falsification mandate lives in the shared prompt file (#5852);
         # the workflow splices it in by reference.
@@ -382,13 +385,18 @@ class TestPrReadiness:
 
     def test_gpt_review_uses_only_falsification_pass_for_comment_and_gate(self) -> None:
         workflow = _workflow("codex-review.yml")
+        discovery_step = workflow[
+            workflow.index("- name: GPT 5.6 review (discovery pass)") : workflow.index(
+                "- name: GPT 5.6 review (falsification pass)"
+            )
+        ]
         review_step = workflow[
-            workflow.index("- name: GPT 5.6 review (discovery + falsification)") : workflow.index(
+            workflow.index("- name: GPT 5.6 review (falsification pass)") : workflow.index(
                 "- name: Redact credential shapes from review output"
             )
         ]
 
-        assert "DISCOVERY PASS" in review_step
+        assert "DISCOVERY PASS" in discovery_step
         assert "cat .review-prompts-gpt/gpt-falsification-mandate.md" in review_step
         assert "cat .review-prompts-gpt/gpt-falsification-verdict.md" in review_step
         assert "DISCOVERY_OUTPUT_MAX_BYTES:" in review_step
@@ -396,6 +404,86 @@ class TestPrReadiness:
         # Pass 2 (falsification) is the only verdict consumed downstream.
         assert "cp codex-pass-2.md codex-review-output.md" in review_step
         assert 'cat "codex-pass-3.md"' not in review_step
+        # A pass-1 failure recorded in the earlier step must still reach the
+        # verdict assembly, or a half-completed review would publish a clean
+        # pass-2 verdict and pass the gate.
+        assert "printf ' 1' >> codex-failed-passes" in discovery_step
+        assert 'failed_passes="$(cat codex-failed-passes 2>/dev/null || true)"' in review_step
+
+    def test_each_model_call_starts_on_a_fresh_bedrock_session(self) -> None:
+        """One AssumeRole session lasts an hour; both model calls used to share
+        it, so a first call that consumed most of the hour left the second to
+        die on `401 ... security token ... expired` and fail the gate closed
+        with no verdict. Every lane whose job timeout exceeds the session
+        lifetime must re-assume between its two calls, and each call must be
+        wall-bounded under that lifetime where the lane drives the CLI itself.
+        """
+        lanes = {
+            "codex-review.yml": "GPT 5.6 review (falsification pass)",
+            "claude-review.yml": "Opus 4.8 validation",
+            "fork-gpt-review.yml": "GPT 5.6 review (falsification pass)",
+            "fork-opus-review.yml": "Opus 4.8 validation",
+        }
+        for name, second_call in lanes.items():
+            doc = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+            steps = list(doc["jobs"].values())[0]["steps"]
+            creds = [
+                i
+                for i, step in enumerate(steps)
+                if "configure-aws-credentials" in (step.get("uses") or "")
+            ]
+            second = next(i for i, step in enumerate(steps) if step.get("name") == second_call)
+            assert len(creds) == 2, f"{name}: expected a re-assume before {second_call}"
+            assert creds[0] < creds[1] < second, (
+                f"{name}: the second credential assume must sit between the two "
+                f"model calls, not before both"
+            )
+
+        for name in ("codex-review.yml", "fork-gpt-review.yml"):
+            workflow = _workflow(name)
+            assert "PASS_WALL: 55m" in workflow
+            assert workflow.count('timeout "$PASS_WALL" \\') == 2
+
+    def test_no_workspace_write_can_follow_a_pr_planted_symlink(self) -> None:
+        """`: > name` follows a symlink and truncates its TARGET. These lanes
+        check out the PR's merge ref and materialize the base-ref AUTOSDE rules
+        into that same workspace, so a PR committing a tracked symlink at one of
+        these names could erase the rules that judge it and then be reviewed
+        with no blocking rules. Every such write must `rm -f` the name first.
+        """
+        for name in ("codex-review.yml", "fork-gpt-review.yml"):
+            lines = _workflow(name).splitlines()
+            for i, line in enumerate(lines):
+                # Only bare relative targets are workspace paths; a quoted or
+                # $RUNNER_TEMP target is not PR-controlled.
+                m = re.match(r"^\s*: > (?P<path>[\w.-]+)$", line)
+                if m is None:
+                    continue
+                target = m.group("path")
+                assert re.match(rf"^\s*rm -f {re.escape(target)}$", lines[i - 1]), (
+                    f"{name}:{i + 1}: `: > {target}` must be preceded by "
+                    f"`rm -f {target}`, or a PR-planted symlink redirects the write"
+                )
+
+    def test_gpt_pass_walls_fit_inside_the_job_wall(self) -> None:
+        """A pass wall only buys a named timeout if the job wall outlasts it. Two
+        55m passes under a 90m job meant the job wall killed pass 2 first --
+        cancelling the run with no verdict and none of the diagnostic the pass
+        wall exists to produce. The sum of the walls plus setup must fit.
+        """
+        setup_headroom = 15
+        for name in ("codex-review.yml", "fork-gpt-review.yml"):
+            workflow = _workflow(name)
+            walls = [int(m) for m in re.findall(r"^\s*PASS_WALL: (\d+)m$", workflow, re.M)]
+            job_wall = list(
+                yaml.safe_load(workflow)["jobs"].values(),
+            )[0]["timeout-minutes"]
+            assert len(walls) == 2, f"{name}: expected one PASS_WALL per model call"
+            assert sum(walls) + setup_headroom <= job_wall, (
+                f"{name}: pass walls {walls} sum to {sum(walls)}m, which leaves "
+                f"under {setup_headroom}m of the {job_wall}m job wall for setup "
+                f"-- the job wall would cut pass 2 before its own timeout fires"
+            )
 
     def test_utf8_byte_bounds_tolerate_a_split_multibyte_character(self, tmp_path: Path) -> None:
         bash = _bash()
@@ -406,7 +494,7 @@ class TestPrReadiness:
         source = tmp_path / "source.md"
         source.write_bytes("AéB".encode())
 
-        for step_name in ("GPT 5.6 review (discovery + falsification)",):
+        for step_name in ("GPT 5.6 review (falsification pass)",):
             script = _step_script(workflow, step_name)
             function = _shell_function(script, "truncate_utf8")
             result = subprocess.run(

--- a/test/test_prepare_pr_local_review.py
+++ b/test/test_prepare_pr_local_review.py
@@ -276,18 +276,32 @@ def test_gpt_prompt_is_lifted_verbatim_not_paraphrased():
 def test_gpt_two_passes_and_blocking_budget_come_from_the_workflow():
     text = _gpt_text()
     scalars = local_review.block_scalars(text)
-    block = local_review._run_block_with(scalars, "DISCOVERY PASS", "gpt")
     import tempfile
 
+    # The passes run as separate STEPS so each gets its own Bedrock session, so
+    # each instruction is located in the block that carries it. The lookup has to
+    # see through the prompt-file splices: the falsification instruction lives in
+    # a shared prompt file its step `cat`s in, not inline.
     with tempfile.TemporaryDirectory(prefix="gpt-pass-stage-") as stage_dir:
         _stage_gpt_prompts(text, stage_dir)
-        literals = local_review.prompt_segments(block, stage_dir)
-    discovery = local_review.literals_between(
-        literals, "DISCOVERY PASS", "DISCOVERY PASS", "discovery"
-    )
-    falsification = local_review.literals_between(
-        literals, "FALSIFICATION PASS", "UNTRUSTED EVIDENCE", "falsification"
-    )
+        discovery_block = local_review._run_block_with(
+            scalars, "DISCOVERY PASS", "gpt", stage_dir
+        )
+        pass_block = local_review._run_block_with(
+            scalars, "FALSIFICATION PASS", "gpt", stage_dir
+        )
+        discovery = local_review.literals_between(
+            local_review.prompt_segments(discovery_block, stage_dir),
+            "DISCOVERY PASS",
+            "DISCOVERY PASS",
+            "discovery",
+        )
+        falsification = local_review.literals_between(
+            local_review.prompt_segments(pass_block, stage_dir),
+            "FALSIFICATION PASS",
+            "UNTRUSTED EVIDENCE",
+            "falsification",
+        )
     assert len(discovery) == 1
     assert "candidate generation" in discovery[0]
     assert len(falsification) >= 2
@@ -1280,7 +1294,9 @@ def test_prefetched_diff_matches_git_diff(parity_repo, tmp_path):
 # --------------------------------------------------------------------------
 def _intent_run_block():
     scalars = local_review.block_scalars(_gpt_text())
-    return local_review._run_block_with(scalars, "PR INTENT", "gpt")
+    # "PR INTENT" is inline in the step that echoes it, so the lookup returns
+    # before it ever needs a staging dir to resolve a splice through.
+    return local_review._run_block_with(scalars, "PR INTENT", "gpt", "")
 
 
 def test_intent_framing_is_the_workflow_framing():
@@ -1368,11 +1384,15 @@ def test_every_staged_prompt_file_is_spliced_exactly_once_in_loop_order():
         block,
         flags=re.M,
     )
-    pass_block = local_review._run_block_with(scalars, "DISCOVERY PASS", "gpt")
+    # A bare `cat` splice lives in whichever review step consumes it, and the two
+    # passes are separate steps (each needs its own Bedrock session), so scan
+    # every `run:` block instead of the one the discovery instruction is in.
     pass_spliced = [
         m.group("src").rsplit("/", 1)[-1]
-        for m in map(local_review._CAT_BARE_RE.match, pass_block.splitlines())
-        if m is not None
+        for scalar in scalars
+        if scalar.key == "run"
+        for m in map(local_review._CAT_BARE_RE.match, scalar.text.splitlines())
+        if m is not None and m.group("src").startswith(".review-prompts-gpt/")
     ]
     assert spliced == [name for name in staged if name not in pass_spliced]
     assert len(set(spliced)) == len(spliced), "a document splice repeats"
@@ -1461,7 +1481,7 @@ def test_removed_model_pin_fails_loudly():
 
 def test_missing_run_block_fails_loudly():
     with pytest.raises(local_review.ParityError) as exc:
-        local_review._run_block_with([], "DISCOVERY PASS", "wf.yml")
+        local_review._run_block_with([], "DISCOVERY PASS", "wf.yml", "")
     assert "restructured" in str(exc.value)
 
 


### PR DESCRIPTION
## Problem / Motivation

The "GPT 5.6 Review" lane fails with an expired AWS security token partway through the review instead of producing a verdict. On PR #7690 the lane ran its discovery pass, then died inside the falsification pass on `ExpiredTokenException`; the merge gate then failed closed with no review comment, and the log gave no way to tell a spent session from a hung model call. Re-running only helps when the first pass happens to finish fast enough, so the lane is flaky rather than broken, which is worse.

The root cause is a mismatch between two timeouts. `aws-actions/configure-aws-credentials` assumes the Bedrock role once, at the top of the job, for the default **1-hour** session. The job's wall is `timeout-minutes: 90`. Both model calls ran inside a single shell step, sharing that one session — so any discovery pass that consumed most of the hour left the falsification pass with a token that expires mid-call. The Opus lane and both fork lanes carry the identical 1-hour-session / 90-minute-job shape.

## Why it matters

Every PR in this repo is gated on the AI review lanes emitting their `[GPT-REVIEWED]` / `[OPUS-REVIEWED]` markers, and the gate is fail-closed by design. So a session that expires mid-review does not degrade the review — it blocks the merge, with a failure mode that looks like an infrastructure flake and invites a blind re-run. On a large diff, where the discovery pass is slowest, the lane is least likely to survive: the change that most needs review is the one whose review times out.

## What changed (motivation → approach → change)

Symptom: a lane dies on an expired token in its second model call. Root cause: one 1-hour session spans two model calls inside a 90-minute job. The fix has to guarantee each model call starts on a session younger than its own runtime.

Two approaches were possible. Raising `role-duration-seconds` is the smaller diff, but it is capped by the IAM role's `MaxSessionDuration`, which is not defined in this repo — if the role caps at 1 hour, the request hard-fails and every lane breaks at once. Re-assuming the role between passes is IAM-independent: it works whatever the cap is, and it bounds the exposure of each session to a single pass. That is the approach taken.

- **GPT lanes** (`codex-review.yml`, `fork-gpt-review.yml`): the single review step is split into a **discovery pass** step and a **falsification pass** step, with a `configure-aws-credentials` re-assume between them. Each pass is wall-bound at `PASS_WALL: 55m` via `timeout "$PASS_WALL"`, so no single pass can outlive the fresh session it starts on, and a hang now surfaces as exit 124 on a named pass instead of as an expired token.
- The GPT lanes' job wall goes 90 → 130 minutes. A pass wall only buys a named timeout if the job outlasts it: two 55m passes under a 90m job meant the *job* wall killed pass 2 first, cancelling the run with no verdict and none of the diagnostic the pass wall exists to produce. 2 × 55m + ~20m of setup/posting = 130. The Opus lanes stay at 90 — they drive the model through `claude-code-action`, which cannot be wrapped in `timeout`, so they carry no pass walls to contain.
- **Opus lanes** (`claude-review.yml`, `fork-opus-review.yml`): these already ran discovery and validation as separate steps, so they only needed the re-assume inserted before the validation stage, matching the first assume's role and region.
- Every workspace-relative truncation in the two GPT lanes is now `rm -f <name>` before `: > <name>`. `: >` follows a symlink and truncates its *target*; these lanes check out the PR's merge ref and materialize the base-ref AUTOSDE rules into that same workspace, so a PR committing a tracked symlink at one of those names could erase the rules that judge it and then be reviewed with no blocking rules. This covers the marker file this PR adds and the pre-existing `codex-review-output.md` writes beside it, which carried the identical hole -- the `codex-pass-N.md` writes were already `rm -f`-ed, so this restores one spelling for all five sites.
- Pass-1 failure is threaded across the new step boundary through the workspace: the discovery step appends to `codex-failed-passes`, the falsification step reads it and takes the incomplete-review branch. Steps in one job share `$GITHUB_WORKSPACE` with no checkout between them, so the marker survives; if the falsification step is skipped or aborts, `codex-review-output.md` is never written, the marker grep finds nothing, and the gate still fails closed.
- `local_review.py` (the packaged prepare-pr contract extractor) located **both** passes' instructions in the one `run:` block containing "DISCOVERY PASS". Splitting the lane moves the falsification instruction into a different step, so the extractor would have raised a parity failure on every subsequent PR. It now locates each instruction in the block that carries it, via a splice-aware lookup that matches after `cat`-spliced prompt files are expanded — because the falsification mandate arrives from a shared prompt file rather than inline. The splice-aware lookup replaces the old inline-only one outright rather than sitting beside it: it matches inline text first, so it subsumes the old behaviour, and two lookup helpers for one job would drift.

## Tests

`test/test_ai_review_workflows.py`:
- `test_each_model_call_starts_on_a_fresh_bedrock_session` (new) — asserts all four lanes have exactly two `configure-aws-credentials` steps ordered so one precedes each model call, which is the invariant that actually prevents the bug.
- `test_no_workspace_write_can_follow_a_pr_planted_symlink` (new) -- scans both GPT lanes and requires every bare `: > <name>` to be immediately preceded by `rm -f <name>`, so the symlink hole cannot come back at a site added later.
- `test_gpt_pass_walls_fit_inside_the_job_wall` (new) — asserts the two pass walls plus setup headroom fit under the job wall, so the named pass timeout stays the binding one. This is the invariant the first revision got wrong.
- Three existing GPT-lane tests updated to the split shape, pinning `PASS_WALL: 55m` and exactly two `timeout "$PASS_WALL"` wrappers per GPT lane.
- `test_gpt_review_uses_only_falsification_pass_for_comment_and_gate` (existing) pins the cross-step failure thread: a failed pass 1 cannot publish a clean pass-2 verdict.

`test/test_prepare_pr_local_review.py`: two tests that assumed both passes live in one `run:` block updated to the per-instruction lookup, locking in that the extractor keeps working for a lane whose passes are separate steps — and, because both lookups resolve to the same block for a single-step lane, for the old shape too.

## Manual verification

N/A — the change is workflow YAML whose invariants (step ordering, credential re-assume placement, pass wall, cross-step failure threading) are asserted directly against the parsed workflow files. The fix cannot be exercised end-to-end before it is on `main`: `pull_request` runs use the PR's merge ref, so this PR's own review lanes still run the old single-session shape.

## Related Issues

no linked issue: reported from a CI failure, not a tracked issue. It unblocks the failing
"GPT 5.6 Review" lane on PR #7690 (a pull request, not an issue, so nothing closes on
merge here); that PR stays blocked until this lands on `main`, because `pull_request` runs
use the PR's merge ref.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a credential/session lifetime shorter than the job wall it runs under, with two long operations sharing one session — assume-once + N sequential model calls is the general shape.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changes
- [x] No secrets, credentials, or internal references in the diff
