### PR TITLE
fix(artifacts): memoize the artifacts fallback to satisfy the eslint ratchet

### DIFF
--- a/website/src/pages/ArtifactsPage.tsx
+++ b/website/src/pages/ArtifactsPage.tsx
@@ -1158,7 +1158,11 @@ export default function ArtifactsPage() {  const navigate = useNavigate()
     queryFn: () => api.artifacts({}),
   })
 
-  const artifacts = data?.artifacts || []
+  // Memoized so hooks depending on `artifacts` (the undo-bar useCallback and
+  // the tag/starred useMemos) see a stable reference between fetches — the
+  // bare `|| []` fallback minted a fresh array every render, which the
+  // exhaustive-deps rule flags once per consuming hook.
+  const artifacts = useMemo(() => data?.artifacts || [], [data?.artifacts])
 
   // ── Drag-move undo ────────────────────────────────────────────────────────
   // The offer's whole lifecycle — pending until the server acks, one-way to


### PR DESCRIPTION
## Problem / Motivation

`Frontend Lint & Type Check` is red on `main` itself, so every open
PR's lint check fails: #7558 ratcheted `--max-warnings` to 603, but the
tree currently emits **604** (verified on a clean `origin/main`
worktree: `npx eslint src/` -> 604 problems).

The over-cap warning is `ArtifactsPage.tsx`'s bare
`const artifacts = data?.artifacts || []`: the fallback mints a fresh
array every render, and `react-hooks/exhaustive-deps` flags it once per
consuming hook. It was flagged twice when the ratchet was set; the
move-undo bar (#7259) then added a third consuming hook (`useCallback`),
landing main at 604.

## Change

One line: wrap the initialization in `useMemo` — the exact fix the rule
names. This removes all three instances (the two pre-ratchet ones and
the new one): **604 -> 601**, back under the cap with slack.

Behavior is unchanged; consumers additionally gain a stable reference
between fetches instead of a fresh `[]` per render.

## Testing

- Clean-main probe: `eslint src/` 604 (cap 603, exit 1); this branch:
  **601**, exit 0.
- `tsc -b` clean; Artifact page suites 160/160.

<!-- no-visual-delta -->
**Why no screenshot:** reference-identity-only change, no rendered
surface differs.

no linked issue: broken-main lint hotfix found while babysitting PR #7700.


## Pattern harvest

Rule candidate: when a warning-count ratchet (eslint --max-warnings N) is
lowered, CI should verify main's actual count <= N in the same PR — a
concurrently-merging PR that adds one instance of an already-present warning
lands main over the cap and reds every open PR's lint check.
