### PR TITLE
fix(mcp): ignore non-object global config json

### DIFF
--- a/src/kiro_crew/mcp_cleanup.py
+++ b/src/kiro_crew/mcp_cleanup.py
@@ -187,6 +187,8 @@ def clean_stale_managed_mcp() -> list[str]:
         data = json.loads(_kiro_mcp_json().read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return []
+    if not isinstance(data, dict):
+        return []
     servers = data.get("mcpServers", {})
     if not isinstance(servers, dict):
         return []

--- a/test/test_installer_shim_and_cleanup.py
+++ b/test/test_installer_shim_and_cleanup.py
@@ -678,6 +678,15 @@ def test_clean_stale_malformed_json_untouched(tmp_path, monkeypatch):
     assert p.read_text(encoding="utf-8") == "{ not valid json "  # left untouched
 
 
+def test_clean_stale_non_object_json_untouched(tmp_path, monkeypatch):
+    p = tmp_path / "mcp.json"
+    p.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(mcp_cleanup, "_KIRO_MCP_JSON", p)
+
+    assert mcp_cleanup.clean_stale_managed_mcp() == []
+    assert p.read_text(encoding="utf-8") == "[]"
+
+
 def test_clean_stale_no_stale_leaves_file_untouched(tmp_path, monkeypatch):
     p = tmp_path / "mcp.json"
     content = json.dumps(


### PR DESCRIPTION
## Problem / Motivation

`clean_stale_managed_mcp()` handles missing and syntactically invalid global MCP config files as a no-op, but assumes every successfully decoded JSON root is an object. A valid root such as `[]` reaches `data.get(...)` and raises `AttributeError` during explicit setup or first-run cleanup.

## Why it matters

An unusual or externally corrupted user-owned `~/.kiro/settings/mcp.json` can crash setup even though this cleanup helper documents errors as a fail-soft empty result. Cleanup must also avoid rewriting a config shape it does not understand.

## What changed (motivation → approach → change)

Require the decoded root to be a mapping before reading `mcpServers`. Non-object JSON now returns the same no-op result as invalid JSON and leaves the user-owned file byte-for-byte unchanged.

## Tests

Added a regression using a valid JSON array root. It failed on `origin/main` with `AttributeError` and now passes. The five direct `clean_stale` sibling tests pass.

## Manual verification

N/A — the filesystem-backed regression exercises the complete cleanup read path and verifies the file remains unchanged.

## Related Issues

N/A — no matching open issue or PR found; the nearby MCP config ownership PR addresses authorization, not malformed root handling.

## Pattern harvest

Rule candidate: review-prompt
Pattern: validate a decoded JSON root's container type before mapping access.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing direct tests pass and a regression test was added
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — behavior now matches the documented fail-soft contract)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository template states that exact CLA wording is pending; no text has been invented here.