### PR TITLE
fix(virtualizer): hold the reader across an equal-count row swap

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -476,7 +476,7 @@ export function useVirtualChat<T>(
   const heightAnchorPendingRef = useRef<{ key: string; top: number } | null>(null)
 
   /**
-   * ONE compensation routine, FIVE triggers, ONE capture point.
+   * ONE compensation routine, SIX triggers, ONE capture point.
    *
    *   TRIGGER 1 — prepend (load-older history): every index shifts up, so
    *     pre-existing rows move down by the inserted height.
@@ -501,15 +501,16 @@ export function useVirtualChat<T>(
    *   TRIGGER 6 — mid-list SWAP: the thinking row leaves and its replacement
    *     arrives in ONE commit, which React batching makes the ordinary streaming
    *     shape. The net count is unchanged, so a count-delta trigger reads it as a
-   *     no-op. It participates in the height RETIREMENT below but deliberately
-   *     captures NO anchor: the single consumer is invalidated by `windowRange`
-   *     and `itemCount`, and an equal-count swap moves neither, so an anchor
-   *     taken here would sit in the slot and be spent on an unrelated later
-   *     commit — the exact stranded-anchor hazard the render-phase capture
-   *     exists to remove. Compensating it needs a new invalidation key in that
-   *     consumer, which is its own change; tracked in #7234.
+   *     no-op — and the single consumer is invalidated by `windowRange` and
+   *     `itemCount`, neither of which an equal-count commit moves. So this
+   *     trigger carries its OWN invalidation key (`spliceCommit`, bumped in the
+   *     render that captures here), which is what makes the capture safe: the
+   *     anchor is spent in the very commit it describes instead of sitting in the
+   *     slot for an unrelated later commit — the stranded-anchor hazard the
+   *     render-phase capture exists to remove. It participates in the height
+   *     RETIREMENT below on the same commit.
    *
-   * All five are "the height above the reader changed"; the correction is
+   * All six are "the height above the reader changed"; the correction is
    * identical, so they share this slot and the single consumer below. A parallel
    * path would fight this one for `scrollTop`, which is why append folds in here
    * rather than getting an anchor slot of its own.
@@ -539,6 +540,27 @@ export function useVirtualChat<T>(
   const shiftAnchorRef = useRef<{ key: string; top: number } | null>(null)
   const shiftStageRef = useRef<'awaiting-rebase' | 'rebased' | 'ready' | null>(null)
   const prependCountRef = useRef(0)
+  /**
+   * TRIGGER 6's invalidation key for part 2, bumped in the render that captures a
+   * swap anchor. Every other trigger rides a key part 2 already watches — a
+   * prepend, splice or append moves `itemCount`, a window shift moves
+   * `windowRange` — and an equal-count swap moves neither, so without this the
+   * consumer would not run in the commit the anchor was taken for.
+   *
+   * Real state rather than a ref token, for the reason `heightCommit` is: a
+   * counter this effect does not subscribe to is invisible to tooling and needs
+   * an exhaustive-deps exemption to sit in the dep array at all. The bump is the
+   * render-time state-update pattern the session and cache sentinels above use,
+   * and terminates for the same reason they do: `prependPrevRef` has already
+   * advanced by the time React re-invokes the render, so the re-render detects no
+   * swap, captures nothing, and bumps nothing.
+   *
+   * Cost is one extra render pass, and only on a commit that actually captures:
+   * the capture is gated on `!stickRef.current`, so the primary reading mode
+   * (pinned to the bottom) never pays it, and a token append — the commit that
+   * lands per streamed chunk — is not a swap and never reaches the bump.
+   */
+  const [spliceCommit, setSpliceCommit] = useState(0)
   /** Set by part 1 in the commit it schedules a re-base in, cleared by part 2 in
    *  that same commit. Part 2 now also watches `itemCount` (for trigger 3), so
    *  it shares a commit with part 1 and would otherwise consume a prepend anchor
@@ -649,20 +671,25 @@ export function useVirtualChat<T>(
    *  on. Retirement has its own gate below and deliberately does not share this
    *  one. */
   const rowsRemoved = itemCount < prependPrev.count && sameSessionCount && frontKeyHeld
-  // TRIGGERS 4 and 5 — a mid-list splice, either direction. Both capture the
-  // anchor, through the one capture point and the one consumer: both are "a row
-  // came or went above the reader", and the correction part 2 already performs
-  // does not care which direction. Placed BEFORE trigger 2 so that in a render
-  // which does both, the splice's key mapping wins over the window branch's
-  // live-items mapping — the whole point being that live-items mapping is what is
-  // wrong here.
+  /** TRIGGER 6 — an equal-count SWAP: a shared index changed hands while the count
+   *  stood still, which is the placeholder leaving and its replacement arriving in
+   *  one React-batched commit. Same `frontKeyHeld` requirement as 4 and 5, for the
+   *  same reason (the mounted nodes' indices must still name their own rows), and
+   *  the indices do not even shift here — only one row's identity does. */
+  const rowSwapped = itemCount === prependPrev.count && sameSessionCount && frontKeyHeld && anyIndexMoved
+  // TRIGGERS 4, 5 and 6 — a mid-list splice: a row in, a row out, or one row
+  // traded for another. All three capture the anchor, through the one capture
+  // point and the one consumer: each is "a row came or went above the reader",
+  // and the correction part 2 already performs does not care which direction it
+  // moved. Placed BEFORE trigger 2 so that in a render which does both, the
+  // splice's key mapping wins over the window branch's live-items mapping — the
+  // whole point being that live-items mapping is what is wrong here.
   //
-  // There is no equal-count trigger. One existed only to reach the retirement
-  // below, and retirement is now gated on departure directly, so an equal-count
-  // swap is served by that gate with no trigger and no anchor of its own — the
-  // anchor it would have captured had no consumer on a commit that moves neither
-  // `windowRange` nor `itemCount`, and stranded in the slot for an unrelated
-  // later commit to spend. See #7234.
+  // The equal-count SWAP is here rather than excluded because it now brings its
+  // own invalidation key (`spliceCommit`, bumped below). Before that key existed
+  // the anchor had no consumer on a commit that moves neither `windowRange` nor
+  // `itemCount`, so capturing would have stranded it in the slot for an unrelated
+  // later commit to spend — see #7234, and `spliceCommit`'s own doc.
   //
   // Staged 'ready' (correct only, never a re-base): a transient row moves the
   // anchor by one index, so it stays inside the mounted window and is
@@ -689,10 +716,11 @@ export function useVirtualChat<T>(
     const survivingKeys = new Set<string>()
     for (let i = 0; i < items.length; i++) survivingKeys.add(getKey(items[i], i))
     // The anchor keeps the narrower gate: it needs index 0 held (so the mounted
-    // nodes' indices still name their own rows) and a count that actually moved
-    // (so part 2, invalidated by `windowRange` and `itemCount`, runs and spends
-    // it). Retirement has neither dependency, which is why it sits outside.
-    if ((midListInserted || rowsRemoved) && !anchorCapturedThisRender && !stickRef.current) {
+    // nodes' indices still name their own rows) and a commit whose consumer will
+    // actually run — a count change for triggers 4 and 5, and for trigger 6 the
+    // `spliceCommit` bump below, which is what an equal-count commit has instead.
+    // Retirement has neither dependency, which is why it sits outside.
+    if ((midListInserted || rowsRemoved || rowSwapped) && !anchorCapturedThisRender && !stickRef.current) {
       const spliceEl = scrollerRef.current
       const spliceAnchor = spliceEl
         ? captureTopAnchorFrom(spliceEl, elIndexRef.current.entries(), (idx) => {
@@ -709,6 +737,11 @@ export function useVirtualChat<T>(
         shiftAnchorRef.current = spliceAnchor
         shiftStageRef.current = 'ready'
         anchorCapturedThisRender = true
+        // Only the swap needs the bump — the other two already move `itemCount`,
+        // and bumping there would buy an extra render pass for a consumer that
+        // was going to run anyway. The three shapes are mutually exclusive by
+        // their count arithmetic, so this cannot double-fire.
+        if (rowSwapped) setSpliceCommit((n) => n + 1)
       }
     }
     // Keyed on KEY DEPARTURE, not on the net count falling: the harm is a
@@ -1864,8 +1897,9 @@ export function useVirtualChat<T>(
     // `itemCount` is an invalidation key, not a value this body reads: TRIGGER 3
     // captures in a render that changes no windowRange, so without it the
     // correction would wait for an unrelated window commit and be applied to
-    // geometry that had already drifted.
-  }, [windowRange, itemCount, scrollerRef, writeScrollTop, recomputeWindow])
+    // geometry that had already drifted. `spliceCommit` is the same kind of key
+    // for TRIGGER 6, which moves neither of the other two.
+  }, [windowRange, itemCount, spliceCommit, scrollerRef, writeScrollTop, recomputeWindow])
 
   // Same correction for a HEIGHT-SYNC commit (spacer repricing), keyed on the
   // owner's announced version. See heightAnchorPendingRef for why this cannot

--- a/website/src/test/useVirtualChat.prependAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.prependAnchor.test.tsx
@@ -34,6 +34,20 @@ const REAL_H = 100
 const CLIENT = 400
 const SCROLL_HEIGHT = 3000
 
+/** Per-key rendered heights, keyed by the row's virtual key. Empty for every
+ *  case but the equal-count SWAP, whose replacement row has to render TALLER
+ *  than the row it replaces: an equal-height swap moves nothing on screen and
+ *  would pass with no fix at all. Reset in beforeEach. */
+let rowHeightByKey: Record<string, number> = {}
+
+/** Rendered height of one row node — its override when it has one, else the
+ *  flat REAL_H every other case in this file uses. */
+function rowHeightOf(node: HTMLElement): number {
+  const key = node.getAttribute('data-key')
+  const override = key !== null ? rowHeightByKey[key] : undefined
+  return override ?? REAL_H
+}
+
 function rect(top: number, height: number): DOMRect {
   return {
     top, bottom: top + height, height, left: 0, right: 0, width: 0, x: 0, y: top,
@@ -142,7 +156,7 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     const origOffsetH = Object.getOwnPropertyDescriptor(proto, 'offsetHeight')
 
     const childHeight = (child: Element): number => {
-      if ((child as HTMLElement).getAttribute('data-index') !== null) return REAL_H
+      if ((child as HTMLElement).getAttribute('data-index') !== null) return rowHeightOf(child as HTMLElement)
       const h = (child as HTMLElement).style?.height
       return h ? parseFloat(h) : 0
     }
@@ -162,7 +176,7 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     Object.defineProperty(proto, 'offsetHeight', {
       configurable: true,
       get(this: HTMLElement) {
-        return this.getAttribute('data-index') !== null ? REAL_H : 0
+        return this.getAttribute('data-index') !== null ? rowHeightOf(this) : 0
       },
     })
 
@@ -178,6 +192,7 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
   beforeEach(() => {
     localStorage.clear()
     frames = []
+    rowHeightByKey = {}
     origRaf = globalThis.requestAnimationFrame
     globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
       frames.push(cb)
@@ -241,7 +256,7 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
       configurable: true,
       get: () => Array.from(el.children).reduce((h, c) => {
         const node = c as HTMLElement
-        if (node.getAttribute('data-index') !== null) return h + REAL_H
+        if (node.getAttribute('data-index') !== null) return h + rowHeightOf(node)
         return h + (parseFloat(node.style?.height || '0') || 0)
       }, 0),
     })
@@ -572,6 +587,59 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
   })
 
+  it('holds the reading position when a row is SWAPPED at equal count above the reader', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef } = mountScrolledUp(base)
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+    const at = indexOf(base, before!.key)
+    expect(at).toBeGreaterThan(0)
+
+    // The ordinary streaming shape: React batches the placeholder LEAVING and its
+    // replacement ARRIVING into one commit, so the net count never moves. The
+    // replacement renders 3x taller than the row it replaces — an equal-height
+    // swap displaces nothing and would pass without any fix.
+    const replaced = base[at - 1].id
+    rowHeightByKey = { out0: REAL_H * 3 }
+    const swapped = base.map((it, i) => (i === at - 1 ? { id: 'out0' } : it))
+    act(() => { view.rerender(<Harness items={swapped} scrollerRef={scrollerRef} />) })
+
+    // Not vacuous: the placeholder really left and the taller replacement really
+    // mounted in its place, at the same index.
+    expect(screenTopOf(el, replaced)).toBeNull()
+    expect(screenTopOf(el, 'out0')).not.toBeNull()
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  it('holds the reading position across an equal-count SWAP when getKey is INDEX-ADDRESSED', () => {
+    // Same contract as the splice cases: the swap anchor resolves the PREVIOUS
+    // render's items at the mounted nodes' PREVIOUS indices, so it must price
+    // them with the getKey captured WITH them. This render's closure reads the
+    // post-swap key list, which names the replacement where the anchor expects
+    // the row it replaced.
+    const base = mkItems(30)
+    const { el, view, scrollerRef } = mountScrolledUp(base, PositionalHarness)
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+    const at = indexOf(base, before!.key)
+    expect(at).toBeGreaterThan(0)
+
+    const replaced = base[at - 1].id
+    rowHeightByKey = { out0: REAL_H * 3 }
+    const swapped = base.map((it, i) => (i === at - 1 ? { id: 'out0' } : it))
+    act(() => { view.rerender(<PositionalHarness items={swapped} scrollerRef={scrollerRef} />) })
+
+    expect(screenTopOf(el, replaced)).toBeNull()
+    expect(screenTopOf(el, 'out0')).not.toBeNull()
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
   it('still follows to the bottom when a row is SPLICED IN while PINNED', () => {
     const base = mkItems(30)
     const { el, view, scrollerRef, readScrollTop } = mountAtBottom(base)
@@ -604,6 +672,34 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
 
     expect(el.scrollTop).toBe(el.scrollHeight - CLIENT)
     const appended = screenTopOf(el, 'z0')
+    expect(appended).not.toBeNull()
+    expect(appended!).toBeGreaterThanOrEqual(0)
+    expect(appended!).toBeLessThan(CLIENT)
+  })
+
+  it('does not hold position for a PINNED reader across an equal-count SWAP', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef, readScrollTop } = mountAtBottom(base)
+
+    const beforeTop = readScrollTop()
+    rowHeightByKey = { out0: REAL_H * 3 }
+    const swapped = base.map((it, i) => (i === 10 ? { id: 'out0' } : it))
+    act(() => { view.rerender(<Harness items={swapped} scrollerRef={scrollerRef} />) })
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+    // The swap capture is gated on stick, so a pinned reader must never be pulled
+    // BACK UP to where a row used to sit. (Following the taller replacement down
+    // is the ResizeObserver's job, which this harness does not provide — the
+    // assertion here is only that the anchor correction stays out of it.)
+    expect(readScrollTop()).toBeGreaterThanOrEqual(beforeTop)
+
+    // And stick survives: the next streamed message still lands at the bottom.
+    act(() => {
+      view.rerender(<Harness items={[...swapped, { id: 'z1' }]} scrollerRef={scrollerRef} />)
+    })
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+    expect(el.scrollTop).toBe(el.scrollHeight - CLIENT)
+    const appended = screenTopOf(el, 'z1')
     expect(appended).not.toBeNull()
     expect(appended!).toBeGreaterThanOrEqual(0)
     expect(appended!).toBeLessThan(CLIENT)


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** scroll-position fix with no static visual delta -- the change is where the viewport sits across one commit, which a before/after still cannot show. Reproduced numerically instead (700px of drift in the harness).

## Problem / Motivation

The render-phase scroll-anchor capture has **one** consumer, and it is invalidated by `windowRange` and `itemCount`. An **equal-count commit** moves neither, so the consumer does not run in that commit.

That left one shape of the transient-row jitter uncompensated after #7198: the "thinking" placeholder **leaving** and its replacement **arriving** in one React-batched update. The net count never moves, so no count-delta trigger fires -- and when the replacement renders taller than the row it replaced, everything above a reader scrolled up moves, and their row walks off under them.

Measured in the `prependAnchor` harness with a 3x-taller replacement: **700px**. Two hundred of that is the row itself growing; the rest is the mean re-pricing every unmeasured row above the reader, because `getHeight` prices an unmeasured row from the running mean of the measured ones, so one new measurement re-prices the whole region.

## Why it matters

It is the ordinary streaming shape, not an edge case: React batches the placeholder's removal and the output's insertion into a single update, so this fires on every placeholder-to-output transition of every turn. A reader scrolled back through a transcript while an agent is still working gets the #6076 jitter for each one, even with #7198 landed.

## What changed (motivation -> approach -> change)

**The capture was never the missing piece -- the invalidation key was.** #7198 could see the swap (it already retires the departed row's height there) and deliberately declined to capture an anchor: with no key that moves on an equal-count commit, the anchor would have sat in the shared slot until some later commit changed `windowRange` or `itemCount`, and then been spent on unrelated geometry -- the stranded-anchor hazard the render-phase capture exists to remove. Capturing without the key would have traded a 700px drift for a nondeterministic yank.

So the key comes first, and the capture follows it:

**1. `spliceCommit`, a counter bumped in the render that captures a swap anchor**, added to part 2's deps. Every other trigger already rides a key that consumer watches -- a prepend, splice or append moves `itemCount`, a window shift moves `windowRange`. Only the swap has neither, so it brings its own, and the anchor is now spent in the very commit it describes.

It is real state rather than a ref token, for the reason `heightCommit` in this same file is: a counter the effect does not subscribe to is invisible to tooling and needs an `exhaustive-deps` exemption to sit in a dep array at all. The bump is the render-time state-update pattern the session and height-cache sentinels above it already use, and it terminates for the same reason they do -- `prependPrevRef` has advanced by the time React re-invokes the render, so the second pass detects no swap, captures nothing and bumps nothing.

**2. TRIGGER 6 joins the existing splice gate**, through the same capture point, the same slot, the same consumer and the same key mapping (previous items at the mounted node's previous index, filtered to keys that survive the commit, so the replaced row's key falls forward to the next survivor). No parallel anchor path -- a second path would fight this one for `scrollTop`.

**Cost is one extra render pass, and only on a commit that actually captures.** The bump sits INSIDE the capture, which is gated on `!stickRef.current`, so the primary reading mode (pinned to the bottom) never pays it; and a token append is not a swap, so the commit that lands per streamed chunk never reaches it.

**What this deliberately does NOT change: the offset memo's deps.** The issue proposed adding the key there too, and on main that is already covered by a different mechanism: #7198's retirement block calls `heightIndex.sync(itemCount)` in the render phase (`useVirtualChat.ts:1050`), precisely because the memo is keyed on `itemCount`. A swap that departs a key -- which is every swap -- therefore already re-syncs the tree in its own commit, and adding the key to the memo would buy a second O(N) walk over the same heights in the same render. Confirmed empirically: the cases below hold at <=1px with the memo untouched.

Diff is confined to `website/src/hooks/virtualizer/useVirtualChat.ts` and its `prependAnchor` harness. No reformatting.

## Tests

`useVirtualChat.prependAnchor.test.tsx` grows a per-key height override (`rowHeightByKey`), because an equal-height swap displaces nothing and would pass with no fix at all. Three cases, each red before:

| New case | Reverted change | On the revert | On this branch |
|---|---|---|---|
| row SWAPPED at equal count above the reader | TRIGGER 6 capture | drifted **700px** | holds (<=1px) |
| same, with an INDEX-ADDRESSED `getKey` (ChatPage's shape) | TRIGGER 6 capture | drifted **700px** | holds (<=1px) |
| row SWAPPED at equal count above the reader | `spliceCommit` dep only | drifted **700px** | holds (<=1px) |
| same, INDEX-ADDRESSED | `spliceCommit` dep only | drifted **700px** | holds (<=1px) |

Both halves are load-bearing, proven separately: reverting only the gate widening (anchor never captured) and reverting only the dep (anchor captured, consumer never runs) each reproduce the full 700px.

```
x holds the reading position when a row is SWAPPED at equal count above the reader
  AssertionError: expected 700 to be less than or equal to 1
x holds the reading position across an equal-count SWAP when getKey is INDEX-ADDRESSED
  AssertionError: expected 700 to be less than or equal to 1
```

Plus a pinned counterpart, `does not hold position for a PINNED reader across an equal-count SWAP`, which pins the gate: a pinned reader is never pulled back up to where a row used to sit, and stick survives (the next streamed message still lands at the bottom). Non-vacuity is asserted in each case -- the replaced row really is gone and the taller replacement really mounted at the same index.

**No existing assertion weakened.** The virtualizer family is **223/223** green (`anchorRestore`, `followDisengage`, `heightSyncAnchor`, `integration`, `layoutShrink`, `observerBackfill`, `postStreamLurch`, `prependAnchor`, `railCollapse`, `spacerLurch`, `viewportResize`, `zeroHeightGuard`, `useVirtualChat`, `UseVirtualChatCoverage`, `HeightCache`, `HeightCache.multiInstance`, `virtualizerHeightOwner`, `ScrollAnchorCache`, `ChatPage.queueBandReanchor`) -- the family-wide pass the issue asked for. The consumer side is **155/155** green across the files that assert scroll behaviour through this hook (`ChatPage.navFarJump`, `ChatPane.scrollChrome`, `useChatScrollFollow`, `useScrollManager`, `useScrollManagerCov80`, `FollowController`, `WindowCalculator`, `McpAppFrame`, `ArtifactsPage.singleScroller`, `ThinkingBlock`), which is where an extra render pass would show up if it were visible at all. `tsc -b`, `eslint` and `jscpd` clean.

## Manual verification

N/A -- the jitter is a scroll-position delta, and the harness reproduces it numerically: its deterministic layout engine makes the rows genuinely move, so every number above is measured rather than asserted against source text.

## Related Issues

Closes #7234
Refs #7198, #6076

## Pattern harvest

Rule candidate: review-prompt

Pattern: **when a shared consumer is invalidated by a proxy for "something changed", any producer whose change the proxy cannot express is silently unserved -- and the fix belongs in the invalidation contract, not in the producer.** Here the proxy was a pair of count/range values standing in for "the geometry above the reader moved", and the one commit shape that moves geometry without moving either value had no way to reach the consumer. The tell is a comment explaining that a detection is correct but deliberately not acted on: #7198 identified the swap, retired its height, and had to write down that it could not anchor it. That asymmetry -- half a commit shape handled, the other half documented as out of reach -- is the reviewable signal that an invalidation key, not a trigger, is missing. The general question to ask of any effect whose deps are values rather than events: enumerate the commit shapes that change none of them, and check that none of them is a shape the effect exists to serve.
