### PR TITLE
feat: add telegram session search

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -1739,6 +1739,24 @@ The channel's transport, forum routing and mid-turn machinery are described in
 the sections above; what follows is what is specific to its rendering and its
 Bot API surface.
 
+### Telegram's read-only session search
+
+`/sessions` and its singular `/session` alias remain direct-message-only,
+single-operator, and read-only. With no argument they use the shared recent-sessions
+collector, preserving the ten-row newest-first list, live marker and agent label. With
+search words they call `ConversationLog.search_sessions` off the event loop, so title
+and message-content matching, AND-term semantics, CJK handling, recency weighting,
+and ranking are the same as dashboard history search rather than a Telegram-only title
+filter. Incognito and temporary rows are excluded after a bounded over-fetch, before
+the ten-row display cap, so private content cannot leave a match trace and private hits
+cannot starve later public results. Live markers restore dashboard stems through the
+shared history-key helper and resolve irreversible channel filename folds through
+`SessionMap`, never by guessing colon positions. Both successful and failed reads emit
+`telegram.sessions_data_access`; displayed query text, titles, agents and errors are
+redacted and bounded. Search results contain no callback controls and direct users to
+`/kirocrew dashboard`, so this capability does not claim inbound session binding
+before Telegram owns the resume transaction and routing path.
+
 ### Telegram's upload half (`telegram/`)
 
 The second channel wired onto `outbound_files.py`, and it differs from Discord in

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -92,12 +92,16 @@ At startup the bot publishes the menu commands from `COMMAND_SPEC` through `setM
 - `/status` — uptime, message counts, tool decisions, sessions
 - `/ping` — answers `pong`. Answered by the gateway itself, never by the model,
   so it still works when the thing that is wedged is the model.
-- `/sessions` — the ten most recent conversations, newest first, with a mark for
-  whichever is live. Read-only: opening one is `/kirocrew dashboard`. **Direct
-  message only**, like `/kirocrew dashboard`: the listing names every conversation
-  on the host, and a forum Topic is readable by the whole supergroup, so answering
-  there would show your conversation titles to members who are not on
-  `allowed_user_ids` at all. In a Topic it refuses and points you to a DM.
+- `/sessions [search words]` (or `/session [search words]`) — with no words, the ten
+  most recent conversations, newest first, with a mark for whichever is live. Add
+  words to use the same title-and-message-content ranking as dashboard history search;
+  incognito and temporary transcripts stay excluded. Results remain read-only and
+  open through `/kirocrew dashboard`. **Direct message only**, like `/kirocrew
+  dashboard`: either form can name conversations from across the host, and a forum
+  Topic is readable by the whole supergroup, so answering there would show titles to
+  members who are not on `allowed_user_ids` at all. In a Topic it refuses and points
+  you to a DM. It also refuses when `allowed_user_ids` contains several people,
+  because the bot cannot tell which one owns the host-wide history.
 - `/title <text>` — rename this conversation, so its dashboard sidebar row reads
   as something other than the first forty characters you happened to type.
 - `/cron` (or `/crons`) `list | pause <id> | resume <id> | remove <id>|all` — manage scheduled

--- a/src/kiro_crew/telegram/commands.py
+++ b/src/kiro_crew/telegram/commands.py
@@ -11,7 +11,7 @@ Commands:
   /stop        — stop the current reply and clear the queue (alias: /cancel)
   /status      — runtime stats (uptime, messages, tool decisions, sessions)
   /ping        — liveness check (answers "pong")
-  /sessions    — list the most recent conversations
+  /sessions    — list recent conversations; add words to search (alias: /session)
   /title       — rename this conversation
   /cron        — list / pause / resume / remove scheduled jobs
   /spawn       — run a task in a background subagent (alias: /bg)
@@ -68,7 +68,7 @@ _AGENT_ALIASES = frozenset(("/agent", "/agents"))
 _STATUS_ALIASES = frozenset(("/status",))
 # Liveness shortcut, matching the Slack transport path's bare ``ping``.
 _PING_ALIASES = frozenset(("/ping",))
-_SESSIONS_ALIASES = frozenset(("/sessions",))
+_SESSIONS_ALIASES = frozenset(("/session", "/sessions"))
 _TITLE_ALIASES = frozenset(("/title",))
 _CRON_ALIASES = frozenset(("/cron", "/crons"))
 # ``/bg`` mirrors Slack's ``bg <task>`` keyword form.
@@ -257,7 +257,7 @@ COMMAND_SPEC: tuple[tuple[str, str], ...] = (
     ("model", "Choose the model from a list"),
     ("agent", "Choose the agent from a list"),
     ("status", "Show runtime stats"),
-    ("sessions", "List the most recent conversations"),
+    ("sessions", "List recent conversations; add words to search"),
     ("cron", "Manage scheduled jobs (list / pause / resume / remove)"),
     ("voice", "Speak the answers here too (on / off)"),
     ("temporary", "This conversation reads and saves no memory"),

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -36,7 +36,7 @@ from kiro_crew.acp.client import AcpError
 from kiro_crew.agent_discovery import list_agents
 from kiro_crew.config.loader import ACTIVATION_MENTION, ACTIVATION_OFF
 from kiro_crew.executors import run_in_embed_pool
-from kiro_crew.history import mint_row_mid
+from kiro_crew.history import is_incognito_transcript, mint_row_mid
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging import auto_title, privacy_mode
 from kiro_crew.messaging.attachments import IngestLimits, append_attachment_context
@@ -74,6 +74,7 @@ from kiro_crew.messaging.renderer import (
     display_safe,
     session_provenance_tag,
 )
+from kiro_crew.messaging.session_resume import SEARCH_FETCH_LIMIT, history_dashboard_key
 from kiro_crew.messaging.session_trust import add_trusted_session, is_session_trusted
 from kiro_crew.messaging.sessions_view import collect_recent_sessions_audited
 from kiro_crew.messaging.transport import InboundMessage
@@ -217,6 +218,7 @@ _SESSIONS_LIMIT = 10
 #: Per-row caps, so one pathological title cannot consume the whole message.
 _SESSION_TITLE_CHARS = 60
 _SESSION_AGENT_CHARS = 24
+_SESSION_QUERY_CHARS = 100
 #: ``/title`` ceiling. The dashboard sidebar row truncates well before this; the
 #: cap is here so a persisted transcript never carries an unbounded title.
 _TITLE_MAX_CHARS = 80
@@ -575,7 +577,12 @@ class TelegramDispatcher:
                 cmd, route, chat_id, user_id, thread=reply_thread, subject="conversation list"
             ):
                 return
-            await self._handle_sessions(chat_id, caller=str(user_id), thread=reply_thread)
+            await self._handle_sessions(
+                chat_id,
+                parse_command_argument(text),
+                caller=str(user_id),
+                thread=reply_thread,
+            )
             return
         if cmd == "title":
             await self._handle_title(route, chat_id, parse_command_argument(text))
@@ -1992,43 +1999,120 @@ class TelegramDispatcher:
     # ── /sessions, /title and the service-backed commands ──────────────────
 
     async def _handle_sessions(
-        self, chat_id: int, *, caller: str = "", thread: int | None = None
+        self,
+        chat_id: int,
+        query: str = "",
+        *,
+        caller: str = "",
+        thread: int | None = None,
     ) -> None:
-        """List the most recent conversations, newest first.
+        """List recent conversations, or search their titles and message content.
 
-        Read-only. A Resume button would need per-chat inbound rerouting (the
+        Still read-only. A Resume button would need per-chat inbound rerouting (the
         machinery Discord carries in ``discord/session_resume.py``) which this
         channel does not have, and a button that binds a session the next typed
-        message then bypasses is worse than no button — so the card points at the
-        dashboard instead of implying a capability.
+        message then bypasses is worse than no button. Search uses ConversationLog's
+        dashboard ranking rather than a Telegram-only title filter, but renders the
+        same bounded title/agent rows as the recent list.
 
         *caller* is the requesting user's id, and the audit record's subject. It was
         the constant ``"telegram"``, which is the SOURCE, not the subject: with more
-        than one entry in ``allowed_user_ids`` — the forum case this channel now
-        serves — a read of every conversation's titles could not be attributed to a
-        participant. Slack passes its own caller id for the same reason.
+        than one entry in ``allowed_user_ids`` — the forum case this channel serves —
+        a read of every conversation's titles must be attributable to a participant.
         """
-        rows = await collect_recent_sessions_audited(
-            self.sessions,
-            caller=caller or "telegram",
-            source="telegram",
-            limit=_SESSIONS_LIMIT,
-            with_messages=False,
-        )
-        if rows is None:
-            await self._reply(chat_id, "Sessions unavailable.", thread=thread)
-            return
+        normalized_query = " ".join(query.split())
+        rows: list[dict] | None
+        if normalized_query:
+            operation = "telegram.sessions_data_access"
+            if self.conv_log is None:
+                sel().log_api_access(
+                    caller=caller or "telegram",
+                    operation=operation,
+                    outcome="error",
+                    source="telegram",
+                    resources="0 sessions read (conversation log unavailable)",
+                )
+                await self._reply(chat_id, "Sessions unavailable.", thread=thread)
+                return
+            try:
+                found = await asyncio.to_thread(
+                    self.conv_log.search_sessions,
+                    query,
+                    SEARCH_FETCH_LIMIT,
+                )
+                rows = [
+                    row
+                    for row in found
+                    if isinstance(row, dict) and not is_incognito_transcript(row.get("memory_mode"))
+                ][:_SESSIONS_LIMIT]
+            except Exception as exc:
+                sel().log_api_access(
+                    caller=caller or "telegram",
+                    operation=operation,
+                    outcome="error",
+                    source="telegram",
+                    resources="0 sessions read (search failed)",
+                    error=display_safe(str(exc))[:200],
+                )
+                logger.exception("telegram: session search failed")
+                await self._reply(chat_id, "Sessions unavailable.", thread=thread)
+                return
+            sel().log_api_access(
+                caller=caller or "telegram",
+                operation=operation,
+                outcome="allowed",
+                source="telegram",
+                resources=f"{len(rows)} sessions read",
+            )
+        else:
+            rows = await collect_recent_sessions_audited(
+                self.sessions,
+                caller=caller or "telegram",
+                source="telegram",
+                limit=_SESSIONS_LIMIT,
+                with_messages=False,
+            )
+            if rows is None:
+                await self._reply(chat_id, "Sessions unavailable.", thread=thread)
+                return
+
+        query_label = display_safe(normalized_query)[:_SESSION_QUERY_CHARS]
         if not rows:
-            await self._reply(chat_id, "No recent conversations.", thread=thread)
+            if normalized_query:
+                await self._reply(
+                    chat_id,
+                    f"No conversations matched “{query_label}”. Try fewer words, "
+                    "or use /sessions to see the most recent conversations.",
+                    thread=thread,
+                )
+            else:
+                await self._reply(chat_id, "No recent conversations.", thread=thread)
             return
-        lines = ["🧵 Recent conversations:"]
+
+        if normalized_query:
+            lines = [f"🔎 Conversation search for “{query_label}”:"]
+        else:
+            lines = ["🧵 Recent conversations:"]
         for row in rows:
-            mark = "🟢" if row["active"] else "⚫"
-            title = redact(str(row["title"]))[:_SESSION_TITLE_CHARS]
-            agent = redact(str(row["agent"]))[:_SESSION_AGENT_CHARS]
+            key = str(row.get("key") or "")
+            if normalized_query:
+                logical_key = (
+                    history_dashboard_key(key) or self.sessions.channel_key_for_stem(key) or key
+                )
+                active = bool(logical_key and self.sessions.has_session(logical_key))
+            else:
+                active = bool(row["active"])
+            mark = "🟢" if active else "⚫"
+            title = redact(str(row.get("title") or key or "Untitled session"))[
+                :_SESSION_TITLE_CHARS
+            ]
+            agent = redact(str(row.get("agent") or "kirocrew"))[:_SESSION_AGENT_CHARS]
             lines.append(f"{mark} {title} — {agent}")
         lines.append("")
-        lines.append("Open one with /kirocrew dashboard.")
+        if normalized_query:
+            lines.append("Open one with /kirocrew dashboard.")
+        else:
+            lines.append("Search with /sessions <words>, or open one with /kirocrew dashboard.")
         await self._reply(chat_id, "\n".join(lines), thread=thread)
 
     async def _handle_title(self, route: tuple[str, str], chat_id: int, arg: str) -> None:

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -436,6 +436,9 @@ class FakeSessions:
     def has_session(self, key: str) -> bool:
         return self._has
 
+    def channel_key_for_stem(self, stem: str) -> str:
+        return ""
+
     async def try_acquire(self, key: str) -> bool:
         # Mirror the real atomic acquire-if-idle: refuse if a turn holds the
         # semaphore or no session exists; otherwise "acquire" and record it.
@@ -630,6 +633,7 @@ class TestBotMentionSuffix:
 
     def test_parse_command_with_mention_and_trailing_args(self) -> None:
         assert parse_command("/yolo@KiroCrewBot on", "KiroCrewBot") == "yolo"
+        assert parse_command("/session@KiroCrewBot launch", "KiroCrewBot") == "sessions"
 
     def test_parse_command_mention_is_case_insensitive(self) -> None:
         assert parse_command("/NEW@KiroCrewBot", "kirocrewbot") == "new"

--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -1024,6 +1024,7 @@ class TestCommandSurface:
             ("/status", "status"),
             ("/ping", "ping"),
             ("/sessions", "sessions"),
+            ("/session launch plan", "sessions"),
             ("/title rename me", "title"),
             ("/cron list", "cron"),
             ("/crons list", "cron"),
@@ -1254,10 +1255,22 @@ class TestSessionsCommand:
     async def test_rows_are_listed_with_a_live_marker_and_redacted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        dispatcher, client, _ = _dispatcher({1})
+        dispatcher, client, sessions = _dispatcher({1})
+        stem_lookup = MagicMock(return_value="")
+        sessions.channel_key_for_stem = stem_lookup  # type: ignore[method-assign]
         rows = [
-            {"title": f"leak {_AWS_KEY}", "agent": "kirocrew", "active": True},
-            {"title": "older thing", "agent": "researcher", "active": False},
+            {
+                "key": "telegram_kirocrew_direct_1",
+                "title": f"leak {_AWS_KEY}",
+                "agent": "kirocrew",
+                "active": True,
+            },
+            {
+                "key": "other_session",
+                "title": "older thing",
+                "agent": "researcher",
+                "active": False,
+            },
         ]
         monkeypatch.setattr(
             "kiro_crew.telegram.transport_dispatch.collect_recent_sessions_audited",
@@ -1268,6 +1281,152 @@ class TestSessionsCommand:
         assert "🟢" in out and "⚫" in out
         assert "older thing" in out and "researcher" in out
         assert _AWS_KEY not in out
+        stem_lookup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_singular_alias_searches_titles_and_message_content(
+        self, tmp_path: Any
+    ) -> None:
+        from kiro_crew.history import ConversationLog
+
+        dispatcher, client, _ = _dispatcher({1})
+        log = ConversationLog(base_dir=tmp_path / "sessions")
+        await asyncio.to_thread(
+            log.append,
+            "dashboard:matching",
+            "user",
+            "The blue marmot owns the launch checklist",
+        )
+        await asyncio.to_thread(log.set_title, "dashboard:matching", "Unrelated title")
+        await asyncio.to_thread(log.append, "dashboard:other", "user", "Different topic")
+        await asyncio.to_thread(log.set_title, "dashboard:other", "Other session")
+        dispatcher.conv_log = log
+
+        await dispatcher.handle_message(_msg("/session blue marmot"))
+
+        out = client.sent[-1][0]
+        assert "Conversation search" in out and "Unrelated title" in out
+        assert "Other session" not in out
+
+    @pytest.mark.asyncio
+    async def test_search_excludes_both_private_modes_and_overfetches(self) -> None:
+        dispatcher, client, _ = _dispatcher({1})
+        limits: list[int] = []
+
+        def _search(_query: str, limit: int) -> list[dict]:
+            limits.append(limit)
+            return [
+                {
+                    "key": "dashboard_incognito",
+                    "title": "Incognito secret",
+                    "memory_mode": "incognito",
+                },
+                {
+                    "key": "dashboard_temporary",
+                    "title": "Temporary secret",
+                    "memory_mode": "temporary",
+                },
+                {
+                    "key": "dashboard_public",
+                    "title": "Public launch plan",
+                    "memory_mode": "persistent",
+                },
+            ]
+
+        dispatcher.conv_log = SimpleNamespace(search_sessions=_search)
+
+        await dispatcher.handle_message(_msg("/session launch"))
+
+        out = client.sent[-1][0]
+        assert "Public launch plan" in out
+        assert "Incognito secret" not in out and "Temporary secret" not in out
+        assert limits and limits[0] > 10, "filtering after a 10-row fetch can starve public hits"
+
+    @pytest.mark.asyncio
+    async def test_search_restores_dashboard_stems_before_the_live_check(self) -> None:
+        dispatcher, client, sessions = _dispatcher({1})
+        seen: list[str] = []
+
+        def _has_session(key: str) -> bool:
+            seen.append(key)
+            return key == "dashboard:matching"
+
+        sessions.has_session = _has_session  # type: ignore[method-assign]
+        dispatcher.conv_log = SimpleNamespace(
+            search_sessions=lambda *_a, **_kw: [
+                {
+                    "key": "dashboard_matching",
+                    "title": "Matching session",
+                    "memory_mode": "persistent",
+                }
+            ]
+        )
+
+        await dispatcher.handle_message(_msg("/session matching"))
+
+        assert "🟢 Matching session" in client.sent[-1][0]
+        assert seen == ["dashboard:matching"]
+
+    @pytest.mark.asyncio
+    async def test_search_uses_the_session_map_for_channel_stems(self) -> None:
+        dispatcher, client, sessions = _dispatcher({1})
+        seen: list[str] = []
+        channel_key = "telegram:kirocrew:direct:1"
+
+        sessions.channel_key_for_stem = (  # type: ignore[method-assign]
+            lambda stem: channel_key if stem == "telegram_kirocrew_direct_1" else ""
+        )
+
+        def _has_session(key: str) -> bool:
+            seen.append(key)
+            return key == channel_key
+
+        sessions.has_session = _has_session  # type: ignore[method-assign]
+        dispatcher.conv_log = SimpleNamespace(
+            search_sessions=lambda *_a, **_kw: [
+                {
+                    "key": "telegram_kirocrew_direct_1",
+                    "title": "Live Telegram work",
+                    "memory_mode": "persistent",
+                }
+            ]
+        )
+
+        await dispatcher.handle_message(_msg("/session live work"))
+
+        assert "🟢 Live Telegram work" in client.sent[-1][0]
+        assert seen == [channel_key]
+
+    @pytest.mark.asyncio
+    async def test_a_search_with_no_matches_says_what_was_searched(self) -> None:
+        dispatcher, client, _ = _dispatcher({1})
+        dispatcher.conv_log = SimpleNamespace(search_sessions=lambda *_a, **_kw: [])
+
+        await dispatcher.handle_message(_msg("/sessions missing phrase"))
+
+        assert "No conversations matched “missing phrase”" in client.sent[-1][0]
+
+    @pytest.mark.asyncio
+    async def test_a_search_failure_is_audited_and_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.telegram.transport_dispatch.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: seen.append(kw)),
+        )
+        dispatcher, client, _ = _dispatcher({1})
+
+        def _boom(*_a: Any, **_kw: Any) -> list[dict]:
+            raise OSError("search index unavailable")
+
+        dispatcher.conv_log = SimpleNamespace(search_sessions=_boom)
+
+        await dispatcher.handle_message(_msg("/session launch"))
+
+        assert seen and seen[-1]["outcome"] == "error"
+        assert seen[-1]["source"] == "telegram"
+        assert client.sent[-1][0] == "Sessions unavailable."
 
 
 class TestAgentPicker:
@@ -2278,7 +2437,9 @@ class TestSessionsIsDirectMessageOnly:
         assert "direct message" not in reply
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("command", ["/sessions", "/cron list", "/spawn list"])
+    @pytest.mark.parametrize(
+        "command", ["/sessions", "/session launch", "/cron list", "/spawn list"]
+    )
     async def test_a_listing_needs_an_unambiguous_owner_even_in_a_dm(self, command: str) -> None:
         """A DM is the right audience; it also has to be the right PERSON.
 


### PR DESCRIPTION
## Problem / Motivation

Telegram exposes only a bare, read-only `/sessions` list. The Discord-parity singular `/session` spelling falls through as model input, and words after `/sessions` are ignored, so a mobile user cannot find an older conversation from a remembered title or phrase.

## Why it matters

Session discovery is the safe prerequisite to Telegram resume controls. It should use the same ranking and privacy rules as dashboard history without prematurely adding buttons, bindings, rerouting, replay, or a resume capability declaration.

## What changed (motivation → approach → change)

- Added `/session` as an alias of the canonical `/sessions` command while keeping one Bot API menu row.
- Preserved bare `/sessions` on the existing audited ten-row recent-list path.
- Added read-only `/session(s) <words>` search through `ConversationLog.search_sessions`, off the event loop, so title/content matching, AND terms, CJK handling, recency, and ranking match dashboard search.
- Kept the existing direct-message and single-operator gate in front of both spellings.
- Over-fetches through the shared search bound, then excludes `incognito` and `temporary` rows before Telegram's ten-row cap so private hits neither leak nor starve public results.
- Restores dashboard stems with the shared helper and irreversible channel stems through `SessionMap` before live-marker checks; the plain recent path performs no search-only stem scans.
- Keeps results bounded, redacted, audited, button-free, and directed to `/kirocrew dashboard`.
- Leaves picker callbacks, durable bindings, inbound rerouting, replay, resumed-command targeting, live-row persistence, and `supports_session_resume` untouched.

## Tests

- Red-first parser and bot-mention tests for `/session`.
- End-to-end content-search coverage using a real `ConversationLog`.
- Empty-result and audited-failure coverage.
- Single-operator gate coverage for the singular alias.
- Private-mode exclusion plus over-fetch coverage.
- Dashboard and channel transcript-stem live-marker coverage.
- Regression proving bare `/sessions` performs no search-only stem lookups.
- `666 passed`: `test/test_telegram.py` and `test/test_telegram_parity.py`.
- Black, isort, flake8, mypy across 1,262 source files, docs lint, scrub, vendor, security/static checks, frontend build/type/lint/i18n, cross-surface frontend tests, Electron tests, and bundle analysis passed.
- Full backend profile: 80,952 passed, 306 skipped, 5 xfailed; 90 failures and 2 setup errors were host/base-environment failures. Representative real-home and AF_UNIX failures reproduced on clean current `origin/main`; the two extra full-run-only failures pass when isolated on both the clean stacked parent and clean main.
- Final SHA-pinned fallback GPT and Opus reviews were clean. The normal local-review extractor exited 40 because the CI workflow no longer contains its expected literal `FALSIFICATION PASS` shape.

## Manual verification

N/A — Telegram command output, authorization, search ranking, privacy filtering, and failure behavior are covered by focused channel tests; this adds no graphical UI.

## Related Issues

No linked issue: no open issue exactly matches Telegram's singular session alias and read-only search capability.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
