### PR TITLE
fix(meetings): release a meeting whose agents were retired out from under it

### DIFF
--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
@@ -455,6 +455,15 @@ class MeetingSession:
     #: Live transcript translation, or None when no target language is configured
     #: (the default). Not an ``AgentQueue``: see ``domain/translate.py``.
     translations: "TranslationQueue | None" = field(default=None, init=False)
+    #: Set once, the first time this session's transcript ingress is opened
+    #: (``_ActiveMeeting.resume_dispatches``) — i.e. it finished agent init and
+    #: became genuinely usable. Monotonic: never cleared, because it records that
+    #: the meeting REACHED the ready state, not that it is ready right now
+    #: (ingress toggles off on every suspend). ``abandoned`` reads it to tell a
+    #: meeting retired mid-init (never ready → terminal) apart from an
+    #: established meeting whose idle slots were reaped but resume on the next
+    #: line (was ready → recoverable, must NOT be treated as abandoned).
+    became_ready: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
         config = self.config if self.config is not None else store.read_config()
@@ -636,6 +645,39 @@ class MeetingSession:
         return (time.time() - self.started_at) > k.MAX_SESSION_DURATION
 
     @property
+    def abandoned(self) -> bool:
+        """Whether this meeting was retired mid-init and never became usable.
+
+        The case this guards: a gateway-wide session sweep (the dashboard's "Kiro
+        identity changed" reconcile) retires this meeting's agent sessions while
+        it is still initializing, so it holds the single-active-meeting latch
+        with no live slot and never reaches dispatch-ready. Because it is young,
+        :attr:`expired` stays False, so without this signal it wedges the latch
+        as ``status: active`` forever.
+
+        Two conditions, BOTH required:
+
+        * ``not became_ready`` — the meeting never finished init (ingress was
+          never opened). This is what excludes the healthy case an idle sweep
+          creates: an ESTABLISHED meeting that goes quiet past the idle timeout
+          has its agent slots reaped from the session registry too (they are not
+          persistent/channel-exempt), making every ``has_session`` read False —
+          but it already became ready, its slots were reaped with the resume SID
+          preserved, and its next line resumes them via ``get_or_create``. That
+          meeting is recoverable and must NOT read as abandoned.
+        * every installed agent slot is gone from the registry — no live session
+          resolves for any ``slot_key``.
+
+        Returns False when there is no session manager or no installed slot to
+        judge, so expiry/teardown stay in charge and it never fires spuriously.
+        """
+        if self.became_ready:
+            return False
+        if self.sessions is None or not self.agents:
+            return False
+        return not any(self.sessions.has_session(queue.key) for queue in self.agents.values())
+
+    @property
     def agents_paused(self) -> bool:
         return any(queue.paused for queue in self.agents.values())
 
@@ -654,6 +696,7 @@ class MeetingSession:
             },
             "agents_paused": self.agents_paused,
             "expired": self.expired,
+            "abandoned": self.abandoned,
         }
 
     async def flush_all(self) -> None:

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
@@ -132,6 +132,11 @@ class _ActiveMeeting:
         if self.session is session:
             self.accepting_dispatches = True
             self.buffering_session = None
+            # Monotonic: records that this meeting finished init and became
+            # usable at least once, so `abandoned` can distinguish a
+            # never-ready mid-init retirement from an idle-reaped-but-resumable
+            # established meeting.
+            session.became_ready = True
 
     def set(self, session: MeetingSession | None) -> None:
         """Install *session*, replacing any current one.
@@ -562,6 +567,14 @@ async def dispatch_admission(
                 status=410,
                 code="meeting_session_replaced",
             )
+        # NOTE: only `expired` (a real TTL lapse) tears the meeting down here, NOT
+        # `abandoned`. A meeting whose agent slots were reclaimed (identity sweep, or
+        # an ordinary idle/cleanup sweep on a merely-quiet-but-valid meeting) is
+        # recoverable on this path: broadcast -> flush -> dispatch_to_agent ->
+        # get_or_create recreates the slot session and the line lands. Ending on
+        # `abandoned` here would drop that utterance and kill a healthy meeting, so
+        # abandoned is released only by the start latch (where the meeting is being
+        # replaced anyway).
         if session.expired:
             ACTIVE.suspend_dispatches(session)
             expired = session

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
@@ -299,9 +299,23 @@ async def handle_start_meeting(request: web.Request) -> web.Response:
     # install. Both the metadata IO and the drain below are awaits, so two starts
     # interleaving in that gap would BOTH pass the check and the second would replace
     # the first — whose transcript then fails to dispatch with a confusing 409.
+    #
+    # This lock is also what makes `existing.abandoned` race-free in the guard
+    # below. During a meeting's own init there is a window where it is installed
+    # but has no live slots yet and `became_ready` is still False — i.e. it would
+    # read `abandoned`. Because agent init (set -> suspend -> init_agents ->
+    # resume_dispatches) runs entirely INSIDE this same START_LOCK, a competing
+    # start cannot acquire the lock and observe that window: by the time it reads
+    # `existing.abandoned`, the initializing meeting has either finished init
+    # (`became_ready` True) or genuinely failed. Keep init inside this lock.
     async with START_LOCK:
         existing = ACTIVE.get()
-        if existing is not None and existing.meeting_id != meeting_id and not existing.expired:
+        if (
+            existing is not None
+            and existing.meeting_id != meeting_id
+            and not existing.expired
+            and not existing.abandoned
+        ):
             audit("meetings.start", meeting_id, outcome="denied", error="another meeting is active")
             return web.json_response(
                 {"error": "another meeting is already active", "code": "meeting_already_active"},
@@ -350,11 +364,11 @@ async def handle_start_meeting(request: web.Request) -> web.Response:
         # A replacement of a DIFFERENT meeting is a teardown of that meeting, so its
         # metadata needs the same terminal status every other teardown writes.
         #
-        # Only an EXPIRED one can be here — the guard above 409s otherwise — and it
-        # is gone for good: its session was just dropped, and reopening it would show
-        # `active` with nothing installed, so its transcript dispatches would 409 into
-        # the void. Two meetings persisting as `active` at once also breaks the
-        # single-active-meeting invariant the list view reads.
+        # Only an EXPIRED or ABANDONED one can be here — the guard above 409s
+        # otherwise — and it is gone for good: its session was just dropped, and
+        # reopening it would show `active` with nothing installed, so its transcript
+        # dispatches would 409 into the void. Two meetings persisting as `active` at
+        # once also breaks the single-active-meeting invariant the list view reads.
         if outgoing is not None and outgoing.meeting_id != meeting_id:
             await asyncio.to_thread(sess.end_meeting_meta, outgoing.meeting_id, root)
 

--- a/test/meetings_helpers.py
+++ b/test/meetings_helpers.py
@@ -96,6 +96,11 @@ class FakeSessionManager:
         self.calls: list[tuple[str, str, str]] = []
         self.released: list[str] = []
         self.fail = fail
+        #: When None, every key reports as live (the default — the gateway's real
+        #: manager has a live session for each slot it created). Set to a concrete
+        #: set to model a sweep having retired some slots out from under a meeting,
+        #: which is what ``MeetingSession.abandoned`` reads.
+        self.live_keys: set[str] | None = None
 
     async def get_or_create(self, key: str, agent: str | None = None, **_kwargs):
         if self.fail:
@@ -104,6 +109,16 @@ class FakeSessionManager:
 
     def release(self, key: str) -> None:
         self.released.append(key)
+
+    def has_session(self, key: str) -> bool:
+        """Whether a live session exists for *key* (mirrors the real manager).
+
+        Defaults to True for every key so tests that do not care about slot
+        liveness are unchanged; assign ``live_keys`` to model a retirement.
+        """
+        if self.live_keys is None:
+            return True
+        return key in self.live_keys
 
     def prompts_for(self, agent_id: str) -> list[str]:
         """Every prompt sent to *agent_id*'s slot, in order."""

--- a/test/test_meetings_routes.py
+++ b/test/test_meetings_routes.py
@@ -347,6 +347,42 @@ class TestMeetingLifecycleRoutes:
             assert resp.status == 409
 
     @pytest.mark.asyncio
+    async def test_start_releases_an_abandoned_meeting_holding_the_latch(
+        self, app, root: Path, fake_sessions
+    ):
+        """A meeting whose agent slots were retired must not block a fresh start.
+
+        A gateway-wide session sweep (the dashboard's
+        "Kiro identity changed" reconcile) retires a meeting's agent sessions
+        while it is still INITIALIZING. The session object survives, never became
+        dispatch-ready, and is not yet expired, so the single-active-meeting latch
+        stayed held and every later start answered 409 -- the meeting was wedged
+        with no live session.
+        """
+        async with client_for(app) as client:
+            first = await _start_and_get_session(client, "first")
+            # Model the sweep hitting mid-init: slots gone AND never became
+            # dispatch-ready (an established meeting whose idle slots were reaped
+            # keeps became_ready=True and stays recoverable, so it is NOT this).
+            fake_sessions.live_keys = set()
+            first.became_ready = False
+            assert first.abandoned is True
+
+            await client.post(f"{BASE}/meetings/second/init", json={})
+            resp = await client.post(f"{BASE}/meetings/second/start", json={})
+            assert resp.status == 200, await resp.text()
+            # The new meeting took over the latch (checked while the app is up;
+            # ACTIVE is cleared on shutdown when the client context exits).
+            second = _common.ACTIVE.get("second")
+            assert second is not None and second.meeting_id == "second"
+
+        # The abandoned meeting is torn down terminal, not left persisted active
+        # (two `active` meetings at once breaks the single-active invariant).
+        first_meta = store.read_meeting_meta("first", root)
+        assert first_meta is not None
+        assert first_meta["status"] != k.STATUS_ACTIVE
+
+    @pytest.mark.asyncio
     async def test_restart_re_initializes_agents_and_then_notices(self, app, fake_sessions):
         """A restart must re-state OUTPUT_FILE, not just say "carry on".
 

--- a/test/test_meetings_session.py
+++ b/test/test_meetings_session.py
@@ -381,6 +381,66 @@ class TestAgentQueue:
         assert queue.queue == []
 
 
+class TestAbandoned:
+    """The abandoned property: retired mid-init AND never became dispatch-ready.
+
+    A session sweep can retire a meeting's agent sessions
+    while it is still initializing, leaving it holding the single-active-meeting
+    latch with no live slot. ``abandoned`` lets the start latch release only
+    that never-ready case -- an established meeting whose idle slots were reaped
+    (also all-gone from the registry) resumes on its next line and must not read
+    as abandoned.
+    """
+
+    def _session(self, root: Path, manager) -> sess.MeetingSession:
+        return sess.MeetingSession(
+            meeting_id="m",
+            config=store.read_config(root),
+            sessions=manager,
+            agents_enabled=["note-taker"],
+        )
+
+    def test_false_when_all_slots_are_live(self, root: Path):
+        manager = FakeSessionManager()  # live_keys=None -> everything live
+        assert self._session(root, manager).abandoned is False
+
+    def test_true_when_never_ready_and_no_slot_is_live(self, root: Path):
+        manager = FakeSessionManager()
+        manager.live_keys = set()  # the sweep retired every slot mid-init
+        session = self._session(root, manager)
+        # never became_ready (resume_dispatches never fired) -> retired mid-init
+        assert session.became_ready is False
+        assert session.abandoned is True
+
+    def test_false_when_established_meeting_has_slots_reaped(self, root: Path):
+        manager = FakeSessionManager()
+        manager.live_keys = set()  # idle sweep reaped every slot
+        session = self._session(root, manager)
+        session.became_ready = True  # it finished init and became usable
+        # An established-then-idle-reaped meeting resumes via get_or_create on
+        # its next line; it must NOT be treated as abandoned.
+        assert session.abandoned is False
+
+    def test_false_while_any_slot_survives(self, root: Path):
+        manager = FakeSessionManager()
+        # Only the task-extractor slot is still live; that is enough to not be
+        # abandoned -- this is not the retired-out-from-under case.
+        manager.live_keys = {sess.slot_key(k.TASK_EXTRACTOR_ID, "m")}
+        assert self._session(root, manager).abandoned is False
+
+    def test_false_without_a_session_manager(self, root: Path):
+        session = sess.MeetingSession(meeting_id="m", config=store.read_config(root))
+        # No manager to ask -> cannot be shown abandoned; expiry/teardown stay in charge.
+        assert session.abandoned is False
+
+    def test_false_with_no_installed_agent_slots(self, root: Path):
+        manager = FakeSessionManager()
+        manager.live_keys = set()
+        session = self._session(root, manager)
+        session.agents.clear()  # no slots to judge
+        assert session.abandoned is False
+
+
 class TestMeetingSession:
     def _session(self, root: Path, **kwargs) -> sess.MeetingSession:
         return sess.MeetingSession(


### PR DESCRIPTION
## Problem / Motivation

A Meetings meeting can be left permanently wedged. `POST /start` initializes the
three meeting agents serially (~38s with the default roster), and any dashboard
chat turn during that window triggers the gateway-wide "Kiro identity changed"
session reconcile, which retires the meeting's agent sessions out from under it
while it is still initializing. The `MeetingSession` object survives, never
became dispatch-ready, and because it is young its `.expired` flag is still
`False`, so it keeps holding the single-active-meeting latch with no live agent
slot behind it. The meeting is left `status: active` with no live session:
starting any new meeting answers `409 meeting_already_active` (issue #5904).

## Why it matters

The user cannot start a new meeting, and the wedged one shows as active while
doing nothing. There is no self-recovery for the latch: it only releases if the
user happens to start a different meeting.

## What changed (motivation to approach to change)

Root cause: the single-active latch keys on `MeetingSession.expired`, a pure TTL
that has no idea whether the session's agent slots still exist. A swept-mid-init
meeting is un-live but not expired, so it slips through the guard.

The naive signal "all agent slots gone from the registry" is ambiguous: the
ordinary idle sweep (`session_cleanup._expire_idle`, 3600s) also reaps a
merely-quiet established meeting's slots (they are not persistent/channel-exempt),
and that meeting is fully recoverable — its next line resumes the slots via
`dispatch_to_agent -> get_or_create`. Treating that as terminal would drop a
recoverable meeting.

So `abandoned` is defined to fire ONLY for the genuine #5904 state, requiring
BOTH:
- `not became_ready` — a new monotonic flag set the first time
  `_ActiveMeeting.resume_dispatches` opens the session's ingress (i.e. agent init
  completed and it became usable). This excludes every established meeting, which
  by definition already became ready.
- every installed agent slot is gone from the session registry.

The `/start` single-active guard releases the latch for such a meeting, and the
outgoing meeting gets the same terminal `end_meeting_meta` teardown expiry
already uses. (`abandoned` is deliberately NOT surfaced in the status-poll
payload — it has no consumer there; the latch guard reads the property
directly.)

The dispatch path deliberately does NOT tear down on `abandoned` (only on
`expired`): an idle-reaped established meeting must keep resuming on its next
line. The identity-sweep root cause is a maintainer design decision, left
untouched.

## Tests

- `test_meetings_session.py::TestAbandoned` pins the discriminator: all slots
  live -> False; never-ready + no slot live -> True; **established
  (`became_ready=True`) + all slots reaped -> False** (the load-bearing guard for
  the idle-reap case); one surviving slot -> False; no manager / no slots ->
  False.
- `test_meetings_routes.py::test_start_releases_an_abandoned_meeting_holding_the_latch`
  models mid-init retirement (slots gone AND `became_ready` False) and asserts a
  fresh `/start` returns 200, the wedged meeting is written non-`active`, and the
  new meeting takes over.
- Test double: `FakeSessionManager.has_session` / `live_keys` (defaults all-live,
  so existing meetings tests are unaffected).

## Manual verification

N/A, unit coverage sufficient. Backend session-lifecycle logic exercised end to
end over the real aiohttp router with the fake session manager; no UI, socket, or
external service involved.

## Related Issues

Fixes #5904

## Pattern harvest

Rule candidate: review-prompt
Pattern: a liveness signal ("resource gone from the registry") used as a
single-owner-latch release condition, when the same observable state also arises
from a fully-recoverable cause (idle reclamation resumes on next use). Gate the
terminal action on a positive "reached the ready/committed state" marker so a
recoverable transient is never treated as terminal.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable): N/A, no user docs affected
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend session-lifecycle change only; no rendered UI delta.

