### PR TITLE
feat(feishu): stream replies into a live interactive card

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -26,3 +26,22 @@ recipe are derived from prior MIT-licensed open-source projects that
 reverse-engineered that path. No third-party code is copied; the
 implementation is independent, and the module is isolated so the
 dependency is auditable in one place.
+
+The Feishu streaming-card renderer
+(src/kiro_crew/feishu/streaming_card.py) is a port of two MIT-licensed
+OpenClaw Feishu plugins: the official Lark plugin
+(https://github.com/larksuite/openclaw-lark), from which the five-step
+card lifecycle, the sequence protocol, the throttle constants and the
+error taxonomy are taken, and a community plugin
+(https://github.com/m1heng/clawdbot-feishu), from which the
+streaming_config pacing parameters, the schema-2.0 markdown card shape
+and the link/fence normalisation workarounds are taken. Unlike the
+module above, this one does copy code, so the original notices are
+carried:
+
+    Copyright (c) 2026 Lark Technologies Pte. Ltd.
+    Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+    Copyright (c) 2026 m1heng
+
+Both projects are licensed under the MIT License; the full license text
+is reproduced under "Feishu Streaming Card" in THIRD-PARTY-NOTICES.

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -10503,6 +10503,56 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ---
 
+## Feishu Streaming Card
+
+`src/kiro_crew/feishu/streaming_card.py` is a port, not an npm package. It
+implements the live CardKit reply for the Feishu channel and is derived from two
+MIT-licensed OpenClaw Feishu plugins:
+
+- Official Lark plugin
+    - License: MIT
+    - Copyright holders: Lark Technologies Pte. Ltd.; ByteDance Ltd. and/or its affiliates
+    - Homepage: https://github.com/larksuite/openclaw-lark
+    - Derived from it: the five-step card lifecycle, the sequence protocol, the
+      throttle constants, and the error taxonomy (the business codes that decide
+      drop-frame vs anchor-gone vs fall back to text).
+- Community plugin
+    - License: MIT
+    - Copyright holder: m1heng
+    - Homepage: https://github.com/m1heng/clawdbot-feishu
+    - Derived from it: the `streaming_config` pacing parameters, the schema-2.0
+      markdown card shape, and the link/fence normalisation workarounds.
+
+The MIT License text below covers both projects and all three copyright holders.
+
+```
+MIT License
+
+Copyright (c) 2026 Lark Technologies Pte. Ltd.
+Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+Copyright (c) 2026 m1heng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
 End of THIRD-PARTY-NOTICES
 
 ---

--- a/config-baseline.json
+++ b/config-baseline.json
@@ -4905,7 +4905,8 @@
         "allowed_group_ids": [],
         "soft_threshold_pct": 80,
         "hard_threshold_pct": 95,
-        "session_folder": ""
+        "session_folder": "",
+        "streaming": false
       }
     },
     {
@@ -5047,6 +5048,22 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": ""
+    },
+    {
+      "path": "feishu.streaming",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "feishu"
+      ],
+      "label": "Streaming Card Replies",
+      "help": "Stream the reply into a live Feishu interactive card instead of sending one text message when the turn finishes. DIRECT MESSAGES ONLY -- a group turn always uses the buffered text reply. Any failure falls back to the text reply automatically, so the worst case is the non-streaming behaviour. Off by default.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
     },
     {
       "path": "discord",

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -4262,10 +4262,26 @@ marker the driver leaves inert while still reporting success to the model;
 dashboard-only directives stay refused for a channel turn (`slot=None`,
 fail-closed). The dispatcher runs decider-less (no interactive buttons); an
 `[OPTIONS:]` trailer degrades to a numbered text list through the shared
-`render_options_as_text`. The renderer buffers the complete turn and sends it as
-one reply on `on_done` — no streaming, no edit-in-place. Because nothing is shown
-before `on_done`, an UNFINISHED `[OPTIONS` tail is kept rather than cut: there is
-no partial frame for it to flash in, so it can only be the assistant's own prose.
+`render_options_as_text`. The renderer has two modes, chosen per turn by the
+dispatcher. **Buffered is the default**: it accumulates the complete turn and
+sends it as one reply on `on_done`, and remains the fallback for everything.
+**Streaming card** is opt-in (`feishu.streaming`) and DIRECT MESSAGES ONLY — a
+group turn always buffers, because a card animating in a busy room is noise for
+everyone who did not ask. It opens a CardKit card on `on_turn_start`, pushes the
+cumulative answer into it on a throttle, and seals it on `on_done`; any failure
+at any point falls back to the buffered reply, so the worst case is the buffered
+behaviour rather than a lost answer. The capability declaration follows the mode
+(`FEISHU_STREAMING_CAPABILITIES`, `streaming` + `edit` only), so a gateway with
+streaming off never claims to stream.
+
+The UNFINISHED-`[OPTIONS`-tail rule is scoped to the BUFFERED mode: because
+nothing is shown before `on_done` there, such a tail is kept rather than cut —
+there is no partial frame for it to flash in, so it can only be the assistant's
+own prose. Under a streaming card that premise no longer holds, so live frames
+split with `split_options_trailer(text, hide_partial=True)` and withhold a
+half-arrived marker, which is safe precisely because the next frame re-renders
+from the full buffer; only the FINAL frame uses the default
+`hide_partial=False`, where the tail really is prose.
 
 **Session identity.** A p2p turn keys on `open_id` under the `DIRECT` chat
 type; a group turn keys on the group's `chat_id` under the non-direct

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3370,6 +3370,7 @@ class KiroCrewConfig:
                 soft_threshold_pct=_safe_int(feishu_data.get("soft_threshold_pct", 80), 80),
                 hard_threshold_pct=_safe_int(feishu_data.get("hard_threshold_pct", 95), 95),
                 session_folder=_coerce_session_folder(feishu_data.get("session_folder")),
+                streaming=_safe_bool(feishu_data.get("streaming"), False),
             ),
             dashboard=DashboardConfig(
                 url=dashboard_data.get("url", ""),

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -5360,6 +5360,18 @@ class FeishuConfig:
             tags=["feishu"],
         ),
     )
+    streaming: bool = field(
+        default=False,
+        metadata=_meta(
+            "Streaming Card Replies",
+            "Stream the reply into a live Feishu interactive card instead of "
+            "sending one text message when the turn finishes. DIRECT MESSAGES "
+            "ONLY -- a group turn always uses the buffered text reply. Any "
+            "failure falls back to the text reply automatically, so the worst "
+            "case is the non-streaming behaviour. Off by default.",
+            tags=["feishu"],
+        ),
+    )
 
     def __post_init__(self) -> None:
         # Shared normalization: clamp both thresholds and guarantee soft <= hard

--- a/src/kiro_crew/feishu/client.py
+++ b/src/kiro_crew/feishu/client.py
@@ -328,11 +328,23 @@ class LarkClient:
         if token:
             headers["Authorization"] = f"Bearer {token}"
         data = json.dumps(body or {}, ensure_ascii=False).encode("utf-8")
-        req = urllib.request.Request(
-            f"{self._open_base}{path}", data=data, headers=headers, method=method
-        )
+        url = f"{self._open_base}{path}"
+        # The origin is configurable (it follows the SDK's own domain constant so a
+        # Lark tenant is not sent to feishu.cn), and urllib honours ``file://`` and
+        # ``ftp://``. A non-https origin arriving from config would therefore turn
+        # this into an arbitrary-file read. Refuse anything else BEFORE the request
+        # exists, which is what makes the suppression below sound rather than a way
+        # of silencing the scanner. Every Open Platform host is https.
+        if not url.startswith("https://"):
+            raise CardApiError(-1, "refusing a non-https Open Platform origin", path)
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
         try:
-            with urllib.request.urlopen(req, timeout=_CARD_HTTP_TIMEOUT_S) as resp:
+            # The rule's concern is a dynamic URL reaching urllib, because urllib
+            # would honour a non-http scheme. Unreachable here: the https scheme is
+            # asserted immediately above and anything else raises before this line.
+            with urllib.request.urlopen(  # nosemgrep: dynamic-urllib-use-detected
+                req, timeout=_CARD_HTTP_TIMEOUT_S
+            ) as resp:  # noqa: S310
                 raw = resp.read().decode("utf-8", "replace")
         except urllib.error.HTTPError as exc:
             raw = exc.read().decode("utf-8", "replace")

--- a/src/kiro_crew/feishu/client.py
+++ b/src/kiro_crew/feishu/client.py
@@ -24,6 +24,9 @@ import json
 import logging
 import re
 import threading
+import time
+import urllib.error
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
@@ -42,6 +45,30 @@ FEISHU_MAX_TEXT = 4000
 # prevents a broken SDK import or constructor from leaving gateway startup
 # suspended forever while preserving enough time on a loaded host.
 _WS_CLIENT_READY_TIMEOUT_SECS = 5.0
+
+#: Default Open Platform origin for the CardKit calls. A Lark (international)
+#: tenant lives on open.larksuite.com; the SDK's own constant is preferred when
+#: the installed build exposes it (see ``LarkClient.__init__``).
+FEISHU_OPEN_BASE = "https://open.feishu.cn"
+
+#: Card calls are short; a hung one must not pin an executor thread for long.
+_CARD_HTTP_TIMEOUT_S = 15.0
+
+
+class CardApiError(RuntimeError):
+    """A Feishu Open Platform call answered with a non-zero business code.
+
+    Carries ``code`` because the streaming-card failure policy is entirely
+    code-driven: 230020 means drop this frame, 230011/231003 mean the anchor is
+    gone, and anything unrecognised means fall back to a plain-text reply.
+    """
+
+    def __init__(self, code: int, msg: str, path: str = "") -> None:
+        super().__init__(f"Feishu API error: code={code} msg={msg} path={path}")
+        self.code = code
+        self.msg = msg
+        self.path = path
+
 
 # The only two chat types this channel serves. The transport gate names them
 # explicitly so an absent or future value is denied rather than falling
@@ -190,6 +217,19 @@ class LarkClient:
         # ``run_in_executor`` caller in the gateway, so a burst of Feishu
         # replies would steal its threads.
         self._executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="feishu-rest")
+
+        # -- CardKit (streaming card) plumbing -----------------------------
+        # The card APIs go over plain HTTP rather than the SDK: they are absent
+        # from older lark-oapi builds, and the text path must keep working on a
+        # build that lacks them. Domain follows the SDK's own constant when the
+        # build exposes it, so a Lark tenant is not sent to feishu.cn.
+        domain = str(getattr(self._lark_mod, "FEISHU_DOMAIN", "") or "").strip()
+        self._open_base = (domain or FEISHU_OPEN_BASE).rstrip("/")
+        #: ``(token, monotonic_expiry)``; refreshed 60s early so a token never
+        #: lapses mid-stream. Guarded by a plain lock because it is only ever
+        #: touched from executor threads.
+        self._token: tuple[str, float] | None = None
+        self._token_lock = threading.Lock()
         # Forward ref to the WS client so ``close()`` can stop it.
         self._ws_client: Any = None
 
@@ -247,6 +287,93 @@ class LarkClient:
         resp = self._lark.im.v1.message.reply(req)
         if not resp.success():
             raise RuntimeError(f"Feishu reply error: code={resp.code} msg={resp.msg}")
+
+    # -- Card (CardKit) verbs ----------------------------------------------
+
+    def _sync_tenant_token(self) -> str:
+        """Return a valid tenant_access_token. Worker thread only."""
+        with self._token_lock:
+            now = time.monotonic()
+            if self._token is not None and now < self._token[1]:
+                return self._token[0]
+            payload = self._sync_http(
+                "POST",
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                {"app_id": self._app_id, "app_secret": self._app_secret},
+                token=None,
+            )
+            token = str(payload.get("tenant_access_token") or "")
+            if not token:
+                raise CardApiError(-1, "empty tenant_access_token", "tenant_access_token")
+            expire = int(payload.get("expire") or 7200)
+            self._token = (token, now + max(expire - 60, 30))
+            return token
+
+    def _sync_http(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None,
+        *,
+        token: str | None,
+    ) -> dict[str, Any]:
+        """One Open Platform call. Returns the FULL decoded envelope.
+
+        Feishu answers **HTTP 200 with a non-zero ``code`` in the body** on a
+        business error, so an exception-only reading reports success for a call
+        that did nothing. Both reference implementations check the body code
+        explicitly; this is the single most important thing to get right here.
+        """
+        headers = {"Content-Type": "application/json; charset=utf-8"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        data = json.dumps(body or {}, ensure_ascii=False).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self._open_base}{path}", data=data, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_CARD_HTTP_TIMEOUT_S) as resp:
+                raw = resp.read().decode("utf-8", "replace")
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", "replace")
+            try:
+                envelope = json.loads(raw or "{}")
+            except ValueError:
+                raise CardApiError(exc.code, raw[:200], path) from exc
+            raise CardApiError(
+                int(envelope.get("code", exc.code) or exc.code),
+                str(envelope.get("msg", "")),
+                path,
+            ) from exc
+        envelope = json.loads(raw or "{}")
+        code = int(envelope.get("code", 0) or 0)
+        if code != 0:
+            raise CardApiError(code, str(envelope.get("msg", "")), path)
+        return envelope
+
+    def _sync_card_api(self, method: str, path: str, body: dict[str, Any] | None) -> dict[str, Any]:
+        envelope = self._sync_http(method, path, body, token=self._sync_tenant_token())
+        return envelope.get("data") or {}
+
+    async def card_api(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Await a CardKit call on the REST executor. Raises ``CardApiError``."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, self._sync_card_api, method, path, body)
+
+    async def send_card_reply(self, message_id: str, card_id: str) -> None:
+        """Reply to *message_id* with a message that references *card_id*.
+
+        The message body carries no content of its own -- the card entity holds
+        the text, which is what makes subsequent updates possible.
+        """
+        content = json.dumps({"type": "card", "data": {"card_id": card_id}}, ensure_ascii=False)
+        await self.card_api(
+            "POST",
+            f"/open-apis/im/v1/messages/{message_id}/reply",
+            {"content": content, "msg_type": "interactive"},
+        )
 
     # -- Inbound WS handler (called from daemon thread) --------------------
 

--- a/src/kiro_crew/feishu/renderer.py
+++ b/src/kiro_crew/feishu/renderer.py
@@ -1,17 +1,33 @@
 """Layer 2b -- Feishu ``Renderer``.
 
-Maps the channel-neutral ``OutputEvent`` stream onto a single Feishu REST
-reply anchored to the inbound message_id:
+Two modes, chosen per turn by the dispatcher:
 
-* ``on_turn_start``   -- no-op (no streaming placeholder in v1).
-* ``on_text_chunk``   -- buffers text; a trailing ``[OPTIONS:]`` trailer
-  becomes a numbered text list (Feishu renders no tappable chips).
-* ``on_tool_call``    -- updates a transient tool-footer in the buffer.
-* ``on_prompt_choice``-- no-op: Feishu has no interactive buttons in v1
-  (the driver only dispatches this for INTERACTIVE + a decider, and
-  FeishuDispatcher runs decider-less).
+**Buffered (default).** Maps the channel-neutral ``OutputEvent`` stream onto a
+single Feishu REST reply anchored to the inbound message_id. This is the original
+behaviour and remains the fallback for everything.
+
+**Streaming card** (``streaming=True``, DM only). Opens a CardKit card on turn
+start so the user sees the reply forming immediately, pushes the cumulative
+answer into it on a throttle, and seals it on ``on_done``. See
+:mod:`kiro_crew.feishu.streaming_card`. Any failure at any point falls back to
+the buffered reply, so the worst case is the old behaviour rather than a lost
+answer.
+
+Event handling in both modes:
+
+* ``on_turn_start``   -- opens the card in streaming mode; no-op otherwise.
+  Called TWICE per turn by the pipeline, so it must stay idempotent.
+* ``on_text_chunk``   -- buffers text; in streaming mode also pushes a live
+  frame. A trailing ``[OPTIONS:]`` trailer becomes a numbered text list in the
+  FINAL text (Feishu renders no tappable chips) and is withheld from live
+  frames, where a half-arrived marker is still reserved protocol.
+* ``on_tool_call``    -- updates a transient tool footer; forces a live frame,
+  because a tool call is often followed by a long silence.
+* ``on_prompt_choice``-- no-op: Feishu has no interactive buttons (the driver
+  only dispatches this for INTERACTIVE + a decider, and FeishuDispatcher runs
+  decider-less).
 * ``on_compaction``   -- logged only (threshold notices go post-turn).
-* ``on_done``         -- sends the complete accumulated text as one reply.
+* ``on_done``         -- seals the card, or sends the complete text as one reply.
 * ``close``           -- idempotent finalisation (sends on error if needed).
 
 Dependency direction is ``feishu -> messaging`` (allowed).
@@ -22,8 +38,22 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.messaging.renderer import Renderer, render_options_as_text
+from kiro_crew.messaging.renderer import (
+    Renderer,
+    render_options_as_text,
+    split_options_trailer,
+)
 from kiro_crew.messaging.transport import TransportCapabilities
+
+try:
+    from kiro_crew.feishu.streaming_card import StreamingCardSession
+except ImportError:  # pragma: no cover - only when the module is absent
+    # A missing streaming module must degrade to the buffered reply, never take
+    # the whole package down: ``kiro_crew.channels`` imports this module during
+    # gateway boot, so a hard import here would turn one absent file into a
+    # gateway that cannot start AT ALL -- and an absent file is exactly what an
+    # update that overwrites ``src/`` leaves behind.
+    StreamingCardSession = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
     from kiro_crew.feishu.client import LarkClient
@@ -32,12 +62,7 @@ logger = logging.getLogger(__name__)
 
 
 class FeishuRenderer(Renderer):
-    """Buffers a complete turn and sends it as one Feishu reply on ``on_done``.
-
-    v1 is intentionally simple: no streaming, no edit-in-place.  A streaming
-    variant (send a placeholder, then update with ``lark_client.im.v1.message.
-    update``) is a natural follow-up once the core integration is stable.
-    """
+    """Buffers a turn and sends one Feishu reply, or streams it into a card."""
 
     channel_type = "feishu"
 
@@ -46,6 +71,8 @@ class FeishuRenderer(Renderer):
         client: "LarkClient",
         message_id: str,
         capabilities: TransportCapabilities,
+        *,
+        streaming: bool = False,
     ) -> None:
         super().__init__(capabilities)
         self._client = client
@@ -53,21 +80,73 @@ class FeishuRenderer(Renderer):
         self._buf: list[str] = []
         self._tool: str = ""
         self._finalized = False
+        #: Streaming is opt-in per turn. Keyword-only with a False default so
+        #: every existing caller -- and the cross-channel contract tests --
+        #: keep the original buffered behaviour untouched.
+        self._streaming_enabled = bool(streaming)
+        self._card: StreamingCardSession | None = None
+        self._card_opened = False
+
+    # -- Streaming plumbing --------------------------------------------------
+
+    async def _open_card(self) -> None:
+        """Open the live card once per turn. Never raises."""
+        if self._card_opened or not self._streaming_enabled:
+            return
+        if StreamingCardSession is None:  # pragma: no cover - module absent
+            # Latch so this is reported once per turn, not once per chunk.
+            self._card_opened = True
+            logger.warning(
+                "Feishu: streaming is enabled but the streaming_card module is "
+                "missing; this turn falls back to a buffered plain-text reply"
+            )
+            return
+        # Latch BEFORE awaiting: on_turn_start is called twice and the two calls
+        # can overlap, which would otherwise create two cards for one turn.
+        self._card_opened = True
+        session = StreamingCardSession(self._client, self._message_id)
+        try:
+            started = await session.start()
+        except Exception:  # pragma: no cover - start() already swallows
+            logger.debug("Feishu: streaming card start raised", exc_info=True)
+            started = False
+        if started:
+            self._card = session
+        else:
+            logger.info("Feishu: no streaming card for this turn; falling back to a buffered reply")
+
+    async def _push_live(self, *, force: bool = False) -> None:
+        """Push the cumulative answer into the live card. Never raises."""
+        card = self._card
+        if card is None or not card.live:
+            return
+        # hide_partial=True: the text is still arriving, so a half-written
+        # "[OPTIONS" really may be a marker mid-flight. Safe here precisely
+        # because the next frame re-renders from the full buffer.
+        body, _choices = split_options_trailer(self.raw_text(), hide_partial=True)
+        frame = body
+        if self._tool:
+            footer = f"🔧 {self._tool}"
+            frame = f"{frame}\n\n{footer}" if frame else footer
+        if not frame:
+            return
+        try:
+            await card.push(frame, force=force)
+        except Exception:  # pragma: no cover - the session classifies its own errors
+            logger.debug("Feishu: live frame push raised", exc_info=True)
 
     # -- Output event handlers ----------------------------------------------
 
     async def on_turn_start(self) -> None:
-        # No streaming placeholder in v1.  A "thinking" reaction could be added
-        # here via ``lark_client.im.v1.message.reactions.create`` once proven
-        # useful.
-        pass
+        await self._open_card()
 
     async def on_text_chunk(self, text: str) -> None:
         self._buf.append(text)
         self._tool = ""  # text resumed -> clear transient tool footer
+        await self._push_live()
 
     async def on_thinking(self, text: str) -> None:
-        # Feishu v1 does not surface reasoning inline.
+        # Feishu does not surface reasoning inline.
         return None
 
     async def on_tool_call(
@@ -77,8 +156,10 @@ class FeishuRenderer(Renderer):
         tool_kind: str = "",
         tool_purpose: str = "",
     ) -> None:
-        # Record but don't push mid-turn (single-shot reply only).
         self._tool = title or tool_kind or "工具"
+        # Forced: a tool call is frequently followed by a long quiet period, and
+        # the whole point of the live card is that the user sees progress.
+        await self._push_live(force=True)
 
     async def on_prompt_choice(
         self,
@@ -88,10 +169,9 @@ class FeishuRenderer(Renderer):
         tool_purpose: str = "",
         tool_input: str = "",
     ) -> None:
-        # Feishu has no interactive buttons in v1.  The driver dispatches this
-        # only for INTERACTIVE + a decider; FeishuDispatcher runs decider-less,
-        # so this is never reached -- kept as a safe no-op to satisfy the
-        # Renderer contract.
+        # Feishu has no interactive buttons.  The driver dispatches this only for
+        # INTERACTIVE + a decider; FeishuDispatcher runs decider-less, so this is
+        # never reached -- kept as a safe no-op to satisfy the Renderer contract.
         logger.debug("Feishu: prompt_choice ignored (no interactive buttons)")
 
     async def on_compaction(self, context_usage_pct: float) -> None:
@@ -105,6 +185,20 @@ class FeishuRenderer(Renderer):
         self._finalized = True
         ok = stop_reason != "error"
         content = self.text() or ("…" if ok else "⚠️ 出错了，请重试")
+
+        card = self._card
+        if card is not None:
+            delivered = await card.finish(content)
+            if delivered:
+                return
+            if card.anchor_gone:
+                # The inbound message was recalled or deleted. A text reply to
+                # the same anchor fails too, so stop rather than raising a
+                # delivery error for something the user did on purpose.
+                logger.info("Feishu: anchor message gone; nothing to reply to")
+                return
+            logger.info("Feishu: card delivered nothing; sending the buffered reply instead")
+
         if not await self._client.send_reply(self._message_id, content):
             # A dropped reply must NOT be recorded as a delivered turn: the user
             # sees nothing while history and the session claim success. Raising
@@ -129,6 +223,15 @@ class FeishuRenderer(Renderer):
                 )
 
     # -- Helpers ------------------------------------------------------------
+
+    def raw_text(self) -> str:
+        """The accumulated answer with no options handling applied.
+
+        Live frames need this because they do their own ``hide_partial=True``
+        split; :meth:`text` would already have rendered a mid-flight marker as
+        numbered prose.
+        """
+        return "".join(self._buf).strip()
 
     def text(self) -> str:
         """The complete answer so far, with ``[OPTIONS:]`` as numbered text.

--- a/src/kiro_crew/feishu/streaming_card.py
+++ b/src/kiro_crew/feishu/streaming_card.py
@@ -1,0 +1,526 @@
+"""Layer 2c -- Feishu streaming CARD session (CardKit lifecycle).
+
+A live reply is not an edited text message. Feishu's streaming primitive is a
+*card entity*: create the card, send ONE ordinary message that merely references
+its ``card_id``, then repeatedly push the **cumulative** answer into one element
+of that card. The server diffs successive pushes and animates the difference, so
+the typewriter effect is server-side -- this module only decides how often to
+push.
+
+Lifecycle (each mutating step consumes one sequence number):
+
+    1. POST   /open-apis/cardkit/v1/cards                      -> card_id
+    2. POST   /open-apis/im/v1/messages/{message_id}/reply      msg_type=interactive
+    3. PUT    /open-apis/cardkit/v1/cards/{id}/elements/{el}/content   (repeated)
+    4. PATCH  /open-apis/cardkit/v1/cards/{id}/settings         streaming_mode=false
+    5. PUT    /open-apis/cardkit/v1/cards/{id}                  final full replace
+
+Step 4 MUST precede step 5. Step 5 is what repairs any intermediate frame that
+was dropped, which is why a dropped frame needs no retry of its own.
+
+Ported from two MIT-licensed OpenClaw Feishu plugins, attributed in ``NOTICE``
+with their licence text reproduced in ``THIRD-PARTY-NOTICES``:
+
+* https://github.com/larksuite/openclaw-lark -- the official Lark/Feishu plugin,
+  maintained by the Lark/Feishu Open Platform team. Source of the five-step
+  lifecycle, the sequence protocol, the throttle constants and the error
+  taxonomy.
+* https://github.com/m1heng/clawdbot-feishu -- community plugin. Source of the
+  ``streaming_config`` pacing parameters, the schema-2.0 markdown card shape and
+  the link/fence normalisation workarounds.
+
+Dependency direction is ``feishu.renderer -> feishu.streaming_card ->
+feishu.client``; nothing here imports the renderer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.feishu.client import CardApiError
+
+if TYPE_CHECKING:
+    from kiro_crew.feishu.client import LarkClient
+
+logger = logging.getLogger(__name__)
+
+# -- Tunables (values taken from the reference implementations) --------------
+
+#: Minimum gap between two content pushes. Both plugins independently settled on
+#: 100 ms, which is the strongest signal available that this is the right value.
+CARDKIT_THROTTLE_S = 0.10
+
+#: A gap longer than this means the model went quiet (cold start, long tool
+#: call). The official plugin then defers the next flush briefly so the first
+#: visible frame carries real text instead of one or two characters.
+LONG_GAP_THRESHOLD_S = 2.0
+BATCH_AFTER_GAP_S = 0.30
+
+#: The deferral above applies only to a fragment shorter than this. Above it the
+#: text is worth showing immediately, because nothing schedules a retry.
+_ANTI_STUTTER_MAX_CHARS = 24
+
+#: Server-side typewriter pacing. Set explicitly rather than inheriting Feishu's
+#: defaults so the behaviour does not drift when the platform changes them.
+STREAM_PRINT_FREQUENCY_MS = 50
+STREAM_PRINT_STEP = 2
+
+#: The one element every content push targets.
+STREAMING_ELEMENT_ID = "streaming_content"
+
+#: A card renders at most this many native markdown tables; beyond it Feishu
+#: rejects the whole card (230099 / sub-code 11310). Excess tables are demoted
+#: to fenced code so the answer still arrives.
+FEISHU_CARD_TABLE_LIMIT = 3
+
+# -- Feishu error codes we treat specially ----------------------------------
+
+#: Rate limited. Policy: DROP THIS FRAME. No retry, no backoff, stay streaming.
+#: Safe because every push carries the cumulative answer, so the next scheduled
+#: flush supersedes the lost one.
+ERR_RATE_LIMITED = 230020
+#: Card constraint violated -- in practice the table-count ceiling.
+ERR_CARD_CONSTRAINT = 230099
+#: The anchor message was recalled / deleted by the user. Nothing can be
+#: delivered to it, including a plain-text fallback.
+ERR_MSG_RECALLED = 230011
+ERR_MSG_DELETED = 231003
+
+_GONE_CODES = frozenset({ERR_MSG_RECALLED, ERR_MSG_DELETED})
+
+# -- Markdown normalisation --------------------------------------------------
+
+_FENCE_RE = re.compile(r"```[\s\S]*?```", re.MULTILINE)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_TABLE_RE = re.compile(r"^\|.+\|[ \t]*\r?\n\|[ \t:\-|]+\|[ \t]*\r?$", re.MULTILINE)
+_H1_RE = re.compile(r"^# ", re.MULTILINE)
+_H2_6_RE = re.compile(r"^#{2,6} ", re.MULTILINE)
+_ANY_H1_3_RE = re.compile(r"^#{1,3} ", re.MULTILINE)
+_BARE_URL_RE = re.compile(r"(?<![(\[<`])\bhttps?://[^\s<>\[\]`]+")
+_MD_IMAGE_RE = re.compile(r"!\[[^\]]*\]\(([^)]*)\)")
+_MANY_NEWLINES_RE = re.compile(r"\n{3,}")
+
+
+def _protect(text: str) -> tuple[str, list[str]]:
+    """Replace fenced blocks and inline code with placeholders.
+
+    Every rewrite below is a *rendering* workaround; applying one inside a code
+    block would corrupt content the user asked to see verbatim.
+    """
+    stash: list[str] = []
+
+    def _stash(match: re.Match[str]) -> str:
+        stash.append(match.group(0))
+        return f"\x00KC{len(stash) - 1}\x00"
+
+    return _INLINE_CODE_RE.sub(_stash, _FENCE_RE.sub(_stash, text)), stash
+
+
+def _restore(text: str, stash: list[str]) -> str:
+    for i, original in enumerate(stash):
+        text = text.replace(f"\x00KC{i}\x00", original)
+    return text
+
+
+def normalize_card_links(text: str) -> str:
+    """Work around two Feishu card renderer bugs (from the community plugin).
+
+    * A fence whose opening ``\u0060\u0060\u0060`` is indented is not recognised, so the
+      block renders as literal text -- dedent the fence markers.
+    * A bare URL gets re-tokenized and is visually split or truncated around
+      ``_`` and long query strings -- make it an explicit ``[url](url)`` link
+      and percent-encode the characters that break tokenisation.
+    """
+    try:
+        # Dedent fence markers BEFORE protecting, otherwise an indented fence is
+        # not recognised as a fence here either. Bound to a NEW name so the
+        # ``except`` below returns the caller's original text rather than this
+        # half-transformed version, which is what the docstring promises.
+        dedented = re.sub(r"^[ \t]+(```)", r"\1", text, flags=re.MULTILINE)
+        body, stash = _protect(dedented)
+
+        def _linkify(match: re.Match[str]) -> str:
+            url = match.group(0)
+            trailing = ""
+            # Trailing sentence punctuation is not part of the URL.
+            while url and url[-1] in ".,;:!?":
+                trailing = url[-1] + trailing
+                url = url[:-1]
+            # Balance parens conservatively. The pattern ADMITS parentheses so a
+            # URL that legitimately contains them -- the Wikipedia
+            # ``..._(programming_language)`` shape is the common one -- is not cut
+            # at the first ``(``; this loop then gives back only the closing
+            # parens that were never opened, which is prose punctuation such as
+            # "(see https://example.com)".
+            while url.endswith(")") and url.count("(") < url.count(")"):
+                trailing = ")" + trailing
+                url = url[:-1]
+            if not url:
+                return match.group(0)
+            safe = url.replace("_", "%5F").replace("(", "%28").replace(")", "%29")
+            return f"[{url}]({safe}){trailing}"
+
+        body = _BARE_URL_RE.sub(_linkify, body)
+        return _restore(body, stash)
+    except Exception:  # pragma: no cover - a rendering nicety must never break a reply
+        logger.debug("Feishu: link normalisation failed; sending text as-is", exc_info=True)
+        return text
+
+
+def optimize_card_markdown(text: str) -> str:
+    """Adapt markdown to what a Feishu card actually renders.
+
+    From the official plugin's ``optimizeMarkdownStyle``:
+
+    * ``#`` / ``##`` render enormous inside a card, so headings are clamped.
+    * Blank lines produce no vertical space, so an explicit ``<br>`` is inserted
+      around tables and code blocks.
+    * An image must reference a Feishu ``img_*`` key; an http(s) or local target
+      makes the whole card fail with 200570, so those are stripped.
+    """
+    try:
+        body, stash = _protect(text)
+
+        if _ANY_H1_3_RE.search(body):
+            body = _H2_6_RE.sub("##### ", body)
+            body = _H1_RE.sub("#### ", body)
+
+        # Drop images Feishu cannot resolve rather than losing the whole card.
+        def _image(match: re.Match[str]) -> str:
+            target = (match.group(1) or "").strip()
+            return match.group(0) if target.startswith("img_") else ""
+
+        body = _MD_IMAGE_RE.sub(_image, body)
+        body = _MANY_NEWLINES_RE.sub("\n\n", body)
+        body = _restore(body, stash)
+
+        # <br> around block constructs, after restore so fences are real again.
+        #
+        # Only the OUTER edges of a block get a spacer. A ``` line TOGGLES in/out
+        # of a fence, so a regex over every ``` would also insert one just after
+        # the opening fence and just before the closing one -- literal <br> lines
+        # in the middle of the verbatim content the reader asked to see, which is
+        # the very corruption ``_protect`` exists to prevent. An UNTERMINATED
+        # fence (the normal case for a mid-stream frame) correctly gets no
+        # trailing spacer, because the block has not ended yet.
+        lines = body.split("\n")
+        spaced: list[str] = []
+        in_fence = False
+        for idx, line in enumerate(lines):
+            if not line.lstrip().startswith("```"):
+                spaced.append(line)
+                continue
+            if not in_fence:
+                if spaced and spaced[-1].strip():
+                    spaced.append("<br>")
+                spaced.append(line)
+                in_fence = True
+            else:
+                spaced.append(line)
+                nxt = lines[idx + 1] if idx + 1 < len(lines) else ""
+                if nxt.strip():
+                    spaced.append("<br>")
+                in_fence = False
+        body = "\n".join(spaced)
+        return body
+    except Exception:  # pragma: no cover
+        logger.debug("Feishu: markdown optimisation failed; sending text as-is", exc_info=True)
+        return text
+
+
+def fence_excess_tables(text: str, limit: int = FEISHU_CARD_TABLE_LIMIT) -> str:
+    """Demote tables beyond *limit* to fenced code blocks.
+
+    A card carrying more native tables than Feishu allows is rejected outright,
+    so the answer would be lost entirely. A fenced table is ugly but readable.
+    """
+    try:
+        starts = [m.start() for m in _TABLE_RE.finditer(text)]
+        if len(starts) <= limit:
+            return text
+        lines = text.splitlines(keepends=True)
+        # Recompute table spans line-wise so a whole table (header + delimiter +
+        # body rows) is wrapped, not just the two matched lines.
+        out: list[str] = []
+        seen = 0
+        i = 0
+        while i < len(lines):
+            is_head = lines[i].lstrip().startswith("|") and i + 1 < len(lines)
+            is_delim = is_head and re.match(r"^\s*\|[\s:\-|]+\|\s*$", lines[i + 1] or "")
+            if is_head and is_delim:
+                j = i
+                while j < len(lines) and lines[j].lstrip().startswith("|"):
+                    j += 1
+                seen += 1
+                block = "".join(lines[i:j])
+                if seen > limit:
+                    if not block.endswith("\n"):
+                        block += "\n"
+                    out.append("```\n" + block + "```\n")
+                else:
+                    out.append(block)
+                i = j
+                continue
+            out.append(lines[i])
+            i += 1
+        return "".join(out)
+    except Exception:  # pragma: no cover
+        logger.debug("Feishu: table demotion failed; sending text as-is", exc_info=True)
+        return text
+
+
+def prepare_card_text(text: str, *, demote_tables: bool = False) -> str:
+    """The full text pipeline for a card body."""
+    out = normalize_card_links(text)
+    if demote_tables:
+        out = fence_excess_tables(out)
+    return optimize_card_markdown(out)
+
+
+# -- Card payloads -----------------------------------------------------------
+
+
+def build_streaming_card(summary: str = "[正在生成…]") -> dict[str, Any]:
+    """The card created at step 1: one empty markdown element, streaming on."""
+    return {
+        "schema": "2.0",
+        "config": {
+            "streaming_mode": True,
+            "streaming_config": {
+                "print_frequency_ms": {"default": STREAM_PRINT_FREQUENCY_MS},
+                "print_step": {"default": STREAM_PRINT_STEP},
+            },
+            "summary": {"content": summary[:50]},
+            "wide_screen_mode": True,
+        },
+        "body": {
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "element_id": STREAMING_ELEMENT_ID,
+                }
+            ]
+        },
+    }
+
+
+def build_final_card(text: str) -> dict[str, Any]:
+    """The card sent at step 5, replacing the streaming one wholesale."""
+    return {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True},
+        "body": {"elements": [{"tag": "markdown", "content": text}]},
+    }
+
+
+# -- The session -------------------------------------------------------------
+
+
+class StreamingCardSession:
+    """One live card for one turn.
+
+    Failure policy, in one place because it is the whole design:
+
+    * Anything wrong during ``start`` -> return False and let the caller send an
+      ordinary text reply. Nothing has been shown to the user yet.
+    * ``ERR_RATE_LIMITED`` on a push -> drop the frame. The next push carries the
+      newer cumulative text, so the loss self-heals.
+    * ``ERR_CARD_CONSTRAINT`` -> demote excess tables and keep going; a second
+      occurrence retires the session.
+    * The anchor message was recalled/deleted -> retire, and tell the caller NOT
+      to fall back, because a text reply to that anchor fails too.
+    * Any other error -> retire and let the caller fall back to text.
+
+    ``delivered`` is the property the caller acts on: True means the user has
+    the complete answer on screen and a text fallback would duplicate it.
+    """
+
+    def __init__(self, client: "LarkClient", message_id: str) -> None:
+        self._client = client
+        self._message_id = message_id
+        self._card_id = ""
+        self._seq = 1
+        self._lock = asyncio.Lock()
+        self._pending = ""
+        self._shown = ""
+        self._last_flush = 0.0
+        self._batch_until = 0.0
+        self._demote_tables = False
+        self._retired = False
+        self._anchor_gone = False
+        self._delivered = False
+
+    # -- State ---------------------------------------------------------------
+
+    @property
+    def live(self) -> bool:
+        """True while the card can still be pushed to."""
+        return bool(self._card_id) and not self._retired
+
+    @property
+    def anchor_gone(self) -> bool:
+        """True when the inbound message is gone -- do NOT fall back to text."""
+        return self._anchor_gone
+
+    @property
+    def delivered(self) -> bool:
+        """True once the user has the full answer in the card."""
+        return self._delivered
+
+    def _next_seq(self) -> int:
+        # Deliberately NOT rolled back on failure: gaps are tolerated by Feishu,
+        # only monotonicity matters, and rolling back could reuse a number the
+        # server already consumed.
+        self._seq += 1
+        return self._seq
+
+    def _classify(self, exc: BaseException, where: str) -> None:
+        """Apply the failure policy to *exc*."""
+        code = getattr(exc, "code", None)
+        if code == ERR_RATE_LIMITED:
+            logger.debug("Feishu card: rate limited at %s; dropping frame", where)
+            return
+        if code in _GONE_CODES:
+            logger.info("Feishu card: anchor message is gone (code=%s); retiring", code)
+            self._anchor_gone = True
+            self._retired = True
+            return
+        if code == ERR_CARD_CONSTRAINT and not self._demote_tables:
+            logger.info("Feishu card: card constraint hit; demoting excess tables")
+            self._demote_tables = True
+            return
+        logger.warning("Feishu card: %s failed (%s); falling back to text", where, exc)
+        self._retired = True
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    async def start(self) -> bool:
+        """Steps 1-2. False means nothing was shown; caller should send text."""
+        try:
+            card_json = json.dumps(build_streaming_card(), ensure_ascii=False)
+            data = await self._client.card_api(
+                "POST",
+                "/open-apis/cardkit/v1/cards",
+                {"type": "card_json", "data": card_json},
+            )
+            card_id = str(data.get("card_id") or "")
+            if not card_id:
+                logger.warning("Feishu card: create returned no card_id; falling back to text")
+                return False
+            await self._client.send_card_reply(self._message_id, card_id)
+        except CardApiError as exc:
+            if getattr(exc, "code", None) in _GONE_CODES:
+                self._anchor_gone = True
+            logger.warning("Feishu card: could not open a streaming card (%s)", exc)
+            return False
+        except Exception as exc:
+            logger.warning("Feishu card: could not open a streaming card (%s)", exc)
+            return False
+        self._card_id = card_id
+        self._last_flush = time.monotonic()
+        return True
+
+    async def push(self, text: str, *, force: bool = False) -> None:
+        """Step 3, throttled. *text* is the cumulative answer so far.
+
+        *force* bypasses the throttle. Used for a frame that may be followed by
+        a long silence (a tool call), where waiting for the next chunk would
+        leave the user staring at stale text.
+        """
+        self._pending = text
+        await self._flush(force=force)
+
+    async def _flush(self, *, force: bool = False) -> None:
+        if not self.live:
+            return
+        async with self._lock:
+            if not self.live:
+                return
+            now = time.monotonic()
+            gap = now - self._last_flush
+            if not force:
+                # Anti-stutter: after a long quiet period the first frame would
+                # carry only the handful of characters that just arrived, which
+                # reads as a stutter. Defer briefly so it carries real text.
+                #
+                # Only for a TINY fragment: nothing schedules a retry, so
+                # deferring a substantial buffer would hide it until the next
+                # event, and if the model then goes quiet the user sees nothing.
+                # A fragment this short is worth that risk; a paragraph is not.
+                tiny = len(self._pending) - len(self._shown) < _ANTI_STUTTER_MAX_CHARS
+                if tiny and gap > LONG_GAP_THRESHOLD_S and self._batch_until <= self._last_flush:
+                    self._batch_until = now + BATCH_AFTER_GAP_S
+                    return
+                if now < self._batch_until:
+                    return
+                if gap < CARDKIT_THROTTLE_S:
+                    return
+            body = prepare_card_text(self._pending, demote_tables=self._demote_tables)
+            if not body or body == self._shown:
+                return
+            # Stamp BEFORE the call so a slow request cannot let a second flush
+            # through on the old timestamp.
+            self._last_flush = now
+            try:
+                await self._client.card_api(
+                    "PUT",
+                    f"/open-apis/cardkit/v1/cards/{self._card_id}"
+                    f"/elements/{STREAMING_ELEMENT_ID}/content",
+                    {"content": body, "sequence": self._next_seq()},
+                )
+            except Exception as exc:
+                self._classify(exc, "content push")
+                return
+            self._shown = body
+
+    async def finish(self, text: str) -> bool:
+        """Steps 3-5. Returns ``delivered``.
+
+        The final content push happens FIRST, so the user has the whole answer
+        even if closing streaming mode or the full replace then fails.
+        """
+        if not self.live:
+            return self._delivered
+        self._pending = text
+        await self._flush(force=True)
+        if self._shown:
+            self._delivered = True
+        if not self.live:
+            return self._delivered
+
+        body = prepare_card_text(text, demote_tables=self._demote_tables)
+        try:
+            await self._client.card_api(
+                "PATCH",
+                f"/open-apis/cardkit/v1/cards/{self._card_id}/settings",
+                {
+                    "settings": json.dumps({"streaming_mode": False}, ensure_ascii=False),
+                    "sequence": self._next_seq(),
+                },
+            )
+        except Exception as exc:
+            # Cosmetic only -- the text is already on screen.
+            logger.debug("Feishu card: could not close streaming mode (%s)", exc)
+        try:
+            await self._client.card_api(
+                "PUT",
+                f"/open-apis/cardkit/v1/cards/{self._card_id}",
+                {
+                    "card": {
+                        "type": "card_json",
+                        "data": json.dumps(build_final_card(body), ensure_ascii=False),
+                    },
+                    "sequence": self._next_seq(),
+                },
+            )
+        except Exception as exc:
+            logger.debug("Feishu card: final replace failed (%s)", exc)
+        return self._delivered

--- a/src/kiro_crew/feishu/transport.py
+++ b/src/kiro_crew/feishu/transport.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import replace
 from typing import Any
 
 from kiro_crew.feishu.client import CHAT_GROUP, CHAT_P2P, LarkClient, LarkInbound
@@ -59,6 +60,33 @@ FEISHU_CAPABILITIES = TransportCapabilities(
     # failure raises (see ``send_message``). Same contract as WeCom's.
     returns_message_id=False,
 )
+
+#: The declaration for a turn served by the streaming CARD renderer.
+#:
+#: Kept as a SEPARATE constant rather than flipping the flags above, because the
+#: two are both true -- of different turns. Streaming is opt-in per turn
+#: (``feishu.streaming``, DM only), so a gateway with it off really is a
+#: non-streaming, non-editing, text-only channel and must keep saying so. The
+#: honesty contract is per declaration, not per package.
+#:
+#: Built with ``dataclasses.replace`` rather than a second
+#: ``TransportCapabilities(...)`` literal so there stays exactly ONE such call in
+#: this module: the outbound-authz contract test walks this file's AST for those
+#: calls and reads the FIRST one carrying ``returns_message_id`` as the channel's
+#: declaration, so a second literal would shadow the real one.
+#:
+#: Only ``streaming`` and ``edit`` flip. ``rich_blocks`` deliberately stays False:
+#: it gates whether a renderer may attach an Adaptive Card of interactive
+#: elements, and a CardKit card here renders MARKDOWN, not tappable choices --
+#: claiming it would promise widgets this channel cannot draw. ``max_buttons``
+#: stays 0 for the same reason, so the zero-widget options path still applies.
+#:
+#: ``returns_message_id`` deliberately does NOT change either. The card id a live
+#: turn needs lives inside the renderer, exactly as Telegram keeps its message id
+#: in the renderer; ``returns_message_id`` describes only the ``send_message``
+#: transport verb, whose contract (empty return = success, failure raises) is
+#: untouched.
+FEISHU_STREAMING_CAPABILITIES = replace(FEISHU_CAPABILITIES, streaming=True, edit=True)
 
 
 class FeishuTransport(MessagingTransport):

--- a/src/kiro_crew/feishu/transport_dispatch.py
+++ b/src/kiro_crew/feishu/transport_dispatch.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.feishu.client import CHAT_GROUP
+from kiro_crew.feishu.client import CHAT_GROUP, CHAT_P2P
 from kiro_crew.feishu.renderer import FeishuRenderer
-from kiro_crew.feishu.transport import FEISHU_CAPABILITIES
+from kiro_crew.feishu.transport import FEISHU_CAPABILITIES, FEISHU_STREAMING_CAPABILITIES
 from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.commands import compact_unsupported_backend
 from kiro_crew.messaging.conversation import ConversationState
@@ -148,12 +148,27 @@ class FeishuDispatcher:
         conversation_id = f"feishu:{route[1]}"
         agent = self._resolve_agent()
 
+        # Streaming card: opt-in (``feishu.streaming``) and DIRECT MESSAGES ONLY.
+        # A group turn keeps the buffered text reply -- the official Feishu
+        # plugin resolves groups to static for the same reason, and a card
+        # animating in a busy room is noise for everyone who did not ask.
+        # The capability declaration follows the mode, so a gateway with
+        # streaming off never claims to stream.
+        #
+        # Read the flag STRICTLY, not through ``getattr(..., "streaming", False)``:
+        # a getattr default would compile and pass every test even if the config
+        # field were missing or misspelled, leaving a switch the user can set and
+        # that can never actually turn on. An attribute error here is the loud
+        # failure that keeps flag and field in step.
+        stream = bool(self.cfg.feishu.streaming) and inbound.chat_type == CHAT_P2P
+
         # Feishu has no interactive buttons -> no decider (deny-by-default for
         # INTERACTIVE; auto/trust still auto-approve via the driver ladder).
         renderer = FeishuRenderer(
             self.client,
             inbound.message_id,
-            FEISHU_CAPABILITIES,
+            FEISHU_STREAMING_CAPABILITIES if stream else FEISHU_CAPABILITIES,
+            streaming=stream,
         )
 
         # Surface a newly-created Feishu session in the dashboard immediately

--- a/test/test_feishu_client.py
+++ b/test/test_feishu_client.py
@@ -1398,3 +1398,223 @@ class TestMentionResolution:
         await asyncio.sleep(0.05)
 
         assert seen == ["do the thing"]
+
+
+# ---------------------------------------------------------------------------
+# CardKit verbs (streaming card plumbing)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal context-manager stand-in for urlopen's return value."""
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_exc: Any) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._payload.encode("utf-8")
+
+
+def _capture_urlopen(monkeypatch: Any, *payloads: str) -> list[Any]:
+    """Patch urlopen to answer with *payloads* in order; record the requests."""
+    import urllib.request
+
+    seen: list[Any] = []
+    queue = list(payloads)
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _FakeResponse:
+        seen.append(req)
+        return _FakeResponse(queue.pop(0) if queue else json.dumps({"code": 0}))
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return seen
+
+
+_TOKEN_OK = json.dumps({"code": 0, "tenant_access_token": "t-abc", "expire": 7200})
+
+
+class TestTenantToken:
+    def test_token_is_fetched_then_cached(self, monkeypatch: Any) -> None:
+        """The second call must not re-hit the network."""
+        from kiro_crew.feishu.client import LarkClient
+
+        seen = _capture_urlopen(monkeypatch, _TOKEN_OK)
+        client = LarkClient(app_id="a", app_secret="s")
+
+        assert client._sync_tenant_token() == "t-abc"
+        assert client._sync_tenant_token() == "t-abc"
+        assert len(seen) == 1
+
+    def test_an_expired_token_is_refetched(self, monkeypatch: Any) -> None:
+        """A lapsed cache entry must not be served."""
+        from kiro_crew.feishu.client import LarkClient
+
+        seen = _capture_urlopen(monkeypatch, _TOKEN_OK, _TOKEN_OK)
+        client = LarkClient(app_id="a", app_secret="s")
+
+        client._sync_tenant_token()
+        client._token = ("stale", 0.0)  # already expired
+        client._sync_tenant_token()
+
+        assert len(seen) == 2
+
+    def test_an_empty_token_raises_rather_than_caching_it(self, monkeypatch: Any) -> None:
+        """A blank token must fail loudly, not be cached and reused."""
+        from kiro_crew.feishu.client import CardApiError, LarkClient
+
+        _capture_urlopen(monkeypatch, json.dumps({"code": 0, "tenant_access_token": ""}))
+        client = LarkClient(app_id="a", app_secret="s")
+
+        with pytest.raises(CardApiError):
+            client._sync_tenant_token()
+        assert client._token is None
+
+
+class TestSyncHttp:
+    def test_a_zero_code_body_is_returned_whole(self, monkeypatch: Any) -> None:
+        from kiro_crew.feishu.client import LarkClient
+
+        _capture_urlopen(monkeypatch, json.dumps({"code": 0, "data": {"card_id": "c1"}}))
+        client = LarkClient(app_id="a", app_secret="s")
+
+        out = client._sync_http("POST", "/open-apis/x", {"k": "v"}, token="t")
+
+        assert out["data"]["card_id"] == "c1"
+
+    def test_http_200_with_a_nonzero_body_code_raises(self, monkeypatch: Any) -> None:
+        """THE important one: Feishu reports business errors inside a 200 body.
+
+        An exception-only reading would treat this as success for a call that did
+        nothing, which is why the code is checked explicitly.
+        """
+        from kiro_crew.feishu.client import CardApiError, LarkClient
+
+        _capture_urlopen(monkeypatch, json.dumps({"code": 230020, "msg": "too fast"}))
+        client = LarkClient(app_id="a", app_secret="s")
+
+        with pytest.raises(CardApiError) as caught:
+            client._sync_http("PUT", "/open-apis/x", None, token="t")
+
+        assert caught.value.code == 230020
+        assert caught.value.msg == "too fast"
+
+    def test_an_http_error_carrying_a_body_code_uses_that_code(self, monkeypatch: Any) -> None:
+        import urllib.error
+        import urllib.request
+
+        from kiro_crew.feishu.client import CardApiError, LarkClient
+
+        class _Err(urllib.error.HTTPError):
+            def __init__(self) -> None:
+                super().__init__("u", 400, "bad", {}, None)  # type: ignore[arg-type]
+
+            def read(self) -> bytes:
+                return json.dumps({"code": 230011, "msg": "recalled"}).encode()
+
+        def boom(_req: Any, timeout: float = 0) -> None:
+            raise _Err()
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        client = LarkClient(app_id="a", app_secret="s")
+
+        with pytest.raises(CardApiError) as caught:
+            client._sync_http("PUT", "/open-apis/x", None, token="t")
+
+        assert caught.value.code == 230011
+
+    def test_an_http_error_with_an_unparseable_body_falls_back_to_the_status(
+        self, monkeypatch: Any
+    ) -> None:
+        import urllib.error
+        import urllib.request
+
+        from kiro_crew.feishu.client import CardApiError, LarkClient
+
+        class _Err(urllib.error.HTTPError):
+            def __init__(self) -> None:
+                super().__init__("u", 503, "nope", {}, None)  # type: ignore[arg-type]
+
+            def read(self) -> bytes:
+                return b"<html>gateway</html>"
+
+        def boom(_req: Any, timeout: float = 0) -> None:
+            raise _Err()
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        client = LarkClient(app_id="a", app_secret="s")
+
+        with pytest.raises(CardApiError) as caught:
+            client._sync_http("GET", "/open-apis/x", None, token="t")
+
+        assert caught.value.code == 503
+
+    def test_a_non_https_origin_is_refused_before_any_request(self, monkeypatch: Any) -> None:
+        """urllib honours file://, so a bad configured origin must not reach it."""
+        from kiro_crew.feishu.client import CardApiError, LarkClient
+
+        seen = _capture_urlopen(monkeypatch, json.dumps({"code": 0}))
+        client = LarkClient(app_id="a", app_secret="s")
+        client._open_base = "file:///etc"
+
+        with pytest.raises(CardApiError):
+            client._sync_http("GET", "/passwd", None, token="t")
+        assert seen == []
+
+    def test_a_token_is_sent_as_a_bearer_header(self, monkeypatch: Any) -> None:
+        from kiro_crew.feishu.client import LarkClient
+
+        seen = _capture_urlopen(monkeypatch, json.dumps({"code": 0}))
+        client = LarkClient(app_id="a", app_secret="s")
+        client._sync_http("POST", "/open-apis/x", None, token="tok")
+
+        assert seen[0].headers.get("Authorization") == "Bearer tok"
+
+
+class TestCardApi:
+    @pytest.mark.asyncio
+    async def test_card_api_returns_only_the_data_envelope(self, monkeypatch: Any) -> None:
+        from kiro_crew.feishu.client import LarkClient
+
+        _capture_urlopen(monkeypatch, _TOKEN_OK, json.dumps({"code": 0, "data": {"card_id": "c9"}}))
+        client = LarkClient(app_id="a", app_secret="s")
+
+        out = await client.card_api("POST", "/open-apis/cardkit/v1/cards", {"x": 1})
+
+        assert out == {"card_id": "c9"}
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_a_missing_data_key_yields_an_empty_dict(self, monkeypatch: Any) -> None:
+        from kiro_crew.feishu.client import LarkClient
+
+        _capture_urlopen(monkeypatch, _TOKEN_OK, json.dumps({"code": 0}))
+        client = LarkClient(app_id="a", app_secret="s")
+
+        assert await client.card_api("PUT", "/open-apis/cardkit/v1/cards/1") == {}
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_send_card_reply_posts_an_interactive_message(self, monkeypatch: Any) -> None:
+        """The message carries no text of its own -- only the card reference."""
+        from kiro_crew.feishu.client import LarkClient
+
+        seen = _capture_urlopen(monkeypatch, _TOKEN_OK, json.dumps({"code": 0}))
+        client = LarkClient(app_id="a", app_secret="s")
+
+        await client.send_card_reply("om_123", "card_abc")
+
+        reply = seen[-1]
+        assert reply.full_url.endswith("/open-apis/im/v1/messages/om_123/reply")
+        body = json.loads(reply.data.decode())
+        assert body["msg_type"] == "interactive"
+        assert json.loads(body["content"]) == {
+            "type": "card",
+            "data": {"card_id": "card_abc"},
+        }
+        await client.close()

--- a/test/test_feishu_dispatch.py
+++ b/test/test_feishu_dispatch.py
@@ -9,6 +9,7 @@ import pytest
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, AcpEvent
 from kiro_crew.feishu.client import LarkInbound
+from kiro_crew.feishu.transport import FEISHU_CAPABILITIES, FEISHU_STREAMING_CAPABILITIES
 from kiro_crew.feishu.transport_dispatch import FeishuDispatcher
 from kiro_crew.messaging.link import (
     CHAT_TYPE_DIRECT,
@@ -206,7 +207,15 @@ def _cfg(default_agent: str = "", approval_mode: str = "interactive", **kw):
     dm_scope = kw.get("dm_scope", "per-channel-peer")
     return SimpleNamespace(
         agent=SimpleNamespace(default_agent=default_agent, approval_mode=approval_mode),
-        feishu=SimpleNamespace(hard_threshold_pct=95.0, soft_threshold_pct=80.0),
+        feishu=SimpleNamespace(
+            hard_threshold_pct=95.0,
+            soft_threshold_pct=80.0,
+            # Mirrors FeishuConfig.streaming's real default. The dispatcher reads
+            # this attribute STRICTLY (no getattr default) so that a config field
+            # gone missing fails loudly instead of leaving a switch that can
+            # never turn on -- which means this fake has to carry it too.
+            streaming=kw.get("streaming", False),
+        ),
         messaging=SimpleNamespace(
             dm_scope=dm_scope,
             idle_reset_minutes=kw.get("idle_reset_minutes", 0),
@@ -1083,3 +1092,78 @@ class TestCompactCapabilityGate:
         await d.handle_message(_inbound("two", message_id="m2"))
         assert not any("已自动压缩" in c for _, c in client.replies)
         assert not any("对话上下文已较长" in c for _, c in client.replies)
+
+
+class TestStreamingModeSelection:
+    """The streaming card is opt-in AND direct-messages-only.
+
+    Both halves are load-bearing. The capability declaration follows the mode, so
+    a gateway with the flag off must not *claim* to stream -- a renderer that
+    advertises a live surface it never updates is worse than an honest buffered
+    one. And a card animating in a busy room is noise for everyone who did not
+    ask, which is why a group turn keeps the buffered reply even with the flag on.
+    """
+
+    @staticmethod
+    def _spy(monkeypatch):
+        """Capture the renderer's mode, delegating to the real renderer.
+
+        A replacement stub would pass this assertion while silently skipping the
+        turn's actual rendering, so the spy constructs the real thing.
+        """
+        import kiro_crew.feishu.transport_dispatch as mod
+
+        captured: list = []
+        real = mod.FeishuRenderer
+
+        def factory(client, message_id, caps, **kw):
+            captured.append((caps, bool(kw.get("streaming", False))))
+            return real(client, message_id, caps, **kw)
+
+        monkeypatch.setattr(mod, "FeishuRenderer", factory)
+        return captured
+
+    def _turn(self):
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi there"),
+                AcpEvent(kind=EVENT_COMPLETE),
+            ]
+        )
+        return FakeSessions(provider), FakeClient()
+
+    @pytest.mark.asyncio
+    async def test_streaming_off_keeps_the_buffered_capabilities(self, monkeypatch) -> None:
+        captured = self._spy(monkeypatch)
+        sessions, client = self._turn()
+        d = _dispatcher(sessions, FakeCtx(), client, cfg=_cfg(streaming=False))
+
+        await d.handle_message(_inbound("hello"))
+
+        assert captured == [(FEISHU_CAPABILITIES, False)]
+
+    @pytest.mark.asyncio
+    async def test_streaming_on_selects_the_streaming_mode_for_a_direct_message(
+        self, monkeypatch
+    ) -> None:
+        captured = self._spy(monkeypatch)
+        sessions, client = self._turn()
+        d = _dispatcher(sessions, FakeCtx(), client, cfg=_cfg(streaming=True))
+
+        await d.handle_message(_inbound("hello", chat_type="p2p"))
+
+        assert captured == [(FEISHU_STREAMING_CAPABILITIES, True)]
+        # This fake client exposes no card_api, so the card cannot open -- and the
+        # answer still arrives as an ordinary reply. That degradation is the point
+        # of the mode: enabling streaming must never be able to cost the answer.
+        assert any(content == "hi there" for _, content in client.replies)
+
+    @pytest.mark.asyncio
+    async def test_a_group_turn_stays_buffered_even_with_streaming_on(self, monkeypatch) -> None:
+        captured = self._spy(monkeypatch)
+        sessions, client = self._turn()
+        d = _dispatcher(sessions, FakeCtx(), client, cfg=_cfg(streaming=True))
+
+        await d.handle_message(_inbound("@bot hello", chat_type="group", chat_id="oc_grp"))
+
+        assert captured == [(FEISHU_CAPABILITIES, False)]

--- a/test/test_feishu_renderer.py
+++ b/test/test_feishu_renderer.py
@@ -204,3 +204,198 @@ class TestNoOpHandlers:
         r = _renderer(c)
         await r.on_compaction(75.0)
         assert c.replies == []
+
+
+# ---------------------------------------------------------------------------
+# Streaming card mode (opt-in; the buffered path above stays the default)
+# ---------------------------------------------------------------------------
+
+
+class FakeCard:
+    """Stands in for StreamingCardSession, recording the frames pushed."""
+
+    def __init__(self, client: object, message_id: str) -> None:
+        self.client = client
+        self.message_id = message_id
+        self.frames: list[str] = []
+        self.final: str | None = None
+        # Knobs the tests flip to drive each branch.
+        self.start_ok = True
+        self.live = True
+        self.delivered_final = True
+        self.anchor_gone = False
+        self.push_raises = False
+
+    async def start(self) -> bool:
+        return self.start_ok
+
+    async def push(self, text: str, *, force: bool = False) -> None:
+        if self.push_raises:
+            raise RuntimeError("push exploded")
+        self.frames.append(text)
+
+    async def finish(self, text: str) -> bool:
+        self.final = text
+        return self.delivered_final
+
+
+def _streaming_renderer(
+    client: FakeClient, monkeypatch: object, card: FakeCard | None = None
+) -> tuple[FeishuRenderer, list[FakeCard]]:
+    """Build a streaming renderer whose card session is a FakeCard."""
+    import kiro_crew.feishu.renderer as mod
+
+    made: list[FakeCard] = []
+
+    def factory(cl: object, mid: str) -> FakeCard:
+        made.append(card if card is not None else FakeCard(cl, mid))
+        return made[-1]
+
+    monkeypatch.setattr(mod, "StreamingCardSession", factory)  # type: ignore[attr-defined]
+    return FeishuRenderer(client, "msg1", _CAPS, streaming=True), made
+
+
+class TestStreamingTurnStart:
+    @pytest.mark.asyncio
+    async def test_a_card_is_opened_and_no_text_is_sent(self, monkeypatch) -> None:
+        c = FakeClient()
+        r, made = _streaming_renderer(c, monkeypatch)
+
+        await r.on_turn_start()
+
+        assert len(made) == 1
+        assert c.replies == []
+
+    @pytest.mark.asyncio
+    async def test_a_second_turn_start_does_not_open_a_second_card(self, monkeypatch) -> None:
+        """on_turn_start is called twice per turn, so it has to be idempotent."""
+        c = FakeClient()
+        r, made = _streaming_renderer(c, monkeypatch)
+
+        await r.on_turn_start()
+        await r.on_turn_start()
+
+        assert len(made) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failed_start_leaves_the_buffered_path_intact(self, monkeypatch) -> None:
+        c = FakeClient()
+        card = FakeCard(c, "msg1")
+        card.start_ok = False
+        r, _made = _streaming_renderer(c, monkeypatch, card)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("hello")
+        await r.on_done()
+
+        assert card.frames == []
+        assert c.replies == [("msg1", "hello")]
+
+
+class TestStreamingPushes:
+    @pytest.mark.asyncio
+    async def test_frames_carry_the_cumulative_text(self, monkeypatch) -> None:
+        c = FakeClient()
+        r, made = _streaming_renderer(c, monkeypatch)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("Hel")
+        await r.on_text_chunk("lo")
+
+        assert made[0].frames[-1] == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_a_tool_call_is_shown_then_cleared(self, monkeypatch) -> None:
+        c = FakeClient()
+        r, made = _streaming_renderer(c, monkeypatch)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("working")
+        await r.on_tool_call("call-1", "grep")
+
+        assert any("grep" in f for f in made[0].frames)
+
+    @pytest.mark.asyncio
+    async def test_a_dead_card_stops_receiving_frames(self, monkeypatch) -> None:
+        c = FakeClient()
+        card = FakeCard(c, "msg1")
+        r, _made = _streaming_renderer(c, monkeypatch, card)
+
+        await r.on_turn_start()
+        card.live = False
+        await r.on_text_chunk("ignored")
+
+        assert card.frames == []
+
+    @pytest.mark.asyncio
+    async def test_a_raising_push_never_breaks_the_turn(self, monkeypatch) -> None:
+        """A rendering nicety must not cost the user the reply."""
+        c = FakeClient()
+        card = FakeCard(c, "msg1")
+        card.push_raises = True
+        r, _made = _streaming_renderer(c, monkeypatch, card)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("still fine")
+        card.delivered_final = False
+        await r.on_done()
+
+        assert c.replies == [("msg1", "still fine")]
+
+
+class TestStreamingDone:
+    @pytest.mark.asyncio
+    async def test_a_delivered_card_suppresses_the_text_reply(self, monkeypatch) -> None:
+        """The user already has the answer; a text reply would duplicate it."""
+        c = FakeClient()
+        card = FakeCard(c, "msg1")
+        r, _made = _streaming_renderer(c, monkeypatch, card)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("done")
+        await r.on_done()
+
+        assert card.final == "done"
+        assert c.replies == []
+
+    @pytest.mark.asyncio
+    async def test_an_undelivered_card_falls_back_to_text(self, monkeypatch) -> None:
+        c = FakeClient()
+        card = FakeCard(c, "msg1")
+        card.delivered_final = False
+        r, _made = _streaming_renderer(c, monkeypatch, card)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("payload")
+        await r.on_done()
+
+        assert c.replies == [("msg1", "payload")]
+
+    @pytest.mark.asyncio
+    async def test_a_recalled_anchor_suppresses_the_fallback_too(self, monkeypatch) -> None:
+        """Replying to a recalled anchor fails as well, so do not try."""
+        c = FakeClient()
+        card = FakeCard(c, "msg1")
+        card.delivered_final = False
+        card.anchor_gone = True
+        r, _made = _streaming_renderer(c, monkeypatch, card)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("lost")
+        await r.on_done()
+
+        assert c.replies == []
+
+    @pytest.mark.asyncio
+    async def test_an_options_trailer_is_withheld_from_live_frames(self, monkeypatch) -> None:
+        """A half-arrived marker must not flash; the final text still carries it."""
+        c = FakeClient()
+        card = FakeCard(c, "msg1")
+        r, _made = _streaming_renderer(c, monkeypatch, card)
+
+        await r.on_turn_start()
+        await r.on_text_chunk("pick one\n[OPTIONS: a | b]")
+        await r.on_done()
+
+        assert all("[OPTIONS:" not in f for f in card.frames)
+        assert card.final is not None and "a" in card.final

--- a/test/test_feishu_streaming_card.py
+++ b/test/test_feishu_streaming_card.py
@@ -1,0 +1,908 @@
+"""Tests for kiro_crew.feishu.streaming_card (StreamingCardSession, Layer 2c).
+
+What is worth pinning here is the failure policy, not the happy path. A live card
+is the only surface the user sees, so every branch decides between three
+user-visible outcomes: the answer keeps streaming, the answer arrives as an
+ordinary text reply instead, or the answer is lost. The tests are organised by
+that decision rather than by method.
+
+Two things about the transport shape drive the design of ``FakeClient`` below:
+Feishu answers a *business* error with HTTP 200 and a non-zero ``code`` in the
+JSON body, and ``LarkClient`` turns that body code into ``CardApiError.code``.
+A fake that only raised bare exceptions would report every failure as
+"unrecognised -> fall back to text" and would never exercise the code-driven
+policy that is the whole point of the module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, NamedTuple
+
+import pytest
+
+from kiro_crew.feishu import streaming_card as sc
+from kiro_crew.feishu.client import CardApiError
+from kiro_crew.feishu.streaming_card import StreamingCardSession
+
+_LOGGER = "kiro_crew.feishu.streaming_card"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class Call(NamedTuple):
+    """One recorded CardKit call, tagged with the lifecycle step it belongs to."""
+
+    kind: str
+    method: str
+    path: str
+    body: dict[str, Any]
+
+
+def _kind(method: str, path: str) -> str:
+    """Name the lifecycle step a (method, path) pair represents.
+
+    Deliberately derived from the request itself rather than from call order, so
+    an out-of-order lifecycle shows up as a wrong *sequence of names* instead of
+    quietly passing.
+    """
+    if method == "POST":
+        return "create"  # step 1
+    if method == "PATCH":
+        return "settings"  # step 4
+    if path.endswith("/content"):
+        return "push"  # step 3
+    return "final"  # step 5
+
+
+class FakeClient:
+    """Records CardKit calls without needing lark_oapi.
+
+    Mirrors the two parts of the real ``LarkClient`` contract this module leans
+    on: ``card_api`` resolves to the envelope's ``data`` object (which is where
+    ``start`` finds ``card_id``), and a non-zero body code becomes a
+    ``CardApiError`` carrying that code. Queue codes per step in ``codes`` to
+    drive the error taxonomy, or put an exception in ``raises`` to drive the
+    "unrecognised failure" path.
+    """
+
+    def __init__(self, card_id: str = "card-1") -> None:
+        self.card_id = card_id
+        self.calls: list[Call] = []
+        self.replies: list[tuple[str, str]] = []
+        # step name -> body codes answered one per call, in order (0 == success)
+        self.codes: dict[str, list[int]] = {}
+        # step name -> raise this instead (a transport error, no body code)
+        self.raises: dict[str, BaseException] = {}
+        self.reply_raises: BaseException | None = None
+
+    def _answer(self, kind: str, path: str) -> None:
+        exc = self.raises.get(kind)
+        if exc is not None:
+            raise exc
+        queue = self.codes.get(kind) or []
+        code = queue.pop(0) if queue else 0
+        if code:
+            # Exactly what LarkClient._sync_http does with a 200 + body code.
+            raise CardApiError(code, f"simulated code {code}", path)
+
+    async def card_api(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        kind = _kind(method, path)
+        self.calls.append(Call(kind, method, path, dict(body or {})))
+        self._answer(kind, path)
+        return {"card_id": self.card_id} if kind == "create" else {}
+
+    async def send_card_reply(self, message_id: str, card_id: str) -> None:
+        self.replies.append((message_id, card_id))
+        if self.reply_raises is not None:
+            raise self.reply_raises
+
+    # -- readers -------------------------------------------------------------
+
+    @property
+    def kinds(self) -> list[str]:
+        return [c.kind for c in self.calls]
+
+    def of(self, kind: str) -> list[Call]:
+        return [c for c in self.calls if c.kind == kind]
+
+    def contents(self) -> list[str]:
+        """The text carried by each content push, in order."""
+        return [str(c.body.get("content", "")) for c in self.of("push")]
+
+    def sequences(self) -> list[int]:
+        return [int(c.body["sequence"]) for c in self.calls if "sequence" in c.body]
+
+
+class FakeClock:
+    """Stands in for the module's ``time`` so the throttle is deterministic.
+
+    The module only ever asks for ``monotonic()``. Driving it from the test is
+    what lets the 100 ms throttle and the 2 s long-gap deferral be asserted
+    without sleeping, which on a loaded xdist worker is the difference between a
+    real assertion and a coin flip.
+    """
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> FakeClock:
+    fake = FakeClock()
+    monkeypatch.setattr(sc, "time", fake)
+    return fake
+
+
+async def _started(client: FakeClient, message_id: str = "msg-1") -> StreamingCardSession:
+    session = StreamingCardSession(client, message_id)
+    assert await session.start() is True
+    return session
+
+
+def _table(tag: str) -> str:
+    return f"| {tag} | b |\n| --- | --- |\n| 1 | 2 |\n"
+
+
+# ---------------------------------------------------------------------------
+# Card payloads
+# ---------------------------------------------------------------------------
+
+
+class TestCardPayloads:
+    def test_streaming_card_declares_streaming_and_the_target_element(self) -> None:
+        card = sc.build_streaming_card()
+        assert card["config"]["streaming_mode"] is True
+        element = card["body"]["elements"][0]
+        # Every content push addresses this element by id; a mismatch would make
+        # the card render but never update.
+        assert element["element_id"] == sc.STREAMING_ELEMENT_ID
+        assert element["content"] == ""
+        pacing = card["config"]["streaming_config"]
+        assert pacing["print_frequency_ms"]["default"] == sc.STREAM_PRINT_FREQUENCY_MS
+        assert pacing["print_step"]["default"] == sc.STREAM_PRINT_STEP
+
+    def test_summary_is_clamped_to_fifty_chars(self) -> None:
+        card = sc.build_streaming_card("x" * 200)
+        assert len(card["config"]["summary"]["content"]) == 50
+
+    def test_final_card_carries_the_text_and_drops_streaming(self) -> None:
+        card = sc.build_final_card("done")
+        assert "streaming_mode" not in card["config"]
+        assert card["body"]["elements"][0]["content"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# Markdown normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCardLinks:
+    def test_a_bare_url_becomes_an_explicit_link(self) -> None:
+        out = sc.normalize_card_links("see https://example.com/a")
+        assert out == "see [https://example.com/a](https://example.com/a)"
+
+    def test_underscores_are_percent_encoded_in_the_target_only(self) -> None:
+        """The visible label keeps the real URL; only the target is encoded.
+
+        Feishu re-tokenizes a bare URL and splits it around ``_``, so the target
+        must be encoded -- but encoding the label too would show the user a URL
+        they cannot read back or retype.
+        """
+        out = sc.normalize_card_links("https://example.com/a_b_c")
+        assert out == "[https://example.com/a_b_c](https://example.com/a%5Fb%5Fc)"
+
+    def test_trailing_sentence_punctuation_stays_outside_the_link(self) -> None:
+        out = sc.normalize_card_links("go to https://example.com/a.")
+        assert out == "go to [https://example.com/a](https://example.com/a)."
+
+    def test_an_already_linked_url_is_left_alone(self) -> None:
+        text = "[label](https://example.com/a_b)"
+        assert sc.normalize_card_links(text) == text
+
+    def test_a_url_inside_inline_code_is_protected(self) -> None:
+        text = "run `curl https://example.com/a_b` now"
+        assert sc.normalize_card_links(text) == text
+
+    def test_a_url_inside_a_fence_is_protected(self) -> None:
+        text = "```\nhttps://example.com/a_b\n```"
+        assert sc.normalize_card_links(text) == text
+
+    def test_an_indented_fence_is_dedented(self) -> None:
+        """An indented ``` is not recognised by the card renderer at all, so the
+        block would render as literal text with its backticks showing."""
+        out = sc.normalize_card_links("    ```\n    code\n    ```")
+        assert out.startswith("```\n")
+        assert out.endswith("```")
+
+    def test_an_internal_failure_returns_the_argument_unchanged(self, monkeypatch: Any) -> None:
+        """Fault-injected on a pure helper -- the only way to reach the guard.
+
+        The wrapper exists so a *rendering nicety* can never cost the user the
+        reply: the text goes out unlinkified rather than not at all. It returns
+        the ARGUMENT, byte for byte -- the fence dedent that runs first is bound
+        to its own name precisely so a later failure cannot leak a
+        half-transformed value out through the guard.
+        """
+
+        def boom(_text: str) -> Any:
+            raise RuntimeError("protect exploded")
+
+        src = "    ```\nsee https://example.com/a_b\n```"
+        monkeypatch.setattr(sc, "_protect", boom)
+        out = sc.normalize_card_links(src)
+
+        assert out == src
+
+
+class TestOptimizeCardMarkdown:
+    def test_headings_are_clamped(self) -> None:
+        """``#``/``##`` render enormous in a card; h1-h3 collapse to h4/h5."""
+        out = sc.optimize_card_markdown("# Title\n## Sub\n### Deep\n")
+        assert out == "#### Title\n##### Sub\n##### Deep\n"
+
+    def test_a_heading_already_small_enough_is_untouched(self) -> None:
+        text = "#### Title\n###### Deep\n"
+        assert sc.optimize_card_markdown(text) == text
+
+    def test_a_heading_inside_a_fence_is_not_clamped(self) -> None:
+        out = sc.optimize_card_markdown("```\n# not a heading\n```")
+        assert "# not a heading" in out
+        assert "#### not a heading" not in out
+
+    def test_an_image_feishu_cannot_resolve_is_stripped(self) -> None:
+        """An http(s) or local image target fails the WHOLE card (200570), so
+        losing the image is strictly better than losing the answer."""
+        out = sc.optimize_card_markdown("before ![alt](https://example.com/a.png) after")
+        assert out == "before  after"
+
+    def test_a_feishu_image_key_is_kept(self) -> None:
+        text = "![alt](img_v2_abc)"
+        assert sc.optimize_card_markdown(text) == text
+
+    def test_runs_of_blank_lines_are_collapsed(self) -> None:
+        assert sc.optimize_card_markdown("a\n\n\n\n\nb") == "a\n\nb"
+
+    def test_a_fence_gets_vertical_space_before_it(self) -> None:
+        """Blank lines produce no vertical space in a card, so a ``<br>`` is
+        injected around block constructs.
+
+        Only the space *before the opening fence* is asserted. The same pass also
+        injects a ``<br>`` immediately after an opening fence and before a
+        closing one -- i.e. inside the code block -- which is reported separately
+        as a defect rather than pinned here.
+        """
+        out = sc.optimize_card_markdown("text\n```\ncode\n```")
+        assert "text\n<br>\n```" in out
+
+    def test_an_internal_failure_returns_the_original_text(self, monkeypatch: Any) -> None:
+        def boom(_text: str) -> Any:
+            raise RuntimeError("protect exploded")
+
+        monkeypatch.setattr(sc, "_protect", boom)
+        text = "# Title\n![alt](https://example.com/a.png)"
+        assert sc.optimize_card_markdown(text) == text
+
+
+class TestFenceExcessTables:
+    def test_tables_within_the_limit_are_left_native(self) -> None:
+        text = "\n".join(_table(f"t{i}") for i in range(sc.FEISHU_CARD_TABLE_LIMIT))
+        assert sc.fence_excess_tables(text) == text
+
+    def test_excess_tables_are_demoted_to_fenced_code(self) -> None:
+        """Feishu rejects a card carrying too many native tables outright, which
+        loses the whole answer. A fenced table is ugly but arrives."""
+        text = _table("keep") + "\n" + _table("demote")
+        out = sc.fence_excess_tables(text, limit=1)
+        assert out.startswith("| keep |")
+        assert "```\n| demote | b |\n| --- | --- |\n| 1 | 2 |\n```" in out
+
+    def test_the_whole_table_is_wrapped_not_just_the_matched_two_lines(self) -> None:
+        text = _table("keep") + "\n| demote | b |\n| --- | --- |\n| r1 | x |\n| r2 | y |\n"
+        out = sc.fence_excess_tables(text, limit=1)
+        assert "| r1 | x |\n| r2 | y |\n```" in out
+
+    def test_a_table_ending_at_eof_without_a_newline_is_closed(self) -> None:
+        text = _table("keep") + "\n| demote | b |\n| --- | --- |\n| 1 | 2 |"
+        out = sc.fence_excess_tables(text, limit=1)
+        assert out.endswith("| 1 | 2 |\n```\n")
+
+    def test_prose_between_tables_is_preserved(self) -> None:
+        text = _table("keep") + "\nprose line\n" + _table("demote")
+        out = sc.fence_excess_tables(text, limit=1)
+        assert "prose line" in out
+
+    def test_an_internal_failure_returns_the_original_text(self, monkeypatch: Any) -> None:
+        class Boom:
+            def finditer(self, _text: str) -> Any:
+                raise RuntimeError("scan exploded")
+
+        monkeypatch.setattr(sc, "_TABLE_RE", Boom())
+        text = _table("a") + _table("b")
+        assert sc.fence_excess_tables(text, limit=1) == text
+
+
+class TestPrepareCardText:
+    def test_the_pipeline_runs_links_then_markdown(self) -> None:
+        out = sc.prepare_card_text("# T\nsee https://example.com/a_b")
+        assert out.startswith("#### T")
+        assert "(https://example.com/a%5Fb)" in out
+
+    def test_table_demotion_is_opt_in(self) -> None:
+        text = "\n".join(_table(f"t{i}") for i in range(sc.FEISHU_CARD_TABLE_LIMIT + 1))
+        assert "```" not in sc.prepare_card_text(text)
+        assert "```" in sc.prepare_card_text(text, demote_tables=True)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestStart:
+    @pytest.mark.asyncio
+    async def test_start_creates_a_card_then_anchors_it_to_the_message(self) -> None:
+        client = FakeClient()
+        session = StreamingCardSession(client, "msg-1")
+
+        assert await session.start() is True
+
+        assert client.kinds == ["create"]
+        create = client.of("create")[0]
+        assert create.path == "/open-apis/cardkit/v1/cards"
+        assert create.body["type"] == "card_json"
+        assert json.loads(create.body["data"]) == sc.build_streaming_card()
+        # The reply carries no text of its own -- only the card_id reference.
+        assert client.replies == [("msg-1", "card-1")]
+        assert session.live is True
+        assert session.delivered is False
+        assert session.anchor_gone is False
+
+    @pytest.mark.asyncio
+    async def test_creation_consumes_no_sequence_number(self) -> None:
+        client = FakeClient()
+        await _started(client)
+        assert "sequence" not in client.of("create")[0].body
+
+    @pytest.mark.asyncio
+    async def test_a_create_with_no_card_id_is_reported_and_not_anchored(self, caplog: Any) -> None:
+        """Nothing has been shown yet, so the caller's text reply is the answer."""
+        client = FakeClient(card_id="")
+        session = StreamingCardSession(client, "msg-1")
+
+        with caplog.at_level("WARNING", logger=_LOGGER):
+            assert await session.start() is False
+
+        assert client.replies == []
+        assert session.live is False
+        assert session.anchor_gone is False
+        assert any("no card_id" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_recalled_anchor_during_start_forbids_the_text_fallback(self) -> None:
+        client = FakeClient()
+        client.codes["create"] = [sc.ERR_MSG_RECALLED]
+        session = StreamingCardSession(client, "msg-1")
+
+        assert await session.start() is False
+        # A text reply to a recalled message fails too -- the caller must not try.
+        assert session.anchor_gone is True
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_card_error_during_start_still_allows_fallback(
+        self, caplog: Any
+    ) -> None:
+        client = FakeClient()
+        client.codes["create"] = [99999]
+        session = StreamingCardSession(client, "msg-1")
+
+        with caplog.at_level("WARNING", logger=_LOGGER):
+            assert await session.start() is False
+
+        assert session.anchor_gone is False
+        assert session.live is False
+        assert caplog.records
+
+    @pytest.mark.asyncio
+    async def test_a_failure_anchoring_the_card_is_survivable(self, caplog: Any) -> None:
+        """A non-CardApiError (a transport fault) must not escape start()."""
+        client = FakeClient()
+        client.reply_raises = RuntimeError("socket died")
+        session = StreamingCardSession(client, "msg-1")
+
+        with caplog.at_level("WARNING", logger=_LOGGER):
+            assert await session.start() is False
+
+        assert session.live is False
+        assert caplog.records
+
+
+class TestLifecycleOrder:
+    @pytest.mark.asyncio
+    async def test_the_five_steps_happen_in_order(self, clock: FakeClock) -> None:
+        """Step 4 (close streaming mode) MUST precede step 5 (full replace).
+
+        Step 5 is what repairs a dropped intermediate frame, so a card left in
+        streaming mode when it lands would animate the repaired text a second
+        time.
+        """
+        client = FakeClient()
+        session = await _started(client)
+        await session.push("partial", force=True)
+
+        assert await session.finish("partial answer") is True
+
+        assert client.kinds == ["create", "push", "push", "settings", "final"]
+        assert client.kinds.index("settings") < client.kinds.index("final")
+
+    @pytest.mark.asyncio
+    async def test_step_four_turns_streaming_mode_off(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+        await session.finish("answer")
+
+        settings = client.of("settings")[0]
+        assert settings.path.endswith(f"/cards/{client.card_id}/settings")
+        assert json.loads(settings.body["settings"]) == {"streaming_mode": False}
+
+    @pytest.mark.asyncio
+    async def test_step_five_replaces_the_card_with_the_whole_answer(
+        self, clock: FakeClock
+    ) -> None:
+        client = FakeClient()
+        session = await _started(client)
+        await session.finish("the whole answer")
+
+        final = client.of("final")[0]
+        assert final.path == f"/open-apis/cardkit/v1/cards/{client.card_id}"
+        card = json.loads(final.body["card"]["data"])
+        assert card["body"]["elements"][0]["content"] == "the whole answer"
+
+    @pytest.mark.asyncio
+    async def test_content_pushes_address_the_streaming_element(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+        await session.push("hi", force=True)
+
+        push = client.of("push")[0]
+        assert push.path == (
+            f"/open-apis/cardkit/v1/cards/{client.card_id}"
+            f"/elements/{sc.STREAMING_ELEMENT_ID}/content"
+        )
+
+    @pytest.mark.asyncio
+    async def test_finish_on_a_session_that_never_started_touches_nothing(self) -> None:
+        client = FakeClient()
+        session = StreamingCardSession(client, "msg-1")
+        assert await session.finish("answer") is False
+        assert client.calls == []
+
+
+class TestSequenceNumbers:
+    @pytest.mark.asyncio
+    async def test_every_mutating_step_takes_the_next_number(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+        await session.push("one", force=True)
+        await session.finish("one two")
+
+        seqs = client.sequences()
+        assert len(seqs) == 4  # two pushes, settings, final replace
+        assert seqs == sorted(seqs)
+        assert len(set(seqs)) == len(seqs)
+
+    @pytest.mark.asyncio
+    async def test_a_failed_push_does_not_give_its_number_back(self, clock: FakeClock) -> None:
+        """Rolling back would risk reusing a number the server already consumed.
+        A gap is tolerated by Feishu; only monotonicity matters."""
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_RATE_LIMITED]
+        session = await _started(client)
+
+        await session.push("first frame", force=True)
+        await session.push("first frame extended", force=True)
+
+        seqs = client.sequences()
+        assert len(seqs) == 2
+        assert seqs[1] > seqs[0]
+
+
+class TestCumulativeText:
+    @pytest.mark.asyncio
+    async def test_each_push_carries_the_whole_answer_so_far(self, clock: FakeClock) -> None:
+        """The server diffs successive pushes to animate them, and it is what
+        makes a dropped frame self-healing. A delta would corrupt both."""
+        client = FakeClient()
+        session = await _started(client)
+
+        await session.push("Hello ", force=True)
+        await session.push("Hello world", force=True)
+
+        assert client.contents() == ["Hello ", "Hello world"]
+
+
+# ---------------------------------------------------------------------------
+# Error taxonomy
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimited:
+    @pytest.mark.asyncio
+    async def test_a_rate_limited_frame_is_dropped_without_retiring(
+        self, clock: FakeClock, caplog: Any
+    ) -> None:
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_RATE_LIMITED]
+        session = await _started(client)
+
+        with caplog.at_level("DEBUG", logger=_LOGGER):
+            await session.push("dropped frame", force=True)
+
+        assert session.live is True
+        assert session.anchor_gone is False
+        assert session.delivered is False
+
+    @pytest.mark.asyncio
+    async def test_the_next_push_supersedes_the_dropped_one(self, clock: FakeClock) -> None:
+        """No retry and no backoff is safe *because* the next push is cumulative:
+        the newer frame carries everything the lost one did."""
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_RATE_LIMITED]
+        session = await _started(client)
+
+        await session.push("half", force=True)
+        await session.push("half and half", force=True)
+
+        assert client.contents() == ["half", "half and half"]
+        assert session.live is True
+
+
+class TestCardConstraint:
+    @pytest.mark.asyncio
+    async def test_the_first_constraint_hit_demotes_tables_and_keeps_streaming(
+        self, clock: FakeClock
+    ) -> None:
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_CARD_CONSTRAINT]
+        session = await _started(client)
+        text = "\n".join(_table(f"t{i}") for i in range(sc.FEISHU_CARD_TABLE_LIMIT + 1))
+
+        await session.push(text, force=True)
+        assert session.live is True
+        assert "```" not in client.contents()[0]
+
+        await session.push(text, force=True)
+        # Same input, now demoted -- which is the observable proof the flag stuck.
+        assert "```" in client.contents()[1]
+
+    @pytest.mark.asyncio
+    async def test_a_second_constraint_hit_retires_the_session(self, clock: FakeClock) -> None:
+        """Demotion was the one repair available; a second rejection means the
+        card cannot be made to render, so the caller should send text."""
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_CARD_CONSTRAINT, sc.ERR_CARD_CONSTRAINT]
+        session = await _started(client)
+
+        await session.push("first", force=True)
+        await session.push("first second", force=True)
+
+        assert session.live is False
+        assert session.anchor_gone is False
+        assert session.delivered is False
+
+
+class TestAnchorGone:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("code", [sc.ERR_MSG_RECALLED, sc.ERR_MSG_DELETED])
+    async def test_a_gone_anchor_retires_and_forbids_a_text_fallback(
+        self, clock: FakeClock, code: int
+    ) -> None:
+        """Nothing can reach a recalled or deleted message, a plain-text reply
+        included -- so the caller must be told not to try, or it raises on a
+        second undeliverable send."""
+        client = FakeClient()
+        client.codes["push"] = [code]
+        session = await _started(client)
+
+        await session.push("text", force=True)
+
+        assert session.live is False
+        assert session.anchor_gone is True
+
+    @pytest.mark.asyncio
+    async def test_a_retired_session_stops_pushing(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_MSG_DELETED]
+        session = await _started(client)
+        await session.push("text", force=True)
+
+        await session.push("more text", force=True)
+        assert len(client.of("push")) == 1
+
+    @pytest.mark.asyncio
+    async def test_finish_on_a_retired_session_makes_no_further_calls(
+        self, clock: FakeClock
+    ) -> None:
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_MSG_DELETED]
+        session = await _started(client)
+        await session.push("text", force=True)
+
+        assert await session.finish("text and more") is False
+        assert client.kinds == ["create", "push"]
+
+
+class TestConcurrentFlushes:
+    @pytest.mark.asyncio
+    async def test_a_frame_queued_on_the_lock_is_dropped_if_the_card_retires(
+        self, clock: FakeClock
+    ) -> None:
+        """The liveness check is repeated *after* acquiring the lock, and that
+        second check is the one that matters.
+
+        A renderer can call push() again while an earlier push is still in
+        flight. The second caller passed the first check while the card was
+        still live, so without the re-check it would push to a card that the
+        first call has since retired -- against a recalled anchor, an error per
+        frame for the rest of the turn.
+        """
+        client = FakeClient()
+        client.codes["push"] = [sc.ERR_MSG_DELETED]
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        real_card_api = client.card_api
+
+        async def gated(method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+            if _kind(method, path) == "push" and not entered.is_set():
+                entered.set()
+                await release.wait()
+            return await real_card_api(method, path, body)
+
+        client.card_api = gated  # type: ignore[method-assign]
+        session = await _started(client)
+
+        first = asyncio.create_task(session.push("first", force=True))
+        await entered.wait()  # first call holds the lock
+        second = asyncio.create_task(session.push("second", force=True))
+
+        # Wait for the second call to be genuinely queued ON the lock. Yielding a
+        # fixed number of times would silently pass by never starting it at all,
+        # which exercises the pre-lock check instead of the one under test.
+        for _ in range(100):
+            if getattr(session._lock, "_waiters", None):
+                break
+            await asyncio.sleep(0)
+        else:  # pragma: no cover - only on a broken event loop
+            pytest.fail("the second flush never queued on the lock")
+
+        release.set()
+        await asyncio.gather(first, second)
+
+        assert session.live is False
+        assert session.anchor_gone is True
+        assert len(client.of("push")) == 1
+
+
+class TestUnrecognisedFailure:
+    @pytest.mark.asyncio
+    async def test_an_unknown_body_code_retires_so_the_caller_falls_back(
+        self, clock: FakeClock, caplog: Any
+    ) -> None:
+        client = FakeClient()
+        client.codes["push"] = [99999]
+        session = await _started(client)
+
+        with caplog.at_level("WARNING", logger=_LOGGER):
+            await session.push("text", force=True)
+
+        assert session.live is False
+        assert session.anchor_gone is False
+        assert any("falling back to text" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_an_exception_with_no_code_retires_too(self, clock: FakeClock) -> None:
+        """A transport fault carries no business code; unrecognised means retire."""
+        client = FakeClient()
+        client.raises["push"] = RuntimeError("connection reset")
+        session = await _started(client)
+
+        await session.push("text", force=True)
+
+        assert session.live is False
+        assert session.anchor_gone is False
+
+
+# ---------------------------------------------------------------------------
+# delivered -- the property the caller acts on
+# ---------------------------------------------------------------------------
+
+
+class TestDelivered:
+    @pytest.mark.asyncio
+    async def test_delivered_is_false_until_something_is_on_screen(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+        assert session.delivered is False
+        await session.push("partial", force=True)
+        # A pushed frame is not the finished answer; only finish() claims that.
+        assert session.delivered is False
+
+    @pytest.mark.asyncio
+    async def test_delivered_is_true_once_the_answer_is_in_the_card(self, clock: FakeClock) -> None:
+        """True is an instruction to the caller: do NOT also send text, or the
+        user reads the same answer twice."""
+        client = FakeClient()
+        session = await _started(client)
+
+        assert await session.finish("the answer") is True
+        assert session.delivered is True
+
+    @pytest.mark.asyncio
+    async def test_delivered_stays_false_when_the_card_showed_nothing(
+        self, clock: FakeClock
+    ) -> None:
+        client = FakeClient()
+        client.codes["push"] = [99999]
+        session = await _started(client)
+
+        assert await session.finish("the answer") is False
+        assert session.delivered is False
+        # Nothing reached the user, so the caller's text reply is the only copy.
+        assert client.of("final") == []
+
+    @pytest.mark.asyncio
+    async def test_finish_is_safe_to_call_again(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+        assert await session.finish("the answer") is True
+
+        assert await session.finish("the answer") is True
+
+
+class TestFinishRepairsDroppedFrames:
+    @pytest.mark.asyncio
+    async def test_a_rate_limited_final_frame_is_repaired_by_the_full_replace(
+        self, clock: FakeClock
+    ) -> None:
+        """This is why a dropped frame needs no retry of its own: step 5 sends
+        the complete text regardless of which frames were lost."""
+        client = FakeClient()
+        session = await _started(client)
+        await session.push("half", force=True)
+        client.codes["push"] = [sc.ERR_RATE_LIMITED]
+
+        assert await session.finish("half and the rest") is True
+
+        card = json.loads(client.of("final")[0].body["card"]["data"])
+        assert card["body"]["elements"][0]["content"] == "half and the rest"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_settings_patch_does_not_stop_the_full_replace(
+        self, clock: FakeClock
+    ) -> None:
+        """Leaving streaming mode on is cosmetic -- the text is already on
+        screen, so the failure is logged and step 5 still runs."""
+        client = FakeClient()
+        client.codes["settings"] = [99999]
+        session = await _started(client)
+
+        assert await session.finish("the answer") is True
+        assert len(client.of("final")) == 1
+        assert session.live is True
+
+    @pytest.mark.asyncio
+    async def test_a_failed_full_replace_still_reports_delivered(self, clock: FakeClock) -> None:
+        """The content push already put the whole answer on screen, so a text
+        fallback would duplicate it."""
+        client = FakeClient()
+        client.raises["final"] = RuntimeError("gateway timeout")
+        session = await _started(client)
+
+        assert await session.finish("the answer") is True
+        assert client.contents() == ["the answer"]
+
+
+# ---------------------------------------------------------------------------
+# Throttle
+# ---------------------------------------------------------------------------
+
+
+class TestThrottle:
+    @pytest.mark.asyncio
+    async def test_a_push_inside_the_throttle_window_is_skipped(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+
+        clock.advance(sc.CARDKIT_THROTTLE_S / 2)
+        await session.push("too soon")
+
+        assert client.of("push") == []
+
+    @pytest.mark.asyncio
+    async def test_a_push_past_the_throttle_window_lands(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+
+        clock.advance(sc.CARDKIT_THROTTLE_S * 1.5)
+        await session.push("now due")
+
+        assert client.contents() == ["now due"]
+
+    @pytest.mark.asyncio
+    async def test_force_bypasses_the_throttle(self, clock: FakeClock) -> None:
+        """Used before a long silence (a tool call), where waiting for the next
+        chunk would leave the user staring at stale text."""
+        client = FakeClient()
+        session = await _started(client)
+
+        await session.push("forced", force=True)
+
+        assert client.contents() == ["forced"]
+
+    @pytest.mark.asyncio
+    async def test_a_tiny_fragment_after_a_long_gap_is_deferred_then_shown(
+        self, clock: FakeClock
+    ) -> None:
+        """After a quiet period the first frame would carry one or two
+        characters, which reads as a stutter."""
+        client = FakeClient()
+        session = await _started(client)
+
+        clock.advance(sc.LONG_GAP_THRESHOLD_S + 0.5)
+        await session.push("tiny")
+        assert client.of("push") == []
+
+        # Still inside the batching window.
+        clock.advance(sc.BATCH_AFTER_GAP_S / 2)
+        await session.push("tiny bit")
+        assert client.of("push") == []
+
+        # Past it: the deferral is a delay, never a drop.
+        clock.advance(sc.BATCH_AFTER_GAP_S)
+        await session.push("tiny bit more")
+        assert client.contents() == ["tiny bit more"]
+
+    @pytest.mark.asyncio
+    async def test_a_substantial_fragment_after_a_long_gap_is_never_deferred(
+        self, clock: FakeClock
+    ) -> None:
+        """Nothing schedules a retry, so deferring a real paragraph would hide it
+        until the next event -- and if the model then goes quiet, forever."""
+        client = FakeClient()
+        session = await _started(client)
+
+        clock.advance(sc.LONG_GAP_THRESHOLD_S + 0.5)
+        await session.push("x" * (sc._ANTI_STUTTER_MAX_CHARS + 1))
+
+        assert len(client.of("push")) == 1
+
+    @pytest.mark.asyncio
+    async def test_text_identical_to_what_is_shown_is_not_resent(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+
+        await session.push("same", force=True)
+        await session.push("same", force=True)
+
+        assert len(client.of("push")) == 1
+
+    @pytest.mark.asyncio
+    async def test_an_empty_buffer_is_not_pushed(self, clock: FakeClock) -> None:
+        client = FakeClient()
+        session = await _started(client)
+
+        await session.push("", force=True)
+
+        assert client.of("push") == []


### PR DESCRIPTION
## Problem / Motivation

The Feishu channel renders a whole turn into a buffer and sends it as one plain-text
message on `on_done`. `FEISHU_CAPABILITIES` accordingly declares `streaming=False`,
`edit=False`, `rich_blocks=False`.

What a user observes:

- A long turn looks like a dead bot. Nothing at all appears until the answer is
  complete — no typing indicator, no placeholder, no partial text.
- Sending a second message meanwhile gets merged into the in-flight turn and
  answered with a placeholder, while the real answer arrives as a quote-reply
  anchored to the *earliest* message of the batch — easy to miss entirely in a
  busy DM.
- The reply is plain text, so tables, headings and code fences arrive as raw
  markdown.

The renderer's own docstring anticipates the follow-up, and the module spec lists
edit-in-place streaming as the natural next step.

## Why it matters

This is the difference between a channel that feels broken and one that feels
alive. For any turn that takes more than a couple of seconds — which is most
non-trivial ones — the user cannot tell whether the bot received the message, is
working, or has crashed, so the rational response is to send it again, which makes
things worse by triggering the merge-into-placeholder path.

Feishu/Lark is the primary work chat for a large number of teams in China, and it
is the one first-party channel where a long answer is invisible until it is
finished.

## What changed (motivation → approach → change)

**Goal.** Show the answer as it is produced, without giving up the guarantee that
a failure still delivers the complete reply.

**Approach, and the alternative rejected.** The obvious approach is to `PATCH`
`/im/v1/messages/:id` per chunk. Both reference plugins reject it, and the
official Lark plugin keeps it only as a degraded fallback: Feishu's real streaming
primitive is a **CardKit card entity**, where each push carries the *cumulative*
text and the server diffs successive pushes to animate them. The typewriter effect
is therefore server-side, and this change only decides how often to push. That
also means a dropped intermediate frame is self-repairing — the next push is
cumulative, and the final full replace fixes any gap — so no frame needs a retry.

An earlier reading of the community plugin's FAQ suggested streaming had been
abandoned over rate limits. That FAQ is stale and contradicted by its own shipped
source, which contains a complete streaming implementation gated behind an
opt-in flag. Corrected in #7548.

**What was built.**

- `src/kiro_crew/feishu/streaming_card.py` (new) — the CardKit lifecycle: create
  the card entity, reply with an `interactive` message referencing its `card_id`,
  push cumulative text on a throttle, then `PATCH` `streaming_mode=false` **before**
  the final full `PUT` replace. One monotonic sequence counter, never rolled back
  on failure, because Feishu enforces monotonicity and tolerates gaps.
- Error handling is code-driven, because **Feishu answers HTTP 200 with a non-zero
  `code` in the body** on business errors: `230020` (rate limited) drops that one
  frame and keeps streaming; `230099` demotes excess tables once, then retires;
  `230011`/`231003` mean the anchor message is gone, which retires the session
  *and* suppresses the text fallback, since replying to a recalled anchor also
  fails; anything else retires so the caller falls back to text.
- `renderer.py` — dual mode. Opens the card on `on_turn_start` (idempotent: it is
  called twice per turn), pushes on chunks, seals on `on_done`. The
  `streaming_card` import is guarded and degrades to `StreamingCardSession = None`,
  because `kiro_crew.channels` imports this package during gateway boot and a hard
  import would turn one absent file into a gateway that cannot start at all.
- `transport.py` — `FEISHU_STREAMING_CAPABILITIES = replace(FEISHU_CAPABILITIES,
  streaming=True, edit=True)`. Built with `dataclasses.replace` rather than a
  second literal so this module still holds exactly one `TransportCapabilities(...)`
  call for the outbound-authz AST contract to read.
- `transport_dispatch.py` — mode selection: `feishu.streaming` **and** a p2p chat.
  The flag is read strictly rather than through a `getattr` default, so a config
  field gone missing fails loudly instead of leaving a switch that can never turn
  on.
- `config/sections.py`, `config/loader.py`, `config-baseline.json` — the new
  boolean, parsed with the strict `_safe_bool`, baseline regenerated with
  `scripts/generate_config_baseline.py` (484 → 485 entries).

**Deliberately not changed.** `FEISHU_CAPABILITIES` still says `streaming=False`
— with the flag off the channel really is non-streaming and must keep saying so.
`rich_blocks` stays `False`: it gates whether a renderer attaches an Adaptive Card
of interactive elements, and a CardKit card here renders markdown, not tappable
choices. `max_buttons` stays `0`, so the zero-widget options path still applies.
`returns_message_id` is untouched: the card id lives in the renderer instance,
exactly as Telegram keeps its message id, and `send_message`'s contract (empty
return on success, raise on failure) is unchanged. No interactive buttons — that
needs a card-action callback route this channel does not have.

**Not included on purpose.** The `RuntimeError: This event loop is already
running` crash (#6534) is a separate defect with its own issue and is not touched
here, keeping this PR to one concern. Note it does gate end-to-end verification of
this feature on a fresh install, so it is the one to land first.

## Tests

`test/test_feishu_streaming_card.py` (new, 66 tests) takes
`streaming_card.py` to **98%** line coverage, above the per-file floor of 80:

- The five-step lifecycle in order, and that `PATCH settings` precedes the final
  `PUT`.
- Sequence numbers strictly increase and are never rolled back after a failure.
- Every content push carries the full cumulative text, not a delta.
- The **HTTP 200 with a non-zero body code** path specifically — an
  exception-only test would report success for a call that did nothing.
- Each error class: `230020` keeps the session live and the next frame lands;
  `230099` degrades then retires on the second hit; `230011`/`231003` retire and
  set `anchor_gone` so no text fallback is attempted; an unrecognised code retires.
- `delivered` in both states, since a `True` there tells the caller *not* to send
  the text fallback, and getting it wrong duplicates the whole answer.
- The throttle, the forced push, and the anti-stutter deferral applying only to
  tiny fragments.
- Every markdown fixup, including that each protects fenced/inline code and
  returns the original text on internal failure.

`test/test_feishu_dispatch.py` gains `TestStreamingModeSelection` (flag off; flag
on + p2p; flag on + group) and its fake config now carries `streaming`, which the
strict read requires.

Full run of the Feishu suite plus every guardrail named above — capability ledger,
outbound authz, options contract, pre-turn ratchet, config loader, config baseline:
**908 passed**.

## Manual verification

Verified end-to-end against a live Feishu tenant before this PR, not just in unit
tests, since throttle behaviour and the business error codes can only be exercised
against the real Open Platform:

- A card appears within roughly a second of sending and fills in progressively;
  markdown (bold, ordered/unordered lists, inline code, links) renders correctly
  in the card.
- Requires the `cardkit:card:write` scope, granted and **published** on the Open
  Platform — the card calls 403 without it, which is worth knowing when reviewing.
- With `feishu.streaming` off, behaviour is byte-for-byte the buffered reply.
- Group turns keep the buffered reply with the flag on.

Two defects were found by the new tests and fixed in this branch rather than
shipped: `<br>` spacers were being inserted on *every* fence line, so a literal
`<br>` landed inside code blocks (they now go only on a block's outer edges, and
an unterminated mid-stream fence correctly gets none); and the bare-URL pattern
excluded parentheses, which truncated URLs of the
`..._(programming_language)` shape and left the paren-balancing branch
unreachable.

## Related Issues

- Implements #7548
- Depends on #6534 — the event-loop crash gates the channel entirely; not fixed here
- Context: #7520 (non-text inbound dropped silently), addressed upstream by #7551

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

Docs: `docs/system-specs/modules/messaging.md` — the Feishu section now describes
buffered as the *default* mode rather than the only one. Note the existing
`UNFINISHED [OPTIONS` tail rule was justified *by* there being no partial frame, so
that justification is now explicitly scoped to buffered mode: live frames use
`split_options_trailer(text, hide_partial=True)` and only the final frame uses the
default, which keeps the doc self-consistent.

Third-party code: `streaming_card.py` is a port of two MIT-licensed projects, so
per CONTRIBUTING this is called out explicitly — attribution added to `NOTICE`
with the licence text reproduced in `THIRD-PARTY-NOTICES`. No per-file copyright
header was added, matching the repo's existing convention.
