### PR TITLE
fix(config): order the write-back migration save against concurrent config writes

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3261,7 +3261,24 @@ class KiroCrewConfig:
 
             if needs_migration and not cfg._degraded_sections:
                 _write_migration_backup(path)
-                cfg.save()
+                # Pass the ticket drawn BEFORE this method's read (see the top
+                # of this function and next_config_load_ticket) rather than
+                # letting save() draw a fresh one. cfg is a snapshot from that
+                # earlier read; a concurrent dashboard PATCH or CLI write that
+                # has since saved a NEWER config carries a higher ticket, and
+                # save() drops this write rather than clobbering it with the
+                # stale snapshot. Migration is one-shot but idempotent: a
+                # dropped write just means this process's on-disk config
+                # stays in its legacy shape, and the NEXT load — whether of
+                # the concurrent write above or a later one — re-detects and
+                # retries.
+                if not cfg.save(ticket=ticket):
+                    logger.info(
+                        "config: write-back migration skipped — a concurrent "
+                        "config write landed after this load's read; writing "
+                        "back this stale snapshot would have discarded it. "
+                        "Retried on the next load."
+                    )
             elif needs_migration:
                 # This load DISCARDED something (a malformed section, an
                 # unreadable file). cfg.save() serializes only the parsed
@@ -3364,7 +3381,7 @@ class KiroCrewConfig:
         slack_section["observe_ttl_hours"] = self.observe_ttl_hours
         return d
 
-    def save(self) -> None:
+    def save(self, ticket: int | None = None) -> bool:
         """Write current config to ~/.kiro/crew/config.json.
 
         Stamps a ``meta`` block with the current version and timestamp
@@ -3372,7 +3389,27 @@ class KiroCrewConfig:
 
         Values that exist in ``config.local.json`` are stripped from the
         output to prevent overlay settings from leaking into the base file.
+
+        *ticket* orders this write against a concurrent one the same way
+        :func:`publish_autocompact_pct` orders its publish: pass the ticket
+        drawn from :func:`next_config_load_ticket` BEFORE the read that
+        produced this config, and if a save carrying a higher ticket has
+        already landed, THIS write is dropped -- returns ``False`` -- rather
+        than clobbering it with a stale snapshot.
+
+        Omitting *ticket* draws a fresh one, which therefore always wins.
+        That is correct for the overwhelmingly common caller: read, mutate,
+        save, all in one go, nothing else could have raced it into being
+        "newer". Only a caller REPLAYING an earlier read across a gap where
+        something else may have saved in the meantime -- currently just the
+        write-back migration in ``_load_resolved`` -- needs to pass the
+        ticket it drew before that read, so a concurrent write landing in the
+        gap survives instead of being silently overwritten.
+
+        Returns ``True`` if the write happened, ``False`` if it was dropped
+        as stale.
         """
+        global _CONFIG_WRITE_TICKET
 
         d = self.to_dict()
 
@@ -3405,14 +3442,28 @@ class KiroCrewConfig:
             except (json.JSONDecodeError, OSError):
                 pass
 
-        # Atomic + mode-preserving: a concurrent reader must never observe a
-        # half-written config, and the write must not widen who can read a file
-        # that may hold inline credentials. See write_config_atomically.
-        write_config_atomically(config_path(), stamp_config_meta(d))
+        # Compare-and-write-and-record under one lock, same reasoning as
+        # publish_autocompact_pct: splitting the compare from the record would
+        # let two concurrent saves both pass the comparison and race the
+        # write, so whichever's write_config_atomically call finishes LAST
+        # would win regardless of ticket order. Drawn OUTSIDE any lock we
+        # already hold -- next_config_load_ticket takes its own, disjoint
+        # lock, so there is no reentrancy hazard in acquiring it here.
+        my_ticket = ticket if ticket is not None else next_config_load_ticket()
+        with _CONFIG_WRITE_TICKET_LOCK:
+            if my_ticket < _CONFIG_WRITE_TICKET:
+                return False
+            # Atomic + mode-preserving: a concurrent reader must never observe
+            # a half-written config, and the write must not widen who can
+            # read a file that may hold inline credentials. See
+            # write_config_atomically.
+            write_config_atomically(config_path(), stamp_config_meta(d))
+            _CONFIG_WRITE_TICKET = my_ticket
         # Drop the validated-data cache so the next load() re-reads this write.
         # mtime-keying already detects the change; this makes it immediate even
         # if the filesystem mtime resolution is coarse.
         _invalidate_config_cache()
+        return True
 
     @staticmethod
     def _resolve_agent_model() -> str:
@@ -4295,6 +4346,25 @@ def publish_autocompact_pct(config: "KiroCrewConfig", ticket: int | None = None)
 def published_autocompact_pct() -> float:
     """The published compaction threshold."""
     return _CONFIG_AUTOCOMPACT_PCT
+
+
+#: Highest ticket associated with a config.json write that has actually landed
+#: on disk, via :meth:`KiroCrewConfig.save`. Same ordering contract as
+#: :data:`_CONFIG_AUTOCOMPACT_TICKET` -- a ticket lower than this one is a
+#: write whose read started before a write that has already landed, so
+#: applying it would clobber that later write -- but this one guards a real
+#: file, not an in-memory rebind. Only ``save()``'s write-back migration
+#: caller (:meth:`KiroCrewConfig._load_resolved`) currently passes an
+#: explicit ticket; every other caller reads, mutates, and saves in one go,
+#: so it draws a fresh one at write time and always wins (see ``save``).
+_CONFIG_WRITE_TICKET: int = 0
+
+#: Serializes the compare-and-write-and-record inside :meth:`KiroCrewConfig.save`
+#: into one atomic step, the same way :data:`_CONFIG_AUTOCOMPACT_LOCK` serializes
+#: the compact/publish compare-and-set. Without it, two concurrent ``save()``
+#: calls could both pass the ticket comparison before either records its
+#: ticket, and whichever writes last would win regardless of ticket order.
+_CONFIG_WRITE_TICKET_LOCK = threading.Lock()
 
 
 def resolve_effective_agent(agent_name: str | None, project_dir: str | None = None) -> str:

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -5715,6 +5715,186 @@ class TestMigrationBackupContainment:
         assert not (home / "config.json.bak").exists()
 
 
+class TestMigrationSaveOrderingAgainstConcurrentWrites:
+    """Regression tests for #7793.
+
+    The write-back migration ``cfg.save()`` inside ``_load_resolved`` used to
+    fire unconditionally: ``cfg`` is a snapshot from a read earlier in the same
+    call, so a concurrent config write (a dashboard PATCH, a CLI write, another
+    process's load) landing between that read and this save was silently
+    discarded when the migration write finished last.
+
+    The fix reuses the ticket-ordering contract ``publish_autocompact_pct``
+    already established for this exact class of problem: ``_load_resolved``
+    passes the ticket it drew BEFORE its read into ``cfg.save(ticket=...)``,
+    and ``save()`` drops a write whose ticket is lower than one already
+    recorded rather than clobbering it.
+    """
+
+    # A config with neither "agents" nor "default_agent" is what makes load()
+    # take the migration write-back branch (see TestMigrationBackupContainment).
+    _LEGACY = {"telegram": {"allow_forum": True}}
+
+    def test_concurrent_write_between_read_and_migration_save_survives(
+        self, tmp_path: Path
+    ) -> None:
+        """Pins the exact race from the issue.
+
+        1. A load reads a legacy config and decides it needs migration.
+        2. Before its ``cfg.save()`` write-back fires, a concurrent write --
+           modeled the way a real dashboard PATCH handler writes: its own
+           ``load()`` + mutate + ``save()`` -- lands and saves a newer config.
+        3. The migrating load's write-back must then be DROPPED rather than
+           clobbering the concurrent write with its now-stale snapshot.
+
+        ``_write_migration_backup`` is the last thing ``_load_resolved`` calls
+        before ``cfg.save()``, so patching it to perform the concurrent write
+        lands that write deterministically inside the race window instead of
+        depending on thread scheduling.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        cfg_file = home / "config.json"
+        cfg_file.write_text(json.dumps(self._LEGACY), encoding="utf-8")
+
+        real_backup = loader_module._write_migration_backup
+
+        def _backup_then_concurrent_write(path: Path) -> None:
+            real_backup(path)
+            # The concurrent writer: reads the (still legacy-shaped) file,
+            # changes one field, and saves -- exactly the read/mutate/save
+            # shape every dashboard handler and CLI command uses.
+            concurrent_cfg = KiroCrewConfig.load()
+            concurrent_cfg.dashboard.theme_mode = "dark"
+            assert concurrent_cfg.save(), "the concurrent write itself must land"
+
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=home),
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_file),
+            unittest.mock.patch(
+                "kiro_crew.config.loader._write_migration_backup",
+                side_effect=_backup_then_concurrent_write,
+            ),
+        ):
+            cfg = KiroCrewConfig.load()
+
+        # Guard the guard: the migrating load's in-memory result still carries
+        # the migration (only the DISK write is gated), otherwise this test
+        # would pass for the wrong reason if the branch stopped firing.
+        assert cfg.agents, "migration write-back branch did not run, test is vacuous"
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert (
+            on_disk.get("dashboard", {}).get("theme_mode") == "dark"
+        ), "the concurrent write was discarded by the stale migration save"
+
+    def test_save_with_a_stale_ticket_is_dropped(self, tmp_path: Path) -> None:
+        """The ticket contract in isolation, without going through load().
+
+        A save() carrying a ticket lower than one already recorded must leave
+        the newer write's content on disk untouched -- matching
+        publish_autocompact_pct's "a ticket lower than the one already
+        published is dropped" contract.
+
+        Tickets are DRAWN, not hardcoded: next_config_load_ticket() is a
+        single monotonic counter shared with every other load() in this test
+        process, so a literal like ``5`` could already be behind
+        ``_CONFIG_WRITE_TICKET`` by the time this test runs. Drawing the stale
+        ticket strictly before the fresh one guarantees stale < fresh
+        regardless of how many tickets earlier tests issued.
+        """
+        from kiro_crew.config.loader import next_config_load_ticket
+
+        cfg_file = tmp_path / "config.json"
+
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path),
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_file),
+        ):
+            stale_ticket = next_config_load_ticket()
+            fresh_ticket = next_config_load_ticket()
+
+            fresh = KiroCrewConfig()
+            fresh.dashboard.theme_mode = "fresh"
+            stale = KiroCrewConfig()
+            stale.dashboard.theme_mode = "stale"
+
+            assert fresh.save(ticket=fresh_ticket) is True
+            assert stale.save(ticket=stale_ticket) is False, "a lower ticket must be dropped"
+
+            on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+            assert on_disk["dashboard"]["theme_mode"] == "fresh"
+
+    def test_concurrent_migration_saves_never_let_an_older_ticket_win(self, tmp_path: Path) -> None:
+        """The compare-and-write-and-record must be atomic across threads.
+
+        Mirrors test_autocompact_default.test_concurrent_publishes_never_let_
+        an_older_ticket_win: a compare followed by a separate write+record
+        would let two concurrent saves both pass the comparison and race the
+        actual write, so whichever finishes LAST wins regardless of ticket
+        order. Interleaving is forced here rather than hoped for: a stalled
+        lock parks the low-ticket writer inside its critical section while
+        the high-ticket writer completes first.
+        """
+        import threading
+
+        from kiro_crew.config.loader import next_config_load_ticket
+
+        cfg_file = tmp_path / "config.json"
+        # Drawn in order, so low_ticket < high_ticket by construction --
+        # see test_save_with_a_stale_ticket_is_dropped for why literals aren't
+        # safe here.
+        low_ticket = next_config_load_ticket()
+        high_ticket = next_config_load_ticket()
+        low = KiroCrewConfig()
+        low.dashboard.theme_mode = "low"
+        high = KiroCrewConfig()
+        high.dashboard.theme_mode = "high"
+
+        entered = threading.Event()
+        release = threading.Event()
+        real_lock = loader_module._CONFIG_WRITE_TICKET_LOCK
+
+        class _StallOnce:
+            """Lock stand-in that parks the FIRST holder inside the critical section."""
+
+            def __init__(self) -> None:
+                self._first = True
+
+            def __enter__(self):
+                real_lock.acquire()
+                if self._first:
+                    self._first = False
+                    entered.set()
+                    release.wait(timeout=5)
+                return self
+
+            def __exit__(self, *exc) -> None:
+                real_lock.release()
+
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path),
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_file),
+        ):
+            try:
+                loader_module._CONFIG_WRITE_TICKET_LOCK = _StallOnce()
+                t_low = threading.Thread(target=low.save, kwargs={"ticket": low_ticket})
+                t_low.start()
+                assert entered.wait(timeout=5), "the first (low-ticket) writer never entered"
+
+                t_high = threading.Thread(target=high.save, kwargs={"ticket": high_ticket})
+                t_high.start()
+                release.set()
+                t_low.join(timeout=5)
+                t_high.join(timeout=5)
+            finally:
+                loader_module._CONFIG_WRITE_TICKET_LOCK = real_lock
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["dashboard"]["theme_mode"] == "high", "the newer ticket must win"
+        assert loader_module._CONFIG_WRITE_TICKET == high_ticket
+
+
 # Transports carrying a soft/hard context-threshold pair, and those carrying
 # only the soft nudge (their hard backstop is the backend autocompactor).
 # A future transport that forgets _threshold_pct / _normalize_threshold_pair


### PR DESCRIPTION
Closes #7793

## Problem

`KiroCrewConfig.load()`'s write-back migration in `_load_resolved` (`src/kiro_crew/config/loader.py`) calls `cfg.save()` unconditionally after detecting a legacy config shape needing migration. `cfg` is a snapshot from a read earlier in the same call, and nothing orders that save against a concurrent config write (a dashboard PATCH, a CLI write) landing between the migration's read and its save — the concurrent write is silently discarded when the migration's write lands last. This is reachable today because `chat_runner.py` already calls `KiroCrewConfig.load()` off the event loop via `asyncio.to_thread`.

The sibling `publish_autocompact_pct(cfg, ticket)` in the same `load()` already solves exactly this class of problem: it takes an ordering ticket drawn *before* the read, and a publish holding a ticket lower than one already published is dropped.

## Fix

Extends that same ticket-ordering contract to `save()` itself, rather than inventing a new mechanism:

- `KiroCrewConfig.save()` gains an optional `ticket` parameter. Every existing call site omits it, so `save()` draws a fresh ticket at write time — which always wins. That's correct for the overwhelmingly common shape (read, mutate, save, all in one go — nothing could have raced it into being "newer").
- `_load_resolved` passes the ticket it already draws before its own read into the migration's `cfg.save(ticket=ticket)` call. If a save carrying a higher ticket has landed on disk since (the concurrent write), this save is dropped instead of clobbering it with the stale snapshot.
- The compare, the actual `write_config_atomically` call, and recording the new high-water ticket happen under one lock — closing the same compare-then-write TOCTOU window `publish_autocompact_pct`'s own docstring calls out.

Migration is one-shot but idempotent: a dropped write just means this process's on-disk config stays in its legacy shape a little longer, and the concurrent write's own load (or a later one) re-detects and retries.

### Why not the other two shapes from the issue

- **Serializing under the loader's own lock** — the migration write is reachable from a worker thread (`asyncio.to_thread`), off the dashboard's event-loop-bound `_get_config_lock`. Sharing an `asyncio.Lock` across that thread boundary is its own hazard, so this would need a new cross-thread primitive rather than reusing what's there. The ticket mechanism is already thread-safe (`threading.Lock`) and needs no new concept.
- **`load(migrate=False)` read-only mode** — a reasonable complementary idea per the issue, but unrelated API surface not needed to close this specific race. Left out to keep this PR scoped to the ordering fix.

## Tests

Added `TestMigrationSaveOrderingAgainstConcurrentWrites` in `test/test_config_loader.py`:

- `test_concurrent_write_between_read_and_migration_save_survives` — reproduces the exact race from the issue: a load detects migration-needed, a concurrent write (its own load + mutate + save, the same shape every dashboard handler uses) lands before the migration's `cfg.save()` fires, and the concurrent write survives on disk.
- `test_save_with_a_stale_ticket_is_dropped` — pins `save()`'s ticket contract in isolation.
- `test_concurrent_migration_saves_never_let_an_older_ticket_win` — forces the compare-write-record critical section to interleave across real threads (mirrors `test_autocompact_default.py`'s equivalent test for `publish_autocompact_pct`).

`.venv/bin/python3 -m pytest test/test_config_loader.py -q` — 499 passed, 1 skipped (pre-existing skip, unrelated).
`.venv/bin/python3 -m pytest test/test_autocompact_default.py -q` — 16 passed (confirms the shared ticket-counter machinery is untouched).
`black` / `isort` / `flake8` / `mypy` clean on both touched files.

`CHANGELOG.md` not touched, per this repo's fix-PR policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)