### PR TITLE
fix(ci): stop gates reporting verdicts on reads they never made

### DIFF
--- a/.github/workflows/disposition-deferral-check.yml
+++ b/.github/workflows/disposition-deferral-check.yml
@@ -61,8 +61,53 @@ jobs:
           else
             valid=""
             for n in $refs; do
-              issue_json="$(gh api "repos/$REPO/issues/$n" 2>/dev/null || true)"
-              [ -z "$issue_json" ] && continue
+              # An issue this loop could not READ is not an invalid reference.
+              # `2>/dev/null || true` collapsed a transient API failure onto
+              # the same empty string as "this number is not an issue here",
+              # so a network blip made every referenced follow-up look
+              # unresolvable and the author was blamed for an untracked
+              # deferral they had in fact tracked. Only HTTP 404 means the
+              # reference does not resolve; any other failure is retried and
+              # then fails this check closed -- re-runnable -- instead of
+              # posting a false refusal.
+              issue_json=""
+              read_ok=""
+              for attempt in 1 2 3; do
+                gh_err="$(mktemp)"
+                if issue_json="$(gh api "repos/$REPO/issues/$n" 2>"$gh_err")"; then
+                  read_ok=1
+                  rm -f "$gh_err"
+                  break
+                fi
+                if grep -q "HTTP 404" "$gh_err"; then
+                  rm -f "$gh_err"
+                  read_ok=404
+                  break
+                fi
+                echo "Reading issue #$n failed on attempt $attempt:"
+                cat "$gh_err" >&2
+                rm -f "$gh_err"
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$read_ok" ]; then
+                echo "::error::Could not read issue #$n from the API after 3 attempts, so this check cannot tell whether the deferral is tracked. This is a read failure, not an untracked deferral -- re-run this job."
+                # This lane is advisory by design (an issue_comment run has no
+                # PR-visible check row), so a silent red run in the Actions tab
+                # is a signal nobody sees. Leave the unverified state where the
+                # promise was made -- best-effort: if the API is down enough
+                # that this post also fails, the exit 1 below is still the
+                # ground truth.
+                reply="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/reply.md"
+                {
+                  echo "<!-- deferred-finding-check -->"
+                  echo "**Could not verify this deferral.** Reading issue #$n from the API failed after 3 attempts, so this check could not tell whether the deferral is tracked. This is a read failure, not a judgement about the deferral -- re-run the deferral check. Checked disposition: ${COMMENT_URL}"
+                } > "$reply"
+                gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$(cat "$reply")" >/dev/null || true
+                exit 1
+              fi
+              [ "$read_ok" = "404" ] && continue
               # Skip refs that are PRs, not issues.
               if printf '%s' "$issue_json" | jq -e '.pull_request' >/dev/null 2>&1; then
                 continue
@@ -96,6 +141,10 @@ jobs:
           fi
 
           echo "Deferral promise is incomplete — replying with requirements."
+          # The reply is staged under the runner's temp dir (not a hardcoded
+          # /tmp path) so the behavioural test's TMPDIR containment binds and
+          # no artifact outlives a local run.
+          reply="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/reply.md"
           # Markdown emphasis next to an expansion MUST be braced: bash treats a
           # trailing `_` as part of the variable name, so `$COMMENT_URL_` is a
           # different, unset variable and `set -u` kills this script before the
@@ -114,5 +163,5 @@ jobs:
             echo "$problems"
             echo ""
             echo "_An untracked deferral is how flagged findings ship anyway — 63% of this repo's traceable escaped bugs were flagged and then deferred without follow-through. Checked disposition: ${COMMENT_URL}_"
-          } > /tmp/reply.md
-          gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$(cat /tmp/reply.md)" >/dev/null
+          } > "$reply"
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$(cat "$reply")" >/dev/null

--- a/.github/workflows/first-principles-review.yml
+++ b/.github/workflows/first-principles-review.yml
@@ -157,7 +157,33 @@ jobs:
             echo "::error::empty diff for $BASE_SHA...HEAD; failing closed."
             exit 1
           fi
-          raw="$(gh api "repos/$REPO/pulls/$PR" --jq '"Title: \(.title)\n\nDescription:\n\(.body // "")"' 2>/dev/null || true)"
+          # A title/description this step could not READ is not a PR without
+          # stated intent. `2>/dev/null || true` discarded both the error text
+          # and the exit status, so a transient API failure handed the reviewer
+          # an empty intent file and the lane judged a PR that appeared to
+          # state nothing -- blaming the author for a description the workflow
+          # never read. The common case is transient, so absorb it here rather
+          # than spending the author's re-run on it: up to three attempts with
+          # a short backoff. A read that never succeeds fails closed while
+          # naming the read as the cause; a genuinely empty description reads
+          # successfully on the first attempt and is judged as written, which
+          # is correct.
+          raw=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if raw="$(gh api "repos/$REPO/pulls/$PR" --jq '"Title: \(.title)\n\nDescription:\n\(.body // "")"')"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR title and description failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's title and description from the API after 3 attempts, so the review would judge a PR that appears to state no intent. This is a read failure, not a missing description -- re-run this job."
+            exit 1
+          fi
           # Strip embedded media: a screenshot-heavy body is pure cost to a
           # reviewer that judges prose, and an attachment URL is not intent.
           stripped="$(printf '%s' "$raw" | perl -0777 -pe 's/!\[[^\]]*\]\([^)]*\)/[image removed]/g; s{<img\b[^>]*>}{[image removed]}gi; s{<video\b.*?</video>}{[video removed]}gsi; s{<source\b[^>]*>}{[media removed]}gi; s{https?://\S*user-attachments\S*}{[media removed]}g' 2>/dev/null || printf '%s' "$raw")"

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -309,7 +309,33 @@ jobs:
           INTENT: ${{ runner.temp }}/pr-intent.txt
         run: |
           set -uo pipefail
-          raw="$(gh api "repos/$REPO/pulls/$PR" --jq '"Title: \(.title)\n\nDescription:\n\(.body // "")"' 2>/dev/null || true)"
+          # A title/description this step could not READ is not a PR without
+          # stated intent. `2>/dev/null || true` discarded both the error text
+          # and the exit status, so a transient API failure handed the reviewer
+          # an empty intent file and the lane judged a PR that appeared to
+          # state nothing -- blaming the author for a description the workflow
+          # never read. The common case is transient, so absorb it here rather
+          # than spending the author's re-run on it: up to three attempts with
+          # a short backoff. A read that never succeeds fails closed while
+          # naming the read as the cause; a genuinely empty description reads
+          # successfully on the first attempt and is judged as written, which
+          # is correct.
+          raw=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if raw="$(gh api "repos/$REPO/pulls/$PR" --jq '"Title: \(.title)\n\nDescription:\n\(.body // "")"')"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR title and description failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's title and description from the API after 3 attempts, so the review would judge a PR that appears to state no intent. This is a read failure, not a missing description -- re-run this job."
+            exit 1
+          fi
           # Strip embedded media: a screenshot-heavy body is pure cost to a
           # reviewer that judges prose, and an attachment URL is not intent.
           stripped="$(printf '%s' "$raw" | perl -0777 -pe 's/!\[[^\]]*\]\([^)]*\)/[image removed]/g; s{<img\b[^>]*>}{[image removed]}gi; s{<video\b.*?</video>}{[video removed]}gsi; s{<source\b[^>]*>}{[media removed]}gi; s{https?://\S*user-attachments\S*}{[media removed]}g' 2>/dev/null || printf '%s' "$raw")"

--- a/.github/workflows/pr-scope.yml
+++ b/.github/workflows/pr-scope.yml
@@ -51,14 +51,33 @@ jobs:
 
           # Vendored code and review screenshots are excluded: they inflate both
           # metrics without adding anything a reviewer must reason about.
-          files="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- . \
+          #
+          # A diff this step could not COMPUTE is not an empty diff.
+          # `2>/dev/null || true` collapsed a failed `git diff` (a base or head
+          # object absent after a force-push race, a pruned base branch) onto
+          # the same empty string as "no files changed", so the step printed
+          # "No reviewable files changed." having measured nothing. This check
+          # is advisory by contract -- it never fails the build -- so an
+          # uncomputable diff refuses to report a verdict instead: a loud
+          # warning, no scope claim, and still exit 0.
+          if ! files="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- . \
             ':(exclude)src/kiro_crew/_vendor/**' \
-            ':(exclude)temp-screenshots/**' \
-            2>/dev/null || true)"
-          lines="$(git diff --numstat "$BASE_SHA...$HEAD_SHA" -- . \
+            ':(exclude)temp-screenshots/**')"; then
+            echo "::warning::Could not compute the diff between the base and head commits, so this advisory check measured nothing. This is a read failure, not a self-contained scope -- re-run this job for a real measurement."
+            echo "PR scope was NOT measured: the diff could not be computed." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Same read, same failure mode, for the line count: keep the exit
+          # status out of the awk pipeline so a failed `git diff` cannot be
+          # summed into a legitimate-looking 0.
+          if ! numstat="$(git diff --numstat "$BASE_SHA...$HEAD_SHA" -- . \
             ':(exclude)src/kiro_crew/_vendor/**' \
-            ':(exclude)temp-screenshots/**' \
-            2>/dev/null | awk '{a+=$1; d+=$2} END {print a+d+0}')"
+            ':(exclude)temp-screenshots/**')"; then
+            echo "::warning::Could not compute the line-count diff between the base and head commits, so this advisory check measured nothing. This is a read failure, not a self-contained scope -- re-run this job for a real measurement."
+            echo "PR scope was NOT measured: the diff could not be computed." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          lines="$(printf '%s\n' "$numstat" | awk '{a+=$1; d+=$2} END {print a+d+0}')"
 
           if [ -z "$files" ]; then
             echo "No reviewable files changed."

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -1308,6 +1308,115 @@ class TestFirstPrinciplesIntentCapSurvivesALongBody:
         assert raw.decode("utf-8").split("\n", 1)[0] == "x" * 7999
 
 
+class TestIntentReadFailureFailsClosed:
+    """Execute the ACTUAL PR-intent read from both lanes with ``gh`` stubbed.
+
+    `2>/dev/null || true` used to collapse a failed API read onto the same
+    empty string as a PR with no description, so the reviewer judged a PR that
+    appeared to state no intent and the author was blamed for a description
+    the workflow never read. These cases pin the three outcomes apart: a read
+    that succeeds is judged as written, a transient failure is absorbed by the
+    bounded retry, and a read that never succeeds fails the step closed while
+    naming the read as the cause.
+    """
+
+    def _read_block(self, lane: str) -> str:
+        workflow = _workflow(lane)
+        step = (
+            "Fetch PR intent (untrusted data file)"
+            if lane.startswith("fork-")
+            else "Prefetch the change as data files"
+        )
+        script = _step_script(workflow, step)
+        start = script.index('raw=""')
+        end = script.index("# Strip embedded media")
+        return script[start:end]
+
+    def _run_read(
+        self, tmp_path: Path, lane: str, gh_status: int = 0, fail_first: int = 0
+    ):
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the read block is Bash; skip where Bash is absent")
+        body_file = tmp_path / "api-reply.txt"
+        body_file.write_text("Title: t\n\nDescription:\nprose\n", encoding="utf-8")
+        attempts = tmp_path / "gh-attempts"
+        gh = tmp_path / "gh"
+        stub = f'#!/bin/sh\nprintf x >> "{attempts}"\n'
+        if gh_status:
+            # Stand in for an API failure on every attempt (5xx, rate limit).
+            stub += f'echo "gh: could not reach the API" >&2\nexit {gh_status}\n'
+        elif fail_first:
+            stub += (
+                f'if [ "$(wc -c < "{attempts}")" -le {fail_first} ]; then\n'
+                '  echo "gh: HTTP 502" >&2\n'
+                "  exit 1\n"
+                "fi\n"
+                f'cat "{body_file}"\n'
+            )
+        else:
+            stub += f'cat "{body_file}"\n'
+        gh.write_text(stub, encoding="utf-8", newline="\n")
+        gh.chmod(0o755)
+        out_file = tmp_path / "raw-out.txt"
+        # Reproduce the step's own prologue (`pipefail` plus the runner's
+        # `bash -e`), then persist `$raw` so the assertion reads what the rest
+        # of the step would have been handed.
+        script = (
+            "set -uo pipefail\n"
+            + self._read_block(lane)
+            + f'\nprintf \'%s\' "$raw" > "{out_file}"\n'
+        )
+        result = subprocess.run(
+            [bash, "-e", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                # tmp_path first so the `gh` stub wins; starve any real gh of
+                # credentials so a stub-resolution failure can never turn into
+                # a live API call.
+                "PATH": f"{tmp_path}{os.pathsep}/usr/local/bin{os.pathsep}/usr/bin{os.pathsep}/bin",
+                "GH_TOKEN": "",
+                "GITHUB_TOKEN": "",
+                "LC_ALL": "C",
+                "REPO": "example/repo",
+                "PR": "1",
+                "TMPDIR": str(tmp_path),
+            },
+            cwd=tmp_path,
+        )
+        return result, attempts, out_file
+
+    @pytest.mark.parametrize("lane", FP_LANES)
+    def test_successful_read_is_judged_as_written(self, lane: str, tmp_path: Path):
+        result, attempts, out_file = self._run_read(tmp_path, lane)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out_file.read_text(encoding="utf-8").startswith("Title: t"), (
+            out_file.read_text(encoding="utf-8")
+        )
+        assert attempts.read_text(encoding="utf-8") == "x", "retry fired on a good read"
+
+    @pytest.mark.parametrize("lane", FP_LANES)
+    def test_transient_read_failure_is_absorbed(self, lane: str, tmp_path: Path):
+        result, attempts, out_file = self._run_read(tmp_path, lane, fail_first=1)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out_file.read_text(encoding="utf-8").startswith("Title: t")
+        assert attempts.read_text(encoding="utf-8") == "xx", "expected exactly one retry"
+
+    @pytest.mark.parametrize("lane", FP_LANES)
+    def test_unreadable_intent_fails_closed_not_silent(self, lane: str, tmp_path: Path):
+        # The failure this pins: a read that never succeeds must fail the step
+        # (re-runnable) instead of handing the reviewer an empty intent file.
+        result, attempts, _ = self._run_read(tmp_path, lane, gh_status=1)
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "This is a read failure, not a missing description" in result.stdout, (
+            result.stdout
+        )
+        assert attempts.read_text(encoding="utf-8") == "xxx", "expected three attempts"
+
+
 class TestForkFirstPrinciplesContractStateIsThreeValued:
     """`steps.contract.outputs.available` has three states and two of them are
     opposite facts.

--- a/test/test_fix_loop_discipline.py
+++ b/test/test_fix_loop_discipline.py
@@ -17,10 +17,14 @@ still there and still pointed at the same names.
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Iterator
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -449,3 +453,155 @@ class TestDeferralDiscipline:
         assert LABEL in text
         assert "Due: YYYY-MM-DD" in text
         assert "never deferrable" in text
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="the deferral step runs under bash on ubuntu-latest",
+)
+class TestDeferralCheckIssueReadFailure:
+    """Execute the ACTUAL deferral-validation step with ``gh`` stubbed.
+
+    `2>/dev/null || true` used to collapse a transient API failure onto the
+    same empty string as "this number is not an issue here", so a network blip
+    made every referenced follow-up look unresolvable and the checker posted a
+    refusal blaming the author for an untracked deferral they had in fact
+    tracked. These cases pin the outcomes apart: HTTP 404 keeps its meaning
+    (the reference does not resolve), a transient failure is absorbed by the
+    bounded retry, and a read that never succeeds fails the check closed
+    without posting the false refusal.
+    """
+
+    def _run_check(self, tmp_path: Path, mode: str):
+        bash = shutil.which("bash")
+        if bash is None:
+            pytest.skip("the step is Bash; skip where Bash is absent")
+        jq = shutil.which("jq")
+        if jq is None:
+            pytest.skip("the step shells out to jq; skip where jq is absent")
+        wf = yaml.safe_load(DEFERRAL_CHECK.read_text(encoding="utf-8"))
+        steps = wf["jobs"]["validate-deferral"]["steps"]
+        step = next(
+            (
+                s
+                for s in steps
+                if s.get("name") == "Check the deferral names a tracked follow-up issue"
+            ),
+            None,
+        )
+        assert step is not None, "deferral validation step not found"
+        issue_file = tmp_path / "issue.json"
+        issue_file.write_text(
+            '{"state":"open","labels":[{"name":"deferred-finding"}],'
+            '"assignees":[{"login":"owner"}],"body":"Due: 2031-01-01","milestone":null}',
+            encoding="utf-8",
+        )
+        attempts = tmp_path / "gh-attempts"
+        posts = tmp_path / "gh-posts"
+        gh = tmp_path / "gh"
+        # The stub serves two shapes: the comment POST at the refusal tail
+        # (recorded, never failed) and the issue read (mode-dependent).
+        stub = (
+            "#!/bin/sh\n"
+            'case "$*" in\n'
+            "  *comments*)\n"
+            f'    printf \'%s\\n\' "$*" >> "{posts}"\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            f'printf x >> "{attempts}"\n'
+        )
+        if mode == "persistent-failure":
+            stub += 'echo "gh: HTTP 500 Internal Server Error" >&2\nexit 1\n'
+        elif mode == "not-found":
+            stub += 'echo "gh: Not Found (HTTP 404)" >&2\nexit 1\n'
+        elif mode == "transient-then-good":
+            stub += (
+                f'if [ "$(wc -c < "{attempts}")" -le 1 ]; then\n'
+                '  echo "gh: HTTP 502 Bad Gateway" >&2\n'
+                "  exit 1\n"
+                "fi\n"
+                f'cat "{issue_file}"\n'
+            )
+        else:
+            stub += f'cat "{issue_file}"\n'
+        gh.write_text(stub, encoding="utf-8", newline="\n")
+        gh.chmod(0o755)
+        env = {
+            # tmp_path first so the `gh` stub wins; jq's own directory follows
+            # so the hermetic PATH still finds it on hosts where it does not
+            # live in a standard system dir. Starve any real gh of credentials
+            # so a stub-resolution failure can never turn into a live API call.
+            "PATH": (
+                f"{tmp_path}{os.pathsep}{Path(jq).parent}{os.pathsep}"
+                f"/usr/local/bin{os.pathsep}/usr/bin{os.pathsep}/bin"
+            ),
+            "GH_TOKEN": "",
+            "GITHUB_TOKEN": "",
+            "LC_ALL": "C",
+            "COMMENT_BODY": (
+                "<!-- ai-review-disposition target=gpt head=abc -->\n"
+                "- **finding**: accepted-and-deferred -- tracked in #123"
+            ),
+            "REPO": "example/repo",
+            "PR_NUMBER": "999",
+            "COMMENT_URL": "https://example.com/pr/999#comment-1",
+            "TMPDIR": str(tmp_path),
+        }
+        result = subprocess.run(
+            [bash, "-c", step["run"]],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        return result, attempts, posts
+
+    def test_tracked_deferral_passes_on_one_read(self, tmp_path: Path) -> None:
+        result, attempts, posts = self._run_check(tmp_path, "good")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "tracked by issue #123" in result.stdout, result.stdout
+        assert not posts.exists(), "a refusal was posted for a tracked deferral"
+        assert attempts.read_text(encoding="utf-8") == "x", "retry fired on a good read"
+
+    def test_transient_issue_read_is_absorbed(self, tmp_path: Path) -> None:
+        result, attempts, posts = self._run_check(tmp_path, "transient-then-good")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "tracked by issue #123" in result.stdout, result.stdout
+        assert not posts.exists(), "a refusal was posted despite the retry succeeding"
+        assert attempts.read_text(encoding="utf-8") == "xx", "expected exactly one retry"
+
+    def test_persistent_read_failure_fails_closed_without_blaming_the_author(
+        self, tmp_path: Path
+    ) -> None:
+        # The failure this pins: a read that never succeeds must fail the
+        # check (re-runnable) instead of posting a refusal that blames the
+        # author for an untracked deferral the checker never actually read.
+        # What IS posted is the unverified-state notice -- this lane has no
+        # PR-visible check row, so a silent red run would be a signal nobody
+        # sees.
+        result, attempts, posts = self._run_check(tmp_path, "persistent-failure")
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "This is a read failure, not an untracked deferral" in result.stdout, result.stdout
+        posted = posts.read_text(encoding="utf-8") if posts.exists() else ""
+        assert posted, "the unverified-state notice was never posted"
+        assert "Could not verify this deferral" in posted, posted
+        assert "not yet tracked" not in posted, "the false refusal was still posted"
+        assert attempts.read_text(encoding="utf-8") == "xxx", "expected three attempts"
+
+    def test_missing_issue_keeps_meaning_an_untracked_deferral(self, tmp_path: Path) -> None:
+        # HTTP 404 is the one failure that legitimately means "this reference
+        # does not resolve": the refusal path must still fire, on the first
+        # attempt, with no retry spent on it.
+        result, attempts, posts = self._run_check(tmp_path, "not-found")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Deferral promise is incomplete" in result.stdout, result.stdout
+        posted = posts.read_text(encoding="utf-8") if posts.exists() else ""
+        assert "not yet tracked" in posted, "the refusal reply was never posted"
+        assert attempts.read_text(encoding="utf-8") == "x", "a 404 must not be retried"
+        # The reply is staged under the step's temp dir, so this test's TMPDIR
+        # containment binds -- executing the real step must not leave an
+        # artifact at a hardcoded host path that outlives the run.
+        assert (tmp_path / "reply.md").exists(), "reply was not staged under TMPDIR"

--- a/test/test_pr_quality_gates.py
+++ b/test/test_pr_quality_gates.py
@@ -451,6 +451,129 @@ class TestPrScope:
         assert ":(exclude)temp-screenshots/**" in wf
 
 
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="the measure step runs under bash on ubuntu-latest",
+)
+class TestPrScopeMeasureLogic:
+    """Execute the real scope-measurement step with ``git`` stubbed.
+
+    The step is advisory by contract (it never exits nonzero), which is
+    exactly why a swallowed read failure was invisible: a failed ``git diff``
+    used to collapse onto the same empty string as "no files changed", and
+    the step reported a verdict -- "No reviewable files changed." -- about a
+    diff it never obtained. These cases pin which of the two empty results
+    produced the answer, without loosening the advisory contract.
+    """
+
+    def _run_measure(
+        self,
+        tmp_path: Path,
+        files_out: str = "",
+        numstat_out: str = "",
+        git_status: int = 0,
+        numstat_status: int = 0,
+    ):
+        wf = yaml.safe_load(_read("pr-scope.yml"))
+        steps = wf["jobs"]["pr-scope"]["steps"]
+        step = next((s for s in steps if s.get("name") == "Measure diff breadth"), None)
+        assert step is not None, "step 'Measure diff breadth' not found"
+        files_file = tmp_path / "files.txt"
+        files_file.write_text(files_out, encoding="utf-8")
+        numstat_file = tmp_path / "numstat.txt"
+        numstat_file.write_text(numstat_out, encoding="utf-8")
+        git = tmp_path / "git"
+        if git_status:
+            body = f'echo "fatal: bad object" >&2\nexit {git_status}\n'
+        else:
+            # The step reads the same range twice (`--name-only`, then
+            # `--numstat`); serve each call the matching fixture.
+            numstat_body = (
+                f'echo "fatal: bad object" >&2; exit {numstat_status}'
+                if numstat_status
+                else f'cat "{numstat_file}"'
+            )
+            body = (
+                'case "$*" in\n'
+                f"  *--numstat*) {numstat_body} ;;\n"
+                f'  *) cat "{files_file}" ;;\n'
+                "esac\n"
+            )
+        git.write_text(f"#!/bin/sh\n{body}", encoding="utf-8", newline="\n")
+        git.chmod(0o755)
+        summary = tmp_path / "summary.md"
+        summary.touch()
+        env = {
+            # tmp_path first so the `git` stub wins the lookup.
+            "PATH": f"{tmp_path}{os.pathsep}/usr/local/bin{os.pathsep}/usr/bin{os.pathsep}/bin",
+            "LC_ALL": "C",
+            "BASE_SHA": "1111111111111111111111111111111111111111",
+            "HEAD_SHA": "2222222222222222222222222222222222222222",
+            # Thresholds come from the step's own env stanza so the test
+            # exercises the values the workflow actually ships.
+            "MAX_AREAS": str(step["env"]["MAX_AREAS"]),
+            "MAX_LINES": str(step["env"]["MAX_LINES"]),
+            "GITHUB_STEP_SUMMARY": str(summary),
+            "TMPDIR": str(tmp_path),
+        }
+        result = subprocess.run(
+            ["bash", "-c", step["run"]],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        return result, summary.read_text(encoding="utf-8")
+
+    def test_measured_diff_reports_scope(self, tmp_path):
+        result, summary = self._run_measure(
+            tmp_path,
+            files_out="src/kiro_crew/session/state.py\n",
+            numstat_out="10\t2\tsrc/kiro_crew/session/state.py\n",
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "distinct areas: 1" in result.stdout, result.stdout
+        assert "### PR scope" in summary, summary
+
+    def test_empty_diff_is_a_real_verdict(self, tmp_path):
+        # A diff that READS successfully and is empty keeps its existing
+        # meaning: nothing reviewable changed.
+        result, _ = self._run_measure(tmp_path, files_out="", numstat_out="")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No reviewable files changed." in result.stdout, result.stdout
+
+    def test_uncomputable_diff_refuses_the_verdict_but_stays_advisory(self, tmp_path):
+        # The failure this pins: a failed `git diff` used to be swallowed into
+        # the same empty string as "no files changed", so the step claimed
+        # "No reviewable files changed." having measured nothing. The step must
+        # now refuse to report any scope claim -- while still exiting 0,
+        # because this gate's advisory contract (test_never_exits_nonzero)
+        # is deliberate.
+        result, summary = self._run_measure(tmp_path, git_status=128)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "read failure" in result.stdout, result.stdout
+        assert "::warning::" in result.stdout, result.stdout
+        assert "No reviewable files changed." not in result.stdout, result.stdout
+        assert "Scope looks self-contained." not in result.stdout, result.stdout
+        assert "NOT measured" in summary, summary
+
+    def test_uncomputable_line_count_also_refuses(self, tmp_path):
+        # The second read of the same range has the same failure mode, and its
+        # old form additionally piped the failure into `awk`, which summed
+        # nothing into a legitimate-looking 0.
+        result, summary = self._run_measure(
+            tmp_path,
+            files_out="src/kiro_crew/session/state.py\n",
+            numstat_status=128,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "read failure" in result.stdout, result.stdout
+        assert "Scope looks self-contained." not in result.stdout, result.stdout
+        assert "NOT measured" in summary, summary
+
+
 class TestDesignReviewBlocks:
     """A BLOCK verdict must reach the required `PR Readiness` status.
 


### PR DESCRIPTION
Closes #7474

## What

Three CI verdict-feeding sites read a fallible value with `2>/dev/null || true`, collapsing a read FAILURE onto the same empty string as a legitimately-empty result, so each gate reported a verdict about input it never obtained — the fail-open class #7426 removed from `screenshot-evidence.yml`. Each site gets its own fail-shape judgement:

- **`pr-scope.yml`** (fails open, highest priority): an uncomputable diff no longer prints "No reviewable files changed." The step refuses the verdict with a loud `::warning` and a step-summary note — while keeping its advisory never-fail contract (`test_never_exits_nonzero` forbids `exit 1`, so the failure branch exits 0). The `--numstat` read is separated from the `awk` pipeline so a failed diff cannot be summed into a legitimate-looking `0`.
- **`first-principles-review.yml` + `fork-first-principles-review.yml`**: a failed PR title/description read no longer hands the reviewer an empty intent file that blames the author for a description the workflow never read. Three attempts with short backoff absorb the transient class (matching the #7426 shape); a read that never succeeds fails the step closed, naming the read as the cause.
- **`disposition-deferral-check.yml`**: a transient API failure no longer makes every referenced follow-up look unresolvable (which posted a false refusal blaming the author). HTTP 404 keeps its meaning — the reference does not resolve; any other failure retries then fails the check closed WITHOUT posting the refusal, instead posting a "could not verify — re-run" notice (this lane has no PR-visible check row, so a silent red run is a signal nobody sees). The refusal reply is now staged under `RUNNER_TEMP`/`TMPDIR` instead of a hardcoded `/tmp/reply.md`.

## Tests

14 new behavioural tests execute the real step scripts with `git`/`gh` stubbed (hermetic env, tmp_path-first PATH, credentials starved), pinning the three outcomes apart per site: a successful-but-empty read keeps its existing meaning, a transient failure is absorbed by the bounded retry, a persistent failure fails closed. All mutation-verified in both directions: reverting each workflow fix turns the matching tests red (10 failed / 4 behavior-preserved on the original code), and the reviewer lane's independent 7-mutant sweep was all-caught. Full runs of the three touched test files: 300 passed. Gates green locally: black baseline, isort, flake8 7.1.0, subprocess-encoding, brand, harness, docs-lint.

Pre-push dual-model review: GPT lane 1 blocking (the `/tmp/reply.md` test side effect — fixed by containing the reply path in the workflow itself), Opus lane the same blocking plus 2 advisories (unverified-state notice — accepted, implemented; 5x backoff — rebutted below).

Rebutted advisory (backoff `sleep "$attempt"` vs `gh_read`'s `attempt * 5`): #7474's own suggested direction prescribes the #7426 shape ("three attempts with a short backoff, matching the `for attempt in` convention"), and a secondary-rate-limit window is cleared by neither 3s nor 15s of backoff, so the 5x multiplier buys none of the claimed benefit while tripling the behavioural tests' failure-path wall time.

## Pattern harvest

Rule candidate: a CI step that reads a fallible value must keep the read's exit status separate from the value — `if ! value="$(cmd)"; then fail-shape; fi` — and the fail-shape is a per-gate judgement: fail closed when the gate is blocking and re-runnable, refuse-the-verdict-loudly when the gate is contractually advisory, and preserve any failure mode that carries legitimate meaning (HTTP 404 = "does not resolve").
Class: `2>/dev/null || true` on verdict-feeding reads; 67 occurrences across 19 workflow files remain. The four sites named by #7474 are fixed here; the First Principles lane falsified the initial "rest are benign" classification — six further verdict-feeding reads (the five duplicated "Resolve human override" reads plus the codex round-convergence ledger read) are tracked in #7839. A lint over `.github/workflows/**` catching a NEW `2>/dev/null || true` whose value reaches a conditional is deferred per the issue's own scope note.



<!-- readiness-refresh 2026-09-02T10:36Z -->

