### PR TITLE
test(apps): pin Library reachability to shipped builtin manifests

### DIFF
--- a/website/src/test/libraryFilter.test.ts
+++ b/website/src/test/libraryFilter.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
 import { describe, it, expect } from 'vitest'
 
 import { keepInLibrary, libraryView } from '../pages/apps/useAppsData'
@@ -149,5 +152,77 @@ describe('libraryView holds a row in place across a toggle', () => {
     libraryView([named('alpha', true)], view)
     libraryView([], view)
     expect(view.size).toBe(0)
+  })
+})
+
+/**
+ * The same predicate, fed the manifests we actually SHIP rather than fixtures.
+ *
+ * The cases above pin `keepInLibrary` itself, so they fail if someone rewrites the
+ * predicate. They cannot fail for the other half of the same bug: a builtin that
+ * becomes unreachable because its OWN manifest changed. `hidden` is the only field
+ * that withholds a disabled builtin from Library, and Discover suppresses the same
+ * name by design, so adding it to a manifest is what puts an app in neither tab --
+ * the state AWS Control was reported to be in. Read from disk, in the same shape
+ * the gateway serves (a builtin registers `origin: 'builtin'`, and default-off means
+ * `enabled: false`), so either half of the invariant breaking fails a test.
+ */
+describe('every builtin we ship stays reachable while disabled', () => {
+  /** Concealment is a product decision; this list is the record of it. */
+  const SANCTIONED_HIDDEN = ['channels', 'workflows']
+
+  const BUILTINS = resolve(__dirname, '../../../src/kiro_crew/apps/builtins')
+
+  type Manifest = { name: string; hidden?: boolean }
+
+  const shipped: Manifest[] = readdirSync(BUILTINS, { withFileTypes: true })
+    .filter(e => e.isDirectory() && !e.name.startsWith('.') && !e.name.startsWith('_'))
+    .map(e => join(BUILTINS, e.name, 'app.json'))
+    .filter(existsSync)
+    .map(f => JSON.parse(readFileSync(f, 'utf8')) as Manifest)
+
+  /** A disabled builtin exactly as `GET /api/apps` reports one. */
+  const asDisabled = (manifest: Manifest) =>
+    ({ origin: 'builtin', enabled: false, manifest } as unknown as Parameters<typeof keepInLibrary>[0])
+
+  it('reads the real manifests', () => {
+    // Guards the walk itself: a bad path yields an empty list, and every
+    // assertion below would then pass over nothing.
+    expect(shipped.length).toBeGreaterThan(10)
+  })
+
+  it('lists every builtin that does not conceal itself, while disabled', () => {
+    for (const manifest of shipped.filter(m => !m.hidden)) {
+      expect(keepInLibrary(asDisabled(manifest)), `'${manifest.name}' is unreachable while disabled`)
+        .toBe(true)
+    }
+  })
+
+  it('lists aws-control, the app this invariant was written for', () => {
+    // Named rather than left to the sweep: it ships default-off with no published
+    // catalog row, which is the exact combination that had no surface at all.
+    const awsControl = shipped.find(m => m.name === 'aws-control')
+    expect(awsControl, 'aws-control no longer ships as a builtin').toBeDefined()
+    expect(awsControl!.hidden, 'aws-control must not conceal itself').toBeFalsy()
+    expect(keepInLibrary(asDisabled(awsControl!))).toBe(true)
+  })
+
+  it('holds the set of self-concealing builtins to the sanctioned two', () => {
+    // Not a style rule. A new name here is an app reachable from no tab, so it
+    // has to be chosen deliberately and land in this list with it.
+    expect(shipped.filter(m => m.hidden).map(m => m.name).sort()).toEqual(SANCTIONED_HIDDEN)
+  })
+
+  it('withholds those two while they are disabled, from their real manifests', () => {
+    // The contrast case, asserted over shipped bytes rather than a fixture: if
+    // `hidden` stopped being honoured, the assertions above would still pass
+    // (the flag is present either way) while concealment silently stopped
+    // working. This is the half that reads the OUTPUT for those manifests.
+    const concealing = shipped.filter(m => m.hidden)
+    expect(concealing.map(m => m.name).sort()).toEqual(SANCTIONED_HIDDEN)
+    for (const manifest of concealing) {
+      expect(keepInLibrary(asDisabled(manifest)), `'${manifest.name}' should stay concealed while disabled`)
+        .toBe(false)
+    }
   })
 })


### PR DESCRIPTION
## 1. What is the problem?

AWS Control was reported as unreachable: it ships `defaultEnabled: false`, and the
belief was that a disabled builtin is filtered out of the Library *and* absent from
Discover, leaving a fresh install with no surface that lists it.

That is no longer true. `e6155d1eb` already fixed it, and the investigation confirmed
the app is reachable today. What is missing is a guard: only half the invariant is
tested, so the bug can return through the untested half without anything failing.

`keepInLibrary` currently reads:

```ts
return app.enabled || app.origin !== 'builtin' || !app.manifest?.hidden
```

`libraryFilter.test.ts` pins that predicate, so a rewrite of it fails. It cannot fail
for the other half of the same bug: a builtin that becomes unreachable because its
**own manifest** gained `hidden: true`. `hidden` is the only field that withholds a
disabled builtin from Library, and Discover suppresses the same name by design, so
adding it to a manifest is exactly what puts an app in neither tab. The existing
cases are hand-built fixtures (`papyrus`, `channels`), so no shipped manifest is read
by any test.

## 2. Why this issue matters to the user

An app in neither tab cannot be turned on from the dashboard at all. The only
remaining routes are hand-editing `installed.json` or calling the enable API
directly. That is the state AWS Control was believed to be in, and it is a state a
one-word manifest edit can re-create silently for any builtin. Nothing in CI would
notice: the change is in a JSON file no test reads, and every predicate test would
stay green.

## 3. How our fix solves it

Chaining symptom to root cause: the symptom is "no surface lists the app"; the
mechanism is `keepInLibrary` returning `false`; the two inputs that produce that are
the predicate itself and the manifest's `hidden` flag. The predicate is covered; the
flag is not. So this reads the manifests we actually ship and asserts the invariant
over them, in the same shape the gateway serves (`origin: 'builtin'`,
`enabled: false`, the real manifest object):

- every builtin that does not conceal itself is listed while disabled;
- `aws-control` by name, because it is the app this was reported against and it is
  the exact combination that had no surface: default-off with no published catalog
  row;
- the self-concealing set is held to `channels` + `workflows`, so a third one has to
  be a deliberate edit to that list rather than a side effect.

**Why not flip `defaultEnabled` to `true`,** which was the other candidate fix.
Three independent reasons, each from the code:

1. It does not solve the reported problem. `register_builtin_apps()`'s already-exists
   branch never writes `enabled`, and `backfill_default_on_builtins()` iterates only
   `_DEFAULT_ON_BACKFILL` (`{"command-bar"}`), never the manifest. So the flip reaches
   new installs only and leaves every existing install exactly as it was.
2. It fails the project's own admission test. `_DEFAULT_ON_BACKFILL`'s comment admits
   a name only when "existing installs were never in a position to choose... it
   appears on no store or launcher surface they could have found it on". AWS Control
   appears on the Library, so it does not qualify.
3. It would enable an app that touches AWS credentials for everyone who upgrades.
   21 of 23 builtins ship default-off, and every builtin carrying a `backend` block is
   off; the two exceptions replace or are a host surface. Default-off is the house
   rule here, not an oversight.

No production code changes. This PR is the test only.

## 4. What tests we did

- `npx vitest run src/test/libraryFilter.test.ts` gives **17 passed** (12 pre-existing,
  5 new).
- **Mutation-tested the new guard**, because a ratchet that cannot fail is worthless.
  Adding `"hidden": true` to `aws_control/app.json` turns it red:
  ```
  AssertionError: aws-control must not conceal itself: expected true to be falsy
  AssertionError: expected [ 'aws-control', 'channels', ...(1) ] to deeply equal [ 'channels', 'workflows' ]
  Tests  2 failed | 14 passed (16)
  ```
  All 12 pre-existing tests stayed green under that mutation, which is the direct
  evidence that they cannot catch this class and the new ones can. Manifest restored.
- `npx tsc --noEmit` and `npx eslint src/test/libraryFilter.test.ts` are both clean.
- Verified the premise empirically in an isolated pod rather than by reading code
  alone. A fresh install's own record (`apps/aws-control/installed.json` in the pod's
  isolated home) reports `enabled: false`, `origin: "builtin"`,
  `defaultOnBackfilled: false`, and the manifest declares no `hidden`, which is the
  exact input triple under which `keepInLibrary` returns `true`.
- Re-verified every finding after rebasing onto `origin/main`, which had moved 110
  commits: the predicate, `aws-control`'s manifest, and the hidden set are all
  unchanged, and the test passes on that base.

Not verified: a screenshot of the rendered Library, and it cannot be produced from an
agent shell at all. A pod's dashboard is unreachable from there because the pod
verifies which process owns its port before serving, and that check can never resolve
from an agent shell: the shell runs in an isolated PID namespace while the pod runs on
the host, so `netstat` reports the listener with PID `-` and `lsof` returns nothing.
The clean proof is the pod's OWN port rather than a collision: with a deliberately
pinned free port the pod reported healthy (HTTP 200) and the owner was still
unresolvable. Issuing that dashboard credential is separately fenced from the agent.
Both are correct posture, not obstacles to route around. For this particular claim the
unit test is stronger evidence anyway: it is deterministic and cannot be confounded by
a stale bundle or a port.

## 5. Any other suggestions on the work

- **No catalog row should be published for `aws-control`.** Builtins deliberately get
  no installable Discover row, because `_coordinates` returns `None` for any source
  that is not `git`: a row for code the client already has would render an install
  control that cannot work. Library is the sanctioned surface for an installed
  builtin, and it now works. Publishing a row would add a second, weaker answer to a
  question already answered.
- The invariant this pins spans two languages: the predicate is TypeScript, the
  manifests are shipped by Python. This test deliberately reads across that boundary,
  following the precedent already set by `appManifest.test.ts`. If that direction is
  unwanted, the equivalent home is a Python ratchet beside the existing
  `defaultEnabled` one in `test_builtin_app_optional_enable.py`. Say which you prefer
  and I will move it.
- `_DEFAULT_ON_BACKFILL`'s comment is the clearest statement of the default-on policy
  in the codebase and it is what settled this decision. Worth being aware of before
  any future request to flip a builtin's default.

