### PR TITLE
fix: tolerate a CRLF fence in the two LF-only frontmatter dialects

### DIFF
--- a/src/kiro_crew/frontmatter.py
+++ b/src/kiro_crew/frontmatter.py
@@ -113,33 +113,34 @@ def parse_block_scalar_header(value: str) -> tuple[str, int | None] | None:
 # Fence extraction for the "column0_fence" dialect: the opener must be exactly
 # ``---`` at position 0 followed by a newline; the closer is the next line
 # that *starts with* ``---`` (trailing text after the closer is tolerated).
-_COLUMN0_BLOCK_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+# An optional CR before each fence newline is tolerated. Most SKILL.md reads
+# fold CRLF to LF before parsing (``Path.read_text``'s universal newlines,
+# ``skills._decode_skill_text``), but the grammar must not depend on callers
+# pre-folding: text reaches it VERBATIM too — the Agent SOP description
+# reader decodes raw bytes, so a Windows-authored document showed no
+# description at all — and through :func:`set_frontmatter_fields` a fence
+# this pattern cannot see makes a field edit PREPEND a brand-new block above
+# the existing one instead of rewriting it. Interior lines may still carry a
+# trailing ``\r``; the line parser strips it, so a resolved value is equal to
+# its LF twin's — the same break normalisation a YAML reader applies.
+_COLUMN0_BLOCK_RE = re.compile(r"^---\r?\n(.*?)\r?\n---", re.DOTALL)
 
-# As above, but tolerating CRLF. A steering file authored on Windows has
-# ``---\r\n``, which the LF-only fence above does not match at all — so its
-# declaration was invisible (the tab reported the default mode and the
-# runtime skipped the document entirely) and an edit PREPENDED a second
-# front-matter block instead of rewriting the first.
-#
-# The inner group is OPTIONAL: an opener immediately followed by a closer
-# (``---\n---``, an empty block) has no line between them for ``(.*?)\n`` to
-# consume, so the non-optional form never matched it at all — the extractor
-# reported "no fence", and a mode edit then PREPENDED a brand-new fence in
-# front of the empty one instead of populating it, doubling the block. A
-# match with the group absent (``None``, distinct from the empty string a
-# real-but-blank line would capture) is exactly that zero-line case.
+# As above, and ADDITIONALLY matching the EMPTY block. The inner group is
+# OPTIONAL: an opener immediately followed by a closer (``---\n---``) has no
+# line between them for ``(.*?)\n`` to consume, so the non-optional form
+# never matched it at all — the extractor reported "no fence", and a mode
+# edit then PREPENDED a brand-new fence in front of the empty one instead of
+# populating it, doubling the block. A match with the group absent (``None``,
+# distinct from the empty string a real-but-blank line would capture) is
+# exactly that zero-line case. Whether an empty block counts as a fence is a
+# per-dialect accepted-input decision — steering opts in, the skill dialects
+# keep their non-optional group — which is why this stays a separate pattern.
 _COLUMN0_BLOCK_CRLF_RE = re.compile(r"^---\r?\n(?:(.*?)\r?\n)?---", re.DOTALL)
 
-# DEFERRED, deliberately: ``column0_fence`` (``SKILL_LOADER``) and
-# ``leading_ws_fence`` (``SKILL_UPDATE``) keep the LF-only grammar, so a
-# Windows-authored SKILL.md still has invisible front matter. Widening them
-# changes what the skills catalog and the update merge ACCEPT — a behaviour
-# change with its own review surface and its own snapshot corpus, which is
-# why each dialect is a separate constant. Steering was fixed here because
-# its own feature depends on the declaration being read at all.
-# Fence extraction for the "leading_ws_fence" dialect: identical, except any
-# whitespace (including blank lines) may precede the opening fence.
-_LEADING_WS_BLOCK_RE = re.compile(r"^\s*---\n(.*?)\n---", re.DOTALL)
+# Fence extraction for the "leading_ws_fence" dialect: as "column0_fence"
+# (CR tolerance included), except any whitespace (including blank lines) may
+# precede the opening fence.
+_LEADING_WS_BLOCK_RE = re.compile(r"^\s*---\r?\n(.*?)\r?\n---", re.DOTALL)
 
 # How the frontmatter block is located within the document. Each mode is the
 # fence grammar of the dialects that name it; they are not interchangeable.

--- a/src/kiro_crew/history_consolidation.py
+++ b/src/kiro_crew/history_consolidation.py
@@ -248,11 +248,14 @@ def _strip_skill_frontmatter(text: str | None) -> str:
     ``stage_skill_candidate`` re-emits frontmatter of its own. Text without a
     leading block is returned unchanged (stripped). A fence LOCATOR, not a
     field parser — deliberately outside ``kiro_crew.frontmatter``; editing
-    its grammar means revisiting ``_frontmatter_value``'s dialect too.
+    its grammar means revisiting ``_frontmatter_value``'s dialect too. Like
+    that dialect's fence, an optional carriage return before each fence
+    newline is tolerated, so the locator strips exactly the block the field
+    parser reads.
     """
     if not text:
         return ""
-    m = re.match(r"^\s*---\n.*?\n---\n?(.*)$", text, re.DOTALL)
+    m = re.match(r"^\s*---\r?\n.*?\r?\n---\r?\n?(.*)$", text, re.DOTALL)
     return (m.group(1) if m else text).strip()
 
 

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -4676,7 +4676,9 @@ class SkillsLoader:
         ``frontmatter._COLUMN0_BLOCK_RE`` — the ``column0_fence`` extraction
         that ``frontmatter.SKILL_LOADER`` binds to the skills surface: the
         closer is the first line after the opener that STARTS with ``---`` —
-        trailing text on the closer line is tolerated and consumed (#6182). Anything
+        trailing text on the closer line is tolerated and consumed (#6182), and
+        an optional carriage return before each fence newline is tolerated the
+        way the parser tolerates one. Anything
         the display parser reads as frontmatter must also be stripped here:
         a stricter closer (the old ``---`` must-be-followed-by-newline
         grammar) let a ``---junk`` or ``--- `` closer parse fields in the UI
@@ -4684,7 +4686,7 @@ class SkillsLoader:
         means revisiting the other.
         """
         if content.startswith("---"):
-            match = re.match(r"^---\n.*?\n---[^\n]*\n?", content, re.DOTALL)
+            match = re.match(r"^---\r?\n.*?\r?\n---[^\n]*\n?", content, re.DOTALL)
             if match:
                 return content[match.end() :].strip()
         return content

--- a/test/test_frontmatter.py
+++ b/test/test_frontmatter.py
@@ -208,7 +208,11 @@ HISTORY_EXPECTED: dict[str, dict[str, str]] = {
     "closer_indented": {},
     "closer_trailing_junk": {"name": "x"},
     "colon_in_value": {"url": "http://example.com:8080"},
-    "crlf": {},
+    # A deliberate accepted-input widening, not drift: the fence tolerates an
+    # optional carriage return before each newline, so a CRLF document reads
+    # exactly like its LF twin instead of as "no frontmatter" (the
+    # pre-consolidation parser returned {} here).
+    "crlf": {"name": "x"},
     "duplicate_keys": {"k": "first"},
     # first_key_wins both ways: the plain value survives a later scalar
     # duplicate (whose lines the shared scanner consumes but the original
@@ -1268,6 +1272,66 @@ def test_crlf_block_scalar_survives_a_mode_edit():
     out = set_frontmatter_fields(doc, {"inclusion": "always"}, STEERING_LOADER)
     assert "\r\r\n" not in out
     assert out.count("\r\n") == out.count("\n")
+
+
+class TestCrlfSkillDocuments:
+    """The skill dialects read a CRLF document without a caller pre-folding.
+
+    Most SKILL.md reads fold CRLF to LF before parsing (``Path.read_text``'s
+    universal newlines, ``skills._decode_skill_text``), so those paths never
+    met the LF-only fence. Text that arrives VERBATIM did: the Agent SOP
+    description reader decodes raw bytes, so a Windows-authored document
+    showed no description at all. And ``set_frontmatter_fields`` is public
+    API reachable with these dialects: a fence the extraction cannot see
+    makes a field edit PREPEND a brand-new block above the existing one — a
+    double-fenced file, with the stale fence left sitting in the body —
+    instead of rewriting it in place.
+    """
+
+    def test_the_declaration_is_visible_to_both_skill_dialects(self) -> None:
+        doc = "---\r\nname: x\r\nalways: true\r\ndescription: hello\r\n---\r\nbody\r\n"
+        expected = {"name": "x", "always": "true", "description": "hello"}
+        assert parse_frontmatter(doc, SKILL_LOADER) == expected
+        assert parse_frontmatter(doc, SKILL_UPDATE) == expected
+
+    def test_a_crlf_document_resolves_exactly_like_its_lf_twin(self) -> None:
+        # The contract is equality with the LF twin because that is what a
+        # YAML reader gives: line breaks are normalised, so a resolved value
+        # carries no stray CR. Same header/body matrix as the steering pin in
+        # TestTheLiteralFoldTheSkillEditorSimulates, extended over every
+        # fence-based dialect.
+        for dialect in (SKILL_LOADER, SKILL_UPDATE, STEERING_LOADER):
+            for header, body in (
+                ("|", ["  one", "", "  two"]),
+                ("|", ["", "  one"]),
+                ("|-", ["  one", "", "  two"]),
+                ("|+", ["  one", ""]),
+                (">", ["  one", "", "  two"]),
+                ("|2", ["  one", "", "  two"]),
+            ):
+                frag = "\n".join(["name: s", f"description: {header}", *body, "mode: always"])
+                lf = f"---\n{frag}\n---\n\nBody\n"
+                crlf = lf.replace("\n", "\r\n")
+                want = parse_frontmatter(lf, dialect)
+                got = parse_frontmatter(crlf, dialect)
+                assert want["name"] == "s", (dialect.extraction, header, body)
+                assert got == want, (dialect.extraction, header, body, got, want)
+                assert not any("\r" in v for v in got.values()), (dialect.extraction, got)
+
+    def test_an_edit_rewrites_rather_than_prepends(self) -> None:
+        # The write-side symptom: with the fence invisible, the writer judged
+        # the document as having no frontmatter yet and created a new block
+        # ABOVE the existing one instead of editing it in place.
+        doc = "---\r\nname: s\r\ndescription: |\r\n  one\r\n---\r\n\r\n# Body\r\n"
+        out = set_frontmatter_fields(doc, {"description": "AFTER"}, SKILL_UPDATE)
+        assert out == "---\r\nname: s\r\ndescription: AFTER\r\n---\r\n\r\n# Body\r\n"
+        assert parse_frontmatter(out, SKILL_UPDATE)["description"] == "AFTER"
+
+    def test_lf_documents_are_unchanged(self) -> None:
+        lf = "---\nname: s\ndescription: before\n---\n\n# Body\n"
+        out = set_frontmatter_fields(lf, {"description": "AFTER"}, SKILL_UPDATE)
+        assert out == "---\nname: s\ndescription: AFTER\n---\n\n# Body\n"
+        assert "\r" not in out
 
 
 class TestInlineComments:

--- a/test/test_history_coverage.py
+++ b/test/test_history_coverage.py
@@ -1443,6 +1443,11 @@ class TestSkillTextHelpers:
         [
             (None, ""),
             ("---\nname: x\n---\nbody text", "body text"),
+            # The locator tolerates a carriage return before each fence
+            # newline, exactly like SKILL_UPDATE's fence: a block the field
+            # parser reads must be a block this strips, or the header rides
+            # into the update-merge prompt under a re-emitted fence.
+            ("---\r\nname: x\r\n---\r\nbody text", "body text"),
             ("no frontmatter", "no frontmatter"),
         ],
     )

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -2119,6 +2119,23 @@ class TestStripFrontmatterCloserParity:
         out = SkillsLoader.strip_frontmatter("---\ndescription: test skill\n---")
         assert out == ""
 
+    def test_crlf_fences_strip_whatever_the_parser_parses(self) -> None:
+        """Line-ending side of the same invariant: the display dialect
+        tolerates a carriage return before each fence newline, so the
+        stripper must too — a CRLF document whose fields render in the UI
+        must not leak its whole block to the model."""
+        from kiro_crew.frontmatter import SKILL_LOADER, parse_frontmatter
+
+        doc = f"---\r\ndescription: test skill\r\n---\r\n{self.BODY}"
+        fields = parse_frontmatter(doc, SKILL_LOADER)
+        assert fields.get("description") == "test skill", (
+            "premise broken: the display parser no longer tolerates a CRLF "
+            "fence — re-check _COLUMN0_BLOCK_RE before touching the stripper"
+        )
+        out = SkillsLoader.strip_frontmatter(doc)
+        assert "description:" not in out, "frontmatter leaked past a CRLF fence"
+        assert out == self.BODY
+
     def test_no_closer_leaves_content_unchanged(self) -> None:
         doc = "---\ndescription: dangling opener, no closer"
         assert SkillsLoader.strip_frontmatter(doc) == doc


### PR DESCRIPTION
## Problem / Motivation

Two of the four frontmatter fence grammars required a bare LF after each fence line: `column0_fence` (`SKILL_LOADER`) and `leading_ws_fence` (`SKILL_UPDATE`). A document saved with Windows line endings (`---\r\n`) does not match either pattern at all, so it reads as having **no frontmatter**: `parse_frontmatter(crlf_doc, SKILL_LOADER)` returns `{}` where the LF twin parses three fields.

Most SKILL.md reads never meet this -- `Path.read_text`'s universal newlines and `skills._decode_skill_text` fold CRLF before parsing. Text that arrives verbatim does meet it: the Agent SOP description reader (`prompts.py`) decodes raw bytes, so a Windows-authored document shows no description in the detail pane. And on the write side, `set_frontmatter_fields` is public API reachable with these dialects: a fence the extraction cannot see makes a field edit **prepend a brand-new block above the existing one** -- a double-fenced file, with the stale fence left sitting in the body.

## Why it matters

The failure is silent in both directions. Read side: metadata quietly vanishes rather than being reported as malformed, so an author on Windows sees a working-looking file that the system ignores. Write side: an edit that "succeeds" corrupts the document -- the same double-fence class already fixed for steering documents. `column0_fence_crlf` (steering) and `line_scan` (onboarding import) already tolerate the carriage return, so which dialect a caller happens to bind decides whether a Windows file works -- an inconsistency nobody chose.

## What changed (motivation -> approach -> change)

Symptom: a CRLF fence is invisible to two dialects. Root cause: their patterns spell the fence boundary as a bare `\n`, while `column0_fence_crlf` already spells it `\r?\n`. Change, kept minimal per the issue (no consolidation of the four dialects -- separate measured work):

- `_COLUMN0_BLOCK_RE` and `_LEADING_WS_BLOCK_RE` tolerate an optional carriage return before each fence newline. The line parser already strips interior carriage returns, so a resolved value equals its LF twin's -- the same break normalisation a YAML reader applies. The empty-block group stays specific to the steering pattern: whether an empty block counts as a fence is a per-dialect accepted-input decision.
- The two fence **locators** whose docstrings are pinned to these grammars move in the same change, so a block the field parser reads is always a block they strip: `SkillsLoader.strip_frontmatter` and `history_consolidation._strip_skill_frontmatter`. Left LF-only, a CRLF block readable by the widened parser would ride past them -- the frontmatter header leaking into the model turn, or under a re-emitted fence in the update merge. Not reachable today (those callers normalize first), closed for parity rather than left as a latent divergence.
- Comments rewritten to state the current grammar and name the real verbatim consumer, replacing the "DEFERRED, deliberately" block that documented the old asymmetry.

Pre-push review: two model-pinned lanes (GPT 5.6, Opus). GPT's blocking finding claimed the CRLF header leaks through `load_skill` into the model turn; disproved on reachability (`load_skill` folds line endings via `_decode_skill_text`, `skills.py:473`), but its locator-parity core matched Opus's advisory and is fixed as above. Opus's differential probe: accepted-input delta confined to CRLF-opener documents across a 21-case corpus x 4 dialects; every LF case byte-identical.

## Tests

- `TestCrlfSkillDocuments` (new): CRLF declaration visible to both skill dialects; LF-twin equality matrix (6 block-scalar headers x LF/CRLF x `SKILL_LOADER`/`SKILL_UPDATE`/`STEERING_LOADER`, values carry no stray carriage return); a field edit on a CRLF document rewrites in place instead of prepending; LF documents byte-identical through the writer.
- `HISTORY_EXPECTED["crlf"]` corpus snapshot moves `{}` -> `{"name": "x"}` -- the deliberate accepted-input widening, commented as such at the snapshot.
- `TestStripFrontmatterCloserParity::test_crlf_fences_strip_whatever_the_parser_parses` (new): the parser/stripper parity invariant extended to the line-ending axis.
- `_strip_skill_frontmatter` gains a CRLF parametrize case.
- Full backend gates green locally: black baseline, subprocess encoding, isort, flake8, brand, harness parity, mypy (4 pre-existing errors in untouched `transcribe.py`/`cloudwatch.py` from boto3-stubs drift in the local env), pytest 80885 passed (91 failures + 2 errors reproduced identically on unmodified `main` in the same host env -- host-layout/dependency artifacts, none import `frontmatter`).

## Manual verification

N/A -- unit coverage sufficient: the change is a pure text-in/text-out parser with the LF-twin contract asserted differentially, and a review-lane probe additionally compared `main` vs `HEAD` over a 21-case corpus across all four dialects.

## Related Issues

Closes #7786

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a fence/boundary REGEX widened without its sibling LOCATORS -- grep for docstrings that say 'editing either grammar means revisiting the other' and require the co-edit in the same diff"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
