### PR TITLE
fix(cloud): resolve taskkill from the trusted system dirs, not PATH

### DIFF
--- a/src/kiro_crew/cloud/ssm.py
+++ b/src/kiro_crew/cloud/ssm.py
@@ -405,9 +405,20 @@ def kill_port_forward(proc: Optional[subprocess.Popen]) -> None:
         pid = getattr(proc, "pid", None)
         if pid is None:
             return False
+        # Resolved from the fixed system directories, never a bare argv name:
+        # CreateProcess searches the calling image's directory and the CWD before
+        # PATH, and a gateway PATH can legitimately lead with agent-writable
+        # directories -- so `["taskkill", ...]` lets a planted shim run with this
+        # process's privileges on the teardown path. `platform_compat` already
+        # resolves the SAME binary this way at both of its own taskkill sites.
+        # ``None`` means unavailable, which is the case this helper already
+        # returns False for so the caller escalates.
+        taskkill_bin = platform_compat.trusted_system_bin("taskkill")
+        if taskkill_bin is None:
+            return False
         try:
             subprocess.run(
-                ["taskkill", "/T", "/F", "/PID", str(pid)],
+                [taskkill_bin, "/T", "/F", "/PID", str(pid)],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=10,

--- a/test/test_cloud_connect.py
+++ b/test/test_cloud_connect.py
@@ -254,6 +254,10 @@ class TestConnect:
             connect.connect("i-0abc", "dev", "us-east-1")
 
 
+#: Stands in for what `trusted_system_bin` returns on Windows; never spawned.
+TASKKILL_BIN = r"C:\Windows\System32	askkill.exe"
+
+
 class TestKillProcessTree:
     def test_kills_whole_group_not_just_parent(self, tmp_path):
         # The SSM tunnel is spawned with start_new_session=True, so the parent
@@ -336,11 +340,19 @@ class TestKillProcessTree:
 
         monkeypatch.setattr(ssm_mod.os, "name", "nt")
         monkeypatch.setattr(ssm_mod.subprocess, "run", fake_run)
+        # `taskkill` is resolved through `platform_compat.trusted_system_bin`, so
+        # the real lookup answers None off Windows. Stubbed, or the tree kill is
+        # skipped and this test falls through to the POSIX branch -- which would
+        # `killpg` the REAL pid 4321 on a CI host, taking the worker with it.
+        monkeypatch.setattr(
+            ssm_mod.platform_compat, "trusted_system_bin", lambda name: TASKKILL_BIN
+        )
         ssm_mod.kill_port_forward(FakeProc())
 
         assert calls, "Windows must attempt a tree kill"
         argv = calls[0]
-        assert argv[0] == "taskkill"
+        assert argv[0] == TASKKILL_BIN
+        assert argv[0] != "taskkill", "the binary must not come from PATH"
         assert "/T" in argv, "/T is what reaps the plugin child"
         assert "/F" in argv
         assert str(FakeProc.pid) in argv

--- a/test/test_cloud_ssm_cov80.py
+++ b/test/test_cloud_ssm_cov80.py
@@ -384,6 +384,11 @@ class _FakeProc:
         return 0
 
 
+#: A resolved absolute path standing in for what ``trusted_system_bin`` returns
+#: on Windows. The value is never reached: every spawn here is stubbed.
+_TASKKILL_BIN = r"C:\Windows\System32\taskkill.exe"
+
+
 class TestKillPortForward:
     def test_none_and_already_exited_are_noops(self) -> None:
         assert ssm.kill_port_forward(None) is None
@@ -404,10 +409,71 @@ class TestKillPortForward:
 
         monkeypatch.setattr(ssm.os, "name", "nt")
         monkeypatch.setattr(ssm.subprocess, "run", _run)
+        # Stubbed so the branch runs on a POSIX CI host, where a real lookup for
+        # a Windows-only tool answers None.
+        monkeypatch.setattr(ssm.platform_compat, "trusted_system_bin", lambda name: _TASKKILL_BIN)
         proc = _FakeProc()
         ssm.kill_port_forward(proc)
-        assert calls == [["taskkill", "/T", "/F", "/PID", "4242"]]
+        assert calls == [[_TASKKILL_BIN, "/T", "/F", "/PID", "4242"]]
         assert proc.terminated is False
+
+    def test_taskkill_is_resolved_from_the_trusted_system_dirs(self, monkeypatch) -> None:
+        """A bare argv name is a PATH-hijack seam on exactly this teardown path.
+
+        `CreateProcess` searches the calling image's directory and the CWD before
+        `PATH`, and a gateway `PATH` can legitimately lead with agent-writable
+        directories, so `["taskkill", ...]` lets a planted `taskkill.exe` run with
+        this process's privileges. `AGENTS.md` names `trusted_system_bin` as the
+        required spelling for `taskkill`, and `platform_compat` already resolves the
+        same binary that way at both of its own sites.
+        """
+        calls: list[list[str]] = []
+
+        def _run(argv, **_kwargs):
+            calls.append(argv)
+
+            class _R:
+                returncode = 0
+
+            return _R()
+
+        monkeypatch.setattr(ssm.os, "name", "nt")
+        monkeypatch.setattr(ssm.subprocess, "run", _run)
+        monkeypatch.setattr(
+            ssm.platform_compat,
+            "trusted_system_bin",
+            lambda name: _TASKKILL_BIN if name == "taskkill" else None,
+        )
+
+        ssm.kill_port_forward(_FakeProc())
+
+        assert calls == [[_TASKKILL_BIN, "/T", "/F", "/PID", "4242"]]
+        assert calls[0][0] != "taskkill"
+
+    def test_an_unresolvable_taskkill_spawns_nothing_and_falls_back(self, monkeypatch) -> None:
+        """``None`` means unavailable, and the fallback must not spawn a bare name.
+
+        Degrading to `["taskkill", ...]` when the trusted lookup misses would put
+        the hijack back on exactly the host where the vetted copy is absent.
+        """
+        monkeypatch.setattr(ssm.os, "name", "nt")
+        monkeypatch.setattr(
+            ssm.subprocess, "run", lambda argv, **k: pytest.fail(f"spawned {argv!r}")
+        )
+        monkeypatch.setattr(ssm.platform_compat, "trusted_system_bin", lambda name: None)
+        monkeypatch.setattr(
+            ssm.os,
+            "getpgid",
+            lambda pid: (_ for _ in ()).throw(ProcessLookupError()),
+            # Windows has no os.getpgid; these tests SIMULATE the nt branch and must
+            # still run there. Same convention as test_cloud_ssm.py.
+            raising=False,
+        )
+        proc = _FakeProc()
+
+        ssm.kill_port_forward(proc)
+
+        assert proc.terminated is True
 
     def test_windows_taskkill_failure_falls_back_to_terminate(self, monkeypatch) -> None:
         monkeypatch.setattr(ssm.os, "name", "nt")


### PR DESCRIPTION
## Problem / Motivation

`cloud/ssm.py::_kill_tree_windows` — the Windows branch of `kill_port_forward` — spawns the process-tree kill by **bare argv name**:

```python
subprocess.run(["taskkill", "/T", "/F", "/PID", str(pid)], ...)
```

`AGENTS.md`'s cross-platform table names the required spelling for exactly this tool:

> Spawn a system tool (`ps`, `lsof`, `netstat`, `taskkill`) → `trusted_system_bin(name)`, treating `None` as "unavailable" — **NOT** a bare argv name (resolved through a `PATH` that can lead with same-uid-writable dirs)

`platform_compat` already honours it, resolving **the same binary** through `trusted_system_bin("taskkill")` at both of its own taskkill sites. This was the only bare-argv `taskkill` spawn left in the tree.

## Why it matters

`trusted_system_bin`'s docstring states the threat directly: "A gateway's `PATH` can legitimately lead with agent-writable directories (a worktree venv's `bin`, `~/.local/bin`), so a bare argv name lets a planted shim run with the gateway's environment."

On Windows the exposure is wider than `PATH` alone. With `shell=False` and a bare name, `CreateProcess` searches the calling application's directory and then the **current directory** before consulting `PATH` — so a `taskkill.exe` dropped into either is executed instead of the system tool, with this process's privileges.

The call site is not obscure: it runs on every SSM port-forward teardown, and the process being torn down is one the agent asked for. The hijacked binary also receives the real pid, so a shim can decline to kill and leave the forwarded port bound while reporting success — the same failure the surrounding code already guards against by judging success on `proc.wait` rather than taskkill's exit code.

## What changed (motivation → approach → change)

Symptom: one spawn of a system tool resolves through an untrusted search order.

Root cause: the site predates the `trusted_system_bin` convention and was never migrated, so `platform_compat` and `cloud/ssm.py` disagree about how to find the same executable.

Change: resolve through `platform_compat.trusted_system_bin("taskkill")` (already imported in this module) and pass the absolute path as argv[0].

`None` means the tool is unavailable, and this helper's documented contract for that case is already "return False so the caller can still fall back if taskkill is missing or refuses" — so `None` returns False and the caller reaches its parent-only escalation exactly as before. It deliberately does **not** fall back to the bare name: doing so would restore the hijack on precisely the host where the vetted copy is absent, which is the wrong direction for a security fallback.

Behaviour on POSIX is unreachable — the whole helper is inside `if os.name == "nt"`.

## Tests

Two new cases in the existing `test/test_cloud_ssm_cov80.py`. No new test file; no subprocess is spawned.

**Two existing tests pinned the bare name and are updated**, one in each of the
two files that exercise this branch:

| Test | What it locks in |
|---|---|
| `test_cloud_ssm_cov80.py::test_windows_tree_kill_is_preferred` (updated) | argv[0] is the resolved absolute path, not `"taskkill"` — it previously asserted the bare name, i.e. it pinned the defect |
| `test_cloud_connect.py::test_windows_uses_a_tree_kill_not_a_parent_only_terminate` (updated) | same assertion, same reason |
| `test_taskkill_is_resolved_from_the_trusted_system_dirs` (new) | the resolver is consulted for the name `"taskkill"` and its answer is what reaches argv |
| `test_an_unresolvable_taskkill_spawns_nothing_and_falls_back` (new) | `None` spawns **nothing** (a bare-name fallback fails the test) and the caller still escalates to `terminate()` |

Both updated tests now also stub `trusted_system_bin`, and that is load-bearing
rather than cosmetic: a real lookup for a Windows-only tool answers `None` off
Windows, so without the stub the tree kill is skipped and the simulated Windows
branch falls through to the POSIX one — where `os.killpg(os.getpgid(4321), SIGKILL)`
fires against a **real** pid on a CI host. That is not hypothetical; it crashed an
xdist worker on this PR's first two runs, and it is why a third file is in the diff.
`test_cloud_ssm_cov80.py`'s sibling cases already stubbed `os.getpgid` for exactly
this reason, with a comment saying pid 4321 "may well belong to an unrelated live
process"; `test_cloud_connect.py` did not, because it never reached that path while
taskkill was spawned by bare name.

Measured on `4b27ec95f`:

```
red-before (fix reverted, tests unchanged):  3 failed, 4 passed, 1 skipped
    2 x AssertionError: argv[0] == 'taskkill', expected the resolved path
    1 x Failed: spawned ['taskkill', '/T', '/F', '/PID', '4242']
after the fix:                               7 passed, 1 skipped
```

`test_cloud_connect.py::TestKillProcessTree` — `4 passed`.

The skip is a pre-existing POSIX-only case in that class.

Siblings: `test_cloud_connect.py`, `test_cloud_login.py`, `test_cloud_ssm.py` and
`test_cloud_ssm_cov80.py` — `140 passed, 4 skipped`. (`test_cloud_login.py` stubs
`kill_port_forward` wholesale, so it is unaffected.) `test_spawn_audit.py` — `12 passed` (the allowlist entry `cloud/ssm.py::_kill_tree_windows` is unchanged; this PR narrows how that spawn resolves its binary, it does not add or remove a spawn). `flake8` clean on all three files. `black`: the two `test_cloud_ssm*` files are not in `.github/black-baseline.txt`, so both must be clean and are; `test_cloud_connect.py` is baselined, the gate passes, and none of the added lines is reformatted. `mypy` reports 0 findings in the touched module. `git diff --check` clean.

## Manual verification

N/A — unit coverage sufficient: the fix is entirely in which string reaches argv[0], asserted at the `trusted_system_bin` seam, and the branch is Windows-only so a POSIX manual run would exercise nothing. Reproducing the hijack itself would mean planting an executable in a search directory, which is the behaviour under test, not a verification step.

## Related Issues

None — found by auditing the tree against `AGENTS.md`'s `platform_compat` "use this / NOT that" table.

## Pattern harvest

Rule candidate: `semgrep`
Pattern: a system tool (`ps`, `lsof`, `netstat`, `taskkill`, `tasklist`) spawned by bare argv name instead of `platform_compat.trusted_system_bin`.

`AGENTS.md` already states the rule and `test_spawn_audit` already enumerates every first-party spawn, but the audit checks that a spawn is *allowlisted*, not *how it resolves its binary* — so an allowlisted site can still take its executable from an untrusted search order, which is what happened here. A pattern matching a spawn whose argv[0] is a string literal in that tool set would have caught it mechanically, and the check is cheap because the sanctioned spellings are all `trusted_system_bin(...)` or an absolute path.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
