### PR TITLE
fix(messaging): skip non-record transcript lines

### DIFF
--- a/src/kiro_crew/messaging/sessions_view.py
+++ b/src/kiro_crew/messaging/sessions_view.py
@@ -209,6 +209,8 @@ def _collect_recent_sessions(
             except ValueError:
                 # Covers json.JSONDecodeError, which subclasses ValueError.
                 continue
+            if not isinstance(d, dict):
+                continue
             if d.get("_type") == "metadata":
                 title = d.get("title") or title
                 agent = d.get("agent") or agent

--- a/test/test_slack_sessions_view.py
+++ b/test/test_slack_sessions_view.py
@@ -231,6 +231,24 @@ class TestCollectRecentSessions:
         assert rows[0]["title"] == "ok"
         assert rows[0]["msgs"] == [{"role": "user", "content": "hi"}]
 
+    def test_skips_valid_json_lines_that_are_not_records(self, sess_dir):
+        path = sess_dir / "dashboard_non_record.jsonl"
+        path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"_type": "metadata", "title": "ok"}),
+                    "null",
+                    json.dumps(["not", "a", "record"]),
+                    json.dumps({"role": "user", "content": "hi"}),
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        rows = _collect_recent_sessions(None)
+
+        assert rows[0]["msgs"] == [{"role": "user", "content": "hi"}]
+
     def test_truncates_long_message_content(self, sess_dir):
         big = "x" * 10000
         _write_jsonl(sess_dir / "dashboard_a.jsonl", title="t", messages=[("user", big)])


### PR DESCRIPTION
## Problem / Motivation

The shared recent-session collector skips syntactically invalid JSONL lines, but assumes every successfully decoded JSON value is an object. A valid scalar such as `null` therefore raises at `d.get(...)` and aborts the whole session-list request.

## Why it matters

One malformed transcript line can make recent sessions unavailable across the channel surfaces that share this collector, instead of only ignoring the unusable line.

## What changed (motivation → approach → change)

After decoding each line, require the transcript record to be a JSON object before reading record fields. Non-object JSON values now follow the same skip behavior as syntactically malformed lines, while later valid records in the transcript remain available.

## Tests

Added a regression covering both a JSON scalar and array between valid metadata and message records. It failed on `origin/main` with `AttributeError` and passes with the guard. The full direct sibling test file passes: 58 passed, 1 skipped.

## Manual verification

N/A — the deterministic collector regression exercises the complete parsing path without an external service.

## Related Issues

N/A — no matching open issue or PR found.

## Pattern harvest

Rule candidate: review-prompt
Pattern: validate a decoded JSON value's container type before mapping access.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing direct tests pass and a regression test was added
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no public contract changed)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository template states that exact CLA wording is pending; no text has been invented here.