### PR TITLE
fix(slack): read the heartbeat-suppression log line through the composed context

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -218,6 +218,7 @@ from kiro_crew.platform import boot_platform
 from kiro_crew.platform.context import (
     PlatformCompositionError,
     current_context,
+    redact_log_via_context,
     redact_via_context,
     safe_context_call,
 )
@@ -5297,9 +5298,13 @@ class GatewayOrchestrator:
             # Only notify when task is complete — suppress delivery for
             # incomplete tasks (HEARTBEAT_KEEP) to avoid spamming every cycle.
             if is_keep_response(result_safe):
+                # Context-aware, and sliced AFTER: this process composes (it calls
+                # `boot_platform`), so a loaded companion's extra patterns must run
+                # here rather than the OSS baseline pass. Truncating second is what
+                # keeps a credential from surviving as an unmatchable fragment.
                 logger.info(
                     "Heartbeat task incomplete, suppressing delivery: %s",
-                    redact_and_truncate(task_text, 80),
+                    redact_log_via_context(task_text)[:80],
                 )
             else:
                 task_safe = redact_and_truncate(task_text, 100)


### PR DESCRIPTION
## What is the problem?

`test_security_posture.py::TestGateSideLogRedactorSpelling::test_no_new_gate_side_log_line_reads_the_baseline_redactor` fails on `main`:

```
New gate-side log/audit line(s) reading the BASELINE redactor
slack/gateway.py: 7 sites, census says 6.
```

The offender is main commit `7d05970c7` ("fix: redact full text before bounding at core-path slice sites (#7390) (#7424)"). Its change to `slack/gateway.py` was a genuine improvement -- the heartbeat-suppression log line previously interpolated `task_text[:80]` with no redaction at all -- but it reached its text through `redact_and_truncate`, which is a BASELINE redactor. That grew the module's gate-side baseline-log count from 6 to 7 without the census being raised, so the gate fires.

This test runs on Backend Tests (Windows) shard 3, so **every open PR is red on that shard** regardless of its own contents.

## Why it matters to the user

Two separate costs.

The CI cost is immediate: a failing required shard on every open PR, which also reds Coverage Gate and PR Readiness downstream. Nobody can tell their own breakage from this one.

The security cost is the reason this is a conversion rather than a census bump. A gate-side log line that reads a baseline redactor is scanned by the OSS pass even on a host that has a companion loaded, so the companion's extra credential and cookie patterns never run on that text. The line logs heartbeat task text, which is model-authored and can carry whatever the task was handling.

## How our fix solves it

`redact_log_via_context`'s docstring sets the standard for when a baseline redactor is acceptable at a log site: a process that deliberately does not compose keeps its logs, and it names `mcp_gateway.gatewayd` as that case. `slack/gateway.py` is not that process -- it calls `boot_platform(cfg)` itself, so it composes, and a companion's policy is exactly what should apply to its log lines.

So the site is converted rather than grandfathered:

```python
logger.info(
    "Heartbeat task incomplete, suppressing delivery: %s",
    redact_log_via_context(task_text)[:80],
)
```

The slice comes AFTER the redaction, which is the contract that same docstring states -- truncating second is what keeps a credential from surviving as an unmatchable fragment. That is also precisely the bug class `7d05970c7` set out to fix, so this keeps its intent and only corrects which redactor runs.

The census entry for the module therefore stays at 6. Raising it to 7 would also have turned the shard green, but it would have recorded a companion-blind log line as accepted in the one process most likely to have a companion loaded, and `test_the_census_holds_no_slack` exists to keep that number falling rather than climbing.

## What tests we did

- The failing test now passes; all 47 tests in `test/test_security_posture.py` pass, including `test_the_census_holds_no_slack`, which would fail had the count moved away from the census in either direction.
- 206 passed, 1 skipped across the heartbeat-related suites, covering the delivery path this line sits in.
- Gates clean on the changed file: flake8, isort, the baselined black gate, and mypy.
- Confirmed the failure is main-owned before changing anything: a detached worktree at `origin/main` containing none of my work reproduces the assertion byte-for-byte, and it passes at an older merge-base. It is platform-independent despite surfacing only on the Windows shard, because the assertion is a static census of source files and that shard is simply where the test is scheduled.

## Any other suggestions on the work

`slack/gateway.py` still carries 6 grandfathered baseline log sites, and this PR deliberately does not touch them -- converting them is a wider change that deserves its own review. Two other `redact_and_truncate` calls in the same commit's hunk (`task_safe`, `task_preview`) are assignments feeding delivery rather than log writes, so the census does not count them and they are left alone.

No `Closes` trailer: no issue tracks this. It unblocks Backend Tests (Windows) shard 3 for every open PR.

## Pattern harvest

Rule candidate: when you add or change redaction on a gate-side LOG line, pick the redactor by asking whether that module's process composes a platform context, not by reaching for the nearest `redact_*` helper. A process that calls `boot_platform` composes, so its log lines must go through `redact_log_via_context`; only a process that deliberately does not compose (`mcp_gateway.gatewayd` is the one the docstring names) is entitled to a baseline redactor. Apply the truncation after the redactor returns, never inside it.

Worth harvesting because the defect arrived inside a fix for the adjacent bug. #7424 was correcting redact-then-truncate ordering across many call sites, got that ordering right here, and still picked the companion-blind redactor -- so a reviewer scanning for the bug being fixed would see a correct diff. The `_BASELINE_LOG_SITE_CENSUS` gate is what caught it, and the tempting way to clear that gate is to raise the number, which converts a caught defect into an accepted one. The census entry is the accounting, not the remedy.
