### PR TITLE
fix(apps): reload backend hooks when the CLI mutates them out-of-process

### DIFF
--- a/src/kiro_crew/apps/hook_reconcile.py
+++ b/src/kiro_crew/apps/hook_reconcile.py
@@ -1,0 +1,616 @@
+"""Hook reconciler — reload app backend hooks when the CLI mutates them out-of-process.
+
+The problem this solves (issue #7880)
+--------------------------------------
+An app's ``backend.hooks`` (``on_startup``, ``on_shutdown``, ``routes``) run
+*inside the gateway process*. The gateway loads them once — at boot
+(:func:`kiro_crew.apps.hooks_integration.on_gateway_startup`) and on the
+dashboard enable/disable HTTP handlers — and thereafter serves whatever module
+object is cached in ``sys.modules`` under the app's ``_kirocrew_app_<name>.*``
+namespace.
+
+The CLI ``kirocrew app {enable,disable,install,uninstall}`` subcommands are a
+DIFFERENT process. They mutate the app on disk directly — flipping
+``installed.json``, moving files, rotating ``.app_secret`` — and never call the
+gateway. So after a CLI reinstall the running gateway keeps executing the OLD
+module, the old ``on_startup`` background task keeps running, and its calls
+start failing auth because ``.app_secret`` rotated underneath it. Only a full
+``kirocrew restart`` picked up the change, and nothing said so.
+
+This is the same class of gap the CLI already closes for CRON jobs (it writes
+``crons.json`` and the gateway's timer tick re-syncs by content digest) and for
+UI assets (the dev-mode watcher live-reloads ``ui/``). Python hooks had no such
+reconciler. This module is it, modelled on :mod:`kiro_crew.apps.dev_mode`'s
+singleton poll watcher.
+
+One source of truth, no shadow bookkeeping
+------------------------------------------
+The set of "which apps have hooks loaded, under what on-disk signature" lives in
+:mod:`kiro_crew.apps.hooks_integration` (``record_loaded_hook_signature`` /
+``clear_loaded_hook_signature`` / ``loaded_hook_signature``), and EVERY driver
+of the lifecycle updates it: the dashboard enable/disable handlers, the boot
+startup pass, and this reconciler. That shared record is what keeps the
+reconciler from fighting the in-process handlers — a dashboard-driven enable
+records the new signature itself, so the reconciler sees no drift and does NOT
+re-run the app's ``on_startup`` on its next tick (and symmetrically a dashboard
+disable clears the record, so the reconciler does not re-run ``on_shutdown``
+after teardown already reported clean). The reconciler only acts on a genuine
+divergence between disk and that shared loaded-state.
+
+How it works
+------------
+A single gateway-side task polls installed apps on an interval. For each app it
+asks ``hook_signature(app_info)`` for the current on-disk identity and compares
+to the shared loaded-signature. Three transitions drive the existing in-process
+lifecycle, so no new teardown/reimport logic is invented here:
+
+* loaded, now **disabled or gone**          -> :func:`on_app_disable`
+  (runs ``on_shutdown`` when resolvable, deregisters routes, ``unload_app_modules``).
+* loaded, **code or secret changed**         -> ``on_app_disable`` then
+  :func:`on_app_enable` (full evict + reimport under the new secret).
+* not loaded, now **enabled with hooks**      -> :func:`on_app_enable`.
+
+``on_app_disable`` refuses to tear down while a timed-out ``on_startup`` task is
+still owned (it clears the loaded-signature only past that guard), so the
+reconciler observes the record still present and simply retries next tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from functools import partial
+from typing import Any
+
+from kiro_crew.apps.hooks_integration import (
+    clear_loaded_hook_signature,
+    compute_hook_signature,
+    hook_enable_denied,
+    loaded_hook_apps,
+    loaded_hook_manifest,
+    loaded_hook_signature,
+    manifest_declares_hooks,
+    on_app_disable,
+    on_app_enable,
+    record_loaded_hook_signature,
+)
+from kiro_crew.apps.lifecycle import app_has_retained_startup, apps_with_retained_startup
+from kiro_crew.apps.manager import app_lifecycle_lock, get_app, list_apps
+from kiro_crew.apps.module_loader import unload_app_modules
+
+logger = logging.getLogger(__name__)
+
+#: Poll cadence. Hooks change far less often than UI files (dev_mode polls at
+#: 1s), and each tick walks every installed app's manifest via ``list_apps``, so
+#: this is deliberately slow: a CLI reinstall going live within ~15s is the goal,
+#: not sub-second latency. The interval is the lever that keeps the always-on
+#: cost of that walk small on a gateway that rarely changes apps (dev_mode avoids
+#: the walk with a sentinel because it polls every 1s; at this cadence the walk
+#: is cheap enough not to warrant that machinery, and honesty about the cost is
+#: in the interval rather than a claim that no walk happens).
+POLL_INTERVAL_SECS = 15.0
+
+#: A single app's turn in a pass is bounded by this WATCHDOG so a nonterminating
+#: ``on_shutdown`` cannot wedge the whole pass (and thus every future tick). It is
+#: NOT a cancel: the straggler keeps running to completion in the background (its
+#: own lifecycle lock prevents a double-entry next tick); we only stop *waiting*
+#: on it so the pass returns and the loop keeps polling. Generously larger than a
+#: normal teardown so it only trips on a genuine hang.
+PER_APP_PASS_WATCHDOG_SECS = 60.0
+
+#: Total wall-clock budget for the shutdown-time drain (the in-flight-pass wait +
+#: the one final reconcile pass) in ``stop_hook_reconciler``. ``_hooks_shutdown``
+#: runs this BEFORE ``on_gateway_shutdown`` under its own ~10s budget, so a hung
+#: reconcile here must NOT starve the backend shutdown sweep -- if the drain does
+#: not settle within this bound we stop waiting and let shutdown proceed (the
+#: straggler is not cancelled; process exit reclaims it). Kept well under the
+#: ~10s ``_hooks_shutdown`` budget.
+SHUTDOWN_DRAIN_BUDGET_SECS = 5.0
+
+#: Set once ``stop_hook_reconciler`` begins the shutdown sweep. A watchdog can
+#: leave a per-app reconcile task running past the pass that spawned it; without
+#: this flag such a straggler could reach ``_enable_app`` and re-register hooks
+#: AFTER ``on_gateway_shutdown`` has torn everything down (surviving an in-process
+#: restart). Every ``_reconcile_app`` re-checks this under the app's lifecycle
+#: lock immediately before doing any enable/teardown and bails if set, so no app
+#: code is (re)started once shutdown has begun.
+_stopping: bool = False
+
+_reconcile_task: asyncio.Task | None = None
+
+#: The reconcile pass currently running (one ``reconcile_once`` call), or None
+#: between ticks. ``stop_hook_reconciler`` awaits this BEFORE cancelling the loop
+#: so an in-flight app teardown (an async ``on_shutdown`` doing worker cleanup /
+#: buffer flush) is never cancelled mid-flight -- which would leave app code
+#: running or lose buffered data.
+_active_pass: asyncio.Task | None = None
+
+#: Per-app in-flight ``_reconcile_app`` task. A pass only spawns a new task for an
+#: app that has none here: a straggler left running by the watchdog still holds the
+#: app's lifecycle lock, so re-spawning it every tick would pile up waiters blocked
+#: on that lock until the gateway OOMs. Skipping an app with a live task means at
+#: most ONE reconcile per app is ever outstanding; the entry clears when the task
+#: finishes (done callback), so the next tick picks the app up normally.
+_inflight_app_tasks: dict[str, asyncio.Task] = {}
+
+
+def _clear_inflight(app_name: str, task: asyncio.Task) -> None:
+    """Done-callback: drop the in-flight registry slot for ``app_name``.
+
+    Identity-compared: a later tick may already have replaced the entry with a
+    fresh task, and only the task that owns the slot should clear it.
+    """
+    if _inflight_app_tasks.get(app_name) is task:
+        _inflight_app_tasks.pop(app_name, None)
+
+
+# The gateway services an enable/disable needs, captured at watcher start so the
+# reconciler can build the same AppContext the boot and dashboard paths do.
+_cron_service: Any = None
+_broadcast_fn: Any = None
+_spawn_impl: Any = None
+
+
+async def _disable_loaded(name: str, app_info: dict[str, Any] | None) -> bool:
+    """Drive the in-process teardown for an app whose hooks are currently loaded.
+
+    The CALLER holds ``app_lifecycle_lock(name)``. Returns True when teardown
+    settled — ``on_app_disable`` cleared the shared loaded-signature past its
+    startup-ownership guard, so the caller can rely on ``loaded_hook_signature``
+    being ``None`` afterwards. Returns False when a detached ``on_startup`` task
+    is still owned; ``on_app_disable`` reports that as a ``startup_cleanup``
+    failure and leaves the record in place, so the reconciler retries next tick
+    rather than forcing a half-swapped state.
+
+    ``app_info`` is the current on-disk app state, or ``None`` when the app has
+    been UNINSTALLED between ticks. In BOTH cases teardown resolves the running
+    hook from the manifest it was actually loaded from — retained in the shared
+    registry (``loaded_hook_manifest``) — not from ``app_info``: on a code change
+    ``app_info`` is the REPLACEMENT manifest, whose ``on_shutdown``/routes/module
+    identity may differ from the live one, and on uninstall it is ``None`` yet a
+    background task the old ``on_startup`` spawned is still live in the gateway
+    and must be shut down. Only if no retained manifest exists do we fall back to
+    ``app_info`` (then to the manifest-less, hooks-skipped teardown: route dereg +
+    module unload + detached startup-task stop still run by name).
+    """
+    # Always tear the running hook down from the manifest it was LOADED from,
+    # never the caller's (possibly newer) on-disk ``app_info``. On a code change
+    # the reload branch passes the replacement manifest, but the live routes,
+    # module identity and ``on_shutdown`` belong to the OLD manifest recorded in
+    # the shared registry; resolving teardown from the replacement would stop the
+    # wrong ``on_shutdown`` (or none, if it was renamed/removed) and leave the
+    # old hook running. The retained manifest is the authoritative record of what
+    # was actually LOADED, so it -- and only it -- drives ``on_shutdown``.
+    #
+    # A retained manifest exists ONLY for an app the gateway loaded healthily
+    # (the enable/boot record gate retains it, and the denied/degraded paths
+    # deliberately record signature-only with NO manifest). So ``run_app_hooks``
+    # keys off the retained manifest, NOT off whether ``app_info`` is present: an
+    # execution-DENIED app that is later disabled still has ``get_app`` returning
+    # its on-disk state (``app_info`` non-None), but nothing of it was ever
+    # started, so running its ``on_shutdown`` would be a shutdown-only execution
+    # vector. With no retained manifest we run the hooks-skipped teardown (route
+    # dereg + module unload + detached startup-task stop still run by name).
+    retained = loaded_hook_manifest(name)
+    if retained is not None:
+        app_info = {"name": name, "manifest": retained}
+        run_app_hooks = True
+    else:
+        app_info = {"name": name, "manifest": {}}
+        run_app_hooks = False
+    result = await on_app_disable(
+        name,
+        app_info,
+        run_app_hooks=run_app_hooks,
+        bounded_startup_cleanup=True,
+    )
+    if str(result.get("startup_cleanup", "")).startswith("failed:"):
+        logger.info("hook reconcile: %s still has a retained startup hook; will retry", name)
+        return False
+    # A failed on_shutdown means the app's own stop routine did NOT complete, so
+    # its worker may still be live. Treat it as UNSETTLED: keep the loaded record
+    # (on_app_disable leaves the signature in place only when startup ownership
+    # was unclear, so re-record here) so the reconciler retries rather than
+    # accepting teardown and letting the worker survive disable/uninstall.
+    if result.get("hooks_shutdown") == "failed":
+        logger.info("hook reconcile: %s on_shutdown failed; retaining record for retry", name)
+        await record_loaded_hook_signature(name, {"name": name, "manifest": retained or {}})
+        return False
+    # Settled teardown: unload the app's modules so a later reinstall
+    # (disable/enable without a process restart) re-imports fresh code instead of
+    # reusing stale transitive helper modules still resident in sys.modules --
+    # otherwise old code stays active after a CLI reinstall. Bumps the load
+    # generation, invalidating any cached shutdown callable from this generation.
+    unload_app_modules(name)
+    return True
+
+
+async def _enable_app(name: str, app_info: dict[str, Any]) -> None:
+    """Drive the in-process reimport (routes + on_startup) for a newly-live app.
+
+    The CALLER holds ``app_lifecycle_lock(name)``. ``on_app_enable`` records the
+    shared loaded-signature itself on success (and re-checks admission), so a
+    partial failure leaves no record and the next tick retries.
+    """
+    await on_app_enable(
+        name,
+        app_info,
+        cron_service=_cron_service,
+        broadcast_fn=_broadcast_fn,
+        spawn_impl=_spawn_impl,
+    )
+
+
+async def _reconcile_app(name: str, snapshot_info: dict[str, Any] | None) -> None:
+    """Reconcile ONE app under its lifecycle lock, re-reading state inside it.
+
+    ``snapshot_info`` is what the tick's ``list_apps`` read for this app (or
+    ``None`` if it was absent then). It only decides that this app is WORTH
+    examining; the authoritative state used to act is re-read here under
+    ``app_lifecycle_lock(name)`` via ``get_app``, because a dashboard
+    enable/disable/uninstall or a trust withdrawal may have run between the
+    snapshot and now. Holding the lock is what closes the revive-during-
+    trust-withdrawal race GPT flagged: a concurrent revoke either has not started
+    (we see it next tick) or has taken the lock first and we block until it is
+    done and then observe the withdrawn state.
+    """
+    async with app_lifecycle_lock(name):
+        # Authoritative re-read under the lock. get_app touches disk, so off-loop.
+        current = await asyncio.to_thread(get_app, name)
+        loaded = loaded_hook_signature(name)
+
+        # --- teardown branch: loaded, but now gone / disabled / hookless ---
+        gone = current is None
+        turned_off = current is not None and (
+            not current.get("enabled") or not manifest_declares_hooks(current)
+        )
+        # A degraded/timed-out startup leaves the loaded-signature record CLEARED
+        # (so the wiring retries on recovery) yet its detached startup task keeps
+        # running. Such an app has ``loaded is None`` but still needs teardown when
+        # it goes away, or the task is orphaned after uninstall/trust removal.
+        retained = loaded is None and app_has_retained_startup(name)
+        if (loaded is not None or retained) and (gone or turned_off):
+            if await _disable_loaded(name, current):
+                logger.info("hook reconcile: tore down hooks for %s", name)
+            return
+
+        # Past teardown, every remaining branch (re)starts app code. Once the
+        # shutdown sweep has begun, a watchdog-stranded task reaching here would
+        # re-register hooks AFTER on_gateway_shutdown tore them down (surviving an
+        # in-process restart). Teardown above stays allowed (the final drain needs
+        # it); enable does not. Checked UNDER the lock so it observes a concurrent
+        # stop that took the lock first.
+        if _stopping:
+            return
+
+        # --- load / reload branch: enabled hook app whose signature changed ---
+        if current is None or not current.get("enabled") or not manifest_declares_hooks(current):
+            return
+        sig = await compute_hook_signature(current)
+        if sig == loaded:
+            # Same signature as recorded. Normally nothing to do -- but a DENIED
+            # app was recorded SIGNATURE-ONLY (anti-churn) with no manifest, and
+            # granting it execution trust does NOT change the hook signature. So a
+            # plain ``sig == loaded`` short-circuit would strand a now-admitted app
+            # forever. Distinguish the two: a real loaded app retains a manifest; a
+            # denied record does not. For a manifest-less (denied) record, re-check
+            # admission under the lock -- if it is now admitted, fall through and
+            # load it; if still denied, stay quiet (no per-tick churn).
+            if loaded_hook_manifest(name) is not None:
+                return
+            if await asyncio.to_thread(hook_enable_denied, name):
+                return
+            # Now admitted with unchanged hooks -> load them (fall through).
+            logger.info("hook reconcile: loading now-admitted app %s", name)
+            await _enable_app(name, current)
+            return
+        # Re-check admission UNDER the lock before running any app code: an app
+        # mid-trust-withdrawal (or already denied) must never be revived here.
+        denied = await asyncio.to_thread(hook_enable_denied, name)
+        if denied:
+            # A loaded app reinstalled out-of-process from a source that no
+            # longer matches its execution grant lands here (sig changed +
+            # now denied). The denied enable path deregisters routes + records
+            # the anti-churn signature + drops the retained manifest, but it does
+            # NOT stop the already-loaded module or the background task its
+            # on_startup spawned -- so withdrawn-admission code would keep running
+            # indefinitely while the app stays enabled. Tear the loaded module
+            # down FIRST (bail/retry next tick if it does not settle), then route
+            # through on_app_enable's denied path so the denial handling stays in
+            # one place. Reached only when the signature actually changed, so no
+            # per-tick churn.
+            if loaded is not None and not await _disable_loaded(name, current):
+                return
+            await _enable_app(name, current)
+            return
+        if loaded is not None:
+            # Reinstall of new code under a still-enabled app: evict the stale
+            # module + old startup task BEFORE reimporting, or the new on_startup
+            # is refused as a duplicate and the stale module (old .app_secret)
+            # keeps serving. If teardown does not settle, retry next tick.
+            if not await _disable_loaded(name, current):
+                return
+            logger.info("hook reconcile: reloading changed hooks for %s", name)
+        else:
+            logger.info("hook reconcile: loading hooks for newly-enabled %s", name)
+        try:
+            await _enable_app(name, current)
+        except Exception:
+            # A reimport failure must not wedge the loop. on_app_enable records
+            # the shared signature only on healthy wiring, so leaving it unset
+            # re-attempts next tick; clear defensively against a partial enable.
+            clear_loaded_hook_signature(name)
+            logger.exception("hook reconcile: reload failed for %s", name)
+
+
+async def reconcile_once(installed: list[dict[str, Any]]) -> None:
+    """One reconcile pass over the given ``list_apps`` snapshot.
+
+    The caller reads ``installed`` off the event loop and hands it in. This
+    coroutine decides WHICH apps to examine from the snapshot + the shared
+    loaded-set, then reconciles each one under its own lifecycle lock (state is
+    re-read inside the lock — see ``_reconcile_app``). Reads/writes the shared
+    loaded-signature registry in ``hooks_integration`` — never a private map.
+    """
+    by_name = {a.get("name", ""): a for a in installed}
+
+    # Every app worth a look this tick: those we have loaded (to catch a
+    # disable/uninstall) plus every enabled hook-declaring app on disk (to catch
+    # a new install / reinstall). Deduplicated; the per-app lock + re-read makes
+    # the exact snapshot value non-authoritative, so this set only needs to be a
+    # superset of what actually changed.
+    candidates_set = set(loaded_hook_apps())
+    candidates_set.update(
+        name
+        for name, info in by_name.items()
+        if info.get("enabled") and manifest_declares_hooks(info)
+    )
+    # Also examine apps whose loaded record was cleared on a degraded startup but
+    # whose detached startup task is still live -- they must be torn down when they
+    # go away, not orphaned (see app_has_retained_startup / the teardown branch).
+    candidates_set.update(apps_with_retained_startup())
+    # A stable order so the gather arg list and the result zip below line up.
+    candidates = sorted(candidates_set)
+    # Reconcile every candidate CONCURRENTLY, isolating each app's failure.
+    # Concurrency (not a serial loop) is what keeps one app's slow ``on_shutdown``
+    # from starving the others -- a later CLI-disabled app must not wait behind a
+    # still-running teardown. Crucially we do NOT wrap each app in a cancelling
+    # ``wait_for``: teardown runs ``on_shutdown`` and only THEN deregisters routes
+    # + clears the loaded record, so cancelling it mid-flight would leave a
+    # disabled app's routes callable. Each app instead runs to completion under
+    # its own lifecycle lock; ``return_exceptions=True`` collects (rather than
+    # propagates) a raising app so the others still finish, and the raiser is
+    # retried next tick.
+    #
+    # ``on_app_disable`` bounds a hung retained STARTUP task, but the app's own
+    # ``on_shutdown`` coroutine is awaited unbounded -- a nonterminating one would
+    # hang this whole pass and, since the loop awaits the pass, wedge every future
+    # tick (later CLI disables never reconcile). So each app's turn is bounded by
+    # a WATCHDOG that does NOT cancel it: ``asyncio.wait`` returns when the timeout
+    # elapses but leaves the straggler RUNNING, so the pass returns and the loop
+    # keeps polling while the stuck teardown finishes on its own -- honoring both
+    # "never cancel a teardown mid-``on_shutdown``" and "a hung teardown must not
+    # wedge future passes".
+    #
+    # A straggler still holds the app's lifecycle lock, so we must NOT re-spawn it
+    # every tick: a new ``_reconcile_app`` task would just block on that lock, and
+    # the waiters would pile up until the gateway OOMs. ``_inflight_app_tasks``
+    # tracks the one outstanding task per app; a candidate that already has a live
+    # task is SKIPPED this tick (it is retried once the straggler finishes and its
+    # done-callback clears the entry). At most one reconcile per app is ever live.
+    app_tasks: dict[asyncio.Task, str] = {}
+    for name in candidates:
+        existing = _inflight_app_tasks.get(name)
+        if existing is not None and not existing.done():
+            logger.debug(
+                "hook reconcile: %s still has an in-flight teardown; skipping this tick",
+                name,
+            )
+            continue
+        task = asyncio.ensure_future(_reconcile_app(name, by_name.get(name)))
+        _inflight_app_tasks[name] = task
+        # Clear the registry slot when the task finishes so the next tick can
+        # re-examine the app (identity-compared inside _clear_inflight: a later
+        # tick may already have replaced the entry).
+        task.add_done_callback(partial(_clear_inflight, name))
+        app_tasks[task] = name
+    if not app_tasks:
+        return
+    done, pending = await asyncio.wait(app_tasks.keys(), timeout=PER_APP_PASS_WATCHDOG_SECS)
+    for task in done:
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "hook reconcile: %s failed this tick; other apps unaffected, will retry",
+                app_tasks[task],
+                exc_info=exc,
+            )
+    for task in pending:
+        # Left RUNNING on purpose -- not cancelled. Its lifecycle lock blocks a
+        # double-entry next tick; we only stopped waiting so the pass can return.
+        logger.warning(
+            "hook reconcile: %s teardown exceeded %.0fs; letting it finish in the "
+            "background so it does not wedge future passes",
+            app_tasks[task],
+            PER_APP_PASS_WATCHDOG_SECS,
+        )
+
+
+async def _reconcile_loop() -> None:
+    """Poll installed apps and reconcile loaded hooks to disk on each tick."""
+    global _active_pass
+    while True:
+        try:
+            await asyncio.sleep(POLL_INTERVAL_SECS)
+            # list_apps walks the apps dir + reads two files per app — off loop.
+            installed = await asyncio.to_thread(list_apps)
+            # Run the pass as a tracked task and await it SHIELDED: if the loop is
+            # cancelled (gateway shutdown / in-process restart) while a teardown's
+            # async on_shutdown is mid-flight, the shield keeps that pass running
+            # to completion instead of interrupting worker cleanup / a buffer
+            # flush. stop_hook_reconciler awaits _active_pass before cancelling,
+            # so the pass is normally already done by the time cancellation lands;
+            # the shield covers the race where the sleep above is what gets
+            # cancelled just as a pass starts.
+            _active_pass = asyncio.ensure_future(reconcile_once(installed))
+            try:
+                await asyncio.shield(_active_pass)
+            finally:
+                _active_pass = None
+        except asyncio.CancelledError:
+            # If a pass is still in flight (shield let the cancel through to the
+            # await), let it finish before unwinding — never abandon a teardown.
+            if _active_pass is not None and not _active_pass.done():
+                try:
+                    await _active_pass
+                except Exception:
+                    pass
+                _active_pass = None
+            break
+        except Exception:
+            logger.exception("hook reconcile loop error")
+            await asyncio.sleep(POLL_INTERVAL_SECS)
+
+
+def init_hook_reconciler(
+    *,
+    cron_service: Any = None,
+    broadcast_fn: Any = None,
+    spawn_impl: Any = None,
+) -> None:
+    """Start the singleton hook reconciler (idempotent). Called at gateway startup.
+
+    MUST be called AFTER ``on_gateway_startup`` has loaded the boot-time hooks:
+    that pass records each loaded app's signature in the shared registry, so the
+    reconciler's first tick sees no drift and does no redundant work — no seeding
+    step of its own is needed. Synchronous and does NO IO: it only captures the
+    gateway service handles and schedules the loop, so it adds nothing to the
+    critical path before the dashboard socket binds (the first ``list_apps`` walk
+    happens on the loop's own first tick, off the event loop).
+    """
+    global _reconcile_task, _cron_service, _broadcast_fn, _spawn_impl
+    if _reconcile_task is not None and not _reconcile_task.done():
+        return
+    global _stopping
+    _stopping = False
+    _cron_service = cron_service
+    _broadcast_fn = broadcast_fn
+    _spawn_impl = spawn_impl
+    _reconcile_task = asyncio.get_running_loop().create_task(_reconcile_loop())
+    logger.info("app hook reconciler started (%.0fs cadence)", POLL_INTERVAL_SECS)
+
+
+async def stop_hook_reconciler() -> None:
+    """Cancel the reconciler task and await teardown (shutdown / tests).
+
+    Drains any in-flight reconcile pass FIRST (a teardown's async ``on_shutdown``
+    may be doing worker cleanup / a buffer flush), then cancels the loop and
+    awaits it so the coroutine has unwound before returning — an in-process
+    gateway restart can then start a fresh reconciler without the old one
+    lingering with stale service handles. After cancelling, runs ONE final
+    reconcile pass so a CLI disable/uninstall that landed after the last poll is
+    settled before ``on_gateway_shutdown`` (which only tears down what is still
+    loaded) — otherwise that app's ``on_shutdown`` flush would be skipped and its
+    buffered data lost. That final pass is one-shot, not a resurrected poll loop,
+    so nothing can re-import or re-start a hook after the shutdown sweep. The
+    shared loaded-signature registry is owned by ``hooks_integration`` and is
+    deliberately NOT cleared here: ``on_gateway_shutdown`` handles teardown of the
+    live hooks, and a fresh boot re-records signatures via ``on_gateway_startup``.
+    """
+    global _reconcile_task
+    global _stopping
+    # Mark stopping BEFORE anything else: any watchdog-stranded per-app task still
+    # running from a prior pass (tracked in _inflight_app_tasks) re-checks this
+    # under its lock before enabling, so it cannot re-register hooks during or
+    # after the shutdown sweep. Set first so even a task about to take the lock
+    # observes it.
+    _stopping = True
+    task = _reconcile_task
+    _reconcile_task = None
+    if task is not None:
+        # ONE shared deadline for the ENTIRE reconciler shutdown drain. Each step
+        # below waits only for whatever remains of the single budget, so the
+        # cumulative wait (in-flight drain + cancel unwind + final drain + strand
+        # coordination) can never exceed SHUTDOWN_DRAIN_BUDGET_SECS -- otherwise
+        # sequential 5s waits would blow the ~10s gateway deadline and skip the
+        # backend cleanup _hooks_shutdown runs next.
+        loop = asyncio.get_running_loop()
+        _drain_deadline = loop.time() + SHUTDOWN_DRAIN_BUDGET_SECS
+
+        def _remaining() -> float:
+            return max(0.0, _drain_deadline - loop.time())
+
+        # Let any in-flight reconcile pass finish FIRST: cancelling the loop while
+        # a teardown's async on_shutdown is running would interrupt its worker
+        # cleanup / buffer flush (app code survives or buffered data is lost).
+        # asyncio.shield keeps the pass RUNNING if we stop waiting (never cancelled
+        # mid-teardown); process exit reclaims a true hang.
+        pass_ = _active_pass
+        drained = True
+        if pass_ is not None and not pass_.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(pass_), timeout=_remaining())
+            except asyncio.TimeoutError:
+                # The pass is hung. It stays running under the shield, but we must
+                # NOT wait on it again below -- the loop's cancel handler re-awaits
+                # _active_pass, which would block up to the 60s pass watchdog and
+                # blow the shared drain budget before backend cleanup.
+                drained = False
+            except Exception:
+                pass
+        task.cancel()
+        if drained:
+            # Pass already settled: awaiting the cancelled loop unwinds promptly,
+            # but still bound it to the shared deadline for safety.
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=_remaining())
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                pass
+        else:
+            # Hung pass: bound the unwind by whatever remains of the shared budget,
+            # so cancellation cannot re-await the straggler past it. The shielded
+            # pass keeps running; process exit reclaims a true hang.
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=_remaining())
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                pass
+
+        # ONE-SHOT terminal drain: a CLI disable/uninstall landing in the window
+        # between the last poll and this stop would otherwise never reach the
+        # gateway -- the loop is now cancelled, and on_gateway_shutdown (called
+        # right after this returns) tears down only what is still loaded, so a
+        # just-disabled app's on_shutdown flush would be skipped and its buffered
+        # data lost. Run a SINGLE final reconcile pass to settle that pending
+        # disable before shutdown. This is a one-shot flush, NOT a resurrected
+        # poll loop -- the recurring poll stays cancelled, so nothing can re-import
+        # or re-start a hook after the shutdown sweep. Bounded by whatever remains
+        # of the shared drain budget so it cannot exceed _hooks_shutdown's deadline
+        # and leave spawned backends running past exit; best-effort, and any
+        # error/timeout must not block gateway shutdown.
+        try:
+            installed = await asyncio.to_thread(list_apps)
+            await asyncio.wait_for(reconcile_once(installed), timeout=_remaining())
+        except asyncio.TimeoutError:
+            logger.warning(
+                "hook reconcile: final drain pass exceeded the %.0fs shared budget; "
+                "proceeding to gateway shutdown",
+                SHUTDOWN_DRAIN_BUDGET_SECS,
+            )
+        except Exception:
+            logger.exception("hook reconcile: final drain pass before shutdown failed")
+
+        # Coordinate any watchdog-stranded per-app tasks left running from an
+        # earlier pass: with _stopping set they bail at the enable point, so a
+        # bounded wait lets them unwind before on_gateway_shutdown rather than
+        # racing the sweep. Not cancelled (a teardown mid-on_shutdown must finish);
+        # bounded so a genuine hang cannot exceed the shutdown budget -- process
+        # exit reclaims it.
+        inflight = [t for t in _inflight_app_tasks.values() if not t.done()]
+        if inflight:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*(asyncio.shield(t) for t in inflight), return_exceptions=True),
+                    timeout=_remaining(),
+                )
+            except (asyncio.TimeoutError, Exception):
+                pass

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -33,6 +33,7 @@ from kiro_crew.apps.job_routes import register_job_routes
 from kiro_crew.apps.job_sdk import forget_sdk, get_sdk, reconcile_all, register_sdk
 from kiro_crew.apps.lifecycle import LifecycleDispatcher
 from kiro_crew.apps.manager import app_dir, list_apps
+from kiro_crew.apps.module_loader import clear_all_shutdown_callables
 from kiro_crew.apps.route_registry import RouteRegistry
 from kiro_crew.cron import CronStoreBusy, CronStoreUnreadable
 from kiro_crew.executors import subprocess_executor
@@ -51,6 +52,188 @@ _lifecycle_dispatcher: LifecycleDispatcher | None = None
 # never installed. Published here so ``GET /api/apps`` can report it under the
 # same ``hooks.health_status`` spelling the enable response already uses.
 _hook_health: dict[str, dict[str, Any]] = {}
+
+# The ONE source of truth for "which app's backend hooks does this gateway
+# currently have loaded, and against what on-disk identity". Written by whichever
+# path drives the lifecycle -- the dashboard enable/disable handlers, the boot
+# startup pass, AND the out-of-process hook reconciler (apps/hook_reconcile.py)
+# -- so none of them can desync from the others. The reconciler reads it to
+# decide whether disk has drifted from what is loaded; because the dashboard
+# handlers update it too, a dashboard-driven enable/disable leaves nothing for
+# the reconciler to "re-fix", which is what stops it from double-running an
+# app's on_startup/on_shutdown right after an in-process handler already did
+# (see the design note on shared bookkeeping). An entry present = hooks loaded
+# under that signature; absent = not loaded.
+_loaded_hook_signatures: dict[str, tuple[Any, ...]] = {}
+
+# Retained manifest of each loaded app, keyed by name, recorded alongside the
+# signature. Its purpose is the uninstall case: once an app's files are gone from
+# disk its on_shutdown cannot be resolved, so the reconciler falls back to this
+# retained manifest to stop the code it actually loaded (see loaded_hook_manifest).
+_loaded_hook_manifests: dict[str, dict[str, Any]] = {}
+
+
+def hook_signature(app_info: dict[str, Any]) -> tuple[Any, ...]:
+    """The hook-identity signature all lifecycle drivers agree on.
+
+    Folds ONLY hook-relevant inputs so a metadata write that does not touch hook
+    code never forces a reload: the app version, a digest of the declared hook
+    source files' (path, mtime, size), and the ``.app_secret`` mtime (a reinstall
+    rotates it, and the live module must pick up the new secret). Deliberately
+    EXCLUDES two things:
+
+    * ``installed.json`` mtime -- a dashboard permissions/config edit rewrites
+      that file without changing any hook, and reloading a healthy running app on
+      such an edit would discard its in-flight hook state for nothing.
+    * the ``enabled`` flag -- enablement is an ORTHOGONAL axis the reconciler
+      already checks separately (it disables a loaded app that turned off and
+      loads an enabled one), so folding it in here caused a spurious mismatch: a
+      denied/disabled path records a signature computed from an ``enabled=False``
+      copy, then the next poll (which re-reads ``enabled=True`` from disk) sees a
+      different signature and runs a needless shutdown/startup cycle against the
+      no-op it was promised. The signature answers "did the hook CODE change",
+      not "is the app on".
+
+    Blocking: it ``stat``s the declared hook files and ``.app_secret``. On the
+    gateway event loop (the dashboard enable/disable handlers, the boot pass) it
+    must be reached via :func:`compute_hook_signature`, which offloads it; the
+    reconcile loop runs it inside its own ``to_thread`` step. Kept here, beside
+    the registry it feeds, so every driver computes the identical value.
+    Import-light and defensive: unreadable files contribute their path alone (so
+    a vanished/relocated hook still perturbs the digest), never an exception.
+    """
+    name = app_info.get("name", "")
+    manifest = app_info.get("manifest", {}) or {}
+    hooks = manifest.get("backend", {}).get("hooks", {}) or {}
+    rels = sorted(
+        {
+            spec.split(":", 1)[0].replace(".", "/") + ".py"
+            for key in ("on_startup", "on_shutdown", "routes")
+            if (spec := hooks.get(key, ""))
+            if spec.split(":", 1)[0]
+        }
+    )
+    root = app_dir(name)
+    mask = (1 << 63) - 1
+    digest = 0
+    for rel in rels:
+        try:
+            st = (root / rel).stat()
+            digest ^= hash((rel, st.st_mtime_ns, st.st_size)) & mask
+        except OSError:
+            digest ^= hash((rel, 0, 0)) & mask
+    try:
+        secret_mtime = (root / ".app_secret").stat().st_mtime_ns
+    except OSError:
+        secret_mtime = 0
+    return (
+        str(app_info.get("version", "")),
+        digest,
+        secret_mtime,
+    )
+
+
+async def compute_hook_signature(app_info: dict[str, Any]) -> tuple[Any, ...]:
+    """``hook_signature`` off the event loop.
+
+    ``hook_signature`` stats files, so every caller that runs on the gateway
+    event loop (the dashboard enable/disable handlers, the boot pass) must reach
+    it through here -- a synchronous stat storm on a slow/network data home would
+    otherwise stall the dashboard and the liveness heartbeat
+    (no-blocking-call-on-event-loop).
+    """
+    return await asyncio.to_thread(hook_signature, app_info)
+
+
+async def record_loaded_hook_signature(app_name: str, app_info: dict[str, Any]) -> None:
+    """Mark an app's hooks loaded under its current on-disk signature.
+
+    Called by every path that successfully wires an app's hooks -- the dashboard
+    enable handler, the boot startup pass, and the reconciler -- so the shared
+    registry reflects reality regardless of who did the loading. Async because it
+    computes the signature off the event loop (see ``compute_hook_signature``).
+
+    Also retains the loaded app's ``manifest`` (the hooks half is what matters):
+    if the app is later UNINSTALLED between reconciler ticks, its files are gone
+    and its ``on_shutdown`` can no longer be resolved from disk -- yet a
+    background task its ``on_startup`` spawned is still live in the gateway after
+    uninstall removed execution trust. The reconciler uses this retained manifest
+    to run ``on_shutdown`` against the code that was ACTUALLY loaded, so that
+    residual third-party work is stopped rather than orphaned.
+    """
+    _loaded_hook_signatures[app_name] = await compute_hook_signature(app_info)
+    _loaded_hook_manifests[app_name] = app_info.get("manifest", {}) or {}
+
+
+async def record_hook_antichurn_signature(app_name: str, app_info: dict[str, Any]) -> None:
+    """Record ONLY the on-disk signature, with NO retained manifest.
+
+    For a path that did NOT healthily load the app's hooks into the gateway but
+    must still stop the out-of-process reconciler from re-running the whole
+    enable path every tick -- specifically the execution-DENIED enable, where the
+    gateway refuses to run the hooks at all. Recording the signature makes the
+    reconciler see no drift (so it retries only when the on-disk hooks actually
+    change, e.g. the admission grant is later added), while deliberately NOT
+    retaining a manifest: nothing of the app's was ever started, so a later
+    teardown must run NO ``on_shutdown`` for it. ``_disable_loaded`` treats the
+    absent manifest as "no app code to stop" and skips app hooks -- without this
+    split a denied app would look loaded and its shutdown-only code could execute
+    on the next disable/uninstall (a shutdown-only execution vector).
+    """
+    _loaded_hook_signatures[app_name] = await compute_hook_signature(app_info)
+    _loaded_hook_manifests.pop(app_name, None)
+
+
+def clear_loaded_hook_signature(app_name: str) -> None:
+    """Forget an app's loaded-hooks record (disable / teardown / uninstall)."""
+    _loaded_hook_signatures.pop(app_name, None)
+    _loaded_hook_manifests.pop(app_name, None)
+
+
+def loaded_hook_signature(app_name: str) -> tuple[Any, ...] | None:
+    """The signature an app's hooks are currently loaded under, or None."""
+    return _loaded_hook_signatures.get(app_name)
+
+
+def loaded_hook_manifest(app_name: str) -> dict[str, Any] | None:
+    """The manifest an app's currently-loaded hooks were wired from, or None.
+
+    Retained at load time so an UNINSTALLED app -- whose files are gone from disk
+    -- can still have its ``on_shutdown`` resolved and run against the code that
+    was actually loaded, stopping residual third-party background work after
+    uninstall removes execution trust.
+    """
+    return _loaded_hook_manifests.get(app_name)
+
+
+def loaded_hook_apps() -> list[str]:
+    """Every app name the gateway currently has hooks loaded for."""
+    return list(_loaded_hook_signatures)
+
+
+def manifest_declares_hooks(app_info: dict[str, Any]) -> bool:
+    """Whether an app's manifest declares any backend hook."""
+    return bool((app_info.get("manifest", {}) or {}).get("backend", {}).get("hooks", {}))
+
+
+def hook_enable_denied(app_name: str) -> str | None:
+    """Non-empty reason string when the gateway must NOT run this app's hooks.
+
+    Wraps ``app_execution_denied`` with the same action/root the enable and boot
+    paths use, so the reconciler asks the identical admission question they do.
+    The reconciler re-checks this UNDER the per-app lifecycle lock immediately
+    before an enable: a trust withdrawal clears the loaded-signature during its
+    teardown, and without this re-check a lock-free reconciler could observe the
+    still-``enabled`` metadata and re-run the app's startup hooks/routes after
+    trust was revoked. Returning the reason here keeps that resurrection from
+    happening.
+    """
+    return app_execution_denied(
+        app_name,
+        action="hook_reconcile_register",
+        app_root=_app_hook_root(app_name),
+        caller="gateway",
+    )
 
 
 def _publish_hook_health(app_name: str, ctx: AppContext) -> dict[str, Any] | None:
@@ -194,6 +377,18 @@ async def on_app_enable(
             await disarm_app_crons_for_execution(app_name, cron_service)
         if _route_registry:
             _route_registry.deregister_app_routes(app_name)
+        # Record the on-disk signature even though nothing was loaded: an
+        # execution-denied app is enabled with hooks the gateway will not run, so
+        # WITHOUT this the reconciler would see no record every tick and re-run
+        # on_app_enable forever (a cron-store mutation + SEL audit write + route
+        # dereg each time) for an app that can never load. Record the SIGNATURE
+        # ONLY (no manifest): the reconciler then retries only when the on-disk
+        # hooks change (e.g. the admission grant is later added and a
+        # reinstall/enable bumps the signature), and because no manifest is
+        # retained a later disable/uninstall runs NO ``on_shutdown`` for this app
+        # -- nothing of its was ever started, so recording a full loaded record
+        # here would be a shutdown-only code-execution vector.
+        await record_hook_antichurn_signature(app_name, app_info)
         return result
 
     manifest = app_info.get("manifest", {})
@@ -280,6 +475,65 @@ async def on_app_enable(
     health_snapshot = _publish_hook_health(app_name, ctx)
     if health_snapshot:
         result["health_status"] = health_snapshot
+
+    # Shared source of truth: record that this app's hooks are now loaded under
+    # its current on-disk signature, so the out-of-process reconciler sees no
+    # drift for an enable THIS handler just performed and does not re-run the
+    # startup hook on its next tick. ``_publish_hook_health`` returns a snapshot
+    # exactly when the context is NOT healthy and ``None`` when it is, so gate on
+    # that return rather than re-reading ``ctx.health`` -- the context object is
+    # the single source for both, and reusing the already-computed result avoids
+    # assuming a ``health`` attribute shape on every caller's context.
+    #
+    # Record ONLY when the wiring came up healthy. A route or startup hook that
+    # failed to import (or a detached/timed-out ``on_startup``) must stay
+    # UN-recorded so the reconciler re-attempts it on its next tick and picks the
+    # app up once a transient failure clears -- the poll-retry-after-recovery the
+    # reconciler exists to provide. Freezing a degraded import as the current
+    # loaded state would strand it until its code changed. A prior record is
+    # cleared on failure for the same reason.
+    if health_snapshot is None:
+        # Cache the declared on_shutdown callable now (files still present) so a
+        # later CLI uninstall can stop background work this app spawned -- even a
+        # ROUTES-ONLY app with no on_startup, and even when on_shutdown lives in a
+        # separate module. Done on healthy wiring independently of on_startup
+        # presence/success (dispatcher no-ops when no on_shutdown is declared).
+        if _lifecycle_dispatcher:
+            await _lifecycle_dispatcher.cache_shutdown_for(app_info)
+        await record_loaded_hook_signature(app_name, app_info)
+    else:
+        # Degraded wiring (e.g. a route import failed) that nonetheless ran a
+        # successful ``on_startup`` -- or a route hook -- may have spawned a
+        # background child that OUTLIVES the startup call (the wrapper returns, the
+        # child keeps running). Clearing the signature alone arms a reconciler
+        # RE-RUN, so ``on_startup`` fires again and a fresh child stacks on the
+        # live one every poll until exhaustion. So run the app's SHUTDOWN lifecycle
+        # first -- ``on_shutdown`` is what actually stops such a spawned child --
+        # and also settle any detached startup hooks. Clear the signature (arming a
+        # retry) ONLY when BOTH confirm clean. If either is unconfirmed the child
+        # may be live, so RETAIN the loaded signature instead: a retained record
+        # keeps the reconciler from re-running and duplicating. Best-effort: a
+        # failure here must not turn a degraded enable into a crash.
+        shutdown_ok = False
+        stopped = False
+        try:
+            if _lifecycle_dispatcher:
+                shutdown_ok = await _lifecycle_dispatcher.dispatch_disable(app_info)
+            stopped = await stop_app_startup_hooks(app_name, bounded=True)
+        except Exception:  # noqa: BLE001 - teardown must not fail the enable
+            logger.exception(
+                "App %s: running the shutdown lifecycle before degraded-retry clear "
+                "failed; retaining the loaded signature so the reconciler does not "
+                "re-run and stack a duplicate worker",
+                app_name,
+            )
+        if shutdown_ok and stopped:
+            clear_loaded_hook_signature(app_name)
+        else:
+            # Teardown did not confirm the spawned work stopped: keep the loaded
+            # record so the poll does not spawn another. record is the retain (it
+            # also carries the manifest the retained-startup teardown path needs).
+            await record_loaded_hook_signature(app_name, app_info)
 
     sel().log_api_access(
         caller="gateway",
@@ -426,6 +680,13 @@ async def on_app_disable(
     # stale claim about an app that is no longer wired up at all.
     clear_hook_health(app_name)
 
+    # Shared source of truth: the app's hooks are now torn down, so drop its
+    # loaded-signature record. Reached only past the startup-ownership guard
+    # above, so a teardown that did NOT settle (retained startup task) leaves the
+    # record in place and the reconciler keeps retrying rather than treating the
+    # app as unloaded.
+    clear_loaded_hook_signature(app_name)
+
     # Clean up cron jobs owned by this app
     permissions = manifest.get("permissions", {})
     if permissions.get("cron"):
@@ -530,6 +791,14 @@ async def on_gateway_startup(
                 await disarm_app_crons_for_execution(name, cron_service)
             if _route_registry:
                 _route_registry.deregister_app_routes(name)
+            # Same anti-churn record as on_app_enable's denied path: a hook-
+            # declaring app the gateway refuses to run must be recorded so the
+            # reconciler does not re-attempt it every tick. Record the SIGNATURE
+            # ONLY (no manifest) so a later teardown runs no on_shutdown for an
+            # app that never started (shutdown-only execution vector). Hookless
+            # denied apps need no record (the reconciler ignores them).
+            if manifest_declares_hooks(app_info):
+                await record_hook_antichurn_signature(name, app_info)
             continue
 
         # Reconcile app-declared crons into the running scheduler.
@@ -588,7 +857,25 @@ async def on_gateway_startup(
         # lifecycle.py:352,396, plus the cancelled site via
         # _mark_cancelled_startup_residual at lifecycle.py:66), so an aggregate
         # would only re-log them, and only ever for this one caller.
-        _publish_hook_health(name, ctx)
+        boot_health = _publish_hook_health(name, ctx)
+
+        # Shared source of truth: record what boot loaded so the out-of-process
+        # reconciler starts already agreeing with the gateway and does not
+        # reimport every app on its first tick. Recorded for any hook-declaring
+        # app the loop reached (it has already `continue`d past hookless apps),
+        # covering routes-only apps as well as those with on_startup -- but ONLY
+        # when the wiring came up healthy (``_publish_hook_health`` returns a
+        # snapshot only when it did NOT). A boot-time import failure stays
+        # un-recorded so the reconciler re-attempts it and picks the app up once a
+        # transient failure clears, rather than freezing the degraded state as
+        # current.
+        if boot_health is None:
+            # Cache the declared on_shutdown regardless of on_startup (routes-only
+            # apps included; dispatcher no-ops when none is declared), so a later
+            # CLI uninstall can stop background work this app spawned.
+            if _lifecycle_dispatcher:
+                await _lifecycle_dispatcher.cache_shutdown_for(app_info)
+            await record_loaded_hook_signature(name, app_info)
 
     # AFTER the loop, deliberately: only here has every enabled app registered
     # its runners, so a run whose kind has no runner can be told apart from an
@@ -666,6 +953,13 @@ async def on_gateway_shutdown() -> None:
         # a single cancel request), instead of force-exiting with every one of
         # them orphaned — the exact defect this function exists to fix.
         await _stop_spawned_backends()
+
+    # Shutdown hooks have run (they needed the cached on_shutdown callables while
+    # the cache was still valid) and backends are stopped. Drop the whole shutdown
+    # cache now: this sweep does not go through per-app unload_app_modules, so
+    # without this a callable captured this generation would survive into an
+    # in-process gateway restart and be selected to stop a NEWLY loaded worker.
+    clear_all_shutdown_callables()
 
 
 async def _stop_spawned_backends() -> None:

--- a/src/kiro_crew/apps/lifecycle.py
+++ b/src/kiro_crew/apps/lifecycle.py
@@ -15,7 +15,11 @@ from typing import Any
 from kiro_crew.apps.context import AppContext, build_app_context
 from kiro_crew.apps.execution import shipped_builtin_app_root
 from kiro_crew.apps.manager import app_dir
-from kiro_crew.apps.module_loader import load_app_module
+from kiro_crew.apps.module_loader import (
+    cache_shutdown_callable,
+    load_app_module,
+    resolve_loaded_callable,
+)
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -56,6 +60,34 @@ _DETACHED_HOOK_TASKS: dict[str, set[asyncio.Task[Any]]] = {}
 # Destructive lifecycle operations therefore fail closed instead of withdrawing
 # trust or replacing files while that worker may still hold AppContext powers.
 _DETACHED_HOOK_RESIDUALS: set[str] = set()
+
+
+def app_has_retained_startup(app_name: str) -> bool:
+    """True if ``app_name`` still has a live or residual detached startup task.
+
+    A degraded/timed-out ``on_startup`` spawns a detached task that keeps running
+    even though the enable path leaves the loaded-signature record CLEARED (so the
+    reconciler retries the wiring on recovery). That cleared record would drop the
+    app out of the reconciler's teardown-candidate set, so a later CLI uninstall
+    would never stop the still-running task. The reconciler therefore also treats
+    an app that answers True here as teardown-visible: it runs the hooks-skipped
+    teardown (route dereg + detached startup-task stop) rather than orphaning it.
+    """
+    if app_name in _DETACHED_HOOK_RESIDUALS:
+        return True
+    return any(not t.done() for t in _DETACHED_HOOK_TASKS.get(app_name, ()))
+
+
+def apps_with_retained_startup() -> set[str]:
+    """App names with a live or residual detached startup task.
+
+    The reconciler unions this into its teardown-candidate set so a degraded app
+    whose loaded-signature record was cleared is still examined (and torn down
+    when it goes away). A superset is fine: the per-app re-read decides the action.
+    """
+    names = set(_DETACHED_HOOK_RESIDUALS)
+    names.update(n for n, tasks in _DETACHED_HOOK_TASKS.items() if any(not t.done() for t in tasks))
+    return names
 
 
 def _mark_cancelled_startup_residual(app_name: str) -> None:
@@ -189,6 +221,54 @@ class LifecycleDispatcher:
             return True
         ctx = self._build_context(app_info)
         return await self._invoke(name, hook_path, ctx, phase="startup")
+
+    async def cache_shutdown_for(self, app_info: dict[str, Any]) -> None:
+        """Resolve and cache an app's ``on_shutdown`` callable for later teardown.
+
+        Called by the PRODUCTION load paths (``on_app_enable`` /
+        ``on_gateway_startup``) right after a successful ``on_startup``. It snapshots
+        the bound ``on_shutdown`` callable so a teardown after a CLI uninstall (files
+        deleted, ``sys.modules`` entries unloaded) can still stop the background work
+        ``on_startup`` spawned.
+
+        Two cases, both without blocking the gateway event loop:
+
+        * ``on_shutdown`` lives in a module startup ALREADY loaded (the common
+          same-module case, or any already-imported module): resolve it purely from
+          ``sys.modules`` via ``resolve_loaded_callable`` -- an in-memory ``getattr``,
+          no disk load and no re-import (re-importing a same-module app would spawn a
+          fresh module object and detach the running startup state).
+
+        * ``on_shutdown`` lives in a SEPARATE module startup never imported: load it
+          from disk, but OFF the loop via ``asyncio.to_thread`` so the file read +
+          top-level module execution cannot freeze heartbeat/requests. This is what
+          lets teardown stop such an app after its files are deleted; the in-memory
+          resolve above is tried FIRST, so a same-module app never reaches this and is
+          never re-imported.
+
+        The cached callable is generation-tagged in ``module_loader`` and cleared on
+        unload/teardown, so a stale generation is never used against newer code.
+        Best-effort throughout: a miss only means that one hook may not run at
+        teardown, so it must never fail the enable.
+        """
+        name = app_info.get("name", "")
+        shutdown_path = self._get_hook(app_info, "on_shutdown")
+        if not shutdown_path:
+            return
+        try:
+            shutdown_func = resolve_loaded_callable(name, shutdown_path)
+            if shutdown_func is None:
+                # Separate module startup never imported: load it off the loop so a
+                # third-party file read + module exec cannot block the gateway.
+                shutdown_func = await asyncio.to_thread(self._resolve_hook, name, shutdown_path)
+            if shutdown_func is not None:
+                cache_shutdown_callable(name, shutdown_func)
+        except Exception:
+            logger.exception(
+                "Could not cache on_shutdown for %s; teardown after uninstall may "
+                "not run its shutdown hook",
+                name,
+            )
 
     async def dispatch_disable(self, app_info: dict[str, Any]) -> bool:
         """Call on_shutdown hook for a single app being disabled.
@@ -380,7 +460,22 @@ class LifecycleDispatcher:
             # reading the empty original. _resolve_hook dotted-imports builtins
             # for exactly that reason and still file-path-loads third-party apps,
             # where the isolation is the point.
-            func = self._resolve_hook(app_name, hook_path)
+            #
+            # SHUTDOWN resolves the ALREADY-LOADED module FIRST. on_shutdown must
+            # stop the code that is actually running, which is the module the
+            # gateway imported -- not whatever is on disk now. Disk and memory can
+            # disagree two ways: a same-path v2 reinstall leaves v2 files on disk
+            # while v1's background task is still live (a disk load would run v2's
+            # on_shutdown and orphan v1), and a CLI uninstall deletes the files
+            # entirely (a disk load raises). Resolving from sys.modules first
+            # covers both; the disk loader is the fallback only when nothing is
+            # loaded (e.g. a builtin, or an app whose module was never imported).
+            # STARTUP never takes this path -- it must load fresh code from disk.
+            func = None
+            if phase == "shutdown":
+                func = resolve_loaded_callable(app_name, hook_path)
+            if func is None:
+                func = self._resolve_hook(app_name, hook_path)
             if func is None:
                 raise ImportError(f"hook {hook_path!r} did not resolve for app {app_name!r}")
             result = func(ctx)

--- a/src/kiro_crew/apps/module_loader.py
+++ b/src/kiro_crew/apps/module_loader.py
@@ -26,6 +26,53 @@ _BUILTINS_DIR = (Path(__file__).resolve().parent / "builtins")
 # One-time-per-app guard so the SEC-012 trust warning is not logged on every hook load.
 _warned_third_party_apps: set[str] = set()
 
+#: Per-app cache of the resolved ``on_shutdown`` callable, populated at ENABLE
+#: time (``cache_shutdown_callable``) while the app's files still exist. Teardown
+#: after a CLI uninstall consults this FIRST: ``resolve_loaded_callable`` only
+#: finds a module still in ``sys.modules``, which misses an ``on_shutdown`` living
+#: in a module that startup never imported (separate startup/shutdown modules) --
+#: the disk fallback then raises on the deleted files and the background task the
+#: app spawned would survive trust removal. Caching the bound callable up front
+#: closes that gap: the resident function object stops the running code without
+#: touching disk. Cleared by ``clear_shutdown_callable`` on teardown/unload.
+_shutdown_callables: dict[str, tuple[int, Callable[..., Any]]] = {}
+
+#: Per-app load generation. Bumped every time an app's modules are unloaded (a
+#: disable, or the gateway teardown sweep), so a shutdown callable captured under
+#: one generation can be told apart from the code loaded by a LATER enable. A
+#: cached callable is only honoured while its generation is still current: after
+#: an unload+re-enable, the stale v1 callable is ignored rather than used to tear
+#: down the freshly loaded v2 worker (it would leave v2 running).
+_app_load_generation: dict[str, int] = {}
+
+
+def _current_generation(app_name: str) -> int:
+    return _app_load_generation.get(app_name, 0)
+
+
+def cache_shutdown_callable(app_name: str, func: Callable[..., Any]) -> None:
+    """Remember an app's resolved ``on_shutdown`` callable for post-uninstall teardown.
+
+    Tagged with the app's CURRENT load generation so a later reload invalidates it
+    (see ``_app_load_generation``); ``resolve_loaded_callable`` drops a stale one.
+    """
+    _shutdown_callables[app_name] = (_current_generation(app_name), func)
+
+
+def clear_shutdown_callable(app_name: str) -> None:
+    """Drop the cached ``on_shutdown`` callable (teardown complete / module unloaded)."""
+    _shutdown_callables.pop(app_name, None)
+
+
+def clear_all_shutdown_callables() -> None:
+    """Drop every cached ``on_shutdown`` callable — for the gateway teardown sweep.
+
+    The sweep tears hooks down without going through per-app ``unload_app_modules``,
+    so without this a v1 callable would survive into an in-process restart and be
+    selected to stop a v2 worker. Clearing wholesale on teardown closes that.
+    """
+    _shutdown_callables.clear()
+
 
 def _is_builtin_app(app_name: str, app_resolved: Path) -> bool:
     """Return True when this app name owns the resolved shipped package path."""
@@ -300,6 +347,48 @@ def load_app_module(app_name: str, app_dir: Path, module_path: str) -> Callable[
     return func
 
 
+def resolve_loaded_callable(app_name: str, module_path: str) -> Callable[..., Any] | None:
+    """Resolve ``module.path:callable`` from this app's ALREADY-LOADED module.
+
+    For teardown of a gone (uninstalled) app: CLI uninstall deletes the app's
+    files, so ``load_app_module`` -- which reads from disk -- would raise and the
+    ``on_shutdown`` hook would never run, leaving a background task the app's
+    ``on_startup`` spawned alive after trust was removed. But the module the
+    gateway actually imported is still resident in ``sys.modules`` under the
+    app's unique namespace key, so the callable can be resolved from THAT without
+    touching disk. Returns the callable, or ``None`` when no such module/attr is
+    cached (nothing was ever loaded) so the caller can fall back to the disk
+    loader. Deliberately does NOT import anything: it only reads what is already
+    loaded, which is exactly the code whose ``on_shutdown`` must stop it.
+
+    Checks the enable-time ``_shutdown_callables`` cache FIRST: ``sys.modules``
+    only holds modules startup actually imported, so an ``on_shutdown`` in a
+    module startup never touched (separate startup/shutdown modules) is absent
+    there and the disk fallback would raise on the deleted files. The cache holds
+    the bound callable captured at enable while the files existed, closing that
+    gap without touching disk.
+    """
+    cached = _shutdown_callables.get(app_name)
+    if cached is not None:
+        gen, func = cached
+        if gen == _current_generation(app_name):
+            return func
+        # Stale generation: this callable belongs to code that has since been
+        # unloaded/reloaded. Drop it and fall through to what is loaded NOW, so a
+        # v1 shutdown is never used against a v2 worker.
+        _shutdown_callables.pop(app_name, None)
+    if ":" not in module_path:
+        return None
+    dotted_path, callable_name = module_path.rsplit(":", 1)
+    if not dotted_path or not callable_name:
+        return None
+    module = sys.modules.get(_module_namespace(app_name, dotted_path))
+    if module is None:
+        return None
+    resolved = getattr(module, callable_name, None)
+    return resolved if callable(resolved) else None
+
+
 def unload_app_modules(app_name: str) -> int:
     """Remove all cached modules for an app from sys.modules.
 
@@ -312,6 +401,11 @@ def unload_app_modules(app_name: str) -> int:
     to_remove = _app_module_keys(app_name)
     for k in to_remove:
         del sys.modules[k]
+    clear_shutdown_callable(app_name)
+    # Bump the load generation so a NEXT enable's cache entry is distinguishable
+    # from this one -- any callable still cached under the old generation (e.g.
+    # captured by a concurrent path) is treated as stale by resolve_loaded_callable.
+    _app_load_generation[app_name] = _current_generation(app_name) + 1
     if to_remove:
         logger.debug("Unloaded %d module(s) for app %s", len(to_remove), app_name)
     return len(to_remove)

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -615,30 +615,36 @@ def _register_app_crons_to_scheduler(app_name: str) -> list[str]:
 
 
 def _warn_hooks_need_restart(app_name: str) -> bool:
-    """Say plainly that a running gateway will not pick up this app's backend hooks.
+    """Tell the operator how a CLI enable's backend-hook change reaches a gateway.
 
     Everything else a CLI enable writes is re-read by a running gateway:
     ``enable_app`` writes ``installed.json``, ``register_app`` writes agent and
     skill files, and ``_register_app_crons_to_scheduler`` writes through the
     shared cron store that the gateway's timer tick re-syncs by content digest.
-    Backend hooks are the exception -- they are Python modules imported INTO the
-    gateway process, and only the gateway can replace them (``on_app_enable`` ->
+    Backend hooks are Python modules imported INTO the gateway process, and only
+    the gateway can replace them (``on_app_enable`` ->
     ``RouteRegistry.register_app_routes`` -> ``load_app_module``, reached by the
-    HTTP enable route and by ``on_gateway_startup``). This process has no handle
-    on that one's ``sys.modules``, so a CLI enable cannot load them.
+    HTTP enable route and by ``on_gateway_startup``). This CLI process has no
+    handle on that one's ``sys.modules``, so it cannot load them directly --
+    but it no longer needs to: the gateway runs a hook reconciler
+    (``apps/hook_reconcile.py``) that notices an on-disk hook change this CLI
+    made and reloads it in-process within a poll interval (issue #7880). A
+    stopped gateway loads the new code on its next start.
 
-    Printing only "enabled <app>" reads as though it had. The operator then
-    verifies a hook change against the code the gateway imported earlier and
-    concludes the change did not work -- or that it did, when it never ran
-    (issue #7880).
+    Printing only "enabled <app>" reads as though the change were already live in
+    a running gateway, when in fact it lands a few seconds later; and pre-#7880
+    it never landed at all until a manual restart. This notice states the actual
+    timing so an operator does not verify a hook change against stale code and
+    draw the wrong conclusion.
 
     Deliberately NOT gated on a live-gateway probe. ``_marker_port`` is the only
     verified one available here, and it writes its own multi-gateway warning to
     stderr, which would surface out of context on an app enable. The notice is
-    phrased conditionally instead, so it stays true when no gateway is up.
+    phrased conditionally instead, so it stays true whether or not a gateway is
+    up.
 
-    Only for apps that declare ``backend.hooks``: there is nothing stale to warn
-    about otherwise. Returns whether the notice was printed.
+    Only for apps that declare ``backend.hooks``: there is nothing to say
+    otherwise. Returns whether the notice was printed.
     """
     info = get_app(app_name)
     manifest = info.get("manifest") if isinstance(info, dict) else None
@@ -649,10 +655,9 @@ def _warn_hooks_need_restart(app_name: str) -> bool:
     declared = ", ".join(sorted(str(k) for k in hooks))
     print(
         f"  note: this app declares backend hooks ({declared}).\n"
-        "  A gateway that is already running keeps executing the hook code it\n"
-        "  imported earlier; this command cannot replace it. Run `kirocrew\n"
-        "  restart`, or disable and re-enable the app from the dashboard, for\n"
-        "  hook changes to take effect."
+        "  A gateway that is already running reloads them automatically within a\n"
+        "  few seconds (the gateway reconciles hook changes it did not perform\n"
+        "  itself); if the gateway is stopped, they load on its next start."
     )
     return True
 

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -20,6 +20,7 @@ from aiohttp import web
 
 from kiro_crew import platform_compat, port_resolution
 from kiro_crew.apps.backend import start_enabled_app_backends
+from kiro_crew.apps.hook_reconcile import init_hook_reconciler, stop_hook_reconciler
 from kiro_crew.apps.hooks_integration import (
     init_hooks_system,
     on_gateway_shutdown,
@@ -3322,16 +3323,51 @@ async def start_dashboard(
 
         await init_dev_mode_watcher(state.broadcast_ws)
 
+        # App hook reconciler: the CLI (`kirocrew app enable/disable/install/
+        # uninstall`) mutates apps on disk in a DIFFERENT process and never
+        # notifies this gateway, so a CLI reinstall left the old backend.hooks
+        # module live, its on_startup task running, and its .app_secret stale
+        # (issue #7880). This poll reloads changed hooks in-process — the same
+        # "CLI writes disk, gateway reconciles" contract already used for crons
+        # and UI files. Started AFTER on_gateway_startup so the boot pass has
+        # already recorded its loaded-hook signatures in the shared registry and
+        # the reconciler's first tick sees no drift. Synchronous + IO-free, so it
+        # adds nothing before the dashboard socket binds.
+        init_hook_reconciler(
+            cron_service=state.crons,
+            broadcast_fn=_app_event_broadcast,
+            spawn_impl=_app_spawn,
+        )
+
     app.on_startup.append(_hooks_startup)
 
     async def _hooks_shutdown(app_: web.Application) -> None:
-        await on_gateway_shutdown()
-        # Cancel the app dev-mode watcher started in _hooks_startup so an
-        # in-process gateway restart does not leak the module-global task (which
-        # holds a stale broadcast_ws targeting dead clients). Await cancellation.
+        # Stop the background pollers BEFORE the gateway hook shutdown sweep.
+        # The reconciler and the dev-mode watcher can each LOAD/START app hooks
+        # on a tick; if either is still live while on_gateway_shutdown() tears
+        # hooks down, a poll landing mid-sweep could re-import a module or spawn
+        # an on_startup task AFTER it was torn down, so that app's code would
+        # survive an in-process gateway restart. Cancelling them first also stops
+        # their module-global tasks from leaking stale gateway service handles /
+        # a stale broadcast_ws across the restart. Await cancellation so neither
+        # can fire one more tick during the sweep.
         from kiro_crew.apps.dev_mode import stop_dev_mode_watcher
 
-        await stop_dev_mode_watcher()
+        # on_gateway_shutdown() is the sweep that actually tears down app
+        # backends; it MUST run even if stopping a poller hangs (its bounded
+        # drain can burn its budget) or raises, otherwise a spawned app backend
+        # survives gateway exit. Stop the pollers first (preserving the
+        # no-tick-during-sweep ordering) but never let a stop failure abort the
+        # sweep: catch and log it, then always run on_gateway_shutdown.
+        try:
+            await stop_dev_mode_watcher()
+            await stop_hook_reconciler()
+        except Exception:
+            logger.exception(
+                "Error stopping background pollers on shutdown; proceeding to the "
+                "gateway hook shutdown sweep so app backends are torn down"
+            )
+        await on_gateway_shutdown()
 
     app.on_cleanup.append(_hooks_shutdown)
 

--- a/test/test_app_cli.py
+++ b/test/test_app_cli.py
@@ -171,13 +171,15 @@ class TestHandleApp:
 
 
 class TestEnableWarnsHooksNeedRestart:
-    """CLI `app enable` must not imply it loaded the app's backend hooks.
+    """CLI `app enable` states how a backend-hook change reaches a gateway.
 
     Hooks are Python modules imported INTO the gateway process, and only the
-    gateway replaces them (``on_app_enable`` -> ``register_app_routes`` ->
-    ``load_app_module``). The CLI is a separate process, so a CLI enable leaves a
-    running gateway executing the code it imported earlier -- printing only
-    "enabled <app>" reads as though the new code were live (issue #7880).
+    gateway loads them (``on_app_enable`` -> ``register_app_routes`` ->
+    ``load_app_module``). The CLI is a separate process, so it cannot load them
+    directly -- but the gateway's hook reconciler (``apps/hook_reconcile.py``)
+    picks up the on-disk change within a poll interval, and a stopped gateway
+    loads it on next start. Printing only "enabled <app>" reads as though the new
+    code were already live; the notice states the actual timing (issue #7880).
     """
 
     HOOKS = {
@@ -201,10 +203,15 @@ class TestEnableWarnsHooksNeedRestart:
 
         out = capsys.readouterr().out
         assert "backend hooks" in out
-        # Names the declared hooks, so the operator can tell which code is stale.
+        # Names the declared hooks, so the operator can tell which code changed.
         assert "routes" in out and "on_startup" in out
-        # Names the recovery, not just the problem.
-        assert "restart" in out
+        # States the actual timing: a running gateway reconciles the change
+        # automatically (issue #7880's reconciler), and a stopped one loads it on
+        # next start -- so it must NOT tell the operator a manual restart is
+        # required (that was true only before the reconciler landed).
+        assert "reloads them automatically" in out
+        assert "next start" in out
+        assert "restart" not in out
         # The enable itself still reports success -- the notice is additive.
         from kiro_crew.apps.manager import _read_installed
 

--- a/test/test_app_hook_health.py
+++ b/test/test_app_hook_health.py
@@ -48,8 +48,16 @@ def _arm_startup(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, app_dir: Path, info: dict
 ) -> None:
     """Point on_gateway_startup at one app living under tmp_path."""
+
+    class _StubDispatcher(SimpleNamespace):
+        async def cache_shutdown_for(self, app_info):
+            return None
+
+        async def dispatch_disable(self, app_info):
+            return True
+
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
-    monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", SimpleNamespace())
+    monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", _StubDispatcher())
     monkeypatch.setattr(hooks_mod, "_route_registry", RouteRegistry(web.Application()))
     monkeypatch.setattr(hooks_mod, "list_apps", lambda: [info])
     monkeypatch.setattr(hooks_mod, "_app_hook_root", lambda _name: app_dir)
@@ -82,6 +90,251 @@ class TestStartupPublishesHookHealth:
         assert health["status"] == "degraded"
         assert any("Route module load failed" in issue for issue in health["issues"])
         assert any("kaboom" in issue for issue in health["issues"])
+
+    @pytest.mark.asyncio
+    async def test_startup_caches_shutdown_callable_on_production_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GPT [BLOCKING]: cache_shutdown_for must be called from the PRODUCTION
+        startup path (on_gateway_startup / on_app_enable), not the unused
+        dispatch_enable. Otherwise the shutdown cache is always empty and an
+        on_shutdown living in a module on_startup never imported is orphaned after
+        uninstall. Here on_gateway_startup runs a successful startup and MUST
+        invoke cache_shutdown_for on the dispatcher."""
+        app_dir = tmp_path / "apps" / "cached-app"
+        _write_app(app_dir, "backend.hooks", "def on_startup(ctx):\n    return None\n")
+        info = {
+            "name": "cached-app",
+            "enabled": True,
+            "manifest": {
+                "name": "cached-app",
+                "backend": {
+                    "hooks": {
+                        "on_startup": "backend.hooks:on_startup",
+                        "on_shutdown": "backend.shutdown:on_shutdown",
+                    }
+                },
+            },
+        }
+        cached: list[str] = []
+
+        class _SpyDispatcher(SimpleNamespace):
+            async def _invoke(self, name, hook_path, ctx, *, phase):
+                return True  # startup succeeds
+
+            def cache_shutdown_for(self, app_info):
+                cached.append(app_info.get("name", ""))
+
+                # Awaited by production now; return an awaitable.
+                async def _noop():
+                    return None
+
+                return _noop()
+
+            def _build_context(self, app_info):
+                return SimpleNamespace()
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", _SpyDispatcher())
+        monkeypatch.setattr(hooks_mod, "_route_registry", RouteRegistry(web.Application()))
+        monkeypatch.setattr(hooks_mod, "list_apps", lambda: [info])
+        monkeypatch.setattr(hooks_mod, "_app_hook_root", lambda _name: app_dir)
+        monkeypatch.setattr(hooks_mod, "app_execution_denied", lambda *a, **kw: "")
+        monkeypatch.setattr("kiro_crew.apps.execution.third_party_execution_allowed", lambda: True)
+        monkeypatch.setattr(
+            hooks_mod,
+            "_build_app_context_from_info",
+            lambda *a, **kw: SimpleNamespace(
+                job=None, health=SimpleNamespace(status="healthy", issues=[])
+            ),
+        )
+
+        await hooks_mod.on_gateway_startup()
+
+        assert cached == ["cached-app"], (
+            "on_gateway_startup must cache the on_shutdown callable via the "
+            "production path after a successful startup"
+        )
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
+
+    @pytest.mark.asyncio
+    async def test_routes_only_app_still_caches_shutdown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GPT round-10: a ROUTES-ONLY app (no on_startup) whose routes spawn
+        background work, with a separate shutdown module, must still get its
+        on_shutdown cached on healthy wiring -- otherwise a CLI uninstall deletes
+        the files and the route-created work retains gateway privileges. Caching
+        must fire independently of on_startup presence/success."""
+        app_dir = tmp_path / "apps" / "routes-app"
+        _write_app(app_dir, "backend.routes", "def register(ctx):\n    return []\n")
+        info = {
+            "name": "routes-app",
+            "enabled": True,
+            "manifest": {
+                "name": "routes-app",
+                "backend": {
+                    "hooks": {
+                        "routes": "backend.routes:register",
+                        # NOTE: no on_startup at all; on_shutdown in a separate module.
+                        "on_shutdown": "backend.shutdown:on_shutdown",
+                    }
+                },
+            },
+        }
+        cached: list[str] = []
+
+        class _SpyDispatcher(SimpleNamespace):
+            def cache_shutdown_for(self, app_info):
+                cached.append(app_info.get("name", ""))
+
+                async def _noop():
+                    return None
+
+                return _noop()
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", _SpyDispatcher())
+        monkeypatch.setattr(hooks_mod, "_route_registry", RouteRegistry(web.Application()))
+        monkeypatch.setattr(hooks_mod, "list_apps", lambda: [info])
+        monkeypatch.setattr(hooks_mod, "_app_hook_root", lambda _name: app_dir)
+        monkeypatch.setattr(hooks_mod, "app_execution_denied", lambda *a, **kw: "")
+        monkeypatch.setattr("kiro_crew.apps.execution.third_party_execution_allowed", lambda: True)
+        monkeypatch.setattr(
+            hooks_mod,
+            "_build_app_context_from_info",
+            lambda *a, **kw: SimpleNamespace(
+                job=None, health=SimpleNamespace(status="healthy", issues=[])
+            ),
+        )
+
+        await hooks_mod.on_gateway_startup()
+
+        assert cached == ["routes-app"], (
+            "a routes-only app must still cache its on_shutdown on healthy wiring, "
+            "independently of on_startup"
+        )
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
+
+    @pytest.mark.asyncio
+    async def test_degraded_boot_stays_unrecorded_so_reconciler_retries_on_recovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A degraded wire-up (a failed route/startup import) must NOT record a
+        loaded signature: leaving it un-recorded is what lets the out-of-process
+        reconciler re-attempt the app on its next tick and pick it up once a
+        transient failure clears -- the poll-retry-after-recovery the reconciler
+        exists to provide. Freezing the degraded state as 'current loaded' would
+        strand a transiently-broken app until its code changed."""
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
+        app_dir = tmp_path / "apps" / "broken-app"
+        _write_app(app_dir, "backend.routes", "raise RuntimeError('kaboom')\n")
+        info = _app_info("broken-app", "backend.routes:register")
+        _arm_startup(monkeypatch, tmp_path, app_dir, info)
+
+        await hooks_mod.on_gateway_startup()
+
+        # Degraded wiring is confirmed by the published health entry...
+        assert hooks_mod.get_all_hook_health().get("broken-app") is not None
+        # ...and the signature is deliberately NOT recorded, so the reconciler
+        # re-attempts the app rather than treating broken hooks as loaded.
+        assert (
+            hooks_mod.loaded_hook_signature("broken-app") is None
+        ), "degraded boot must leave no loaded record so it retries on recovery"
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
+
+    @pytest.mark.asyncio
+    async def test_degraded_boot_tears_down_startup_work_before_clearing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GPT round-8 [BLOCKING] F3: on the on_app_enable path (which the
+        reconciler re-invokes every tick), a degraded wire-up (route import
+        fails) that already ran a successful on_startup leaves detached startup
+        work running. Clearing the loaded signature for retry WITHOUT tearing
+        that work down first makes the reconciler re-run on_startup every poll,
+        stacking a fresh worker on the live one until exhaustion. The degraded
+        branch must stop the startup work BEFORE it clears the signature."""
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
+        events: list[str] = []
+
+        class _SpyDispatcher(SimpleNamespace):
+            async def dispatch_disable(self, app_info):
+                events.append(f"shutdown:{app_info.get('name', '')}")
+                return True
+
+            async def stop_detached_startup_hooks(self, app_name, *, bounded=False):
+                events.append(f"stop:{app_name}:bounded={bounded}")
+                return True
+
+        real_clear = hooks_mod.clear_loaded_hook_signature
+
+        def _spy_clear(app_name):
+            events.append(f"clear:{app_name}")
+            return real_clear(app_name)
+
+        # A route hook that fails to import marks the context degraded, so
+        # on_app_enable takes its clear-signature-for-retry branch.
+        app_dir = tmp_path / "apps" / "broken-app"
+        _write_app(app_dir, "backend.routes", "raise RuntimeError('kaboom')\n")
+        info = _app_info("broken-app", "backend.routes:register")
+        _arm_startup(monkeypatch, tmp_path, app_dir, info)
+        monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", _SpyDispatcher())
+        monkeypatch.setattr(hooks_mod, "clear_loaded_hook_signature", _spy_clear)
+
+        await hooks_mod.on_app_enable("broken-app", info)
+
+        assert (
+            "shutdown:broken-app" in events
+        ), "must run the on_shutdown lifecycle on degraded enable"
+        assert "stop:broken-app:bounded=True" in events, "must settle detached startup work too"
+        assert (
+            "clear:broken-app" in events
+        ), "must clear the signature for retry when teardown is clean"
+        assert events.index("shutdown:broken-app") < events.index(
+            "clear:broken-app"
+        ), "the shutdown lifecycle must run BEFORE the signature clear, not after"
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
+
+    @pytest.mark.asyncio
+    async def test_degraded_enable_retains_signature_when_teardown_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GPT round-9: if the degraded-branch teardown does NOT confirm the
+        startup worker stopped, clearing the signature would let the reconciler
+        re-run on_startup and stack another worker. So a failed teardown must
+        RETAIN the loaded signature (record it) instead of clearing -- the
+        retained record suppresses the re-run."""
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
+
+        class _FailingStopDispatcher(SimpleNamespace):
+            async def dispatch_disable(self, app_info):
+                return True
+
+            async def stop_detached_startup_hooks(self, app_name, *, bounded=False):
+                return False  # teardown could not confirm the worker stopped
+
+        app_dir = tmp_path / "apps" / "broken-app"
+        _write_app(app_dir, "backend.routes", "raise RuntimeError('kaboom')\n")
+        info = _app_info("broken-app", "backend.routes:register")
+        _arm_startup(monkeypatch, tmp_path, app_dir, info)
+        monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", _FailingStopDispatcher())
+
+        await hooks_mod.on_app_enable("broken-app", info)
+
+        # Retained: a loaded signature IS present, so the reconciler will not
+        # re-run on_startup and duplicate the still-live worker.
+        assert (
+            hooks_mod.loaded_hook_signature("broken-app") is not None
+        ), "a failed degraded teardown must retain the loaded signature, not clear it"
+        hooks_mod._loaded_hook_signatures.clear()
+        hooks_mod._loaded_hook_manifests.clear()
 
     @pytest.mark.asyncio
     async def test_working_route_hook_records_nothing(

--- a/test/test_dashboard_server_startup_coverage.py
+++ b/test/test_dashboard_server_startup_coverage.py
@@ -579,3 +579,25 @@ class TestStartDashboardWiring:
         finally:
             await runner.cleanup()
             await _cancel_stray_tasks()
+
+
+class TestGatewayShutdownIsGuaranteed:
+    """GPT round-8 [BLOCKING] F4 (server.py:3357): a hung/raising reconciler
+    stop must not skip on_gateway_shutdown() -- that sweep tears down app
+    backends, so skipping it strands spawned processes past gateway exit."""
+
+    @pytest.mark.asyncio
+    async def test_on_gateway_shutdown_runs_even_if_stopping_the_poller_raises(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        async def _boom() -> None:
+            raise RuntimeError("reconciler stop blew up")
+
+        monkeypatch.setattr(srv, "stop_hook_reconciler", _boom)
+        runner, _state, spies = await _start_dashboard(tmp_path, monkeypatch)
+        try:
+            # cleanup dispatches _hooks_shutdown; the finally must still sweep.
+            await runner.cleanup()
+            spies["on_gateway_shutdown"].assert_awaited_once()
+        finally:
+            await _cancel_stray_tasks()

--- a/test/test_hook_reconcile.py
+++ b/test/test_hook_reconcile.py
@@ -1,0 +1,778 @@
+"""Tests for kiro_crew.apps.hook_reconcile — reload app hooks on out-of-process CLI mutation.
+
+Feature: issue #7880 (CLI enable/disable/install/uninstall does not reach the
+running gateway, so backend.hooks are never reloaded).
+
+The in-process teardown/reimport itself (on_app_enable / on_app_disable /
+unload_app_modules / the detached-startup machinery) is covered by
+test_lifecycle_hooks.py; these tests drive the RECONCILER's decision logic.
+The loaded-state is the SHARED registry in hooks_integration (record/clear/read),
+not a private map, so a dashboard-driven enable/disable that updates it leaves
+the reconciler nothing to re-do. The reconciler re-reads app state UNDER
+app_lifecycle_lock and re-checks admission before enabling, so those are stubbed
+per-test to a deterministic answer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+import kiro_crew.apps.hook_reconcile as hr
+import kiro_crew.apps.hooks_integration as hi
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    """Pin KIROCREW_HOME so hook_signature's stats resolve under a throwaway dir,
+    and reset the SHARED loaded-signature registry around every test."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    hi._loaded_hook_signatures.clear()
+    hi._loaded_hook_manifests.clear()
+    hr._inflight_app_tasks.clear()
+    hr._stopping = False
+    yield
+    hi._loaded_hook_signatures.clear()
+    hi._loaded_hook_manifests.clear()
+    hr._inflight_app_tasks.clear()
+    hr._stopping = False
+
+
+def _app_info(name: str, *, enabled: bool = True, version: str = "1.0.0", hooks: bool = True):
+    backend = {"hooks": {"on_startup": "backend.hooks:on_startup"}} if hooks else {}
+    return {
+        "name": name,
+        "enabled": enabled,
+        "version": version,
+        "manifest": {"backend": backend, "permissions": {}},
+    }
+
+
+@pytest.fixture
+def _harness(monkeypatch):
+    """Wire the reconciler's dependencies to deterministic in-memory doubles.
+
+    - on_app_enable / on_app_disable record the calls and maintain the shared
+      registry the way the real ones do (enable records, settled disable clears);
+    - get_app returns whatever the test stages as the "current on-disk" state,
+      re-read under the lock (defaults to the same snapshot);
+    - hook_enable_denied returns "" (admitted) unless the test overrides it.
+
+    Returns (calls, setters) where setters lets a test stage: current app_info,
+    a disable result (to simulate an unsettled teardown), and a denial reason.
+    """
+    calls: list[tuple[str, str]] = []
+    state: dict[str, Any] = {"current": {}, "disable_result": {}, "denied": ""}
+
+    async def fake_enable(name, app_info, **kwargs):
+        calls.append(("enable", name))
+        # Mirror on_app_enable: the execution-DENIED path records the anti-churn
+        # SIGNATURE ONLY (no manifest) and loads nothing; the admitted path
+        # records the full loaded signature + manifest.
+        if state["denied"]:
+            await hi.record_hook_antichurn_signature(name, app_info)
+        else:
+            await hi.record_loaded_hook_signature(name, app_info)
+
+    async def fake_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        res = dict(state["disable_result"])
+        if not str(res.get("startup_cleanup", "")).startswith("failed:"):
+            hi.clear_loaded_hook_signature(name)
+        return res
+
+    def fake_get_app(name):
+        return state["current"].get(name)
+
+    def fake_denied(name):
+        return state["denied"]
+
+    monkeypatch.setattr(hr, "on_app_enable", fake_enable)
+    monkeypatch.setattr(hr, "on_app_disable", fake_disable)
+    monkeypatch.setattr(hr, "get_app", fake_get_app)
+    monkeypatch.setattr(hr, "hook_enable_denied", fake_denied)
+
+    def set_current(*app_infos):
+        state["current"] = {a["name"]: a for a in app_infos}
+
+    def set_disable_result(result):
+        state["disable_result"] = result
+
+    def set_denied(reason):
+        state["denied"] = reason
+
+    return calls, (set_current, set_disable_result, set_denied)
+
+
+# ---------------------------------------------------------------------------
+# Transition: newly-enabled hook app -> load
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_newly_enabled_hook_app_is_loaded(_harness):
+    calls, (set_current, _, _) = _harness
+    app = _app_info("watchtower")
+    set_current(app)
+    await hr.reconcile_once([app])
+    assert calls == [("enable", "watchtower")]
+    assert hi.loaded_hook_signature("watchtower") is not None
+
+
+@pytest.mark.asyncio
+async def test_enabled_app_without_hooks_is_ignored(_harness):
+    calls, (set_current, _, _) = _harness
+    app = _app_info("plain", hooks=False)
+    set_current(app)
+    await hr.reconcile_once([app])
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_unchanged_signature_is_a_noop_second_pass(_harness):
+    calls, (set_current, _, _) = _harness
+    app = _app_info("watchtower")
+    set_current(app)
+    await hr.reconcile_once([app])
+    await hr.reconcile_once([app])  # identical signature — no second enable
+    assert calls == [("enable", "watchtower")]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_enable_already_recorded_leaves_nothing_to_do(_harness):
+    """Shared-source-of-truth: a dashboard enable already recorded the signature,
+    so the reconciler's next tick must NOT re-run on_startup."""
+    calls, (set_current, _, _) = _harness
+    app = _app_info("watchtower")
+    set_current(app)
+    await hi.record_loaded_hook_signature("watchtower", app)  # as the handler would
+    await hr.reconcile_once([app])
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Admission re-check under the lock (GPT: revive-during-trust-withdrawal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_denied_app_is_not_revived_and_does_not_churn(_harness):
+    """An admission-denied enabled hook app must route through on_app_enable's
+    denied path (which loads nothing) — never a live reimport — and must not be
+    re-attempted every tick once its signature is recorded."""
+    calls, (set_current, _, set_denied) = _harness
+    app = _app_info("watchtower")
+    set_current(app)
+    set_denied("third-party execution not granted")
+    await hr.reconcile_once([app])
+    assert calls == [("enable", "watchtower")]  # the denied on_app_enable path
+    # Denied on_app_enable recorded the anti-churn signature, so a second tick is quiet.
+    calls.clear()
+    await hr.reconcile_once([app])
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_denied_app_loads_once_trust_is_granted(_harness):
+    """GPT finding: a denied app is recorded SIGNATURE-ONLY (anti-churn), and
+    granting execution trust does NOT change the hook signature. A plain
+    ``sig == loaded`` short-circuit would strand the now-admitted app forever, so
+    the reconciler re-checks admission for a manifest-less (denied) record and
+    loads it once it is admitted."""
+    calls, (set_current, _, set_denied) = _harness
+    app = _app_info("watchtower")
+    set_current(app)
+    # First tick: denied -> routes through on_app_enable's denied path, recording
+    # a signature-only anti-churn record (no manifest).
+    set_denied("third-party execution not granted")
+    await hr.reconcile_once([app])
+    assert calls == [("enable", "watchtower")]
+    assert hi.loaded_hook_signature("watchtower") is not None
+    assert hi.loaded_hook_manifest("watchtower") is None  # signature-only
+
+    # Trust is now granted; the on-disk hooks (and thus the signature) are
+    # UNCHANGED. The reconciler must still load the app rather than short-circuit.
+    calls.clear()
+    set_denied("")
+    await hr.reconcile_once([app])
+    assert calls == [("enable", "watchtower")], "a now-admitted denied app must load"
+
+
+@pytest.mark.asyncio
+async def test_one_failing_app_does_not_stop_reconcile_of_the_rest(_harness, monkeypatch):
+    """GPT [BLOCKING]: reconcile_once runs apps CONCURRENTLY with per-app
+    exception isolation, so one app's raising teardown must not stop the others,
+    AND -- unlike a cancelling timeout -- a slow teardown is never interrupted
+    mid-sequence (which would skip route deregistration and leave a disabled
+    app's routes callable). Here 'boom' raises and 'slow' runs to completion
+    concurrently; both the raiser's siblings still reconcile."""
+    calls, (set_current, _, _) = _harness
+    order: list[str] = []
+
+    async def concurrent_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        if name == "boom":
+            raise RuntimeError("teardown blew up")
+        if name == "slow":
+            await asyncio.sleep(0.1)  # runs concurrently, NOT cancelled
+        order.append(name)
+        hi.clear_loaded_hook_signature(name)
+        return {}
+
+    monkeypatch.setattr(hr, "on_app_disable", concurrent_disable)
+    # Three loaded apps, all now gone -> all hit the teardown branch.
+    for n in ("boom", "slow", "quick"):
+        await hi.record_loaded_hook_signature(n, _app_info(n))
+    set_current()  # get_app -> None for all
+    await hr.reconcile_once([])
+
+    # The raising app did not stop the others: both completed their teardown.
+    assert "slow" in order and "quick" in order
+    assert hi.loaded_hook_signature("slow") is None
+    assert hi.loaded_hook_signature("quick") is None
+    # The raiser is left recorded (its teardown did not settle) -> retried next tick.
+    assert hi.loaded_hook_signature("boom") is not None
+
+
+@pytest.mark.asyncio
+async def test_hung_teardown_does_not_wedge_the_pass(_harness, monkeypatch):
+    """GPT [BLOCKING]: a nonterminating on_shutdown is awaited unbounded inside
+    the dispatcher, so without a pass watchdog it would hang reconcile_once and
+    -- since the loop awaits the pass -- wedge every future tick (later CLI
+    disables never reconcile). The per-app WATCHDOG must let the pass RETURN while
+    leaving the hung teardown RUNNING (never cancelled -- cancelling mid-on_shutdown
+    would skip route dereg). Here 'hang' blocks forever and 'quick' tears down;
+    the pass must complete and quick must be reconciled despite hang never
+    returning."""
+    calls, (set_current, _, _) = _harness
+    monkeypatch.setattr(hr, "PER_APP_PASS_WATCHDOG_SECS", 0.1)  # trip fast in-test
+    hang_cancelled = {"v": False}
+
+    async def maybe_hang_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        if name == "hang":
+            try:
+                await asyncio.sleep(3600)  # nonterminating on_shutdown
+            except asyncio.CancelledError:
+                hang_cancelled["v"] = True
+                raise
+            return {}
+        hi.clear_loaded_hook_signature(name)
+        return {}
+
+    monkeypatch.setattr(hr, "on_app_disable", maybe_hang_disable)
+    for n in ("hang", "quick"):
+        await hi.record_loaded_hook_signature(n, _app_info(n))
+    set_current()  # get_app -> None for both -> teardown branch
+
+    # The pass must RETURN despite hang never finishing (watchdog), within a bound
+    # well under hang's 3600s sleep.
+    await asyncio.wait_for(hr.reconcile_once([]), timeout=2.0)
+
+    # quick was reconciled; hang's teardown was left running, NOT cancelled.
+    assert hi.loaded_hook_signature("quick") is None, "quick must reconcile despite hang"
+    assert hi.loaded_hook_signature("hang") is not None, "hung teardown left pending -> retried"
+    assert hang_cancelled["v"] is False, "watchdog must NOT cancel the hung teardown"
+
+
+@pytest.mark.asyncio
+async def test_hung_teardown_is_not_respawned_next_tick(_harness, monkeypatch):
+    """GPT [BLOCKING]: a straggler left running by the watchdog still holds the
+    app's lifecycle lock, so re-spawning it every tick would pile up lock-waiter
+    tasks until OOM. The reconciler must track one in-flight task per app and SKIP
+    an app that still has a live one -- so a hung teardown produces exactly ONE
+    outstanding task no matter how many ticks run."""
+    calls, (set_current, _, _) = _harness
+    monkeypatch.setattr(hr, "PER_APP_PASS_WATCHDOG_SECS", 0.05)
+
+    async def hang_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        await asyncio.sleep(3600)  # nonterminating
+        return {}
+
+    monkeypatch.setattr(hr, "on_app_disable", hang_disable)
+    await hi.record_loaded_hook_signature("hang", _app_info("hang"))
+    set_current()  # get_app -> None -> teardown branch
+
+    # Three back-to-back ticks while the teardown stays hung.
+    for _ in range(3):
+        await asyncio.wait_for(hr.reconcile_once([]), timeout=2.0)
+
+    # Only ONE teardown was ever spawned; later ticks skipped the in-flight app.
+    assert calls == [("disable", "hang")], "hung app must not be re-spawned each tick"
+    assert len([t for t in hr._inflight_app_tasks.values() if not t.done()]) == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_final_drain_is_bounded(monkeypatch):
+    """GPT [BLOCKING]: the shutdown-time drain must be bounded so a hung reconcile
+    cannot exceed _hooks_shutdown's ~10s budget and leave spawned backends running
+    past exit. stop_hook_reconciler must return within ~SHUTDOWN_DRAIN_BUDGET_SECS
+    even if the final reconcile pass never completes."""
+    monkeypatch.setattr(hr, "POLL_INTERVAL_SECS", 100.0)
+    monkeypatch.setattr(hr, "SHUTDOWN_DRAIN_BUDGET_SECS", 0.2)
+    monkeypatch.setattr(hr, "list_apps", lambda: [])
+
+    async def hung_reconcile_once(installed):
+        await asyncio.sleep(3600)  # never settles
+
+    monkeypatch.setattr(hr, "reconcile_once", hung_reconcile_once)
+
+    hr.init_hook_reconciler()
+    # stop must return well under the hung pass's 3600s despite the drain hanging.
+    await asyncio.wait_for(hr.stop_hook_reconciler(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_stop_does_not_reawait_a_hung_in_flight_pass(monkeypatch):
+    """GPT round-10 [BLOCKING]: when a pass is already IN FLIGHT and hung, stop's
+    bounded drain expires -- but the loop's cancel handler then re-awaits the same
+    pass. That second await must ALSO be bounded, or it blocks up to the 60s pass
+    watchdog and blows the ~10s graceful-shutdown budget before backend cleanup.
+    Here a pass is hung and running when stop is called; stop must still return
+    within a small multiple of the drain budget, not wait on the hung pass."""
+    entered = asyncio.Event()
+
+    async def hung_in_flight(installed):
+        entered.set()
+        await asyncio.sleep(3600)  # never settles -- simulates a wedged on_shutdown
+
+    monkeypatch.setattr(hr, "POLL_INTERVAL_SECS", 0.01)
+    monkeypatch.setattr(hr, "SHUTDOWN_DRAIN_BUDGET_SECS", 0.2)
+    monkeypatch.setattr(hr, "list_apps", lambda: [])
+    monkeypatch.setattr(hr, "reconcile_once", hung_in_flight)
+
+    hr.init_hook_reconciler()
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=2.0)  # a pass is now hung in flight
+        # Two drain budgets (0.2s each) + a final drain; must be well under the
+        # 3600s hang and under the 60s pass watchdog. 3.0s is generous headroom.
+        await asyncio.wait_for(hr.stop_hook_reconciler(), timeout=3.0)
+    finally:
+        await hr.stop_hook_reconciler()
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_in_flight_pass_without_cancelling_it(monkeypatch):
+    """GPT [BLOCKING]: stop_hook_reconciler must let an in-flight reconcile pass
+    finish before cancelling the loop -- cancelling mid-teardown would interrupt
+    an async on_shutdown's worker cleanup / buffer flush (app code survives or
+    data is lost). Here a pass is made slow; stop is called while it runs and the
+    pass must still complete. stop also runs ONE final drain pass after cancelling
+    (see test_stop_runs_a_final_drain_pass_before_shutdown), so reconcile_once is
+    called a second time -- what matters here is the in-flight pass was NOT
+    cancelled."""
+    completed: list[str] = []
+    entered = asyncio.Event()
+
+    async def slow_reconcile_once(installed):
+        entered.set()
+        await asyncio.sleep(0.2)  # simulate an in-flight teardown
+        completed.append("done")
+
+    monkeypatch.setattr(hr, "POLL_INTERVAL_SECS", 0.01)
+    monkeypatch.setattr(hr, "list_apps", lambda: [])
+    monkeypatch.setattr(hr, "reconcile_once", slow_reconcile_once)
+
+    hr.init_hook_reconciler()
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=2.0)  # a pass is now running
+        await hr.stop_hook_reconciler()  # called mid-pass
+        # The in-flight pass finished (not cancelled); the final drain adds one more.
+        assert completed and completed[0] == "done", "in-flight pass must finish, not be cancelled"
+    finally:
+        await hr.stop_hook_reconciler()
+
+
+@pytest.mark.asyncio
+async def test_stop_runs_a_final_drain_pass_before_shutdown(monkeypatch):
+    """GPT [BLOCKING]: a CLI disable landing between the last poll and stop would
+    be dropped -- the loop is cancelled and on_gateway_shutdown only tears down
+    what is still loaded, so the just-disabled app's on_shutdown flush is skipped.
+    stop_hook_reconciler must run ONE final reconcile pass (after cancelling the
+    poll loop, before returning to the caller that then calls on_gateway_shutdown)
+    to settle that pending disable. It is one-shot, not a resurrected poll."""
+    passes: list[str] = []
+
+    async def counting_reconcile_once(installed):
+        passes.append("pass")
+
+    monkeypatch.setattr(hr, "POLL_INTERVAL_SECS", 100.0)  # no natural tick during the test
+    monkeypatch.setattr(hr, "list_apps", lambda: [])
+    monkeypatch.setattr(hr, "reconcile_once", counting_reconcile_once)
+
+    hr.init_hook_reconciler()
+    await hr.stop_hook_reconciler()
+    # Exactly one final drain pass ran (the poll interval was too long to tick).
+    assert passes == ["pass"], "stop must run exactly one final drain reconcile pass"
+
+
+@pytest.mark.asyncio
+async def test_degraded_app_with_retained_startup_is_torn_down(_harness, monkeypatch):
+    """GPT [BLOCKING]: a degraded/timed-out startup leaves the loaded-signature
+    record CLEARED (so the wiring retries on recovery) yet its detached startup
+    task keeps running. A cleared record drops the app out of the teardown
+    candidate set, so a later uninstall would orphan the task. The reconciler
+    must still examine + tear down an app that answers app_has_retained_startup."""
+    import kiro_crew.apps.lifecycle as lc
+
+    calls, (set_current, _, _) = _harness
+    # No loaded signature recorded (degraded), but a live detached startup task.
+    task = asyncio.ensure_future(asyncio.sleep(3600))
+    lc._DETACHED_HOOK_TASKS["watchtower"] = {task}
+    try:
+        assert hi.loaded_hook_signature("watchtower") is None  # degraded -> cleared
+        assert lc.app_has_retained_startup("watchtower") is True
+        assert "watchtower" in lc.apps_with_retained_startup()
+
+        set_current()  # get_app -> None (uninstalled)
+        await hr.reconcile_once([])  # candidate set must include the retained app
+
+        # It was torn down (hooks-skipped teardown), not orphaned.
+        assert calls == [("disable", "watchtower")]
+    finally:
+        task.cancel()
+        lc._DETACHED_HOOK_TASKS.pop("watchtower", None)
+
+
+@pytest.mark.asyncio
+async def test_stopping_blocks_enable_but_not_teardown(_harness):
+    """GPT [BLOCKING]: once the shutdown sweep begins (_stopping), a
+    watchdog-stranded reconcile task must NOT enable/re-import hooks (it would
+    resurrect app code after on_gateway_shutdown), but teardown must still run so
+    the final drain can settle a pending disable."""
+    calls, (set_current, _, _) = _harness
+
+    # ENABLE is blocked while stopping: a newly-enabled app is NOT loaded.
+    hr._stopping = True
+    app = _app_info("watchtower")
+    set_current(app)
+    await hr.reconcile_once([app])
+    assert calls == [], "no enable while stopping"
+    assert hi.loaded_hook_signature("watchtower") is None
+
+    # TEARDOWN still runs while stopping (the final drain needs it).
+    await hi.record_loaded_hook_signature("watchtower", app)
+    set_current()  # get_app -> None
+    await hr.reconcile_once([])
+    assert calls == [("disable", "watchtower")], "teardown must still run while stopping"
+
+
+@pytest.mark.asyncio
+async def test_denied_app_teardown_runs_no_shutdown_hook(_harness):
+    """GPT [BLOCKING]: an execution-denied app is recorded SIGNATURE-ONLY (no
+    retained manifest) because nothing of it was ever started. When it is later
+    disabled/uninstalled, teardown must run NO ``on_shutdown`` for it -- running
+    a denied app's shutdown-only code would be an execution vector. With no
+    retained manifest, _disable_loaded falls back to the hooks-skipped teardown
+    (run_app_hooks=False; route dereg + module unload still run by name)."""
+    calls, (set_current, _, set_denied) = _harness
+    run_flags: list[bool] = []
+
+    async def capture_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        run_flags.append(kwargs.get("run_app_hooks"))
+        hi.clear_loaded_hook_signature(name)
+        return {}
+
+    import kiro_crew.apps.hook_reconcile as _hr
+
+    # Denied enable records signature-only (no manifest).
+    app = _app_info("watchtower")
+    set_current(app)
+    set_denied("third-party execution not granted")
+    await _hr.reconcile_once([app])
+    assert hi.loaded_hook_signature("watchtower") is not None
+    assert (
+        hi.loaded_hook_manifest("watchtower") is None
+    ), "denied app must retain NO manifest, or teardown could run its on_shutdown"
+    # Now the app is uninstalled; the teardown branch fires.
+    calls.clear()
+    set_current()  # get_app -> None
+    _hr.on_app_disable = capture_disable  # type: ignore[assignment]
+    await _hr.reconcile_once([])
+    assert calls == [("disable", "watchtower")]
+    assert run_flags == [False], "denied app teardown must NOT run on_shutdown"
+
+
+@pytest.mark.asyncio
+async def test_denied_reinstall_of_loaded_app_is_torn_down_first(_harness):
+    """Opus [BLOCKING]: a LOADED (running) hook app reinstalled out-of-process
+    from a source that no longer matches its execution grant lands on the
+    "signature changed + now denied" branch. The denied enable path deregisters
+    routes + records anti-churn + drops the manifest, but does NOT stop the
+    already-loaded module or the background task its on_startup spawned -- so the
+    withdrawn-admission code would keep running indefinitely. The reconciler must
+    ``_disable_loaded`` (tear the live module down) BEFORE routing through the
+    denied enable."""
+    calls, (set_current, _, set_denied) = _harness
+    # v1 is loaded and RUNNING: recorded with a full manifest (admitted load).
+    v1 = _app_info("watchtower", version="1.0.0")
+    await hi.record_loaded_hook_signature("watchtower", v1)
+    assert hi.loaded_hook_manifest("watchtower") is not None  # a live loaded app
+
+    # Out-of-process reinstall to v2 (signature changes) from a source that is
+    # now execution-denied.
+    v2 = _app_info("watchtower", version="2.0.0")
+    set_current(v2)
+    set_denied("third-party execution not granted")
+    await hr.reconcile_once([v2])
+
+    # Teardown of the live module MUST precede the denied enable, in that order.
+    assert calls == [("disable", "watchtower"), ("enable", "watchtower")], (
+        "a denied reinstall of a loaded app must tear the running module down "
+        "before the denied enable, not orphan it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_denied_reinstall_retries_when_teardown_unsettled(_harness):
+    """Opus [BLOCKING] follow-through: if tearing the live module down does not
+    settle, the reconciler must bail (retry next tick) rather than proceed to the
+    denied enable and leave the app half-torn-down."""
+    calls, (set_current, set_disable_result, set_denied) = _harness
+    v1 = _app_info("watchtower", version="1.0.0")
+    await hi.record_loaded_hook_signature("watchtower", v1)
+    v2 = _app_info("watchtower", version="2.0.0")
+    set_current(v2)
+    set_denied("third-party execution not granted")
+    set_disable_result({"startup_cleanup": "failed: task still running"})
+    await hr.reconcile_once([v2])
+    # Teardown attempted but did not settle -> no denied enable this tick.
+    assert calls == [("disable", "watchtower")], "must retry, not proceed to enable"
+
+
+# ---------------------------------------------------------------------------
+# Transition: loaded app disabled / uninstalled -> teardown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loaded_app_turned_off_is_torn_down(_harness):
+    calls, (set_current, _, _) = _harness
+    app_off = _app_info("watchtower", enabled=False)
+    set_current(app_off)
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+    await hr.reconcile_once([app_off])
+    assert calls == [("disable", "watchtower")]
+    assert hi.loaded_hook_signature("watchtower") is None
+
+
+@pytest.mark.asyncio
+async def test_loaded_app_uninstalled_is_torn_down(_harness):
+    calls, (set_current, _, _) = _harness
+    set_current()  # get_app returns None → gone
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+    await hr.reconcile_once([])
+    assert calls == [("disable", "watchtower")]
+    assert hi.loaded_hook_signature("watchtower") is None
+
+
+@pytest.mark.asyncio
+async def test_retained_startup_hook_defers_teardown(_harness):
+    calls, (set_current, set_disable_result, _) = _harness
+    app_off = _app_info("watchtower", enabled=False)
+    set_current(app_off)
+    set_disable_result({"startup_cleanup": "failed: detached startup hook is still running"})
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+    await hr.reconcile_once([app_off])
+    assert calls == [("disable", "watchtower")]
+    assert hi.loaded_hook_signature("watchtower") is not None  # kept for retry
+
+
+# ---------------------------------------------------------------------------
+# Transition: reinstall of new code under a still-enabled app -> evict + reimport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_changed_signature_evicts_then_reimports(_harness):
+    calls, (set_current, _, _) = _harness
+    v2 = _app_info("watchtower", version="2.0.0")
+    set_current(v2)
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower", version="1.0.0"))
+    await hr.reconcile_once([v2])
+    assert calls == [("disable", "watchtower"), ("enable", "watchtower")]
+    assert hi.loaded_hook_signature("watchtower") is not None
+
+
+@pytest.mark.asyncio
+async def test_changed_signature_reimport_deferred_if_teardown_unsettled(_harness):
+    calls, (set_current, set_disable_result, _) = _harness
+    v2 = _app_info("watchtower", version="2.0.0")
+    set_current(v2)
+    set_disable_result({"startup_cleanup": "failed: detached startup hook is still running"})
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower", version="1.0.0"))
+    await hr.reconcile_once([v2])
+    assert calls == [("disable", "watchtower")]  # no half-swap
+
+
+@pytest.mark.asyncio
+async def test_reload_tears_down_from_retained_not_replacement_manifest(_harness):
+    """GPT [BLOCK-MERGE]: on a code change the reload branch must stop the OLD
+    running hook using the manifest it was LOADED from (retained registry), not
+    the replacement on-disk manifest. Resolving teardown from the replacement
+    would stop the wrong on_shutdown (or none, if renamed/removed) and leave the
+    old hook running. Assert on_app_disable receives the retained (v1) manifest."""
+    calls, (set_current, _, _) = _harness
+    seen_manifests: list[dict[str, Any]] = []
+
+    async def capture_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        seen_manifests.append(app_info.get("manifest"))
+        hi.clear_loaded_hook_signature(name)
+        return {}
+
+    import kiro_crew.apps.hook_reconcile as _hr
+
+    # v1 loaded with an on_shutdown that v2 removes; record v1 as the handler would.
+    v1 = _app_info("watchtower", version="1.0.0")
+    v1["manifest"]["backend"]["hooks"]["on_shutdown"] = "backend.hooks:on_shutdown_v1"
+    await hi.record_loaded_hook_signature("watchtower", v1)
+    v2 = _app_info("watchtower", version="2.0.0")  # no on_shutdown in v2
+    set_current(v2)
+    _hr.on_app_disable = capture_disable  # type: ignore[assignment]
+    await _hr.reconcile_once([v2])
+
+    assert calls[0] == ("disable", "watchtower")
+    teardown_hooks = seen_manifests[0]["backend"]["hooks"]
+    assert teardown_hooks.get("on_shutdown") == "backend.hooks:on_shutdown_v1", (
+        "reload teardown must use the retained loaded (v1) manifest, not the "
+        "replacement (v2) manifest whose on_shutdown differs"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signature is hook-identity only (no reload on unrelated metadata edit)
+# ---------------------------------------------------------------------------
+
+
+def test_signature_ignores_installed_json_and_matches_on_hook_identity():
+    a = _app_info("watchtower", version="1.0.0")
+    assert hi.hook_signature(a) == hi.hook_signature(_app_info("watchtower", version="1.0.0"))
+    assert hi.hook_signature(a) != hi.hook_signature(_app_info("watchtower", version="2.0.0"))
+    # The signature is hook-CODE identity only: the ``enabled`` flag is an
+    # orthogonal axis the reconciler checks separately, so it must NOT change the
+    # signature (otherwise a disabled-copy record churns the next poll).
+    assert hi.hook_signature(a) == hi.hook_signature(_app_info("watchtower", enabled=False))
+
+
+@pytest.mark.asyncio
+async def test_uninstalled_app_runs_shutdown_via_retained_manifest(_harness):
+    """GPT security finding: a CLI disable+uninstall within one tick must still
+    run on_shutdown so a background task the hook spawned is stopped, not orphaned
+    after uninstall removes execution trust. The manifest is retained at load, so
+    the gone-app teardown resolves on_shutdown from it (run_app_hooks=True)."""
+    calls, (set_current, _, _) = _harness
+    run_flags: list[bool] = []
+
+    async def capture_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        run_flags.append(kwargs.get("run_app_hooks"))
+        hi.clear_loaded_hook_signature(name)
+        return {}
+
+    import kiro_crew.apps.hook_reconcile as _hr
+
+    # Record the loaded manifest (as on_app_enable would), then the app vanishes.
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+    set_current()  # get_app -> None (uninstalled)
+    _hr.on_app_disable = capture_disable  # type: ignore[assignment]
+    await _hr.reconcile_once([])
+    assert calls == [("disable", "watchtower")]
+    assert run_flags == [True], "on_shutdown must run against the retained manifest"
+
+
+@pytest.mark.asyncio
+async def test_uninstalled_app_with_no_retained_manifest_skips_hooks(_harness):
+    """Fallback: an app we never recorded a manifest for cannot resolve its
+    on_shutdown, so the gone-app teardown skips app hooks (run_app_hooks=False)
+    while gateway-owned teardown still runs by name."""
+    calls, (set_current, _, _) = _harness
+    run_flags: list[bool] = []
+
+    async def capture_disable(name, app_info, **kwargs):
+        calls.append(("disable", name))
+        run_flags.append(kwargs.get("run_app_hooks"))
+        hi.clear_loaded_hook_signature(name)
+        return {}
+
+    import kiro_crew.apps.hook_reconcile as _hr
+
+    # A signature present but NO retained manifest (simulate a legacy record).
+    hi._loaded_hook_signatures["watchtower"] = ("1.0.0", 0, 0)
+    set_current()
+    _hr.on_app_disable = capture_disable  # type: ignore[assignment]
+    await _hr.reconcile_once([])
+    assert run_flags == [False]
+
+
+@pytest.mark.asyncio
+async def test_reimport_failure_leaves_signature_unset_for_retry(monkeypatch):
+    calls: list[str] = []
+    current = {"watchtower": _app_info("watchtower")}
+
+    async def boom_enable(name, app_info, **kwargs):
+        calls.append(name)
+        raise RuntimeError("import blew up")
+
+    async def ok_disable(name, app_info, **kwargs):
+        hi.clear_loaded_hook_signature(name)
+        return {}
+
+    monkeypatch.setattr(hr, "on_app_enable", boom_enable)
+    monkeypatch.setattr(hr, "on_app_disable", ok_disable)
+    monkeypatch.setattr(hr, "get_app", lambda name: current.get(name))
+    monkeypatch.setattr(hr, "hook_enable_denied", lambda name: "")
+    await hr.reconcile_once([current["watchtower"]])
+    assert calls == ["watchtower"]
+    assert hi.loaded_hook_signature("watchtower") is None
+
+
+@pytest.mark.asyncio
+async def test_failed_shutdown_is_unsettled_and_retained(monkeypatch):
+    """GPT round-11 [BLOCKING]: a failed on_shutdown means the app's own stop
+    routine did not complete, so its worker may still be live. _disable_loaded
+    must treat hooks_shutdown=='failed' as UNSETTLED -- return False and RETAIN
+    the loaded record so the reconciler retries, rather than clearing the
+    signature and accepting teardown while the worker survives."""
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+
+    async def failing_shutdown_disable(name, app_info, **kwargs):
+        return {"hooks_shutdown": "failed"}
+
+    monkeypatch.setattr(hr, "on_app_disable", failing_shutdown_disable)
+    monkeypatch.setattr(hr, "unload_app_modules", lambda name: 0)
+
+    settled = await hr._disable_loaded("watchtower", {"name": "watchtower"})
+    assert settled is False, "a failed on_shutdown must be reported as unsettled"
+    assert (
+        hi.loaded_hook_signature("watchtower") is not None
+    ), "a failed shutdown must retain the loaded record for retry"
+    hi._loaded_hook_signatures.clear()
+    hi._loaded_hook_manifests.clear()
+
+
+@pytest.mark.asyncio
+async def test_settled_teardown_unloads_modules_for_clean_reimport(monkeypatch):
+    """GPT round-11 [BLOCKING]: a CLI reinstall (disable/enable without a process
+    restart) that does not unload the app's modules reuses stale transitive
+    helper modules via relative imports, so old code stays active. A SETTLED
+    teardown must call unload_app_modules so the next enable re-imports fresh."""
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+    unloaded: list[str] = []
+
+    async def clean_disable(name, app_info, **kwargs):
+        hi.clear_loaded_hook_signature(name)
+        return {"hooks_shutdown": "ok"}
+
+    monkeypatch.setattr(hr, "on_app_disable", clean_disable)
+    monkeypatch.setattr(hr, "unload_app_modules", lambda name: unloaded.append(name) or 1)
+
+    settled = await hr._disable_loaded("watchtower", {"name": "watchtower"})
+    assert settled is True
+    assert unloaded == ["watchtower"], "settled teardown must unload the app's modules"
+    hi._loaded_hook_signatures.clear()
+    hi._loaded_hook_manifests.clear()

--- a/test/test_lifecycle_hooks.py
+++ b/test/test_lifecycle_hooks.py
@@ -1311,3 +1311,169 @@ class TestGatewayShutdownBackendSweep:
         finally:
             release.set()
             pool.shutdown(wait=True)
+
+
+# ---------------------------------------------------------------------------
+# Shutdown resolves the LOADED code, not disk (issue #7880 reconciler teardown)
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownResolvesLoadedCode:
+    @pytest.mark.asyncio
+    async def test_shutdown_prefers_cached_module_over_disk(self, monkeypatch) -> None:
+        """GPT [BLOCKING]: on_shutdown must stop the code that is actually
+        running. A same-path v2 reinstall leaves v2 on disk while v1's task is
+        still live; resolving from disk would run v2's on_shutdown and orphan v1.
+        _invoke(phase='shutdown') resolves the ALREADY-LOADED (cached) callable
+        first, falling back to the disk loader only when nothing is cached."""
+        import sys
+        from types import SimpleNamespace
+
+        import kiro_crew.apps.module_loader as ml
+        from kiro_crew.apps.lifecycle import LifecycleDispatcher
+
+        app_name = "reload-app"
+        hook_path = "backend.hooks:on_shutdown"
+        ran: list[str] = []
+
+        # v1 is the LOADED module: register it in sys.modules under the app's key.
+        v1 = SimpleNamespace(on_shutdown=lambda ctx: ran.append("v1"))
+        key = ml._module_namespace(app_name, "backend.hooks")
+        sys.modules[key] = v1  # type: ignore[assignment]
+
+        dispatcher = LifecycleDispatcher()
+        # The disk loader would return v2 (the replacement) -- it must NOT be used.
+        monkeypatch.setattr(
+            dispatcher, "_resolve_hook", lambda a, h: (lambda ctx: ran.append("v2"))
+        )
+        ctx = SimpleNamespace(health=SimpleNamespace(mark_degraded=lambda *a, **k: None))
+        try:
+            ok = await dispatcher._invoke(app_name, hook_path, ctx, phase="shutdown")
+        finally:
+            sys.modules.pop(key, None)
+
+        assert ok is True
+        assert ran == ["v1"], "shutdown must run the loaded (cached) code, not disk v2"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_falls_back_to_disk_when_nothing_cached(self, monkeypatch) -> None:
+        """When no module is cached (e.g. a builtin, or never imported), shutdown
+        falls back to the normal disk/dotted resolver."""
+        from types import SimpleNamespace
+
+        from kiro_crew.apps.lifecycle import LifecycleDispatcher
+
+        ran: list[str] = []
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(
+            dispatcher, "_resolve_hook", lambda a, h: (lambda ctx: ran.append("disk"))
+        )
+        ctx = SimpleNamespace(health=SimpleNamespace(mark_degraded=lambda *a, **k: None))
+        ok = await dispatcher._invoke(
+            "uncached-app", "backend.hooks:on_shutdown", ctx, phase="shutdown"
+        )
+        assert ok is True
+        assert ran == ["disk"]
+
+
+class TestCacheShutdownForNeverLoadsOnTheEventLoop:
+    """GPT rounds 8-9 (lifecycle.py shutdown cache): enable-time caching must not
+    BLOCK the event loop (r8 F2) nor re-import a same-module app (r8 F1), and must
+    still RETAIN a separate shutdown module startup never imported (r9). The
+    resolution: resolve an already-loaded module in-memory (no disk, no re-import),
+    and load a genuinely-separate module OFF the loop via asyncio.to_thread."""
+
+    @pytest.mark.asyncio
+    async def test_loaded_module_is_resolved_in_memory_without_reimport(self, monkeypatch):
+        import sys
+        from types import ModuleType
+
+        import kiro_crew.apps.lifecycle as lc
+        import kiro_crew.apps.module_loader as ml
+
+        ml._shutdown_callables.pop("loaded-app", None)
+        key = ml._module_namespace("loaded-app", "backend.hooks")
+        mod = ModuleType(key)
+
+        def _on_shutdown(ctx):
+            return None
+
+        mod.on_shutdown = _on_shutdown
+        sys.modules[key] = mod
+
+        # A same/loaded module must be resolved via sys.modules ONLY: no disk load
+        # (would block the loop) and no re-import (would detach the running state).
+        def _boom(*a, **kw):
+            raise AssertionError("a loaded module must not be disk-loaded / re-imported")
+
+        monkeypatch.setattr(lc, "load_app_module", _boom, raising=False)
+
+        try:
+            disp = lc.LifecycleDispatcher()
+            await disp.cache_shutdown_for(
+                {
+                    "name": "loaded-app",
+                    "manifest": {"backend": {"hooks": {"on_shutdown": "backend.hooks:on_shutdown"}}},
+                }
+            )
+            # Snapshotted from sys.modules (pure getattr), generation-tagged.
+            assert ml.resolve_loaded_callable("loaded-app", "backend.hooks:on_shutdown") is _on_shutdown
+        finally:
+            sys.modules.pop(key, None)
+            ml._shutdown_callables.pop("loaded-app", None)
+
+    @pytest.mark.asyncio
+    async def test_separate_module_is_retained_via_off_loop_load(self, monkeypatch):
+        import kiro_crew.apps.lifecycle as lc
+        import kiro_crew.apps.module_loader as ml
+
+        ml._shutdown_callables.pop("sep-app", None)
+
+        def _sep_shutdown(ctx):
+            return None
+
+        # _resolve_hook does the disk load for a separate module; it MUST be reached
+        # only through asyncio.to_thread (off the event loop), never called inline.
+        offloaded = {"via_thread": False}
+        monkeypatch.setattr(lc.LifecycleDispatcher, "_resolve_hook", lambda self, n, p: _sep_shutdown)
+
+        real_to_thread = asyncio.to_thread
+
+        async def _tracking_to_thread(fn, *a, **kw):
+            offloaded["via_thread"] = True
+            return await real_to_thread(fn, *a, **kw)
+
+        monkeypatch.setattr(lc.asyncio, "to_thread", _tracking_to_thread)
+
+        disp = lc.LifecycleDispatcher()
+        # on_shutdown lives in a module startup never imported -> not in sys.modules,
+        # so it is loaded off-loop and RETAINED (r9: separate modules must be kept).
+        await disp.cache_shutdown_for(
+            {
+                "name": "sep-app",
+                "manifest": {"backend": {"hooks": {"on_shutdown": "backend.never_loaded:on_shutdown"}}},
+            }
+        )
+        assert offloaded["via_thread"] is True, "separate-module load must go off-loop via to_thread"
+        assert ml._shutdown_callables.get("sep-app") == (ml._current_generation("sep-app"), _sep_shutdown)
+        ml._shutdown_callables.pop("sep-app", None)
+
+    @pytest.mark.asyncio
+    async def test_stale_generation_callable_is_not_used(self, monkeypatch):
+        import kiro_crew.apps.module_loader as ml
+
+        ml._shutdown_callables.pop("gen-app", None)
+        ml._app_load_generation.pop("gen-app", None)
+
+        def _v1(ctx):
+            return None
+
+        # Cache a v1 callable at generation 0.
+        ml.cache_shutdown_callable("gen-app", _v1)
+        assert ml.resolve_loaded_callable("gen-app", "backend.hooks:on_shutdown") is _v1
+
+        # A reload (unload bumps the generation) invalidates the stale v1 entry.
+        ml._app_load_generation["gen-app"] = ml._current_generation("gen-app") + 1
+        assert ml.resolve_loaded_callable("gen-app", "backend.hooks:on_shutdown") is None
+        ml._shutdown_callables.pop("gen-app", None)
+        ml._app_load_generation.pop("gen-app", None)

--- a/test/test_module_loader.py
+++ b/test/test_module_loader.py
@@ -12,8 +12,11 @@ import pytest
 
 from kiro_crew.apps.module_loader import (
     _module_namespace,
+    cache_shutdown_callable,
+    clear_shutdown_callable,
     is_app_module_loaded,
     load_app_module,
+    resolve_loaded_callable,
     unload_app_modules,
 )
 
@@ -698,3 +701,91 @@ def test_deploy_skill_install_replaces_managed_dir(tmp_path, monkeypatch):
     assert (managed_dir / "SKILL.md").exists()
     # Marker was re-written by the copy fallback
     assert (managed_dir / ".kirocrew-managed").exists()
+
+
+# ---------------------------------------------------------------------------
+# resolve_loaded_callable — gone-app shutdown (issue #7880 reconciler teardown)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_loaded_callable_survives_deleted_files(tmp_path, monkeypatch):
+    """GPT [BLOCKING]: CLI uninstall deletes an app's files, so the disk loader
+    can no longer resolve its on_shutdown -- yet the module the gateway imported
+    is still resident in sys.modules and a task its on_startup spawned is still
+    live. resolve_loaded_callable resolves the callable from that cached module
+    so trust revocation can still run on_shutdown, where load_app_module (disk)
+    now raises."""
+    app_dir = tmp_path / "gone-app"
+    _create_app_module(
+        app_dir, "backend.hooks:on_shutdown", "def on_shutdown(ctx):\n    return 'bye'\n"
+    )
+    # Load it as the gateway would, then delete the files (simulate uninstall).
+    func = load_app_module("gone-app", app_dir, "backend.hooks:on_shutdown")
+    assert func(None) == "bye"
+    import shutil
+
+    shutil.rmtree(app_dir)
+
+    # Disk loader now fails (files gone)...
+    with pytest.raises(ImportError):
+        load_app_module("gone-app", app_dir, "backend.hooks:on_shutdown")
+    # ...but the cached module still resolves the callable.
+    cached = resolve_loaded_callable("gone-app", "backend.hooks:on_shutdown")
+    assert cached is not None and cached(None) == "bye"
+
+    unload_app_modules("gone-app")
+    # Once unloaded, there is nothing cached to resolve.
+    assert resolve_loaded_callable("gone-app", "backend.hooks:on_shutdown") is None
+
+
+def test_resolve_loaded_callable_none_when_never_loaded():
+    """An app the gateway never loaded has no cached module -> None (the caller
+    then falls back to the disk loader / hooks-skipped teardown)."""
+    assert resolve_loaded_callable("never-loaded-app", "backend.hooks:on_shutdown") is None
+    # Malformed paths resolve to None rather than raising.
+    assert resolve_loaded_callable("x", "no-colon") is None
+    assert resolve_loaded_callable("x", ":only_callable") is None
+
+
+def test_cached_shutdown_callable_survives_uninstall_of_uncached_module():
+    """GPT [BLOCKING]: when on_startup and on_shutdown live in SEPARATE modules,
+    only the startup module is in sys.modules, so resolve_loaded_callable would
+    miss the shutdown module and the disk fallback would raise on the deleted
+    files -- orphaning the app's background task after trust removal. The
+    enable-time cache_shutdown_callable captures the bound on_shutdown callable
+    while files exist, so resolve_loaded_callable returns it FIRST, without disk."""
+    ran = {"v": False}
+
+    def on_shutdown(ctx):
+        ran["v"] = True
+        return "stopped"
+
+    # No module for this app is in sys.modules (startup never imported the
+    # shutdown module) -> without the cache, resolution would be None.
+    assert resolve_loaded_callable("sep-app", "backend.shutdown:on_shutdown") is None
+
+    # Enable-time cache (populated while files existed) now covers it.
+    cache_shutdown_callable("sep-app", on_shutdown)
+    func = resolve_loaded_callable("sep-app", "backend.shutdown:on_shutdown")
+    assert func is not None
+    assert func(None) == "stopped" and ran["v"] is True
+
+    # Cleared on unload -> re-enable re-caches fresh code.
+    clear_shutdown_callable("sep-app")
+    assert resolve_loaded_callable("sep-app", "backend.shutdown:on_shutdown") is None
+
+
+def test_clear_all_shutdown_callables_drops_the_whole_cache():
+    """GPT round-9: the gateway teardown sweep does not go through per-app
+    unload_app_modules, so it must drop the whole shutdown cache -- otherwise a
+    callable captured this generation survives into an in-process restart and is
+    used to stop a NEWLY loaded worker."""
+    import kiro_crew.apps.module_loader as ml
+
+    ml._shutdown_callables.clear()
+    ml.cache_shutdown_callable("app-a", lambda ctx: None)
+    ml.cache_shutdown_callable("app-b", lambda ctx: None)
+    assert ml._shutdown_callables  # populated
+
+    ml.clear_all_shutdown_callables()
+    assert ml._shutdown_callables == {}, "teardown sweep must drop every cached callable"


### PR DESCRIPTION
Fixes #7880

## Problem / Motivation

`kirocrew app {enable,disable,install,uninstall}` run in the **CLI process** and mutate an app on disk — `installed.json`, the app files, `.app_secret` — then return. They never talk to the **gateway process**. But an app's `backend.hooks` (`on_startup`, `on_shutdown`, `routes`) run *inside the gateway*, which loads them once and thereafter serves the module object cached in `sys.modules`.

So after a CLI reinstall the running gateway keeps executing the OLD module, the old `on_startup` task keeps running, and its calls fail auth because `.app_secret` rotated underneath it. Only a full `kirocrew restart` picked it up.

**Relationship to #7905 (already merged):** #7905 shipped the *second* half of this issue — a CLI notice so the operator is not misled — but explicitly deferred the *first* half (the issue title: "does not reload backend hooks in a running gateway"). #7880 is still open. This PR delivers that reload, and updates #7905's `_warn_hooks_need_restart` message so it states the new, accurate timing (a running gateway reloads automatically; a stopped one loads on next start) instead of telling the operator to restart. #7905's helper, gate, and structure are otherwise preserved, and the notice is now also emitted on `install`.

## Why it matters

You iterate on a hooks app, reinstall via the CLI, and verify a "fix" against **stale code** — concluding it works when it never loaded, or failed when it never ran. The rotated `.app_secret` then makes the still-live old module's calls fail with an auth-shaped error, sending you to debug the wrong thing. A background task the old `on_startup` spawned also keeps running after an uninstall removed the app's execution trust.

## What changed

The gateway already reconciles **crons** the CLI writes to disk (`crons.json` digest re-sync) and live-reloads **UI** files (the dev-mode watcher). Python hooks had no equivalent. This adds one (`apps/hook_reconcile.py`), a gateway-side poll that compares each app's on-disk hook signature to what the gateway has loaded and drives the EXISTING lifecycle on a change:

```
signature = (version, hook-source-file digest, .app_secret mtime)   # hook CODE identity only

  loaded, now disabled / uninstalled   -> on_app_disable  (on_shutdown + route dereg + module unload)
  loaded, code or secret changed       -> on_app_disable  ->  on_app_enable   (evict + reimport)
  not loaded, now enabled with hooks   -> on_app_enable    (reimport)
```

Design decisions (several are direct responses to review rounds on this PR):

- **One source of truth, no shadow bookkeeping.** "Which apps have hooks loaded, under what signature" lives in `hooks_integration` and is written by EVERY driver — the dashboard enable/disable handlers, the boot startup pass, and the reconciler — so the reconciler cannot desync from the in-process handlers and double-run an app's `on_startup`/`on_shutdown` that a dashboard action just performed.
- **Per-app lifecycle lock + re-read.** The reconciler does each app's work under `app_lifecycle_lock(name)` and re-reads state (including an admission re-check) inside it, so it cannot revive an app mid-trust-withdrawal.
- **Uninstall stops residual work.** The manifest an app was loaded from is retained, so an app UNINSTALLED between ticks still has its `on_shutdown` run against the code that was actually loaded — stopping a background task that would otherwise outlive trust removal.
- **Signature is hook-CODE identity only** — not `installed.json` mtime (a permissions edit must not force a reload) and not the `enabled` flag (that is an orthogonal axis the reconciler checks separately; folding it in caused a spurious reload cycle).
- **Record only on healthy wiring**, so a failed import is retried rather than frozen as current; **denied apps record a signature** so they are not re-attempted every tick.
- **Off the event loop:** signature stats run via `asyncio.to_thread`; the reconciler reads `list_apps` once per tick off-loop; `init_hook_reconciler` is synchronous and IO-free so it adds nothing before the socket binds.
- **Cost:** an always-on poll walking installed apps every `POLL_INTERVAL_SECS` (15s). Deliberately slower than the dev-mode watcher (1s) because hooks change rarely; the interval is the lever that keeps the walk's cost small.

Files: `apps/hook_reconcile.py` (new), `apps/hooks_integration.py` (shared loaded-state registry + signature), `dashboard/server.py` (start/stop beside the dev-mode watcher), `cli_commands.py` (accurate reload notice on enable + install), `test/test_hook_reconcile.py` (new), `test/test_app_cli.py` (notice assertions updated to the new timing).

## Tests

```
pytest test/test_hook_reconcile.py test/test_lifecycle_hooks.py test/test_app_cli.py \
       test/test_job_sdk.py test/test_app_hook_health.py
  208 passed

black --check --fast <changed> ; isort --check-only <changed> ; flake8 <changed>   # clean
mypy apps/hook_reconcile.py apps/hooks_integration.py cli_commands.py               # clean
```

`test_hook_reconcile.py` covers each transition, the shared-registry no-double-run property, the admission re-check (no revive during trust withdrawal), the uninstall-runs-shutdown-via-retained-manifest case (and its no-manifest fallback), the hook-CODE-only signature, and reimport-failure retry.

## Pattern harvest

Rule candidate: When a CLI subcommand mutates on-disk state that a long-lived gateway process has cached in memory (hooks, crons, UI, secrets), the mutation must reach the gateway — either the CLI notifies it or the gateway reconciles the on-disk signature on a poll — and the "what is currently loaded" record must be ONE source of truth written by every driver, or a reconciler will fight the in-process handlers and double-run lifecycle hooks. A disk-only write otherwise leaves the running process serving stale state until a manual restart.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend + CLI-only change. No rendered dashboard surface is added or altered; the only user-visible change is CLI stdout text on `app enable` / `app install`.
