### PR TITLE
fix(security): model publish option arity so the floor tag holds

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -893,15 +893,83 @@ working) whose separated values are consumed, and a no-value table
 (`_PUSH_NO_VALUE_OPTS` plus the structural `--no-*` rule and the short-option
 bundles) vouching that a neighbour token is positional. Anything else — a future
 git option, an unmodelled arity such as `--recurse-submodules`'s — hits the
-**fail-protective fallback**: the positional split is not trusted, the bare tag is
-emitted (the current branch may be protected; suppressed only when an all-branches
-flag already covers a superset), and EVERY positional is scanned as a refspec
+**fail-protective fallback**: the positional split is not trusted, BOTH
+no-refspec rows are emitted — the bare tag, plus the single-arg tag whenever
+positionals are visible, since an untrusted split cannot distinguish option
+values from a remote and disabling whichever single row the fallback happened
+to pick was demonstrated as a bypass three times in review (suppressed only
+when an all-branches flag already covers a superset) — and EVERY positional is
+scanned as a refspec
 candidate so an actual protected name still reports its precise catalog row. A
 token with an attached `=` value never disturbs the split, whatever the option, so
 it is skipped as before; a bare `--` ends option parsing exactly as git reads it.
 The invariant this buys: an unrecognised option can change the answer only toward
 MORE protection, so the erasure class cannot silently reopen when git grows a new
-value-taking option. (Note the earlier retraction of a 35-entry option table on
+value-taking option. The same fallback covers word FRAGMENTS: the scan tokenizes
+on whitespace while the shell fuses a quoted or escape-continued span into one
+word, so a value like `--push-option='ci skip'` arrives as fragments whose tail
+would read as a refspec. `_push_token_shell_read` (one shared walk serving both
+the fragment and operator-piece signals) walks the shell's own
+quote/escape state over each raw token — backslash escapes outside quotes, inside
+double quotes, and inside `$'...'` ANSI-C strings, but is literal inside plain
+single quotes — and any token whose state does not return to normal (an open
+quote, or a trailing escape that consumed the separator) poisons the positional
+split the same protective way. An ESCAPED quote is data, not a delimiter: a
+character-count/parity test was bypassed by `\"` in review, which is why the walk
+tracks state rather than counting. Complete words keep their precise reading in
+both directions — `"feat\"x"` is not flagged, and the quote-splice `'ma'\''in'`
+still reads as exactly the protected-branch row. The `$`-lookback for ANSI-C can
+misread `$$'` (PID expansion) as ANSI-C, which only ever OVER-flags, never the
+reverse. Word-PRODUCING syntax is handled before the split assigns slots at all:
+a `$` anywhere in any token — or a token-LEADING `~`, which is env-driven text
+rather than path syntax (bare `~` IS `$HOME`, and `HOME=refs/heads` turns
+`~/main` into a protected refspec; a mid-word `~` stays literal data) — lands
+the segment on the ungated branch (parameter
+expansion word-splits AFTER this scan — `V='ci.skip main'; git push --repo=origin
+--push-option $V` hands git a `main` refspec the split never saw — and this slot
+must not be weaker than the refspec slot's existing `$` posture), while glob
+characters (`*` `?` `[`) and extglob patterns (`@(` `+(` `!(`) in any token keep
+the wildcard-refspec identity, since
+pathname expansion can produce words and none of those characters is legal in a
+refname. Shell OPERATORS are consumed by the shell, never by git, so they are
+handled before any argv-level reading (and before `--`, which is git's
+end-of-options, not the shell's): a `#`-opened comment truncates the segment's
+remaining tokens; a redirection token is excluded with the shell's own arity (an
+attached target — `2>err`, `2>&1` — is self-contained, a bare operator consumes
+the next word), which keeps `git push origin feature-x 2>&1` allowed while
+`git push origin </dev/null` reads as the precise remote-only shape instead of
+scanning a phantom refspec; a bare `&` (a single ampersand is not a segment
+separator upstream, only `&&` is) or operator glue mid-word marks the split
+untrusted AND scans the operator-delimited pieces, so a protected name cannot
+hide behind glue — except that a word glued to a WELL-FORMED redirection
+(`origin>/dev/null`, `main>log`) decomposes precisely instead: the pre-operator
+word stays positional and the redirection is consumed, because bash reads it
+exactly that way and the fallback's bare tag was the WRONG catalog identity for
+a remote-only push (an identity miss is itself a hazard under per-rule
+opt-out). Redirection arity also recognises bash NAMED descriptors
+(`{name}>...` is all redirection — read as a word, the `{name}` became a
+phantom refspec erasing every tag) and quoted TARGETS (`>'log'` — the operator
+grammar admits no quotes, so a quote can only sit in the target group;
+refusing the whole token for it had mislabelled the shape), while fragment
+tokens (open quote state) still poison the split protectively. Quoted operator characters are data and none of this fires. A segment
+whose CUMULATIVE quote/escape state is still open at its end continues into the
+next line — bash line continuation (`\<newline>` vanishes) and quoted newlines
+splice words across the newline segment boundary, so `origin ma\` + newline +
+`in` pushes `main` while no scanned token spells it — and lands on the ungated
+sentinel (the `ma$in` posture); a mid-segment open whose quote closes before
+segment end stays on the disableable fallback, because in-segment joining can
+only fuse whitespace into a word (never a valid refname) and the pieces stay
+visible to the superset scan. The invariant
+has two different strengths, stated honestly: the OPTION-ARITY axis fails
+protective by construction (an unrecognised option lands in the fallback), while
+the SHELL-SYNTAX axis rests on the metacharacter inventory being complete — a
+construct the scan does not know parses as an ordinary word — so that inventory
+is pinned as a checked property
+(`test_every_bash_metacharacter_is_accounted_for` maps every bash metacharacter
+to the layer that accounts for it: upstream separators, upstream
+substitution/expansion ungating, the `$`/glob pre-checks, redirection/comment
+consumption, the fragment walk, or a documented benign rationale). (Note the
+earlier retraction of a 35-entry option table on
 the dangerous-PREFIX axis is not precedent against these tables: prefix matching
 is a set intersection where extra names are inert, while arity decides which
 tokens are refspecs at all, so a table here does change outcomes.)

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -880,6 +880,32 @@ is free, since git refuses an ambiguous abbreviation itself and the command neve
 runs; a fully-spelled unrelated flag such as `--atomic` is unaffected, being a
 prefix of nothing dangerous.
 
+**Option arity is modelled, and a mis-parse can only over-protect.** Only `--repo`
+had its separated value consumed, so every other value-taking push option
+(`-o`/`--push-option`, `--receive-pack`, `--exec`) leaked its value into the
+positional list, where it was read as a remote or refspec. The consequence was not
+a misclassification but an ERASURE: for `--repo=origin --push-option ci.skip` the
+leaked `ci.skip` became the sole "refspec", it normalizes to a non-protected name,
+and the tag set came back empty — which is an ALLOW, since the tag set drives the
+protected-branch decision. The scan now carries an explicit arity table
+(`_PUSH_VALUE_OPTS`, resolved through `_push_option_matches` so abbreviations keep
+working) whose separated values are consumed, and a no-value table
+(`_PUSH_NO_VALUE_OPTS` plus the structural `--no-*` rule and the short-option
+bundles) vouching that a neighbour token is positional. Anything else — a future
+git option, an unmodelled arity such as `--recurse-submodules`'s — hits the
+**fail-protective fallback**: the positional split is not trusted, the bare tag is
+emitted (the current branch may be protected; suppressed only when an all-branches
+flag already covers a superset), and EVERY positional is scanned as a refspec
+candidate so an actual protected name still reports its precise catalog row. A
+token with an attached `=` value never disturbs the split, whatever the option, so
+it is skipped as before; a bare `--` ends option parsing exactly as git reads it.
+The invariant this buys: an unrecognised option can change the answer only toward
+MORE protection, so the erasure class cannot silently reopen when git grows a new
+value-taking option. (Note the earlier retraction of a 35-entry option table on
+the dangerous-PREFIX axis is not precedent against these tables: prefix matching
+is a set intersection where extra names are inert, while arity decides which
+tokens are refspecs at all, so a table here does change outcomes.)
+
 **Opt-out state — keystone `denied_commands.json`.** The opt-out state is a
 security ceiling, so it lives in its OWN keystone file
 `~/.kiro/crew/denied_commands.json` (respecting `KIROCREW_HOME`) — NOT in the

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5437,8 +5437,10 @@ _PUSH_REPO_OPTS = frozenset({"repo"})
 #: REMOTE also shifts the positional split), resolved through
 #: ``_push_option_matches`` so abbreviations keep working (finding 2).
 #: Attached forms (``--push-option=x``) bind the value inside the token and
-#: never disturb the split, so they need no entry here.
-_PUSH_VALUE_OPTS = frozenset({"push-option", "receive-pack", "exec"}) | _PUSH_REPO_OPTS
+#: never disturb the split, so they need no entry here. (``repo`` itself is
+#: deliberately NOT unioned in: the dedicated ``_PUSH_REPO_OPTS`` branch runs
+#: first and would make the member unreachable — First Principles review.)
+_PUSH_VALUE_OPTS = frozenset({"push-option", "receive-pack", "exec"})
 
 #: Long push options that never consume the NEXT token: booleans, plus the
 #: optional-value options (``--signed``, ``--force-with-lease``) whose value
@@ -5480,6 +5482,134 @@ _PUSH_VALUE_SHORTS = frozenset({"o"})
 _PUSH_NO_VALUE_SHORTS = frozenset({"f", "n", "q", "v", "u", "d", "4", "6"})
 
 
+def _push_token_shell_read(token: str) -> "tuple[list[str] | None, bool]":
+    """One quote/escape-state walk over a RAW (pre-dequote) token, returning
+    ``(operator_pieces, open_state)``.
+
+    ``operator_pieces`` — the token split at unquoted ``<`` ``>`` ``&``, or
+    None when it carries none (the common case). A mid-word operator means
+    the shell hands git a DIFFERENT word than this scan sees: ``main>log`` is
+    the argument ``main`` plus the redirection ``>log``, i.e. it pushes main.
+    The caller scans each piece as a refspec candidate so a protected name
+    cannot hide behind operator glue; quoted operators are data and produce
+    no split.
+
+    ``open_state`` — True when the shell's quote/escape state has not
+    RETURNED TO NORMAL by the token's end: an open quote or a trailing escape
+    means the whitespace that split this token was itself quoted or escaped —
+    the token is a FRAGMENT of a word fused across the split, the shape that
+    let ``--push-option='ci skip'`` erase the floor tag. The walk uses the
+    shell's own rules: a backslash escapes the next character outside quotes,
+    inside double quotes, and inside ``$'...'`` ANSI-C strings, but is
+    LITERAL inside plain single quotes; an ESCAPED quote is data, not a
+    delimiter. (Counting quote characters — an earlier shape here — was
+    bypassed by ``\\"``: the escaped quote flipped the parity even though it
+    closes nothing. Found by the GPT 5.6 review lane on #7808.) A complete
+    word with escaped quotes therefore keeps its precise reading, both
+    directions. The ``$``-lookback for ANSI-C can misread ``$$'`` (PID
+    expansion) as ANSI-C, but that direction only ever OVER-flags — a
+    plain-single reading closes at every quote the ANSI reading skips, so the
+    walk can end "still open" where bash split normally, never the reverse.
+
+    ONE walk serves both signals (a review subtraction: the identical state
+    machine briefly shipped twice); both consequences are protective-only —
+    a hit poisons the positional split, never widens an allow.
+    """
+    pieces: list[str] = []
+    buf: list[str] = []
+    found = False
+    trailing_escape = False
+    state = 0  # 0 = normal, 1 = single-quoted, 2 = double-quoted
+    ansi = False  # the open single quote was $'...' (ANSI-C): backslash escapes
+    i = 0
+    n = len(token)
+    while i < n:
+        ch = token[i]
+        if state == 0:
+            if ch == "\\":
+                if i + 1 >= n:
+                    trailing_escape = True  # the escaped char was the separator
+                    break
+                buf.append(token[i : i + 2])
+                i += 2
+                continue
+            if ch in "<>&()":
+                found = True
+                if buf:
+                    pieces.append("".join(buf))
+                    buf = []
+                i += 1
+                continue
+            if ch == "'":
+                state = 1
+                ansi = i > 0 and token[i - 1] == "$"
+            elif ch == '"':
+                state = 2
+        elif state == 1:
+            if ansi and ch == "\\":
+                if i + 1 >= n:
+                    trailing_escape = True  # escapes the separator inside $'...'
+                    break
+                buf.append(token[i : i + 2])
+                i += 2
+                continue
+            if ch == "'":
+                state = 0
+        else:  # state == 2, inside double quotes
+            if ch == "\\":
+                if i + 1 >= n:
+                    trailing_escape = True  # escaped separator / continuation
+                    break
+                buf.append(token[i : i + 2])
+                i += 2
+                continue
+            if ch == '"':
+                state = 0
+        buf.append(ch)
+        i += 1
+    if buf:
+        pieces.append("".join(buf))
+    return (pieces if found else None, state != 0 or trailing_escape)
+
+
+#: A token that BEGINS with a redirection: optional fd number, ``&``, or bash
+#: NAMED descriptor ``{name}`` prefix, then ``<`` or ``>`` (doubled, or ``>|``
+#: clobber, or ``>&``/``<&`` fd-dup). ``{name}>...`` is ALL redirection — read
+#: as a word, the ``{name}`` became a phantom refspec and erased every tag
+#: (GPT 5.6 round 11 on #7808). ``<<-`` (the tab-stripping heredoc) folds its
+#: ``-`` INTO the operator — left in the remainder it faked a self-contained
+#: token and the separated delimiter word became a phantom refspec (round 7)
+#: — while a ``-`` after an fd-dup (``>&-`` close, ``2>&1-`` move) is a
+#: disposition the remainder correctly keeps. group(3) is whatever follows
+#: the operator run — an ATTACHED target/fd makes the token self-contained;
+#: an empty remainder means the shell takes the NEXT word as the
+#: target/delimiter.
+_PUSH_REDIRECTION_RE = re.compile(r"^([0-9]*|&|\{[A-Za-z_][A-Za-z0-9_]*\})(<<-|[<>][<>&|]*)(.*)$")
+
+
+def _push_token_redirection(token: str) -> "tuple[bool, bool]":
+    """(is_redirection, consumes_next_word) for a RAW token.
+
+    Quotes and escapes are refused only where they could FOOL the grammar —
+    the prefix/operator span. The redirection operator grammar itself admits
+    no quote characters, so a quote can only ever sit in the TARGET group:
+    ``>'log'`` is a plain redirection with a quoted target, and refusing the
+    whole token for it pushed the shape into the fallback with the WRONG
+    catalog identity (GPT 5.6 round 11 on #7808). A token that is a fragment
+    (open quote state / trailing escape) is still refused — the caller's walk
+    poisons the split for those. The shell consumes a redirection before the
+    program runs, so such a token is never an argv word — treating it as a
+    positional is how ``git push origin </dev/null`` erased the single-arg
+    tag (round 4, verified real and pre-existing on main).
+    """
+    m = _PUSH_REDIRECTION_RE.match(token)
+    if m is None:
+        return (False, False)
+    if _push_token_shell_read(token)[1]:
+        return (False, False)  # fragment: the walk handles it protectively
+    return (True, m.group(3) == "")
+
+
 def _push_option_matches(token: str, names: "frozenset[str]") -> bool:
     """True when ``token`` is ``--`` plus a PREFIX of any option in ``names``.
 
@@ -5513,9 +5643,12 @@ def _push_option_matches(token: str, names: "frozenset[str]") -> bool:
 # If the agent is on main and pushes HEAD, it pushes to main on the remote.
 _AMBIGUOUS_REFS = {"head", "@", "fetch_head"}
 
-# Refspecs containing shell expansion or git-revision syntax cannot be
-# statically verified — deny them as ambiguous.
-_AMBIGUOUS_REFSPEC_RE = re.compile(r"[$`]|@\{")
+# Refspec spellings that resolve only at runtime: ``@{upstream}`` / ``@{u}``
+# git-revision syntax. (The ``$``/backtick branches this once carried are now
+# subsumed upstream — the per-token ``$`` check and the segment-level
+# expansion ungate both run before any refspec reaches this — so they were
+# removed as shadowed duplicates per First Principles review on #7808.)
+_AMBIGUOUS_REFSPEC_RE = re.compile(r"@\{")
 
 # TRUE shell command separators (NOT command-substitution boundaries). Used to
 # scan the PRE-SPLIT text for substitution glued into a push target — see
@@ -5527,10 +5660,20 @@ _CMD_SEPARATOR_RE = re.compile(r"&&|\|\||[;|\n]")
 # -> deny (fail closed):
 #   - command substitution   $(...)   and backticks  `...`
 #   - parameter expansion     ${...}
+#   - PROCESS substitution   <(...) / >(...)  -- the shell substitutes a
+#     /dev/fd path WORD, so the construct is a positional the split cannot
+#     model; mis-reading it as a removable redirection shifted a value
+#     option's consumption onto the remote and downgraded a protected push to
+#     the disableable single-arg row (GPT 5.6 round 8 on #7808). The operator
+#     adjacency ``<(``/``>(`` is required, so a parenthesis inside a quoted
+#     refname stays data -- but the match is deliberately CONSERVATIVE about
+#     quoting: a QUOTED ``<(`` spelling (a ref literally named ``feat<(x)``)
+#     also matches and over-denies, the same fail-closed posture this regex
+#     already takes for a quoted ``$(``.
 #   - BRACE expansion         {a,b} / {1..5}  -- bash expands ``ma{i,i}n`` to
 #     ``main`` and ``{main,x}`` to ``main x`` BEFORE git sees the token, so a
 #     brace group containing a comma or ``..`` must be treated as ambiguous.
-_AMBIGUOUS_EXPANSION_RE = re.compile(r"\$\(|\$\{|`|\{[^{}]*(?:,|\.\.)[^{}]*\}")
+_AMBIGUOUS_EXPANSION_RE = re.compile(r"\$\(|\$\{|`|[<>]\(|\{[^{}]*(?:,|\.\.)[^{}]*\}")
 
 
 def _dequote_token(token: str) -> str:
@@ -5632,17 +5775,175 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
     # split that may contain a leaked option value is how the floor tag was
     # erased. A bare ``--`` ends option parsing, exactly as git reads it.
     repo_in_flag = False
-    unrecognised_option = False
     positional_only = False
     non_flags: list[str] = []
     skip_next = False
-    for tok in tokens:
+    # One shared quote/escape walk per raw token yields both shell signals:
+    # operator PIECES (unquoted < > & split the word) and OPEN STATE (an
+    # unterminated quote or trailing escape means the shell fused a
+    # whitespace-spanning word this whitespace tokenizer split apart). Either
+    # signal means no per-token reading of the split can be trusted.
+    shell_reads = [_push_token_shell_read(t) for t in arg_tokens]
+    # ``#`` at the start of a WORD comments out the REST of the segment, so
+    # the shell never passes those tokens to git: truncate before any other
+    # reading, or ``git push origin #main`` scans a phantom refspec while the
+    # shell runs a remote-only push. A ``#`` is word-initial only when the
+    # whitespace before it was a REAL separator: if ANY earlier token leaves
+    # the shell state open (trailing escape / unterminated quote fuses across
+    # the split), the ``#`` may be mid-word — truncating there discarded a
+    # real trailing refspec (GPT 5.6 round 5 on #7808, verified: an
+    # escaped-space option value fused into ``#x`` dropped ``main`` from the
+    # scan, leaving only the disableable bare tag). With an open token seen,
+    # truncation is skipped entirely: the open state already poisons the
+    # split protectively and the superset scan keeps every later positional
+    # visible.
+    _open_seen = False
+    for _idx, _raw in enumerate(arg_tokens):
+        if _raw.startswith("#") and not _open_seen:
+            arg_tokens = arg_tokens[:_idx]
+            tokens = tokens[:_idx]
+            shell_reads = shell_reads[:_idx]
+            break
+        _open_seen = _open_seen or shell_reads[_idx][1]
+    unrecognised_option = any(open_state for _pieces, open_state in shell_reads)
+    # A segment whose CUMULATIVE quote/escape state is still open at its end
+    # continues into the NEXT line: bash line continuation (backslash-newline
+    # vanishes entirely) and quoted newlines splice words ACROSS the segment
+    # split, so the real refspec may be assembled from pieces this segment
+    # cannot see — ``origin ma\`` + newline + ``in`` pushes MAIN while no
+    # token here spells it (GPT 5.6 round 6 on #7808, verified real). An
+    # unreconstructable name gets the same posture as ``ma$in``: the ungated
+    # sentinel, which no catalog row can switch off. Deliberately NARROWER
+    # than ungating on any per-token open state: a MID-segment open (a quoted
+    # value containing a space, whose quote closes before segment end) stays
+    # on the DISABLEABLE fallback, because joining within one segment can
+    # only fuse whitespace into the word — never a valid refname — and every
+    # piece stays visible to the superset scan below. The cumulative state is
+    # the per-token walk run over the joined segment (whitespace is inert to
+    # the state machine).
+    if arg_tokens and _push_token_shell_read(" ".join(arg_tokens))[1]:
+        tags.add(_GIT_PUBLISH_UNGATED)
+    pending_redirection_target = False
+    for raw, tok, (operator_pieces, _open) in zip(arg_tokens, tokens, shell_reads):
+        if tok:
+            # Word-producing shell syntax makes ANY token unverifiable, no
+            # matter which slot the split assigns it (GPT 5.6 round 3 on
+            # #7808, verified real): ``V='ci.skip main'; git push
+            # --repo=origin --push-option $V`` expands and word-splits AFTER
+            # this scan, handing git a ``main`` refspec the split never saw —
+            # and consuming the literal ``$V`` had REGRESSED that case from
+            # the ungated posture (the leaked value used to hit the refspec
+            # ambiguity check) to the disableable bare rule. A ``$`` anywhere
+            # therefore lands on the ungated branch, the same posture as
+            # ``ma$in``; ``$(``/``${``/backticks never reach here because the
+            # caller's expansion regex already ungated the whole segment.
+            # Glob characters (``* ? [``) are pathname expansion — a file
+            # named ``main`` makes ``ma[i]n`` push main — and none of them is
+            # legal in a refname, so they keep the wildcard-refspec identity
+            # the leaked-value scan used to give them, at zero cost to real
+            # commands.
+            if "$" in tok or tok.startswith("~"):
+                # Tilde expansion is env-driven text, not path syntax: bare
+                # ``~`` IS ``$HOME`` (``HOME=main`` publishes main), ``~±``
+                # and ``~N`` read PWD/OLDPWD/DIRSTACK, and even ``~/main``
+                # resolves to ``refs/heads/main`` under a crafted
+                # ``HOME=refs/heads`` — so a leading unquoted ``~`` is as
+                # unverifiable as ``$`` (GPT 5.6 round 15 on #7808, verified
+                # real). Mid-word ``~`` is literal in an argv word and stays
+                # data.
+                tags.add(_GIT_PUBLISH_UNGATED)
+            # Extglob patterns (``@( +( !(`` — and ``?( *(``, already covered
+            # by their leading glob char) are pathname expansion too when the
+            # shell has extglob on, so they take the same wildcard identity:
+            # like a glob, they can only ever match existing FILE names
+            # (GPT 5.6 round 9 on #7808, verified: ``@(main)`` beside a file
+            # named ``main`` expands to a push of main with no tag at all).
+            if any(ch in tok for ch in "*?[") or any(op in tok for op in ("@(", "+(", "!(")):
+                tags.add("git-publish-push-wildcard-refspec")
+        # Shell operators are consumed by the SHELL, so they are handled
+        # before every argv-level reading — including after ``--``, which is
+        # git's end-of-options, not the shell's (GPT 5.6 round 4 on #7808).
+        if pending_redirection_target:
+            # The word a bare redirection operator takes as its target; the
+            # shell removes it from argv.
+            pending_redirection_target = False
+            continue
+        is_redirection, consumes_next = _push_token_redirection(raw)
+        if is_redirection:
+            # Modelled with the shell's own arity so ``2>&1`` keeps a feature
+            # push allowed while ``origin </dev/null`` reads as the precise
+            # remote-only shape instead of scanning a phantom refspec.
+            pending_redirection_target = consumes_next
+            continue
+        if operator_pieces is not None:
+            # A word GLUED to its redirection: bash reads ``origin>/dev/null``
+            # as the word ``origin`` plus a redirection, i.e. a remote-only
+            # push whose true row is SINGLE-ARG — the protective fallback
+            # emitted BARE for it, and a wrong identity is itself a hazard
+            # under per-rule opt-out (GPT 5.6 round 10 on #7808, verified
+            # real). When the token decomposes cleanly — a non-flag word,
+            # then a well-formed redirection (no risky ``&`` beyond an
+            # fd-dup) — keep the word positional and consume the redirection
+            # exactly as the shell does, with no fallback. Anything murkier
+            # (a bare ``&`` command boundary, a flag-shaped prefix, quotes
+            # inside the redirection) keeps the protective fallback below.
+            prefix = operator_pieces[0] if operator_pieces else ""
+            rest = raw[len(prefix) :] if prefix and raw.startswith(prefix) else ""
+            dequoted_prefix = _dequote_token(prefix)
+            # A flag GLUED to a redirection: the flag identity must not be
+            # lost to the fallback — ``--all>/dev/null`` is an all-branches
+            # push, and emitting only the disableable no-refspec rows let an
+            # operator who disabled those admit it while mirror-all stayed
+            # enabled (GPT 5.6 round 16 on #7808, verified real). The
+            # all-branches check is the one whose MISSED identity is a
+            # bypass; other flag prefixes stay on the fallback, which only
+            # ever over-protects.
+            if _push_option_matches(dequoted_prefix, _PUSH_ALL_BRANCHES_OPTS):
+                tags.add("git-publish-push-mirror-all")
+            if (
+                (rest[:1] in ("<", ">") or rest.startswith(("&>", "&>>")))
+                and dequoted_prefix
+                and not dequoted_prefix.startswith("-")
+                and _push_token_redirection(rest)[0]
+                and (
+                    "&" not in rest
+                    # Glued all-output redirection: the & is the operator head.
+                    or rest.startswith("&")
+                    # Glued fd-dup / fd-close / fd-move: >&2, >&-, >&1-.
+                    or re.fullmatch(r"[<>]{1,2}&([0-9]+-?|-)", rest)
+                )
+            ):
+                # The glued WORD is exactly what the shell hands git as the
+                # argv word, so it must flow wherever a plain word would: a
+                # pending option value first (GPT 5.6 round 13 — appending it
+                # as a positional while ``skip_next`` stayed armed let the
+                # NEXT real word be eaten as the "value" and erased the
+                # tags), else a positional.
+                if skip_next:
+                    skip_next = False
+                else:
+                    non_flags.append(dequoted_prefix)
+                pending_redirection_target = _push_token_redirection(rest)[1]
+                continue
+            # A bare control operator (``&`` — a single ampersand is NOT a
+            # segment separator upstream, only ``&&`` is) or operator glue
+            # mid-word (``main>log`` = the word ``main`` plus a redirection:
+            # it pushes main). The split is untrusted, and the operator-
+            # delimited pieces are scanned as refspec candidates so a
+            # protected name cannot hide behind the glue.
+            unrecognised_option = True
+            non_flags.extend(p for p in (_dequote_token(pc) for pc in operator_pieces) if p)
+            continue
         if skip_next:
             skip_next = False
             continue
         if not tok:
             continue
-        if positional_only or not tok.startswith("-"):
+        if positional_only or tok == "-" or not tok.startswith("-"):
+            # A lone ``-`` is an OPERAND to git's option parser (a repository
+            # spelled ``./-`` is addressable) — skipping it as a flag shifted
+            # the real refspec into the remote slot and downgraded the row
+            # (GPT 5.6 round 13 on #7808).
             non_flags.append(tok)
             continue
         if tok == "--":
@@ -5690,6 +5991,19 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
         # push option cannot silently reopen the erasure class.
         if "git-publish-push-mirror-all" not in tags:
             tags.add("git-publish-push-bare")
+            if non_flags:
+                # An untrusted split cannot distinguish the bare shape from
+                # the remote-only shape — the visible positionals may all be
+                # option values, or one may be the remote. Three review
+                # rounds (10, 13, 14 on #7808) each turned that ambiguity
+                # into a bypass by disabling whichever single row the
+                # fallback happened to emit, so the fallback now names BOTH
+                # no-refspec rows: admitting an unparseable spelling takes
+                # disabling both. (With no positionals at all the remote-only
+                # shape is impossible and bare stands alone; an all-branches
+                # flag still suppresses both, since mirror-all covers a
+                # superset.)
+                tags.add("git-publish-push-single-arg")
         refspecs = non_flags
     else:
         # With the repository supplied by a flag there is no positional remote

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5426,6 +5426,59 @@ _PUSH_ALL_BRANCHES_OPTS = frozenset({"mirror", "all", "branches"})
 #: single-arg rule off published to ``main``.
 _PUSH_REPO_OPTS = frozenset({"repo"})
 
+#: The ARITY table (#7796): push options that take a REQUIRED value git also
+#: accepts as a SEPARATED token (``--push-option ci.skip``). The token scan
+#: must consume that value or it leaks into the positional list, where it is
+#: read as a remote/refspec — and because an option value like ``ci.skip``
+#: normalizes to a non-protected name, the tag set for an otherwise-bare
+#: publish came back EMPTY. An empty tag set IS the allow decision, so one
+#: extra flag switched the protected-branch floor off. Same shape as
+#: ``_PUSH_REPO_OPTS`` (which stays separate because its value being the
+#: REMOTE also shifts the positional split), resolved through
+#: ``_push_option_matches`` so abbreviations keep working (finding 2).
+#: Attached forms (``--push-option=x``) bind the value inside the token and
+#: never disturb the split, so they need no entry here.
+_PUSH_VALUE_OPTS = frozenset({"push-option", "receive-pack", "exec"}) | _PUSH_REPO_OPTS
+
+#: Long push options that never consume the NEXT token: booleans, plus the
+#: optional-value options (``--signed``, ``--force-with-lease``) whose value
+#: git binds in ATTACHED form only. ``--no-*`` negations are recognised
+#: structurally (git's negation never takes a separate value), so they are not
+#: enumerated. ``recurse-submodules`` is deliberately ABSENT: listing an
+#: option here vouches that its separated neighbour is a positional, and being
+#: wrong about that is exactly the #7796 erasure — so an option whose arity is
+#: not modelled with confidence falls to the protective fallback instead.
+_PUSH_NO_VALUE_OPTS = frozenset(
+    {
+        "atomic",
+        "delete",
+        "dry-run",
+        "follow-tags",
+        "force",
+        "force-if-includes",
+        "force-with-lease",
+        "ipv4",
+        "ipv6",
+        "porcelain",
+        "progress",
+        "prune",
+        "quiet",
+        "set-upstream",
+        "signed",
+        "tags",
+        "thin",
+        "verbose",
+        "verify",
+    }
+)
+
+#: Short-option arity, resolved the way git resolves a bundle: booleans may
+#: stack (``-fq``), and the first value-taking short consumes the REST of the
+#: token as its attached value (``-oci.skip``) or, when the rest is empty, the
+#: NEXT token (``-o ci.skip`` — or ``-fo ci.skip``, which is ``-f -o ci.skip``).
+_PUSH_VALUE_SHORTS = frozenset({"o"})
+_PUSH_NO_VALUE_SHORTS = frozenset({"f", "n", "q", "v", "u", "d", "4", "6"})
+
 
 def _push_option_matches(token: str, names: "frozenset[str]") -> bool:
     """True when ``token`` is ``--`` plus a PREFIX of any option in ``names``.
@@ -5570,11 +5623,17 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
     if any(_push_option_matches(tok, _PUSH_ALL_BRANCHES_OPTS) for tok in tokens):
         tags.add("git-publish-push-mirror-all")
     # Skip flags (tokens starting with -); non_flags[0] is the remote and
-    # non_flags[1:] are the refspecs/branches. A flag that CARRIES the repository
-    # (``--repo=x`` / ``--repo x``, or any abbreviation of it) means the remote is
-    # NOT positional, so every remaining token is a refspec. Consuming the
-    # separated form's value keeps it from being read as the remote.
+    # non_flags[1:] are the refspecs/branches. Option ARITY is modelled
+    # explicitly (#7796): a flag that CARRIES the repository (``--repo=x`` /
+    # ``--repo x``) means the remote is NOT positional, a value-taking option's
+    # SEPARATED value is consumed so it is never read as a remote/refspec, and
+    # any option the scan does not recognise poisons the positional split
+    # entirely (see the fail-protective fallback below) — because trusting a
+    # split that may contain a leaked option value is how the floor tag was
+    # erased. A bare ``--`` ends option parsing, exactly as git reads it.
     repo_in_flag = False
+    unrecognised_option = False
+    positional_only = False
     non_flags: list[str] = []
     skip_next = False
     for tok in tokens:
@@ -5583,15 +5642,59 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
             continue
         if not tok:
             continue
-        if tok.startswith("-"):
-            if _push_option_matches(tok, _PUSH_REPO_OPTS):
-                repo_in_flag = True
-                skip_next = "=" not in tok
+        if positional_only or not tok.startswith("-"):
+            non_flags.append(tok)
             continue
-        non_flags.append(tok)
-    # With the repository supplied by a flag there is no positional remote to
-    # drop, so the refspecs start at index 0.
-    refspecs = non_flags if repo_in_flag else non_flags[1:]
+        if tok == "--":
+            positional_only = True
+            continue
+        if _push_option_matches(tok, _PUSH_REPO_OPTS):
+            repo_in_flag = True
+            skip_next = "=" not in tok
+            continue
+        if "=" in tok:
+            # An attached value binds inside the token — whatever the option
+            # is, it cannot disturb the positional split.
+            continue
+        if tok.startswith("--"):
+            if _push_option_matches(tok, _PUSH_VALUE_OPTS):
+                skip_next = True
+            elif not (
+                tok.startswith("--no-")
+                or _push_option_matches(tok, _PUSH_NO_VALUE_OPTS)
+                or _push_option_matches(tok, _PUSH_ALL_BRANCHES_OPTS)
+            ):
+                unrecognised_option = True
+            continue
+        # Short-option token: resolve the bundle char by char like git does.
+        for i, ch in enumerate(tok[1:]):
+            if ch in _PUSH_VALUE_SHORTS:
+                # Rest of the token is the attached value; consume the NEXT
+                # token only when there is no rest.
+                skip_next = i == len(tok) - 2
+                break
+            if ch not in _PUSH_NO_VALUE_SHORTS:
+                unrecognised_option = True
+                break
+    if unrecognised_option:
+        # Fail-protective invariant (#7796, shape C): an option this scan does
+        # not model might take a separated value, so the positional split
+        # cannot be trusted — the "remote" it would drop may really be a
+        # leaked option value. Read the segment protectively instead: the
+        # current branch might be protected (the bare tag — unless an
+        # all-branches flag already names the target set exhaustively, the
+        # finding-3 suppression, in which case mirror-all covers a superset of
+        # bare), and EVERY positional is scanned as a refspec candidate so an
+        # actual protected name still reports its own precise catalog row. A
+        # mis-parse can therefore only ever OVER-protect: a future value-taking
+        # push option cannot silently reopen the erasure class.
+        if "git-publish-push-mirror-all" not in tags:
+            tags.add("git-publish-push-bare")
+        refspecs = non_flags
+    else:
+        # With the repository supplied by a flag there is no positional remote
+        # to drop, so the refspecs start at index 0.
+        refspecs = non_flags if repo_in_flag else non_flags[1:]
     if not refspecs and "git-publish-push-mirror-all" not in tags:
         # Bare ``push`` or ``push <remote>`` with no explicit branch — the
         # current branch might be protected.  The two spellings are separate

--- a/test/test_push_branch_gate.py
+++ b/test/test_push_branch_gate.py
@@ -738,6 +738,60 @@ class TestUnrecognisedOptionsReadProtectively:
         tags = security._git_publish_floor_tags("git push -z origin feature-x")
         assert "git-publish-push-bare" in tags
 
+    def test_a_quoted_value_containing_whitespace_reads_protectively(self):
+        # GPT 5.6 review findings on #7808 (rounds 1-2), verified real: the
+        # tokenizer is whitespace-split, so a quoted (or escape-continued)
+        # value spanning whitespace reaches the scan as FRAGMENTS — consuming
+        # one token left the tail fragment trusted as a refspec, and the
+        # erasure was back. Round 2: an ESCAPED quote is data, not a
+        # delimiter, so counting quote characters was bypassed by \" — the
+        # fragment test now tracks the shell's own quote/escape state and
+        # flags any token whose state does not return to normal.
+        for cmd in (
+            "git push --repo=origin --push-option='ci skip'",
+            'git push --repo=origin --push-option="ci skip"',
+            "git push --repo=origin --push-option 'ci skip'",
+            "git push --repo=origin -o 'ci skip'",
+            "git push --repo=origin --push-option=ci\\ skip",
+            'git push --repo=origin --push-option="ci\\" skip\\""',
+            "git push --repo=origin --push-option='ci'\\'' skip'",
+            "git push --repo=origin --push-option=$'ci\\' skip'",
+            # ANSI-C-only signal: under a plain-single reading BOTH fragments
+            # scan clean (the tail's quotes pair up), so this row is what
+            # proves the $'...' escape branch is load-bearing.
+            "git push --repo=origin --push-option=$'a\\' bc'\\''d'",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert "git-publish-push-bare" in tags, (
+                f"{cmd!r}: a whitespace-fused option value erased the floor "
+                f"tag again: {set(tags)}"
+            )
+
+    def test_a_protected_name_beside_a_fragmented_value_keeps_its_tag(self):
+        tags = security._git_publish_floor_tags("git push --push-option='ci skip' origin main")
+        assert "git-publish-push-protected-branch-name" in tags
+
+    def test_balanced_quoting_still_parses_precisely(self):
+        # The fragment signal is the quote/escape state not returning to
+        # normal; complete words — including ones with ESCAPED quotes — keep
+        # their existing precise reading, both directions: no over-deny of a
+        # feature push, and no loss of the precise tag identity.
+        assert not security._git_publish_floor_tags("git push origin 'feature-x'")
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "git push origin 'main'"
+        )
+        assert security._git_publish_floor_tags(
+            'git push --repo=origin "--push-option=ci.skip"'
+        ) == frozenset({"git-publish-push-bare"})
+        # An escaped quote inside a COMPLETE word is data, not a fragment.
+        assert not security._git_publish_floor_tags('git push origin "feat\\"x"')
+        # The quote-splice spelling of a protected name reads EXACTLY as the
+        # protected-branch row: dequote evasion-resistance intact, and no
+        # spurious bare tag riding along from a fragment false-positive.
+        assert security._git_publish_floor_tags("git push origin 'ma'\\''in'") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+
     def test_the_protective_reading_still_names_a_protected_target_precisely(self):
         # Not trusting the split widens the refspec scan to EVERY positional,
         # so a protected name still reports its own catalog row — an operator
@@ -784,6 +838,431 @@ class TestUnrecognisedOptionsReadProtectively:
         # suppression), and mirror-all already covers a superset of bare.
         tags = security._git_publish_floor_tags("git push --all --frobnicate v")
         assert tags == frozenset({"git-publish-push-mirror-all"})
+
+    def test_an_expandable_value_lands_on_the_ungated_branch(self):
+        # GPT 5.6 round 3, verified real: a token the split consumes or drops
+        # is not inert text — `V='ci.skip main'; git push --repo=origin
+        # --push-option $V` expands and word-splits AFTER this scan, handing
+        # git `main` as a refspec the split never saw. Consuming the literal
+        # `$V` had REGRESSED this from main's accidental posture (the leaked
+        # value hit the refspec ambiguity check -> the ungated sentinel) to
+        # the disableable bare rule. Any unquoted expansion syntax anywhere in
+        # the segment now lands on the ungated branch, the same posture as
+        # `ma$in`: no single catalog row can be disabled to admit it.
+        for cmd in (
+            "git push --repo=origin --push-option $v",
+            "git push --repo=origin -o $v",
+            "git push --repo=origin --push-option=$v",
+            "git push --repo=origin --receive-pack $hook",
+            "git push --repo=$r",
+            "git push $remote feature-x",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert security._GIT_PUBLISH_UNGATED in tags, (
+                f"{cmd!r}: an expandable token classified as only "
+                f"disableable rules: {set(tags)}"
+            )
+
+    def test_a_glob_value_or_remote_is_the_wildcard_shape(self):
+        # Pathname expansion also produces words: `--push-option ma*` with a
+        # matching file hands git extra positional words. Main's accidental
+        # value-scan already tagged these wildcard-refspec; the consumed value
+        # must keep that identity rather than degrading to bare.
+        for cmd in (
+            "git push --repo=origin --push-option ma*",
+            "git push --repo=origin --push-option=ma*",
+            "git push ma* feature-x",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert "git-publish-push-wildcard-refspec" in tags, (
+                f"{cmd!r}: a glob-capable dropped token lost the wildcard " f"tag: {set(tags)}"
+            )
+
+    def test_glob_characters_beyond_star_in_a_refspec_are_wildcards(self):
+        # `ma[i]n` expands against CWD files BEFORE git runs — a file named
+        # `main` makes it push main. `?` and `[` are never legit in refnames
+        # (git refuses them), so over-protecting costs no real command.
+        for cmd in ("git push origin ma[i]n", "git push origin ma?n"):
+            assert "git-publish-push-wildcard-refspec" in security._git_publish_floor_tags(
+                cmd
+            ), f"{cmd!r} was not read as a wildcard shape"
+
+    def test_extglob_patterns_are_wildcards_too(self):
+        # GPT 5.6 round 9, verified real: with `shopt -s extglob` (or
+        # BASHOPTS=extglob), `@(main)` / `+(main)` / `!(x)` are pathname
+        # patterns — beside a file named `main`, `git push origin @(main)`
+        # expands to a push of MAIN, and the scan gave it NO tags. Extglob is
+        # pathname expansion, so it takes the same catalog identity as
+        # `*`/`?`/`[` (the wildcard row), not the substitution sentinel:
+        # like a glob, it can only ever match existing FILE names. `?(` and
+        # `*(` were already covered by their leading glob character.
+        for cmd in (
+            "git push origin @(main)",
+            "git push origin +(main)",
+            "git push origin !(x)",
+            "git push --repo=origin --push-option @(x)",
+        ):
+            assert "git-publish-push-wildcard-refspec" in security._git_publish_floor_tags(
+                cmd
+            ), f"{cmd!r} was not read as a wildcard shape"
+        # No operator adjacency, no extglob: an ordinary parenthesised
+        # refname spelling stays data.
+        assert not security._git_publish_floor_tags("git push origin 'feat(x)'")
+
+    def test_plain_values_and_remotes_keep_their_precise_reading(self):
+        # No expansion syntax, no glob: the new checks add nothing.
+        assert security._git_publish_floor_tags(
+            "git push --repo=origin --push-option ci.skip"
+        ) == frozenset({"git-publish-push-bare"})
+        assert not security._git_publish_floor_tags("git push origin feature-x")
+        assert not security._git_publish_floor_tags(
+            "git push --push-option ci.skip origin feature-x"
+        )
+
+    def test_a_heredoc_strip_operator_consumes_its_delimiter(self):
+        # GPT 5.6 round 7, verified real: `<<-` is a complete operator (the
+        # tab-stripping heredoc); its `-` landed in the regex REMAINDER, so
+        # the token read as self-contained and the separated delimiter word
+        # became a phantom refspec — erasing the tag exactly like round 4's
+        # `</dev/null`. The `-` is part of the operator only for `<<`.
+        assert security._git_publish_floor_tags("git push origin <<- EOF") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert security._git_publish_floor_tags("git push --repo=origin <<- EOF") == frozenset(
+            {"git-publish-push-bare"}
+        )
+        # fd-close / fd-move spellings keep their self-contained reading:
+        # their trailing '-' is an fd disposition, not a separated target.
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "git push origin >&- main"
+        )
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "git push origin main 2>&1-"
+        )
+
+    def test_process_substitution_lands_on_the_ungated_branch(self):
+        # GPT 5.6 round 8, verified real: `<(cmd)` / `>(cmd)` are WORDS (the
+        # shell substitutes a /dev/fd path), not removable redirections —
+        # dropping `-o <(echo)` as a redirection shifted the option's value
+        # consumption onto `origin` and downgraded a push of MAIN to the
+        # disableable single-arg row. Process substitution is substitution:
+        # it joins `$(`/`${`/backticks on the upstream ungated branch.
+        for cmd in (
+            "git push -o <(echo) origin main",
+            "git push --push-option >(cat) origin main",
+            "git push origin <(echo x)",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert security._GIT_PUBLISH_UNGATED in tags, (
+                f"{cmd!r}: process substitution classified as only "
+                f"disableable rules: {set(tags)}"
+            )
+        # A parenthesis without the operator adjacency is an ordinary
+        # refname character and stays data.
+        assert not security._git_publish_floor_tags("git push origin 'feat(x)'")
+
+    def test_a_named_fd_redirection_is_not_a_word(self):
+        # GPT 5.6 round 11, verified real — a regression the round-10
+        # decomposition introduced: bash's named descriptor `{fd}>...` is
+        # ALL redirection, but `{fd}` read as the pre-operator word and
+        # became the sole "refspec", erasing every tag while the shell ran a
+        # remote-only push with all rules enabled.
+        assert security._git_publish_floor_tags("git push origin {fd}>/dev/null") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert security._git_publish_floor_tags("git push --repo=origin {fd}>err") == frozenset(
+            {"git-publish-push-bare"}
+        )
+        # Quoted, it is an ordinary (weird) refname and stays data.
+        assert not security._git_publish_floor_tags("git push origin '{fd}'")
+
+    def test_a_quoted_redirection_target_keeps_redirection_arity(self):
+        # Round 11's second leg: quotes can only ever appear in the TARGET
+        # group of a redirection token (the operator grammar admits none), so
+        # refusing the whole token for containing a quote pushed `>'log'`
+        # into the fallback and mislabelled a remote-only push as bare.
+        assert security._git_publish_floor_tags("git push origin >'log'") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert security._git_publish_floor_tags("git push origin main 2>'err'") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+
+    def test_shell_redirections_are_not_refspecs(self):
+        # GPT 5.6 round 4, verified real (and pre-existing on main): the
+        # shell consumes a redirection BEFORE git runs, so `git push origin
+        # </dev/null` executes a remote-only push while the scan read
+        # `</dev/null` as the refspec — a phantom positional filled the
+        # refspec slot and the single-arg tag was erased. Redirections are
+        # modelled with the shell's own arity: an attached target is
+        # self-contained, a bare operator consumes the next word.
+        assert security._git_publish_floor_tags("git push origin </dev/null") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert security._git_publish_floor_tags("git push origin > log") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert security._git_publish_floor_tags("git push --repo=origin 2>err") == frozenset(
+            {"git-publish-push-bare"}
+        )
+
+    def test_redirected_pushes_keep_their_precise_reading(self):
+        # The modelling is precise, not a blanket fallback: the everyday
+        # scripted spelling `... 2>&1` stays an allowed feature push, and a
+        # redirected protected push keeps its precise tag.
+        assert not security._git_publish_floor_tags("git push origin feature-x 2>&1")
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "git push origin main 2>&1"
+        )
+
+    def test_a_glued_operator_cannot_hide_a_protected_name(self):
+        # `main>log` is the word `main` plus the redirection `>log` to the
+        # shell — it pushes MAIN. The glued word is decomposed precisely:
+        # the pre-operator word is a positional, the redirection is consumed.
+        tags = security._git_publish_floor_tags("git push origin main>log")
+        assert "git-publish-push-protected-branch-name" in tags
+
+    def test_a_glued_redirection_keeps_the_precise_positional_identity(self):
+        # GPT 5.6 round 10, verified real: `origin>/dev/null` is the word
+        # `origin` plus a redirection — a remote-only push, whose true row is
+        # SINGLE-ARG. The protective fallback emitted BARE instead, so an
+        # operator who disabled only the bare rule had this shape allowed
+        # while its real row was still enabled. The pre-operator word is now
+        # kept as a positional and the redirection consumed, exactly as bash
+        # reads it — no fallback, no identity drift, and glued legit pushes
+        # stay allowed.
+        assert security._git_publish_floor_tags("git push origin>/dev/null") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert security._git_publish_floor_tags("git push origin main>log") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+        assert not security._git_publish_floor_tags("git push origin feature-x>log")
+        assert not security._git_publish_floor_tags("git push --repo=origin ci.skip>log")
+        # A glued separated-target form consumes the NEXT word as the target.
+        assert security._git_publish_floor_tags("git push origin> log") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        # Glued fd-close and all-output forms are redirections too (GPT 5.6
+        # round 12): `origin>&-` closes stdout and `origin&>/dev/null`
+        # redirects everything — both remote-only pushes, single-arg rows.
+        assert security._git_publish_floor_tags("git push origin>&-") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert security._git_publish_floor_tags("git push origin&>/dev/null") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert not security._git_publish_floor_tags("git push --repo=origin ci>&2")
+        # A glued & is NOT a redirection (it is a command boundary) and keeps
+        # the protective fallback.
+        assert "git-publish-push-bare" in security._git_publish_floor_tags(
+            "git push origin& echo x"
+        )
+
+    def test_a_glued_value_still_feeds_a_pending_option(self):
+        # GPT 5.6 round 13, verified real: with a separated `--repo` pending
+        # its value, a GLUED word+redirection token fed its word into the
+        # positional list instead of the option — `--repo origin>/dev/null
+        # main` then consumed `main` as the "value" and returned NO tags
+        # while the shell hands git a protected push. The glued word now
+        # feeds the pending option value exactly as the shell's argv does.
+        assert security._git_publish_floor_tags(
+            "git push --repo origin>/dev/null main"
+        ) == frozenset({"git-publish-push-protected-branch-name"})
+        assert security._git_publish_floor_tags("git push --repo origin>/dev/null") == frozenset(
+            {"git-publish-push-bare"}
+        )
+
+    def test_a_glued_all_branches_flag_keeps_its_identity(self):
+        # GPT 5.6 round 16, verified real: `--all>/dev/null` is the
+        # all-branches flag plus a redirection, but the flag-shaped prefix
+        # bailed to the fallback, emitting only the disableable no-refspec
+        # rows — disabling those admitted an all-branches push while
+        # mirror-all stayed enabled. The prefix is now classified against
+        # the all-branches set (abbreviations included) before the fallback,
+        # and the finding-3 suppression then yields exactly the true row.
+        assert security._git_publish_floor_tags("git push --all>/dev/null") == frozenset(
+            {"git-publish-push-mirror-all"}
+        )
+        assert security._git_publish_floor_tags("git push --mirr>log") == frozenset(
+            {"git-publish-push-mirror-all"}
+        )
+        # Other glued flag prefixes keep the protective fallback (over-deny
+        # only — a redirected force push is denied, never admitted).
+        tags = security._git_publish_floor_tags("git push --force>/dev/null origin feature-x")
+        assert "git-publish-push-bare" in tags
+
+    def test_a_lone_dash_is_a_positional_not_an_option(self):
+        # Round 13's second leg: git's own option parsing treats a lone `-`
+        # as an OPERAND (a repository spelled `./-` is addressable), but the
+        # scan skipped it as a flag, shifting `main` into the remote slot and
+        # downgrading the row to single-arg.
+        assert security._git_publish_floor_tags("git push - main") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+        assert not security._git_publish_floor_tags("git push - feature-x")
+
+    def test_spaced_subshell_parens_read_protectively(self):
+        # GPT 5.6 round 14, verified real: in `( ... )` with spaces, the `)`
+        # token read as a refspec and erased every tag for an otherwise-bare
+        # publish inside a subshell. Unquoted parens are shell operators;
+        # they now poison the split like the other operator glue. (The
+        # glued spelling without spaces never tokenizes a clean `git` word
+        # and was already ungated upstream.)
+        tags = security._git_publish_floor_tags("( git push --repo=origin )")
+        assert "git-publish-push-bare" in tags
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "( git push origin main )"
+        )
+
+    def test_the_untrusted_fallback_names_both_no_refspec_rows(self):
+        # Rounds 10, 13 and 14 each turned the fallback's single identity
+        # into a bypass by disabling whichever row it happened to emit. An
+        # untrusted split with visible positionals cannot distinguish the
+        # bare shape from the remote-only shape, so BOTH rows fire; with no
+        # positionals the remote-only shape is impossible and bare stands
+        # alone; an all-branches flag suppresses both.
+        tags = security._git_publish_floor_tags("git push --recurse-submodules check origin")
+        assert {"git-publish-push-bare", "git-publish-push-single-arg"} <= tags
+        assert security._git_publish_floor_tags("git push --frobnicate") == frozenset(
+            {"git-publish-push-bare"}
+        )
+        assert security._git_publish_floor_tags("git push --all --frobnicate v") == frozenset(
+            {"git-publish-push-mirror-all"}
+        )
+
+    def test_a_comment_truncates_the_argv_like_the_shell_does(self):
+        # `#` at the start of a word comments out the rest of the segment,
+        # so `git push origin #main` runs a remote-only push: the precise
+        # single-arg tag, not an erased one and not a fallback.
+        assert security._git_publish_floor_tags("git push origin #main") == frozenset(
+            {"git-publish-push-single-arg"}
+        )
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "git push origin main #x"
+        )
+        assert not security._git_publish_floor_tags("git push origin feature-x #main")
+
+    def test_a_fused_hash_is_not_a_comment_and_cannot_discard_a_refspec(
+        self,
+    ):  # GPT 5.6 round 5, verified real: `#` opens a comment only at the
+        # START of a word. When an earlier token leaves the shell state open
+        # (a trailing escape or an unterminated quote fuses across the
+        # split), a `#`-leading token may be MID-WORD — truncating there
+        # discarded the real trailing `main`, leaving only the disableable
+        # bare tag. Truncation now requires every preceding token to have
+        # closed cleanly; otherwise the open state poisons the split and the
+        # superset scan keeps the trailing protected name visible.
+        for cmd in (
+            "git push --repo=origin --push-option=ci\\ #x main",
+            "git push origin 'a #b' main",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert "git-publish-push-protected-branch-name" in tags, (
+                f"{cmd!r}: a word-fused '#' truncated the scan and dropped "
+                f"the protected refspec: {set(tags)}"
+            )
+
+    def test_a_background_operator_reads_protectively(self):
+        # A single `&` is NOT a segment separator upstream (only `&&` is), so
+        # the second command rides inside this segment's token list. The
+        # split is untrusted, and the superset scan keeps a protected name in
+        # the trailing command visible.
+        tags = security._git_publish_floor_tags("git push origin & git push origin2 main")
+        assert "git-publish-push-protected-branch-name" in tags
+        assert "git-publish-push-bare" in tags
+
+    def test_quoted_operator_characters_stay_data(self):
+        # A quoted operator is an ordinary character the shell passes
+        # through (git allows < > & in refnames), so the precise reading
+        # holds and nothing over-denies.
+        assert not security._git_publish_floor_tags("git push origin 'feat<x'")
+
+    def test_a_line_continuation_lands_on_the_ungated_branch(self):
+        # GPT 5.6 round 6, verified real: backslash-newline VANISHES in bash,
+        # so `origin ma\` + newline + `in` splices to a push of MAIN — while
+        # the newline is a segment boundary here, so no token in this segment
+        # spells the name and the scan emitted only the DISABLEABLE bare tag.
+        # A segment whose cumulative quote/escape state is open at its end is
+        # therefore unreconstructable — the ungated posture, like ma$in.
+        for cmd in (
+            "git push origin ma\\\nin",
+            'git push origin "ma\\\nin"',
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert security._GIT_PUBLISH_UNGATED in tags, (
+                f"{cmd!r}: a spliced-across-segments word classified as only "
+                f"disableable rules: {set(tags)}"
+            )
+
+    def test_a_mid_segment_fused_value_stays_on_the_disableable_fallback(self):
+        # Deliberately narrower than ungating any open token: a quoted value
+        # whose quote CLOSES before segment end cannot splice into the next
+        # line, in-segment joining can only fuse whitespace into the word
+        # (never a valid refname), and the pieces stay visible to the
+        # superset scan — so the operator-facing bare row keeps covering it.
+        for cmd in (
+            "git push --repo=origin --push-option='ci skip'",
+            "git push --repo=origin --push-option='ci skip' origin feature-x",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert security._GIT_PUBLISH_UNGATED not in tags, (
+                f"{cmd!r}: a closed in-segment fusion escalated to the "
+                f"ungated sentinel: {set(tags)}"
+            )
+            assert "git-publish-push-bare" in tags
+
+    def test_every_bash_metacharacter_is_accounted_for(self):
+        """The shell-syntax inventory, as a checked property (Design review).
+
+        The option-arity axis fails protective by CONSTRUCTION (unrecognised
+        option -> fallback); the shell-syntax axis cannot — a construct the
+        scan does not know about parses as an ordinary word — so its safety
+        rests on this inventory being COMPLETE over bash's metacharacters.
+        Every row names the layer that accounts for the character. Adding a
+        bash construct? It must land in one of these layers, and a row here.
+        """
+        floor = security._git_publish_floor_tags
+        UNGATED = security._GIT_PUBLISH_UNGATED
+        # Segment separators — split upstream (_CMD_SEPARATOR_RE), each side
+        # scanned on its own, so the push half keeps its precise tag.
+        assert floor("git push origin | cat") == {"git-publish-push-single-arg"}
+        assert floor("git push origin; echo x") == {"git-publish-push-single-arg"}
+        assert floor("git push origin && echo x") == {"git-publish-push-single-arg"}
+        # Substitution / expansion glue — ungated upstream
+        # (_AMBIGUOUS_EXPANSION_RE): $(, ${, backtick, brace-with-comma/range.
+        assert floor("git push origin `x`") == {UNGATED}
+        assert floor("git push origin $(echo main)") == {UNGATED}
+        assert floor("git push origin ma{i,x}n") == {UNGATED}
+        # Parameter expansion in any slot — the $ pre-check (ungated). A
+        # LEADING tilde is the same layer: it is env-driven text, not path
+        # syntax (bare `~` IS $HOME; `HOME=refs/heads` turns `~/main` into a
+        # protected refspec), so it cannot be vouched benign. Round 15
+        # corrected this inventory: tilde originally sat in the benign group
+        # with a "expands to a path" rationale, and the rationale was the bug.
+        assert UNGATED in floor("git push $remote feature-x")
+        assert UNGATED in floor("git push origin ~")
+        assert UNGATED in floor("git push origin ~main")
+        assert UNGATED in floor("git push ~/repo.git feature-x")
+        # Pathname expansion in any slot — the glob pre-check (wildcard row).
+        assert "git-publish-push-wildcard-refspec" in floor("git push origin ma?n")
+        # Redirections — consumed with the shell's arity; comments truncate;
+        # a lone & or operator glue reads protectively (this class).
+        assert floor("git push origin </dev/null") == {"git-publish-push-single-arg"}
+        assert floor("git push origin #x") == {"git-publish-push-single-arg"}
+        assert "git-publish-push-bare" in floor("git push origin & echo x")
+        # Quoting and escapes — the shared walk: fragments poison the split.
+        assert "git-publish-push-bare" in floor("git push --repo=origin -o 'a b'")
+        # Subshell parens glue onto the verb token, so no clean ``git`` token
+        # survives and the unparseable fallback ungates the segment.
+        assert floor("(git push origin main)") == {UNGATED}
+        # Benign by bash semantics, deliberately NOT flagged: a comma-free
+        # brace passes through LITERALLY (a ref named ``{main}`` is not
+        # ``main``); ``!`` history expansion does not run in non-interactive
+        # shells; a mid-word ``~`` is literal in an argv word.
+        assert floor("git push origin {main}") == frozenset()
+        assert floor("git push origin !x") == frozenset()
+        assert floor("git push origin feat~x") == frozenset()
 
     def test_end_of_options_marker_makes_everything_after_it_positional(self):
         # A bare ``--`` ends option parsing in git; the scan must read what
@@ -873,12 +1352,13 @@ class TestParserBranchTable:
         ),
         (
             "--frobnicate ci.skip origin feature-x",
-            {BARE},
-            "unrecognised option: split untrusted, protective bare reading",
+            {BARE, SINGLE},
+            "unrecognised option: split untrusted, BOTH no-refspec rows (the "
+            "positionals may be values or a remote — rounds 10/13/14)",
         ),
         (
             "--frobnicate ci.skip origin main",
-            {BARE, NAME},
+            {BARE, SINGLE, NAME},
             "protective reading scans every positional, precise tag preserved",
         ),
         ("--frobnicate", {BARE}, "unrecognised and nothing positional — bare either way"),
@@ -886,6 +1366,12 @@ class TestParserBranchTable:
             "--all --frobnicate v",
             {MIRROR},
             "fallback does not stack bare onto mirror-all (finding 3 suppression)",
+        ),
+        (
+            "--repo=origin --push-option ma*",
+            {BARE, WILD},
+            "a glob-capable consumed value keeps the wildcard identity: pathname "
+            "expansion can hand git words this scan never saw",
         ),
     )
 

--- a/test/test_push_branch_gate.py
+++ b/test/test_push_branch_gate.py
@@ -639,3 +639,266 @@ def test_an_all_branches_push_does_not_also_carry_the_single_arg_tag():
     # And the bare/single-arg shapes still tag when no all-branches flag is present.
     assert "git-publish-push-single-arg" in security._git_publish_floor_tags("git push origin")
     assert "git-publish-push-bare" in security._git_publish_floor_tags("git push")
+
+
+class TestValueTakingOptionArity:
+    """Push options with a REQUIRED, separable value must have that value
+    consumed, not leaked into the positional list. (#7796 — the fourth finding
+    in this parser span.)
+
+    Measured on the unfixed parser: appending ``--push-option ci.skip`` (or
+    ``-o``, ``--receive-pack``, ``--exec``) to the bare ``--repo=origin``
+    publish flipped the floor from {bare} to EMPTY — an ALLOW, because the
+    leaked value was read as the only refspec and ``ci.skip`` is not a
+    protected name. The tag set IS the protected-branch decision, so one extra
+    flag switched the floor off.
+    """
+
+    SEPARATED = (
+        ("-o", "ci.skip"),
+        ("--push-option", "ci.skip"),
+        ("--receive-pack", "/usr/bin/git-receive-pack"),
+        ("--exec", "/usr/bin/git-receive-pack"),
+    )
+
+    def test_a_separated_value_does_not_erase_the_floor_tag(self):
+        base = security._git_publish_floor_tags("git push --repo=origin")
+        assert base == frozenset({"git-publish-push-bare"})
+        for opt, val in self.SEPARATED:
+            cmd = f"git push --repo=origin {opt} {val}"
+            assert security._git_publish_floor_tags(cmd) == base, (
+                f"{cmd!r}: appending one option changed the floor answer — the "
+                "separated value leaked into the positional list and erased the tag"
+            )
+
+    def test_a_separated_value_is_not_read_in_place_of_a_real_target(self):
+        for opt, val in self.SEPARATED:
+            cmd = f"git push {opt} {val} origin main"
+            tags = security._git_publish_floor_tags(cmd)
+            assert "git-publish-push-protected-branch-name" in tags, (
+                f"{cmd!r}: the real protected target lost its tag to the leaked "
+                f"option value: {set(tags)}"
+            )
+
+    def test_a_consumed_value_keeps_a_feature_branch_push_allowed(self):
+        # Kills the ARITY-TABLE mutant separately from the fallback mutant:
+        # drop a family from the table and these commands fall to the
+        # protective fallback and DENY, so this test is what proves the table
+        # (precision) is load-bearing, not just the fallback (protection).
+        for opt, val in self.SEPARATED:
+            cmd = f"git push {opt} {val} origin feature-x"
+            assert not security._git_publish_floor_tags(cmd), (
+                f"{cmd!r}: a legitimate feature-branch push with a known "
+                "value-taking option must stay allowed"
+            )
+
+    def test_the_attached_form_keeps_parsing_as_before(self):
+        # ``=`` binds the value inside the token, so it can never disturb the
+        # positional split; these already parsed correctly and must not regress.
+        for cmd in (
+            "git push --repo=origin --push-option=ci.skip",
+            "git push --repo=origin -oci.skip",
+        ):
+            assert security._git_publish_floor_tags(cmd) == frozenset(
+                {"git-publish-push-bare"}
+            ), f"{cmd!r}: the attached form regressed"
+
+    def test_value_option_abbreviations_consume_like_git(self):
+        # Git resolves an unambiguous long-option prefix, so ``--push-opt`` is
+        # ``--push-option`` — its separated value must be consumed too (the
+        # same resolution rule finding 2 established for the danger flags).
+        cmd = "git push --repo=origin --push-opt ci.skip"
+        assert security._git_publish_floor_tags(cmd) == frozenset({"git-publish-push-bare"})
+
+    def test_a_short_bundle_ending_in_o_consumes_like_git(self):
+        # ``-fo ci.skip`` is ``-f -o ci.skip``: the first value-taking short in
+        # a bundle takes the rest of the token or, when the rest is empty, the
+        # NEXT token.
+        cmd = "git push --repo=origin -fo ci.skip"
+        assert security._git_publish_floor_tags(cmd) == frozenset({"git-publish-push-bare"})
+
+
+class TestUnrecognisedOptionsReadProtectively:
+    """The invariant that closes the class (#7796 shape C): an option the scan
+    does not model might take a separated value, so the positional split cannot
+    be trusted — read the segment protectively instead. A mis-parse can then
+    only ever OVER-protect; a future value-taking push option cannot silently
+    reopen the erasure.
+    """
+
+    def test_an_unknown_separated_long_option_cannot_erase_the_floor(self):
+        cmd = "git push --frobnicate ci.skip origin feature-x"
+        tags = security._git_publish_floor_tags(cmd)
+        assert "git-publish-push-bare" in tags, (
+            f"{cmd!r}: an unrecognised option left the positional split trusted "
+            f"— the erasure class is open again: {set(tags)}"
+        )
+
+    def test_an_unknown_short_flag_reads_protectively(self):
+        tags = security._git_publish_floor_tags("git push -z origin feature-x")
+        assert "git-publish-push-bare" in tags
+
+    def test_the_protective_reading_still_names_a_protected_target_precisely(self):
+        # Not trusting the split widens the refspec scan to EVERY positional,
+        # so a protected name still reports its own catalog row — an operator
+        # who disabled the bare rule is still covered by the protected one.
+        tags = security._git_publish_floor_tags("git push --frobnicate ci.skip origin main")
+        assert (
+            "git-publish-push-protected-branch-name" in tags
+        ), f"the protective reading dropped the precise protected tag: {set(tags)}"
+
+    def test_known_no_value_flags_do_not_trip_the_fallback(self):
+        # The guard against over-denial: every boolean / attached-optional-value
+        # push option is modelled, so ordinary feature-branch pushes keep
+        # working. (``--signed`` / ``--force-with-lease`` take a value in
+        # ATTACHED form only — git never consumes a separate token for them.)
+        for cmd in (
+            "git push --force origin feature-x",
+            "git push --force-with-lease origin feature-x",
+            "git push --signed origin feature-x",
+            "git push --no-verify origin feature-x",
+            "git push -f origin feature-x",
+            "git push -fq origin feature-x",
+            "git push --atomic --dry-run origin feature-x",
+        ):
+            assert not security._git_publish_floor_tags(cmd), (
+                f"{cmd!r}: a known no-value flag was read as unrecognised and "
+                "over-denied a legitimate feature-branch push"
+            )
+
+    def test_recurse_submodules_is_deliberately_not_vouched_for(self):
+        # Its arity is not modelled (optional-value in current git, and the
+        # separated spelling is exactly the leak shape if that ever changes),
+        # so the separated form reads protectively while the attached form —
+        # which cannot leak — parses as before.
+        assert "git-publish-push-bare" in security._git_publish_floor_tags(
+            "git push --recurse-submodules check origin feature-x"
+        )
+        assert not security._git_publish_floor_tags(
+            "git push --recurse-submodules=check origin feature-x"
+        )
+
+    def test_an_all_branches_flag_keeps_its_single_tag_under_the_fallback(self):
+        # The fallback does not stack the bare tag on top of mirror-all: the
+        # all-branches flag names the target set exhaustively (finding 3's
+        # suppression), and mirror-all already covers a superset of bare.
+        tags = security._git_publish_floor_tags("git push --all --frobnicate v")
+        assert tags == frozenset({"git-publish-push-mirror-all"})
+
+    def test_end_of_options_marker_makes_everything_after_it_positional(self):
+        # A bare ``--`` ends option parsing in git; the scan must read what
+        # follows as positionals, not drop or consume it as flags.
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "git push -- origin main"
+        )
+        assert not security._git_publish_floor_tags("git push -- origin feature-x")
+
+    def test_end_of_options_stops_option_parsing_for_later_dash_tokens(self):
+        # After ``--``, a dash-prefixed token is a POSITIONAL in git's reading
+        # (the only way to push a ref whose name starts with a dash), so it
+        # must be read as a refspec candidate — not dropped as a flag (the old
+        # scan's single-arg misread) and not fed to the unrecognised-option
+        # fallback (which would over-deny a shape git accepts).
+        assert not security._git_publish_floor_tags("git push -- origin -x")
+
+
+class TestParserBranchTable:
+    """Every branch of the positional/arity parser, with why each is correct.
+
+    The issue makes this table an explicit acceptance condition: four
+    consecutive findings landed in this one span, each fix narrowing one branch
+    while the adjacent one stayed wrong, so the parser's whole behaviour is
+    pinned here as data rather than implied by scattered tests. The same table
+    appears in the PR body.
+    """
+
+    BARE = "git-publish-push-bare"
+    SINGLE = "git-publish-push-single-arg"
+    MIRROR = "git-publish-push-mirror-all"
+    NAME = "git-publish-push-protected-branch-name"
+    REF_PATH = "git-publish-push-protected-ref-path"
+    AMBIG = "git-publish-push-ambiguous-ref"
+    WILD = "git-publish-push-wildcard-refspec"
+
+    # (push args, exact expected tag set, why this is the correct reading)
+    TABLE = (
+        ("", {BARE}, "no target named — the current branch may be protected"),
+        ("origin", {SINGLE}, "remote only, no refspec — same current-branch risk, its own row"),
+        ("origin feature-x", set(), "explicit non-protected target — the allowed shape"),
+        ("origin main", {NAME}, "explicit protected target by bare name"),
+        ("origin refs/heads/main", {REF_PATH}, "protected target by ref path — separate row"),
+        ("origin head", {AMBIG}, "symbolic ref resolves at runtime — unverifiable"),
+        ("origin refs/heads/*:refs/heads/*", {WILD}, "wildcard expands to many refs"),
+        ("origin main feature-x", {NAME}, "ALL refspecs scanned, one protected suffices"),
+        ("--repo=origin", {BARE}, "remote in the flag, nothing names a branch — bare"),
+        ("--repo origin", {BARE}, "separated repo value consumed, still bare"),
+        ("--repo=origin main", {NAME}, "remote in flag, so the sole positional is a refspec"),
+        ("--all origin", {MIRROR}, "all-branches flag; single-arg deliberately suppressed"),
+        ("--mirror", {MIRROR}, "mirror pushes everything"),
+        ("--force origin feature-x", set(), "boolean flag — force to a feature branch is allowed"),
+        ("-fq origin feature-x", set(), "short bundle of modelled no-value options"),
+        (
+            "--force-with-lease origin feature-x",
+            set(),
+            "optional-value option: git binds a value in attached form only",
+        ),
+        ("-o ci.skip origin feature-x", set(), "arity: -o consumes its separated value"),
+        (
+            "--push-option ci.skip origin main",
+            {NAME},
+            "value consumed, the real protected target still read",
+        ),
+        ("--push-option=ci.skip origin feature-x", set(), "attached value cannot leak"),
+        (
+            "--repo=origin --push-option ci.skip",
+            {BARE},
+            "the #7796 erasure row: value consumed, bare tag preserved",
+        ),
+        (
+            "--receive-pack /usr/bin/git-receive-pack origin feature-x",
+            set(),
+            "arity: --receive-pack consumes its separated value",
+        ),
+        (
+            "--exec /usr/bin/git-receive-pack origin main",
+            {NAME},
+            "arity: --exec consumes its value, protected target still read",
+        ),
+        ("-- origin main", {NAME}, "end-of-options: everything after -- is positional"),
+        ("-- origin feature-x", set(), "end-of-options with a feature target stays allowed"),
+        (
+            "-- origin -x",
+            set(),
+            "a dash-named refspec after -- is positional, not an option",
+        ),
+        (
+            "--frobnicate ci.skip origin feature-x",
+            {BARE},
+            "unrecognised option: split untrusted, protective bare reading",
+        ),
+        (
+            "--frobnicate ci.skip origin main",
+            {BARE, NAME},
+            "protective reading scans every positional, precise tag preserved",
+        ),
+        ("--frobnicate", {BARE}, "unrecognised and nothing positional — bare either way"),
+        (
+            "--all --frobnicate v",
+            {MIRROR},
+            "fallback does not stack bare onto mirror-all (finding 3 suppression)",
+        ),
+    )
+
+    def test_the_parser_branch_table(self):
+        for args, expected, why in self.TABLE:
+            cmd = f"git push {args}".strip()
+            got = security._git_publish_floor_tags(cmd)
+            assert got == frozenset(
+                expected
+            ), f"{cmd!r}: expected {set(expected) or '{}'} because {why}; got {set(got) or '{}'}"
+
+    def test_substitution_glue_stays_on_the_ungated_branch(self):
+        # Kept out of TABLE because the sentinel is not a catalog row: the
+        # anti-obfuscation branches are upstream of this parser and unaffected.
+        got = security._git_publish_floor_tags("git push origin $(echo main)")
+        assert got == frozenset({security._GIT_PUBLISH_UNGATED})


### PR DESCRIPTION
The git-publish floor's token scan modelled only the `-` prefix, not option **arity**. Exactly one option family (`--repo`) had its separated value consumed, so every other value-taking push option (`-o`/`--push-option`, `--receive-pack`, `--exec`) leaked its value into the positional list, where it was read as a remote or refspec. The leaked value normalizes to a non-protected name, so the tag set came back **empty — and an empty tag set is an ALLOW**, because the tag set drives the protected-branch decision. Appending one flag to a bare publish on a protected branch switched the floor off.

Fixes #7796 (the fourth finding in this parser span on #7705, split out because the ask is an invariant that closes the class).

## Why the #7705 table retraction is not precedent against this

A 35-entry long-option table was added and then removed on #7705 with a proof it changed zero verdicts — but that proof was about dangerous-option **prefix matching**, a set intersection where extra names can only add candidates and so really were inert. **Arity is a different axis: it decides which tokens are refspecs at all, so a table there does change outcomes** — the four measured rows below are exactly such outcome changes.

## Re-measured table (base `63a043a7e`, which includes #7705's merge)

The issue's table was taken on `e474f9eae`; all four rows reproduce identically on the current base, including with finding 3's fallback-suppression live:

| push arguments | floor tags before | floor tags after |
|---|---|---|
| `--repo=origin` | `['git-publish-push-bare']` | `['git-publish-push-bare']` |
| `--repo=origin --push-option ci.skip` | `[]` | `['git-publish-push-bare']` |
| `--repo=origin -o ci.skip` | `[]` | `['git-publish-push-bare']` |
| `--repo=origin --receive-pack /usr/bin/git-receive-pack` | `[]` | `['git-publish-push-bare']` |

(`--exec`, the `--receive-pack` alias, reproduced and is fixed identically.)

## Fix — issue shape (C) combined with (A)

1. **Arity table** (`_PUSH_VALUE_OPTS`: `repo`, `push-option`, `receive-pack`, `exec`) — the four families git accepts with a separated REQUIRED value have that value consumed. Resolved through the existing `_push_option_matches`, so abbreviations keep working the way finding 2 established (`--push-opt ci.skip` consumes). This is `_PUSH_REPO_OPTS` widened, not a new mechanism.
2. **Modelled no-value options** (`_PUSH_NO_VALUE_OPTS` + a structural `--no-*` rule + git-faithful short-option bundles): booleans and the attached-only optional-value options (`--signed`, `--force-with-lease`), so ordinary feature-branch pushes — `--force origin feature-x`, `-fq origin feature-x` — keep working unchanged. Short bundles resolve char-by-char like git: `-fo ci.skip` is `-f -o ci.skip`; `-oci.skip` is attached.
3. **Fail-protective fallback** for anything still unrecognised: the positional split is not trusted — the bare tag is emitted (the current branch may be protected) **and every positional is scanned as a refspec candidate**, so an actual protected name in the segment still reports its own precise catalog row. The superset scan matters: with bare alone, an operator who had disabled the bare rule would have been exposed through any unknown option; with it, `--frobnicate v origin main` still carries `protected-branch-name`. A mis-parse can therefore only ever OVER-protect, which is the invariant that ends the class — (A) alone reopens silently on the next value-taking git option.

Tag identities are preserved exactly: every branch that classified correctly before emits the same tag it did; the fallback emits the bare catalog row (the issue's prescribed protective reading), deliberately NOT the ungated anti-obfuscation sentinel — an unrecognised option is a readable shape an operator may legitimately opt out of, unlike substitution glue.

**End-of-options:** a bare `--` previously fell into the `-`-prefix skip; it now ends option parsing exactly as git reads it, so a dash-named refspec after `--` is a positional (`git push -- origin -x` no longer misreads as single-arg / an unknown option).

**`--recurse-submodules` is deliberately in neither table:** listing an option as no-value vouches that its separated neighbour is positional, and being wrong about that is this very bug. Its separated form falls to the protective fallback; its attached form (`--recurse-submodules=check`) parses as before, because a token with an attached `=` value can never disturb the split regardless of the option.

## Parser branch table

Asserted verbatim in `TestParserBranchTable::test_the_parser_branch_table` (28 rows); the acceptance condition from the issue. Summary by branch:

| branch | example | tags | why correct |
|---|---|---|---|
| bare | *(none)* | `bare` | no target named; current branch may be protected |
| remote only | `origin` | `single-arg` | its own catalog row |
| explicit feature target | `origin feature-x` | *(none)* | the allowed shape |
| protected by name | `origin main` | `protected-branch-name` | |
| protected by ref path | `origin refs/heads/main` | `protected-ref-path` | separate row so opt-out disables what fired |
| symbolic ref | `origin head` | `ambiguous-ref` | resolves at runtime |
| wildcard | `origin refs/heads/*:refs/heads/*` | `wildcard-refspec` | expands to many refs |
| multi-refspec | `origin main feature-x` | `protected-branch-name` | ALL refspecs scanned |
| repo in flag | `--repo=origin` / `--repo origin` | `bare` | remote not positional; separated value consumed |
| repo in flag + refspec | `--repo=origin main` | `protected-branch-name` | sole positional is a refspec |
| all-branches | `--all origin` | `mirror-all` | single-arg suppressed (finding 3) |
| no-value flags | `--force origin feature-x`, `-fq …`, `--force-with-lease …` | *(none)* | modelled arity; no over-deny |
| value option, separated | `--push-option ci.skip origin main` | `protected-branch-name` | value consumed, real target read |
| value option, attached | `--push-option=ci.skip origin feature-x` | *(none)* | `=` binds inside the token |
| the erasure row | `--repo=origin --push-option ci.skip` | `bare` | value consumed, bare preserved |
| end-of-options | `-- origin main` / `-- origin -x` | `protected-branch-name` / *(none)* | positionals after `--`, exactly git's reading |
| unrecognised option | `--frobnicate v origin feature-x` | `bare` | split untrusted, protective reading |
| unrecognised + protected present | `--frobnicate v origin main` | `bare`+`protected-branch-name` | superset scan keeps the precise row |
| unrecognised + all-branches | `--all --frobnicate v` | `mirror-all` | fallback does not stack bare onto a superset tag |
| substitution glue | `origin $(echo main)` | ungated sentinel | upstream anti-obfuscation branch, untouched |

## Verification

- **Red before green:** the new tests were written first and run against the unmodified parser — 8 failed (all four separated-value families, both unrecognised-option shapes, the short-bundle row, the branch table), the attached-form and no-value pins passed, exactly as the erasure predicts. Re-confirmed cross-tree: the branch's test file against an `origin/main` worktree source fails the same 8 and passes the other 66.
- **Zero regression, both directions:** `origin/main`'s 58-test suite runs green against the fixed parser; the fixed branch's full file (74 tests) is green against the branch. `git worktree` at `origin/main` used for the cross runs; pytest `pythonpath = src` verified to import each tree's own source.
- **Mutation-checked, table and fallback separately** (each mutant applied via sed, suite run, then restored; full suite green after restore):
  - drop `push-option` from `_PUSH_VALUE_OPTS` → killed by `test_a_consumed_value_keeps_a_feature_branch_push_allowed` + branch table (the arity table is load-bearing for precision, not rescued silently by the fallback);
  - empty `_PUSH_VALUE_SHORTS` → killed by the same pair (`-o` rows);
  - neutralize the long-option `unrecognised_option` flag → killed by `test_an_unknown_separated_long_option_cannot_erase_the_floor`, the recurse-submodules pin, branch table;
  - neutralize the short-option flag → killed by `test_an_unknown_short_flag_reads_protectively`;
  - neutralize the `--` end-of-options marker → killed by `test_end_of_options_stops_option_parsing_for_later_dash_tokens` + branch table;
  - fallback stops scanning positionals (`refspecs = []`) → killed by `test_the_protective_reading_still_names_a_protected_target_precisely`;
  - fallback drops the bare tag → killed by both unknown-option tests + branch table.
- **Gates:** `scripts/local-gate.py --base origin/main` classified the diff backend-only and ran the FULL backend suite: branch 80,486 passed / 223 failed + 2 errors; an identical run in a pristine `origin/main` worktree: 80,467 passed / 226 failed + 2 errors. Sorted unique failing-id sets diffed BOTH directions: zero branch-only failures (the one branch-only line is a captured asyncio log artifact, not a test id); the three main-only ids (`test_release_macos_fail_closed.py`) fail identically on BOTH trees when rerun deterministically (3 failed / 3 passed each side) — xdist-scheduling-dependent environmental flakes, unrelated to this diff. `scripts/check_black_formatting.py` passes; isort/flake8 clean on touched files.
- Docs: `docs/system-specs/modules/security.md` updated in the same commit (arity model, fail-protective fallback, attached-form rule, `--`, and the retraction distinction).

## Review rounds 1-16 (GPT 5.6, all verified real, adopted)

**Round 1** — the scan tokenizes on whitespace while the shell fuses a quoted or escape-continued span into ONE word, so `--push-option='ci skip'` arrived as fragments; consuming one token left the tail fragment trusted as a refspec and the erasure was back (reproduced in five spellings).

**Round 2** — the round-1 fix counted quote characters, and an ESCAPED quote is data, not a delimiter: `--push-option="ci\" skip\""` flipped the parity without closing anything and the bypass was back (reproduced). `_push_token_is_word_fragment` now walks the shell's own quote/escape state — backslash escapes outside quotes, inside double quotes, and inside `$'...'` ANSI-C strings; literal inside plain single quotes — and flags any token whose state does not return to normal. Two-directional precision pinned: complete words with escaped quotes are NOT flagged (`"feat\"x"` stays allowed; the quote-splice `'ma'\''in'` reads exactly as the protected-branch row — the parity heuristic over-flagged both), and an ANSI-C-only spelling whose fragments both scan clean under a plain-single reading (`$'a\' bc'\''d'`) pins the `$'...'` escape branch as load-bearing. Stated residual: the `$`-lookback can misread `$$'` (PID expansion) as ANSI-C, which only ever OVER-flags.

**Round 3** — a consumed or dropped token is not inert text: with `V='ci.skip main'`, a publish carrying `--repo=origin` and a separated `--push-option $V` expands and word-splits AFTER this scan, handing git a `main` refspec the split never saw — and consuming the literal `$V` had REGRESSED that case from main's accidental posture (the leaked value hit the refspec `$`-ambiguity check → the non-disableable ungated sentinel) to the disableable bare rule (reproduced on both trees). Fix, slot-independent: a `$` anywhere in ANY token lands the segment on the ungated branch (the exact posture `ma$in` already had in the refspec slot); glob characters (`*` `?` `[`) in any token keep the wildcard-refspec identity, since pathname expansion also produces words (`ma[i]n` beside a file named `main` pushes main) and none of those characters is legal in a refname, so no real command is lost. This also upgraded two siblings found while verifying: attached `--push-option=$v` (pre-existing bare on main → ungated) and the positional remote slot (`git push $remote feature-x` was allowed on main → ungated).

**Round 4** — shell operators are consumed by the SHELL, never by git: `git push origin </dev/null` executed a remote-only push while the scan read `</dev/null` as the refspec (phantom positional, single-arg tag erased) — and worse, `git push origin main>log` pushed MAIN with no tag at all, since the glued word hid the name (both reproduced, both pre-existing on main). Fix, three shell-faithful parts: a `#`-opened comment truncates the segment's remaining tokens exactly as the shell does (`origin #main` reads as the precise single-arg row); a redirection token is excluded with the shell's own arity — attached target/fd (`2>err`, `2>&1`) self-contained, bare operator consumes the next word — which keeps the everyday `git push origin feature-x 2>&1` ALLOWED while `origin </dev/null` reads as the precise remote-only shape; a bare `&` (a single ampersand is not a segment separator upstream, only `&&` is) or mid-word operator glue marks the split untrusted AND scans the operator-delimited pieces, so `main>log`'s protected name is seen. Quoted operator characters stay data (`'feat<x'` unaffected — git permits `<>&` in refnames).

**Round 5** — `#` opens a comment only at the start of a WORD: when an earlier token leaves the shell state open (a trailing escape or an unterminated quote fusing across the split), a `#`-leading token can be MID-WORD, and truncating there discarded a real trailing `main` refspec, leaving only the disableable bare tag (reproduced in both the escaped-space and open-quote spellings). Truncation now requires every preceding token to have closed cleanly; otherwise truncation is skipped entirely — the open state already poisons the split protectively and the superset scan keeps the trailing protected name visible. Word-initial comments keep their exact reading (`origin #main` → single-arg; `feature-x #main` → allowed).

**Round 6** — bash line continuation: `\<newline>` VANISHES, so `git push origin ma\` + newline + `in` splices to a push of MAIN across the newline segment boundary — no token in the scanned segment spells the name, and only the disableable bare tag fired (reproduced; the double-quoted continuation sibling too). Fix: a segment whose CUMULATIVE quote/escape state is still open at its end (the shared walk run over the joined segment) is unreconstructable and lands on the ungated sentinel, the `ma$in` posture. Deliberately NARROWER than the review's suggested "ungate any open state": a mid-segment open (a quoted value whose quote closes before segment end, e.g. `--push-option='ci skip'`) cannot splice into the next line, in-segment joining can only fuse whitespace into a word — never a valid refname — and the pieces stay visible to the superset scan, so those keep the operator-facing DISABLEABLE bare row (pinned both directions).

**Round 7** — `<<-` (the tab-stripping heredoc) is a complete operator: its `-` landed in the redirection regex's REMAINDER, so the token read as self-contained and the separated delimiter word became a phantom refspec — `git push origin <<- EOF` erased the single-arg tag exactly like round 4's `</dev/null` (reproduced). One-alternation fix in `_PUSH_REDIRECTION_RE` (`<<-` folded into the operator, tried before the general run), with the fd-close/fd-move spellings (`>&-`, `2>&1-`) pinned to keep their self-contained reading — their trailing `-` is an fd disposition, not a separated target.

**Round 8** — process substitution: `<(cmd)` / `>(cmd)` are WORDS (the shell substitutes a /dev/fd path), not removable redirections — dropping `-o <(echo)` as a redirection shifted the option's value consumption onto `origin` and downgraded a push of MAIN to the disableable single-arg row (reproduced). Process substitution is SUBSTITUTION: `[<>]\(` joins `$(`/`${`/backticks in the upstream ungating regex, checked before redirection parsing ever sees the token; a parenthesis without the operator adjacency stays refname data (pinned).

**Round 9** — extglob: with `shopt -s extglob`, `@(main)` / `+(main)` / `!(x)` are pathname patterns — beside a file named `main`, a publish of `origin @(main)` expanded to a push of MAIN with NO tags (reproduced). Extglob is pathname expansion, so it takes the WILDCARD catalog identity beside `*`/`?`/`[` (it can only ever match existing file names), not the substitution sentinel the review suggested — the identity distinction is the round-3 layering, kept consistent; `?(` and `*(` were already covered by their leading glob character, and quoted parens stay refname data (pinned).

**Round 10** — glued redirections and IDENTITY precision: `origin>/dev/null` is the word `origin` plus a redirection — a remote-only push whose true row is SINGLE-ARG — but the protective fallback emitted BARE, so an operator who disabled only the bare rule had the shape allowed while its real row was still enabled (reproduced; the same fallback also over-denied glued legit pushes like `feature-x>log`). A word glued to a WELL-FORMED redirection now decomposes precisely — pre-operator word kept positional, redirection consumed with its arity — while murky glue (a bare `&` boundary, flag-shaped prefixes, quoted redirection text, risky `&` in the target) keeps the protective fallback.

**Round 11** — two legs, both verified. (a) Bash NAMED descriptors: `{fd}>/dev/null` is ALL redirection, but the round-10 decomposition read `{fd}` as the pre-operator word — it became the sole "refspec" and every tag was erased (a regression this PR's own round 10 introduced, caught before merge). The `{name}` prefix now joins the fd-number/`&` alternatives in the redirection grammar. (b) Quoted TARGETS: the operator grammar admits no quote characters, so a quote can only sit in the target group — refusing the whole token for containing one had pushed `>'log'` into the fallback with the wrong catalog identity. The refusal is now precise: fragment state (open quote / trailing escape) still refuses protectively, completed quoted targets keep redirection arity. Quoted `'{fd}'` stays refname data (pinned).

**Round 12** — glued fd-close and all-output redirections: `origin>&-` (close stdout) and `origin&>/dev/null` fell past the glued-decomposition's `&`-guard into the fallback, mislabelling remote-only pushes as bare (reproduced). The guard now admits the fd-close/move alternatives and the `&>`/`&>>` operator head, both pinned with the fd-dup precision row (`ci>&2` with a repo flag stays an allowed value). Advisory adopted: the process-substitution regex's conservative quoted-match behaviour is now documented at the regex (a ref literally named `feat<(x)` over-denies, the same fail-closed posture as a quoted `$(`).

**Round 13** — two legs, both verified. (a) A glued word+redirection token while a separated option value was PENDING fed its word into the positional list instead of the option, so the next real word was eaten as the "value" and every tag was erased (`--repo origin` glued to `>/dev/null`, then `main`, returned NO tags). The glued word now flows exactly where the shell's argv word would: pending option value first, else positional. (b) A lone `-` is an OPERAND to git's own option parser (a repository spelled `./-` is addressable), but the scan skipped it as a flag, shifting the refspec into the remote slot and downgrading the row to single-arg. Both pinned with allowed-spelling precision rows.

**Round 14** — two legs plus a class-fix, all verified. (a) Spaced subshell parens: in `( ... )` the `)` token read as a refspec and erased every tag; unquoted parens now join the operator walk (the glued spelling was already ungated upstream; quoted parens stay refname data). (b) The `--recurse-submodules check origin` row exposed the fallback single-identity gap a THIRD time (after rounds 10 and 13), so the class is now fixed rather than re-patched: an untrusted split with visible positionals emits BOTH no-refspec rows (bare + single-arg — it cannot distinguish option values from a remote), superseding this PR's earlier round-11 decline of the same idea, which three measured bypasses have overruled; with no positionals bare stands alone, and the finding-3 mirror-all suppression is unchanged. This round also folds in the two deferred advisory subtractions (First Principles): `_AMBIGUOUS_REFSPEC_RE` shrunk to `@\{` (its `$`/backtick branches are shadowed by the per-token `$` check and the upstream expansion ungate) and the unreachable `repo` member dropped from `_PUSH_VALUE_OPTS`.

**Round 15** — tilde: `HOME=main` makes a bare `~` refspec expand to `main`, and `HOME=refs/heads` makes even `~/main` a protected refspec — the inventory's "tilde expands to a path" rationale WAS the bug (reproduced). A token-LEADING unquoted `~` now joins `$` on the ungated branch (it is env-driven text, not path syntax); a mid-word `~` stays literal data, and `~` is illegal in refnames so the over-protection costs no real command. The inventory test row moved from the benign group to the expansion layer with the corrected rationale.

**Round 16** — glued all-branches flag: `--all>/dev/null` bailed to the fallback because its prefix is flag-shaped, emitting only the two disableable no-refspec rows while the true row (mirror-all) stayed silent — disabling those two admitted an all-branches push (reproduced, abbreviations included). The glued prefix is now classified against the all-branches set before the fallback; the finding-3 suppression then yields exactly the true row. Other glued flag prefixes stay on the fallback, which only over-protects (pinned with the redirected force-push row).

Red-first all sixteen rounds; thirty-seven mutants killed separately against committed state (round 1: quote check, backslash check, wiring; round 2: double-quote escape consume, ANSI branch, normal-state escape consume, wiring; round 3: the `$` check and the glob check; round 4: redirection classification, redirection consume-next arity, operator split, comment truncation, piece scan; round 5: the open-seen truncation guard and its state tracking; round 6: the cumulative segment-end check; round 7: the `<<-` alternation; advisory round: the five walk mutants re-killed against the merged function; plus the original arity/fallback/`--`/superset-scan/bare-tag set); full backend re-run after each round with failing-id sets byte-identical vs the `origin/main` worktree (per-round single divergent ids rerun identically on both trees serially — xdist scheduling flakes).

## Advisory round (Design + First Principles CONCERNS, both dispositioned)

Adopted: the duplicate quote/escape state machines merged into one walk (`_push_token_shell_read`, FP subtraction a; mutants re-run against the merged function); the invariant claim narrowed (option-arity axis protective by construction, shell-syntax axis resting on a complete inventory) and that inventory pinned as a checked property (`test_every_bash_metacharacter_is_accounted_for`, Design's watch). Declined with rationale: the raw-token character allowlist (cannot admit quoting without reintroducing the walk) and dropping `_PUSH_VALUE_SHORTS` (the short half of the arity table). Deferred-and-tracked: the bash-faithful word lexer consolidation is #7832 (FP's standing-cause watch). The `$`-ungated posture is defended on slot-consistency grounds and explicitly flagged for the merging maintainer in the disposition comment.

## Pattern harvest

Rule candidate: when a token scan skips "flags" by prefix, every value-taking option's SEPARATED value lands in the positional read — model option arity explicitly and make the unrecognised case fail toward MORE protection, never less, so the enumeration going stale cannot silently reopen the hole. Known out-of-scope sibling: `_git_push_args` (the subcommand locator in the same module) also skips leading `git`-level flags with a one-value heuristic; it is upstream of this parser, fails toward treating a segment as unparseable (the ungated sentinel), and is not an erasure surface.

<!-- no-visual-delta -->
No frontend surface: a backend-only parser change with no user-facing string; the evidence is the branch-table assertions and the mutation matrix above.
