### PR TITLE
fix(apps): three places the Job SDK asserted a fact it never verified

### DIFF
--- a/docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md
+++ b/docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md
@@ -77,6 +77,45 @@ active work, and kills tracked process trees (`server.py`,
 from leaving Dev Fleet subprocesses behind; it also shows why a durable record
 cannot imply that its original process is still executable.
 
+## Job SDK process scope
+
+`JobSDK` records the liveness of the gateway process. `_ORIGIN` is minted once per
+gateway process, a run's worker is a thread in that process, and `reconcile`
+resolves every non-terminal record whose origin is not the current `_ORIGIN`
+(`src/kiro_crew/apps/job_sdk.py`, `_ORIGIN`, `JobSDK.start`, `JobSDK._execute`, and
+`JobSDK.reconcile`). Staleness is decided by one question: whether the gateway
+process that minted the record survived.
+
+An app declaring `backend.entryPoint` does not execute its work in that process.
+`start_app_backend` spawns the backend under `popen_limited` as a separate OS
+process with its own interpreter and rlimit profile
+(`src/kiro_crew/apps/backend.py`, `start_app_backend`), and that app's teardown
+hook runs on the backend's own aiohttp application rather than the gateway's
+(`src/kiro_crew/apps/builtins/dev_fleet/app.json`, `backend.entryPoint`;
+`dev_fleet/server.py`, `dev_fleet_cleanup` registered on `on_cleanup`).
+`JobSDK.register` binds a kind to a Python callable held in the gateway
+(`job_sdk.py`, `JobSDK.register`), so a runner defined in a backend process has no
+registration path.
+
+Together the two produce a record that contradicts the work it describes. At
+gateway startup `_reap_stale_app_backends` terminates a backend left by a prior
+gateway generation only when the pid's identity positively matches the recorded
+one; when identity cannot be confirmed the pid is left alone (`backend.py`,
+`_reap_stale_app_backends`). A backend spared by that check keeps executing, and
+the new gateway's reconciliation marks its runs `INTERRUPTED`, recording that the
+gateway restarted while the run was executing and that no runner is registered for
+its kind — a backend-process runner has no registration path, so the resolved
+record's `interrupt_cause` is `runner_unregistered` (`job_sdk.py`,
+`JobSDK.reconcile` and `CAUSE_RUNNER_UNREGISTERED`).
+`INTERRUPTED` is a member of `TERMINAL_STATES`, so that record is neither
+reconciled again nor resumed (`job_sdk.py`, `TERMINAL_STATES`).
+
+This scope is load-bearing: an app whose run registry is process memory reports
+nothing after a restart, and reporting nothing is accurate, while a durable record
+written from a process that does not own the work reports a run as ended when it
+has not ended. Dev Fleet's registry is the process-memory case (see "Dev Fleet
+runs"). `JobSDK` describes work that the gateway process itself executes.
+
 ## View position is not an App SDK contract
 
 Builtin apps are mounted by the single-segment `/:builtinApp` route, and

--- a/src/kiro_crew/apps/job_routes.py
+++ b/src/kiro_crew/apps/job_routes.py
@@ -114,6 +114,13 @@ def _public_view(run: JobRun, cancelling: frozenset[str]) -> dict[str, Any]:
     otherwise report ``status: cancelled`` and ``cancelling: true`` together --
     the cancel both finished and still pending. Once the status carries the
     answer there is nothing left to be pending.
+
+    ``interrupted_from`` and ``interrupt_cause`` are served for the reason they
+    exist. They are not host facts -- they are the two facts a client needs to
+    recover from an interruption, and a client is the only party that can act on
+    them: whether the run may have committed side effects, and whether retrying
+    it is even possible now. Withholding them would leave the record honest and
+    the API not.
     """
     return {
         "run_id": run.run_id,
@@ -125,6 +132,8 @@ def _public_view(run: JobRun, cancelling: frozenset[str]) -> dict[str, Any]:
         "updated_at": run.updated_at,
         "finished_at": run.finished_at,
         "error": run.error,
+        "interrupted_from": run.interrupted_from,
+        "interrupt_cause": run.interrupt_cause,
     }
 
 

--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -66,11 +66,27 @@ atomic for a reader, so the reads go through ``atomic_write``'s
 
 Staleness is decided by ``_ORIGIN``, a token minted once per gateway process —
 not by pid, which can be reused by the very process doing the reconciling.
+
+That token is the GATEWAY process, which also bounds what this SDK describes, and
+the bound is per RUNNER rather than per app. A registration only exists where the
+callable lives: ``register`` binds a kind to a callable held here in the gateway,
+so only runners registered from gateway-side code -- an app's hooks, its routes --
+are ones this SDK can execute or reconcile. An app declaring ``backend.entryPoint``
+is additionally spawned as its own OS process (``apps/backend.py``,
+``start_app_backend``), and that does NOT remove its SDK: the context builder gates
+``ctx.job`` on ``permissions.jobs`` alone, so such an app still receives a
+``JobSDK`` and the gateway hooks still publish it behind the shared routes. What it
+cannot do is register a runner from that separate process, so work executing there
+is invisible here. The consequence is not merely that such work is unsupported: on
+a restart that ``_reap_stale_app_backends`` leaves the backend alive through,
+``reconcile`` marks any record it left behind ``INTERRUPTED``, a terminal state no
+later pass revisits.
 """
 
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -112,6 +128,70 @@ INTERRUPTED = "interrupted"
 
 #: A run in a terminal state is never resumed and never reconciled.
 TERMINAL_STATES = frozenset({DONE, FAILED, CANCELLED, INTERRUPTED})
+
+#: Why a run was reconciled, on the record. A closed SET rather than a bool
+#: because the not-registered case already covers two different events -- the app
+#: was disabled, or the kind was removed -- so a boolean would freeze that
+#: conflation on the day the field is introduced. Adding the third value later
+#: costs one constant and one table entry.
+CAUSE_PROCESS_GONE = "process_gone"
+CAUSE_RUNNER_UNREGISTERED = "runner_unregistered"
+#: The record was minted by THIS process and its worker is gone from the live
+#: table without a terminal write -- ``_write_terminal`` spent both attempts and
+#: said so. Distinct from the two above because ``origin == _ORIGIN`` is positive
+#: evidence that no restart happened, so neither restart cause can be true.
+#:
+#: What this cause leaves open depends on the OTHER axis, so the message takes its
+#: consequence clause from ``interrupted_from`` rather than asserting one: a
+#: ``running`` record genuinely leaves the outcome unknown, while a ``starting`` one
+#: does not (see ``_WRITE_LOST_BODY_NEVER_RAN``).
+CAUSE_TERMINAL_WRITE_LOST = "terminal_write_lost"
+
+#: How far a run had got, in words -- and deliberately COARSER than
+#: ``interrupted_from`` itself. A consumer needs ``queued`` apart from
+#: ``starting`` (only one of them owns a dedupe key), but a person reading a
+#: message does not: both mean no line of the runner's body ran. Keeping the
+#: field's granularity and the sentence's granularity separate is the reason the
+#: message is derived here rather than being the only record of what happened.
+_PROGRESS_PHRASE = {
+    QUEUED: "had not started yet",
+    STARTING: "had not started yet",
+    RUNNING: "was running",
+}
+
+#: The ONE place an interruption's message is composed. A table keyed on cause,
+#: not a nested conditional: with two axes the conditional form needs four arms
+#: and grows multiplicatively, while this grows by one line per cause. The
+#: ``process_gone`` + ``running`` cell reproduces the message this SDK shipped
+#: with, byte for byte, because that cell was the only one that was ever true.
+_INTERRUPT_MESSAGE = {
+    CAUSE_PROCESS_GONE: "the gateway restarted while this {progress}",
+    CAUSE_RUNNER_UNREGISTERED: (
+        "the gateway restarted while this {progress}, and no runner is registered for {kind!r}"
+    ),
+    CAUSE_TERMINAL_WRITE_LOST: (
+        "this run's final state could not be written while this {progress}, so {consequence}"
+    ),
+}
+
+#: Statuses a ``terminal_write_lost`` record can carry that prove the body NEVER RAN,
+#: rather than leaving the outcome unknown. Completing the ``starting`` -> ``running``
+#: transition is a PRECONDITION for calling the runner: if that write fails the run is
+#: marked failed and the runner is never invoked. So a record still at ``starting``
+#: (or ``queued``) whose terminal write was also lost proves execution never began --
+#: there is nothing unknown about it, and saying otherwise would be this module's own
+#: defect, a record declining to state what it knows.
+_WRITE_LOST_BODY_NEVER_RAN = frozenset({QUEUED, STARTING})
+_WRITE_LOST_NEVER_RAN = (
+    "its body never ran: the transition to running is a precondition for calling the "
+    "runner, and this record never reached it"
+)
+_WRITE_LOST_OUTCOME_UNKNOWN = "whether its work finished is not known"
+
+#: Used when a record carries a status this build does not know -- a file written
+#: by a newer gateway, or hand-edited. The pass must still resolve it, and the
+#: message must not claim a progress it cannot support.
+_UNKNOWN_PROGRESS_PHRASE = "had not finished"
 
 #: Length of an SDK-minted run id (``uuid.uuid4().hex``). Validated, not just
 #: assumed: a caller reaches ``{run_id}`` on the HTTP surface directly, and a
@@ -158,6 +238,252 @@ def _redact(text: str) -> str:
         return text
 
 
+def _interrupt_error(cause: str, interrupted_from: str, kind: str) -> str:
+    """Compose an interruption's human-readable message. The ONLY site that does.
+
+    Two facts go in, and they are independent because they describe different
+    TIMES: ``interrupted_from`` is how far the run got before it stopped being
+    accounted for, ``cause`` is why nobody can account for it now. NOT "before its
+    process died" -- ``CAUSE_TERMINAL_WRITE_LOST`` exists precisely for a run whose
+    process is still alive and only lost the write. Neither fact implies the other,
+    so both are on the record; the sentence is derived from them here rather than
+    being the place they are stored.
+
+    An unrecognised ``cause`` falls back to the process-gone template instead of
+    raising: this runs inside the pass that clears stuck ``running`` records, and
+    a record with a cause this build does not know must still be resolved.
+    """
+    template = _INTERRUPT_MESSAGE.get(cause) or _INTERRUPT_MESSAGE[CAUSE_PROCESS_GONE]
+    progress = _PROGRESS_PHRASE.get(interrupted_from, _UNKNOWN_PROGRESS_PHRASE)
+    # Derived from the SECOND axis, not asserted: only `terminal_write_lost` has a
+    # `{consequence}` slot, and the other templates ignore the extra keyword. An
+    # unknown status is treated as outcome-unknown, which is the honest default when
+    # the progress axis itself cannot be read.
+    consequence = (
+        _WRITE_LOST_NEVER_RAN
+        if interrupted_from in _WRITE_LOST_BODY_NEVER_RAN
+        else _WRITE_LOST_OUTCOME_UNKNOWN
+    )
+    return template.format(progress=progress, kind=kind, consequence=consequence)
+
+
+#: The ONE verdict every returned suspendable gets, worded as the contract violation
+#: it is. It deliberately does NOT say the body never ran: for a drained generator it
+#: did, and this SDK cannot tell that case from a suspendable closed before it began.
+#: Saying "never ran" would replace a false success with a false explanation, which is
+#: the same defect one layer down.
+_SUSPENDABLE_RETURNED = (
+    "{name}, which a runner must not return: this SDK never drives what a runner "
+    "hands back, and the object itself cannot say what it did -- one that ran to "
+    "completion and one closed before it began are identical from here"
+)
+
+#: The suspendable carriers, matched by kind ALONE. There is deliberately no state
+#: table: the state cannot answer the question the record needs answered.
+#: ``CLOSED``/``frame is None`` covers BOTH a suspendable drained to completion and one
+#: closed before it ever began, and those two are indistinguishable from the object --
+#: verified, not assumed (see :func:`_undriven_result` for what was measured and
+#: rejected). So the classifier stops inferring history and states a rule instead.
+#:
+#: Two rejected alternatives, both of which look more precise and are traps:
+#:
+#: * the ``cr_frame``/``gi_frame``/``ag_frame`` attribute with an ``f_lasti``
+#:   comparison. ``f_lasti`` is ``-1`` for an unstarted frame up to 3.10 and an
+#:   instruction offset (``0``) from 3.11, so a ``< 0`` test silently matches NOTHING
+#:   on 3.12 -- every ``async def`` runner would be recorded ``done`` again, the very
+#:   defect this module exists to remove.
+#: * ``gc.get_referents``, which DOES separate the two closed histories on 3.12:
+#:   ``('str', 'str')`` for a drained generator against ``('code', 'function', 'str',
+#:   'str')`` for one closed unstarted, stable across trials, creation order and an
+#:   explicit ``gc.collect()``. It is still refused, because it is an undocumented
+#:   interpreter internal, generators were restructured in 3.11 with lazily-created
+#:   frames, and CI runs 3.10 AND 3.12. A classifier that is right on one interpreter
+#:   and wrong on another writes false records confidently, which is worse than
+#:   declining to classify.
+_SUSPENDABLE_KINDS: tuple[tuple[str, Any], ...] = (
+    ("a coroutine", inspect.iscoroutine),
+    ("a generator", inspect.isgenerator),
+    ("an async generator", inspect.isasyncgen),
+)
+
+
+def _undriven_result(result: Any) -> str:
+    """Name why a runner's return value is not a completed unit of work, else ``""``.
+
+    The counterpart to :func:`_lazy_call_shape`, and the load-bearing half. That one
+    inspects the callable's SHAPE at registration, which is a proxy: it can only
+    refuse the spellings somebody thought of. This one reads the FACT, at the one
+    moment it exists -- whatever the runner handed back, once.
+
+    ONE PROTOCOL QUESTION WITH TWO CARRIERS, then allow. The question is "is this
+    thing finished?", and two kinds of object answer it:
+
+    * a SUSPENDABLE cannot answer it, so it is refused outright;
+    * a FUTURE answers it by ``done()``, and then by how it settled.
+
+    **Suspendables, ONE verdict, and this reverses an earlier decision in this same
+    change set.** Earlier rounds read the frame state and allowed ``CLOSED`` on the
+    reasoning that a closed frame ran to completion. That was wrong, and the reason is
+    worth stating because it is the module's own thesis turned on itself: ``CLOSED``
+    covers a suspendable drained to completion AND one closed before it ever began, so
+    allowing it recorded a completion nobody observed -- exactly the class of claim
+    this module exists to remove. The two cases were then MEASURED rather than assumed
+    to differ: no public attribute, ``dir()`` entry, code object, ``gi_frame``,
+    ``gi_running`` or ``gi_yieldfrom`` separates them.
+
+    ``gc.get_referents`` does separate them on 3.12, reliably, and is refused anyway --
+    see :data:`_SUSPENDABLE_KINDS` for the measurement and why depending on it would be
+    a defect rather than a fix.
+
+    So the rule replaced the inference: a returned suspendable is a CONTRACT VIOLATION
+    whatever its state. The reason string says only what this SDK knows -- that it will
+    not accept the object and cannot tell what it did. It deliberately does NOT say the
+    body never ran, because for a drained generator it did; that wording would swap a
+    false success for a false explanation. Nothing legitimate is refused: the SDK
+    discards return values by design, so returning a suspendable cannot serve a runner
+    even in principle.
+
+    An async generator needs no separate case now. It used to have one because its
+    state was not portably readable (``inspect.getasyncgenstate`` is 3.12+ while this
+    module supports 3.10) -- and no state is read any more, so the special case that
+    existed to avoid a version-dependent record dissolves into the general rule.
+
+    **Futures, four verdicts, and deliberately NOT flattened.** Unlike a suspendable, a
+    future does answer the question, so the distinctions it draws are kept. ``done()``
+    False is pending, so unfinished. ``done()`` True splits, because ``done()`` answers
+    "is it settled", not "did it succeed" -- and ``cancelled()`` MUST be asked before
+    ``exception()``, since on a cancelled future ``exception()`` RAISES
+    ``CancelledError`` rather than returning it. That is a ``BaseException``, so it
+    would sail through ``_execute``'s ``except Exception`` and crash the function whose
+    job is classifying failures.
+
+    **An unsettled future is FAILED, and that verdict is true rather than
+    convenient.** The runner's contract is to do its work before returning, so
+    handing back something unfinished violates it -- ``failed`` is what this SDK
+    observed about the RUN, not a guess about the work.
+
+    What this SDK cannot do is STOP that work. An unsettled
+    ``concurrent.futures.Future`` stands for a thread it does not own, and
+    terminalizing the run releases the dedupe key -- so an owner who retries gets a
+    second run overlapping work that never stopped. Relabelling the status would not
+    change that: the overlap is a consequence of the contract violation, not
+    something the record misstates. So the reason string SAYS the work may still be
+    running, because the owner reading that record is the only party who can judge
+    whether a retry is safe. The missing capability -- no way to stop work a runner
+    spawned outside this thread -- is filed rather than pretended away.
+
+    **Why this is complete, which after nine review rounds is a fair thing to ask.**
+    Not because cases stopped being found, but because the two carriers are now
+    answered on different grounds. Suspendables need no enumeration at all: every
+    state, known or added by a future Python, reaches the same verdict, so there is no
+    fourth state to discover and no state table to go stale. The future protocol offers
+    pending, cancelled, exception and result, and this maps every one of those.
+
+    **Default: allow.** Safe now in a way the old default was not. The old code asked
+    ``isawaitable`` first, so a non-awaitable future reached the default and was
+    called fine; the future carrier now catches it by ``done()``, so what still
+    reaches the default is genuinely a plain return value.
+    """
+    # Carrier 1: a suspendable, refused by KIND -- its state is not consulted,
+    # because no state it can report answers "did the work happen".
+    for name, is_kind in _SUSPENDABLE_KINDS:
+        if is_kind(result):
+            return _SUSPENDABLE_RETURNED.format(name=name)
+
+    # Carrier 2: a future, which answers by `done()` and then by how it settled.
+    done = getattr(result, "done", None)
+    if callable(done):
+        if not done():
+            return (
+                "a future that is not settled, so the runner returned before its work "
+                "finished; that work may still be running somewhere this SDK does not "
+                "own and cannot stop, so a retry of this run can overlap it"
+            )
+        cancelled = getattr(result, "cancelled", None)
+        if callable(cancelled) and cancelled():
+            return "a cancelled future, so the work it stood for never completed"
+        exception = getattr(result, "exception", None)
+        if callable(exception):
+            # Safe without a timeout because ``done()`` is established, so it cannot
+            # block. Retrieving it also MARKS it retrieved, which suppresses the
+            # "never retrieved" warning :func:`_close_quietly` handles for the
+            # unsettled case -- classification and quiet retirement meet here.
+            exc = exception()
+            if exc is not None:
+                return (
+                    f"a future that failed with {type(exc).__name__}, "
+                    "so the work it stood for ran and raised"
+                )
+        return ""
+
+    # Carries neither answer and still needs driving: nothing here will do it.
+    if inspect.isawaitable(result):
+        return _SUSPENDABLE_RETURNED.format(name="a bare awaitable")
+
+    return ""
+
+
+def _close_quietly(result: Any) -> None:
+    """Close an undriven result so it does not warn from the garbage collector.
+
+    A coroutine that is never awaited emits ``RuntimeWarning: coroutine ... was
+    never awaited`` when collected, at a point far from the run that caused it.
+    The record already says what happened, so the warning is noise pointing at
+    the wrong place.
+
+    Two shapes, because they do not share a method. Coroutines and generators
+    expose a synchronous ``close``. A future does NOT -- neither ``asyncio.Future``
+    nor ``concurrent.futures.Future`` has ``close``, so an earlier version of this
+    docstring named futures among the closable and was wrong about the one object
+    the sentence was about. A pending future is retired with ``cancel`` instead,
+    which is what stops it warning that its exception was never retrieved. An
+    async generator's ``aclose`` is itself a coroutine needing a loop, so it is
+    left to the interpreter rather than driven from this thread.
+    """
+    for method in ("close", "cancel"):
+        handler = getattr(result, method, None)
+        if not callable(handler):
+            continue
+        try:
+            handler()
+        except Exception:  # noqa: BLE001 - closing is hygiene, never the outcome
+            logger.debug("could not retire an undriven job result", exc_info=True)
+        return
+
+
+def _lazy_call_shape(fn: Any) -> str:
+    """Name the shape of a callable whose CALL does not run its body, else ``""``.
+
+    Three shapes return a lazy object instead of doing the work: a coroutine
+    function, an async generator function, and a plain generator function. The
+    SDK calls its runner on a worker thread and discards the return value, so for
+    all three the body never executes. Before the execution-side check existed
+    such a run was then recorded ``done``; today :func:`_undriven_result` reads the
+    returned object and records ``failed``, so this guard is a fast, friendly error
+    at registration rather than the safety property.
+    One defect with three spellings, so the check names the class rather than the
+    one spelling that was reported.
+
+    A callable OBJECT is examined through its ``__call__``, because that is what
+    invocation actually reaches -- ``inspect`` reports the instance itself as an
+    ordinary object, so a check written against bare functions passes it through.
+    That was the gap two reviewers found in the first version of this guard.
+
+    No legitimate runner is refused by this: a callable whose invocation returns a
+    lazy object cannot do the work the SDK is calling it to do, whatever it is.
+    """
+    for target in (fn, getattr(fn, "__call__", None)):
+        if target is None:
+            continue
+        if inspect.iscoroutinefunction(target):
+            return "a coroutine function"
+        if inspect.isasyncgenfunction(target):
+            return "an async generator function"
+        if inspect.isgeneratorfunction(target):
+            return "a generator function"
+    return ""
+
+
 @dataclass
 class JobRun:
     """One run's durable record. Serialized whole; never partially updated.
@@ -179,6 +505,21 @@ class JobRun:
     updated_at: str = ""
     finished_at: str = ""
     error: str = ""
+    #: Set only by ``reconcile``: the status this run held when a process that no
+    #: longer exists was executing it. Structured because a CONSUMER acts on it --
+    #: a run interrupted from ``running`` may have side effects already committed,
+    #: while one interrupted from ``queued`` or ``starting`` provably has none, and
+    #: those need different recovery. Before this field the pass overwrote
+    #: ``status`` in place and chose ``error`` from whether a runner was
+    #: registered, so all three collapsed into one record that read "while this was
+    #: running" even for a run whose worker thread was never started.
+    interrupted_from: str = ""
+    #: Set only by ``reconcile``: why the run could not be resumed, from the
+    #: ``CAUSE_*`` set. Orthogonal to ``interrupted_from`` -- that says how far the
+    #: run got, this says whether the kind can be serviced now -- so a consumer
+    #: deciding "offer a retry" reads this one and a consumer deciding "warn about
+    #: partial work" reads the other.
+    interrupt_cause: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -351,6 +692,28 @@ class JobStore:
             # string. Reached only off the loop (the routes offload every call),
             # which is what lets the helper's sleep apply at all.
             raw = read_bytes_with_retry(self._path(run_id)).decode("utf-8")
+        # Only the damage that genuinely means "no such record": the file is not
+        # there, its parent is not a directory, or its bytes are not the UTF-8
+        # JSON this store writes (``ValueError`` covers the ``UnicodeDecodeError``
+        # from the decode above and the malformed id ``_path`` rejects).
+        #
+        # ``PermissionError`` is deliberately NOT here, even though the comment
+        # above is about it. On Windows a concurrent ``os.replace`` makes a reader
+        # fail with a sharing violation that is TRANSIENT -- ``read_bytes_with_retry``
+        # exists to outlast it, and re-raises only once its budget is spent or when
+        # it is called on the event loop, where the budget cannot be spent at all.
+        # Returning ``None`` there would answer "this run does not exist" about a
+        # record that is present and intact, so a polling client reading 404 as
+        # "gone" would drop live work. The same argument covers the rest of
+        # ``OSError`` -- ``EIO``, ``EMFILE``, ``EBUSY`` are facts about the host,
+        # not about whether this run was ever started. They belong to the caller,
+        # which is why ``get`` lets them out and the route answers 500: an honest
+        # "ask again" instead of a confident wrong answer.
+        #
+        # This is narrower than the sibling ``iter_runs`` scan below on purpose.
+        # That scan is a partial result -- skipping one damaged file still returns
+        # the others -- while this is a targeted lookup whose ``None`` asserts
+        # absence, and absence is not something an unreadable file establishes.
         except (FileNotFoundError, NotADirectoryError, ValueError):
             return None
         try:
@@ -438,7 +801,13 @@ class JobSDK:
 
     # ── The one writer ──
 
-    def _persist(self, run: JobRun, handle: JobHandle | None = None) -> bool:
+    def _persist(
+        self,
+        run: JobRun,
+        handle: JobHandle | None = None,
+        *,
+        only_if_not_terminal: bool = False,
+    ) -> bool:
         """Write a run's record. The ONLY path that writes one.
 
         Three callers used to write directly -- start, the worker's terminal
@@ -457,7 +826,21 @@ class JobSDK:
         * the record is JSON-safe by construction: every field except ``error``
           is minted by the SDK from a str, an int or a bool.
 
-        Returns True when the record is on disk.
+        ``only_if_not_terminal`` ENFORCES THE MODULE'S OWN INVARIANT that a record
+        in :data:`TERMINAL_STATES` is never revisited. It is not a new rule and not
+        a heuristic: :meth:`reconcile` decides from a snapshot and writes later, so
+        a worker that finished in between had its true terminal record overwritten
+        by a false one. That is why the re-read is HERE rather than next to the
+        decision -- ``self._lock`` is not reentrant, so this is the only place the
+        re-read and the write are one atomic step. A check near the decision would
+        narrow the window; it would not close it.
+
+        The re-read costs one file read per non-terminal record, on the boot pass
+        only, inside a lock this method already holds across a file write.
+
+        Returns True when the record is on disk. A refusal -- discarded, already
+        terminal, or a failed write -- returns False, and every caller treats that
+        the same way: do not count it, do not audit it as done.
         """
         # INVARIANT: nothing a runner supplied reaches disk unsanitized. This is
         # ONE line because ``error`` is the only field a runner supplies, and
@@ -468,6 +851,14 @@ class JobSDK:
         with self._lock:
             if handle is not None and handle.discarded.is_set():
                 return False
+            if only_if_not_terminal:
+                # Re-read INSIDE the write's lock: the caller's snapshot is stale by
+                # construction, and the worker's own terminal write goes through
+                # this same lock, so a record that reads terminal here is finished
+                # and must not be revisited.
+                latest = self._store.read(run.run_id)
+                if latest is not None and latest.is_terminal:
+                    return False
             try:
                 self._store.write(run)
                 return True
@@ -484,9 +875,39 @@ class JobSDK:
         app's assertion that ``fn`` polls ``handle.cancelled`` at checkpoints;
         the SDK cannot verify it, so the consumer's migration checklist has to
         name those checkpoints.
+
+        A CALLABLE WHOSE INVOCATION DOES NOT RUN ITS BODY IS REFUSED HERE, at
+        registration, rather than failing at run time. ``_execute`` calls
+        ``fn(handle)`` on a worker thread and discards the return value by design,
+        and three shapes return a lazy object instead of doing the work: a
+        coroutine function, an async generator function, and a plain generator
+        function. For each, the object is dropped and no line of the runner's body
+        ever runs. Such a run USED to be recorded ``done`` -- a run reporting
+        success having executed nothing, and silent, since an un-awaited coroutine
+        warning goes to the gateway log at most. That is now caught at execution by
+        ``_undriven_result`` and recorded ``failed``, so refusing here is the early
+        friendly error and not the thing that makes the record honest. The check
+        goes through ``__call__`` as well as the object itself, so a callable
+        instance with an ``async def __call__`` is caught too.
+
+        Refusing is deliberately not the same as supporting: driving a coroutine
+        correctly means deciding which loop owns it, how cancellation crosses
+        the thread boundary, and what a blocking runner does to that loop, and
+        those are design questions this refusal does not answer. It answers only
+        the question a caller cannot currently ask -- "did my runner run" -- at
+        the one point where the answer is still cheap.
         """
         if not kind:
             raise ValueError("job kind must be a non-empty string")
+        lazy = _lazy_call_shape(fn)
+        if lazy:
+            raise ValueError(
+                f"job kind {kind!r} was registered with {lazy}; the runner is called on "
+                "a worker thread and its return value is discarded, so its body would "
+                "never execute and the run would still be recorded as done. Register a "
+                "callable that does the work when called (it may drive its own loop "
+                "with asyncio.run)."
+            )
         with self._lock:
             self._runners[kind] = _Runner(fn=fn, cancellable=cancellable)
         logger.info("App %s registered job kind: %s", self._app_name, kind)
@@ -658,20 +1079,89 @@ class JobSDK:
     def _execute(self, run: JobRun, runner: _Runner, handle: JobHandle) -> None:
         """The worker body. Sole writer of this run's record from here on.
 
-        The runner's return value is DISCARDED. P1 records that a run finished,
-        not what it produced: a return value is arbitrary nested data, and
-        holding it is what required a recursive sanitizer over channels no P1
-        consumer reads. It returns in P2 on a type that is safe by construction.
+        The runner's return value is DISCARDED, but it is INSPECTED first. P1
+        records that a run finished, not what it produced: a return value is
+        arbitrary nested data, and holding it is what required a recursive
+        sanitizer over channels no P1 consumer reads. It returns in P2 on a type
+        that is safe by construction.
+
+        One thing is read off it before it is dropped, and it is the fact this
+        method could not otherwise state honestly: whether the runner actually did
+        the work. If the call handed back something that still needs to be driven
+        -- an awaitable, or an async generator -- then the body did not run to
+        completion and ``done`` would be a false record. ``register`` refuses the
+        callable SHAPES that produce this, but a shape check is an adjacent-state
+        proxy and cannot see every route to it: a plain ``def run(h): return
+        _do_it(h)`` over an ``async def _do_it`` passes every registration check
+        and still returns an unperformed coroutine. Observing the result is the
+        only place the fact itself is available, which makes this the safety
+        property and the registration guard a fast, friendly error.
+
+        A returned suspendable is refused BY KIND, not by what its state seems to
+        say. Generator FUNCTIONS are still refused at registration; a returned
+        generator, coroutine or async generator is failed whatever it has done,
+        because the object cannot say what it did -- a drained generator and one
+        closed before it ever began are identical from here. So the SDK refuses the
+        shape rather than guessing the history. This does NOT assert the body never
+        ran: for a drained generator it did, and that run is still failed because
+        the rule is stated rather than inferred. Earlier forms of this docstring
+        read the frame state and allowed the closed one; see
+        :func:`_undriven_result` for the reversal and what was measured.
         """
         # Completing the STARTING -> RUNNING transition is the worker's first act,
         # because the worker is the only party that knows it is actually running.
         # Through the guarded writer, so a disable that landed between the launch
         # and this line refuses it rather than recreating a deleted record.
         run.status = RUNNING
-        self._persist(run, handle)
         try:
-            runner.fn(handle)
-            run.status = CANCELLED if handle.cancelled.is_set() else DONE
+            # The transition is a PRECONDITION for running the body, not a
+            # notification alongside it. This return used to be discarded, so a
+            # failed write left the record at `starting` while the runner went on
+            # to commit real work -- and if the process then died before the
+            # terminal write, `reconcile` read that record and stated the run had
+            # never begun. There is no way to correct that claim after the fact,
+            # because the knowledge that the write failed dies with the process.
+            # So the run does not begin unless the record can say it began.
+            #
+            # The cost is deliberate: a transient store error now fails a run that
+            # might have succeeded. For an SDK whose product is a durable record,
+            # a run that is not recorded is worse than a run not attempted.
+            if not self._persist(run, handle):
+                run.status = FAILED
+                run.error = (
+                    f"the store could not record run {run.run_id} as running, so its "
+                    f"body was never started; a run this SDK cannot say began is one "
+                    f"it does not begin"
+                )
+                logger.warning(
+                    "App %s job %s (%s) not started: the running transition did not persist",
+                    self._app_name,
+                    run.run_id,
+                    run.kind,
+                )
+            else:
+                result = runner.fn(handle)
+                undriven = _undriven_result(result)
+                if undriven:
+                    # Inside the SAME try, so the terminal write below is still the
+                    # one write site. A second write path here is what leaked a
+                    # dedupe claim before, and `_write_terminal` already owns the
+                    # discard check.
+                    run.status = FAILED
+                    run.error = (
+                        f"the runner for {run.kind!r} returned {undriven}, so this "
+                        "run is recorded as failed rather than done"
+                    )
+                    _close_quietly(result)
+                    logger.warning(
+                        "App %s job %s (%s) returned %s and did no work",
+                        self._app_name,
+                        run.run_id,
+                        run.kind,
+                        undriven,
+                    )
+                else:
+                    run.status = CANCELLED if handle.cancelled.is_set() else DONE
         except Exception as exc:  # noqa: BLE001 - a runner's failure is data, not a crash
             run.status = FAILED
             run.error = _redact(str(exc))[:2000]
@@ -804,10 +1294,18 @@ class JobSDK:
         """Resolve records left non-terminal by a process that is gone.
 
         A run must never be left ``running`` forever and must never silently
-        vanish — the two directions the hand-rolled predecessors got wrong. The
-        reason distinguishes a lost process from a kind whose runner is no
-        longer registered (the app was disabled, or the kind was removed), which
-        is why this runs only after every app has registered.
+        vanish — the two directions the hand-rolled predecessors got wrong. Each
+        resolved record carries TWO facts rather than a sentence: how far the run
+        had got (``interrupted_from``) and why it cannot be resumed
+        (``interrupt_cause``). They are independent because they describe
+        different times -- past progress, present capability -- and a consumer
+        acts on them separately: a run interrupted from ``running`` may have
+        committed side effects, one interrupted from ``queued`` or ``starting``
+        provably has not, and only the cause says whether offering a retry makes
+        sense. ``error`` is composed from both by :func:`_interrupt_error`, which
+        is why the pass no longer has to choose one of two strings from the runner
+        table alone. This runs only after every app has registered, so a missing
+        runner means the kind is gone rather than not yet loaded.
 
         This is the ONE path that consumes records it did not write -- a file
         left by an older build, or hand-edited during an incident -- so a single
@@ -815,6 +1313,16 @@ class JobSDK:
         ``ValueError`` on a run id it will not turn into a path, and letting that
         escape would abandon every remaining run of this app, leaving exactly the
         stuck-``running`` state the pass exists to clear.
+
+        **This pass decides from a snapshot, so it must not trust it at write
+        time.** ``iter_runs`` yields a record decoded from disk; by the time this
+        loop writes, a worker may have completed and left ``_live``. The write
+        therefore goes through ``_persist(only_if_not_terminal=True)``, which
+        re-reads under the same lock it writes with. That enforces the invariant
+        this module already states -- a record in :data:`TERMINAL_STATES` is never
+        revisited -- rather than adding a new rule: without it this pass overwrote
+        a true terminal record with a false one, which is a worse failure than any
+        unverified claim, because the truth was on disk and this pass deleted it.
         """
         flipped = 0
         for run in self._store.iter_runs():
@@ -829,14 +1337,44 @@ class JobSDK:
             # state the pass exists to clear.
             if run.origin == _ORIGIN and live:
                 continue
+            # BOTH axes are recorded, and the message is DERIVED from them. The
+            # previous form assigned `status` over the top of the only evidence of
+            # how far the run got, then picked one of two strings from `known`
+            # alone -- so a run whose worker thread was never started was written
+            # a record claiming it "was running", and a consumer could not tell a
+            # run that committed side effects from one that provably had not.
+            run.interrupted_from = run.status
+            # Own origin is tested FIRST because it is the one VERIFIED fact here:
+            # this record was minted by this process, so the process cannot have
+            # restarted -- and both restart causes would say it did. `known` is a
+            # proxy (is a runner registered) and a proxy must not outrank the fact
+            # sitting next to it. Reaching this line with a matching origin means
+            # the guard above found no live worker, which is `_write_terminal`
+            # having spent both of its attempts.
+            #
+            # Composed into a local and assigned ONCE, so the field keeps its
+            # single assignment site from a constant -- the ratchet that turns
+            # "SDK-minted" from a claim into something checkable.
+            if run.origin == _ORIGIN:
+                cause = CAUSE_TERMINAL_WRITE_LOST
+            elif known:
+                cause = CAUSE_PROCESS_GONE
+            else:
+                cause = CAUSE_RUNNER_UNREGISTERED
+            run.interrupt_cause = cause
             run.status = INTERRUPTED
             run.finished_at = _now()
-            run.error = (
-                "the gateway restarted while this was running"
-                if known
-                else f"the gateway restarted and no runner is registered for {run.kind!r}"
-            )
-            if not self._persist(run):
+            run.error = _interrupt_error(run.interrupt_cause, run.interrupted_from, run.kind)
+            # `only_if_not_terminal` re-reads under the write's lock. The
+            # `is_terminal` check at the top of this loop reads a SNAPSHOT: a
+            # worker can finish between that read and this write, and the earlier
+            # `live` check does not close the window because a worker leaves
+            # `_live` only AFTER its terminal write has landed. Without the
+            # re-read this pass overwrote a true `done` with `interrupted`, and
+            # the cause it wrote was `terminal_write_lost` -- claiming the
+            # terminal write was lost when it had in fact succeeded and this pass
+            # destroyed it.
+            if not self._persist(run, only_if_not_terminal=True):
                 continue
             flipped += 1
             self._audit("job_interrupted", run.run_id, "ok")

--- a/test/test_job_routes.py
+++ b/test/test_job_routes.py
@@ -259,6 +259,50 @@ async def test_start_registered_kind_returns_run_without_params(
 
 
 @pytest.mark.asyncio
+async def test_the_interruption_fields_reach_the_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """``interrupted_from`` and ``interrupt_cause`` are served, unlike origin/pid.
+
+    They are not host facts: they are the two facts a client needs in order to
+    recover from an interruption -- whether the run may have committed side
+    effects, and whether retrying it is possible now -- and the client is the only
+    party that can act on either. A record that carries them behind an API that
+    withholds them leaves the record honest and the API not.
+    """
+    from kiro_crew.apps.job_sdk import (
+        CAUSE_RUNNER_UNREGISTERED,
+        INTERRUPTED,
+        STARTING,
+        JobRun,
+    )
+
+    _setup_guards(tmp_path, monkeypatch)
+    run_id = "5c" * 16
+    sdk.store.write(
+        JobRun(
+            run_id=run_id,
+            app=sdk.app_name,
+            kind="vanished",
+            status=STARTING,
+            origin="a-process-that-is-gone",
+        )
+    )
+    assert sdk.reconcile() == 1
+
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/{run_id}")
+        assert resp.status == 200
+        run = (await resp.json())["run"]
+    assert run["status"] == INTERRUPTED
+    assert run["interrupted_from"] == STARTING
+    assert run["interrupt_cause"] == CAUSE_RUNNER_UNREGISTERED
+    # Still withheld: these have no client meaning and never gained one.
+    assert "origin" not in run
+    assert "pid" not in run
+
+
+@pytest.mark.asyncio
 async def test_unknown_kind_error_is_scrubbed_before_it_is_reflected(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
 ) -> None:

--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -12,10 +12,15 @@ what makes such a suite flaky on a loaded runner.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+import inspect
 import json
 import logging
+import os
+import re
 import threading
 import time
+import uuid
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -49,6 +54,12 @@ from kiro_crew.apps.job_sdk import (
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
+
+
+#: Whether a 0o000 mode actually denies THIS process. Root reads straight through
+#: it, so the tests that provoke a real ``PermissionError`` from the filesystem
+#: have nothing to provoke and must skip rather than assert a false negative.
+_MODE_BITS_BITE = hasattr(os, "geteuid") and os.geteuid() != 0
 
 
 def _wait_terminal(sdk: JobSDK, run_id: str, timeout: float = 5.0) -> JobRun:
@@ -192,6 +203,13 @@ class TestHappyRun:
             "updated_at",
             "finished_at",
             "error",
+            # Written only by ``reconcile``, and only for a run whose process is
+            # gone. Both are drawn from SDK-owned closed sets (a status constant
+            # and a ``CAUSE_*`` constant), so neither is a channel a runner or a
+            # caller can reach -- which is why they are here and not a result
+            # field wearing a new name.
+            "interrupted_from",
+            "interrupt_cause",
         }
 
 
@@ -1024,6 +1042,73 @@ class TestDiscardGuard:
         handle, _store, _sdk = _handle_over(tmp_path, run)
         assert handle.run_id == run.run_id
 
+    def test_reconcile_does_not_overwrite_a_run_that_finished_mid_pass(self, sdk: JobSDK) -> None:
+        """A REAL interleaving, and the assertion is that the record is UNCHANGED.
+
+        `reconcile` decides from a snapshot `iter_runs` decoded from disk, and writes
+        later. A worker that finishes in between has already written its terminal
+        record AND left `_live` -- the departure happens after the write -- so the
+        `live` check does not close the window. Before the fix this pass wrote
+        `interrupted` over a true `done`, with cause `terminal_write_lost`: it
+        claimed the terminal write was lost when the write had succeeded and this
+        pass had destroyed it.
+
+        The ordering is driven, not mocked: every step of `reconcile` runs for real
+        and only the worker's completion is scheduled, using the generator's own
+        yield as the suspension point. A mocked ordering would prove the mock.
+
+        The assertion is full-record equality, deliberately. "reconcile returned
+        early" is a PROXY for "the record was not corrupted", and substituting a
+        proxy for the fact is the defect this whole change set exists to remove --
+        so this test must not commit it either.
+        """
+        release = threading.Event()
+        body_entered = threading.Event()
+
+        def runner(handle: JobHandle) -> None:
+            body_entered.set()
+            release.wait(5)
+
+        sdk.register("work", runner)
+        run_id = sdk.start("work")
+        assert body_entered.wait(5), "the worker never entered its body"
+
+        deadline = time.monotonic() + 5
+        while sdk.get(run_id).status != RUNNING and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert sdk.get(run_id).status == RUNNING
+
+        real_iter = sdk._store.iter_runs  # noqa: SLF001 - driving the interleaving
+        finished: list[dict] = []
+
+        def interleaved():
+            for run in real_iter():
+                if run.run_id == run_id:
+                    # The snapshot reconcile will decide from says `running`...
+                    assert run.status == RUNNING
+                    # ...and now the worker really completes and really leaves _live.
+                    release.set()
+                    end = time.monotonic() + 5
+                    while time.monotonic() < end:
+                        latest = sdk.get(run_id)
+                        if latest.is_terminal and run_id not in sdk._live:  # noqa: SLF001
+                            finished.append(latest.to_dict())
+                            break
+                        time.sleep(0.01)
+                    assert finished, "the worker did not settle in time"
+                yield run
+
+        sdk._store.iter_runs = interleaved  # type: ignore[method-assign] # noqa: SLF001
+        try:
+            sdk.reconcile()
+        finally:
+            sdk._store.iter_runs = real_iter  # type: ignore[method-assign] # noqa: SLF001
+
+        terminal_record = finished[0]
+        assert terminal_record["status"] == DONE, "premise: the run really completed"
+        # THE assertion: the record on disk is byte-for-byte what the worker wrote.
+        assert sdk.get(run_id).to_dict() == terminal_record
+
 
 class TestReconcilePoisonRecord:
     """One unusable record must cost only itself.
@@ -1189,14 +1274,23 @@ class TestClaimAndWriteFailurePaths:
         self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A lost terminal write leaves the record reading `running` while the
-        work is finished, so one retry covers the transient case."""
+        work is finished, so one retry covers the transient case.
+
+        Targeted by the STATUS being written rather than by call index. An earlier
+        form failed the second write and called it the terminal one, but the second
+        write is the ``starting`` -> ``running`` transition -- so it never exercised
+        a terminal write at all, and it passed only because a failed running
+        transition was being ignored. That is the defect this change set fixes, so
+        the guard had to stop depending on it.
+        """
         real_write = sdk.store.write
-        calls: list[int] = []
+        calls: list[str] = []
+        failed_once: list[bool] = []
 
         def flaky(run):
-            calls.append(1)
-            # Fail only the terminal write (the initial one is call 1).
-            if len(calls) == 2:
+            calls.append(run.status)
+            if run.status in job_sdk.TERMINAL_STATES and not failed_once:
+                failed_once.append(True)
                 raise OSError("transient")
             return real_write(run)
 
@@ -1205,7 +1299,8 @@ class TestClaimAndWriteFailurePaths:
         run_id = sdk.start("work")
         run = _wait_terminal(sdk, run_id)
         assert run.status == DONE
-        assert len(calls) >= 3, f"the retry did not happen: {len(calls)} write(s)"
+        assert failed_once, "the terminal write was never made to fail"
+        assert calls.count(DONE) >= 2, f"the retry did not happen: {calls}"
 
 
 class TestRecordIsAlwaysWritable:
@@ -1324,9 +1419,157 @@ class TestSanitizeInvariant:
             "created_at",
             "updated_at",
             "finished_at",
+            # Set only by ``reconcile``, from closed sets this module owns: a
+            # status constant and a ``CAUSE_*`` constant. No runner and no caller
+            # can reach either, so the one-line backstop still has one input.
+            "interrupted_from",
+            "interrupt_cause",
         }
         fields = set(JobRun.__dataclass_fields__)
         assert fields - sdk_minted == {"error"}
+
+    def test_a_write_lost_starting_record_says_the_body_never_ran(self, sdk: JobSDK) -> None:
+        """The consequence is DERIVED from the progress axis, not asserted.
+
+        Round 1 made the `starting` -> `running` transition a precondition for calling
+        the runner, so a record still at `starting` whose terminal write was lost
+        proves execution never began. Saying "not known" there would be this module's
+        own defect: a record declining to state what it knows.
+        """
+        run_id = uuid.uuid4().hex
+        sdk.store.write(
+            JobRun(
+                run_id=run_id,
+                app=sdk.app_name,
+                kind="work",
+                status=STARTING,
+                origin=job_sdk._ORIGIN,
+            )
+        )
+        assert sdk.reconcile() >= 1
+        rec = sdk.get(run_id)
+        assert rec.interrupt_cause == job_sdk.CAUSE_TERMINAL_WRITE_LOST
+        assert rec.interrupted_from == STARTING
+        assert "never ran" in rec.error
+        assert "precondition" in rec.error
+        assert "not known" not in rec.error
+
+    def test_a_write_lost_running_record_still_says_the_outcome_is_unknown(
+        self, sdk: JobSDK
+    ) -> None:
+        """The other side: `running` genuinely leaves the outcome open, so the two
+        progress values must not collapse onto one consequence."""
+        sdk.register("work", lambda h: None)
+        run_id = uuid.uuid4().hex
+        sdk.store.write(
+            JobRun(
+                run_id=run_id,
+                app=sdk.app_name,
+                kind="work",
+                status=RUNNING,
+                origin=job_sdk._ORIGIN,
+            )
+        )
+        assert sdk.reconcile() >= 1
+        rec = sdk.get(run_id)
+        assert rec.interrupt_cause == job_sdk.CAUSE_TERMINAL_WRITE_LOST
+        assert "not known" in rec.error
+        assert "never ran" not in rec.error
+
+    def test_an_own_origin_record_is_not_blamed_on_a_restart(self, sdk: JobSDK) -> None:
+        """The cause must not claim a restart when this process minted the record.
+
+        `origin == _ORIGIN` is positive evidence the gateway did NOT restart, so
+        both restart causes are false there however `known` reads. Reachable
+        without a restart: `reconcile_all` runs after the app loop, while an app's
+        `on_startup` hook can already have started a job in this same process, so
+        a job whose terminal write is lost is reconciled by the process that
+        minted it.
+        """
+        sdk.register("work", lambda h: None)
+        run_id = uuid.uuid4().hex
+        sdk.store.write(
+            JobRun(
+                run_id=run_id,
+                app=sdk.app_name,
+                kind="work",
+                status=RUNNING,
+                origin=job_sdk._ORIGIN,  # minted by THIS process
+            )
+        )
+        assert sdk.reconcile() >= 1
+        rec = sdk.get(run_id)
+        assert rec.status == INTERRUPTED
+        assert rec.interrupt_cause == job_sdk.CAUSE_TERMINAL_WRITE_LOST
+        assert rec.interrupted_from == RUNNING
+        # The message must not claim a restart, and must not guess the outcome.
+        assert "restart" not in rec.error.lower()
+        assert "not known" in rec.error
+
+    def test_a_foreign_origin_record_still_reports_the_restart(self, sdk: JobSDK) -> None:
+        """The other side, so the new branch cannot swallow the original cause."""
+        sdk.register("work", lambda h: None)
+        run_id = uuid.uuid4().hex
+        sdk.store.write(
+            JobRun(
+                run_id=run_id,
+                app=sdk.app_name,
+                kind="work",
+                status=RUNNING,
+                origin="a-process-that-is-gone",
+            )
+        )
+        assert sdk.reconcile() >= 1
+        rec = sdk.get(run_id)
+        assert rec.interrupt_cause == job_sdk.CAUSE_PROCESS_GONE
+        assert "restarted" in rec.error
+
+    def test_a_foreign_origin_unregistered_kind_still_reports_unregistered(
+        self, sdk: JobSDK
+    ) -> None:
+        """The third arm: the `known` split survives, scoped to foreign origins."""
+        run_id = uuid.uuid4().hex
+        sdk.store.write(
+            JobRun(
+                run_id=run_id,
+                app=sdk.app_name,
+                kind="never-registered",
+                status=RUNNING,
+                origin="a-process-that-is-gone",
+            )
+        )
+        assert sdk.reconcile() >= 1
+        rec = sdk.get(run_id)
+        assert rec.interrupt_cause == job_sdk.CAUSE_RUNNER_UNREGISTERED
+
+    def test_the_interruption_fields_can_only_hold_values_this_module_minted(self) -> None:
+        """The claim that makes the two new fields SDK-minted rather than a
+        payload channel: every value either is written from a module constant, or
+        is a status this module defined.
+
+        Pinned as the INVARIANT rather than as one literal expression. An earlier
+        form asserted the exact text of the cause conditional, so adding a third
+        cause failed it for the wrong reason -- the single assignment site was
+        still intact, only the expression had changed.
+        """
+        source = Path(job_sdk.__file__).read_text(encoding="utf-8")
+        # ``interrupted_from`` is only ever assigned the record's own status, and
+        # ``interrupt_cause`` only ever a CAUSE_* constant -- one site each.
+        assert source.count("run.interrupted_from = ") == 1
+        assert "run.interrupted_from = run.status" in source
+        assert source.count("run.interrupt_cause = ") == 1
+        # The one site assigns a local, so the local's every value must itself be
+        # a CAUSE_* constant. Checked inside `reconcile`, where it is composed.
+        body = source.split("def reconcile(")[1].split("def _persist(")[0]
+        assert "run.interrupt_cause = cause" in body
+        cause_writes = [
+            ln.strip().split("=", 1)[1].strip()
+            for ln in body.splitlines()
+            if re.match(r"\s*cause\s*=\s*", ln)
+        ]
+        assert cause_writes, "the cause local is never assigned -- harness stale"
+        for value in cause_writes:
+            assert value.startswith("CAUSE_"), f"cause assigned a non-constant: {value!r}"
 
 
 class TestDisableIsTerminalForTheSDK:
@@ -1687,6 +1930,1008 @@ class TestStartingStateClosesTheLaunchWindow:
         )
         assert sdk.reconcile() == 1
         assert sdk.get("7b" * 16).status == INTERRUPTED
+
+
+class TestCoroutineRunnerIsRefusedAtRegistration:
+    """An ``async def`` runner would report DONE having executed nothing.
+
+    ``_execute`` calls ``fn(handle)`` on a worker thread and discards the return
+    value by design. Calling a coroutine function returns a coroutine object
+    instead of doing the work, so the body never runs, the object is dropped
+    un-awaited, and the terminal write says ``done``. Refused at ``register``,
+    where the answer is still cheap.
+    """
+
+    def test_a_coroutine_function_is_refused(self, sdk: JobSDK) -> None:
+        async def runner(handle: JobHandle) -> None:  # pragma: no cover - never called
+            raise AssertionError("the body of a refused runner must never execute")
+
+        with pytest.raises(ValueError, match="coroutine function"):
+            sdk.register("async-work", runner)
+
+    def test_the_refused_kind_is_not_registered(self, sdk: JobSDK) -> None:
+        """The refusal must leave NO runner behind.
+
+        Validating after the table write would register the kind and then raise,
+        leaving a kind whose every ``start`` records a done run that did nothing --
+        the exact outcome the refusal exists to prevent.
+        """
+
+        async def runner(handle: JobHandle) -> None:  # pragma: no cover - never called
+            raise AssertionError("unreachable")
+
+        with pytest.raises(ValueError):
+            sdk.register("async-work", runner)
+        assert sdk.kinds() == []
+        assert sdk.is_cancellable("async-work") is False
+        # And the kind is genuinely absent, not merely missing from the listing.
+        with pytest.raises(UnknownJobKind):
+            sdk.start("async-work")
+
+    def test_an_async_partial_and_an_async_lambda_alias_are_refused(self, sdk: JobSDK) -> None:
+        """``iscoroutinefunction`` unwraps ``functools.partial``, so this holds."""
+        import functools
+
+        async def runner(handle: JobHandle) -> None:  # pragma: no cover - never called
+            raise AssertionError("unreachable")
+
+        with pytest.raises(ValueError, match="coroutine function"):
+            sdk.register("partial-async", functools.partial(runner))
+        aliased = runner
+        with pytest.raises(ValueError, match="coroutine function"):
+            sdk.register("aliased-async", aliased)
+        assert sdk.kinds() == []
+
+    def test_a_callable_object_with_an_async_call_is_refused(self, sdk: JobSDK) -> None:
+        """The shape a check written against bare functions passes through.
+
+        ``inspect`` reports the INSTANCE as an ordinary object, so
+        ``iscoroutinefunction(instance)`` is False while invoking it still returns
+        a coroutine. Two reviewers found this gap in the first version of the
+        guard, which is why the check goes through ``__call__`` too.
+        """
+
+        class AsyncRunner:
+            async def __call__(self, handle: JobHandle) -> None:  # pragma: no cover
+                raise AssertionError("the body of a refused runner must never execute")
+
+        instance = AsyncRunner()
+        # The premise: the instance alone does not look like a coroutine function.
+        assert inspect.iscoroutinefunction(instance) is False
+        assert inspect.iscoroutinefunction(instance.__call__) is True
+        with pytest.raises(ValueError, match="coroutine function"):
+            sdk.register("async-call", instance)
+        assert sdk.kinds() == []
+
+    def test_generator_shapes_are_refused_too(self, sdk: JobSDK) -> None:
+        """Same defect, two more spellings.
+
+        Calling a generator or async-generator function returns a lazy object and
+        runs nothing, so the record would say ``done`` for a body that never
+        executed -- identical to the coroutine case, and identically silent.
+        """
+
+        def sync_gen(handle: JobHandle):  # pragma: no cover - never invoked
+            yield 1
+
+        async def async_gen(handle: JobHandle):  # pragma: no cover - never invoked
+            yield 1
+
+        with pytest.raises(ValueError, match="generator function"):
+            sdk.register("sync-gen", sync_gen)
+        with pytest.raises(ValueError, match="async generator function"):
+            sdk.register("async-gen", async_gen)
+        assert sdk.kinds() == []
+
+    def test_ordinary_callables_are_still_accepted(self, sdk: JobSDK) -> None:
+        """The refusal must not narrow what a real app can register."""
+        import functools
+
+        def plain(handle: JobHandle) -> None:
+            return None
+
+        class Callable_:
+            def __call__(self, handle: JobHandle) -> None:
+                return None
+
+        sdk.register("plain", plain)
+        sdk.register("lambda", lambda h: None)
+        sdk.register("partial", functools.partial(plain))
+        sdk.register("object", Callable_())
+        assert sdk.kinds() == ["lambda", "object", "partial", "plain"]
+
+    def test_a_sync_runner_that_drives_its_own_loop_still_works(self, sdk: JobSDK) -> None:
+        """The refusal names ``asyncio.run`` as the supported path, so prove it."""
+        seen: list[str] = []
+
+        async def body() -> None:
+            seen.append("ran")
+
+        sdk.register("wrapped", lambda h: asyncio.run(body()))
+        run_id = sdk.start("wrapped")
+        assert _wait_terminal(sdk, run_id).status == DONE
+        assert seen == ["ran"]
+
+
+# ---------------------------------------------------------------------------
+# An interruption records TWO facts, and the message is derived from them
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptionRecordsBothAxes:
+    """``reconcile`` used to overwrite ``status`` and pick ``error`` from the
+    runner table alone, so a run whose worker thread was never started was
+    written a record claiming it "was running", and a consumer could not tell a
+    run that may have committed side effects from one that provably had not.
+
+    The two facts are independent because they describe different times: how far
+    the run got (past) and whether the kind can be serviced now (present).
+    """
+
+    @staticmethod
+    def _seed(sdk: JobSDK, status: str, kind: str) -> str:
+        run_id = uuid.uuid4().hex
+        sdk.store.write(
+            JobRun(
+                run_id=run_id,
+                app=sdk.app_name,
+                kind=kind,
+                status=status,
+                origin="a-process-that-is-gone",
+            )
+        )
+        return run_id
+
+    @pytest.mark.parametrize("status", [QUEUED, STARTING, RUNNING])
+    def test_the_prior_status_is_preserved(self, sdk: JobSDK, status: str) -> None:
+        sdk.register("work", lambda h: None)
+        run_id = self._seed(sdk, status, "work")
+        assert sdk.reconcile() == 1
+        run = sdk.get(run_id)
+        assert run is not None
+        assert run.status == INTERRUPTED
+        assert run.interrupted_from == status
+
+    def test_the_cause_distinguishes_a_lost_process_from_a_missing_runner(
+        self, sdk: JobSDK
+    ) -> None:
+        sdk.register("known", lambda h: None)
+        known = self._seed(sdk, RUNNING, "known")
+        gone = self._seed(sdk, RUNNING, "vanished")
+        assert sdk.reconcile() == 2
+        assert sdk.get(known).interrupt_cause == job_sdk.CAUSE_PROCESS_GONE
+        assert sdk.get(gone).interrupt_cause == job_sdk.CAUSE_RUNNER_UNREGISTERED
+
+    def test_the_two_axes_are_independent(self, sdk: JobSDK) -> None:
+        """Every (prior status, cause) combination is separately observable.
+
+        This is the assertion the old single-string form could not satisfy: it
+        produced ONE record shape for all three prior statuses, so a consumer had
+        no way back to what actually happened.
+        """
+        sdk.register("known", lambda h: None)
+        for status in (QUEUED, STARTING, RUNNING):
+            for kind in ("known", "vanished"):
+                self._seed(sdk, status, kind)
+        assert sdk.reconcile() == 6
+        pairs = {(r.interrupted_from, r.interrupt_cause) for r in sdk.store.iter_runs()}
+        assert pairs == {
+            (status, cause)
+            for status in (QUEUED, STARTING, RUNNING)
+            for cause in (job_sdk.CAUSE_PROCESS_GONE, job_sdk.CAUSE_RUNNER_UNREGISTERED)
+        }
+
+    def test_a_run_that_never_started_is_not_described_as_running(self, sdk: JobSDK) -> None:
+        """The one behavioural claim about the message, as opposed to its wording.
+
+        A ``queued`` or ``starting`` record provably ran no line of the runner's
+        body, so a message asserting it was running is false -- which is what the
+        old form wrote for every prior status.
+        """
+        sdk.register("work", lambda h: None)
+        never = [self._seed(sdk, status, "work") for status in (QUEUED, STARTING)]
+        did = self._seed(sdk, RUNNING, "work")
+        assert sdk.reconcile() == 3
+        for run_id in never:
+            assert "was running" not in sdk.get(run_id).error
+        assert "was running" in sdk.get(did).error
+
+    def test_the_message_still_names_the_restart(self, sdk: JobSDK) -> None:
+        """Every consumer of a reconciled record reads ``error`` for the cause,
+        so the message must remain recognisable for all six combinations."""
+        sdk.register("known", lambda h: None)
+        for status in (QUEUED, STARTING, RUNNING):
+            for kind in ("known", "vanished"):
+                self._seed(sdk, status, kind)
+        assert sdk.reconcile() == 6
+        for run in sdk.store.iter_runs():
+            assert "restart" in run.error.lower()
+
+    def test_an_unregistered_kind_is_still_named_in_the_message(self, sdk: JobSDK) -> None:
+        run_id = self._seed(sdk, RUNNING, "vanished")
+        assert sdk.reconcile() == 1
+        assert "vanished" in sdk.get(run_id).error
+
+    def test_both_fields_survive_a_round_trip_through_disk(self, sdk: JobSDK) -> None:
+        """The fields are only useful if a LATER process can read them back --
+        which is the whole point, since the writer is a process that has died."""
+        sdk.register("work", lambda h: None)
+        run_id = self._seed(sdk, STARTING, "work")
+        assert sdk.reconcile() == 1
+        raw = json.loads((sdk.store.dir / f"{run_id}.json").read_text(encoding="utf-8"))
+        assert raw["interrupted_from"] == STARTING
+        assert raw["interrupt_cause"] == job_sdk.CAUSE_PROCESS_GONE
+        assert JobRun.from_dict(raw).interrupted_from == STARTING
+        assert JobRun.from_dict(raw).interrupt_cause == job_sdk.CAUSE_PROCESS_GONE
+
+    def test_a_run_that_was_never_interrupted_carries_neither_field(self, sdk: JobSDK) -> None:
+        """The fields are set ONLY by reconcile, so a normal run must leave them
+        empty -- a consumer switching on them must not see a stale value."""
+        sdk.register("work", lambda h: None)
+        run_id = sdk.start("work")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+        assert run.interrupted_from == ""
+        assert run.interrupt_cause == ""
+
+    def test_composition_tolerates_a_status_or_cause_it_does_not_know(self) -> None:
+        """The pass that clears stuck ``running`` records must not be stoppable by
+        a record written by a newer build, so neither lookup may raise."""
+        assert job_sdk._interrupt_error(job_sdk.CAUSE_PROCESS_GONE, "from-the-future", "k")
+        assert job_sdk._interrupt_error("cause-from-the-future", RUNNING, "k")
+        assert "was running" in job_sdk._interrupt_error("cause-from-the-future", RUNNING, "k")
+
+    def test_the_message_is_composed_at_exactly_one_site(self) -> None:
+        """A ratchet, not a behaviour check: the value of the table is that adding
+        a cause edits one place. A second composition site would let the two
+        drift, which is the failure the lookup table replaced -- and a behaviour
+        test cannot see a second site that happens to agree today.
+        """
+        source = Path(job_sdk.__file__).read_text(encoding="utf-8")
+        # One definition, one call. `reconcile` is the only caller.
+        assert source.count("_interrupt_error(") == 2
+        # The templates exist only in the table: no other line builds a sentence.
+        assert source.count("the gateway restarted while this") == 2
+        # And the table is read only inside the composition helper.
+        assert source.count("_INTERRUPT_MESSAGE") == 3  # the def, plus .get + fallback
+
+
+# ---------------------------------------------------------------------------
+# An unreadable record is absent, not a crash
+# ---------------------------------------------------------------------------
+
+
+class TestAMalformedRecordIsAbsentAnUnreadableOneIsNot:
+    """``read`` answers ``None`` for a record whose bytes it cannot make sense of,
+    and lets an environmental fault out.
+
+    The distinction is what ``None`` claims. A missing file, a bad path, or bytes
+    that are not the UTF-8 JSON this store writes establish that there is no such
+    record. A ``PermissionError`` establishes nothing of the kind: on Windows it is
+    the transient sharing violation a concurrent ``os.replace`` produces, which
+    ``read_bytes_with_retry`` is built to outlast, and the record is present and
+    intact throughout. Answering "absent" there is the same unverified assertion
+    this change set exists to remove, so those escape to the caller.
+    """
+
+    @staticmethod
+    def _unreadable(sdk: JobSDK) -> tuple[str, Path]:
+        run_id = uuid.uuid4().hex
+        sdk.store.write(JobRun(run_id=run_id, app=sdk.app_name, kind="k", status=DONE))
+        path = sdk.store.dir / f"{run_id}.json"
+        return run_id, path
+
+    @pytest.mark.skipif(
+        not _MODE_BITS_BITE,
+        reason="root reads through a 0o000 mode, so the PermissionError cannot be provoked",
+    )
+    def test_a_mode_that_blocks_the_read_is_not_reported_as_absent(self, sdk: JobSDK) -> None:
+        """The record is intact the whole time -- only the mode changed."""
+        run_id, path = self._unreadable(sdk)
+        os.chmod(path, 0o000)
+        try:
+            with pytest.raises(PermissionError):
+                sdk.get(run_id)
+        finally:
+            os.chmod(path, 0o600)
+        # Restoring the mode restores the record, which is the proof that "absent"
+        # would have been a lie: nothing about the record ever changed.
+        assert sdk.get(run_id).status == DONE
+
+    def test_a_permission_error_escapes_rather_than_reading_as_absent(self, sdk: JobSDK) -> None:
+        """Pins the direction #7703 depends on: an on-loop read lets it out."""
+        run_id, _ = self._unreadable(sdk)
+        raised: list[str] = []
+
+        def boom(path):
+            raised.append(str(path))
+            raise PermissionError(13, "Permission denied")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(job_sdk, "read_bytes_with_retry", boom)
+            with pytest.raises(PermissionError):
+                sdk.get(run_id)
+        assert raised, "the patched reader was never reached"
+
+    def test_an_environmental_oserror_escapes_too(self, sdk: JobSDK) -> None:
+        """``EIO`` is a fact about the host, not about whether this run exists."""
+        run_id, _ = self._unreadable(sdk)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                job_sdk,
+                "read_bytes_with_retry",
+                lambda path: (_ for _ in ()).throw(OSError(5, "I/O error")),
+            )
+            with pytest.raises(OSError):
+                sdk.get(run_id)
+
+    def test_bytes_that_are_not_utf_8_read_as_absent(self, sdk: JobSDK) -> None:
+        """The other half: damage the decode cannot survive IS absence."""
+        run_id, path = self._unreadable(sdk)
+        path.write_bytes(b"\xff\xfe not utf-8")
+        assert sdk.get(run_id) is None
+
+    def test_the_three_absence_cases_answer_none(self, sdk: JobSDK) -> None:
+        """The cases where ``None`` is the honest answer, kept while the tuple narrowed."""
+        assert sdk.get(uuid.uuid4().hex) is None  # FileNotFoundError
+        assert sdk.get("not-a-run-id") is None  # ValueError from _path
+        for exc in (FileNotFoundError(), NotADirectoryError()):
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(
+                    job_sdk,
+                    "read_bytes_with_retry",
+                    lambda path, e=exc: (_ for _ in ()).throw(e),
+                )
+                assert sdk.get(uuid.uuid4().hex) is None
+
+    def test_a_damaged_record_does_not_stop_reconciliation(self, sdk: JobSDK) -> None:
+        """Why the scan keeps its own broader guard: a record ``get`` now raises on
+        is one the reconcile pass must still walk past."""
+        if not _MODE_BITS_BITE:
+            pytest.skip("root reads through a 0o000 mode")
+        sdk.register("work", lambda h: None)
+        stale = uuid.uuid4().hex
+        sdk.store.write(
+            JobRun(
+                run_id=stale,
+                app=sdk.app_name,
+                kind="work",
+                status=RUNNING,
+                origin="a-process-that-is-gone",
+            )
+        )
+        _, path = self._unreadable(sdk)
+        os.chmod(path, 0o000)
+        try:
+            assert sdk.reconcile() == 1
+            assert sdk.get(stale).status == INTERRUPTED
+        finally:
+            os.chmod(path, 0o600)
+
+
+# ---------------------------------------------------------------------------
+class TestAnUndrivenResultIsFailedNotDone:
+    """The safety property, as opposed to the registration guard's friendly error.
+
+    ``register`` refuses callable SHAPES that cannot do work when called, but a
+    shape check is a proxy and cannot see every route to the same outcome. The
+    fact -- "did this runner do the work" -- is only available from what the call
+    handed back, which is where this checks it.
+    """
+
+    def test_a_sync_runner_returning_a_coroutine_is_failed(self, sdk: JobSDK) -> None:
+        """The form NO registration check can see.
+
+        `def run(h): return _do_it(h)` over an `async def _do_it` is an ordinary
+        refactor. The wrapper is a plain function, so every shape predicate says
+        it is fine; it runs far enough to construct the coroutine, hands it back,
+        and the work never happens.
+        """
+        ran: list[str] = []
+
+        async def _do_it(handle: JobHandle) -> None:  # pragma: no cover - never awaited
+            ran.append("body")
+
+        def wrapper(handle: JobHandle):
+            return _do_it(handle)
+
+        # The premise: this defeats the registration guard entirely.
+        assert job_sdk._lazy_call_shape(wrapper) == ""
+        sdk.register("wrapped", wrapper)
+        run = _wait_terminal(sdk, sdk.start("wrapped"))
+        assert run.status == FAILED
+        # Pinned on the FACT the record must convey, not on a particular word. An
+        # earlier form asserted "await" appeared in the message, which broke when
+        # the reason was reworded to name the protocol rather than the type -- the
+        # same literal-string brittleness this change set keeps running into.
+        assert "coroutine" in run.error
+        assert "must not return" in run.error
+        # It must NOT claim the body never ran: that is only knowable for THIS
+        # shape, and the rule is stated for all suspendables uniformly.
+        assert "never ran" not in run.error
+        assert run.kind in run.error
+        assert ran == [], "the coroutine body must not have run"
+
+    def test_a_runner_returning_an_async_generator_is_failed(self, sdk: JobSDK) -> None:
+        async def _gen(handle: JobHandle):  # pragma: no cover - never driven
+            yield 1
+
+        def wrapper(handle: JobHandle):
+            return _gen(handle)
+
+        sdk.register("agen", wrapper)
+        run = _wait_terminal(sdk, sdk.start("agen"))
+        assert run.status == FAILED
+        assert "async generator" in run.error
+
+    def test_a_runner_returning_a_future_is_failed(self, sdk: JobSDK) -> None:
+        """A PENDING future: `isawaitable` is the predicate, not `iscoroutine`.
+
+        Pending is the half that means the work did not happen -- something else
+        was going to complete this future and nothing on this thread ever will.
+        """
+
+        def wrapper(handle: JobHandle):
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.create_future()
+            finally:
+                loop.close()
+
+        sdk.register("fut", wrapper)
+        run = _wait_terminal(sdk, sdk.start("fut"))
+        assert run.status == FAILED
+
+    def test_a_runner_returning_a_completed_future_is_done(self, sdk: JobSDK) -> None:
+        """The mirror, and the same rule as a returned plain generator.
+
+        A DONE future is evidence the work happened; the object is then just a
+        discarded return value like any other. Flagging it would record `failed`
+        for a run that did everything asked of it -- the same unverified assertion
+        this change set exists to remove, pointed the other way.
+        """
+        did_work: list[str] = []
+
+        def wrapper(handle: JobHandle):
+            did_work.append(handle.run_id)
+            loop = asyncio.new_event_loop()
+            try:
+                fut = loop.create_future()
+                fut.set_result({"ok": True})
+                return fut
+            finally:
+                loop.close()
+
+        sdk.register("donefut", wrapper)
+        run = _wait_terminal(sdk, sdk.start("donefut"))
+        assert run.status == DONE, run.error
+        assert did_work, "the runner body never ran"
+
+    def test_a_thread_pool_future_was_never_in_scope(self, sdk: JobSDK) -> None:
+        """`concurrent.futures.Future` is not awaitable, so it never reached the
+        check at all -- worth pinning, because the reported form named a sync
+        runner returning one and that shape was never affected."""
+        import concurrent.futures
+
+        cf: concurrent.futures.Future = concurrent.futures.Future()
+        cf.set_result(1)
+        assert not inspect.isawaitable(cf)
+        assert job_sdk._undriven_result(cf) == ""
+
+    def test_an_ordinary_runner_is_still_done(self, sdk: JobSDK) -> None:
+        """The check must not fail a runner that did its work and returned data."""
+        sdk.register("plain", lambda h: {"rows": 3})
+        assert _wait_terminal(sdk, sdk.start("plain")).status == DONE
+
+    def test_a_returned_suspended_generator_is_failed(self, sdk: JobSDK) -> None:
+        """Began and did not finish, which is not the same as finished.
+
+        An earlier revision allowed this on the grounds that the runner's body had
+        run. It had run PARTWAY: nothing in the SDK drives what a runner returns, so
+        a suspended frame never resumes and the work is incomplete. Recording `done`
+        would assert a completion nobody observed.
+        """
+        reached: list[str] = []
+
+        def wrapper(handle: JobHandle):
+            def steps():
+                reached.append("first")
+                yield 1
+                reached.append("second")  # pragma: no cover - never resumed
+                yield 2
+
+            gen = steps()
+            next(gen)  # begins the body, stops at the first yield
+            return gen
+
+        sdk.register("gen-suspended", wrapper)
+        run = _wait_terminal(sdk, sdk.start("gen-suspended"))
+        assert run.status == FAILED
+        assert "must not return" in run.error
+        # And the proof it really was incomplete: the rest never ran.
+        assert reached == ["first"]
+
+    def test_a_returned_never_started_generator_is_failed(self, sdk: JobSDK) -> None:
+        """Still failed, but no longer for a reason of its own.
+
+        Earlier rounds gave this state a distinct message ("never began") because it is
+        a distinct fact. The state is no longer consulted, so it now shares the one
+        suspendable verdict -- the cost of the tightening, recorded here rather than
+        left for a reader to infer from a deleted assertion.
+        """
+
+        def wrapper(handle: JobHandle):
+            return (n for n in range(3))  # never stepped
+
+        sdk.register("gen-unstarted", wrapper)
+        run = _wait_terminal(sdk, sdk.start("gen-unstarted"))
+        assert run.status == FAILED
+        assert "must not return" in run.error
+
+    def test_a_returned_drained_generator_is_failed_and_this_reverses_an_earlier_call(
+        self, sdk: JobSDK
+    ) -> None:
+        """THE INVERSION. An earlier revision of this same change set asserted DONE here.
+
+        The reversal is deliberate and this test is its record. `CLOSED` was read as
+        "ran to completion", which is true of this generator -- the body really did run.
+        But `CLOSED` equally covers a suspendable closed before it ever began, and the
+        two are indistinguishable from the object, so allowing the state meant recording
+        a completion nobody observed for the OTHER case. A rule that cannot tell the
+        cases apart must not claim to.
+
+        So the work here genuinely happened and the run is still FAILED. That is the
+        cost of the tightening, stated rather than hidden: the SDK refuses the object
+        because it cannot interpret it, and the reason must not pretend the body never
+        ran, because here it did.
+        """
+        drained = []
+
+        def wrapper(handle: JobHandle):
+            gen = (drained.append(n) or n for n in range(3))
+            list(gen)  # drained: frame is now None, body really ran
+            return gen
+
+        sdk.register("gen-drained", wrapper)
+        run = _wait_terminal(sdk, sdk.start("gen-drained"))
+        assert run.status == FAILED
+        assert drained == [0, 1, 2], "premise: the body DID run"
+        assert "must not return" in run.error
+        assert "never ran" not in run.error, "must not claim what is false here"
+
+    def test_every_suspendable_state_reaches_the_same_verdict(self) -> None:
+        """Completeness by state-INDEPENDENCE, which is a stronger claim than a map.
+
+        The old form enumerated the language's frame states and asserted a verdict for
+        each, so a future Python adding a state broke it. The rule no longer reads state
+        at all, so the property to pin is that no state -- including the two CLOSED
+        histories that motivated the change -- can reach an allow.
+        """
+
+        def gen_fn():
+            yield 1
+            yield 2
+
+        created = gen_fn()
+        suspended = gen_fn()
+        next(suspended)
+        drained = gen_fn()
+        list(drained)
+        closed_unstarted = gen_fn()
+        closed_unstarted.close()
+
+        cases = {
+            inspect.GEN_CREATED: created,
+            inspect.GEN_SUSPENDED: suspended,
+            "GEN_CLOSED (drained)": drained,
+            "GEN_CLOSED (closed unstarted)": closed_unstarted,
+        }
+        verdicts = set()
+        for label, obj in cases.items():
+            reason = job_sdk._undriven_result(obj)
+            assert reason != "", f"{label} reached an allow"
+            assert "never ran" not in reason, f"{label} claims execution it cannot know"
+            verdicts.add(reason)
+
+        # The two CLOSED histories are the whole reason for the rule: they differ in
+        # what happened and are identical to the classifier, so they MUST NOT be
+        # distinguished by the record.
+        assert job_sdk._undriven_result(drained) == job_sdk._undriven_result(closed_unstarted)
+        assert len(verdicts) == 1, f"state still leaks into the verdict: {verdicts}"
+        created.close()
+        suspended.close()
+
+    def test_an_unsettled_future_discloses_that_the_work_may_still_run(self) -> None:
+        """The record must warn the owner, because the SDK cannot stop the work.
+
+        An unsettled future stands for a thread this SDK does not own. Marking the run
+        terminal releases the dedupe key, so an owner who retries can start a second
+        run overlapping work that never stopped. `failed` is the true verdict about the
+        RUN -- the runner returned before finishing, violating its contract -- but the
+        reason has to name what the SDK cannot control, since the owner reading it is
+        the only party who can judge whether retrying is safe.
+        """
+        pool_future: concurrent.futures.Future = concurrent.futures.Future()
+        try:
+            verdict = job_sdk._undriven_result(pool_future)
+            assert "not settled" in verdict
+            # The disclosure, pinned on the FACTS it must convey rather than wording.
+            assert "may still be running" in verdict
+            assert "cannot stop" in verdict
+            assert "overlap" in verdict
+        finally:
+            pool_future.cancel()
+
+    def test_the_states_are_reachable_and_deliberately_not_distinguished(self) -> None:
+        """The states are real; the verdict ignores them ON PURPOSE.
+
+        This test asserted the opposite until round 9 -- that all three produced
+        DISTINCT verdicts, and that closed produced an allow. Both assertions are now
+        inverted, because a verdict that varies by state implies the state is
+        informative, and for CLOSED it is not.
+        """
+
+        created = (x for x in [1, 2])
+        suspended = (x for x in [1, 2])
+        next(suspended)
+        closed = (x for x in [1, 2])
+        list(closed)
+
+        # The states really are reachable and really do differ...
+        assert inspect.getgeneratorstate(created) == inspect.GEN_CREATED
+        assert inspect.getgeneratorstate(suspended) == inspect.GEN_SUSPENDED
+        assert inspect.getgeneratorstate(closed) == inspect.GEN_CLOSED
+        assert closed.gi_frame is None, "closed is the state where the frame is gone"
+
+        # ...and none of that reaches the record.
+        verdicts = {job_sdk._undriven_result(g) for g in (created, suspended, closed)}
+        assert len(verdicts) == 1, f"state leaked into the verdict: {verdicts}"
+        assert job_sdk._undriven_result(closed) != "", "closed was allowed until round 9"
+
+    def test_a_failed_running_transition_does_not_run_the_body(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The transition is a precondition, not a notification.
+
+        If the store cannot record that the run is running, the body must not run:
+        a record left at `starting` while the runner commits side effects is one
+        `reconcile` later reads as "never began", and that claim cannot be
+        corrected after the fact because the knowledge dies with the process.
+        """
+        ran: list[str] = []
+        real_write = sdk.store.write
+
+        def refuse_running(run):
+            if run.status == RUNNING:
+                raise OSError("the store is unavailable")
+            return real_write(run)
+
+        sdk.register("work", lambda h, **kw: ran.append(h.run_id))
+        monkeypatch.setattr(sdk.store, "write", refuse_running)
+        run = _wait_terminal(sdk, sdk.start("work"))
+        assert run.status == FAILED
+        assert not ran, "the body ran even though the running transition was lost"
+        assert "never started" in run.error
+
+    def test_a_failed_running_transition_never_reports_never_began(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole point: no surviving record can claim a run did not begin while
+        its side effects exist. Since the body is refused, `starting` is true."""
+        real_write = sdk.store.write
+
+        def refuse_running(run):
+            if run.status == RUNNING:
+                raise OSError("the store is unavailable")
+            return real_write(run)
+
+        sdk.register("work", lambda h, **kw: {"ok": True})
+        monkeypatch.setattr(sdk.store, "write", refuse_running)
+        run = _wait_terminal(sdk, sdk.start("work"))
+        # It is recorded as failed, not left for reconcile to describe.
+        assert run.status == FAILED
+        assert run.interrupted_from == ""
+        assert run.interrupt_cause == ""
+
+    def test_every_result_shape_in_the_table_has_a_verdict(self) -> None:
+        """A TABLE of factory -> expected verdict, asserted by protocol.
+
+        A table rather than a case per type, because appending a branch per reported
+        shape is the failure mode this design replaced -- and because the protocol
+        checks mean most new shapes need no row at all. Each row names which QUESTION
+        the object answers, so the verdict follows from the answer rather than from
+        the type.
+        """
+        loop = asyncio.new_event_loop()
+
+        def a_coroutine():
+            async def _c():  # pragma: no cover - never driven, by design
+                return 1
+
+            return _c()
+
+        def an_async_gen():
+            async def _a():  # pragma: no cover - never driven, by design
+                yield 1
+
+            return _a()
+
+        def unstarted_gen():
+            return (x for x in [1, 2])
+
+        def started_gen():
+            g = (x for x in [1, 2])
+            next(g)
+            return g
+
+        def drained_gen():
+            g = (x for x in [1, 2])
+            list(g)
+            return g
+
+        def unsettled_future():
+            return loop.create_future()
+
+        def cancelled_future():
+            f = loop.create_future()
+            f.cancel()
+            return f
+
+        def failed_future():
+            f = loop.create_future()
+            f.set_exception(ValueError("inner op"))
+            return f
+
+        def settled_future():
+            f = loop.create_future()
+            f.set_result({"ok": True})
+            return f
+
+        def unsettled_pool_future():
+            return concurrent.futures.Future()
+
+        def cancelled_pool_future():
+            f: concurrent.futures.Future = concurrent.futures.Future()
+            f.cancel()
+            return f
+
+        def failed_pool_future():
+            f: concurrent.futures.Future = concurrent.futures.Future()
+            f.set_exception(ValueError("inner op"))
+            return f
+
+        def settled_pool_future():
+            f: concurrent.futures.Future = concurrent.futures.Future()
+            f.set_result(1)
+            return f
+
+        def bare_awaitable():
+            class BareAwaitable:
+                def __await__(self):  # pragma: no cover - never driven
+                    yield
+
+            return BareAwaitable()
+
+        # (question answered, factory, expected fragment) -- "" means a completed unit
+        table: list[tuple[str, object, str]] = [
+            # Q1: has its body begun?
+            ("suspendable: never began (coroutine)", a_coroutine, "must not return"),
+            ("suspendable: never began (generator)", unstarted_gen, "must not return"),
+            ("suspendable: suspended partway", started_gen, "must not return"),
+            # Was "" (allowed) until round 9; see the inversion test for why.
+            ("suspendable: closed, drained", drained_gen, "must not return"),
+            # Q2: is it settled? -- asyncio's flavour...
+            ("Q2 unsettled", unsettled_future, "not settled"),
+            ("Q2 cancelled", cancelled_future, "cancelled future"),
+            ("Q2 settled badly", failed_future, "ran and raised"),
+            ("Q2 settled well", settled_future, ""),
+            # ...and the thread-pool flavour, which is NOT awaitable. These four are
+            # the round the type table missed entirely, and they needed no new row:
+            # they answer Q2, so the same code path classifies them.
+            ("Q2 unsettled (thread pool)", unsettled_pool_future, "not settled"),
+            ("Q2 cancelled (thread pool)", cancelled_pool_future, "cancelled future"),
+            ("Q2 settled badly (thread pool)", failed_pool_future, "ran and raised"),
+            ("Q2 settled well (thread pool)", settled_pool_future, ""),
+            # Answers neither question.
+            ("neither, no loop here to drive it", an_async_gen, "must not return"),
+            ("neither, but still needs driving", bare_awaitable, "must not return"),
+        ]
+        try:
+            for label, factory, expected in table:
+                result = factory()  # type: ignore[operator]
+                verdict = job_sdk._undriven_result(result)
+                if expected == "":
+                    assert verdict == "", f"{label}: expected a completed unit, got {verdict!r}"
+                else:
+                    assert expected in verdict, f"{label}: {verdict!r} does not say {expected!r}"
+
+            # The three settled outcomes must be told APART, not merely all failed.
+            reasons = {
+                job_sdk._undriven_result(f())
+                for f in (unsettled_future, cancelled_future, failed_future)
+            }
+            assert len(reasons) == 3, f"the settled outcomes were flattened: {reasons}"
+        finally:
+            loop.close()
+
+    def test_the_two_protocol_questions_cover_the_space(self) -> None:
+        """The claim the design rests on, pinned: any object needing to be driven
+        answers at least one of the two questions.
+
+        This is what makes the classifier bounded. A future reports settledness; a
+        suspendable reports whether its body has begun; an `__await__` object wraps
+        one of those. So a lazy type nobody enumerated cannot slip through as a
+        silent `done` -- which is exactly how `concurrent.futures.Future` did.
+        """
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def coro_fn():  # pragma: no cover - never driven
+                return 1
+
+            def gen_fn():  # pragma: no cover - never driven
+                yield 1
+
+            cf: concurrent.futures.Future = concurrent.futures.Future()
+            c = coro_fn()
+            g = gen_fn()
+            for obj in (c, g, loop.create_future(), cf):
+                answers_settled = callable(getattr(obj, "done", None))
+                answers_begun = any(is_kind(obj) for _n, is_kind in job_sdk._SUSPENDABLE_KINDS)
+                assert answers_settled or answers_begun, (
+                    f"{type(obj).__name__} answers neither protocol question, so it "
+                    "would be recorded done -- the classifier is not bounded"
+                )
+                assert job_sdk._undriven_result(obj) != "", f"{type(obj).__name__} slipped through"
+            c.close()
+            g.close()
+            cf.cancel()
+        finally:
+            loop.close()
+
+    def test_the_unstarted_check_does_not_rely_on_f_lasti(self) -> None:
+        """Version guard, because the obvious implementation is a trap.
+
+        `f_lasti` is -1 for an unstarted frame up to 3.10 and an instruction offset
+        (0) from 3.11, so a `< 0` test matches NOTHING on 3.12 and every `async def`
+        runner would be recorded `done` again. Pinned on the value itself so the
+        trap cannot be reintroduced by someone simplifying the protocol table.
+        """
+
+        async def coro_fn():  # pragma: no cover - never driven
+            return 1
+
+        c = coro_fn()
+        try:
+            assert inspect.getcoroutinestate(c) == inspect.CORO_CREATED
+            # The exact-state helper says "unstarted"; f_lasti may or may not.
+            assert job_sdk._undriven_result(c) != ""
+            lasti = c.cr_frame.f_lasti
+            assert isinstance(lasti, int)  # the attribute exists; its MEANING varies
+        finally:
+            c.close()
+
+    def test_a_valid_result_is_not_failed_closed(self) -> None:
+        """The positive direction, because a classifier with only negative tests
+        eventually fails closed on something legitimate -- and that error looks like
+        a real failure, so it is harder to notice than the one it replaced."""
+        for ok in ({"ok": True}, None, 0, "", [1, 2], object(), 3.5, True, b"bytes"):
+            assert job_sdk._undriven_result(ok) == "", f"{ok!r} was wrongly flagged"
+
+    def test_classifying_a_cancelled_future_does_not_raise(self) -> None:
+        """`exception()` RAISES `CancelledError` on a cancelled future, and that is
+        a `BaseException` -- so the wrong check order would escape `_execute`'s
+        `except Exception` rather than being recorded. Pinned because the safe
+        order is invisible in the code once it is correct."""
+        loop = asyncio.new_event_loop()
+        try:
+            fut = loop.create_future()
+            fut.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                fut.exception()  # the trap this ordering exists to avoid
+            assert not issubclass(asyncio.CancelledError, Exception)
+            # The classifier asks cancelled() first, so it answers instead of raising.
+            assert "cancelled future" in job_sdk._undriven_result(fut)
+        finally:
+            loop.close()
+
+    def test_a_runner_returning_a_failed_future_is_failed_not_done(self, sdk: JobSDK) -> None:
+        """End to end: a settled-but-failed future is a failure, not a success.
+
+        `done()` answers "is it settled", not "did it succeed"; an earlier revision
+        of this change set conflated the two and recorded `done`.
+        """
+
+        def wrapper(handle: JobHandle):
+            loop = asyncio.new_event_loop()
+            try:
+                fut = loop.create_future()
+                fut.set_exception(ValueError("the inner operation failed"))
+                return fut
+            finally:
+                loop.close()
+
+        sdk.register("failedfut", wrapper)
+        run = _wait_terminal(sdk, sdk.start("failedfut"))
+        assert run.status == FAILED
+        assert "ValueError" in run.error
+        assert "ran and raised" in run.error
+        # And it must NOT claim the body never ran, because it did.
+        assert "never ran" not in run.error
+
+    def test_a_runner_returning_a_cancelled_future_is_failed(self, sdk: JobSDK) -> None:
+        """The third outcome, kept distinct from the other two."""
+
+        def wrapper(handle: JobHandle):
+            loop = asyncio.new_event_loop()
+            try:
+                fut = loop.create_future()
+                fut.cancel()
+                return fut
+            finally:
+                loop.close()
+
+        sdk.register("cancelledfut", wrapper)
+        run = _wait_terminal(sdk, sdk.start("cancelledfut"))
+        assert run.status == FAILED
+        assert "cancelled future" in run.error
+        assert "never completed" in run.error
+
+    def test_a_pending_future_is_retired_by_cancel_not_close(self) -> None:
+        """Futures have no `close`, so the hygiene path must reach for `cancel`.
+
+        Pinned directly on the observable rather than through a run, because the
+        earlier docstring asserted futures were closable and nothing failed -- the
+        claim was wrong and untested at the same time.
+        """
+        loop = asyncio.new_event_loop()
+        try:
+            fut = loop.create_future()
+            assert not hasattr(fut, "close"), "if futures gain close(), revisit the order"
+            job_sdk._close_quietly(fut)
+            assert fut.cancelled(), "a pending future was left un-retired"
+        finally:
+            loop.close()
+
+    def test_a_coroutine_is_retired_by_close(self) -> None:
+        """The other arm of the same loop, so neither method can quietly go away."""
+
+        async def never_awaited():  # pragma: no cover - never driven, by design
+            return 1
+
+        coro = never_awaited()
+        job_sdk._close_quietly(coro)
+        # A closed coroutine refuses to be started, which is what silences the
+        # "was never awaited" warning at collection time.
+        with pytest.raises(RuntimeError):
+            coro.send(None)
+
+    def test_the_undriven_failure_writes_once_through_the_guarded_path(self, sdk: JobSDK) -> None:
+        """One-writer-per-run is load-bearing, so neither new branch may add a
+        write site: each sets fields and lets the existing terminal write persist
+        them, exactly like the `except` branch."""
+        source = Path(job_sdk.__file__).read_text(encoding="utf-8")
+        body = source.split("def _execute(")[1].split("def _write_terminal(")[0]
+        # `_persist` appears once (the STARTING -> RUNNING write); the terminal
+        # write goes through `_write_terminal`, which owns the retry + discard check.
+        assert body.count("self._persist(") == 1
+        assert body.count("self._write_terminal(") == 1
+
+    def test_an_undriven_coroutine_is_closed_so_it_does_not_warn(self, sdk: JobSDK) -> None:
+        """The record already says what happened; a garbage-collector warning
+        fired later points at the wrong place."""
+        closed: list[bool] = []
+
+        class Probe:
+            def __await__(self):  # pragma: no cover - never awaited
+                yield
+
+            def close(self) -> None:
+                closed.append(True)
+
+        sdk.register("probe", lambda h: Probe())
+        assert _wait_terminal(sdk, sdk.start("probe")).status == FAILED
+        assert closed == [True]
 
 
 class TestForeignRecordFieldsAreCoerced:


### PR DESCRIPTION
## Problem / Motivation

Four places in the newly-landed Job SDK (#6682) wrote or served a claim the SDK
had never verified, and review found a fifth inside this PR's own new code. Each
is silent -- the record reads as an ordinary success or an ordinary failure, so
nothing tells the reader the claim is wrong.

1. `register()` accepted a coroutine function. `_execute` calls `fn(handle)` on a
   worker thread and discards the return value by design, so an `async def`
   runner returns a coroutine that is dropped un-awaited: no line of the runner's
   body executes, and the terminal write records `done`.
2. `reconcile()` flattened three distinct events into one record. It assigned
   `status` over the top of the only evidence of how far a run had got, then
   chose `error` from whether a runner is registered -- so a run that died
   between claiming and launching was written "the gateway restarted while this
   was running", which is false by the module's own definition of `starting`.
3. `JobStore.read` crashed on a record whose bytes it could not decode, so a
   damaged record took down the lookup instead of reading as absent.
4. `_execute` set `status = RUNNING`, called `_persist`, and discarded the return.
   A lost write left the record at `starting` while the runner went on to commit
   real work; if the process then died before the terminal write, `reconcile` read
   that record and stated the run had never begun -- while side effects existed.
   Found by review on this PR, in the code this PR added `interrupted_from` to.
5. `reconcile` chose the interruption cause from whether a runner is registered,
   so a record minted by THIS process with no live worker was written "the gateway
   restarted while this was running" -- while the gateway was still up. Found by
   review, in the cause vocabulary this PR itself introduces.

## Why it matters

A durable run record is only worth having if what it says is true. All three
failures are silent and all three mislead in the direction of false confidence:

- A run that reports success having executed nothing is the worst outcome
  available here. The only trace is an un-awaited-coroutine warning in the
  gateway log, and an app author gets a green `done` for work that never ran.
- A consumer cannot tell a run that may have committed side effects from one
  that provably committed none. Code Review Sage writes two *different* recovery
  messages for exactly that distinction: a review interrupted from `starting`
  posted nothing, while one interrupted from `running` may have already delivered
  comments to a pull request.
- A 500 where a 404 is the honest answer is unactionable for a client, and the
  two readers of the same file disagreed about identical damage: `iter_runs`
  twelve lines below already treated an unreadable record as merely skippable.

## What changed (motivation -> approach -> change)

**One PR rather than three** because there is one story: the record or the API
asserted a fact the SDK never verified. Each fix closes the gap at the point
where the answer is still cheap to get.

**D1 -- a run that did no work is recorded `failed`, not `done`.** The symptom is
a `done` record for work that never ran. There are two halves, and only one of
them is the safety property.

*The registration guard is a fast, friendly error.* `register()` refuses a
callable whose invocation cannot do work: a coroutine function, an async
generator function, or a plain generator function -- called, each returns a lazy
object, the body never executes, and the record says `done`. The check goes
through `__call__` as well as the object itself, because that is what invocation
reaches: `inspect` reports a callable *instance* as an ordinary object, so a
check written against bare functions lets an `async def __call__` straight
through. It runs BEFORE the runner-table write, so a refused kind leaves no
runner behind. Its value is timing and a clear message -- the app author hears
about it in their own `on_startup`, not from a run record later.

*The execution check is the safety property.* A shape check is a proxy and can
only refuse spellings somebody thought of. Measured, three forms and what each
guard sees:

| form | registration guard | execution check |
| --- | --- | --- |
| `async def` runner | refused | n/a |
| instance with `async def __call__` | refused | n/a |
| `def run(h): return _do_it(h)` over an `async def` | **passes** | **failed** |
| ordinary sync runner | passes | done |

Row three is the one that matters: a plain wrapper returning a coroutine is an
ordinary refactor, not an exotic construction. It is a plain function, so every
shape predicate says it is fine; it runs far enough to construct the coroutine,
hands it back, `_execute` discards it by design, and the work never happens. No
guard that enumerates callable shapes can ever see it.

So after `runner.fn(handle)` returns, if the result still needs driving -- an
awaitable, or an async generator -- the run is recorded `failed` with an error
naming the cause, and the result is closed so it does not warn from the garbage
collector at a point far from the run that caused it. That makes the whole class
unreachable however the callable was written, including forms nobody has thought
of yet.

Two boundaries, both deliberate. The new branch sits **inside the existing
`try`** and only sets fields -- the terminal write below is still the one write
site, because one-writer-per-run is what keeps a lost write from leaking a dedupe
claim (pinned by a test that counts the write calls in `_execute`). And a
returned *plain generator* is not treated as failure: generator functions are
refused at registration, while a generator object handed back by a runner that
did its work is ambiguous in a way an awaitable is not.

Deliberate scope line: **driving coroutines properly is a design question,
refusing them is not.** Doing it right means deciding which loop owns the
coroutine, how cancellation crosses the thread boundary, and what a blocking
runner does to that loop. This change answers none of those. It answers only the
question a caller cannot currently ask -- "did my runner run".

**D2 -- record both axes of an interruption and derive the message.** The root
cause is that one string was carrying two independent facts. They are
independent because they describe different *times*: how far the run got (past)
and whether the kind can be serviced now (present). Neither implies the other,
and a consumer reads them for different decisions -- whether to warn about
partial work, and whether a retry is even possible.

- `interrupted_from` holds the prior status, drawn from the existing
  `QUEUED`/`STARTING`/`RUNNING` constants. No new vocabulary.
- `interrupt_cause` is a small closed set (`process_gone`,
  `runner_unregistered`), not a bool: `reconcile`'s own docstring already admits
  the not-registered branch covers two events -- the app was disabled, or the kind
  was removed -- so a boolean would freeze that conflation on the day the field
  lands. Adding the third value costs one constant and one table entry.
- `error` is still populated, composed at ONE site from a table keyed on cause
  with the progress interpolated. With two axes a conditional needs four arms and
  grows multiplicatively; the table grows by one line per cause. The
  `process_gone` + `running` cell reproduces the previously shipped string byte
  for byte, because that cell was the only one that was ever true.

**D4 -- `read` treats an unreadable record as absent.** It caught
`FileNotFoundError` and `NotADirectoryError`, so a record whose bytes are not the
UTF-8 JSON this store writes crashed the lookup instead of reading as absent. The
fix adds `ValueError` (which covers the `UnicodeDecodeError` from the explicit
decode, and the malformed id `_path` rejects) and nothing else.

It deliberately does NOT catch `PermissionError`, and an earlier revision of this
PR got that wrong. That revision widened the tuple to `OSError` on the argument
that `read`'s own adjacent comment is about the Windows `PermissionError` case, so
not catching it looked like an oversight. It was not. A sharing violation from a
concurrent `os.replace` is TRANSIENT -- `read_bytes_with_retry` exists to outlast
it -- so answering `None` claims "no such run" about a record that is present and
intact, and a client reading 404 as "gone" drops live work. The same holds for the
rest of `OSError`: `EIO`, `EMFILE` and `EBUSY` are facts about the host, not about
whether the run was started. Those reach the route as a 500, which honestly says
"ask again" instead of confidently saying the wrong thing.

That is the same defect this PR is named for, committed by one of its own fixes:
`read` asserted an absence it had not verified. It is now pinned from both sides --
a mutant that restores the `OSError` widening is killed by this PR's own tests and
independently by `test_on_loop_read_propagates_permission_error_offloaded_read_retries`,
which #7703 added to keep that error propagating.

**The RUNNING transition is now a precondition, not a notification.** `_execute`
called `self._persist(run, handle)` and threw the boolean away, then ran the body
as though it had succeeded. If the store cannot record that a run is running, the
SDK no longer runs it: the run is marked `failed` with a reason naming the write,
and `runner.fn` is never called.

The alternative -- execute anyway and simply never claim "never started" -- is
unachievable across a crash, because the knowledge that the write failed dies with
the process. Only refusing to start keeps every surviving record's claim true.

**State the cost plainly: a transient store error now fails a run that might have
succeeded.** That is a real regression in availability, chosen deliberately. For an
SDK whose product is a durable record, a run nobody can account for is worse than a
run not attempted, and the failure is at least visible and retryable by the caller
rather than silently misdescribed later. Neither branch adds a write site -- both
set fields and let the single terminal write persist them, which the source ratchet
pins at exactly one `_persist` and one `_write_terminal` inside `_execute`.

**The interruption cause no longer lets a proxy outrank a fact.** `reconcile`
picked between two causes on `known` (is a runner registered for this kind), and
both of those causes say the gateway restarted. But `run.origin == _ORIGIN` -- one
line above -- is positive evidence that it did not: this process minted the
record. So a record this process wrote, whose worker is gone from the live table,
was being told it had survived a restart that never happened. Not an unverified
claim but a counter-verified one, with the evidence in hand at the point of the
write.

Own origin is now tested first, because a verified fact must outrank a proxy, and
it selects a third cause: `terminal_write_lost`. Reaching that branch means
`_write_terminal` spent both attempts and logged that the run would be reconciled,
so what is genuinely unknown is whether the work finished -- and the message says
exactly that rather than guessing either way. The `known` split survives, scoped to
foreign origins where a restart really is the explanation.

**This is reachable without any restart, which is what makes it a fix rather than
a rebuttal.** `reconcile_all` has one call chain and aiohttp fires it once per
process, so the obvious reading is "reaching reconcile implies a restart happened".
That reading is wrong: `reconcile_all` runs AFTER the app loop, while
`register_sdk` runs BEFORE each app's `on_startup` hook -- so an app's startup hook
can start a job in this same process, and a job whose terminal write is lost is
then reconciled by the process that minted it. The rebuttal that the call chain
alone suggests would have been false.

**The write-lost message states what is known, per axis.** An earlier revision gave
that cause ONE sentence ending "whether its work finished is not known", which is true
for a `running` record and false for a `starting` one: making the running transition a
precondition (above) means a record still at `starting` whose terminal write was lost
proves the body never ran. The consequence clause is now DERIVED from the progress axis
-- exactly what the two-axis design is for -- so a `starting` record says its body
never ran and names the precondition, and only `running` says the outcome is unknown.
An unreadable status falls back to outcome-unknown, which is the honest default when
the axis itself cannot be read.

The cause is composed into a local and assigned once, so `interrupt_cause` keeps
the single-assignment-site property the ratchet checks. That ratchet had to be
rewritten: it pinned the exact TEXT of the old conditional, so a third cause failed
it for the wrong reason while the invariant it existed to protect was intact. It
now asserts the invariant -- one assignment site, and every value the local can
hold is a `CAUSE_*` constant.

**The classifier asks PROTOCOL questions, not type questions, and that is the
whole design.** An earlier form enumerated types -- coroutine, async generator,
generator, `asyncio.Future` -- and was extended once per review round, five rounds
running, each fix producing the next finding. The last one was
`concurrent.futures.Future`: not awaitable, so it fell through the early return and
a pending or failed one was recorded `DONE`. A type list is open-ended. Two protocol
questions close the space:

1. **Does it report whether it is SETTLED?** Anything with `done()` -- both future
   flavours, `Task`, and anything written to the same protocol. Unsettled means the
   work is unfinished and nothing here will finish it; settled splits three ways,
   because `done()` answers "is it settled", not "did it succeed".
2. **Can it say what it did?** A suspendable cannot -- see round 9 below. `*_CLOSED`
   covers both a drained suspendable and one closed before it began, so the state is
   refused as an answer and the kind alone decides.

Measured across every shape these rounds chased:

| object | carrier | state | verdict |
| --- | --- | --- | --- |
| coroutine / generator, never began | suspendable | not consulted | failed: contract violation |
| coroutine / generator, suspended partway | suspendable | not consulted | failed: contract violation |
| coroutine / generator, ran to completion | suspendable | not consulted | failed: contract violation (was `allowed` before round 9) |
| async generator | suspendable | not consulted | failed: contract violation |
| bare awaitable | suspendable | not consulted | failed: contract violation |
| `asyncio.Future`, unsettled | future | `done()` False | failed |
| `asyncio.Future`, cancelled | future | settled | failed: never completed |
| `asyncio.Future`, holds an exception | future | settled | failed: ran and raised |
| `asyncio.Future`, holds a value | future | settled | allowed |
| `concurrent.futures.Future`, all four | future | as above | same four verdicts |
| plain value | none | n/a | allowed |

**One protocol question, two carriers, answered on different grounds.** The question
is "is this finished?" A future answers it, by `done()` and then by how it settled, so
its four verdicts are kept and deliberately not flattened. A suspendable does NOT answer
it -- `*_CLOSED` conflates two histories -- so it is refused by kind, and its state is
never read. Keeping the future distinctions while collapsing the suspendable ones is the
rule: report what the object can tell you, and refuse what it cannot.

**Why this is complete, which after nine review rounds is a fair thing to ask.** Not
because cases stopped being found, but because the two carriers rest on different
arguments. Suspendables need no enumeration at all: every state reaches one verdict, so a
future Python adding a state cannot produce an unmapped case and there is no table to go
stale. The future protocol offers pending, cancelled, exception and result, and every one
is mapped. What remains true of the old argument is why an unreadable answer fails
rather than passes: for a durable record an uninterpretable state is precisely where
`done` must not be asserted -- and that default is pinned by a mutant, after a first
attempt at pinning it survived.

The three frame verdicts are three because they are three different facts. "Never
began" says the runner returned instead of running. "Suspended partway" says it ran
and stopped, and since the SDK never drives what a runner returns, that frame never
resumes -- so `done` would assert a completion nobody observed. An earlier revision of
this PR allowed suspended frames on the grounds that "the body ran", which was true
and insufficient.

(`CLOSED` also covers a suspendable closed before it ever began, indistinguishable
from a drained one because the frame is gone either way. Disclosed rather than
papered over: a runner that builds a generator, closes it unstarted and hands it back
is telling us nothing, and this reads it as finished.)

**The test that this is a fix rather than another row: it would have caught
`concurrent.futures.Future` before anyone reported it.** That type needed no
enumeration -- it answers question 1, so all four of its states are classified by the
same code path that handles `asyncio.Future`. A reviewer can check that claim against
the table above.

An async generator is answered ahead of both questions because its state does not
matter: driving one needs a running loop this worker thread does not have, so it is
undriven whatever it reports. (`inspect.getasyncgenstate` is also 3.12+ while this
module supports 3.10, so that state is not uniformly readable.) An awaitable
answering neither question is undriven by elimination. Anything answering neither and
not awaitable is an ordinary value, discarded by design.

**One implementation detail is a trap worth naming, because the obvious form of this
check silently breaks on half the CI matrix.** The uniform-looking way to ask "has
this body begun" is the frame attribute (`cr_frame` / `gi_frame` / `ag_frame`) plus an
`f_lasti` comparison. `f_lasti` is `-1` for an unstarted frame up to 3.10 and an
instruction offset (`0`) from 3.11, and CI runs both 3.10 and 3.12 -- so a `< 0` test
matches NOTHING on 3.12 and every `async def` runner would be recorded `done` again,
which is the defect this PR exists to remove. Measured, not assumed: on 3.12.13 an
unstarted coroutine, generator and async generator all report `f_lasti == 0`. The
`inspect.get*state` helpers are exact and have been present since 3.2 and 3.5, so
those are used instead, and a test pins the distinction so the trap cannot be
reintroduced by someone simplifying the table.

The async-generator arm is the one place this cannot be state-checked at all:
`inspect.getasyncgenstate` is 3.12+, so on 3.10 the state is unreadable and a
version-dependent record would be its own defect. It is therefore unconditional, on
the independent ground that driving one needs a running loop this worker thread does
not have.

**The cause remains unfixed and is filed as
[#7804](https://github.com/kirodotdev/KiroCrew/issues/7804), with its other half as
[#7814](https://github.com/kirodotdev/KiroCrew/issues/7814).** The SDK still never
observes whether work happened; it inspects what came back. The runner surface is
`cancelled`, `discarded` and `run_id`, with no progress channel -- `grep -c 'def
progress'` returns 0. The protocol fix makes the classifier right about what it can
see, which is not the same as observing the fact: a runner that returns a plain value
having done nothing is indistinguishable from one that did everything.

The tests are written as a TABLE of factory to expected verdict rather than a case per
type, because appending a branch per reported shape is the failure mode this design
replaced. Two of the rows assert properties rather than instances: that every object
needing to be driven answers at least one protocol question, and that a legitimate
value is not failed closed -- a classifier carrying only negative tests eventually
rejects something valid, and that error looks like a real failure, so it is harder to
notice than the one it replaced.

**The generator case is worth keeping in view, because it is why the protocol
framing matters.** An earlier revision allowed any returned generator, arguing the
runner's body
had already run and the generator was incidental. That argument is true for a
generator the runner stepped and false for one it merely created -- creating a
generator runs no body, so a never-started generator is the unawaited-coroutine case
wearing different clothes, which the same function correctly fails. One row, two
opposite truths, and a test pinning only the benign one.

It was never the judgement call it was argued to be, only an unmeasured one:
`inspect.getgeneratorstate` distinguishes `GEN_CREATED` from `GEN_SUSPENDED` and
`GEN_CLOSED`, so this is the pending-versus-done rule already applied to futures,
asked of a generator. Applying it removes the last hand-argued exception from the
classifier. (`GEN_CLOSED` does also cover a generator closed before it ever started,
indistinguishable from a drained one and read as ok -- a runner that builds a
generator, closes it unstarted and hands it back is telling us nothing either way.)

Async generators are deliberately NOT state-checked: driving one needs a running
loop this worker thread does not have, so a returned async generator is undriven
whatever state it is in -- and `inspect.getasyncgenstate` is 3.12+ while this module
supports 3.10, so the state is not uniformly readable the way a sync generator's is.

The three future outcomes get three distinct reasons rather than one, because a
cancelled future and a future holding an exception are different facts and a record
that flattens them tells the next reader less than it knows. `_execute`'s message
also stopped hardcoding "its body did not run to completion", which was true only
for the lazy rows and false for the two new ones.

**One ordering detail is load-bearing and invisible once correct.** `cancelled()`
must be asked before `exception()`: on a cancelled future -- both `asyncio`'s and
`concurrent.futures`' -- `exception()` RAISES `CancelledError` rather than returning
it, and `asyncio.CancelledError` is a `BaseException`, so it would pass straight
through `_execute`'s `except Exception` and escape the error handling of the very
run this function exists to describe. Verified rather than assumed, and pinned by a
mutant that neutralises the `cancelled()` guard so a cancelled future reaches
`exception()`. Retrieving the exception also marks it retrieved, which suppresses
the "never retrieved" warning `_close_quietly` already reasons about for the pending
case -- classification and quiet retirement are answering the same question here.

Worth recording that the reported form was narrower than described:
`concurrent.futures.Future` is not awaitable at all, so a thread-pool runner never
reached this check. Pinned as its own row so the boundary stays explicit.

**`_public_view` serves the two new fields.** D2's justification is a consumer
requirement, and the consumer is a future one -- stating that precisely, because
it matters: Code Review Sage *demonstrates* the requirement today, writing two
different recovery messages for exactly this distinction, but it does so in its
own `_RUNS` store and does not use the Job SDK at all. No app registers a JobSDK
runner yet. So the fields have no reader in-tree, and First Principles is right
to say so (see its CONCERNS below).

Given that, the reason to serve them rather than only store them is
consistency: a client is the only party that can act on either fact -- whether
the run may have committed side effects, and whether retrying is possible now --
so a record that carries them behind an API that withholds them is the same
record-honest/API-not split as D4. If the fields are worth persisting they are
worth serving; if they are not worth serving they are not worth persisting. They
stand or fall together, which is why they are not split.

**Three pre-existing tests were updated, and here is why.** Stating this plainly
because an author who silently edits a drift guard looks like one routing around it:

- `test_a_returned_value_is_not_persisted_anywhere` asserts the exact serialized
  field set.
- `test_error_is_the_only_runner_supplied_field` asserts `error` is the only
  runner-supplied field.

Both failed, both were working as designed -- they exist to stop the build until
somebody justifies a new field, and the second was written in P1 for precisely
this moment. Both new fields are listed as SDK-minted, because `reconcile` writes
them from closed sets this module owns and no runner or caller can reach either,
so `error` remains the only runner-supplied field and the one-line sanitize
backstop still has one input.

The third is different in kind and worth reading closely:

- `test_a_transient_terminal_write_is_retried` failed the SECOND store write and
  called it the terminal one. The second write is the `starting` -> `running`
  transition, so the test never exercised a terminal write at all -- and it passed
  only because a failed running transition was being ignored, which is the defect
  fixed below. Its premise was the bug. It now targets the write by the STATUS
  being written rather than by call index, so it tests the retry it is named for
  and cannot silently re-encode the same assumption.

"SDK-minted" is only true if nothing runner-supplied can reach those fields, and
a sentence in a test docstring cannot enforce that. So a **ratchet** was added:
`interrupted_from` and `interrupt_cause` each have exactly ONE assignment site,
from a constant. That turns the claim into a checkable invariant.

## Tests

Every test pins **fields and behaviour, never wording** -- a test on prose is a
test on wording, and the wording is the part expected to change.

- `TestCoroutineRunnerIsRefusedAtRegistration` -- a coroutine function is
  refused; a **callable object with an `async def __call__`** is refused, with the
  premise pinned (`iscoroutinefunction(instance)` is False while
  `iscoroutinefunction(instance.__call__)` is True, which is why the check needs
  both); **generator and async-generator** runners are refused; the refused kind is
  left unregistered (verified three ways: `kinds()`, `is_cancellable`, and
  `start()` raising `UnknownJobKind`); an async `functools.partial` and an aliased
  async def are refused; ordinary callables (plain function, lambda, partial,
  `__call__` object) still register; and a sync runner driving its own loop with
  `asyncio.run` still works, since that is the path the refusal message names.
- `TestInterruptionRecordsBothAxes` -- the prior status is preserved for each of
  `queued`/`starting`/`running`; the cause distinguishes a lost process from a
  missing runner; **all six (status, cause) combinations are separately
  observable**, which is the assertion the old single-string form could not
  satisfy; a run that never started is not described as running; the message
  still names the restart for all six; both fields survive a round trip through
  disk (the point, since the writer is a process that has died); a normal run
  leaves both fields empty; and composition tolerates a status or cause this
  build does not know, so a record from a newer gateway cannot stop the pass.
- `TestAMalformedRecordIsAbsentAnUnreadableOneIsNot` -- the two directions are
  pinned separately. Absent: a non-UTF-8 record, a missing file, a bad path and a
  malformed id all answer `None`. NOT absent: a real `0o000` record (skipped as
  root, where mode bits do not bite), a patched `PermissionError`, and an `EIO`
  `OSError` all propagate, and restoring the mode restores the record -- which is
  the proof that `None` would have been a lie, since nothing about it ever changed.
  A damaged record still does not stop reconciliation, which is why the scan below
  keeps its own broader guard while this lookup narrows.
- `test_the_interruption_fields_reach_the_client` (routes) -- the two fields are
  served over HTTP while `origin`/`pid` stay withheld.

- `TestAnUndrivenResultIsFailedNotDone` -- the safety property. A sync wrapper
  returning a coroutine reports `failed` and its body provably never ran (with the
  premise pinned: `_lazy_call_shape(wrapper)` is `""`, so no registration check
  could have caught it); a returned async generator reports `failed`; a returned
  Future reports `failed`, which is why the predicate is `isawaitable` and not
  `iscoroutine`; an ordinary runner returning data is still `done`; a returned
  plain generator is still `done`, pinning the documented boundary; the undriven
  result is closed; and a source ratchet counts the write calls in `_execute` so
  the new branch cannot become a second write site.

**Mutation-verified.** Each fix was broken with a syntactically valid mutation
applied one at a time, and re-verified after the rebase onto current main:

| Mutation | Result |
| --- | --- |
| undriven result reports done instead of failed (the whole point) | KILLED |
| the undriven result is not closed (warns from the collector later) | KILLED |
| drop the __call__ leg -- reproduces the hole GPT found | KILLED |
| drop the generator legs, keep only the coroutine one | KILLED |
| predicate looks right but tests the wrong protocol | KILLED |
| guard placed AFTER the table write (kind stays registered) | KILLED |
| prior status not preserved (the old implicit assumption) | KILLED |
| cause collapsed to one value | KILLED |
| message claims a never-started run was running | KILLED |
| a second composition site is introduced | KILLED |
| the swallow re-introduced -- read() eats PermissionError again | KILLED |
| the swallow re-introduced -- killed by my own tests too, not just main's | KILLED |
| ValueError dropped, so a non-UTF-8 record crashes instead of reading absent | KILLED |
| the running transition's return is discarded again (the reported defect) | KILLED |
| futures lose their cancel path, so a pending future is never retired | KILLED |
| own-origin check dropped -- reproduces the reported defect exactly | KILLED |
| the proxy outranks the fact -- known tested before own-origin | KILLED |
| the new cause swallows the restart case for foreign origins | KILLED |
| the future PROTOCOL narrowed back to awaitables (the round-6 defect) | KILLED |
| unsettled futures pass as done | KILLED |
| the cancelled leg dropped, so exception() is reached on a cancelled future | KILLED |
| settled-badly futures pass as done | KILLED |
| the unsettled reason drops the overlap disclosure | KILLED |
| the write-lost message claims a restart after all | KILLED |
| the consequence axis collapses -- starting told its outcome is unknown | KILLED |
| inverted -- a running record told its body never ran | KILLED |
| RUNNING wrongly added to the never-ran set | KILLED |
| the suspendable carrier dropped entirely | KILLED |
| the generator kind removed -- round 9's defect exactly | KILLED |
| the coroutine kind removed | KILLED |
| the async generator kind removed | KILLED |
| the verdict claims the body never ran -- Raymond's wording constraint | KILLED |
| the by-elimination awaitable leg dropped | KILLED |
| state smuggled back in -- CLOSED allowed again | KILLED |
| the awaitable leg widened, so an ordinary value is failed closed | KILLED |
| the reconcile call site drops the terminal guard | KILLED |
| the re-read inside _persist is neutered | KILLED |
| the terminal test inverted, so finished runs are the ones overwritten | KILLED |
| the re-read reads a different run, so the guard never matches | KILLED |

39 mutants, each confirmed to still parse (a mutation that does not compile
proves nothing), source restored to a matching sha256 after every run. Three rows
carry the most weight: the first, because reporting `done` for a run that did
nothing is the defect this whole PR is about; the `OSError` swallow, because that
widening was in an earlier revision of this PR and is now pinned against by both
this PR's tests and main's; and the discarded `_persist` return, because that
mutant restores the exact defect review found here.

One mutant SURVIVED on the first run of this round -- removing the `cancel` path
from `_close_quietly` broke nothing, because the behaviour was asserted only in a
docstring that was itself wrong about it. That is the harness earning its place: a
fix nothing can detect the absence of is not pinned. It is now covered from both
sides, `cancel` for a pending future and `close` for a coroutine.

## The class, enumerated

The reviewer found one more instance of the same class on each of three rounds. That
is a fact about the class, not about the rounds, so the answer is an enumeration
rather than another patch. Every assignment to a lifecycle-assertion field
(`status`, `interrupted_from`, `interrupt_cause`, `error`, `finished_at`, `origin`)
in `job_sdk.py`: **18 sites across 4 functions.**

| site | writes | what it observes |
| --- | --- | --- |
| `_persist` | `error` | sanitizes a value already present; asserts nothing |
| `start` (3) | `status`, `error`, `finished_at` | the thread-start call raised |
| `_execute` | `status = RUNNING` | now a precondition, and the write is checked |
| `_execute` (2) | `status`, `error` | `_persist` returned False |
| `_execute` (2) | `status`, `error` | the result table's verdict for what was returned |
| `_execute` | `status = DONE` | the runner returned without raising |
| `_execute` (2) | `status`, `error` | the runner raised |
| `_execute` | `finished_at` | the clock |
| `reconcile` | `interrupted_from` | the record's own prior status |
| `reconcile` | `interrupt_cause` | own origin first, then the registration proxy |
| `reconcile` | `status = INTERRUPTED` | no live worker for a non-terminal record |
| `reconcile` (2) | `finished_at`, `error` | derived from the two axes at one site |

Seventeen of the eighteen now record what they observed.

**The eighteenth is a disclosed gap, deliberately left, and here is why.**
`status = CANCELLED if handle.cancelled.is_set() else DONE` infers that the work
stopped early from the fact that a cancel was REQUESTED. Cancellation is
cooperative and polling is optional, so a runner that never reads the flag finishes
all of its work and is still recorded `cancelled`. Verified end to end against the
real SDK: a runner that ignores the flag completed, and the record read `cancelled`.

It is left because closing it is a semantics change to shipped behaviour, not a
tightening of this PR's own code:

- The line is **P1's, not this PR's** -- it is on `main` today, and this PR's diff
  only re-indents it while wrapping it in the new precondition branch.
- **Four pre-existing tests pin the current meaning**, three of them at the route
  level, so the HTTP surface's definition of `cancelled` is part of the contract.
  One of them states in its own comment that its runner does not poll the flag, and
  still asserts the run ends `cancelled`.
- So P1 defines `cancelled` as "a cancel was requested and the run then ended",
  which the code implements faithfully. Redefining it as "the work was truncated"
  changes an API meaning and would need its own change with its own review.

Making that judgement inside a PR whose subject is exactly this class, without
saying so, is the failure mode this section exists to prevent. Named here so the
next reader inherits the finding rather than rediscovering it.

## Manual verification

N/A -- unit coverage sufficient. All three fixes are backend-only and every
observable was exercised in-process against the real modules, including the two
behaviours that needed execution rather than reading: that a coroutine runner's
body never runs, and that a record whose bytes cannot be decoded reads as absent
while an environmental fault still escapes.

## Round 9: a returned suspendable is a contract violation, and this REVERSES an
earlier decision in this same change set

Earlier rounds read a returned suspendable's frame state and ALLOWED `CLOSED`, on the
reasoning that a closed frame ran to completion. A test pinned that as correct. Both are
now inverted, deliberately, and a reviewer who read those rounds should see the reversal
stated here rather than infer it from a flipped assertion.

The reason is this change set's own thesis turned on itself. `CLOSED` covers a
suspendable drained to completion AND one closed before it ever began. Allowing the
state recorded `DONE` for the second case -- a completion nobody observed, which is the
exact class of claim the PR exists to remove. The distinction was then measured rather
than assumed: no public attribute, `dir()` entry, code object, `gi_frame`, `gi_running`
or `gi_yieldfrom` separates a drained generator from one closed unstarted.

**Rejected alternative, and this is the reason the tightening is a judgement rather than
a shrug.** The distinction IS observable. `gc.get_referents` returns `('str', 'str')` for
a drained generator and `('code', 'function', 'str', 'str')` for one closed unstarted --
stable across five trials, both creation orders, an explicit `gc.collect()`, and with or
without a closure cell, with same-history controls matching each other. It is refused
anyway: it is an undocumented interpreter internal, generators were restructured in 3.11
with lazily-created frames, and CI runs 3.10 AND 3.12. A classifier that is right on one
interpreter and wrong on another writes false records with confidence, which is worse
than declining to classify. That is the same trap as the `f_lasti` test rejected in an
earlier round, and it was found by looking for it rather than by review.

So the inference is replaced by a rule: any returned suspendable is a runner-contract
violation and records FAILED, whatever its state. **The reason string does not say the
body never ran**, because for a drained generator it did -- that wording would swap a
false success for a false explanation, which is the same defect one layer down and the
reason an earlier round's proposed remedy was refused.

What this costs, stated rather than buried: a runner that drains a generator and returns
it did real work and is now recorded FAILED. Three things bound that cost, all measured
rather than argued. No runner is registered anywhere in `src/` -- every `.register(` call
is `atexit`, `selectors`, or an MCP/workflow registry -- and no app declares the `jobs`
permission, so there is no installed base to break. The reach is narrower than it
sounds: `itertools.chain`, `map`, `filter`, `zip`, `enumerate`, `reversed`, list/set/dict
views, `range` and file objects are not suspendables, so returning any of them is
untouched, and generator FUNCTIONS were already refused at registration. And a false
FAILED does not re-run work: there is no retry-on-failure in this module -- the only
"attempts" are `_write_terminal`'s two write attempts -- so the cost lands as a visible
record for an owner to judge, not as duplicated execution.

The tightening also removes code. The per-kind state tables and their three verdict
constants are gone, and the async-generator special case dissolves with them: it existed
only because `inspect.getasyncgenstate` is 3.12+ while this module supports 3.10, and no
state is read any more. Completeness is now a stronger claim than a state map -- the
verdict cannot vary by state, so a future Python adding a fourth state cannot produce an
unmapped case.

## Round 10: reconciliation could destroy a true terminal record

This is the most serious defect in the change set, and it is different in kind from
the others. Every earlier finding was about a record asserting something nobody
verified. This one **deleted a fact that was already on disk and wrote a false one over
it.**

`reconcile` skips terminal records -- but it tests `is_terminal` against a SNAPSHOT that
`iter_runs` decoded from disk, and it writes later. A worker that finishes in the gap
has already written its terminal record and left `_live`, and the `live` check cannot
close the window because a worker leaves `_live` only AFTER its terminal write lands. So
the pass wrote `interrupted` over a true `done`. The cause it recorded was
`terminal_write_lost`: it claimed the terminal write had been lost when the write had in
fact succeeded and this pass had destroyed it.

Reproduced by driving the real interleaving, not by reasoning:

```
before      : running | live: True
snapshot    : running (this is what reconcile decided from)
on disk now : done | live: False
reconcile   : flipped = 1
AFTER       : interrupted | cause: terminal_write_lost
```

**The fix enforces a rule this module already states rather than adding one.**
`TERMINAL_STATES` are documented as never revisited, so a pass that overwrites a terminal
record is not merely producing a wrong value -- it is violating the module's own stated
invariant. The write now goes through `_persist(only_if_not_terminal=True)`, which
**re-reads inside the same lock acquisition it writes with**. The placement is the fix:
`self._lock` is not reentrant, so `_persist` is the only place the re-read and the write
are one atomic step. A second check next to the decision would have narrowed the window
and left it open, and the worker's own terminal write goes through that same lock, so a
record that reads terminal there is finished. Cost is one file read per non-terminal
record on the boot pass, inside a lock already held across a file write.

The regression test asserts **full-record equality with what the worker wrote** -- not
that `reconcile` returned early. "Returned early" is a proxy for "did not corrupt", and
substituting a proxy for the fact is the defect this PR exists to remove, so the test
must not commit it either. The ordering is driven rather than mocked: every step of
`reconcile` runs for real and only the worker's completion is scheduled, using the
generator's own yield as the suspension point. Mutation-verified -- with the guard
removed the test fails on the record diff (`interrupted_from: 'running'` against `''`),
which is the record content, not a return value.

## Whole-module prose audit

Because seven of the defects in this change set were prose a code change invalidated,
every claim the module makes was re-checked against the code as it now stands rather
than only the sentences a reviewer happened to flag.

Inventory, extracted mechanically from the AST rather than by eye: **472 behaviour
claims** -- 190 sentences across 30 docstrings, plus 282 comment lines that assert what
happens rather than restate a line. 209 carry an absolute ("only", "never", "cannot",
"every") or name another callable, which is where prose goes stale.

13 of those are decidable by grep rather than by argument, and all 13 hold now:
`_persist` is the only record writer (1 call site); `_interrupt_error` is the only
message-composition site (3 `_INTERRUPT_MESSAGE` references: def, lookup, fallback);
`_execute` has exactly one `_persist` and one `_write_terminal`; `interrupted_from` and
`interrupt_cause` each have one assignment site; `cancelled()` precedes `exception()`;
`getasyncgenstate` is referenced only in prose, never called; no `f_lasti` comparison
exists; every `CAUSE_*` has a template; `_PROGRESS_PHRASE` covers all three
pre-terminal statuses; `_WRITE_LOST_BODY_NEVER_RAN` is exactly the pre-execution set;
the runner is called with the handle alone; and `grep 'def progress'` returns 0.

**Two claims were still false, and both were falsified by THIS PR rather than
pre-existing.** `_lazy_call_shape`'s docstring and the `register` docstring both said a
lazy-returning runner's run "is recorded `done`" in the present tense -- true of the
defect, false since the execution-side check records `failed`. Both now state it as the
prior behaviour and name `_undriven_result` as what makes the record honest, which also
corrects the standing of the registration guard: it is the friendly early error, not
the safety property. Neither had been reported by any reviewer.

That was the audit's result at the time. **It did not hold, and the way it failed is
the more useful finding.**

The audit ran before round 9. Round 9's by-kind rule then created a FRESH stale claim in
`_execute`'s docstring -- prose still saying a returned generator is classified by
whether its body has begun, which the ruling had just made false -- and a reviewer found
it, not the audit. So the audit was not a one-time repair. It is a step that any
behavioural change re-opens, and the honest statement is not "we cleaned up the drift"
but **nothing checks prose, so drift returns with every change**. The mechanically
checkable claims survived because a script checks them; every claim that rotted was one
only a reader could have caught.

That is also why the count matters less than the mechanism. Of the claims found false
across the whole change set, none were pre-existing defects in main -- every one was
prose that a change in THIS PR invalidated, including two created by the PR's own later
rounds. A prose claim has no test, so the only thing standing between it and a false
statement about behaviour is whoever happens to read it next.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a durable record asserts a lifecycle fact its writer never observed.

**The sharper finding, arrived at after seven instances: every single one was prose
that a code change invalidated, and nothing checks prose.** Seven claim-versus-code
defects surfaced across this change set -- a comment arguing the exception tuple
"collapses rather than widening" when it widened; a docstring saying futures expose a
synchronous `close` when neither flavour has one; a claim that `backend.entryPoint`
leaves an app with no registration path when the context builder gates only on the
`jobs` permission; a note calling the returned-generator case ambiguous when
`getgeneratorstate` decides it; a sentence saying `interrupted_from` measures progress
"before its process died", falsified by the same-process write loss this PR added a
cause for; plus the two lifecycle records the PR opened with. **One of the seven was
created by this PR's own round-5 fix**, which is the part that matters: the mechanism
is ongoing, not historical. Code has tests; prose has nothing, so a fix silently
turns its own neighbouring comment into a lie.

That reframes the whole change set. It began as "three places the SDK asserted a fact
it never verified" and the real subject is larger: **an assertion is an assertion
whether it lives in a record or in a comment, and only one of the two has a gate.**
A repo that wants this class closed needs the prose adjacent to a change treated as
part of the change's blast radius -- the practical form being that editing a
conditional means re-reading the comment above it, because that comment was written
to describe the branch you just replaced.

All three defects are one failure mode, which is what makes them one PR. In each
case the writer substituted a proxy for the fact it recorded, and every proxy
failed silently in the direction of false confidence:

- `done` came from "the runner returned without raising", not from "the runner
  ran". Calling a coroutine function returns without raising and executes nothing.
- "the gateway restarted while this was running" came from "a runner is
  registered for this kind", not from the run's own prior status -- which the same
  line had just overwritten.
- A 500 came from "an exception escaped", not from the fact actually observed,
  which was "this record cannot be read" -- that is, a 404.

Stated so a reviewer can apply it to unrelated code: **when a writer records a
terminal or lifecycle outcome, ask what it observed. If the answer is "no
exception was raised" or "some adjacent state was true", it is asserting rather
than reporting.** The tell is a proxy standing in for the fact, and the cost is
always a record that looks normal while being wrong.

One slice of this is mechanically checkable and worth a lint or semgrep rule:
**a callback type whose return is `Any` cannot reject a coroutine function.**
`JobFn = Callable[["JobHandle"], Any]` looks like it constrains the runner and
does not. Verified rather than assumed -- mypy over an `async def` both assigned
to `JobFn` and passed to `register()` reports no issues, because `Coroutine` is
assignable to `Any`. So a registry that will never await its callback cannot rely
on the annotation. That travels to every `Callable[..., Any]` registration point
whose call site discards the return.

**The rule caught this PR's own first fix, which is the strongest thing about
it.** D1 originally shipped as a registration-time inspection of the callable's
shape -- and a registration-time shape check is exactly an adjacent-state proxy,
the thing the rule names. It failed the way the rule predicts, twice: a reviewer
found that an `async def __call__` instance bypasses it, and then measuring the
guard against a matrix of forms surfaced a second bypass nobody had named -- a
plain `def run(h): return _do_it(h)` over an `async def`, which defeats every
possible shape predicate. Applying the rule to the fix produced a different
design: observe the fact instead. "Did the runner do the work" is available at
exactly one place, what the call handed back, and checking there makes the class
unreachable rather than the enumerated spellings refused. The shape guard was
kept, demoted to what it is honestly good for -- telling the app author at
`register()` rather than in a run record later.

That is the generalizable shape of the remedy, not just of the defect: **when a
check inspects a proxy, ask where the fact itself is observable, and move the
check there.** The proxy check can stay as a fast error; it must not be the
safety property.

What does not generalize, said plainly: D4's specific shape is too local to lint,
since narrowing an exception tuple is usually deliberate. What does travel is the
sibling form: two readers of the same resource disagreeing about what damage
means. Here `read` and the `iter_runs` scan twelve lines below now disagree ON
PURPOSE, and the reason is the generalizable part -- a scan that skips one file
still returns the others, so a partial result is honest, while a targeted lookup's
`None` asserts absence, and absence is not something an unreadable file
establishes.

**The rule has now caught this PR's own fixes three times, which is the strongest
evidence for it.** Beyond D1's shape-versus-fact story above, review found two
more instances in this change set itself:

- D4's first form widened `read` to catch `OSError`, which made `get` answer 404
  for a transient Windows sharing violation -- `read` asserting an absence it had
  not observed, about a record that was present and intact. Main's #7703 test
  independently requires that error to propagate.
- `_execute` set `status = RUNNING`, called `_persist`, and **discarded the
  return**, then ran the body on the assumption the write had succeeded. A lost
  write left the record at `starting` while the runner committed real work, and
  `reconcile` later read that record and stated the run had never begun. The
  proxy here is subtler than a lifecycle field: it is *assumed success of an
  operation whose result was available and ignored*.

That last one sharpens the rule into a second checkable form: **a write whose
return value reports failure must be checked before anything acts on its assumed
success.** Mechanically greppable at any call site that discards a boolean-returning
persist. The remedy also follows the rule's own logic -- make the transition a
precondition for running the body, so no surviving record can claim a run did not
begin while its side effects exist. The correction that was NOT taken is worth
recording too: mapping stale `starting` to `running` would have made one lie
universal to hide another, which is why the field exists in the first place.

**And then the rule caught the fix to the fix, which is the part worth generalizing.**
Exempting `done()` futures from the undriven check was itself an unverified
assertion: `done()` means settled, not successful, so a future holding an exception
and a cancelled future were both recorded `DONE`. Two consecutive review rounds each
found a defect inside the previous round's fix, in the same function, and the reason
is structural rather than careless -- `_undriven_result` is the single place where
"did the work happen" is decided, and every appended branch is another chance to
answer it wrongly for a shape nobody enumerated.

The remedy generalizes better than any of the individual fixes: **stop discovering
the input shapes by being told about them, and enumerate the contract instead.** The
function now carries a table of every result shape with its verdict, and one test per
row, so a shape nobody considered is a visibly missing row rather than a silent
`done` in a durable record. The tell that a function needs this treatment is a
sequence of appended `if` branches, each added in response to a specific reported
input -- patch-per-report is a growth pattern, and it converges on the enumerated set
only by accident.

**Applied once more to the whole file, which is how the enumeration above exists.**
After the third round found a third instance of the same class, the response was to
count the class rather than fix the report: 18 lifecycle-assertion write sites, each
classified by what it observes. That enumeration is what found the `cancelled` gap --
no reviewer reported it, and it is now disclosed rather than waiting to be found in a
fourth round. The rule generalizes past a single function: **when a reviewer finds one
more instance of a class every round, enumerate the class and the rounds stop.**

**And the sharpest version, because the corrected enumeration still missed a state.**
Moving from types to protocols was the right level, and the protocol table STILL had
only two suspendable outcomes -- unstarted and everything else -- so a suspended frame
was recorded as completed work. The abstraction was right; its content was borrowed
from how the problem had been discussed rather than from Python's own definition of
the states. The language defines three, the conversation had two, and the code
inherited the conversation. **So: enumerate from the AUTHORITY, not from your own
framing of it.** The check is mechanical -- name the source that defines the set
(a language reference, a protocol spec, a schema) and count its members against your
rows. If you cannot name that source, you are enumerating your own understanding, and
it will be missing whatever you had not thought to say out loud.

The step before that one still holds and is worth keeping: **enumerate at the right
LEVEL, or the enumeration is just a longer list of instances.** Writing down the
result shapes did
not stop the rounds, because the enumeration was of TYPES. Types are open-ended --
each round added a row and the next round found the type that row had missed. The
protocol questions close the space because the language defines them: three
suspendable kinds with a `*_CREATED` state, one future protocol, and `__await__` must
wrap one of those. **The tell that an enumeration is at the wrong level is that it
grows on contact with reality**: if reviewers keep adding rows, the rows are instances
and there is a question underneath them that would cover the lot. The check is
whether a candidate abstraction would have caught the last thing reported without
being told about it -- here it would have, since `concurrent.futures.Future` needs no
row.

A related caution, learned the hard way in this PR's own tooling. The mutation
harness anchors on source text, so every one of these rewrites silently invalidated
anchors: four went stale in one round (matching 0 times, therefore proving nothing
while still reporting), then one more, then ten at once in the protocol rewrite; one
mutant was inert because it moved a `getattr` rather than the call it was supposed to
reorder; a rewritten ratchet failed for the wrong reason because it pinned an
expression's TEXT instead of the invariant; and a test asserting the word "await"
appeared in an error message broke when the message was reworded to name the protocol
instead of the type. **A test that pins a literal string stops testing the moment the
string moves**, and it fails in the direction that looks like a real defect, which
costs a round to diagnose.

**And one more refinement of the enumeration rule, from the round that followed it.**
Enumerating the result shapes did not by itself catch the generator problem, because
the enumeration inherited a row that was too coarse -- "generator object, ok" reads
like a decided case, so writing the table down did not expose that two opposite
truths were hiding inside it. **An enumeration is only as good as the granularity of
its rows**, and the tell for a row that needs splitting is a justification that
argues about the input's HISTORY rather than its type: "the runner already did its
work" is a claim about what happened before the value was returned, and if that claim
can be true or false for the same type, it is two rows. The check that settles it is
whether the distinction is observable -- here `inspect.getgeneratorstate` made it
observable, so what had been defended as a deliberate boundary was only an unmeasured
one.

A documentation instance of the same class is fixed in this push too: the module
docstring claimed an app declaring `backend.entryPoint` "has no registration path",
while `context.py` gates `ctx.job` on `permissions.jobs` alone and the gateway hooks
publish it regardless. The scope is per RUNNER, not per app -- such an app does get an
SDK, and what it cannot do is register a runner from its own process. A false claim
about the SDK's own scoping, in the module whose subject is writers asserting what
they never observed.

A second pattern, about process rather than code. Two pre-existing drift guards
(`test_a_returned_value_is_not_persisted_anywhere` and
`test_error_is_the_only_runner_supplied_field`) failed on this change and both
were right to: they exist to stop the build until somebody justifies a new field
on the record, and the second was written in P1 for exactly this moment. That is
a guard doing its job, and worth naming as a pattern to copy. The follow-on
lesson is that satisfying such a guard with prose is not enough -- "SDK-minted"
is only true if nothing runner-supplied can reach the field, and a sentence in a
test docstring cannot enforce that. The ratchet added here (each new field has
exactly ONE assignment site, from a constant) is what converts the claim into
something checkable. That guard-plus-ratchet pairing generalizes to any
invariant currently asserted only in a docstring.

A third, and the sharpest of the process patterns: **a test can encode the very
defect it appears to guard against.** `test_a_transient_terminal_write_is_retried`
failed the second store write and named it the terminal one. It was the
`starting` -> `running` transition, so the test never exercised a terminal write,
and it passed only because that transition's failure was being ignored. Green, and
evidence of nothing. The tell is a test that identifies its target POSITIONALLY
(call index, ordinal) rather than by a property of the thing itself -- when the
sequence changes, the assertion silently moves to a different subject. It now
selects the write by the status being written.

## Notes

The `cancelling` work that landed with #6682 (`cancelling_ids`, and
`_public_view`'s required `cancelling` argument) is main's, not this PR's; the
rebase kept it intact and this PR only adds two keys to the same dict.

Related follow-ups from the same audit, none of which this PR claims to fix:
#7588 (no retention, and status-only liveness makes eviction unsafe), #7590 (P2
payload channels, with measured requirements from two consumers), #7591 (what
migrating Code Review Sage would require), plus #7582 and #7583. #7589 asked for
exactly the `cancelling` mechanism that shipped in #6682.

The AWS Control backup consumer PR depends on this one but is **not blocked by
it**: that branch carries its own `test_the_runner_is_not_a_coroutine_function`,
so it does not rely on D1 landing first.

Refs #6682
