### PR TITLE
fix(ci): drop a dead eslint directive and re-equal the warning ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1326,16 +1326,7 @@ jobs:
         # The ceiling must EQUAL the measured count, not sit above it: slack is
         # silent admission, and a warning that lands inside it never surfaces
         # again. Re-measure with `cd website && npx eslint src/` when burning down.
-        #
-        # The 604 this replaces was a fleet unblock: 7362b6a2b (#7259) landed a
-        # third react-hooks/exhaustive-deps warning in ArtifactsPage.tsx while this
-        # said 603, so main measured one over its own ceiling and every open PR
-        # touching website/** went red on a warning its diff never wrote (#7511 is
-        # why main's own runs did not report it first). That page now measures zero
-        # warnings, and removing two jsx-a11y warnings here takes the tree to 599 —
-        # so the ceiling returns to the count the tree actually measures, with the
-        # slack the instruction above forbids taken back out.
-        run: npx eslint src/ --max-warnings 599
+        run: npx eslint src/ --max-warnings 597
 
       - name: Copy/paste detection
         working-directory: website

--- a/website/src/apps/issue-radar/components/crew-ghost-sprite.gen.mjs
+++ b/website/src/apps/issue-radar/components/crew-ghost-sprite.gen.mjs
@@ -170,7 +170,16 @@ const browser = await chromium.launch()
 const page = await browser.newPage()
 const { dataUrl, problems, report } = await page.evaluate(
   ({ program, geo, outfits, pixels }) => {
-    // eslint-disable-next-line no-eval
+    // `program` is the drawing source built as a template literal in THIS file,
+    // handed to the page so the browser context can call `drawCrewGhost`.
+    // Nothing here is remote or user-supplied.
+    //
+    // Deliberately NOT an `eslint-disable-next-line no-eval`: every rule block in
+    // `eslint.config.js` is scoped to `src/**/*.{ts,tsx}`, so no rule — `no-eval`
+    // included — is enabled for a `.mjs` file, and eslint charges the directive
+    // itself against the `--max-warnings` ceiling that CI forbids raising. Re-add
+    // it if a config block ever brings `.mjs` under a preset that turns `no-eval`
+    // on.
     eval(program)
     const canvas = document.createElement('canvas')
     canvas.width = geo.CELL_W * outfits.length * geo.SCALE


### PR DESCRIPTION
## Problem / Motivation

Two pieces of frontend lint debt on `main`, both invisible to the gate that is supposed
to catch them.

**1. A dead eslint directive.**

```
website/src/apps/issue-radar/components/crew-ghost-sprite.gen.mjs
  173:5  warning  Unused eslint-disable directive (no problems were reported from 'no-eval')
```

**2. The ceiling sits above the measured count.** On current `main` the gate reads
`--max-warnings 599` while `cd website && npx eslint src/` measures **598** — one free
slot. That is exactly the state the gate's own comment forbids:

> The ceiling must EQUAL the measured count, not sit above it: **slack is silent
> admission**, and a warning that lands inside it never surfaces again.

A free slot means the next real warning lands without ever failing a check.

## Why it matters

The ratchet only works while the ceiling tracks the count. With slack in it, the check
reports green through the first regressions and the ratchet silently stops being one —
and the ceiling is the only thing standing between the tree and unbounded warning
growth, since none of these rules is an error.

The dead directive is the smaller half, but it is also the more misleading one: it reads
as a deliberate, load-bearing suppression, and it suppresses nothing.

## What changed (motivation → approach → change)

**The directive was never functional.** Every rule block in `website/eslint.config.js` is
scoped to `src/**/*.{ts,tsx}`, so no rule is enabled for a `.mjs` file — `no-eval`
included — and the directive could never suppress anything. Replaced it with a plain
comment that keeps the intent (why `eval` is safe in that generator: `program` is a
template literal built in the same file and handed to the Playwright page so the browser
context can call `drawCrewGhost` — nothing remote or user-supplied) and records the
condition under which the directive should come back.

**Then re-measured and set the ceiling to the count**, 599 → **597**, which is the
direction the comment mandates. It is not a raise: it is lower than both the old ceiling
and the count before this change. 597 is measured, not derived — `--max-warnings 597`
exits 0 and `--max-warnings 596` fails.

**The ceiling comment loses its transient half.** The paragraph above the `run:` line
narrated a specific earlier 604/603/599 episode, complete with a commit SHA and three PR
numbers. Those numbers are wrong the moment the ceiling moves — which this PR does — and
the root `AGENTS.md` comment rule forbids that shape outright ("NOT a task log: no PR/CR
numbers … or commit SHAs"). The durable half, the EQUAL-the-count instruction and how to
re-measure, stays verbatim.

**Rejected alternative.** Adding a `src/**/*.mjs` rule block would make the directive
*used* and also drop the warning — and would extend lint coverage to a file currently
linted by nothing. But it brings the generator's four `console` calls in as `no-console`
warnings, so it needs the ceiling **raised**, which the comment forbids. Probed and
reverted.

## Tests

`test/test_eslint_warning_ceiling.py` already pins the two things that can be pinned
without running eslint: that `ci.yml` declares exactly ONE `--max-warnings` literal, and
that no prose transcribes its value. Neither can measure the count, and the module's own
docstring says so — "Only running eslint can measure that, so it is not pinned here --
the gate itself is that test." That gate, `npx eslint src/ --max-warnings 597`, is the
assertion for this change: with the ceiling at the count, the next added warning fails
it.

## Manual verification

Ran the frontend job's gates verbatim from `ci.yml`:

| | `origin/main` | this branch |
|---|---|---|
| `npx eslint src/` | `598 problems (0 errors, 598 warnings)` | `597 problems (0 errors, 597 warnings)` |
| `npx eslint src/ --max-warnings 597` | would fail (598 > 597) | **pass** (rc=0) |
| `npx eslint src/ --max-warnings 596` | would fail | **fails** (ceiling has no slack) |
| `npx tsc -b` | pass | pass |
| `npx jscpd .` | pass (0 clones) | pass (0 clones) |

`.github/workflows/ci.yml` parses as YAML, and
`test/test_eslint_warning_ceiling.py test/test_security_posture.py` are green (49 passed)
— including `TestGateSideLogRedactorSpelling`, whose shard-3 red on the previous head was
the inherited baseline-redactor census cascade and is cured by the rebase, with no code
change.

The generator is not itself generated — its header documents running it by hand — so
nothing regenerates the removed line back.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the only `website/src` change is a comment inside
`crew-ghost-sprite.gen.mjs`, a hand-run Node generator that is never bundled or
rendered. No component, layout, style, or user-visible string changes, and the committed
sprite sheet it produces is byte-identical.

## Related Issues

no linked issue: lint-count drift against the gate's own ceiling rule; there is no
tracked issue for it.

## Pattern harvest

Rule candidate: lint
Pattern: an `eslint-disable` directive in a file that no config block covers is silently
dead — it suppresses nothing, and the unused-directive warning it produces is charged to
the `--max-warnings` ratchet instead of failing where it was written. Every rule block in
`website/eslint.config.js` is scoped to `src/**/*.{ts,tsx}`, so any directive in a
`src/**/*.{js,mjs,cjs}` file is in this class. Promoting unused disable directives from
`warn` to `error` (`linterOptions.reportUnusedDisableDirectives`) would surface the next
one where it is written rather than months later as an unattributable ratchet overflow.

Second, narrower candidate for whoever owns the gate: the ceiling and the count can only
drift apart silently, because a *lower* count never fails anything. A CI step asserting
equality — rather than `<=` — would catch each slot at the moment it opens. Both are
additions to the gate rather than parts of this fix, so both are deferred here.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

