### PR TITLE
fix(ops-mission-control): never publish the token or policy store over a failed read

### DIFF
--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
@@ -129,9 +129,48 @@ def policy_path() -> Path:
 
 
 def _read() -> dict[str, Any]:
+    """The stored ceiling, or ``{}`` when there is nothing readable.
+
+    A DISPLAY/GATE read: it must degrade to the caller's DEFAULT rather than
+    raise, because every reader here backs a security decision that has a safe
+    answer -- an unreadable ceiling reads as ``observe`` with no act-rules, which
+    is the most restrictive state, not a permissive one. See
+    :func:`_read_for_update` for why a writer may not stand on the same answer.
+    """
     try:
         raw = json.loads(policy_path().read_text(encoding="utf-8"))
     except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _read_for_update() -> dict[str, Any]:
+    """The ceiling a read-modify-write is allowed to publish over.
+
+    ``_PolicyLock`` documents that every writer here is a read-modify-write and
+    that ``atomic_write`` REPLACES the whole file. So an empty base is not
+    "nothing to carry forward" -- it is "discard every other operator-only key",
+    and this file holds ALL of them: the autonomy ceiling, the outbound ledger
+    remote and Slack channel, the rotation identity, the primary-instance flag.
+    Only a MISSING file makes that base true.
+
+    Losing them is not a preference reset. Each key is fenced onto the keystone
+    floor precisely because the agent must not be able to set it, and every one
+    reverts to a value the agent CAN influence: ``mode`` and ``autonomy_rules``
+    fall back to a default the route re-derives, and the destination and identity
+    keys fall back to absent, which is how the off-shift refusal and the
+    ``not_primary`` gate get their inputs. Silently dropping the operator's
+    ceiling on one transient EACCES is the failure this file exists to prevent,
+    arriving by accident instead of by attack. The error propagates and the
+    write is abandoned instead.
+
+    Corruption keeps reading as empty, matching :func:`_read`: the document
+    parsed to nothing usable, so there is no stored ceiling left to lose by
+    replacing it.
+    """
+    try:
+        raw = json.loads(policy_path().read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
         return {}
     return raw if isinstance(raw, dict) else {}
 
@@ -224,11 +263,15 @@ def set_ceiling(*, mode: str | None = None, rules: list[Any] | None = None) -> N
     could fix because the interleaving comes from another request.
 
     ``None`` means "leave unchanged", so this is also the single-field writer.
+
+    Raises ``OSError`` when the existing ceiling could not be read; see
+    :func:`_read_for_update` for why that is not collapsed to an empty document
+    here.
     """
     if mode is None and rules is None:  # pragma: no cover — programming error, not input
         raise ValueError("set_ceiling requires at least one of mode/rules")
     with _PolicyLock():
-        data = _read()
+        data = _read_for_update()
         if mode is not None:
             data[_MODE_KEY] = mode
         if rules is not None:
@@ -269,11 +312,15 @@ def get(key: str, default: Any = None) -> Any:
 
 
 def put(key: str, value: Any) -> None:
-    """Write one operator-only value. Dashboard-PUT only — see the module docstring."""
+    """Write one operator-only value. Dashboard-PUT only — see the module docstring.
+
+    Raises ``OSError`` when the existing ceiling could not be read, for the reason
+    :func:`_read_for_update` gives.
+    """
     if key not in OPERATOR_ONLY_KEYS:  # pragma: no cover — programming error, not input
         raise KeyError(f"{key!r} is not an operator-only key; use config.json for it")
     with _PolicyLock():
-        data = _read()
+        data = _read_for_update()
         data[key] = value
         _write(data)
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
@@ -1499,6 +1499,52 @@ async def _handle_put_provider_config(request: web.Request) -> web.StreamRespons
     return web.json_response({"ok": True, "provider": provider_id, "config": saved})
 
 
+async def _settings_write_or_refuse(
+    fn: Any,
+    *args: Any,
+    code: str,
+    applied: dict[str, Any],
+    **kwargs: Any,
+) -> web.Response | None:
+    """Run one settings write off-loop. ``None`` on success, else the 503 to return.
+
+    The keystone policy store refuses rather than publishing over a read it could not
+    make, so any write reaching it can raise ``OSError``. Letting one escape gives
+    aiohttp's default 500 -- a plain-text body with no ``code``, which the repo requires
+    on an error response. On this route the ambiguity is the security-relevant part:
+    ``mode`` and ``autonomy_rules`` ARE the authorization ceiling, so "did my change
+    land?" is exactly the question the operator cannot be left guessing about. 503 rather
+    than 500 because the condition is transient and retrying is correct.
+
+    Accepts ``**kwargs`` so the one write here that takes keyword arguments
+    (``policy_store.set_ceiling``, which must stay a single call to commit ``mode`` and
+    ``autonomy_rules`` under one lock) goes through this same path rather than being
+    spelled out a second time beside it.
+
+    NOT every store behind this handler has that guarantee yet. ``set_top_level`` writes
+    the app config, whose read still collapses a failure to ``{}`` -- so on a transient
+    ``config.json`` read failure it truncates the file and returns 200 without this
+    helper ever seeing an ``OSError``. The strict read that closes it is in the companion
+    PR for ``providers/__init__.py``; the ``app_config_unwritable`` code here covers only
+    the write-side failure that store can already raise today. Do not read this helper as
+    proof of coverage it does not have.
+
+    The refusal reports ``applied`` to the AUDIT LOG rather than in the response body.
+    Phase 2 is a SEQUENCE of writes, so an earlier one may already have committed and a
+    partial ceiling apply is a security state worth recording -- but the dashboard's own
+    ``req`` helper reads only ``error`` from a non-2xx body and discards the rest, so a
+    field there would have had no reader. The audit line has one, and it mirrors the
+    ``settings_put`` line the success path already writes.
+    """
+    try:
+        await asyncio.to_thread(fn, *args, **kwargs)
+    except OSError as exc:
+        logger.warning("ops-mission-control: settings write refused (%s)", code)
+        _audit("settings_put", f"refused after {sorted(applied)}", "failure")
+        return web.json_response({"ok": False, "error": str(exc), "code": code}, status=503)
+    return None
+
+
 async def _handle_put_settings(request: web.Request) -> web.StreamResponse:
     """Update app-level settings: autonomy mode, primary flag, cycle tuning.
 
@@ -1763,18 +1809,48 @@ async def _handle_put_settings(request: web.Request) -> web.StreamResponse:
     # Slack output. A channel ID is not a credential, so it belongs here rather
     # than in the secret store — and this app stores no Slack token at all, it
     # reuses Kiro Crew's own client (see slack_out for why).
+    #
+    # These three go through the refusal helper even though they do not name
+    # `policy_store` here: `slack_out.set_settings` and `ledger_sync.set_settings` reach
+    # `policy_store.put` INTERNALLY (their keys are operator-only, so they must), and
+    # `notify_out.set_settings` reaches `set_top_level`. Guarding only the call sites that
+    # spell `policy_store` left these three to answer a refused keystone write with a
+    # plain 500 — the destination keys are exactly the ones an agent must not be able to
+    # redirect, so they are the last place to leave the operator guessing whether their
+    # change landed. Found in review (GPT 5.6).
     if slack_enabled is not None:
-        await asyncio.to_thread(slack_out.set_settings, enabled=slack_enabled)
+        refused = await _settings_write_or_refuse(
+            slack_out.set_settings,
+            code="policy_store_unwritable",
+            applied=applied,
+            enabled=slack_enabled,
+        )
+        if refused is not None:
+            return refused
         applied["slack_enabled"] = slack_enabled
 
     if slack_channel is not None:
-        await asyncio.to_thread(slack_out.set_settings, channel_id=slack_channel)
+        refused = await _settings_write_or_refuse(
+            slack_out.set_settings,
+            code="policy_store_unwritable",
+            applied=applied,
+            channel_id=slack_channel,
+        )
+        if refused is not None:
+            return refused
         applied["slack_channel"] = slack_channel
 
     # Local desktop notifications. Nothing to configure beyond on/off — there is no
     # destination and no credential, which is the whole point of this channel.
     if notify_enabled is not None:
-        await asyncio.to_thread(notify_out.set_settings, enabled=notify_enabled)
+        refused = await _settings_write_or_refuse(
+            notify_out.set_settings,
+            code="app_config_unwritable",
+            applied=applied,
+            enabled=notify_enabled,
+        )
+        if refused is not None:
+            return refused
         applied["notify_enabled"] = notify_enabled
 
     if wants_sync:
@@ -1782,12 +1858,16 @@ async def _handle_put_settings(request: web.Request) -> web.StreamResponse:
         # the git/sandbox machinery, and this module is imported at gateway start.
         from kiro_crew.apps.builtins.ops_mission_control.backend import ledger_sync
 
-        await asyncio.to_thread(
+        refused = await _settings_write_or_refuse(
             ledger_sync.set_settings,
+            code="policy_store_unwritable",
+            applied=applied,
             enabled=sync_enabled,
             remote_url=remote_url,
             branch_name=branch_name,
         )
+        if refused is not None:
+            return refused
         for sync_key, sync_value in (
             ("ledger_sync_remote", remote_url),
             ("ledger_sync_branch", branch_name),
@@ -1797,14 +1877,26 @@ async def _handle_put_settings(request: web.Request) -> web.StreamResponse:
                 applied[sync_key] = sync_value
 
     for numeric_key, numeric_value in numerics.items():
-        await asyncio.to_thread(set_top_level, numeric_key, numeric_value)
+        refused = await _settings_write_or_refuse(
+            set_top_level, numeric_key, numeric_value, code="app_config_unwritable", applied=applied
+        )
+        if refused is not None:
+            return refused
         applied[numeric_key] = numeric_value
 
     # The authorization inputs go to the keystone store, not `set_top_level` (which writes
     # the agent-writable config.json): they ARE the security ceiling, and this authenticated PUT
     # is their sole writer. See `policy_store`.
     if primary is not None:
-        await asyncio.to_thread(policy_store.put, policy_store.PRIMARY_KEY, primary)
+        refused = await _settings_write_or_refuse(
+            policy_store.put,
+            policy_store.PRIMARY_KEY,
+            primary,
+            code="policy_store_unwritable",
+            applied=applied,
+        )
+        if refused is not None:
+            return refused
         applied["primary_instance"] = primary
     # ONE call for both halves, so they commit under ONE lock acquisition. `mode` and
     # `autonomy_rules` are a single authorization decision (`effective = min(app_mode,
@@ -1814,7 +1906,15 @@ async def _handle_put_settings(request: web.Request) -> web.StreamResponse:
     # cannot close that window, because the interleaving comes from another request rather
     # than from ordering inside this one. Found in review (GPT 5.6).
     if mode is not None or rules is not None:
-        await asyncio.to_thread(policy_store.set_ceiling, mode=mode, rules=rules)
+        refused = await _settings_write_or_refuse(
+            policy_store.set_ceiling,
+            code="policy_store_unwritable",
+            applied=applied,
+            mode=mode,
+            rules=rules,
+        )
+        if refused is not None:
+            return refused
         if mode is not None:
             applied["mode"] = mode
         if rules is not None:
@@ -1822,16 +1922,40 @@ async def _handle_put_settings(request: web.Request) -> web.StreamResponse:
     if login is not None:
         from kiro_crew.apps.builtins.ops_mission_control.backend.providers import schedule_file
 
-        await asyncio.to_thread(policy_store.put, policy_store.SCHEDULE_LOGIN_KEY, login)
+        refused = await _settings_write_or_refuse(
+            policy_store.put,
+            policy_store.SCHEDULE_LOGIN_KEY,
+            login,
+            code="policy_store_unwritable",
+            applied=applied,
+        )
+        if refused is not None:
+            return refused
         # A changed identity invalidates the cached `gh` answer, which is only a fallback for
         # an unset login — leaving it would keep answering with the previous operator.
         await asyncio.to_thread(schedule_file.reset_login_cache)
         applied["schedule_github_login"] = login
     if strict is not None:
-        await asyncio.to_thread(policy_store.put, policy_store.SCHEDULE_STRICT_KEY, strict)
+        refused = await _settings_write_or_refuse(
+            policy_store.put,
+            policy_store.SCHEDULE_STRICT_KEY,
+            strict,
+            code="policy_store_unwritable",
+            applied=applied,
+        )
+        if refused is not None:
+            return refused
         applied["schedule_strict_gating"] = strict
     if pd_user is not None:
-        await asyncio.to_thread(policy_store.put, policy_store.PAGERDUTY_USER_KEY, pd_user)
+        refused = await _settings_write_or_refuse(
+            policy_store.put,
+            policy_store.PAGERDUTY_USER_KEY,
+            pd_user,
+            code="policy_store_unwritable",
+            applied=applied,
+        )
+        if refused is not None:
+            return refused
         applied["pagerduty_user_id"] = pd_user
 
     _audit("settings_put", f"{sorted(applied)}", "success")
@@ -1879,7 +2003,20 @@ async def _handle_put_secret(request: web.Request) -> web.StreamResponse:
             status=400,
         )
 
-    await asyncio.to_thread(put_secret, provider_id, field_name, value)
+    try:
+        await asyncio.to_thread(put_secret, provider_id, field_name, value)
+    except OSError as exc:
+        # Reported, not raised — the same shape ``_handle_rotation_arm`` uses for a
+        # refusing cron store, and for the same reason its comment gives: escaping
+        # here becomes aiohttp's default 500, a plain-text body with no ``code`` for
+        # the UI to branch on. On THIS route the ambiguity is the security-relevant
+        # part: the operator cannot tell whether the credential they just typed is
+        # now stored. 503 rather than 500 because the condition is transient and
+        # retrying is the correct client behaviour.
+        logger.warning("ops-mission-control: secret save refused, store unwritable")
+        return web.json_response(
+            {"ok": False, "error": str(exc), "code": "secret_store_unwritable"}, status=503
+        )
     return web.json_response({"ok": True, "provider": provider_id, "field": field_name})
 
 
@@ -1889,7 +2026,18 @@ async def _handle_delete_secret(request: web.Request) -> web.StreamResponse:
         return web.json_response(
             {"error": "provider_id is required", "code": "missing_required_field"}, status=400
         )
-    removed = await asyncio.to_thread(delete_secret, provider_id)
+    try:
+        removed = await asyncio.to_thread(delete_secret, provider_id)
+    except OSError as exc:
+        # The revocation route needs this MORE than the save route. Its whole purpose
+        # is to let an operator stop trusting a credential, and the failure this
+        # replaces is the one where they were told the token was already gone. A
+        # coded refusal is the only answer that leaves them correctly believing the
+        # token is still live.
+        logger.warning("ops-mission-control: secret revocation refused, store unwritable")
+        return web.json_response(
+            {"ok": False, "error": str(exc), "code": "secret_store_unwritable"}, status=503
+        )
     return web.json_response({"ok": True, "removed": removed})
 
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
@@ -197,11 +197,13 @@ class KeystoneFileBackend:
     def _path(self) -> Path:
         return self._pinned_path if self._pinned_path is not None else secrets_path()
 
-    def _read(self) -> dict[str, dict[str, str]]:
-        try:
-            raw = json.loads(self._path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, OSError, json.JSONDecodeError):
-            return {}
+    @staticmethod
+    def _coerce(raw: Any) -> dict[str, dict[str, str]]:
+        """Normalize a parsed store to ``provider -> {field: value}``, all strings.
+
+        Shared by both readers below so the only thing that can differ between
+        them is which read FAILURES are allowed to answer "empty".
+        """
         if not isinstance(raw, dict):
             return {}
         out: dict[str, dict[str, str]] = {}
@@ -209,6 +211,45 @@ class KeystoneFileBackend:
             if isinstance(fields, dict):
                 out[str(provider)] = {str(k): str(v) for k, v in fields.items()}
         return out
+
+    def _read(self) -> dict[str, dict[str, str]]:
+        """Every stored secret, or ``{}`` when there is nothing readable.
+
+        A LOOKUP read: ``get``/``configured_fields`` answer "not configured"
+        rather than raising, so the Settings UI still renders and a provider
+        whose token cannot be loaded is refused by the fail-closed
+        ``has_secrets`` check instead of 500ing the route. See
+        :meth:`_read_for_update` for why a mutation may not stand on the same
+        answer.
+        """
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return {}
+        return self._coerce(raw)
+
+    def _read_for_update(self) -> dict[str, dict[str, str]]:
+        """The store a read-modify-write is allowed to publish over.
+
+        ``put`` and ``delete`` rewrite the WHOLE file from what they read, so an
+        empty base is not "no secrets to carry forward" -- it is "delete every
+        provider token already stored". Only a MISSING file makes that true. An
+        unreadable one (a transient EACCES/EIO, a scanner holding the handle on
+        Windows) is a store we still have, and this file is the only copy that
+        exists: a provider token is not derivable from anything else on the box,
+        so truncating it means the operator must mint new credentials at
+        PagerDuty and Datadog, and every poll fails closed until they do. The
+        error propagates and the mutation is abandoned instead.
+
+        Corruption keeps reading as empty, matching :meth:`_read`: the document
+        parsed to nothing usable, so there is no stored token left to lose by
+        replacing it.
+        """
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+        return self._coerce(raw)
 
     def _lock(self) -> "_SecretLock":
         return _SecretLock(self._path)
@@ -243,14 +284,24 @@ class KeystoneFileBackend:
         # onto a stale snapshot and the later atomic replace would DELETE the first secret while
         # both returned 200. On the credential store a lost update is a lost secret. Found in
         # review — the same class as the config/index/ledger/policy locks elsewhere in this app.
+        #
+        # The base is ``_read_for_update``, not ``_read``: the lock serializes
+        # writers but says nothing about a read that FAILED, and this write
+        # replaces the whole file. See that method for why one transient EACCES
+        # must abandon the save rather than publish an empty store over it.
         with self._lock():
-            data = self._read()
+            data = self._read_for_update()
             data.setdefault(provider_id, {})[field_name] = value
             self._write(data)
 
     def delete(self, provider_id: str) -> bool:
+        # ``_read_for_update`` for the same reason as ``put``, plus one specific to
+        # revocation: on an unreadable store the lenient read reported the provider
+        # absent, so this returned False and the audit logged ``not_found`` — telling
+        # the operator there was nothing to revoke while the live token was still on
+        # disk and still working. A raise is the honest answer.
         with self._lock():
-            data = self._read()
+            data = self._read_for_update()
             if provider_id not in data:
                 return False
             del data[provider_id]

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
@@ -10,6 +10,7 @@ write. Found in review; fixed by moving them to `ops_mission_control_policy.json
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -746,3 +747,107 @@ class TestPolicyLockdownOrdering(_HomeIsolated):
             policy_store.read_mode("unset"), models.MODE_OBSERVE,
             "a transient write failure destroyed the previously recorded ceiling",
         )
+
+
+class TestTheCeilingIsNeverPublishedOverAFailedRead(_HomeIsolated):
+    """The BASE read of a read-modify-write may not fail open.
+
+    ``_read`` collapses every failure to ``{}``, which is right for the gate
+    readers — an unreadable ceiling resolves to ``observe`` with no act-rules,
+    the most restrictive answer, not a permissive one. It is wrong as the base of
+    ``set_ceiling``/``put``, which rewrite the WHOLE file: there ``{}`` means
+    "discard every other operator-only key", and this one file holds ALL of them
+    — the ceiling, the ledger remote, the Slack channel, the rotation identity,
+    the primary-instance flag.
+
+    Every one of those falls back to a value the agent CAN influence, so a
+    transient EACCES reproduces by accident the exact bypass the keystone floor
+    exists to prevent. The class above proved a failed WRITE cannot reach the
+    previous ceiling; a failed READ went around it, because the write that
+    followed succeeded — it just wrote a document with everything missing.
+    """
+
+    def _unreadable_policy(self):
+        """Fail ONLY the policy file's read, as a transient EACCES would.
+
+        Scoped by path: a blanket ``read_text`` failure would also break home
+        resolution and ``config.json``, and the test would pass for the wrong
+        reason.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        target = policy_store.policy_path()
+        real_read_text = Path.read_text
+
+        def _guarded(path_self, *args, **kwargs):
+            if Path(path_self) == target:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        return mock.patch.object(Path, "read_text", _guarded)
+
+    def test_a_read_that_failed_never_truncates_the_ceiling(self):
+        """The durable harm, asserted directly: every OTHER operator-only key
+        the operator set must still be on the fenced floor afterwards."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        policy_store.set_ceiling(mode="observe", rules=[])
+        policy_store.put("slack_channel", "#ops-the-operator-chose")
+        policy_store.put("ledger_sync_remote", "https://git.example/ops-ledger.git")
+        before = policy_store.policy_path().read_bytes()
+
+        with self._unreadable_policy():
+            with contextlib.suppress(OSError):
+                policy_store.set_ceiling(mode="act")
+            with contextlib.suppress(OSError):
+                policy_store.put("primary_instance", True)
+
+        self.assertEqual(
+            policy_store.policy_path().read_bytes(), before,
+            "a failed read was published back over the ceiling",
+        )
+        self.assertEqual(
+            policy_store.get("slack_channel"), "#ops-the-operator-chose",
+            "a failed read dropped the operator's outbound destination",
+        )
+        self.assertEqual(
+            policy_store.get("ledger_sync_remote"), "https://git.example/ops-ledger.git",
+            "a failed read dropped the operator's ledger remote",
+        )
+
+    def test_an_unreadable_ceiling_refuses_the_write(self):
+        """The operator must be told, rather than being handed a 200 for a
+        ceiling change that did not happen."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        with self._unreadable_policy():
+            with self.assertRaises(OSError):
+                policy_store.set_ceiling(mode="act")
+
+    def test_an_unreadable_ceiling_refuses_a_single_key_write(self):
+        """``put`` is the generic setter for the destination and identity keys,
+        and rewrites the same whole file, so it needs the same refusal."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        with self._unreadable_policy():
+            with self.assertRaises(OSError):
+                policy_store.put("slack_channel", "#somewhere-else")
+
+    def test_a_missing_ceiling_is_still_a_first_write(self):
+        """Absent is the one failure where ``{}`` is the truth. The guard must
+        not turn the operator's very first settings save into an error."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        self.assertFalse(policy_store.policy_path().exists())
+        policy_store.set_ceiling(mode="act")
+        self.assertEqual(policy_store.read_mode("observe"), "act")
+
+    def test_a_corrupt_ceiling_still_repairs_on_write(self):
+        """Existing tolerance, pinned so the unreadable-file guard is not
+        mistaken for a licence to start failing on corruption too."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        policy_store.policy_path().parent.mkdir(parents=True, exist_ok=True)
+        policy_store.policy_path().write_text("{ not json", encoding="utf-8")
+        policy_store.set_ceiling(mode="act")
+        self.assertEqual(policy_store.read_mode("observe"), "act")

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
@@ -13,6 +13,7 @@ caught.
 """
 
 import json
+import os
 import shutil
 import tempfile
 import unittest
@@ -3267,3 +3268,163 @@ class TestApprovedProposalSchedulesVerification(unittest.IsolatedAsyncioTestCase
         stored = store.get_incident(iid)
         assert stored is not None
         self.assertNotIn(stored.verification, models.OPEN_VERIFICATIONS)
+
+
+class TestAStoreThatRefusesToWriteIsReportedNotCrashed(unittest.IsolatedAsyncioTestCase):
+    """A refused keystone write must answer with the app's coded error, not a bare 500.
+
+    The two stores behind these routes are read-modify-writes that now REFUSE rather than
+    publishing over a read they could not make, so each write can raise ``OSError``. Nothing
+    converts that into a body: ``sel_audit_middleware`` logs and re-raises, and
+    ``deny_audit_middleware`` only handles ``web.HTTPException`` — so an escaping error becomes
+    aiohttp's default ``500`` with a plain-text body and no ``code`` to branch on.
+
+    On these particular routes the ambiguity is the security-relevant part. ``mode`` and
+    ``autonomy_rules`` ARE the authorization ceiling, and the secret routes decide whether a
+    live credential is stored or revoked — "did my change land?" is exactly the question the
+    operator must not be left guessing about. ``_handle_rotation_arm`` already set the shape
+    for this in the same file (``503 cron_store_unreadable``, with its progress list attached).
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self._prev = os.environ.get("KIROCREW_HOME")
+        self.addCleanup(self._restore_home)
+        os.environ["KIROCREW_HOME"] = self.tmp
+
+    def _restore_home(self):
+        if self._prev is None:
+            os.environ.pop("KIROCREW_HOME", None)
+        else:
+            os.environ["KIROCREW_HOME"] = self._prev
+
+    @staticmethod
+    def _refuse(*_a, **_kw):
+        raise PermissionError(13, "Permission denied")
+
+    async def _client(self, app):
+        from aiohttp.test_utils import TestClient, TestServer
+
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        self.addAsyncCleanup(client.close)
+        return client
+
+    async def test_a_refused_secret_save_is_a_coded_503_not_a_500(self):
+        token = "u+ThisIsTheActualTokenValue"
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(routes, "put_secret", self._refuse):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/providers/pagerduty/secret",
+                    json={"field": "api_token", "value": token},
+                )
+                self.assertEqual(resp.status, 503)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "secret_store_unwritable")
+        self.assertIs(body["ok"], False)
+        # A refusal must not echo the credential it failed to store.
+        self.assertNotIn(token, json.dumps(body))
+
+    async def test_a_refused_revocation_never_reports_success(self):
+        """The load-bearing one. The failure this replaces did not 500 — it returned
+        ``{"ok": true, "removed": false}``, i.e. "there was nothing to revoke", while the
+        live token was still on disk. Anything 2xx here is the bug."""
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(routes, "delete_secret", self._refuse):
+                client = await self._client(app)
+                resp = await client.delete(
+                    "/api/apps/ops-mission-control/providers/pagerduty/secret"
+                )
+                self.assertEqual(resp.status, 503, "a refused revocation answered as success")
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "secret_store_unwritable")
+        self.assertNotIn("removed", body, "the refusal must not claim a removal verdict")
+
+    async def test_a_refused_ceiling_write_is_a_coded_503(self):
+        """The ceiling is the one value where a silent partial apply is a security state."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(policy_store, "set_ceiling", self._refuse):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/settings", json={"mode": "observe"}
+                )
+                self.assertEqual(resp.status, 503)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "policy_store_unwritable")
+        self.assertIs(body["ok"], False)
+
+    async def test_a_refused_destination_write_is_a_coded_503_too(self):
+        """The keys reached THROUGH an intermediary, which the first pass missed.
+
+        `slack_out.set_settings` and `ledger_sync.set_settings` call `policy_store.put`
+        internally -- their keys are operator-only, so they must -- so guarding only the
+        call sites that literally spell `policy_store` left the destination writes
+        answering a refused keystone write with a plain 500. These are the keys an agent
+        must not be able to redirect, so they are the last place to leave the operator
+        guessing. Found in review (GPT 5.6).
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import slack_out
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(slack_out, "set_settings", self._refuse):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/settings", json={"slack_channel": "C123456"}
+                )
+                self.assertEqual(resp.status, 503, "a refused destination write answered 200")
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "policy_store_unwritable")
+
+    async def test_a_refusal_body_carries_no_field_the_dashboard_discards(self):
+        """`req` in the app's own api.ts reads only `error` from a non-2xx body.
+
+        An earlier revision shipped an `applied` key here on the reasoning that naming
+        what landed is actionable. It is -- but not there, because nothing reads it. The
+        partial set goes to the audit log instead, which has a reader and mirrors the
+        `settings_put` line the success path already writes.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(policy_store, "set_ceiling", self._refuse):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/settings", json={"mode": "observe"}
+                )
+                body = await resp.json()
+
+        self.assertNotIn("applied", body)
+        self.assertEqual(sorted(body), ["code", "error", "ok"])
+
+    async def test_an_ordinary_settings_write_still_succeeds(self):
+        """Negative control: the guard must not break the route it protects."""
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            client = await self._client(app)
+            resp = await client.put(
+                "/api/apps/ops-mission-control/settings", json={"mode": "observe"}
+            )
+            self.assertEqual(resp.status, 200)
+            body = await resp.json()
+
+        self.assertIs(body["ok"], True)
+        self.assertEqual(body["applied"]["mode"], "observe")

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
@@ -11,11 +11,13 @@ than a mock. A rename of ``SECRETS_FILENAME`` that forgot to update
 so this is the test that catches it.
 """
 
+import contextlib
 import os
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from kiro_crew import security
 from kiro_crew.apps.builtins.ops_mission_control.backend import secrets
@@ -391,6 +393,103 @@ class TestSecretStoreLockdownOrdering(unittest.TestCase):
             self.backend.get("pagerduty", "api_token"), "u+secretvalue",
             "a transient write failure destroyed the previously stored token",
         )
+
+
+class TestSecretStoreNeverPublishesOverAFailedRead(unittest.TestCase):
+    """The BASE read of a read-modify-write may not fail open.
+
+    ``_read`` collapses every failure to ``{}``, which is right for ``get`` and
+    ``configured_fields`` — a lookup that cannot load answers "not configured",
+    the Settings page still renders, and the fail-closed ``has_secrets`` check
+    refuses the provider. It is wrong as the base of ``put``/``delete``, which
+    rewrite the WHOLE file: there ``{}`` means "delete every provider token
+    already stored", and one transient EACCES/EIO published it.
+
+    This is the store's LAST unguarded loss path. The class above proved a failed
+    WRITE cannot reach the previous store; a failed READ went around it, because
+    the write that followed was perfectly successful — it just wrote nothing.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.store = self.tmp / "secrets.json"
+        self.backend = secrets.KeystoneFileBackend(self.store)
+
+    def _unreadable_store(self):
+        """Fail ONLY the secret file's read, as a transient EACCES would.
+
+        Scoped by path: a blanket ``read_text`` failure would also break the home
+        resolution and lock paths, and the test would pass for the wrong reason.
+        """
+        real_read_text = Path.read_text
+
+        def _guarded(path_self, *args, **kwargs):
+            if Path(path_self) == self.store:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        return mock.patch.object(Path, "read_text", _guarded)
+
+    def test_a_read_that_failed_never_truncates_the_store(self):
+        """The durable harm, asserted directly: the stored token must survive.
+
+        A provider token is not derivable from anything else on the box, so this
+        file is the only copy — truncating it means the operator has to mint new
+        credentials at PagerDuty and Datadog, and every poll fails closed until
+        they do.
+        """
+        self.backend.put("pagerduty", "api_token", "u+thisisthestoredtoken")
+        before = self.store.read_bytes()
+
+        with self._unreadable_store():
+            with contextlib.suppress(OSError):
+                self.backend.put("datadog", "api_key", "a" * 32)
+            with contextlib.suppress(OSError):
+                self.backend.delete("pagerduty")
+
+        self.assertEqual(
+            self.store.read_bytes(), before,
+            "a failed read was published back over the store",
+        )
+        self.assertEqual(
+            self.backend.get("pagerduty", "api_token"), "u+thisisthestoredtoken",
+            "a failed read destroyed a token that was still on disk",
+        )
+
+    def test_an_unreadable_store_refuses_the_save(self):
+        """A save that was not recorded must not answer as though it were."""
+        with self._unreadable_store():
+            with self.assertRaises(OSError):
+                self.backend.put("datadog", "api_key", "a" * 32)
+
+    def test_an_unreadable_store_refuses_the_revocation(self):
+        """The revocation half, which loses no data and still lies.
+
+        On an unreadable store the lenient read reported the provider absent, so
+        ``delete`` returned False and ``delete_secret`` audited ``not_found`` —
+        telling the operator there was nothing to revoke while the live token was
+        still on disk and still working.
+        """
+        self.backend.put("pagerduty", "api_token", "u+thisisthestoredtoken")
+        with self._unreadable_store():
+            with self.assertRaises(OSError):
+                self.backend.delete("pagerduty")
+
+    def test_a_missing_store_is_still_a_first_write(self):
+        """Absent is the one failure where ``{}`` is the truth. The guard must
+        not turn the very first credential save into an error."""
+        self.assertFalse(self.store.exists())
+        self.backend.put("pagerduty", "api_token", "u+thefirsttoken")
+        self.assertEqual(self.backend.get("pagerduty", "api_token"), "u+thefirsttoken")
+
+    def test_a_corrupt_store_still_repairs_on_write(self):
+        """Existing tolerance, pinned so the unreadable-file guard is not
+        mistaken for a licence to start failing on corruption too. A document
+        that parsed to nothing usable has no stored token left to lose."""
+        self.store.write_text("{ not json", encoding="utf-8")
+        self.backend.put("pagerduty", "api_token", "u+afterthecorruption")
+        self.assertEqual(self.backend.get("pagerduty", "api_token"), "u+afterthecorruption")
 
 
 class TestDescribeSecrets(unittest.TestCase):


### PR DESCRIPTION
## 1. What is the problem?

Two reads in `ops_mission_control` collapse **every** read failure to an empty document, and
both are the base of a whole-file rewrite:

| Site | Lenient read | Mutations standing on it |
| --- | --- | --- |
| `backend/secrets.py` | `KeystoneFileBackend._read` | `put`, `delete` |
| `backend/policy_store.py` | `_read` | `set_ceiling`, `put` |

Each `except` clause names `OSError`, so a transient `EACCES`/`EIO` -- a scanner holding the
handle on Windows, a torn read, a permissions blip -- is indistinguishable from "the file is
not there yet". The mutation then rewrites the whole document from that empty base. The write
half is flawless; it just writes nothing.

Both lenient reads are *correct where they are used as reads*. `get` answering "not configured"
keeps the Settings page rendering and lets the fail-closed `has_secrets` check refuse the
provider; an unreadable ceiling resolving to `observe` with no act-rules is the most restrictive
answer available, not a permissive one. The defect is not the leniency -- it is reusing a lookup
answer as a mutation base.

Three distinct failures come out of that, and they are not variations of one thing.

**Truncation of the credential store.** `put` rewrites the whole file, so an empty base means
"delete every stored provider token". A provider token is not derivable from anything else on
the box, so this file is the only copy.

**A failed revocation reported as completed.** This is a separate harm class, not a corollary of
the truncation above. `delete` destroys nothing: on an unreadable store the lenient read reported
the provider absent, so it returned `False` and the audit recorded
`secret_delete outcome=not_found`. **The operator's belief and the disk disagree, and the audit
log sides with the operator.** They asked for a credential to be revoked and were told there was
nothing there to revoke, while a live, working token sits on disk.

**A fail-open on the file that defines who is constrained.** For `policy_store` the argument is a
security one, not a data-loss one. That single file holds every operator-only key -- the autonomy
ceiling (`mode`, `autonomy_rules`), the ledger sync remote, the Slack channel, the rotation
identity, the primary-instance flag -- and each is fenced onto the keystone floor precisely
because the agent must not be able to set it. Each also falls back to a value the constrained
party *can* influence. So one transient read failure reproduced, by accident, the exact bypass
the keystone exists to prevent.

The per-file locks already in place (`_SecretLock`, `_PolicyLock`) do not help: they serialize
writers and say nothing about a read that failed.

## 2. Why this issue matters to the user

None of the three reports itself, and they fail in different directions.

**The truncation is loud, eventually.** Every stored token vanishing means the operator goes back
to PagerDuty and Datadog to mint new credentials, and every poll fails closed until they do.
Disruptive, but it announces itself the next time something needs the token.

**The false revocation is silent, and that makes it worse.** A person who believes a credential is
revoked stops treating it as live: they stop rotating it, stop counting it in an access review,
and stop caring where it has been. Meanwhile the token still authenticates. There is no later
moment when this surfaces, because everything keeps working -- that is precisely the problem. Of
the three failures here this is the one to fix first, even though it loses no data.

**The fail-open ceiling is an accident that looks exactly like an attack.** `effective =
min(app_mode, rule_mode)` is only a ceiling if the party it constrains cannot raise it. Losing
the file drops `mode` and `autonomy_rules` back to a re-derived default and the destination and
identity keys to absent -- and absent is how the off-shift refusal and the `not_primary` gate get
their inputs. The threat model this app documents at length is an agent writing those values; the
bug arrives at a similar place with no agent involved.

## 3. How our fix solves it

The chain from symptom to root cause: *stored state disappears, or a revocation is falsely
reported* <- *a whole-file write publishes an empty document* <- *the mutation's base read answered
"empty"* <- *the base read cannot tell an absent file from an unreadable one, because one `except`
clause covers both*.

The fix cuts the chain at the last link. Each module gains a private `_read_for_update` used
**only** as the base of a mutation, in which:

- a **missing** file still reads as empty -- nothing has been written yet, so empty is the truth,
  and the operator's first save must not become an error;
- a **genuine read error propagates**, so the mutation is abandoned rather than published over
  state nobody read;
- **corruption keeps reading as empty**, unchanged. A document that parsed to nothing usable has
  no stored token or ceiling left to lose by being replaced, which matches the lookup reads.

This is the idiom already in the tree, not a new one: `mcp_quarantine._load_for_update`,
`config/loader.read_config_for_update`, and most directly #7620 (`8064a9bb5`), which applied
exactly this shape to `aws_control`'s `library.py` and `shares.py`.

`secrets.py` had multi-line normalization after the parse, so it was extracted into a shared
`_coerce` rather than duplicated -- which is what makes the two readers provably identical apart
from which failures answer "empty", the one thing that is supposed to differ.

**The three routes that write these stores now refuse with a coded error** rather than letting
the newly-propagating `OSError` land as aiohttp's default 500 (a plain-text body with no `code`
to branch on -- nothing in the middleware chain converts it, `sel_audit_middleware` logs and
re-raises). This follows `_handle_rotation_arm`'s existing `503 cron_store_unreadable` shape in
the same file, whose own comment states the rule: "escaping here becomes a 500".

- `_handle_put_secret`, `_handle_delete_secret` -> `503 secret_store_unwritable`. The revocation
  route needs it most: the failure being replaced was not a 500 but
  `{"ok": true, "removed": false}`, and any 2xx there is the bug in section 1.
- `_handle_put_settings` -> `503 policy_store_unwritable` / `app_config_unwritable`. This covers the
  three writes that reach `policy_store.put` through an **intermediary** rather than naming it:
  `slack_out.set_settings` (`slack_out.py:134`, `:136`) and `ledger_sync.set_settings`
  (`ledger_sync.py:327`, `:329`) own operator-only keys, so guarding only the call sites that spell
  `policy_store` left the Slack channel and the ledger remote -- the two keys an agent must not be
  able to redirect -- answering a plain 500.
- The partial-apply set goes to the **audit log**, not the refusal body. Phase 2 is a sequence of
  writes, so an earlier one may already have committed and a partial ceiling apply is a security
  state worth recording -- but the dashboard's own `req` helper
  (`website/src/apps/ops-mission-control/api.ts:1077`) reads only `error` from a non-2xx body and
  discards the rest, so a field there would have had no reader. The audit line has one, and mirrors
  the `settings_put` line the success path already writes.

One gap stated rather than papered over: `set_top_level` writes the app config, whose read still
collapses a failure to `{}`, so a transient `config.json` read failure truncates that file and
returns 200 without the helper ever seeing an `OSError`. The strict read closing it is in #7794; the
`app_config_unwritable` code here covers only the write-side failure that store can already raise
today. The helper docstring says so explicitly.

`503` rather than `500` throughout because the condition is transient and retrying is the correct
client behaviour.

## 4. What tests we did

**16 new tests.** Five per store module plus six on the route layer.

- `test_a_read_that_failed_never_truncates_*` -- asserts the **durable harm directly**: the stored
  token, and the operator's other keystone keys, are still there after a failed-read mutation is
  attempted. Asserts on disk state, not on the exception.
- `test_an_unreadable_store_refuses_the_save` / `..._the_revocation`, and the policy equivalents
  for `set_ceiling` and `put` -- the caller is told, rather than handed a silent no-op that reads
  as success. The revocation one exists separately because that half loses no data and still lied.
- `test_a_missing_*_is_still_a_first_write` -- **negative control.** Absent is the one failure where
  empty is the truth; the guard must not turn a first save into an error.
- `test_a_corrupt_*_still_repairs_on_write` -- **negative control.** Pins the existing corruption
  tolerance so the new guard cannot be mistaken for a licence to start failing on corruption.
- `TestAStoreThatRefusesToWriteIsReportedNotCrashed` -- six route tests: the coded 503 on a
  refused save (asserting the refusal does not echo the credential), the refused revocation
  (asserting `removed` is absent, so no removal verdict is claimed), the refused ceiling write, the
  refused **destination** write through `slack_out.set_settings` (the intermediary path the first
  pass missed), a check that the refusal body carries no field the dashboard discards, and a negative
  control that an ordinary settings write still returns 200.

Each unreadable-file fixture is **scoped to the target path** (`read_text` fails only for that one
file). A blanket failure would also break home resolution and the lock sidecars, and the test
would pass for the wrong reason.

**Mutation-verified, six probes.** Reverting `secrets.put`/`delete` or `policy_store.set_ceiling`
to the lenient reader reds exactly that module's loss guard plus its refusal, while all negative
controls stay green. Removing the revocation route's mapping reds its test with `500 != 503`, and so
does removing the Slack destination guard. The `secrets` probe reproduces the loss literally: the
store goes from `{"pagerduty": {"api_token": ...}}` to `{"datadog": {...}}` -- the PagerDuty token
deleted by a *read* failure.

**Gates:** `isort` and `flake8` clean on all 6 changed files. `mypy` reports 4 errors, all in
`transcribe.py` and `providers/cloudwatch.py` -- neither in this diff; they reproduce when those
two files are checked alone. App suite `937 passed, 44 skipped, 257 subtests` (from 921 on `main`,
+16). Run with `-o addopts=""` to avoid the baked-in xdist parallelism.

## 5. Any other suggestions on the work

1. **The same defect in `store.py` and `providers/__init__.py` ships as #7794**, deliberately split
   rather than bundled. Those two are the mechanical half -- an incident index and a config
   file, no authorization decision -- and `store.py` alone carries six locked read-modify-writes,
   which is where the review surface of this change lives. Splitting on the risk boundary keeps a
   nit on the ops board's index from holding up the credential fix. That PR carries a caller-policy
   change too: making the index read strict meant `dispatch.run_cycle`'s two maintenance passes
   raised out of the heartbeat, which its own ordering doctrine forbids.

2. **Two further sites of this pattern remain, tracked in #7789**, one with durable harm
   (`aws_control/backend/backup.py:78` -- `read_state` feeds `_locked_state_update`'s whole-file
   rewrite, so a transient read failure drops the per-account `nightly` authorization bit and every
   run record). Six sites in two apps have now been fixed by hand in two days, so that issue also
   proposes an AST ratchet keyed on the *write* rather than the read -- most lenient reads in `src/`
   are legitimate lookup reads, so the write is the discriminator.

3. **#7790 remains open for the handlers this PR does not touch.** The coded-error mapping added
   here covers the secret and settings routes. `_handle_put_provider_config`, the hygiene handler's
   `prune_closed`, and the fall-through in `_handle_transition` / `_handle_decide_proposal` still
   answer with a bare untyped 500; that is pre-existing and reachable on `main` today, since every
   one of those paths writes through `atomic_write`, which raises.

4. **A non-UTF-8 file still escapes both lookup reads.** `read_text(encoding="utf-8")` raises
   `UnicodeDecodeError`, a `ValueError` and not an `OSError`, so neither `except` catches it --
   meaning `get_secret` on a mojibake'd store raises rather than answering "not configured".
   Unchanged by this PR (it propagates before and after, and propagating is the safe direction for a
   mutation), and #7620 left the same edge. `config/loader` is the module that names
   `UnicodeDecodeError` explicitly; these two reads arguably should too.

Sibling fix: #7620 (`8064a9bb5`), same defect class in `aws_control`.

## Pattern harvest

Rule candidate: semgrep, plus a ratchet test for the half a pattern rule cannot see (tracked in #7789)
Pattern: a read that collapses every failure to an empty document, used as the base of a whole-file rewrite

Not a one-off, and the count is the evidence: six sites across two apps in two days -- #7620's
`library.py` and `shares.py`, this PR's two, #7794's two -- plus two still open in #7789, one of
them with durable harm. Three rounds of manual discovery for one mechanical shape says the class
needs retiring, not the instance.

Semgrep can match the lenient `except (..., OSError, json.JSONDecodeError): return {}` cheaply, but
that half alone is not the defect: ten sites in `src/` match it and most are legitimate display or
lookup reads, so a rule keyed on the read would be almost entirely false positives. The
discriminator is the coupling -- the same function's result reaching a writer that replaces the
whole document -- which is a dataflow question rather than a syntactic one. That is why #7789
proposes keying the ratchet on the WRITE: for each module, find the lenient reader, then check
whether its return value flows into an `atomic_write` in the same file.
