### PR TITLE
fix(knowledge): take the ingestion pipeline's store connections off the loop

### DIFF
--- a/.github/sync-io-in-async-baseline.txt
+++ b/.github/sync-io-in-async-baseline.txt
@@ -17,5 +17,4 @@
 # cleanup tracked at #7019):
 #   python3 scripts/check_sync_io_in_async.py --report
 63 src/kiro_crew/dashboard/handlers/knowledge.py
-15 src/kiro_crew/knowledge/ingestion.py
 2 src/kiro_crew/knowledge/watcher.py

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -559,8 +559,13 @@ class IngestionPipeline:
         # having agreed to it. This is the same scrub the artifact path already applies
         # to its body, in the same position -- ahead of the hash, so the stored text
         # and its identity agree and a re-scan is stable.
-        if source_id and self._source_is_auto_added(source_id):
-            text = _redact_for_ingest(text)
+        # Offloaded like every other store touch in this method: the helper is a
+        # plain `def` that runs a SELECT one frame down, so on the loop it is the
+        # interprocedural take no name-based AST scan can see. Kept out of an
+        # `and` chain so the offloaded call's return type is inferred on its own.
+        if source_id:
+            if await asyncio.to_thread(self._source_is_auto_added, source_id):
+                text = _redact_for_ingest(text)
 
         # 2. Hash check + source resolution
         content_hash = hashlib.sha256(text.encode()).hexdigest()
@@ -576,14 +581,15 @@ class IngestionPipeline:
                 resolve_old_group = True
             props: dict[str, object] = {}
             existing: dict | None = {"id": source_id}  # sentinel — source already exists
-            src_row = self.store.db.execute(
-                "SELECT uri, properties FROM sources WHERE id = ?", (source_id,)).fetchone()
+            src_row = await asyncio.to_thread(
+                lambda: self.store.db.execute(
+                    "SELECT uri, properties FROM sources WHERE id = ?", (source_id,)).fetchone())
             uri = src_row["uri"] if src_row else display_name
             props = json.loads(src_row["properties"] or "{}") if src_row else {}
         else:
             # Local file path: find or create source by URI
             uri = str(p.resolve())
-            existing = self.store.get_source_by_uri(uri)
+            existing = await asyncio.to_thread(self.store.get_source_by_uri, uri)
             if existing:
                 props = json.loads(existing.get('properties', '{}')) if isinstance(existing.get('properties'), str) else existing.get('properties', {})
                 if props.get('content_hash') == content_hash:
@@ -592,10 +598,11 @@ class IngestionPipeline:
                 resolve_old_group = True
             else:
                 props = {}
-                source_id = self.store.add_source(
+                source_id = await asyncio.to_thread(functools.partial(
+                    self.store.add_source,
                     name=display_name, source_type='local_file', uri=uri,
                     properties={'content_hash': content_hash, **meta},
-                )
+                ))
 
         # 3. Job record
         # One hop for the whole gate: it resolves the pre-existing item group
@@ -613,10 +620,19 @@ class IngestionPipeline:
             return dupe_job
         job_id = uuid4().hex[:12]
         now = datetime.now().isoformat()
-        self.store.db.execute(
-            "INSERT INTO ingestion_jobs (id, source_id, status, created_at, updated_at) VALUES (?, ?, 'processing', ?, ?)",
-            (job_id, source_id, now, now))
-        self.store.db.commit()
+
+        # The row below is what every later step keys off, and the failure
+        # handler at the bottom of this method assumes it exists — so it travels
+        # as a run_to_completion hop, not a bare to_thread: a cancellation
+        # arriving while the work item is still queued would drop the INSERT and
+        # leave the body writing progress against a job row nobody created.
+        def _insert_job() -> None:
+            self.store.db.execute(
+                "INSERT INTO ingestion_jobs (id, source_id, status, created_at, updated_at) VALUES (?, ?, 'processing', ?, ?)",
+                (job_id, source_id, now, now))
+            self.store.db.commit()
+
+        await run_to_completion(_insert_job)
 
         # The job row above is persisted as 'processing' BEFORE any fallible
         # work runs, and nothing below ever wrote 'failed' on an uncaught
@@ -635,12 +651,21 @@ class IngestionPipeline:
             )
         except Exception:
             try:
-                self.store.db.execute(
-                    "UPDATE ingestion_jobs SET status = 'failed', updated_at = ? WHERE id = ?",
-                    (datetime.now().isoformat(), job_id))
-                self.store.db.execute(
-                    "UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
-                self.store.db.commit()
+                # Also a run_to_completion hop: this is the write that stops the
+                # folder watcher retrying the file every scan, so a cancellation
+                # arriving while this hop is awaited must not drop it. (The
+                # `except Exception` above never sees CancelledError itself --
+                # this is about the await inside the handler, not the failure
+                # that got us here.)
+                def _mark_failed() -> None:
+                    self.store.db.execute(
+                        "UPDATE ingestion_jobs SET status = 'failed', updated_at = ? WHERE id = ?",
+                        (datetime.now().isoformat(), job_id))
+                    self.store.db.execute(
+                        "UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
+                    self.store.db.commit()
+
+                await run_to_completion(_mark_failed)
             except Exception:  # noqa: BLE001 - never mask the original error
                 logger.warning("failed to mark ingestion job %s failed", job_id, exc_info=True)
             raise
@@ -666,8 +691,13 @@ class IngestionPipeline:
         chunks = await asyncio.to_thread(_run_chunker, chunker, ext, text, uri)
 
         total = len(chunks)
-        self.store.db.execute("UPDATE ingestion_jobs SET items_total = ? WHERE id = ?", (total, job_id))
-        self.store.db.commit()
+
+        def _set_total() -> None:
+            self.store.db.execute(
+                "UPDATE ingestion_jobs SET items_total = ? WHERE id = ?", (total, job_id))
+            self.store.db.commit()
+
+        await asyncio.to_thread(_set_total)
 
         # 5. Extract all chunks in batch via pool
         chunk_contents = [chunk['content'] for chunk in chunks]
@@ -693,23 +723,48 @@ class IngestionPipeline:
                     or f"{Path(display_name).stem} chunk {i}"
                 )
                 item_tags = ['content_type:markdown'] if is_markdown else None
-                item_id = self.store.add_item(
-                    title=item_title,
-                    content=chunk['content'],
-                    item_type=extraction.get('category', 'document'),
-                    source_id=source_id,
-                    chunk_index=chunk.get('chunk_index', i),
-                    summary=extraction.get('summary'),
-                    namespace=namespace,
-                    tags=item_tags,
-                    content_hash=content_hash,
-                )
-                created_item_ids.append(item_id)
-                self.store.add_source_location(
-                    item_id=item_id, source_id=source_id,
-                    chunk_range=f"{chunk.get('line_start', 0)}-{chunk.get('line_end', 0)}",
-                    section_title=chunk.get('section_title'),
-                )
+
+                # add_item opens its own BEGIN/COMMIT and add_source_location
+                # commits on the same autocommit connection, so on the loop each
+                # blocked every other session's turn for the connection's whole
+                # busy timeout — the defect the store's on-loop guard reports
+                # from here.
+                #
+                # ONE run_to_completion unit, and both properties matter:
+                #
+                # *Uncancellable*, because to_thread does not stop a worker that
+                # has already started. A cancellation landing between add_item's
+                # COMMIT and this coroutine resuming would skip the append (and
+                # every finalizer above it), leaving a searchable item that no
+                # rollback can name. run_to_completion drains the hop instead, so
+                # the commit and the record of it cannot come apart.
+                #
+                # *One unit*, because the append must sit BETWEEN the two writes:
+                # a chunk whose location write raises has to already be in
+                # created_item_ids or the partial-failure rollback leaves the
+                # item orphaned. Inside the hop that ordering is preserved
+                # exactly as it was inline.
+                def _write_chunk() -> str:
+                    new_id = self.store.add_item(
+                        title=item_title,
+                        content=chunk['content'],
+                        item_type=extraction.get('category', 'document'),
+                        source_id=source_id,
+                        chunk_index=chunk.get('chunk_index', i),
+                        summary=extraction.get('summary'),
+                        namespace=namespace,
+                        tags=item_tags,
+                        content_hash=content_hash,
+                    )
+                    created_item_ids.append(new_id)
+                    self.store.add_source_location(
+                        item_id=new_id, source_id=source_id,
+                        chunk_range=f"{chunk.get('line_start', 0)}-{chunk.get('line_end', 0)}",
+                        section_title=chunk.get('section_title'),
+                    )
+                    return new_id
+
+                item_id = await run_to_completion(_write_chunk)
                 # Entity storage is O(entities): find_entity does a full-table
                 # alias scan and each add_entity/add_mention/add_entity_relation
                 # commits + mutates the graph. On a many-entity chunk this blocked
@@ -815,7 +870,7 @@ class IngestionPipeline:
         resolve_old_group = False
         if source_id is None:
             uri = f"{source_type}://{content_hash[:16]}"
-            existing = self.store.get_source_by_uri(uri)
+            existing = await asyncio.to_thread(self.store.get_source_by_uri, uri)
             if existing:
                 props = json.loads(existing.get('properties', '{}')) if isinstance(existing.get('properties'), str) else existing.get('properties', {})
                 if props.get('content_hash') == content_hash:
@@ -823,10 +878,11 @@ class IngestionPipeline:
                 source_id = existing['id']
                 resolve_old_group = True
             else:
-                source_id = self.store.add_source(
+                source_id = await asyncio.to_thread(functools.partial(
+                    self.store.add_source,
                     name=title, source_type=source_type, uri=uri,
                     properties={'content_hash': content_hash},
-                )
+                ))
         elif old_item_ids is None:
             # Existing source, replace-all (single-text / remote-sync source).
             resolve_old_group = True
@@ -847,10 +903,17 @@ class IngestionPipeline:
 
         job_id = uuid4().hex[:12]
         now = datetime.now().isoformat()
-        self.store.db.execute(
-            "INSERT INTO ingestion_jobs (id, source_id, status, created_at, updated_at) VALUES (?, ?, 'processing', ?, ?)",
-            (job_id, source_id, now, now))
-        self.store.db.commit()
+
+        # run_to_completion, not a bare to_thread: every step below keys off this
+        # row, so a cancellation landing while the work item is still queued must
+        # not be able to drop the INSERT (see ingest_file).
+        def _insert_job() -> None:
+            self.store.db.execute(
+                "INSERT INTO ingestion_jobs (id, source_id, status, created_at, updated_at) VALUES (?, ?, 'processing', ?, ?)",
+                (job_id, source_id, now, now))
+            self.store.db.commit()
+
+        await run_to_completion(_insert_job)
 
         chunks = await asyncio.to_thread(self.chunker.chunk, text)
         total = len(chunks)
@@ -873,24 +936,31 @@ class IngestionPipeline:
                 for ent in extraction.get('entities', []):
                     ent['name'] = _redact(ent.get('name')) or ''
                     ent['description'] = _redact(ent.get('description'))
-                item_id = self.store.add_item(
-                    title=chunk.get('section_title') or f"{title} chunk {i}",
-                    content=chunk['content'],
-                    item_type=extraction.get('category', 'document'),
-                    source_id=source_id,
-                    chunk_index=chunk.get('chunk_index', i),
-                    summary=extraction.get('summary'),
-                    content_hash=content_hash,
-                )
-                # Appended BEFORE add_source_location/_store_entities/_embed_item
-                # so a chunk that raises partway through is still captured for
-                # the partial-failure rollback (mirrors _ingest_file_body).
-                created_item_ids.append(item_id)
-                self.store.add_source_location(
-                    item_id=item_id, source_id=source_id,
-                    chunk_range=f"{chunk.get('line_start', 0)}-{chunk.get('line_end', 0)}",
-                    section_title=chunk.get('section_title'),
-                )
+
+                # ONE uncancellable unit, for both reasons spelled out in
+                # _ingest_file_body: a cancellation must not be able to land
+                # between the COMMIT and the record of it, and the append has to
+                # sit BETWEEN the two writes so a failing location write still
+                # leaves the item nameable by the partial-failure rollback.
+                def _write_chunk() -> str:
+                    new_id = self.store.add_item(
+                        title=chunk.get('section_title') or f"{title} chunk {i}",
+                        content=chunk['content'],
+                        item_type=extraction.get('category', 'document'),
+                        source_id=source_id,
+                        chunk_index=chunk.get('chunk_index', i),
+                        summary=extraction.get('summary'),
+                        content_hash=content_hash,
+                    )
+                    created_item_ids.append(new_id)
+                    self.store.add_source_location(
+                        item_id=new_id, source_id=source_id,
+                        chunk_range=f"{chunk.get('line_start', 0)}-{chunk.get('line_end', 0)}",
+                        section_title=chunk.get('section_title'),
+                    )
+                    return new_id
+
+                item_id = await run_to_completion(_write_chunk)
                 # Entity storage is O(entities): find_entity does a full-table
                 # alias scan and each add_entity/add_mention/add_entity_relation
                 # commits + mutates the graph. On a many-entity chunk this blocked
@@ -1030,19 +1100,28 @@ class IngestionPipeline:
             None, self.embedder.embed_for_item, title, summary, content
         )
         if vec:
-            self.store.db.execute(
-                "UPDATE items SET embedding = ?, embedding_sig = ?, embedded_at = ? WHERE id = ?",
-                (floats_to_bytes(vec), sig,
-                 datetime.now().isoformat(), item_id))
-            self.store.db.commit()
+            blob = floats_to_bytes(vec)
+            stamped_at = datetime.now().isoformat()
+
+            def _stamp() -> None:
+                self.store.db.execute(
+                    "UPDATE items SET embedding = ?, embedding_sig = ?, embedded_at = ? WHERE id = ?",
+                    (blob, sig, stamped_at, item_id))
+                self.store.db.commit()
+
+            # A dropped stamp is safe in the one direction that matters: the
+            # sig-gated sweep re-embeds an unstamped row, so this needs the plain
+            # to_thread rather than run_to_completion.
+            await asyncio.to_thread(_stamp)
 
     async def generate_source_summary(self, source_id: str) -> None:
         """Generate a file-level summary from chunk summaries via LLM pool. No-op if pool unavailable."""
         if not self.extractor._pool:
             return
-        rows = self.store.db.execute(
-            "SELECT summary FROM items WHERE source_id = ? AND summary IS NOT NULL AND summary != '' ORDER BY chunk_index",
-            (source_id,)).fetchall()
+        rows = await asyncio.to_thread(
+            lambda: self.store.db.execute(
+                "SELECT summary FROM items WHERE source_id = ? AND summary IS NOT NULL AND summary != '' ORDER BY chunk_index",
+                (source_id,)).fetchall())
         if not rows:
             return
         chunk_summaries = "\n".join(r["summary"] for r in rows)
@@ -1066,10 +1145,14 @@ class IngestionPipeline:
             if isinstance(data, dict) and _summary_shaped(data):
                 topic = _redact(data.get("topic", ""))
                 themes = json.dumps([r for t in data.get("themes", [])[:5] if (r := _redact(t))])
-                self.store.db.execute(
-                    "UPDATE sources SET summary_topic = ?, summary_themes = ? WHERE id = ?",
-                    (topic, themes, source_id))
-                self.store.db.commit()
+
+                def _store_summary() -> None:
+                    self.store.db.execute(
+                        "UPDATE sources SET summary_topic = ?, summary_themes = ? WHERE id = ?",
+                        (topic, themes, source_id))
+                    self.store.db.commit()
+
+                await asyncio.to_thread(_store_summary)
         except Exception:
             logger.debug("Source summary generation failed for %s", source_id, exc_info=True)
 

--- a/test/test_knowledge_ingestion_off_loop.py
+++ b/test/test_knowledge_ingestion_off_loop.py
@@ -1,0 +1,314 @@
+"""``IngestionPipeline`` must take no knowledge-store connection on the loop (#7019).
+
+The store's ``db`` accessor is the one chokepoint every query funnels through, and
+since #7640 it reports an on-loop take. ``knowledge/ingestion.py`` was the second
+largest holder of those takes: 15 recorded in
+``.github/sync-io-in-async-baseline.txt`` plus the interprocedural ones no
+name-based AST scan can see (``add_item``, ``add_source_location``,
+``get_source_by_uri``, ``add_source`` are plain ``def``\\ s that reach ``self.db``
+one frame down). ``add_item`` opens a ``BEGIN`` write transaction, so on the loop it
+blocked every other session's turn for the connection's whole 10s busy timeout, and
+a stall past ``dashboard.loop_stall_exit_after_secs`` (25s) makes the watchdog kill
+the gateway (#1572).
+
+Why this shape of test. Asserting "no exception escaped" would be VACUOUS here: the
+per-chunk body catches ``Exception`` and logs it, so a strict-mode
+``OnLoopStoreError`` from ``add_item`` is swallowed and the coroutine returns
+normally. These tests instead swap in a guard that RECORDS every on-loop take and
+proceeds, so a violation is reported with its stack no matter which ``except`` sits
+above it -- and each test additionally asserts the work actually landed, so a
+pipeline that silently does nothing cannot pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import traceback
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.knowledge import store as store_mod
+from kiro_crew.knowledge.ingestion import IngestionPipeline
+from kiro_crew.knowledge.readers import FileReader
+from kiro_crew.knowledge.store import KnowledgeStore
+
+
+class _RecordingGuard:
+    """Stands in for the store's module-level guard, recording on-loop takes.
+
+    Deliberately records-and-proceeds rather than raising: a raise would be
+    caught by the pipeline's per-chunk ``except Exception`` and the violation
+    would vanish. Off-loop takes are the sanctioned path and are ignored, exactly
+    as the real guard ignores them.
+    """
+
+    def __init__(self) -> None:
+        self.takes: list[str] = []
+
+    def check(self) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return  # off-loop: the sanctioned path
+        self.takes.append("".join(traceback.format_stack(limit=8)))
+
+    def reset_throttle(self) -> None:  # pragma: no cover - API parity only
+        pass
+
+    def report(self, takes: list[str] | None = None) -> str:
+        rows = self.takes if takes is None else takes
+        return f"{len(rows)} on-loop store take(s):\n\n" + "\n---\n".join(rows)
+
+
+@pytest.fixture()
+def guard(monkeypatch) -> _RecordingGuard:
+    """Swap the store's guard for a recorder.
+
+    ``KnowledgeStore.db`` reads the module global, so patching the attribute
+    covers every store instance the pipeline touches.
+    """
+    rec = _RecordingGuard()
+    monkeypatch.setattr(store_mod, "_ON_LOOP_DB_GUARD", rec)
+    return rec
+
+
+@pytest.fixture()
+def kstore(tmp_path):
+    # Built OFF the loop on purpose: __init__ runs schema init, migrations and the
+    # graph load through self.db, so constructing one inside an async test would
+    # itself be an on-loop take and would mask the thing under test.
+    s = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    yield s
+    s.close()
+
+
+def _two_chunks(text, **kw):
+    half = max(1, len(text) // 2)
+    return [
+        {
+            "content": text[:half],
+            "chunk_index": 0,
+            "section_title": None,
+            "line_start": 0,
+            "line_end": 0,
+        },
+        {
+            "content": text[half:],
+            "chunk_index": 1,
+            "section_title": None,
+            "line_start": 1,
+            "line_end": 1,
+        },
+    ]
+
+
+def _extraction():
+    return {"category": "document", "summary": "s", "entities": []}
+
+
+class _Embedder:
+    """Minimal stand-in so ``_embed_item`` reaches its UPDATE + commit."""
+
+    model = "test-model"
+    content_budget = 128
+
+    def embed_for_item(self, title, summary, content):
+        return [0.1, 0.2, 0.3]
+
+
+@pytest.fixture()
+def pipeline(kstore):
+    extractor = MagicMock()
+    extractor._pool = None
+    extractor.extract_batch = AsyncMock(return_value=[_extraction(), _extraction()])
+    chunker = MagicMock()
+    for attr in ("chunk", "chunk_markdown", "chunk_code", "chunk_slides"):
+        getattr(chunker, attr).side_effect = _two_chunks
+    return IngestionPipeline(
+        store=kstore,
+        extractor=extractor,
+        chunker=chunker,
+        reader=FileReader(),
+        embedder=_Embedder(),
+    )
+
+
+def _items(kstore, source_id):
+    return kstore.db.execute(
+        "SELECT id, embedding FROM items WHERE source_id = ?", (source_id,)
+    ).fetchall()
+
+
+class TestHarness:
+    """The recorder must actually catch a take, or every test below is vacuous."""
+
+    @pytest.mark.asyncio
+    async def test_recorder_catches_an_on_loop_take(self, guard, kstore):
+        kstore.db.execute("SELECT 1").fetchone()
+        assert guard.takes, "recorder saw nothing: the guard swap did not take effect"
+
+
+class TestIngestFile:
+    @pytest.mark.asyncio
+    async def test_new_source_ingest_stays_off_loop(self, pipeline, kstore, guard, tmp_path):
+        f = tmp_path / "doc.md"
+        f.write_text("# heading\nbody text long enough to split", encoding="utf-8")
+
+        # This async test body sets up through the store, which is itself an
+        # on-loop take and not the subject: only what the pipeline does counts.
+        guard.takes.clear()
+        job_id = await pipeline.ingest_file(str(f))
+        # Snapshot BEFORE the outcome assertions: those read the store from this
+        # async test body, which is itself an on-loop take and not the subject.
+        violations = list(guard.takes)
+
+        assert job_id is not None
+        assert (pipeline.get_job_status(job_id) or {}).get("status") == "completed"
+        src = kstore.get_source_by_uri(str(f.resolve()))
+        assert src is not None, "source row was never created"
+        rows = _items(kstore, src["id"])
+        assert len(rows) == 2, "both chunks must land, or the assertion above is vacuous"
+        assert all(r["embedding"] for r in rows), "_embed_item never stamped the rows"
+        assert not violations, guard.report(violations)
+
+    @pytest.mark.asyncio
+    async def test_existing_source_ingest_stays_off_loop(self, pipeline, kstore, guard, tmp_path):
+        # Exercises the source_id branch: the SELECT on sources, then the whole
+        # chunk loop against an existing aggregate source.
+        source_id = kstore.add_source("agg", "local_folder", str(tmp_path))
+        f = tmp_path / "doc.md"
+        f.write_text("# heading\nbody text long enough to split", encoding="utf-8")
+
+        # This async test body sets up through the store, which is itself an
+        # on-loop take and not the subject: only what the pipeline does counts.
+        guard.takes.clear()
+        job_id = await pipeline.ingest_file(str(f), source_id=source_id, old_item_ids=[])
+        violations = list(guard.takes)
+
+        assert job_id is not None
+        assert (pipeline.get_job_status(job_id) or {}).get("status") == "completed"
+        assert len(_items(kstore, source_id)) == 2
+        assert not violations, guard.report(violations)
+
+    @pytest.mark.asyncio
+    async def test_failure_path_marks_the_job_off_loop(self, pipeline, kstore, guard, tmp_path):
+        # The 'failed' stamp is what stops the folder watcher retrying the file
+        # every scan, and it used to run two blocking statements on the loop.
+        async def _boom(**kw):
+            raise RuntimeError("boom")
+
+        pipeline._ingest_file_body = _boom
+        f = tmp_path / "doc.md"
+        f.write_text("# heading\nbody", encoding="utf-8")
+
+        # This async test body sets up through the store, which is itself an
+        # on-loop take and not the subject: only what the pipeline does counts.
+        guard.takes.clear()
+        with pytest.raises(RuntimeError, match="boom"):
+            await pipeline.ingest_file(str(f))
+        violations = list(guard.takes)
+
+        src = kstore.get_source_by_uri(str(f.resolve()))
+        assert src is not None
+        row = kstore.db.execute(
+            "SELECT status FROM ingestion_jobs WHERE source_id = ?", (src["id"],)
+        ).fetchone()
+        assert row is not None and row["status"] == "failed", "the failed stamp never landed"
+        assert (
+            kstore.db.execute(
+                "SELECT sync_status FROM sources WHERE id = ?", (src["id"],)
+            ).fetchone()["sync_status"]
+            == "error"
+        )
+        assert not violations, guard.report(violations)
+
+
+class TestIngestText:
+    @pytest.mark.asyncio
+    async def test_text_ingest_stays_off_loop(self, pipeline, kstore, guard):
+        # This async test body sets up through the store, which is itself an
+        # on-loop take and not the subject: only what the pipeline does counts.
+        guard.takes.clear()
+        job_id = await pipeline.ingest_text("body text long enough to split", "a title")
+        violations = list(guard.takes)
+
+        assert job_id is not None
+        assert (pipeline.get_job_status(job_id) or {}).get("status") == "completed"
+        rows = kstore.db.execute("SELECT id FROM items").fetchall()
+        assert len(rows) == 2
+        assert not violations, guard.report(violations)
+
+
+class TestSourceSummary:
+    @pytest.mark.asyncio
+    async def test_summary_read_and_write_stay_off_loop(self, pipeline, kstore, guard):
+        source_id = kstore.add_source("s", "manual", "manual://x")
+        kstore.add_item("t", "c", "document", source_id=source_id, summary="a summary")
+        pipeline.extractor._pool = MagicMock()
+        pipeline.extractor._pool.send = AsyncMock(
+            return_value='{"topic": "a topic", "themes": ["x", "y", "z"]}'
+        )
+
+        # This async test body sets up through the store, which is itself an
+        # on-loop take and not the subject: only what the pipeline does counts.
+        guard.takes.clear()
+        await pipeline.generate_source_summary(source_id)
+        violations = list(guard.takes)
+
+        row = kstore.db.execute(
+            "SELECT summary_topic FROM sources WHERE id = ?", (source_id,)
+        ).fetchone()
+        assert row["summary_topic"] == "a topic", "the summary write never landed"
+        assert not violations, guard.report(violations)
+
+
+class TestChunkWriteIsOneUncancellableUnit:
+    """The item COMMIT and the record of it must not come apart under cancellation.
+
+    Offloading is not free: ``asyncio.to_thread`` does not stop a worker that has
+    already started, so a naive two-hop offload (``add_item``, then append, then
+    ``add_source_location``) opens a window the on-loop version never had. A
+    gateway shutdown landing between ``add_item``'s COMMIT and the coroutine
+    resuming would skip the append and every finalizer above it, leaving a
+    searchable item that no rollback can name and the next scan re-ingests --
+    duplicating it while the first copy stays untracked.
+
+    ``run_to_completion`` around the whole unit closes it: the hop is drained
+    before the cancellation proceeds, so the commit, the append and the location
+    write always travel together.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancel_after_the_commit_still_writes_the_location(self, pipeline, kstore):
+        committed = threading.Event()
+        real_add_item = kstore.add_item
+
+        def _add_item_then_stall(*a, **kw):
+            # The cancellation is aimed at exactly the gap this test exists for:
+            # the item is committed, and the awaiting coroutine has not resumed.
+            new_id = real_add_item(*a, **kw)
+            committed.set()
+            time.sleep(0.3)
+            return new_id
+
+        kstore.add_item = _add_item_then_stall
+
+        task = asyncio.create_task(pipeline.ingest_text("body text long enough to split", "t"))
+        assert await asyncio.to_thread(committed.wait, 10), "the first chunk never committed"
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        items = kstore.db.execute("SELECT id FROM items").fetchall()
+        assert items, "add_item's commit vanished, so this test proves nothing"
+        located = {
+            r["item_id"]
+            for r in kstore.db.execute("SELECT item_id FROM source_locations").fetchall()
+        }
+        assert items[0]["id"] in located, (
+            "the write unit was torn in half: the item committed but its source location "
+            "was skipped, so nothing can name it"
+        )


### PR DESCRIPTION
`knowledge/ingestion.py` was the second largest holder of on-loop knowledge-store
calls: 15 recorded in `.github/sync-io-in-async-baseline.txt`, plus five
interprocedural ones no name-based AST scan can see, because `add_item`,
`add_source_location`, `get_source_by_uri`, `add_source` and
`_source_is_auto_added` are plain `def`s that reach `self.db` one frame down.

`add_item` is the worst of them: it opens a `BEGIN` write transaction, so on the
loop it blocked every other session's turn for the connection's whole 10s busy
timeout, and a stall past `dashboard.loop_stall_exit_after_secs` (25s) makes the
watchdog kill the gateway and drop every in-flight turn in every channel (#1572).
Since #7640 the store's `db` accessor reports each take, and a folder scan warns
from this file on a live gateway.

Every take in the file is now offloaded, following the pattern already used by its
own neighbours (`_run_chunker`, `_store_entities`, `_maybe_dedup`, `_finalize`):

- reads and best-effort writes go through `asyncio.to_thread`;
- writes whose loss would strand state go through `run_to_completion`: the two
  `ingestion_jobs` rows later steps key off (the `processing` insert and the
  `failed` stamp that stops the folder watcher retrying the file), and the
  per-chunk write unit below.

The per-chunk unit is the subtle one. Offloading is not free: `asyncio.to_thread`
does not stop a worker that has already started, so a two-hop offload (`add_item`,
then the `created_item_ids` append, then `add_source_location`) would open a window
the on-loop version never had -- a cancellation landing between the COMMIT and the
coroutine resuming skips the append and every finalizer above it, leaving a
searchable item no rollback can name and a job row stuck in `processing`. All three
steps therefore travel as ONE `run_to_completion` hop, with the append kept BETWEEN
the two writes so a failing location write still leaves the item nameable by the
partial-failure rollback.

Part of #7019; the baseline entry for this file drops from 15 to gone.

## Pattern harvest

Rule candidate: reviewer checklist / semgrep
Pattern: moving a blocking write off the event loop with `asyncio.to_thread`
introduces a cancellation point that did not exist when the call was synchronous.
Where the awaiting coroutine records or acts on the write (appending an id,
writing a state row, invoking a callback), the commit and that bookkeeping must
travel as one shielded hop -- this repo already has the primitive for it,
`run_to_completion`. A bare `to_thread` around such a write is the defect: the
worker finishes and commits, the awaiter never resumes, and the two come apart.
The generalizable trigger is "offloaded write whose result the caller must record",
not knowledge ingestion specifically; the same shape exists anywhere an
offload-cleanup pass converts a synchronous commit into an awaited one.

## Testing

`test/test_knowledge_ingestion_off_loop.py` swaps the store's module-level guard
for one that RECORDS on-loop takes and proceeds, then drives `ingest_file` (new
source, existing source, failure path), `ingest_text` and
`generate_source_summary` and asserts nothing was taken on the loop.

Recording rather than raising is deliberate: the per-chunk body catches
`Exception`, so a strict-mode raise from `add_item` would be swallowed and the
test would pass while the defect stood. Each test also asserts the work actually
landed (items present, embeddings stamped, job `completed`, failure stamped), so a
pipeline that quietly does nothing cannot pass either, and a harness self-check
proves the recorder sees a take when one happens.

A separate test pins the cancellation property: it cancels an in-flight ingest at
exactly the gap above (item committed, coroutine not yet resumed) and asserts the
source location still landed. It fails with "the write unit was torn in half"
against the two-hop shape and passes with the shielded hop.

Verified non-vacuous: 5 of the 6 guard tests fail against this file's pre-change
version (25, 24, 23, 8 and 3 recorded takes); the sixth is the harness check that
must pass both ways.

Also green: the `sync-io-in-async` gate with the pruned baseline, the black
baseline gate, isort, flake8, mypy on the changed file, and the knowledge /
ingestion / on-loop suites (53 tests).

