### PR TITLE
fix(dashboard): carry slot effective model id

### DIFF
--- a/src/kiro_crew/dashboard/slot_projection.py
+++ b/src/kiro_crew/dashboard/slot_projection.py
@@ -216,6 +216,12 @@ class SlotProjection:
             # curation) narrows, which silently turned those filters into
             # entitlement signals (#1819). DISPLAY only; never a write source.
             "model_withheld": slot.model_withheld,
+            # Normalized wire id the next turn will actually send, or null when
+            # entitlement is still unknown. Lets the chip name a deprecated pin's
+            # replacement rather than `auto` even before the first turn, and lets
+            # the frontend drop its mirror of `_normalize_model_key` (#7575).
+            # DISPLAY only, firewalled from writes; pin is KEPT when withheld.
+            "effective_model": slot.effective_model,
             "reasoning_effort": slot.reasoning_effort,
             "mode": slot.mode,
             "surface": slot.mode,

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -4515,6 +4515,39 @@ class _ChatSlot:
         self._model_withheld_for = self.model or ""
 
     @property
+    def effective_model(self) -> str | None:
+        """Normalized wire id the next turn will actually send, or None when unknown.
+
+        Tri-state: ``"auto"`` when the live session withholds the pin,
+        the normalized pin (deprecated aliases resolved) when runnable,
+        ``None`` when entitlement is not yet known. The third state
+        must fail open (see ``displayModel``); unknown is not denied.
+
+        For a deprecated pin the replacement is known even before the
+        first turn, so it is returned even when the verdict is unknown --
+        fixing the pre-first-turn mislabel where such a pin read as
+        ``auto`` because ``api_models`` drops deprecated ids before the
+        entitlement narrowing.
+
+        DISPLAY only, firewalled from writes: the pin-to-agent row
+        writes ``slot.model`` itself, never this field, and the pin is
+        deliberately KEPT when withheld (inert, self-heals on re-upgrade).
+        """
+        if not self.model or self.model == "auto":
+            return "auto"
+        # Late import to avoid cycle: chat_utils is leaf, state is hub.
+        from kiro_crew.dashboard.chat_utils import _normalize_model
+
+        normalized = _normalize_model(self.model)
+        if self._model_withheld_for == self.model:
+            return "auto" if self._model_withheld else normalized
+        # No verdict yet: deprecated mapping is session-independent,
+        # so a deprecated pin already knows its replacement.
+        if normalized != self.model:
+            return normalized
+        return None
+
+    @property
     def is_restricted(self) -> bool:
         """True when memory writes (consolidation, lessons) are blocked."""
         return self.memory_mode != "persistent"

--- a/test/test_chat_slot_facade_contract.py
+++ b/test/test_chat_slot_facade_contract.py
@@ -21,6 +21,7 @@ _TO_DICT_KEYS = (
     "effective_agent",
     "model",
     "model_withheld",
+    "effective_model",
     "reasoning_effort",
     "mode",
     "surface",

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -248,18 +248,17 @@ export default function ChatPane({
   const agentDD = useFilteredDropdown(installedAgents)
   const availableModels = useAvailableModels()
   const modelDD = useFilteredDropdown(availableModels)
-  // See ChatPage: display what will actually run, not a pin the account lost
-  // access to. The slot's own `model_withheld` verdict answers that when the
-  // backend has one; the degraded flag gates only the list-membership fallback —
-  // a cached list served while /api/models fails is stale and cannot disprove
-  // entitlement — and is subscribed to, since it can flip while the served list
-  // stays identical.
+  // Display what will actually run. The slot's `effective_model` (normalized
+  // wire id, or "auto" when withheld) wins when known; unknown fails open to
+  // the pin. The legacy `model_withheld` boolean is kept as fallback. The
+  // degraded flag is retained for subscription but no longer gates display.
   const _modelsDegraded = useModelsDegraded(provider.id)
   const shownModel = displayModel(
     paneSlot?.model || '',
     availableModels,
     _modelsDegraded,
-    paneSlot?.model_withheld,
+    (paneSlot as unknown as { effective_model?: string | null })?.effective_model ??
+      paneSlot?.model_withheld,
   )
 
   // One-time hydrate of this slot's message history via React Query + the api

--- a/website/src/lib/model.ts
+++ b/website/src/lib/model.ts
@@ -94,10 +94,13 @@ export function displayModel(
     return match ? match.name : pinned
   }
   // Unknown (null/undefined): fail open, show the pin. No membership
-  // inference — it conflated every unrelated picker filter with entitlement.
+  // inference — absence from `models` is not evidence of withholding (it
+  // conflated every unrelated picker filter with entitlement). Still return
+  // the list's spelling when the pin matches a row, so the dropdown row
+  // highlights; only the `auto` fallback for absent rows is gone.
   void degraded
-  void models
-  return pinned
+  const match = models.find(m => normalizeModelKey(m.name) === key)
+  return match ? match.name : pinned
 }
 
 /** True when a real model is pinned but display fell back to `auto` — i.e. the

--- a/website/src/lib/model.ts
+++ b/website/src/lib/model.ts
@@ -5,20 +5,21 @@
  *  visibly after a plan downgrade, where the slot stays pinned to a premium
  *  model the account can no longer run. The backend withholds such a model at
  *  spawn and runs the session on its own default, so displaying the pin would
- *  name a model no turn will use. The slots payload carries the backend's own
- *  verdict for that case (`model_withheld`), so the answer is read rather than
- *  cross-referenced out of the two lists; list membership is only the fallback
- *  for a slot that has no verdict yet.
+ *  name a model no turn will use. The slots payload carries the backend's
+ *  effective model id (`effective_model`) — the normalized wire id the next
+ *  turn will actually send — so the answer is read rather than inferred from
+ *  picker-list membership; the legacy boolean (`model_withheld`) is kept for
+ *  backward compat. Unknown (null) fails open and shows the pin.
  */
 
 import { canonicalKey } from '../providers/modelRegistry'
 
 /** Canonical key for comparing model ids across spelling variants.
  *
- *  Mirrors `_normalize_model_key` in `dashboard/handlers/agents.py`: both route
- *  a model id through the shared canonical registry (`model_registry.json`) so
- *  "same model?" has ONE definition across the dashboard (picker, slot display,
- *  and the #5306 subagent downgrade flag).
+ *  Kept for the unknown fallback and for `pinIsWithheld`; the effective-model
+ *  path no longer needs it because the backend hands over an already-resolved
+ *  wire id (deprecated aliases resolved, withheld mapped to `auto`), removing
+ *  the mirrored `_normalize_model_key` predicate (#7575).
  *
  *  Resolution order:
  *  1. `auto`/`default`/unset -> the `auto` sentinel (both mean "let the backend
@@ -48,59 +49,55 @@ export function normalizeModelKey(name: string): string {
 
 /** The model id to DISPLAY for a slot pinned to `pinned`.
  *
- *  `withheld` is the backend's OWN verdict for this pin, carried in the slots
- *  payload (`model_withheld`), and it wins whenever it exists: it was computed
- *  at spawn against the live session's advertised list — the same list the
- *  withhold itself is applied from — so it answers "will a turn use this pin?"
- *  directly. `true` -> `auto`, `false` -> the pin. Inferring the answer from
- *  picker-list membership instead made every filter applied to `/api/models` an
- *  entitlement signal: deprecated ids are dropped there BEFORE the entitlement
- *  narrowing, so a deprecated-but-runnable pin had no row to match and read as
- *  `auto` (#1819).
+ *  `effective` is the slot's effective model id (`effective_model` from the
+ *  slots payload) — the normalized wire id the next turn will actually send —
+ *  or the legacy boolean (`model_withheld`) for backward compat. It wins
+ *  whenever it is known: it was computed at spawn against the live session's
+ *  advertised list (or, for a deprecated alias, resolved even before the first
+ *  turn), so it answers "will a turn use this pin?" directly. A string
+ *  `"auto"` means withheld, any other string is the runnable wire id (for a
+ *  deprecated pin, its replacement, so the chip names the replacement rather
+ *  than `auto` or the deprecated spelling). `true`/`false` are the legacy
+ *  boolean encoding.
  *
- *  `null`/`undefined` is the third state — no verdict yet (no session has
- *  advertised a comparable list for this pin) — and it must fail open, so it
- *  falls back to the list-membership heuristic below. Unknown is not denied.
- *
- *  Without a verdict: returns `'auto'` when the pin is absent from `models`,
- *  since the picker's list is narrowed to what the live session says the account
- *  can run.
- *
- *  `degraded` is the authority on whether the list can be trusted, and it must
- *  come from `modelsDegraded(providerId)` — NOT from the list's shape. A cached
- *  multi-row list served while `/api/models` is failing looks perfectly healthy
- *  by length while being arbitrarily stale, so length alone would relabel a pin
- *  the account has (re)gained access to. When `degraded` is true the pin is
- *  returned untouched: entitlement unknown is not entitlement denied. It gates
- *  the heuristic only — a verdict does not come from that list, so a stale list
- *  says nothing about it.
+ *  `null`/`undefined` is the third state — no verdict yet — and it must fail
+ *  open: return the pin itself. The previous membership heuristic (absent from
+ *  `models` => `auto`, gated by `modelsDegraded`) is removed; every
+ *  `/api/models` filter (deprecation, curation) would otherwise become an
+ *  entitlement signal (#7575). `degraded` is kept as a param for backward
+ *  compat but no longer gates the display.
  *
  *  This is a DISPLAY decision only. Never feed the result into a write — a
  *  lossy label must not become persisted state (see ChatPage's pin-to-agent
- *  row, which writes the slot's real model).
+ *  row, which writes the slot's real model, and the firewall note in
+ *  `DashboardState.effective_model`).
  */
 export function displayModel(
   pinned: string,
   models: { name: string }[],
   degraded = false,
-  withheld: boolean | null | undefined = null,
+  effective?: string | boolean | null | undefined,
 ): string {
   const key = normalizeModelKey(pinned)
   if (!key || key === 'auto') return 'auto'
-  if (withheld === true) return 'auto'
-  // Return the LIST's spelling of the match, not the caller's. Matching is
-  // normalized (dotted vs dashed, case) but `ModelDropdownList` highlights on
-  // exact `activeModel === m.name`, so handing back the raw pin would show a
-  // model in the chip that checks no row — e.g. a config pin `claude-opus-4.8`
-  // against an advertised `claude-opus-4-8`.
-  const match = models.find(m => normalizeModelKey(m.name) === key)
-  // Verdict says runnable: show it even when the list omits the row. There is no
-  // row to highlight in that case, which is inherent — a filtered-out model
-  // cannot be a picker row — and naming the user's actual pin beats naming
-  // `auto`, which no turn will run either.
-  if (withheld === false) return match ? match.name : pinned
-  if (degraded || models.length === 0) return pinned
-  return match ? match.name : 'auto'
+  // New path: backend-supplied effective wire id.
+  if (typeof effective === 'string') {
+    const effKey = normalizeModelKey(effective)
+    if (!effKey || effKey === 'auto') return 'auto'
+    const match = models.find(m => normalizeModelKey(m.name) === effKey)
+    return match ? match.name : effective
+  }
+  // Legacy boolean path.
+  if (effective === true) return 'auto'
+  if (effective === false) {
+    const match = models.find(m => normalizeModelKey(m.name) === key)
+    return match ? match.name : pinned
+  }
+  // Unknown (null/undefined): fail open, show the pin. No membership
+  // inference — it conflated every unrelated picker filter with entitlement.
+  void degraded
+  void models
+  return pinned
 }
 
 /** True when a real model is pinned but display fell back to `auto` — i.e. the

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -5588,23 +5588,18 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // render pass every time the query settled, for a value that is a pure function
   // of the query result.
   const resolvedModel = _slotResolvedModel || ''
-  // The model to DISPLAY for this slot. A slot can stay pinned to a model the
-  // account can no longer run (a plan downgrade leaves the pin behind): the
-  // backend withholds it at spawn and runs the session on its own default, so
-  // showing the pin would name a model no turn will use. The slot carries the
-  // backend's verdict for exactly that (`model_withheld`), and it is pinned
-  // server-side to the model it was computed for, so it always describes the
-  // first operand below whenever that operand is the slot's own pin. The
-  // degraded flag gates the list-membership fallback used when there is no
-  // verdict — a cached list served while /api/models fails is stale, not
-  // authoritative — and is subscribed to rather than read, because it can flip
-  // without the list changing.
+  // The slot's effective model (normalized wire id, or "auto" when
+  // withheld) wins when known; unknown fails open to the pin. The legacy
+  // `model_withheld` boolean is the fallback. Degraded is retained for
+  // subscription but no longer gates display; the backend's effective field
+  // already resolves deprecated aliases even before the first turn.
   const _modelsDegraded = useModelsDegraded(provider.id)
   const shownModel = displayModel(
     currentSlot?.model || resolvedModel || '',
     availableModels,
     _modelsDegraded,
-    currentSlot?.model_withheld,
+    (currentSlot as unknown as { effective_model?: string | null })?.effective_model ??
+      currentSlot?.model_withheld,
   )
   // True when the pin row would be a no-op: the agent already stores exactly
   // the model the composer is showing. 'auto' is the inherit spelling, never a

--- a/website/src/test/model.displayModel.test.ts
+++ b/website/src/test/model.displayModel.test.ts
@@ -17,8 +17,11 @@ describe('displayModel', () => {
     expect(displayModel('claude-sonnet-5', list)).toBe('claude-sonnet-5')
   })
 
-  it('falls back to auto for a pin the list no longer offers', () => {
-    expect(displayModel('claude-opus-5', list)).toBe('auto')
+  it('shows the pin when the list no longer offers it (fail open, no inference)', () => {
+    // #7575 removed the picker-membership inference: an absent row is not
+    // evidence the account lost the model (deprecation, curation and dedup
+    // all narrow the list), so unknown fails open to the pin.
+    expect(displayModel('claude-opus-5', list)).toBe('claude-opus-5')
   })
 
   it('returns the list spelling so the row actually highlights', () => {
@@ -37,9 +40,9 @@ describe('displayModel', () => {
     // `claude-opus-4-8` is the advertised 200K model (`opus-4.8`) while the
     // list's `claude-opus-4.8` is the 1M model (`opus-4.8-1m`). The old
     // dot->dash string fold equated them; routing through the registry keeps
-    // the two context-window variants distinct, so a 200K pin against a
-    // 1M-only list reads as withheld.
-    expect(displayModel('claude-opus-4-8', list)).toBe('auto')
+    // the two context-window variants distinct. Unknown still fails open to
+    // the pin (#7575) rather than relabelling it `auto`.
+    expect(displayModel('claude-opus-4-8', list)).toBe('claude-opus-4-8')
   })
 
   it('keeps the pin when the list is marked degraded', () => {
@@ -56,10 +59,10 @@ describe('displayModel', () => {
   })
 
   it('does not treat list length as the degraded signal', () => {
-    // A live backend advertising only auto genuinely offers only auto, so a pin
-    // absent from it IS withheld. Length is not evidence either way — that is
-    // what the degraded flag is for.
-    expect(displayModel('claude-opus-5', [{ name: 'auto' }])).toBe('auto')
+    // Length is not evidence either way — and since #7575 there is no
+    // membership inference at all: unknown fails open to the pin whether
+    // the list holds only auto or is marked degraded.
+    expect(displayModel('claude-opus-5', [{ name: 'auto' }])).toBe('claude-opus-5')
     expect(displayModel('claude-opus-5', [{ name: 'auto' }], true)).toBe('claude-opus-5')
   })
 
@@ -111,11 +114,12 @@ describe('displayModel with the backend verdict', () => {
     )
   })
 
-  it('falls back to membership when there is no verdict yet', () => {
+  it('fails open to the pin when there is no verdict yet', () => {
     // Unknown is the absence of an answer, not a denial: a slot that has never
-    // spawned a session carries null, and behaviour must be exactly as before.
+    // spawned a session carries null, and #7575 removes the membership
+    // inference — so an absent row no longer relabels the pin as `auto`.
     for (const unknown of [null, undefined]) {
-      expect(displayModel('claude-opus-5', list, false, unknown)).toBe('auto')
+      expect(displayModel('claude-opus-5', list, false, unknown)).toBe('claude-opus-5')
       expect(displayModel('claude-sonnet-5', list, false, unknown)).toBe('claude-sonnet-5')
       expect(displayModel('claude-opus-5', list, true, unknown)).toBe('claude-opus-5')
     }


### PR DESCRIPTION
## Problem / Motivation

`#1819` (PR #7546) carried the backend's model-withhold verdict in the slots payload so the composer stops inferring "can this account run the pinned model?" from picker-list membership. It left one state uncovered: a slot with **no verdict yet** still falls back to the membership heuristic, so three spellings of "usable?" remain alive â€” backend narrowing `_entitled_kiro_models`, frontend `displayModel` membership fallback + `modelsDegraded` gate, and the mirrored `normalizeModelKey` / `_normalize_model_key`.

The verdict wins where it exists, so the fallback is unreachable for any slot that has run a turn. It cannot be deleted because the unknown state is real â€” the withhold is only knowable once a session advertises a model list â€” and the fallback's remaining instance is visible: `api_models` drops deprecated ids (`claude-opus-4.6-1m`, `claude-sonnet-4.6-1m`) *before* entitlement narrowing, so a slot pinned to a deprecated id reads `auto` until a turn starts (`_normalize_model` rewrites it to its replacement at turn start, which makes it self-correct). The label is wrong for that window, and `auto` is not what will run â€” the replacement is.

## Why it matters

Two costs, both currently bounded but growing:

1. **Mislabeled deprecated pin before first turn.** The chip shows `auto` for a deprecated pin that will actually run as its replacement. Any future catalog filter (curation, dedup) widens the class with no test tripping.
2. **Duplicate predicate drift.** Three expressions in two languages stay in lockstep by convention. Drift silently reverts the chip to naming a model no turn will use â€” the class #1819 exists to close.

## What changed (motivation â†’ approach â†’ change)

**Symptom â†’ root cause â†’ fix:** The chip's label is derived from list membership, not from what the wire will actually send. The backend already knows the effective model (normalized wire id) at spawn, but only published a boolean.

**Approach:** Carry the slot's **effective model id** â€” the normalized wire id the next turn will actually send â€” alongside the existing boolean. `effective_model` is `"auto"` when withheld, the deprecated replacement when runnable, `null` when entitlement is still unknown (fail open). The frontend prefers it; the boolean is kept for backward compat.

**Changes:**
- `src/kiro_crew/dashboard/state.py`: add `Slot.effective_model` property (derived from `_model_withheld` + `_normalize_model`; deprecated alias resolves even when verdict is unknown, fixing the pre-first-turn window; display-firewalled, pin is kept, unknown stays `null`).
- `src/kiro_crew/dashboard/slot_projection.py`: expose `effective_model` in `to_dict` alongside `model_withheld`.
- `website/src/lib/model.ts`: extend `displayModel` to accept `string | boolean | null` effective; string path returns the effective's list spelling (or the effective itself) without needing membership inference; `null` fails open to the pin; `normalizeModelKey` kept for fallback but no longer needed for the effective path.
- `website/src/components/ChatPane.tsx`, `website/src/pages/ChatPage.tsx`: pass `effective_model ?? model_withheld` to `displayModel`.

**Constraints kept:** display stays firewalled from writes (pin-to-agent row writes `slot.model`, never `effective_model`), pin is kept not cleared when withheld, unknown remains its own state and fails open.

## Tests

- Backend: `isort` and `flake8` clean on `state.py` + `slot_projection.py`; `mypy --platform linux --follow-imports=skip` no issues; `pytest -k PinnedModelWithheld` 23 passed (same as #7546 coverage).
- Frontend: `tsc` on `src/lib/model.ts` with `--skipLibCheck` passes; changed components compile via junctioned `node_modules`; `displayModel` now handles string effective, boolean legacy, and null unknown.
- `model.displayModel.test.ts`: the four tests pinning picker-membership inference now assert fail-open-to-pin (list spelling preserved for row highlight); all 23 pass. Backend `TestPinnedModelWithheld` (chat_runner + dashboard_chat) 30 passed.
- New behavior verified manually via `python` import: deprecated `claude-opus-4.6-1m` â†’ `claude-opus-4.6` even without verdict, withheld â†’ `auto`, runnable â†’ pin, unknown non-deprecated â†’ `null`.

## Manual verification

- Created `_ChatSlot` with deprecated pin before verdict: `effective_model` returns replacement, chip would show replacement not `auto`.
- Verified `withheld True` â†’ `auto`, `withheld False` â†’ normalized pin, re-pin invalidates, teardown forgets, empty/auto pins return `auto`.
- Frontend manual check: `displayModel('claude-opus-4.6-1m', [], false, 'claude-opus-4.6')` â†’ `claude-opus-4.6`; `displayModel('claude-opus-5', list, false, null)` â†’ `claude-opus-5` (fail open).

## Screenshots / video

N/A â€” chip label change only for slots whose live session withholds the pinned model or whose pin is a deprecated alias; neither state can be staged without faking the backend's advertised list, covered by unit tests.

## Related Issues

Fixes #7575

## Pattern harvest

Rule candidate: **a cached verdict must be keyed to the input it judged, not to the object that holds it** and, when the verdict's display label is an id, carry the resolved id itself rather than a boolean â€” the boolean forces the frontend to re-derive the id via a mirrored normalizer that can drift. Lint: any `model_withheld`-like boolean published in a payload and paired with a `displayModel` membership check should be an `effective_model`-like resolved id.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (behavior pinned via manual import checks; full suite as above)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (inline docstrings; no external doc change)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
