### PR TITLE
fix(dashboard): give chat nav refusals a machine-readable code

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1212,
+    "missing_code": 1209,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1443,
+  "_compliant": 1531,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -41,9 +41,6 @@
     },
     "dashboard/chat_mirror.py": {
       "missing_code": 7
-    },
-    "dashboard/chat_nav.py": {
-      "missing_code": 3
     },
     "dashboard/chat_orchestrator.py": {
       "missing_code": 4

--- a/src/kiro_crew/dashboard/chat_nav.py
+++ b/src/kiro_crew/dashboard/chat_nav.py
@@ -104,15 +104,19 @@ async def api_chat_nav_resolve_links(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     if not isinstance(body, dict):
         # A valid-but-non-dict JSON body (array/scalar/string) would raise on
         # body.get() below; reject it as malformed rather than 500.
-        return web.json_response({"error": "invalid request body"}, status=400)
+        return web.json_response(
+            {"error": "invalid request body", "code": "body_not_object"}, status=400
+        )
 
     links = body.get("links", [])
     if not isinstance(links, list) or not links:
-        return web.json_response({"error": "links array required"}, status=400)
+        return web.json_response(
+            {"error": "links array required", "code": "links_required"}, status=400
+        )
     # Cap at 20 links per request, then normalize each entry to a string
     # url/context at this boundary — a non-dict entry or non-string field would
     # otherwise raise during prompt construction and surface as a spurious 500.

--- a/test/test_chat_nav.py
+++ b/test/test_chat_nav.py
@@ -129,6 +129,8 @@ class TestApiEndpoint:
         async with TestClient(TestServer(app)) as client:
             resp = await client.post("/api/chat/nav/resolve-links", data="not json")
             assert resp.status == 400
+            body = await resp.json()
+            assert body["code"] == "invalid_json"
 
     @pytest.mark.asyncio
     async def test_empty_links(self):
@@ -143,6 +145,13 @@ class TestApiEndpoint:
         async with TestClient(TestServer(app)) as client:
             resp = await client.post("/api/chat/nav/resolve-links", json={"links": []})
             assert resp.status == 400
+            body = await resp.json()
+            assert body["code"] == "links_required"
+            # A present-but-not-a-list links field refuses at the same site.
+            resp = await client.post("/api/chat/nav/resolve-links", json={"links": "x"})
+            assert resp.status == 400
+            body = await resp.json()
+            assert body["code"] == "links_required"
 
     @pytest.mark.asyncio
     async def test_success(self, monkeypatch):
@@ -278,6 +287,8 @@ class TestApiEndpointResilience:
             for payload in ([1, 2, 3], "x", 42):
                 resp = await client.post("/api/chat/nav/resolve-links", json=payload)
                 assert resp.status == 400, f"body={payload!r} should be 400"
+                body = await resp.json()
+                assert body["code"] == "body_not_object"
 
     @pytest.mark.asyncio
     async def test_resolver_error_fails_soft_with_audit_event(self, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

The nav panel's link-label endpoint (`POST /api/chat/nav/resolve-links`) refused every bad request with a bare `{"error": "<developer sentence>"}` and nothing else. There are three refusal bodies in `src/kiro_crew/dashboard/chat_nav.py`: an unparseable JSON body (`chat_nav.py:107`), a valid-but-non-dict JSON body such as an array, string, or number (`chat_nav.py:112`), and a `links` field that is missing, not a list, or empty (`chat_nav.py:118`). The only way for a client to tell one refusal from another was to string-match prose that was written for a log line, and an ordinary copy-edit to any of those sentences would silently break a client branch built on it.

## Why it matters

These three bodies are an entry on the error-code worklist in `error-code-baseline.json`, which `test/test_error_code_contract.py` maintains as the repo's ratchet for exactly this debt: a non-2xx JSON body is supposed to carry a machine-readable `code` the client can switch on, with the human sentence demoted to advisory. This module was one of the remaining entries with `missing_code: 3`. The gap is quiet but real: today the prose is the only identifier, the prose is English, and the prose can change under a copy-edit, so any consumer that wants to distinguish "your JSON was unparseable" from "your links field was wrong" has to match sentences. The endpoint's current consumer happens to fail soft (link-labeling is a cosmetic enrichment and the UI falls back to the raw URL chip), but the API contract is broader than the one page that calls it today.

## What changed (motivation → approach → change)

Symptom: three 400 bodies carry no `code`. Root cause: the module predates the code convention. Fix: each body now carries a `code` beside its unchanged sentence, and the codes are the tree's established spellings rather than inventions:

- `invalid_json` for the unparseable body, the spelling already used at 49 other sites across the dashboard
- `body_not_object` for the valid-but-non-dict body, the same code `handlers/_shared.py:173` and `chat_fork.py:134` use for the identical condition
- `links_required` for the missing-or-non-list `links` field, following the `X_required` family (`message_required`, `content_required`, `slot_required`)

PR #7079 set the precedent I followed here: reuse a code where the condition already has one, and change nothing about the human sentence so an existing client that renders it keeps working.

The dashboard's sole consumer of this endpoint (`useChatNavigation`, via `resolveNavLinks` in `src/api/client.ts`) fail-softs through react-query and never renders the error prose, so there is no frontend consumer to move in this PR. The codes are additive and the failure path behaves identically to before.

The baseline edit is the gate doing its job. Regenerating `error-code-baseline.json` drops the module's entry and moves the tracked total from `missing_code: 1212` to `1209`, per the worklist's own instruction of one PR per file. I kept this PR to exactly one file: converting the other ~40 remaining entries in the same change would be the helpful-looking move, but the worklist prescribes small per-file conversions precisely so each stays reviewable, and the gate reds on any newly landed uncoded handler regardless. On the new code's spelling, I chose `links_required` over `links_array_required` to match the family's shortest form (`message_required`, not `message_field_required`); happy to rename if a maintainer prefers the longer one.

## Tests

I extended the three existing 400-path tests in `test/test_chat_nav.py` to assert the `code` in the response body, and wrote the handler change second: the extended tests failed first with `KeyError: 'code'`, so the assertions demonstrably catch a missing code rather than merely passing alongside it.

- `test_invalid_json` pins `invalid_json` on the unparseable-body branch
- `test_non_dict_body_returns_400` pins `body_not_object` across array, string, and number bodies
- `test_empty_links` pins `links_required` on both the empty-list shape and the present-but-not-a-list shape

```
python -m pytest test/test_chat_nav.py -q            # 21 passed
python -m pytest test/test_error_code_contract.py -q # 6 passed
python test/test_error_code_contract.py              # exit 0, totals 1209 / 18 / 43
python -m flake8 src/kiro_crew/dashboard/chat_nav.py test/test_chat_nav.py   # clean
python -m mypy src/kiro_crew/dashboard/chat_nav.py   # Success: no issues found
```

## Manual verification

N/A: the response contract is fully pinned by the aiohttp `TestClient` tests above, and no UI surface renders these refusals (the only consumer fail-softs by design), so there is no visual state to check beyond what the tests assert.

## Pattern harvest

Not generalizable: the defect class already has its rule, the `test_error_code_contract.py` AST ratchet plus the per-file worklist this PR converts one entry of; a second gate would only re-measure the same thing. The one residual gap in the class, a `code` key whose value is a sentence rather than an identifier, is documented as a known false negative in the gate itself and needs a maintainer decision on value shape rather than a drive-by rule.

## Related Issues

No dedicated issue for these three sites; this converts one entry of the per-file worklist in `error-code-baseline.json`. The reuse-don't-invent and unchanged-prose conventions follow the merged shape of PR #7079.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title — one commit: `fix(dashboard): give chat nav refusals a machine-readable code`
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; codes follow the tree's established spellings
- [x] Documentation updated (if applicable) — N/A: no doc describes these three refusal bodies; the contract itself is documented by `test_error_code_contract.py`
- [x] No secrets, credentials, or internal references in the diff