### PR TITLE
test: wait for crew companion escape listener

### DIFF
--- a/website/src/test/CrewCompanionPanelCoverage.test.tsx
+++ b/website/src/test/CrewCompanionPanelCoverage.test.tsx
@@ -478,6 +478,11 @@ describe('what the panel reports back so it is not closed on blur', () => {
 describe('closing the panel', () => {
   it('closes on Escape', async () => {
     await mountPanel()
+    // The card DOM commits before passive effects run. `panelHold(false)` is the
+    // preceding effect in Panel, so observing it proves the effect flush reached
+    // the key-listener registration below it; firing as soon as the card exists
+    // races that registration under a loaded shard.
+    await waitFor(() => expect(api.panelHold).toHaveBeenCalledWith(false))
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(api.panelClose).toHaveBeenCalled()
   })


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** this changes only a Vitest synchronization barrier; production code and rendered UI are byte-identical.

## What

Fixes a deterministic race in `CrewCompanionPanelCoverage.test.tsx` that currently breaks every frontend-touching merge ref.

`mountPanel()` returns when the card DOM exists, but React commits that DOM before passive effects necessarily run. The Escape test fired immediately, racing the effect that registers the `window.keydown` listener; on a loaded shard `panelClose` was never called.

The test now waits for `panelHold(false)`, the preceding effect in `Panel`. Observing that call proves the same passive-effect flush reached the key-listener registration below it before Escape is dispatched.

No linked issue: this is a focused broken-main CI heal discovered while driving #7841.

## Evidence

- Exact failing test reproduced on #7841's pristine base SHA: `expected vi.fn() to be called at least once` at line 482.
- The seed PR changes zero frontend files.
- Current `main` has no change to either the panel or this test since that base.
- After fix: targeted Escape test 1/1 pass; full coverage file 36/36 pass.
- `npx tsc -b` passes.

## Pattern harvest

Rule candidate: when a component registers behavior in `useEffect`, a mounted DOM node is not a readiness barrier; wait for an observable signal from the same effect flush before dispatching the event under test.
