### PR TITLE
test: isolate the creation rate limiter's module-level buckets between tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1239,3 +1239,28 @@ def healthy_host_memory(monkeypatch: pytest.MonkeyPatch) -> None:
     # Also keeps the 5s-TTL refresh thread behind the cached verdict from
     # starting, so no test leaves one probing the host after it ends.
     monkeypatch.setattr(subagent, "cached_admission_check", _admit)
+
+
+@pytest.fixture(autouse=True)
+def _reset_create_rate_limit_buckets():
+    """Clear the session/folder creation rate limiter between tests.
+
+    ``kiro_crew.dashboard.create_rate_limit`` keeps its per-(verb, caller)
+    buckets in MODULE-LEVEL state (deliberately: the production guard needs no
+    durable state), so every session-creating test in a pytest process
+    accumulates timestamps under shared caller keys. A shard whose test
+    composition performs more than the per-window budget of creates within one
+    wall-clock window then refuses a legitimate test create with
+    ``create_rate_limited`` — a pass/fail outcome decided by shard composition
+    and runner speed, not the code under test (#7836; observed twice on the
+    Windows shard in one day, on PRs touching neither the limiter nor
+    session_control). The limiter's own direct tests build their scenarios on
+    top of a clean slate, so clearing between tests changes nothing for them.
+    """
+    from kiro_crew.dashboard import create_rate_limit
+
+    with create_rate_limit._lock:
+        create_rate_limit._buckets.clear()
+    yield
+    with create_rate_limit._lock:
+        create_rate_limit._buckets.clear()


### PR DESCRIPTION
## Problem / Motivation

`test/test_session_control.py` fails intermittently on CI with `SessionControlError: too many sessions created recently (code=create_rate_limited)` — observed twice today on the Windows shard 3, on two PRs whose diffs touch neither `session_control.py` nor the rate limiter (#7836).

## Why it matters

One flaky shard fails the whole CI run, and on fork PRs every AI review lane gates on run-level CI success — so each occurrence silently delays a full review round. Outcomes currently depend on shard composition and runner speed, not the code under test.

## What changed (motivation → approach → change)

Symptom: unrelated tests refused with `create_rate_limited`. Root cause: `kiro_crew.dashboard.create_rate_limit` keeps its per-(verb, caller) buckets in module-level state (deliberate in production — the guard needs no durable state), and nothing resets it between tests, so every session-creating test in a pytest process accumulates timestamps under shared caller keys; a shard performing more than the per-window budget (20 session-creates / 300s) trips the limiter mid-suite.

Change: one autouse fixture in `test/conftest.py` — following the existing `_reset_safety_override_between_tests` / `_reset_degraded_config_observations` pattern — clears `create_rate_limit._buckets` under the limiter's own `_lock` before and after every test. The limiter's direct tests (`test_create_rate_limit.py`) build their scenarios from a clean slate, so their behavior is unchanged; production code is untouched.

## Tests

No new tests — this IS test infrastructure. Verified the two suites nearest the change: `test_create_rate_limit.py` + `test_session_control.py`, 150/150 passing locally, plus black/flake8/isort on the touched file.

## Manual verification

N/A — the change is a test fixture; the affected suites passing is the verification.

## Related Issues

Fixes #7836

## Pattern harvest

Rule candidate: review-prompt
Pattern: "module-level mutable state (rate limiters, caches, observation sets) needs a conftest reset fixture the moment it ships — any test exercising the code path inherits every earlier test's state"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
