### PR TITLE
fix(test): poll job store off the event loop in test_job_routes

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -32,6 +32,21 @@ async def test_read_message(self, tmp_path):
     ...
 ```
 
+Never poll a synchronous store read from an async test. A plain `sdk.get(...)` /
+`store.read(...)` inside an `async def` test runs ON the event loop, where
+`read_bytes_with_retry` deliberately re-raises the Windows sharing-violation
+`PermissionError` instead of sleeping the loop for its retry budget — so a poll
+that races a concurrent `atomic_write` `os.replace` is a Windows-only flake that
+POSIX shards can never reproduce (#7703). Offload every such read the way the
+production routes do (`job_routes.py`):
+
+```python
+# WRONG: reads on the loop; retry budget is one attempt, and time.sleep stalls the loop
+run = sdk.get(run_id); time.sleep(0.02)
+# RIGHT: the retry applies off-loop, and the loop keeps running
+run = await asyncio.to_thread(sdk.get, run_id); await asyncio.sleep(0.02)
+```
+
 ### Mocking kiro-cli
 Never spawn real `kiro-cli` in tests. Mock the subprocess:
 ```python

--- a/test/test_job_routes.py
+++ b/test/test_job_routes.py
@@ -18,6 +18,7 @@ at ``job_routes`` module scope, so it is patched there.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 import time
 from pathlib import Path
@@ -121,26 +122,38 @@ def _base(app: str = APP) -> str:
     return f"/api/apps/{app}/_jobs"
 
 
-def _wait_terminal(sdk: JobSDK, run_id: str, deadline: float = _DEADLINE) -> js.JobRun:
-    """Poll until the run reaches a terminal state or the deadline passes."""
+async def _wait_terminal(sdk: JobSDK, run_id: str, deadline: float = _DEADLINE) -> js.JobRun:
+    """Poll until the run reaches a terminal state or the deadline passes.
+
+    ``async``, with every ``sdk.get`` offloaded via ``asyncio.to_thread`` — the
+    same shape ``job_routes.py`` uses for every store read.  Every caller is an
+    async test, so a plain ``sdk.get`` here would run ON the event loop, where
+    ``read_bytes_with_retry`` deliberately re-raises ``PermissionError`` instead
+    of sleeping the loop for its retry budget.  When the job worker's concurrent
+    ``os.replace`` is in flight, that surfaces the Windows sharing violation as
+    a flaky test failure (#7703).  Off the loop the retry applies, exactly as it
+    does for the production routes.
+    """
     end = time.monotonic() + deadline
     while time.monotonic() < end:
-        run = sdk.get(run_id)
+        run = await asyncio.to_thread(sdk.get, run_id)
         if run is not None and run.is_terminal:
             return run
-        time.sleep(0.02)
-    run = sdk.get(run_id)
+        await asyncio.sleep(0.02)
+    run = await asyncio.to_thread(sdk.get, run_id)
     raise AssertionError(f"run {run_id} did not reach a terminal state: {run and run.status}")
 
 
-def _wait_status(sdk: JobSDK, run_id: str, status: str, deadline: float = _DEADLINE) -> js.JobRun:
+async def _wait_status(
+    sdk: JobSDK, run_id: str, status: str, deadline: float = _DEADLINE
+) -> js.JobRun:
     end = time.monotonic() + deadline
     while time.monotonic() < end:
-        run = sdk.get(run_id)
+        run = await asyncio.to_thread(sdk.get, run_id)
         if run is not None and run.status == status:
             return run
-        time.sleep(0.02)
-    run = sdk.get(run_id)
+        await asyncio.sleep(0.02)
+    run = await asyncio.to_thread(sdk.get, run_id)
     raise AssertionError(f"run {run_id} never reached {status!r}: {run and run.status}")
 
 
@@ -242,7 +255,7 @@ async def test_start_registered_kind_returns_run_without_params(
         assert field in run
     assert run["kind"] == "quick"
     assert run["cancellable"] is False
-    _wait_terminal(sdk, run["run_id"])
+    await _wait_terminal(sdk, run["run_id"])
 
 
 @pytest.mark.asyncio
@@ -293,7 +306,7 @@ async def test_start_with_malformed_body_is_treated_as_empty_not_500(
         )
         assert resp.status == 200
         run = (await resp.json())["run"]
-    _wait_terminal(sdk, run["run_id"])
+    await _wait_terminal(sdk, run["run_id"])
 
 
 @pytest.mark.asyncio
@@ -341,7 +354,7 @@ async def test_active_and_recent_return_runs_array(
     _setup_guards(tmp_path, monkeypatch)
     sdk.register("k", lambda handle, **p: {"ok": True})
     rid = sdk.start("k")
-    _wait_terminal(sdk, rid)
+    await _wait_terminal(sdk, rid)
     async with TestClient(TestServer(_make_app())) as client:
         active = await client.get(f"{_base()}/active")
         recent = await client.get(f"{_base()}/recent")
@@ -407,7 +420,7 @@ async def test_get_existing_run_is_200(
     _setup_guards(tmp_path, monkeypatch)
     sdk.register("k", lambda handle, **p: {"ok": True})
     rid = sdk.start("k")
-    _wait_terminal(sdk, rid)
+    await _wait_terminal(sdk, rid)
     async with TestClient(TestServer(_make_app())) as client:
         resp = await client.get(f"{_base()}/{rid}")
         assert resp.status == 200
@@ -438,7 +451,7 @@ async def test_cancel_non_cancellable_run_is_409_with_run(
     # A terminal, non-cancellable run: cancel_async returns False.
     sdk.register("k", lambda handle, **p: {"ok": True})
     rid = sdk.start("k")
-    _wait_terminal(sdk, rid)
+    await _wait_terminal(sdk, rid)
     async with TestClient(TestServer(_make_app())) as client:
         resp = await client.post(f"{_base()}/{rid}/cancel")
         assert resp.status == 409
@@ -463,13 +476,13 @@ async def test_cancel_live_cancellable_run_is_200_cancelling(
     sdk.register("blocker", _blocking, cancellable=True)
     rid = sdk.start("blocker")
     assert started.wait(timeout=_DEADLINE), "runner never started"
-    _wait_status(sdk, rid, js.RUNNING)
+    await _wait_status(sdk, rid, js.RUNNING)
     async with TestClient(TestServer(_make_app())) as client:
         resp = await client.post(f"{_base()}/{rid}/cancel")
         assert resp.status == 200
         assert (await resp.json())["cancelling"] is True
     # The worker observes the signal and settles into CANCELLED.
-    run = _wait_terminal(sdk, rid)
+    run = await _wait_terminal(sdk, rid)
     assert run.status == js.CANCELLED
 
 
@@ -513,7 +526,7 @@ async def test_requested_cancel_is_visible_to_a_later_read_of_the_run(
     rid = sdk.start("slow")
     try:
         assert started.wait(timeout=_DEADLINE), "runner never started"
-        _wait_status(sdk, rid, js.RUNNING)
+        await _wait_status(sdk, rid, js.RUNNING)
         async with TestClient(TestServer(_make_app())) as client:
             assert (await client.post(f"{_base()}/{rid}/cancel")).status == 200
             # A brand-new read, holding nothing from the cancel call.
@@ -526,7 +539,7 @@ async def test_requested_cancel_is_visible_to_a_later_read_of_the_run(
         assert run["status"] == js.RUNNING
     finally:
         release.set()
-    assert _wait_terminal(sdk, rid).status == js.CANCELLED
+    assert (await _wait_terminal(sdk, rid)).status == js.CANCELLED
 
 
 @pytest.mark.asyncio
@@ -539,7 +552,7 @@ async def test_requested_cancel_is_visible_in_the_active_list(
     rid = sdk.start("slow")
     try:
         assert started.wait(timeout=_DEADLINE), "runner never started"
-        _wait_status(sdk, rid, js.RUNNING)
+        await _wait_status(sdk, rid, js.RUNNING)
         async with TestClient(TestServer(_make_app())) as client:
             assert (await client.post(f"{_base()}/{rid}/cancel")).status == 200
             resp = await client.get(f"{_base()}/active")
@@ -550,7 +563,7 @@ async def test_requested_cancel_is_visible_in_the_active_list(
         assert adopted[0]["cancelling"] is True
     finally:
         release.set()
-    assert _wait_terminal(sdk, rid).status == js.CANCELLED
+    assert (await _wait_terminal(sdk, rid)).status == js.CANCELLED
 
 
 @pytest.mark.asyncio
@@ -563,14 +576,14 @@ async def test_a_run_nobody_cancelled_reads_not_cancelling(
     rid = sdk.start("slow")
     try:
         assert started.wait(timeout=_DEADLINE), "runner never started"
-        _wait_status(sdk, rid, js.RUNNING)
+        await _wait_status(sdk, rid, js.RUNNING)
         async with TestClient(TestServer(_make_app())) as client:
             run = (await (await client.get(f"{_base()}/{rid}")).json())["run"]
         assert run["cancelling"] is False
         assert run["status"] == js.RUNNING
     finally:
         release.set()
-    _wait_terminal(sdk, rid)
+    await _wait_terminal(sdk, rid)
 
 
 @pytest.mark.asyncio
@@ -589,11 +602,11 @@ async def test_a_recorded_cancel_is_no_longer_cancelling(
     rid = sdk.start("slow")
     try:
         assert started.wait(timeout=_DEADLINE), "runner never started"
-        _wait_status(sdk, rid, js.RUNNING)
+        await _wait_status(sdk, rid, js.RUNNING)
         async with TestClient(TestServer(_make_app())) as client:
             assert (await client.post(f"{_base()}/{rid}/cancel")).status == 200
             release.set()
-            assert _wait_terminal(sdk, rid).status == js.CANCELLED
+            assert (await _wait_terminal(sdk, rid)).status == js.CANCELLED
             run = (await (await client.get(f"{_base()}/{rid}")).json())["run"]
         assert run["status"] == js.CANCELLED
         assert run["cancelling"] is False
@@ -697,3 +710,73 @@ async def test_sdk_refusal_becomes_a_coded_503_not_a_bare_500(
             assert (await resp.json())["code"] == "job_start_failed"
     finally:
         forget_sdk(APP)
+
+
+# ---------------------------------------------------------------------------
+# The off-loop-read invariant behind the polling helpers (#7703)
+# ---------------------------------------------------------------------------
+
+
+def test_wait_helpers_are_coroutine_functions() -> None:
+    """A revert to synchronous helpers must fail loudly, not flake on Windows.
+
+    The helpers poll ``sdk.get``; every caller is an async test.  Synchronous,
+    they read ON the event loop, where ``read_bytes_with_retry`` deliberately
+    re-raises the Windows sharing-violation ``PermissionError`` instead of
+    sleeping the loop for its retry budget — a flake nobody can reproduce on
+    a POSIX box (#7703).  ``async`` + ``asyncio.to_thread`` is the contract.
+    """
+    assert inspect.iscoroutinefunction(_wait_terminal)
+    assert inspect.iscoroutinefunction(_wait_status)
+
+
+@pytest.mark.asyncio
+async def test_on_loop_read_propagates_permission_error_offloaded_read_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """Prove the #7703 defect directly, without a Windows shard.
+
+    With Windows semantics shimmed (``platform_compat.IS_WINDOWS`` true) and the
+    record's first ``Path.read_bytes`` raising ``PermissionError`` — the sharing
+    violation a concurrent ``os.replace`` produces — a synchronous ``sdk.get``
+    from the event loop propagates the error (``read_bytes_with_retry`` gives up
+    its retry budget on the loop, by design), while the offloaded polls the
+    helpers now use retry off-loop and succeed.  Shimmed on the module attribute
+    only — never ``os.name``, which breaks ``Path.home()`` on POSIX.
+    """
+    from kiro_crew import platform_compat
+
+    sdk.register("k", lambda handle, **p: {"ok": True})
+    rid = sdk.start("k")
+    # Settle the run first so no real writer races the injected failure.
+    await _wait_terminal(sdk, rid)
+
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    real_read_bytes = Path.read_bytes
+    inject = {"armed": False}
+
+    def flaky_read_bytes(self: Path) -> bytes:
+        if inject["armed"] and self.name == f"{rid}.json":
+            inject["armed"] = False
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", flaky_read_bytes)
+
+    # The OLD shape: a sync read on the event loop — one attempt, error escapes.
+    inject["armed"] = True
+    with pytest.raises(PermissionError):
+        sdk.get(rid)
+    inject["armed"] = False
+
+    # The NEW shape: both helpers poll off-loop, so the retry budget applies
+    # and the poll survives the same injected sharing violation.
+    inject["armed"] = True
+    run = await _wait_terminal(sdk, rid)
+    assert run.run_id == rid
+    assert not inject["armed"], "_wait_terminal never hit the injected error"
+
+    inject["armed"] = True
+    run = await _wait_status(sdk, rid, js.DONE)
+    assert run.status == js.DONE
+    assert not inject["armed"], "_wait_status never hit the injected error"


### PR DESCRIPTION
## Symptom

`Backend Tests (Windows)` shard 2 intermittently fails
`test/test_job_routes.py::test_get_existing_run_is_200` with
`PermissionError: [Errno 13] Permission denied` on the run's record JSON under the pytest tmp
(`app-data/jobs/<hex>.json`). Non-deterministic: the same shard over the same backend code passed on
#7686 and failed on #7696 minutes apart, with no Python in either diff. Linux shards never see it.

## Root cause

The test file's polling helpers `_wait_terminal` / `_wait_status` were plain `def` helpers calling
`sdk.get(run_id)` + `time.sleep(0.02)`. Every caller is an `@pytest.mark.asyncio` coroutine, so the
poll read the job record **on the event loop**. On that path `read_bytes_with_retry`
(`src/kiro_crew/atomic_write.py`) deliberately re-raises `PermissionError` instead of sleeping the
one loop for its retry budget (`on_event_loop()` gate) — so the retry budget is effectively one
attempt. When the job worker's concurrent `os.replace` (the last step of `atomic_write`) happened to
be in flight, the Windows sharing violation surfaced as an uncaught `PermissionError` out of
`sdk.get` and reddened the test. `JobStore.read` catches only
`(FileNotFoundError, NotADirectoryError, ValueError)`, which is why the traceback names the final
`.json`, not a `.tmp`.

Production never sees this because every route offloads the read
(`await asyncio.to_thread(sdk.get, …)` at `job_routes.py:256, 287, 295, 311`) — and `JobStore.read`'s
docstring states that off-loop invariant explicitly. The test file was the only caller breaking it.

POSIX permits reading a file mid-replace, which is the entire "Windows only" observation — there is
no Windows-specific logic branch involved.

**The earlier triage hypothesis on #7703 ("a background JobSDK worker still holds an open handle
while the test/teardown replaces or unlinks it") is superseded**: the failure is on the READER side,
not the unlink, and the writer's replace is already retried (`replace_with_retry` runs on the worker
thread with its full budget). **#7296 is not a duplicate** (the issue-summary bot suggested the
link): that one is annotation-only, has no test identity, and an empty failed-log archive.

## Fix (test-only, by design)

Following the in-tree precedent the routes already set (`job_routes.py`'s `asyncio.to_thread`
offload):

- Convert `_wait_terminal` / `_wait_status` to `async def`, polling via
  `await asyncio.to_thread(sdk.get, run_id)` and `await asyncio.sleep(0.02)` (the `await` also stops
  the poll from monopolising the loop thread, which `time.sleep` did). Deadline semantics and the
  `AssertionError` message shapes are unchanged.
- `await` them at **all 15 call sites** — the 7 that existed when the branch was cut plus the 8 added
  by #7680, which merged mid-flight and reused the helpers synchronously (caught as 3 failing tests
  on rebase; a textual-clean, semantically-conflicting merge). The task spec counted "9 call sites"
  from a grep that included the two `def` lines; the re-verified count at branch time was 7.
- Audited the file for any other synchronous `sdk.*` read from an async test (`get`, `list_active`,
  `list_recent`, `iter_runs`): none — the only other match is a `monkeypatch.setattr(sdk,
  "list_recent", …)`, not a read. The identically-named helpers in
  `test_workflows_nudge_wiring.py` / `test_workflows_registry.py` are already async and unrelated
  (out of scope per spec).
- Recorded the convention in `docs/system-specs/common/testing-conventions.md` (§ Async tests):
  never poll a synchronous store read from an async test; offload like the routes do. The invariant
  previously lived only in `JobStore.read`'s docstring, which is what let this happen.

Deliberately **not** done, per the spec's correctness analysis: adding `PermissionError` to
`JobStore.read`'s except clause (would turn an existing record into `None` — `_wait_terminal` reads
that as "not terminal yet" and `list_active` as a vanished record, the silent-skip hazard
`iter_runs`' docstring warns about), and weakening `atomic_write.py`'s `on_event_loop()` gate (would
put a sleep on the gateway loop). Both trade a loud test failure for a silent production one.

## Verification

- **Red-before-green, without a Windows shard** —
  `test_on_loop_read_propagates_permission_error_offloaded_read_retries` proves the invariant
  directly: with `platform_compat.IS_WINDOWS` shimmed true (module attribute only — never a global
  `os.name` patch, which breaks `Path.home()` on POSIX) and the record's first `Path.read_bytes`
  raising `PermissionError`, a synchronous `sdk.get` from the loop propagates the error, while both
  converted helpers retry off-loop and succeed.
- **Shape guard** — `test_wait_helpers_are_coroutine_functions` asserts both helpers are coroutine
  functions, so a future revert to the synchronous shape fails loudly instead of reintroducing an
  unreproducible Windows-only flake.
- **Mutation checks (all three killed, both directions — green on fix, red on mutant):**
  1. `_wait_terminal`'s poll made synchronous (`await asyncio.to_thread(sdk.get, run_id)` →
     `sdk.get(run_id)`; the helper-internal read IS the offload — call sites hold no `to_thread`):
     injected-PermissionError test FAILED with the propagated `PermissionError`.
  2. Same mutation on `_wait_status`: injected-PermissionError test FAILED on its `_wait_status` leg.
  3. Both helpers fully reverted to main's synchronous bodies (guard tests kept): shape guard FAILED
     (`assert False` on `iscoroutinefunction`).
- **Affected suite in full:** `test/test_job_routes.py` = **28 passed, 0 failed** (22 pre-existing +
  4 from #7680 + 2 new) on the fix branch; **26 passed, 0 failed** on an `origin/main` worktree.
  Failing-test id sets byte-identical both directions (both empty).
- **Full backend suite both directions** (fix branch vs `origin/main` git worktree, `-n auto`):
  fix 225 failed + 2 errors, main 224 failed + 2 errors; id-set diff = exactly one test
  (`test_pod_e2e_harness_paths.py::test_health_refuses_a_foreign_port_holder_and_names_the_conflict`),
  which passes standalone on the fix branch — a load flake of its 1-second
  `POD_E2E_HEALTH_TIMEOUT` under two concurrent full suites, not a regression. Excluding it, the
  226 remaining failing ids are byte-identical both directions, all pre-existing environmental
  (AF_UNIX path length, missing host node for installer tests, platform-context composition).
- **Frontend cross-surface guards:** 197 spec files / 5358 tests, all passed (node 22).
- Lint/format/types: `black` 26.3.1 (repo gate script), `isort`, `flake8`, `mypy` — clean.

<!-- no-visual-delta -->
No frontend surface changes — backend test file + docs only; a still frame cannot show a
concurrency fix. Evidence is the injected-PermissionError invariant test above.

## Pattern harvest

Rule candidate: **an invariant that callers must uphold ("only call this off the event loop") must
be enforced or conventionalised, not just documented at the callee** — `JobStore.read` documented
the off-loop contract but nothing checked it, so the first synchronous test-side caller compiled,
passed on POSIX, and flaked only on Windows CI. This PR adds the convention to
`testing-conventions.md` and a shape guard in the test file. Knowingly out of scope (already async,
different subject): the `_wait_terminal` helpers in `test/test_workflows_nudge_wiring.py` and
`test/test_workflows_registry.py`; no other sync store-read polls from async tests were found in
`test/test_job_routes.py`, and other test modules were not audited per the spec's
no-opportunistic-widening constraint.

Fixes #7703
