### PR TITLE
fix(papyrus): refuse a Windows junction in both directory walks

### DIFF
--- a/src/kiro_crew/apps/builtins/papyrus/backend/store.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/store.py
@@ -496,7 +496,11 @@ def list_files(project: Path) -> list[str]:
         for entry in entries:
             if entry.name.startswith("."):
                 continue
-            if entry.is_symlink():
+            # `is_reparse_link`, not `is_symlink()`: a junction is a DIRECTORY
+            # link `is_symlink()` does not report, so it fell through to the
+            # `is_dir()` arm below and the walk followed it out of the project,
+            # returning outside names under project-relative paths.
+            if is_reparse_link(entry):
                 continue
             if entry.is_dir():
                 stack.append(entry)
@@ -515,7 +519,10 @@ def list_projects(root: Path | None = None) -> list[ProjectSummary]:
     """
     out: list[ProjectSummary] = []
     for entry in sorted(projects_dir(root).iterdir()):
-        if not entry.is_dir() or entry.is_symlink() or entry.name.startswith("."):
+        # Same helper as `safe_project_dir`, which refuses a linked project entry
+        # outright: a junction under `projects/` is a directory `is_symlink()`
+        # misses, so it was enumerated here as a real project.
+        if not entry.is_dir() or is_reparse_link(entry) or entry.name.startswith("."):
             continue
         main_file = resolve_main_file(entry)
         if main_file is None:

--- a/test/test_papyrus_store.py
+++ b/test/test_papyrus_store.py
@@ -845,3 +845,81 @@ class TestReparseLinkCoversJunctions:
         with mock.patch.object(store, "is_reparse_link", return_value=True):
             with pytest.raises(store.PathRejected, match="symlink"):
                 store.safe_project_dir("looks-real", tmp_path)
+
+
+class TestTheWalkAndTheScanRefuseJunctionsToo:
+    """Both directory walks must refuse a link through ``is_reparse_link``.
+
+    ``is_reparse_link``'s own docstring states the contract: "every place this
+    module refuses a link at a name Kiro Crew owns has to refuse a junction too, or
+    the refusal is POSIX-only". ``safe_project_dir`` honours it. ``list_files`` and
+    ``list_projects`` asked ``is_symlink()``, which does NOT report a Windows
+    directory junction -- and a junction is precisely a DIRECTORY link, so it is the
+    ``is_dir()`` arm of both loops that it reaches:
+
+    * ``list_files`` skips the link, then descends the directory. A junction is not
+      skipped and IS a directory, so the walk follows it out of the project and
+      returns names from wherever it points, under project-relative paths.
+    * ``list_projects`` skips a linked entry, then treats the directory as a real
+      project. A junction under ``projects/`` is therefore enumerated as a project,
+      which is the entry ``safe_project_dir`` refuses outright at the other door.
+
+    Junctions are the link type a Windows user can create WITHOUT elevation, so
+    these are the platform's cheapest bypass. Asserted through the shared helper
+    rather than by creating a real junction, because ``os.path.isjunction`` is 3.12+
+    and always ``False`` off Windows -- the same technique the project-entry test
+    above uses.
+    """
+
+    def test_the_file_walk_does_not_descend_a_junction(self, project: Path) -> None:
+        outside = project.parent / "outside"
+        outside.mkdir()
+        (outside / "secret.tex").write_text("secret", encoding="utf-8")
+        junction = project / "linked"
+        junction.mkdir()
+        (junction / "secret.tex").write_text("secret", encoding="utf-8")
+
+        with mock.patch.object(store, "is_reparse_link", lambda p: Path(p) == junction):
+            listed = store.list_files(project)
+
+        assert "linked/secret.tex" not in listed
+        assert "main.tex" in listed
+
+    def test_the_file_walk_consults_the_shared_helper(self, project: Path) -> None:
+        """A junction is only refused if the walk ASKS the helper about it."""
+        (project / "sub").mkdir(exist_ok=True)
+        seen: list[str] = []
+
+        def _spy(p):
+            seen.append(Path(p).name)
+            return False
+
+        with mock.patch.object(store, "is_reparse_link", _spy):
+            store.list_files(project)
+
+        assert "sub" in seen
+
+    def test_a_junction_under_projects_is_not_listed_as_a_project(self, data_root: Path) -> None:
+        pdir = store.projects_dir(data_root)
+        real = pdir / "paper"
+        real.mkdir(parents=True)
+        (real / "main.tex").write_text("", encoding="utf-8")
+        junction = pdir / "pwn"
+        junction.mkdir()
+        (junction / "main.tex").write_text("", encoding="utf-8")
+
+        with mock.patch.object(store, "is_reparse_link", lambda p: Path(p) == junction):
+            names = [p.name for p in store.list_projects(data_root)]
+
+        assert names == ["paper"]
+
+    @requires_symlinks
+    def test_a_symlinked_project_entry_is_still_skipped(self, data_root: Path) -> None:
+        """Regression control: the POSIX leg the previous check already covered."""
+        pdir = store.projects_dir(data_root)
+        real = pdir / "paper"
+        real.mkdir(parents=True)
+        (real / "main.tex").write_text("", encoding="utf-8")
+        make_dir_link(pdir / "alias", real)
+
+        assert [p.name for p in store.list_projects(data_root)] == ["paper"]


### PR DESCRIPTION
## Problem / Motivation

`papyrus/backend/store.py` defines `is_reparse_link` specifically because a **Windows directory junction is a reparse point that `is_symlink()` does not report**, and it is the one link type a Windows user can create *without elevation*. Its docstring states the contract plainly: "every place this module refuses a link at a name KiroCrew owns has to refuse a junction too, or the refusal is POSIX-only."

`safe_project_dir` honours it. The module's two directory walks do not — both still ask `is_symlink()`:

- **`list_files`** skips `is_symlink()` entries and then descends `is_dir()` ones. A junction is neither skipped nor a non-directory, so it falls straight through the skip into the descend arm and the walk follows it **out of the project**.
- **`list_projects`** applies the same symlink-only skip before treating the entry as a real project. A junction under `projects/` is therefore enumerated as a project — the exact entry `safe_project_dir` refuses outright at the other door.

## Why it matters

`list_files` is the editor's file tree. Following a junction returns names from wherever it points, presented under **project-relative paths** (`entry.relative_to(project)` still succeeds, because the path is textually inside the project). That is a containment escape in the listing surface — the specific failure the function's own docstring names: "following one is how a tree walk escapes containment."

`list_projects` is the project picker. A junction planted under `projects/` shows up as a paper, and `resolve_main_file` is then run against a directory the containment gate would have rejected. `safe_project_dir` refuses a linked project entry *before containment is even asked about*, on the stated reasoning that "a link can satisfy containment while still not being the directory it claims to be" — `list_projects` reaches the same entries without passing through that gate.

Both are Windows-only, which is why they survived: on POSIX a directory link *is* a symlink and the existing checks already catch it. Junctions are the platform's cheapest bypass precisely because they need no privilege.

**Deliberately not claimed:** `_config_path`'s `is_symlink()` check on `.papyrus.json` is left alone and is **not** a third instance. A junction is a *directory* link, so it cannot stand at a file name, and a Windows **file** symlink is reported by `is_symlink()` — that guard is already complete. Only the two `is_dir()`-guarded loops are reachable this way.

## What changed (motivation → approach → change)

Symptom: two link refusals in this module are POSIX-only.

Root cause: they predate `is_reparse_link` and were never migrated onto it, so the junction leg is missing at exactly the two sites that branch on `is_dir()`.

Change: route both through the shared helper, with a comment at each site naming why `is_symlink()` was insufficient there. No new helper, no new policy — this applies the module's existing one to the two places it had not reached.

Behaviour is unchanged on POSIX: `is_reparse_link` starts with `if path.is_symlink(): return True`, and its junction legs (`os.path.isjunction`, then the `st_file_attributes` / `st_reparse_tag` fallback) are both `False` off Windows.

## Tests

Four cases added to the existing `TestReparseLinkCoversJunctions` neighbourhood in `test/test_papyrus_store.py`, using the technique that class already established for the project-entry guard: assert through the shared helper rather than by creating a real junction, because `os.path.isjunction` is 3.12+ and always `False` off Windows. That makes them deterministic on Linux CI, where a real junction cannot exist.

| Test | What it locks in |
|---|---|
| `test_the_file_walk_does_not_descend_a_junction` | a link-reported directory inside the project is skipped, and its contents never appear in the listing |
| `test_the_file_walk_consults_the_shared_helper` | the walk actually *asks* `is_reparse_link` about a subdirectory — a junction is only refused if the question is put |
| `test_a_junction_under_projects_is_not_listed_as_a_project` | a link-reported entry under `projects/` is not enumerated |
| `test_a_symlinked_project_entry_is_still_skipped` | POSIX regression control with a real link (`requires_symlinks`) |

Measured on `4b27ec95f`:

```
red-before (fix reverted, tests unchanged):  3 failed, 1 skipped
after the fix:                               4 passed  (1 skipped on Windows)
whole file after the fix:                  114 passed, 16 skipped
```

The skip is the `requires_symlinks` control, which needs privilege this dev host lacks; it runs on CI.

Siblings: `test_papyrus_routes.py`, `test_papyrus_gitops.py`, `test_papyrus_latex.py` — `302 passed, 17 skipped`. `mypy` reports 0 findings in the touched module. `black`: both files are in `.github/black-baseline.txt` and the gate passes; none of the added lines is reformatted (checked line by line), so the baseline count is unchanged and no collateral reformat is included. `git diff --check` clean.

## Manual verification

N/A — unit coverage sufficient: the guard is asserted at the `is_reparse_link` seam, which is the same technique the pre-existing project-entry test uses and the only one that is deterministic on non-Windows CI. Creating a real junction would exercise nothing on the platforms CI runs.

## Related Issues

None — found by auditing this module's `is_symlink()` call sites against the contract `is_reparse_link`'s own docstring states.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a hardened replacement helper lands with its first call site, and the sibling call sites of the primitive it replaces are never migrated — so the hardening covers one door and the audit reads as done.

The concrete shape to look for: a module defines `is_X_hardened()` whose docstring says *every* site must use it, and `grep` still shows bare `X()` in the same module. It recurs here in a load-bearing way because the bypass is platform-specific: on the developer's platform the old primitive and the new helper agree, so nothing fails locally and nothing fails in CI. The same audit is worth running for `os.symlink` vs `symlink_or_junction` and `path.is_symlink()` vs `is_link_or_junction` across the tree, which `AGENTS.md`'s `platform_compat` table already names as the required spellings.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
