### PR TITLE
fix(ci): stop the fix-loop lanes failing silently

### DIFF
--- a/.github/scripts/fix_loop_metrics.py
+++ b/.github/scripts/fix_loop_metrics.py
@@ -13,7 +13,12 @@ window of the current branch's history:
   deferrals -- open `deferred-finding` issues: tracked share (assignee +
                'Due: YYYY-MM-DD' body line or milestone due), overdue count
   harvest   -- merged fix-titled PRs in the window carrying a
-               '## Pattern harvest' section
+               '## Pattern harvest' section. Scoped to PRs merged into the
+               DEFAULT branch whose own hygiene check RAN under the gate: a
+               release-branch PR ran that branch's workflow version and a PR
+               whose hygiene check never ran was never asked, so neither is a
+               non-adopter. Both are counted separately, leaving `escapes` to
+               mean what it says.
 
 Needs `git` (full-depth checkout) and `gh` (GH_TOKEN) on PATH. Emits JSON to
 --out and a markdown table to --summary. Pure stdlib by design: the weekly
@@ -158,6 +163,90 @@ def deferral_metrics(repo: str) -> dict:
     }
 
 
+def default_branch(repo: str) -> str:
+    """The repo's own default branch, so the harvest denominator is not a literal.
+
+    Derived rather than hardcoded because it decides which PRs the gate is even
+    expected to have run on: a release-branch PR runs the workflow version that
+    lives on THAT branch.
+    """
+    data = gh_json("repo", "view", repo, "--json", "defaultBranchRef")
+    name = ((data or {}).get("defaultBranchRef") or {}).get("name") or ""
+    if not name:
+        raise RuntimeError(f"could not resolve the default branch of {repo}")
+    return str(name)
+
+
+# When the Pattern harvest requirement began applying. Used to date the PR's own
+# hygiene RUN, never the PR itself -- see gate_ran_on.
+HARVEST_GATE_ACTIVE_ISO = "2026-08-31T08:01:43Z"
+
+# The workflow that carries the hygiene gate, as its filename on disk.
+GATE_WORKFLOW = "code-review.yml"
+
+
+def gate_ran_on(repo: str, head_sha: str) -> bool:
+    """Whether the harvest gate actually evaluated this PR.
+
+    Applicability is derived from the RUN that carried the gate, not from when the
+    PR was opened and not from when a check attempt started -- both are proxies
+    that fail in opposite directions:
+
+    * The PR's creation time excludes a PR opened before the rollout and pushed to
+      afterwards. That PR DID get a gate-bearing run, so if it merged with no
+      section it escaped, and excluding it publishes a false zero.
+    * A check attempt's start time includes a PRE-gate run that was re-run (or
+      queued) after activation. A re-run re-executes the ORIGINAL workflow
+      version, so the gate was never in it, and including it manufactures an
+      escape.
+
+    A workflow run's ``created_at`` is the invariant both proxies miss: it is set
+    once when the run is created and a re-run updates ``run_started_at`` instead.
+    A `pull_request` run uses the workflow from the merge ref, so a run created
+    after the gate merged necessarily carried the harvest step.
+
+    False when no such run exists on the head -- a PR whose workflows are still
+    awaiting maintainer approval was never asked.
+
+    One API call per candidate PR (~100 a week). A failed call raises, per this
+    module's contract: a report that silently drops a PR understates its own
+    denominator.
+    """
+    if not head_sha:
+        return False
+    payload = gh_json(
+        "api",
+        f"repos/{repo}/actions/workflows/{GATE_WORKFLOW}/runs" f"?head_sha={head_sha}&per_page=100",
+    )
+    runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+    return any(
+        str(r.get("created_at") or "") >= HARVEST_GATE_ACTIVE_ISO
+        for r in runs
+        if r.get("created_at")
+    )
+
+
+# What the PR Hygiene gate accepts, transcribed from its own two `grep -qiE`
+# patterns in `.github/workflows/code-review.yml`. They MUST stay identical: the
+# gate is case-insensitive and space-tolerant, so a body reading
+# `### pattern harvest` passes it -- and a stricter reading here would publish
+# that PR as an escape, corrupting the one number this metric exists to make
+# trustworthy. `test_fix_loop_discipline.py` extracts the gate's patterns and
+# fails when these drift from them.
+#
+# Both are required, matching the gate: the heading alone is not a harvest, and a
+# PR that merged without satisfying what the gate demands IS an escape.
+HARVEST_HEADING_RE = re.compile(r"^##+ *Pattern harvest", re.MULTILINE | re.IGNORECASE)
+HARVEST_ANSWER_RE = re.compile(
+    r"^ *(Rule candidate|Not generalizable) *:", re.MULTILINE | re.IGNORECASE
+)
+
+
+def has_harvest_section(body: str) -> bool:
+    """Whether *body* satisfies the same contract the hygiene gate enforces."""
+    return bool(HARVEST_HEADING_RE.search(body) and HARVEST_ANSWER_RE.search(body))
+
+
 def harvest_metrics(repo: str, since_iso: str) -> dict:
     """since_iso is the exact UTC timestamp of the window start; the gh search
     uses its date as a coarse pre-filter and mergedAt enforces the precise
@@ -174,7 +263,7 @@ def harvest_metrics(repo: str, since_iso: str) -> dict:
         "--limit",
         "1000",
         "--json",
-        "title,body,mergedAt",
+        "title,body,mergedAt,baseRefName,headRefOid",
     )
     if len(prs) >= 1000:
         raise RuntimeError(
@@ -183,11 +272,30 @@ def harvest_metrics(repo: str, since_iso: str) -> dict:
         )
     prs = [p for p in prs if (p.get("mergedAt") or "") >= since_iso]
     fix_prs = [p for p in prs if FIX_SUBJECT_RE.match(p.get("title") or "")]
-    with_section = sum(1 for p in fix_prs if "## Pattern harvest" in (p.get("body") or ""))
+
+    # Two exclusions, both answering "was this PR ever asked for a section?".
+    # A PR merged into a release branch ran that branch's workflow version, which
+    # has no harvest step; a PR whose hygiene check never ran under the gate was
+    # likewise never asked. Counting either as a non-adopter reports a hole that
+    # does not exist -- the first audit of this mechanism misread the first case
+    # and called two release backports escapes. They are reported separately so a
+    # REAL escape still stands out.
+    base = default_branch(repo)
+    on_default = [p for p in fix_prs if (p.get("baseRefName") or "") == base]
+    other_base = len(fix_prs) - len(on_default)
+    in_scope = [p for p in on_default if gate_ran_on(repo, str(p.get("headRefOid") or ""))]
+    never_asked = len(on_default) - len(in_scope)
+    with_section = sum(1 for p in in_scope if has_harvest_section(p.get("body") or ""))
     return {
-        "merged_fix_prs": len(fix_prs),
+        "merged_fix_prs": len(in_scope),
         "with_harvest_section": with_section,
-        "adoption_pct": round(100 * with_section / len(fix_prs), 1) if fix_prs else None,
+        "adoption_pct": round(100 * with_section / len(in_scope), 1) if in_scope else None,
+        # A non-zero count here is the signal to investigate: the gate ran on
+        # these PRs, it is required on this branch, and they merged anyway.
+        "escapes": len(in_scope) - with_section,
+        "excluded_other_base": other_base,
+        "excluded_gate_never_ran": never_asked,
+        "default_branch": base,
     }
 
 
@@ -267,11 +375,20 @@ def main() -> int:
         json.dump(result, f, indent=2)
 
     vol, szz, dfr, hrv = result["volume"], result["szz"], result["deferrals"], result["harvest"]
+
+    def pct(value: object) -> str:
+        """Render a percentage, or `n/a` when the denominator was zero.
+
+        A `None` percentage formatted straight into the table published `None%`,
+        which reads as a measurement rather than as an empty denominator.
+        """
+        return "n/a" if value is None else f"{value}%"
+
     lines = [
         "| Metric | Value |",
         "|---|---|",
         f"| Commits in window | {vol['commits']} |",
-        f"| Fix commits | {vol['fix_commits']} ({vol['fix_pct']}%) |",
+        f"| Fix commits | {vol['fix_commits']} ({pct(vol['fix_pct'])}) |",
         f"| SZZ coverage | {vol['szz_analyzed']}/{vol['fix_commits']}"
         f"{' (CAPPED — trends only, not totals)' if vol['szz_capped'] else ' (full)'} |",
         f"| SZZ: introduced by reviewed PR | {szz['classes']['traced_to_pr']} |",
@@ -279,9 +396,14 @@ def main() -> int:
         f"| SZZ: pure addition (omission) | {szz['classes']['add_only']} |",
         f"| Median bug age (days) | {szz['median_age_days']} |",
         f"| Deferred findings open / tracked / overdue | "
-        f"{dfr['open']} / {dfr['tracked']} ({dfr['tracked_pct']}%) / {dfr['overdue']} |",
+        f"{dfr['open']} / {dfr['tracked']} ({pct(dfr['tracked_pct'])}) / {dfr['overdue']} |",
         f"| Harvest-section adoption on fix PRs | "
-        f"{hrv['with_harvest_section']}/{hrv['merged_fix_prs']} ({hrv['adoption_pct']}%) |",
+        f"{hrv['with_harvest_section']}/{hrv['merged_fix_prs']} ({pct(hrv['adoption_pct'])}) |",
+        # Escapes are the actionable half: on the default branch the gate is
+        # required, so a gap means it did not run and wants investigating.
+        f"| Harvest escapes (default-branch fix PRs with no section) | {hrv['escapes']} |",
+        f"| Excluded: another base / gate never ran | "
+        f"{hrv['excluded_other_base']} / {hrv['excluded_gate_never_ran']} |",
     ]
     with open(args.summary, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")

--- a/.github/workflows/disposition-deferral-check.yml
+++ b/.github/workflows/disposition-deferral-check.yml
@@ -96,6 +96,12 @@ jobs:
           fi
 
           echo "Deferral promise is incomplete — replying with requirements."
+          # Markdown emphasis next to an expansion MUST be braced: bash treats a
+          # trailing `_` as part of the variable name, so `$COMMENT_URL_` is a
+          # different, unset variable and `set -u` kills this script before the
+          # reply is posted. That failure is invisible from the outside — the
+          # refusal simply never arrives — so `test_fix_loop_discipline.py`
+          # pins every expansion in these workflows to a defined name.
           {
             echo "<!-- deferred-finding-check -->"
             echo "**This deferral is not yet tracked.** An \`accepted-and-deferred\` disposition must name an open follow-up issue that has:"
@@ -107,6 +113,6 @@ jobs:
             echo "What is missing:"
             echo "$problems"
             echo ""
-            echo "_An untracked deferral is how flagged findings ship anyway — 63% of this repo's traceable escaped bugs were flagged and then deferred without follow-through. Checked disposition: $COMMENT_URL_"
+            echo "_An untracked deferral is how flagged findings ship anyway — 63% of this repo's traceable escaped bugs were flagged and then deferred without follow-through. Checked disposition: ${COMMENT_URL}_"
           } > /tmp/reply.md
           gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$(cat /tmp/reply.md)" >/dev/null

--- a/.github/workflows/fix-loop-analysis.yml
+++ b/.github/workflows/fix-loop-analysis.yml
@@ -30,6 +30,12 @@ on:
 permissions:
   contents: read
   issues: write
+  # The harvest denominator asks which workflow RUN carried the gate, so the
+  # metrics step reads the Actions API. Without this the scheduled token gets a
+  # 403 and the metrics step aborts -- taking the whole weekly report with it,
+  # because a report that silently drops PRs understates its own denominator and
+  # so must fail loudly instead.
+  actions: read
   id-token: write # OIDC role assumption for Bedrock
 
 jobs:
@@ -161,6 +167,7 @@ jobs:
                concrete recommendation. No emojis. Percentages to one decimal.
 
       - name: File the weekly report issue
+        id: file_issue
         if: always() && steps.metrics.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -187,21 +194,37 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --description "Weekly fix-loop analysis reports" \
             --color 5319e7 --force
+          # ONE source of truth for "the analysis half actually produced a
+          # report". The model action can exit 0 without writing the file, so a
+          # title, a body branch or a re-raise keyed on the step's outcome alone
+          # would publish a normal-looking issue and a green run over metrics-only
+          # output -- the exact silent failure this workflow is meant to surface.
+          ANALYSIS_OK=0
+          if [ "$NARRATE_OUTCOME" = "success" ] && [ -s fix-loop-report.md ]; then
+            ANALYSIS_OK=1
+          fi
+          echo "analysis_ok=$ANALYSIS_OK" >> "$GITHUB_OUTPUT"
           TITLE="Fix loop report — $(date -u +%Y-%m-%d)"
+          if [ "$ANALYSIS_OK" = "0" ]; then
+            # The issue list is where a reader actually looks. A run whose model
+            # half produced nothing still publishes real numbers, so the issue
+            # must say so in the one place that is read without opening anything.
+            TITLE="$TITLE (metrics only — no analysis)"
+          fi
           {
             echo "## Deterministic metrics (window since $SINCE_ISO)"
             echo ""
             sanitize < "$RUNNER_TEMP/metrics.md"
             echo ""
-            if [ "$NARRATE_OUTCOME" = "success" ] && [ -s fix-loop-report.md ]; then
+            if [ "$ANALYSIS_OK" = "1" ]; then
               echo "## Analysis"
               echo ""
               sanitize < fix-loop-report.md
             else
               echo "## Analysis"
               echo ""
-              echo "_The model classification step did not complete this run;"
-              echo "only the deterministic metrics above are available. Re-run"
+              echo "_The model classification step did not produce a report this"
+              echo "run; only the deterministic metrics above are available. Re-run"
               echo "via workflow_dispatch for the narrative half._"
             fi
             echo ""
@@ -212,3 +235,27 @@ jobs:
             --title "$TITLE" \
             --label fix-loop-report \
             --body-file "$RUNNER_TEMP/issue-body.md"
+
+      # The model step is fail-soft so a broken narrative can never cost the
+      # deterministic numbers -- but `continue-on-error` also made the whole run
+      # report SUCCESS, and a weekly job nobody has reason to open is exactly
+      # where a permanently broken half hides. The first scheduled run failed
+      # here and published a metrics-only issue while the Actions list stayed
+      # green.
+      #
+      # So the failure is re-raised AFTER the issue is filed: the numbers still
+      # land (that step is `if: always()`), and the run goes red, which is the
+      # only signal anyone actually receives. It keys on the filing step's
+      # `analysis_ok`, not on the model step's outcome, because the action can
+      # exit 0 having written nothing.
+      - name: Re-raise a missing analysis
+        if: always() && steps.file_issue.outputs.analysis_ok == '0'
+        run: |
+          echo "::error::The Fable 5 analysis step produced no report; the weekly" \
+            "issue was filed with the deterministic metrics only. A failure that" \
+            "assumes the Bedrock role successfully but reports num_turns 1 and zero" \
+            "cost is an IAM action mismatch, not a model or credential problem:" \
+            "claude-code-action streams, so the role needs" \
+            "bedrock:InvokeModelWithResponseStream, which a role provisioned for" \
+            "a non-streaming converse caller does not carry."
+          exit 1

--- a/test/test_fix_loop_discipline.py
+++ b/test/test_fix_loop_discipline.py
@@ -16,7 +16,12 @@ still there and still pointed at the same names.
 
 from __future__ import annotations
 
+import importlib.util
+import re
 from pathlib import Path
+from typing import Iterator
+
+import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE = ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
@@ -32,6 +37,343 @@ PREPARE_PR = (
 )
 
 LABEL = "deferred-finding"
+
+ANALYSIS = ROOT / ".github" / "workflows" / "fix-loop-analysis.yml"
+METRICS_SCRIPT = ROOT / ".github" / "scripts" / "fix_loop_metrics.py"
+
+# Names the runner defines for every step, plus shell specials. A reference to
+# one of these is defined even though nothing in the workflow assigns it.
+_RUNNER_PROVIDED = frozenset(
+    {
+        "CI",
+        "HOME",
+        "PATH",
+        "PWD",
+        "SHELL",
+        "TMPDIR",
+        "IFS",
+        "RANDOM",
+        "LINENO",
+        "BASH_ENV",
+        "BASH_SOURCE",
+        "FUNCNAME",
+        "OSTYPE",
+        "HOSTNAME",
+        "USER",
+        "LANG",
+    }
+)
+
+
+def _shell_steps(workflow: Path) -> Iterator[tuple[str, str, set[str], str]]:
+    """Yield (job, step name, names defined for it, the shell body) per run step."""
+    doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    workflow_env = set((doc.get("env") or {}).keys())
+    for job_id, job in (doc.get("jobs") or {}).items():
+        job_env = workflow_env | set((job.get("env") or {}).keys())
+        for step in job.get("steps") or []:
+            body = step.get("run")
+            if not body:
+                continue
+            defined = job_env | set((step.get("env") or {}).keys())
+            yield job_id, str(step.get("name") or "<unnamed>"), defined, str(body)
+
+
+def _assigned_in_block(body: str) -> set[str]:
+    """Names the shell body itself creates, so a local variable is not a miss."""
+    names: set[str] = set()
+    names |= set(re.findall(r"^\s*(?:local\s+|export\s+)?([A-Za-z_][A-Za-z0-9_]*)\+?=", body, re.M))
+    names |= set(re.findall(r"\bfor\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\b", body))
+    names |= set(re.findall(r"\bread\s+(?:-r\s+)?([A-Za-z_][A-Za-z0-9_]*)", body))
+    return names
+
+
+def undefined_expansions(body: str, defined: set[str]) -> set[str]:
+    """Variable names the block expands but nothing defines.
+
+    GitHub `${{ ... }}` expressions are removed first: they are substituted
+    before the shell ever sees them, so their contents are not shell names.
+    Whole-line comments are removed too -- a line whose first non-space
+    character is `#` is unconditionally a comment in bash, so prose describing
+    an expansion must not read as one. A TRAILING `#` is deliberately left
+    alone: it is ambiguous inside a string (`grep -oE '#[0-9]+'`), and cutting
+    at it would truncate real code.
+    """
+    shell = re.sub(r"\$\{\{.*?\}\}", "", body, flags=re.S)
+    shell = "\n".join(line for line in shell.splitlines() if not line.lstrip().startswith("#"))
+    known = defined | _assigned_in_block(shell) | _RUNNER_PROVIDED
+    referenced = {
+        m.group(1)
+        for m in re.finditer(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)", shell)
+        if not m.group(1).startswith(("GITHUB_", "RUNNER_", "INPUT_", "ACTIONS_"))
+    }
+    return referenced - known
+
+
+class TestNoSilentlyBrokenShell:
+    """A reference to an undefined name is invisible until the unhappy path runs.
+
+    `set -euo pipefail` makes an unset expansion fatal, and these two lanes are
+    non-blocking by design: the deferral checker replies instead of failing a
+    required check, and the analysis step is `continue-on-error`. So a typo in a
+    branch that only executes when something is WRONG takes the whole reply or
+    the whole narrative down while the run still reports success.
+
+    That is not hypothetical. `Checked disposition: $COMMENT_URL_` -- a markdown
+    italic terminator absorbed into the variable name -- killed the refusal reply
+    on every one of the first 18 incomplete deferrals, and nothing went red.
+    """
+
+    WORKFLOWS = (DEFERRAL_CHECK, AUDIT, ANALYSIS)
+
+    def test_extractor_catches_the_defect_it_was_written_for(self) -> None:
+        """Pin the ratchet itself against the exact shape that escaped.
+
+        A linter for a class nobody can reproduce is a linter nobody can trust,
+        so the historical form is asserted directly rather than assumed covered.
+        """
+        assert undefined_expansions('echo "at: $COMMENT_URL_"', {"COMMENT_URL"}) == {"COMMENT_URL_"}
+        assert undefined_expansions('echo "at: ${COMMENT_URL}_"', {"COMMENT_URL"}) == set()
+
+    def test_every_expansion_resolves(self) -> None:
+        misses: list[str] = []
+        for workflow in self.WORKFLOWS:
+            for job, step, defined, body in _shell_steps(workflow):
+                unknown = undefined_expansions(body, defined)
+                if unknown:
+                    misses.append(f"{workflow.name} :: {job} :: {step} -> {sorted(unknown)}")
+        assert not misses, "shell steps expand names nothing defines:\n" + "\n".join(misses)
+
+
+class TestFailedHalvesAreVisible:
+    """Fail-soft must not mean fail-silent.
+
+    Letting the model step fail is the right product call -- a broken narrative
+    must never cost the deterministic numbers. But `continue-on-error` also made
+    the run report SUCCESS, so a weekly job nobody opens became the perfect place
+    for a permanently broken half to hide: the first scheduled run published a
+    metrics-only issue and the Actions list stayed green.
+    """
+
+    def test_the_analysis_failure_is_reraised_after_the_issue_is_filed(self) -> None:
+        doc = yaml.safe_load(ANALYSIS.read_text(encoding="utf-8"))
+        steps = doc["jobs"]["analyze"]["steps"]
+        filed = next(i for i, s in enumerate(steps) if str(s.get("id") or "") == "file_issue")
+        reraise = [i for i, s in enumerate(steps) if "analysis_ok" in str(s.get("if") or "")]
+        assert reraise, "a missing analysis must re-raise so the run goes red"
+        assert reraise[-1] > filed, (
+            "the re-raise must come AFTER the issue is filed, or the deterministic "
+            "numbers are lost with the narrative"
+        )
+        assert "exit 1" in str(steps[reraise[-1]].get("run") or "")
+
+    def test_an_empty_report_counts_as_no_analysis(self) -> None:
+        """The action can exit 0 having written nothing.
+
+        Keying the title, the body and the re-raise off the model step's outcome
+        alone would then publish a normal-looking issue over metrics-only output
+        and leave the run green -- the failure mode this workflow exists to end.
+        One computed flag drives all three.
+        """
+        doc = yaml.safe_load(ANALYSIS.read_text(encoding="utf-8"))
+        filing = next(
+            s for s in doc["jobs"]["analyze"]["steps"] if str(s.get("id") or "") == "file_issue"
+        )
+        body = str(filing.get("run") or "")
+        assert "-s fix-loop-report.md" in body, "emptiness must be part of the verdict"
+        assert 'echo "analysis_ok=' in body, "the verdict must be published as a step output"
+
+    def test_the_issue_title_says_when_only_numbers_landed(self) -> None:
+        """The issue list is the surface a reader scans without opening anything."""
+        text = ANALYSIS.read_text(encoding="utf-8")
+        assert "metrics only" in text, "a degraded report must be labelled in its title"
+
+
+class TestHarvestRecognitionMatchesTheGate:
+    """What the metric counts as a harvest must be what the gate accepts.
+
+    The gate is case-insensitive and space-tolerant (`grep -qiE`), so a body
+    reading `### pattern harvest` passes it. A stricter reading in the metric
+    publishes that PR as an escape -- corrupting the single number the metric
+    exists to make trustworthy, in the direction that manufactures alarm.
+
+    Two halves are pinned: the patterns are literally the gate's own, and the
+    behaviour they produce is asserted on the shapes that differ between a
+    substring test and the gate.
+    """
+
+    def _module(self):
+        spec = importlib.util.spec_from_file_location("fix_loop_metrics", METRICS_SCRIPT)
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_patterns_are_transcribed_from_the_gate(self) -> None:
+        """Drift is silent: both sides keep working, and only the count is wrong."""
+        gate_patterns = set(re.findall(r"grep -qiE '([^']+)'", CODE_REVIEW.read_text("utf-8")))
+        mod = self._module()
+        for attr in ("HARVEST_HEADING_RE", "HARVEST_ANSWER_RE"):
+            pattern = getattr(mod, attr).pattern
+            assert pattern in gate_patterns, (
+                f"{attr} is {pattern!r}, which the hygiene gate does not use; "
+                f"the gate's patterns are {sorted(gate_patterns)}"
+            )
+
+    def test_the_shapes_the_gate_accepts_are_counted(self) -> None:
+        """Each body here passes the gate but fails a case-sensitive substring test."""
+        mod = self._module()
+        accepted = (
+            "## Pattern harvest\nRule candidate: semgrep",
+            "### pattern harvest\nRule candidate: semgrep",
+            "##   Pattern harvest\nRule candidate: semgrep",
+            "## PATTERN HARVEST\n  not generalizable : one-off",
+        )
+        for body in accepted:
+            assert mod.has_harvest_section(body), f"the gate accepts this body: {body!r}"
+
+    def test_a_heading_with_no_answer_is_not_a_harvest(self) -> None:
+        """The gate demands both, so a PR that merged with only a heading escaped."""
+        mod = self._module()
+        assert not mod.has_harvest_section("## Pattern harvest\n<!-- comment only -->")
+        assert not mod.has_harvest_section("Rule candidate: semgrep")
+
+
+class TestTheMetricsTokenCanReachWhatItReads:
+    """An explicit `permissions:` block zeroes every scope it does not list.
+
+    So a new API surface in the metrics script is a silent 403 waiting for the
+    next scheduled run, and because `gh_json` raises rather than publish a false
+    zero, that 403 costs the entire weekly report -- the total break the fail-soft
+    split exists to prevent. The scopes are asserted from the endpoints the script
+    actually names, so adding a call without its grant fails here rather than on a
+    Monday.
+    """
+
+    # API path fragment -> the GITHUB_TOKEN scope line it requires.
+    REQUIRED_SCOPES = {
+        "/actions/": "actions: read",
+        "/check-runs": "checks: read",
+    }
+
+    def test_every_api_surface_the_script_reads_is_granted(self) -> None:
+        script = METRICS_SCRIPT.read_text(encoding="utf-8")
+        doc = yaml.safe_load(ANALYSIS.read_text(encoding="utf-8"))
+        granted = doc.get("permissions") or {}
+        for fragment, scope in self.REQUIRED_SCOPES.items():
+            if fragment not in script:
+                continue
+            key, _, value = scope.partition(": ")
+            assert granted.get(key) == value, (
+                f"the metrics script reads {fragment}, which needs `{scope}`; an "
+                f"explicit permissions block grants nothing it does not list, so "
+                f"the scheduled run 403s and files no report at all"
+            )
+
+
+class TestHarvestDenominator:
+    """`escapes` must mean "the gate ran and this merged anyway" -- nothing else.
+
+    Two ways to corrupt it, in opposite directions, and both have already
+    happened. Counting a PR the gate never applied to manufactures a hole: the
+    first audit of this mechanism reported two release backports as escapes. And
+    excluding by the PR's CREATION time hides a real one: a PR opened before the
+    rollout but pushed to afterwards gets a fresh hygiene run carrying the gate,
+    so if it merged with no section it escaped -- and a creation-time filter
+    publishes that as zero.
+
+    Applicability is therefore read off the PR's own hygiene run.
+    """
+
+    def _module(self):
+        spec = importlib.util.spec_from_file_location("fix_loop_metrics", METRICS_SCRIPT)
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    @staticmethod
+    def _fake_gh(prs: list[dict], run_created: dict[str, str] | None = None):
+        """Stand in for `gh`: the default-branch probe, the gate-run probe, the PR list."""
+        created = run_created or {}
+
+        def fake_gh_json(*args, **kwargs):
+            if args and args[0] == "repo":
+                return {"defaultBranchRef": {"name": "main"}}
+            if args and args[0] == "api":
+                sha = str(args[1]).split("head_sha=")[1].split("&")[0]
+                when = created.get(sha)
+                return {"workflow_runs": [{"created_at": when}] if when else []}
+            return prs
+
+        return fake_gh_json
+
+    @staticmethod
+    def _pr(title: str, body: str, sha: str, base: str = "main") -> dict:
+        return {
+            "title": title,
+            "body": body,
+            "mergedAt": "2026-09-01T00:00:00Z",
+            "baseRefName": base,
+            "headRefOid": sha,
+        }
+
+    def test_other_base_prs_are_excluded_not_counted_as_escapes(self) -> None:
+        mod = self._module()
+        prs = [
+            self._pr("fix: a", "## Pattern harvest\nRule candidate: semgrep", "sha-a"),
+            self._pr("fix: b", "no section", "sha-b", base="release/0.5.0"),
+            self._pr("feat: c", "", "sha-c"),
+        ]
+        fake = self._fake_gh(prs, {"sha-a": "2026-09-01T00:00:00Z"})
+        mod.gh_json = fake
+        out = mod.harvest_metrics("o/r", "2026-08-31T00:00:00Z")
+        assert out["merged_fix_prs"] == 1, "only default-branch fix PRs are in scope"
+        assert out["escapes"] == 0, "a release backport is not an escape"
+        assert out["excluded_other_base"] == 1
+        assert out["adoption_pct"] == 100.0
+
+    def test_a_pr_whose_hygiene_never_ran_under_the_gate_is_excluded(self) -> None:
+        """Two ways to have never been asked: an older run, or no run at all.
+
+        The older-run case covers a re-run too: re-running a pre-gate run
+        re-executes the ORIGINAL workflow version, and the run's `created_at`
+        stays put, so it must not be read as gate-bearing.
+        """
+        mod = self._module()
+        prs = [
+            self._pr("fix: pre-gate run", "no section", "sha-old"),
+            self._pr("fix: no run at all", "no section", "sha-none"),
+        ]
+        mod.gh_json = self._fake_gh(prs, {"sha-old": "2026-08-30T00:00:00Z"})
+        out = mod.harvest_metrics("o/r", "2026-08-31T00:00:00Z")
+        assert out["merged_fix_prs"] == 0
+        assert out["escapes"] == 0
+        assert out["excluded_gate_never_ran"] == 2
+        assert out["adoption_pct"] is None, "an empty denominator must not render a percentage"
+
+    def test_a_pre_gate_pr_re_run_under_the_gate_is_a_real_escape(self) -> None:
+        """The case a creation-time filter hides.
+
+        This PR predates the rollout, so it would have been excluded by its own
+        creation date -- but it was pushed to afterwards, the gate ran on it, and
+        it merged with no section. That is an escape and must be reported.
+        """
+        mod = self._module()
+        prs = [self._pr("fix: opened early, pushed late", "no section", "sha-late")]
+        mod.gh_json = self._fake_gh(prs, {"sha-late": "2026-09-01T00:00:00Z"})
+        out = mod.harvest_metrics("o/r", "2026-08-31T00:00:00Z")
+        assert out["merged_fix_prs"] == 1
+        assert out["escapes"] == 1
+        assert out["excluded_gate_never_ran"] == 0
+
+    def test_a_real_escape_is_still_reported(self) -> None:
+        mod = self._module()
+        prs = [self._pr("fix: a", "no section", "sha-a")]
+        mod.gh_json = self._fake_gh(prs, {"sha-a": "2026-09-01T00:00:00Z"})
+        out = mod.harvest_metrics("o/r", "2026-08-31T00:00:00Z")
+        assert out["escapes"] == 1
+        assert out["adoption_pct"] == 0.0
 
 
 class TestPatternHarvest:


### PR DESCRIPTION
## Problem / Motivation

The two fix-loop lanes merged on 2026-08-31 ([#6967](https://github.com/kirodotdev/KiroCrew/pull/6967), [#6969](https://github.com/kirodotdev/KiroCrew/pull/6969)) were audited after 35 hours of real traffic (165 PRs merged into `main`, 182 fix/revert PRs opened). The Pattern-harvest gate works. Three things around it fail **silently**:

1. **The deferred-finding checker never posts its refusal.** Its reply line ended `Checked disposition: $COMMENT_URL_` — the trailing `_` was a markdown italic terminator, but bash read it as part of the variable name, so `set -euo pipefail` killed the script before `gh api` posted anything. Of the runs that reached the refusal path, **18 of 18 crashed**; zero `<!-- deferred-finding-check -->` comments exist in the repo. Every incomplete deferral since the merge went un-flagged.

2. **The weekly analysis reports success while half of it is dead.** The first scheduled run (2026-08-31 17:12) assumed its Bedrock role fine, then the Fable 5 step failed (`is_error:true`, `num_turns: 1`, `total_cost_usd: 0`, empty `modelUsage`, fallback model too). `continue-on-error` swallowed it, the run concluded **success**, and [issue #7324](https://github.com/kirodotdev/KiroCrew/issues/7324) was filed with the numbers only. Nothing anywhere went red.

3. **The harvest metric manufactures escapes.** It counted every merged fix PR without the section as a non-adopter, including PRs the gate never applied to. Measured live: `18 escapes` — of which **0 were real**. Two were release backports (a PR based on `release/0.5.0` runs that branch's workflow version, which predates the gate) and the rest were opened before the gate existed, against a template that had no such section.

## Why it matters

A non-blocking lane whose failure is also invisible is worse than no lane: it reports the coverage without providing it. The deferral checker is the enforcement half of the discipline that the repo's own SZZ analysis identified as its largest traceable escape class (63% of traceable escaped bugs were findings a reviewer raised and a disposition deferred). It has been inert since the hour it merged, and nothing said so.

The metric defect is the same failure in the other direction: a weekly report whose first published figure is ~100% noise spends its credibility before anyone reads the second one.

## What changed (motivation → approach → change)

**1. The refusal reply posts again.** `$COMMENT_URL_` → `${COMMENT_URL}_`. Root cause is not the typo but *where* it lived: a branch that only executes when something is wrong, in inline YAML bash that nothing could test. So the fix is paired with a ratchet (below) rather than left as a one-line patch.

**2. A failed analysis step is re-raised — after the issue is filed.** Keeping the model step fail-soft is the right call: a broken narrative must never cost the deterministic numbers. But the run must not read as success. The filing step is already `if: always()`, so the numbers land first and a new final step then exits 1 with the diagnosis. The degraded issue also says so **in its title** (`(metrics only — analysis step failed)`), because the issue list is the surface a reader scans without opening anything.

The `::error::` names the likely cause, which the failure signature pins down: credentials assumed successfully, one turn, zero cost, empty `modelUsage`, both model ids failing identically. That is an IAM action mismatch, not a model or trust-policy problem — `claude-code-action` streams, so the role needs `bedrock:InvokeModelWithResponseStream`, which a role provisioned for a non-streaming `converse` caller does not carry. **The AWS-side grant is not in this PR**; this change makes its absence visible every week instead of never.

**3. The harvest metric measures what the gate applied to.** Two exclusions, both answering "was this PR ever asked?" — merged into a non-default branch, or opened before the gate began applying — reported as their own buckets so `escapes` means what it says. `adoption_pct` also renders `n/a` instead of `None%` on an empty denominator.

## Tests

`test/test_fix_loop_discipline.py`, +5 (17 total in the file):

- **`TestNoSilentlyBrokenShell`** — parses every `run:` block in the three fix-loop workflows and asserts each `$VAR` resolves to a step/job env key, a runner-provided name, or an assignment in the same block. This is the generalizable rule the bug earns: `set -u` makes an undefined expansion fatal, and in a non-blocking lane that only bites on the unhappy path. A companion unit test pins the extractor against the exact historical string (`$COMMENT_URL_` flagged, `${COMMENT_URL}_` clean) so the ratchet is not trusted on faith. It found a live instance while being written — the literal in the new explanatory comment — which is why whole-line comments are stripped (a leading `#` is unconditionally a comment in bash; a trailing one is ambiguous inside `grep -oE '#[0-9]+'` and is deliberately left alone).
- **`TestFailedHalvesAreVisible`** — the re-raise step exists, is conditioned on the analysis step failing, exits non-zero, and comes *after* the issue-filing step (before it, the numbers would be lost with the narrative).
- **`TestHarvestDenominator`** — a release backport and a pre-gate PR are excluded rather than counted as escapes; a real escape (default-branch, opened under the gate, no section) is still reported.

## Manual verification

`harvest_metrics` run against live `gh` data for the window since the merge, before and after:

| | before | after |
|---|---|---|
| in-scope merged fix PRs | 99 | **71** |
| with section | 81 (81.8%) | **71 (100%)** |
| escapes | **18** | **0** |
| excluded (other base / pre-gate) | — | 2 / 28 |

So the gate has **zero escapes among the PRs it actually applied to**, and the 18 were entirely the queue that was already in flight when it landed. That bucket decays to zero on its own.

The two workflow changes are shell/YAML with no local runner: both files parse under `yaml.safe_load` (the new ratchet loads them), and the re-raise step's placement and condition are pinned by test rather than by a live run — a scheduled weekly job cannot be exercised locally, and the next real run is the verification.

## Related Issues

no linked issue: this is follow-up on defects found by auditing [#6967](https://github.com/kirodotdev/KiroCrew/pull/6967) and [#6969](https://github.com/kirodotdev/KiroCrew/pull/6969) in production, not a reported bug.

## Pattern harvest

Rule candidate: lint
Pattern: inline workflow bash expanding an undefined name — markdown emphasis absorbed into the variable (`$VAR_`) — is fatal under `set -u` but only on a branch that runs when something is already wrong, so a non-blocking lane loses its entire output while the run stays green.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the metric's scoping is documented in the script's own module docstring, which is where its contract lives
- [x] No secrets, credentials, or internal references in the diff
