### PR TITLE
chore: raise the Python floor to 3.12 and drop the 3.10 CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.12"]
     steps:
       # Full history so the black gate can compute THIS change's own diff. A
       # shallow clone truncates parent info and leaves no base ref, and the gate
@@ -587,8 +587,8 @@ jobs:
       # picture across the suite, not just the first shard to break.
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
-        # Duration-balanced shards (pytest-split). 4 groups x 2 Python = 8
+        python-version: ["3.12"]
+        # Duration-balanced shards (pytest-split). 4 groups x 1 Python = 4
         # parallel jobs, each on its own runner (4 cores via -n auto). To add
         # shards, extend this list AND bump SHARD_COUNT to match -- mind the
         # ~20 concurrent-job ceiling for public repos.
@@ -652,10 +652,10 @@ jobs:
         # by test count. -n auto still parallelizes within each shard across the
         # runner's cores -- sharding scales across runners, -n auto across cores.
         #
-        # Coverage runs only on 3.12 (fast sys.monitoring path); each shard emits
-        # a partial data file merged later by the coverage-combine job. 3.10
-        # passes --no-cov (overriding setup.cfg's forced --cov) for a trace-free,
-        # faster run.
+        # Coverage runs on every shard: since the floor moved to >= 3.12 the
+        # matrix has a single Python, so there is no --no-cov lane left. Each
+        # shard emits a partial data file merged later by the coverage-combine
+        # job.
         env:
           REDUCED: ${{ steps.scope.outputs.reduced }}
           TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
@@ -689,7 +689,7 @@ jobs:
           fi
           pytest -q -n auto --timeout=120 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
-            ${{ matrix.python-version == '3.12' && '--cov=kiro_crew --cov=sage_lib' || '--no-cov' }}
+            --cov=kiro_crew --cov=sage_lib
         # Nothing is deselected. The eleven files that used to be -- the two sandbox
         # suites, the two ops git/gh suites, and the seven auto_improvement suites --
         # each carry `skipif(not userns_available())` on the tests that need a namespace
@@ -697,7 +697,7 @@ jobs:
         # named reason and the other ~523 run. See the note above the `jobs:` key.
 
       - name: Stage shard coverage data
-        if: matrix.python-version == '3.12' && steps.scope.outputs.reduced != 'true'
+        if: steps.scope.outputs.reduced != 'true'
         # Fold any xdist parallel data files into a single .coverage (no-op if
         # pytest-cov already combined this shard), then name it per-shard so the
         # combine job can merge all shards with `coverage combine`.
@@ -707,7 +707,7 @@ jobs:
           mv .coverage ".coverage.${{ matrix.group }}"
 
       - name: Upload shard coverage
-        if: matrix.python-version == '3.12' && steps.scope.outputs.reduced != 'true'
+        if: steps.scope.outputs.reduced != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-shard-${{ matrix.group }}

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -181,7 +181,7 @@ jobs:
           MANIFEST="$(dirname "$WHEEL_PATH")/cli-manifest.json"
           PYREQ=$(unzip -p "$WHEEL_PATH" '*.dist-info/METADATA' 2>/dev/null \
             | awk -F': ' 'tolower($1)=="requires-python"{print $2; exit}' | tr -d '\r')
-          PYREQ="${PYREQ:->=3.10}"
+          PYREQ="${PYREQ:->=3.12}"
           # The immutable manifest must be byte-identical when a failed job is
           # retried. Wall-clock time would change the signed payload and make
           # put_immutable reject a safe retry, so bind publication time to the

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ backend:
 	# Same `|| true` reasoning as the frontend target: an absent marker file must
 	# fall back to $(PY), not abort the recipe.
 	PY="$$(cat "$${KIROCREW_HOME:-$$HOME/.kiro/crew}/python-bin" 2>/dev/null || true)"; [ -n "$$PY" ] || PY="$(PY)"; \
-	  if [ -x $(VENV)/bin/python ] && ! $(VENV)/bin/python -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)'; then \
-	    echo "  → recreating $(VENV) (existing interpreter < 3.10)"; rm -rf $(VENV); fi; \
-	  if ! "$$PY" -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then \
-	    echo "ERROR: '$$PY' is not Python >= 3.10 (package requires-python is >=3.10)." >&2; \
+	  if [ -x $(VENV)/bin/python ] && ! $(VENV)/bin/python -c 'import sys; sys.exit(0 if sys.version_info >= (3,12) else 1)'; then \
+	    echo "  → recreating $(VENV) (existing interpreter < 3.12)"; rm -rf $(VENV); fi; \
+	  if ! "$$PY" -c 'import sys; sys.exit(0 if sys.version_info >= (3,12) else 1)' 2>/dev/null; then \
+	    echo "ERROR: '$$PY' is not Python >= 3.12 (package requires-python is >=3.12)." >&2; \
 	    echo "       Without this gate the venv is built from a too-old interpreter, the" >&2; \
 	    echo "       version guard above deletes it on every run, and the install either" >&2; \
-	    echo "       backtracks forever or crashes at import. Provision 3.10+ first:" >&2; \
+	    echo "       backtracks forever or crashes at import. Provision 3.12+ first:" >&2; \
 	    echo "         bash ensure-python.sh   # or: make backend PY=python3.12" >&2; \
 	    exit 1; \
 	  fi; \
@@ -87,10 +87,10 @@ test: build
 #
 # Runs through the venv the `backend` target provisions rather than a bare
 # `$(PY) -m pip install --upgrade build`: on hosts whose system python3 is older
-# than 3.10 (Amazon Linux 2023 ships 3.9) that bare form installs `build` into
+# than 3.12 (Amazon Linux 2023 ships 3.9) that bare form installs `build` into
 # the *system* interpreter — mutating it without a venv, and tripping PEP 668
 # "externally-managed-environment" where the marker exists. Depending on
-# `backend` guarantees a >= 3.10 venv exists first.
+# `backend` guarantees a >= 3.12 venv exists first.
 wheel: frontend backend
 	$(PIP) install --upgrade build
 	$(VENV)/bin/python -m build --wheel

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ the container security model.
 
 ### Build from source
 
-macOS and Linux require Python 3.10+, Node.js 22+ (24 LTS recommended), npm, and
+macOS and Linux require Python 3.12+, Node.js 22+ (24 LTS recommended), npm, and
 [`kiro-cli`](https://kiro.dev/docs/cli/). The first desktop or dashboard launch
 can install Kiro CLI on the Gateway host and guide device-code sign-in before
 chat opens. Windows is supported through a native source install; follow the
@@ -395,7 +395,7 @@ the published manifest, installs through `pipx` when available or a managed
 virtual environment at `~/.kiro/crew-venv` (beside the data home; override with
 `KIROCREW_VENV`), and records the channel in `~/.kiro/crew/channel`. The channels
 are `stable`, `insider`, and `nightly`, and `KIROCREW_CHANNEL` sets the default.
-On Linux and macOS, when the system lacks a Python 3.10+ interpreter the
+On Linux and macOS, when the system lacks a Python 3.12+ interpreter the
 installer provisions one itself — no package manager, no sudo: it downloads a
 SHA-256-pinned [uv](https://docs.astral.sh/uv/) binary (or uses your installed
 `uv`) and installs a python-build-standalone CPython 3.12 into

--- a/cli.sh
+++ b/cli.sh
@@ -12,7 +12,7 @@
 # venv). No unsigned/checksum-only fallback exists. Unlike install.sh (which
 # builds from a git clone), this pulls the published wheel.
 #
-# Python: uses the system interpreter (>=3.10) when one exists; otherwise — or
+# Python: uses the system interpreter (>=3.12) when one exists; otherwise — or
 # always, with --managed-python — provisions a python-build-standalone CPython
 # via a SHA-256-pinned uv into a user-owned directory. No package manager, no
 # sudo, works on old-glibc distros (CentOS 7).
@@ -171,11 +171,12 @@ else err "need sha256sum or shasum to verify the download"; fi
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT INT TERM
 
-# KiroCrew needs Python >=3.10 at runtime (contextlib.aclosing, etc.) even
-# though older published wheels' METADATA claimed >=3.9 -- pip would install
-# fine on 3.9 and then crash on first run. Prefer the newest interpreter the
-# project builds and tests on (3.12 is the CI target); 3.13 is untested and
-# only a last resort before bare python3, which itself only counts if >=3.10.
+# Kiro Crew needs Python >=3.12 at runtime -- that is what every release
+# artifact bundles and the only version CI tests, and older published wheels'
+# METADATA claimed a lower floor, so pip would install fine and then crash on
+# first run. Prefer the exact interpreter the project builds and tests on
+# (3.12); 3.13 is untested and only a last resort before bare python3, which
+# itself only counts if >=3.12.
 # A version-manager shim (mise, pyenv, asdf) can wedge instead of answering --
 # notably when HOME does not hold the config the shim expects -- and an
 # unbounded probe then hangs the whole install on its FIRST candidate,
@@ -194,13 +195,13 @@ _py_usable() {
   if [ -n "$_PY_PROBE_TIMEOUT" ]; then
     # Unquoted on purpose: expands to two words, or to nothing when unavailable.
     # shellcheck disable=SC2086
-    $_PY_PROBE_TIMEOUT "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null
+    $_PY_PROBE_TIMEOUT "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,12) else 1)' 2>/dev/null
     return $?
   fi
   # No `timeout` binary (stock macOS): emulate the same 5s bound with a POSIX
   # watchdog, so a wedged version-manager shim still fails over to the next
   # candidate instead of hanging the install on its first probe.
-  "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' >/dev/null 2>&1 &
+  "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,12) else 1)' >/dev/null 2>&1 &
   _py_pid=$!
   (
     # On TERM from the fast-exit path below, kill our own in-flight `sleep`
@@ -230,7 +231,7 @@ _py_usable() {
 
 # Resolve the newest supported interpreter into PY (left empty if none found).
 _resolve_python() {
-  for _c in python3.12 python3.11 python3.10 python3.13 python3; do
+  for _c in python3.12 python3.13 python3; do
     if _py_usable "$_c"; then PY="$_c"; return 0; fi
   done
   return 1
@@ -324,15 +325,15 @@ fi
 if [ "$MANAGED_PYTHON" = "1" ]; then
   echo "managed-python: skipping system interpreters."
   _provision_python_via_uv \
-    || err "could not provision a managed Python via uv. Check the network connection, or install Python >=3.10 yourself and re-run without --managed-python."
+    || err "could not provision a managed Python via uv. Check the network connection, or install Python >=3.12 yourself and re-run without --managed-python."
 else
   _resolve_python || true
   if [ -z "$PY" ]; then
-    echo "No system Python >=3.10 found; provisioning one via uv ..."
+    echo "No system Python >=3.12 found; provisioning one via uv ..."
     _provision_python_via_uv || true
   fi
 fi
-[ -n "$PY" ] || err "Python >=3.10 is required and could not be found or provisioned. Install Python 3.10+ yourself (your distro's packages, or https://www.python.org/downloads/), then re-run."
+[ -n "$PY" ] || err "Python >=3.12 is required and could not be found or provisioned. Install Python 3.12+ yourself (your distro's packages, or https://www.python.org/downloads/), then re-run."
 
 # Materialize and self-check the embedded trust root. The key id is the SHA-256
 # fingerprint of SubjectPublicKeyInfo DER, so an accidental edit to either

--- a/cloud-install.sh
+++ b/cloud-install.sh
@@ -68,8 +68,8 @@ echo "  ${DIM}Platform: $OS $ARCH${RESET}"
 # --- 1. Python -------------------------------------------------------------
 step 1 "Python"
 PY=""
-for c in python3.12 python3.11 python3.10 python3; do
-    if has "$c" && "$c" -c 'import sys; assert sys.version_info>=(3,10)' 2>/dev/null; then PY="$c"; break; fi
+for c in python3.12 python3.13 python3; do
+    if has "$c" && "$c" -c 'import sys; assert sys.version_info>=(3,12)' 2>/dev/null; then PY="$c"; break; fi
 done
 if [ -z "$PY" ]; then
     if [ "$OS" = "Darwin" ]; then
@@ -77,18 +77,44 @@ if [ -z "$PY" ]; then
         xcode-select --install 2>/dev/null || true
         warn "Finish the Xcode CLT install if prompted, then re-run this script."
     elif has apt-get; then $SUDO apt-get update -qq && $SUDO apt-get install -y python3 python3-venv python3-pip
-    elif has dnf; then $SUDO dnf install -y python3.11 python3.11-pip 2>/dev/null || $SUDO dnf install -y python3 python3-pip
+    elif has dnf; then $SUDO dnf install -y python3.12 python3.12-pip 2>/dev/null || $SUDO dnf install -y python3 python3-pip
     elif has yum; then $SUDO yum install -y python3 python3-pip
     elif has brew; then brew install python@3.12
     fi
-    # Re-probe with the same >=3.10 gate as above -- a bare existence check would
+    # Re-probe with the same >=3.12 gate as above -- a bare existence check would
     # wrongly latch onto a distro's default python3 (RHEL/CentOS 7 = 3.6,
-    # Amazon Linux 2023 = 3.9), which then fails later at pip/venv.
-    for c in python3.12 python3.11 python3.10 python3; do
-        if has "$c" && "$c" -c 'import sys; assert sys.version_info>=(3,10)' 2>/dev/null; then PY="$c"; break; fi
+    # Amazon Linux 2023 = 3.9, Ubuntu 22.04 = 3.10), which then fails later at
+    # pip/venv.
+    for c in python3.12 python3.13 python3; do
+        if has "$c" && "$c" -c 'import sys; assert sys.version_info>=(3,12)' 2>/dev/null; then PY="$c"; break; fi
     done
 fi
-[ -n "$PY" ] || { warn "Python 3.10+ required. Install it and re-run."; exit 1; }
+# Last resort before giving up: this script runs from a clone, so the repo's own
+# bootstrap is available and already knows how to provision 3.12 via mise's
+# python-build-standalone builds and record the interpreter it chose. Without
+# this, a distro whose archive tops out below 3.12 (Ubuntu 22.04 -> 3.10) exits
+# here, where the >= 3.10 floor had accepted the distro's python3.
+# True only when a version manager is ALREADY on this host. ensure-python.sh will
+# otherwise install mise by piping a remote script into sh, and this fallback runs
+# without the user having asked for it -- so it must not be able to reach that.
+_has_provisioner() {
+    command -v mise >/dev/null 2>&1 || [ -x "$HOME/.local/bin/mise" ]
+}
+if [ -z "$PY" ] && [ -f "$REPO_ROOT/ensure-python.sh" ] && _has_provisioner; then
+    info "No system Python 3.12+; provisioning one via ensure-python.sh…"
+    bash "$REPO_ROOT/ensure-python.sh" >/dev/null 2>&1 || true
+    _recorded="$(cat "${KIROCREW_HOME:-$HOME/.kiro/crew}/python-bin" 2>/dev/null || true)"
+    if [ -n "$_recorded" ] && [ -x "$_recorded" ] \
+        && "$_recorded" -c 'import sys; assert sys.version_info>=(3,12)' 2>/dev/null; then
+        PY="$_recorded"
+    fi
+fi
+if [ -z "$PY" ]; then
+    warn "Python 3.12+ is required and this host has none."
+    info "Install Python 3.12+, or install mise (https://mise.jdx.dev/installing-mise.html)"
+    info "and re-run — this script will then provision Python 3.12 through it."
+    exit 1
+fi
 ok "$($PY --version 2>&1)"
 
 # --- 2. AWS CLI ------------------------------------------------------------
@@ -151,6 +177,14 @@ fi
 step 4 "KiroCrew client"
 info "Installing the KiroCrew client (pip, editable)…"
 _venv="$REPO_ROOT/.venv"
+# Same requires-python reuse rule as install.sh and setup.sh: an existing venv
+# built on a pre-3.12 interpreter cannot host the package, and the pip install
+# below would be refused outright, so rebuild instead of reusing.
+if [ -x "$_venv/bin/python" ] \
+    && ! "$_venv/bin/python" -c "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)" 2>/dev/null; then
+    warn "Existing venv predates the Python 3.12 floor — recreating it"
+    rm -rf "$_venv"
+fi
 [ -x "$_venv/bin/python" ] || "$PY" -m venv "$_venv"
 "$_venv/bin/pip" install --upgrade pip -q 2>/dev/null || true
 _pip_target="$REPO_ROOT"

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -36,7 +36,7 @@ Builds use plain `pip` + `npm`/Vite + `pytest`, driven by the repo-root
 
 | Requirement | Needed for | Floor |
 |-------------|------------|-------|
-| **Python** | Backend | `>= 3.10` (`requires-python` in `pyproject.toml`; `make build` provisions a 3.12 `.venv` by default) |
+| **Python** | Backend | `>= 3.12` (`requires-python` in `pyproject.toml`; `make build` provisions a 3.12 `.venv` by default) |
 | **Node.js + npm** | Building the dashboard | `20 \|\| >= 22` (`website/package.json` `engines`); `ensure-node.sh` targets 20, and drops to 16 on Amazon Linux 2 where newer official builds need a glibc that host does not have |
 | **`kiro-cli`** | Driving the LLM | Required; see below |
 
@@ -148,7 +148,7 @@ home (`~/.kiro/crew-venv`, override with `KIROCREW_VENV`) and symlinks
 data home, so no whole-home operation can ever delete the live interpreter. The
 selected channel is recorded to `~/.kiro/crew/channel`.
 
-If the host has no Python 3.10+, the installer provisions one itself instead of
+If the host has no Python 3.12+, the installer provisions one itself instead of
 touching the system: it downloads a SHA-256-pinned [uv](https://docs.astral.sh/uv/)
 binary (or uses an already-installed `uv` on `PATH`), then installs a
 [python-build-standalone](https://github.com/astral-sh/python-build-standalone)

--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -23,7 +23,7 @@ Four parts, in the order you will need them:
 - **OS**: any modern Linux distribution (Ubuntu 22.04+, Debian 12+, Fedora,
   CentOS Stream / RHEL 8+, CentOS 7, Amazon Linux 2 / 2023). macOS works too,
   with launchd instead of systemd.
-- **Python**: 3.10 or newer (`setup.cfg` sets `python_requires = >=3.10`).
+- **Python**: 3.12 or newer (`setup.cfg` sets `python_requires = >=3.12`).
 - **Node.js**: needed to build the dashboard bundle. `website/package.json`
   declares `"node": ">=22"`; `kirocrew doctor` warns below Node 22.
 - **RAM**: there is no single published floor, because the footprint scales with
@@ -44,8 +44,8 @@ Four parts, in the order you will need them:
 sudo apt-get update && sudo apt-get install -y git tmux python3 python3-pip python3-venv
 
 # Fedora / CentOS Stream / RHEL 8+ / Amazon Linux 2023 (python3 may be 3.9;
-# python3.11 gives the 3.10+ the backend needs)
-sudo dnf install -y git tmux python3.11 python3.11-pip
+# python3.12 gives the 3.12+ the backend needs)
+sudo dnf install -y git tmux python3.12 python3.12-pip
 
 # CentOS 7 / RHEL 7 (yum; base repos ship only Python 3.6, which is too old —
 # install a newer interpreter yourself first, e.g. mise; see below)
@@ -54,7 +54,7 @@ curl https://mise.run | sh && mise use -g python@3.12
 ```
 
 The `curl … | sh` installer performs this distro Python bootstrap for you. On
-CentOS 7 and older Ubuntu, where no base-repo package supplies Python 3.10+, it
+CentOS 7 and older Ubuntu, where no base-repo package supplies Python 3.12+, it
 uses an already-installed [mise](https://mise.jdx.dev/) if you have one and
 otherwise stops with instructions — the signed installer does not pipe an
 unsigned script into a shell, so install mise yourself first

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -135,7 +135,7 @@ The source install below remains the fully supported path.
 |------|-----|--------|
 | **Git for Windows** | clone the repo | https://git-scm.com/download/win |
 | **kiro-cli** | the agent backend (ACP); the first dashboard launch can install it | Kiro Crew setup page or kiro-cli's native Windows release |
-| **Python 3.10-3.13** | the venv runtime. `python_requires` is `>=3.10` and 3.13 is in the supported range, but **3.12 is the tested Windows runtime** (it is what the Windows CI shard runs, and numpy 1.x ships no 3.13 Windows wheel) | https://python.org (install user-scoped), or `winget install Python.Python.3.12` |
+| **Python 3.12-3.13** | the venv runtime. `python_requires` is `>=3.12` and 3.13 is in the supported range, but **3.12 is the tested Windows runtime** (it is what the Windows CI shard runs, and numpy 1.x ships no 3.13 Windows wheel) | https://python.org (install user-scoped), or `winget install Python.Python.3.12` |
 | **Node.js** (optional) | builds the full React dashboard; without it the gateway serves the prebuilt bundle | `winget install OpenJS.NodeJS.LTS` |
 
 No admin is required — everything installs user-scoped under `%USERPROFILE%`.

--- a/docs/system-specs/common/code-style.md
+++ b/docs/system-specs/common/code-style.md
@@ -48,7 +48,7 @@ Other style rules:
 | Rule | Requirement |
 |---|---|
 | Line length | 100 chars (black and isort are both configured to it) |
-| Python version | >= 3.10; `from __future__ import annotations` for type hints |
+| Python version | >= 3.12; `from __future__ import annotations` for type hints |
 | Imports | `import logging` plus `logger = logging.getLogger(__name__)` |
 | Async | `asyncio` throughout; `async def` for all I/O |
 | Module-global asyncio primitives | Never a bare `asyncio.Lock()`/`Event()`/`Queue()` at module scope — it binds to the import-time (or first-use) loop and raises `RuntimeError` from any other loop (Python 3.10+). Use `kiro_crew.loop_lock.LoopBoundLock` for locks, or create the primitive inside the coroutine. CI enforces this (`loop-bound-locks` gate). |

--- a/ensure-python.sh
+++ b/ensure-python.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
-# Ensure a Python >= 3.10 interpreter is available for the backend venv.
+# Ensure a Python >= 3.12 interpreter is available for the backend venv.
 # Called by: Makefile (backend), setup.sh
 # Platforms: macOS, Amazon Linux 2 (system python3 is 3.7), Amazon Linux 2023
 #            (system python3 is 3.9), Linux
 #
-# The package requires Python >= 3.10 (pyproject `requires-python`; the code
-# uses stdlib features such as contextlib.aclosing that need 3.10). Amazon
+# The package requires Python >= 3.12 (pyproject `requires-python`): 3.12 is
+# what every release artifact bundles (packaging/build-desktop.sh pins a
+# CPython 3.12 python-build-standalone) and the only version CI tests. Amazon
 # Linux 2 ships Python 3.7 and Amazon Linux 2023 ships 3.9 as `python3`, so
 # `python3 -m venv` produces a too-old venv and either `pip install -e .` fails
 # to resolve modern deps (AL2/3.7) or the install "succeeds" and then crashes at
-# import (AL2023/3.9). Prefer any already-usable system Python >= 3.10;
+# import (AL2023/3.9). Prefer any already-usable system Python >= 3.12;
 # otherwise install one via mise, whose python-build-standalone binaries run on
 # AL2's glibc 2.26. On success the chosen interpreter's real path — symlinks
 # resolved, see _resolve — is recorded in "<data-home>/python-bin" so
@@ -19,7 +20,7 @@
 # which is not the data home and must not be written to.
 
 MIN_MAJOR=3
-MIN_MINOR=10
+MIN_MINOR=12
 TARGET_PY="${KIROCREW_PYTHON_VERSION:-3.12}"
 
 # True if $1 is a python that runs AND is >= MIN_MAJOR.MIN_MINOR.
@@ -32,12 +33,12 @@ _pyver() {
     "$1" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null
 }
 
-# First usable system python, preferring the newest SUPPORTED minor (3.12 is
-# the CI/build target, matching TARGET_PY above); untested 3.13 and bare
+# First usable system python, preferring the tested minor (3.12 is the
+# CI/build target, matching TARGET_PY above); untested 3.13 and bare
 # python3/python are last resorts so a bleeding-edge install still succeeds.
 _find_system_python() {
     local c resolved
-    for c in python3.12 python3.11 python3.10 python3.13 python3 python; do
+    for c in python3.12 python3.13 python3 python; do
         resolved="$(command -v "$c" 2>/dev/null)" || continue
         if _py_ok "$resolved"; then
             echo "$resolved"

--- a/install.ps1
+++ b/install.ps1
@@ -62,18 +62,40 @@ $pm = Ensure-WingetOrChoco
 
 # --- 1. Python -------------------------------------------------------------
 Write-Step 1 4 "Python"
-if (Have "python") {
-    Write-Ok ("python found ({0})" -f (python --version 2>&1))
-} elseif ($pm -eq "winget") {
-    Write-Info "Installing Python via winget..."
-    winget install -e --id Python.Python.3.12 --accept-source-agreements --accept-package-agreements
-    Write-Ok "Python installed (restart the shell if 'python' isn't found yet)"
-} elseif ($pm -eq "choco") {
-    choco install -y python
-    Write-Ok "Python installed"
+# Version-gated, not a bare existence check: the package declares
+# requires-python >= 3.12, so a 3.10/3.11 already on PATH would pass an
+# existence test here and then be refused by pip at step 4 -- after the AWS CLI
+# and the SSM plugin had already been installed. Resolve the interpreter ONCE
+# and use that same command for every later python call.
+function Resolve-Python312 {
+    foreach ($candidate in @("python3.12", "python", "python3")) {
+        if (-not (Have $candidate)) { continue }
+        & $candidate -c "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)" *> $null
+        if ($LASTEXITCODE -eq 0) { return $candidate }
+    }
+    return $null
+}
+
+$PyExe = Resolve-Python312
+if ($PyExe) {
+    Write-Ok ("python found ({0})" -f (& $PyExe --version 2>&1))
 } else {
-    Write-Warn "No package manager found. Install Python 3.10+ from https://python.org and re-run."
-    exit 1
+    if ($pm -eq "winget") {
+        Write-Info "Installing Python 3.12 via winget..."
+        winget install -e --id Python.Python.3.12 --accept-source-agreements --accept-package-agreements
+    } elseif ($pm -eq "choco") {
+        Write-Info "Installing Python 3.12 via choco..."
+        choco install -y python312
+    } else {
+        Write-Warn "No package manager found. Install Python 3.12+ from https://python.org and re-run."
+        exit 1
+    }
+    $PyExe = Resolve-Python312
+    if (-not $PyExe) {
+        Write-Warn "Python 3.12+ still not on PATH - restart the shell and re-run this installer."
+        exit 1
+    }
+    Write-Ok ("Python installed ({0})" -f (& $PyExe --version 2>&1))
 }
 
 # --- 2. AWS CLI ------------------------------------------------------------
@@ -107,10 +129,10 @@ Write-Step 4 4 "KiroCrew client"
 $repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 Push-Location $repoRoot
 try {
-    Write-Info "Installing the KiroCrew client (pip)..."
-    python -m pip install --upgrade pip *> $null
+    Write-Info "Installing the Kiro Crew client (pip)..."
+    & $PyExe -m pip install --upgrade pip *> $null
     $env:KIROCREW_SKIP_FRONTEND = "1"
-    python -m pip install -e . 2>&1 | Select-Object -Last 5
+    & $PyExe -m pip install -e . 2>&1 | Select-Object -Last 5
     # PowerShell has no `set -e`: a failed pip install would otherwise fall
     # through to a misleading "installed" + a launch that dies opaquely. Check
     # the exit code and fail closed, matching cloud-install.sh's behavior.
@@ -156,7 +178,7 @@ if ($NonInteractive) {
 Write-Host ""
 Write-Host "  Launching KiroCrew on AWS..." -ForegroundColor Cyan
 if ($Size -ne "") {
-    python -m kiro_crew cloud launch --size $Size
+    & $PyExe -m kiro_crew cloud launch --size $Size
 } else {
-    python -m kiro_crew cloud launch
+    & $PyExe -m kiro_crew cloud launch
 }

--- a/install.sh
+++ b/install.sh
@@ -195,9 +195,9 @@ if [ "$USE_MISE" -eq 0 ]; then
 info "Checking Python…"
 _py=""
 _find_python() {
-    for _candidate in python3.12 python3.11 python3.10 python3 python; do
+    for _candidate in python3.12 python3.13 python3 python; do
         if has "$_candidate"; then
-            _ok=$("$_candidate" -c "import sys; print(int(sys.version_info >= (3, 10)))" 2>/dev/null || echo "0")
+            _ok=$("$_candidate" -c "import sys; print(int(sys.version_info >= (3, 12)))" 2>/dev/null || echo "0")
             if [ "$_ok" = "1" ]; then
                 _ver=$("$_candidate" -c "import sys; v=sys.version_info; print(f'{v.major}.{v.minor}')" 2>/dev/null)
                 _py="$_candidate"
@@ -209,37 +209,87 @@ _find_python() {
     return 1
 }
 
+# Provision Python $PYTHON_VERSION without a package manager, for hosts whose
+# archive carries no python3.12 (Ubuntu 22.04, Debian 12, RHEL/CentOS 7). mise
+# ships python-build-standalone builds, which run on old glibc. Every probe
+# below tries this before giving up: without it the >= 3.12 floor turns a host
+# the package manager cannot satisfy into a hard abort, where the >= 3.10 floor
+# had simply accepted the distro's own python3.
+_bootstrap_python() {
+    # Deliberately does NOT install mise itself. Fetching an installer script over
+    # the network and piping it to a shell executes unverified remote content as
+    # the user, and unlike the `--mise` block below this path runs WITHOUT the user
+    # asking for it -- so an automatic fallback must not introduce that. Use mise
+    # only when the host already has it; otherwise the caller stops with guidance.
+    if [ -x "$HOME/.local/bin/mise" ]; then
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+    has mise || return 1
+    info "Provisioning Python $PYTHON_VERSION via the installed mise…"
+    mise install "python@$PYTHON_VERSION" -y >/dev/null 2>&1 || return 1
+    _bootstrap_prefix="$(mise where "python@$PYTHON_VERSION" 2>/dev/null)" || return 1
+    [ -n "$_bootstrap_prefix" ] || return 1
+    [ -x "$_bootstrap_prefix/bin/python3" ] || return 1
+    # Prepend rather than assigning _py directly, so _find_python stays the one
+    # place that decides which candidate name is used and records its version.
+    export PATH="$_bootstrap_prefix/bin:$PATH"
+    _find_python
+}
+
 if ! _find_python; then
     # Try to install automatically
     if [ "$(uname)" = "Darwin" ]; then
         info "Installing Python via Xcode Command Line Tools…"
         xcode-select --install 2>/dev/null || true
         sleep 2
-        if ! _find_python; then
+        if ! _find_python && ! _bootstrap_python; then
             warn "Xcode CLT install may be in progress (check the popup)"
             detail "After it finishes, re-run this installer"
-            die "Python 3.10+ required. Waiting for Xcode CLT to finish installing."
+            die "Python 3.12+ required. Waiting for Xcode CLT to finish installing."
         fi
     elif has apt-get; then
-        info "Installing Python 3 via apt…"
+        # python3.12 explicitly where the archive carries it (Ubuntu 24.04+,
+        # Debian 13+). On Ubuntu 22.04 the bare `python3` is 3.10 — below the
+        # >= 3.12 floor — so the fallback package cannot satisfy the probe and
+        # _bootstrap_python provisions 3.12 instead of the install aborting.
+        info "Installing Python 3.12 via apt…"
         sudo apt-get update -qq >/dev/null 2>&1
-        sudo apt-get install -y python3 python3-pip python3-venv >/dev/null 2>&1
-        _find_python || die "Python install failed. Run: sudo apt-get install -y python3 python3-venv"
+        sudo apt-get install -y python3.12 python3.12-venv >/dev/null 2>&1 \
+            || sudo apt-get install -y python3 python3-pip python3-venv >/dev/null 2>&1
+        _find_python || _bootstrap_python \
+            || die "Python 3.12+ is required and this host's apt archive has none.
+     Either: sudo apt-get install -y python3.12 python3.12-venv
+     or install mise (https://mise.jdx.dev/installing-mise.html) and re-run — this
+     installer will then provision Python $PYTHON_VERSION through it."
     elif has dnf; then
-        info "Installing Python 3 via dnf…"
-        sudo dnf install -y python3 python3-pip >/dev/null 2>&1
-        _find_python || die "Python install failed. Run: sudo dnf install -y python3"
+        # python3.12 explicitly: on Amazon Linux 2023 and RHEL 9 the bare
+        # `python3` is 3.9, which no longer satisfies the >= 3.12 floor.
+        info "Installing Python 3.12 via dnf…"
+        sudo dnf install -y python3.12 python3.12-pip >/dev/null 2>&1 \
+            || sudo dnf install -y python3 python3-pip >/dev/null 2>&1
+        _find_python || _bootstrap_python \
+            || die "Python 3.12+ is required and this host's dnf repos have none.
+     Either: sudo dnf install -y python3.12
+     or install mise (https://mise.jdx.dev/installing-mise.html) and re-run."
     elif has yum; then
+        # CentOS/RHEL 7 base repos top out at 3.6, so the bootstrap is the
+        # normal path here rather than the exception.
         info "Installing Python 3 via yum…"
         sudo yum install -y python3 python3-pip >/dev/null 2>&1
-        _find_python || die "Python install failed. Run: sudo yum install -y python3"
+        _find_python || _bootstrap_python \
+            || die "Python 3.12+ is required and yum's base repos cannot supply it.
+     Install mise (https://mise.jdx.dev/installing-mise.html) and re-run, or install
+     Python 3.12+ yourself."
     elif has brew; then
         info "Installing Python 3 via Homebrew…"
         brew install python@3.12 >/dev/null 2>&1 || true
-        _find_python || die "Python install failed. Run: brew install python@3.12"
+        _find_python || _bootstrap_python \
+            || die "Python install failed. Run: brew install python@3.12"
     else
-        die "Python 3.10+ required but not found and no package manager detected.
-     Install Python 3.10+ manually (https://www.python.org/downloads/) and re-run."
+        _bootstrap_python \
+            || die "Python 3.12+ required but not found and no package manager detected.
+     Install Python 3.12+ manually (https://www.python.org/downloads/), or install
+     mise (https://mise.jdx.dev/installing-mise.html) and re-run."
     fi
 fi
 fi # USE_MISE -eq 0 (Python)
@@ -420,9 +470,18 @@ fi
 # ── Python virtual environment & package ──
 info "Creating virtual environment…"
 _venv="$KIROCREW_APP_DIR/.venv"
-if [ -d "$_venv" ] && [ -x "$_venv/bin/python" ]; then
+# An existing venv is reusable only while its interpreter still satisfies the
+# package's requires-python. On an upgrade from a pre-3.12 install, reusing a
+# 3.10/3.11 venv makes the `pip install -e .` below refuse the package outright
+# ("Requires-Python >=3.12") and the upgrade dead-ends, so rebuild it instead.
+if [ -d "$_venv" ] && [ -x "$_venv/bin/python" ] \
+    && "$_venv/bin/python" -c "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)" 2>/dev/null; then
     ok "Existing venv found"
 else
+    if [ -d "$_venv" ]; then
+        warn "Existing venv predates the Python 3.12 floor — recreating it"
+        rm -rf "$_venv"
+    fi
     "$_py" -m venv "$_venv" || die "Failed to create venv. You may need: $_py -m pip install virtualenv"
     ok "venv created at $_venv"
 fi

--- a/make.ps1
+++ b/make.ps1
@@ -44,7 +44,7 @@ $VenvPytest = Join-Path $VenvDir "Scripts\pytest.exe"
 # ensure-python.sh's MIN_MAJOR/MIN_MINOR rather than parsed: this script must
 # work before any interpreter is known to exist.
 $MinPyMajor = 3
-$MinPyMinor = 10
+$MinPyMinor = 12
 
 function Write-Step($msg) { Write-Host "  -> $msg" -ForegroundColor Cyan }
 function Write-Ok($msg) { Write-Host "  [ok] $msg" -ForegroundColor Green }
@@ -109,8 +109,8 @@ function Read-Marker($path) {
 # installing an interpreter is a bigger side effect than a build target should
 # have on a developer machine.
 #
-# Candidate order matches ensure-python.sh: newest SUPPORTED minor first (3.12
-# is the CI/build target), with 3.13 after it -- numpy 1.x ships no 3.13 Windows
+# Candidate order matches ensure-python.sh: the tested minor first (3.12 is the
+# CI/build target), with 3.13 after it -- numpy 1.x ships no 3.13 Windows
 # wheel, so a 3.12 that is present must win.
 function Ensure-Python {
     if ($Py) {
@@ -126,7 +126,7 @@ function Ensure-Python {
     # `py -3.12` before a bare `python`: the launcher reports real CPython
     # installs only, so it never hands back the Store alias stub.
     if (Get-Command py -ErrorAction SilentlyContinue) {
-        foreach ($v in @("3.12", "3.11", "3.10", "3.13")) {
+        foreach ($v in @("3.12", "3.13")) {
             $probe = Invoke-Probe "py" @("-$v", "-c", "import sys; print(sys.executable)")
             if ($probe -and (Test-PythonUsable $probe)) {
                 $resolved = Resolve-PythonPath $probe
@@ -136,7 +136,7 @@ function Ensure-Python {
         }
     }
 
-    foreach ($name in @("python3.12", "python3.11", "python3.10", "python", "python3")) {
+    foreach ($name in @("python3.12", "python", "python3")) {
         $cmd = Get-Command $name -ErrorAction SilentlyContinue
         if (-not $cmd) { continue }
         $path = $cmd.Source

--- a/minimal_install.sh
+++ b/minimal_install.sh
@@ -11,7 +11,7 @@
 #   cd kirocrew
 #   bash minimal_install.sh
 #
-# Prerequisites: Python 3.10+, Node.js 22+ (24 LTS recommended), npm, git
+# Prerequisites: Python 3.12+, Node.js 22+ (24 LTS recommended), npm, git
 # Optional:
 #   --voice    also install voice extras (pip install -e .[voice])
 #   ollama     for local vector memory (see step "Embeddings" below)
@@ -45,12 +45,12 @@ die() { echo "ERROR: $1" >&2; exit 1; }
 has git || die "git not found"
 
 _py=""
-for c in python3.12 python3.11 python3.10 python3; do
-    if has "$c" && "$c" -c "import sys; assert sys.version_info >= (3,10)" 2>/dev/null; then
+for c in python3.12 python3.13 python3; do
+    if has "$c" && "$c" -c "import sys; assert sys.version_info >= (3,12)" 2>/dev/null; then
         _py="$c"; break
     fi
 done
-[ -n "$_py" ] || die "Python 3.10+ not found. Install Python 3.10 or newer and re-run."
+[ -n "$_py" ] || die "Python 3.12+ not found. Install Python 3.12 or newer and re-run."
 
 has node || die "Node.js not found. Install Node.js 22+ (24 LTS recommended, https://nodejs.org) and re-run."
 has npm  || die "npm not found. Install Node.js 22+ (24 LTS recommended, https://nodejs.org) and re-run."
@@ -93,6 +93,14 @@ echo ""
 
 # ── 2. Python venv + package install (pip) ──
 _venv="$REPO_DIR/.venv"
+# Same requires-python reuse rule as the other installers: an existing venv built
+# on a pre-3.12 interpreter cannot host the package, and the `pip install -e .`
+# below would be refused outright with "Requires-Python >=3.12", so rebuild it.
+if [ -x "$_venv/bin/python" ] \
+    && ! "$_venv/bin/python" -c "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)" 2>/dev/null; then
+    echo "  ↳ existing venv predates the Python 3.12 floor — recreating it"
+    rm -rf "$_venv"
+fi
 if [ ! -d "$_venv" ] || [ ! -x "$_venv/bin/python" ]; then
     echo "→ Creating virtual environment…"
     "$_py" -m venv "$_venv" || die "Failed to create venv. Try: $_py -m pip install --user virtualenv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ name = "kirocrew"
 version = "0.6.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
-# macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.
+# macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.12-3.13.
 # Must be declared in this [project] table: when it exists, setuptools reads
 # requires-python from here (not setup.cfg), and an absent value makes the
 # build backend raise SpecifierSet(None) -> TypeError during wheel builds.
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 # optional-dependencies must be listed here too: the extras live in setup.cfg
 # ([options.extras_require]), and once a [project] table exists setuptools
 # ignores setup.cfg metadata unless the field is declared dynamic. Omitting it

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,14 +2,15 @@
 zip_safe = True
 include_package_data = True
 # macOS (x86_64 + arm64), Linux (x86_64 + aarch64), and Windows, CPython
-# 3.10-3.13. Declaring this gives pip a clear, early error on an unsupported
+# 3.12-3.13. Declaring this gives pip a clear, early error on an unsupported
 # interpreter instead of a late syntax/dependency failure.
 #
 # Must match pyproject.toml's requires-python: that [project] value is the one
 # that actually lands in the built metadata, so a looser bound here is dead
-# config that misleads readers into thinking 3.9 is supported (it is not — the
-# code uses contextlib.aclosing, added in 3.10).
-python_requires = >=3.10
+# config that misleads readers into thinking 3.10/3.11 is supported (they are
+# not — every release artifact bundles CPython 3.12, ensure-python.sh
+# provisions 3.12, and 3.12 is the only version CI tests).
+python_requires = >=3.12
 package_dir =
     = src
 packages = find:
@@ -301,7 +302,7 @@ addopts =
     # Coverage is NOT enabled by default: measured on a 1,231-test subset it
     # costs +21% wall time (52.5s -> 63.4s) and +36% peak worker RSS (387MB ->
     # 527MB) on every local and agent run, while CI asks for it explicitly
-    # (ci.yml passes --cov=kiro_crew on the 3.12 shards and --no-cov on 3.10,
+    # (ci.yml passes --cov=kiro_crew on the 3.12 shards,
     # and the coverage-combine job builds coverage.xml from the shard data
     # files). `pytest --cov=kiro_crew` still gives a term-missing report via
     # [coverage:report] below; add --cov-report for the html/xml artifacts.

--- a/setup.sh
+++ b/setup.sh
@@ -43,15 +43,34 @@ _check() {
 
 echo "── Step 1: Python ──"
 _py=""
-for _candidate in python3.12 python3.11 python3.10 python3; do
-    if _check "$_candidate" && "$_candidate" -c "import sys; assert sys.version_info >= (3,10)" 2>/dev/null; then
+for _candidate in python3.12 python3.13 python3; do
+    if _check "$_candidate" && "$_candidate" -c "import sys; assert sys.version_info >= (3,12)" 2>/dev/null; then
         _py="$_candidate"
         break
     fi
 done
+# See cloud-install.sh's _has_provisioner: the automatic fallback may use a
+# version manager that is already installed, and may never install one, because
+# ensure-python.sh would do that by piping a remote script into sh.
+_has_provisioner() {
+    command -v mise >/dev/null 2>&1 || [ -x "$HOME/.local/bin/mise" ]
+}
+if [ -z "$_py" ] && [ -f "$_kirocrew_dir/ensure-python.sh" ] && _has_provisioner; then
+    # Runs from a clone, so the repo's own bootstrap is available: provision
+    # 3.12 rather than stopping on a distro whose archive cannot supply it.
+    echo "  → No system Python 3.12+; provisioning one via ensure-python.sh…"
+    bash "$_kirocrew_dir/ensure-python.sh" >/dev/null 2>&1 || true
+    _recorded="$(cat "${KIROCREW_HOME:-$HOME/.kiro/crew}/python-bin" 2>/dev/null || true)"
+    if [ -n "$_recorded" ] && [ -x "$_recorded" ] \
+        && "$_recorded" -c "import sys; assert sys.version_info >= (3,12)" 2>/dev/null; then
+        _py="$_recorded"
+    fi
+fi
 if [ -z "$_py" ]; then
-    echo "  ❌ Python 3.10+ required but not found."
-    echo "     Install Python 3.10+ (https://www.python.org/downloads/) and re-run."
+    echo "  ❌ Python 3.12+ required and could not be provisioned."
+    echo "     Install Python 3.12+ (https://www.python.org/downloads/), or install mise"
+    echo "     (https://mise.jdx.dev/installing-mise.html) and re-run — this script will"
+    echo "     then provision Python 3.12 through it."
     cd - > /dev/null 2>&1
     return 1 2>/dev/null || exit 1
 fi
@@ -181,8 +200,16 @@ fi
 
 # Backend: venv + pip install -e .
 _venv="$_kirocrew_dir/.venv"
-if [ ! -d "$_venv" ] || [ ! -x "$_venv/bin/python" ]; then
-    echo "→ Creating virtual environment..."
+# Same requires-python reuse rule as install.sh: a pre-3.12 venv cannot host the
+# package, so rebuild rather than pip-install into it and hit a hard refusal.
+if [ ! -d "$_venv" ] || [ ! -x "$_venv/bin/python" ] \
+    || ! "$_venv/bin/python" -c "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)" 2>/dev/null; then
+    if [ -d "$_venv" ]; then
+        echo "→ Recreating virtual environment (existing interpreter < 3.12)..."
+        rm -rf "$_venv"
+    else
+        echo "→ Creating virtual environment..."
+    fi
     "$_py" -m venv "$_venv" || {
         echo "  ❌ Failed to create venv"
         cd - > /dev/null 2>&1

--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -334,9 +334,12 @@ Resources:
       #   suppression) -- just cheap insurance so first boot degrades to swap
       #   instead of a kill under a transient spike. Unused headroom on every
       #   tier is harmless. Best-effort: never fails on swap.
-      # "System packages": install.sh needs Python >= 3.10; AL2023's default
-      #   python3 is 3.9, so python3.11 is installed explicitly (install.sh's
-      #   _find_python prefers python3.12/3.11/3.10 over the bare python3).
+      # "System packages": install.sh needs Python >= 3.12; AL2023's default
+      #   python3 is 3.9, so python3.12 is installed explicitly (install.sh's
+      #   _find_python prefers python3.12 over the bare python3). That install
+      #   is best-effort and kept OUT of the essential set: where the AL2023
+      #   repos carry no python3.12, install.sh provisions its own pinned
+      #   interpreter instead, so a missing package must not fail the boot.
       #   ripgrep is optional and must never fail the bootstrap.
       # "Node.js": the frontend build (vite 8 + rolldown) REQUIRES Node >= 22;
       #   AL2023's default AppStream nodejs is 18, on which the build dies
@@ -461,11 +464,15 @@ Resources:
           fi
 
           echo "--- installing system packages ---"
-          # python3.11 explicitly: install.sh needs >= 3.10, AL2023's default
-          # python3 is 3.9 (see "System packages" above).
-          dnf install -y git tmux python3.11 python3.11-pip python3 python3-pip \
+          dnf install -y git tmux python3 python3-pip \
             unzip tar gzip which \
-            || fail "essential package install failed (git/python3.11/unzip)"
+            || fail "essential package install failed (git/python3/unzip)"
+          # python3.12 explicitly: install.sh needs >= 3.12, AL2023's default
+          # python3 is 3.9 (see "System packages" above). Best-effort -- if the
+          # repos carry no python3.12, install.sh's _bootstrap_python provisions
+          # one via mise rather than failing the boot.
+          dnf install -y python3.12 python3.12-pip \
+            || echo "python3.12 unavailable from dnf; install.sh will provision one"
           dnf install -y ripgrep || echo "ripgrep unavailable (optional), continuing"
 
           echo "--- installing Node.js ---"

--- a/src/kiro_crew/dep_sync.py
+++ b/src/kiro_crew/dep_sync.py
@@ -944,6 +944,25 @@ def sync_or_reinstall(
         )
         return sync(repo, target_py, emit, timeout=timeout)
 
+    # The same requires-python gate the dependency-only substitute applies, and
+    # for the same reason -- except here pip WOULD enforce it, by refusing the
+    # build with "Requires-Python". Refusing first turns an opaque pip failure on
+    # an already-merged revision into a named reason plus the recovery hint
+    # `_refuse` prints.
+    floor_spec = requires_python(repo)
+    floor_version = interpreter_version(target_py) if floor_spec else None
+    if floor_spec and floor_version:
+        breach = python_floor_breach(floor_spec, floor_version)
+        if breach:
+            return _refuse(
+                emit,
+                f"the merged revision requires Python {floor_spec} but the target "
+                f"venv runs {floor_version[0]}.{floor_version[1]}.{floor_version[2]}, "
+                "so pip will refuse to install it.",
+                target_py,
+                repo,
+            )
+
     # `-e <repo>` rather than `-e .` with a cwd: the target is explicit in the argv
     # instead of implied by the working directory this happens to run in.
     argv = [str(target_py), "-m", "pip", "install", "-e", str(repo), "--quiet"]

--- a/src/kiro_crew/docs/getting-started.md
+++ b/src/kiro_crew/docs/getting-started.md
@@ -10,7 +10,7 @@ like Slack, Discord, and Telegram.
 
 | Requirement | Needed for | Floor |
 |-------------|------------|-------|
-| **Python** + pip | Backend | `>= 3.10` |
+| **Python** + pip | Backend | `>= 3.12` |
 | **Node.js** + npm | Building the dashboard from source | `>= 22` (24 LTS recommended) |
 | **`kiro-cli`** | Driving the LLM | Required, on your `PATH` |
 

--- a/src/kiro_crew/docs/troubleshooting.md
+++ b/src/kiro_crew/docs/troubleshooting.md
@@ -194,7 +194,7 @@ cd website && npm install && npm run build 2>&1 | tail -20
 ```
 
 Node must be `20` or `>= 22`; an older Node fails the Vite build. Python must be
-`>= 3.10`.
+`>= 3.12`.
 
 ### Embedding model download failed
 

--- a/src/kiro_crew/mcp_grant.py
+++ b/src/kiro_crew/mcp_grant.py
@@ -101,7 +101,7 @@ def artifact_presence(path: Path) -> bool | None:
     Deliberately NOT ``Path.is_file()``. From Python 3.14 that method swallows
     every ``OSError`` and answers ``False``, so an unreadable cache home -- a
     permission error, a stalled mount -- would be indistinguishable from "nothing
-    was ever written". This package declares ``requires-python >= 3.10`` with no
+    was ever written". This package declares ``requires-python >= 3.12`` with no
     ceiling, so a build running on 3.14 would silently collapse the tri-state and
     tell the owner of an authorized server to sign in again. Stat-ing explicitly
     and classifying the errno answers the same on every supported version.

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -4150,17 +4150,17 @@ def _is_windows_store_python_stub(path: str) -> bool:
 
 
 def find_python_interpreter(reject: Optional[Callable[[str], bool]] = None) -> str | None:
-    """Resolve a real CPython >= 3.10 interpreter, or None.
+    """Resolve a real CPython >= 3.12 interpreter, or None.
 
     Single source of truth for "where is a usable system python" on every
-    platform. Prefers versioned names (3.12/3.11), then bare ``python``/
-    ``python3``, with free-threaded-prone ``python3.13`` LAST so a usable
-    3.12/3.11/3.10 wins first. Rejects
+    platform. Prefers the exact tested version (``python3.12``), then bare
+    ``python``/``python3``, with free-threaded-prone ``python3.13`` LAST so a
+    usable 3.12 wins first. Rejects
     Brazil-path/build interpreters and — critically on Windows — the Microsoft
     Store alias stub (see :func:`_is_windows_store_python_stub`): running that
     stub is what emits the "Python was not found" nag, so we must never spawn it.
 
-    ``reject`` is an optional predicate run against each >= 3.10 candidate path;
+    ``reject`` is an optional predicate run against each >= 3.12 candidate path;
     return True to skip it and FALL THROUGH to the next candidate (not abort).
     Callers with extra constraints the shared resolver can't express — e.g. the
     STT prereq probe needs pip and a non-free-threaded build — pass it here so a
@@ -4172,9 +4172,9 @@ def find_python_interpreter(reject: Optional[Callable[[str], bool]] = None) -> s
     whisper installs that must not land in the gateway's venv).
     """
     names = (
-        ("python3.12", "python3.11", "python3.10", "python", "python3")
+        ("python3.12", "python", "python3")
         if IS_WINDOWS
-        else ("python3.12", "python3.11", "python3.10", "python3", "python3.13")
+        else ("python3.12", "python3", "python3.13")
     )
     for name in names:
         p = shutil.which(name)
@@ -4197,11 +4197,11 @@ def find_python_interpreter(reject: Optional[Callable[[str], bool]] = None) -> s
                 **UTF8_TEXT,
             ).strip()
             major, _, minor = out.partition(".")
-            if not (int(major) == 3 and int(minor) >= 10):
+            if not (int(major) == 3 and int(minor) >= 12):
                 continue
         except (OSError, ValueError, subprocess.SubprocessError):
             continue
-        # >= 3.10 and resolvable. Let the caller veto it (e.g. free-threaded /
+        # >= 3.12 and resolvable. Let the caller veto it (e.g. free-threaded /
         # no pip) and keep searching the remaining candidates.
         if reject is not None and reject(p):
             continue

--- a/test/test_ensure_python_symlink.py
+++ b/test/test_ensure_python_symlink.py
@@ -33,8 +33,6 @@ SCRIPT = Path(__file__).parent.parent / "ensure-python.sh"
 _PROBED_NAMES = (
     "python3.13",
     "python3.12",
-    "python3.11",
-    "python3.10",
     "python3",
     "python",
 )

--- a/test/test_installer_distro.py
+++ b/test/test_installer_distro.py
@@ -1,7 +1,7 @@
 """Managed-Python (uv) bootstrap coverage for the shell installers.
 
 The published one-liner ``curl … cli.sh | sh`` must bring up a runnable gateway
-even when the host has no usable Python 3.10+. cli.sh does this WITHOUT the
+even when the host has no usable Python 3.12+. cli.sh does this WITHOUT the
 system package manager: it fetches a SHA-256-pinned uv tarball (or uses an
 already-installed ``uv``) and provisions a python-build-standalone CPython into
 a user-owned directory. These tests run the real ``cli.sh`` under a fabricated
@@ -108,12 +108,11 @@ def _run_cli_with_fake_env(
         uv.chmod(0o755)
 
     # Every interpreter cli.sh probes for is an executable stub reporting an
-    # OLD (<3.10) version, so the isolated PATH guarantees the "no usable
+    # OLD (<3.12) version, so the isolated PATH guarantees the "no usable
     # python" branch. The stub answers cli.sh's version check (exit 1) and
     # `--version`. Extra names in ``interpreters`` (e.g. the fake interpreter a
     # uv stub claims to have installed) are created too.
-    default_names = ("python3.13", "python3.12", "python3.11",
-                     "python3.10", "python3", "python")
+    default_names = ("python3.13", "python3.12", "python3", "python")
     for name in {*default_names, *(interpreters or {})}:
         stub = tools / name
         stub.write_text(
@@ -122,7 +121,7 @@ def _run_cli_with_fake_env(
             else (
                 "#!/bin/sh\n"
                 'case "$*" in\n'
-                "  *version_info*) exit 1 ;;\n"  # cli.sh's >=3.10 gate -> too old
+                "  *version_info*) exit 1 ;;\n"  # cli.sh's >=3.12 gate -> too old
                 "  *--version*) echo 'Python 3.6.8' ;;\n"
                 "  *) exit 1 ;;\n"
                 "esac\n"
@@ -172,7 +171,7 @@ def test_cli_fails_over_from_a_wedged_interpreter_candidate(tmp_path: Path) -> N
     )
 
     combined = result.stdout + result.stderr
-    assert "Python >=3.10 is required" not in combined, combined
+    assert "Python >=3.12 is required" not in combined, combined
 
 
 def test_cli_bounds_wedged_interpreter_without_timeout_binary(tmp_path: Path) -> None:
@@ -200,7 +199,7 @@ def test_cli_bounds_wedged_interpreter_without_timeout_binary(tmp_path: Path) ->
     )
 
     combined = result.stdout + result.stderr
-    assert "Python >=3.10 is required" not in combined, combined
+    assert "Python >=3.12 is required" not in combined, combined
 
 
 def test_cli_watchdog_path_still_rejects_too_old_interpreters(tmp_path: Path) -> None:
@@ -231,7 +230,7 @@ def test_cli_falls_back_to_pinned_uv_when_no_python(tmp_path: Path) -> None:
     # The failure guidance must tell the user what to do next, without
     # hardcoding one distro's package manager as the answer.
     combined = result.stdout + result.stderr
-    assert "Python >=3.10 is required and could not be found or provisioned" in combined
+    assert "Python >=3.12 is required and could not be found or provisioned" in combined
 
 
 def test_cli_uses_installed_uv_before_downloading_one(tmp_path: Path) -> None:
@@ -251,7 +250,7 @@ def test_cli_uses_installed_uv_before_downloading_one(tmp_path: Path) -> None:
     result, markers = _run_cli_with_fake_env(
         tmp_path,
         with_uv=uv_stub,
-        # The provisioned interpreter must satisfy the same >=3.10 usability
+        # The provisioned interpreter must satisfy the same >=3.12 usability
         # probe as a system one; this stub models the PBS python uv installed.
         interpreters={
             "uv-python": (
@@ -277,7 +276,7 @@ def test_cli_uses_installed_uv_before_downloading_one(tmp_path: Path) -> None:
     # hermetic env cannot satisfy the trust-root/manifest steps), it must not
     # be the interpreter requirement.
     combined = result.stdout + result.stderr
-    assert "Python >=3.10 is required" not in combined, combined
+    assert "Python >=3.12 is required" not in combined, combined
     assert "could not provision a managed Python" not in combined, combined
 
 
@@ -515,7 +514,7 @@ def test_cli_system_python_flag_overrides_the_recorded_choice(tmp_path: Path) ->
 
     combined = result.stdout + result.stderr
     assert "Reusing the recorded managed-python choice" not in combined
-    assert "Python >=3.10 is required" not in combined, combined
+    assert "Python >=3.12 is required" not in combined, combined
     curl_marker = markers / "curl"
     if curl_marker.exists():
         assert "astral-sh/uv" not in curl_marker.read_text()

--- a/test/test_installer_python_floor.py
+++ b/test/test_installer_python_floor.py
@@ -1,0 +1,470 @@
+"""The >= 3.12 floor must not turn a supported host or an upgrade into a dead end.
+
+Raising ``requires-python`` is only half a floor bump. Every host-facing entry point
+carries its OWN copy of two decisions -- "is this interpreter good enough" and "is
+this venv still reusable" -- and each one fails differently when it is missed:
+
+* A probe that ends in ``die``/``exit`` turns a host that used to install into one
+  that aborts. Under the old >= 3.10 floor the distro's own ``python3`` satisfied
+  every probe on Ubuntu 22.04, so the package-manager branch was always sufficient;
+  under >= 3.12 it is not.
+* A venv reused on its executability alone makes ``pip install -e .`` refuse the
+  package ("Requires-Python >=3.12"), so a documented ``git pull && bash install.sh``
+  upgrade dead-ends with no way forward.
+
+The table these tests enforce, one row per entry point:
+
+===================== ============= ======================== ==================
+entry point           floor-gated?  provisions when missing  venv reuse gated
+===================== ============= ======================== ==================
+``install.sh``        yes           ``_bootstrap_python``    yes
+``setup.sh``          yes           ``ensure-python.sh``     yes
+``cloud-install.sh``  yes           ``ensure-python.sh``     yes
+``cli.sh``            yes           ``uv``                   by construction
+``ensure-python.sh``  yes           ``mise``                 n/a
+``install.ps1``       yes           winget / choco 3.12      n/a (no venv)
+``Makefile``          yes           ``ensure-python.sh``     yes
+``make.ps1``          yes           advises (dev build)      yes
+``minimal_install``   yes           advises (documented)     n/a
+===================== ============= ======================== ==================
+
+The last two advise rather than provision on purpose: ``make.ps1`` is the developer
+build path and offers ``-Py <path>`` instead, and ``minimal_install.sh`` declares
+"Prerequisites: Python 3.12+" as its contract.
+
+These tests pin each decision at the source, because none is reachable from a unit
+test on this host: the shell paths need a distro whose archive lacks python3.12, and
+the reuse paths need a pre-3.12 venv.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import dep_sync
+
+REPO = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO / "install.sh"
+SETUP_SH = REPO / "setup.sh"
+CLOUD_INSTALL_SH = REPO / "cloud-install.sh"
+INSTALL_PS1 = REPO / "install.ps1"
+
+# The predicate the shell installers use to decide a venv is still reusable.
+_VENV_FLOOR_PROBE = "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)"
+
+
+def _discover_venv_owners() -> list[Path]:
+    """Every shell entry point that assigns `_venv=`, found rather than listed.
+
+    The round-4 revision of this file hand-maintained this list and got it wrong:
+    `minimal_install.sh` owns `$REPO_DIR/.venv` and was recorded as owning none, so
+    the reuse rule was never enforced there and the review found the gap instead.
+    Discovering the owners means a new installer -- or one that grows a venv later --
+    is covered the moment it lands, and the list cannot silently disagree with the
+    tree again.
+    """
+    owners = []
+    for script in sorted(REPO.glob("*.sh")):
+        body = script.read_text(encoding="utf-8")
+        if '_venv="' in body and '"$_venv/bin/pip"' in body:
+            owners.append(script)
+    assert owners, "no venv-owning shell installer found -- the discovery is broken"
+    return owners
+
+
+# Entry points that own a venv and so must gate its reuse.
+_VENV_OWNERS = _discover_venv_owners()
+_VENV_OWNER_IDS = [p.name for p in _VENV_OWNERS]
+
+
+def test_the_venv_owner_discovery_sees_every_known_installer():
+    """A floor under the discovery itself, so a broken glob cannot pass vacuously."""
+    found = {p.name for p in _VENV_OWNERS}
+    assert {
+        "install.sh",
+        "setup.sh",
+        "cloud-install.sh",
+        "minimal_install.sh",
+    } <= found, f"venv-owner discovery missed a known installer: {sorted(found)}"
+
+
+# Entry points that run from a clone and so can delegate to the repo's bootstrap,
+# paired with the variable each one's own probe assigns the interpreter to. The
+# variable is what makes the reachability assertion below meaningful: the bootstrap
+# has to be guarded on THAT probe having come up empty.
+_CLONE_LOCAL = [(SETUP_SH, "_py"), (CLOUD_INSTALL_SH, "PY")]
+_CLONE_LOCAL_IDS = [p.name for p, _ in _CLONE_LOCAL]
+
+
+def _lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+# ---------------------------------------------------------------------------
+# install.sh: no probe may end in `die` without trying the bootstrap first
+# ---------------------------------------------------------------------------
+
+
+def test_install_sh_defines_a_python_bootstrap():
+    """The fallback has to exist before any branch can lean on it."""
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    assert "_bootstrap_python() {" in body
+    # It must provision the version the rest of the script targets, not a literal
+    # that can drift away from PYTHON_VERSION.
+    bootstrap = body.split("_bootstrap_python() {", 1)[1].split("\n}", 1)[0]
+    assert 'mise install "python@$PYTHON_VERSION"' in bootstrap
+    assert "_find_python" in bootstrap, "the bootstrap must re-probe, not set _py itself"
+
+
+def test_every_install_sh_python_probe_tries_the_bootstrap_before_dying():
+    """A `_find_python || die` with no bootstrap is the abort regression itself.
+
+    Ubuntu 22.04 is the case that made this a regression rather than a
+    pre-existing limitation: `apt install python3` gives 3.10, which passed the
+    old floor and fails the new one.
+    """
+    offenders = []
+    for number, line in enumerate(_lines(INSTALL_SH), start=1):
+        if "_find_python ||" not in line:
+            continue
+        if "_bootstrap_python" in line:
+            continue
+        offenders.append(f"{number}: {line.strip()}")
+    assert not offenders, "these probes abort instead of provisioning Python 3.12:\n" + "\n".join(
+        offenders
+    )
+
+
+def test_install_sh_has_no_bare_die_for_a_missing_interpreter():
+    """The no-package-manager branch must provision too, not just advise."""
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    no_pkg_mgr = body.split("no package manager detected", 1)[0].rsplit("else", 1)[1]
+    assert "_bootstrap_python" in no_pkg_mgr
+
+
+# ---------------------------------------------------------------------------
+# setup.sh / cloud-install.sh: delegate to the repo's own bootstrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("script", "var"), _CLONE_LOCAL, ids=_CLONE_LOCAL_IDS)
+def test_clone_local_installers_provision_before_giving_up(script, var):
+    """Both run from a clone, so `ensure-python.sh` is right there to be used.
+
+    The guard is asserted, not just the call: a bootstrap block that is present but
+    reachable only when the probe SUCCEEDED (or never, behind a constant) is dead
+    code that reads like a fallback. So the condition has to name the same variable
+    the probe assigns and require it to be empty.
+    """
+    body = script.read_text(encoding="utf-8")
+    guard = re.compile(
+        r'if \[ -z "\$'
+        + re.escape(var)
+        + r'" \]\s*&&\s*\[ -f "[^"]*ensure-python\.sh" \]\s*&&\s*_has_provisioner; then'
+    )
+    assert guard.search(body), (
+        f"{script.name} has no reachable `ensure-python.sh` fallback guarded on an "
+        f"empty ${var} AND an already-installed provisioner -- it either gives up "
+        "instead of provisioning, or can reach ensure-python.sh's fetch-and-run"
+    )
+    # And it must consume what the bootstrap recorded, not re-guess.
+    assert "python-bin" in body
+
+
+@pytest.mark.parametrize(("script", "var"), _CLONE_LOCAL, ids=_CLONE_LOCAL_IDS)
+def test_the_bootstrap_attempt_precedes_the_give_up_branch(script, var):
+    """A bootstrap after the exit is unreachable code, not a fallback."""
+    body = script.read_text(encoding="utf-8")
+    bootstrap_at = body.index("ensure-python.sh")
+    # Keyed on the guidance the give-up branch prints rather than on one wording of
+    # the failure line, which has been rewritten twice as the remedy changed.
+    give_up = body.index("mise.jdx.dev/installing-mise.html")
+    assert bootstrap_at < give_up
+
+
+@pytest.mark.parametrize(("script", "var"), _CLONE_LOCAL, ids=_CLONE_LOCAL_IDS)
+def test_the_provisioned_interpreter_is_revalidated_before_use(script, var):
+    """`ensure-python.sh` recording a path is not proof the path clears the floor."""
+    body = script.read_text(encoding="utf-8")
+    tail = body[body.index("ensure-python.sh") :]
+    assert (
+        "version_info" in tail.split("fi", 1)[0] or "version_info >= (3,12)" in tail
+    ), f"{script.name} adopts the recorded interpreter without re-checking the floor"
+
+
+# ---------------------------------------------------------------------------
+# every venv owner: an existing venv is reusable only at >= 3.12
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("script", _VENV_OWNERS, ids=_VENV_OWNER_IDS)
+def test_venv_reuse_is_gated_on_the_interpreter_version(script):
+    """Executable-ness is not enough: a 3.10 venv is executable and unusable."""
+    body = script.read_text(encoding="utf-8")
+    assert (
+        _VENV_FLOOR_PROBE in body
+    ), f"{script.name} decides venv reuse without checking the interpreter version"
+    # And the too-old venv must be removed, not installed into.
+    assert 'rm -rf "$_venv"' in body
+
+
+@pytest.mark.parametrize("script", _VENV_OWNERS, ids=_VENV_OWNER_IDS)
+def test_the_venv_reuse_probe_appears_before_the_first_pip_install(script):
+    """A check that runs after pip has already been handed the venv is no check."""
+    body = script.read_text(encoding="utf-8")
+    probe_at = body.index(_VENV_FLOOR_PROBE)
+    pip_at = body.index('"$_venv/bin/pip"')
+    assert probe_at < pip_at
+
+
+@pytest.mark.parametrize(
+    ("reported", "reusable"),
+    [("3.10.14", False), ("3.11.9", False), ("3.12.0", True), ("3.13.1", True)],
+)
+def test_the_reuse_probe_accepts_exactly_the_supported_interpreters(tmp_path, reported, reusable):
+    """Run the real predicate against a stub interpreter, not a paraphrase of it.
+
+    The stub reports a version and nothing else, which is all the predicate reads.
+    """
+    stub = tmp_path / "python"
+    major, minor, micro = reported.split(".")
+    stub.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        f"sys.version_info = ({major}, {minor}, {micro}, 'final', 0)\n"
+        "exec(sys.argv[-1])\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    proc = subprocess.run(
+        [sys.executable, str(stub), "-c", _VENV_FLOOR_PROBE],
+        capture_output=True,
+    )
+    # The stub is driven through this suite's own interpreter so the test needs no
+    # 3.10 build on the host; argv[-1] carries the predicate verbatim.
+    assert (proc.returncode == 0) is reusable
+
+
+# ---------------------------------------------------------------------------
+# install.ps1: the Windows cloud client had no version gate at all
+# ---------------------------------------------------------------------------
+
+
+def test_install_ps1_gates_python_on_the_floor_not_on_existence():
+    """`Have "python"` accepted a 3.10 and let pip refuse it four steps later."""
+    body = INSTALL_PS1.read_text(encoding="utf-8")
+    assert "function Resolve-Python312" in body
+    assert "sys.version_info >= (3, 12)" in body
+    assert 'if (Have "python") {' not in body, (
+        "install.ps1 still gates Python on existence alone, so a pre-3.12 "
+        "interpreter is accepted and refused later by pip"
+    )
+
+
+def test_install_ps1_installs_the_pinned_python_when_none_qualifies():
+    """The remedy has to be 3.12 specifically, on both package managers."""
+    body = INSTALL_PS1.read_text(encoding="utf-8")
+    assert "Python.Python.3.12" in body
+    assert "choco install -y python312" in body
+
+
+def test_install_ps1_runs_pip_through_the_resolved_interpreter():
+    """A bare `python -m pip` would undo the resolution the probe just did."""
+    offenders = [
+        f"{number}: {line.strip()}"
+        for number, line in enumerate(_lines(INSTALL_PS1), start=1)
+        if re.search(r"(?<![&$\w.-])python -m ", line)
+    ]
+    assert not offenders, "these calls bypass the resolved interpreter:\n" + "\n".join(offenders)
+
+
+# ---------------------------------------------------------------------------
+# dep_sync: the in-process editable reinstall is the third reuser
+# ---------------------------------------------------------------------------
+
+
+def test_editable_reinstall_refuses_a_venv_below_the_declared_floor(tmp_path, capsys):
+    """pip would refuse this anyway -- refusing first names the reason.
+
+    Without the gate the failure is a raw pip "Requires-Python" error on a
+    revision whose git merge has already landed, with no recovery hint.
+    """
+    repo = tmp_path
+    (repo / "setup.cfg").write_text("[options]\npython_requires = >=3.12\n", encoding="utf-8")
+
+    with (
+        patch.object(
+            dep_sync,
+            "installed_package_origin",
+            return_value=str(repo / "src" / "kiro_crew" / "__init__.py"),
+        ),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync, "requires_python", return_value=">=3.12"),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 11, 9)),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        rc = dep_sync.sync_or_reinstall(repo, Path("py"))
+
+    assert rc == dep_sync.REFUSED
+    assert not sp.run.called, "pip must not be invoked against a venv below the floor"
+    err = capsys.readouterr().err
+    assert "3.12" in err
+    assert "3.11.9" in err
+
+
+def test_editable_reinstall_proceeds_when_the_venv_meets_the_floor(tmp_path):
+    """The gate must not stand in the way of the normal path."""
+    repo = tmp_path
+    (repo / "setup.cfg").write_text("[options]\npython_requires = >=3.12\n", encoding="utf-8")
+
+    with (
+        patch.object(
+            dep_sync,
+            "installed_package_origin",
+            return_value=str(repo / "src" / "kiro_crew" / "__init__.py"),
+        ),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync, "requires_python", return_value=">=3.12"),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 12, 3)),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value.returncode = 0
+        rc = dep_sync.sync_or_reinstall(repo, Path("py"))
+
+    assert rc == 0
+    assert sp.run.called
+    argv = sp.run.call_args[0][0]
+    assert argv[1:5] == ["-m", "pip", "install", "-e"]
+
+
+def test_the_floor_gate_is_read_from_the_repo_not_hardcoded(tmp_path):
+    """A future floor bump must not need this gate edited again."""
+    repo = tmp_path
+    (repo / "setup.cfg").write_text("[options]\npython_requires = >=3.14\n", encoding="utf-8")
+
+    with (
+        patch.object(
+            dep_sync,
+            "installed_package_origin",
+            return_value=str(repo / "src" / "kiro_crew" / "__init__.py"),
+        ),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 12, 3)),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        rc = dep_sync.sync_or_reinstall(repo, Path("py"))
+
+    assert rc == dep_sync.REFUSED
+    assert not sp.run.called
+
+
+def test_no_floor_declared_does_not_block_the_reinstall(tmp_path):
+    """`requires_python` returning None means no floor, not an unreadable one."""
+    repo = tmp_path
+    (repo / "setup.cfg").write_text("[options]\n", encoding="utf-8")
+
+    with (
+        patch.object(
+            dep_sync,
+            "installed_package_origin",
+            return_value=str(repo / "src" / "kiro_crew" / "__init__.py"),
+        ),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync, "requires_python", return_value=None),
+        patch.object(dep_sync, "subprocess") as sp,
+    ):
+        sp.run.return_value.returncode = 0
+        rc = dep_sync.sync_or_reinstall(repo, Path("py"))
+
+    assert rc == 0
+    assert sp.run.called
+
+
+# ---------------------------------------------------------------------------
+# The floor is declared in more than one place; they must not drift apart
+# ---------------------------------------------------------------------------
+
+
+def test_the_declared_floor_agrees_across_the_shell_entry_points():
+    """One host-facing floor, spelled the same in every probe that enforces it."""
+    floors = set()
+    for script in (*_VENV_OWNERS, REPO / "cli.sh", INSTALL_PS1):
+        body = script.read_text(encoding="utf-8")
+        floors.update(
+            (m.group("major"), m.group("minor"))
+            for m in re.finditer(
+                r"sys\.version_info\s*>=\s*\((?P<major>\d+),\s*(?P<minor>\d+)\)", body
+            )
+        )
+    assert floors == {("3", "12")}, f"probes disagree on the floor: {sorted(floors)}"
+
+
+# ---------------------------------------------------------------------------
+# The automatic bootstrap must not execute unverified network content
+# ---------------------------------------------------------------------------
+
+
+def test_the_automatic_bootstrap_does_not_pipe_a_remote_script_to_a_shell():
+    """`--mise` is an opt-in; the automatic fallback is not, so it must not fetch-and-run.
+
+    The distinction is consent, not mechanism: a user who passes `--mise` has asked
+    for the version manager, while `_bootstrap_python` runs on its own when a probe
+    comes up empty. Executing a downloaded installer there would run unverified
+    remote content as the user on a path nobody opted into.
+    """
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    bootstrap = body.split("_bootstrap_python() {", 1)[1].split("\n}", 1)[0]
+    assert "curl" not in bootstrap, (
+        "_bootstrap_python fetches over the network; it must use an already-installed "
+        "provisioner instead"
+    )
+    assert "mise.run" not in bootstrap
+
+
+def test_the_bootstrap_requires_an_already_installed_provisioner():
+    """It may use mise; it may not install it."""
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    bootstrap = body.split("_bootstrap_python() {", 1)[1].split("\n}", 1)[0]
+    assert "has mise || return 1" in bootstrap
+
+
+def test_the_give_up_messages_name_a_way_forward():
+    """Once the bootstrap cannot self-provision, the exit has to be actionable."""
+    body = INSTALL_SH.read_text(encoding="utf-8")
+    # Every die that follows a failed bootstrap names mise as the route.
+    dies = [
+        line
+        for line in body.splitlines()
+        if "_bootstrap_python" in line and "die" not in line and "||" in line
+    ]
+    assert dies, "no bootstrap-then-die sites found to check"
+    assert body.count("mise.jdx.dev/installing-mise.html") >= 3
+
+
+@pytest.mark.parametrize(("script", "var"), _CLONE_LOCAL, ids=_CLONE_LOCAL_IDS)
+def test_the_fallback_cannot_install_its_own_provisioner(script, var):
+    """`ensure-python.sh` installs mise by piping a remote script into sh.
+
+    That is acceptable where the user asked for it and unacceptable on a fallback
+    that fires by itself, so the automatic path may only USE a version manager the
+    host already has. The predicate is spelled identically in both scripts so the
+    posture is one decision rather than two that can drift.
+    """
+    body = script.read_text(encoding="utf-8")
+    assert "_has_provisioner() {" in body
+    predicate = body.split("_has_provisioner() {", 1)[1].split("\n}", 1)[0]
+    assert "command -v mise" in predicate
+    assert "curl" not in predicate, "the presence check must not fetch anything"
+
+
+@pytest.mark.parametrize(("script", "var"), _CLONE_LOCAL, ids=_CLONE_LOCAL_IDS)
+def test_the_give_up_branch_names_the_provisioner_route(script, var):
+    """Once the fallback can decline to run, the exit has to say how to enable it."""
+    body = script.read_text(encoding="utf-8")
+    assert "mise.jdx.dev/installing-mise.html" in body

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -608,7 +608,7 @@ class TestFindPythonInterpreter:
 
     def test_returns_none_when_only_stub_or_too_old(self, monkeypatch):
         # No usable interpreter: which() yields only the stub (Windows) / nothing,
-        # or an interpreter that reports < 3.10. Either way → None, never the stub.
+        # or an interpreter that reports < 3.12. Either way → None, never the stub.
         if pc.IS_WINDOWS:
             stub = r"C:\Users\me\AppData\Local\Microsoft\WindowsApps\python3.EXE"
             monkeypatch.setattr("shutil.which", lambda name: stub)
@@ -982,8 +982,8 @@ class TestDirLinkShims:
         assert pc.is_link_or_junction(link)
         # 0xA0000003 = IO_REPARSE_TAG_MOUNT_POINT, spelled literally rather than
         # read from the module under test (so the assertion is independent of it)
-        # and rather than via os.path.isjunction (3.12+ only; this project
-        # supports 3.10).
+        # and rather than via os.path.isjunction, which would couple the
+        # assertion to the same stdlib helper the module itself may use.
         assert os.lstat(str(link)).st_reparse_tag == 0xA0000003
         pc.unlink_link_or_junction(link)
         assert not link.exists()
@@ -2510,7 +2510,7 @@ class TestFindPythonInterpreterReal:
         # The selection-side twin of test_origin_probe_ignores_pythonpath: at
         # child startup the ``site`` module imports any ``sitecustomize.py``
         # found on the caller's PYTHONPATH, and that module can monkeypatch
-        # ``sys.version_info`` — here forcing this real >= 3.10 interpreter to
+        # ``sys.version_info`` — here forcing this real >= 3.12 interpreter to
         # report 3.4, which would make the version gate reject it and steer
         # selection. The gate runs the probe isolated (-I), so the decoy is
         # never imported and the candidate is judged by its REAL version.
@@ -2524,7 +2524,7 @@ class TestFindPythonInterpreterReal:
         )
         monkeypatch.setenv("PYTHONPATH", str(decoy))
         # Every candidate name resolves to this suite's own interpreter — a
-        # real, runnable >= 3.10 CPython on every platform CI runs.
+        # real, runnable >= 3.12 CPython on every platform CI runs.
         monkeypatch.setattr("shutil.which", lambda name: sys.executable)
 
         assert pc.find_python_interpreter() == sys.executable

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -1767,13 +1767,13 @@ class TestFindPythonInterpreter:
         self._resolve(
             monkeypatch,
             {
-                "python3.12": "/brazil-path/python3.12",
-                "python3.11": "/x/build/private/python3.11",
-                "python3.10": "/usr/bin/python3.10",
+                "python3.12": "/x/build/private/python3.12",
+                "python3": "/brazil-path/python3",
+                "python3.13": "/usr/bin/python3.13",
             },
         )
-        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "3.10\n")
-        assert pc.find_python_interpreter() == "/usr/bin/python3.10"
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "3.13\n")
+        assert pc.find_python_interpreter() == "/usr/bin/python3.13"
 
     def test_skips_the_microsoft_store_stub(self, monkeypatch):
         stub = r"C:\Users\u\AppData\Local\Microsoft\WindowsApps\python.exe"
@@ -1797,16 +1797,16 @@ class TestFindPythonInterpreter:
 
     def test_the_reject_predicate_falls_through_rather_than_aborting(self, monkeypatch):
         # A single unusable interpreter must not short-circuit the whole search.
-        # POSIX order is 3.12, 3.11, 3.10, python3, 3.13 — vetoing 3.12 must
-        # land on 3.11, not give up.
+        # POSIX order is 3.12, python3, 3.13 — vetoing 3.12 must land on
+        # python3, not give up.
         monkeypatch.setattr(pc, "IS_WINDOWS", False)
         self._resolve(
             monkeypatch,
-            {"python3.12": "/usr/bin/python3.12", "python3.11": "/usr/bin/python3.11"},
+            {"python3.12": "/usr/bin/python3.12", "python3": "/usr/bin/python3"},
         )
         monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "3.12\n")
         picked = pc.find_python_interpreter(reject=lambda p: p.endswith("3.12"))
-        assert picked == "/usr/bin/python3.11"
+        assert picked == "/usr/bin/python3"
 
     def test_nothing_resolvable_is_none(self, monkeypatch):
         self._resolve(monkeypatch, {})


### PR DESCRIPTION
## Problem

CI ran the backend suite and the lint/type job on both Python 3.10 and 3.12, but no
release route can produce a 3.10 artifact:

- `packaging/build-desktop.sh` provisions and bundles a **CPython 3.12**
  python-build-standalone on macOS, Windows and Linux, and smoke-tests through
  `bin/python3.12`.
- `build-wheel.yml`, `build.yml`, `build-windows.yml` and `build-desktop.yml` all pin
  `setup-python` to `"3.12"`, and Playwright deps resolve with `--python-version 3.12`.
- `ensure-python.sh` targets `3.12` (`KIROCREW_PYTHON_VERSION:-3.12`).

So the 3.10 lane tested only the source-install path, while occupying four extra
runners per CI run (~12 min each) on a repo that sits near the 20-concurrent-job
ceiling. It also went the other way: the declared floor was `>=3.10`, so a 3.10 host
was *promised* support that no release artifact and no packaging script delivers.

## Why it matters

The floor was documentation that disagreed with the product. A 3.10 user got a
tested-looking CI badge for a configuration nothing ships, and the project paid four
runners a run to keep that fiction measured.

## What changed

Floor raised to `>=3.12` everywhere it is declared, and every independent probe that
carried its own hardcoded copy of the floor moved with it:

| Surface | Change |
|---|---|
| `pyproject.toml`, `setup.cfg` | `requires-python` / `python_requires` -> `>=3.12` |
| `.github/workflows/ci.yml` | `python-version` matrix `["3.10", "3.12"]` -> `["3.12"]` on the lint job and the backend-test job; the now-constant `matrix.python-version == '3.12'` guards on the coverage steps and the `--cov`/`--no-cov` selector collapse |
| `.github/workflows/publish-cli.yml` | manifest `PYREQ` fallback -> `>=3.12` |
| `install.sh`, `minimal_install.sh`, `cloud-install.sh`, `setup.sh`, `cli.sh` | candidate loops drop `python3.11`/`python3.10`, version probes gate on `(3, 12)`, messages updated |
| `ensure-python.sh` | `MIN_MINOR=12`, candidate loop `python3.12 python3.13 python3 python` |
| `Makefile`, `make.ps1`, `install.ps1` | venv version gate and recreate-check -> `3.12`; `$MinPyMinor = 12`; candidate lists trimmed |
| `src/kiro_crew/platform_compat.py` | `find_python_interpreter` candidate tuples and the `minor >= 10` gate -> `>= 12` |
| `src/kiro_crew/cloud/templates/kirocrew-ec2.yaml` | AL2023 bootstrap installs `python3.12` instead of `python3.11`, as a best-effort line outside the essential `dnf` set |
| docs | README, `docs/guides/install.md`, `remote-and-mobile.md`, `windows-install.md`, `src/kiro_crew/docs/getting-started.md`, `troubleshooting.md`, `docs/system-specs/common/code-style.md` |

### Raising the floor needed behaviour fixes, not just new numbers

A floor is enforced independently by nine entry points, and several of them turned
"cannot satisfy the floor" into a dead end rather than a provisioning step. Under
`>=3.10` the distro's own `python3` satisfied every probe on Ubuntu 22.04, so a
package-manager branch was always sufficient; under `>=3.12` it is not, and a probe
that ends in `die` turns a host that used to install into one that aborts. Separately,
a venv reused on its executability alone makes `pip install -e .` refuse the package
outright, dead-ending the documented `git pull && bash install.sh` upgrade.

The full table is now enforced by `test/test_installer_python_floor.py` rather than
asserted in prose:

| entry point | floor-gated probe | provisions when nothing qualifies | venv reuse gated |
|---|---|---|---|
| `install.sh` | yes | **`_bootstrap_python`** (mise / python-build-standalone) | **yes** |
| `setup.sh` | yes | **`ensure-python.sh`** | **yes** |
| `cloud-install.sh` | yes | **`ensure-python.sh`** | **yes** |
| `cli.sh` | yes | `_provision_python_via_uv` (already present) | by construction — re-points the venv at the resolved interpreter before pip |
| `ensure-python.sh` | yes (`MIN_MINOR=12`) | mise | n/a |
| `install.ps1` | **yes** | **winget `Python.Python.3.12` / choco `python312`** | n/a — installs into the resolved interpreter, no venv |
| `Makefile` | yes | `ensure-python.sh` | yes (already present) |
| `make.ps1` | yes (`$MinPyMinor = 12`) | advises winget, offers `-Py <path>` | yes (already present) |
| `minimal_install.sh` | yes | advises — "Prerequisites: Python 3.12+" is its stated contract | n/a |

Bold entries are new in this PR. What each fix does:

- **`install.sh` had no automatic bootstrap at all.** `USE_MISE` is assigned in exactly
  two places (`USE_MISE=0`, and `--mise) USE_MISE=1`), nothing sets it on a failed
  probe, and the mise block runs *before* the probe — so every package-manager branch
  ended in `_find_python || die`. Added one `_bootstrap_python()` helper that installs
  mise if absent, provisions `python@$PYTHON_VERSION`, prepends its `bin` to `PATH` and
  re-probes through `_find_python` so the candidate-name contract stays in one place.
  All six terminal probes now try it before dying: apt, dnf, yum, brew, the Xcode-CLT
  path, and the no-package-manager `else`.
- **`install.ps1` had no version gate at all.** `if (Have "python")` is an existence
  check, so a 3.10/3.11 already on `PATH` was accepted at step 1 and refused by pip at
  step 4 — after the AWS CLI and the SSM Session Manager plugin had been installed.
  Added `Resolve-Python312`, which probes `python3.12`/`python`/`python3` against the
  floor and, when none qualifies, installs 3.12 by name and re-probes. The resolved
  command is used for every later `python` call (`pip install -e .`,
  `kiro_crew cloud launch`) so the resolution cannot be undone downstream.
- **`cloud-install.sh` and `setup.sh` exited instead of provisioning.** Both run from a
  clone, so both now fall back to `ensure-python.sh` — the repo's own bootstrap — and
  re-validate the interpreter it recorded before giving up.
- **Three paths reused a venv blind.** `install.sh`, `setup.sh` and `cloud-install.sh`
  each decided reuse on `-x "$_venv/bin/python"`. All three now require the existing
  interpreter to satisfy the floor and `rm -rf` the venv otherwise.
- **The in-process upgrade reused it too.** `dep_sync.sync_or_reinstall` pip-installs
  editable into the running venv, and the existing `python_floor_breach` gate was wired
  only to the dependency-only substitute. pip does enforce the floor there, but as an
  opaque build failure on a revision whose git merge has already landed — so the gate
  now runs on the reinstall branch and refuses with a named reason.

## Who is affected

Nobody on a release artifact: desktop, wheel and installer paths were already 3.12.

Source installs on a host whose **system** Python is 3.10 (Ubuntu 22.04) or 3.11
(Debian 12) now route through a provisioned 3.12 instead of the system interpreter.
Amazon Linux 2 and 2023 are unaffected — their system Python (3.7 / 3.9) was already
below the old floor and already bootstrapped. An existing pre-3.12 `.venv` is rebuilt
on the next installer run.

## Tests

- **New: `test/test_installer_python_floor.py`** (27 tests) pins every row of the table
  above, none of which is reachable from a unit test on a 3.12 host: no `install.sh`
  probe may end in `die` without attempting `_bootstrap_python`; the clone-local
  installers must carry a *reachable* `ensure-python.sh` fallback (the guard shape is
  asserted, not just the call, so a block behind a constant fails) and must re-validate
  what it recorded; all three venv owners must gate reuse on the interpreter version
  *before* the first `pip` invocation; `install.ps1` must not gate on existence and must
  run pip through the resolved interpreter; `dep_sync.sync_or_reinstall` refuses below
  the floor without invoking pip, proceeds at or above it, reads the floor from the repo
  rather than a literal, and treats "no floor declared" as no floor. The reuse predicate
  itself is executed against stub interpreters reporting 3.10 / 3.11 / 3.12 / 3.13.
- **All nine fixes mutation-verified**: reverting each one individually makes its test
  fail. Two mutations initially slipped through — the reachability test only checked
  that the string `ensure-python.sh` was present, so replacing the guard with a
  constant passed — and that test was tightened to assert the guard's shape before the
  round was accepted.
- `test/test_installer_distro.py`, `test/test_ensure_python_symlink.py`,
  `test/test_platform_compat.py`, `test/test_platform_compat_coverage.py` updated
  where they encoded the old floor (probe candidate lists, the `>=3.10 is required`
  error string, the reject-predicate fall-through order).
- `1005 passed, 22 skipped` across the installer, cloud, brand, platform-compat,
  dep-sync, CI-surface, config-baseline, build-parity and pip-consistency suites.
- `scripts/docs-lint.sh` clean (253 files). `BRAND_BASE_REF=origin/main
  scripts/check_brand_name.py` clean. `black --check`, `flake8`, `isort`, `mypy` clean
  on touched Python. `bash -n` clean on all six shell entry points. `ci.yml` and
  `publish-cli.yml` parse as YAML.
- `test/test_installer_distro.py` and `test/test_platform_compat_coverage.py` are in
  `.github/black-baseline.txt`; their diffs are the targeted edits only, with no black
  reformat folded in.

**One honest gap:** there is no PowerShell parser or linter in CI, and `pwsh` is not
installed on the machine this was written on, so the `install.ps1` change is verified
by source-level assertions and review only — not by executing it.

## Manual verification

N/A — unit coverage sufficient. The fixed paths need hosts this machine is not (a
distro whose archive lacks python3.12, a pre-3.12 `.venv`, and Windows), which is why
each is pinned at the source and the reuse predicate is executed against stub
interpreters rather than described.

<!-- no-visual-delta -->
**Why no screenshot:** no frontend or rendered surface is touched; the diff is
packaging metadata, shell/PowerShell installers, CI config and their tests.

## Review rounds

- **Round 2** — Brand Name Gate: the rewritten `cli.sh` header comment spelled the
  product name as one word. Reworded. Rebased onto current `origin/main`.
- **Round 3** — two GPT BLOCKING findings on `4485a7479` (`install.sh:232` abort,
  `pyproject.toml:14` venv reuse), both accepted and fixed rather than rebutted: each
  is completeness of this PR's own change, not added scope. The round-2 body claimed a
  mise fallthrough existed in `install.sh`; that claim was wrong and is corrected here.
- **Round 4** — GPT handed over two more instances of the same shape
  (`install.ps1`, `cloud-install.sh:72`). Rather than patch the next instance, every
  host-facing entry point was audited and the table above was made an enforced
  invariant. `setup.sh` had the identical gap and was fixed in the same round instead
  of waiting to be handed over.
- **Round 5** — two more genuine defects, both accepted: `install.sh`'s new automatic
  bootstrap piped `https://mise.run` into `sh`, which executes unverified remote
  content on a path the user did not opt into (the pre-existing `--mise` block does
  ask); and `minimal_install.sh` reused its `.venv` blind. The second was an error in
  round 4's own table, which recorded that script as owning no venv — so the table is
  no longer hand-maintained: `_discover_venv_owners()` finds every root `*.sh` that
  assigns `_venv=` and drives `"$_venv/bin/pip"`, and every discovered owner is
  parametrised through the reuse assertions. `_bootstrap_python` now requires mise to
  be present rather than installing it, and each give-up message names both routes
  forward.

## Not in scope

- **Provisioning posture, repo-wide.** `ensure-python.sh:116` still runs
  `curl -fsSL https://mise.run | sh`, and round 4 made it reachable from the
  `setup.sh` / `cloud-install.sh` fallbacks. The vetted alternative already exists in
  `cli.sh` — a SHA-256-pinned `uv` download with `--proto '=https'
  --proto-redir '=https'` and a checksum refusal — and the install docs already
  describe the installer that way. Unifying all five shell entry points onto that one
  mechanism is a cross-cutting change with its own pin-maintenance burden and is not a
  floor bump, so it is deliberately left for a follow-up rather than folded in here.
  What this PR does guarantee is that it introduces no new unconsented fetch-and-run.
- `CHANGELOG.md` — per CONTRIBUTING this repo writes the changelog at release time,
  and a floor bump belongs in that release's "Before you upgrade" section.
- `minimal_install.sh` and `make.ps1` advise rather than provision, by contract: the
  first documents its prerequisites, the second is the developer build path and offers
  `-Py <path>`. Both are rows in the enforced table so the choice is explicit rather
  than an omission.
- `platform/wheel_engine.py` builds its shadow venv from `sys.executable`, so it
  inherits the running interpreter and has no way to escape a too-old base. That is
  pre-existing and unchanged by this PR; it is not an upgrade path a source install
  reaches, and fixing it means giving the engine its own interpreter-resolution step.

no linked issue: housekeeping — the floor bump and the CI-lane removal were raised in
review discussion rather than tracked as an issue.
