### PR TITLE
fix(sandbox): stop cron-history construction from bypassing the OS-gate mask

### DIFF
--- a/src/kiro_crew/cron_history.py
+++ b/src/kiro_crew/cron_history.py
@@ -69,7 +69,22 @@ class CronHistoryStore:
         cron_max_index_records: int = _MAX_INDEX_RECORDS,
     ):
         self._dir = (base_dir or config_dir()) / "cron-history"
-        self._dir.mkdir(parents=True, exist_ok=True)
+        # NOT created here. `cron-history` is one of `sandbox.py`'s
+        # `_CREW_HIDDEN_LEAVES` -- bind-masked on Linux and read+write-denied by
+        # Seatbelt on macOS, because no in-sandbox reader is supposed to touch it.
+        # `mcp_cron.py` nonetheless constructs a `CronService` (and therefore a
+        # `CronHistoryStore`) on every tool call, including pure reads like
+        # `cron_list`/`cron_status`, so an eager mkdir here ran unconditionally
+        # inside the sandbox against a path the OS gate masks -- harmless on
+        # Linux (the bind mount pre-creates the target, so `exist_ok=True`
+        # swallows it), but a `PermissionError` under a properly enforced
+        # Seatbelt deny would propagate and take down every `mcp_cron` tool.
+        # `_lock()` below creates the directory lazily, immediately before the
+        # one thing that actually needs it to exist -- a real write -- mirroring
+        # `webhooks.py`'s `locked()`, which defers its own masked-leaf mkdir the
+        # same way. Every read method here already tolerates a missing
+        # directory/file via `Path.exists()`, so construction and reads no
+        # longer touch the filesystem at all.
         self._index_path = self._dir / "_index.jsonl"
         self._summary_cap = cron_summary_cap
         self._trace_cap = cron_trace_cap_kb * 1024
@@ -86,7 +101,15 @@ class CronHistoryStore:
         return self._dir / ".history.lock"
 
     def _lock(self) -> int:
-        """Acquire advisory lock, return fd."""
+        """Acquire advisory lock, return fd.
+
+        Only the write paths (``_append_sync``, ``_rotate_sync``,
+        ``_rotate_all_sync``, ``_delete_job_history_sync``) call this, so the
+        directory is created here, lazily, rather than in ``__init__`` -- see
+        the comment there for why construction must not touch this masked
+        path.
+        """
+        self._dir.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(self._lock_path()), os.O_WRONLY | os.O_CREAT, 0o600)
         platform_compat.acquire_lock(fd, exclusive=True)
         return fd

--- a/test/test_cron_history.py
+++ b/test/test_cron_history.py
@@ -224,6 +224,67 @@ async def test_delete_nonexistent_returns_false(store: CronHistoryStore) -> None
     assert await store.delete_job_history("nope") is False
 
 
+# ── construction must not touch the (sandbox-masked) directory ──────────
+#
+# `cron-history` is HIDDEN under sandbox.py's `_CREW_HIDDEN_LEAVES` (see
+# issue #7742 / PR #7439): no in-sandbox reader is supposed to touch it, yet
+# `mcp_cron.py` constructs a fresh `CronService` -> `CronHistoryStore` on
+# every tool call, including pure reads. An eager `mkdir` in `__init__` ran
+# unconditionally against that masked path from inside the sandbox -- a
+# no-op on Linux (bind-mount pre-creates the target) but a live risk of an
+# uncaught `PermissionError` under a properly enforced macOS Seatbelt deny.
+# These pin the directory creation to the one place that actually needs it:
+# an in-flight write.
+
+
+def test_construction_does_not_create_directory(tmp_path: Path) -> None:
+    """Merely instantiating the store must not touch the filesystem.
+
+    A masked/read-denied `base_dir` (e.g. under a Seatbelt deny on macOS)
+    must not raise just because a caller built a `CronHistoryStore` -- most
+    callers (every `mcp_cron` tool invocation) never read or write history at
+    all.
+    """
+    target = tmp_path / "cron-history"
+    CronHistoryStore(base_dir=tmp_path)
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_pure_reads_do_not_create_directory(store: CronHistoryStore, tmp_path: Path) -> None:
+    """Read-only calls on a store with no history yet must not create the dir.
+
+    Every read method already tolerates a missing directory via
+    `Path.exists()`; this pins that they never fall back to creating one.
+    """
+    target = tmp_path / "cron-history"
+
+    records, total = await store.get_job_history("job1")
+    assert (records, total) == ([], 0)
+    assert not target.exists()
+
+    records, total = await store.get_all_history()
+    assert (records, total) == ([], 0)
+    assert not target.exists()
+
+    assert await store.get_run_detail("job1", "run1") is None
+    assert not target.exists()
+
+    await store.rotate("job1")  # short-circuits on a missing job file
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_append_creates_directory_lazily(store: CronHistoryStore, tmp_path: Path) -> None:
+    """The first real write is what creates the directory, not construction."""
+    target = tmp_path / "cron-history"
+    assert not target.exists()
+
+    await store.append(_record())
+
+    assert target.is_dir()
+
+
 # ── path traversal ───────────────────────────────────────────────────────
 
 

--- a/test/test_mcp_cron_history_mask.py
+++ b/test/test_mcp_cron_history_mask.py
@@ -1,0 +1,92 @@
+"""Regression coverage for issue #7742.
+
+PR #7439 (`fix(sandbox): mask the crew governance tree at the OS gate`)
+classified `cron-history` as one of `sandbox.py`'s `_CREW_HIDDEN_LEAVES` on
+the premise that nothing running inside the sandbox touches it: bind-masked
+on Linux, and both read- and write-denied by Seatbelt on macOS.
+
+That premise did not hold. `mcp_cron.py`'s `_call_tool_inner` builds a fresh
+`CronService(base_dir=config_dir())` on *every* tool call -- including pure
+reads like `cron_list` -- and `CronService.__init__` always constructs a
+`CronHistoryStore`, whose `__init__` used to `mkdir(parents=True,
+exist_ok=True)` that masked directory unconditionally, with no exception
+handling. `mcp_cron` is spawned by kiro-cli under the sandbox launcher, so
+every one of those tool calls performed a write against a path the OS gate
+hides. Harmless on Linux (the launcher's bind-mount pre-creates the target,
+so `exist_ok=True` swallows the resulting `FileExistsError`), but a
+`PermissionError` under a properly enforced macOS Seatbelt deny would not be
+swallowed and would take down every `mcp_cron` tool.
+
+These tests pin the fix (construction is inert; the directory is created
+lazily, only by an actual write) at the exact call path the issue names:
+`_call_tool_inner`. They are platform-agnostic -- they assert the directory
+is never touched by a read, which holds regardless of what the OS gate does
+with it -- so they cover the Linux-observable behavior change described in
+the issue. They cannot exercise the macOS Seatbelt deny itself (a real
+kernel decision, not something `tmp_path` can simulate); see the PR
+description for what still needs manual macOS verification.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from kiro_crew.mcp_cron import _call_tool_inner
+
+
+@pytest.fixture(autouse=True)
+def _cron_caller_is_named(named_cron_caller):
+    """State cron_add's precondition; see the fixture's own docstring."""
+
+
+def _history_dir(tmp_path):
+    return tmp_path / "cron-history"
+
+
+class TestReadOnlyToolCallsDoNotTouchHistoryDir:
+    """The exact call path the issue names: a read-only `mcp_cron` tool."""
+
+    def test_cron_list_on_empty_store_leaves_history_dir_absent(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+        result = _call_tool_inner("cron_list", {})
+
+        assert isinstance(result, str)
+        assert not _history_dir(tmp_path).exists()
+
+    def test_cron_list_with_jobs_still_leaves_history_dir_absent(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        job_name = f"job-{uuid.uuid4().hex[:8]}"
+        _call_tool_inner("cron_add", {"name": job_name, "message": "hi", "every": 120})
+        assert not _history_dir(tmp_path).exists()
+
+        result = _call_tool_inner("cron_list", {})
+
+        assert job_name in result or "cron job" in result.lower()
+        assert not _history_dir(tmp_path).exists()
+
+    def test_repeated_read_only_calls_never_create_history_dir(self, monkeypatch, tmp_path):
+        """Every `_call_tool_inner` invocation builds a brand-new `CronService`
+        (and therefore a brand-new `CronHistoryStore`) from scratch -- this is
+        not a "first call is expensive, rest are free" story, so repeat it.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+        for _ in range(5):
+            _call_tool_inner("cron_list", {})
+
+        assert not _history_dir(tmp_path).exists()
+
+
+def test_cron_add_does_not_touch_history_dir(monkeypatch, tmp_path):
+    """A write to the job store proper is still not a write to history."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+    result = _call_tool_inner(
+        "cron_add", {"name": f"job-{uuid.uuid4().hex[:8]}", "message": "hi", "every": 60}
+    )
+
+    assert "Added job" in result
+    assert not _history_dir(tmp_path).exists()


### PR DESCRIPTION
## Problem / Motivation

`CronHistoryStore.__init__` eagerly created `cron-history/`. Sandboxed `mcp_cron` constructs this store on every tool call, including read-only calls, even though the OS sandbox deliberately hides that directory. On macOS, the construction-time `mkdir` can therefore raise `PermissionError` and abort the tool call.

## Why it matters

Read-only cron operations should not touch a protected history directory. Keeping construction inert preserves the sandbox boundary without re-exposing cross-session history or breaking legitimate gateway-side history writes.

## What changed (motivation → approach → change)

The sandboxed cron path does not read or write history content; its only interaction was the eager constructor side effect. Directory creation is now deferred to `_lock()`, which is shared by the actual write paths. Existing read methods already tolerate a missing directory, while the first real write still creates it.

## Tests

- Added coverage proving construction and pure reads do not create `cron-history/`.
- Added coverage proving the first append creates the directory lazily.
- Added integration coverage for read-only `mcp_cron` calls and `cron_add`.
- Ran the focused cron and sandbox suites: 415 tests passed.

## Manual verification

The behavior and exact call path were verified through automated integration tests. A real macOS Seatbelt run remains useful because this environment cannot reproduce the platform-specific denial.

## Related Issues

Closes #7742

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository's CLA placeholder remains pending OSPO wording.
