### PR TITLE
fix(ci): fail review lanes closed when the override or ledger read fails (#7839)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -138,11 +138,37 @@ jobs:
         run: |
           exact="<!-- ai-review-human-override target=fable head=$HEAD "
           all="<!-- ai-review-human-override target=all head=$HEAD "
-          record="$(gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null \
+          # A comments feed this step could not READ is not a PR with no
+          # override recorded. `2>/dev/null || true` discarded both the error
+          # text and the exit status, so a transient API failure collapsed
+          # onto the same empty string as "no override recorded" and the lane
+          # re-gated a verdict a human had already cleared with
+          # /ai-review override. The common case is transient, so absorb it
+          # here: up to three attempts with a short backoff. A read that never
+          # succeeds fails this run CLOSED while naming the read as the cause;
+          # a PR genuinely carrying no override still reads successfully and
+          # resolves to inactive, as before.
+          comments=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if comments="$(gh api "repos/$REPO/issues/$PR/comments" --paginate)"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR comments failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's comments after 3 attempts, so this lane cannot tell whether a human override is recorded for $HEAD. Failing closed rather than re-gating a verdict a human may have cleared -- re-run this job."
+            exit 1
+          fi
+          record="$(printf '%s' "$comments" \
             | jq -sr --arg exact "$exact" --arg all "$all" \
               'add // [] | [.[] | select(.user.login == "github-actions[bot]")
               | select((.body | startswith($exact)) or (.body | startswith($all)))]
-              | (last.body // "")' 2>/dev/null || true)"
+              | (last.body // "")')"
           actor="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\1/p')"
           source="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\2/p')"
           if [ -n "$actor" ] && [ -n "$source" ]; then

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -87,11 +87,37 @@ jobs:
         run: |
           exact="<!-- ai-review-human-override target=gpt head=$HEAD "
           all="<!-- ai-review-human-override target=all head=$HEAD "
-          record="$(gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null \
+          # A comments feed this step could not READ is not a PR with no
+          # override recorded. `2>/dev/null || true` discarded both the error
+          # text and the exit status, so a transient API failure collapsed
+          # onto the same empty string as "no override recorded" and the lane
+          # re-gated a verdict a human had already cleared with
+          # /ai-review override. The common case is transient, so absorb it
+          # here: up to three attempts with a short backoff. A read that never
+          # succeeds fails this run CLOSED while naming the read as the cause;
+          # a PR genuinely carrying no override still reads successfully and
+          # resolves to inactive, as before.
+          comments=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if comments="$(gh api "repos/$REPO/issues/$PR/comments" --paginate)"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR comments failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's comments after 3 attempts, so this lane cannot tell whether a human override is recorded for $HEAD. Failing closed rather than re-gating a verdict a human may have cleared -- re-run this job."
+            exit 1
+          fi
+          record="$(printf '%s' "$comments" \
             | jq -sr --arg exact "$exact" --arg all "$all" \
               'add // [] | [.[] | select(.user.login == "github-actions[bot]")
               | select((.body | startswith($exact)) or (.body | startswith($all)))]
-              | (last.body // "")' 2>/dev/null || true)"
+              | (last.body // "")')"
           actor="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\1/p')"
           source="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\2/p')"
           if [ -n "$actor" ] && [ -n "$source" ]; then
@@ -301,11 +327,34 @@ jobs:
           # anyone can comment on a public-repo PR, so the marker prefix alone
           # is forgeable and author identity is what carries the authority.
           # The ledger is capped and nonce-fenced like PR INTENT, and it can
-          # only DOWNGRADE repetition, never approve anything. Fail-soft: on
-          # any fetch error the review runs without a ledger, which is exactly
-          # the no-ledger behavior.
-          comments_json="$(gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null \
-            | jq -s 'add // []' 2>/dev/null || printf '[]')"
+          # only DOWNGRADE repetition, never approve anything. A comments feed
+          # this step could not READ is not a PR with no prior rulings: the
+          # old fail-soft (`2>/dev/null ... || printf '[]'`) collapsed a
+          # failed read onto "no ledger", so a transient API failure
+          # re-litigated findings a writer had already disposed. Absorb the
+          # transient class with a bounded retry; a COMMENTS read that never
+          # succeeds fails this run CLOSED while naming the read as the cause
+          # -- re-running the job is cheaper than re-litigating disposed
+          # findings. (The collaborator-permission read below still fail-opens
+          # to "not a writer"; that residual half is tracked separately and
+          # needs 404-vs-transport handling, not this mechanical shape.)
+          ledger_comments=""
+          ledger_read_ok=""
+          for attempt in 1 2 3; do
+            if ledger_comments="$(gh api "repos/$REPO/issues/$PR/comments" --paginate)"; then
+              ledger_read_ok=1
+              break
+            fi
+            echo "Reading the PR comments for the convergence ledger failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$ledger_read_ok" ]; then
+            echo "::error::Could not read this PR's comments after 3 attempts, so the round-convergence ledger cannot be built and previously disposed findings would be re-litigated. Failing closed -- re-run this job."
+            exit 1
+          fi
+          comments_json="$(printf '%s' "$ledger_comments" | jq -s 'add // []')"
           disp_authors="$(printf '%s' "$comments_json" \
             | jq -r '.[] | select((.body // "") | startswith("<!-- ai-review-disposition ")) | (.user.login // empty)' 2>/dev/null \
             | sort -u || true)"

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -54,11 +54,37 @@ jobs:
         run: |
           exact="<!-- ai-review-human-override target=design head=$HEAD "
           all="<!-- ai-review-human-override target=all head=$HEAD "
-          record="$(gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null \
+          # A comments feed this step could not READ is not a PR with no
+          # override recorded. `2>/dev/null || true` discarded both the error
+          # text and the exit status, so a transient API failure collapsed
+          # onto the same empty string as "no override recorded" and the lane
+          # re-gated a verdict a human had already cleared with
+          # /ai-review override. The common case is transient, so absorb it
+          # here: up to three attempts with a short backoff. A read that never
+          # succeeds fails this run CLOSED while naming the read as the cause;
+          # a PR genuinely carrying no override still reads successfully and
+          # resolves to inactive, as before.
+          comments=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if comments="$(gh api "repos/$REPO/issues/$PR/comments" --paginate)"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR comments failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's comments after 3 attempts, so this lane cannot tell whether a human override is recorded for $HEAD. Failing closed rather than re-gating a verdict a human may have cleared -- re-run this job."
+            exit 1
+          fi
+          record="$(printf '%s' "$comments" \
             | jq -sr --arg exact "$exact" --arg all "$all" \
               'add // [] | [.[] | select(.user.login == "github-actions[bot]")
               | select((.body | startswith($exact)) or (.body | startswith($all)))]
-              | (last.body // "")' 2>/dev/null || true)"
+              | (last.body // "")')"
           actor="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\1/p')"
           source="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\2/p')"
           if [ -n "$actor" ] && [ -n "$source" ]; then

--- a/.github/workflows/first-principles-review.yml
+++ b/.github/workflows/first-principles-review.yml
@@ -198,11 +198,37 @@ jobs:
         run: |
           exact="<!-- ai-review-human-override target=first-principles head=$HEAD "
           all="<!-- ai-review-human-override target=all head=$HEAD "
-          record="$(gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null \
+          # A comments feed this step could not READ is not a PR with no
+          # override recorded. `2>/dev/null || true` discarded both the error
+          # text and the exit status, so a transient API failure collapsed
+          # onto the same empty string as "no override recorded" and the lane
+          # re-gated a verdict a human had already cleared with
+          # /ai-review override. The common case is transient, so absorb it
+          # here: up to three attempts with a short backoff. A read that never
+          # succeeds fails this run CLOSED while naming the read as the cause;
+          # a PR genuinely carrying no override still reads successfully and
+          # resolves to inactive, as before.
+          comments=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if comments="$(gh api "repos/$REPO/issues/$PR/comments" --paginate)"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR comments failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's comments after 3 attempts, so this lane cannot tell whether a human override is recorded for $HEAD. Failing closed rather than re-gating a verdict a human may have cleared -- re-run this job."
+            exit 1
+          fi
+          record="$(printf '%s' "$comments" \
             | jq -sr --arg exact "$exact" --arg all "$all" \
               'add // [] | [.[] | select(.user.login == "github-actions[bot]")
               | select((.body | startswith($exact)) or (.body | startswith($all)))]
-              | (last.body // "")' 2>/dev/null || true)"
+              | (last.body // "")')"
           actor="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\1/p')"
           source="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\2/p')"
           if [ -n "$actor" ] && [ -n "$source" ]; then

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -92,11 +92,37 @@ jobs:
         run: |
           exact="<!-- ai-review-human-override target=ux head=$HEAD "
           all="<!-- ai-review-human-override target=all head=$HEAD "
-          record="$(gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null \
+          # A comments feed this step could not READ is not a PR with no
+          # override recorded. `2>/dev/null || true` discarded both the error
+          # text and the exit status, so a transient API failure collapsed
+          # onto the same empty string as "no override recorded" and the lane
+          # re-gated a verdict a human had already cleared with
+          # /ai-review override. The common case is transient, so absorb it
+          # here: up to three attempts with a short backoff. A read that never
+          # succeeds fails this run CLOSED while naming the read as the cause;
+          # a PR genuinely carrying no override still reads successfully and
+          # resolves to inactive, as before.
+          comments=""
+          read_ok=""
+          for attempt in 1 2 3; do
+            if comments="$(gh api "repos/$REPO/issues/$PR/comments" --paginate)"; then
+              read_ok=1
+              break
+            fi
+            echo "Reading the PR comments failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::error::Could not read this PR's comments after 3 attempts, so this lane cannot tell whether a human override is recorded for $HEAD. Failing closed rather than re-gating a verdict a human may have cleared -- re-run this job."
+            exit 1
+          fi
+          record="$(printf '%s' "$comments" \
             | jq -sr --arg exact "$exact" --arg all "$all" \
               'add // [] | [.[] | select(.user.login == "github-actions[bot]")
               | select((.body | startswith($exact)) or (.body | startswith($all)))]
-              | (last.body // "")' 2>/dev/null || true)"
+              | (last.body // "")')"
           actor="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\1/p')"
           source="$(printf '%s\n' "$record" | sed -nE '1s/^.* actor=([^ ]+) source=([0-9]+) -->$/\2/p')"
           if [ -n "$actor" ] && [ -n "$source" ]; then

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -57,6 +58,28 @@ def _prompt(name: str) -> str:
 
 def _workflow(name: str) -> str:
     return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def _stub_path(tmp_path: Path) -> str:
+    """PATH for executing a workflow read block with stubbed commands.
+
+    ``tmp_path`` comes first so the ``gh``/``sleep`` stubs win. The read
+    blocks pipe through a standalone ``jq``, which on the Windows runners'
+    Git Bash does not live under the Unix defaults -- resolve the host's real
+    ``jq`` and append its directory, skipping when the host has none.
+    """
+    jq = shutil.which("jq")
+    if jq is None:
+        pytest.skip("the read block pipes through jq; skip where jq is absent")
+    return os.pathsep.join(
+        [
+            str(tmp_path),
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            str(Path(jq).parent),
+        ]
+    )
 
 
 def _review_prompt(stage: str) -> str:
@@ -2507,3 +2530,250 @@ class TestDeploymentNeutralFramingParity:
             assert "a team deployment stays per-user" not in flat, name
             assert "Keep the review proportional to that shape" not in flat, name
             assert "Judge reachability against that shape" not in flat, name
+
+
+OVERRIDE_READ_LANES = (
+    "ux-review.yml",
+    "design-review.yml",
+    "claude-review.yml",
+    "codex-review.yml",
+    "first-principles-review.yml",
+)
+
+
+class TestOverrideReadFailureFailsClosed:
+    """Execute the ACTUAL override-record read from each lane with ``gh`` stubbed.
+
+    ``2>/dev/null || true`` used to collapse a failed comments read onto the
+    same empty string as "no override recorded", so a transient API failure
+    re-gated a verdict a human had already cleared with ``/ai-review
+    override``. These cases pin the three outcomes apart: a read that succeeds
+    resolves the recorded override, a transient failure is absorbed by the
+    bounded retry, and a read that never succeeds fails the step closed while
+    naming the read as the cause.
+    """
+
+    HEAD = "0" * 40
+
+    def _read_block(self, lane: str) -> str:
+        script = _step_script(_workflow(lane), "Resolve human override")
+        start = script.index('exact="')
+        end = script.index('actor="')
+        return script[start:end]
+
+    def _run_read(
+        self, tmp_path: Path, lane: str, gh_status: int = 0, fail_first: int = 0
+    ):
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the read block is Bash; skip where Bash is absent")
+        body = (
+            f"<!-- ai-review-human-override target=all head={self.HEAD} "
+            "actor=alice source=42 -->"
+        )
+        reply = tmp_path / "api-reply.json"
+        reply.write_text(
+            '[{"user":{"login":"github-actions[bot]"},"body":'
+            + f'"{body}"' + "}]",
+            encoding="utf-8",
+        )
+        attempts = tmp_path / "gh-attempts"
+        gh = tmp_path / "gh"
+        stub = f'#!/bin/sh\nprintf x >> "{attempts}"\n'
+        if gh_status:
+            # Stand in for an API failure on every attempt (5xx, rate limit).
+            stub += f'echo "gh: could not reach the API" >&2\nexit {gh_status}\n'
+        elif fail_first:
+            stub += (
+                f'if [ "$(wc -c < "{attempts}")" -le {fail_first} ]; then\n'
+                '  echo "gh: HTTP 502" >&2\n'
+                "  exit 1\n"
+                "fi\n"
+                f'cat "{reply}"\n'
+            )
+        else:
+            stub += f'cat "{reply}"\n'
+        gh.write_text(stub, encoding="utf-8", newline="\n")
+        gh.chmod(0o755)
+        # The retry backoff is real in CI but pure latency in a test; stub it
+        # to a no-op so the failure cases do not sleep through the suite.
+        sleep_stub = tmp_path / "sleep"
+        sleep_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
+        sleep_stub.chmod(0o755)
+        out_file = tmp_path / "record-out.txt"
+        # Reproduce the runner's own prologue (`bash -e`, no pipefail -- these
+        # steps declare no `set` line), then persist `$record` so the assertion
+        # reads what the rest of the step would have been handed.
+        script = (
+            self._read_block(lane)
+            + f'\nprintf \'%s\' "$record" > "{out_file}"\n'
+        )
+        result = subprocess.run(
+            [bash, "-e", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                # tmp_path first so the `gh` stub wins; starve any real gh of
+                # credentials so a stub-resolution failure can never turn into
+                # a live API call. GH_CONFIG_DIR keeps a fallback gh from
+                # loading the user's persisted authentication.
+                "PATH": _stub_path(tmp_path),
+                "GH_TOKEN": "",
+                "GITHUB_TOKEN": "",
+                "GH_CONFIG_DIR": str(tmp_path),
+                "LC_ALL": "C",
+                "REPO": "example/repo",
+                "PR": "1",
+                "HEAD": self.HEAD,
+                "TMPDIR": str(tmp_path),
+            },
+            cwd=tmp_path,
+        )
+        return result, attempts, out_file, body
+
+    @pytest.mark.parametrize("lane", OVERRIDE_READ_LANES)
+    def test_successful_read_resolves_the_recorded_override(
+        self, lane: str, tmp_path: Path
+    ):
+        result, attempts, out_file, body = self._run_read(tmp_path, lane)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out_file.read_text(encoding="utf-8") == body
+        assert attempts.read_text(encoding="utf-8") == "x", "retry fired on a good read"
+
+    @pytest.mark.parametrize("lane", OVERRIDE_READ_LANES)
+    def test_transient_read_failure_is_absorbed(self, lane: str, tmp_path: Path):
+        result, attempts, out_file, body = self._run_read(
+            tmp_path, lane, fail_first=1
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out_file.read_text(encoding="utf-8") == body
+        assert attempts.read_text(encoding="utf-8") == "xx"
+
+    @pytest.mark.parametrize("lane", OVERRIDE_READ_LANES)
+    def test_persistent_read_failure_fails_closed(self, lane: str, tmp_path: Path):
+        result, attempts, out_file, _ = self._run_read(tmp_path, lane, gh_status=1)
+        assert result.returncode != 0, "a read that never succeeded passed the step"
+        assert "::error::" in result.stdout
+        assert "re-run this job" in result.stdout
+        assert attempts.read_text(encoding="utf-8") == "xxx"
+        assert not out_file.exists(), "a record was emitted from a failed read"
+
+    @pytest.mark.parametrize("lane", OVERRIDE_READ_LANES)
+    def test_no_lane_still_swallows_the_override_read(self, lane: str):
+        # The defect shape itself must not return: within the resolve block the
+        # comments read carries no stderr/exit-status suppression. Judge only
+        # code lines -- the block's own comment QUOTES the banned shape while
+        # explaining why it is gone.
+        block = "\n".join(
+            line
+            for line in self._read_block(lane).splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert 'issues/$PR/comments" --paginate 2>/dev/null' not in block
+        assert "|| true" not in block
+
+
+class TestLedgerReadFailureFailsClosed:
+    """Execute the ACTUAL round-convergence ledger read with ``gh`` stubbed.
+
+    The old fail-soft (``|| printf '[]'``) collapsed a failed comments read
+    onto "no prior rulings", so a transient API failure re-litigated findings
+    a writer had already disposed.
+    """
+
+    def _read_block(self) -> str:
+        script = _step_script(_workflow("codex-review.yml"), "Write review prompt")
+        start = script.index('ledger_comments=""')
+        end = script.index('disp_authors="')
+        return script[start:end]
+
+    def _run_read(self, tmp_path: Path, gh_status: int = 0, fail_first: int = 0):
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the read block is Bash; skip where Bash is absent")
+        attempts = tmp_path / "gh-attempts"
+        gh = tmp_path / "gh"
+        stub = f'#!/bin/sh\nprintf x >> "{attempts}"\n'
+        if gh_status:
+            stub += f'echo "gh: could not reach the API" >&2\nexit {gh_status}\n'
+        elif fail_first:
+            stub += (
+                f'if [ "$(wc -c < "{attempts}")" -le {fail_first} ]; then\n'
+                '  echo "gh: HTTP 502" >&2\n'
+                "  exit 1\n"
+                "fi\n"
+                "printf '%s' '[{\"a\":1}][{\"b\":2}]'\n"
+            )
+        else:
+            # --paginate concatenates one JSON array per page; emit two pages
+            # so the assertion proves the pages are merged, not just echoed.
+            stub += "printf '%s' '[{\"a\":1}][{\"b\":2}]'\n"
+        gh.write_text(stub, encoding="utf-8", newline="\n")
+        gh.chmod(0o755)
+        sleep_stub = tmp_path / "sleep"
+        sleep_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
+        sleep_stub.chmod(0o755)
+        out_file = tmp_path / "ledger-out.json"
+        script = (
+            self._read_block()
+            + f'\nprintf \'%s\' "$comments_json" > "{out_file}"\n'
+        )
+        result = subprocess.run(
+            [bash, "-e", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                "PATH": _stub_path(tmp_path),
+                "GH_TOKEN": "",
+                "GITHUB_TOKEN": "",
+                "GH_CONFIG_DIR": str(tmp_path),
+                "LC_ALL": "C",
+                "REPO": "example/repo",
+                "PR": "1",
+                "TMPDIR": str(tmp_path),
+            },
+            cwd=tmp_path,
+        )
+        return result, attempts, out_file
+
+    def test_successful_read_merges_the_pages(self, tmp_path: Path):
+        result, attempts, out_file = self._run_read(tmp_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads(out_file.read_text(encoding="utf-8")) == [
+            {"a": 1},
+            {"b": 2},
+        ]
+        assert attempts.read_text(encoding="utf-8") == "x"
+
+    def test_transient_read_failure_is_absorbed(self, tmp_path: Path):
+        result, attempts, out_file = self._run_read(tmp_path, fail_first=1)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads(out_file.read_text(encoding="utf-8")) == [
+            {"a": 1},
+            {"b": 2},
+        ]
+        assert attempts.read_text(encoding="utf-8") == "xx"
+
+    def test_persistent_read_failure_fails_closed(self, tmp_path: Path):
+        result, attempts, out_file = self._run_read(tmp_path, gh_status=1)
+        assert result.returncode != 0, "a read that never succeeded passed the step"
+        assert "::error::" in result.stdout
+        assert attempts.read_text(encoding="utf-8") == "xxx"
+        assert not out_file.exists(), "a ledger was emitted from a failed read"
+
+    def test_ledger_read_no_longer_swallows_its_status(self):
+        # The defect shape itself must not return. Judge only code lines --
+        # the block's own comment QUOTES the banned shape while explaining
+        # why it is gone.
+        block = "\n".join(
+            line
+            for line in self._read_block().splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert 'issues/$PR/comments" --paginate 2>/dev/null' not in block
+        assert "|| true" not in block
+        assert "|| printf" not in block


### PR DESCRIPTION
## Problem / Motivation

Each of the five review lanes (GPT, Opus, Design, UX, First Principles) resolves the human-override record by reading the PR's comments with `gh api ... 2>/dev/null | jq ... 2>/dev/null || true`. Both the error text and the exit status are discarded, so a failed read collapses onto the same empty string as "no override recorded". A transient API failure (5xx, rate limit) makes the lane re-gate a verdict a human already cleared with `/ai-review override`. A sixth same-shape read -- the GPT lane's round-convergence ledger -- collapses onto "no prior rulings" and re-litigates findings a repository writer already disposed.

## Why it matters

The override exists precisely so a maintainer's ruling beats the bot. When a transient read failure silently voids that ruling, the maintainer sees a red lane on a PR they just cleared, has to notice the override "disappeared", and must re-post it -- and every push after that re-arms the same lottery. The ledger half re-opens findings that were already adjudicated, burning review rounds on settled questions.

## What changed (motivation → approach → change)

Symptom: a cleared verdict re-gates after a green-looking run. Root cause: value and exit status were fused -- the read's failure and "no override" are the same empty string. Change (same shape as the intent-read fix in #7835): separate them at all six enumerated sites. Each read gets a bounded retry (3 attempts, 1s/2s backoff) for the transient class; a read that never succeeds fails the run CLOSED with a `::error::` naming the read as the cause, instead of degrading to "no override" / "no ledger". A PR genuinely carrying no override (or no rulings) still reads successfully and resolves as before. The dedupe-id comment reads in the same files are deliberately untouched: their failure yields at worst a duplicate comment, never a verdict.

Sites: `ux-review.yml`, `design-review.yml`, `claude-review.yml`, `first-principles-review.yml` (override read), `codex-review.yml` (override read + convergence-ledger read).

Tradeoff, on the record: for a PR carrying no override, a persistently failed read used to resolve (accidentally) to the correct "inactive" and now reds the lane until re-run. That is what failing closed means -- a re-runnable red beats a silently discarded human ruling.

Residual, deliberately out of scope: the ledger step's collaborator-permission read still fail-opens to "not a writer"; it needs 404-vs-transport handling rather than this mechanical shape and is tracked in #7853.

## Tests

`test/test_ai_review_workflows.py`: two new classes execute the ACTUAL read blocks from the workflow files under the runner's own shell mode (`bash -e`, no pipefail) with `gh` stubbed and credentials starved (`GH_TOKEN`/`GITHUB_TOKEN` empty, `GH_CONFIG_DIR` pinned to tmp). For each of the five lanes and for the ledger: a successful read resolves the record / merges the pages (and proves the retry does not fire), a transient failure is absorbed by the retry, a persistent failure exits non-zero with the `::error::` and never emits a value. A banned-shape guard pins that the swallowing read cannot silently return.

## Manual verification

N/A -- the tests execute the real workflow blocks byte-for-byte (extracted from the YAML at test time), and the change is CI-behavioral with no UI surface.

## Related Issues

Closes #7839. Refs #7853 (residual permission-read fail-open, filed from this PR's review).

## Pattern harvest

Rule candidate: review-prompt
Pattern: "fallible read collapsed onto its own empty/default value -- exit status never reaches the consumer (`2>/dev/null || true` feeding a verdict)"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
