### PR TITLE
fix: retry rejected OAuth mint once

### DIFF
--- a/docs/architecture/design-notes/connections-status-tiers.md
+++ b/docs/architecture/design-notes/connections-status-tiers.md
@@ -60,10 +60,21 @@ existing contract exactly: the POST reserves a row and returns
 `{ok, slug, state, token}`, the GET is the card's authoritative feed for a
 card-initiated mint (`idle|minting|waiting|granted|failed|expired`, with
 `oauth_url` only while `waiting`), and the frontend keeps polling it at its own
-cadence. The status endpoint is **additive** and never mints: it observes the
-mint table to distinguish `awaiting_consent` from `not_connected`, and that is
-the whole of its relationship to minting. Approval-URL ownership stays with the
-mint engine.
+cadence. Approval-URL ownership stays with the mint engine.
+
+A cold mint whose URL is rejected by `oauth_url_contains_credential` disposes
+that dedicated process, protected PID, and ephemeral spec, then creates one
+fresh dedicated attempt with a new provider OAuth state. The retry keeps the
+caller's row token, so the initiating tab continues to own the result. A second
+rejection is terminal and surfaces the existing `failed` / `mint_url_rejected`
+state; no other failure class retries. Warm URLs pass the same credential gate
+before they become adoptable. A rejected warm claim is released, so a later
+Connect follows the cold path and reaches this single retry owner rather than
+carrying a second policy in the warm engine or dashboard handler.
+
+The status endpoint is **additive** and never mints: it observes the mint table
+to distinguish `awaiting_consent` from `not_connected`, and that is the whole of
+its relationship to minting.
 
 ## connectedSince is source-backed
 

--- a/src/kiro_crew/connections/mint.py
+++ b/src/kiro_crew/connections/mint.py
@@ -608,6 +608,9 @@ async def _claim_mint_pid_when_spawned(client: Any, holdings: MintState) -> None
         await asyncio.sleep(_MINT_PID_CLAIM_POLL_SECONDS)
 
 
+_MINT_URL_REJECTION_ATTEMPTS = 2
+
+
 async def start_oauth_mint(
     slug: str,
     mcp_url: str,
@@ -617,7 +620,8 @@ async def start_oauth_mint(
     """Mint ``slug``'s approval URL on a dedicated promptless session.
 
     Fire-and-forget. Never raises: failures are recorded in the mint table and
-    surface on the card as a coarse reason code.
+    surface on the card as a coarse reason code. A URL rejected by the credential
+    guard gets one fresh process and OAuth state before rejection becomes terminal.
 
     ``token``/``prior`` come from :func:`reserve_mint_row` when a caller already
     made the row visible; without them this installs its own row.
@@ -657,51 +661,64 @@ async def start_oauth_mint(
     # Accumulates what this flow owns, so every exit path releases all of it.
     holdings: MintState = {}
     try:
-        acp_client_cls = _acp_client_factory()
-        # One server, not all of them: see _write_mint_agent_spec.
-        agent_name, spec_path = await asyncio.to_thread(_write_mint_agent_spec, slug)
-        holdings["agent"] = agent_name
-        holdings["spec_path"] = spec_path
         # Off the loop: resolving the data home creates it when a KIROCREW_HOME
         # override is in play, so this is a write and not merely a path join.
         mint_work_dir = await asyncio.to_thread(data_home)
-        client = acp_client_cls(
-            work_dir=mint_work_dir / "connections" / "mint",
-            model="auto",
-            agent=agent_name,
-            sandbox_mode="auto",
-            session_key=f"connections-mint-{slug}",
-        )
-        holdings["client"] = client
-        # session/new with NO prompt: MCP init is eager, so the challenge
-        # buffered during init is available right after ready.
-        #
-        # The PID claim races readiness on purpose. The child is spawned partway
-        # THROUGH ensure_ready, and nothing claims it as a session, so the orphan
-        # sweep reaps it once it ages past the spawn grace. Waiting for readiness
-        # would leave that whole initialization window -- up to the readiness
-        # timeout -- open to the sweep killing a mint that is still starting.
-        claim = asyncio.get_running_loop().create_task(
-            _claim_mint_pid_when_spawned(client, holdings)
-        )
-        try:
-            await asyncio.wait_for(client.ensure_ready(), timeout=_MINT_READY_TIMEOUT_SECONDS)
-        finally:
-            claim.cancel()
-            # Covers the fast path, where readiness beat the poller's first tick,
-            # AND the failure path, so a spawned child is always released.
-            _claim_mint_pid(client, holdings)
-
         oauth_url = ""
-        for req in client.pop_pending_oauth_requests():
-            if req.get("serverName") == slug and req.get("oauthUrl"):
-                oauth_url = str(req["oauthUrl"])
+        for attempt in range(_MINT_URL_REJECTION_ATTEMPTS):
+            acp_client_cls = _acp_client_factory()
+            # One server, not all of them: see _write_mint_agent_spec.
+            agent_name, spec_path = await asyncio.to_thread(_write_mint_agent_spec, slug)
+            holdings["agent"] = agent_name
+            holdings["spec_path"] = spec_path
+            client = acp_client_cls(
+                work_dir=mint_work_dir / "connections" / "mint",
+                model="auto",
+                agent=agent_name,
+                sandbox_mode="auto",
+                session_key=f"connections-mint-{slug}",
+            )
+            holdings["client"] = client
+            # session/new with NO prompt: MCP init is eager, so the challenge
+            # buffered during init is available right after ready.
+            #
+            # The PID claim races readiness on purpose. The child is spawned partway
+            # THROUGH ensure_ready, and nothing claims it as a session, so the orphan
+            # sweep reaps it once it ages past the spawn grace. Waiting for readiness
+            # would leave that whole initialization window -- up to the readiness
+            # timeout -- open to the sweep killing a mint that is still starting.
+            claim = asyncio.get_running_loop().create_task(
+                _claim_mint_pid_when_spawned(client, holdings)
+            )
+            try:
+                await asyncio.wait_for(client.ensure_ready(), timeout=_MINT_READY_TIMEOUT_SECONDS)
+            finally:
+                claim.cancel()
+                # Covers the fast path, where readiness beat the poller's first tick,
+                # AND the failure path, so a spawned child is always released.
+                _claim_mint_pid(client, holdings)
+
+            oauth_url = ""
+            for req in client.pop_pending_oauth_requests():
+                if req.get("serverName") == slug and req.get("oauthUrl"):
+                    oauth_url = str(req["oauthUrl"])
+                    break
+            credential_bearing = (
+                await asyncio.to_thread(oauth_url_contains_credential, oauth_url)
+                if oauth_url
+                else False
+            )
+            if not credential_bearing:
                 break
-        if oauth_url and oauth_url_contains_credential(oauth_url):
+
             # The same predicate the chat consent path applies before surfacing a
             # banner. The value is never logged or recorded.
             logger.warning("OAuth mint for %r produced a URL with a credential pattern", slug)
             await _dispose_mint(holdings)
+            holdings = {}
+            if attempt + 1 < _MINT_URL_REJECTION_ATTEMPTS:
+                continue
+
             async with _mints_lock:
                 if _mints.get(slug, {}).get("token") == my_token:
                     _mints[slug] = {

--- a/test/test_connections_mint.py
+++ b/test/test_connections_mint.py
@@ -489,7 +489,7 @@ async def test_a_late_failure_does_not_clobber_the_live_row(monkeypatch: pytest.
 
 
 @pytest.mark.asyncio
-async def test_a_credential_bearing_url_is_refused_and_never_recorded(
+async def test_a_credential_bearing_url_is_disposed_and_retried_once(
     monkeypatch: pytest.MonkeyPatch, protected_pids: set[int], caplog
 ):
     tainted = "https://auth.example.com/authorize?client_id=abc&access_token=AKIAIOSFODNN7EXAMPLE"
@@ -499,26 +499,93 @@ async def test_a_credential_bearing_url_is_refused_and_never_recorded(
             super().__init__(**kwargs)
             self.requests = [{"serverName": "notion", "oauthUrl": tainted}]
 
-    monkeypatch.setattr(mint, "_acp_client_factory", lambda: _Tainted)
+    attempts = iter([_Tainted, _FakeClient])
+    monkeypatch.setattr(mint, "_acp_client_factory", lambda: next(attempts))
     logged: list[str] = []
     monkeypatch.setattr(
         mint,
         "_log_mint_outcome",
         lambda slug, outcome, detail: logged.append(f"{outcome} {detail}"),
     )
+    token, prior = await mint.reserve_mint_row("notion")
 
     with caplog.at_level("WARNING"):
-        await mint.start_oauth_mint("notion", _URL)
+        await mint.start_oauth_mint("notion", _URL, token, prior)
 
-    # Same predicate the chat consent path applies. The card gets a coarse
-    # failure, and the value appears in no log line and no audit event.
     view = mint.pending_mint_for("notion")
+    assert view is not None
+    assert view["token"] == token
+    assert _state_only(view) == {"state": "waiting", "oauth_url": _AUTHORIZE}
+    assert len(_FakeClient.instances) == 2
+    rejected, fresh = _FakeClient.instances
+    assert rejected.shutdowns == 1
+    assert fresh.shutdowns == 0
+    assert protected_pids == {fresh._pid}
+    assert logged == ["ok url_minted=True"]
+    assert "AKIAIOSFODNN7EXAMPLE" not in caplog.text
+    assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(logged)
+
+    await mint._dispose_mint(mint._mints["notion"])
+    assert fresh.shutdowns == 1
+    assert protected_pids == set()
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_url_and_its_retry_are_screened_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    seen: list[int] = []
+    verdicts = iter([True, False])
+
+    def _screen(_url: str) -> bool:
+        seen.append(threading.get_ident())
+        return next(verdicts)
+
+    monkeypatch.setattr(mint, "oauth_url_contains_credential", _screen)
+
+    await mint.start_oauth_mint("notion", _URL)
+    clients = list(_FakeClient.instances)
+    await mint._dispose_mint(mint._mints["notion"])
+
+    assert len(seen) == 2
+    assert threading.get_ident() not in seen
+    assert len(clients) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_second_credential_bearing_url_surfaces_failure_without_a_third_attempt(
+    monkeypatch: pytest.MonkeyPatch, protected_pids: set[int], caplog
+):
+    tainted = "https://auth.example.com/authorize?client_id=abc&access_token=AKIAIOSFODNN7EXAMPLE"
+
+    class _Tainted(_FakeClient):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.requests = [{"serverName": "notion", "oauthUrl": tainted}]
+
+    attempts = iter([_Tainted, _Tainted])
+    monkeypatch.setattr(mint, "_acp_client_factory", lambda: next(attempts))
+    logged: list[str] = []
+    monkeypatch.setattr(
+        mint,
+        "_log_mint_outcome",
+        lambda slug, outcome, detail: logged.append(f"{outcome} {detail}"),
+    )
+    token, prior = await mint.reserve_mint_row("notion")
+
+    with caplog.at_level("WARNING"):
+        await mint.start_oauth_mint("notion", _URL, token, prior)
+
+    view = mint.pending_mint_for("notion")
+    assert view is not None
+    assert view["token"] == token
     assert _state_only(view) == {"state": "failed", "reason": "mint_url_rejected"}
+    assert len(_FakeClient.instances) == 2
+    assert [client.shutdowns for client in _FakeClient.instances] == [1, 1]
+    assert protected_pids == set()
     assert logged == ["error reason=mint_url_rejected"]
     assert "AKIAIOSFODNN7EXAMPLE" not in caplog.text
     assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(logged)
-    assert protected_pids == set()
-    assert _FakeClient.instances[-1].shutdowns == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

A valid provider OAuth authorization URL can occasionally be rejected as `mint_url_rejected` when its newly generated entropy happens to resemble a credential pattern. The current mint attempt then fails even though generating fresh OAuth state would usually avoid the collision.

## Why it matters

One probabilistic safety-check collision currently turns a normal Connect click into a terminal authorization failure. Users must retry manually and the failure can look provider-specific even though the provider is healthy.

## What changed (motivation → approach → change)

The mint flow now retries exactly once, and only after `mint_url_rejected`. The retry creates a fresh mint attempt with fresh OAuth state. A second rejection remains terminal, while timeout, process-death, cancellation, and every other failure keep their existing behavior. Row ownership and teardown remain explicit so the failed attempt cannot leak into the retry.

## Tests

- Added deterministic coverage for one fresh retry after `mint_url_rejected`.
- Pins that a second rejection is terminal.
- Pins cancellation, timeout, existing-grant, row-token, watcher, and teardown behavior.
- Post-rebase focused suite: 112 passed.
- isort, Flake8, mypy, and documentation gates passed.

## Manual verification

N/A — the behavior is deterministic at the mint-engine boundary and is covered without contacting an external provider or handling credential material.

## Related Issues

no linked issue: discovered during the post-G1 Connections bug bash.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A bounded retry must key on one explicitly transient machine code and create fresh attempt state; broad retries can duplicate side effects or hide terminal failures.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
