### PR TITLE
fix(ops-mission-control): never publish the incident index or app config over a failed read

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -129,13 +129,11 @@ src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_index.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_notify_out.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
-src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers_datadog_cov80.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_slack_out.py
-src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_webhook.py
 src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
 src/kiro_crew/apps/builtins/papyrus/backend/latex.py

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/dispatch.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/dispatch.py
@@ -27,6 +27,7 @@ See ``docs/system-specs/modules/ops-mission-control.md`` (dispatch cycle).
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -471,9 +472,35 @@ def verify_pending_actions(
                 verification=verdict,
                 verification_detail=detail,
             )
-        except (KeyError, ValueError):
+        except json.JSONDecodeError:
+            # Corruption does NOT get the tolerance below, and this clause exists only
+            # to stop it taking it by accident: `JSONDecodeError` subclasses
+            # `ValueError`, which the next clause already catches for a completely
+            # different reason (an illegal status transition). Without this the two
+            # would share one handler and a corrupt index would be swallowed by a
+            # debug log written for a grammar error.
+            #
+            # Refusing is the deliberate choice, and the difference from the OSError
+            # case is persistence. An unreadable index is transient: the next
+            # heartbeat probably succeeds, so skipping one annotation costs nothing.
+            # A corrupt index fails identically on every future cycle until a person
+            # intervenes -- so tolerating it means degrading indefinitely while the
+            # board still renders and nothing reports why. That is the same
+            # looks-like-health failure the display reads now log, and the reason this
+            # one has to escape.
+            raise
+        except (KeyError, ValueError, OSError):
             # Pruned or raced away between the read and the write. Not an error worth
             # failing a cycle for, and nothing else in the cycle depends on it.
+            #
+            # ``OSError`` joins the two race cases rather than escaping: the strict
+            # for-update index read means `update_fields` can now refuse instead of
+            # silently truncating, and that refusal must not become the one thing that
+            # aborts a cycle. Tolerating it is safe precisely BECAUSE the store refused --
+            # the mutation was abandoned before it wrote, so nothing is half-applied and
+            # the only cost is this annotation, which the next verification pass redoes.
+            # The store staying strict and this caller staying tolerant are the same
+            # decision seen from two ends, not a contradiction. Found in review (GPT 5.6).
             logger.debug(
                 "ops-mission-control: could not record verification for %s",
                 incident.incident_id,
@@ -581,7 +608,26 @@ async def run_cycle(
     # in a cron of its own because a TTL that only advances when a separate job fires
     # is a TTL that silently stops existing when that job is paused — and every other
     # cron here is pausable by design.
-    expired = await asyncio.to_thread(store.expire_stale_proposals)
+    try:
+        expired = await asyncio.to_thread(store.expire_stale_proposals)
+    except OSError:
+        # Any index-maintenance I/O failure, not only an unreadable index: this also
+        # catches the sidecar lock and the atomic write, which could always raise. The
+        # strict for-update read just made the case common enough to matter. Either way
+        # the durable state is intact -- a failed read abandons the mutation before it
+        # writes, and a failed write leaves the previous document in place -- so the only
+        # thing lost is this cycle's TTL stamping, which the next heartbeat redoes.
+        #
+        # Raising instead would cost the ENTIRE cycle from here down: every claim, the
+        # Slack pin mirror, the desktop notifications and the cycle's SEL entry. This
+        # function is ordered specifically so a later fault cannot cost an earlier step
+        # ("a Slack outage can never cost us a claim"), and a maintenance pass that reruns
+        # every heartbeat is the clearest case of that rule. Found in review.
+        logger.warning(
+            "ops-mission-control: proposal expiry skipped, dispatch index I/O failed",
+            exc_info=True,
+        )
+        expired = []
     if expired:
         logger.info(
             "ops-mission-control: %d proposal(s) expired unanswered: %s",
@@ -666,7 +712,32 @@ async def run_cycle(
 
     claimed: list[ClaimedIncident] = []
     for signal in candidates[:limit]:
-        result = await asyncio.to_thread(_claim_one, signal)
+        try:
+            result = await asyncio.to_thread(_claim_one, signal)
+        except OSError:
+            # `claim` itself keeps raising -- a compare-and-set has no safe degraded
+            # answer, because `None` already means "another instance owns this signal".
+            # But the CALLER must not let that abort the cycle, and the ordering here is
+            # why: the pre-filter above reads the index leniently, so an unreadable index
+            # empties `owned`, every firing signal becomes a candidate, and this line
+            # raises before `webhook.ack`, the stale sweep, the Slack pin mirror,
+            # `_notify_cycle_changes` and the cycle's SEL entry. Incidents claimed EARLIER
+            # in this same loop are durably on disk, so escaping here means an in-flight
+            # investigation nobody is ever told about -- and it made the maintenance-pass
+            # guard below unreachable on any install with something firing, which is the
+            # only install where it matters. Found in review (Design Review, Fable 5).
+            #
+            # `break`, not `continue`: whatever stopped this claim will stop every
+            # remaining one the same way, so continuing only repeats the failure per
+            # candidate. Nothing was published either way -- the abandoned mutation wrote
+            # nothing -- and the next heartbeat retries from a clean read.
+            logger.warning(
+                "ops-mission-control: claiming stopped early after %d claim(s), "
+                "dispatch index I/O failed",
+                len(claimed),
+                exc_info=True,
+            )
+            break
         if result is not None:
             # Gather evidence HERE, on the credentialed gateway, rather than letting
             # the investigating agent fetch it — the agent has no AWS credentials and
@@ -720,13 +791,26 @@ async def run_cycle(
     verifications = await asyncio.to_thread(verify_pending_actions, signals, registry.poll_health())
 
     stale_after = _config_int(_CONFIG_STALE_AFTER, DEFAULT_STALE_AFTER_SECS)
-    released = await asyncio.to_thread(
-        store.sweep_stale,
-        stale_after,
-        # 0 / unset means "derive from the working threshold", which is what
-        # ``sweep_stale`` does for ``None``.
-        _config_int(_CONFIG_NEEDS_HUMAN_STALE_AFTER, 0) or None,
-    )
+    try:
+        released = await asyncio.to_thread(
+            store.sweep_stale,
+            stale_after,
+            # 0 / unset means "derive from the working threshold", which is what
+            # ``sweep_stale`` does for ``None``.
+            _config_int(_CONFIG_NEEDS_HUMAN_STALE_AFTER, 0) or None,
+        )
+    except OSError:
+        # Same policy and same breadth as the proposal expiry above: any
+        # index-maintenance I/O failure, the lock and the atomic write included. The
+        # ordering argument is even more direct here -- the three steps that follow are
+        # the Slack mirror, the notification bus and the SEL entry, each of which the
+        # comments below place AFTER the claim precisely so its failure cannot cost one.
+        # An abandoned sweep releases nothing and is retried on the next heartbeat.
+        logger.warning(
+            "ops-mission-control: stale sweep skipped, dispatch index I/O failed",
+            exc_info=True,
+        )
+        released = []
 
     # Mirror newly-claimed incidents onto the Slack pin board. After the claim, so
     # a Slack outage can never cost us a claim; each send is already failure-

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/models.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/models.py
@@ -23,6 +23,7 @@ See ``docs/system-specs/modules/ops-mission-control.md`` (data model).
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -64,6 +65,61 @@ STATE_UNKNOWN = "unknown"
 #: ``suppressed`` means "we read it and a human parked it".
 STATE_SUPPRESSED = "suppressed"
 VALID_STATES: frozenset[str] = frozenset({STATE_FIRING, STATE_OK, STATE_UNKNOWN, STATE_SUPPRESSED})
+
+
+class CorruptDocumentError(json.JSONDecodeError):
+    """A stored document that PARSED but is not usable as a mutation base.
+
+    Raised by the ``*_for_update`` readers when a document is valid JSON yet structurally
+    wrong -- a root that is not an object, or a row that is not one. Those cases destroy
+    data exactly like a parse failure does if the reader normalizes them away, because the
+    mutation rewrites the whole file from whatever the reader returned.
+
+    Subclasses :class:`json.JSONDecodeError` DELIBERATELY, and that is load-bearing rather
+    than convenient: every caller's corruption clause is written against
+    ``json.JSONDecodeError``, so this routes correctly through all of them with no change,
+    while a fresh exception type would be caught by none and would silently reopen the very
+    data loss those clauses exist to stop. Note that both are ``ValueError`` subclasses, so
+    a caller with an unrelated ``except ValueError`` will still claim this unless its
+    corruption arm comes first.
+
+    The subclass exists so the raises are greppable and their intent explicit instead of a
+    parser exception carrying a meaning the parser never assigned it. Suggested in review
+    (Design Review) and worth having before #7805 replicates this idiom across the four
+    merged siblings.
+    """
+
+
+class UnknownFieldError(CorruptDocumentError):
+    """A stored document holding a field THIS build does not know about.
+
+    A newer build added a field and wrote it; this reader's ``to_dict`` is ``asdict()`` over
+    the fields it knows, so the key would vanish on write.
+
+    **The reachable path today is a version ROLLBACK on one instance, not two instances sharing
+    a file.** An earlier version of this docstring justified it by ledger sync, which was wrong:
+    ``ledger_sync`` says "Only the ledger. NOT the dispatch index" and explains why -- the
+    index is last-writer-wins on a shared key, so syncing it would let two instances each
+    believe they own an incident. Caught in review (First Principles). What remains, and is
+    ordinary, is a bad release rolled back on a single machine: the file on disk was written
+    by the newer build, and the older build now reads it.
+
+    The other way to reach it is a future SCHEMA MIGRATION that retires a key, since an old
+    record then carries a field the new ``to_dict`` does not emit. That is indistinguishable
+    from the rollback case at the point of detection, which is why neither this class nor the
+    message it carries asserts which direction the skew runs.
+
+    The mutation must still refuse -- writing would strip the newer build's data, which is the
+    same loss every other refusal here prevents. What differs is the REMEDY: the file is fine
+    and the reader is behind, so the operator needs to move this instance forward, not repair a
+    document. Reporting it as corruption sends them to fix something that is not broken.
+
+    Subclasses :class:`CorruptDocumentError` so every caller that already refuses corruption
+    refuses this too with no change -- the distinction only has to be visible where an
+    operator reads it, which is the route layer's error code. Raised on data that is merely
+    NEWER; genuine content loss stays a plain ``CorruptDocumentError``.
+    """
+
 
 STATUS_UNCLAIMED = "unclaimed"
 STATUS_DISPATCHED = "dispatched"

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/__init__.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/__init__.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 from kiro_crew import platform_compat
+from kiro_crew.apps.builtins.ops_mission_control.backend.models import CorruptDocumentError
 from kiro_crew.apps.manager import app_data_dir
 from kiro_crew.atomic_write import atomic_write
 
@@ -71,14 +73,101 @@ class _ConfigLock:
                 self._fd = None
 
 
+def _config_path() -> Path:
+    return app_data_dir(APP_NAME) / CONFIG_FILENAME
+
+
 def read_config() -> dict[str, Any]:
-    """Non-secret app config, or ``{}`` when absent/corrupt."""
-    path = app_data_dir(APP_NAME) / CONFIG_FILENAME
+    """Non-secret app config, or ``{}`` when absent/corrupt.
+
+    A DISPLAY/LOOKUP read: every accessor below it resolves to the caller's
+    default, so an unreadable config reads as "nothing configured" and an adapter
+    that needs a value stays disabled rather than 500ing the Settings page. See
+    :func:`_read_config_for_update` for why a writer may not stand on the same
+    answer.
+
+    An absent file is silent -- that is a fresh install, not a fault. Anything else
+    is logged, because this degradation is the quietest one in the app: every
+    provider stops polling while their credentials stay in the keystone store, so
+    Settings still shows each one as configured and nothing reports that the app
+    has gone deaf.
+    """
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        data = json.loads(_config_path().read_text(encoding="utf-8"))
+    except FileNotFoundError:
         return {}
-    return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning(
+            "ops-mission-control: app config unreadable; every provider will read as "
+            "unconfigured and polling will stop",
+            exc_info=True,
+        )
+        return {}
+    if isinstance(data, dict):
+        return data
+    # A non-object root (`[]`, a bare string, `null`) parses fine, so no handler above fires
+    # -- and this branch answered `{}` in silence while the docstring above promised
+    # "anything else is logged". Worse than an ordinary stale comment: the sentence it
+    # contradicts is the one arguing that THIS degradation must not be quiet, because every
+    # provider stops polling while Settings still shows them configured. Found in review
+    # (GPT 5.6). The index display read grew the same warning a head earlier; this is its twin.
+    logger.warning(
+        "ops-mission-control: app config root is not an object; every provider will read as "
+        "unconfigured and polling will stop",
+    )
+    return {}
+
+
+def _read_config_for_update() -> dict[str, Any]:
+    """The config a read-modify-write is allowed to publish over.
+
+    ``merge_provider_config`` and ``set_top_level`` both rewrite the WHOLE file
+    from what they read -- the merge is per-FIELD within one provider slot, not
+    per-file -- so an empty base is not "nothing to carry forward", it is "drop
+    every other provider's configuration and every top-level key". Only a MISSING
+    file makes that true; an unreadable one (a transient EACCES/EIO, a scanner
+    holding the handle on Windows) is config we still have.
+
+    The loss is quiet and it disables detection: ``provider_enabled`` defaults to
+    ``False``, so a wiped config does not error, it just stops polling every
+    provider the operator had switched on -- while their tokens remain in the
+    keystone store, so the Settings page still shows each provider as
+    credentialed. The operator is left with an app that reports no signals and
+    looks configured.
+
+    Corruption propagates too -- the same deliberate divergence from the four merged
+    siblings of this idiom that :func:`store._read_index_for_update` explains. A
+    half-written or hand-broken config still names every provider the operator
+    enabled; replacing it discards that and leaves them re-entering settings they
+    already chose. Refusing surfaces the corruption instead.
+    """
+    try:
+        data = json.loads(_config_path().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as exc:
+        # Re-raised as the named type so every refusal from this reader is one
+        # `CorruptDocumentError` regardless of which door it came through. See the matching
+        # clause in `store._read_index_for_update` for the reasoning.
+        raise CorruptDocumentError(exc.msg, exc.doc, exc.pos) from exc
+    except UnicodeDecodeError as exc:
+        # Not valid UTF-8, so `json.loads` never runs. `UnicodeDecodeError` is a `ValueError`
+        # but not a `JSONDecodeError`, so unwrapped it would slip past every corruption clause
+        # into the tolerant arms and be swallowed. Found in review (GPT 5.6).
+        raise CorruptDocumentError(
+            f"app config is not valid UTF-8: {exc.reason}",
+            exc.object.decode("utf-8", "replace")[:120],
+            0,
+        ) from exc
+    if not isinstance(data, dict):
+        # Valid JSON that is not an object -- `[]`, a bare string, `null` -- parses without
+        # raising, so normalizing it to `{}` here would let the mutation rewrite the whole
+        # file from empty and destroy a config nobody could read. That is the same loss this
+        # reader exists to prevent, reached without a parse failure. Reported as a decode
+        # error because the document IS unusable, and because every caller already routes
+        # that correctly. Found in review (GPT 5.6).
+        raise CorruptDocumentError("app config root is not a JSON object", str(data)[:120], 0)
+    return data
 
 
 def provider_config(provider_id: str) -> dict[str, Any]:
@@ -164,7 +253,7 @@ def write_config(payload: dict[str, Any]) -> None:
     ``secrets.py``; the route layer rejects any key that looks secret-bearing
     before calling this.
     """
-    path = app_data_dir(APP_NAME) / CONFIG_FILENAME
+    path = _config_path()
     atomic_write(path, json.dumps(payload, indent=2, sort_keys=True))
 
 
@@ -174,15 +263,35 @@ def merge_provider_config(provider_id: str, updates: dict[str, Any]) -> dict[str
     Returns the provider's resulting config. A merge rather than a replace so a
     settings form that submits only the field it changed cannot silently drop the
     rest of the provider's configuration.
+
+    Raises ``OSError`` when the existing config could not be read; see
+    :func:`_read_config_for_update` for why that is not collapsed to an empty
+    document here, which would drop every OTHER provider's slot -- the same loss
+    the per-field merge exists to prevent, one level up.
     """
     with _ConfigLock():
-        config = read_config()
+        config = _read_config_for_update()
         providers = config.get("providers")
-        if not isinstance(providers, dict):
+        if providers is None:
             providers = {}
+        elif not isinstance(providers, dict):
+            # The per-slot half of the wrong-shape door, and it was still open: the strict
+            # read refuses a bad ROOT, but a valid-JSON config whose `providers` key is a
+            # list or a string was normalized to `{}` right here -- and since this function
+            # rewrites the whole file, that wiped every provider slot on the next merge.
+            # Exactly the loss `_coerce_index(strict=True)` closed on the index side, one
+            # level down. Found in review (Design Review), which noticed the description
+            # claimed per-row refusal while the config only had it at the root.
+            raise CorruptDocumentError(
+                "app config 'providers' is not an object", str(providers)[:120], 0
+            )
         slot = providers.get(provider_id)
-        if not isinstance(slot, dict):
+        if slot is None:
             slot = {}
+        elif not isinstance(slot, dict):
+            raise CorruptDocumentError(
+                f"app config slot {provider_id!r} is not an object", str(slot)[:120], 0
+            )
         slot.update(updates)
         providers[provider_id] = slot
         config["providers"] = providers
@@ -191,8 +300,12 @@ def merge_provider_config(provider_id: str, updates: dict[str, Any]) -> dict[str
 
 
 def set_top_level(key: str, value: Any) -> None:
-    """Set one non-provider config key (autonomy mode, tuning, primary flag)."""
+    """Set one non-provider config key (autonomy mode, tuning, primary flag).
+
+    Raises ``OSError`` when the existing config could not be read, for the reason
+    :func:`_read_config_for_update` gives.
+    """
     with _ConfigLock():
-        config = read_config()
+        config = _read_config_for_update()
         config[key] = value
         write_config(config)

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
@@ -18,6 +18,7 @@ is set.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 from datetime import datetime, timedelta, timezone
@@ -54,6 +55,7 @@ from kiro_crew.apps.builtins.ops_mission_control.backend.models import (
     VERIFY_PENDING,
     LedgerEntry,
     Signal,
+    UnknownFieldError,
     resolve_silence_secs,
     utc_now_iso,
 )
@@ -183,6 +185,63 @@ def _audit(op: str, target: str, outcome: str, *, error: str = "") -> None:
         outcome=outcome,
         resources=target,
         error=error,
+    )
+
+
+def _store_read_refusal(exc: Exception, *, code: str) -> web.Response:
+    """Map a strict reader's refusal to a coded response.
+
+    The store and config readers now refuse rather than publishing a mutation over a
+    read they could not make, so every handler that mutates them can see two failures
+    that previously could not happen. They get DIFFERENT statuses because the operator's
+    next move differs: an unreadable file is transient, so 503 correctly says "retry",
+    while a corrupt one needs a person to repair it, so 503 would send them at something
+    that cannot succeed and 500 is the honest answer.
+
+    Centralized because four handlers need the identical pair, and three review lanes
+    independently flagged that translating it at some of them and not others is worse
+    than not translating it anywhere -- an operator cannot tell a route that reports the
+    condition from one that swallows it.
+
+    ``JSONDecodeError`` MUST be matched before any ``ValueError`` arm at the call site.
+    It is a `ValueError` subclass, so an existing arm for a domain error will otherwise
+    claim it and report corruption as that domain error -- which is the same accident
+    this change fixes in `verify_pending_actions`, `reconcile` and
+    `_schedule_verification`.
+    """
+    if isinstance(exc, UnknownFieldError):
+        # Refused for the same reason as corruption -- writing would strip a newer instance's
+        # field -- but the file is FINE and this reader is behind, so the remedy is an upgrade
+        # rather than a repair. Reporting it as corruption sends the operator to fix something
+        # that is not broken. Found in review (Design Review). Ordered before the
+        # `CorruptDocumentError` arm below, which it subclasses.
+        return web.json_response(
+            {
+                "ok": False,
+                "error": (
+                    "the stored document holds a field this build does not serialize; "
+                    "writing would drop it, so check whether this instance needs upgrading"
+                ),
+                "code": f"{code}_version_skew",
+            },
+            status=409,
+        )
+    if isinstance(exc, json.JSONDecodeError):
+        return web.json_response(
+            {
+                "ok": False,
+                "error": "the stored document is unreadable and must be repaired",
+                "code": f"{code}_corrupt",
+            },
+            status=500,
+        )
+    return web.json_response(
+        {
+            "ok": False,
+            "error": "the store is not readable right now; try again",
+            "code": f"{code}_unreadable",
+        },
+        status=503,
     )
 
 
@@ -545,6 +604,14 @@ async def _handle_transition(request: web.Request) -> web.StreamResponse:
         return web.json_response(
             {"error": "unknown incident", "code": "unknown_incident"}, status=404
         )
+    except (json.JSONDecodeError, OSError) as exc:
+        # BEFORE the `ValueError` arm, and that order is the whole point: a corrupt index
+        # was being reported as `409 illegal_transition` carrying the JSON parser's message
+        # -- corruption misclassified as the operator making an illegal move, which sends
+        # them to fix their own request instead of the file. Found in review (Opus 4.8),
+        # and it is the same `JSONDecodeError`-under-`ValueError` accident this change
+        # already closed at three other callers.
+        return _store_read_refusal(exc, code="dispatch_index")
     except ValueError as exc:
         # An illegal transition is a client error, not a server fault.
         return web.json_response({"error": str(exc), "code": "illegal_transition"}, status=409)
@@ -671,9 +738,16 @@ async def _handle_claim(request: web.Request) -> web.StreamResponse:
     mode = rotation.resolve_mode(signal)
     # `operator`, not the heartbeat default: this route IS the board's manual claim,
     # and telling the two apart afterwards is the whole point of the field.
-    incident = await asyncio.to_thread(
-        store.claim, signal, operating_mode=mode, claimed_by=CLAIMED_BY_OPERATOR
-    )
+    try:
+        incident = await asyncio.to_thread(
+            store.claim, signal, operating_mode=mode, claimed_by=CLAIMED_BY_OPERATOR
+        )
+    except (json.JSONDecodeError, OSError) as exc:
+        # `claim` raises on both failures by design -- a compare-and-set has no safe
+        # degraded answer, since `None` already means "another instance owns this signal".
+        # The board's manual claim therefore needs the same coded translation as its
+        # siblings; unwrapped it answered a bare 500. Found in review (Opus 4.8).
+        return _store_read_refusal(exc, code="dispatch_index")
     if incident is None:
         return web.json_response(
             {"error": "signal is already claimed", "code": "signal_already_claimed"}, status=409
@@ -692,7 +766,29 @@ async def _handle_claim(request: web.Request) -> web.StreamResponse:
 
     # Attach what the ledger already knows, exactly as the heartbeat does — a
     # manual claim from the board must not start colder than an automatic one.
-    claimed = await asyncio.to_thread(dispatch.attach_ledger_matches, incident)
+    #
+    # The claim is already durably on disk and the webhook is already acked, so a fault from
+    # HERE ON must not be reported as a failed claim. `attach_ledger_matches` writes through
+    # `store.update_fields` -> `transition` -> `_read_index_for_update()`, which this change
+    # gave two new ways to raise -- and unguarded it answered a bare uncoded 500 while every
+    # sibling mutating route got the coded translation. Found in review (Opus 4.8).
+    #
+    # Deliberately NOT the coded refusal that review suggested, for the same reason
+    # `_schedule_verification` reports rather than raises: a 503 here says "the claim failed,
+    # retry" about a claim that SUCCEEDED, and the retry answers `409 signal_already_claimed`.
+    # It would also skip the audit entry, leaving a real claim unrecorded. The ledger
+    # annotation is the deferrable half -- the dispatch cycle re-derives matches on its next
+    # pass -- so the honest degraded answer is the claim without its matches, audited as such.
+    try:
+        claimed = await asyncio.to_thread(dispatch.attach_ledger_matches, incident)
+        claim_note = ""
+    except (json.JSONDecodeError, OSError):
+        logger.exception(
+            "ops-mission-control: claimed %s but could not attach ledger matches",
+            incident.incident_id,
+        )
+        claimed = dispatch.ClaimedIncident(incident=incident)
+        claim_note = "claimed without ledger matches; the index was unreadable"
     # Broker the provider evidence too, for the same reason: the agent that picks this
     # up has no AWS credentials, so the gateway is the only thing that can read the
     # alarm history and logs it needs to diagnose. Non-fatal.
@@ -700,7 +796,7 @@ async def _handle_claim(request: web.Request) -> web.StreamResponse:
     # Onto the pin board, exactly as the heartbeat does — a hand-claimed incident
     # must not be invisible to the channel watching the board.
     await slack_out.publish(claimed.incident, _slack_client(request))
-    _audit("incident_claim", incident.incident_id, "success")
+    _audit("incident_claim", incident.incident_id, "success", error=claim_note)
     return web.json_response({**claimed.to_dict(), "brief": dispatch.investigation_brief(claimed)})
 
 
@@ -930,6 +1026,33 @@ def _schedule_verification(incident_id: str, action: str, duration_secs: Any) ->
             verification=verdict,
             verification_detail="",
         )
+    except json.JSONDecodeError:
+        # Corruption gets its OWN handler here, but it must NOT raise. Both callers have
+        # ALREADY performed the real external write by the time this runs (`result.ok and
+        # not result.simulated`), so raising turns a successful action into a 500 and invites
+        # the operator to retry it -- in `act` mode that is a second real write against their
+        # production tooling. Found in review: Design Review caught that corruption was
+        # silently swallowed by the clause below (`JSONDecodeError` subclasses `ValueError`),
+        # and GPT 5.6 then caught that re-raising misreports a completed action. Neither
+        # remedy alone is right.
+        #
+        # So it is REPORTED rather than either swallowed or raised: its own clause, an
+        # exception log, and a SEL audit entry recording that the action ran with no
+        # verification scheduled. That is the same choice #7788 made for a partial ceiling
+        # apply in this file -- the audit log is the durable reader, and unlike a new
+        # `verification` value it needs no vocabulary the dashboard cannot render. The
+        # persistence argument still holds (corruption never self-heals), which is why it is
+        # audited as a failure rather than folded into the tolerant arm.
+        logger.exception(
+            "ops-mission-control: index corrupt, verification not scheduled for %s", incident_id
+        )
+        _audit(
+            "action_verification_unscheduled",
+            incident_id,
+            "failure",
+            error="index corrupt; action executed with no recheck scheduled",
+        )
+        return "", ""
     except (KeyError, ValueError, OSError):
         logger.exception("ops-mission-control: could not schedule verification for %s", incident_id)
         return "", ""
@@ -1242,6 +1365,17 @@ async def _handle_propose(request: web.Request) -> web.StreamResponse:
         return web.json_response(
             {"error": "unknown incident", "code": "unknown_incident"}, status=404
         )
+    except (json.JSONDecodeError, OSError) as exc:
+        # BEFORE the `ValueError` arm. `propose_action` reaches the strict reader through
+        # `update_fields` -> `transition` -> `_read_index_for_update()`, so a corrupt index
+        # raises `CorruptDocumentError`, which IS a `ValueError` -- and the arm below would
+        # report it as `400 invalid_proposal`. That is worse than the bare 500 it replaces:
+        # a 400 tells the operator their proposal was malformed, so they re-type the form
+        # while the real fault sits on disk untouched. Found by auditing every
+        # `ValueError`-family arm in this file against the rule stated on
+        # `_store_read_refusal`; this was the only one of ten that could reach a strict
+        # reader and did not already have this clause.
+        return _store_read_refusal(exc, code="dispatch_index")
     except ValueError as exc:
         return web.json_response({"error": str(exc), "code": "invalid_proposal"}, status=400)
 
@@ -1297,6 +1431,14 @@ async def _handle_decide_proposal(request: web.Request) -> web.StreamResponse:
         return web.json_response(
             {"error": "unknown incident", "code": "unknown_incident"}, status=404
         )
+    except (json.JSONDecodeError, OSError) as exc:
+        # `decide_proposal` is a locked read-modify-write that now refuses rather than
+        # publishing over a failed read. Previously this could only answer a coded 404, so
+        # both new failures became a bare 500. The request is a human's approval of a
+        # production action, so "did my approval land?" must not be ambiguous.
+        logger.warning("ops-mission-control: proposal decision refused for %s", incident_id)
+        _audit("incident_proposal_decide", incident_id, "failure", error="index unreadable")
+        return _store_read_refusal(exc, code="dispatch_index")
     if not decision["ok"]:
         _audit("incident_proposal_decide", incident_id, "rejected", error=decision["reason"])
         return web.json_response(
@@ -1494,7 +1636,17 @@ async def _handle_put_provider_config(request: web.Request) -> web.StreamRespons
             {"error": "no config fields supplied", "code": "no_recognized_fields"}, status=400
         )
 
-    saved = await asyncio.to_thread(merge_provider_config, provider_id, updates)
+    # `merge_provider_config` refuses rather than publishing over a read it could not make,
+    # so this call can raise both failures. Routed through the shared mapper rather than
+    # answering here: hand-rolling a second response pair beside the helper built for
+    # exactly this was flagged in review (First Principles), and it was right -- two sites
+    # constructing the same two responses is how their statuses drift apart.
+    try:
+        saved = await asyncio.to_thread(merge_provider_config, provider_id, updates)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("ops-mission-control: provider config write refused (%s)", provider_id)
+        _audit("provider_config_put", f"{provider_id}:{sorted(updates)}", "failure")
+        return _store_read_refusal(exc, code="app_config")
     _audit("provider_config_put", f"{provider_id}:{sorted(updates)}", "success")
     return web.json_response({"ok": True, "provider": provider_id, "config": saved})
 
@@ -1538,6 +1690,23 @@ async def _settings_write_or_refuse(
     """
     try:
         await asyncio.to_thread(fn, *args, **kwargs)
+    except json.JSONDecodeError as exc:
+        # `set_top_level` reaches the app config, whose update reader now refuses on a
+        # malformed document -- so this helper, which caught only `OSError`, let the bare
+        # 500 back in for exactly the store the docstring above said the companion PR would
+        # make strict. That companion PR is this one, so the hole opened here the moment the
+        # reader landed. Found in review (First Principles).
+        #
+        # The response comes from the shared mapper rather than being built here, so this
+        # helper and the four route-level sites cannot drift on either status.
+        logger.warning("ops-mission-control: settings write refused, document corrupt (%s)", code)
+        _audit("settings_put", f"refused after {sorted(applied)}", "failure")
+        # The caller's code names the WRITE being refused (`policy_store_unwritable`), which
+        # is right for the `OSError` arm below and merged behaviour there. For corruption the
+        # suffix would double up into `..._unwritable_corrupt`, so the base noun is taken and
+        # the mapper names the condition: `policy_store_corrupt`.
+        base = code[: -len("_unwritable")] if code.endswith("_unwritable") else code
+        return _store_read_refusal(exc, code=base)
     except OSError as exc:
         logger.warning("ops-mission-control: settings write refused (%s)", code)
         _audit("settings_put", f"refused after {sorted(applied)}", "failure")
@@ -2236,7 +2405,20 @@ async def _handle_ledger_hygiene(request: web.Request) -> web.StreamResponse:
     # Retire old CLOSED incidents. Here rather than on the claim path because pruning is
     # maintenance: doing it in `claim` would make an ordinary claim occasionally pay for a
     # large rewrite. Open work is never pruned, whatever the age.
-    incidents_pruned = await asyncio.to_thread(store.prune_closed)
+    #
+    # Degraded rather than fatal, for the same reason `dispatch.run_cycle`'s maintenance
+    # passes are: `prune_closed` now propagates a failed index read, and it sits BEFORE the
+    # push below. Letting it escape would mean one EACCES on this cron skips pushing the
+    # ledger that `hygiene` just deduped -- a later fault costing an earlier step's work.
+    # Pruning is the most deferrable thing here (the next run retires the same incidents),
+    # while the push is what other instances are waiting on. A corrupt index is deliberately
+    # NOT caught: that never self-heals, so it must stop the cron loudly instead of quietly
+    # skipping the prune on every future run.
+    try:
+        incidents_pruned = await asyncio.to_thread(store.prune_closed)
+    except OSError:
+        logger.exception("ops-mission-control: could not prune closed incidents; skipping")
+        incidents_pruned = 0
     pushed = await ledger_sync.sync_safely(direction="push")
 
     changed = any(summary.get(k) for k in ("deduped", "decayed", "pruned"))

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/slot_watch.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/slot_watch.py
@@ -27,6 +27,7 @@ See ``docs/system-specs/modules/ops-mission-control.md``.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -128,8 +129,38 @@ def reconcile(incident_id: str, slot: dict[str, Any] | None) -> Incident | None:
 
     try:
         return store.transition(incident_id, status, blocked_reason=reason)
+    except json.JSONDecodeError:
+        # Corruption is excluded from the tolerance below on purpose, and this clause
+        # exists to stop it being taken by accident: `JSONDecodeError` subclasses
+        # `ValueError`, which the next clause catches for the unrelated case of an
+        # illegal transition. Sharing one handler would file "the ledger is corrupt"
+        # under "we lost a race" at debug level.
+        #
+        # Unlike the EACCES path below, corruption is not transient: it will fail every
+        # future reconcile identically until a person fixes the file, so swallowing it
+        # means this instance quietly stops syncing status forever.
+        raise
     except (KeyError, ValueError):
         logger.debug("ops-mission-control: reconcile lost a race on %s", incident_id)
+        return None
+    except OSError:
+        # Reconciliation's whole job is to survive a mess, so it keeps its tolerant
+        # contract even though the store below it is now strict: `transition` reads the
+        # index for update, which refuses rather than publishing over a read it could not
+        # make, and that refusal must not turn a best-effort reconcile into a raised
+        # error on the board request that triggered it.
+        #
+        # Tolerating it is safe BECAUSE the store refused: the mutation was abandoned
+        # before writing, so the incident keeps whatever status it already had -- which is
+        # exactly what returning ``None`` here already means -- and the next reconcile
+        # pass retries from a clean read. Logged one level up from the race cases
+        # (`warning`, not `debug`) because an unreadable index is a real fault worth
+        # seeing, where losing a race is ordinary. Found in review (GPT 5.6).
+        logger.warning(
+            "ops-mission-control: reconcile skipped %s, dispatch index I/O failed",
+            incident_id,
+            exc_info=True,
+        )
         return None
 
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
@@ -51,8 +51,10 @@ from kiro_crew.apps.builtins.ops_mission_control.backend.models import (
     VALID_CLAIMANTS,
     VERIFY_NOT_CHECKABLE,
     VERIFY_STILL_FIRING,
+    CorruptDocumentError,
     Incident,
     Signal,
+    UnknownFieldError,
     proposal_digest,
     utc_now_iso,
 )
@@ -158,21 +160,235 @@ def incident_log_path(incident_id: str) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def _read_index_unlocked() -> dict[str, Incident]:
-    try:
-        raw = json.loads(index_path().read_text(encoding="utf-8"))
-    except (FileNotFoundError, OSError, json.JSONDecodeError):
-        return {}
+def _lost(original: Any, roundtripped: Any) -> bool:
+    """True if a value this build UNDERSTANDS came back changed or shortened.
+
+    Only keys present in BOTH are compared, so a field this build does not know about is
+    not treated as loss here -- :func:`_unknown` handles that case separately, because the
+    two have different remedies. Compares PARSED structures rather than text, so key order
+    and formatting cannot produce a false refusal.
+    """
+    if isinstance(original, dict):
+        if not isinstance(roundtripped, dict):
+            return True
+        return any(
+            _lost(value, roundtripped[key])
+            for key, value in original.items()
+            if key in roundtripped
+        )
+    if isinstance(original, list):
+        if not isinstance(roundtripped, list) or len(original) != len(roundtripped):
+            return True
+        return any(_lost(a, b) for a, b in zip(original, roundtripped))
+    return original != roundtripped
+
+
+def _unknown(original: Any, roundtripped: Any) -> bool:
+    """True if the document holds a field this build would silently DROP on write.
+
+    That is version skew, not corruption: a newer build added a field, and this reader's
+    ``to_dict`` is ``asdict()`` over the fields it knows, so the key vanishes from the round
+    trip. The reachable path is a ROLLBACK on one machine -- ``ledger_sync`` deliberately does
+    not sync the index ("Only the ledger. NOT the dispatch index"), so this is not two
+    instances sharing a file. The mutation must still refuse, because writing would strip the
+    newer build's data, but the remedy is "move this instance forward", not "repair this file".
+    Found in review (Design Review for the case, First Principles for the wrong justification
+    I first gave it).
+
+    Note what this makes load-bearing, since it is worth knowing rather than discovering:
+    ``to_dict(from_dict(x))`` must preserve every field ``x`` already had, or a mutation
+    refuses. Serializer idempotence is now an availability property of the store, not just a
+    correctness one. The suite exercises it on every incident shape the app writes, which is
+    the check that keeps it honest.
+
+    **This rule outlaws migrate-on-write, and a future schema change must extend it rather
+    than fight it.** Renaming or dropping a field means old records carry a key the new
+    ``to_dict`` does not emit, which is indistinguishable HERE from a field written by a newer
+    build -- both are "on disk, absent from the round trip". So a migration cannot simply
+    rewrite records through the normal write path; it needs an explicit carve-out naming the
+    retired keys, added at the same time as the rename. Named in review (Design Review). The
+    error text deliberately does not claim which direction the skew runs, because this
+    function cannot tell.
+    """
+    if isinstance(original, dict):
+        if not isinstance(roundtripped, dict):
+            return False
+        return any(
+            key not in roundtripped or _unknown(value, roundtripped[key])
+            for key, value in original.items()
+        )
+    if isinstance(original, list) and isinstance(roundtripped, list):
+        return any(_unknown(a, b) for a, b in zip(original, roundtripped))
+    return False
+
+
+def _coerce_index(raw: Any, *, strict: bool = False) -> dict[str, Incident]:
+    """Normalize a parsed index document, skipping entries that will not load.
+
+    Shared by both readers below so the only thing that can differ between them is which
+    read FAILURES are allowed to answer "empty".
+
+    ``strict`` is the update path, and it refuses on a rule about CONTENT rather than a list
+    of shapes: **deserialize, re-serialize, and refuse if anything that was on disk did not
+    survive.** Three review rounds each found the same class of loss one layer deeper than
+    the last -- the document root, then a row, then a nested field like ``"signal": []``
+    coerced to an empty ``Signal`` -- because each fix enumerated a shape, and any
+    enumeration can be beaten by a deeper example. This rule cannot: it covers the root, the
+    rows, the nested fields and every layer beneath them at once, and it is the invariant the
+    docstrings were already claiming.
+
+    That is also why this reader now has FEWER checks than it did a round ago. The
+    ``isinstance`` guards for the row and the nested fields are gone, because dropping a row
+    or blanking a field is exactly what the round trip detects. A smaller diff is the honest
+    signal that this is the real rule rather than another patch on top of one.
+
+    Why it matters on the mutation path specifically: the caller rewrites the WHOLE file from
+    what this returns, so any content the coercion quietly replaced is destroyed. The display
+    read keeps coercing and renders what it can -- one unreadable row must not blank a board.
+
+    It logs the degradations that explain a THIN board: an unreadable file, an unparseable one,
+    a non-object root, and a row it had to skip. It deliberately does NOT log a nested
+    coercion (a row whose ``"signal"`` was replaced by an empty one), because detecting that
+    requires the same round trip the strict path does, and this function runs on every board
+    poll and every dispatch cycle. The mutation path catches those, which is where they cost
+    something. An earlier version of this docstring claimed it logged whenever it degraded,
+    full stop -- that was wider than the code, and review was right to say so (GPT 5.6).
+    """
     if not isinstance(raw, dict):
+        if strict:
+            raise CorruptDocumentError("index root is not a JSON object", str(raw)[:120], 0)
+        logger.warning(
+            "ops-mission-control: incident index root is not an object; the board will render empty"
+        )
         return {}
     out: dict[str, Incident] = {}
     for key, value in raw.items():
-        if isinstance(value, dict):
-            try:
-                out[str(key)] = Incident.from_dict(value)
-            except (TypeError, ValueError):
-                logger.warning("ops-mission-control: skipping malformed index entry %r", key)
+        if not isinstance(value, dict):
+            logger.warning("ops-mission-control: skipping index entry %r, not an object", key)
+            continue
+        try:
+            out[str(key)] = Incident.from_dict(value)
+        except (TypeError, ValueError):
+            logger.warning("ops-mission-control: skipping malformed index entry %r", key)
+    if strict:
+        roundtripped = {key: incident.to_dict() for key, incident in out.items()}
+        for key, original in raw.items():
+            survived = roundtripped.get(str(key))
+            if survived is None or _lost(original, survived):
+                raise CorruptDocumentError(
+                    f"index entry {key!r} would not survive a read-write cycle",
+                    str(original)[:120],
+                    0,
+                )
+            if _unknown(original, survived):
+                raise UnknownFieldError(
+                    f"index entry {key!r} holds a field this build does not serialize, so a "
+                    "write would drop it",
+                    str(original)[:120],
+                    0,
+                )
+            # Referential integrity, which the round trip structurally CANNOT see: both sides
+            # of it preserve a key/`incident_id` mismatch faithfully, so `_lost` passes. But
+            # `expire_stale_proposals` iterates `index.values()` and writes back with
+            # `index[inc.incident_id] = ...`, so a row stored under `INV-1` whose id says
+            # `INV-9` is REKEYED on the next expiry sweep -- leaving `INV-1` behind as a
+            # duplicate, or overwriting a real `INV-9`. Found in review (GPT 5.6), and it is
+            # the one hole the equivalence rule could not close on its own: the corruption
+            # manifests at WRITE time, not at read time.
+            if str(survived.get("incident_id", "")) != str(key):
+                raise CorruptDocumentError(
+                    f"index entry {key!r} carries incident_id "
+                    f"{survived.get('incident_id', '')!r}; a write would rekey it",
+                    str(original)[:120],
+                    0,
+                )
     return out
+
+
+def _read_index_unlocked() -> dict[str, Incident]:
+    """The dispatch index, or ``{}`` when there is nothing readable.
+
+    A DISPLAY read: the board, the counts and ``find_by_signal`` must answer on an
+    index they could not load rather than failing the route. See
+    :func:`_read_index_for_update` for why a mutation may not stand on the same
+    answer.
+
+    An absent file is silent -- that is a fresh install, not a fault. Anything else
+    is logged, because the failure this degrades into looks exactly like health: an
+    empty board renders as "nothing is wrong". Nothing else would prompt an
+    operator to look.
+    """
+    try:
+        raw = json.loads(index_path().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning(
+            "ops-mission-control: dispatch index unreadable; the board will render empty",
+            exc_info=True,
+        )
+        return {}
+    return _coerce_index(raw)
+
+
+def _read_index_for_update() -> dict[str, Incident]:
+    """The index a read-modify-write is allowed to publish over.
+
+    Callers hold ``_IndexLock``; this only decides what an unreadable file means.
+
+    Every mutation below rewrites the WHOLE document from what it read, so an
+    empty base is not "no incidents to carry forward" -- it is "delete every
+    incident on the board". Only a MISSING file makes that true. An unreadable
+    one (a transient EACCES/EIO, a scanner holding the handle on Windows) is an
+    index we still have.
+
+    Truncating it is worse than losing a view, because the index IS the claim
+    ledger. ``claim`` is a compare-and-set against these rows: with the board
+    emptied, every signal reads as unowned, so the next heartbeat re-claims
+    alarms that are already being worked and opens duplicate investigations of
+    each one -- and in ``act`` mode a duplicate investigation is a second real
+    write against the operator's production paging. The per-incident markdown
+    logs survive on disk but nothing indexes them any more, and an open incident
+    that is no longer listed is never swept, resolved, or answered.
+
+    Corruption propagates too, and that is a DELIBERATE divergence from the four
+    merged siblings of this idiom (``library.py``, ``shares.py``, ``secrets.py``,
+    ``policy_store.py``), which all still read an unparseable document as empty.
+    Their justification is real -- a document that failed to parse carries nothing
+    to merge into -- but "cannot merge into" is not "safe to destroy". A truncated
+    index still holds most of its records verbatim, and replacing it discards the
+    operator's only chance to recover them by hand. Refusing costs one skipped
+    mutation and a visible error; overwriting costs the records, silently. Found in
+    review (GPT 5.6). The siblings need the same treatment in a follow-up --
+    ``secrets.py`` most of all, since there the discarded bytes are credentials.
+    """
+    try:
+        raw = json.loads(index_path().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as exc:
+        # Re-raised as the named type so that EVERY refusal from this reader is one
+        # `CorruptDocumentError`, whatever door it came through -- a bad byte stream here, a
+        # bad shape in `_coerce_index` below. Review noted the subclass was one no catcher
+        # distinguished (First Principles), which was fair while a parse failure still
+        # arrived as the bare base class: the type described the raise site instead of being
+        # the reader's contract. Catchers written against `json.JSONDecodeError` keep working
+        # unchanged, because it still IS one.
+        raise CorruptDocumentError(exc.msg, exc.doc, exc.pos) from exc
+    except UnicodeDecodeError as exc:
+        # A file that is not valid UTF-8 never reaches `json.loads`, so it arrives as
+        # `UnicodeDecodeError` -- which is a `ValueError` but NOT a `JSONDecodeError`. Left
+        # unwrapped it slips past every corruption clause in this change and lands in the
+        # tolerant `except (KeyError, ValueError, OSError)` arms instead, silently swallowed:
+        # the exact accidental tolerance this change exists to close, reached through a
+        # sibling exception type. Found in review (GPT 5.6). Wrapped so a corrupt byte stream
+        # is one condition regardless of which decoder noticed it first.
+        raise CorruptDocumentError(
+            f"index is not valid UTF-8: {exc.reason}",
+            exc.object.decode("utf-8", "replace")[:120],
+            0,
+        ) from exc
+    return _coerce_index(raw, strict=True)
 
 
 def _write_index_unlocked(index: dict[str, Incident]) -> None:
@@ -271,7 +487,7 @@ def claim(
     the signal a responder most needs to see ("we fixed this and it came back").
     """
     with _IndexLock():
-        index = _read_index_unlocked()
+        index = _read_index_for_update()
 
         for inc in index.values():
             if inc.signal.id != signal.id:
@@ -334,7 +550,7 @@ def transition(incident_id: str, new_status: Any, **updates: Any) -> Incident:
     must not assert any status, so it cannot revert a concurrent transition.
     """
     with _IndexLock():
-        index = _read_index_unlocked()
+        index = _read_index_for_update()
         incident = index.get(incident_id)
         if incident is None:
             raise KeyError(incident_id)
@@ -443,7 +659,7 @@ def sweep_stale(stale_after_secs: int, needs_human_after_secs: int | None = None
     released: list[str] = []
     now = datetime.now(timezone.utc)
     with _IndexLock():
-        index = _read_index_unlocked()
+        index = _read_index_for_update()
         changed = False
         for incident_id, inc in index.items():
             if inc.status not in _SWEEPABLE_STATUSES:
@@ -520,7 +736,7 @@ def prune_closed(*, keep: int = MAX_CLOSED_INCIDENTS) -> int:
     long-running incident that just finished is treated as recent.
     """
     with _IndexLock():
-        index = _read_index_unlocked()
+        index = _read_index_for_update()
         closed = [inc for inc in index.values() if inc.status in TERMINAL_STATUSES]
         if len(closed) <= keep:
             return 0
@@ -738,7 +954,7 @@ def decide_proposal(incident_id: str, *, approve: bool, digest: str = "") -> dic
     and an approval are both "exactly one winner" decisions on shared JSON.
     """
     with _IndexLock():
-        index = _read_index_unlocked()
+        index = _read_index_for_update()
         incident = index.get(incident_id)
         if incident is None:
             raise KeyError(incident_id)
@@ -842,8 +1058,8 @@ def expire_stale_proposals(*, now: str = "") -> list[str]:
     cutoff = now or utc_now_iso()
     touched: list[str] = []
     with _IndexLock():
-        index = _read_index_unlocked()
-        for inc in index.values():
+        index = _read_index_for_update()
+        for key, inc in list(index.items()):
             proposal = dict(inc.proposed_action or {})
             if str(proposal.get("state", "")) != PROPOSAL_PENDING:
                 continue
@@ -854,7 +1070,14 @@ def expire_stale_proposals(*, now: str = "") -> list[str]:
             proposal["decided_at"] = cutoff
             # Mutate the record in the locked index rather than calling ``update_fields``,
             # which would take the lock again (and re-enter ``transition``).
-            index[inc.incident_id] = replace(inc, proposed_action=proposal)
+            #
+            # Written back under the key it was READ under, not under ``inc.incident_id``. On a
+            # consistent document those are the same string and this is a no-op; on an
+            # inconsistent one the old form MOVED the record, duplicating it or overwriting a
+            # real incident. The strict reader now refuses such a document, so this is
+            # belt-and-braces -- but the function that rewrites the index should not be the one
+            # relying on the reader to have checked. Found in review (GPT 5.6).
+            index[key] = replace(inc, proposed_action=proposal)
             touched.append(inc.incident_id)
         if touched:
             _write_index_unlocked(index)

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_dispatch.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_dispatch.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 class _HomeIsolated(unittest.IsolatedAsyncioTestCase):
@@ -1381,3 +1382,239 @@ class TestOwnedRedeliveriesLeaveTheSpool(_HomeIsolated):
         claimed_ids = {c.incident.signal.id for c in result.claimed}
         self.assertIn("webhook:alert/2", claimed_ids)
         self.assertEqual(webhook.queue_depth(), 0)
+
+
+class TestAMaintenancePassCannotCostTheCycle(_HomeIsolated):
+    """``run_cycle`` is ordered so that a LATER fault costs no EARLIER step.
+
+    Its own comments say so at three points: the shared-repo pull is "never fatal",
+    the Slack mirror runs "after the claim, so a Slack outage can never cost us a
+    claim", and the notification bus runs after both "so a bus fault can cost
+    neither".
+
+    The strict for-update index read made ``expire_stale_proposals`` and
+    ``sweep_stale`` RAISE on an unreadable index, where they previously degraded to
+    a silent no-op. Both are maintenance passes that rerun on every heartbeat, and
+    both abandon their write before touching the file — so the durable state is
+    already safe and the cycle must log and carry on. Letting them escape would
+    make one transient EACCES cost this cycle's claims, the Slack mirror, the
+    notifications and the SEL entry, which inverts the rule above. The expiry is
+    the worse of the two because it runs near the TOP of the cycle, so it would
+    cost everything below it. Found in review (Design Review, Fable 5).
+
+    The CLAIM path still RAISES out of `store.claim` -- a compare-and-set has no safe
+    degraded answer -- but `run_cycle` catches it and stops claiming, because the
+    pre-filter above the loop reads the index leniently. An unreadable index therefore
+    empties `owned`, every firing signal becomes a candidate, and the claim raises
+    BEFORE the sweep guard below it, which made that guard unreachable on any install
+    with something firing. Found in review (Design Review, Fable 5), which also noted
+    that the stub-based tests below could not have caught it -- hence the two
+    end-to-end cycle tests at the end of this class.
+    """
+
+    @staticmethod
+    def _refusing_index(*_a, **_kw):
+        raise PermissionError(13, "Permission denied")
+
+    def _index_reads_fail(self, *, only_once_claimed: bool = False):
+        """Make the index file's read fail, as a transient EACCES would.
+
+        Scoped to that one path so home resolution, the lock sidecar and the
+        per-incident logs still work -- a blanket failure would abort the cycle
+        somewhere else and the test would pass for the wrong reason.
+
+        ``only_once_claimed`` arms the fault the moment the index actually HOLDS an
+        incident, rather than after a fixed number of reads. That keeps the test
+        anchored to the state that matters -- "there is now something to lose" -- and
+        independent of how many times a cycle happens to read the file, which varies
+        with the maintenance passes and is not what either test is about.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        target = store.index_path()
+        real_read_text = Path.read_text
+
+        def _guarded(path_self, *args, **kwargs):
+            if Path(path_self) != target:
+                return real_read_text(path_self, *args, **kwargs)
+            if not only_once_claimed:
+                raise PermissionError(13, "Permission denied")
+            text = real_read_text(path_self, *args, **kwargs)
+            if "INV-" in text:
+                raise PermissionError(13, "Permission denied")
+            return text
+
+        return mock.patch.object(Path, "read_text", _guarded)
+
+    async def test_a_failed_proposal_expiry_does_not_cost_the_claim(self):
+        """The expiry runs before the poll, so escaping it costs the whole cycle."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch, store
+
+        self._add_source([self._signal(title="live one")])
+
+        with mock.patch.object(store, "expire_stale_proposals", self._refusing_index):
+            result = await dispatch.run_cycle()
+
+        self.assertEqual(len(result.claimed), 1, "a failed proposal expiry cost the claim")
+        self.assertEqual(result.claimed[0].incident.signal.title, "live one")
+        self.assertEqual(result.polled, 1)
+
+    async def test_a_failed_stale_sweep_does_not_cost_the_claim(self):
+        """The sweep runs immediately before the Slack mirror and the SEL entry."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch, store
+
+        self._add_source([self._signal(title="live one")])
+
+        with mock.patch.object(store, "sweep_stale", self._refusing_index):
+            result = await dispatch.run_cycle()
+
+        self.assertEqual(len(result.claimed), 1, "a failed stale sweep cost the claim")
+        self.assertEqual(result.released, [], "an abandoned sweep must release nothing")
+
+    async def test_both_failing_together_still_leaves_a_usable_cycle(self):
+        """One unreadable index fails both passes at once — the realistic case."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch, store
+
+        self._add_source([self._signal(title="live one")])
+
+        with mock.patch.object(store, "expire_stale_proposals", self._refusing_index):
+            with mock.patch.object(store, "sweep_stale", self._refusing_index):
+                result = await dispatch.run_cycle()
+
+        self.assertEqual(len(result.claimed), 1)
+        self.assertEqual(result.released, [])
+        self.assertEqual(result.skipped_reason, "", "the cycle reported itself as skipped")
+
+    # -- end-to-end: a real cycle against a real unreadable index -------------
+    #
+    # The three tests above stub `store.expire_stale_proposals` / `store.sweep_stale`
+    # directly, which proves the guards work but NOT that they are reachable. They are
+    # not, on the path that matters: the claim loop raises first. These two drive
+    # `run_cycle` with a firing candidate and a genuinely unreadable index instead.
+
+    async def test_an_unreadable_index_does_not_abort_the_whole_cycle(self):
+        """The cycle must reach its end and report, not escape as an exception.
+
+        Before the claim-loop guard this raised `PermissionError` out of `run_cycle`,
+        taking the webhook ack, the Slack pin mirror, the notification bus and the SEL
+        entry with it -- on every heartbeat for as long as the index stayed unreadable.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch
+
+        self._add_source([self._signal(native_id="alarm/one", title="one")])
+
+        # Unreadable from the pre-filter onward: the persistent case.
+        with self._index_reads_fail():
+            result = await dispatch.run_cycle()
+
+        self.assertEqual(result.polled, 1, "the cycle must still report what it polled")
+        self.assertEqual(result.claimed, [], "nothing could be claimed against a failed read")
+
+    async def test_a_claim_already_made_this_cycle_is_not_lost(self):
+        """The transient case, which is the worse one.
+
+        A signal claimed before the failure is durably on disk. If the loop escapes, that
+        incident is never mirrored to Slack, never notified and never audited -- an
+        in-flight investigation the team is never told about. The cycle must carry the
+        claims it did make through to the end.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch
+
+        self._add_source(
+            [
+                self._signal(native_id="alarm/one", title="one"),
+                self._signal(native_id="alarm/two", title="two"),
+            ]
+        )
+
+        # Armed the moment the index actually holds an incident, so the first claim
+        # genuinely lands and the second one meets the fault.
+        with self._index_reads_fail(only_once_claimed=True):
+            result = await dispatch.run_cycle()
+
+        self.assertEqual(
+            [c.incident.signal.title for c in result.claimed],
+            ["one"],
+            "the claim made before the failure was dropped from the cycle result",
+        )
+        self.assertEqual(result.polled, 2)
+
+    async def test_a_failed_verification_write_does_not_cost_the_cycle(self):
+        """The narrow race GPT named: snapshot succeeds, the write's read fails.
+
+        `verify_pending_actions` iterates the LENIENT `store.read_index()`, so a fully
+        unreadable index shows it no incidents and it never reaches the write at all. The
+        reachable window is the transient one -- the snapshot read succeeds, then
+        `update_fields`' own for-update read fails -- which is what stubbing the write to
+        raise reproduces exactly. Its `except` already tolerated the two race cases
+        (`KeyError`/`ValueError`, "pruned or raced away"); `OSError` now joins them,
+        because a store that REFUSED to publish over a failed read must not thereby become
+        the one thing that aborts a heartbeat. Found in review (GPT 5.6).
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch, store
+        from kiro_crew.apps.builtins.ops_mission_control.backend.models import (
+            MODE_ACT,
+            VERIFY_PENDING,
+        )
+
+        signal = self._signal(native_id="alarm/acted", title="acted on")
+        incident = store.claim(signal, operating_mode=MODE_ACT)
+        assert incident is not None
+        store.update_fields(
+            incident.incident_id,
+            last_action="silence",
+            last_action_at="2020-01-01T00:00:00Z",
+            verify_after="2020-01-01T00:00:00Z",
+            verification=VERIFY_PENDING,
+        )
+        self._add_source([signal])
+
+        with mock.patch.object(store, "update_fields", self._refusing_index):
+            result = await dispatch.run_cycle()
+
+        self.assertEqual(result.polled, 1, "a refused verification write aborted the cycle")
+        # The verdict was reached but could not be persisted; the next pass redoes it.
+        stored = store.get_incident(incident.incident_id)
+        assert stored is not None
+        self.assertEqual(stored.verification, VERIFY_PENDING)
+
+    async def test_a_corrupt_index_is_not_swallowed_by_the_verification_tolerance(self):
+        """Corruption must escape where an unreadable index is tolerated.
+
+        The clause above tolerates `KeyError`/`ValueError` (raced away) and `OSError`
+        (transient). `JSONDecodeError` subclasses `ValueError`, so without an explicit
+        clause it would take that tolerance by accident and a corrupt index would be
+        filed under a debug log written for a pruned incident. It must not be: an
+        unreadable index is transient and the next heartbeat retries, while a corrupt
+        one fails identically forever until a person intervenes -- so swallowing it
+        degrades the app indefinitely while the board still renders.
+
+        Stubbed for the same reason as the `OSError` sibling: `verify_pending_actions`
+        iterates the LENIENT `read_index`, which answers empty on a corrupt file, so
+        the reachable window is the transient one where the snapshot parses and the
+        write's own read meets the corruption.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch, store
+        from kiro_crew.apps.builtins.ops_mission_control.backend.models import (
+            MODE_ACT,
+            VERIFY_PENDING,
+        )
+
+        signal = self._signal(native_id="alarm/corrupt", title="corrupt case")
+        incident = store.claim(signal, operating_mode=MODE_ACT)
+        assert incident is not None
+        store.update_fields(
+            incident.incident_id,
+            last_action="silence",
+            last_action_at="2020-01-01T00:00:00Z",
+            verify_after="2020-01-01T00:00:00Z",
+            verification=VERIFY_PENDING,
+        )
+        self._add_source([signal])
+
+        def _corrupt(*_a, **_kw):
+            raise json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        with mock.patch.object(store, "update_fields", _corrupt):
+            with self.assertRaises(json.JSONDecodeError):
+                await dispatch.run_cycle()

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py
@@ -9,6 +9,7 @@ or hanging provider must degrade to a per-source error, never take down the poll
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import shutil
@@ -1396,13 +1397,11 @@ class TestTheCloudWatchConsoleLinkCannotBeRedirected(unittest.IsolatedAsyncioTes
         from kiro_crew.apps.builtins.ops_mission_control.backend.providers import cloudwatch
 
         source = inspect.getsource(cloudwatch)
-        code = "\n".join(
-            line for line in source.splitlines() if not line.lstrip().startswith("#")
-        )
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
         raw_reads = [
             line.strip()
             for line in code.splitlines()
-            if 'region = ' in line and "_validated_region" not in line and "_region()" not in line
+            if "region = " in line and "_validated_region" not in line and "_region()" not in line
         ]
         self.assertEqual(
             raw_reads,
@@ -1606,7 +1605,9 @@ class TestConcurrentStoreWritesDoNotLoseData(unittest.TestCase):
             backend.delete("pagerduty")
             backend.delete("datadog")
         self.assertEqual(
-            losses, 0, f"{losses}/30 secret rounds lost a credential — a lost update here is a lost secret"
+            losses,
+            0,
+            f"{losses}/30 secret rounds lost a credential — a lost update here is a lost secret",
         )
 
     def test_no_module_open_codes_a_config_read_modify_write(self):
@@ -1902,8 +1903,14 @@ class TestPollersMarkTruncationSoAbsenceIsNotRecovery(unittest.IsolatedAsyncioTe
         def _issues(n: int) -> str:
             return json.dumps(
                 [
-                    {"number": i, "title": f"#{i}", "labels": [], "createdAt": "", "url": "",
-                     "assignees": []}
+                    {
+                        "number": i,
+                        "title": f"#{i}",
+                        "labels": [],
+                        "createdAt": "",
+                        "url": "",
+                        "assignees": [],
+                    }
                     for i in range(n)
                 ]
             )
@@ -1985,3 +1992,246 @@ class TestRunGhTimeoutReapsChild(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(HangProc.kill_calls, 1)
         self.assertEqual(HangProc.communicate_calls, 2)
         self.assertEqual(HangProc.wait_calls, 0)
+
+
+class TestTheAppConfigIsNeverPublishedOverAFailedRead(unittest.TestCase):
+    """The BASE read of a read-modify-write may not fail open.
+
+    ``read_config`` collapses every failure to ``{}``, which is right for the
+    accessors above it — each resolves to the caller's default, so an unreadable
+    config reads as "nothing configured" and the Settings page still renders. It
+    is wrong as the base of ``merge_provider_config``/``set_top_level``, which
+    rewrite the WHOLE file: the merge is per-FIELD within one provider slot, not
+    per-file, so ``{}`` means "drop every other provider's configuration and every
+    top-level key".
+
+    The loss is quiet and it disables detection. ``provider_enabled`` defaults to
+    ``False``, so a wiped config does not error — it just stops polling every
+    provider the operator switched on, while their tokens remain in the keystone
+    store so the Settings page still shows each provider as credentialed. The
+    operator is left with an app that reports no signals and looks configured.
+
+    Isolates ``KIROCREW_HOME`` for the same reason the sibling classes here do:
+    these tests WRITE provider config.
+    """
+
+    def setUp(self):
+        self._tmp = Path(tempfile.mkdtemp())
+        # addCleanup on the line after mkdtemp: unittest skips tearDown when setUp
+        # raises, so cleaning up there leaks the directory on every setUp failure
+        # (and trips the temp-residue guard). Same reasoning as `_HomeIsolated` in
+        # test_policy_store.py, which carries this note too.
+        self.addCleanup(shutil.rmtree, self._tmp, ignore_errors=True)
+        self._prev_home = os.environ.get("KIROCREW_HOME")
+        self.addCleanup(self._restore_home)
+        os.environ["KIROCREW_HOME"] = str(self._tmp)
+
+    def _restore_home(self):
+        if self._prev_home is None:
+            os.environ.pop("KIROCREW_HOME", None)
+        else:
+            os.environ["KIROCREW_HOME"] = self._prev_home
+
+    @staticmethod
+    def _config_path() -> Path:
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+        from kiro_crew.apps.manager import app_data_dir
+
+        return app_data_dir(providers.APP_NAME) / providers.CONFIG_FILENAME
+
+    def _unreadable_config(self):
+        """Fail ONLY the app config's read, as a transient EACCES would.
+
+        Scoped by path: a blanket ``read_text`` failure would also break home
+        resolution and the app manifest, and the test would pass for the wrong
+        reason.
+        """
+        target = self._config_path()
+        real_read_text = Path.read_text
+
+        def _guarded(path_self, *args, **kwargs):
+            if Path(path_self) == target:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        return mock.patch.object(Path, "read_text", _guarded)
+
+    def test_a_read_that_failed_never_truncates_the_config(self):
+        """The durable harm, asserted directly: the OTHER providers the operator
+        configured must still be enabled afterwards."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        providers.merge_provider_config("pagerduty", {"enabled": True})
+        providers.merge_provider_config("datadog", {"enabled": True, "site": "datadoghq.eu"})
+        providers.set_top_level("stale_after_secs", 1800)
+        before = self._config_path().read_bytes()
+
+        with self._unreadable_config():
+            with contextlib.suppress(OSError):
+                providers.merge_provider_config("cloudwatch", {"enabled": True})
+            with contextlib.suppress(OSError):
+                providers.set_top_level("stale_after_secs", 60)
+
+        self.assertEqual(
+            self._config_path().read_bytes(),
+            before,
+            "a failed read was published back over the config",
+        )
+        self.assertTrue(
+            providers.provider_enabled("pagerduty"),
+            "a failed read silently switched off a provider the operator enabled",
+        )
+        self.assertEqual(
+            providers.config_value("datadog", "site"),
+            "datadoghq.eu",
+            "a failed read dropped another provider's configuration",
+        )
+        self.assertEqual(providers.read_config().get("stale_after_secs"), 1800)
+
+    def test_an_unreadable_config_refuses_the_merge(self):
+        """A settings save that was not recorded must not answer as though it
+        were — and must not report back a slot it never persisted."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        with self._unreadable_config():
+            with self.assertRaises(OSError):
+                providers.merge_provider_config("pagerduty", {"enabled": True})
+
+    def test_an_unreadable_config_refuses_a_top_level_write(self):
+        """``set_top_level`` rewrites the same whole file, so it needs the same
+        refusal."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        with self._unreadable_config():
+            with self.assertRaises(OSError):
+                providers.set_top_level("stale_after_secs", 60)
+
+    def test_a_missing_config_is_still_a_first_write(self):
+        """Absent is the one failure where ``{}`` is the truth. The guard must
+        not turn the operator's very first provider save into an error."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        self.assertFalse(self._config_path().exists())
+        slot = providers.merge_provider_config("pagerduty", {"enabled": True})
+        self.assertEqual(slot, {"enabled": True})
+        self.assertTrue(providers.provider_enabled("pagerduty"))
+
+    def test_a_corrupt_config_refuses_the_merge_instead_of_replacing_it(self):
+        """Inverted deliberately: this used to assert repair-on-write.
+
+        A half-written or hand-broken config still names every provider the operator
+        enabled. Replacing it discards that and leaves them re-entering settings they
+        already chose, so the merge refuses and surfaces the corruption instead. See
+        `store._read_index_for_update` for why this diverges from the four merged
+        siblings of the idiom. Found in review (GPT 5.6).
+        """
+        import json as _json
+
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        path = self._config_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"providers": {"datadog": {"enabled": true}', encoding="utf-8")
+
+        with self.assertRaises(_json.JSONDecodeError):
+            providers.merge_provider_config("pagerduty", {"enabled": True})
+
+    def test_a_corrupt_config_is_left_exactly_as_it_was(self):
+        """The point of refusing: the operator's settings must survive on disk."""
+        import contextlib
+        import json as _json
+
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        truncated = '{"providers": {"datadog": {"enabled": true, "site": "datadoghq.eu"}'
+        path = self._config_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(truncated, encoding="utf-8")
+
+        with contextlib.suppress(_json.JSONDecodeError):
+            providers.set_top_level("stale_after_secs", 60)
+
+        self.assertEqual(
+            path.read_text(encoding="utf-8"),
+            truncated,
+            "the refused write still overwrote the recoverable config",
+        )
+
+    def test_the_display_read_logs_a_non_object_root(self):
+        """The last silent branch, and the docstring promised it was not silent.
+
+        A non-object root parses fine, so no `except` fires, and this branch answered `{}`
+        without a word -- while the paragraph above it argued that THIS degradation must not be
+        quiet, because every provider stops polling while Settings still shows them
+        configured. Found in review (GPT 5.6); the index display read grew the same warning a
+        head earlier and this is its twin.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        providers._config_path().write_text("[]", encoding="utf-8")
+        with self.assertLogs("kiro_crew", level="WARNING") as caught:
+            self.assertEqual(providers.read_config(), {})
+        self.assertTrue(any("root is not an object" in m for m in caught.output))
+
+    def test_a_config_that_is_valid_json_but_not_an_object_refuses_the_merge(self):
+        """The normalization door, config side.
+
+        `[]` parses without raising, so the strict reader's `except FileNotFoundError`
+        never fires -- but coercing it to `{}` would let the merge rewrite the whole file
+        from empty and drop every provider the operator enabled. Valid JSON is not the
+        same as a usable document. Found in review (GPT 5.6).
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        providers._config_path().write_text("[]", encoding="utf-8")
+
+        with self.assertRaises(json.JSONDecodeError):
+            providers.merge_provider_config("datadog", {"enabled": True})
+
+        self.assertEqual(providers._config_path().read_text(encoding="utf-8"), "[]")
+
+    def test_a_providers_key_of_the_wrong_shape_refuses_the_merge(self):
+        """The per-slot half of the wrong-shape door, which was still open.
+
+        The strict read refuses a bad ROOT, but `merge_provider_config` normalized a
+        `providers` key that was not an object straight to `{}` -- and since it rewrites the
+        whole file, that wiped every provider slot on the next merge. Same loss the index
+        side closed with `strict=True`, one level down. Found in review (Design Review),
+        which spotted that the description claimed per-row refusal while the config had it
+        only at the root.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, providers
+
+        for label, doc in (
+            ("providers is a list", '{"providers": ["pagerduty"]}'),
+            ("providers is a string", '{"providers": "pagerduty"}'),
+            ("one slot is a string", '{"providers": {"datadog": "enabled"}}'),
+        ):
+            with self.subTest(shape=label):
+                providers._config_path().write_text(doc, encoding="utf-8")
+                with self.assertRaises(models.CorruptDocumentError):
+                    providers.merge_provider_config("datadog", {"enabled": True})
+                self.assertEqual(
+                    providers._config_path().read_text(encoding="utf-8"),
+                    doc,
+                    "the refused merge still rewrote the file",
+                )
+
+    def test_a_missing_providers_key_is_still_a_normal_first_write(self):
+        """The absent case stays absent-means-empty; only a WRONG shape refuses."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        providers._config_path().write_text('{"stale_after_secs": 1800}', encoding="utf-8")
+        saved = providers.merge_provider_config("datadog", {"enabled": True})
+        self.assertIs(saved["enabled"], True)
+        self.assertEqual(providers.read_config()["stale_after_secs"], 1800)
+
+    def test_the_display_read_still_tolerates_corruption(self):
+        """The asymmetry, pinned. Only the MUTATION base got strict -- the Settings
+        page must still render on a config it cannot parse."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import providers
+
+        path = self._config_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ not json", encoding="utf-8")
+        self.assertEqual(providers.read_config(), {})

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
@@ -641,6 +641,40 @@ class TestLedgerHygieneWiring(unittest.IsolatedAsyncioTestCase):
             result = routes._index_ledger_safely()
         self.assertEqual(result, {"scanned": 0, "written": 0, "skipped": 0, "embedded": 0})
 
+    async def test_a_prune_fault_cannot_cost_the_ledger_push(self):
+        """`prune_closed` sits before the push, and making the index read strict gave it a
+        new way to raise.
+
+        Letting it escape would mean one EACCES skips pushing the ledger `hygiene` just
+        deduped -- a later fault costing an earlier step's work, which is the rule
+        `dispatch.run_cycle`'s maintenance guards exist to keep. Pruning is the most
+        deferrable step here (the next run retires the same incidents); the push is what
+        other instances are waiting on. Found in review (Opus 4.8), which named the ordering
+        consequence rather than the status code.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        def _refuse():
+            raise PermissionError(13, "Permission denied")
+
+        with mock.patch.object(store, "prune_closed", _refuse):
+            response, order = await self._run()
+
+        self.assertEqual(response.status, 200)
+        self.assertIn("sync:push", order, "the push must still run after a failed prune")
+        self.assertLess(order.index("hygiene"), order.index("sync:push"))
+
+    async def test_a_corrupt_index_still_stops_the_hygiene_pass(self):
+        """Corruption never self-heals, so it must not be skipped quietly on every run."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        def _corrupt():
+            raise json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        with mock.patch.object(store, "prune_closed", _corrupt):
+            with self.assertRaises(json.JSONDecodeError):
+                await self._run()
+
 
 if __name__ == "__main__":
     unittest.main()
@@ -3366,6 +3400,259 @@ class TestAStoreThatRefusesToWriteIsReportedNotCrashed(unittest.IsolatedAsyncioT
         self.assertEqual(body["code"], "policy_store_unwritable")
         self.assertIs(body["ok"], False)
 
+    async def test_a_refused_provider_config_write_is_a_coded_503(self):
+        """The companion strict read landed, so this write can now refuse too.
+
+        This helper's docstring said `set_top_level` had no such guarantee "yet" and
+        pointed at the companion PR for `providers/__init__.py`. That PR is this change,
+        so `merge_provider_config` now propagates a failed read and this route needed the
+        same coded refusal. Found in review (Opus 4.8, Design Review).
+        """
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(routes, "merge_provider_config", self._refuse):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/providers/datadog/config",
+                    json={"site": "datadoghq.eu"},
+                )
+                self.assertEqual(resp.status, 503)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "app_config_unreadable")
+
+    async def test_a_corrupt_provider_config_is_a_coded_500_not_a_bare_one(self):
+        """Corruption is not retryable, so it must not be advertised as a 503.
+
+        Found in review (GPT 5.6): the coded refusal covered only `OSError`, so a malformed
+        `config.json` still answered the bare uncoded 500 this PR set out to remove.
+        """
+        corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        def _corrupt(*_a, **_kw):
+            raise corrupt
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(routes, "merge_provider_config", _corrupt):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/providers/datadog/config",
+                    json={"site": "datadoghq.eu"},
+                )
+                self.assertEqual(resp.status, 500)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "app_config_corrupt")
+
+    async def test_a_claim_survives_a_failed_ledger_annotation(self):
+        """The claim is committed before the annotation runs, so it must not be un-reported.
+
+        `attach_ledger_matches` writes through `store.update_fields` -> `transition` ->
+        `_read_index_for_update()`, which this change gave two new ways to raise. Unguarded it
+        answered a bare uncoded 500 for a claim that had ALREADY been written durably and whose
+        webhook had already been acked. Found in review (Opus 4.8).
+
+        Its suggested fix was the coded 503 the sibling routes use, and that is wrong here for
+        the same reason it was wrong at `_schedule_verification`: a 503 says "the claim failed,
+        retry" about a claim that succeeded, the retry answers `409 signal_already_claimed`, and
+        the audit entry for a real claim is never written. The annotation is the deferrable half
+        -- the dispatch cycle re-derives matches next pass -- so the degraded answer is the
+        claim without its matches, still 200, still audited, with the degradation recorded.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch, models
+
+        firing = models.Signal.create(
+            source="cloudwatch", native_id="alarm/x", title="broke", labels={"alarm_name": "x"}
+        )
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(
+                routes.get_registry(), "poll_all", mock.AsyncMock(return_value=([firing], {}))
+            ):
+                with mock.patch.object(dispatch, "attach_ledger_matches", self._refuse):
+                    with mock.patch.object(routes, "_audit") as audited:
+                        client = await self._client(app)
+                        resp = await client.post(
+                            "/api/apps/ops-mission-control/incident/claim",
+                            json={"signal": {"id": firing.id, "source": "cloudwatch"}},
+                        )
+                        body = await resp.json()
+
+        self.assertEqual(resp.status, 200, "a committed claim was reported as failed")
+        self.assertTrue(body["incident"]["incident_id"])
+        self.assertEqual(body["matches"], [], "matches degrade to empty, not to an error")
+        claims = [c for c in audited.call_args_list if c.args[0] == "incident_claim"]
+        self.assertEqual(len(claims), 1, "the claim must be audited exactly once")
+        self.assertEqual(claims[0].args[2], "success")
+        self.assertIn("without ledger matches", claims[0].kwargs.get("error", ""))
+
+    async def test_a_corrupt_index_is_not_reported_as_an_illegal_transition(self):
+        """The misclassification, pinned. This is the worst of the uncoded cases.
+
+        `_handle_transition` caught `except ValueError`, and `JSONDecodeError` subclasses
+        `ValueError`, so a corrupt index answered `409 illegal_transition` carrying the JSON
+        parser's message -- telling the operator their own state change was invalid when the
+        real fault was a broken file. A 409 sends them to fix their request; nothing sends
+        them to the file. Found in review (Opus 4.8); it is the same accident this change
+        closed at three non-route callers.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        def _corrupt(*_a, **_kw):
+            raise corrupt
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(store, "get_incident", lambda *_a, **_kw: None):
+                with mock.patch.object(store, "transition", _corrupt):
+                    client = await self._client(app)
+                    resp = await client.post(
+                        "/api/apps/ops-mission-control/incident/transition",
+                        json={"id": "INV-1", "status": "resolved"},
+                    )
+                    body = await resp.json()
+
+        self.assertNotEqual(resp.status, 409, "corruption was blamed on the operator's request")
+        self.assertNotEqual(body.get("code"), "illegal_transition")
+        self.assertEqual(resp.status, 500)
+        self.assertEqual(body["code"], "dispatch_index_corrupt")
+
+    async def test_an_unreadable_index_on_transition_is_a_retryable_coded_503(self):
+        """The other half: transient gets 503, so "retry" is only said when it can work."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(store, "get_incident", lambda *_a, **_kw: None):
+                with mock.patch.object(store, "transition", self._refuse):
+                    client = await self._client(app)
+                    resp = await client.post(
+                        "/api/apps/ops-mission-control/incident/transition",
+                        json={"id": "INV-1", "status": "resolved"},
+                    )
+                    body = await resp.json()
+
+        self.assertEqual(resp.status, 503)
+        self.assertEqual(body["code"], "dispatch_index_unreadable")
+
+    async def test_a_refused_manual_claim_is_coded_rather_than_a_bare_500(self):
+        """`claim` raises on both failures by design, so the board's own route must translate."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        firing = models.Signal.create(
+            source="cloudwatch", native_id="alarm/x", title="broke", labels={"alarm_name": "x"}
+        )
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(
+                routes.get_registry(), "poll_all", mock.AsyncMock(return_value=([firing], {}))
+            ):
+                with mock.patch.object(store, "claim", self._refuse):
+                    client = await self._client(app)
+                    resp = await client.post(
+                        "/api/apps/ops-mission-control/incident/claim",
+                        json={"signal": {"id": firing.id, "source": "cloudwatch"}},
+                    )
+
+        self.assertEqual(resp.status, 503)
+        self.assertEqual((await resp.json())["code"], "dispatch_index_unreadable")
+
+    async def test_a_corrupt_policy_store_on_settings_is_a_coded_500(self):
+        """The regression this change introduced into a MERGED helper.
+
+        `_settings_write_or_refuse` caught only `OSError`. Making the config reader refuse on
+        a malformed document gave `set_top_level` a second way to raise, and the bare 500 came
+        back for it -- in the one helper whose docstring had promised this PR would close that
+        gap. Found in review (First Principles).
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        def _corrupt(*_a, **_kw):
+            raise corrupt
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(policy_store, "set_ceiling", _corrupt):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/settings", json={"mode": "observe"}
+                )
+                body = await resp.json()
+
+        self.assertEqual(resp.status, 500)
+        self.assertEqual(body["code"], "policy_store_corrupt")
+        self.assertIs(body["ok"], False)
+
+    async def test_a_corrupt_index_is_not_reported_as_an_invalid_proposal(self):
+        """The last reachable `ValueError` arm, found by auditing all ten in this file.
+
+        `propose_action` reaches the strict reader through `update_fields` -> `transition`,
+        so a corrupt index raises `CorruptDocumentError` -- a `ValueError` -- and the
+        `except ValueError` arm reported it as `400 invalid_proposal`. That is worse than the
+        bare 500 it replaces: a 400 blames the operator's proposal, so they re-type the form
+        while the real fault sits on disk. Nine of the ten arms needed nothing -- three
+        already carried this clause and six cannot reach a strict reader at all.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        def _corrupt(*_a, **_kw):
+            raise corrupt
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(store, "propose_action", _corrupt):
+                client = await self._client(app)
+                resp = await client.post(
+                    "/api/apps/ops-mission-control/incident/propose",
+                    json={"id": "INV-1", "action": "silence", "sink": "pagerduty"},
+                )
+                body = await resp.json()
+
+        self.assertNotEqual(resp.status, 400, "corruption was blamed on the operator's proposal")
+        self.assertNotEqual(body.get("code"), "invalid_proposal")
+        self.assertEqual(resp.status, 500)
+        self.assertEqual(body["code"], "dispatch_index_corrupt")
+
+    async def test_a_refused_proposal_decision_is_a_coded_503(self):
+        """A human's approval of a production action must not fail ambiguously.
+
+        `decide_proposal` is a locked read-modify-write that now refuses rather than
+        publishing over a failed read. Before this arm the handler could only answer a
+        coded 404, so a transient read failure became a bare 500 with no `code`.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(store, "decide_proposal", self._refuse):
+                client = await self._client(app)
+                resp = await client.post(
+                    "/api/apps/ops-mission-control/incident/proposal/decide",
+                    json={"id": "INV-1", "approve": True},
+                )
+                self.assertEqual(resp.status, 503)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "dispatch_index_unreadable")
+
     async def test_a_refused_destination_write_is_a_coded_503_too(self):
         """The keys reached THROUGH an intermediary, which the first pass missed.
 
@@ -3428,3 +3715,58 @@ class TestAStoreThatRefusesToWriteIsReportedNotCrashed(unittest.IsolatedAsyncioT
 
         self.assertIs(body["ok"], True)
         self.assertEqual(body["applied"]["mode"], "observe")
+
+
+class TestCorruptionIsNotSwallowedWhenSchedulingVerification(unittest.TestCase):
+    """Corruption while scheduling a recheck must be REPORTED -- neither swallowed nor raised.
+
+    Two review lanes found opposite halves of this. Design Review caught that a corrupt index
+    was silently swallowed: `_schedule_verification` catches `(KeyError, ValueError, OSError)`
+    and `JSONDecodeError` subclasses `ValueError`, so corruption was filed under the
+    raced-away case at debug level and the action ran with no recheck, forever, invisibly.
+    GPT 5.6 then caught that simply re-raising is also wrong: both callers have ALREADY done
+    the real external write by the time this runs, so a raise turns a completed action into a
+    500 and invites a retry -- in `act` mode, a second real write against production.
+
+    So corruption gets its own clause that logs and writes a SEL audit entry, then returns
+    `("", "")` like the transient case. The action's true outcome still reaches the operator,
+    and the lost verification is durably recorded rather than dropped.
+    """
+
+    @staticmethod
+    def _raiser(exc):
+        def _fn(*_a, **_kw):
+            raise exc
+
+        return _fn
+
+    def test_a_corrupt_index_is_audited_rather_than_raising_after_the_action_ran(self):
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)
+        with mock.patch.object(store, "update_fields", self._raiser(corrupt)):
+            with mock.patch.object(routes, "_audit") as audited:
+                result = routes._schedule_verification("INV-1", "silence", 60)
+
+        self.assertEqual(result, ("", ""), "a completed action must not be reported as failed")
+        ops = [c.args[0] for c in audited.call_args_list]
+        self.assertIn(
+            "action_verification_unscheduled",
+            ops,
+            "corruption was swallowed with no durable record",
+        )
+        outcome = next(c for c in audited.call_args_list if c.args[0] == "action_verification_unscheduled")
+        self.assertEqual(outcome.args[2], "failure")
+
+    def test_a_transient_failure_is_not_audited_as_an_unscheduled_verification(self):
+        """The asymmetry: a transient miss is retried by the next pass, so it stays quiet."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        denied = PermissionError(13, "Permission denied")
+        with mock.patch.object(store, "update_fields", self._raiser(denied)):
+            with mock.patch.object(routes, "_audit") as audited:
+                result = routes._schedule_verification("INV-1", "silence", 60)
+
+        self.assertEqual(result, ("", ""))
+        ops = [c.args[0] for c in audited.call_args_list]
+        self.assertNotIn("action_verification_unscheduled", ops)

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_slot_watch.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_slot_watch.py
@@ -321,5 +321,107 @@ class TestPersistence(_HomeIsolated):
         self.assertEqual(reread.blocked_reason, BLOCKED_ON_APPROVAL)
 
 
+class TestReconcileKeepsItsTolerantContract(_HomeIsolated):
+    """`reconcile` is a background truth-sync, so it must survive what the store refuses.
+
+    The store's mutation base is now strict: `transition` reads the index for update and
+    RAISES rather than publishing over a read it could not make. That is right for the
+    store and wrong to let escape here -- reconciliation's whole job is to survive a mess,
+    and it already skips illegal transitions and lost races by returning `None`.
+
+    Tolerating the refusal is safe BECAUSE the store refused: the mutation was abandoned
+    before writing, so the incident keeps the status it already had, which is exactly what
+    `None` already means to every caller. The next reconcile pass retries from a clean
+    read. Found in review (GPT 5.6), whose suggested remedy was to revert the strict
+    reader -- that would restore the silent-truncation bug, so the tolerance was moved to
+    the caller that wants it instead.
+
+    On WHY these stub `store.transition` rather than making the file unreadable: `reconcile`
+    looks the incident up through `store.get_incident`, which goes through the LENIENT
+    `read_index`. So a fully unreadable index makes that lookup answer `None` and the
+    function returns before `transition` is ever called -- a file-level fault cannot reach
+    the path under test, and a test written that way passes without exercising it (mine did,
+    until the mutation probe caught it). The reachable window is the transient one GPT
+    named: the lookup succeeds, then `transition`'s own for-update read fails. Stubbing the
+    write to raise is that window, exactly.
+    """
+
+    @staticmethod
+    def _refusing_write(*_a, **_kw):
+        raise PermissionError(13, "Permission denied")
+
+    def test_a_refused_transition_skips_the_reconcile_instead_of_raising(self):
+        from unittest import mock
+
+        from kiro_crew.apps.builtins.ops_mission_control.backend import slot_watch, store
+        from kiro_crew.apps.builtins.ops_mission_control.backend.models import (
+            STATUS_NEEDS_HUMAN,
+        )
+
+        inc = self._claim()
+        # A slot that really derives a change, so the reconcile reaches `transition`.
+        # Asserted rather than assumed: a shape that derived nothing would make this
+        # test pass without exercising the path at all.
+        slot = {"pending_approval": True}
+        derived, _ = slot_watch.derive_status(inc, slot)
+        self.assertEqual(derived, STATUS_NEEDS_HUMAN, "premise: this slot derives a change")
+
+        with mock.patch.object(store, "transition", self._refusing_write):
+            self.assertIsNone(
+                slot_watch.reconcile(inc.incident_id, slot),
+                "a refused transition must skip the reconcile, not raise out of it",
+            )
+
+    def test_the_incident_keeps_the_status_it_already_had(self):
+        """The durable half: a skipped reconcile must not have changed anything."""
+        from unittest import mock
+
+        from kiro_crew.apps.builtins.ops_mission_control.backend import slot_watch, store
+
+        inc = self._claim()
+        before = inc.status
+
+        with mock.patch.object(store, "transition", self._refusing_write):
+            slot_watch.reconcile(inc.incident_id, {"pending_approval": True})
+
+        after = store.get_incident(inc.incident_id)
+        assert after is not None
+        self.assertEqual(after.status, before, "a skipped reconcile changed the incident")
+
+    def test_a_corrupt_index_is_refused_rather_than_tolerated(self):
+        """The deliberate asymmetry: EACCES is tolerated here, corruption is not.
+
+        The difference is persistence. An unreadable index is transient -- the next
+        reconcile probably succeeds, so skipping one status sync costs nothing. A
+        corrupt index fails identically on every future reconcile until a person fixes
+        the file, so tolerating it means this instance quietly stops syncing status
+        forever while the board still renders.
+
+        `JSONDecodeError` subclasses `ValueError`, which the tolerant clause already
+        catches for the unrelated illegal-transition case -- so without an explicit
+        clause the two failure modes would share one handler and corruption would be
+        filed under "we lost a race" at debug level. This pins that they do not.
+
+        Stubbed rather than driven from a corrupt file for the same reason as the
+        `OSError` tests above: `reconcile` looks the incident up through the LENIENT
+        `read_index`, which answers empty on a corrupt file, so the function returns
+        before `transition` is reached. The reachable window is the transient one --
+        the lookup parses, then the write's own read meets the corruption.
+        """
+        import json
+        from unittest import mock
+
+        from kiro_crew.apps.builtins.ops_mission_control.backend import slot_watch, store
+
+        inc = self._claim()
+
+        def _corrupt(*_a, **_kw):
+            raise json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        with mock.patch.object(store, "transition", _corrupt):
+            with self.assertRaises(json.JSONDecodeError):
+                slot_watch.reconcile(inc.incident_id, {"pending_approval": True})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
@@ -10,6 +10,7 @@ directly rather than through the HTTP layer.
 data home.
 """
 
+import contextlib
 import json
 import shutil
 import tempfile
@@ -979,9 +980,7 @@ class TestTierArming(_HomeIsolated):
         manifest = json.loads(
             (Path(rotation.__file__).resolve().parents[1] / "app.json").read_text(encoding="utf-8")
         )
-        message = next(
-            c["message"] for c in manifest["crons"] if c["name"] == "rotation-check"
-        )
+        message = next(c["message"] for c in manifest["crons"] if c["name"] == "rotation-check")
         self.assertIn("/rotation/arm", message)
         self.assertNotIn("cron_pause", message)
         self.assertNotIn("cron_resume", message)
@@ -2398,9 +2397,7 @@ class TestArmingOnAnAlreadyUnreadableStore(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(body["ok"])
         self.assertEqual(body["code"], "cron_store_unreadable")
         self.assertEqual(body["changed"], [])
-        self.assertEqual(
-            svc.calls, [], "nothing may be written while the store cannot be read"
-        )
+        self.assertEqual(svc.calls, [], "nothing may be written while the store cannot be read")
 
     async def test_the_real_cron_service_reaches_the_state_the_fake_models(self):
         """The fake above is only worth anything if the real service gets here.
@@ -2785,9 +2782,7 @@ class TestTheWriteGateConsultsEveryRotation(_HomeIsolated):
         """Indeterminacy keeps permitting, whichever contract the source implements."""
         from kiro_crew.apps.builtins.ops_mission_control.backend import rotation
 
-        self._install(
-            self._async_only_source("companion-rota", on_shift=False, unknown=True)
-        )
+        self._install(self._async_only_source("companion-rota", on_shift=False, unknown=True))
         self.assertFalse(rotation._definitely_off_shift())
 
     def test_an_async_only_source_that_raises_is_a_fault_not_an_absence(self):
@@ -2981,11 +2976,18 @@ class TestProposalExpiryIsAtomic(_HomeIsolated):
         from kiro_crew.apps.builtins.ops_mission_control.backend import store
 
         source = inspect.getsource(store.expire_stale_proposals)
-        code = "\n".join(
-            line for line in source.splitlines() if not line.lstrip().startswith("#")
-        )
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
         self.assertIn("_IndexLock()", code)
-        self.assertIn("_read_index_unlocked()", code)
+        # The STRICT reader specifically. `_read_index_unlocked` collapses a FAILED read to
+        # an empty index, which is right for the board and wrong as the base of this
+        # whole-document rewrite -- reading through it here would publish an empty index
+        # over every incident on one transient EACCES.
+        self.assertIn("_read_index_for_update()", code)
+        self.assertNotIn(
+            "_read_index_unlocked()",
+            code,
+            "the sweep rewrites the index from the lenient display read",
+        )
         self.assertNotIn(
             "update_fields(",
             code,
@@ -2993,7 +2995,7 @@ class TestProposalExpiryIsAtomic(_HomeIsolated):
         )
         self.assertNotIn(
             "read_index()",
-            code.replace("_read_index_unlocked()", ""),
+            code.replace("_read_index_for_update()", ""),
             "the sweep reads through the unlocked snapshot",
         )
 
@@ -3182,9 +3184,7 @@ class TestUpdateFieldsDoesNotCarryAStaleStatus(_HomeIsolated):
         from kiro_crew.apps.builtins.ops_mission_control.backend import store
 
         source = inspect.getsource(store.update_fields)
-        code = "\n".join(
-            line for line in source.splitlines() if not line.lstrip().startswith("#")
-        )
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
         self.assertIn("_KEEP_STATUS", code)
         self.assertNotIn(
             ".status",
@@ -3192,3 +3192,509 @@ class TestUpdateFieldsDoesNotCarryAStaleStatus(_HomeIsolated):
             "update_fields reads a status outside the lock; it must pass _KEEP_STATUS",
         )
         self.assertNotIn("get_incident(", code)
+
+
+class TestTheIndexIsNeverPublishedOverAFailedRead(_HomeIsolated):
+    """The BASE read of a read-modify-write may not fail open.
+
+    ``_read_index_unlocked`` collapses every failure to ``{}``, which is right for
+    the board, the counts and ``find_by_signal`` — a render must not fail on an
+    index it could not load. It is wrong as the base of the six locked mutations,
+    which rewrite the WHOLE document: there ``{}`` means "delete every incident on
+    the board", and one transient EACCES/EIO published it.
+
+    The index is not a view, it is the CLAIM LEDGER: ``claim`` is a compare-and-set
+    against these rows. Emptied, every signal reads as unowned, so the next
+    heartbeat re-claims alarms already being worked and opens a duplicate
+    investigation of each — and in ``act`` mode a duplicate investigation is a
+    second real write against the operator's production paging. The per-incident
+    markdown logs survive on disk with nothing indexing them, and an open incident
+    that is no longer listed is never swept, resolved, or answered.
+    """
+
+    def _unreadable_index(self):
+        """Fail ONLY the index file's read, as a transient EACCES would.
+
+        Scoped by path: a blanket ``read_text`` failure would also break home
+        resolution and the per-incident logs, and the test would pass for the
+        wrong reason.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        target = store.index_path()
+        real_read_text = Path.read_text
+
+        def _guarded(path_self, *args, **kwargs):
+            if Path(path_self) == target:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(path_self, *args, **kwargs)
+
+        return mock.patch.object(Path, "read_text", _guarded)
+
+    def test_a_read_that_failed_never_truncates_the_index(self):
+        """The durable harm, asserted directly: the incidents already claimed
+        must still be on the board afterwards."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        first = store.claim(self._signal(native_id="alarm/one"), operating_mode=models.MODE_OBSERVE)
+        second = store.claim(
+            self._signal(native_id="alarm/two"), operating_mode=models.MODE_OBSERVE
+        )
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+        assert first is not None and second is not None
+        before = store.index_path().read_bytes()
+
+        with self._unreadable_index():
+            with contextlib.suppress(OSError):
+                store.claim(
+                    self._signal(native_id="alarm/three"), operating_mode=models.MODE_OBSERVE
+                )
+            with contextlib.suppress(OSError):
+                store.prune_closed(keep=0)
+
+        self.assertEqual(
+            store.index_path().read_bytes(),
+            before,
+            "a failed read was published back over the index",
+        )
+        self.assertEqual(
+            sorted(store.read_index()),
+            sorted([first.incident_id, second.incident_id]),
+            "a failed read dropped incidents that were still claimed",
+        )
+
+    def test_an_unreadable_index_refuses_a_claim(self):
+        """A claim is a compare-and-set. It cannot be decided against an index
+        nobody read, and ``None`` here would read as "someone else owns it"."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        store.claim(self._signal(native_id="alarm/one"), operating_mode=models.MODE_OBSERVE)
+        with self._unreadable_index():
+            with self.assertRaises(OSError):
+                store.claim(self._signal(native_id="alarm/two"), operating_mode=models.MODE_OBSERVE)
+
+    def test_an_unreadable_index_refuses_a_transition(self):
+        """``transition`` raises ``KeyError`` for an unknown incident, so on the
+        lenient read a real incident became "unknown" — a 404 for a row that is
+        on disk. The read failure must surface as itself."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        inc = store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+        assert inc is not None
+        with self._unreadable_index():
+            with self.assertRaises(OSError):
+                store.transition(inc.incident_id, models.STATUS_INVESTIGATING)
+
+    def test_a_missing_index_is_still_a_first_claim(self):
+        """Absent is the one failure where ``{}`` is the truth. The guard must
+        not turn the app's very first claim into an error."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        self.assertFalse(store.index_path().exists())
+        inc = store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+        self.assertIsNotNone(inc)
+        assert inc is not None
+        self.assertIn(inc.incident_id, store.read_index())
+
+    def test_a_corrupt_index_refuses_the_mutation_instead_of_replacing_it(self):
+        """Inverted deliberately: this used to assert repair-on-write.
+
+        The four merged siblings of this idiom (`library.py`, `shares.py`,
+        `secrets.py`, `policy_store.py`) still read an unparseable document as empty,
+        and their reasoning is real -- nothing parsed, so there is nothing to merge
+        into. But "cannot merge into" is not "safe to destroy": a truncated index
+        still holds most of its records verbatim, and the mutation would replace the
+        file and take them with it. Refusing costs one skipped mutation and a visible
+        error; the old behaviour cost the records, silently. Found in review (GPT 5.6).
+
+        The fixture writes malformed JSON to the real index path, so the corruption
+        is reached by the update reader itself rather than simulated -- and `claim`
+        is used because it is the mutation with no prior lookup to short-circuit on.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        store.index_path().write_text('{"INV-1": {"incident_id": "INV-1"', encoding="utf-8")
+        with self.assertRaises(json.JSONDecodeError):
+            store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+
+    def test_a_corrupt_index_is_left_exactly_as_it_was(self):
+        """The point of refusing: the salvageable bytes must survive on disk."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        truncated = '{"INV-1": {"incident_id": "INV-1", "status": "dispatched"'
+        store.index_path().write_text(truncated, encoding="utf-8")
+
+        with contextlib.suppress(json.JSONDecodeError):
+            store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+
+        self.assertEqual(
+            store.index_path().read_text(encoding="utf-8"),
+            truncated,
+            "the refused mutation still overwrote the recoverable document",
+        )
+
+    def test_the_display_read_still_tolerates_corruption(self):
+        """The asymmetry, pinned. Only the MUTATION base got strict.
+
+        The board must still render on a corrupt index -- failing the route would
+        turn a recoverable file into an unusable app, which is the opposite of the
+        point. So `read_index` keeps collapsing to empty (and now logs why).
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        store.index_path().write_text("{ not json", encoding="utf-8")
+        self.assertEqual(store.read_index(), {})
+
+    def test_a_skipped_entry_is_not_silently_deleted_by_the_next_mutation(self):
+        """Normalization was the second door into the same data loss.
+
+        `_coerce_index` skips a value that is not an object -- and skipped it with no log
+        at all, unlike the unloadable-row case beside it. On the display read that is
+        right: one bad row must not blank the board. On the update path it is the whole
+        bug in miniature, because the mutation rewrites the file from what the reader
+        returned, so a skipped row is deleted from disk permanently with no error and no
+        parse failure to notice. Found in review (GPT 5.6) -- the strict reader had closed
+        the malformed-JSON door and left this one open.
+
+        The fixture uses a non-object VALUE rather than an unloadable one because that is
+        the reachable half: `Incident.from_dict` coerces every field through `str()` and
+        type guards, so it essentially never raises for a dict. Strict mode covers that
+        path too, but this is the one a hand-edit or a merge artifact actually produces.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        good = store.claim(self._signal(native_id="alarm/keep"), operating_mode=models.MODE_OBSERVE)
+        assert good is not None
+        raw = json.loads(store.index_path().read_text(encoding="utf-8"))
+        raw["INV-BROKEN"] = "this row is not an object"
+        store.index_path().write_text(json.dumps(raw), encoding="utf-8")
+        before = store.index_path().read_text(encoding="utf-8")
+
+        with self.assertRaises(json.JSONDecodeError):
+            store.claim(self._signal(native_id="alarm/new"), operating_mode=models.MODE_OBSERVE)
+
+        self.assertEqual(
+            store.index_path().read_text(encoding="utf-8"),
+            before,
+            "the mutation deleted a row it merely could not read",
+        )
+        self.assertIn("INV-BROKEN", store.index_path().read_text(encoding="utf-8"))
+
+    def test_an_index_that_is_valid_json_but_not_an_object_refuses_the_mutation(self):
+        """`[]` parses fine, so no JSONDecodeError fires -- but it is still not a document
+        a whole-file rewrite may be based on."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        store.index_path().write_text("[]", encoding="utf-8")
+
+        with self.assertRaises(json.JSONDecodeError):
+            store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+
+        self.assertEqual(store.index_path().read_text(encoding="utf-8"), "[]")
+
+    def test_both_corruption_doors_raise_the_named_type(self):
+        """The reader's contract: every refusal is ONE exception type, either door.
+
+        Review observed that `CorruptDocumentError` was a subclass no catcher distinguished
+        (First Principles). That was fair, and it applied to the tests too -- every corruption
+        test here asserts the BASE `json.JSONDecodeError`, so nothing would have noticed the
+        reader handing back a bare base instance. This pins the type itself, so the subclass
+        is the reader's contract rather than decoration at the raise site.
+
+        Both doors are checked because they arrive differently: a bad byte stream comes from
+        `json.loads` and is re-raised, while a bad shape is constructed in `_coerce_index`.
+        Catchers written against `json.JSONDecodeError` keep working either way -- asserted
+        here too, since that compatibility is the whole reason for subclassing.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        for label, content in (
+            ("unparseable bytes", "{ not json"),
+            ("valid JSON, wrong shape", "[]"),
+        ):
+            with self.subTest(door=label):
+                store.index_path().write_text(content, encoding="utf-8")
+                with self.assertRaises(models.CorruptDocumentError):
+                    store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+                # The base class still catches it; that is why the subclass is safe.
+                store.index_path().write_text(content, encoding="utf-8")
+                with self.assertRaises(json.JSONDecodeError):
+                    store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+
+    def test_a_row_whose_id_disagrees_with_its_key_refuses_the_mutation(self):
+        """The one hole the round-trip rule structurally could not close.
+
+        Both sides of the round trip preserve a key/`incident_id` mismatch faithfully, so
+        `_lost` passes and `_unknown` passes. But the corruption manifests at WRITE time:
+        `expire_stale_proposals` iterated `index.values()` and wrote back with
+        `index[inc.incident_id] = ...`, so a row stored under `INV-1` whose id says `INV-9` was
+        REKEYED on the next expiry sweep -- leaving `INV-1` behind as a duplicate, or
+        overwriting a real `INV-9`. Found in review (GPT 5.6).
+
+        This is a referential invariant of the document (the key IS the id), not another shape
+        check, which is why it needs its own assertion rather than being folded into the
+        equivalence rule.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        good = store.claim(self._signal(native_id="alarm/keep"), operating_mode=models.MODE_OBSERVE)
+        assert good is not None
+        raw = json.loads(store.index_path().read_text(encoding="utf-8"))
+        raw[good.incident_id]["incident_id"] = "INV-SOMEONE-ELSE"
+        store.index_path().write_text(json.dumps(raw), encoding="utf-8")
+        before = store.index_path().read_text(encoding="utf-8")
+
+        with self.assertRaises(models.CorruptDocumentError):
+            store.claim(self._signal(native_id="alarm/new"), operating_mode=models.MODE_OBSERVE)
+
+        self.assertEqual(store.index_path().read_text(encoding="utf-8"), before)
+
+    def test_the_expiry_sweep_writes_rows_back_under_the_key_it_read(self):
+        """Belt-and-braces for the same defect, at the write rather than the read.
+
+        The reader now refuses an inconsistent document, but the function that REWRITES the
+        index should not be the one relying on that. Pinned by driving a real expiry and
+        asserting the key set is unchanged -- on a consistent document the old and new forms
+        agree, so only a rekey could alter it.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        inc = store.claim(self._signal(native_id="alarm/prop"), operating_mode=models.MODE_ACT)
+        assert inc is not None
+        store.propose_action(
+            inc.incident_id, action="silence", sink="pagerduty", note="n", duration_secs=1
+        )
+        keys_before = set(json.loads(store.index_path().read_text(encoding="utf-8")))
+
+        store.expire_stale_proposals(now="2099-01-01T00:00:00Z")
+
+        self.assertEqual(
+            set(json.loads(store.index_path().read_text(encoding="utf-8"))),
+            keys_before,
+            "the expiry sweep moved a record to a different key",
+        )
+
+    def test_a_file_that_is_not_utf8_takes_the_corruption_path(self):
+        """The sibling exception that slipped past every corruption clause.
+
+        `read_text(encoding="utf-8")` raises `UnicodeDecodeError` on invalid bytes, so
+        `json.loads` never runs. `UnicodeDecodeError` is a `ValueError` but NOT a
+        `JSONDecodeError` -- so unwrapped it missed every `except json.JSONDecodeError` this
+        change added and landed in the tolerant `except (KeyError, ValueError, OSError)` arms
+        instead, silently swallowed. That is the exact accidental tolerance this change exists
+        to close, reached through a different exception type. Found in review (GPT 5.6).
+
+        Asserted as `CorruptDocumentError` rather than `UnicodeDecodeError`, because the point
+        is that a corrupt byte stream is ONE condition regardless of which decoder noticed it.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        store.index_path().write_bytes(b'{"INV-1": "\xff\xfe not utf8"}')
+        before = store.index_path().read_bytes()
+
+        with self.assertRaises(models.CorruptDocumentError):
+            store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+
+        self.assertEqual(store.index_path().read_bytes(), before)
+
+    def test_the_display_read_survives_a_file_that_is_not_utf8(self):
+        """The asymmetry holds for this door too: the board still renders."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        store.index_path().write_bytes(b'{"INV-1": "\xff\xfe not utf8"}')
+        self.assertEqual(store.read_index(), {})
+
+    def test_the_serializer_round_trips_every_shape_the_app_writes(self):
+        """The availability property the round-trip refusal now depends on.
+
+        Because a mutation refuses when `to_dict(from_dict(x))` does not preserve what `x`
+        held, serializer idempotence stopped being merely a correctness concern and became an
+        AVAILABILITY one: a field that does not survive its own round trip would make every
+        claim, transition, sweep and decide refuse. Named in review (Design Review) as
+        "serializer idempotence load-bearing for store availability", which is accurate, so
+        this pins it on the shapes the app actually produces rather than leaving it implied.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        incident = store.claim(self._signal(), operating_mode=models.MODE_ACT)
+        assert incident is not None
+        store.propose_action(
+            incident.incident_id, action="silence", sink="pagerduty", note="n", duration_secs=60
+        )
+        store.update_fields(
+            incident.incident_id,
+            diagnosis="d",
+            ledger_matches=["L-1", "L-2"],
+            last_action="silence",
+            verification=models.VERIFY_PENDING,
+            verify_after="2026-01-01T00:00:00Z",
+        )
+        store.transition(incident.incident_id, models.STATUS_INVESTIGATING)
+
+        for key, original in json.loads(store.index_path().read_text(encoding="utf-8")).items():
+            with self.subTest(incident=key):
+                self.assertEqual(
+                    models.Incident.from_dict(original).to_dict(),
+                    original,
+                    "a field the app writes does not survive its own round trip",
+                )
+
+    def test_a_field_from_a_newer_build_refuses_without_calling_the_file_corrupt(self):
+        """Version skew must refuse the write and NOT be reported as corruption.
+
+        `to_dict` is `asdict()` over the fields this build knows, so a row written by a newer
+        build loses that key on the round trip. Refusing is right -- writing would strip data
+        the newer build stored. But the file is FINE: the remedy is to move this instance
+        forward, not to repair a document, so it must not be classified with corruption.
+
+        The reachable path is a ROLLBACK on one machine. `ledger_sync` deliberately does not
+        sync the index ("Only the ledger. NOT the dispatch index", because the index is
+        last-writer-wins and syncing it would let two instances each believe they own an
+        incident), so this is NOT two instances sharing a file -- an earlier version of this
+        docstring said it was, which First Principles caught. Design Review found the case
+        itself: without it, one rolled-back instance refuses EVERY mutation forever while
+        telling the operator to fix a healthy file.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        good = store.claim(self._signal(native_id="alarm/keep"), operating_mode=models.MODE_OBSERVE)
+        assert good is not None
+        raw = json.loads(store.index_path().read_text(encoding="utf-8"))
+        raw[good.incident_id]["a_field_from_the_future"] = {"nested": True}
+        store.index_path().write_text(json.dumps(raw), encoding="utf-8")
+        before = store.index_path().read_text(encoding="utf-8")
+
+        with self.assertRaises(models.UnknownFieldError):
+            store.claim(self._signal(native_id="alarm/new"), operating_mode=models.MODE_OBSERVE)
+
+        self.assertEqual(
+            store.index_path().read_text(encoding="utf-8"),
+            before,
+            "the newer instance's field was stripped",
+        )
+        # It IS still refused like corruption -- every caller that refuses one refuses both.
+        self.assertIsInstance(
+            models.UnknownFieldError("m", "d", 0),
+            models.CorruptDocumentError,
+        )
+
+    def test_a_malformed_nested_field_is_not_silently_replaced(self):
+        """The deepest shape door, and the one my own earlier note pointed at without my seeing it.
+
+        `Incident.from_dict` COERCES these three nested fields instead of raising: `signal`
+        to an empty `Signal`, `ledger_matches` to `[]`, `proposed_action` to `None`. So a row
+        whose `"signal"` is `[]` loads clean, and the next mutation writes the empty
+        substitute back -- permanently discarding the source, native id, title and labels
+        that were on disk, with no parse failure and nothing logged.
+
+        Found in review (GPT 5.6). Two rounds earlier I recorded that `from_dict` "essentially
+        never raises" and concluded its raising branch was near-dead code; the correct
+        conclusion was that its TOLERANCE is a data-loss door one level below the two I had
+        just closed.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        good = store.claim(self._signal(native_id="alarm/keep"), operating_mode=models.MODE_OBSERVE)
+        assert good is not None
+
+        for field, bad in (
+            ("signal", []),
+            ("ledger_matches", {"not": "a list"}),
+            ("proposed_action", "not an object"),
+        ):
+            with self.subTest(field=field):
+                raw = json.loads(store.index_path().read_text(encoding="utf-8"))
+                raw[good.incident_id][field] = bad
+                store.index_path().write_text(json.dumps(raw), encoding="utf-8")
+                before = store.index_path().read_text(encoding="utf-8")
+
+                with self.assertRaises(models.CorruptDocumentError):
+                    store.claim(
+                        self._signal(native_id="alarm/new"), operating_mode=models.MODE_OBSERVE
+                    )
+
+                self.assertEqual(
+                    store.index_path().read_text(encoding="utf-8"),
+                    before,
+                    f"a malformed {field} was replaced with an empty substitute",
+                )
+
+    def test_an_absent_nested_field_is_still_a_normal_record(self):
+        """Absent is not corrupt: these keys are missing on pre-feature records."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        good = store.claim(self._signal(native_id="alarm/keep"), operating_mode=models.MODE_OBSERVE)
+        assert good is not None
+        raw = json.loads(store.index_path().read_text(encoding="utf-8"))
+        for field in ("ledger_matches", "proposed_action"):
+            raw[good.incident_id].pop(field, None)
+        store.index_path().write_text(json.dumps(raw), encoding="utf-8")
+
+        second = store.claim(
+            self._signal(native_id="alarm/new"), operating_mode=models.MODE_OBSERVE
+        )
+        self.assertIsNotNone(second)
+        self.assertIn(good.incident_id, store.read_index())
+
+    def test_the_display_read_logs_every_structural_degradation(self):
+        """The PR claims the display reads log when they degrade; they did not, for shape.
+
+        A non-object root returned `{}` and a non-object row hit a bare `continue`, both
+        silent -- so the description's promise was wider than the code. Found in review
+        (GPT 5.6). The board must still render, which is why these log rather than raise.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import store
+
+        store.index_path().write_text("[]", encoding="utf-8")
+        with self.assertLogs("kiro_crew", level="WARNING") as caught:
+            self.assertEqual(store.read_index(), {})
+        self.assertTrue(any("root is not an object" in m for m in caught.output))
+
+        store.index_path().write_text('{"INV-1": "not an object"}', encoding="utf-8")
+        with self.assertLogs("kiro_crew", level="WARNING") as caught:
+            self.assertEqual(store.read_index(), {})
+        self.assertTrue(any("not an object" in m for m in caught.output))
+
+    def test_the_display_read_still_tolerates_a_skipped_entry(self):
+        """The asymmetry again: one unreadable row must not blank the whole board."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        good = store.claim(self._signal(native_id="alarm/keep"), operating_mode=models.MODE_OBSERVE)
+        assert good is not None
+        raw = json.loads(store.index_path().read_text(encoding="utf-8"))
+        raw["INV-BROKEN"] = "this row is not an object"
+        store.index_path().write_text(json.dumps(raw), encoding="utf-8")
+
+        self.assertEqual(sorted(store.read_index()), [good.incident_id])
+
+    def test_a_raising_read_still_releases_the_index_lock(self):
+        """ "Raise while holding `_IndexLock`" became reachable for the first time here.
+
+        `_read_index_unlocked` never raised -- it swallowed every failure -- so before
+        this change no mutation could leave the `with _IndexLock():` block by exception,
+        and nothing had to be exception-safe about the release. Now the strict read can
+        raise inside that block on every one of the six mutations.
+
+        If the release were not exception-safe the app would WEDGE rather than error:
+        every later mutation would block forever on a lock nobody holds, and `flock` is
+        per-descriptor so the same process deadlocks against itself. That is a worse
+        outcome than the data loss this PR fixes, and it is the one thing the change puts
+        at risk that no existing test could reach. Asserted behaviourally -- a second
+        mutation must complete -- so a regression shows up as a hang under CI's timeout
+        rather than as a passing test.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import models, store
+
+        inc = store.claim(self._signal(), operating_mode=models.MODE_OBSERVE)
+        assert inc is not None
+
+        with self._unreadable_index():
+            with self.assertRaises(OSError):
+                store.transition(inc.incident_id, models.STATUS_INVESTIGATING)
+
+        # The lock must be free again, on the very next attempt.
+        moved = store.transition(inc.incident_id, models.STATUS_INVESTIGATING)
+        self.assertEqual(moved.status, models.STATUS_INVESTIGATING)
+        # ...and the index must still hold exactly the one incident, not a second copy.
+        self.assertEqual(list(store.read_index()), [inc.incident_id])


### PR DESCRIPTION
Two reads in `ops_mission_control` collapse every failure to an empty document and then feed a
whole-file rewrite, so one transient read error makes the app believe a store is empty and publish
that emptiness back over it.

## 1. What is the problem?

`store._read_index_unlocked` and `providers.read_config` both `return {}` on any failure. As DISPLAY
reads that is correct -- the board must render on an index it could not load. But they are also the BASE
of a read-modify-write that rewrites the whole file, where empty means "delete every incident".

The index is not a view, it is the CLAIM ledger: `claim` is a compare-and-set against those rows.
Emptied, every signal reads as unowned, so the next heartbeat re-claims alarms already being worked and
opens a duplicate investigation of each.

An emptied config does not error, which is what makes it quiet: `provider_enabled` defaults to False,
so polling stops for every provider the operator switched on while their credentials stay in the
keystone store and Settings still shows each one as configured.

## 2. Why this issue matters to the user

The failure is silent, durable, and looks like good news: a clean board and no firing signals is the
same picture as a quiet night. Nothing errors, nothing is logged, and the in-flight incidents are gone
from disk. In `act` mode, duplicate investigations mean duplicate real writes to PagerDuty or Datadog.

## 3. How our fix solves it

Each module gains a private `*_for_update` reader used **only** as the base of a mutation, in which a
**missing** file still reads as empty (nothing has been written yet, so empty is the truth), and every
other way of failing to read it propagates so the mutation is abandoned:

- **unreadable** -- EACCES, EIO, a scanner holding the handle on Windows
- **unparseable** -- malformed JSON
- **anything the load would silently rewrite** -- checked structurally, not by enumerating shapes
That third rule is the one worth reviewing. Three review rounds each found the same loss one layer
deeper: the document root, then a row, then a nested field (`"signal": []` coercing to an empty
`Signal`). Every fix that enumerated a shape was beaten by a deeper example. So the index reader now
**deserializes, re-serializes, and refuses if anything on disk did not survive** -- comparing parsed
structures so key order cannot cause a false refusal. It made the reader SMALLER: the per-row and
per-field `isinstance` guards are deleted, because dropping a row or blanking a field is exactly what the
round trip detects.

The guarantee is "never publish over a read that failed", and a read that silently rewrote what it
could not understand is a read that failed.

Corruption propagating is a **deliberate divergence from four merged siblings** (`library.py:95`,
`shares.py:60`, `secrets.py:231`, `policy_store.py:147`), which read an unparseable document as empty.
Their rationale is real -- such a document carries nothing to merge into. The counter is stronger:
**"cannot merge into" is not "safe to destroy."** A truncated file still holds most of its records.
Tracked in #7805, `secrets.py` first, where the discarded bytes are provider credentials that exist
nowhere else. A fifth reader shares the SHAPE (`ledger_index._read_cursor`) and is exempt on the merits:
its write is a set UNION, so an empty read only adds ids and can never drop one.

The display reads stay lenient -- failing a render would turn a recoverable file into an unusable app
-- and now LOG every degradation other than an absent file, structural ones included.

**Caller policy differs by what has already happened.** `claim` raises on everything -- a
compare-and-set has no safe degraded answer. `dispatch.run_cycle`'s maintenance passes and
`slot_watch.reconcile` tolerate `OSError` (transient) but refuse corruption (persistent).
`routes._schedule_verification` and the post-claim ledger annotation REPORT instead: their irreversible
step has already happened, so raising would call a completed action failed and invite a retry that writes
twice. Both log and audit the degradation.

`json.JSONDecodeError` subclasses `ValueError`, so an existing `except ValueError` silently claims
corruption and reports it as a validation error. All ten such arms were audited: one was reachable and
wrong (`_handle_propose` answered `400 invalid_proposal` on a corrupt store), three already carried the
clause, six cannot reach a strict reader. One shared `_store_read_refusal` maps three conditions at five
sites: 503 `*_unreadable` (retry works), 500 `*_corrupt` (repair the file), and 409 `*_version_skew` -- a
file written by a NEWER build after a rollback, refused so the write cannot strip the newer field.

## 4. What tests we did

**Is this change workable? The mechanism, not a count.** Revert one line and a named test reddens:

| Revert | Test that reddens | What the redness means to the operator |
| --- | --- | --- |
| `_read_index_for_update`'s `except FileNotFoundError:` back to `return {}` | `test_a_read_that_failed_never_truncates_the_index` | Two claimed incidents vanish from disk; the board comes back clean while both investigations are still in flight. Fails on `"a failed read was published back over the index"`, a byte comparison against a snapshot. |
| `_coerce_index`'s round-trip equivalence refusal | `test_a_malformed_nested_field_is_not_silently_replaced` (3 subtests) and `test_a_skipped_entry_is_not_silently_deleted_by_the_next_mutation` | An incident whose `signal` is malformed comes back with the signal silently BLANKED and the original gone from disk -- source, native id, title, labels. Disabling the one rule reds all four, which is the evidence it covers the row and nested-field layers together rather than by enumeration. |
| `merge_provider_config`'s per-slot refusal | `test_a_providers_key_of_the_wrong_shape_refuses_the_merge` | Every provider slot is wiped because one key was a list instead of an object. |
| Move `_handle_propose`'s corruption arm AFTER its `ValueError` arm | `test_a_corrupt_index_is_not_reported_as_an_invalid_proposal` | A corrupt store is reported as bad INPUT (`400`), so the operator re-types the form while the real fault sits on disk. Fails with `400 == 400`. |
| Drop the audit entry in `_schedule_verification` | `test_a_corrupt_index_is_audited_rather_than_raising_after_the_action_ran` | An executed production action is left with no recheck scheduled and nothing anywhere says so. |

Each was run in that reverted state and observed red, then restored. Twenty-eight probes in total; two
of them caught a test passing for the wrong reason, both from asserting something weaker than the
claim being made.

**45 new tests.** App suite `986 passed, 44 skipped, 266 subtests` (from 921 on `main`). Run with
`-o addopts=""` to avoid the baked-in xdist parallelism. All seven repo gates green, including
`mypy src/kiro_crew/` (4 errors, all pre-existing).

## 5. Any other suggestions on the work

1. **Two commits, deliberately.** The black-baseline prune is separate because AGENTS.md says
   formatting a baselined file "belongs in its own commit". `MAX_COMMITS` is 2.
2. **Follow-ups filed, not promised in prose:** #7805 (the merged siblings, `secrets.py` first,
   plus the exception-type decision), #7789 (remaining sites), #7790 (handlers answering a bare
   untyped 500 for other reasons).

## Pattern harvest

A lenient read is safe as a DISPLAY read and unsafe as a MUTATION BASE, and the same function is often
both. The discriminator is not the read -- most lenient reads in `src/` are legitimate -- it is whether
a whole-file WRITE derives from it. The second lesson cost three review rounds: a guard that enumerates
bad SHAPES is defeated by a deeper example every time, so the check has to be about CONTENT survival.

Rule candidate: for any `read -> mutate -> write_all`, the read must tell "absent" from "unreadable",
and must refuse when deserializing would discard content the file already held.
