### PR TITLE
refactor(menu): drop redundant caller-level menu height caps

### DIFF
--- a/website/src/components/CronJobMoveMenu.tsx
+++ b/website/src/components/CronJobMoveMenu.tsx
@@ -28,7 +28,13 @@ export default function CronJobMoveMenu({ folders, currentFolderId, onMove, onNe
           <Folder size={13} />
         </Btn>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-[160px] max-h-[240px] overflow-y-auto">
+      {/* Intentional tighter cap: the folder list can grow long, so a fixed
+          240px keeps this picker compact. Composed via min() with the
+          primitive's available-height var so the viewport never-clip floor is
+          preserved on a short viewport (a bare max-h-[240px] would override the
+          primitive's cap, since cn()'s tailwind-merge dedupes max-h-*). overflow
+          is left to the primitive. */}
+      <DropdownMenuContent align="end" className="min-w-[160px] max-h-[min(240px,var(--radix-dropdown-menu-content-available-height))]">
         <DropdownMenuItem onSelect={() => { onMove(''); setOpen(false) }}>
           <Folder size={13} className="text-muted shrink-0" />
           <span>{i18nT('pages.schedulePage.cronFolders.ungrouped')}</span>

--- a/website/src/components/CronRowActions.tsx
+++ b/website/src/components/CronRowActions.tsx
@@ -111,7 +111,12 @@ export default function CronRowActions({
             <Folder size={13} className="shrink-0 text-muted" />
             <span>{i18nT('pages.schedulePage.cronFolders.move_to_folder')}</span>
           </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="min-w-[160px] max-h-[240px] overflow-y-auto">
+          {/* Intentional tighter cap composed via min() with the primitive's
+              available-height var: 240px keeps the folder submenu compact while
+              preserving the viewport never-clip floor (a bare max-h-[240px]
+              would override the primitive, since cn()'s tailwind-merge dedupes
+              max-h-*). overflow is left to the primitive. */}
+          <DropdownMenuSubContent className="min-w-[160px] max-h-[min(240px,var(--radix-dropdown-menu-content-available-height))]">
             <DropdownMenuItem onSelect={() => move('')}>
               <Folder size={13} className="shrink-0 text-muted" />
               <span>{i18nT('pages.schedulePage.cronFolders.ungrouped')}</span>

--- a/website/src/components/InstanceTabBar.tsx
+++ b/website/src/components/InstanceTabBar.tsx
@@ -532,7 +532,7 @@ function SwitcherMenu({
       <DropdownMenuContent
         align="start"
         aria-label={i18nT('components.instanceTabBar.instances')}
-        className="min-w-[240px] max-w-[340px] max-h-[60vh] overflow-y-auto"
+        className="min-w-[240px] max-w-[340px]"
       >
         <DropdownMenuRadioGroup value={activeId ?? LOCAL_VALUE}>
           {entries.map((entry, i) => (

--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -99,7 +99,12 @@ function FolderChip({ artifact }: { artifact: Artifact }) {
           {current ? current.name : 'folder'}
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-[190px] max-h-[300px] overflow-y-auto">
+      {/* Intentional tighter cap composed via min() with the primitive's
+          available-height var: 300px keeps the folder picker compact while
+          preserving the viewport never-clip floor (a bare max-h would override
+          the primitive, since cn()'s tailwind-merge dedupes max-h-*). overflow
+          is left to the primitive. */}
+      <DropdownMenuContent align="start" className="min-w-[190px] max-h-[min(300px,var(--radix-dropdown-menu-content-available-height))]">
         <FolderPickerItems
           folders={folders}
           currentFolderId={artifact.folder_id || null}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -395,7 +395,12 @@ export function ChatHeaderMenu({ activeSlot, agent, onReveal, onRename, mode }: 
                 <span className="flex-1">{i18nT('pages.chatPage.mcp_servers')}</span>
                 <ChevronRight size={12} className="text-muted" />
               </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="min-w-[240px] max-w-[300px] max-h-[340px] overflow-y-auto px-3 py-2">
+              {/* Intentional tighter cap composed via min() with the primitive's
+                  available-height var: 340px keeps the MCP tools submenu compact
+                  while preserving the viewport never-clip floor (a bare max-h
+                  would override the primitive, since cn()'s tailwind-merge dedupes
+                  max-h-*). overflow is left to the primitive. */}
+              <DropdownMenuSubContent className="min-w-[240px] max-w-[300px] max-h-[min(340px,var(--radix-dropdown-menu-content-available-height))] px-3 py-2">
                 <McpToolsPanel
                   servers={servers}
                   toolsByServer={toolsByServer}

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -5395,7 +5395,13 @@ function ChatSidebar({
                       <Folder size={14} className="text-muted" /> {i18nT('pages.chatSidebar.new_chat_in_folder')}
                       <ChevronRight size={13} className="ml-auto text-muted" />
                     </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent className="max-h-[300px] overflow-y-auto">
+                    {/* Intentional tighter cap composed via min() with the
+                        primitive's available-height var: 300px keeps the folder
+                        list submenu compact while preserving the viewport
+                        never-clip floor (a bare max-h would override the
+                        primitive, since cn()'s tailwind-merge dedupes max-h-*).
+                        overflow is left to the primitive. */}
+                    <DropdownMenuSubContent className="max-h-[min(300px,var(--radix-dropdown-menu-content-available-height))]">
                       {folderRows}
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
@@ -5439,7 +5445,13 @@ function ChatSidebar({
                         <Server size={14} className="text-info" /> {i18nT('pages.chatSidebar.new_chat_on_crew')}
                         <ChevronRight size={13} className="ml-auto text-muted" />
                       </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent className="max-h-[300px] overflow-y-auto">
+                      {/* Intentional tighter cap composed via min() with the
+                          primitive's available-height var: 300px keeps the crew
+                          list submenu compact while preserving the viewport
+                          never-clip floor (a bare max-h would override the
+                          primitive, since cn()'s tailwind-merge dedupes max-h-*).
+                          overflow is left to the primitive. */}
+                      <DropdownMenuSubContent className="max-h-[min(300px,var(--radix-dropdown-menu-content-available-height))]">
                         {crewRows}
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
@@ -5605,7 +5617,7 @@ function ChatSidebar({
                   popper wrapper to `max-content`, so the inline pickers' caption
                   sentences (a phone renders them here instead of in a flyout)
                   would otherwise stretch the menu past the screen edge. */}
-              <DropdownMenuContent align="end" className="min-w-[180px] max-w-[calc(100vw-1rem)] max-h-[70vh] overflow-y-auto">
+              <DropdownMenuContent align="end" className="min-w-[180px] max-w-[calc(100vw-1rem)]">
                 <DropdownMenuLabel className="text-[11px] uppercase tracking-[.04em]">{i18nT('pages.chatSidebar.filter')}</DropdownMenuLabel>
                 {SESSION_FILTERS.map(filterDef => {
                   const active = activeFilters.has(filterDef.key)
@@ -5904,8 +5916,9 @@ function ChatSidebar({
                 {/* Folders sit LAST on purpose: the list grows with the user's
                     folder count, so anything below it would get pushed out of
                     easy reach. Being last, it can simply overflow into the
-                    menu's own scroll (max-h on DropdownMenuContent) with no
-                    inner scroll region of its own. */}
+                    menu's own scroll (the DropdownMenuContent primitive caps to
+                    the available viewport height and scrolls) with no inner
+                    scroll region of its own. */}
                 {!boardLaneActive && folderFilterRows.length > 0 && (
                   <>
                     <DropdownMenuSeparator />


### PR DESCRIPTION
## Problem / Motivation

Now that the shared Radix menu primitives cap content height to
`max-h-[var(--radix-*-content-available-height)] overflow-y-auto overscroll-contain`
and scroll (PR #7186), several dashboard callers still carry their own
per-menu `max-h-[…] overflow-y-auto` point patches that predate the
primitive-level fix. Those are redundant second spellings that can drift
from the primitive over time.

## Why it matters

A caller cap whose only purpose was "don't let the menu overflow the
viewport, scroll instead" now duplicates behavior the primitive
guarantees. Leaving the duplicates in place invites drift: a future
change to the primitive default silently stops applying at those sites,
and a reader can't tell an intentional tighter cap from a leftover patch.

## What changed

A per-site pass over the caps the issue lists, splitting them by intent:

- **Removed** the two caps whose sole job the primitive now does — pure
  "don't exceed the viewport" viewport-fraction caps:
  - `InstanceTabBar.tsx` — instance switcher menu `max-h-[60vh] overflow-y-auto`
  - `ChatSidebar.tsx` — session filter menu `max-h-[70vh] overflow-y-auto`

  (The `max-w-[calc(100vw-1rem)]` phone-fit cap on the filter menu is a
  horizontal constraint the primitive does not provide, so it stays.)

- **Kept, but composed correctly** — the genuinely tighter fixed-pixel
  caps that hold a growable list submenu compact. Because `cn()` runs
  `tailwind-merge`, which dedupes `max-h-*`, a bare `max-h-[<px>]` would
  *override* the primitive's `max-h-[var(--radix-*-content-available-height)]`
  and lose the never-clip viewport floor on a short viewport. So each kept
  cap is spelled `max-h-[min(<px>,var(--radix-dropdown-menu-content-available-height))]`
  (the codebase's existing pattern in `AgentSelector.tsx`) — genuinely
  tighter *and* still floored to the viewport. Their now-redundant
  `overflow-y-auto` is dropped (the primitive supplies it), and each is
  annotated with the accurate model:
  - `CronJobMoveMenu.tsx` folder picker (240px)
  - `CronRowActions.tsx` move-to-folder submenu (240px)
  - `ArtifactDetailPage.tsx` folder picker (300px)
  - `ChatPage.tsx` MCP tools submenu (340px)
  - `ChatSidebar.tsx` new-chat-in-folder / new-chat-on-crew submenus (300px)

- Updated the `ChatSidebar` folder-scroll rationale comment to reference
  the primitive cap instead of the removed caller `max-h`.

The plain `<div className="max-h-… overflow-y-auto">` inner scroll
regions in these files are not menu-content primitives and are out of
scope — left untouched.

This matches the shape the triage comment suggested: a mechanical removal
of the caps the primitive default subsumes, plus a short annotated list
of the intentionally-tighter caps that remain. Behavior at the two
removed sites now follows the primitive (cap to available viewport
height, scroll) instead of a fixed viewport fraction; both still scroll
and never clip.

## Tests

- `npx tsc -b` — clean.
- `npx eslint` on all six changed files — 0 errors, 0 new warnings.
- `npx vitest run` on the suites that exercise the touched menus —
  67/67 pass:
  - `menuContentOverflow.test.tsx` (the primitive cap/scroll test from #7186)
  - `InstanceTabBar.test.tsx`
  - `cronFoldersSchedulePage.test.tsx`
  - `ChatSidebar.createMenu.test.tsx`
- Re-verified after addressing the Design/First-Principles review: the
  kept caps now compose via `min()` so the primitive's viewport floor is
  preserved, and the duplicate `overflow-y-auto` is removed.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** there is no rendered delta at rest or in the
common case — the change only swaps two menus' redundant fixed
viewport-fraction caps (`60vh`/`70vh`) for the primitive's own
`max-h-[var(--radix-*-content-available-height)]`, which Radix already
applies, so a short menu renders at content height and a full one still
scrolls exactly as before. The only reachable difference is an edge case
(a menu whose content exceeds the fraction on a tall viewport where the
primitive's available-height is larger): it may grow marginally taller
before scrolling instead of scrolling at the fixed fraction — still
capped to the viewport, still scrollable, never clipped. A screenshot at
rest would show no difference and would be misleading evidence for that
edge case; the four kept caps and all comment/annotation changes have no
visual effect at all.

## Pattern harvest

Not generalizable: a one-off cleanup of duplicated CSS caps against a
primitive default; no reusable rule.

## Related Issues

Fixes #7227
