### PR TITLE
fix(diagnostics): resolve kiro-cli via resolve_kiro_cli() instead of bare PATH lookup

### DIFF
--- a/src/kiro_crew/diagnostics.py
+++ b/src/kiro_crew/diagnostics.py
@@ -37,6 +37,7 @@ from urllib.parse import quote, urlencode
 
 from kiro_crew import __version__, release_channel
 from kiro_crew.config.loader import config_dir
+from kiro_crew.kiro_cli import resolve_kiro_cli
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
@@ -276,9 +277,28 @@ def _macos_crash_reports() -> list[Path]:
 
 
 def _kiro_cli_version() -> str:
+    """Probe the installed Kiro CLI's ``--version`` output.
+
+    Resolves the binary through :func:`resolve_kiro_cli` — the same fixed-dir
+    + ``PATH`` search the gateway and ACP launch paths use — rather than
+    spawning the bare name ``kiro-cli``. A bare-name spawn only sees the
+    collector process's OWN inherited ``PATH``, which on a desktop app
+    launched from Finder/Dock is launchd's minimal environment, not the login
+    shell's. That made a genuinely-installed CLI report ``unavailable`` —
+    indistinguishable from "not installed" — even while the gateway was
+    successfully spawning it via the resolver. See
+    https://github.com/kirodotdev/KiroCrew/issues/7674.
+
+    ``unavailable`` is now reserved for the resolver genuinely finding
+    nothing; a resolved binary that fails to run reports distinctly so the
+    two cases are never collapsed onto the same triage-misleading string.
+    """
+    binary = resolve_kiro_cli()
+    if not binary:
+        return "unavailable"
     try:
         out = subprocess.run(
-            ["kiro-cli", "--version"],
+            [binary, "--version"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -286,7 +306,7 @@ def _kiro_cli_version() -> str:
         )
         return (out.stdout or out.stderr).strip() or "unknown"
     except (OSError, subprocess.SubprocessError):
-        return "unavailable"
+        return "present but not runnable"
 
 
 #: PEP 440 prerelease segment — see

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -340,6 +340,86 @@ def test_include_logs_false_excludes_gateway(tmp_path, monkeypatch):
         assert "versions.txt" in z.namelist()
 
 
+class TestKiroCliVersionProbe:
+    """Regression coverage for #7674.
+
+    ``_kiro_cli_version()`` used to spawn the bare name ``["kiro-cli",
+    "--version"]``, which resolves only through the collector process's own
+    inherited ``PATH``. A desktop app launched from Finder/Dock on macOS
+    inherits launchd's minimal ``PATH`` (no ``~/.local/bin``), so a perfectly
+    good install reported ``unavailable`` — indistinguishable from "not
+    installed" — even while the gateway ran the same binary via
+    ``resolve_kiro_cli()``.
+    """
+
+    def test_resolves_a_binary_absent_from_the_inherited_path(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The probe must find an install that only a fixed dir would surface.
+
+        ``kiro-cli`` lives in ``~/.local/bin`` — the first fixed entry
+        ``known_kiro_cli_dirs`` searches — while the inherited ``PATH`` is a
+        launchd-style minimal one that excludes it. A bare-name
+        ``["kiro-cli", ...]`` spawn would raise ``FileNotFoundError`` here;
+        going through ``resolve_kiro_cli()`` must still find it.
+        """
+        home = tmp_path / "home"
+        bin_dir = home / ".local" / "bin"
+        bin_dir.mkdir(parents=True)
+        fake = bin_dir / "kiro-cli"
+        fake.write_text("#!/bin/sh\necho 'kiro-cli 9.9.9'\n")
+        fake.chmod(0o755)
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setattr("kiro_crew.kiro_cli.sys.platform", "linux")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")  # excludes bin_dir
+
+        assert diagnostics._kiro_cli_version() == "kiro-cli 9.9.9"
+
+    def test_reports_unavailable_only_when_the_resolver_finds_nothing(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Genuinely absent stays 'unavailable' — the resolver found no binary."""
+        home = tmp_path / "home"
+        home.mkdir()
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setattr("kiro_crew.kiro_cli.sys.platform", "linux")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        assert diagnostics._kiro_cli_version() == "unavailable"
+
+    def test_resolved_binary_that_fails_to_run_is_not_reported_as_unavailable(
+        self, monkeypatch
+    ) -> None:
+        """A resolved-but-broken binary must not collapse onto 'unavailable'.
+
+        That string means "not installed" to a triage reader; a binary the
+        resolver found but that failed to execute is a different, more
+        actionable state.
+        """
+        monkeypatch.setattr(diagnostics, "resolve_kiro_cli", lambda: "/no/such/kiro-cli")
+
+        assert diagnostics._kiro_cli_version() == "present but not runnable"
+
+    def test_spawns_the_resolved_path_not_the_bare_name(self, monkeypatch) -> None:
+        """The probe must pass resolve_kiro_cli()'s absolute path to subprocess,
+        never the bare command name that only searches the inherited PATH."""
+        monkeypatch.setattr(
+            diagnostics, "resolve_kiro_cli", lambda: "/opt/kiro/kiro-cli"
+        )
+        seen: dict[str, object] = {}
+
+        def _fake_run(argv, **kwargs):
+            seen["argv"] = argv
+            return MagicMock(stdout="kiro-cli 1.2.3\n", stderr="")
+
+        monkeypatch.setattr(diagnostics.subprocess, "run", _fake_run)
+
+        assert diagnostics._kiro_cli_version() == "kiro-cli 1.2.3"
+        assert seen["argv"] == ["/opt/kiro/kiro-cli", "--version"]
+
+
 def test_issue_url_is_well_formed(tmp_path, monkeypatch):
     home = tmp_path / "home"
     _isolate(monkeypatch, home)


### PR DESCRIPTION
Closes #7674

## Root cause

`_kiro_cli_version()` (`src/kiro_crew/diagnostics.py`) spawned the bare name `["kiro-cli", "--version"]`, which resolves only through the collector process's own inherited `PATH`. A desktop app launched from Finder/Dock on macOS inherits launchd's minimal `PATH`, not the login shell's, so `~/.local/bin` (and similar install dirs) are absent from the collector's environment even when the CLI is installed there and the gateway is successfully spawning it through `resolve_kiro_cli()`.

The result: a working install reported `kiro-cli: unavailable` in both places a maintainer reads first — `versions.txt` in the diagnostics bundle and the prefilled bug-report footer — indistinguishable from "not installed," and this false signal had already misdirected two triage passes on #3084 and spawned #7233.

## Fix

`_kiro_cli_version()` now resolves the binary through `resolve_kiro_cli()` (`src/kiro_crew/kiro_cli.py`) — the same fixed-dir + `PATH` search the gateway and ACP launch paths already use — and spawns the absolute path it returns:

- `unavailable` is now reported only when the resolver genuinely finds nothing.
- A binary the resolver *did* find but that fails to execute now reports `present but not runnable` instead of collapsing onto the same "not installed" string.

Both user-visible call sites (`_versions_text()` and the issue-template footer in `_issue_url()`) share `_kiro_cli_version()`, so the one fix covers both.

## Testing

Added `TestKiroCliVersionProbe` to `test/test_diagnostics.py`:
- resolves a binary that lives only in a fixed `known_kiro_cli_dirs()` entry (`~/.local/bin`) while the inherited `PATH` excludes it entirely (the exact scenario from the bundle evidence in the issue)
- still reports `unavailable` when the resolver finds nothing
- reports `present but not runnable` (not `unavailable`) for a resolved-but-broken binary
- asserts the probe spawns the resolved absolute path, never the bare command name

`.venv/bin/python3 -m pytest test/test_diagnostics.py -q` → 50 passed.
Also ran `test/test_env.py`, `test/test_cli_doctor.py`, `test/test_kiro_prerequisite.py`, `test/test_acp_client.py` — all pass except one pre-existing, unrelated failure (`TestResolveKiroBinEnvOverride::test_spawn_passes_installed_path_through_exact_wrappers`, a `pass_fds`/platform assertion that fails identically on a clean `upstream/main` checkout).

`black`/`isort`/`flake8`/`mypy` run on touched files: no new issues introduced by this change (the local venv's `black` disagrees with pre-existing formatting in both files unrelated to my edits — verified the diff `black --diff` proposes doesn't touch any of the lines I added).

No `CHANGELOG.md` changes, per this repo's fix-PR convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)