### PR TITLE
fix(ci): use context redactor for Slack log

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -218,6 +218,7 @@ from kiro_crew.platform import boot_platform
 from kiro_crew.platform.context import (
     PlatformCompositionError,
     current_context,
+    redact_log_via_context,
     redact_via_context,
     safe_context_call,
 )
@@ -5299,7 +5300,7 @@ class GatewayOrchestrator:
             if is_keep_response(result_safe):
                 logger.info(
                     "Heartbeat task incomplete, suppressing delivery: %s",
-                    redact_and_truncate(task_text, 80),
+                    redact_log_via_context(task_text)[:80],
                 )
             else:
                 task_safe = redact_and_truncate(task_text, 100)


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Current `main` is deterministically red in a required backend shard because
`src/kiro_crew/slack/gateway.py` has seven gate-side log sites that use the
baseline OSS redactor while the security census allows six.

## Why it matters

Every pull request built against current main can fail the same Linux/Windows/
Python shard before its own changes are evaluated. This blocks PR Readiness and
prevents Stage-2 review dispatch across the repository.

## What changed (motivation → approach → change)

PR #7424 correctly changed the heartbeat incomplete-task log to redact the full
text before bounding it, but selected `redact_and_truncate`. Slack gateway can
compose a platform companion, so gate-side logs must use the context-aware
redactor rather than expanding the baseline census.

This change routes only that logger argument through
`redact_log_via_context(task_text)[:80]`. Redaction still runs over the full text
before the display bound, while composed deployments receive the stronger
platform scan. The separate delivered-task preview remains on
`redact_and_truncate` because it is not a gate-side log argument.

## Tests

- `test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor`: passed
- `test/test_core_path_redact_before_bound.py`: passed
- Combined targeted set: **7 passed**
- Black, isort, flake8, mypy, and `git diff --check`: passed

## Manual verification

N/A — the existing AST census and redact-before-bound tests exercise the exact
source contract.

## Related Issues

Fixes #7757

## Pattern harvest

Rule candidate: review-prompt
Pattern: A new logger/audit argument in a companion-capable process must use `redact_log_via_context` before any output bound, not the baseline redactor.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no user-facing contract changed)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template does not currently provide CLA attestation wording.
