### PR TITLE
test: deflake the sidecar move test and cut six slow gates

### DIFF
--- a/test/source_corpus.py
+++ b/test/source_corpus.py
@@ -1,0 +1,118 @@
+"""One cached read of the ``kiro_crew`` source tree, shared by every AST ratchet.
+
+Several gates in this suite pin a structural property of the whole package by
+walking ``src/kiro_crew/**/*.py`` and ``ast.parse``-ing each file. Independently
+they each paid the same costs, and the suite paid them once per gate:
+
+* the ``rglob`` walk and the read of ~41 MB of source (0.32 s), and
+* a full ``ast.parse`` of all 1254 modules (2.8 s), even though a violation of
+  any one gate can only exist in a file whose TEXT already contains the token
+  that gate matches on.
+
+So the corpus is read once here and cached, and each gate declares the literals
+its pattern requires. :func:`parsed_candidates` parses only the files that can
+possibly match, which is 10-22 files for the narrow gates and about a third of
+the tree for the broad ones.
+
+Two things this module deliberately does NOT do.
+
+It does not cache parsed trees. Retaining all 1254 modules' ASTs measures at
+~900 MB RSS and 3.2 M live nodes, which is per xdist worker, and it makes the
+parse itself 4x slower (11.1 s vs 2.3 s) because every later generational
+collection then traverses that live set -- a tax the whole rest of the session
+pays. Trees are therefore yielded and dropped.
+
+And it never narrows a gate. A literal is only accepted as a filter when the
+gate's AST pattern cannot match without that literal appearing in the source
+text, so filtering removes files that were always going to be non-matches.
+Exclusions (``_vendor``, ``testing/``) stay in the calling gate, because which
+files a gate polices is that gate's contract, not this module's.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+
+def src_root() -> Path:
+    """Locate the ``kiro_crew`` package.
+
+    Prefer the importable package (correct regardless of CWD / install layout);
+    fall back to the in-repo path so a gate also runs standalone under a bare
+    ``python3`` with no deps installed.
+    """
+    try:
+        import kiro_crew  # noqa: PLC0415
+
+        return Path(kiro_crew.__file__).resolve().parent
+    except Exception:
+        return Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+
+@functools.lru_cache(maxsize=1)
+def _read_tree() -> tuple[tuple[tuple[Path, str], ...], tuple[Path, ...]]:
+    """``((path, text), ...), (unreadable, ...)`` for the whole package, once."""
+    readable: list[tuple[Path, str]] = []
+    unreadable: list[Path] = []
+    for path in sorted(src_root().rglob("*.py")):
+        try:
+            readable.append((path, path.read_text(encoding="utf-8")))
+        except (OSError, UnicodeDecodeError):
+            # Recorded rather than swallowed: a file no gate can read is a file
+            # no gate can see, and `test_source_corpus.py` fails on a non-empty
+            # list so going blind cannot look like a green run.
+            unreadable.append(path)
+    return tuple(readable), tuple(unreadable)
+
+
+def source_texts() -> tuple[tuple[Path, str], ...]:
+    """Every readable ``*.py`` under the package, as ``(path, text)`` pairs."""
+    return _read_tree()[0]
+
+
+def unreadable_files() -> tuple[Path, ...]:
+    """Files the corpus could not decode. Expected empty; pinned by a test."""
+    return _read_tree()[1]
+
+
+def candidate_sources(
+    require_all: Sequence[str] = (),
+    require_any: Sequence[str] = (),
+) -> tuple[tuple[Path, str], ...]:
+    """Files whose text holds every ``require_all`` and one of ``require_any``.
+
+    An empty ``require_any`` imposes no alternation, so passing neither argument
+    returns the whole corpus.
+    """
+    return tuple(
+        (path, text)
+        for path, text in source_texts()
+        if all(lit in text for lit in require_all)
+        and (not require_any or any(lit in text for lit in require_any))
+    )
+
+
+def parsed_candidates(
+    require_all: Sequence[str] = (),
+    require_any: Sequence[str] = (),
+    *,
+    skip_syntax_errors: bool = True,
+) -> Iterator[tuple[Path, str, ast.Module]]:
+    """Yield ``(path, text, tree)`` for each candidate file, one tree at a time.
+
+    Trees are not retained between iterations, so a gate over a third of the
+    tree costs one parse and no lasting heap. With ``skip_syntax_errors`` false
+    the ``SyntaxError`` propagates, for a gate that treats an unparseable module
+    as a hole in its own coverage rather than as the compiler's problem.
+    """
+    for path, text in candidate_sources(require_all, require_any):
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError:
+            if skip_syntax_errors:
+                continue
+            raise
+        yield path, text, tree

--- a/test/test_no_blocking_call_on_loop.py
+++ b/test/test_no_blocking_call_on_loop.py
@@ -70,6 +70,8 @@ import io
 import pathlib
 import tokenize
 
+from source_corpus import parsed_candidates, src_root
+
 # module name -> attribute names that block when run on the loop AND have no
 # legitimate on-loop use (so a hard failure is always correct).
 _BANNED: dict[str, set[str]] = {
@@ -95,18 +97,8 @@ _NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
 
 
 def _src_root() -> pathlib.Path:
-    """Locate the kiro_crew source tree.
-
-    Prefer the importable package (correct regardless of CWD / install layout);
-    fall back to the in-repo path so the gate also runs standalone under a bare
-    ``python3`` with no deps installed (used for fast local triage).
-    """
-    try:
-        import kiro_crew  # noqa: PLC0415
-
-        return pathlib.Path(kiro_crew.__file__).resolve().parent
-    except Exception:
-        return pathlib.Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+    """Locate the kiro_crew source tree (see ``source_corpus.src_root``)."""
+    return src_root()
 
 
 def _import_bindings(tree: ast.Module) -> tuple[dict[str, str], dict[str, str]]:
@@ -189,6 +181,10 @@ def _suppressed_lines(source: str) -> set[int]:
     not only the call's first line.
     """
     out: set[int] = set()
+    if _SUPPRESS not in source:
+        # No comment token can carry the marker if the text does not, and
+        # re-lexing every async module to learn that costs 3.5s across the tree.
+        return out
     try:
         for tok in tokenize.generate_tokens(io.StringIO(source).readline):
             if tok.type == tokenize.COMMENT and _SUPPRESS in tok.string:
@@ -200,9 +196,17 @@ def _suppressed_lines(source: str) -> set[int]:
     return out
 
 
-def find_violations(source: str, path: str = "<source>") -> list[tuple[str, int, str]]:
-    """Return ``(path, lineno, dotted_name)`` for banned calls in async bodies."""
-    tree = ast.parse(source)
+def find_violations(
+    source: str, path: str = "<source>", *, tree: ast.Module | None = None
+) -> list[tuple[str, int, str]]:
+    """Return ``(path, lineno, dotted_name)`` for banned calls in async bodies.
+
+    ``tree`` lets a caller that already parsed *source* hand the tree over; it
+    must be the parse of *source*, since the suppression scan re-tokenizes the
+    text.
+    """
+    if tree is None:
+        tree = ast.parse(source)
     module_aliases, func_aliases = _import_bindings(tree)
     suppressed = _suppressed_lines(source)
     out: list[tuple[str, int, str]] = []
@@ -229,26 +233,31 @@ def find_violations(source: str, path: str = "<source>") -> list[tuple[str, int,
     return out
 
 
+#: A banned call only counts inside an ``ast.AsyncFunctionDef``, which cannot be
+#: parsed from text lacking the ``async`` keyword -- so a module without it holds
+#: no violation and is not worth parsing. The literal is the bare keyword and NOT
+#: ``"async def"``: ``async  def f():`` (two spaces) is valid Python, so the
+#: two-word spelling is not a necessary condition and would skip such a file.
+#:
+#: The banned names are deliberately not filtered on either. They resolve through
+#: import aliases (``import subprocess as sp``), so the literal at the call site
+#: is not predictable from ``_BANNED``.
+_REQUIRE_ALL = ("async",)
+
+
 def collect_repo_violations() -> list[tuple[str, int, str]]:
     """Scan every ``kiro_crew/**/*.py`` for on-loop blocking calls."""
-    root = _src_root()
-    base = root.parent
+    base = _src_root().parent
     out: list[tuple[str, int, str]] = []
-    for py in sorted(root.rglob("*.py")):
-        try:
-            src = py.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
+    for py, src, tree in parsed_candidates(_REQUIRE_ALL):
+        # A syntactically-invalid module is the compiler's problem, not this
+        # gate's, so `parsed_candidates` skips it rather than masking the real
+        # build error.
         try:
             rel = str(py.relative_to(base))
         except ValueError:
             rel = str(py)
-        try:
-            out.extend(find_violations(src, rel))
-        except SyntaxError:
-            # A syntactically-invalid module is the compiler's problem, not
-            # this gate's; skip rather than mask the real build error.
-            continue
+        out.extend(find_violations(src, rel, tree=tree))
     return out
 
 

--- a/test/test_sandbox_off_loop.py
+++ b/test/test_sandbox_off_loop.py
@@ -28,6 +28,8 @@ import pytest
 # Ensure the source tree is importable without pip install.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
+from source_corpus import parsed_candidates, src_root  # noqa: E402
+
 from kiro_crew.sandbox import (  # noqa: E402
     sandboxed_spawn_argv_async,
     shielded_prepare_off_loop,
@@ -199,13 +201,16 @@ class TestNoBareSandboxedSpawnArgvHops:
 
     _CHOKEPOINT = "sandboxed_spawn_argv"
 
+    #: Literals a bare hop needs before its AST shape can possibly match: the
+    #: chokepoint's own name (``reaching`` is computed per FILE, so a hop can
+    #: only be handed a reaching name if this module spells the chokepoint) and
+    #: one of the two hop spellings.
+    _REQUIRE_ALL = ("sandboxed_spawn_argv",)
+    _REQUIRE_ANY = ("run_in_executor", "to_thread")
+
     @staticmethod
     def _src_root() -> Path:
-        return Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
-
-    def _python_files(self) -> list[Path]:
-        root = self._src_root()
-        return sorted(root.rglob("*.py"))
+        return src_root()
 
     @classmethod
     def _names_that_reach_the_chokepoint(cls, tree: ast.Module) -> set[str]:
@@ -256,12 +261,8 @@ class TestNoBareSandboxedSpawnArgvHops:
 
     def test_no_bare_hops_to_sandboxed_spawn_argv(self):
         violations: list[str] = []
-        for path in self._python_files():
+        for path, _text, tree in parsed_candidates(self._REQUIRE_ALL, self._REQUIRE_ANY):
             rel = path.relative_to(self._src_root())
-            try:
-                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-            except SyntaxError:
-                continue
             reaching = self._names_that_reach_the_chokepoint(tree)
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):
@@ -308,11 +309,9 @@ class TestNoBareSandboxedSpawnArgvHops:
                         violations.append(f"{rel}:{node.lineno}: direct call to {name}")
                 self.generic_visit(node)
 
-        for path in self._python_files():
-            try:
-                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-            except SyntaxError:
-                continue
+        for path, _text, tree in parsed_candidates(
+            require_any=("wrap_argv", "sandboxed_spawn_argv")
+        ):
             Visitor(path).visit(tree)
 
         assert not violations, (

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -123,7 +123,9 @@ def _scope_body(scope: ast.AST):
         stack.extend(ast.iter_child_nodes(node))
 
 
-def _gate_side_baseline_log_sites(source: str) -> set[tuple[int, str]]:
+def _gate_side_baseline_log_sites(
+    source: str, *, tree: ast.AST | None = None
+) -> set[tuple[int, str]]:
     """Find log/audit writes in *source* whose text came from a BASELINE redactor.
 
     The property, not a name: a baseline redactor's result reaches a log write —
@@ -141,7 +143,8 @@ def _gate_side_baseline_log_sites(source: str) -> set[tuple[int, str]]:
     Returns ``{(lineno, "<log call>")}`` — the count is what the ratchet pins;
     the rendering is for the failure message.
     """
-    tree = ast.parse(source)
+    if tree is None:
+        tree = ast.parse(source)
     scopes: list[ast.AST] = [tree]
     scopes += [
         node
@@ -266,17 +269,20 @@ def _package_baseline_log_census() -> "tuple[tuple[str, int], ...]":
     cannot parse is a module it cannot see, and skipping one quietly is how a
     scan-based gate goes blind.
     """
-    from pathlib import Path
+    from source_corpus import parsed_candidates, src_root  # noqa: PLC0415
 
-    pkg = Path(security.__file__).resolve().parent
+    pkg = src_root()
     found: list[tuple[str, int]] = []
-    for path in sorted(pkg.rglob("*.py")):
+    # Every name in `_BASELINE_REDACTORS` starts with "redact", so a module
+    # without that text cannot hold a site and is not worth parsing. The
+    # SyntaxError is still not swallowed (`skip_syntax_errors=False`).
+    for path, source, tree in parsed_candidates(("redact",), skip_syntax_errors=False):
         rel = path.relative_to(pkg).as_posix()
         if rel.startswith(("_vendor/", "testing/")):
             continue
         if "/tests/" in rel or rel.endswith("_test.py"):
             continue
-        sites = _gate_side_baseline_log_sites(path.read_text(encoding="utf-8"))
+        sites = _gate_side_baseline_log_sites(source, tree=tree)
         if sites:
             found.append((rel, len(sites)))
     return tuple(found)

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -2792,11 +2792,20 @@ def test_a_mirror_link_landing_during_the_await_still_refuses(tmp_path, monkeypa
 def test_the_slot_cap_is_re_checked_after_the_await(tmp_path, monkeypatch):
     """The ceiling is read from live state, so it can fill inside the window too.
 
+    The ceiling is lowered for this test because what is under test is WHEN it is
+    read, not what it is: minting the production 500 slots is superlinear and cost
+    ~17s of pure setup for no extra property. The caller's own slot stays under the
+    lowered cap -- asserted below -- so the refusal can only come from the fill that
+    lands inside the await.
+
     Mutation guard: checking the cap only before the await lets two concurrent
     creations land over the ceiling.
     """
     state = _make_state(tmp_path)
     caller = _slot(state, "chat-1")
+    monkeypatch.setattr(sc, "MAX_LIVE_SLOTS", 3)
+    # Without this the test could pass on a cap checked only BEFORE the await.
+    assert state.live_slot_count() < sc.MAX_LIVE_SLOTS
 
     def _resolve_then_fill(_workspace):
         for i in range(sc.MAX_LIVE_SLOTS):

--- a/test/test_session_map_locking.py
+++ b/test/test_session_map_locking.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from source_corpus import parsed_candidates
 
 import kiro_crew.session_map as session_map_mod
 from kiro_crew.session_map import SESSION_MAP_FILENAME, SessionMap
@@ -505,14 +506,14 @@ class TestNoAwaitInsideBatch:
                     yield node
                     break
 
+    #: A block can only be one this gate cares about if the module spells
+    #: ``batched_save``, so nothing else is worth parsing.
+    _REQUIRE_ALL = ("batched_save",)
+
     def test_no_batch_block_awaits(self):
         offenders: list[str] = []
-        for path in SRC.rglob("*.py"):
+        for path, _text, tree in parsed_candidates(self._REQUIRE_ALL):
             if "_vendor" in path.parts:
-                continue
-            try:
-                tree = ast.parse(path.read_text(encoding="utf-8"))
-            except SyntaxError:  # pragma: no cover - the tree compiles in CI
                 continue
             for block in self._batch_blocks(tree):
                 for inner in ast.walk(block):

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -854,6 +854,16 @@ class TestSidecarFiles:
         _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
         sidecar = kiro_home / "sessions" / "cli" / "aaaa1111.lock"
         sidecar.write_bytes(b"lock")
+        # Age it with the rest of its session. The unit's age comes from the
+        # .json/.jsonl pair alone, but the move loop's revival check stats EVERY
+        # file it stages against a wall-clock instant, so a sidecar left stamped
+        # "now" is a file written after this batch was certified -- the state the
+        # check exists to refuse. Leaving it fresh passed only on the microseconds
+        # between this write and that instant, and a backward CLOCK_REALTIME step
+        # inside that window inverted it: "all 1 selected session(s) were resumed
+        # while being staged". An idle session's sidecar is as old as its logs.
+        aged = _NOW - 40 * _DAY
+        os.utime(sidecar, (aged, aged))
 
         batch = session_storage.move_to_trash(
             ["aaaa1111"], reason="manual", index=_index(), now=_NOW

--- a/test/test_source_corpus.py
+++ b/test/test_source_corpus.py
@@ -1,0 +1,159 @@
+"""The corpus behind every AST ratchet: not stale, not empty, not narrowing.
+
+``source_corpus`` makes the whole-tree gates cheap two ways -- it reads the tree
+once and caches it, and it parses only the files whose text can possibly match
+the calling gate's pattern. Both are silent failure modes: a cache that comes
+back empty, or a literal filter that is not actually a necessary condition,
+leaves every one of those gates green while seeing nothing. Neither shows up as a
+failure anywhere else, which is why they are pinned here rather than trusted.
+
+The cache is pinned by shape, and each filter two ways: its literals must still
+appear in the very source the gate exists to reject (so a renamed chokepoint
+breaks this test instead of quietly emptying that gate), and it must still
+exclude a real part of the tree (so a filter that has stopped narrowing is
+noticed rather than paid for).
+
+On soundness of the filters themselves: for the identifier-based ones the
+argument is textual. ``_batch_blocks`` fires only on an ``ast.Attribute`` spelled
+``batched_save``, and no such node can be parsed from text that does not contain
+those characters; the same holds for ``sandboxed_spawn_argv`` and for the
+``redact*`` family. The keyword-based one is the exception worth stating: an
+``ast.AsyncFunctionDef`` needs the ``async`` KEYWORD, but not the two-word string
+``async def`` -- ``async  def f():`` parses -- which is why the blocking gate
+filters on the bare keyword and why that spelling is asserted below.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+import test_no_blocking_call_on_loop as blocking
+import test_sandbox_off_loop as sandbox
+import test_session_map_locking as session_map
+from source_corpus import candidate_sources, source_texts, src_root, unreadable_files
+
+#: The tree is ~1250 modules. A floor well under that catches the failure that
+#: matters -- a corpus that came back empty or nearly so -- without turning an
+#: ordinary file addition or deletion into a test edit.
+_MIN_FILES = 800
+
+#: The census filter, which lives in ``test_security_posture`` as a literal at
+#: its one call site because that gate has no class to hang it on.
+_CENSUS_REQUIRE_ALL = ("redact",)
+
+
+class TestCorpusHealth:
+    """A stale or empty corpus is the one failure that makes every gate green."""
+
+    def test_the_corpus_is_not_empty_or_stale(self):
+        texts = source_texts()
+        assert len(texts) >= _MIN_FILES, (
+            f"source_corpus returned {len(texts)} files; every whole-tree ratchet "
+            "reads this, so a short corpus makes all of them pass while blind."
+        )
+
+    def test_every_file_is_python_under_the_package(self):
+        root = src_root()
+        assert (root / "security.py").is_file(), f"{root} is not the kiro_crew package"
+        for path, _text in source_texts():
+            assert path.suffix == ".py"
+            assert path.is_relative_to(root)
+
+    def test_no_file_was_skipped_as_unreadable(self):
+        assert unreadable_files() == (), (
+            "The corpus could not decode these files, so no ratchet can see them: "
+            f"{[str(p) for p in unreadable_files()]}"
+        )
+
+    def test_sources_are_the_real_file_contents(self):
+        """Pins the read, not just the count: a corpus of empty strings is worse."""
+        by_name = {path.name: text for path, text in source_texts()}
+        assert "def redact" in by_name["security.py"]
+        assert "def batched_save" in by_name["session_map.py"]
+
+    def test_a_filter_returns_a_subset_and_no_filter_returns_everything(self):
+        assert set(candidate_sources(blocking._REQUIRE_ALL)) <= set(source_texts())
+        assert candidate_sources() == source_texts()
+
+
+class TestFilterLiteralsStillMatchWhatTheGatesReject:
+    """Each filter, applied to source the gate exists to fail on.
+
+    This is the half a rename breaks: move ``batched_save`` and the gate keeps
+    passing on a tree it can no longer see into, unless something asserts that
+    the filter admits a known violation. Each case is the same shape the gate's
+    own meta-test plants.
+    """
+
+    @staticmethod
+    def _admits(source: str, require_all=(), require_any=()) -> bool:
+        return all(lit in source for lit in require_all) and (
+            not require_any or any(lit in source for lit in require_any)
+        )
+
+    def test_a_bare_hop_survives_the_sandbox_filter(self):
+        cls = sandbox.TestNoBareSandboxedSpawnArgvHops
+        violating = (
+            "import asyncio\n"
+            "async def f(argv):\n"
+            "    return await asyncio.to_thread(sandboxed_spawn_argv, argv)\n"
+        )
+        assert self._admits(violating, cls._REQUIRE_ALL, cls._REQUIRE_ANY)
+        # ... and the indirect spelling, which is the one the gate was widened for.
+        indirect = (
+            "def _prepare(argv):\n"
+            "    return sandboxed_spawn_argv(argv)\n"
+            "async def f(loop, pool, argv):\n"
+            "    return await loop.run_in_executor(pool, _prepare, argv)\n"
+        )
+        assert self._admits(indirect, cls._REQUIRE_ALL, cls._REQUIRE_ANY)
+
+    def test_an_awaiting_batch_block_survives_the_session_map_filter(self):
+        violating = "async def f(s):\n" "    with s.batched_save():\n" "        await s.flush()\n"
+        assert self._admits(violating, session_map.TestNoAwaitInsideBatch._REQUIRE_ALL)
+
+    def test_an_on_loop_blocking_call_survives_the_blocking_filter(self):
+        violating = "import time\nasync def f():\n    time.sleep(1)\n"
+        assert self._admits(violating, blocking._REQUIRE_ALL)
+
+    def test_the_blocking_filter_admits_the_two_space_async_spelling(self):
+        """``async  def`` parses, so ``"async def"`` would be an unsound filter."""
+        odd = "import time\nasync  def f():\n    time.sleep(1)\n"
+        assert isinstance(ast.parse(odd).body[1], ast.AsyncFunctionDef)
+        assert "async def" not in odd
+        assert self._admits(odd, blocking._REQUIRE_ALL)
+        assert blocking.find_violations(odd), "the gate itself must flag this shape"
+
+    def test_a_baseline_log_site_survives_the_census_filter(self):
+        violating = (
+            "def apply(stderr):\n"
+            "    logger.error('install failed: %s', redact(stderr.decode()))\n"
+        )
+        assert self._admits(violating, _CENSUS_REQUIRE_ALL)
+
+
+class TestFiltersStillNarrowTheTree:
+    """A filter that keeps everything is cost with no benefit left in it."""
+
+    @pytest.mark.parametrize(
+        ("label", "require_all", "require_any", "ceiling"),
+        [
+            (
+                "sandbox-bare-hop",
+                sandbox.TestNoBareSandboxedSpawnArgvHops._REQUIRE_ALL,
+                sandbox.TestNoBareSandboxedSpawnArgvHops._REQUIRE_ANY,
+                100,
+            ),
+            ("session-map-batch", session_map.TestNoAwaitInsideBatch._REQUIRE_ALL, (), 100),
+            ("security-census", _CENSUS_REQUIRE_ALL, (), 700),
+            ("blocking-on-loop", blocking._REQUIRE_ALL, (), 900),
+        ],
+    )
+    def test_the_filter_narrows_the_tree(self, label, require_all, require_any, ceiling):
+        kept = candidate_sources(require_all, require_any)
+        assert kept, f"{label}: matched nothing, so that gate now scans an empty tree"
+        assert len(kept) < ceiling, (
+            f"{label}: kept {len(kept)} of {len(source_texts())} files, so the filter "
+            "is no longer buying anything -- either the tree or the literal moved."
+        )


### PR DESCRIPTION
## Problem / Motivation

A full-suite run surfaced one flaky failure and five slow tests that together
dominate the suite's tail:

```
43.93s call  test/test_session_control.py::test_the_slot_cap_is_re_checked_after_the_await
32.19s call  test/test_sandbox_off_loop.py::TestNoBareSandboxedSpawnArgvHops::test_no_bare_hops_to_sandboxed_spawn_argv
28.00s call  test/test_no_blocking_call_on_loop.py::test_no_blocking_call_on_event_loop
23.71s call  test/test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor
20.61s call  test/test_session_map_locking.py::TestNoAwaitInsideBatch::test_no_batch_block_awaits

FAILED test/test_session_storage.py::TestSidecarFiles::test_an_unrecognised_sidecar_moves_with_its_session
  kiro_crew.session_storage.SessionStorageError: all 1 selected session(s) were
  resumed while being staged; nothing was moved
```

None of the six was slow or flaky for the reason its symptom suggested.

## Why it matters

The flake fails a required backend shard on a diff that cannot have caused it,
so every PR unlucky enough to hit the window pays a re-run. Its trigger is a
backward `CLOCK_REALTIME` step (NTP or VM host time sync), which is not rare on
CI runners and is invisible in the failure text — the error names a revival
guard, so the reader looks for a session-storage bug that is not there.

The five slow tests are ~104s of the suite's serial tail. Four of them pay the
same cost independently, so the suite pays it four times.

## What changed (motivation → approach → change)

**The flake — a test bug, not a production race.** `_cli_half` ages the
session's `.json`/`.jsonl` pair to 40 days, but the test then wrote the `.lock`
sidecar and left it stamped with the current wall clock. `move_to_trash`'s
revival guard stats every file it stages against `validated_at = time.time()`
and refuses the session when `mtime > validated_at`. The aged pair clears that
by 40 days; the sidecar cleared it only by the microseconds between
`sidecar.write_bytes()` returning and `validated_at` being read, so any backward
realtime step inside that window inverts the comparison. Fixed by `os.utime`-ing
the sidecar to the same age as the rest of its session, matching what
`_cli_half`, `_transcript` and `_archive_segment` already do for every other
file in the module.

No production code changed, and no real user was exposed: a genuine reclaim
candidate must pass `age_days >= MIN_RECLAIM_AGE_DAYS`, so its files sit *days*
below `validated_at`, while a sidecar being written right now genuinely means
something has the session open — which is what the guard is for. The asymmetry
is deliberate: `_scan_raw_uncached` computes age from `_CLI_SUFFIXES` only,
while `_unit_paths` stages every file including unrecognised sidecars.

**The slot-cap test — production-scale setup for a non-scale property.** It
filled the production ceiling `MAX_LIVE_SLOTS = 500` with real slots to prove
the cap is re-read *after* the await. `state.get_or_create_slot` is superlinear
in the live slot count (first 50 slots: 0.14s; remaining 450: 17.0s), and the
fill runs inside `asyncio.to_thread`, so the cost surfaced in a profile as
17.46s inside `select.epoll.poll` rather than as anything to do with slots.
Lowered the ceiling for this test with `monkeypatch.setattr(sc,
"MAX_LIVE_SLOTS", 3)` — the production check reads the module global at call
time, so the patch binds. The property is unchanged: the caller's own slot
leaves the count at 1, under the lowered cap (asserted explicitly), so the
refusal can still only come from the fill that lands inside the await.

**The four AST ratchets — the same tree walk, four times.** Each independently
walked `src/kiro_crew/**/*.py` and `ast.parse`-d every file: the rglob plus
~41 MB of reads (0.32s) and a full parse of all 1254 modules (2.8s), per gate.
New `test/source_corpus.py` reads the corpus once behind an `lru_cache`, and
each gate declares the literals its AST pattern *cannot match without*, so
`parsed_candidates` parses only the files that can possibly match — 10–22 files
for the narrow gates, about a third of the tree for the broad ones.

Every filter is a necessary condition, not a narrowing:

| Gate | Required literal | Why it is necessary |
|---|---|---|
| `test_no_batch_block_awaits` | `batched_save` | `_batch_blocks` matches only `expr.func.attr == "batched_save"` |
| gate-side redactor census | `redact` | every name in `_BASELINE_REDACTORS` starts with `redact` |
| bare-hop gate | `sandboxed_spawn_argv` + (`run_in_executor`\|`to_thread`) | `reaching` is computed per file, so a hop can only be handed a reaching name if that module spells the chokepoint |
| on-loop blocking gate | `async` | a banned call only counts inside an `ast.AsyncFunctionDef`, which cannot parse from text lacking the keyword |

The `async` filter is the bare keyword and deliberately **not** `"async def"`:
`async  def f():` (two spaces) is valid Python, so the two-word spelling is not
a necessary condition. The banned names themselves are not filtered on, because
they resolve through import aliases (`import subprocess as sp`) and the literal
at the call site is not predictable from `_BANNED`.

Two things the module deliberately does not do. It does **not** cache parsed
trees: retaining all 1254 modules' ASTs measures ~900 MB RSS and 3.2M live
nodes *per xdist worker*, and makes the parse itself 4x slower (11.1s vs 2.3s)
because every later generational collection then traverses that live set — a
tax the whole rest of the session pays. Trees are yielded and dropped. And it
never narrows a gate: exclusions (`_vendor`, `testing/`) stay in the calling
gate, because which files a gate polices is that gate's contract, not the
corpus module's.

Timings, same machine, slowest call per test:

| Test | Before | After |
|---|---|---|
| slot cap re-checked after the await | 18.51s | 0.74s |
| no blocking call on event loop | 13.53s | 5.20s |
| no bare hops to `sandboxed_spawn_argv` | 8.60s | 1.10s |
| gate-side log redactor spelling | 7.57s | 4.78s |
| async never calls sync chokepoints | 5.55s | 0.97s |
| no batch block awaits | 5.46s | 0.50s |

The four ratchet files run 45.7s → 16.8s serially while gaining 14 tests.

## Tests

- `test/test_source_corpus.py` (new, 14 tests) pins the shared corpus itself: that it is non-empty and not stale, that `source_texts()` returns the real file contents, that `unreadable_files()` is empty (a file no gate can read is a file no gate can see, so going blind cannot look like a green run), and that each gate's declared literals really are necessary conditions for its own AST pattern.
- Every one of the four ratchets still asserts the same property at the same strictness, and each was mutation-verified by planting a real violation in a fresh module under `src/kiro_crew/`: a bare `asyncio.to_thread` hop reaching the chokepoint, an on-loop `subprocess.run` inside an `async def`, an `await` inside a `batched_save` block, and a gate-side `logger.warning` reading `redact`. Each gate failed on its own mutation and passed again once reverted.
- The slot-cap test was mutation-verified by capturing the live count *before* the `to_thread` await and testing that instead — the exact defect its docstring names. The test fails on that mutation.
- The sidecar fix was verified against a forced race: `session_storage.time.time` monkeypatched to `real() - 0.5` around `move_to_trash` reproduced the reported error 100% of the time, and the aged-sidecar variant passes under the identical step, and again at an 86,400s step.

## Manual verification

N/A — unit coverage sufficient; this is a test-only diff with no production
change, and the behaviours at issue are all directly exercised above.

Verification actually run: 471 tests pass across all seven touched files under
`-n 4` on the current base. `check_black_formatting`, `isort`, `check_loop_bound_locks`,
`check_subprocess_encoding`, `check_testpaths_coverage`, `check_harness_parity`,
`check_focus_cue`, `check_agent_sdk_boundary`, `check_sync_io_in_async`,
`check_brand_name`, `check_changelog_history`, `check_builtin_skill_scope`,
`check_per_file_coverage`, `scrub-lint` and `run_scoped_tests --test` all pass.

The full backend suite on this branch reports 95 failures; **94 are byte-identical
on clean `origin/main`** (HOME-isolation, sensitive-path, service-ownership and
xdist-budget tests that fail on a dev box, not in CI), verified by running the same
16 files in a detached `origin/main` worktree. The 95th,
`test_public_repo_chip_status.py::test_schedule_dedups_by_repo_and_skips_issue_and_jira`,
passes 33/33 in isolation on **both** this branch and clean base — a load-order
flake in a file this diff does not touch. No failure occurs in any of the eight
files changed here.

## Related Issues

no linked issue: found by reading a full-suite `--durations` report, not filed as an issue first.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a test that establishes production-scale state to prove a property that
is not about scale — filling a real ceiling, or re-walking a whole source tree —
pays a cost its own assertion never needs. Four of the six tests here share it.
The sibling pattern for the flake: a fixture that ages *some* of a unit's files
and leaves the rest stamped `now`, when the code under test inspects all of them
against a single wall-clock instant.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing or documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
