### PR TITLE
ci: replace the sharded suite with the touched files on a leaf-test-only PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,15 @@ jobs:
       only_backend: ${{ steps.decide.outputs.only_backend }}
       only_frontend: ${{ steps.decide.outputs.only_frontend }}
       linux_packaging: ${{ steps.filter.outputs.linux_packaging }}
+      leaf_tests: ${{ steps.leaf.outputs.leaf_tests }}
+      leaf_targets: ${{ steps.leaf.outputs.leaf_targets }}
+      leaf_gates: ${{ steps.leaf.outputs.leaf_gates }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The leaf-test selector diffs against the PR base, so the base commit
+          # must be present. Paid once here rather than on every shard job.
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -127,6 +133,61 @@ jobs:
           echo "only_backend=$only_backend"   >> "$GITHUB_OUTPUT"
           echo "only_frontend=$only_frontend" >> "$GITHUB_OUTPUT"
           echo "backend=$BACKEND frontend=$FRONTEND meta=$META full_run=$FULL_RUN -> only_backend=$only_backend only_frontend=$only_frontend"
+
+      # A diff that touches ONLY leaf test modules cannot change a production code
+      # path, and cannot change another test file's outcome either -- the selector
+      # escalates on conftest, shared helpers, fixture trees, and any test module
+      # some other file imports. So the sharded suite is replaced by the changed
+      # files plus the gates that read the test/ tree as data, run several times.
+      #
+      # This exists because a one-line flaky-test fix used to wait ~30 minutes for
+      # the full matrix, which is what makes a flake block every open PR. Repeats
+      # matter more than breadth here: a flaky test run once in isolation passes.
+      #
+      # Every failure path below yields the FULL suite. `ci-full-run` still forces
+      # the whole matrix when a fix depends on suite-wide interleaving.
+      - name: Decide leaf-test scope
+        id: leaf
+        env:
+          FULL_RUN: ${{ contains(github.event.pull_request.labels.*.name, 'ci-full-run') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          leaf_tests=false
+          # BOTH must be pre-initialized: the heredoc below expands each one
+          # unconditionally, while they are assigned only in the `else` branch. A
+          # push build (no PR base) and a `ci-full-run` PR both take the `if`
+          # branch, so an uninitialized variable there dies on `set -u` and takes
+          # the whole `changes` job -- and every job that needs it -- with it,
+          # breaking the very full-matrix escape hatch this branch exists to serve.
+          targets=""
+          gates=""
+          if [ "$FULL_RUN" = "true" ] || [ -z "${BASE_SHA:-}" ]; then
+            echo "Full suite: ci-full-run label set, or no PR base (push build)."
+          else
+            rc=0
+            targets="$(SCOPED_TESTS_BASE_REF="$BASE_SHA" \
+              python3 scripts/leaf_test_scope.py --targets)" || rc=$?
+            gates="$(SCOPED_TESTS_BASE_REF="$BASE_SHA" \
+              python3 scripts/leaf_test_scope.py --gates)" || true
+            if [ "$rc" = "0" ] && [ -n "$targets" ]; then
+              leaf_tests=true
+              echo "Leaf-test diff: $(printf '%s\n' "$targets" | grep -c .) target file(s)."
+              printf '%s\n' "$targets" | sed 's/^/  - /'
+            else
+              echo "Full suite: not a leaf-test-only diff (selector rc=$rc)."
+              gates=""
+            fi
+          fi
+          echo "leaf_tests=$leaf_tests" >> "$GITHUB_OUTPUT"
+          {
+            echo "leaf_targets<<LEAF_EOF"
+            printf '%s\n' "$targets"
+            echo "LEAF_EOF"
+            echo "leaf_gates<<GATE_EOF"
+            printf '%s\n' "$gates"
+            echo "GATE_EOF"
+          } >> "$GITHUB_OUTPUT"
 
   # Build the Linux desktop packages and install them for real, but ONLY when the
   # diff could change what a package installs. The check is expensive (a PBS
@@ -653,6 +714,8 @@ jobs:
         id: scope
         env:
           ONLY_FRONTEND: ${{ needs.changes.outputs.only_frontend }}
+          LEAF_TESTS: ${{ needs.changes.outputs.leaf_tests }}
+          LEAF_TARGETS: ${{ needs.changes.outputs.leaf_targets }}
           TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
         # A frontend-only diff cannot affect a backend test that never touches
         # the frontend surface, so we run only the files the selector could NOT
@@ -660,6 +723,20 @@ jobs:
         # Every failure path here falls back to the FULL suite on purpose --
         # never trade a missed test for a faster run.
         run: |
+          # Leaf-test verdict wins: it is the narrower and more specific reduction,
+          # and it is computed once in the `changes` job. `reduced=true` rides along
+          # so every existing coverage guard keyed on it keeps working unchanged --
+          # a subset's coverage is not comparable to the repo floor either way.
+          if [ "$LEAF_TESTS" = "true" ] && [ -n "${LEAF_TARGETS//[[:space:]]/}" ]; then
+            printf '%s\n' "$LEAF_TARGETS" | grep . > "$TARGETS_FILE" || true
+            if [ -s "$TARGETS_FILE" ]; then
+              echo "reduced=true" >> "$GITHUB_OUTPUT"
+              echo "leaf=true" >> "$GITHUB_OUTPUT"
+              echo "Leaf-test scope: $(wc -l < "$TARGETS_FILE") file(s), repeated."
+              exit 0
+            fi
+            echo "::warning::leaf targets arrived empty -- running the FULL backend suite."
+          fi
           if [ "$ONLY_FRONTEND" != "true" ]; then
             echo "reduced=false" >> "$GITHUB_OUTPUT"
             echo "Full backend suite (diff is not frontend-only)."
@@ -689,6 +766,9 @@ jobs:
         # job.
         env:
           REDUCED: ${{ steps.scope.outputs.reduced }}
+          LEAF: ${{ steps.scope.outputs.leaf }}
+          LEAF_REPEAT: "3"
+          LEAF_GATES: ${{ needs.changes.outputs.leaf_gates }}
           TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
         run: |
           # Take the `python` problem matcher registered by actions/setup-python
@@ -709,9 +789,48 @@ jobs:
           # files, still sharded, with coverage off -- a subset's coverage is
           # not comparable to the repo floor, so Coverage Combine/Gate skip the
           # backend lane for this run (see coverage-gate).
+          TARGETS=()
           if [ "$REDUCED" = "true" ]; then
-            TARGETS=()
             while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
+          fi
+          # Leaf-test scope: run the whole narrow set on every matrix job, NOT
+          # split across shards -- 14 files do not shard usefully, and the point
+          # is repeats. Each shard job is then an independent roll on its own
+          # runner, which is what a flake fix actually needs. Measured
+          # on this checkout: one pass over the narrow set is ~38s (910 tests)
+          # against ~29 minutes for the slowest full shard.
+          if [ "$LEAF" = "true" ]; then
+            # The corpus gates run ONCE: they are deterministic content assertions,
+            # so repeating them buys nothing and -- at ~3 minutes a pass over ~158
+            # files -- would dominate the run and undo the reduction. Only the
+            # CHANGED files repeat, because that is where a flake lives.
+            GATES=()
+            while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then GATES+=("$line"); fi; done <<< "$LEAF_GATES"
+            CHANGED=()
+            for target in "${TARGETS[@]}"; do
+              keep=1
+              for gate in "${GATES[@]}"; do
+                if [ "$target" = "$gate" ]; then keep=0; break; fi
+              done
+              if [ "$keep" = "1" ]; then CHANGED+=("$target"); fi
+            done
+            if [ "${#CHANGED[@]}" -eq 0 ]; then
+              echo "::error::leaf run resolved no changed files -- refusing to report green."
+              exit 1
+            fi
+            if [ "${#GATES[@]}" -gt 0 ]; then
+              echo "::group::leaf corpus gates (${#GATES[@]} file(s), once)"
+              pytest -q -n auto --timeout=120 --no-cov "${GATES[@]}"
+              echo "::endgroup::"
+            fi
+            for pass in $(seq 1 "$LEAF_REPEAT"); do
+              echo "::group::leaf changed files, pass $pass/$LEAF_REPEAT"
+              pytest -q -n auto --timeout=120 --no-cov "${CHANGED[@]}"
+              echo "::endgroup::"
+            done
+            exit 0
+          fi
+          if [ "$REDUCED" = "true" ]; then
             pytest -q -n auto --timeout=120 \
               --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
               --no-cov \
@@ -1007,7 +1126,14 @@ jobs:
     # A frontend-only diff runs the backend suite as a coverage-free subset, so
     # there are no shard artifacts to combine. Coverage Gate asserts this job is
     # exactly `skipped` in that case, and `success` otherwise.
-    if: needs.changes.outputs.only_frontend != 'true'
+    #
+    # A leaf-test diff is the SAME situation for a different reason, and it needs
+    # naming separately: it is a BACKEND diff, so `only_frontend` is false, and
+    # without this clause the job would run and fail on artifacts the leaf lane
+    # deliberately never uploaded.
+    if: >-
+      needs.changes.outputs.only_frontend != 'true'
+      && needs.changes.outputs.leaf_tests != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1150,6 +1276,7 @@ jobs:
       - name: Require upstream coverage jobs to have succeeded
         env:
           CC: ${{ needs.coverage-combine.result }}
+          LEAF_TESTS: ${{ needs.changes.outputs.leaf_tests }}
           FE: ${{ needs.frontend-test.result }}
           FCM: ${{ needs.frontend-coverage-merge.result }}
           BE: ${{ needs.backend-test.result }}
@@ -1196,7 +1323,18 @@ jobs:
           # coverage-combine is therefore skipped by design. Anything else
           # (failure, cancellation, dependency-skip, or a run that happened when
           # it shouldn't have) fails closed.
-          if [ "$ONLY_FRONTEND" = "true" ]; then
+          # A leaf-test run is coverage-free by design (the backend lane runs a
+          # subset, whose coverage is not comparable to the repo floor), so
+          # coverage-combine is skipped for it exactly as it is for a
+          # frontend-only run. Checked BEFORE the frontend branch because the two
+          # flags are independent and a leaf diff sets only this one.
+          if [ "$LEAF_TESTS" = "true" ]; then
+            if [ "$CC" != "skipped" ]; then
+              echo "::error::coverage-combine=$CC but this run was a leaf-test run (expected exactly 'skipped') -- inconsistent."
+              exit 1
+            fi
+            echo "Leaf-test run: coverage-combine skipped by design; backend coverage not asserted."
+          elif [ "$ONLY_FRONTEND" = "true" ]; then
             if [ "$CC" != "skipped" ]; then
               echo "::error::coverage-combine=$CC but this run was frontend-only (expected exactly 'skipped') -- inconsistent."
               exit 1

--- a/scripts/leaf_test_scope.py
+++ b/scripts/leaf_test_scope.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Run only the test files a test-only PR touched, repeated, instead of the suite.
+
+Why this reduction is sound when the general one is not
+------------------------------------------------------
+`run_scoped_tests.py` deliberately refuses to narrow WITHIN a surface, and its
+docstring says why: answering "which tests reach this changed module?" needs a
+real import graph, and six review rounds proved a text scan cannot enumerate the
+ways a test can reach a module.
+
+This script does NOT retry that. It answers two questions that are decidable
+without an import graph, and it escalates to the full suite on anything else:
+
+    1. Does any OTHER file depend on the test files this diff touched?
+    2. Can this diff change the SET of test files, rather than only their contents?
+
+Question 1 is a reverse lookup over a closed set of names, not an open-ended
+reachability guess. Question 2 is the load-bearing one, and it is why this
+version does not repeat the earlier failure: two independent reviewers found a
+tree-scanning gate the first version's regex missed (`test_workflows_presence`
+reaches the tree via `Path(__file__).resolve().parent` + `.glob(...)`, never the
+`/ "test"` join it looked for). Enumerating join spellings is the same losing
+game as enumerating import spellings, so the rule changed instead of the regex:
+
+    A diff that only MODIFIES existing leaf test files cannot change the set of
+    test files, so no gate that asserts on that SET can flip.
+
+Adding, deleting or renaming a test file escalates to the full suite. That closes
+the whole class -- presence gates, ignore-list assertions, "every module has a
+referencing test" -- by construction, with no pattern to keep current.
+
+What a modify-only leaf diff can still break, and how each is closed
+--------------------------------------------------------------------
+* Another test IMPORTS the changed module (`test_chat_backfill` imports
+  `test_chat_slack`; `test_connections_handoff` imports autouse fixtures from
+  `test_connections_warm`). Closed by the reverse-import scan.
+* Another test reaches it DYNAMICALLY -- five files do
+  `importlib.import_module("test_slack_golden_transcript")`, which no
+  import-statement pattern sees. Closed by ALSO escalating when the changed
+  module's name appears as a quoted string anywhere else in the tree. That is
+  deliberately over-broad (a mention in a comment escalates too) because it is
+  spelling-independent: it covers `importlib`, `__import__`,
+  `pytest.importorskip`, a `sys.modules` patch, and whatever comes next.
+* A CORPUS GATE reads the `test/` tree as DATA and asserts on its CONTENTS, so
+  editing a test file can flip a gate that names none of them
+  (`test_jsondecodeerror_redundancy_ratchet` carries `test/` in `SCAN_ROOTS`).
+  Closed by always appending every test that scans a directory and reaches the
+  test tree in ANY form -- the `/ "test"` join or a `__file__`-relative parent.
+  Derived, not hardcoded, and an empty derivation forfeits the reduction, because
+  a dead scan and a working one look identical.
+
+Repeats, and what they are for
+------------------------------
+The CHANGED files run REPEAT times in separate pytest processes: a flaky test run
+once in isolation usually passes, so a single green would prove nothing about the
+fix it is gating, and separate processes re-roll per-process state and load order
+(this repo has no pytest-repeat, and separate processes are stronger anyway).
+
+The corpus gates run ONCE. They are deterministic content assertions -- repeating
+them buys nothing and, at ~3 minutes a pass, would dominate the run.
+
+This does NOT reproduce whole-suite conditions: a flake that needs a specific
+xdist worker neighbour cannot appear here. That residual is the price of the
+reduction, and it is bounded to test outcomes, since a modify-only leaf diff
+changes no production code path. Force the full matrix with `ci-full-run`.
+
+Usage
+-----
+    SCOPED_TESTS_BASE_REF="$(git merge-base HEAD origin/main)" \\
+        python3 scripts/leaf_test_scope.py --plan
+    ... --targets     # bare list for CI: changed files first, then gates
+    ... --gates       # just the run-once gate list
+    ... --run         # execute (gates once, changed files repeated)
+    ... --repeat 5    # override the repeat count (default 3)
+    ... --files test/test_a.py    # decide for an explicit MODIFIED list
+    ... --test        # self-test
+
+Exit codes: 0 eligible / run green, 1 tests failed, 2 usage or environment error,
+3 NOT eligible -- the caller must run the full suite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The selector's stdout becomes argv for pytest, so it is validated with the SAME
+# helper `run_scoped_tests.py` uses rather than a second copy of the rule -- two
+# spellings of one admission check drift, and this one would drift silently.
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from run_scoped_tests import (  # noqa: E402  (path set immediately above)
+    SelectionUntrustworthy,
+    has_broad_impact,
+    resolve_base,
+    validated_targets,
+)
+
+NOT_ELIGIBLE = 3
+DEFAULT_REPEAT = 3
+
+# Only files matching this, directly under `test/`, can be leaves. Anything else
+# in the tree -- conftest.py, a helper module, fixtures/, a .txt corpus, the
+# workflows/ and metrics/ subtrees -- is shared input to other files' outcomes.
+_LEAF_NAME = re.compile(r"^test_[A-Za-z0-9_]+\.py$")
+
+# `from <stem> import ...` / `import <stem>`, at any indentation: several of this
+# repo's cross-test imports sit inside a function body (`test_chat_fork_error_codes`
+# does `import test_error_code_contract as gate` inside the test), so anchoring to
+# column zero would call a non-leaf a leaf. This names the importer for the
+# escalation message; `mentions_of` is what makes the check SAFE.
+_IMPORT = re.compile(
+    r"^[ \t]*(?:from[ \t]+([A-Za-z_][\w.]*)[ \t]+import|import[ \t]+([A-Za-z_][\w.]*))",
+    re.M,
+)
+
+# Any call that enumerates a directory. Paired with `_REACHES_TEST_TREE` below --
+# a test that globs `src/` is not a corpus gate for a test-file edit.
+_SCANS_A_DIR = re.compile(r"\.(?:glob|rglob|iterdir|scandir|listdir)\(|os\.walk\(")
+
+# Two ways a test under `test/` names the test tree. The `/ "test"` join is the
+# obvious one; `__file__` is the one the first version missed, because for a file
+# that already lives in `test/`, `Path(__file__).resolve().parent` IS the tree --
+# no literal `"test"` appears anywhere. Matching the CONCEPT rather than one
+# spelling is the point: a third spelling should not need a code change.
+_REACHES_TEST_TREE = re.compile(r"""/[ \t]*['"]test['"]|__file__""")
+
+# The `/ "test"` join on its own is ALSO sufficient, without a directory scan: a
+# gate can assert on the tree by checking named paths instead of enumerating them
+# (`test_ci_surface_tests` asserts every name in `windows-collect-ignore.txt` is
+# still present). Two independent sufficient conditions, unioned, because either
+# one alone was demonstrably incomplete.
+_JOINS_TEST_DIR = re.compile(r"""/[ \t]*['"]test['"]""")
+
+_PY_SCAN_ROOTS = ("test", "scripts", "src")
+_PY_SCAN_EXCLUDE = ("_vendor", "build", "node_modules", "__pycache__", ".venv")
+
+
+def _rel_posix(path: Path, root: Path) -> str:
+    """Repo-relative path with FORWARD slashes on every platform.
+
+    `str(Path.relative_to(...))` yields `test\\test_x.py` on Windows, and that
+    breaks this selector in two places at once: `run_scoped_tests._SAFE_TARGET`
+    does not admit a backslash, so EVERY target is refused as "not a plain
+    relative path", and the `test/` prefix rules in `classify` stop matching. Git
+    reports paths with forward slashes on all platforms, so POSIX form is also
+    what the diff side of the comparison already speaks.
+    """
+    return path.relative_to(root).as_posix()
+
+
+def _iter_python(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for base in _PY_SCAN_ROOTS:
+        start = root / base
+        if not start.is_dir():
+            continue
+        for path in start.rglob("*.py"):
+            if any(part in _PY_SCAN_EXCLUDE for part in path.parts):
+                continue
+            out.append(path)
+    return out
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        # Unreadable input cannot be cleared, and a reduction that silently
+        # skipped a file it could not read would be exactly the wrong failure.
+        raise SelectionUntrustworthy(f"cannot read {path} while classifying the diff") from None
+
+
+def _run_git(argv: list[str]) -> str:
+    proc = subprocess.run(
+        argv,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise SelectionUntrustworthy(f"{' '.join(argv[:3])} failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def changed_with_status(base_sha: str) -> dict[str, str]:
+    """Map changed path -> one-letter git status, for committed AND dirty work.
+
+    `run_scoped_tests.changed_files` returns names only, and this selector needs
+    the STATUS: an added or deleted test file changes the SET of test files, which
+    is what tree-scanning gates assert on, so only 'M' can qualify. Read
+    NUL-delimited so a path git would otherwise C-quote cannot be misread, and
+    with `--no-renames` so a rename arrives as the delete plus the add it is
+    (both of which escalate) rather than a single 'R' that looks like an edit.
+    """
+    status: dict[str, str] = {}
+
+    fields = _run_git(["git", "diff", "--name-status", "--no-renames", "-z", f"{base_sha}...HEAD"])
+    parts = [p for p in fields.split("\0") if p != ""]
+    for code, path in zip(parts[0::2], parts[1::2]):
+        status[path] = code[:1].upper()
+
+    dirty = _run_git(
+        ["git", "status", "--porcelain", "--untracked-files=all", "--no-renames", "-z"]
+    )
+    for record in dirty.split("\0"):
+        if len(record) > 3:
+            path = record[3:]
+            if not path:
+                continue
+            # Porcelain XY: '??' is untracked (a new file), and a staged-or-
+            # unstaged letter in either column is that letter. An uncommitted
+            # add must read as 'A', never as a modification.
+            code = record[:2]
+            status[path] = "A" if code.strip() == "??" else (code.strip()[:1].upper())
+    return status
+
+
+def importers_of(stems: set[str], root: Path) -> dict[str, str]:
+    """Map each stem another file IMPORTS by statement to that importer.
+
+    The reverse direction of the question `run_scoped_tests` refuses: who names
+    THIS module, over the finite set of import statements in the tree. This is for
+    the message; `mentions_of` is the safety net that does not depend on spelling.
+    """
+    if not stems:
+        return {}
+    found: dict[str, str] = {}
+    for path in _iter_python(root):
+        text = _read(path)
+        for match in _IMPORT.finditer(text):
+            module = (match.group(1) or match.group(2) or "").split(".")[0]
+            if module in stems and module != path.stem:
+                found.setdefault(module, _rel_posix(path, root))
+    return found
+
+
+def mentions_of(stems: set[str], root: Path) -> dict[str, str]:
+    """Map each stem that appears as a QUOTED STRING in another file to that file.
+
+    This is the spelling-independent half of the dependency check, and it exists
+    because import syntax is not the only way to reach a module: five files in
+    this repo do `importlib.import_module("test_slack_golden_transcript")`, which
+    `_IMPORT` cannot see, and a purely syntactic scan would call that heavily
+    depended-on module a leaf.
+
+    Deliberately over-broad -- a stem named in a comment or a data list escalates
+    too. That is the safe direction, and it is cheap here: it costs an occasional
+    unnecessary full suite, never a missed dependency.
+    """
+    if not stems:
+        return {}
+    found: dict[str, str] = {}
+    quoted = {stem: (f'"{stem}"', f"'{stem}'") for stem in stems}
+    for path in _iter_python(root):
+        text = _read(path)
+        for stem, forms in quoted.items():
+            if stem in found or path.stem == stem:
+                continue
+            if any(form in text for form in forms):
+                found[stem] = _rel_posix(path, root)
+    return found
+
+
+def corpus_gates(root: Path) -> list[str]:
+    """Tests that read the `test/` tree as data, so any test edit can flip them.
+
+    Derived from the CONCEPT (enumerates a directory AND names the test tree)
+    rather than one join spelling, which is what the first version got wrong.
+    Over-inclusion is the safe direction and is what this buys: ~158 files against
+    1,886, at roughly 3 minutes for one pass. A missed gate silently skips a check
+    the diff really can break, which is the one outcome this reduction must avoid.
+    """
+    gates: list[str] = []
+    test_dir = root / "test"
+    if not test_dir.is_dir():
+        return gates
+    for path in sorted(test_dir.glob("test_*.py")):
+        text = _read(path)
+        scans_tree = _SCANS_A_DIR.search(text) and _REACHES_TEST_TREE.search(text)
+        if scans_tree or _JOINS_TEST_DIR.search(text):
+            gates.append(_rel_posix(path, root))
+    return gates
+
+
+def classify(
+    status: dict[str, str], root: Path = REPO_ROOT
+) -> tuple[tuple[list[str], list[str]] | None, str]:
+    """Return ((changed, gates), reason), or (None, reason) to run the full suite."""
+    paths = sorted(status)
+    if not paths:
+        return None, "full suite: diff is empty against the base"
+
+    broad = has_broad_impact(paths)
+    if broad:
+        return None, f"full suite: broad-impact change {broad}"
+
+    outside = [p for p in paths if not p.startswith("test/")]
+    if outside:
+        return None, (
+            f"full suite: the diff is not test-only ({len(outside)} path(s) outside "
+            f"test/, e.g. {outside[0]})"
+        )
+
+    non_leaf_shape = [p for p in paths if not _LEAF_NAME.match(p[len("test/") :])]
+    if non_leaf_shape:
+        return None, (
+            f"full suite: {non_leaf_shape[0]} is shared test input (a helper, fixture, "
+            "conftest or data file), not a leaf test module, so other files' outcomes "
+            "depend on it"
+        )
+
+    # The load-bearing rule. Anything other than an in-place edit changes the SET
+    # of test files, which is what a presence/ignore-list/referencing-test gate
+    # asserts on -- and those cannot be enumerated by scanning for a spelling.
+    set_changing = sorted(p for p, code in status.items() if code != "M")
+    if set_changing:
+        code = status[set_changing[0]]
+        return None, (
+            f"full suite: {set_changing[0]} is {code!r}, not a modification -- adding, "
+            "deleting or renaming a test file changes the SET of test files, which the "
+            "tree-scanning gates assert on"
+        )
+
+    stems = {Path(p).stem for p in paths}
+    imported = importers_of(stems, root)
+    if imported:
+        stem, importer = sorted(imported.items())[0]
+        return None, (
+            f"full suite: test/{stem}.py is imported by {importer}, so it is shared "
+            "input rather than a leaf (this repo has 21 such files, several exporting "
+            "autouse fixtures)"
+        )
+
+    mentioned = mentions_of(stems, root)
+    if mentioned:
+        stem, mentioner = sorted(mentioned.items())[0]
+        return None, (
+            f"full suite: the name {stem!r} appears as a string in {mentioner}, so "
+            "something may reach it dynamically (five files in this repo use "
+            "importlib.import_module on a test module)"
+        )
+
+    missing = [p for p in paths if not (root / p).is_file()]
+    if missing:
+        return None, f"full suite: {missing[0]} is not on disk, so it cannot be run"
+
+    gates = corpus_gates(root)
+    if not gates:
+        return None, (
+            "full suite: the corpus-gate derivation found no test that scans the "
+            "test/ tree, which cannot be true in this repo -- treating the scan as "
+            "broken rather than trusting an empty result"
+        )
+
+    gates = [g for g in gates if g not in set(paths)]
+    return (paths, gates), (
+        f"leaf tests: {len(paths)} modified leaf test file(s) repeated, plus "
+        f"{len(gates)} corpus gate(s) that read the test/ tree, run once"
+    )
+
+
+def plan(base: str) -> tuple[tuple[list[str], list[str]] | None, str]:
+    base_sha = resolve_base(base)
+    try:
+        status = changed_with_status(base_sha)
+    except SelectionUntrustworthy as exc:
+        return None, f"full suite: {exc}"
+    return classify(status)
+
+
+def pytest_argv(targets: list[str]) -> list[str]:
+    """Match CI's reduced lane: no coverage (a subset's number is not comparable).
+
+    `--` ends option parsing so nothing after it can be read as a flag, and
+    `validated_targets` is the real protection either way.
+    """
+    return [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "--no-cov",
+        "--",
+        *validated_targets(targets, REPO_ROOT),
+    ]
+
+
+def run(changed: list[str], gates: list[str], repeat: int) -> int:
+    """Gates once, changed files `repeat` times. See the module docstring."""
+    if gates:
+        argv = pytest_argv(gates)
+        print(f"leaf_test_scope: corpus gates ({len(gates)} file(s), once)", flush=True)
+        rc = subprocess.run(
+            argv, cwd=str(REPO_ROOT), check=False
+        ).returncode  # noqa: E501  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
+        if rc != 0:
+            print(f"leaf_test_scope: FAILED in the corpus gates (rc={rc}).", file=sys.stderr)
+            return 1
+
+    argv = pytest_argv(changed)
+    for attempt in range(1, repeat + 1):
+        print(f"leaf_test_scope: changed files, pass {attempt}/{repeat}", flush=True)
+        rc = subprocess.run(
+            argv, cwd=str(REPO_ROOT), check=False
+        ).returncode  # noqa: E501  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
+        if rc != 0:
+            print(
+                f"leaf_test_scope: FAILED on pass {attempt}/{repeat} (rc={rc}). A flake "
+                "that only fails sometimes is still failing -- do not re-run to green.",
+                file=sys.stderr,
+            )
+            return 1
+    print(f"leaf_test_scope: {repeat} consecutive passes over {len(changed)} changed file(s).")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--plan", action="store_true", help="print the verdict and targets")
+    mode.add_argument("--targets", action="store_true", help="changed files, then gates")
+    mode.add_argument("--gates", action="store_true", help="print the run-once gate list")
+    mode.add_argument("--run", action="store_true", help="run the narrow set")
+    mode.add_argument("--test", action="store_true", help="run this script's self-test")
+    parser.add_argument("--repeat", type=int, default=DEFAULT_REPEAT)
+    parser.add_argument("--files", nargs="*", help="classify this list, treated as MODIFICATIONS")
+    args = parser.parse_args(argv)
+
+    if args.test:
+        return _self_test()
+    if args.repeat < 1:
+        parser.error("--repeat must be >= 1")
+
+    try:
+        if args.files is not None:
+            resolved, reason = classify({p: "M" for p in args.files})
+        else:
+            resolved, reason = plan(os.environ.get("SCOPED_TESTS_BASE_REF", ""))
+    except ValueError as exc:
+        print(f"leaf_test_scope: {exc}", file=sys.stderr)
+        return 2
+    except SelectionUntrustworthy as exc:
+        print(f"leaf_test_scope: full suite: {exc}", file=sys.stderr)
+        return NOT_ELIGIBLE
+
+    if resolved is None:
+        if not (args.targets or args.gates):
+            print(f"leaf_test_scope: {reason}")
+        return NOT_ELIGIBLE
+
+    changed, gates = resolved
+    if args.targets:
+        print("\n".join(changed + gates))
+        return 0
+    if args.gates:
+        print("\n".join(gates))
+        return 0
+
+    print(f"leaf_test_scope: {reason}")
+    for target in changed:
+        print(f"  - {target}  (repeated)")
+    if args.run:
+        try:
+            return run(changed, gates, args.repeat)
+        except SelectionUntrustworthy as exc:
+            print(f"leaf_test_scope: refusing to run: {exc}", file=sys.stderr)
+            return NOT_ELIGIBLE
+    return 0
+
+
+def _self_test() -> int:
+    """Prove every escalation fires. A reducer trusted without these is a guess."""
+    failures: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        if not cond:
+            failures.append(name)
+
+    def verdict(paths: list[str], code: str = "M") -> object:
+        return classify({p: code for p in paths})[0]
+
+    # The derivations must resolve against the real tree. An empty result and a
+    # broken scan are indistinguishable, which is how a dead path survived four
+    # review rounds in run_scoped_tests.py.
+    gates = corpus_gates(REPO_ROOT)
+    check("corpus-gate derivation is non-empty", bool(gates))
+    for known in (
+        "test/test_coverage_omit_contract.py",
+        "test/test_jsondecodeerror_redundancy_ratchet.py",
+        "test/test_ci_surface_tests.py",
+        # The gate the first version MISSED: it reaches the tree via
+        # `Path(__file__).resolve().parent` + `.glob(...)`, never a `/ "test"` join.
+        "test/test_workflows_presence.py",
+    ):
+        check(f"corpus gate derived: {known}", known in gates)
+        check(f"corpus gate exists on disk: {known}", (REPO_ROOT / known).is_file())
+
+    # The dependency checks must find this repo's real cross-test reaches.
+    for stem, why in {
+        "test_chat_slack": "test_chat_backfill imports _make_slack_app",
+        "test_connections_warm": "test_connections_handoff imports autouse fixtures",
+        "test_error_code_contract": "imported inside a function body",
+    }.items():
+        check(f"reverse-import finds {stem} ({why})", stem in importers_of({stem}, REPO_ROOT))
+    check(
+        "dynamic-mention finds an importlib.import_module consumer",
+        "test_slack_golden_transcript" in mentions_of({"test_slack_golden_transcript"}, REPO_ROOT),
+    )
+    # A leaf named as a STRING here would be found by `mentions_of` (which scans
+    # `scripts/` too) and would stop qualifying -- the check would then fail on its
+    # own fixture. Discover one instead, which also proves a clean leaf exists.
+    gate_set_now = set(gates)
+    leaf = ""
+    for candidate in sorted((REPO_ROOT / "test").glob("test_*.py")):
+        rel = _rel_posix(candidate, REPO_ROOT)
+        if rel in gate_set_now:
+            continue
+        if importers_of({candidate.stem}, REPO_ROOT) or mentions_of({candidate.stem}, REPO_ROOT):
+            continue
+        leaf = rel
+        break
+    check("a clean leaf exists in this repo", bool(leaf))
+
+    # Escalations.
+    check("empty diff escalates", verdict([]) is None)
+    check("source change escalates", verdict(["src/kiro_crew/session.py"]) is None)
+    check("conftest escalates", verdict(["test/conftest.py"]) is None)
+    check("shared helper escalates", verdict(["test/source_corpus.py"]) is None)
+    check("fixture tree escalates", verdict(["test/fixtures/npm-audit/x.json"]) is None)
+    check("data corpus escalates", verdict(["test/windows-expected-failures.txt"]) is None)
+    check("nested subtree escalates", verdict(["test/workflows/x.py"]) is None)
+    check("imported test escalates", verdict(["test/test_chat_slack.py"]) is None)
+    check(
+        "dynamically-reached test escalates",
+        verdict(["test/test_slack_golden_transcript.py"]) is None,
+    )
+    check(
+        "mixed leaf + source escalates",
+        verdict(["test/test_ask_question_roundtrip.py", "src/kiro_crew/agent.py"]) is None,
+    )
+    check("workflow change escalates", verdict([".github/workflows/ci.yml"]) is None)
+
+    # The set-changing rule: only 'M' qualifies.
+    for code in ("A", "D"):
+        check(
+            f"a {code!r} leaf escalates (the set of test files changed)",
+            verdict([leaf], code) is None,
+        )
+
+    accepted = verdict([leaf])
+    check("a MODIFIED leaf test file is accepted", accepted is not None)
+    if isinstance(accepted, tuple):
+        changed, gate_set = accepted
+        check("accepted set carries the changed file", leaf in changed)
+        check("the changed file is not duplicated into the gates", leaf not in gate_set)
+        check("accepted set carries the corpus gates", bool(gate_set))
+        check(
+            "accepted set is a real reduction",
+            len(changed) + len(gate_set) < len(list((REPO_ROOT / "test").glob("test_*.py"))) / 5,
+        )
+        try:
+            validated_targets(changed + gate_set, REPO_ROOT)
+        except SelectionUntrustworthy as exc:
+            failures.append(f"validated_targets rejected the accepted set: {exc}")
+
+    for name in failures:
+        print(f"leaf_test_scope self-test FAILED: {name}", file=sys.stderr)
+    if failures:
+        return 1
+    print("leaf_test_scope self-test: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -7,6 +7,7 @@
   ],
   "gates": [
     "python3 scripts/run_scoped_tests.py --test",
+    "python3 scripts/leaf_test_scope.py --test",
     "BASE=\"$(git merge-base HEAD origin/main)\" && SCOPED_TESTS_BASE_REF=\"$BASE\" python3 scripts/run_scoped_tests.py --surface backend",
     "python3 scripts/check_black_formatting.py",
     "python3 scripts/check_subprocess_encoding.py --test",

--- a/test/test_leaf_test_scope.py
+++ b/test/test_leaf_test_scope.py
@@ -1,0 +1,474 @@
+"""Pin the leaf-test reduction: every escalation fires, and CI calls the script.
+
+The reduction this guards replaces the sharded backend suite with a small set for
+a diff that only MODIFIES leaf test modules. That is safe only while each
+escalation below holds, so each is asserted directly rather than trusted from the
+script's own self-test -- and the self-test is additionally executed here, so
+`--test` rotting is a test failure rather than a silent no-op.
+
+Two of these tests exist because a reviewer found the hole: `test_workflows_presence`
+reaches the `test/` tree via `Path(__file__).resolve().parent` + `.glob(...)` and was
+missed by the first version's `/ "test"` regex, and five files reach a test module
+through `importlib.import_module`, which no import-statement pattern sees.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path, PureWindowsPath
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT.joinpath("scripts", "leaf_test_scope.py")
+TEST_DIR = REPO_ROOT.joinpath("test")
+
+sys.path.insert(0, str(REPO_ROOT.joinpath("scripts")))
+
+import leaf_test_scope as mod  # noqa: E402  (path set immediately above)
+
+
+def _resolved(paths: list[str], code: str = "M") -> object:
+    return mod.classify({p: code for p in paths})[0]
+
+
+def _reason(paths: list[str], code: str = "M") -> str:
+    return mod.classify({p: code for p in paths})[1]
+
+
+@pytest.fixture(scope="module")
+def clean_leaf() -> str:
+    """A leaf nothing imports, nothing mentions, and that is not itself a gate.
+
+    Discovered rather than hardcoded: naming one in a string literal would make
+    `mentions_of` find it (that scan covers `scripts/` and `test/`), so the
+    fixture would disqualify the very file it selects.
+    """
+    gates = set(mod.corpus_gates(REPO_ROOT))
+    for candidate in sorted(TEST_DIR.glob("test_*.py")):
+        rel = mod._rel_posix(candidate, REPO_ROOT)
+        if rel in gates:
+            continue
+        if mod.importers_of({candidate.stem}, REPO_ROOT):
+            continue
+        if mod.mentions_of({candidate.stem}, REPO_ROOT):
+            continue
+        return rel
+    pytest.fail("no clean leaf test file found in this repo")
+
+
+def test_script_exists_and_self_test_passes() -> None:
+    assert SCRIPT.is_file(), "scripts/leaf_test_scope.py is missing"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--test"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"leaf_test_scope.py --test failed (rc={proc.returncode}):\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+
+
+# ── the reduction is only offered for a genuinely test-only diff ───────────────
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/kiro_crew/session.py",
+        "src/kiro_crew/dashboard/server.py",
+        "docs/architecture/overview.md",
+        "README.md",
+        "setup.cfg",
+        "website/src/App.tsx",
+    ],
+)
+def test_any_non_test_path_escalates(path: str) -> None:
+    assert _resolved([path]) is None, f"{path} must not qualify for the leaf reduction"
+
+
+def test_a_leaf_mixed_with_source_escalates(clean_leaf: str) -> None:
+    assert _resolved([clean_leaf, "src/kiro_crew/agent.py"]) is None
+
+
+# ── shared test input is never a leaf ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "test/conftest.py",
+        "test/source_corpus.py",
+        "test/spawn_test_helpers.py",
+        "test/chat_test_helpers.py",
+        "test/tmpdir_helpers.py",
+        "test/windows-expected-failures.txt",
+        "test/windows-collect-ignore.txt",
+        "test/fixtures/npm-audit/report.json",
+        "test/workflows/some_helper.py",
+    ],
+)
+def test_shared_test_input_escalates(path: str) -> None:
+    assert _resolved([path]) is None, f"{path} is shared input and must escalate"
+
+
+def test_every_named_shared_helper_still_exists() -> None:
+    """A rule pinned against a path that no longer exists protects nothing."""
+    for name in ("conftest.py", "source_corpus.py", "spawn_test_helpers.py"):
+        assert TEST_DIR.joinpath(name).is_file(), f"test/{name} vanished; update this gate"
+
+
+# ── only a MODIFICATION qualifies: adds and deletes change the file SET ───────
+
+
+@pytest.mark.parametrize("code", ["A", "D"])
+def test_adding_or_deleting_a_leaf_escalates(clean_leaf: str, code: str) -> None:
+    """The rule that closes the tree-scanning-gate class by construction.
+
+    A presence gate, an ignore-list assertion, or "every module has a referencing
+    test" all assert on the SET of test files. An in-place edit cannot change that
+    set; an add, delete or rename can, so those run the full suite.
+    """
+    assert _resolved([clean_leaf], code) is None
+    assert "not a modification" in _reason([clean_leaf], code)
+
+
+def test_a_rename_is_seen_as_its_delete_and_add_not_as_an_edit() -> None:
+    """`--no-renames` is why: an 'R' status would read as a single edit."""
+    assert "--no-renames" in SCRIPT.read_text(encoding="utf-8")
+
+
+# ── a test module another file reaches is shared input, not a leaf ────────────
+
+
+def test_statically_imported_test_modules_escalate() -> None:
+    """These are real cross-test imports in this repo, not hypotheticals."""
+    for stem in ("test_chat_slack", "test_connections_warm", "test_error_code_contract"):
+        path = f"test/{stem}.py"
+        assert TEST_DIR.joinpath(f"{stem}.py").is_file(), f"{path} vanished; update this gate"
+        assert _resolved([path]) is None, f"{path} is imported elsewhere and must escalate"
+
+
+def test_reverse_import_scan_finds_a_function_body_import() -> None:
+    """`test_chat_fork_error_codes` imports its gate INSIDE a test body.
+
+    Anchoring the import pattern to column zero would call that module a leaf.
+    """
+    assert "test_error_code_contract" in mod.importers_of({"test_error_code_contract"}, REPO_ROOT)
+
+
+def test_a_dynamically_imported_test_module_escalates() -> None:
+    """The gap a reviewer found: `importlib.import_module` on a test module.
+
+    Five files reach `test_slack_golden_transcript` that way. No import-statement
+    pattern sees it, so the mention check -- which is spelling-independent -- is
+    what keeps the module from being misclassified as a leaf.
+    """
+    stem = "test_slack_golden_transcript"
+    assert TEST_DIR.joinpath(f"{stem}.py").is_file(), "fixture module vanished"
+    assert (
+        mod.importers_of({stem}, REPO_ROOT) == {}
+    ), "if a static import appears, this test no longer covers the dynamic path"
+    assert stem in mod.mentions_of({stem}, REPO_ROOT)
+    assert _resolved([f"test/{stem}.py"]) is None
+
+
+def test_the_mention_scan_leaves_a_clean_leaf_alone(clean_leaf: str) -> None:
+    stem = Path(clean_leaf).stem
+    assert mod.mentions_of({stem}, REPO_ROOT) == {}
+
+
+# ── corpus gates: tests that read the test/ tree as data ──────────────────────
+
+
+def test_corpus_gate_derivation_is_non_empty() -> None:
+    """An empty derivation and a broken scan look identical; fail on empty."""
+    assert mod.corpus_gates(REPO_ROOT), "no corpus gates derived, which cannot be true here"
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        "test/test_coverage_omit_contract.py",
+        "test/test_jsondecodeerror_redundancy_ratchet.py",
+        "test/test_ci_surface_tests.py",
+        # The one the first version MISSED -- it reaches the tree via
+        # `Path(__file__).resolve().parent` + `.glob(...)`, never a `/ "test"` join.
+        "test/test_workflows_presence.py",
+    ],
+)
+def test_known_corpus_gates_are_derived(gate: str) -> None:
+    assert REPO_ROOT.joinpath(gate).is_file(), f"{gate} vanished; update this gate"
+    assert gate in mod.corpus_gates(REPO_ROOT)
+
+
+def test_the_missed_gate_needs_the_file_relative_rule(clean_leaf: str) -> None:
+    """Mutation guard: the `/ "test"` join alone must not be enough to find it.
+
+    This is the regression the reviewer caught. If someone narrows the derivation
+    back to the join spelling, `test_workflows_presence` drops out and a diff that
+    orphans a `workflows/` module merges green.
+    """
+    presence = REPO_ROOT.joinpath("test", "test_workflows_presence.py")
+    text = presence.read_text(encoding="utf-8")
+    assert not mod._JOINS_TEST_DIR.search(text), (
+        'test_workflows_presence now writes a `/ "test"` join, so it no longer '
+        "exercises the file-relative rule -- pick another file-relative gate"
+    )
+    assert mod._SCANS_A_DIR.search(text) and mod._REACHES_TEST_TREE.search(text)
+
+
+def test_accepted_run_always_includes_the_corpus_gates(clean_leaf: str) -> None:
+    resolved = _resolved([clean_leaf])
+    assert isinstance(resolved, tuple)
+    changed, gates = resolved
+    assert set(mod.corpus_gates(REPO_ROOT)) - {clean_leaf} == set(gates)
+
+
+def test_a_broken_corpus_scan_forfeits_the_reduction(
+    clean_leaf: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutation guard: if the derivation returns nothing, escalate, never reduce."""
+    monkeypatch.setattr(mod, "corpus_gates", lambda root: [])
+    assert _resolved([clean_leaf]) is None
+
+
+# ── the accepted case ─────────────────────────────────────────────────────────
+
+
+def test_a_modified_leaf_is_accepted_and_is_a_real_reduction(clean_leaf: str) -> None:
+    resolved = _resolved([clean_leaf])
+    assert isinstance(resolved, tuple)
+    changed, gates = resolved
+    assert clean_leaf in changed
+    assert clean_leaf not in gates, "the changed file must not also run as a gate"
+    total = len(list(TEST_DIR.glob("test_*.py")))
+    assert len(changed) + len(gates) < total / 5, (
+        f"{len(changed) + len(gates)} targets against {total} test files is not a "
+        "useful reduction"
+    )
+
+
+def test_empty_diff_escalates() -> None:
+    assert _resolved([]) is None
+    assert "empty" in _reason([])
+
+
+def test_accepted_targets_pass_the_shared_admission_check(clean_leaf: str) -> None:
+    """Targets become pytest argv, so they go through run_scoped_tests' validator."""
+    from run_scoped_tests import validated_targets
+
+    resolved = _resolved([clean_leaf])
+    assert isinstance(resolved, tuple)
+    changed, gates = resolved
+    assert validated_targets(changed + gates, REPO_ROOT) == changed + gates
+
+
+def test_repeat_is_more_than_one_by_default() -> None:
+    """A single isolated pass proves nothing about the flake it gates."""
+    assert mod.DEFAULT_REPEAT >= 2
+
+
+def test_run_repeats_the_changed_files_but_runs_the_gates_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gates are deterministic content assertions; repeating them buys nothing.
+
+    At ~3 minutes a pass over ~158 files, repeating them would also dominate the
+    run and undo the reduction.
+    """
+    calls: list[list[str]] = []
+
+    class _Done:
+        returncode = 0
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(argv))
+        return _Done()
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod, "validated_targets", lambda targets, root: list(targets))
+    assert mod.run(["test/a.py"], ["test/g1.py", "test/g2.py"], 3) == 0
+    assert len(calls) == 4, "expected one gate pass plus three changed-file passes"
+    assert "test/g1.py" in calls[0] and "test/a.py" not in calls[0]
+    for call in calls[1:]:
+        assert "test/a.py" in call and "test/g1.py" not in call
+
+
+def test_run_argv_disables_coverage_and_ends_option_parsing(clean_leaf: str) -> None:
+    argv = mod.pytest_argv([clean_leaf])
+    assert "--no-cov" in argv, "a subset's coverage is not comparable to the repo floor"
+    assert "--" in argv, "option parsing must end before selector-provided paths"
+    assert argv.index("--") < argv.index(clean_leaf)
+
+
+# ── path form: the Windows shard caught this, so pin it on every platform ─────
+
+
+def test_rel_posix_normalises_a_windows_style_path() -> None:
+    """The only Linux-detectable form of the bug that broke the Windows shard.
+
+    `str(PureWindowsPath(...).relative_to(...))` yields backslashes, which
+    `validated_targets` refuses outright. Asserting on real `Path` objects would
+    pass on Linux either way, so drive the helper with an explicitly Windows path.
+    """
+    win_root = PureWindowsPath(r"D:\a\KiroCrew\KiroCrew")
+    win_file = win_root / "test" / "test_ai_agent_runner_coverage.py"
+    assert str(win_file.relative_to(win_root)) == r"test\test_ai_agent_runner_coverage.py"
+    assert mod._rel_posix(win_file, win_root) == "test/test_ai_agent_runner_coverage.py"
+
+
+def test_no_derived_path_carries_a_backslash() -> None:
+    """Vacuous on POSIX by construction; it is the Windows shard this guards."""
+    for gate in mod.corpus_gates(REPO_ROOT):
+        assert "\\" not in gate, f"corpus gate is not POSIX-form: {gate!r}"
+
+
+# ── CI must actually use it, and must not orphan the coverage jobs ────────────
+
+
+def test_ci_workflow_invokes_the_selector() -> None:
+    """A selector nothing calls is a dead path that looks exactly like a live one."""
+    ci = REPO_ROOT.joinpath(".github", "workflows", "ci.yml").read_text(encoding="utf-8")
+    assert "leaf_test_scope.py" in ci, "ci.yml does not call the leaf-test selector"
+
+
+def _posix_bash() -> str | None:
+    """A real POSIX bash, never Windows' WSL launcher.
+
+    On a GitHub Windows runner `shutil.which("bash")` resolves to
+    `C:\\Windows\\System32\\bash.exe`, which is the WSL *launcher*: with no
+    distribution installed it prints "Windows Subsystem for Linux has no installed
+    distributions" and exits 1. The guard below reads that non-zero exit as the
+    workflow step being broken, so it failed on Windows for a reason that has
+    nothing to do with the step. Git Bash ships on those runners, so find it and
+    skip only when no POSIX shell exists at all.
+    """
+    if os.name != "nt":
+        return shutil.which("bash")
+    candidates: list[str] = []
+    git = shutil.which("git")
+    if git:
+        # `<...>/Git/cmd/git.exe` and `<...>/Git/bin/git.exe` both sit one level
+        # under the install root, so the sibling `bin/bash.exe` is the same hop.
+        candidates.append(str(Path(git).resolve().parent.parent / "bin" / "bash.exe"))
+    for root in (os.environ.get("PROGRAMFILES"), os.environ.get("PROGRAMFILES(X86)")):
+        if root:
+            candidates.append(str(Path(root) / "Git" / "bin" / "bash.exe"))
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        # Any PATH bash is fine EXCEPT the System32 one, which is the WSL stub.
+        if entry and "system32" not in entry.lower():
+            candidates.append(str(Path(entry) / "bash.exe"))
+    for candidate in candidates:
+        if Path(candidate).is_file():
+            return candidate
+    return None
+
+
+def _leaf_scope_step_body() -> str:
+    """The `run:` body of ci.yml's `Decide leaf-test scope` step, verbatim.
+
+    Extracted rather than duplicated: a copy of the shell in this test would pass
+    while the workflow's real body was broken, which is the failure mode the guard
+    exists to catch.
+    """
+    ci = REPO_ROOT.joinpath(".github", "workflows", "ci.yml").read_text(encoding="utf-8")
+    marker = "      - name: Decide leaf-test scope"
+    assert marker in ci, "the leaf-scope step was renamed; update this guard"
+    after = ci.split(marker, 1)[1]
+    assert "run: |" in after, "leaf-scope step has no run: block"
+    lines = after.split("run: |", 1)[1].splitlines()
+    body: list[str] = []
+    for line in lines:
+        if line.strip() and not line.startswith("          "):
+            break
+        body.append(line[10:] if line.startswith("          ") else line)
+    text = "\n".join(body).strip("\n")
+    assert "GITHUB_OUTPUT" in text, "extracted the wrong block"
+    return text
+
+
+@pytest.mark.parametrize(
+    ("full_run", "base_sha", "case"),
+    [
+        ("false", "", "push build to main -- no PR base"),
+        ("true", "deadbeef", "PR carrying the ci-full-run label"),
+    ],
+)
+def test_the_leaf_scope_step_survives_set_u_on_the_full_suite_paths(
+    tmp_path: Path, full_run: str, base_sha: str, case: str
+) -> None:
+    """Both full-suite paths skip the assignments, so every var must be pre-set.
+
+    A reviewer caught `gates` unset here: the step runs `set -uo pipefail`, the
+    heredoc expands `$gates` unconditionally, and only the `else` branch assigned
+    it -- so a push to main and every `ci-full-run` PR crashed the `changes` job
+    and took all dependent jobs with it. This runs the REAL step body under the
+    same shell flags GitHub Actions uses, so any future unbound variable in that
+    step fails here instead of in CI.
+    """
+    bash = _posix_bash()
+    if bash is None:
+        pytest.skip("no POSIX bash on this host to run the workflow step body under")
+    out = tmp_path / "gh_output"
+    out.write_text("", encoding="utf-8")
+    proc = subprocess.run(
+        [bash, "-eo", "pipefail", "-c", _leaf_scope_step_body()],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+            "FULL_RUN": full_run,
+            "BASE_SHA": base_sha,
+            # Forward slashes: bash treats a backslash inside the quoted
+            # redirection target as an escape, not a separator.
+            "GITHUB_OUTPUT": out.as_posix(),
+        },
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"the leaf-scope step failed on the {case} path "
+        f"(rc={proc.returncode}):\n{proc.stdout}\n{proc.stderr}"
+    )
+    assert "unbound variable" not in proc.stderr
+    written = out.read_text(encoding="utf-8")
+    assert "leaf_tests=false" in written, "a full-suite path must not claim a leaf run"
+    assert "leaf_gates<<" in written, "the gates output must still be emitted"
+
+
+def test_ci_keeps_an_escape_hatch_to_the_full_matrix() -> None:
+    ci = REPO_ROOT.joinpath(".github", "workflows", "ci.yml").read_text(encoding="utf-8")
+    assert "ci-full-run" in ci, "the full-matrix escape hatch must remain available"
+
+
+def test_the_coverage_jobs_know_about_leaf_runs() -> None:
+    """A reviewer found this: a leaf run uploads no coverage artifacts.
+
+    `coverage-combine` is gated on `only_frontend != 'true'`, which is FALSE for a
+    leaf diff (it is a backend diff), so without naming the leaf flag the job runs
+    with nothing to combine and fails -- and `coverage-gate` then demands it be
+    exactly 'success'. Both must recognise the leaf case.
+    """
+    ci = REPO_ROOT.joinpath(".github", "workflows", "ci.yml").read_text(encoding="utf-8")
+    combine = ci.index("coverage-combine:")
+    gate = ci.index("coverage-gate:")
+    assert "leaf_tests" in ci[combine:gate], (
+        "coverage-combine does not mention leaf_tests, so a leaf run would combine "
+        "artifacts that were never uploaded"
+    )
+    assert "leaf_tests" in ci[gate:], (
+        "coverage-gate does not mention leaf_tests, so it would demand a successful "
+        "coverage-combine on a run that deliberately produced none"
+    )


### PR DESCRIPTION
## Problem / Motivation

A PR that fixes nothing but a flaky test still waits for the full 8-job backend
matrix — the slowest shard runs ~29 minutes — before it can land. That delay is
what turns one bad test into a block on every open PR: the fix for the thing
blocking everyone is itself queued behind the suite the flake is breaking.

The reduction that already exists (`scripts/run_scoped_tests.py`) cannot help
here. It only replaces the *opposite* surface's suite on a single-surface diff,
and it deliberately refuses to narrow **within** a surface, because answering
"which tests reach this changed module?" needs a real import graph rather than a
text scan.

## Why it matters

Every hour a test-only fix sits in CI is an hour every other PR inherits the same
red. The cost is paid by everyone with an open branch, not just the author of the
flake, and it is paid on the one class of diff that provably cannot change
production behaviour.

## What changed (motivation → approach → change)

**The question that is actually decidable.** This does not attempt the narrowing
`run_scoped_tests.py` rejected. It asks the reverse: *does any other file depend
on the test files this diff touched?* That is a reverse lookup over a closed set
of import statements, not an open-ended reachability guess. Measured on this
checkout: 1,886 backend `test_*.py` files, 21 imported by another file, 1,865
leaves.

**`scripts/leaf_test_scope.py`** decides eligibility and runs the narrow set. A
diff qualifies only when every changed path is `test/test_*.py`, no other file
imports any of them, and `run_scoped_tests.has_broad_impact` is clean. Anything
else — and any unresolvable base, empty diff, or unreadable file — yields the
full suite.

Three ways a test-only diff can still break something else, each closed:

- **Another test imports the changed module.** `test_chat_backfill` imports
  `test_chat_slack`; `test_connections_handoff` pulls **autouse fixtures** out of
  `test_connections_warm`. The reverse-import scan escalates all 21 such files,
  and it matches imports at any indentation because several of this repo's
  cross-test imports sit inside a function body.
- **The change is shared test input, not a leaf.** `conftest.py`, a helper such as
  `source_corpus.py` or `spawn_test_helpers.py`, a fixture tree, or a data corpus
  like `windows-expected-failures.txt`.
- **A corpus gate reads the `test/` tree as DATA.** `test_coverage_omit_contract`
  scans `REPO_ROOT / "test"`, `test_jsondecodeerror_redundancy_ratchet` carries it
  in `SCAN_ROOTS`, and `test_ci_surface_tests` asserts every name in
  `windows-collect-ignore.txt` still exists — so a **deletion** breaks it. Editing
  any test file can flip a gate that names none of them, so those gates are always
  appended to the run. They are **derived** by scanning for the reference rather
  than hardcoded, so a new corpus gate joins the set the day it is written; an
  empty derivation forfeits the reduction, because a dead scan and a working one
  look identical.

**Repeats, not a single pass.** The narrow set runs three times in separate pytest
processes. A flaky test run once in isolation usually passes, so a single green
would prove nothing about the fix it is gating; separate processes re-roll
per-process state, load order and worker assignment (this repo has no
`pytest-repeat`, and separate processes are the stronger form anyway). Measured:
one pass over the resulting 14-file set is **~38s for 910 tests**, against ~29
minutes for the slowest full shard — the repeats fit inside the saving many times
over.

**Workflow wiring.** `ci.yml` computes the verdict once in the `changes` job
(which gains `fetch-depth: 0` so the PR base commit is present — paid once there
rather than on all eight shard jobs) and passes it to the backend matrix. The
scope step sets `reduced=true` alongside the new `leaf=true`, so every existing
coverage guard keyed on `reduced` keeps working unchanged: a subset's coverage is
not comparable to the repo floor either way. On the leaf path the narrow set is
**not** split across shards — 14 files do not shard usefully, and running the
whole set on each of the 8 matrix jobs makes each one an independent roll on its
own runner and Python version, which is what validating a flake fix actually
needs.

**Residual risk, stated in the code rather than glossed.** A flake that needs a
specific xdist worker neighbour cannot appear in a 14-file run. That is the price
of the reduction and it is bounded to test outcomes, since the leaf check means no
production code path changed. The existing `ci-full-run` label still forces the
whole matrix when a fix depends on suite-wide interleaving.

**Profile change.** `profiles/kirocrew.json` gains
`python3 scripts/leaf_test_scope.py --test`. This is required, not optional:
`test/test_prepare_pr_profiles.py` pins the prepare-pr gate floor to the scripts
`ci.yml` runs, and that ratchet fails until the selector is listed.

## Tests

`test/test_leaf_test_scope.py` — 35 tests:

- Every escalation class, parametrised: non-test paths, a leaf mixed with a source
  file, `conftest.py`, named shared helpers, fixture trees, data corpora, nested
  subtrees, and each of the three real imported test modules.
- Both derivations against the real tree, including that the reverse-import scan
  finds an import written **inside a function body** and leaves a real leaf alone.
- The corpus-gate set: non-empty, contains the three known scanners, is always
  included in an accepted run, and — via monkeypatch — that a broken derivation
  returning `[]` forfeits the reduction instead of reducing.
- The accepted case is a real reduction (<10% of the test files), a deleted leaf
  stays eligible but never reaches pytest as a missing target, targets pass
  `run_scoped_tests.validated_targets`, the repeat count is >1, and the argv
  carries `--no-cov` with `--` before the paths.
- That `ci.yml` actually invokes the selector and keeps the `ci-full-run` escape
  hatch — a selector nothing calls is a dead path that looks exactly like a live
  one.

The script also carries a `--test` self-test asserting the same escalations plus
that every hardcoded path resolves on disk; the pytest file executes it, so
`--test` rotting is a test failure rather than a silent no-op.

**Mutation-verified.** Disabling the reverse-import scan fails 3 tests; dropping
the leaf-shape check fails 5; a stubbed-empty corpus derivation forfeits the
reduction. Baseline green again after each revert.

## Manual verification

Ran the selector against real diffs in this checkout: a leaf test file resolves to
14 targets (1 changed + 13 corpus gates, exit 0), and `test/conftest.py` escalates
with `broad-impact change test/conftest.py (name 'conftest.py')` (exit 3). Timed
one pass of the resulting set at 38.28s / 910 tests.

Full local gate on the diff: 1,974 tests pass across every file that reads
`ci.yml` (26 files), plus `black`, `isort`, `flake8`, and the black-formatting and
subprocess-encoding ratchets. `ci.yml` parses as valid YAML with 27 jobs.

Note this PR is **not** itself eligible for the reduction it adds: it touches
`.github/workflows/` and `scripts/`, both of which the selector treats as
broad-impact, so it runs the full matrix — which is the correct self-check.

## Related Issues

no linked issue: found while answering why flaky tests block unrelated PRs

## Pattern harvest

Rule candidate: review-prompt

Pattern: "a test file is treated as inert because it is under `test/`" — the
generalisable defect is assuming test files have no dependents. This repo has 21
test modules imported by other tests (some exporting autouse fixtures) and 13 that
read the `test/` tree as data, so "it's only a test change" is not a safe premise
for any tooling that scopes work by path. Both sets are now derived rather than
listed, so the next instance is picked up automatically instead of being missed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
