### PR TITLE
test: make acp spawn pass_fds assertion platform-aware for darwin (#7792)

### DIFF
--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -8857,7 +8857,92 @@ class TestResolveKiroBinEnvOverride:
         )
         # No inherited snapshot descriptor: the installed binary is exec'd in
         # place, so there is nothing to hand down to the wrapper chain.
-        assert "pass_fds" not in spawn_call.kwargs
+        #
+        # macOS is the exception, and for a different fd:
+        # bind_voice_safe_agent_workspace opens the agent workspace as a
+        # directory descriptor there so the child enters it by fchdir instead of
+        # re-resolving a pathname a same-UID symlink retarget could aim
+        # elsewhere. _spawn hands that descriptor to create_subprocess_limited
+        # as chdir_fd, which folds exactly that one fd into pass_fds so the
+        # spawn shim inherits it. Off darwin the binding returns None, so
+        # chdir_fd is None and pass_fds stays absent. The binding is also gated
+        # on the harness owning an internal sandbox (ACP_BACKENDS_INTERNAL_SANDBOX,
+        # which the default Kiro backend built here belongs to), so a backend
+        # outside that set stays on the pathname cwd whatever the platform says.
+        if sys.platform == "darwin":
+            pass_fds = spawn_call.kwargs["pass_fds"]
+            # Exactly the bound workspace descriptor, nothing else: no snapshot
+            # fd is inherited here, so the only descriptor handed down is the
+            # one the fchdir binding produced. Which int it is, is pinned on
+            # every OS by the forced-darwin companion below.
+            assert isinstance(pass_fds, tuple)
+            assert len(pass_fds) == 1
+            assert isinstance(pass_fds[0], int) and pass_fds[0] >= 0
+        else:
+            assert "pass_fds" not in spawn_call.kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "the binding opens the workspace as a directory descriptor, which "
+            "needs O_DIRECTORY; Windows has no such flag and os.open on a "
+            "directory raises, so a forced-darwin binding refuses with "
+            "'cannot-verify' before any spawn is attempted"
+        ),
+    )
+    async def test_spawn_passes_exactly_the_bound_workspace_fd_on_darwin(
+        self, tmp_path, monkeypatch
+    ):
+        # The darwin half of the assertion above runs on no CI shard, because no
+        # macOS job collects this module. The binding gate is a runtime
+        # sys.platform read rather than an import-time constant, so forcing the
+        # platform runs the REAL binding on any POSIX host and pins the whole
+        # composition: _spawn -> bind_voice_safe_agent_workspace_async ->
+        # create_subprocess_limited(chdir_fd=...) -> a pass_fds holding exactly
+        # that descriptor. Spy-and-delegate rather than stub, so the fd compared
+        # against pass_fds is the one the real binding opened.
+        from kiro_crew.acp import client as client_module
+
+        fake = tmp_path / "kiro-cli"
+        fake.write_bytes(b"#!/bin/sh\n")
+        fake.chmod(0o755)
+        launch_path = str(fake)
+        mock_exec = AsyncMock(side_effect=RuntimeError("spawn failed"))
+        bound_fds: list[int | None] = []
+        real_bind = client_module.bind_voice_safe_agent_workspace_async
+
+        async def spy_bind(workspace):
+            spawn_dir, descriptor = await real_bind(workspace)
+            bound_fds.append(descriptor)
+            return spawn_dir, descriptor
+
+        with (
+            patch.object(client_module, "_resolve_kiro_bin", return_value=launch_path),
+            patch.object(
+                client_module,
+                "wrap_argv",
+                side_effect=lambda argv, mode, **kwargs: (list(argv), None),
+            ),
+            patch.object(client_module, "assert_voice_runtime_outside_agent_workspace"),
+            patch.object(client_module, "cgroup_scope_argv", side_effect=lambda argv: list(argv)),
+            patch.object(
+                client_module, "bind_voice_safe_agent_workspace_async", side_effect=spy_bind
+            ),
+            patch("asyncio.create_subprocess_exec", mock_exec),
+        ):
+            client = AcpClient(work_dir=tmp_path / "workspace")
+            monkeypatch.setattr(sys, "platform", "darwin")
+
+            with pytest.raises(RuntimeError, match="spawn failed"):
+                await client._spawn()
+
+        assert len(bound_fds) == 1
+        bound_fd = bound_fds[0]
+        assert isinstance(bound_fd, int)
+        # The spy reads the descriptor before _spawn's failure handler closes it,
+        # so the value survives even though the fd itself does not.
+        assert mock_exec.await_args.kwargs["pass_fds"] == (bound_fd,)
 
     def test_env_override_ignored_when_missing_file(self, tmp_path):
         # A configured-but-nonexistent path must not be returned; resolution


### PR DESCRIPTION
Fixes #7792.

## What
`test/test_acp_client.py::TestResolveKiroBinEnvOverride::test_spawn_passes_installed_path_through_exact_wrappers` failed deterministically on macOS while staying green in the Linux/Windows-only CI shards.

Since #6971 ("fix(macos): enter the bound agent workspace by fchdir, not /dev/fd"), `AcpClient._spawn` binds the agent workspace to a directory descriptor on darwin and passes it as `chdir_fd` (src/kiro_crew/acp/client.py). `create_subprocess_limited` then folds that descriptor into `pass_fds` via `_pass_fds_including` (src/kiro_crew/sandbox.py). The old assertion `assert "pass_fds" not in spawn_call.kwargs` predated that binding, so it failed on macOS.

## Change (test-only, no product code change)
1. The final assertion is platform-aware:
   - On `darwin`: `spawn_call.kwargs["pass_fds"]` is a length-1 tuple holding one non-negative descriptor - exactly the bound workspace fd, with no inherited snapshot fd.
   - Elsewhere: unchanged, `"pass_fds" not in spawn_call.kwargs` (nothing binds off darwin, so `chdir_fd` is `None`).
2. A companion test, `test_spawn_passes_exactly_the_bound_workspace_fd_on_darwin`, so the darwin branch is not shipped unexecuted. No macOS CI job collects this module (`Gateway Tests (macOS)` collects the gateway / socketsec / platform-compat set, not `test_acp_client.py`), and the two tests that come closest each pin only one half in isolation: `test_spawn_exec_shim.py::test_chdir_fd_rides_the_shim_and_is_inherited_by_it` pins the `chdir_fd` -> `pass_fds` fold with synthetic fds, and `test_sandbox_argv.py` pins the binding with `os.open` / `os.fstat` / ancestor lookups all faked. Neither runs the composition. The binding gate is a runtime `sys.platform` read rather than an import-time constant, so the companion forces the platform and runs the REAL binding on any POSIX host: it SPIES on `bind_voice_safe_agent_workspace_async` (delegating to it, recording the descriptor it returns) and asserts `pass_fds == (that_fd,)`. That upgrades "some non-negative int" to "exactly the descriptor the binding opened", and the spy reads the value before `_spawn`'s failure handler closes the fd. It is skipped only on Windows, where a directory `os.open` needs `O_DIRECTORY` and the forced binding would refuse with `cannot-verify` before reaching the spawn.

`monkeypatch.setattr(sys, "platform", "darwin")` is the existing idiom in this file (six sites) and in `test/test_sandbox_argv.py`. `platform_compat.IS_MACOS` deliberately is NOT used: it is frozen at import, so it would not respond to the monkeypatch.

## Not a documented-behaviour change
No spec is touched, because nothing documented changes. `docs/system-specs/modules/acp-client.md` records that the resolve-to-exec snapshot is gone "with the descriptor registry, `pass_fds` inheritance, ..." - that clause is scoped to the withdrawn snapshot mechanism, and the fchdir workspace binding is a different descriptor with a different purpose. The changed test's own comment draws that distinction inline.

## Testing (Linux host)
- Two-sided proof of the darwin branch, forced with `monkeypatch`: against the PRE-fix assertion it fails with `assert 'pass_fds' not in {... 'pass_fds': (15,) ...}` - a length-1 tuple of a non-negative int, exactly what the new branch asserts; with the fix it passes. (The earlier claim in this body that the darwin branch could only be validated by derivation was wrong: the platform gate is a runtime read, so the real binding runs under monkeypatch on Linux.)
- The companion test fails as designed when the forced platform is changed back to `linux` (`isinstance(None, int)` is False, i.e. no descriptor is bound), so it exercises the darwin path rather than passing vacuously.
- `test/test_acp_client.py` whole file: 555 passed (`-n 2 --dist loadgroup`).
- `test/test_security_posture.py`: 53 passed (the shard-3 redactor census ratchet).
- flake8 clean, isort clean, `scripts/check_black_formatting.py` clean, brand and harness-parity gates clean, docs-lint clean. (This repo gates with flake8 / isort / mypy, not ruff; mypy covers `src/` only and no product code changed.)
