### PR TITLE
fix(a11y): mark two non-interactive wrappers as presentation and retighten the lint ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1327,15 +1327,15 @@ jobs:
         # silent admission, and a warning that lands inside it never surfaces
         # again. Re-measure with `cd website && npx eslint src/` when burning down.
         #
-        # 604 is a RAISE from 603, against the instruction above, and it buys
-        # nothing but an unblock. 7362b6a2b (#7259) landed a third
-        # react-hooks/exhaustive-deps warning in ArtifactsPage.tsx while this said
-        # 603, so main measured one over its own ceiling and every open PR
+        # The 604 this replaces was a fleet unblock: 7362b6a2b (#7259) landed a
+        # third react-hooks/exhaustive-deps warning in ArtifactsPage.tsx while this
+        # said 603, so main measured one over its own ceiling and every open PR
         # touching website/** went red on a warning its diff never wrote (#7511 is
-        # why main's own runs did not report it first). Fixing the dependency
-        # belongs to that page's owner, not to a fleet unblock: issue #7695 carries
-        # it, and this returns to 603 in the same PR that clears it.
-        run: npx eslint src/ --max-warnings 604
+        # why main's own runs did not report it first). That page now measures zero
+        # warnings, and removing two jsx-a11y warnings here takes the tree to 599 —
+        # so the ceiling returns to the count the tree actually measures, with the
+        # slack the instruction above forbids taken back out.
+        run: npx eslint src/ --max-warnings 599
 
       - name: Copy/paste detection
         working-directory: website

--- a/website/src/apps/design-critique/Composer.tsx
+++ b/website/src/apps/design-critique/Composer.tsx
@@ -82,7 +82,12 @@ export default function Composer(p: Props) {
     )
 
   return (
-    <div style={S.composerMid} onDragOver={p.onDragOver} onDragLeave={p.onDragLeave} onDrop={p.onDrop}>
+    // Drag-and-drop is a pointer-only shortcut layered over this card; the
+    // keyboard path is the role="button" drop tile above, which opens the same
+    // file picker on Enter/Space. `presentation` marks the drop surface as
+    // layout rather than a control — the card's real inputs and buttons below
+    // keep their own semantics.
+    <div style={S.composerMid} role="presentation" onDragOver={p.onDragOver} onDragLeave={p.onDragLeave} onDrop={p.onDrop}>
       <div style={S.card}>
         <input
           ref={inputRef}

--- a/website/src/apps/design-critique/FindingRow.tsx
+++ b/website/src/apps/design-critique/FindingRow.tsx
@@ -32,6 +32,12 @@ export default function FindingRow({
   return (
     <div
       ref={rowRef}
+      // Styling and hover-highlight only: the row's activation lives on the
+      // <Clickable> below, which is where focus and Enter/Space already land.
+      // `presentation` says so rather than inventing a button role on a wrapper
+      // that contains other controls; a div's implicit role is generic, so this
+      // removes nothing from the accessibility tree.
+      role="presentation"
       style={{
         ...S.finding,
         borderBottom: isActive ? '1px solid transparent' : '1px solid var(--border)',


### PR DESCRIPTION
<!-- no-visual-delta -->

**Why no screenshot:** the diff adds two `role="presentation"` attributes and changes one CI number — the accessibility tree loses nothing and no pixel moves, so a before/after pair would be two identical images.

## What

| Site | Change |
|---|---|
| `design-critique/Composer.tsx` drop surface | `role="presentation"` — the drag handlers are a pointer-only shortcut; the keyboard path is the existing `role="button"` drop tile |
| `design-critique/FindingRow.tsx` row wrapper | `role="presentation"` — hover styling only; activation already lives on the `<Clickable>` child |
| `.github/workflows/ci.yml` | `--max-warnings 604` → `599` |

Both wrappers carried pointer handlers while their activation lived on a child control, so jsx-a11y read them as non-native interactive elements. `presentation` states what they are, and since a `div`'s implicit role is generic, it removes nothing from the accessibility tree.

## Why the ceiling moves

The step's own comment requires it: "the ceiling must EQUAL the measured count, not sit above it: slack is silent admission, and a warning that lands inside it never surfaces again."

It had drifted to 604 as a deliberate fleet unblock — `7362b6a2b` (#7259) landed a third `react-hooks/exhaustive-deps` warning in `ArtifactsPage.tsx` while the ceiling said 603, so main measured one over its own ceiling and every open PR touching `website/**` went red on a warning its diff never wrote. That page measures **zero** warnings now, so the slack has no remaining justification. Removing two more warnings takes the tree to 599, which is what this sets.

## Pattern harvest

Rule candidate: CI — make the eslint ratchet self-measuring instead of a hand-maintained literal. The defect class is "the ceiling and the tree disagree," and it fired twice in one day in opposite directions: #7696 raised 603 → 604 to unblock the fleet, and this PR lowers it to 599. Both were manual re-measurements of a number CI can compute. Two mechanisms, either sufficient: (a) have the Lint step measure the merge base itself and fail only on growth relative to it, which is what the step's comment already describes in prose — that removes the literal and with it the window where a merge into a moved `main` fails on a warning the diff never wrote; or (b) if the literal stays, add a check that fails when it does not equal the measured count, so slack cannot accumulate silently, which is the property the comment asks for and nothing currently enforces.

Not generalizable: the two `role="presentation"` fixes themselves. `useSemanticElements` is already an enforced lint rule, so this class is caught at authoring time; these two sites predate its coverage of their pattern rather than escaping it.

## Deliberately not fixed here

The pin marker in `DesignCritiquePage.tsx` carries `role={interactive ? 'button' : undefined}` and `tabIndex={interactive ? 0 : undefined}`. jsx-a11y resolves only *literal* role values, so that pin is neither a button nor presentational to the linter, and a keyboard user gets a `<span>` with a click handler — a real defect. Fixing it means splitting into literal branches, which means hoisting the shared style object, which moves CSS `box-shadow` strings onto lines the **diff-scoped i18n gate** counts at zero tolerance. Two gates disagree on that line; resolving it belongs to that page (whose i18n debt is already tracked), not to a ceiling correction. Left as a warning, inside the new ceiling.

## Tested

- `npx eslint src/` (cwd `website`, deps synced via `npm ci` against current main's lockfile): 601 → **599** warnings, 0 errors.
- Ceiling verified exact: passes at `--max-warnings 599`, fails at `598`.
- Diff-scoped i18n gate with the PR's own base: `19 checks · PASS`.
- `npx tsc -b`: clean. `DesignCritique*` specs: 6 files, 107 tests, all pass.

## Notes

[PR #7569](https://github.com/kirodotdev/KiroCrew/pull/7569) is burning the same ceiling down repo-wide and touches these files too; it can drop the redundant hunks on its next rebase. Kept small so the ceiling correction can land on its own.
