### PR TITLE
fix(dashboard): gap MCP Management servers-view cards

### DIFF
--- a/website/src/pages/settings/McpManagement.tsx
+++ b/website/src/pages/settings/McpManagement.tsx
@@ -977,7 +977,13 @@ export function McpManagement() {
           unmeasuredCount={unmeasuredCount}
         />
       </TabsContent>
-      <TabsContent value="servers">
+      {/* The servers view stacks a lede header, two inline banners and three
+          cards as SIBLINGS. The `space-y-4` on the <Tabs> root only gaps the tab
+          rail from the panel below it -- it cannot reach inside a panel -- so
+          without a gap class here the cards render flush against each other,
+          unlike the assessment view (which wraps its body in `space-y-4`) and
+          every other settings panel. Match that rhythm on the panel itself. */}
+      <TabsContent value="servers" className="space-y-4">
       {/* No <h2> here: the Developer tab header already names this surface, and a
           second copy of the title read as two stacked headings. */}
       <header>

--- a/website/src/test/McpManagement.test.tsx
+++ b/website/src/test/McpManagement.test.tsx
@@ -1388,4 +1388,21 @@ describe('state chip honours the rewriter, not just the allowlist', () => {
     expect(await screen.findByText('direct', { selector: 'span' })).toBeTruthy()
     expect(screen.getByText('no stdio', { selector: 'span' })).toBeTruthy()
   })
+
+  it('gaps the servers panel cards the same way the assessment view does', async () => {
+    // The lede header, the two inline banners and the three cards are SIBLINGS
+    // inside the servers tab panel. The `space-y-4` on the <Tabs> root only gaps
+    // the tab rail from the panel; it cannot reach inside the panel, so without a
+    // gap class ON the panel the cards render flush against each other -- the
+    // inconsistency this fix removes. Assert the panel carries the spacing class
+    // so a later refactor that drops it fails here rather than only on screen.
+    vi.spyOn(api, 'mcpGatewayStatus').mockResolvedValue(status() as never)
+    vi.spyOn(api, 'mcpGatewayServers').mockResolvedValue({ servers: [server()] } as never)
+
+    mount()
+    // The active tab panel is the servers view (the default). Radix renders it
+    // with role="tabpanel"; the inactive assessment panel is not in the DOM.
+    const panel = await screen.findByRole('tabpanel')
+    expect(panel.className).toContain('space-y-4')
+  })
 })


### PR DESCRIPTION
## Problem / Motivation

On the **MCP Management** settings page (Developer › MCP Management), the **Servers** view stacks its cards flush against one another — the "Share backends across sessions" card, the "Pre-resolve npm servers" card, and the servers table sit with their borders touching and no vertical gap. That is inconsistent with the page's own **Sharing assessment** tab and with every other settings panel, which space their cards ~1rem apart.

## Why it matters

It reads as a visual bug on a first-class settings surface: adjacent bordered cards with touching edges look like one broken container rather than three distinct controls. Anyone landing on this page (it is the default sub-view) sees it.

## What changed (motivation → approach → change)

- **Symptom:** the servers-view cards render flush; the assessment view and other panels do not.
- **Root cause:** the page is `<Tabs className="space-y-4">` with two `<TabsContent>` panels. Tailwind's `space-y-*` only sets margins between an element's *direct children*, so the root's `space-y-4` gaps the tab rail from the panel — it cannot reach inside a panel. The **assessment** panel wraps its body in `<div className="space-y-4">` (correct), but the **servers** panel put its lede header, banners and three `<section>` cards as direct siblings with no gap class.
- **Change:** add `className="space-y-4"` to the servers `<TabsContent>`, giving its cards the same 1rem rhythm as the assessment view and the rest of the dashboard. One class; no structural or behavioural change.

## Tests

- Added `gaps the servers panel cards the same way the assessment view does` in `website/src/test/McpManagement.test.tsx`: renders the page and asserts the active servers `tabpanel` carries the `space-y-4` class. Verified it fails red without the fix and green with it.
- Full `McpManagement.test.tsx` suite: 54/54 pass. `tsc -b` clean, `eslint` clean on both changed files.

## Manual verification

Verified the fix by rendering the page locally and confirming the servers-view cards gain the same vertical gap as the assessment view. Unit test locks the panel's spacing class.

## Screenshots / video

Captured on an **isolated gateway with mocked, synthetic data** (invented `demo-server-*` / `demo-agent-*` names — no real environment data in frame).

**Before** — the three cards are flush, borders touching, no gap:

![MCP Management servers view before — cards flush](https://github.com/RohanK6/KiroCrew/raw/8c951a43e2b1ff7a06c9be64b63942ebdb276800/mcp-card-spacing-v2/before.png)

**After** — each card separated by a 1rem gap, matching the rest of the dashboard:

![MCP Management servers view after — cards spaced](https://github.com/RohanK6/KiroCrew/raw/8c951a43e2b1ff7a06c9be64b63942ebdb276800/mcp-card-spacing-v2/after.png)
## Related Issues

Fixes #7896

## Pattern harvest

Rule candidate: A Radix `Tabs` root's `space-y-*` gaps the tab rail from the content block only; it does NOT space the children *inside* a `TabsContent` panel. A panel that stacks multiple sibling cards must carry its own gap class (or a wrapping `space-y-*` div) — exactly what the sibling panel on the same page already does. When one panel wraps its body and another does not, the unwrapped one silently renders flush.



