### PR TITLE
fix: harvest late warm oauth requests

### DIFF
--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -99,19 +99,26 @@ attaches to the reaper in its own slice.
 - **A frame becomes readable only when something DRAINS the session queue.**
   `pop_pending_oauth_requests()` reads a list that only `drain_init` appends to, and
   `create_session` runs exactly one drain before it hands the handle over. The settle loop
-  originally slept between pops, which consumes nothing — so a provider whose `oauth_request`
+  originally slept between pops, which consumes nothing -- so a provider whose `oauth_request`
   landed after that create-time drain's idle exit was unreachable however many rounds elapsed.
-  The 3s budget was never the binding constraint; the loop had no mechanism to absorb a late
-  frame at all, and in a multi-provider activation the later providers are exactly the ones at
-  risk. Each waiting round is now a bounded `drain_init(duration=0.5, idle_exit=0.5,
+  Each wait is now a bounded `drain_init(duration=0.5, idle_exit=0.5,
   no_report_ceiling=0.0)`. The ceiling argument is load-bearing: it arms the idle shortcut at
   entry so the call cannot hold waiting for a "first report" this session already produced
-  during `create_session`'s own drain — which is precisely the idle-window semantics that made
-  an *unbounded* drain the wrong tool here. Bounded per round it is the right one, the total
-  wall-clock budget is unchanged, and an activation whose frames are already staged still
-  short-circuits on the first pop without opening a window. Beyond the budget the claim is
-  released and the cold path serves that provider, which is the correct fallback rather than a
-  defect.
+  during `create_session`'s own drain. Six consecutive quiet drains end collection, while each
+  newly collected provider renews that quiet budget. The absolute cap is six drain windows per
+  expected provider -- 3 seconds times the roster size -- because a handle accepts at most one
+  OAuth request per server. Progress can therefore carry a multi-provider activation beyond the
+  old fixed 3-second cutoff without making the wait unbounded.
+- **An adoption miss gets one last read from the process already paid for.** Each live warm
+  session retains its provider roster internally. When Connect finds no adoptable table row, it
+  first rebuilds the current candidate plan. The provider must still be visible and enabled,
+  have a definitive absent-grant verdict, remain compatible with the configured entry, and ask
+  for the same URL, scopes, and client ID the retained session activated. Only then does Connect
+  re-run the same bounded collector on that session, materialize every attributable late frame
+  through the ordinary claim, credential-screen, watcher, and settlement paths, and retry
+  adoption before reserving a dedicated cold row. Any failed revalidation uses the cold path
+  without reading the old handle. The roster and yielded-provider diagnostics stay internal;
+  customers still see only the existing card states.
 
 ## Specs are read once at spawn
 
@@ -203,8 +210,11 @@ quietly drop the filesystem work the guard's coverage rests on without failing i
 gone rather than on a cause, which is what covers a process that went away by a route no expiry
 path anticipated. PR #5899 is a different cause and a different table: it owns
 **Disconnect-driven grant revocation**, and the two meet only where a revoke should re-warm.
-**Proactive refresh** attaches to `_warm_mint_reaper`, which now exists; **a
-supervisor/watchdog** is absent, as are the accessors it would need.
+**Proactive refresh** attaches to `_warm_mint_reaper`, which now exists. The dependent
+resilience slice remains deliberately absent: a mid-visit supervisor must detect a shared
+session that dies after the page's initial warm and re-arm a replacement activation without a
+Connect click. This slice only re-drains a session that is still live; it neither supervises nor
+re-arms one.
 
 Three residuals the lifecycle slice was required to close, and did:
 

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -105,8 +105,9 @@ Connections page fires once on mount. It scans the candidates and hands them ove
 it reports and the rows the engine claims come from one registry read. The consumer of what it
 warms is :func:`adopt_shared_mint`, which ``POST /api/connections/mint`` tries BEFORE reserving
 a row of its own -- without it that endpoint's ``reserve_mint_row`` popped the shared row and
-disposed the very URL the click had been warmed for. Proactive refresh attaches in
-:func:`_warm_mint_reaper` when slice N3 lands.
+disposed the very URL the click had been warmed for. A table miss re-drains the newest live
+shared session that activated the provider and retries adoption before the dedicated cold path.
+Proactive refresh attaches in :func:`_warm_mint_reaper` when its dependent slice lands.
 
 TWO AXES, and conflating them is what the handoff had to separate. ``shared`` is OWNERSHIP: an
 unclaimed premint any Connect may adopt, and the only mark a row still ``minting`` carries.
@@ -184,8 +185,9 @@ _WARM_SESSION_DESTROY_TIMEOUT_SECONDS = 10.0
 #: this only buys back a session already on its way; see ``_abandon_session_creation``.
 _WARM_SESSION_REAP_TIMEOUT_SECONDS = 10.0
 _WARM_KILL_TIMEOUT_SECONDS = 20.0
-#: The oauth_request frame lands a beat AFTER set_mode returns (~0.35s measured),
-#: beyond drain_init's idle window for a slow provider. Poll rather than race it.
+#: One bounded drain window. A run stops after this many consecutive quiet windows,
+#: while each newly observed provider renews that quiet budget. The absolute cap scales by
+#: the expected roster, so unique progress cannot extend collection without bound.
 _WARM_OAUTH_SETTLE_SECONDS = 0.5
 _WARM_OAUTH_SETTLE_ROUNDS = 6
 #: A tenth of the mint TTL: long enough that reopening the gallery reuses the
@@ -384,6 +386,21 @@ def _warm_candidate_scan() -> tuple[list[Provider], list[Provider]]:
     return universe, _warm_activation_candidates(universe)
 
 
+def _current_warm_redrain_entry(slug: str) -> dict[str, Any] | None:
+    """The current eligible authorization entry for a late-session re-drain.
+
+    Rebuild the same candidate plan activation uses rather than trusting the provider
+    snapshot retained by an older session. This rechecks visibility, enabled state, the
+    tri-state grant verdict, configured-entry compatibility, and the registry auth shape.
+    The caller runs this off the event loop because those checks read user-owned files.
+    """
+    _universe, candidates = _warm_candidate_scan()
+    provider = next((item for item in candidates if item["slug"] == slug), None)
+    if provider is None:
+        return None
+    return _warm_spec_plan([provider]).entries.get(mcp_server_alias(slug))
+
+
 def mintable_providers() -> list[Provider]:
     """Providers an activation should warm right now, registry order."""
     return _warm_candidate_scan()[1]
@@ -392,6 +409,34 @@ def mintable_providers() -> list[Provider]:
 def _wanted_aliases(providers: list[Provider]) -> frozenset[str]:
     """The server aliases an activation must produce a challenge for."""
     return frozenset(mcp_server_alias(provider["slug"]) for provider in providers)
+
+
+async def _collect_oauth_requests(handle: Any, wanted: frozenset[str]) -> list[dict[str, str]]:
+    """Collect challenges until the queue stays quiet, bounded by the expected roster."""
+    collected: dict[str, dict[str, str]] = {}
+    quiet_drains = 0
+    drains = 0
+    hard_drain_limit = max(1, len(wanted)) * _WARM_OAUTH_SETTLE_ROUNDS
+    while True:
+        before = len(collected)
+        for request in handle.pop_pending_oauth_requests():
+            name = str(request.get("serverName") or "")
+            if name and request.get("oauthUrl"):
+                collected[name] = request
+        if len(collected) > before:
+            quiet_drains = 0
+        if wanted and wanted <= collected.keys():
+            break
+        if quiet_drains >= _WARM_OAUTH_SETTLE_ROUNDS or drains >= hard_drain_limit:
+            break
+        await handle.drain_init(
+            duration=_WARM_OAUTH_SETTLE_SECONDS,
+            idle_exit=_WARM_OAUTH_SETTLE_SECONDS,
+            no_report_ceiling=0.0,
+        )
+        drains += 1
+        quiet_drains += 1
+    return list(collected.values())
 
 
 def _auth_shape(entry: dict[str, Any]) -> tuple[str, tuple[str, ...], str]:
@@ -772,6 +817,7 @@ class _WarmSession:
     handle: Any
     expires_at: float
     settled: bool = False
+    providers: tuple[Provider, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -922,7 +968,9 @@ class _WarmMintRuntime:
                 return None
             generation = self._generation
             try:
-                activation, requests = await self._activate_locked(agent, _wanted_aliases(wanted))
+                activation, requests = await self._activate_locked(
+                    agent, _wanted_aliases(wanted), tuple(wanted)
+                )
             except Exception as exc:
                 if self.is_alive():
                     # One activation failed but the process still serves: its other verifiers
@@ -1117,7 +1165,10 @@ class _WarmMintRuntime:
                 self._sessions.pop(activation, None)
 
     async def _activate_locked(
-        self, agent: str, wanted: frozenset[str]
+        self,
+        agent: str,
+        wanted: frozenset[str],
+        providers: tuple[Provider, ...] = (),
     ) -> tuple[int, list[dict[str, str]]]:
         """Activate ``agent`` on the shared process and return its challenges."""
         runtime = self._runtime
@@ -1152,39 +1203,10 @@ class _WarmMintRuntime:
             generation=self._generation,
             handle=handle,
             expires_at=time.monotonic() + _MINT_TTL_SECONDS,
+            providers=providers,
         )
-        collected: dict[str, dict[str, str]] = {}
         try:
-            for round_index in range(_WARM_OAUTH_SETTLE_ROUNDS):
-                for request in handle.pop_pending_oauth_requests():
-                    name = str(request.get("serverName") or "")
-                    if name and request.get("oauthUrl"):
-                        collected[name] = request
-                if wanted and wanted <= collected.keys():
-                    break
-                if round_index + 1 < _WARM_OAUTH_SETTLE_ROUNDS:
-                    # CONSUME the queue rather than sleep past it. This is the whole
-                    # mechanism: ``pop_pending_oauth_requests`` reads a list that only
-                    # ``drain_init`` appends to, and ``create_session`` runs exactly one
-                    # drain before handing the handle over -- so a bare sleep here moved
-                    # nothing, and a frame arriving after that drain's idle exit was
-                    # unreachable however many rounds elapsed. The budget was never the
-                    # binding constraint; the loop had no way to absorb a late frame at all.
-                    #
-                    # ``no_report_ceiling=0.0`` is load-bearing: it arms the idle shortcut at
-                    # entry, so this call cannot hold waiting for a "first report" that this
-                    # session already produced during ``create_session``'s own drain. That is
-                    # precisely the idle-window semantics that made an unbounded drain the
-                    # wrong tool here -- bounded per round, it is the right one. Each round is
-                    # therefore a window of at most ``_WARM_OAUTH_SETTLE_SECONDS`` that
-                    # returns as soon as the queue goes quiet, so the total budget is
-                    # unchanged and a satisfied activation still short-circuits on the pop
-                    # above without opening a window at all.
-                    await handle.drain_init(
-                        duration=_WARM_OAUTH_SETTLE_SECONDS,
-                        idle_exit=_WARM_OAUTH_SETTLE_SECONDS,
-                        no_report_ceiling=0.0,
-                    )
+            requests = await _collect_oauth_requests(handle, wanted)
         except BaseException:
             # Nothing will ever be stamped with this activation, so the session it
             # registered would leak past the sweep's settled-only rule. Marked settled and
@@ -1199,7 +1221,40 @@ class _WarmMintRuntime:
             if await _destroy_session_quietly(handle):
                 self._sessions.pop(activation, None)
             raise
-        return activation, list(collected.values())
+        return activation, requests
+
+    async def redrain_for(self, slug: str) -> _WarmMintResult | None:
+        """Drain a current-compatible live session for ``slug`` without spawning another."""
+        current_entry = await asyncio.to_thread(_current_warm_redrain_entry, slug)
+        if current_entry is None:
+            return None
+        async with self._lock:
+            for activation, record in reversed(list(self._sessions.items())):
+                if not self.generation_is_live(record.generation):
+                    continue
+                activated_provider = next(
+                    (provider for provider in record.providers if provider["slug"] == slug),
+                    None,
+                )
+                if activated_provider is None:
+                    continue
+                activated_entry = _registry_server_entry(activated_provider)
+                if activated_entry is None or _auth_shape(activated_entry) != _auth_shape(
+                    current_entry
+                ):
+                    return None
+                requests = await _collect_oauth_requests(
+                    record.handle, frozenset({mcp_server_alias(slug)})
+                )
+                if not requests:
+                    return None
+                return _WarmMintResult(
+                    generation=record.generation,
+                    activation=activation,
+                    providers=[activated_provider],
+                    requests=requests,
+                )
+        return None
 
     async def shutdown(self) -> None:
         async with self._lock:
@@ -1573,15 +1628,15 @@ def _mint_is_adopted(entry: MintState | None) -> bool:
     )
 
 
-async def adopt_shared_mint(slug: str, mcp_url: str) -> str | None:
+async def _adopt_shared_row(slug: str, mcp_url: str) -> str | None:
     """Take ownership of ``slug``'s UNCLAIMED premint. Returns its new row token, or None.
 
     THE handoff, and the reason the premint has a consumer at all. Connect used to call
     ``reserve_mint_row`` unconditionally, which pops WHATEVER row is at the slug -- so
     ``start_oauth_mint`` disposed the very URL the warm table had minted for that click
     and the cold spawn it then paid was the only thing the user ever saw. ``None`` means
-    nothing was adoptable and the caller must fall back to that cold path, which is
-    still correct and still the only path for a provider warming never covered.
+    no row was adoptable at this instant; the public flow may recover a late frame from the
+    existing live session before it falls through to the dedicated cold path.
 
     FOUR refusals, each closing a different way to hand back a URL that cannot work: no
     row; a row that is not an unclaimed premint (``shared`` absent -- a cold flow's or
@@ -1633,6 +1688,20 @@ async def adopt_shared_mint(slug: str, mcp_url: str) -> str | None:
         # module pins every such hop with a drift guard.
         await asyncio.to_thread(_log_warm_event, "connections_warm_mint_adopt", f"provider:{slug}")
     return adopted
+
+
+async def adopt_shared_mint(slug: str, mcp_url: str) -> str | None:
+    """Adopt a warm row, recovering late frames from the live shared session once."""
+    adopted = await _adopt_shared_row(slug, mcp_url)
+    if adopted is not None:
+        return adopted
+    try:
+        redrained = await _warm_mint.redrain_for(slug)
+        if redrained is not None:
+            await _recover_redrained_requests(redrained)
+    except Exception:  # noqa: BLE001 -- a dedicated cold mint remains the fallback
+        logger.debug("warm mint adoption re-drain failed", exc_info=True)
+    return await _adopt_shared_row(slug, mcp_url)
 
 
 async def _claim_shared_mints(slugs: list[str]) -> tuple[dict[str, str], list[MintState]]:
@@ -1788,6 +1857,44 @@ async def _absorb_warm_requests(result: _WarmMintResult, claims: dict[str, str])
         )
     if unfulfilled:
         await _release_shared_claims(unfulfilled)
+    return minted
+
+
+def _providers_with_requests(result: _WarmMintResult) -> list[Provider]:
+    names = {
+        str(request.get("serverName") or "")
+        for request in result.requests
+        if request.get("oauthUrl")
+    }
+    return [
+        provider
+        for provider in result.providers
+        if provider["slug"] in names or mcp_server_alias(provider["slug"]) in names
+    ]
+
+
+async def _recover_redrained_requests(result: _WarmMintResult) -> list[str]:
+    """Install attributable late frames through the ordinary warm-table fences."""
+    providers = _providers_with_requests(result)
+    if not providers:
+        return []
+    claims, displaced = await _claim_shared_mints([provider["slug"] for provider in providers])
+    if not claims:
+        return []
+    try:
+        await _dispose_displaced_rows(displaced)
+        narrowed = _WarmMintResult(
+            generation=result.generation,
+            activation=result.activation,
+            providers=providers,
+            requests=result.requests,
+        )
+        minted = await _absorb_warm_requests(narrowed, claims)
+    except BaseException:
+        await _release_shared_claims(claims)
+        raise
+    if minted:
+        logger.info("Shared mint re-drain recovered late row(s): %s", ", ".join(sorted(minted)))
     return minted
 
 

--- a/test/test_connections_handoff.py
+++ b/test/test_connections_handoff.py
@@ -538,6 +538,146 @@ async def test_connect_falls_back_to_a_cold_mint_when_nothing_is_adoptable(
 
 
 @pytest.mark.asyncio
+async def test_connect_does_not_redrain_a_stale_authorization_shape(
+    monkeypatch: pytest.MonkeyPatch, cold_mint: dict[str, int]
+):
+    class _StaleHandle:
+        def __init__(self) -> None:
+            self.pops = 0
+
+        def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+            self.pops += 1
+            return [{"serverName": "notion", "oauthUrl": _URL}]
+
+    current = _provider()
+    current["recommended_scopes"] = ["write"]
+    activated = _provider()
+    activated["recommended_scopes"] = ["read"]
+    monkeypatch.setattr(connections, "get_provider", lambda slug: current)
+    monkeypatch.setattr(warm, "get_visible_providers", lambda: [current])
+    monkeypatch.setattr(warm, "list_servers", lambda: [])
+    monkeypatch.setattr(warm, "grant_present", lambda url: False)
+    monkeypatch.setattr(warm, "_read_agent_spec", lambda *args, **kwargs: {})
+    _warm_process(monkeypatch)
+    handle = _StaleHandle()
+    session = warm._WarmSession(
+        generation=1,
+        handle=handle,
+        expires_at=float("inf"),
+        settled=True,
+        providers=(activated,),
+    )
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {1: session})
+    client = await _client()
+    try:
+        resp = await client.post("/api/connections/mint", json={"slug": "notion"})
+        body = await resp.json()
+    finally:
+        await client.close()
+
+    assert resp.status == 200
+    assert body["state"] == "minting"
+    assert body["token"] == "cold-token"
+    assert handle.pops == 0, "a stale session must not be read"
+    assert cold_mint["reserved"] == 1 and cold_mint["spawned"] == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_redrains_the_live_warm_session_before_spawning_cold(
+    monkeypatch: pytest.MonkeyPatch, cold_mint: dict[str, int]
+):
+    class _LateHandle:
+        def __init__(self) -> None:
+            self.drains = 0
+            self._pending: list[dict[str, str]] = []
+
+        def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+            pending, self._pending = self._pending, []
+            return pending
+
+        async def drain_init(self, **kwargs: Any) -> None:
+            self.drains += 1
+            self._pending.append({"serverName": "notion", "oauthUrl": _URL})
+
+    provider = _provider()
+    monkeypatch.setattr(warm, "get_visible_providers", lambda: [provider])
+    monkeypatch.setattr(warm, "list_servers", lambda: [])
+    monkeypatch.setattr(warm, "grant_present", lambda url: False)
+    monkeypatch.setattr(warm, "_read_agent_spec", lambda *args, **kwargs: {})
+    _warm_process(monkeypatch)
+    handle = _LateHandle()
+    session = warm._WarmSession(
+        generation=1,
+        handle=handle,
+        expires_at=float("inf"),
+        settled=True,
+        providers=(provider,),
+    )
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {1: session})
+    client = await _client()
+    try:
+        resp = await client.post("/api/connections/mint", json={"slug": "notion"})
+        body = await resp.json()
+    finally:
+        await client.close()
+
+    assert resp.status == 200
+    assert body["state"] == "waiting"
+    assert body["token"] == _mints["notion"]["token"]
+    assert handle.drains == 1
+    assert cold_mint == {"reserved": 0, "spawned": 0, "disposed": 0}
+    assert _mints["notion"]["oauth_url"] == _URL
+
+
+@pytest.mark.asyncio
+async def test_connect_redrain_does_not_publish_a_sibling_challenge(
+    monkeypatch: pytest.MonkeyPatch, cold_mint: dict[str, int]
+):
+    class _SiblingHandle:
+        def __init__(self) -> None:
+            self._pending: list[dict[str, str]] = []
+
+        def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+            pending, self._pending = self._pending, []
+            return pending
+
+        async def drain_init(self, **kwargs: Any) -> None:
+            self._pending.extend(
+                [
+                    {"serverName": "notion", "oauthUrl": _URL},
+                    {"serverName": "linear", "oauthUrl": "https://linear.test/authorize"},
+                ]
+            )
+
+    notion, linear = _provider("notion"), _provider("linear")
+    monkeypatch.setattr(warm, "get_visible_providers", lambda: [notion])
+    monkeypatch.setattr(warm, "list_servers", lambda: [])
+    monkeypatch.setattr(warm, "grant_present", lambda url: False)
+    monkeypatch.setattr(warm, "_read_agent_spec", lambda *args, **kwargs: {})
+    _warm_process(monkeypatch)
+    session = warm._WarmSession(
+        generation=1,
+        handle=_SiblingHandle(),
+        expires_at=float("inf"),
+        settled=True,
+        providers=(notion, linear),
+    )
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {1: session})
+    client = await _client()
+    try:
+        response = await client.post("/api/connections/mint", json={"slug": "notion"})
+        body = await response.json()
+    finally:
+        await client.close()
+
+    assert response.status == 200
+    assert body["state"] == "waiting"
+    assert _mints["notion"]["oauth_url"] == _URL
+    assert "linear" not in _mints, "a sibling challenge was not validated for this Connect"
+    assert cold_mint == {"reserved": 0, "spawned": 0, "disposed": 0}
+
+
+@pytest.mark.asyncio
 async def test_the_premint_then_connect_round_trip_serves_the_warm_url(
     monkeypatch: pytest.MonkeyPatch, cold_mint: dict[str, int]
 ):

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -253,6 +253,7 @@ def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
         "warm_spec_providers",
         "_warm_activation_candidates",
         "_warm_candidate_scan",
+        "_current_warm_redrain_entry",
         "mintable_providers",
         "_warm_spec_plan",
         "_warm_spec_is_foreign",
@@ -1752,7 +1753,21 @@ _MUST_BE_PROTECTED = [
         "asyncio.shield(create)",
         warm._WarmMintRuntime._activate_locked,
     ),
-    ("_activate_locked", "handle.drain_init", warm._WarmMintRuntime._activate_locked),
+    (
+        "_activate_locked",
+        "_collect_oauth_requests",
+        warm._WarmMintRuntime._activate_locked,
+    ),
+    (
+        "_recover_redrained_requests",
+        "_dispose_displaced_rows",
+        warm._recover_redrained_requests,
+    ),
+    (
+        "_recover_redrained_requests",
+        "_absorb_warm_requests",
+        warm._recover_redrained_requests,
+    ),
     (
         "_abandon_session_creation_locked",
         "_destroy_session_quietly",
@@ -1919,6 +1934,9 @@ class _SessionHandle:
 
     def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
         return []
+
+    async def drain_init(self, **kwargs: Any) -> None:
+        return None
 
 
 @pytest.mark.asyncio
@@ -2246,6 +2264,37 @@ async def test_a_frame_arriving_after_the_create_drain_is_still_absorbed(
 
 
 @pytest.mark.asyncio
+async def test_each_new_frame_renews_the_quiet_budget_past_the_old_fixed_limit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    handle = _QueuedOauthHandle({"linear": 5, "vercel": 10})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    _, requests = await warm._warm_mint._activate_locked("agent", frozenset({"linear", "vercel"}))
+
+    assert sorted(str(request["serverName"]) for request in requests) == ["linear", "vercel"]
+    assert handle.drains == 10
+
+
+@pytest.mark.asyncio
+async def test_progress_is_still_bounded_by_the_expected_roster(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    wanted = frozenset({"linear", "vercel", "missing"})
+    handle = _QueuedOauthHandle({"linear": 6, "vercel": 12})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    _, requests = await warm._warm_mint._activate_locked("agent", wanted)
+
+    assert sorted(str(request["serverName"]) for request in requests) == ["linear", "vercel"]
+    assert handle.drains == len(wanted) * warm._WARM_OAUTH_SETTLE_ROUNDS
+
+
+@pytest.mark.asyncio
 async def test_the_settle_loop_stops_as_soon_as_every_wanted_frame_is_in(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2276,8 +2325,8 @@ async def test_the_settle_loop_consumes_on_every_round_it_waits(
     await warm._warm_mint._activate_locked("agent", frozenset({"linear", "never"}))
 
     assert (
-        handle.drains == warm._WARM_OAUTH_SETTLE_ROUNDS - 1
-    ), "every round that waits must consume; the last round pops and does not wait"
+        handle.drains == warm._WARM_OAUTH_SETTLE_ROUNDS
+    ), "every quiet round must consume before the inactivity budget is exhausted"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Warm OAuth sessions can receive a provider challenge after the original fixed settle budget ends. The frame remains queued inside a process that has already paid activation cost, but Connect sees no adoptable row and falls back to a dedicated cold mint.

## Why it matters

Affected Connect clicks discard a usable warm-session path and pay the full cold-spawn latency. Multi-provider activation makes later provider frames the most likely to cross the old fixed cutoff.

## What changed (motivation → approach → change)

The collector now treats consecutive quiet drains as its inactivity budget: every newly observed provider renews that budget, while a roster-derived hard cap keeps collection bounded. Warm sessions retain their provider roster, and an adoption miss re-drains the newest live matching session once, routes attributable late frames through the existing claim, credential-screen, token-fence, watcher, and settlement paths, then retries adoption before cold fallback.

The owning warm-table design note documents the progress-sensitive bound, the recovery path, and the unchanged boundary: this does not add a supervisor or proactive re-arm after a shared session dies.

## Tests

- Added coverage proving provider progress can extend collection beyond the old fixed limit without exceeding the roster-derived hard cap.
- Added an endpoint-level handoff test proving Connect re-drains a live warm session and avoids a cold spawn.
- Updated the cancellation-protection drift guard for the extracted collector and recovery awaits.
- Ran 134 focused backend tests across `test_connections_warm.py` and `test_connections_handoff.py`.
- Ran the resolved profile's format, import, type, docs, security, policy, frontend build, 5,468-test cross-surface, Electron, duplication, and bundle-size gates.

## Manual verification

N/A — deterministic fake session handles cover late queue arrival and the real dashboard endpoint handoff; no external provider behavior or rendered UI changes.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** The diff changes backend warm-session harvesting plus tests and its design note; rendered output is unchanged.

## Related Issues

no linked issue: this is an independent Wave-1 warm-harvest slice.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Bounded async collectors should renew inactivity budgets on unique progress while retaining a cardinality-derived absolute cap.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
