### PR TITLE
test: await icon-swap transitions in AppIconLocalFallback (#7437)

### DIFF
--- a/website/src/test/AppIconLocalFallback.test.tsx
+++ b/website/src/test/AppIconLocalFallback.test.tsx
@@ -12,7 +12,7 @@
  * proves nothing. The suite also locks the default-inert contract: consumers
  * that do not pass a fallback (every pre-existing call site) are unchanged.
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -103,8 +103,13 @@ describe('AppIcon — local-art fallback on load failure', () => {
     // new primary renders, and on failure the fallback gets retried too.
     rerender(<AppIcon iconUrl={NEXT} iconUrlFallback={LOCAL} />)
     await waitFor(() => expect(imgBySrc(NEXT)).not.toBeNull())
+    // Settle before firing: the changed URL re-runs the per-URL reset effect,
+    // and an error dispatched before it flushes is wiped by it (#7437).
+    await act(async () => {})
     fireEvent.error(imgBySrc(NEXT)!)
-    expect(imgBySrc(LOCAL)).not.toBeNull()
+    // Await the swap: on a loaded runner the error-driven re-render can land
+    // after this line executes, so a synchronous read sees the old frame (#7437).
+    await waitFor(() => expect(imgBySrc(LOCAL)).not.toBeNull())
   })
 })
 
@@ -160,23 +165,37 @@ describe('AppDetailPage — installed app icon falls back to local art (#6804)',
     renderDetail()
 
     // The registry asset stays the PRIMARY src — no precedence flip.
-    const primary = await waitFor(() => {
-      const el = imgBySrc(REGISTRY)
-      expect(el).not.toBeNull()
-      return el!
-    })
+    await waitFor(() => expect(imgBySrc(REGISTRY)).not.toBeNull())
+
+    // Settle the frame before firing: waitFor polls on real timers, so it can
+    // observe the img from an intermediate commit while load()'s remaining
+    // state updates and AppIcon's per-URL reset effect are still pending. An
+    // error fired against that frame is wiped by the reset and the swap never
+    // happens — the swap-lost mode of #7437. Drain them, then fire on a fresh
+    // query of the settled DOM rather than a captured element.
+    await act(async () => {})
 
     // Registry CDN unreachable: the src must actually CHANGE to the local route.
-    fireEvent.error(primary)
-    await waitFor(() => expect(imgBySrc(LOCAL)).not.toBeNull())
-    expect(imgBySrc(REGISTRY)).toBeNull()
+    // Both halves of the transition are asserted inside one awaited condition:
+    // on a loaded runner the swap can complete in two frames, and a synchronous
+    // sibling check would read the intermediate one (#7437).
+    fireEvent.error(imgBySrc(REGISTRY)!)
+    await waitFor(() => {
+      expect(imgBySrc(LOCAL)).not.toBeNull()
+      expect(imgBySrc(REGISTRY)).toBeNull()
+    })
 
     // Local bytes gone too (uninstalled mid-render): terminal state is the
-    // glyph, with no broken-image frame left in the icon box.
+    // glyph, with no broken-image frame left in the icon box. The settle here
+    // is symmetry with the one above — fallbackUrl has not changed since
+    // mount, so no pending reset effect is expected at this point.
+    await act(async () => {})
     fireEvent.error(imgBySrc(LOCAL)!)
     const box = document.querySelector('.w-24.h-24')!
-    await waitFor(() => expect(box.querySelector('img')).toBeNull())
-    expect(box.querySelector('svg')).not.toBeNull()
+    await waitFor(() => {
+      expect(box.querySelector('img')).toBeNull()
+      expect(box.querySelector('svg')).not.toBeNull()
+    })
   })
 })
 


### PR DESCRIPTION
# Summary

Test-only hardening of `website/src/test/AppIconLocalFallback.test.tsx` to close the flaky icon-swap race reported in #7437. No component or source changes — the issue provides evidence the component is correct, and both review lanes verified the mechanism against `AppIcon.tsx` / `AppDetailPage.tsx`.

Three race mechanisms closed:

1. **Intermediate-frame reads** — synchronous sibling assertions immediately after an awaited `waitFor` (`imgBySrc(REGISTRY)` null check at ~L173, `svg` present check at ~L180) could read the first half of a two-frame transition on a loaded runner. Every post-transition assertion is now folded into the awaited condition, requiring both halves of each transition in the *same* poll — strictly stronger than the old await-then-sync pair.
2. **Swap-lost mode** — `waitFor` polls on real timers, so it can observe the `<img>` from a commit whose passive effects (AppIcon's per-URL `setImgFailed(false)` reset) have not flushed yet; an `error` event fired against that frame is wiped by the reset and the swap never happens (reproduced locally on a cold first run). An `await act(async () => {})` settle now drains pending commits/effects before each post-transition fire, and the error is fired on a freshly queried element instead of a captured reference (a captured node can be detached by an intermediate commit).
3. **Sibling case sweep** — the same sync-after-awaited-transition pattern at ~L107 (`expect(imgBySrc(LOCAL)).not.toBeNull()` straight after `fireEvent.error`) in "a changed icon clears BOTH failure latches" is hardened identically. The fully synchronous cases are untouched: `render`/`rerender` are act-wrapped and flush effects inline, so they have no such window.

Closes #7437

# Testing

- Target file: 20/20 consecutive green runs, including 10 runs under full CPU load (nproc spinners) simulating a loaded runner; also verified the base test passes 3/3 unmodified before the change.
- `npx tsc -b` clean; `npx eslint` on the changed file clean (`await act(async () => {})` has precedent in 15 other test files; no `no-unnecessary-act` rule configured).
- Full frontend suite: 1742 files / 27418 tests green.
- Backend gates on the shared venv (isort / flake8 / mypy) clean; full backend pytest 79260 passed with 92 failures all in known host-env classes (home-marker artifact tests, `AF_UNIX path too long`, xdist host-budget) — the diff touches exactly one frontend test file, so none are attributable.
- Diff-scoped brand and black gates pass post-commit.

# Pre-push review

- GPT lane (gpt-5.6-sol): PASS, no findings.
- Opus lane (claude-opus-5): PASS, 2 Low advisories — the comment-precision one is applied in this head; the optional `waitFor` timeout-message one is declined as non-structural per the finding's own text (a regression now surfaces as a `waitFor` timeout at the annotated line, which names the transition being awaited).

🤖 Generated by Kiro Crew Auto-Pipeline [operator: CrysisDeu#0c98c3a2]
