### PR TITLE
fix: drop an unused binding to bring eslint warnings back under the ceiling

### DIFF
--- a/website/src/test/issueRadarNarrowViewport.test.ts
+++ b/website/src/test/issueRadarNarrowViewport.test.ts
@@ -164,7 +164,7 @@ describe('Issue Radar at narrow widths', () => {
   })
 
   it('names the LIST in the Back control, not one item from it', async () => {
-    const s = await shell()
+    await shell()
     // `changeRequestTitle` is singular ("Pull Request") and reads as the item you
     // are looking at; Back returns to the list, which is the plural.
     // The PR pane owns its own Back control now, so the label lives there.


### PR DESCRIPTION
## Problem / Motivation

The Frontend Lint gate runs `npx eslint src/ --max-warnings 603`, but a clean checkout of main measures **604 warnings**: an unused `const s = await shell()` binding (`website/src/test/issueRadarNarrowViewport.test.ts:167`) landed while a string of backend-only merges skipped the Frontend Lint job entirely, so main's own CI never surfaced it.

## Why it matters

Every frontend-touching PR currently inherits a red `Frontend Lint & Type Check` regardless of its own diff (confirmed on PR #7731: its two changed src files carry zero warnings, yet the job fails at 604 > 603). Until this lands, no frontend PR can go green.

## What changed (motivation → approach → change)

The gate's own comment says the ceiling must EQUAL the measured count — so fix the count, don't raise the ceiling. Drop the unused binding, keep the `shell()` call (its render is the test's setup). `npx eslint src/` measures exactly 603 again.

## Tests

No behavior change; the touched test file still passes (16/16). The lint gate itself is the pin.

## Manual verification

`npx eslint src/` on this branch: `604 → 603 warnings, 0 errors`. Verified the 604 reproduces on pristine origin/main (7126fa16b) before the fix.

<!-- no-visual-delta -->
**Why no screenshot:** test-only unused-binding removal; no rendered surface changes.

no linked issue: gate breakage found during PR #7731's babysit; fix is one line, filed directly.


## Pattern harvest

- **Root-cause class:** ratchet-gate blind spot — a count-pinned gate (`--max-warnings 603`) only runs when its path filter matches, so a violation that lands alongside frontend changes survives as long as every SUBSEQUENT merge is backend-only; the breakage then surfaces on the next unrelated frontend PR instead of the culprit.
- **Detection gap:** main's own CI conclusion stayed green across the window because the Frontend Lint job was skipped, not passed — a skipped required-context reads the same as green in the branch-level rollup.
- **Harvest:** when a frontend PR inherits a ratchet red its own files cannot explain, measure the pristine base first (`npx eslint src/` on origin/main) before touching the branch; and consider running count-pinned ratchets on a low-frequency schedule against main so a skip window cannot hide a regression.

Rule candidate: a count-pinned ratchet gate (`--max-warnings N`, baseline ceilings) should also run on a scheduled workflow against main, not only on path-filtered PR triggers — a skip window must not be able to hide a regression until an unrelated PR inherits it.

