### PR TITLE
test: deflake two suites that leaked process-wide module state

### DIFF
--- a/test/test_external_logout_detection.py
+++ b/test/test_external_logout_detection.py
@@ -20,6 +20,23 @@ from kiro_crew import kiro_prerequisite as kp
 from kiro_crew.session import _MAX_CONCURRENT_COLD_STARTS as _MAX_COLD_STARTS_FOR_TEST
 
 
+@pytest.fixture(autouse=True)
+def _private_sel_root_per_test(sel_private_root):
+    """Every test in this module gets its OWN SEL root (issue #7029).
+
+    ``identity_fingerprint`` is audit-or-deny: it returns "absent" unless a
+    CRITICAL SEL event lands first. On the event-loop thread the chain-lock
+    acquire is a single non-blocking attempt that refuses rather than stall the
+    loop -- correct product behaviour -- so on the worker's SHARED SEL root an
+    async test asserting a NON-EMPTY fingerprint is racing writers it never
+    created (another test still flushing, another xdist worker on the same
+    path). It then reads "" and fails on a property it never meant to test.
+    ``sel_private_root`` removes the concurrent writer: a fresh per-test,
+    per-worker directory nothing else writes.
+    """
+    yield
+
+
 def _write_store(
     path: Path,
     *,

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -22,6 +22,7 @@ from chat_test_helpers import _make_state
 
 from kiro_crew.config import loader
 from kiro_crew.dashboard import chat_delivery as cd
+from kiro_crew.dashboard import create_rate_limit
 from kiro_crew.dashboard import session_control as sc
 from kiro_crew.dashboard import stop_retry
 from kiro_crew.dashboard.chat_utils import slot_history_key
@@ -51,6 +52,21 @@ def _fresh_stop_windows():
     stop_retry.reset_for_tests()
     yield
     stop_retry.reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_create_budget():
+    """The per-caller create-rate window is process-wide module state.
+
+    Nearly every create test here calls as the same caller (``chat-1``), so the
+    20-per-window budget is consumed by the file itself: left behind, the 21st
+    create in a worker process is refused with ``create_rate_limited`` and the
+    test that happens to be 21st fails for a reason it never asserted. Which
+    test that is depends on xdist distribution, which is what made it flaky.
+    """
+    create_rate_limit.reset_for_tests()
+    yield
+    create_rate_limit.reset_for_tests()
 
 
 def _slot(state, name: str, **kwargs):


### PR DESCRIPTION
## Problem / Motivation

Two suites fail intermittently in CI on a property neither of them is testing.

`test/test_session_control.py`:

```
FAILED test/test_session_control.py::test_the_created_agent_name_is_sanitized_before_storage - kiro_crew.dashboard.session_control.SessionControlError: too many sessions created recently; retry shortly
FAILED test/test_session_control.py::test_the_audit_write_does_not_run_on_the_event_loop - kiro_crew.dashboard.session_control.SessionControlError: too many sessions created recently; retry shortly
```

`test/test_external_logout_detection.py`:

```
FAILED test/test_external_logout_detection.py::TestStoreRelocation::test_a_leftover_default_store_is_not_read_when_relocated - AssertionError: assert '' != ''
 +  where '' = <function identity_fingerprint at 0x7f7edf935bd0>(PosixPath('.../kiro-cli/data.sqlite3'))
```

## Why it matters

Both are unrelated to whatever diff is under test, so every PR that draws one pays a
re-run, and a red that moves between tests trains reviewers to re-run rather than read
a failure. The session-control one also picks its victim by xdist distribution, so the
named test changes run to run.

## What changed (motivation → approach → change)

Both files leaked process-wide module state; each now resets or isolates it per test.

**`test/test_session_control.py` — the create-rate budget was never reset.**
`create_rate_limit` keeps its buckets in module globals and ships a `reset_for_tests()`
that `test_chat_folder_cap.py` and `test_create_rate_limit.py` already call — this file
did not. Nearly every create test here calls as the same caller (`chat-1`) and the file
makes 20+ creates against the 20-per-window budget, so the 21st create in a worker
process is refused with `create_rate_limited` and whichever test lands 21st fails.
Reproduced deterministically with `-n0`: the two tests above failed and the bucket read
exactly 20. Fixed with an autouse fixture clearing the buckets around each test, the
same shape as the existing `_fresh_stop_windows` fixture directly above it.

**`test/test_external_logout_detection.py` — a critical SEL audit racing a foreign
writer.** `identity_fingerprint` is audit-or-deny: it returns "absent" unless a
`critical=True` SEL event is written first. On the event-loop thread the chain-lock
acquire is a single non-blocking attempt that refuses rather than stall the loop
(`sel._acquire_chain_lock_on_loop`) — correct product behaviour, untouched here. On the
worker's shared SEL root that turns an async test asserting a NON-EMPTY fingerprint into
a race against writers the module never created: another test still flushing, or another
xdist worker on the same path. The read then returns `""` and the test fails on a
property it never meant to assert. This is the same mechanism as issue #7029, already
solved for `test_issue_radar_crew_runtime.py`, so the fix is the same: request the
rootdir `sel_private_root` fixture, which rebinds the SEL singleton to a fresh per-test,
per-worker directory nothing else writes.

No production code is touched; both files gain only a fixture.

## Tests

No new test cases — the change is test-isolation for existing ones. Both fixtures were
verified differentially rather than assumed:

- **Create budget:** the failure reproduces under `pytest -n0` on the unfixed file (the
  two named tests fail, `('session_create', 'chat-1')` holds exactly 20 entries) and the
  file is 142/142 green with the fixture.
- **SEL root:** with a foreign process holding the *shared* root's chain lock,
  `test_a_leftover_default_store_is_not_read_when_relocated` reproduces
  `AssertionError: assert '' != ''` plus
  `SEL audit emission failed for internal read read_id=kiro_prerequisite.identity_fingerprint`;
  with the fixture it passes under that same holder, because the holder is a stranger to
  its private root. That is the differential leg `TestSelIsolation` prescribes for #7029.

Green locally: 85/85 in `test_external_logout_detection.py`, 142/142 in
`test_session_control.py`, 227/227 together across repeated randomized runs, plus 911
passing across the neighbouring `test_session_control_boundaries.py`,
`test_create_rate_limit.py`, `test_chat_folder_cap.py` and `test_dashboard_chat.py`.
black, isort, flake8 and mypy clean.

## Manual verification

N/A — test-only change; the differential reproductions above are the verification.

## Related Issues

no linked issue: flaky-test cleanup found while running the suite. Mechanism is the one
issue #7029 describes, but that issue was closed for `test_issue_radar_crew_runtime.py`.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a test file touching process-wide module state (a rate-limit bucket, a
singleton bound to a directory) must reset or privatise it per test — under xdist the
victim is chosen by distribution, so the symptom names an innocent test. Two shipped
fixtures already exist for exactly this (`create_rate_limit.reset_for_tests`,
`sel_private_root`); the recurring defect is a new file not adopting them.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
