### PR TITLE
docs: make the README's channel list and capability claims match the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,8 @@ need an explicit opt-in there.
 
 **Messaging channels are optional**: the default `kirocrew setup` configures
 none, and the dashboard + CLI work without any channel credentials. Connect
-Slack, Discord, Telegram, Teams, Webex, WeCom, or WeChat later, or run
-`kirocrew setup --slack` for the guided Slack path.
+Slack, Discord, Telegram, Teams, Webex, WeCom, WeChat, WhatsApp, Feishu, or
+iMessage later, or run `kirocrew setup --slack` for the guided Slack path.
 
 ## Development Skills (agents and humans)
 

--- a/README.md
+++ b/README.md
@@ -193,10 +193,13 @@ without messaging credentials. Add a messaging channel —
 [Teams](src/kiro_crew/docs/teams-integration.md),
 [Webex](src/kiro_crew/docs/webex-integration.md),
 [WeCom](src/kiro_crew/docs/wecom-integration.md),
-[WeChat](src/kiro_crew/docs/weixin-integration.md), or
-[WhatsApp](src/kiro_crew/docs/whatsapp-integration.md) — when you want to continue
+[WeChat](src/kiro_crew/docs/weixin-integration.md),
+[WhatsApp](src/kiro_crew/docs/whatsapp-integration.md),
+[Feishu](src/kiro_crew/docs/feishu-integration.md), or
+[iMessage](src/kiro_crew/docs/imessage-integration.md) — when you want to continue
 working with the same agent away from the dashboard. Apart from Teams (which
-needs a public HTTPS webhook — see its guide), these channels connect
+needs a public HTTPS webhook — see its guide) and iMessage (which talks to
+Messages.app on the same Mac), these channels connect
 outbound, so you do not need to expose the dashboard port publicly.
 
 ### Docker
@@ -284,7 +287,7 @@ The complete inventory is in [Features](src/kiro_crew/docs/index.md) and
 
 ```mermaid
 flowchart TD
-    S["Desktop app · Web dashboard · CLI · Messaging channels (Slack, Discord, Telegram, Teams, Webex, WeCom, WeChat)"]
+    S["Desktop app · Web dashboard · CLI · Messaging channels (Slack, Discord, Telegram, Teams, Webex, WeCom, WeChat, WhatsApp, Feishu, iMessage)"]
     G["Gateway<br/>access · sessions · memory · schedules · approvals · apps"]
     A["Agent sessions<br/>ACP runtime · kiro-cli · MCP tools · models"]
     S --> G --> A
@@ -338,9 +341,12 @@ logical isolation boundary, not necessarily one OS process.
 | **Telegram** | Reach your agent from private DMs on your phone or laptop, with streaming replies, inline approvals, and commands. |
 | **Discord** | Work from DMs with streaming replies and approvals delivered as message buttons. |
 | **Teams** | Reach your agent from Microsoft Teams chats — replies arrive as complete messages, and approvals are answered by typing. |
-| **Webex** | Work from Webex direct messages with streaming replies and inline approvals. |
+| **Webex** | Work from Webex direct messages with inline approvals; progress shows as edits to one message, which the finished answer replaces. |
 | **WeCom** | Chat through an outbound-connected WeCom AI bot with configured user access and streaming replies. |
-| **WeChat (Weixin)** | Reach your agent from WeChat with configured user access and streaming replies. |
+| **WeChat (Weixin)** | Reach your agent from WeChat with configured user access; a typing indicator runs while the turn works and the reply arrives as complete messages. |
+| **WhatsApp** | Reach your agent from WhatsApp with streaming replies, file exchange, and reactions. |
+| **Feishu (Lark)** | Chat from Feishu DMs and allow-listed group chats through a custom app bot on an outbound long connection — replies arrive as complete messages. |
+| **iMessage** | Chat from the Messages app on your own Mac and Apple devices, with no bot to register and no token to paste — replies arrive as complete messages. |
 | **CLI** | Fast interactive chat and direct automation with `kirocrew chat`, `run`, `cron`, `spawn`, and `security`. |
 
 **Choose how work starts.**
@@ -615,7 +621,7 @@ performance metrics that never leave your machine. See
 | Install and packaging | [Install and build](docs/guides/install.md), [Windows](docs/guides/windows-install.md), [Docker](docs/guides/docker.md), [Desktop](docs/build/desktop-app.md), [Remote host](docs/guides/remote-and-mobile.md), [Release process](docs/build/release.md) |
 | Product capabilities | [Features](src/kiro_crew/docs/index.md), [Skills](skills/README.md), [All user docs](src/kiro_crew/docs/README.md) |
 | All documentation | [docs/](docs/README.md) for contributor and architecture docs |
-| Channels | [Slack](docs/guides/slack-setup.md), [Discord](src/kiro_crew/docs/discord-integration.md), [Telegram](src/kiro_crew/docs/telegram-integration.md), [Teams](src/kiro_crew/docs/teams-integration.md), [Webex](src/kiro_crew/docs/webex-integration.md), [WeCom](src/kiro_crew/docs/wecom-integration.md), [WeChat (Weixin)](src/kiro_crew/docs/weixin-integration.md), [WhatsApp](src/kiro_crew/docs/whatsapp-integration.md) |
+| Channels | [Slack](docs/guides/slack-setup.md), [Discord](src/kiro_crew/docs/discord-integration.md), [Telegram](src/kiro_crew/docs/telegram-integration.md), [Teams](src/kiro_crew/docs/teams-integration.md), [Webex](src/kiro_crew/docs/webex-integration.md), [WeCom](src/kiro_crew/docs/wecom-integration.md), [WeChat (Weixin)](src/kiro_crew/docs/weixin-integration.md), [WhatsApp](src/kiro_crew/docs/whatsapp-integration.md), [Feishu (Lark)](src/kiro_crew/docs/feishu-integration.md), [iMessage](src/kiro_crew/docs/imessage-integration.md) |
 | Architecture | [System architecture](docs/architecture/overview.md), [Memory](docs/system-specs/modules/memory-skills-hooks.md), [MCP](docs/architecture/mcp.md), [App Kit](docs/app-kit/getting-started.md) |
 | Trust and dependencies | [Security](docs/architecture/security-deep-dive.md), [Security policy](SECURITY.md) |
 | Project work | [Contributing](CONTRIBUTING.md), [Tenets](TENETS.md), [Governance](GOVERNANCE.md), [Maintainers](MAINTAINERS.md), [AI assistant rules](AGENTS.md), [Changelog](CHANGELOG.md) |


### PR DESCRIPTION
## Problem / Motivation

Two related drifts in the README's channel tables, both found by checking the transports rather than another prose list.

**Channels that ship but are not listed.** `src/kiro_crew/docs/index.md` — the packaged, user-facing feature index — lists **ten** chat channels. The README and `CONTRIBUTING.md` listed seven or eight, and the two absent from every one of those lists were **Feishu (Lark)** and **iMessage**. Both are fully shipped: a config section in `config/loader.py`, a `TransportCapabilities` declaration, a `MessagingTransport`, tests, and a packaged setup guide. `README.md` did not contain either string once.

**Two rows claimed a capability their transport does not have.** The Webex and WeChat rows both said "streaming replies", while `webex/transport.py:71` and `weixin/transport.py:67` declare `streaming=False`.

## Why it matters

The README is the front door. A reader deciding whether Kiro Crew fits their setup cannot discover a channel that already exists and needs no work — they conclude it is unsupported and stop. That is the expensive kind of doc gap: it costs a user who would have succeeded.

A wrong capability claim costs differently. Someone picks Webex or WeChat *because* the table promised streaming, and finds out after setup that the answer arrives in one bubble. `AGENTS.md` names the general case: *"a doc nobody updated is worse than no doc, because readers still trust it."*

## What changed (motivation → approach → change)

Four lists were behind, by different amounts:

| List | Had | Missing |
|---|---|---|
| README "Add a messaging channel" paragraph | 8 | Feishu, iMessage |
| README architecture diagram, surfaces node | 7 | WhatsApp, Feishu, iMessage |
| README Surfaces table | 7 rows | WhatsApp, Feishu, iMessage |
| `CONTRIBUTING.md` "Connect … later" | 7 | WhatsApp, Feishu, iMessage |

Three details are deliberate rather than mechanical.

**The two corrected rows are corrected differently, because the two cases are not the same failure.** A find-and-replace of "streaming replies" would have been wrong for one of them:

- **WeChat has no streaming at all.** `weixin/turn_renderer.py`: *"iLink has no message-edit / streaming primitive: every `sendmessage` creates a NEW chat bubble … this renderer BUFFERS the whole turn and emits it once on `on_done`"*, with the native typing indicator *"the only progress affordance iLink offers"*. So its row now names the typing indicator and says the reply arrives as complete messages.
- **Webex does show progress, just not a token stream.** `webex/renderer.py` posts a placeholder and edits it into the answer, bounded by a 10-edit budget its docstring calls *"the whole design"* (*"a typewriter edit-stream is structurally impossible"*). So its row says progress shows as edits to one message, which the finished answer replaces.

**WeCom keeps its "streaming replies" wording**, because it earns it: `streaming=True`, and its renderer emits throttled replace-in-place stream frames over WS.

**The three new Surfaces rows describe each channel rather than copying a neighbour.** Feishu and iMessage both declare `streaming=False`, so they say replies arrive as complete messages — the phrasing the Teams row already uses — instead of inheriting the "streaming replies" every DM row around them carries.

**The outbound-connection sentence gained a second exception.** It read *"Apart from Teams (which needs a public HTTPS webhook), these channels connect outbound, so you do not need to expose the dashboard port publicly."* iMessage talks to Messages.app on the same Mac; adding it to the list above that sentence without amending the clause would have made the sentence false for one of its own members.

## Tests

N/A — documentation only, no code path changes. The two gates that own this content pass:

```
./scripts/docs-lint.sh
  docs-lint: scanned 259 markdown files under docs, src/kiro_crew/docs, website/docs
  All documentation checks passed

BRAND_BASE_REF=upstream/main python3 scripts/check_brand_name.py
  brand gate: no misspellings of 'Kiro Crew' in the lines added since upstream/main ✓
```

## Manual verification

Every claim was checked against code, not inferred:

- the ten channels come from the `*Config` fields in `src/kiro_crew/config/loader.py` — slack, wecom, telegram, weixin, whatsapp, feishu, discord, webex, teams, imessage
- each added link target exists in `src/kiro_crew/docs/` and is reachable from that directory's index (docs-lint enforces the second half)
- `streaming` was read off all ten `*_CAPABILITIES` declarations: True for slack, wecom, telegram, discord, whatsapp; False for feishu, weixin, teams, webex, imessage. The table's claims now match that split
- the WeChat and Webex behaviour statements come from `weixin/turn_renderer.py` and `webex/renderer.py`'s own docstrings, quoted above
- the iMessage locality claim comes from `imessage-integration.md`; the Feishu long-connection claim from `feishu-integration.md`

No new markdown file, no second doc on the subject, no index changes needed — every target was already indexed.

## Related Issues

None open for this.

The capability half of the change is a follow-up to the **Design Review** bot's side-observation on the first revision of this PR, which applied the change's own accuracy standard to the rows it had not touched and found Webex and WeChat. I verified both independently before acting on it, and the verification is what produced the two *different* corrections above — the bot's finding was directionally right but treating them alike would have understated Webex.
