### PR TITLE
feat: add conversation-only ChatPanel mode

### DIFF
--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -45,6 +45,31 @@ paths your `app.json` declares. The host injects auth automatically.
 
 For the full hook list see [getting-started.md](getting-started.md#app-sdk-hooks).
 
+## Native Chat Panel
+
+`ChatPanel` mounts Kiro Crew's native chat experience for an existing session. The required
+`slotKey` selects the session. By default, the component keeps the standard embedded ChatPage
+behavior.
+
+```tsx
+import { ChatPanel } from '@kirocrew/app-sdk'
+
+<ChatPanel slotKey="coder-abc123" />
+```
+
+Set `conversationOnly` when the host app already provides navigation and needs the conversation
+without ChatPage's sessions rail. This mode keeps the native transcript, composer, and composer
+controls, and it leaves the host page in charge of the browser URL.
+
+```tsx
+<ChatPanel slotKey="coder-abc123" conversationOnly />
+```
+
+| Prop | Type | Required | Purpose |
+|---|---|---|---|
+| `slotKey` | `string` | yes | Select the Kiro Crew session rendered by the panel |
+| `conversationOnly` | `boolean` | no | Hide ChatPage's sessions rail and disable ChatPage URL synchronization |
+
 ## Chat Marker Protocol
 
 An agent encodes UI affordances inline in the prose it streams. A surface that renders a transcript

--- a/website/src/app-sdk/ChatPanel.tsx
+++ b/website/src/app-sdk/ChatPanel.tsx
@@ -16,9 +16,10 @@ import ChatPage from '../pages/ChatPage'
 
 export interface ChatPanelProps {
   slotKey: string
+  conversationOnly?: boolean
 }
 
-export default function ChatPanel({ slotKey }: ChatPanelProps) {
+export default function ChatPanel({ slotKey, conversationOnly = false }: ChatPanelProps) {
   const dispatch = useAppDispatch()
   const prevSlotRef = useRef<string | null>(null)
 
@@ -31,7 +32,11 @@ export default function ChatPanel({ slotKey }: ChatPanelProps) {
 
   return (
     <div className="flex flex-col h-full min-h-0 overflow-hidden">
-      <ChatPage embedded />
+      <ChatPage
+        embedded
+        embedMode={conversationOnly ? 'chat' : undefined}
+        noUrlSync={conversationOnly || undefined}
+      />
     </div>
   )
 }

--- a/website/src/test/ChatPanel.test.tsx
+++ b/website/src/test/ChatPanel.test.tsx
@@ -16,8 +16,17 @@ vi.mock('../store/chatSlice', () => ({
 }))
 
 vi.mock('../pages/ChatPage', () => ({
-  default: (props: { embedded?: boolean }) => (
-    <div data-testid="chat-page" data-embedded={props.embedded ? 'true' : 'false'}>
+  default: (props: {
+    embedded?: boolean
+    embedMode?: 'chat' | 'sessions'
+    noUrlSync?: boolean
+  }) => (
+    <div
+      data-testid="chat-page"
+      data-embedded={props.embedded ? 'true' : 'false'}
+      data-embed-mode={props.embedMode ?? 'unset'}
+      data-no-url-sync={props.noUrlSync === undefined ? 'unset' : String(props.noUrlSync)}
+    >
       ChatPage
     </div>
   ),
@@ -42,11 +51,21 @@ describe('ChatPanel', () => {
     expect(mockDispatch).toHaveBeenCalled()
   })
 
-  it('renders ChatPage with embedded prop', () => {
+  it('renders ChatPage with embedded prop and preserves the default mode', () => {
     render(<ChatPanel slotKey="my-slot-123" />)
     const chatPage = screen.getByTestId('chat-page')
     expect(chatPage).toBeInTheDocument()
     expect(chatPage.getAttribute('data-embedded')).toBe('true')
+    expect(chatPage.getAttribute('data-embed-mode')).toBe('unset')
+    expect(chatPage.getAttribute('data-no-url-sync')).toBe('unset')
+  })
+
+  it('maps conversationOnly to the native chat embed without URL sync', () => {
+    render(<ChatPanel slotKey="my-slot-123" conversationOnly />)
+    const chatPage = screen.getByTestId('chat-page')
+    expect(chatPage.getAttribute('data-embedded')).toBe('true')
+    expect(chatPage.getAttribute('data-embed-mode')).toBe('chat')
+    expect(chatPage.getAttribute('data-no-url-sync')).toBe('true')
   })
 
   it('does not re-dispatch when slotKey stays the same on rerender', () => {


### PR DESCRIPTION
## Problem / Motivation

Host apps that already own project or session navigation cannot embed the native Kiro Crew conversation without also rendering ChatPage's nested sessions rail and allowing ChatPage to synchronize the browser URL. Replacing the panel with a smaller custom chat surface can remove native composer capabilities.

## Why it matters

Duplicate navigation makes embedded chat harder to understand and wastes horizontal space. A supported conversation-only mode lets App Kit hosts keep their own navigation while retaining the native transcript, composer, attachments, approval mode, goals, voice, and agent, project, model, and effort controls.

## What changed (motivation → approach → change)

The goal is to remove only the nested sessions rail without creating a second chat implementation. `ChatPanel` now accepts an optional `conversationOnly` prop and maps it to ChatPage's existing `embedMode="chat"` and `noUrlSync` contracts. The prop defaults to `false`, so existing consumers retain the current embedded ChatPage behavior.

The App Kit API reference documents both the default and conversation-only forms. The focused component test covers the default compatibility path and the new prop mapping.

## Tests

- `npx vitest run src/test/ChatPanel.test.tsx` — passed: 1 file, 7 tests; covers default behavior and the conversation-only mapping.
- `npx tsc -b` — passed.
- `npx eslint src/app-sdk/ChatPanel.tsx src/test/ChatPanel.test.tsx` — passed.
- `npm --prefix website run build` — passed.
- `./scripts/docs-lint.sh` — passed: 252 Markdown files scanned.
- `mypy src/kiro_crew/` — passed: 1,244 source files.
- Python formatting, lint, scrub, CloudFormation, i18n, duplication, bundle-size, and structural push guards — passed.
- `git diff --check` — passed.

The current full-suite frontend, Electron, and backend gates were also exercised. Their remaining failures reproduce on current `origin/main` or are host-generated state (including host ownership/isolation checks, AF_UNIX path limits, the existing ESLint warning ceiling, and generated vendored bytecode); no failure references the three changed files. The test-generated vendored bytecode was removed and the vendor manifest then passed.

## Manual verification

Verified through the standalone T3 host integration. With `conversationOnly` enabled, the nested sessions rail is absent while the native transcript and full composer controls remain visible, and the host page retains URL ownership.

## Screenshots / video

Rendered evidence was captured through the standalone T3 integration, showing its project/thread navigation beside the native conversation and full composer with no nested sessions rail.

## Related Issues

Fixes #7746

## Checklist

- [x] At most two commits, with a Conventional Commits title
- [x] Existing focused tests pass and new tests cover the new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff
