### PR TITLE
refactor: flatten a chained ternary and a dedup loop in service/

### DIFF
--- a/src/kiro_crew/service/apparmor.py
+++ b/src/kiro_crew/service/apparmor.py
@@ -688,7 +688,13 @@ def _substitutable_by_others(resolved: Path, expected_uid: int | None = None) ->
     not just the instant it is installed.
     """
     getuid = getattr(os, "getuid", None)  # absent on Windows, where this is moot
-    check_uid = expected_uid if expected_uid is not None else (getuid() if getuid is not None else None)
+    check_uid: int | None
+    if expected_uid is not None:
+        check_uid = expected_uid
+    elif getuid is not None:
+        check_uid = getuid()
+    else:
+        check_uid = None
     try:
         info = resolved.stat()
     except OSError as exc:

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -319,13 +319,9 @@ def service_path(home: str) -> str:
         "/bin",
     ]
     env_path = [p for p in os.environ.get("PATH", "").split(":") if p]
-    seen: set[str] = set()
-    out: list[str] = []
-    for entry in required + env_path:
-        if entry not in seen:
-            seen.add(entry)
-            out.append(entry)
-    return ":".join(out)
+    # dict.fromkeys dedupes on first occurrence and preserves insertion order,
+    # so the required prefixes keep their precedence over the installer's $PATH.
+    return ":".join(dict.fromkeys(required + env_path))
 
 
 class Platform(enum.Enum):


### PR DESCRIPTION
## Problem / Motivation

Two spots in `src/kiro_crew/service/` state a simple intention in a shape the
reader has to decode:

- `apparmor.py`'s `_substitutable_by_others` resolved the uid it compares an
  attachment target's owner against through a nested conditional expression on
  one 104-character line. Three candidate values with a strict precedence, read
  right-to-left. This is the uid that decides whether the ownership rule runs at
  all, in the function that gates an AppArmor profile granting unprivileged user
  namespaces — the reader most in need of certainty here is a security reviewer.
- `common.py`'s `service_path` hand-rolled an order-preserving dedup with a
  companion `seen` set and an `out` accumulator: six lines implementing an
  operation the standard library already names.

## Why it matters

Neither is a bug, and nothing a user can observe changes. What changes is the
cost of the next read. `_substitutable_by_others` is on the path that decides a
privilege grant, and `service_path` builds the `PATH` baked into the installed
systemd unit / launchd plist — a PATH-resolution surface. Both are code where a
future reader has to be sure about precedence, and in both the precedence was
recoverable only by parsing an expression rather than by reading it.

## What changed (motivation → approach → change)

This is one module's pass in the module-by-module simplification sweep: one
module, one branch, one commit. Only `src/kiro_crew/service/` is touched.

**`apparmor.py` — chained conditional expression → `if`/`elif`/`else`.** The
detector's `chained-ternary` class. The rewrite states the precedence in the
order it applies: an explicit `expected_uid`, then the calling process's uid,
then `None` on a host without `os.getuid`. Both discriminants stay
`is not None` rather than truthiness, which is the distinction that matters
here: `expected_uid=0` is a service whose `User=` is root, and a truthiness
collapse would have silently skipped the ownership comparison for exactly that
case. `getuid()` is still called only when `expected_uid is None`, so no path
gains a syscall and a `monkeypatch.setattr(os, "getuid", …)` is still observed.

`check_uid` gained an explicit `int | None` annotation so the local does not
absorb the `Any` that `getattr(os, "getuid", None)` yields. To be precise about
why, since it is easy to assume otherwise: mypy accepts the block **either
way** — it joins the branch types rather than inferring from the first
assignment — so the annotation is a typing improvement, not a gate requirement.

**`common.py` — hand-rolled dedup → `dict.fromkeys`.** The judgment class
"logic re-implementing an existing helper". `dict.fromkeys` dedupes on first
occurrence and preserves insertion order (a language guarantee since 3.7; this
repo's floor is 3.10), so the required prefixes keep their precedence over the
installer's `$PATH` and a `$PATH` duplicate of one of them is still dropped as
the second occurrence. The docstring already promised "duplicates are removed
while preserving order"; the code now says it directly. The idiom has ~20
existing call sites in `src/kiro_crew/`, including the identical
`join(dict.fromkeys(...))` shape in `trust_patterns.py`.

**Deliberately NOT in this PR.** The module carries 15 issue-number citations in
comments and docstrings (`#3463`, `#1210`, `#1139`, `#5285`), which `AGENTS.md`'s
comment rule prohibits as task-log references. I started removing them and
reverted: those same numbers appear in 9 test files, two module specs and
`docs/guides/install.md`, where `#5285` in particular functions as a repo-wide
shorthand for one hardening pattern. Stripping them from four files while the
tests and specs that mirror the same prose keep theirs would be an inconsistent
partial sweep and would break cross-references a reader can currently follow.
That is one criterion applied repo-wide or not at all — a maintainer call, not
something to decide inside a refactor PR.

## Tests

No new tests. This is a behavior-preserving refactor with no new branch, no new
failure mode, and no new public surface, so there is nothing a new test could
lock in that an existing one does not.

Existing coverage that exercises the changed code:
`test/test_service.py` calls `_substitutable_by_others` directly at 12 sites,
including a `monkeypatch.setattr(os, "getuid", …)` case for the
`expected_uid`-override path. `test/test_service.py` + `test/test_live_target.py`
+ `test/test_host_service_guard.py`: **404 passed**.

`service_path`'s output order and dedup are asserted by no test, before or after
this change — a pre-existing gap this PR does not widen, and which the equivalence
argument below stands in for.

## Manual verification

N/A — unit coverage plus a differential equivalence proof is sufficient for a
refactor with no rendered or behavioral delta.

Equivalence was established rather than assumed. For the uid resolution: the
full matrix of `expected_uid` ∈ {positive, `0`, `None`} × `getuid` ∈ {present,
absent}, comparing both forms' bound value, its type, **and** the `getuid()`
invocation count — identical in every case, including the `expected_uid=0` root
case. For the dedup: a 200,000-case differential fuzz over `required` × `$PATH`
shapes seeded with duplicates in both halves, plus the edge cases (empty list,
`""` entries, `PATH=":"`, a duplicate inside `required` itself, a `home`
containing a colon) — zero mismatches.

Local gate, on the CI-parity Python 3.12 venv, all green: `flake8`, `isort
--check-only`, `mypy` (1245 files), `check_black_formatting.py`,
`check_subprocess_encoding.py`, `check_brand_name.py`,
`check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`, and `push_guard.py --require-single-on-base`.
Re-run in full after the rebase onto `5272aef86`, and the module re-scanned
after it (0 actionable sites remain).

Two pre-existing failures I confirmed are **not** from this diff:
`test_apps_registry.py::test_install_script_rewriting_manifest_is_refused` and
`::test_provenance_signer_uses_post_script_manifest` fail identically on a
pristine detached `origin/main` worktree with the same venv. Neither touches
`service/`.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — two files under `src/kiro_crew/service/`,
nothing under `website/`, so there is no rendered surface to show. The `changes`
job should report `only_backend=true`.

## Related Issues

no linked issue: routine simplification sweep, not tracked by an issue.

## Pre-review fleet

Five parallel read-only reviewers were run against this diff before opening,
each grounded in this repo's own contracts rather than generic taste —
`AUTOSDE.yaml` blocking rules plus the deterministic greps in
`code-review.yml`; behavior preservation; import semantics and test
patchability; the security keystone and boot path; comment and commit-message
accuracy. Then each finding was adversarially verified.

**One finding survived, and it is fixed.** Three reviewers independently
established that the commit message's original justification for the `int | None`
annotation — that mypy requires it because it infers a conditionally-assigned
local from its first assignment — is false: mypy joins the branch types when the
definition sites are the branches of one `if`/`elif`/`else`, and accepts the
unannotated form even under `--strict`. Confirmed directly by removing the
annotation from the real file and re-running the pinned `mypy` 1.14.1, which
passed. The commit message now states the true reason (keeping `Any` out of the
local's type). The code was left as-is rather than contorted: the annotation is
a small genuine improvement, only its stated rationale was wrong.

Nothing was dropped as a false positive — the other four lanes returned no
findings. Their non-findings worth recording: no import is added, moved or
deleted anywhere in the diff; `seen` and `out` were function locals with zero
references outside the function; neither file matches
`no-new-work-on-gateway-boot-path`'s `file-patterns`; no sensitive-path matcher,
denied-command rule, SEL emit, redaction call or governance intersection is in
the diff; and `getattr(os, "getuid", None)` is the established in-tree pattern
for this (6 existing call sites) rather than a `platform_compat` shim gap —
`local_user_id()` is not comparable to `st_uid` on Windows.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
