### PR TITLE
fix: resume cloud bootstrap after managed reboot

### DIFF
--- a/docs/system-specs/modules/cloud.md
+++ b/docs/system-specs/modules/cloud.md
@@ -87,6 +87,20 @@ rollback, one-command `delete-stack` teardown. AMI resolves from the public
 `WaitCondition` + `cfn-signal` blocks the deploy until the gateway is healthy; a
 failed bootstrap folds the on-box setup-log tail into the signal reason so the cause survives the rollback. Bootstrap failure reasons are normalized to printable ASCII before CloudFormation receives them; otherwise CloudFormation replaces the setup error with a charset error and masks it during rollback (`test_cloud_ec2.py::test_failure_reason_is_filtered_to_printable_ascii`).
 
+Bootstrap is reboot-resilient. UserData performs no package or build work directly:
+it first copies its already-rendered script to
+`/usr/local/sbin/kirocrew-bootstrap`, installs and enables the
+`kirocrew-bootstrap.service` systemd oneshot, starts it without blocking, and
+exits. If an account-level State Manager association such as
+`AWS-RunPatchBaseline` reboots a newly-online managed node during npm/Vite,
+systemd starts the same rendered script again on the next boot. Durable markers
+under `/var/lib/kirocrew-bootstrap/` checkpoint installation separately from
+successful WaitCondition delivery: a reboot after installation retries gateway
+health and the success signal without replacing the checkout, while a reboot
+before installation completes stops any partially enabled gateway and safely
+reruns the idempotent install. Once `signal-complete` exists, later host reboots
+skip bootstrap and only the normal gateway service starts.
+
 The instance bootstrap runs `install.sh --voice` on both its initial attempt and
 retry. This installs the existing `voice` extra (`boto3` and
 `amazon-transcribe`) before the gateway first imports its Transcribe provider;

--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -283,6 +283,17 @@ Resources:
       # EXPANDED size is guarded by test_cloud_ec2.py's UserData size test;
       # when it trips, trim the script or move knowledge here, never delete it.
       #
+      # "Reboot resume": State Manager runs wildcard associations when a new
+      #   managed node first comes online. An account-level
+      #   AWS-RunPatchBaseline association can therefore patch and reboot the
+      #   instance while npm/vite is still running, killing cloud-init itself
+      #   so an in-script retry never executes. UserData immediately persists
+      #   its already-rendered script as an enabled systemd oneshot and exits;
+      #   systemd starts it again after a reboot. Separate install-complete and
+      #   signal-complete markers make the install idempotent while still
+      #   retrying the WaitCondition handshake if the reboot lands between
+      #   those phases. A partially written gateway install is stopped before
+      #   its checkout is replaced, avoiding a resume race with its own unit.
       # "Logging": log via a plain file redirect (NOT `tee` via process
       #   substitution) and do NOT set `pipefail` -- install.sh's progress
       #   spinner writes many \r updates through a pipe, and a tee+pipefail
@@ -375,10 +386,12 @@ Resources:
       #   which is what lets the retry actually re-run it. install.sh is
       #   retried once on a cold first boot: observed on the light tier, the
       #   very first run can be signal-killed mid-build (no clean error, no
-      #   kernel OOM) under first-boot contention (cloud-init + SSM
+      #   kernel OOM) under same-boot contention (cloud-init + SSM
       #   registration + dnf + kiro-cli install + a fresh `npm ci` all
       #   compressed together); a retry on the now-warm box (primed caches,
       #   node_modules present) reliably reaches "installed successfully".
+      #   That retry cannot survive a host reboot because its parent shell is
+      #   killed too; the persistent bootstrap oneshot above owns that case.
       #   `set -e` is relaxed only for the first attempt (the `if` guard); a
       #   failed retry still exits nonzero so the outer `|| fail` signals the
       #   WaitCondition.
@@ -417,6 +430,37 @@ Resources:
           # above UserData, keyed by the section names quoted below.
           # No pipefail + plain-file logging: see "Logging" above.
           set -u
+
+          # cloud-init runs UserData once. Persist the already-rendered script and
+          # hand off immediately so a managed patch reboot can resume it on boot.
+          BOOTSTRAP_SCRIPT=/usr/local/sbin/kirocrew-bootstrap
+          BOOTSTRAP_STATE=/var/lib/kirocrew-bootstrap
+          INSTALL_DONE=$BOOTSTRAP_STATE/install-complete
+          SIGNAL_DONE=$BOOTSTRAP_STATE/signal-complete
+          if [ "$#" -eq 0 ]; then
+            install -m 0700 "$0" "$BOOTSTRAP_SCRIPT"
+            cat > /etc/systemd/system/kirocrew-bootstrap.service <<'UNIT'
+          [Unit]
+          Description=Kiro Crew resumable bootstrap
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/sbin/kirocrew-bootstrap --resume
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+          UNIT
+            systemctl daemon-reload
+            systemctl enable kirocrew-bootstrap.service
+            systemctl start --no-block kirocrew-bootstrap.service
+            exit 0
+          fi
+
+          mkdir -p "$BOOTSTRAP_STATE"
+          [ -f "$SIGNAL_DONE" ] && exit 0
           exec >>/var/log/kirocrew-setup.log 2>&1
           echo "=== KiroCrew bootstrap starting $(date -u) ==="
 
@@ -436,8 +480,13 @@ Resources:
             exit 1
           }
 
-          # The stock AL2023 reboot would SIGTERM the build mid-install: see
-          # "SELinux reboot" above. Best-effort, never fails the bootstrap.
+          if [ ! -f "$INSTALL_DONE" ]; then
+            # A reboot after the gateway unit was enabled but before checkpointing
+            # can queue both units. Stop it before replacing the checkout.
+            systemctl stop kirocrew.service 2>/dev/null || true
+
+            # The stock AL2023 reboot would SIGTERM the build mid-install: see
+            # "SELinux reboot" above. Best-effort, never fails the bootstrap.
           echo "--- suppressing AL2023 first-boot SELinux reboot ---"
           rm -f /run/cloud-init-selinux-reboot 2>/dev/null || true
           rm -f /etc/cloud/cloud.cfg.d/40_selinux-reboot.cfg 2>/dev/null || true
@@ -602,7 +651,13 @@ Resources:
           WantedBy=multi-user.target
           UNIT
           systemctl daemon-reload
-          systemctl enable --now kirocrew.service || fail "could not start kirocrew.service"
+          touch "$INSTALL_DONE"
+          fi
+
+          # This phase is safe to repeat after install completed but before the
+          # WaitCondition acknowledgement was durably recorded.
+          systemctl enable kirocrew.service || fail "could not enable kirocrew.service"
+          systemctl start kirocrew.service || fail "could not start kirocrew.service"
 
           echo "--- waiting for the gateway to answer on 127.0.0.1:${DashboardPort} ---"
           ok=0
@@ -613,9 +668,22 @@ Resources:
           [ "$ok" = "1" ] || fail "gateway did not become healthy within 5 minutes"
 
           echo "=== KiroCrew bootstrap complete $(date -u) ==="
-          /opt/aws/bin/cfn-signal -e 0 -r "kirocrew healthy" "$HANDLE" || \
-            curl -s -X PUT -H 'Content-Type:' --data-binary \
-              "{\"Status\":\"SUCCESS\",\"Reason\":\"kirocrew healthy\",\"UniqueId\":\"kirocrew\",\"Data\":\"ok\"}" "$HANDLE" || true
+          signal_ok=0
+          for attempt in 1 2 3; do
+            if /opt/aws/bin/cfn-signal -e 0 -r "kirocrew healthy" "$HANDLE"; then
+              signal_ok=1
+              break
+            fi
+            if curl -fsS -X PUT -H 'Content-Type:' --data-binary \
+              "{\"Status\":\"SUCCESS\",\"Reason\":\"kirocrew healthy\",\"UniqueId\":\"kirocrew\",\"Data\":\"ok\"}" "$HANDLE"; then
+              signal_ok=1
+              break
+            fi
+            echo "WaitCondition success signal attempt $attempt failed; retrying"
+            sleep 5
+          done
+          [ "$signal_ok" = "1" ] || { echo "could not deliver WaitCondition success"; exit 1; }
+          touch "$SIGNAL_DONE"
 
   # --- WaitCondition: `aws cloudformation deploy` blocks until the box is
   #     actually serving. cfn-signal in UserData reports success/failure.

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -260,6 +260,55 @@ class TestTemplate:
         text = ec2.load_template()
         assert "KIROCREW_REQUIRE_FRONTEND=1" in text
 
+    def test_bootstrap_hands_off_to_persistent_oneshot_before_heavy_work(self):
+        # State Manager applies wildcard associations when a managed node first comes
+        # online. AWS-RunPatchBaseline can therefore reboot a brand-new instance while
+        # cloud-init is still building the frontend. UserData must persist itself and
+        # start an enabled oneshot before any package/build work, so systemd starts the
+        # same rendered script again after that reboot.
+        text = ec2.load_template()
+        handoff = text.index("BOOTSTRAP_SCRIPT=/usr/local/sbin/kirocrew-bootstrap")
+        heavy_work = text.index('echo "--- installing system packages ---"')
+        assert handoff < heavy_work
+        assert 'if [ "$#" -eq 0 ]; then' in text
+        assert 'install -m 0700 "$0" "$BOOTSTRAP_SCRIPT"' in text
+        assert "Type=oneshot" in text
+        assert "ExecStart=/usr/local/sbin/kirocrew-bootstrap --resume" in text
+        assert "RemainAfterExit=yes" in text
+        assert "WantedBy=multi-user.target" in text
+        assert "systemctl enable kirocrew-bootstrap.service" in text
+        assert "systemctl start --no-block kirocrew-bootstrap.service" in text
+
+    def test_bootstrap_checkpoints_install_and_waitcondition_signal_separately(self):
+        # A reboot can land after the gateway is installed but before CloudFormation
+        # receives SUCCESS. Keep separate markers so resume skips destructive install
+        # work but retries the still-missing WaitCondition handshake.
+        text = ec2.load_template()
+        signal_guard = text.index('[ -f "$SIGNAL_DONE" ] && exit 0')
+        install_guard = text.index('if [ ! -f "$INSTALL_DONE" ]; then')
+        install_done = text.index('touch "$INSTALL_DONE"')
+        signal = text.index("/opt/aws/bin/cfn-signal -e 0")
+        signal_done = text.index('touch "$SIGNAL_DONE"')
+        assert signal_guard < install_guard < install_done < signal < signal_done
+        assert "INSTALL_DONE=$BOOTSTRAP_STATE/install-complete" in text
+        assert "SIGNAL_DONE=$BOOTSTRAP_STATE/signal-complete" in text
+
+    def test_bootstrap_resume_cannot_clobber_a_running_gateway(self):
+        # If a reboot lands after the gateway unit was written but before the install
+        # marker, systemd may queue both services on the next boot. Stop the gateway
+        # before replacing its checkout, then mark install complete before starting it
+        # and performing the health/signal phase outside the install guard.
+        text = ec2.load_template()
+        install_guard = text.index('if [ ! -f "$INSTALL_DONE" ]; then')
+        stop_gateway = text.index("systemctl stop kirocrew.service")
+        replace_checkout = text.index("rm -rf kirocrew && mkdir kirocrew")
+        install_done = text.index('touch "$INSTALL_DONE"')
+        start_gateway = text.index("systemctl start kirocrew.service")
+        signal = text.index("/opt/aws/bin/cfn-signal -e 0")
+        assert (
+            install_guard < stop_gateway < replace_checkout < install_done < start_gateway < signal
+        )
+
     def test_bootstrap_installs_voice_extra_before_gateway_boot(self):
         # Remote instances need the Transcribe SDK in their venv before the
         # gateway imports boto3. Keep both the first attempt and retry aligned.


### PR DESCRIPTION
## Problem / Motivation

A fresh `kirocrew cloud launch` can fail during the frontend build when an account-level Systems Manager State Manager association patches and reboots the new EC2 instance. The existing bootstrap runs as one foreground cloud-init process, so the reboot kills both `install.sh` and the outer retry path before the WaitCondition can be signaled.

This was observed as a silent mid-Vite termination followed by `BOOTSTRAP FAILED: kirocrew install.sh failed`.

## Why it matters

Accounts with wildcard `AWS-RunPatchBaseline` associations apply them when a managed node first comes online. Those security-baselined accounts can therefore lose otherwise healthy cloud launches nondeterministically, with CloudFormation rolling the stack back and destroying the only full setup log.

## What changed (motivation → approach → change)

The failure is a host reboot, not an npm error, so another in-process retry cannot solve it. This change moves bootstrap ownership from one-shot cloud-init execution to persistent systemd state:

- UserData immediately copies its already-rendered script to a root-only path and enables a `Type=oneshot` bootstrap service before package/build work.
- Systemd starts the same script again after reboot.
- Separate `install-complete` and `signal-complete` markers distinguish installation from WaitCondition delivery.
- Resume skips destructive install work once installation completed, but still starts/health-checks the gateway and retries the success signal.
- A partially enabled gateway is stopped before an incomplete install replaces its checkout.
- The cloud subsystem specification now documents the reboot-resume contract.

## Tests

- Added `test_bootstrap_hands_off_to_persistent_oneshot_before_heavy_work` to pin persistence and ordering before package work.
- Added `test_bootstrap_checkpoints_install_and_waitcondition_signal_separately` to pin the two-phase resume contract.
- Added `test_bootstrap_resume_cannot_clobber_a_running_gateway` to pin safe gateway/install ordering.
- Mutation proof: all three new tests fail when only the production template is restored to `origin/main`, and pass with this change.
- `test/test_cloud_ec2.py`: 96 passed.
- Expanded UserData guard: 13,616 bytes, leaving 2,768 bytes under EC2's 16 KiB hard limit.
- Deterministic formatting, typing, docs, policy, vendor-manifest, scrub, and CloudFormation gates passed.
- Cross-surface frontend selection: 202 files / 5,468 tests passed.
- Full local backend run: 80,858 passed; the remaining host-specific macOS/cgroup/worker-budget failures reproduce unchanged on `origin/main`.
- Local GPT-5.6-sol and Opus 4.8 contract reviews: PASS.

## Manual verification

- Extracted rendered UserData passes `bash -n`.
- Current `cfn-lint` accepts the modified template.
- Verified the feature branch contains one commit directly on the fetched upstream base.
- No live AWS launch was performed, so an end-to-end forced-reboot deployment remains for maintainer/integration validation.

<!-- no-visual-delta -->
**Why no screenshot:** This changes EC2 bootstrap lifecycle only; it has no rendered UI effect.

## Related Issues

Fixes #5573

## Pattern harvest

Rule candidate: review-prompt
Pattern: Long-running first-boot work must be persisted before a management agent can trigger a host reboot; an in-process retry cannot survive loss of its parent process.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
