### PR TITLE
docs(aws-control): state why the backup push budget is an hour (#7086)

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
@@ -57,6 +57,15 @@ logger = logging.getLogger(__name__)
 APP_NAME = "aws-control"
 KIND_SNAPSHOT = "snapshot"
 KIND_SESSIONS = "sessions"
+
+#: Wall clock for one backup push to S3, passed by both runners into
+#: :func:`storage.put_file` rather than relying on its 600s default. The
+#: nightly snapshot push runs unattended, and an owner-triggered sessions
+#: archive may legitimately need the full hour -- the size ceiling is
+#: ``storage._MAX_PINNED_TRANSFER_BYTES`` (5 GiB), which at 3600s still
+#: requires a ~12 Mbit/s uplink, so a slower push fails at the bound rather
+#: than holding the owner-billed transfer open indefinitely. Tests assert the
+#: constant reaches the uploader on both paths, so it cannot go unread.
 _PUSH_TIMEOUT_SECS = 3600
 
 


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

Issue #7086 reported that `_PUSH_TIMEOUT_SECS = 3600` in `aws_control`'s `backup.py` was declared but never applied, and that it was the only tunable in the file with no `#:` rationale comment.

The functional half is already resolved on main: commit `a8058303a` (PR #7082) wired `timeout=_PUSH_TIMEOUT_SECS` into both `storage.put_file` call sites and added tests asserting the forwarding on both paths. What remains from the issue is the missing rationale comment -- the constant still gives a reader no way to know why the bound is an hour, which matters on a cloud-spend path where the next person to touch the number needs the reasoning, not just the value.

## Why it matters

`_PUSH_TIMEOUT_SECS` bounds an unattended, owner-billed S3 transfer. An undocumented magic number on that path invites two bad edits: shrinking it back toward `put_file`'s 600s default (recreating the truncated-push bug #7082 fixed) or growing it without noticing the transfer is owner-billed and should fail at a bound rather than hang open. The comment ties the value to the constraints that produced it.

## What changed (motivation -> approach -> change)

Comment-only diff: a `#:` rationale block above `_PUSH_TIMEOUT_SECS` in `src/kiro_crew/apps/builtins/aws_control/backend/backup.py`. It states what the constant bounds (wall clock for one push, passed by both runners instead of `put_file`'s 600s default), which callers need it (the unattended nightly snapshot push, and an owner-triggered sessions archive that may legitimately need the full hour), and the arithmetic anchoring the value (the `storage._MAX_PINNED_TRANSFER_BYTES` 5 GiB ceiling at 3600s still requires a ~12 Mbit/s uplink, so a slower push fails at the bound rather than holding the owner-billed transfer open indefinitely).

The comment distinguishes the two call paths deliberately: the nightly hook runs only the snapshot backup; the sessions backup is reachable solely from the owner-driven HTTP handler. An earlier draft merged the two, which would have had a reader sizing the unattended path against the multi-GB sessions archive.

The issue's two open questions -- whether 3600s is still the right value, and whether the nightly loop should carry an outer `asyncio.wait_for` -- are product decisions deliberately not taken here. Fixing by wiring already happened in #7082; this PR completes the issue's remaining documentation ask without changing behavior.

## Tests

No test changes: the forwarding assertions for both push paths already exist in `test/test_aws_control_backup.py` (from #7082), and a comment has no testable behavior. `python -m pytest test/test_aws_control_backup.py` passes (23 tests), and `isort` / `flake8` / `mypy` are clean on the touched file (mypy output byte-identical to main).

## Manual verification

N/A -- comment-only change, zero executable lines touched; unit coverage of the surrounding behavior is unchanged and green.

## Related Issues

Closes #7086

## Pattern harvest

Rule candidate: lint
Pattern: module-level tunable constant (timeout/limit/threshold) without a `#:` rationale comment stating the constraint that produced its value

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
