### PR TITLE
fix(test): reset the create-rate-limit bucket between session-control tests

### DIFF
--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -22,6 +22,7 @@ from chat_test_helpers import _make_state
 
 from kiro_crew.config import loader
 from kiro_crew.dashboard import chat_delivery as cd
+from kiro_crew.dashboard import create_rate_limit
 from kiro_crew.dashboard import session_control as sc
 from kiro_crew.dashboard import stop_retry
 from kiro_crew.dashboard.chat_utils import slot_history_key
@@ -51,6 +52,30 @@ def _fresh_stop_windows():
     stop_retry.reset_for_tests()
     yield
     stop_retry.reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_create_budget():
+    """The create-rate-limit bucket is process-wide module state, keyed per caller.
+
+    Every test here builds its caller as ``_slot(state, "chat-1")``, so they all
+    share one bucket key, and the budget is 20 creates per 300 s. This file makes
+    more than that, and the tests run far faster than the window — so without this
+    reset the creates ACCUMULATE and a later test is refused a create it is the
+    first to ask for, failing on ``create_rate_limited`` instead of exercising
+    whatever it was written for.
+
+    Sharding is why this reads as an intermittent CI failure rather than a
+    permanent one: ``pytest-split`` distributes this file across groups, so
+    whether any one group carries enough creates to cross the budget depends on
+    the split. Running the file whole fails deterministically.
+
+    Same shape as ``test_create_rate_limit.py`` and ``test_chat_folder_cap.py``,
+    which already reset this bucket.
+    """
+    create_rate_limit.reset_for_tests()
+    yield
+    create_rate_limit.reset_for_tests()
 
 
 def _slot(state, name: str, **kwargs):


### PR DESCRIPTION
## Problem / Motivation

`Backend Tests (Windows) (3)` fails intermittently on `main` with two tests refused a session create:

```
test/test_session_control.py::test_the_audit_write_does_not_run_on_the_event_loop
test/test_session_control.py::test_the_created_agent_name_is_sanitized_before_storage
  kiro_crew.dashboard.session_control.SessionControlError: too many sessions created recently; retry shortly
```

Observed on `main` in 2 of the 9 `ci.yml` runs that completed that job in a ~5.5-hour window — runs [33604886863](https://github.com/kirodotdev/KiroCrew/actions/runs/33604886863) (`be2ee947`) and [33599188871](https://github.com/kirodotdev/KiroCrew/actions/runs/33599188871) (`aaad3571`), with byte-identical annotations.

**It is not actually intermittent.** `create_rate_limit._buckets` is process-wide module state keyed `(verb, caller_key)`. Every test in `test/test_session_control.py` builds its caller as `_slot(state, "chat-1")`, so `_key()` returns the same `caller_key` for all of them, and the file has **36 `create_session(` call sites** against a budget of **20 per 300 s** (`MAX_SESSION_CREATES_PER_WINDOW` / `WINDOW_SECS`). The file runs in ~1.5 s — three orders of magnitude inside the window — so the creates accumulate and the 21st onward is refused.

Running the file whole fails **deterministically**:

```
$ pytest test/test_session_control.py
2 failed, 140 passed in 4.69s
```

What makes it *look* intermittent in CI is `pytest-split`: it distributes this file across 4 groups, so whether any one group carries more than 20 creates depends on the split, and the split shifts as tests are added. That also explains why the same shard number passes on 3.10/3.12 while Windows fails — nothing about the failure is platform-specific, only which tests land together.

The file already resets one piece of process-wide state (`stop_retry`) in an autouse fixture; this bucket was simply missed.

## Why it matters

The failure is attributed to whichever test happens to be past the boundary rather than to the cause, so it reads as a defect in `test_the_audit_write_does_not_run_on_the_event_loop` — a test about SEL construction threading — when nothing in that test is broken. A reader who trusts the failure location debugs the wrong subsystem.

It also costs real throughput: the job is part of the `PR Readiness` aggregate, so an unrelated PR inherits a red readiness signal roughly a fifth of the time, and re-running is a ~78% coin flip rather than a fix. Fork contributors cannot even do that — `gh run rerun --failed` returns `Must have admin rights to Repository`.

And it degrades the guard's own test value: once the bucket is saturated, later tests in the file exercise the rate-limit refusal path instead of the behaviour they were written for, so a regression in that behaviour would not be caught.

## What changed (motivation → approach → change)

**Motivation:** the tests must be independent of each other; a create budget consumed by an earlier test is not a property any of these tests is asserting.

**Approach:** reset the bucket per test rather than raising the budget or spreading the caller keys. Raising `MAX_SESSION_CREATES_PER_WINDOW` would weaken a production security control to accommodate a test artifact — that budget is deliberately sized (the module docstring explains it bounds an auto-approved verb against a creation loop). Giving each test a distinct caller key would work but touches 93 call sites and would silently stop covering the shared-caller case. Resetting is what the repo already does elsewhere: `test_create_rate_limit.py` and `test_chat_folder_cap.py` both call `create_rate_limit.reset_for_tests()`, and `reset_for_tests()` exists for exactly this ("module state would otherwise leak across tests").

**Change:** one import plus one autouse fixture in `test/test_session_control.py`, placed beside the existing `_fresh_stop_windows` fixture and shaped identically. No production code changes; no test assertions changed.

```
test/test_session_control.py | 25 +++++++++++++++++++++++++
1 file changed, 25 insertions(+)
```

## Tests

Reproduced first, then fixed — the before/after is the evidence:

```
before:  2 failed, 140 passed in 4.69s
after:   142 passed in 1.46s
```

Confirmed no interaction with the two files that already reset this bucket:

```
$ pytest test/test_session_control.py test/test_create_rate_limit.py test/test_chat_folder_cap.py
154 passed in 1.66s
```

And under CI's own sharding, all four groups green:

```
--splits 4 --group 1   36 passed, 106 deselected
--splits 4 --group 2   36 passed, 106 deselected
--splits 4 --group 3   36 passed, 106 deselected
--splits 4 --group 4   34 passed, 108 deselected
```

No new test is added: the fixture's correctness is demonstrated by the 2 pre-existing failures it clears. A test asserting "the bucket is empty at test start" would assert the fixture against itself.

## Manual verification

Run on macOS arm64 (Python 3.12) against `main` at `8ebf6a87`. Because the repo's dev extras carry a pre-existing pin conflict (`kirocrew:dev` pins `pytest-asyncio==0.20.3` while `[dev]` wants `>=0.21`), the suite was run against the package's own `install_requires` rather than the dev extra:

```
PYTHONPATH=src:test uv run --no-project --python 3.12 \
  --with . --with pytest==9.0.3 --with pytest-asyncio==0.20.3 --with hypothesis \
  --with pytest-timeout --with pytest-xdist==3.5.0 --with pytest-split==0.11.0 \
  python -m pytest test/test_session_control.py -q -o addopts=""
```

I did **not** reproduce on Windows. The mechanism is platform-independent (module-level state, a monotonic window, and the split), and the identical annotation on Linux `main` runs supports that, but I am stating the gap rather than implying I checked it.

## Related Issues

None — this flake does not have an issue filed. Raising one to immediately supersede it with this PR seemed like noise; happy to file one if maintainers prefer the paper trail.

Noticed while investigating #7522 / #7553, where this same job was the only red on a fork PR whose diff cannot reach `session_control`. That is context, not a dependency: this stands alone and touches no file either of those does.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: a test file that exercises a guard backed by **process-wide module state** must reset that state per test, or the guard's own budget leaks between tests and the failure surfaces on an unrelated test past the boundary. The tell is a module-level mutable (`_buckets`, `_last_sweep`) plus a `reset_for_tests()` helper that some test files call and others do not.

The generalizable check: for each module exposing `reset_for_tests()`, every test file that transitively drives it should reset it. `create_rate_limit` had 2 of 3 callers doing so. That is mechanically checkable and would have caught this before it reached CI.

A second, sharper observation: `pytest-split` converts order-dependent failures into *apparently* flaky ones, which is worse than a hard failure because the usual response is a re-run. Anything that fails deterministically when a file runs whole but intermittently under sharding is this class, and the fix is never a re-run.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — no new functionality; 2 pre-existing failures cleared, 142/142 green
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: test-isolation fix, no user-facing or developer-facing doc surface
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
