### PR TITLE
docs(artifacts): state the slug refusal contract on the MCP save tool

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -36,7 +36,7 @@ The dashboard provides a `/artifacts` library page for browse/search and a
 
 | Field | Type | Notes |
 |---|---|---|
-| `slug` | string | URL-safe handle, derived from `name` if not given |
+| `slug` | string | URL-safe handle. Derived from `name` when not given, resolving a collision by suffixing (`-2`, `-3`, …); an explicitly-passed slug is refused — never renamed — when it is already taken or malformed |
 | `name` | string | Human-readable display name |
 | `kind` | enum | `widget`, `html`, `markdown`, `svg`, `json`, `text`, `webapp`, `image` — inferred on save when the caller omits it (see [Kind inference](#kind-inference)) |
 | `source` | enum | `chat` (default), `cron`, `subagent`, `manual`, `import` |

--- a/src/kiro_crew/mcp_tools/artifacts.py
+++ b/src/kiro_crew/mcp_tools/artifacts.py
@@ -76,7 +76,13 @@ def schemas() -> list[dict[str, Any]]:
                     },
                     "slug": {
                         "type": "string",
-                        "description": "Optional explicit slug (lowercase, digits, hyphens). Auto-derived from name when omitted.",
+                        "description": (
+                            "Optional explicit slug (lowercase, digits, hyphens). "
+                            "A taken or malformed slug is REFUSED, never renamed — "
+                            "call artifact_update on the existing slug to version "
+                            "it in place. Omit to derive one from name and let a "
+                            "collision resolve by suffixing (-2, -3, ...)."
+                        ),
                     },
                     "kind": {
                         "type": "string",


### PR DESCRIPTION
## Problem / Motivation

`artifact_save`'s MCP input schema describes `slug` as:

> Optional explicit slug (lowercase, digits, hyphens). Auto-derived from name when omitted.

True, but silent on what happens when a slug *is* passed and is unavailable. The store's
`create()` takes two opposite branches: a name-derived slug goes through `_unique_slug()` and
gets a numeric suffix (`-2`, `-3`, …), while an explicit slug is `_validate_slug`'d and then
raises `ArtifactAlreadyExistsError` if the directory already exists — refused, never renamed.
`_validate_slug` also rejects a malformed slug, including the empty string.

#7178 just landed that full contract as the CLI `--slug` help text. This is the same store
operation described two ways: the CLI caller is told what happens on collision, the MCP caller
is not. This change aligns the MCP schema and the spec's `slug` field row on the wording #7178
already settled — a parity fix, not a new opinion about behaviour.

## Why it matters

The MCP path is the one that most needs the statement, because it is the branch with no
runtime guidance. `artifact_save`'s pre-save duplicate hint — the text that tells a caller to
"call `artifact_update` on the existing slug instead" — is deliberately gated on
`not explicit_slug`. So when a slug is passed explicitly and collides, the caller gets no hint,
only `Error: artifact already exists: <slug>`, and nothing anywhere told it that passing a slug
opted out of the suffixing it would otherwise have received. The schema description is the only
surface that can carry that.

The spec row is included for the same reason #7178 touched this file: it is the normative
description of the field, and it carried the identical omission
(`URL-safe handle, derived from name if not given`). Stating the contract on both surfaces in
one commit keeps it in one voice rather than inviting "why not the spec too".

## What changed (docs only, no behaviour)

- `src/kiro_crew/mcp_tools/artifacts.py` — the `slug` property of the `artifact_save` input
  schema now states all four facts the CLI help states: refused-not-renamed, that malformed
  counts as refused too, `artifact_update` as the in-place escape hatch, and that omitting
  `slug` is what opts into suffixing.
- `docs/system-specs/modules/artifacts.md` — the `meta.json` `slug` row states the same
  contract.

Deliberately out of scope: the store's collision behaviour is unchanged, no store-level warning
is added (#6798 removed exactly that, on purpose), and the CLI help #7178 landed is untouched.
The spec's MCP tool table is left alone as well — those rows are purpose-level, and the
`artifact_save` row names no input parameter except `folder`, so adding `slug` there would
duplicate the contract in a second spec location and invite the two drifting apart.

## Tests

No behavioural test, because there is no behaviour change — the store's branches are unmodified
and already covered. The repo has no precedent for asserting a help or description string
verbatim: #7178's own test (`test_save_parses_an_explicit_slug`) pins the
argv → namespace → command hop, not the help text, so a verbatim-string assertion here would
introduce a test pattern this repo does not use. The string occurs in exactly one place in the
tree, so there is no second copy to keep in sync.

Verification run locally at base `ab3352e9c`:

- `pytest -q` full backend suite, `isort --check-only`, `flake8` (both over
  `src/kiro_crew test conftest.py xdist_budget.py`), `mypy src/kiro_crew/` (1243 files, clean;
  mypy 1.14.1, matching the `pyproject.toml` pin, no `faiss` installed),
  `scripts/docs_lint.py --test` self-test, and `scripts/docs-lint.sh` (252 files) — all green.
- The suite carries pre-existing failures on this host, which sits outside `$HOME` and so trips
  source-root-classification and host-isolation tests (109 of them are
  `subprocess.CalledProcessError` from sandboxed `git`). These were proved pre-existing rather
  than assumed: the identical `pytest -q` invocation was run on a clean worktree at the same
  base, in the same parent directory so source-root classification is identical, and the failure
  **sets** were diffed. Branch 184 node ids, base 185; nothing fails on the branch that does not
  also fail on base. The single base-only entry
  (`test_public_repo_chip_status.py::test_force_synchronously_invalidates_public_before_refresh`)
  failed on base and passed on the branch.
- `tsc -b` / `vitest` were not run: CI gates the frontend jobs behind `only_backend != 'true'`,
  and this diff is entirely in the `backend` bucket (`docs/**` and `src/**`). No frontend spec
  references either changed string.
