### PR TITLE
fix(session): skip vanished result files

### DIFF
--- a/src/kiro_crew/session_workspace.py
+++ b/src/kiro_crew/session_workspace.py
@@ -114,11 +114,15 @@ def list_results(session_id: str) -> list[dict]:
     results = []
     for p in sorted(d.glob("agent-*.md")):
         agent_id = p.stem.removeprefix("agent-")
+        try:
+            size = p.stat().st_size
+        except FileNotFoundError:
+            continue
         results.append(
             {
                 "agent_id": agent_id,
                 "path": str(p),
-                "size": p.stat().st_size,
+                "size": size,
             }
         )
     return results

--- a/test/test_session_workspace.py
+++ b/test/test_session_workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -51,6 +52,22 @@ def test_list_results(fake_config_dir):
     assert len(results) == 2
     assert results[0]["agent_id"] == "abc"
     assert results[1]["agent_id"] == "def"
+
+
+def test_list_results_skips_file_removed_after_scan(fake_config_dir, monkeypatch):
+    from kiro_crew.session_workspace import list_results, write_result
+
+    write_result("s1", "gone", "result")
+    original_glob = Path.glob
+
+    def deleting_glob(path, pattern):
+        for match in original_glob(path, pattern):
+            match.unlink()
+            yield match
+
+    monkeypatch.setattr(Path, "glob", deleting_glob)
+
+    assert list_results("s1") == []
 
 
 def test_history_roundtrip(fake_config_dir):


### PR DESCRIPTION
## Problem / Motivation

`list_results()` enumerates sub-agent result files and then stats each path. If cleanup removes a result after enumeration but before `stat()`, `FileNotFoundError` escapes through callers such as the dashboard session-agents endpoint.

## Why it matters

Result cleanup and dashboard reads can run concurrently. A harmless disappearing result should be omitted from the response, not turn the whole session-results request into an HTTP 500.

## What changed (motivation → approach → change)

Read each result size before appending its metadata and skip only entries that vanished during that read. Other filesystem errors retain their existing behavior.

## Tests

Added a deterministic regression that removes a result after `glob()` discovers it. It failed on `origin/main` with `FileNotFoundError` and now passes. All 10 focused `test_session_workspace.py` tests pass.

## Manual verification

N/A — the regression deterministically exercises the enumeration-to-stat race.

## Related Issues

N/A — no matching open issue or PR found.

## Pattern harvest

Rule candidate: review-prompt
Pattern: directory enumeration is a snapshot candidate, not a guarantee that each path still exists when metadata is read.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing direct tests pass and a regression test was added
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no public contract changed)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository template states that exact CLA wording is pending; no text has been invented here.