### PR TITLE
fix: provision app requirements via pip --target, surface pip failures (#7878)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -410,7 +410,6 @@ test/test_appearance_packs_store.py
 test/test_appearance_packs_transfer.py
 test/test_approval_and_update_task.py
 test/test_approval_threading.py
-test/test_apps_backend_coverage.py
 test/test_apps_instances_loop_offload.py
 test/test_apps_registry.py
 test/test_apps_registry_coverage.py

--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 6977,
+  "_total": 6971,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 8,
@@ -24,7 +24,7 @@
     "src/kiro_crew/agents_janitor.py": 3,
     "src/kiro_crew/appearance_packs/store.py": 1,
     "src/kiro_crew/apple_speech/__init__.py": 2,
-    "src/kiro_crew/apps/backend.py": 8,
+    "src/kiro_crew/apps/backend.py": 7,
     "src/kiro_crew/apps/bridges.py": 7,
     "src/kiro_crew/apps/builtins/__init__.py": 1,
     "src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py": 8,
@@ -700,7 +700,7 @@
     "test/test_apple_speech.py": 6,
     "test/test_approval_chain_no_cryptography.py": 1,
     "test/test_approval_modes_enforcement.py": 2,
-    "test/test_apps_backend_coverage.py": 2,
+    "test/test_apps_backend_coverage.py": 1,
     "test/test_apps_registry.py": 7,
     "test/test_apps_registry_coverage.py": 1,
     "test/test_apps_routes_coverage.py": 27,

--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -42,15 +42,26 @@ resolves it so the server starts under the interpreter its dependencies were
 installed against:
 
 - **A bare Python launcher** (`python`, `python3`, `py`, or the same with `.exe`)
-  resolves to the app's own venv interpreter (`.venv/bin/python3`, or
-  `.venv\Scripts\python.exe` on Windows) when it exists as a runnable file, else
-  to the gateway's own interpreter — never a PATH lookup. Exception: a server
-  whose `args` launch a `kiro_crew` module (`-m kiro_crew...`) always gets the
-  gateway's interpreter, since app venvs cannot import `kiro_crew`.
+  resolves to the gateway's own interpreter whenever the gateway has
+  provisioned the app's `requirements.txt` (a `pip install --target` into
+  `data/.kirocrew-deps/`; python launchers run through a `site.addsitedir`
+  shim so `.pth` files are processed, other commands see the dir on
+  `PYTHONPATH`; under `data/` so app updates keep the last good install) - those
+  wheels are built by that interpreter, so it is the only ABI-consistent
+  choice. Without an active provisioned tree (never provisioned, or
+  provisioning failed), it resolves to the app's own venv
+  interpreter (`.venv/bin/python3`, or `.venv\Scripts\python.exe` on Windows)
+  when it exists as a runnable file created by the same Python minor version
+  as the gateway, else again to the gateway's own interpreter - never a PATH
+  lookup. Exception: a server whose `args` launch a `kiro_crew` module
+  (`-m kiro_crew...`) always gets the gateway's interpreter and never the
+  app deps on `PYTHONPATH`, so an app cannot shadow the gateway's own code.
 - **Any other bare name** (no path separator, no drive qualifier) is rewritten
-  only when the app's venv provides that exact binary as a runnable file (a pip
-  console script — invisible to PATH because the venv is never activated). Note
-  this means a venv-provided binary shadows a same-named PATH dependency.
+  only when the app's provisioned deps dir or its venv provides that exact
+  binary as a runnable file (a pip console script - invisible to PATH because
+  neither layout is ever activated; the venv is consulted only when no deps
+  dir was provisioned). Note this means an app-provided binary shadows a
+  same-named PATH dependency.
   `node`, `npx`, `docker` and friends are otherwise left for PATH, as declared.
 - **A command carrying a path** (absolute or relative) is never rewritten. If it
   does not point at a runnable file at registration time, a warning naming the

--- a/docs/app-kit/publishing-guide.md
+++ b/docs/app-kit/publishing-guide.md
@@ -312,8 +312,10 @@ safeguards:
   rewritten to relative form so the installed copy does not depend on your
   source directory.
 - **Build-input and VCS directories are excluded** at any depth: `node_modules`,
-  `.git`, `__pycache__`, `.venv`. Serve your UI from a committed `ui/dist/`
-  bundle; nothing needed at runtime may live under those names.
+  `.git`, `__pycache__`, `.venv`, and the gateway's own `.kirocrew-deps`
+  provisioning output (plus its transient staging/prior siblings). Serve your
+  UI from a committed `ui/dist/` bundle; nothing needed at runtime may live
+  under those names.
 
 `data/` is preserved across updates and, by default, across uninstall.
 

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -6,24 +6,32 @@ the backend process lifecycle: spawn on enable, health-check, stop on disable.
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
+import hashlib
 import http.client
 import json
 import logging
 import os
+import platform
 import re
 import shutil
 import socket
+import stat
 import subprocess
 import sys
+import sysconfig
+import tempfile
 import threading
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import platform_compat
+from kiro_crew import pinned_fs, platform_compat
+from kiro_crew.apps import deps_boot as _deps_boot_module
 from kiro_crew.apps.admission import app_admission_denied
 from kiro_crew.apps.execution import (
     app_execution_denied,
@@ -31,8 +39,13 @@ from kiro_crew.apps.execution import (
     shipped_builtin_app_root,
     shipped_builtin_module_path,
 )
-from kiro_crew.apps.interpreter import resolve_app_python, venv_python_path
-from kiro_crew.apps.manager import app_dir, get_app_manifest, list_apps
+from kiro_crew.apps.interpreter import app_deps_dir, path_command_is_abi_matched, resolve_app_python
+from kiro_crew.apps.manager import (
+    _DEPS_STAGING_SWEEP_RE,
+    app_dir,
+    get_app_manifest,
+    list_apps,
+)
 from kiro_crew.apps.registry import minimal_env
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
@@ -47,8 +60,14 @@ from kiro_crew.sandbox import (
     run_limited,
     wrap_argv,
 )
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+try:  # optional dependency: the digest has a platform-module fallback
+    from packaging.markers import default_environment as _default_marker_environment
+except Exception:  # pragma: no cover - packaging ships with pip but is not guaranteed
+    _default_marker_environment = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -276,9 +295,7 @@ def _capture_adopted_owners(
             app_name, port,
         )
         return None
-    owners_recheck = platform_compat.loopback_owner_pids(
-        platform_compat.find_port_listeners(port)
-    )
+    owners_recheck = platform_compat.loopback_owner_pids(platform_compat.find_port_listeners(port))
     if set(owners_recheck) != set(owners):
         logger.warning(
             "App %s: port %d owners changed while ownership was being recorded "
@@ -311,9 +328,7 @@ def _pid_is_self_or_descendant_of(pid: int, ancestor: int) -> bool:
 def _spawn_owns_listener(port: int, spawn_pid: int) -> bool:
     """Whether the listener on *port* is our spawn (or one of its descendants)."""
 
-    return any(
-        _pid_is_self_or_descendant_of(pid, spawn_pid) for pid in _listening_pids(port)
-    )
+    return any(_pid_is_self_or_descendant_of(pid, spawn_pid) for pid in _listening_pids(port))
 
 
 def _reserve_free_port(app_name: str) -> int:
@@ -427,6 +442,206 @@ _processes: dict[str, AppProcess] = {}  # app_name -> AppProcess
 # elevated-but-finite NOFILE ceiling as the workload's ANCESTOR. Every other
 # app backend keeps the standard (operator-configurable) resource policy.
 _BUILD_CAPABLE_APPS = frozenset({"dev-fleet"})
+
+# requirements.txt provisioning (pip --target into apps/interpreter.app_deps_dir).
+# The stamp records the digest a successful install came from (requirements
+# bytes + the installing interpreter's ABI tag - see _deps_digest), so a start
+# where neither changed skips pip entirely. Staging/prior are transient swap
+# directories: pip fills staging, success renames it live, and prior briefly
+# holds the outgoing install so a failure at any point leaves either the old
+# tree or the new one - never a half-replaced mix.
+_DEPS_STAMP_NAME = ".requirements-sha256"
+_DEPS_STAGING_NAME = ".kirocrew-deps-staging"
+
+
+#: Read caps for app-controlled provisioning inputs: the gateway buffers
+#: these in ITS OWN memory, so an oversized requirements.txt or stamp file
+#: (or a build hook flooding stderr) must exhaust a bounded buffer, not the
+#: gateway. 1 MiB is orders of magnitude beyond any real requirements.txt.
+_DEPS_REQ_MAX_BYTES = 1024 * 1024
+_DEPS_STAMP_MAX_BYTES = 4096
+_DEPS_PIP_STDERR_TAIL = 16 * 1024
+_DEPS_PRIOR_NAME = ".kirocrew-deps-prior"
+
+
+def _requirements_volatile(requirements: bytes) -> bool:
+    """True when the stamp digest cannot prove the resolved set unchanged.
+
+    The digest covers the top-level requirements.txt bytes only, so any line
+    whose RESOLUTION can change while the line itself does not defeats the
+    stamp: file references (``-r``/``-c``, attached or spaced), editables,
+    local paths, VCS and URL requirements, and ``name @ url`` direct
+    references. For these the caller disables stamp reuse entirely
+    (reprovision every start) rather than re-implementing pip's requirements
+    grammar here - over-matching a rare exotic line costs one redundant pip
+    run, under-matching serves stale dependencies.
+    """
+    for raw in requirements.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(b"#"):
+            continue
+        if line.startswith(
+            (
+                b"-r",
+                b"-c",
+                b"-e",
+                b"-f",
+                b"--requirement",
+                b"--constraint",
+                b"--editable",
+                b"--find-links",
+                b"--no-index",
+                b"--index-url",
+                b"--extra-index-url",
+            )
+        ):
+            # File/constraint references, editables, and RESOLUTION-LOCATION
+            # options: an unchanged `--find-links wheelhouse` line resolves
+            # against local wheels whose CONTENT can change - the stamp
+            # cannot prove the installed set unchanged for any of these.
+            return True
+        if b"://" in line or re.search(rb"\s@\s", line):
+            return True
+        if line.startswith((b".", b"/", b"~")) or re.match(rb"[A-Za-z]:[\\/]", line):
+            return True
+        # A BARE relative path (wheels/pkg.whl) is a local artifact whose
+        # content can change under an unchanged line - any non-option line
+        # carrying a path separator is volatile. Over-matching an exotic
+        # marker expression costs one redundant pip run; under-matching
+        # serves a stale local wheel.
+        if b"/" in line or b"\\" in line:
+            return True
+        # A bare ARCHIVE filename (vendor.whl - no separator at all) is
+        # still a local artifact: pip resolves it against the cwd (the app
+        # root), and its content can change under an unchanged line.
+        if line.lower().endswith(
+            (b".whl", b".zip", b".tar.gz", b".tgz", b".tar.bz2", b".tar.xz", b".tar")
+        ):
+            return True
+    return False
+
+
+def _deps_tree_stamp_current(root: Path, req_file: Path) -> bool:
+    """True when the provisioned tree's stamp names the digest for the
+    CURRENT interpreter and the CURRENT requirements bytes.
+
+    The activation gate, not the provisioning gate: after a Python upgrade a
+    reprovision is attempted, but if it FAILS the stale tree (wheels built
+    for the old ABI) is still on disk - injecting it via PYTHONPATH crashes
+    the backend at import. The stamp digest folds the interpreter's cache
+    tag, platform and full version, so an old-ABI tree can never present a
+    matching stamp. Reads are bounded and no-follow, mirroring the
+    provisioning path; every failure reads as "not current" (no activation -
+    safe direction: the backend runs without the deps and surfaces the
+    provisioning error, instead of crashing on foreign wheels).
+    """
+    try:
+        # Same reader shape as provisioning: resolve, containment-check
+        # against the app root, then a component-pinned no-follow open. A
+        # SUPPORTED in-tree symlink (which provisioning accepts) must also
+        # activate - a direct O_NOFOLLOW open on the link name would refuse
+        # it and strand a successfully provisioned app without its deps.
+        root_resolved = root.resolve(strict=True)
+        open_target = req_file.resolve(strict=True)
+        if root_resolved != open_target and root_resolved not in open_target.parents:
+            return False
+        rfd = _open_contained_nofollow(root_resolved, open_target)
+        with os.fdopen(rfd, "rb") as rfh:
+            if not stat.S_ISREG(os.fstat(rfh.fileno()).st_mode):
+                return False
+            req_bytes = rfh.read(_DEPS_REQ_MAX_BYTES + 1)
+        if len(req_bytes) > _DEPS_REQ_MAX_BYTES:
+            return False
+        digest = _deps_digest(req_bytes)
+
+        def _read_marker(name: str) -> str | None:
+            marker = app_deps_dir(root) / name
+            if platform_compat.is_link_or_junction(marker):
+                return None
+            try:
+                mfd = os.open(str(marker), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            except OSError:
+                return None
+            with os.fdopen(mfd, "rb") as mfh:
+                if not stat.S_ISREG(os.fstat(mfh.fileno()).st_mode):
+                    return None
+                return mfh.read(_DEPS_STAMP_MAX_BYTES).decode("utf-8").strip()
+
+        if digest:
+            stamp_val = _read_marker(_DEPS_STAMP_NAME)
+            if stamp_val is not None and stamp_val == digest:
+                return True
+        # Fall back to the ABI tag: a stamp that mismatches only because the
+        # REQUIREMENTS (or their marker environment) changed still names a
+        # tree of importable wheels - the last good install keeps serving
+        # when a refresh fails (offline pip), exactly as it did before the
+        # stamp gate. A missing or foreign-ABI tag never activates.
+        return _read_marker(_DEPS_ABI_NAME) == _deps_abi_tag()
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+_DEPS_ABI_NAME = ".abi-sha256"
+
+
+def _deps_abi_tag() -> str:
+    """ABI identity of the CURRENT interpreter, independent of requirements.
+
+    What makes ``pip --target`` wheels importable or not: the implementation
+    cache tag (``cpython-312``) and the build platform. Recorded beside the
+    full stamp so activation can tell "stale REQUIREMENTS on the right ABI"
+    (the prior tree still serves - a failed refresh must not strand the
+    backend without its last good install) from "wrong ABI" (never inject).
+    """
+    tag = sys.implementation.cache_tag or ""
+    plat = sysconfig.get_platform()
+    return hashlib.sha256(f"{tag}\n{plat}\n".encode()).hexdigest()
+
+
+def _deps_digest(requirements: bytes) -> str:
+    """Stamp digest for a provisioned deps dir.
+
+    Folds the installing interpreter's cache tag (e.g. ``cpython-312``), the
+    platform tag (e.g. ``macosx-11.0-arm64``), AND the full interpreter
+    version in with the requirements bytes: wheels installed by
+    ``pip --target`` are ABI- and architecture-specific, and a
+    requirements.txt can carry ``python_full_version`` environment markers
+    that flip on a PATCH upgrade - so after a gateway Python upgrade of any
+    granularity, or a cross-architecture home migration, an UNCHANGED
+    requirements.txt must still reprovision. A requirements-only stamp would
+    skip pip and leave a stale or incompatible install live.
+
+    Scope: the digest covers the top-level requirements.txt bytes only.
+    The stamp-skip caller compensates: a requirements.txt that references
+    other files (``-r``/``-c``) disables the skip entirely, so a change
+    confined to an included file can never be masked by a matching stamp.
+    """
+    tag = sys.implementation.cache_tag or ""
+    plat = sysconfig.get_platform()
+    pyver = platform.python_version()
+    # The FULL PEP 508 marker environment, not just the interpreter tuple:
+    # a requirement conditioned on platform_release / platform_version /
+    # implementation details flips on an OS update while the requirements
+    # bytes (and interpreter) stay identical - the stamp must not prove
+    # such a set unchanged. Sorted key=value lines make the digest stable.
+    if _default_marker_environment is not None:
+        marker_env = "\n".join(
+            f"{k}={v}" for k, v in sorted(_default_marker_environment().items())
+        )
+    else:  # packaging unavailable: fall back to the platform module
+        marker_env = "\n".join(
+            (
+                f"platform_release={platform.release()}",
+                f"platform_version={platform.version()}",
+                f"platform_machine={platform.machine()}",
+                f"platform_system={platform.system()}",
+                f"implementation_name={sys.implementation.name}",
+            )
+        )
+    return hashlib.sha256(
+        f"{tag}\n{plat}\n{pyver}\n{marker_env}\n".encode() + requirements
+    ).hexdigest()
+
 
 _lock = threading.Lock()
 
@@ -562,7 +777,9 @@ def start_app_backend(app_name: str) -> AppProcess | None:
                 logger.info("App %s backend already running (pid %d)", app_name, existing.pid)
                 return existing
             if existing.proc is None and existing.adopted_pids:
-                logger.info("App %s backend already adopted (pids %s)", app_name, existing.adopted_pids)
+                logger.info(
+                    "App %s backend already adopted (pids %s)", app_name, existing.adopted_pids
+                )
                 return existing
             # A concurrent start_app_backend is mid-spawn for this app (placeholder with
             # ``starting=True``). Without this guard two callers (gateway boot-reconcile
@@ -584,8 +801,14 @@ def start_app_backend(app_name: str) -> AppProcess | None:
     # AppProcess on success, or None on any failure / no-op path; in EITHER the None
     # case or an exception we must clear the STARTING placeholder so a later retry isn't
     # permanently blocked (and a success path replaces it with the real record).
+    # Held across the whole body: the backend exists as a PROCESS before its
+    # pidfile record does, and a CLI uninstall probing in that window reads
+    # "no record" as "no backend". Under this cross-process lock the probe
+    # waits until the record is persisted (or the spawn torn down) - see
+    # app_backend_lifecycle_flock.
     try:
-        result = _start_app_backend_body(app_name, manifest)
+        with app_backend_lifecycle_flock(app_name):
+            result = _start_app_backend_body(app_name, manifest)
     except Exception:
         _clear_failed_spawn_state(app_name)
         raise
@@ -629,20 +852,812 @@ def _await_inflight_spawn(app_name: str, timeout: float = 20.0) -> AppProcess | 
                 return cur  # resolved to a real process
         time.sleep(0.1)
     # Timed out waiting. If the spawn resolved to a real process right at the deadline,
-    # return it. Otherwise the placeholder is still STARTING (a spawn body that hung
-    # without raising — its owner's None/exception cleanup never fired) — clear it here
-    # so a later retry can attempt a fresh spawn instead of re-entering this 20s wait
-    # forever (the app would otherwise be wedged in 'starting' until a gateway restart).
-    # If the body does eventually finish it will find the entry gone and its own cleanup
-    # is a guarded no-op; the starting= guard ensures we never drop a started real proc.
+    # return it. Otherwise, before clearing, PROBE the spawn owner's lifecycle
+    # flock: provisioning (pip install) routinely outlives this timeout, and
+    # clearing a placeholder whose owner is merely SLOW would let a retry
+    # spawn a SECOND backend and overwrite the first one's tracking. The
+    # owner holds app_backend_lifecycle_flock for the whole body, so a
+    # non-blocking acquire failing means "still working" (leave the
+    # placeholder, return None - the caller reports not-ready, it does not
+    # respawn); acquiring it means the owner is GONE without cleanup (a hang
+    # that escaped its own exception handling) - only then clear so a later
+    # retry is possible.
+    owner_gone = False
+    try:
+        safe = re.sub(r"[^A-Za-z0-9._-]", "_", app_name) or "_"
+        lock_dir = config_dir() / "app_backend_locks"
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        _probe_fd = os.open(str(lock_dir / f"{safe}.lock"), os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            if platform_compat.try_acquire_lock(_probe_fd, exclusive=True):
+                owner_gone = True
+        finally:
+            os.close(_probe_fd)  # closing releases the probe's own lock
+    except OSError:
+        owner_gone = False  # cannot prove the owner is gone: do not clear
     with _lock:
         cur = _processes.get(app_name)
         if cur is not None and not getattr(cur, "starting", False):
             return cur  # resolved to a real process at the deadline
         if cur is not None and getattr(cur, "starting", False):
+            if not owner_gone:
+                logger.info(
+                    "App %s backend spawn still in flight past the wait window "
+                    "(provisioning?) - leaving the placeholder in place",
+                    app_name,
+                )
+                return None
             _processes.pop(app_name, None)
             logger.warning("App %s backend spawn timed out — cleared stale placeholder", app_name)
         return None
+
+
+def _abi_shebang_of(root: Path, script: str) -> str | None:
+    """The ABI-matched interpreter a script's shebang names, or None.
+
+    Thin composition of the bridges shebang reader (sensitive-path gated,
+    bare direct spelling only - argument-bearing shebangs read as None) and
+    the ABI match check. Deferred import: bridges imports THIS module's
+    symbols lazily, and the apps package initializer loads bridges first.
+    """
+    from kiro_crew.apps.bridges import _python_shebang_interpreter
+
+    cand = _python_shebang_interpreter(script)
+    if cand and path_command_is_abi_matched(root, cand):
+        return cand
+    return None
+
+
+def _deps_boot_path() -> Path:
+    """Absolute path of the stdlib-only launch shim (see apps.deps_boot)."""
+    return Path(os.path.abspath(_deps_boot_module.__file__))
+
+
+def _open_contained_nofollow(base: Path, target: Path) -> int:
+    """Open ``target`` under ``base`` with every component no-follow.
+
+    A thin consumer of :mod:`kiro_crew.pinned_fs` (see its module docstring
+    for why per-site pinning is banned): the parent chain is pinned one
+    openat per component and the final name is opened O_NOFOLLOW through
+    it, so neither an ancestor swap nor a final-component link can escape
+    the app root. Where the platform cannot pin
+    (``supports_pinned_walk()`` is False - Windows), the fallback is a
+    single O_NOFOLLOW-less open behind the caller's is_symlink pre-check,
+    backed by symlink creation being privileged there; junction swaps of
+    the DATA dir are separately caught by _PinnedDir.verify.
+    """
+    rel_parts = target.relative_to(base).parts
+    if not rel_parts:
+        raise OSError("requirements path resolves to the app root itself")
+    if not pinned_fs.supports_pinned_walk():
+        return os.open(str(target), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    return pinned_fs.open_in_pinned_parent(
+        str(target.parent),
+        rel_parts[-1],
+        flags=os.O_RDONLY | os.O_NOFOLLOW,
+        mode=0o644,
+        what="app requirements file",
+        refusal=OSError,
+    )
+
+
+class _PinnedDir:
+    """Pin the app data dir against link swaps for one provision transaction.
+
+    A path-based check-then-use is a TOCTOU window: a RUNNING app can swap
+    ``data/`` for a symlink after the validation and have every later rename
+    or delete land in another app's tree. On POSIX the directory is opened
+    O_NOFOLLOW|O_DIRECTORY and HELD: renames go through ``dir_fd`` (they are
+    the operations with delete/replace power over a victim's live tree), and
+    the path-based steps that cannot take a dir_fd (rmtree, mkdir, pip's
+    ``--target``, the stamp write) are each preceded by :meth:`verify`, which
+    re-checks that the path still names the pinned inode. On Windows there
+    is no O_NOFOLLOW or dir_fd; the caller's is_link_or_junction pre-check
+    stands, backed by symlink creation being privileged there.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.fd: int | None = None
+        self._win_id: tuple[int, int] | None = None
+        if pinned_fs.supports_pinned_walk():
+            # pin_parent walks every component openat+O_NOFOLLOW (see
+            # kiro_crew.pinned_fs for the invariants); a link anywhere on
+            # the way - or at the target - is refused, not followed.
+            self.fd = pinned_fs.pin_parent(
+                str(path), what="app data directory", refusal=OSError
+            )
+        else:
+            # Windows: capture the directory identity (volume serial + file
+            # index via st_dev/st_ino) so verify() can detect a junction
+            # swapped in mid-transaction - junction creation needs no
+            # privilege, so the pre-check alone is a TOCTOU window there.
+            if platform_compat.is_link_or_junction(path):
+                raise OSError("app data directory is a symlink/junction; refusing")
+            st = os.stat(str(path))
+            self._win_id = (st.st_dev, st.st_ino)
+
+    def close(self) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+    def verify(self) -> None:
+        """Refuse to proceed when the path names something other than the pinned dir.
+
+        POSIX compares the held fd's identity against a fresh lstat. On
+        Windows there is no held fd, but JUNCTION creation needs no
+        privilege (unlike symlinks), so the swap threat is real there too:
+        re-check that the path is still not a link/junction and still names
+        the directory identity captured at pin time (st_dev/st_ino -
+        Python's stat on Windows fills these from the volume serial and
+        file index).
+        """
+        if self.fd is not None:
+            st_fd = os.fstat(self.fd)
+            st_path = os.lstat(str(self.path))
+            if (st_fd.st_dev, st_fd.st_ino) != (st_path.st_dev, st_path.st_ino):
+                raise OSError("app data directory was replaced mid-provisioning; refusing")
+            return
+        if platform_compat.is_link_or_junction(self.path):
+            raise OSError("app data directory was replaced mid-provisioning; refusing")
+        st_now = os.stat(str(self.path))
+        if self._win_id is not None and (st_now.st_dev, st_now.st_ino) != self._win_id:
+            raise OSError("app data directory was replaced mid-provisioning; refusing")
+
+    def rename(self, src_name: str, dst_name: str) -> None:
+        """Rename WITHIN the pinned dir, immune to a swapped path.
+
+        POSIX renames are dir_fd-relative (cannot be redirected at all);
+        on Windows the identity is revalidated immediately before the
+        path-based rename, shrinking the swap window to the single rename
+        syscall.
+        """
+        if self.fd is not None:
+            os.rename(src_name, dst_name, src_dir_fd=self.fd, dst_dir_fd=self.fd)
+        else:
+            self.verify()
+            os.rename(str(self.path / src_name), str(self.path / dst_name))
+
+    def rename_out(self, src_name: str, dst: Path) -> None:
+        """Move an entry OUT of the pinned dir to a path destination.
+
+        The SOURCE side is the security boundary (it names an entry inside
+        the app-writable pinned dir); it goes through the held fd on POSIX
+        and an identity re-check on Windows. os.rename never follows the
+        final component of the destination, so a link planted at the
+        destination name is replaced, not traversed.
+        """
+        if self.fd is not None:
+            os.rename(src_name, str(dst), src_dir_fd=self.fd)
+        else:
+            self.verify()
+            os.rename(str(self.path / src_name), str(dst))
+
+
+def _pinned_remove_entry(pin: "_PinnedDir", parent: Path, name: str) -> None:
+    """Best-effort delete of ``parent/name`` without a path-follow window.
+
+    A thin consumer of :func:`kiro_crew.pinned_fs.remove_tree_pinned`: the
+    parent chain is re-pinned, the target opened through it, and the whole
+    tree removed by descriptor - approval binds the opened directory to the
+    inode this transaction just observed through its own pin, so a swap
+    between observation and removal is refused, not followed. Links are
+    unlinked via the held descriptor and never traversed. Best-effort by
+    contract: every refusal outcome leaves the entry (or its staged rename)
+    in place and the transaction continues.
+    """
+    if pin.fd is not None:
+        st = pinned_fs.stat_at(pin.fd, name)
+        if st is None:
+            return
+        if not stat.S_ISDIR(st.st_mode):
+            try:
+                os.unlink(name, dir_fd=pin.fd)
+            except OSError:
+                pass
+            return
+        expect = (st.st_dev, st.st_ino)
+
+        def _approve(root_fd: int, _tree: pinned_fs.PinnedTree) -> str | None:
+            opened = os.fstat(root_fd)
+            if (opened.st_dev, opened.st_ino) != expect:
+                return "identity changed since this transaction observed it"
+            return None
+
+        try:
+            pinned_fs.remove_tree_pinned(
+                str(parent / name),
+                what="app generated dependency tree",
+                approve=_approve,
+                refusal=OSError,
+            )
+        except OSError:
+            pass
+        return
+    # No pinned walk on this platform: identity re-check plus path delete,
+    # behind the privileged-symlink argument (junction swaps of data/ are
+    # caught by pin.verify's identity check).
+    try:
+        pin.verify()
+    except OSError:
+        return
+    target = parent / name
+    try:
+        if platform_compat.is_link_or_junction(target):
+            platform_compat.unlink_link_or_junction(target)
+        elif target.exists():
+            shutil.rmtree(str(target), ignore_errors=True)
+    except OSError:
+        pass
+
+
+# Hard on-disk ceiling for a child's captured output spill.
+_DEPS_SPILL_HARD_CAP = 8 * 1024 * 1024
+
+
+@contextlib.contextmanager
+def _capped_spill(spill, hard_cap_bytes: int, poll_secs: float = 0.5):
+    """Bound a subprocess output SPILL file's on-disk growth.
+
+    The child owns the write end of ``spill`` after exec, so the parent
+    cannot bound it per write; without a ceiling a noisy build hook or
+    probe can fill the host disk before the run's own timeout fires. A
+    watchdog thread polls the spill size and, on breach, truncates it back
+    to empty - the child's subsequent writes re-extend from zero, so total
+    on-disk residency never exceeds the cap plus one poll interval's worth
+    of writes, and the run's timeout still bounds wall-clock. The bounded
+    TAIL the caller reads afterwards is unaffected (a flooded run loses old
+    output to the truncation, which is the correct trade: the tail is a
+    diagnostic, not a transcript). No child pid needed, so this composes
+    with a mocked run_limited that spawns nothing.
+    """
+    import threading
+
+    stop = threading.Event()
+    tripped = threading.Event()
+
+    def _watch() -> None:
+        while not stop.wait(poll_secs):
+            try:
+                if os.fstat(spill.fileno()).st_size > hard_cap_bytes:
+                    tripped.set()
+                    spill.seek(0)
+                    spill.truncate(0)
+            except OSError:
+                return
+
+    t = threading.Thread(target=_watch, daemon=True)
+    t.start()
+    try:
+        yield tripped
+    finally:
+        stop.set()
+        t.join(timeout=2)
+
+
+def _audit_provision_failure(app_name: str, provision_error: str) -> str:
+    """The common failure epilogue for EVERY provisioning refusal arm.
+
+    One ERROR log plus one SEL event per failed provisioning, whatever the
+    arm (pip failure, requirements-read refusal, lock failure) - a refusal
+    that skips this is invisible to operators and to the audit trail.
+    Returns the error so callers can ``return _audit_provision_failure(...)``.
+    """
+    logger.error("%s", provision_error)
+    try:
+        sel().log_api_access(
+            caller="gateway",
+            operation="app_backend_spawn",
+            outcome="deps_provision_failed",
+            resources=app_name,
+        )
+    except Exception as sel_exc:
+        logger.debug("SEL audit failed for app %s deps failure: %s", app_name, sel_exc)
+    return provision_error
+
+
+def provision_app_deps(app_name: str, root: Path) -> str:
+    """Provision ``root/requirements.txt`` into the app's deps dir.
+
+    The entire provision transaction (requirements read, interrupted-swap
+    recovery, stamp check, pip into staging, live swap) runs under an
+    exclusive per-app file lock: the backend spawn and a backend-less
+    registration - or two concurrent registrations - would otherwise delete
+    each other's staging tree mid-install and both fail. flock excludes
+    across processes AND across threads (each caller opens its own
+    descriptor), and the stamp check runs inside the lock, so a waiter that
+    blocked behind a successful install skips pip on the stamp it left.
+    """
+    _req = root / "requirements.txt"
+    if not _req.is_file():
+        # is_file() follows a symlink, so it answers False for a DANGLING
+        # requirements.txt link (target missing) as well as for genuine
+        # absence. Only true ABSENCE is "nothing to provision": a present
+        # entry that is not a readable regular file (a broken link, a
+        # non-file) is a provisioning FAILURE, surfaced so the backend does
+        # not spawn importing dependencies that were never installed.
+        if os.path.lexists(_req):
+            return _audit_provision_failure(
+                app_name,
+                f"Refusing requirements.txt for app {app_name}: it is present "
+                f"but not a readable regular file (a dangling symlink or a "
+                f"non-file entry); refusing to skip provisioning silently.",
+            )
+        # Genuine absence: skip the pin and the lock entirely - the
+        # transaction machinery must not create lock files (or take
+        # platform-specific lock paths) for every app without declared
+        # dependencies. The locked body re-checks under the lock, so this
+        # is only a fast path, never the security boundary.
+        return ""
+    deps_parent = app_deps_dir(root).parent
+    lock_path = deps_parent / ".kirocrew-deps.lock"
+    provision_error = ""
+    try:
+        # The deps dir lives under app-writable data/, and every operation
+        # below (lock file, staging, swap) would FOLLOW a link planted
+        # there - an app pointing data/ at another app's tree would have
+        # this provisioning swap attacker-chosen dependencies into the
+        # victim's dir (the same shape the uninstall purge refuses in
+        # manager.py). The gateway creates data/ as a real directory, so a
+        # link is never legitimate: refuse before touching anything through
+        # it.
+        if platform_compat.is_link_or_junction(deps_parent):
+            raise OSError("app data directory is a symlink/junction; refusing to provision")
+        deps_parent.mkdir(parents=True, exist_ok=True)
+        pin = _PinnedDir(deps_parent)
+        try:
+            # The lock file is opened through the PIN (dir_fd on POSIX), so
+            # a link swapped in at data/ cannot redirect its creation; the
+            # O_NOFOLLOW arm refuses a link planted at the lock name itself.
+            # O_RDWR (not read-only): Windows msvcrt.locking requires write
+            # access on the fd (same reason as bridges' _mcp_lock).
+            lflags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+            if pin.fd is not None:
+                lfd = os.open(lock_path.name, lflags, 0o644, dir_fd=pin.fd)
+            else:
+                lfd = os.open(str(lock_path), lflags, 0o644)
+            with os.fdopen(lfd, "r+") as lf:
+                with platform_compat.file_lock(lf.fileno(), exclusive=True):
+                    provision_error = _provision_app_deps_locked(app_name, root, pin)
+        finally:
+            pin.close()
+    except OSError as exc:
+        # file_lock fails CLOSED; an unserialized install could corrupt the
+        # live deps tree, so surface the failure instead of proceeding.
+        provision_error = (
+            f"Failed to serialize dependency provisioning for app {app_name}: {exc}"
+        )
+    if provision_error:
+        return _audit_provision_failure(app_name, provision_error)
+    return provision_error
+
+
+def _write_staging_marker(
+    staging_pin: "_PinnedDir", staging: Path, name: str, content: str
+) -> None:
+    """Write a provisioning marker into staging through its HELD descriptor.
+
+    The markers are written AFTER pip - after arbitrary build-hook code has
+    run with write access to data/ - so a by-name write here is the classic
+    swap window: replace staging with a symlink and the gateway's own write
+    lands outside the app root. Through the descriptor pinned at staging
+    creation the write cannot be redirected (the fd is the directory,
+    whatever the NAME points at now), O_NOFOLLOW refuses a planted link at
+    the marker name, and O_EXCL refuses a planted regular file (a build
+    hook pre-creating a marker is an attack signal - provisioning fails
+    loud rather than trusting it). Windows has no dir_fd: the existing
+    verify()+atomic_write floor stands (junction identity revalidation,
+    same as every other Windows arm of this transaction).
+    """
+    if staging_pin.fd is not None:
+        fd = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o644,
+            dir_fd=staging_pin.fd,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+    else:
+        staging_pin.verify()
+        atomic_write(staging / name, content)
+
+
+def _provision_app_deps_locked(app_name: str, root: Path, pin: _PinnedDir) -> str:
+    """The provision transaction body - caller holds the per-app deps lock.
+
+    Shared by the backend spawn and by backend-less stdio registration (an
+    app can ship only MCP servers - with no backend start, nothing else ever
+    runs pip, and the shim/PYTHONPATH transports would reference a forever-
+    empty tree). Stamp-gated, so repeat calls with unchanged requirements do
+    no network work. Returns an error message ('' when provisioning
+    succeeded or was skipped). CALLERS gate trust: a module-style builtin
+    executes trusted code from inside the kiro_crew package, and provisioning
+    an app-dir requirements.txt for it would let agent-authored wheels load
+    ahead of the trusted module - so this is only ever called for apps whose
+    code runs from the writable app dir itself.
+    """
+    # Install Python dependencies into a per-app deps dir (isolated from the
+    # Kiro Crew runtime). `pip install --target` rather than a venv: packaged
+    # installs bundle an interpreter that ships pip but no ensurepip, so
+    # `-m venv` dies after creating the directory skeleton - and the venv-first
+    # interpreter policy would then prefer that skeleton while it holds none of
+    # the app's dependencies. A --target install needs no bootstrap and works
+    # identically under packaged and source installs; the deps dir reaches the
+    # child via PYTHONPATH (set where the spawn env is built below).
+    # sys.executable, never a bare "python3": the bare name relies on PATH
+    # (absent on some hosts, a Store stub on Windows) - the same policy every
+    # app spawn path applies via apps/interpreter.
+    #
+    # The install is stamp-gated and staged:
+    # - A hash of requirements.txt is stamped into the deps dir on success, and
+    #   a matching stamp skips pip entirely - so a restart with unchanged
+    #   requirements does no network work and an OFFLINE restart of a healthy
+    #   backend raises no alarm (pip --target cannot answer "already
+    #   satisfied" the way a venv install could).
+    # - pip installs into a staging dir that is swapped in only on success, so
+    #   an interrupted or failed (re)install can never corrupt the live deps
+    #   dir in place - the prior good install keeps serving the spawn below.
+    req_file = root / "requirements.txt"
+    provision_error = ""
+    req_bytes: bytes | None = None
+    if req_file.is_file():
+        # The app dir is app-writable, so requirements.txt can be a planted
+        # symlink - and a resolve-then-read pair would be a TOCTOU window a
+        # concurrent writer could race (validate a real file, swap in a
+        # symlink, gateway reads protected bytes and stamps their digest).
+        # The open is O_NOFOLLOW-bound: for a regular file the kernel refuses
+        # any link swapped in before the open, and the fstat regular-file
+        # check runs on the very handle the bytes come from. A LINK at
+        # requirements.txt is legitimate app layout when it stays in-tree
+        # (requirements.txt -> requirements/prod.txt), so a link is accepted
+        # ONLY when its strict resolution stays inside the app root - then
+        # the RESOLVED path is opened, itself O_NOFOLLOW-bound. Every race
+        # collapses to a refusal or to reading a different in-root file
+        # (app-controlled either way: no out-of-root bytes can ever be read
+        # or digested). On Windows os.O_NOFOLLOW is absent; the is_symlink
+        # pre-check substitutes (symlink creation is privileged there).
+        try:
+            root_resolved = root.resolve(strict=True)
+            open_target = req_file.resolve(strict=True)
+            if not open_target.is_relative_to(root_resolved):
+                raise OSError("requirements.txt resolves outside the app root")
+            # Descriptor-relative, every-component-no-follow open: the
+            # containment check above is only a fast refusal - an ancestor
+            # of the resolved path could be swapped for a link between the
+            # check and the open, so the traversal itself is pinned
+            # component by component (see _open_contained_nofollow).
+            fd = _open_contained_nofollow(root_resolved, open_target)
+            with os.fdopen(fd, "rb") as fh:
+                if not stat.S_ISREG(os.fstat(fh.fileno()).st_mode):
+                    raise OSError("requirements.txt is not a regular file")
+                # Bounded read: this buffer lives in the GATEWAY's memory
+                # and the file is app-controlled - cap it instead of letting
+                # a giant file take the gateway down.
+                req_bytes = fh.read(_DEPS_REQ_MAX_BYTES + 1)
+                if len(req_bytes) > _DEPS_REQ_MAX_BYTES:
+                    raise OSError("requirements.txt exceeds the size cap")
+        except OSError:
+            req_bytes = None
+        if req_bytes is None:
+            provision_error = (
+                f"Refusing requirements.txt for app {app_name}: it is a "
+                f"symlink escaping the app directory, not a regular file, or "
+                f"unreadable (out-of-root symlinked requirements are not "
+                f"installed)"
+            )
+    if req_bytes is not None:
+        deps_dir = app_deps_dir(root)
+        prior = deps_dir.parent / _DEPS_PRIOR_NAME
+        # Recover from an interrupted swap: a crash between the two renames
+        # below leaves only the outgoing tree under the prior name. Put it
+        # back before the stamp check, so an offline restart still has its
+        # last good install (and a matching stamp skips pip entirely).
+        if not deps_dir.exists() and prior.exists():
+            try:
+                pin.rename(prior.name, deps_dir.name)
+            except OSError as exc:
+                logger.warning("App %s: could not recover interrupted deps swap: %s", app_name, exc)
+        stamp = deps_dir / _DEPS_STAMP_NAME
+        digest = _deps_digest(req_bytes)
+        # The digest covers the top-level file's bytes only: any requirement
+        # whose RESOLUTION can change while its line does not (file
+        # references, local paths, VCS/URL and direct references) defeats the
+        # stamp, so those disable the skip - reprovision on every start
+        # (correct, just slower) instead of silently serving a stale install.
+        volatile = _requirements_volatile(req_bytes)
+        # The stamp lives in the app-writable tree too, so its read is
+        # no-follow-bound exactly like the requirements read above: a
+        # planted symlink at the stamp name must not make the gateway read
+        # an arbitrary path. Any open/read/decode failure reads as
+        # "unprovisioned" (pip runs - safe direction).
+        provisioned = False
+        if bool(digest) and not volatile:
+            try:
+                # On Windows os.O_NOFOLLOW is absent; the is_link pre-check
+                # substitutes (same pattern as the requirements read) - a
+                # planted stamp link must read as "unprovisioned", not
+                # through to an arbitrary file.
+                if platform_compat.is_link_or_junction(stamp):
+                    raise OSError("stamp is a symlink/junction")
+                sfd = os.open(str(stamp), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+                with os.fdopen(sfd, "rb") as sfh:
+                    if stat.S_ISREG(os.fstat(sfh.fileno()).st_mode):
+                        # Bounded read: a real stamp is one digest line; an
+                        # oversized file reads its head, fails the compare,
+                        # and safely reprovisions.
+                        provisioned = (
+                            sfh.read(_DEPS_STAMP_MAX_BYTES).decode("utf-8").strip() == digest
+                        )
+            except (OSError, UnicodeDecodeError):
+                provisioned = False
+        if not provisioned:
+            # UNIQUE staging name per transaction, created through the PIN:
+            # a fixed name plus path-based mkdir was the last re-pointable
+            # step - a data/ swap after verification would have pip fill (or
+            # a cleanup delete) another app's staging. The dir_fd mkdir
+            # cannot be redirected; the fresh name means no pre-existing
+            # tree to delete through a path; and pip receives the path only
+            # after a final verify, with the flock guaranteeing no sibling
+            # transaction races the window.
+            staging = deps_dir.parent / f"{_DEPS_STAGING_NAME}-{os.getpid()}-{os.urandom(4).hex()}"
+            _env = minimal_env()  # don't leak secrets to pip subprocesses
+            try:
+                # Stale staging trees from crashed transactions (the old
+                # fixed name or unique names another pid left) are swept
+                # best-effort AFTER a verify; pip --target does not replace
+                # a distribution already present, so installs never reuse a
+                # stale tree - the fresh unique name guarantees that
+                # structurally instead of by strict pre-delete.
+                pin.verify()  # path-based steps below cannot take a dir_fd
+                # Stale-staging sweep, DESCRIPTOR-relative: a path glob plus
+                # path rmtree could follow a data/ swapped in after the
+                # verify. Enumerate through the held fd, quarantine each
+                # match to a fresh random name via dir_fd rename (cannot be
+                # redirected), then delete by path - the random name cannot
+                # pre-exist in a victim tree the attacker cannot write, so a
+                # post-swap delete is a harmless ENOENT.
+                if pin.fd is not None:
+                    _stale_names = [
+                        e
+                        for e in os.listdir(pin.fd)
+                        if _DEPS_STAGING_SWEEP_RE.fullmatch(e) is not None
+                        and e != staging.name
+                    ]
+                else:
+                    _stale_names = [
+                        p.name
+                        for p in deps_dir.parent.glob(f"{_DEPS_STAGING_NAME}*")
+                        if _DEPS_STAGING_SWEEP_RE.fullmatch(p.name) is not None
+                        if p.name != staging.name
+                    ]
+                for _stale in _stale_names:
+                    _pinned_remove_entry(pin, deps_dir.parent, _stale)
+                if pin.fd is not None:
+                    os.mkdir(staging.name, 0o755, dir_fd=pin.fd)
+                else:
+                    staging.mkdir(parents=True, exist_ok=True)
+                # Pin staging ITSELF for the rest of the transaction: pip
+                # runs arbitrary build-hook code with write access to data/,
+                # so every gateway step after it that addresses staging by
+                # NAME (the marker writes, the publish rename) needs an
+                # identity the hook cannot re-point. Same tool as the parent
+                # pin; closed on every exit of the transaction.
+                staging_pin = _PinnedDir(staging)
+                pin.verify()  # pip receives a PATH; last re-check before it runs
+                # Stamp-vs-install atomicity: pip RE-OPENS the requirements
+                # path, and a concurrent rewrite after the hash above would
+                # install the replacement while stamping the ORIGINAL digest
+                # - later starts then skip repair and serve the wrong deps.
+                # When the stamp will be trusted (non-volatile), pip installs
+                # from an immutable SNAPSHOT of the very bytes the digest
+                # covers. Volatile requirements never take the stamp
+                # shortcut, and only they can carry file references whose
+                # resolution is relative to the requirements file - so they
+                # keep reading the validated live path, where includes
+                # resolve correctly, with no stamp to skew.
+                req_src = open_target
+                if not volatile:
+                    req_src = staging / "._kirocrew-requirements.snapshot"
+                    # The write is the GATEWAY's own and staging lives in
+                    # app-writable data/: a staging dir swapped for a link
+                    # after its dir_fd mkdir would have a path write land in
+                    # an arbitrary same-user file. Open through the pinned
+                    # parent chain (every component O_NOFOLLOW) with O_EXCL,
+                    # so neither a swapped ancestor nor a planted entry at
+                    # the snapshot name can redirect it. Windows keeps the
+                    # verify+path write behind the junction identity check.
+                    if pinned_fs.supports_pinned_walk():
+                        _sfd = pinned_fs.open_in_pinned_parent(
+                            str(staging),
+                            req_src.name,
+                            flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                            mode=0o644,
+                            what="requirements snapshot",
+                            refusal=OSError,
+                        )
+                        with os.fdopen(_sfd, "wb") as _sfh:
+                            _sfh.write(req_bytes)
+                    else:
+                        pin.verify()
+                        req_src.write_bytes(req_bytes)
+                # pip reads the VALIDATED open_target, not the manifest
+                # name: for an in-tree symlinked requirements.txt a nested
+                # include (`-r base.txt`) resolves relative to the
+                # requirements FILE, so handing pip the symlink path would
+                # resolve includes beside the LINK instead of its target.
+                # The no-follow handle above already refused an out-of-root
+                # requirements.txt before any bytes were hashed; pip's own
+                # re-open is a follow-open, but by then provisioning is
+                # committed to THIS app's tree and the digest was taken from
+                # the validated handle. Include-bearing requirements never
+                # take the stamp shortcut (_requirements_volatile), so they
+                # reprovision on every start - a change confined to an
+                # included file cannot be masked.
+                pip_cmd, _ = wrap_argv(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--quiet",
+                        "--disable-pip-version-check",
+                        "--target",
+                        str(staging),
+                        "-r",
+                        str(req_src),
+                    ],
+                    mode="standard",
+                )
+                pip_cmd = cgroup_scope_argv(pip_cmd)  # cgroup DoS ceiling
+                # check=True: a non-zero pip exit IS a provisioning failure. It
+                # must not be discarded - the backend would spawn without its
+                # dependencies and die on an import error pointing at the app.
+                # cwd=root: relative references (`-e ./lib`) resolve against
+                # the app root, not whatever directory the gateway happens to
+                # be running from.
+                # Bounded capture: capture_output buffers the child's whole
+                # stdout/stderr in the GATEWAY's memory, and a noisy build
+                # hook can flood it. stderr goes to a temp FILE and only a
+                # bounded TAIL is ever read back (attached as exc.stderr for
+                # the redaction pipeline below); stdout is discarded.
+                with tempfile.TemporaryFile() as _pipbuf, _capped_spill(
+                    _pipbuf, _DEPS_SPILL_HARD_CAP
+                ):
+                    try:
+                        run_limited(
+                            pip_cmd,
+                            check=True,
+                            stdout=subprocess.DEVNULL,
+                            stderr=_pipbuf,
+                            timeout=60,
+                            env=_env,
+                            cwd=str(root),
+                        )
+                    except subprocess.CalledProcessError as _pip_exc:
+                        # stderr went to the file, so the exception carries
+                        # none - attach the bounded tail (never clobber a
+                        # stderr some other spawn shape already set).
+                        if not getattr(_pip_exc, "stderr", None):
+                            _pipbuf.seek(0, os.SEEK_END)
+                            _sz = _pipbuf.tell()
+                            _start = max(0, _sz - _DEPS_PIP_STDERR_TAIL)
+                            _pipbuf.seek(_start)
+                            _tail = _pipbuf.read()
+                            if _start > 0:
+                                # The first line is PARTIAL: the seek can
+                                # sever a URL's scheme, and the downstream
+                                # exfil/credential redaction anchors on
+                                # https?:// - a scheme-less remainder would
+                                # carry its query token straight into the
+                                # logs. Drop through the first newline; a
+                                # tail that is one giant line is dropped
+                                # whole (never worth a credential).
+                                _nl = _tail.find(b"\n")
+                                _tail = (
+                                    _tail[_nl + 1 :]
+                                    if _nl != -1
+                                    else b"[pip stderr tail elided: unterminated first line]\n"
+                                )
+                            _pip_exc.stderr = _tail
+                        raise
+                # Editable installs (`-e ./lib`) materialise as
+                # __editable__*.pth hooks. They are RETAINED: python children
+                # launch through the deps_boot shim, whose site.addsitedir
+                # processes .pth files, so editable installs work through
+                # the shim. (Deps-provided python console scripts route
+                # through the same shim via the shebang sniff in bridges, so
+                # editables work there too.)
+                if digest:
+                    _write_staging_marker(staging_pin, staging, _DEPS_STAMP_NAME, digest)
+                # ABI tag is written even for volatile requirements (digest
+                # empty): activation uses it to keep serving the last good
+                # tree when only the requirements resolution went stale, and
+                # to refuse a wrong-ABI tree always.
+                _write_staging_marker(staging_pin, staging, _DEPS_ABI_NAME, _deps_abi_tag())
+                # Swap the fresh install live. Two renames, not an in-place
+                # upgrade, so no state mixes old and new trees; the recovery
+                # above (and the restore in the except arm) covers the window
+                # in which only the prior name exists.
+                pin.verify()
+                # The publish rename moves whatever ENTRY sits at
+                # staging.name - verify it is still the directory this
+                # transaction created (held fd vs fresh lstat), or a build
+                # hook that re-pointed the name would have its tree
+                # published as the live install.
+                staging_pin.verify()
+                _pinned_remove_entry(pin, deps_dir.parent, prior.name)
+                if deps_dir.exists():
+                    pin.rename(deps_dir.name, prior.name)
+                pin.rename(staging.name, deps_dir.name)
+                staging_pin.close()
+                _pinned_remove_entry(pin, deps_dir.parent, prior.name)
+            except Exception as exc:
+                if "staging_pin" in locals():
+                    staging_pin.close()
+                _pinned_remove_entry(pin, deps_dir.parent, staging.name)
+                # If the failure hit between the swap renames (e.g. a locked
+                # directory on Windows), the live name is empty and the good
+                # tree sits under the prior name - put it back.
+                if not deps_dir.exists() and prior.exists():
+                    try:
+                        pin.rename(prior.name, deps_dir.name)
+                    except OSError as restore_exc:
+                        logger.warning(
+                            "App %s: could not restore prior deps after failed swap: %s",
+                            app_name,
+                            restore_exc,
+                        )
+                detail = str(exc)
+                stderr = getattr(exc, "stderr", None)
+                if stderr:
+                    if isinstance(stderr, bytes):
+                        stderr = stderr.decode("utf-8", "replace")
+                    # Redact BEFORE truncating: a suffix cut can split a
+                    # credential from the marker the redactor matches on,
+                    # leaving the secret's tail to survive the pass below -
+                    # the same split-across-a-length-cap shape the MCP report
+                    # capture guards against. pip errors can echo an index
+                    # URL carrying credentials
+                    # (`--index-url https://user:token@host/`); this detail
+                    # reaches the gateway log and the user-visible backend log
+                    # (and /api/logs). Exfiltration-URL redaction runs FIRST:
+                    # an agent-authored requirements path can embed a
+                    # suspicious URL that pip echoes verbatim, and the
+                    # credential/query passes below do not catch a bare
+                    # exfil host.
+                    stderr, _ = redact_exfiltration_urls(stderr.strip())
+                    stderr, _ = redact_credentials(stderr)
+                    # Same order rule for the query-strip below: applied to
+                    # the FULL stderr before the tail cut, or the cut could
+                    # split a URL from its query and leave the token's tail.
+                    stderr = re.sub(r"(https?://[^\s?#]+)\?\S+", r"\1?<redacted-query>", stderr)
+                    detail = f"{detail}: {stderr[-400:]}"
+                detail, _ = redact_exfiltration_urls(detail)
+                detail, _ = redact_credentials(detail)
+                # redact_credentials catches user:pass@ URL forms; a failed
+                # SIGNED or tokenized URL carries its secret in the QUERY
+                # STRING (?X-Amz-Signature=..., ?token=...), which pip echoes
+                # verbatim. Strip query strings from every URL in the detail
+                # (covers URLs arriving via str(exc), not just stderr).
+                detail = re.sub(r"(https?://[^\s?#]+)\?\S+", r"\1?<redacted-query>", detail)
+                provision_error = (
+                    f"Failed to install requirements.txt dependencies for app "
+                    f"{app_name}: {detail}"
+                )
+                # The spawn is still attempted: the deps dir may hold a
+                # previous successful install, and some requirements are
+                # optional. The failure is surfaced instead of swallowed: the
+                # provision_app_deps wrapper's failure epilogue emits the
+                # ERROR log and the deps_provision_failed SEL event for EVERY
+                # nonempty error - this arm, the requirements-read refusal,
+                # and a lock failure - so neither is duplicated here; a
+                # header line in the backend's own log points the import
+                # errors missing deps produce back at provisioning.
+    return provision_error
 
 
 def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
@@ -770,9 +1785,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 # stop can refuse a recycled PID, and the capture is sandwiched
                 # between health checks so a responder that exits mid-capture
                 # cannot hand ownership to a bystander.
-                adopted = _capture_adopted_owners(
-                    app_name, port, manifest.backend.healthCheck
-                )
+                adopted = _capture_adopted_owners(app_name, port, manifest.backend.healthCheck)
                 if adopted is None:
                     return None
                 adopted_pids, adopted_start_times = adopted
@@ -820,41 +1833,18 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         except OSError:
             pass  # port is free — proceed to spawn
 
-    # Install Python dependencies into a per-app venv (isolated from KiroCrew runtime)
     req_file = root / "requirements.txt"
-    if req_file.is_file():
-        venv_dir = root / ".venv"
-        _env = minimal_env()  # don't leak secrets to pip/venv subprocesses
-        try:
-            if not venv_dir.exists():
-                # sys.executable, never a bare "python3": the bare name relies on
-                # PATH (absent on some hosts, a Store stub on Windows) — the same
-                # policy every app spawn path applies via apps/interpreter.
-                venv_cmd, _ = wrap_argv(
-                    [sys.executable, "-m", "venv", str(venv_dir)], mode="standard"
-                )
-                venv_cmd = cgroup_scope_argv(venv_cmd)  # cgroup DoS ceiling
-                run_limited(
-                    venv_cmd,
-                    check=True, capture_output=True, timeout=60, env=_env,
-                )
-            # Invoke pip through the venv's own interpreter: `.venv/bin/pip` is
-            # POSIX-only (Windows venvs ship Scripts\), and `<venv python> -m pip`
-            # is the layout-independent spelling. Without it a Windows venv is
-            # created but never provisioned — and would then be preferred by the
-            # venv-first interpreter policy while holding none of the app's deps.
-            venv_python = str(venv_python_path(root))
-            pip_cmd, _ = wrap_argv(
-                [venv_python, "-m", "pip", "install", "--quiet",
-                 "--disable-pip-version-check", "-r", str(req_file)], mode="standard"
-            )
-            pip_cmd = cgroup_scope_argv(pip_cmd)  # cgroup DoS ceiling
-            run_limited(
-                pip_cmd,
-                capture_output=True, timeout=60, env=_env,
-            )
-        except Exception as exc:
-            logger.warning("Failed to install deps for app %s: %s", app_name, exc)
+    # entry is None means a module-style builtin: it executes TRUSTED code
+    # from inside the kiro_crew package, not from this writable app dir.
+    # Provisioning a requirements.txt found here (or injecting a
+    # .kirocrew-deps the agent could have written) would let agent-authored
+    # wheels load ahead of the trusted module on its PYTHONPATH - a
+    # trust-boundary crossing. Builtins declare their dependencies in the
+    # package's own pyproject, so they never need this path; gate it (and
+    # the PYTHONPATH/shim transports below) on a real file entry point.
+    provision_error = ""
+    if entry is not None:
+        provision_error = provision_app_deps(app_name, root)
 
     # Spawn process — use manifest backend type if available, fall back to heuristic
     # Pass the gateway's resolved config home explicitly: under pods or any
@@ -978,6 +1968,26 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
             env["KIROCREW_PROXY_SECRET"] = _proxy_secret
     except OSError:
         pass
+    # Expose the provisioned deps dir (pip --target, above) to the child.
+    # PYTHONPATH rather than an interpreter switch: it is honored identically
+    # by the app's own venv interpreter and the gateway fallback, on every
+    # platform. Prepended so the app's pinned requirements win over anything
+    # the operator's own PYTHONPATH (passed through by minimal_env) carries.
+    # Gated on the dir existing AND a real file entry point: a module-style
+    # builtin (entry is None) runs trusted package code, and must not have an
+    # agent-writable app dir injected ahead of it (same trust boundary as the
+    # provisioning gate above).
+    _deps_dir = app_deps_dir(root)
+    # Activation additionally requires the stamp to name the digest for the
+    # CURRENT interpreter: a failed reprovision after a Python upgrade leaves
+    # the old-ABI tree on disk, and injecting it would crash the backend at
+    # import (native wheels are ABI-specific).
+    _deps_ready = (
+        entry is not None
+        and _deps_dir.is_dir()
+        and req_file.is_file()
+        and _deps_tree_stamp_current(root, req_file)
+    )
     entry_str = str(entry) if entry else entry_point
 
     # Prefer explicit backend type from manifest over content sniffing
@@ -987,9 +1997,9 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     # Note: module-style entry points (entry is None) are always Python
     # builtin apps and never declare a Node.js backend, so this branch is
     # safe to evaluate before the module-style branch below.
-    if entry is not None and (backend_type == "node" or (
-        not backend_type and entry_str.endswith((".js", ".mjs", ".cjs"))
-    )):
+    if entry is not None and (
+        backend_type == "node" or (not backend_type and entry_str.endswith((".js", ".mjs", ".cjs")))
+    ):
         node_bin = _find_node_binary()
         if not node_bin:
             logger.error(
@@ -1022,9 +2032,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                         [npm_bin, "install", "--production", "--no-audit", "--no-fund"],
                         mode="standard",
                     )
-                    sandboxed_npm = cgroup_scope_argv(
-                        sandboxed_npm
-                    )  # cgroup DoS ceiling
+                    sandboxed_npm = cgroup_scope_argv(sandboxed_npm)  # cgroup DoS ceiling
                     run_limited(
                         sandboxed_npm,
                         cwd=str(root), env=env, capture_output=True, timeout=120,
@@ -1111,6 +2119,67 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         cmd = [python_bin, entry_str]
         cwd = str(root)
 
+    # Provisioned-deps launch shim: PYTHONPATH entries are not site dirs, so
+    # .pth files in the deps tree (editable installs, namespace shims, import
+    # hooks) would silently never be processed - packages that rely on them
+    # install "successfully" and crash at import. Route the child through
+    # deps_boot, which site.addsitedir()s the deps dir (processing .pth) and
+    # then runs the original target with an unchanged argv view. Only when
+    # the child runs the GATEWAY interpreter (deps pin sys.executable; a venv
+    # interpreter means no deps were provisioned) - the shim is gateway code
+    # and must not be imported by a foreign interpreter.
+    #
+    # Shim XOR PYTHONPATH, never both: `python -m kiro_crew.apps.deps_boot`
+    # resolves kiro_crew through sys.path, and a deps-provided kiro_crew copy
+    # on PYTHONPATH would SHADOW the gateway's shim - app code running as the
+    # "shim" on the gateway's own interpreter. A shimmed child therefore gets
+    # NO deps PYTHONPATH (addsitedir supplies the deps only after the trusted
+    # shim has imported); non-shimmable children (node entries - inert there,
+    # and non-gateway interpreters) keep the PYTHONPATH transport.
+    if _deps_ready and cmd and cmd[0] == sys.executable:
+        # By ABSOLUTE PATH, not -m: the child runs with cwd=app root, and
+        # an app-root kiro_crew.py (or kiro_crew/ dir) would shadow the
+        # gateway package for `-m` resolution - the backend would die (or
+        # run app code as the shim) before startup. deps_boot is
+        # stdlib-only, so the path spelling has no import to shadow.
+        # Inserted at the python LAUNCH TARGET, never blindly at argv[1]:
+        # a shebang can carry interpreter flags (#!<python> -I), and a shim
+        # placed before them makes deps_boot read the flag as its script
+        # path. The same walk bridges uses finds the target; a shape with
+        # no resolvable target keeps its launch untouched.
+        from kiro_crew.apps.bridges import _py_target_index
+
+        _ti = _py_target_index(cmd[1:])
+        if _ti is not None:
+            cmd = [
+                cmd[0],
+                *cmd[1 : 1 + _ti],
+                str(_deps_boot_path()),
+                str(_deps_dir),
+                *cmd[1 + _ti :],
+            ]
+    elif _deps_ready and cmd and os.path.isabs(cmd[0]) and _abi_shebang_of(root, cmd[0]):
+        # An EXECUTABLE python script entry (cmd[0] is the script, not an
+        # interpreter): the ABI check on the script path answers no-match,
+        # but its shebang can name an ABI-matched interpreter - exactly the
+        # bridges stdio case. Launch through deps_boot under that
+        # interpreter so the provisioned deps (and their .pth hooks) reach
+        # the backend. The shared shebang reader refuses argument-bearing
+        # shebangs (#!<python> -I keeps its kernel launch, flags intact)
+        # and sensitive paths, so both contracts hold here by construction.
+        _si = _abi_shebang_of(root, cmd[0])
+        cmd = [_si, str(_deps_boot_path()), str(_deps_dir), *cmd]
+    elif _deps_ready and path_command_is_abi_matched(root, cmd[0] if cmd else ""):
+        # PYTHONPATH transport only on a POSITIVE ABI match: the deps tree
+        # is built by the GATEWAY's pip, and an exec backend running a PATH
+        # python of another minor version would import mismatched binary
+        # wheels and die. Anything not positively matched (foreign pythons,
+        # node, shell) gets no deps env at all - the pre-deps status quo.
+        _existing_pp = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            f"{_deps_dir}{os.pathsep}{_existing_pp}" if _existing_pp else str(_deps_dir)
+        )
+
     # Apply OS-level sandbox to app backend process.
     #
     # ``policy_cache`` is bind-mount-hidden in every tier so the AGENT's own
@@ -1139,7 +2208,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     # The app's OWN hidden state leaves (e.g. md-notebook's vault registry, PAT, and
     # sync settings) are unmasked for exactly this spawn: the mask fences agent
     # subprocesses, but this backend is each leaf's only legitimate reader/writer, and
-    # leaving the mask on breaks the app outright (#8762). Unlike the governance cache
+    # leaving the mask on breaks the app outright. Unlike the governance cache
     # these are the app's own read-write state, so the blanket "visible" meaning is the
     # correct one. Empty for every app without declared owned leaves.
     #
@@ -1197,6 +2266,13 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
 
     try:
         log_fh = open(log_path, "w")
+        if provision_error:
+            # Put the real cause at the top of the backend's own (user-visible)
+            # log: the import error missing deps produce reads as an app bug,
+            # and this line points it back at provisioning. Written and flushed
+            # before the spawn, so the child's inherited fd appends after it.
+            log_fh.write(f"[kiro-crew] {provision_error}\n")
+            log_fh.flush()
         # Process-group isolation so stop_app_backend can tree-kill the app. Pass
         # both flags explicitly (NOT via **dict unpack — that breaks mypy's Popen
         # overload resolution on the build fleet): start_new_session=True is a
@@ -1215,9 +2291,9 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 # ceiling: the backend is the ANCESTOR of its build workloads
                 # (vite/pip) and a 1024 hard cap starves every descendant.
                 # All other apps keep the standard configured policy.
-                profile=(RLIMIT_PROFILE_BUILD
-                         if app_name in _BUILD_CAPABLE_APPS
-                         else RLIMIT_PROFILE_TOOL),
+                profile=(
+                    RLIMIT_PROFILE_BUILD if app_name in _BUILD_CAPABLE_APPS else RLIMIT_PROFILE_TOOL
+                ),
             )
         except OSError:
             log_fh.close()
@@ -1648,9 +2724,7 @@ def _gate_mcp_registration(app_name: str, port: int, *, healthy: bool) -> bool:
             # letting `mcp_healthy` advance on it would strand the app's agent without
             # its MCP tools, with nothing left to retry.
             register_io_failures: list[str] = []
-            reregister_app_mcp_servers(
-                app_name, live_port=port, io_failures=register_io_failures
-            )
+            reregister_app_mcp_servers(app_name, live_port=port, io_failures=register_io_failures)
             if register_io_failures:
                 logger.warning(
                     "App %s: %d agent(s) could not be rewritten after MCP registration "
@@ -2290,6 +3364,28 @@ def _pid_alive(pid: int) -> bool:
     return platform_compat.pid_exists(pid)
 
 
+@contextlib.contextmanager
+def app_backend_lifecycle_flock(app_name: str) -> Iterator[None]:
+    """CROSS-PROCESS per-app lock over a backend's spawn transaction.
+
+    The spawn path holds this lock across the whole body - provisioning
+    (pip can run for minutes) through the pidfile record - and the
+    in-flight-spawn waiter probes it non-blockingly: a held lock means the
+    spawn owner is still working, so the waiter leaves the STARTING
+    placeholder alone instead of clearing it and letting a retry spawn a
+    SECOND backend mid-provisioning.
+    """
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", app_name) or "_"
+    lock_dir = config_dir() / "app_backend_locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_dir / f"{safe}.lock"), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        with platform_compat.flock_exclusive(fd):
+            yield
+    finally:
+        os.close(fd)
+
+
 def _read_pidfile() -> dict[str, dict[str, Any]]:
     try:
         with open(_pidfile_path()) as fh:
@@ -2586,8 +3682,7 @@ def start_enabled_app_backends() -> list[str]:
                 _deregister_mcp_servers(name)
             except Exception as exc:  # noqa: BLE001
                 logger.error(
-                    "Boot resource reconcile: FAILED to revoke resources for "
-                    "denied app %s: %s",
+                    "Boot resource reconcile: FAILED to revoke resources for " "denied app %s: %s",
                     name,
                     exc,
                 )
@@ -2640,9 +3735,7 @@ def start_enabled_app_backends() -> list[str]:
         # — otherwise a require_signature policy would strand every core app.
         if app_info.get("origin") != "builtin":
             try:
-                denied = app_admission_denied(
-                    name, manifest=get_app_manifest(name), action="boot"
-                )
+                denied = app_admission_denied(name, manifest=get_app_manifest(name), action="boot")
             except Exception as exc:  # noqa: BLE001 — boot must never crash on re-vet
                 # Fail CLOSED: if the re-vet itself errors (transient I/O, a bug
                 # in the admission logic), treat the app as denied rather than

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import sys
+import zipfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,12 +26,18 @@ from typing import Any, Iterator, Optional
 from urllib.parse import urlparse, urlunparse
 
 from kiro_crew import platform_compat
+from kiro_crew.apps import deps_boot as _deps_boot_module
 from kiro_crew.apps.cron_sdk import CronSDK
 from kiro_crew.apps.execution import (
     app_execution_denied,
     shipped_builtin_app_root,
 )
-from kiro_crew.apps.interpreter import resolve_app_python, venv_provided_command
+from kiro_crew.apps.interpreter import (
+    app_deps_dir,
+    path_command_is_abi_matched,
+    resolve_app_python,
+    venv_provided_command,
+)
 from kiro_crew.apps.manager import (
     app_data_dir,
     app_dir,
@@ -51,7 +58,14 @@ from kiro_crew.cron_script import resolve_script_path
 from kiro_crew.env import emit_env
 from kiro_crew.executors import maintenance_executor
 from kiro_crew.platform.governance import may_skip_gate_now, strip_ungoverned_auto_approve
+from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
+from kiro_crew.zip_vet import ZipInventoryRejected, vet_zip_inventory
+
+#: Absolute path of the stdlib-only launch shim, for interpreters whose
+#: flags (-S/-E/-I) make the ``-m kiro_crew.apps.deps_boot`` spelling
+#: unimportable.
+_DEPS_BOOT_PATH = Path(os.path.abspath(_deps_boot_module.__file__))
 
 logger = logging.getLogger(__name__)
 
@@ -665,11 +679,7 @@ def _unresolvable_tool_refs(agent_data: dict[str, Any]) -> list[str]:
         # exists for exactly the specs (mochi's) that set this flag.
         return [f"{entry} (server {server!r})" for entry, server in candidates]
     ambient = set(_global_mcp_specs())
-    return [
-        f"{entry} (server {server!r})"
-        for entry, server in candidates
-        if server not in ambient
-    ]
+    return [f"{entry} (server {server!r})" for entry, server in candidates if server not in ambient]
 
 
 #: Keys the framework OWNS in a materialized app agent config: each is derived
@@ -1249,10 +1259,7 @@ def _deregister_skills(app_name: str) -> int:
                 # is_link_or_junction: a junction (non-admin Windows) is not a
                 # symlink, and unlink_link_or_junction removes the link, never
                 # the target it points at.
-                if (
-                    platform_compat.is_link_or_junction(flat_link)
-                    and flat_link.resolve() == target
-                ):
+                if platform_compat.is_link_or_junction(flat_link) and flat_link.resolve() == target:
                     platform_compat.unlink_link_or_junction(flat_link)
                 platform_compat.unlink_link_or_junction(item)
         # Only prune the directory if registration is all that was ever in it.
@@ -1984,9 +1991,10 @@ def _live_port_for(app_name: str, live_port: int | None) -> int | None:
 
 
 #: Bare python launchers an app manifest may name. Each is substituted with a resolved
-#: absolute interpreter — the app's own venv python when it exists (the interpreter its
-#: dependencies were installed against), else the RUNNING interpreter, which is the only
-#: one guaranteed to import ``kiro_crew``.
+#: absolute interpreter - the RUNNING interpreter when the gateway provisioned the app's
+#: deps dir (its wheels are ABI-bound to that interpreter), else the app's own venv
+#: python when a version-matched one exists, else the RUNNING interpreter, which is the
+#: only one guaranteed to import ``kiro_crew``.
 _BARE_PYTHON = frozenset({"python", "python3", "py"})
 
 
@@ -2003,24 +2011,149 @@ def resolve_stdio_command(cfg: dict, app_root: Path | None = None) -> dict:
     entry for exactly that reason; this is the same decision for app manifests.
 
     With ``app_root``, the resolution matches what the app's BACKEND launcher already does
-    (see :mod:`kiro_crew.apps.interpreter`): prefer the app's own venv interpreter — that is
-    where its ``requirements.txt`` was installed, so anything else risks starting the server
-    under an interpreter missing the app's dependencies — else fall back to the gateway's
-    ``sys.executable``. The two spawn paths share one policy on purpose; a second divergent
-    copy is the defect this shape removes.
+    (see :mod:`kiro_crew.apps.interpreter`): the gateway's ``sys.executable`` whenever the
+    gateway has provisioned the app's deps dir (``pip install --target`` - those wheels are
+    ABI-bound to that interpreter), else the app's own venv interpreter when a
+    version-matched one exists, else ``sys.executable`` - and expose the provisioned deps
+    dir through ``PYTHONPATH`` exactly as the backend spawn env does, EXCEPT to a server
+    launching a ``kiro_crew`` module, which must never see an app-supplied ``kiro_crew``
+    copy. The two spawn paths share one policy on purpose; a second divergent copy is the
+    defect this shape removes.
 
-    The rewrite rule, precisely: only a BARE name (no path separator) is ever touched, and
-    then only when it is a known python launcher OR the app's venv provides that exact
-    binary (a venv console script — invisible to PATH because the venv is never activated).
-    An absolute path, a command carrying a path, or a bare PATH dependency the venv does not
-    provide (``node``, ``npx``, ``docker``) was chosen deliberately and is left untouched, as
-    is an HTTP entry (no ``command``). Getting this predicate wrong breaks working apps, so
-    the boundary is pinned by tests on both sides.
+    The rewrite rule, precisely: a BARE name (no path separator) is touched when it is a
+    known python launcher OR the app's venv or deps dir provides that exact binary (a pip
+    console script - invisible to PATH because neither layout is ever activated). ONE
+    path-carrying shape is also rewritten: an absolute script whose shebang names an
+    ABI-matched interpreter, which is relaunched through deps_boot under that interpreter
+    so its provisioned deps resolve. Every other path-carrying command, a bare PATH
+    dependency the app does not provide (``node``, ``npx``, ``docker``), and an HTTP entry
+    (no ``command``) was chosen deliberately and is left untouched. Getting this predicate
+    wrong breaks working apps, so the boundary is pinned by tests on both sides.
     """
     command = cfg.get("command")
     if not isinstance(command, str):
         return cfg
     name = command.strip()
+    # Bound on every path: the shim arms below consult it even when the
+    # deps-exposure block does not run (e.g. a gateway-module server).
+    _deps_stamp_ok = False
+    if app_root is not None and not _targets_gateway_module(cfg):
+        # Expose the provisioned deps dir the same way the backend spawn env
+        # does: a --target install carries no interpreter, so PYTHONPATH is the
+        # only bridge - a deps-provided console script's shebang is
+        # sys.executable and imports its own package from here, and a
+        # python-launcher server imports the app's requirements from here.
+        # Prepended so the app's pinned requirements win over a manifest's own
+        # PYTHONPATH. Inert for non-Python commands, and skipped entirely when
+        # the app has no provisioned deps dir. Runs BEFORE the path-command
+        # early return below: a path-based command (./bin/server,
+        # .venv/bin/python) keeps its spelling - with ONE exception, an
+        # absolute script whose shebang names an ABI-matched interpreter,
+        # which is relaunched through deps_boot under that interpreter - and
+        # it still needs the app's provisioned deps on import. NEVER injected into a server that
+        # launches a kiro_crew module: an app that pip-pins its own kiro_crew
+        # copy would otherwise shadow the gateway's code with a foreign
+        # version on the gateway's own interpreter - the same reason
+        # _targets_gateway_module pins sys.executable below. Registration can
+        # precede the first backend spawn (which provisions the dir), so the
+        # path is emitted whenever provisioning is EXPECTED (the app ships a
+        # requirements.txt) even before the dir exists: a missing PYTHONPATH
+        # entry is inert to Python. And ONLY while the requirements.txt is
+        # still declared: an update that removes it must not leave a stale
+        # preserved tree injecting removed dependency code.
+        # ABI gate for PATH-carrying commands: the deps tree is built by the
+        # GATEWAY's pip, so its wheels are ABI-bound to the gateway's
+        # interpreter. Bare names are safe (their resolution below is the
+        # gateway interpreter, a version-probed venv python, or a
+        # deps/venv-provided script whose shebang is one of those two), but
+        # a path-pinned command is arbitrary - a manifest naming a foreign
+        # python (3.11 against 3.12-built wheels) would import mismatched
+        # binary wheels and die. A path command gets the deps PYTHONPATH
+        # only on a POSITIVE match: it resolves to the gateway interpreter
+        # itself, or to the app venv's python when that venv passed the
+        # version probe. Everything else keeps its env untouched - exactly
+        # the pre-deps status quo for that server.
+        deps_dir = app_deps_dir(app_root)
+        _carries_path = bool(
+            os.sep in name
+            or (os.altsep is not None and os.altsep in name)
+            or os.path.splitdrive(name)[0]
+        )
+        _abi_matched_path = _carries_path and path_command_is_abi_matched(app_root, name)
+        # Deferred import (bridges cannot import backend at module load).
+        from kiro_crew.apps.backend import _deps_tree_stamp_current
+
+        # Stamp gate, same as the spawn path: a failed reprovision after a
+        # Python upgrade leaves an old-ABI tree on disk, and injecting it
+        # here would kill the MCP server at import instead of letting it
+        # start without deps and surface the provisioning error.
+        _deps_stamp_ok = (app_root / "requirements.txt").is_file() and _deps_tree_stamp_current(
+            app_root, app_root / "requirements.txt"
+        )
+        # A PATH command that is not itself an interpreter can still be a
+        # PYTHON SCRIPT: an app shipping an absolute-path launcher whose
+        # shebang names an ABI-matched interpreter (the gateway executable
+        # or the probed venv python) imports its provisioned deps exactly
+        # like a bare-python launch - refusing it strands the server with
+        # ModuleNotFoundError. Verified through the shebang, not the name.
+        _abi_shebang_interp = ""
+        if (
+            _carries_path
+            and not _abi_matched_path
+            and _deps_stamp_ok
+            and os.path.isabs(name)
+        ):
+            _cand_interp = _python_shebang_interpreter(name)
+            if _cand_interp and path_command_is_abi_matched(app_root, _cand_interp):
+                _abi_shebang_interp = _cand_interp
+        if _deps_stamp_ok and (
+            not _carries_path or _abi_matched_path or _abi_shebang_interp
+        ):
+            env = dict(cfg.get("env") or {})
+            existing = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = f"{deps_dir}{os.pathsep}{existing}" if existing else str(deps_dir)
+            cfg["env"] = env
+        if _abi_shebang_interp and _deps_stamp_ok:
+            # Launch through deps_boot (same shape as the deps-dir console
+            # script arm): the verified shebang interpreter runs the shim,
+            # the script becomes the shim's target, so .pth processing and
+            # editable installs work. Shim XOR PYTHONPATH, as everywhere.
+            cfg["command"] = _abi_shebang_interp
+            cfg["args"] = [
+                str(_DEPS_BOOT_PATH),
+                str(app_deps_dir(app_root)),
+                name,
+                *(cfg.get("args") or []),
+            ]
+            _strip_deps_pythonpath(cfg, app_deps_dir(app_root))
+            logger.debug(
+                "stdio MCP path command %r: ABI-matched shebang %s - shimmed via deps_boot",
+                name,
+                _abi_shebang_interp,
+            )
+            return cfg
+        if _abi_matched_path and _deps_stamp_ok:
+            # An ABI-MATCHED path python (the gateway executable by path, or
+            # the probed app venv python) is still a python launch: raw
+            # PYTHONPATH would skip .pth hooks and an editable dependency
+            # dies at import. Same shim walk as the bare-python branch - the
+            # command itself is deliberately never rewritten.
+            _args = _normalize_attached_m(list(cfg.get("args") or []))
+            _ti = _py_target_index(_args)
+            if _ti is not None:
+                # ALWAYS the absolute-path spelling here: an ABI-matched
+                # path python can be the app's own venv interpreter, which
+                # has no system-site-packages and cannot import kiro_crew -
+                # `-m kiro_crew.apps.deps_boot` would die at launch. The
+                # stdlib-only shim by path runs under ANY interpreter (the
+                # same reasoning the isolation-flag arm relies on).
+                cfg["args"] = [
+                    *_args[:_ti],
+                    str(_DEPS_BOOT_PATH),
+                    str(deps_dir),
+                    *_args[_ti:],
+                ]
+                _strip_deps_pythonpath(cfg, deps_dir)
     if (
         not name
         or os.sep in name
@@ -2049,19 +2182,242 @@ def resolve_stdio_command(cfg: dict, app_root: Path | None = None) -> dict:
             cfg["command"] = sys.executable
         else:
             cfg["command"] = resolve_app_python(app_root)
+            # Provisioned-deps launch shim (same reasoning as the backend
+            # spawn): PYTHONPATH never processes .pth files, so a python
+            # launcher with provisioned (or expected) deps routes through
+            # deps_boot, which site.addsitedir()s the deps dir first. Only
+            # when the resolved interpreter is the GATEWAY's own (deps pin
+            # sys.executable; the shim is gateway code and must not be
+            # imported by a foreign interpreter). Interpreter options are
+            # WALKED, not guessed: the shim triple is inserted at the target
+            # token (script, -m, -c, or the operand after --), so `-u
+            # server.py` keeps -u consumed by the interpreter and server.py
+            # shimmed; attached -mMODULE/-cCODE spellings are normalized
+            # first. A shape with no resolvable target falls back to the
+            # PYTHONPATH transport.
+            _args = _normalize_attached_m(list(cfg.get("args") or []))
+            if (
+                app_root is not None
+                and cfg["command"] == sys.executable
+                # Stamp-gated like every deps exposure: shimming routes the
+                # server through the deps tree, and a stale-ABI tree must
+                # not be selected any more than it may be PYTHONPATH-injected.
+                and _deps_stamp_ok
+            ):
+                _ti = _py_target_index(_args)
+                if _ti is not None:
+                    # ALWAYS the absolute-path spelling: MCP servers start
+                    # under the SESSION's cwd (an untrusted project), and a
+                    # project shipping kiro_crew/apps/deps_boot.py would
+                    # shadow the -m spelling through sys.path[0] - project
+                    # code running as the "shim". The stdlib-only path
+                    # spelling has no import to shadow, and it is also what
+                    # -S/-E/-I (which kill -m outright) require.
+                    cfg["args"] = [
+                        *_args[:_ti],
+                        str(_DEPS_BOOT_PATH),
+                        str(app_deps_dir(app_root)),
+                        *_args[_ti:],
+                    ]
+                    _strip_deps_pythonpath(cfg, app_deps_dir(app_root))
             # The one remaining silent-death path: a script-entry server that
             # imports gateway-env packages flips to the venv interpreter the
             # moment a venv materialises and dies on import with no warning
             # (the rewritten path exists). Make the chosen interpreter
             # greppable so that diagnosis starts from a log line.
-            logger.debug(
-                "stdio MCP command %r resolved to interpreter %s", name, cfg["command"]
-            )
+            logger.debug("stdio MCP command %r resolved to interpreter %s", name, cfg["command"])
     elif app_root is not None:
         venv_cmd = venv_provided_command(app_root, name)
         if venv_cmd is not None:
             cfg["command"] = venv_cmd
+            deps_dir = app_deps_dir(app_root)
+            _shim_script = venv_cmd
+            if venv_cmd.lower().endswith(".exe"):
+                # pip's WINDOWS launcher: a native .exe with no shebang. The
+                # classic launcher pair ships a companion `<name>-script.py`
+                # beside it - that companion is the python entry and shims
+                # like any other script. An embedded-script .exe (no
+                # companion) stays a direct launch: it re-execs python
+                # itself and cannot be runpy'd.
+                _companion = Path(venv_cmd).with_name(Path(venv_cmd).stem + "-script.py")
+                if _companion.is_file():
+                    _shim_script = str(_companion)
+                elif zipfile.is_zipfile(venv_cmd) and _zip_has_main(venv_cmd):
+                    # EMBEDDED launcher (no companion): the console script
+                    # rides inside the exe as an appended ZIP with a
+                    # __main__.py stub; deps_boot's exe arm extracts and
+                    # dispatches that stub after addsitedir. A ZIP-bearing
+                    # exe WITHOUT the stub (a self-extractor, an installer,
+                    # any PE with an appended archive) is not a launcher --
+                    # wrapping it would make deps_boot's archive read raise
+                    # and the server fail to start, so it falls through to
+                    # the direct-launch arm below.
+                    _shim_script = venv_cmd
+                else:
+                    # A native exe a wheel shipped as data - not a launcher
+                    # at all; shimming it would hand a binary to the ZIP
+                    # reader. Direct launch, exactly as before the shim.
+                    _shim_script = ""
+            elif not _has_python_shebang(venv_cmd):
+                _shim_script = ""
+            if (
+                deps_dir in Path(venv_cmd).parents
+                and _deps_stamp_ok
+                and _shim_script
+            ):
+                # A deps-dir console script is pip-generated - a Python
+                # script whose shebang is the gateway interpreter, a Windows
+                # launcher pair, or an embedded-ZIP exe. Run direct, its
+                # editable/.pth-dependent imports die (PYTHONPATH never
+                # processes .pth), so route it through deps_boot: script and
+                # companion forms as script targets, embedded exes through
+                # the shim's exe arm. Only artifacts that ARE python-backed
+                # (shebang sniff / launcher shapes) - a package can ship
+                # arbitrary bin artifacts, and runpy on a shell script would
+                # break a working launch. Shim XOR PYTHONPATH, as
+                # everywhere.
+                cfg["command"] = sys.executable
+                # absolute-path spelling for the same session-cwd shadowing
+                # reason as the bare-python branch
+                cfg["args"] = [
+                    str(_DEPS_BOOT_PATH),
+                    str(deps_dir),
+                    _shim_script,
+                    *(cfg.get("args") or []),
+                ]
+                _strip_deps_pythonpath(cfg, deps_dir)
     return cfg
+
+
+def _strip_deps_pythonpath(cfg: dict, deps_dir: Path) -> None:
+    """Drop the deps dir from a shimmed server's PYTHONPATH, in place.
+
+    Shim XOR PYTHONPATH: ``-m kiro_crew.apps.deps_boot`` resolves kiro_crew
+    through sys.path, so a deps-provided kiro_crew copy on PYTHONPATH would
+    SHADOW the gateway's shim - app code running as the "shim" on the
+    gateway's own interpreter. addsitedir supplies the deps only after the
+    trusted shim has imported; a manifest's own PYTHONPATH entries pass
+    through untouched.
+    """
+    env = dict(cfg.get("env") or {})
+    parts = [p for p in env.get("PYTHONPATH", "").split(os.pathsep) if p and p != str(deps_dir)]
+    if parts:
+        env["PYTHONPATH"] = os.pathsep.join(parts)
+    else:
+        env.pop("PYTHONPATH", None)
+    if env:
+        cfg["env"] = env
+    else:
+        cfg.pop("env", None)
+
+
+def _zip_has_main(path: str) -> bool:
+    """True when *path* is a ZIP whose archive carries a ``__main__.py``.
+
+    That member is what makes a ZIP-bearing executable a Python launcher
+    deps_boot's exe arm can dispatch; without it the wrap is guaranteed to
+    fail at start. Any read error reads as "not a launcher". Reads are
+    gated on the sensitive-path check like every other content sniff here.
+    """
+    if is_sensitive_path(path):
+        return False
+    try:
+        # Vet the declared inventory BEFORE constructing ZipFile: the
+        # central directory is app-controlled and ZipFile loads it whole
+        # into the gateway's memory - a crafted launcher-shaped exe must
+        # exhaust a cap, not the gateway. Real console-script launchers
+        # carry a handful of members.
+        try:
+            vet_zip_inventory(path, max_members=2048)
+        except ZipInventoryRejected:
+            return False
+        with zipfile.ZipFile(path) as zf:
+            return "__main__.py" in zf.namelist()
+    except (OSError, zipfile.BadZipFile, RuntimeError):
+        return False
+
+
+def _python_shebang_interpreter(script: str) -> str | None:
+    """The ABSOLUTE interpreter path a script's shebang names, or None.
+
+    Only the bare direct spelling (``#!/abs/path/to/python``, no arguments)
+    is returned. An ``env`` form resolves through PATH at spawn time and
+    cannot be ABI-verified ahead of it. A shebang that carries arguments
+    (``#!<python> -I``) is never a rewrite candidate: the kernel passes
+    everything after the interpreter as ONE token with its own splitting
+    rules, and flags like ``-I``/``-E``/``-s`` set the interpreter's
+    isolation posture - a rewrite that drops or re-splits them silently
+    weakens the isolation the script asked for, where the kernel's own
+    shebang launch keeps every flag exactly as written. Such scripts stay
+    on the direct launch.
+
+    The read is gated: ``script`` is a manifest-author-controlled absolute
+    path, and the gateway must not open a protected location outside the
+    sandbox on an app's say-so - the same sensitive-path gate every other
+    file-access surface consults. Any refusal or read failure reads as
+    None - the launch stays exactly what it was.
+    """
+    if is_sensitive_path(script):
+        return None
+    try:
+        with open(script, "rb") as fh:
+            head = fh.read(512)
+    except OSError:
+        return None
+    first = head.split(b"\n", 1)[0]
+    if not first.startswith(b"#!"):
+        return None
+    try:
+        parts = first[2:].decode("utf-8", "strict").strip().split()
+    except UnicodeDecodeError:
+        return None
+    if len(parts) != 1:
+        return None
+    interp = parts[0]
+    if os.path.basename(interp) == "env" or not os.path.isabs(interp):
+        return None
+    return interp
+
+
+def _has_python_shebang(script: str) -> bool:
+    """True when ``script`` opens with a ``#!`` line naming a python.
+
+    pip-generated console scripts do (their shebang is the interpreter that
+    ran pip); native binaries and foreign-language scripts do not. Any read
+    failure reads as "not python" and the launch falls back to direct
+    execution. The read carries the same sensitive-path gate as every
+    shebang sniff: the callers pass app-dir-confined paths today, and the
+    gate keeps that true against any future caller handing this a
+    manifest-verbatim path.
+    """
+    if is_sensitive_path(script):
+        return False
+    try:
+        with open(script, "rb") as fh:
+            head = fh.read(512)
+    except OSError:
+        return False
+    lines = head.split(b"\n")
+    first = lines[0]
+    if not first.startswith(b"#!"):
+        return False
+    if b"python" in first.lower():
+        return True
+    # pip (distlib) emits a shell TRAMPOLINE when the interpreter path is
+    # too long or contains spaces: a /bin/sh shebang whose SECOND line is
+    # exactly the polyglot re-exec - a triple-quote-fenced `exec <python>
+    # "$0" "$@"`. Match that structure, not token presence: a dependency's
+    # ordinary shell wrapper that merely MENTIONS python somewhere must not
+    # be handed to runpy as python source.
+    if b"sh" not in first or len(lines) < 2:
+        return False
+    second = lines[1]
+    q3 = b"\x27\x27\x27"  # three single quotes
+    return (
+        second.startswith(q3 + b"exec\x27 ")
+        and b'"$0" "$@"' in second
+        and b"python" in second.lower()
+    )
 
 
 #: CPython interpreter options that consume the NEXT argv element as their
@@ -2070,6 +2426,88 @@ def resolve_stdio_command(cfg: dict, app_root: Path | None = None) -> dict:
 #: -Xdev). Kept as an explicit table so the scanner's skip logic is checkable
 #: against `python --help` rather than inferred per finding.
 _PY_OPTS_WITH_SEPARATE_VALUE = frozenset({"-X", "-W", "--check-hash-based-pycs"})
+
+
+def _normalize_attached_m(args: list) -> list:
+    """Split attached ``-mMODULE`` / ``-cCODE`` spellings into separate form.
+
+    CPython treats ``-mserver`` and ``-m server`` identically (same for
+    ``-c``); the shim walker only takes over the separate forms, so the
+    attached spellings would silently fall back to the PYTHONPATH transport
+    and skip ``.pth`` processing. Walks the same option-prefix branch table;
+    returns the args unchanged when there is nothing to normalize.
+    """
+    out: list = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if not isinstance(arg, str):
+            return args
+        if arg in ("-m", "-c") or not arg.startswith("-"):
+            return [*out, *args[i:]]
+        if arg == "--":
+            # `python -- server.py` is `python server.py` whenever the
+            # operand does not itself start with a dash - drop the
+            # separator so the walker shims the script. An operand that DOES
+            # start with a dash needs the `--` and stays unshimmable.
+            if i + 1 < len(args) and isinstance(args[i + 1], str) and not args[i + 1].startswith("-"):
+                return [*out, *args[i + 1 :]]
+            return [*out, *args[i:]]
+        if arg.startswith(("-m", "-c")) and len(arg) > 2:
+            return [*out, arg[:2], arg[2:], *args[i + 1 :]]
+        out.append(arg)
+        if arg in _PY_OPTS_WITH_SEPARATE_VALUE:
+            if i + 1 < len(args):
+                out.append(args[i + 1])
+            i += 2
+            continue
+        i += 1
+    return out
+
+
+def _py_target_index(args: list) -> int | None:
+    """Index of the first token CPython treats as the LAUNCH TARGET.
+
+    Walks the interpreter-option prefix with the same branch table as
+    :func:`_targets_gateway_module`, returning the index of the script
+    operand or a separate ``-m`` - the insertion point for the deps_boot
+    shim triple, so interpreter options stay consumed by the interpreter.
+    Separate ``-m`` and ``-c`` ARE targets (deps_boot has arms for both),
+    and attached spellings are split by the normalizer before this walk.
+    ``None`` only for shapes with no resolvable target (a surviving ``--``
+    guarding a dash-led operand, non-string tokens, or an option prefix
+    with no target): those keep the PYTHONPATH transport.
+    """
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if not isinstance(arg, str):
+            return None
+        if arg in ("-m", "-c"):
+            return i if i + 1 < len(args) else None
+        if arg == "--" or (arg.startswith(("-m", "-c")) and len(arg) > 2):
+            # A surviving `--` means the normalizer could not remove it (the
+            # operand starts with a dash): inserting the shim after `--`
+            # would be read as a FILENAME, not an option - unshimmable.
+            return None
+        if arg == "-x" or (
+            arg.startswith("-") and not arg.startswith("--") and "x" in arg[1:]
+        ):
+            # -x tells CPython to SKIP THE FIRST LINE of the script it
+            # launches. Inserting the shim makes deps_boot that script, and
+            # its first line opens the module docstring - the interpreter
+            # dies with SyntaxError. The flag is legacy (non-Python first
+            # lines) and cannot be honored through a shim: unshimmable, the
+            # PYTHONPATH transport keeps serving. Clustered spellings
+            # (-xu) are caught too - a missed one would be the same crash.
+            return None
+        if not arg.startswith("-"):
+            return i
+        if arg in _PY_OPTS_WITH_SEPARATE_VALUE:
+            i += 2
+            continue
+        i += 1
+    return None
 
 
 def _targets_gateway_module(cfg: dict) -> bool:
@@ -2187,6 +2625,75 @@ def _schedule_unresolvable_warning(app_name: str, server_name: str, cfg: dict) -
     )
 
 
+def _maybe_provision_backendless_deps(app_name: str, manifest: "AppManifest") -> None:
+    """Provision requirements.txt for an app whose backend spawn never runs pip.
+
+    That covers an app with NO backend entry point, and also an ADOPTED
+    file-entry backend (an externally-managed instance the gateway never
+    spawns, so the spawn-path provisioning never fires for it).
+
+    Provisioning normally runs in the backend spawn - but an app can ship
+    only stdio MCP servers, and with no backend start nothing else ever runs
+    pip: the shim/PYTHONPATH transports the resolution below emits would
+    reference a forever-empty deps tree and the server would die on its
+    first import. Stamp-gated (repeat registrations with unchanged
+    requirements do no network work), and gated on the backend entry point
+    being ABSENT: when one exists, the backend spawn owns provisioning - a
+    module-style builtin entry point in particular must never have an
+    app-dir requirements.txt provisioned (trust boundary; see
+    provision_app_deps). Failure is logged by the provisioner and
+    registration proceeds: the spawn-time import error points back at the
+    provisioning log line, matching the backend spawn's own behavior.
+    """
+    # Provenance gate, not a manifest gate: a shipped BUILTIN's trust story
+    # is the same one the backend spawn's entry gate enforces - builtin code
+    # is trusted package code, its declared dependencies live in the
+    # package's own pyproject, and an agent-planted requirements.txt in the
+    # (writable) app dir must never have pip execute its build hooks under
+    # the gateway without the third-party grant. shipped_builtin_app_root is
+    # the authoritative provenance check (immutable package composition, not
+    # mutable installed.json fields).
+    if shipped_builtin_app_root(app_name) is not None:
+        return
+    root = app_dir(app_name)
+    entry_point = manifest.backend.entryPoint
+    if entry_point:
+        # Registration provisions for FILE-entry apps too, not only
+        # backend-less ones: a healthy fixed-port backend gets ADOPTED
+        # (never spawned this session), so the spawn-path provisioning
+        # never ran and a dependency-backed stdio server would reference an
+        # empty deps tree. The stamp gate and the per-app flock make the
+        # overlap with a real spawn cheap and safe. A MODULE-style entry
+        # (trusted package code, the backend spawn's own trust gate) still
+        # never provisions app-dir requirements.
+        is_module_entry = (
+            "/" not in entry_point
+            and not entry_point.endswith((".py", ".js", ".ts", ".mjs", ".cjs", ".sh"))
+            and "." in entry_point
+            and not (root / entry_point).exists()
+        )
+        if is_module_entry:
+            return
+    if not os.path.lexists(root / "requirements.txt"):
+        # True ABSENCE only: is_file() would also answer False for a
+        # DANGLING requirements.txt symlink, silently skipping the
+        # provisioner - a present-but-unreadable entry must fall through to
+        # provision_app_deps, whose failure epilogue surfaces it (ERROR log
+        # + SEL event) instead of this fast path eating it.
+        return
+    has_stdio = any(
+        isinstance(cfg, dict) and not cfg.get("url") for cfg in manifest.mcpServers.values()
+    )
+    if not has_stdio:
+        return
+    # Deferred import: bridges is imported during backend's boot path, so it
+    # cannot import backend at module load (same pattern as the other
+    # backend imports in this module).
+    from kiro_crew.apps.backend import provision_app_deps
+
+    provision_app_deps(app_name, root)
+
+
 def _register_mcp_servers(
     app_name: str, manifest: AppManifest, live_port: int | None = None
 ) -> list[str]:
@@ -2217,6 +2724,7 @@ def _register_mcp_servers(
     if not manifest.mcpServers:
         return []
     resolved_port = _live_port_for(app_name, live_port)
+    _maybe_provision_backendless_deps(app_name, manifest)
     registered: list[str] = []
     skipped: list[str] = []
     # Reconcile guard OUTSIDE _mcp_lock: that order is fixed everywhere, so a health
@@ -2344,9 +2852,7 @@ def reregister_app_mcp_servers(
     return registered
 
 
-def scrub_backend_mcp_url(
-    app_name: str, unreconciled: list[str] | None = None
-) -> list[str]:
+def scrub_backend_mcp_url(app_name: str, unreconciled: list[str] | None = None) -> list[str]:
     """Remove an app's backend-dependent MCP entry, keeping the servers that need no port.
 
     Registering with no live port is the existing path for this: it pops each HTTP entry
@@ -2671,9 +3177,7 @@ def register_app(app_name: str) -> RegistrationResult:
     return result
 
 
-def refresh_app_agents(
-    app_name: str, io_failures: list[str] | None = None
-) -> list[str]:
+def refresh_app_agents(app_name: str, io_failures: list[str] | None = None) -> list[str]:
     """Re-materialize just this app's agent configs.
 
     Called when something the agent config is derived from changes (the app's MCP reach

--- a/src/kiro_crew/apps/deps_boot.py
+++ b/src/kiro_crew/apps/deps_boot.py
@@ -1,0 +1,170 @@
+"""Launch shim for app processes with gateway-provisioned dependencies.
+
+Usage (always via the gateway's own interpreter)::
+
+    python -m kiro_crew.apps.deps_boot <deps_dir> <script.py> [args...]
+    python -m kiro_crew.apps.deps_boot <deps_dir> -m <module> [args...]
+    python -m kiro_crew.apps.deps_boot <deps_dir> -c <code> [args...]
+
+Why this exists: provisioned dependencies are a ``pip install --target``
+tree, and the naive transport - prepending the tree to ``PYTHONPATH`` -
+never processes ``.pth`` files, because ``PYTHONPATH`` entries are not site
+directories. Packages that ship a ``.pth`` (editable installs, namespace
+shims, import hooks) then install "successfully" and crash at import time.
+``site.addsitedir`` IS the .pth-processing registration, so the shim runs it
+on the deps dir and only then hands control to the real entry point.
+
+``addsitedir`` appends; the app's pinned requirements must win over the
+gateway environment's own packages, so the deps dir is placed at its FINAL
+front position BEFORE ``addsitedir`` runs. Order matters at that moment,
+not merely afterwards: a ``.pth`` line can ``import`` during site
+processing, and whatever that import resolves to is cached in
+``sys.modules`` - a reordering after the fact cannot evict a wrong module
+cached under the old order. Entries the ``.pth`` files add are then moved
+up next to the deps dir (their imports, when any, target finder modules
+living in the deps dir itself, which is already correctly placed). The
+shim adds no other behavior: argv is rewritten so the target sees exactly
+the argv it would have seen launched directly.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import site
+import sys
+import types
+import zipfile
+
+
+def main(argv: list[str]) -> None:
+    # Path-launch support (`python -S /abs/.../deps_boot.py ...`, used when
+    # import-machinery flags forbid the -m spelling): CPython puts the
+    # SCRIPT's own directory at sys.path[0], which here is kiro_crew/apps/ -
+    # leaving it would let an app import gateway modules by their bare names
+    # (`import interpreter`). Drop it before anything else resolves.
+    _own = os.path.dirname(os.path.abspath(__file__))
+    if sys.path and os.path.abspath(sys.path[0] or os.curdir) == _own:
+        del sys.path[0]
+    if len(argv) < 2 or (argv[1] in ("-m", "-c") and len(argv) < 3):
+        sys.stderr.write(
+            "usage: python -m kiro_crew.apps.deps_boot <deps_dir> "
+            "(<script.py> | -m <module> | -c <code>) [args...]\n"
+        )
+        raise SystemExit(2)
+    deps_dir = argv[0]
+    # CPython-parity placement, established BEFORE site processing: the
+    # plain launch puts the LAUNCH ENTRY (script dir / "" for -c / cwd for
+    # -m) at sys.path[0] and PYTHONPATH entries after it - so the deps go
+    # AFTER the launch entry, or an app-local module colliding with a
+    # dependency name would resolve to the DEPENDENCY under the shim while
+    # resolving to the app's own file in a plain launch. Under -P/-I
+    # (sys.flags.safe_path) the plain launch inserts NO launch entry at
+    # all - the shim must not restore what those flags exist to remove.
+    # The order must be final before addsitedir runs: a .pth import line
+    # executes DURING site processing and caches whatever it resolves in
+    # sys.modules, beyond the reach of any later reordering.
+    safe_path = bool(getattr(sys.flags, "safe_path", False))
+    if argv[1] == "-m":
+        launch = [] if safe_path else [os.getcwd()]
+    elif argv[1] == "-c":
+        launch = [] if safe_path else [""]
+    else:
+        launch = [] if safe_path else [os.path.dirname(os.path.abspath(argv[1]))]
+    deps_entry = os.path.abspath(deps_dir)
+    sys.path[:0] = [*launch, deps_entry]
+    _anchor = len(launch) + 1
+    before = len(sys.path)
+    # addsitedir dedups against entries already on sys.path (by normalized
+    # abspath), so the pre-placed deps entry is not appended again; only
+    # the .pth-added entries land at the tail. Those are moved up next to
+    # the deps dir: their import lines, when any, target finder modules
+    # living in the deps dir itself, already correctly placed - a plain
+    # path line triggers no import at processing time.
+    site.addsitedir(deps_entry)
+    _pth_added = sys.path[before:]
+    del sys.path[before:]
+    sys.path[_anchor:_anchor] = _pth_added
+    if argv[1] == "-m":
+        module, rest = argv[2], argv[3:]
+        sys.argv = [module, *rest]
+        runpy.run_module(module, run_name="__main__", alter_sys=True)
+    elif argv[1] == "-c":
+        code, rest = argv[2], argv[3:]
+        # `python -c` parity: sys.argv[0] is the literal "-c", and the code
+        # runs in a REAL __main__ module registered in sys.modules with the
+        # standard main-module globals (__spec__/__package__/__loader__ are
+        # None for -c) - a bare dict would NameError on code that reads
+        # __spec__ or pickles classes it defines.
+        sys.argv = ["-c", *rest]
+        mod = types.ModuleType("__main__")
+        mod.__dict__.update(
+            {
+                "__name__": "__main__",
+                "__doc__": None,
+                "__package__": None,
+                "__loader__": None,
+                "__spec__": None,
+                "__annotations__": {},
+                "__builtins__": __builtins__,
+            }
+        )
+        sys.modules["__main__"] = mod
+        # The code string is the app manifest's own `-c` operand - exactly
+        # what CPython itself would execute had the manifest launched
+        # python directly; the shim adds no execution power it did not
+        # already have.
+        exec(  # noqa: S102  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
+            compile(code, "<string>", "exec"), mod.__dict__
+        )
+    elif os.name == "nt" and argv[1].lower().endswith(".exe"):
+        # pip's EMBEDDED Windows launcher: a native exe with the console
+        # script appended as a ZIP archive (zipfile reads it directly - the
+        # central directory sits at EOF). Extract the __main__.py stub and
+        # dispatch it here, after addsitedir, so its .pth-dependent imports
+        # resolve - running the exe directly would skip site processing.
+        # Windows-only BY THE GATE above: on POSIX a *.exe name is just a
+        # python script like any other (only python targets ever reach the
+        # shim), and it must take the script dispatch below - this arm's
+        # execv fallback would restart its shebang interpreter WITHOUT the
+        # deps path.
+        target, rest = argv[1], argv[2:]
+        if not zipfile.is_zipfile(target):
+            # Not a launcher after all (the resolver gates on is_zipfile,
+            # but the file can change between resolution and launch): a
+            # native exe cannot be dispatched as python - hand the process
+            # over to it directly, exactly as an unshimmed launch would.
+            os.execv(target, [target, *rest])
+        with zipfile.ZipFile(target) as zf:
+            code = zf.read("__main__.py").decode("utf-8")
+        sys.argv = [target, *rest]
+        mod = types.ModuleType("__main__")
+        mod.__dict__.update(
+            {
+                "__name__": "__main__",
+                "__doc__": None,
+                "__package__": None,
+                "__loader__": None,
+                "__spec__": None,
+                "__annotations__": {},
+                "__builtins__": __builtins__,
+            }
+        )
+        sys.modules["__main__"] = mod
+        # The stub is pip's own generated entry - the same code the exe
+        # would have run had the manifest launched it directly.
+        exec(  # noqa: S102  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
+            compile(code, target, "exec"), mod.__dict__
+        )
+    else:
+        target, rest = argv[1], argv[2:]
+        # Direct-script parity: `python script.py` puts the script's own
+        # directory at sys.path[0] (established above, before site
+        # processing); runpy.run_path does NOT, so a script importing a
+        # sibling module would break under the shim.
+        sys.argv = [target, *rest]
+        runpy.run_path(target, run_name="__main__")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/kiro_crew/apps/interpreter.py
+++ b/src/kiro_crew/apps/interpreter.py
@@ -10,20 +10,33 @@ than the one the app's dependencies were installed against — the process then
 starts under the wrong interpreter and dies on import, with nothing surfaced
 to the user.
 
-The policy: prefer the app's OWN venv interpreter (that is where the app's
-``requirements.txt`` was installed, so it is the only interpreter guaranteed
-to carry the app's dependencies), else fall back to the gateway's own
-``sys.executable`` (always an absolute path to a real interpreter). Keeping
-the policy in one place is the point — two divergent copies is exactly the
+The policy: once the gateway has provisioned the app's dependencies
+(``pip install --target`` into :func:`app_deps_dir`, reaching the child via
+``PYTHONPATH``), the gateway's own ``sys.executable`` is the only
+ABI-consistent interpreter and is used unconditionally. Without an ACTIVE
+provisioned tree (never provisioned, provisioning failed, or requirements
+removed), a POSITIVELY usable app venv is preferred - for a legacy app it
+holds the author-installed dependencies, and a provisioning failure must
+not also take that working environment away - else ``sys.executable``
+(always an absolute path to a real interpreter). Once a provisioned tree
+is active again it reclaims the gateway interpreter. The gateway itself does not create app venvs. Keeping the
+policy in one place is the point - two divergent copies is exactly the
 defect class this module removes.
 """
 
 from __future__ import annotations
 
+import contextlib
+import json
+import os
+import re
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
-from kiro_crew import platform_compat
+from kiro_crew import platform_compat, sandbox
+from kiro_crew.apps.registry import minimal_env
 
 
 def venv_python_path(root: Path) -> Path:
@@ -36,6 +49,54 @@ def venv_python_path(root: Path) -> Path:
     if platform_compat.IS_WINDOWS:
         return root / ".venv" / "Scripts" / "python.exe"
     return root / ".venv" / "bin" / "python3"
+
+
+def app_deps_dir(root: Path) -> Path:
+    """Directory an app's ``requirements.txt`` is provisioned into.
+
+    Populated by ``pip install --target`` (``backend.py``'s spawn path) and
+    exposed to processes spawned on the app's behalf via ``PYTHONPATH``. A
+    plain directory rather than a venv, because venv creation needs
+    ``ensurepip`` - which the packaged install's bundled interpreter does not
+    ship - and the half-created skeleton a failed attempt leaves behind is
+    runnable enough that :func:`resolve_app_python` would prefer it while it
+    holds no dependencies at all. A ``--target`` install has no bootstrap
+    step, so it cannot leave that trap.
+
+    Beneath ``data/``, not the app root: ``update_app`` replaces the app tree
+    but preserves ``data/``, so an update keeps the last good install - a
+    restart right after an update works even when pip (or the network) is
+    unavailable, and the stamp check reprovisions only when requirements
+    actually changed. Staging and prior trees live beside it for the same
+    reason (the two swap renames must stay on one filesystem).
+    """
+    return root / "data" / ".kirocrew-deps"
+
+
+def app_deps_active(root: Path) -> bool:
+    """True when the provisioned deps dir should influence resolution.
+
+    Presence alone is not enough, twice over. ``data/`` (where the deps
+    live) survives app updates, so an update that REMOVES requirements.txt
+    leaves the tree behind - and a stale tree must neither pin the
+    interpreter nor inject removed dependency code. And a tree the spawn
+    would REFUSE to inject (foreign ABI after a Python upgrade whose
+    reprovision failed - the same stamp gate every deps-exposure arm uses)
+    must not influence resolution either: it would suppress the usable-venv
+    fallback in :func:`resolve_app_python` while delivering nothing,
+    leaving the backend on the bare gateway interpreter to crash on the
+    app's imports when a working environment sat available. Active means
+    the app declares a requirements.txt AND the provisioned tree exists
+    AND that tree activates for the CURRENT interpreter.
+    """
+    req = root / "requirements.txt"
+    if not (req.is_file() and app_deps_dir(root).is_dir()):
+        return False
+    # Deferred import: backend imports this module at load, so the
+    # top-level spelling is circular.
+    from kiro_crew.apps.backend import _deps_tree_stamp_current
+
+    return _deps_tree_stamp_current(root, req)
 
 
 def _runnable(path: Path) -> bool:
@@ -54,43 +115,285 @@ def _runnable(path: Path) -> bool:
         return False
 
 
+_PROBE_SPILL_HARD_CAP = 4 * 1024 * 1024
+
+
+@contextlib.contextmanager
+def _capped_probe_spill(spill, poll_secs: float = 0.5):
+    """Bound the probe's output SPILL: a hostile app-controlled interpreter
+    that floods stdout would grow this temp file until the timeout and could
+    fill the host disk. A watchdog truncates it back to empty on breach, so
+    on-disk residency stays within the cap; the short bounded TAIL read
+    afterwards (the probe's real answer is one JSON line, printed last) is
+    unaffected."""
+    import threading
+
+    stop = threading.Event()
+
+    def _watch() -> None:
+        while not stop.wait(poll_secs):
+            try:
+                if os.fstat(spill.fileno()).st_size > _PROBE_SPILL_HARD_CAP:
+                    spill.seek(0)
+                    spill.truncate(0)
+            except OSError:
+                return
+
+    t = threading.Thread(target=_watch, daemon=True)
+    t.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        t.join(timeout=2)
+
+
+def _venv_is_usable(root: Path) -> bool:
+    """Positive evidence that ``root``'s ``.venv`` is a completed, working
+    environment for THIS gateway - not a bootstrap skeleton and not a
+    cross-ABI copy.
+
+    A minor-version match on ``pyvenv.cfg`` is not enough in either direction
+    (the defect this replaces): a failed ``python -m venv`` leaves a skeleton
+    whose ``bin/python3`` is the fully-runnable system interpreter and whose
+    ``pyvenv.cfg`` names the current minor version, so a version check ACCEPTS
+    it; and a venv built by a different minor version but carrying pure-Python
+    deps the app needs would be REJECTED. Neither the file's existence nor its
+    version field is positive evidence that the interpreter runs and owns its
+    site.
+
+    So probe it: run the candidate interpreter and require it to (1) start,
+    (2) report a ``sys.prefix`` inside this venv (it is the venv's own
+    interpreter, not a bare fallback), and (3) report the SAME
+    ``(major, minor)`` as the gateway - provisioned deps reach the child via
+    ``PYTHONPATH`` built by ``sys.executable``, so a differing ABI would mix
+    wheels. The probe is ``-I`` (isolated: ignores env/user site) and
+    ``-S``-free so it sees the venv's own site, timeboxed, and any failure
+    (nonzero, timeout, OSError, unparsable output) is treated as "not usable"
+    - a fallback to ``sys.executable`` is always safe, so the probe fails
+    closed.
+    """
+    venv_py = venv_python_path(root)
+    if not _runnable(venv_py):
+        return False
+    probe = (
+        "import sys,json;"
+        "print(json.dumps([sys.prefix, sys.version_info[0], sys.version_info[1],"
+        " sys.implementation.name, sys.platform]))"
+    )
+    # The candidate interpreter is an app-writable file - an app backend can
+    # plant an arbitrary executable at .venv/bin/python3 - so the probe runs
+    # under the same OS sandbox + resource ceilings as every other app spawn
+    # (wrap_argv + cgroup scope + run_limited), never with more privilege
+    # than an app spawn gets. On a host with no sandbox backend wrap_argv
+    # fail-closes - UNLESS the operator has explicitly opted into
+    # unsandboxed execution, in which case this probe (like every app spawn
+    # under that opt-in) runs unconfined; the opt-in accepts that for all
+    # app code, and the probe adds no exposure beyond the spawn that would
+    # follow it. Every probe failure reads as "no positive evidence" and the
+    # caller falls back to sys.executable - always a safe answer, so nothing
+    # here may propagate an exception into spawn or registration.
+    cleanup_path = None
+    try:
+        argv, cleanup_path = sandbox.wrap_argv([str(venv_py), "-I", "-c", probe], mode="standard")
+        argv = sandbox.cgroup_scope_argv(argv)
+        # Bounded capture: the probe executable is app-controlled and
+        # capture_output would buffer its whole stdout in the GATEWAY's
+        # memory - a hostile "python" that floods output must exhaust a
+        # capped buffer, not the gateway. stdout goes to a temp file and
+        # only a bounded TAIL is read back (the probe's real answer is one
+        # short JSON line, printed last); stderr is discarded outright.
+        with tempfile.TemporaryFile() as _outbuf, _capped_probe_spill(_outbuf):
+            proc = sandbox.run_limited(
+                argv,
+                stdout=_outbuf,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+                # The probe executable is app-controlled: hand it the same
+                # sanitized environment every app subprocess gets, never the
+                # gateway's own (which can carry credentials).
+                env=minimal_env(),
+            )
+            _outbuf.seek(0, os.SEEK_END)
+            _size = _outbuf.tell()
+            _outbuf.seek(max(0, _size - 4096))
+            probe_out = _outbuf.read().decode("utf-8", "replace")
+    except Exception:
+        return False
+    finally:
+        if cleanup_path:
+            try:
+                os.unlink(cleanup_path)
+            except OSError:
+                pass
+    if proc.returncode != 0 or not probe_out.strip():
+        return False
+    try:
+        prefix, major, minor, impl, plat = json.loads(probe_out.strip().splitlines()[-1])
+    except (ValueError, TypeError):
+        return False
+    if (major, minor) != (sys.version_info[0], sys.version_info[1]):
+        return False
+    # Version numbers alone are not ABI: a PyPy (or other-implementation)
+    # venv reporting the same major.minor would still crash on the
+    # CPython-built native wheels the gateway's pip provisions, and a
+    # cross-platform prefix (a copied venv) is equally foreign. Require the
+    # implementation and platform to match the gateway's own.
+    if impl != sys.implementation.name or plat != sys.platform:
+        return False
+    try:
+        # TypeError included: the probe output is app-controlled, so prefix
+        # can be JSON null (or any non-string) and Path(None) must read as
+        # "not usable", never escape into spawn/registration.
+        return Path(prefix).resolve() == (root / ".venv").resolve()
+    except (OSError, TypeError):
+        return False
+
+
 def resolve_app_python(root: Path | None) -> str:
     """Absolute interpreter for processes spawned on an app's behalf.
 
-    Prefers ``<root>/.venv``'s interpreter when it exists as a runnable,
-    non-empty executable (the app's own dependencies live there), else the
-    gateway's ``sys.executable`` — never a bare PATH-resolved name. The
-    runnability check matters: a venv interpreter that lost its execute bit or
-    was truncated to zero bytes (a partial copy, a restore that dropped
-    content) would turn a working ``sys.executable`` fallback into a
-    guaranteed spawn failure. ``root=None`` means "no app context" and
-    resolves straight to ``sys.executable``.
+    When the gateway has provisioned the app's dependencies
+    (:func:`app_deps_dir` exists), the answer is ``sys.executable``
+    unconditionally: those wheels were built by the gateway's interpreter and
+    reach the child via ``PYTHONPATH``, so the gateway's interpreter is the
+    only ABI-consistent choice.
+
+    Without an active provisioned tree, prefers
+    ``<root>/.venv``'s interpreter only when
+    :func:`_venv_is_usable` gives positive evidence it is a completed,
+    same-ABI environment (a probe, not a ``pyvenv.cfg`` heuristic - a failed
+    ``venv`` skeleton passes a version check but is not a usable env), else
+    ``sys.executable`` - never a bare PATH-resolved name. ``root=None`` means
+    "no app context" and resolves straight to ``sys.executable``.
     """
-    if root is not None:
-        venv_py = venv_python_path(root)
-        if _runnable(venv_py):
-            return str(venv_py)
+    if root is not None and not app_deps_active(root):
+        # No ACTIVE provisioned tree here (never provisioned, provisioning
+        # failed, or requirements.txt was removed). A POSITIVELY usable app
+        # venv is the best launch candidate in this state: a legacy app
+        # that manages its own environment holds its author-installed
+        # dependencies there, and when requirements ARE declared the
+        # alternative - the bare gateway interpreter - holds none of them
+        # either, so a failed provisioning must not also take a working
+        # venv away. Usability is the executed probe (interpreter runs,
+        # version + implementation + platform match the gateway), never a
+        # directory-exists heuristic: an empty venv skeleton that passes
+        # the probe is no worse a launch than the bare interpreter it
+        # displaces, and a provisioned tree, once ACTIVE again, reclaims
+        # the gateway interpreter on the next resolution.
+        if _venv_is_usable(root):
+            return str(venv_python_path(root))
     return sys.executable
 
 
-def venv_provided_command(root: Path, name: str) -> str | None:
-    """Absolute path of ``name`` if the app's venv provides it, else ``None``.
+def path_command_is_abi_matched(app_root: Path, name: str) -> bool:
+    """True when a path-carrying command positively matches the deps ABI.
 
-    Covers console scripts a venv install creates (``.venv/bin/<name>`` on
-    POSIX, ``.venv\\Scripts\\<name>.exe`` on Windows — the ``.exe`` suffix is
-    appended only when ``name`` does not already carry it). Only a runnable
-    venv-provided binary is a safe rewrite target: anything else a manifest
-    names bare (``node``, ``docker``) was a deliberate PATH dependency and must
-    be left alone, and a non-executable venv file (a data artifact, a partial
-    pip install) must not displace a command that would otherwise work.
+    Positive means: the path resolves to the gateway's own interpreter, or
+    to the app venv's python while that venv passes the interpreter version
+    probe (:func:`_venv_is_usable`). Any resolution failure reads as "no
+    match" - the server simply does not receive the deps PYTHONPATH.
+    """
+    try:
+        cand = Path(name)
+        if not cand.is_absolute():
+            # A relative path command resolves against the SESSION's cwd at
+            # spawn time, not against the app root this check runs under -
+            # a match proven here says nothing about the interpreter that
+            # will actually execute. Never a positive match.
+            return False
+        resolved = cand.resolve(strict=True)
+    except OSError:
+        return False
+    try:
+        if resolved == Path(sys.executable).resolve():
+            return True
+    except OSError:
+        return False
+    venv_bin = app_root / ".venv" / ("Scripts" if platform_compat.IS_WINDOWS else "bin")
+    if not venv_bin.is_dir():
+        return False
+    try:
+        # Validate WHERE the command lives BEFORE dereferencing it: a venv
+        # python is normally a SYMLINK to the base interpreter, so the
+        # fully-resolved parent is the base install's bin dir, never the
+        # venv's - comparing that made this arm unreachable for standard
+        # venvs and silently dropped their deps. Resolve the parent chain
+        # (that part must be inside .venv/bin) but keep the final component
+        # unresolved; whether the interpreter behind the link is actually
+        # version-matched is _venv_is_usable's probe to answer.
+        if cand.parent.resolve(strict=True) != venv_bin.resolve(strict=True):
+            return False
+    except OSError:
+        return False
+    # EXACT interpreter spelling, not a prefix: `.venv/bin/python-worker`
+    # is a console script, and injecting interpreter operands into it would
+    # kill the server. python / pythonX / pythonX.Y (+.exe) only.
+    if not re.fullmatch(r"python[\d.]*(\.exe)?", cand.name.lower()):
+        return False
+    return _venv_is_usable(app_root)
+
+
+def venv_provided_command(root: Path, name: str) -> str | None:
+    """Absolute path of ``name`` if the app's venv or deps dir provides it.
+
+    Covers console scripts a pip install creates: ``.venv/bin/<name>`` for an
+    app-owned venv (probed only when the venv passes the same minor-version
+    match as :func:`resolve_app_python`), and ``<deps dir>/bin/<name>`` for
+    the gateway's ``pip install --target`` provisioning (``Scripts\\`` on
+    Windows in both layouts; the ``.exe`` suffix is appended only when
+    ``name`` does not already carry it). Both are invisible to PATH - a venv
+    is never activated and a target dir has no activation at all. Only a
+    runnable provided binary is a safe rewrite target: anything else a
+    manifest names bare (``node``, ``docker``) was a deliberate PATH
+    dependency and must be left alone, and a non-executable file (a data
+    artifact, a partial pip install) must not displace a command that would
+    otherwise work.
 
     Callers must pass a bare NAME (no path separators, no drive qualifier) —
     the caller-side guard in ``resolve_stdio_command`` enforces that, keeping
-    the join below inside the venv directory.
+    the joins below inside the probed directories.
     """
     if platform_compat.IS_WINDOWS:
+        scripts = "Scripts"
         exe_name = name if name.lower().endswith(".exe") else f"{name}.exe"
-        candidate = root / ".venv" / "Scripts" / exe_name
     else:
-        candidate = root / ".venv" / "bin" / name
-    return str(candidate) if _runnable(candidate) else None
+        scripts = "bin"
+        exe_name = name
+    # Mirror resolve_app_python's precedence: once the gateway has
+    # provisioned the deps dir, its scripts (shebang: sys.executable) are the
+    # only ABI-consistent choice, and a venv script - whose shebang is the
+    # venv's own interpreter - is skipped unless the venv is positively usable
+    # (probed), because a same-ABI console script from a broken/foreign venv
+    # would still fail.
+    deps_present = app_deps_active(root)
+    bases: list[Path] = []
+    if not deps_present and _venv_is_usable(root):
+        bases.append(root / ".venv" / scripts)
+    # The venv layout is platform-split (bin vs Scripts), but pip's --target
+    # uses its "home" scheme, whose script dir is `bin` on EVERY platform -
+    # while some pip versions have shipped `Scripts` on Windows instead.
+    # Probe both under the deps dir: one extra stat buys correctness across
+    # pip versions, and a bare-name join stays inside the probed dirs.
+    # Gated on ACTIVE deps (declared AND present): data/ survives updates,
+    # so an update that removed requirements.txt must not have a stale tree
+    # keep resolving - and executing - removed dependency scripts. ALSO
+    # gated on the tree being CURRENT for this interpreter (same stamp gate
+    # as every deps-exposure arm in bridges): a stale tree cannot receive
+    # the deps PYTHONPATH/shim, so selecting its console script as the
+    # command guarantees an import crash - the bare name must instead fall
+    # through to PATH resolution or fail visibly, surfacing the
+    # provisioning error. Deferred import: backend imports this module at
+    # load, so the top-level spelling is circular.
+    if deps_present:
+        from kiro_crew.apps.backend import _deps_tree_stamp_current
+
+        if _deps_tree_stamp_current(root, root / "requirements.txt"):
+            bases.append(app_deps_dir(root) / "bin")
+            if platform_compat.IS_WINDOWS:
+                bases.append(app_deps_dir(root) / "Scripts")
+    for base in bases:
+        candidate = base / exe_name
+        if _runnable(candidate):
+            return str(candidate)
+    return None

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -9,6 +9,7 @@ registration (agents, skills, crons) to bridge functions.
 
 from __future__ import annotations
 
+import contextlib
 import ipaddress
 import json
 import logging
@@ -24,6 +25,7 @@ from pathlib import Path
 from typing import Any, Iterator
 from urllib.parse import urlparse
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.admission import app_admission_denied
 from kiro_crew.apps.discovery import discover_builtin_apps
 from kiro_crew.apps.execution import (
@@ -388,13 +390,49 @@ def _check_path_safety(path: str) -> bool:
 # Build-input / VCS directories never needed at runtime.  The app-kit runtime
 # layout is ``app.json`` + backend code + ``ui/dist/`` — ``node_modules`` is
 # npm build input and ``.git`` comes from cloned registry sources.
+# ``.kirocrew-deps`` (plus its transient staging/prior siblings) is the
+# gateway's own ``pip --target`` provisioning of the app's requirements.txt:
+# machine- and platform-specific, re-provisioned at the destination on first
+# spawn, and copying it would put a foreign wheel tree FIRST on the child's
+# PYTHONPATH, shadowing the correctly provisioned copy.
 # ``shutil.ignore_patterns`` matches by basename at every depth, so both
 # ``node_modules`` and ``ui/node_modules`` are dropped.  ``build`` is
 # deliberately NOT listed: the manifest may reference runtime paths anywhere
 # under the app root, and silently dropping a manifest-referenced directory
 # would record a successful install with missing files.  A ``build`` symlink
 # into a huge build tree is already neutralized by ``symlinks=True``.
-_COPY_IGNORE = ("node_modules", ".git", "__pycache__", ".venv")
+_COPY_IGNORE = (
+    "node_modules",
+    ".git",
+    "__pycache__",
+    ".venv",
+    ".kirocrew-deps",
+    ".kirocrew-deps-staging",
+    ".kirocrew-deps-prior",
+    ".kirocrew-deps.lock",
+)
+
+
+# The bare fixed name is reserved too (nothing generates it today, but it
+# is inside the gateway-owned namespace and a plantable look-alike), so the
+# per-transaction suffix is optional. An app-owned name with any OTHER
+# suffix shape (e.g. "-assets") does not match and is preserved data.
+_DEPS_STAGING_SWEEP_RE = re.compile(r"\.kirocrew-deps-staging(-\d+-[0-9a-f]{8})?")
+
+
+def _is_generated_deps_artifact_name(n: str) -> bool:
+    """True only for the EXACT names the gateway's provisioning generates.
+
+    The uninstall sweep deletes what matches; a loose ``.kirocrew-deps*``
+    prefix glob also swallowed app-owned entries that merely share the
+    prefix (e.g. a user's ``.kirocrew-deps-backup``) and permanently
+    deleted preserved data. Generated names are closed-form: the live tree,
+    the prior tree, the lock, and pid-nonce staging dirs.
+    """
+    return (
+        n in (".kirocrew-deps", ".kirocrew-deps-prior", ".kirocrew-deps.lock")
+        or _DEPS_STAGING_SWEEP_RE.fullmatch(n) is not None
+    )
 
 
 def _copy_app_tree(source: Path, dest: Path) -> None:
@@ -420,7 +458,17 @@ def _copy_app_tree(source: Path, dest: Path) -> None:
     _isjunction = getattr(os.path, "isjunction", None)
 
     def _ignore(dir_path: str, names: list[str]) -> set[str]:
-        skip = {n for n in names if n in _COPY_IGNORE}
+        # Staging dirs carry unique per-transaction suffixes
+        # (.kirocrew-deps-staging-<pid>-<nonce>), and an interrupted
+        # install's leftover must neither be copied on update nor survive -
+        # but the match is the STRICT generated pattern, never a bare
+        # prefix: an app-owned name that merely shares the prefix (e.g.
+        # ".kirocrew-deps-staging-assets") is the app's data and must copy.
+        skip = {
+            n
+            for n in names
+            if n in _COPY_IGNORE or _DEPS_STAGING_SWEEP_RE.fullmatch(n) is not None
+        }
         for n in names:
             if n in skip:
                 continue
@@ -939,6 +987,22 @@ def update_app(
 # ---------------------------------------------------------------------------
 
 
+def _remove_any_shape(path: Path) -> None:
+    """Delete ``path`` whatever it is: tree, file, or dangling link.
+
+    ``shutil.rmtree`` refuses non-directories, so a file-shaped dependency
+    artifact (an app writing a FILE named like a deps tree) would survive
+    every uninstall and poison the next quarantine rename. Links are
+    unlinked, never traversed. Missing is fine.
+    """
+    if platform_compat.is_link_or_junction(path):
+        platform_compat.unlink_link_or_junction(path)
+    elif path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
+
+
 def uninstall_app(name: str, *, keep_data: bool = True) -> AppResult:
     """Uninstall an app while preserving its ``data/`` directory by default.
 
@@ -998,21 +1062,239 @@ def uninstall_app(name: str, *, keep_data: bool = True) -> AppResult:
             error_code="trust_grant_not_removed",
         )
 
+    quarantined: list[tuple[Path, Path]] = []
+    _data_pin = None
+    _deps_lock: contextlib.ExitStack | None = None
     try:
         if keep_data:
             data = dest / "data"
             # Move data to temp, remove app dir, move data back
             tmp_data = dest.parent / f".{name}-data-tmp"
+            if platform_compat.is_link_or_junction(data):
+                # A LINKED data dir would make every operation below act on
+                # the link's TARGET - an app pointing data at another app's
+                # tree (or anywhere else) would have this uninstall rename
+                # and delete a foreign deps tree, and "preserve" the victim's
+                # data as its own. Refuse: the gateway creates data/ as a
+                # real directory, so a link here is never legitimate.
+                raise OSError(
+                    f"app {name!r} data directory is a symlink/junction; "
+                    f"refusing to operate through it"
+                )
             if data.is_dir():
+                # The check above is a TOCTOU window against a RUNNING
+                # backend (CLI uninstall does not stop it first): pin the
+                # directory for the whole quarantine transaction - the
+                # enumeration and every rename below go through the pin, so
+                # a data/ swapped for a link after validation cannot
+                # redirect them into another app's tree. Deferred import:
+                # backend imports this module at load, so the reverse import
+                # must not run at module level (same pattern as bridges).
+                from kiro_crew.apps.backend import _PinnedDir
+
+                _data_pin = _PinnedDir(data)
+            if data.is_dir():
+                # data/ preservation exists for USER data. The gateway's own
+                # generated dependency trees (data/.kirocrew-deps*) must NOT
+                # ride through an uninstall: a compromised app could plant
+                # code there (sitecustomize.py), and a later reinstall under
+                # the same name would prepend it to PYTHONPATH - revoked code
+                # executing in a fresh install. Updates still keep the trees
+                # (update never passes through here). QUARANTINE-RENAME, not
+                # delete: the trees are renamed out of data/ (cheap, same
+                # filesystem) so a later failure in THIS uninstall can put
+                # them back - deleting first would leave a failed uninstall
+                # (app still installed) stripped of its working dependencies.
+                # Deletion happens only after every destructive step
+                # committed. Links are unlinked directly (nothing to restore:
+                # the link's target is untouched); rmtree would refuse them.
+                assert _data_pin is not None  # bound by the pin block above
+                _data_pin.verify()  # enumeration reads through the path
+                # Serialize against ACTIVE provisioning: without the same
+                # per-app lock the provision transaction holds, a pip run
+                # racing this uninstall can create staging (or swap a tree
+                # live) AFTER the enumeration below - the tree then survives
+                # in preserved data and executes on a same-name reinstall.
+                # The lock file is opened through the pin (dir_fd), same as
+                # the provisioner's own open.
+                _lflags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+                if _data_pin.fd is not None:
+                    _lfd = os.open(".kirocrew-deps.lock", _lflags, 0o644, dir_fd=_data_pin.fd)
+                else:
+                    _lfd = os.open(str(data / ".kirocrew-deps.lock"), _lflags, 0o644)
+                _deps_lock = contextlib.ExitStack()
+                _lf = _deps_lock.enter_context(os.fdopen(_lfd, "r+"))
+                _deps_lock.enter_context(platform_compat.file_lock(_lf.fileno(), exclusive=True))
+                # NOT the lock file here: we HOLD it - on Windows renaming
+                # or deleting an open file fails with WinError 32, which
+                # took every uninstall down. It is handled after release.
+                _gen_names = [".kirocrew-deps", ".kirocrew-deps-prior"]
+                # Staging names are suffixed per transaction; purge every one
+                # that matches the STRICT generated pattern. A loose prefix
+                # glob here quarantined app-owned same-prefix entries into
+                # the doomed set, which the success path deletes at commit -
+                # permanent loss of preserved data (same defect the post-move
+                # sweep already guards against with the strict matcher).
+                _gen_names.extend(
+                    p.name
+                    for p in data.glob(".kirocrew-deps-staging*")
+                    if _DEPS_STAGING_SWEEP_RE.fullmatch(p.name) is not None
+                )
+                for gen in _gen_names:
+                    gen_path = data / gen
+                    if platform_compat.is_link_or_junction(gen_path):
+                        platform_compat.unlink_link_or_junction(gen_path)
+                    elif gen_path.exists():
+                        doomed = dest.parent / f".{name}-deps-doomed{gen}"
+                        # A stale crash leftover at the doomed name can be
+                        # ANY shape (a file-shaped artifact quarantined by a
+                        # prior run - rmtree refuses files, so a plain rmtree
+                        # here would leave it and the rename below would
+                        # fail forever after). Shape-aware, best-effort.
+                        try:
+                            _remove_any_shape(doomed)
+                        except OSError:
+                            pass
+                        # Pinned move OUT of data/: the source entry is
+                        # resolved against the held descriptor, so a swapped
+                        # data/ cannot make this quarantine a foreign tree.
+                        _data_pin.rename_out(gen, doomed)
+                        quarantined.append((doomed, gen_path))
+                _deps_lock.close()
+                # The lock ARTIFACT rides in preserved data only when it is
+                # a regular file (harmless: the next provisioning re-opens
+                # it O_CREAT). Any OTHER shape - a directory or link an app
+                # planted at the name - would poison the next transaction's
+                # lock open, so purge those now that nothing holds the name.
+                _lock_artifact = data / ".kirocrew-deps.lock"
+                try:
+                    if platform_compat.is_link_or_junction(_lock_artifact):
+                        platform_compat.unlink_link_or_junction(_lock_artifact)
+                    elif _lock_artifact.is_dir():
+                        _data_pin.verify()
+                        shutil.rmtree(str(_lock_artifact), ignore_errors=True)
+                except OSError:
+                    pass
+                _data_pin.verify()
                 shutil.move(str(data), str(tmp_data))
+                # POST-MOVE sweep: the lock cannot be held across the move
+                # (the open lock file lives INSIDE data/ and Windows refuses
+                # to move a tree holding an open file), so a fast concurrent
+                # provisioning could land a tree in the close-to-move
+                # window. The moved tree is PRIVATE now - provisioners
+                # target data/, which does not exist at this point - so purging here has
+                # no race to lose: any deps tree that slipped in dies before
+                # preservation.
+                for _late in list(tmp_data.glob(".kirocrew-deps*")):
+                    if not _is_generated_deps_artifact_name(_late.name):
+                        continue  # app-owned name sharing the prefix: not ours
+                    if _late.name == ".kirocrew-deps.lock" and _late.is_file():
+                        continue  # regular lock file is harmless
+                    try:
+                        if platform_compat.is_link_or_junction(_late):
+                            platform_compat.unlink_link_or_junction(_late)
+                        elif _late.is_dir():
+                            shutil.rmtree(str(_late))
+                        else:
+                            _late.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                # FAIL LOUD on survivors: a running app still holds open
+                # descriptors into the moved tree and can recreate or wedge
+                # entries after the sweep - letting one ride into preserved
+                # data hands a same-name reinstall revoked .pth code, the
+                # exact property this purge exists for. Aborting keeps the
+                # app installed and its trees restorable (the except arm
+                # below restores the quarantined ones).
+                _survivors = [
+                    p.name
+                    for p in tmp_data.glob(".kirocrew-deps*")
+                    if _is_generated_deps_artifact_name(p.name)
+                    and not (p.name == ".kirocrew-deps.lock" and p.is_file())
+                ]
+                if _survivors:
+                    raise OSError(
+                        f"app {name!r}: generated dependency artifacts resisted the "
+                        f"uninstall purge ({', '.join(sorted(_survivors)[:3])}); "
+                        f"refusing to preserve them into reinstallable data"
+                    )
+            if _data_pin is not None:
+                _data_pin.close()
             shutil.rmtree(dest)
             if tmp_data.is_dir():
                 dest.mkdir(parents=True, exist_ok=True)
                 shutil.move(str(tmp_data), str(data))
         else:
             shutil.rmtree(dest)
+        # Point of commit: every destructive step succeeded, the app is
+        # uninstalled - NOW the quarantined trees die. A tree that resists
+        # deletion here is logged, not fatal: under its doomed name it is
+        # unreachable by any reinstall or PYTHONPATH (the security property
+        # the purge exists for), unlike the silently-preserved live tree the
+        # fail-loud rule targets.
+        for doomed, _orig in quarantined:
+            try:
+                _remove_any_shape(doomed)
+            except OSError as exc:
+                logger.warning(
+                    "Could not delete quarantined deps tree %s after uninstalling %s: %s",
+                    doomed,
+                    name,
+                    exc,
+                )
+        quarantined = []
     except OSError as exc:
-        # The delete failed, so the app is STILL INSTALLED — but its grant was
+        if _deps_lock is not None:
+            try:
+                _deps_lock.close()
+            except OSError:
+                pass
+        if _data_pin is not None:
+            try:
+                _data_pin.close()
+            except OSError:
+                pass
+        # The delete failed, so the app is STILL INSTALLED. FIRST move the
+        # preserved data back home if the failure struck mid-move: a raise
+        # after ``data`` was renamed to its temp name would otherwise orphan
+        # the user's entire data directory under a hidden dot-name. Restoring
+        # it first also gives the quarantined-tree restore below its original
+        # parent back.
+        if keep_data:
+            try:
+                _tmp_restore = dest.parent / f".{name}-data-tmp"
+                _data_restore = dest / "data"
+                if _tmp_restore.is_dir() and not _data_restore.exists():
+                    dest.mkdir(parents=True, exist_ok=True)
+                    shutil.move(str(_tmp_restore), str(_data_restore))
+            except OSError as restore_exc:
+                logger.warning(
+                    "Could not restore preserved data for app %s after a "
+                    "failed uninstall: %s",
+                    name,
+                    restore_exc,
+                )
+        # ... then put the quarantined deps trees back (best-effort; if data
+        # could not be restored it may still sit at its temp name, in which
+        # case restore beside it there): a failed uninstall must not leave a
+        # working app stripped of its provisioned dependencies.
+        for doomed, orig in quarantined:
+            try:
+                target = orig
+                if not orig.parent.exists():
+                    alt = dest.parent / f".{name}-data-tmp" / orig.name
+                    if alt.parent.exists():
+                        target = alt
+                if doomed.exists() and not target.exists():
+                    doomed.rename(target)
+            except OSError as restore_exc:
+                logger.warning(
+                    "Could not restore quarantined deps tree %s for app %s: %s",
+                    doomed,
+                    name,
+                    restore_exc,
+                )
+        # ... and its grant was
         # withdrawn above, which would leave a trusted app silently stripped of the
         # permission the operator gave it, from an operation that did not even
         # succeed. Put it back.

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1281,6 +1281,12 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # hygiene so a response echoing a credential or exfiltration URL cannot
         # leak into the log ring / /api/logs stream; not an egress boundary.
         "task_planner.py",
+        # Gate-side log hygiene, same shape as update_provider: redacts pip's
+        # stderr tail (an app requirements.txt can name an index URL carrying
+        # credentials) before the provisioning failure is written to the
+        # gateway log and to the app backend's own log file. Defensive
+        # scrubbing at the point of capture, not an output boundary.
+        "apps/backend.py",
         # Capture-side, not egress: the per-session MCP report scrubs a server
         # name and a failing server's startup error as it RECORDS them, so a
         # credential never enters the accumulator at all. Deliberately earlier

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -3685,3 +3685,56 @@ class TestEnabledStateDistinguishesUnreadableFromDisabled:
         meta.write_text("{ not json", encoding="utf-8")
 
         assert bmod._app_enabled_state("probe") is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="shebang semantics are POSIX-only")
+class TestExecBackendShebangShim:
+    def _spawn_cmd(self, tmp_path, shebang_line: str):
+        """Build the exec-arm inputs and return the resolved cmd."""
+        import kiro_crew.apps.backend as bk
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        root = tmp_path / "app"
+        root.mkdir()
+        (root / "requirements.txt").write_bytes(b"requests\n")
+        d = app_deps_dir(root)
+        d.mkdir(parents=True)
+        (d / bk._DEPS_STAMP_NAME).write_text(bk._deps_digest(b"requests\n"))
+        (d / bk._DEPS_ABI_NAME).write_text(bk._deps_abi_tag())
+        script = root / "run"
+        script.write_text(f"{shebang_line}\nimport requests\n")
+        script.chmod(0o755)
+        return bk, root, script
+
+    def test_an_abi_matched_shebang_script_launches_through_deps_boot(
+        self, tmp_path
+    ):
+        import sys as _sys
+
+        bk, root, script = self._spawn_cmd(tmp_path, f"#!{_sys.executable}")
+        got = bk._abi_shebang_of(root, str(script))
+        assert got == _sys.executable
+
+    def test_an_argument_bearing_shebang_keeps_its_flags(self, tmp_path):
+        """#!<python> -I keeps its kernel launch: the shared reader answers
+        None for argument-bearing shebangs, so no rewrite happens - and the
+        flag REMAINS in what actually executes. Both halves are asserted:
+        not a candidate, and the on-disk launch still carries -I exactly as
+        written (the kernel, not a rewrite, interprets the shebang)."""
+        import sys as _sys
+
+        bk, root, script = self._spawn_cmd(tmp_path, f"#!{_sys.executable} -I")
+        assert bk._abi_shebang_of(root, str(script)) is None
+        first_line = script.read_bytes().split(b"\n", 1)[0]
+        assert first_line == f"#!{_sys.executable} -I".encode()
+        # And a no-candidate script is launched as-is: simulate the exec-arm
+        # decision the spawn makes with this answer.
+        cmd = [str(script), "--serve"]
+        si = bk._abi_shebang_of(root, cmd[0])
+        assert si is None
+        # the arm leaves cmd untouched when there is no shim candidate
+        assert cmd == [str(script), "--serve"]
+
+    def test_a_foreign_shebang_is_not_a_shim_candidate(self, tmp_path):
+        bk, root, script = self._spawn_cmd(tmp_path, "#!/opt/foreign/python3.11")
+        assert bk._abi_shebang_of(root, str(script)) is None

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import re
+import sys
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -187,9 +188,7 @@ class TestAgentRegistration:
         monkeypatch.setattr(bridges_mod, "_global_mcp_specs", lambda: {})
         src = _make_app_source(tmp_path)
         (src / "agents" / "my-agent.json").write_text(
-            json.dumps(
-                {"name": "my-agent", "model": "auto", "tools": ["fs_read", "@ghost/summon"]}
-            )
+            json.dumps({"name": "my-agent", "model": "auto", "tools": ["fs_read", "@ghost/summon"]})
         )
         install_app(src)
         manifest = AppManifest.from_json_file(
@@ -201,9 +200,7 @@ class TestAgentRegistration:
             registered = _register_agents("test-app", manifest, app_root)
 
         assert "test-app/my-agent" in registered  # still registers
-        warning = "\n".join(
-            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
-        )
+        warning = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "WARNING")
         assert "silently never mount" in warning
         assert "@ghost/summon" in warning
         assert "my-agent" in warning
@@ -223,9 +220,7 @@ class TestAgentRegistration:
         from kiro_crew.apps import bridges as bridges_mod
 
         monkeypatch.setattr(bridges_mod, "_global_mcp_specs", lambda: {"ambient-srv": {}})
-        src = _make_app_source(
-            tmp_path, mcpServers={"srv": {"command": "echo", "args": []}}
-        )
+        src = _make_app_source(tmp_path, mcpServers={"srv": {"command": "echo", "args": []}})
         (src / "agents" / "my-agent.json").write_text(
             json.dumps(
                 {
@@ -326,9 +321,7 @@ class TestAgentRegistration:
         assert link.read_text(encoding="utf-8") == good, "…with its old contents intact"
 
     @pytest.mark.parametrize("content", ["[1, 2, 3]", "42", "null", "true", '"a string"'])
-    def test_a_valid_json_non_object_agent_spec_is_skipped(
-        self, tmp_path, app_env, content
-    ):
+    def test_a_valid_json_non_object_agent_spec_is_skipped(self, tmp_path, app_env, content):
         """A spec that is valid JSON but not an object parses fine, so the
         JSONDecodeError guard never fires — but ``.get`` on the parsed value
         would raise AttributeError and take down the whole registration pass.
@@ -995,9 +988,9 @@ class TestMCPRegistration:
         registered = _register_mcp_servers("test-app", manifest)
         assert registered == ["test-app:my-mcp"]
 
-        written = json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"][
-            "test-app:my-mcp"
-        ]["env"]
+        written = json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"]["test-app:my-mcp"][
+            "env"
+        ]
         entries = written["PATH"].split(os.pathsep)
         assert entries[0] == shims, "manifest-authored entries stay first"
         assert usr_bin in entries, "inherited PATH must survive the override"
@@ -1272,7 +1265,11 @@ def _fake_venv_python(app_root: Path) -> Path:
 
     Non-empty and executable on purpose: the resolver rejects zero-byte files
     (the Microsoft-Store-stub / interrupted-copy shape) and files without the
-    execute bit.
+    execute bit. The resolver's usability PROBE (which would execute the
+    interpreter under the OS sandbox) is stubbed for this module by the
+    ``_stub_venv_probe`` autouse fixture - these tests pin the command-rewrite
+    plumbing, and the probe itself is pinned by
+    ``test_apps_backend_coverage.TestInterpreterResolution``.
     """
     if platform_compat.IS_WINDOWS:
         py = app_root / ".venv" / "Scripts" / "python.exe"
@@ -1282,6 +1279,25 @@ def _fake_venv_python(app_root: Path) -> Path:
     py.write_text("#!/bin/sh\n")
     py.chmod(0o755)
     return py
+
+
+@pytest.fixture(autouse=True)
+def _stub_venv_probe(monkeypatch):
+    """Replace the interpreter usability probe with its runnability check.
+
+    The real probe executes the candidate interpreter under the OS sandbox;
+    on hosts without a sandbox backend (Windows CI) it correctly reports "no
+    positive evidence" and the venv is never preferred - which would flip
+    every rewrite-plumbing expectation in this module per-platform. The
+    plumbing is what these tests pin; the probe has its own dedicated tests.
+    """
+    from kiro_crew.apps import interpreter as _interp
+
+    monkeypatch.setattr(
+        _interp,
+        "_venv_is_usable",
+        lambda root: _interp._runnable(_interp.venv_python_path(root)),
+    )
 
 
 class TestStdioInterpreterResolution:
@@ -1313,9 +1329,7 @@ class TestStdioInterpreterResolution:
         data = json.loads(mcp_path.read_text(encoding="utf-8"))
         return data["mcpServers"]["test-app:srv"]
 
-    def test_bare_python_resolves_to_the_app_venv_interpreter(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_bare_python_resolves_to_the_app_venv_interpreter(self, tmp_path, app_env, monkeypatch):
         import sys
 
         created: list[Path] = []
@@ -1384,15 +1398,14 @@ class TestStdioInterpreterResolution:
         )
         assert entry["command"] == "../data/evil"
 
-    def test_a_venv_provided_console_script_is_resolved(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_a_venv_provided_console_script_is_resolved(self, tmp_path, app_env, monkeypatch):
         # A console script pip installed into the app venv is invisible to PATH
         # (the venv is never activated) — resolving it is what makes such a
         # manifest work at all.
         created: list[Path] = []
 
         def make_script(app_root: Path) -> None:
+            _fake_venv_python(app_root)
             if platform_compat.IS_WINDOWS:
                 script = app_root / ".venv" / "Scripts" / "my-mcp-server.exe"
             else:
@@ -1408,12 +1421,8 @@ class TestStdioInterpreterResolution:
         )
         assert entry["command"] == str(created[0])
 
-    @pytest.mark.skipif(
-        platform_compat.IS_WINDOWS, reason="Windows has no execute bit to drop"
-    )
-    def test_a_non_executable_venv_interpreter_is_not_used(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="Windows has no execute bit to drop")
+    def test_a_non_executable_venv_interpreter_is_not_used(self, tmp_path, app_env, monkeypatch):
         # A venv python that lost its execute bit (truncated copy, permissions
         # dropped in transit) must not displace the always-runnable
         # sys.executable fallback — rewriting to it guarantees EACCES at spawn.
@@ -1429,9 +1438,7 @@ class TestStdioInterpreterResolution:
         )
         assert entry["command"] == sys.executable
 
-    @pytest.mark.skipif(
-        platform_compat.IS_WINDOWS, reason="Windows has no execute bit to drop"
-    )
+    @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="Windows has no execute bit to drop")
     def test_a_non_executable_venv_file_never_displaces_a_path_command(
         self, tmp_path, app_env, monkeypatch
     ):
@@ -1460,7 +1467,9 @@ class TestStdioInterpreterResolution:
         import sys
 
         entry = self._register_stdio(
-            tmp_path, app_env, monkeypatch,
+            tmp_path,
+            app_env,
+            monkeypatch,
             {"command": "python3", "args": ["-s", "-m", "kiro_crew.apps.builtins.x.server"]},
             setup=_fake_venv_python,
         )
@@ -1484,9 +1493,7 @@ class TestStdioInterpreterResolution:
         not platform_compat.IS_WINDOWS,
         reason="drive-qualified names are a Windows path form",
     )
-    def test_a_drive_qualified_command_is_never_rewritten(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_a_drive_qualified_command_is_never_rewritten(self, tmp_path, app_env, monkeypatch):
         # `D:foo` carries no separator but names a different drive; joining it
         # under `.venv\Scripts` would DISCARD the venv anchor (pathlib treats
         # the right operand as a new anchor), so the guard must reject it.
@@ -1496,9 +1503,7 @@ class TestStdioInterpreterResolution:
         )
         assert entry["command"] == "D:foo"
 
-    def test_a_zero_byte_venv_interpreter_is_not_used(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_a_zero_byte_venv_interpreter_is_not_used(self, tmp_path, app_env, monkeypatch):
         # The interrupted-copy / Store-stub shape: a zero-byte python.exe
         # passes the Windows extension check (there is no execute bit), so the
         # resolver must reject empty files on every platform.
@@ -1541,25 +1546,22 @@ class TestStdioInterpreterResolution:
         )
         assert entry["command"] == sys.executable
 
-    def test_separate_value_options_do_not_break_the_pin_scan(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_separate_value_options_do_not_break_the_pin_scan(self, tmp_path, app_env, monkeypatch):
         # -X / -W / --check-hash-based-pycs consume the NEXT token as a value;
         # the scanner must skip that value instead of reading it as the script
         # operand and missing the -m that follows.
         import sys
 
         entry = self._register_stdio(
-            tmp_path, app_env, monkeypatch,
-            {"command": "python3",
-             "args": ["-X", "dev", "-W", "ignore", "-m", "kiro_crew.apps.x"]},
+            tmp_path,
+            app_env,
+            monkeypatch,
+            {"command": "python3", "args": ["-X", "dev", "-W", "ignore", "-m", "kiro_crew.apps.x"]},
             setup=_fake_venv_python,
         )
         assert entry["command"] == sys.executable
 
-    def test_an_attached_module_spelling_triggers_the_pin(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_an_attached_module_spelling_triggers_the_pin(self, tmp_path, app_env, monkeypatch):
         # CPython accepts -mMODULE in one token.
         import sys
 
@@ -1570,9 +1572,7 @@ class TestStdioInterpreterResolution:
         )
         assert entry["command"] == sys.executable
 
-    def test_a_dash_c_program_never_triggers_the_pin(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_a_dash_c_program_never_triggers_the_pin(self, tmp_path, app_env, monkeypatch):
         # -c consumes the rest as an inline program; an -m after it belongs to
         # that program's argv, not to CPython. The attached spelling
         # (-cPROGRAM) followed directly by dash tokens is the case where only
@@ -1671,9 +1671,7 @@ class TestStdioInterpreterResolution:
                 {"command": missing, "args": []},
             )
         assert entry["command"] == missing
-        warning = "\n".join(
-            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
-        )
+        warning = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "WARNING")
         assert "test-app" in warning
         assert "srv" in warning
         # The message renders the command with %r, so Windows backslashes appear
@@ -1737,9 +1735,7 @@ class TestStdioInterpreterResolution:
             )
         assert "resolves to no existing executable" not in caplog.text
 
-    def test_one_bad_server_does_not_block_its_siblings(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_one_bad_server_does_not_block_its_siblings(self, tmp_path, app_env, monkeypatch):
         import kiro_crew.apps.bridges as bmod
 
         mcp_path = tmp_path / "mcp.json"
@@ -1802,11 +1798,7 @@ class TestBackendSharesTheInterpreterPolicy:
 
         def historical(root: Path) -> str:
             venv_python = str(root / ".venv" / "bin" / "python3")
-            return (
-                venv_python
-                if (root / ".venv" / "bin" / "python3").is_file()
-                else sys.executable
-            )
+            return venv_python if (root / ".venv" / "bin" / "python3").is_file() else sys.executable
 
         with_venv = tmp_path / "with-venv"
         _fake_venv_python(with_venv)
@@ -1830,6 +1822,701 @@ class TestBackendSharesTheInterpreterPolicy:
         assert '".venv" / "bin" / "python3").is_file()' not in source, (
             "backend.py grew back an inline copy of the interpreter policy"
         )
+
+
+class TestAbiMatchedShebangPathScript:
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="shebang launch semantics are POSIX-only",
+    )
+    def test_a_path_script_with_gateway_shebang_shims_through_deps_boot(
+        self, tmp_path
+    ):
+        """An absolute-path launcher whose shebang names an ABI-matched
+        interpreter is a python launch: it must reach its provisioned deps
+        (via the shim, so .pth files work) instead of dying on import."""
+        import sys as _sys
+
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        launcher = tmp_path / "bin" / "server"
+        launcher.parent.mkdir()
+        launcher.write_text(f"#!{_sys.executable}\nimport requests\n")
+        launcher.chmod(0o755)
+        cfg = resolve_stdio_command(
+            {"command": str(launcher), "args": ["--flag"]}, app_root=tmp_path
+        )
+        assert cfg["command"] == _sys.executable, cfg
+        assert cfg["args"][0].endswith("deps_boot.py"), cfg
+        assert cfg["args"][1] == str(app_deps_dir(tmp_path)), cfg
+        assert cfg["args"][2] == str(launcher), cfg
+        assert cfg["args"][3] == "--flag", cfg
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="shebang launch semantics are POSIX-only",
+    )
+    def test_a_path_script_with_foreign_shebang_stays_direct(self, tmp_path):
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        launcher = tmp_path / "bin" / "server"
+        launcher.parent.mkdir()
+        launcher.write_text("#!/opt/foreign/python3.11\nimport requests\n")
+        launcher.chmod(0o755)
+        cfg = resolve_stdio_command({"command": str(launcher)}, app_root=tmp_path)
+        assert cfg["command"] == str(launcher), cfg
+        assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+
+
+class TestStaleTreeScriptSelection:
+    def test_a_stale_abi_tree_console_script_is_not_selected(self, tmp_path):
+        """Command SELECTION is stamp-gated like every deps-exposure arm: a
+        stale tree cannot receive the deps PYTHONPATH/shim, so pointing the
+        command at its console script guarantees an import crash. The bare
+        name falls through instead and the provisioning error surfaces."""
+        import sys as _sys
+
+        from kiro_crew.apps.interpreter import app_deps_dir, venv_provided_command
+
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        deps_bin = app_deps_dir(tmp_path) / ("Scripts" if _sys.platform == "win32" else "bin")
+        deps_bin.mkdir(parents=True)
+        script = deps_bin / ("tool.exe" if _sys.platform == "win32" else "tool")
+        script.write_bytes(b"#!/usr/bin/python3\nimport dep\n")
+        script.chmod(0o755)
+        # NO stamp / foreign stamp: the tree is not current.
+        assert venv_provided_command(tmp_path, script.name) is None
+        # With a current stamp the same script IS selected.
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        assert venv_provided_command(tmp_path, script.name) == str(script)
+
+
+class TestShebangReaderGates:
+    def test_a_sensitive_command_path_is_never_opened(self, tmp_path, monkeypatch):
+        """The shebang sniff runs on a manifest-author-controlled absolute
+        path: a protected location must be refused by the sensitive-path
+        gate BEFORE any read, not read-and-discarded."""
+        import kiro_crew.apps.bridges as brmod
+
+        opened: list[str] = []
+        real_open = open
+
+        def tracking_open(path, *a, **kw):
+            opened.append(str(path))
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr(brmod, "is_sensitive_path", lambda p: True)
+        monkeypatch.setattr("builtins.open", tracking_open)
+        assert brmod._python_shebang_interpreter("/etc/whatever") is None
+        assert brmod._has_python_shebang("/etc/whatever") is False
+        assert brmod._zip_has_main("/etc/whatever") is False
+        assert opened == [], "gated readers must refuse before opening"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="shebang semantics are POSIX-only"
+    )
+    def test_an_argument_bearing_shebang_is_never_a_rewrite_candidate(
+        self, tmp_path
+    ):
+        """A ``#!<python> -I`` script asks for an isolation posture the
+        rewrite cannot carry faithfully (the kernel passes shebang
+        arguments as one token): the command stays on the direct launch,
+        where the kernel honors every flag exactly as written."""
+        import sys as _sys
+
+        from kiro_crew.apps.bridges import (
+            _python_shebang_interpreter,
+            resolve_stdio_command,
+        )
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        launcher = tmp_path / "bin" / "server"
+        launcher.parent.mkdir()
+        launcher.write_text(f"#!{_sys.executable} -I\nimport sys\n")
+        launcher.chmod(0o755)
+        assert _python_shebang_interpreter(str(launcher)) is None
+        cfg = resolve_stdio_command({"command": str(launcher)}, app_root=tmp_path)
+        assert cfg["command"] == str(launcher), cfg
+        assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+
+
+class TestSkipFirstLineFlagUnshimmable:
+    def test_dash_x_falls_back_to_the_pythonpath_transport(self, tmp_path):
+        """-x skips the launched script's FIRST LINE; shimming would make
+        deps_boot that script and the interpreter dies with SyntaxError on
+        its severed docstring. Unshimmable: direct launch + PYTHONPATH."""
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        (tmp_path / "server.py").write_text("#!custom\nimport sys\n")
+        cfg = resolve_stdio_command(
+            {"command": "python3", "args": ["-x", "server.py"]}, app_root=tmp_path
+        )
+        assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+        assert cfg["args"] == ["-x", "server.py"]
+        # the transport still serves the deps
+        assert str(app_deps_dir(tmp_path)) in (cfg.get("env") or {}).get(
+            "PYTHONPATH", ""
+        ), cfg
+
+
+def _plant_deps_stamp(app_root, req_bytes: bytes) -> None:
+    """Write the CURRENT interpreter's stamp for req_bytes: activation now
+    requires it (a stampless or stale-ABI tree must not inject), so any
+    fixture that expects the deps dir to reach the server plants it."""
+    import kiro_crew.apps.backend as _bk
+    from kiro_crew.apps.interpreter import app_deps_dir as _add
+
+    d = _add(app_root)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / _bk._DEPS_STAMP_NAME).write_text(_bk._deps_digest(req_bytes))
+
+
+class TestStdioDepsDirExposure:
+    """The provisioned deps dir (pip --target) must reach stdio MCP servers the
+    same way it reaches the backend spawn: via PYTHONPATH. A --target install
+    carries no interpreter, so the env is the only bridge - without it a
+    python-launcher server or a deps-provided console script dies on import."""
+
+    def test_the_deps_dir_is_prepended_to_a_stdio_server_pythonpath(self, tmp_path):
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        import sys as _sys
+
+        # an ABI-matched PATH python (here: the gateway interpreter by path)
+        # is a python launch: it routes through the shim so .pth hooks are
+        # processed, the command itself is never rewritten, and the deps
+        # entry is stripped from PYTHONPATH (shim XOR PYTHONPATH) while the
+        # manifest's own entry passes through
+        cfg = resolve_stdio_command(
+            {
+                "command": _sys.executable,
+                "args": ["server.py"],
+                "env": {"PYTHONPATH": "/manifest/own"},
+            },
+            app_root=tmp_path,
+        )
+        assert cfg["command"] == _sys.executable, cfg
+        # PATH spelling, not -m: an ABI-matched path python can be the
+        # app's own venv interpreter, which cannot import kiro_crew
+        assert cfg["args"][0].endswith("deps_boot.py"), cfg
+        assert cfg["args"][1] == str(app_deps_dir(tmp_path)), cfg
+        assert cfg["args"][2] == "server.py", cfg
+        parts = cfg["env"]["PYTHONPATH"].split(os.pathsep)
+        assert str(app_deps_dir(tmp_path)) not in parts, cfg
+        assert "/manifest/own" in parts, cfg
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="shebang launch semantics are POSIX-only; Windows uses the launcher pair",
+    )
+    def test_a_deps_console_script_routes_through_the_shim(self, tmp_path):
+        """A deps-dir console script is a pip-generated Python script; run
+        direct, its editable/.pth-dependent imports die (PYTHONPATH never
+        processes .pth). It launches through deps_boot on the gateway
+        interpreter - the same one its shebang names - and the deps
+        PYTHONPATH entry is stripped (shim XOR PYTHONPATH)."""
+        import sys as _sys
+
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        deps_bin = app_deps_dir(tmp_path) / "bin"
+        deps_bin.mkdir(parents=True)
+        script = deps_bin / "mytool"
+        script.write_bytes(b"#!" + _sys.executable.encode() + b"\nimport mypkg\n")
+        script.chmod(0o755)
+        (tmp_path / "requirements.txt").write_bytes(b"-e ./lib\n")
+        _plant_deps_stamp(tmp_path, b"-e ./lib\n")
+        cfg = resolve_stdio_command(
+            {"command": "mytool", "args": ["--serve"]}, app_root=tmp_path
+        )
+        assert cfg["command"] == _sys.executable, cfg
+        assert cfg["args"][0].endswith("deps_boot.py"), cfg
+        assert cfg["args"][1:] == [
+            str(app_deps_dir(tmp_path)),
+            str(script),
+            "--serve",
+        ], cfg
+        pp = (cfg.get("env") or {}).get("PYTHONPATH", "")
+        assert str(app_deps_dir(tmp_path)) not in pp.split(os.pathsep), cfg
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="shebang launch semantics are POSIX-only; Windows uses the launcher pair",
+    )
+    def test_a_pip_shell_trampoline_script_is_recognized_as_python(self, tmp_path):
+        """pip emits a /bin/sh trampoline when the interpreter path is long
+        or space-bearing; the script is still python and must route through
+        the shim, or its .pth-dependent imports silently die."""
+        import sys as _sys
+
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        deps_bin = app_deps_dir(tmp_path) / "bin"
+        deps_bin.mkdir(parents=True)
+        script = deps_bin / "tramptool"
+        q3 = b"\x27\x27\x27"  # three single quotes
+        script.write_bytes(
+            b"#!/bin/sh\n"
+            + q3
+            + b"exec\x27 "
+            + _sys.executable.encode()
+            + b' "$0" "$@"\n'
+            + b"\x27 "
+            + q3
+            + b"\nimport mypkg\n"
+        )
+        script.chmod(0o755)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        cfg = resolve_stdio_command({"command": "tramptool"}, app_root=tmp_path)
+        assert cfg["command"] == _sys.executable, cfg
+        assert cfg["args"][0].endswith("deps_boot.py"), cfg
+        assert cfg["args"][1] == str(app_deps_dir(tmp_path)), cfg
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="shebang launch semantics are POSIX-only; Windows uses the launcher pair",
+    )
+    def test_a_shell_wrapper_mentioning_python_is_not_a_trampoline(self, tmp_path):
+        """Only pip's exact polyglot structure (second line: triple-quoted
+        exec re-launch) reads as a trampoline. An ordinary dependency shell
+        wrapper that merely RUNS a python command must stay a shell script
+        - runpy would parse it as python source and crash the server."""
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        deps_bin = app_deps_dir(tmp_path) / "bin"
+        deps_bin.mkdir(parents=True)
+        script = deps_bin / "wraptool"
+        script.write_bytes(
+            b"#!/bin/sh\n"
+            b"set -e\n"
+            b"exec python3 -m something --flag \"$@\"\n"
+        )
+        script.chmod(0o755)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        cfg = resolve_stdio_command({"command": "wraptool"}, app_root=tmp_path)
+        assert cfg["command"] == str(script), cfg
+        assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+
+    def test_a_windows_launcher_pair_shims_via_the_companion_script(self, tmp_path):
+        """pip's classic Windows launcher is a native .exe (no shebang) with
+        a `<name>-script.py` companion holding the python entry - the
+        companion shims through deps_boot. An embedded-script .exe with no
+        companion stays a direct launch."""
+        import sys as _sys
+
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        deps_bin = app_deps_dir(tmp_path) / ("Scripts" if _sys.platform == "win32" else "bin")
+        deps_bin.mkdir(parents=True)
+        exe = deps_bin / "wintool.exe"
+        exe.write_bytes(b"MZnative")
+        exe.chmod(0o755)
+        companion = deps_bin / "wintool-script.py"
+        companion.write_bytes(b"import mypkg\n")
+        (tmp_path / "requirements.txt").write_bytes(b"-e ./lib\n")
+        _plant_deps_stamp(tmp_path, b"-e ./lib\n")
+        cfg = resolve_stdio_command({"command": "wintool.exe"}, app_root=tmp_path)
+        if cfg["command"] == _sys.executable:
+            # resolver found the exe (Windows probe layout): companion shims
+            assert cfg["args"][0].endswith("deps_boot.py"), cfg
+            assert cfg["args"][1] == str(app_deps_dir(tmp_path)), cfg
+            assert cfg["args"][2] == str(companion), cfg
+        else:
+            # POSIX probe does not resolve .exe names from deps bin - the
+            # command passes through untouched (nothing to shim here)
+            assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+
+    def test_a_zip_bearing_exe_without_main_stub_stays_direct(self, tmp_path):
+        """zipfile.is_zipfile answers True for any exe with an appended
+        archive (self-extractors, installers). Only a __main__.py stub makes
+        it a launcher deps_boot can dispatch - anything else must launch
+        directly instead of crashing in the archive read."""
+        import io
+        import sys as _sys
+        import zipfile as _zipfile
+
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        deps_bin = app_deps_dir(tmp_path) / ("Scripts" if _sys.platform == "win32" else "bin")
+        deps_bin.mkdir(parents=True)
+        buf = io.BytesIO()
+        with _zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("payload.dat", "not a launcher")
+        exe = deps_bin / ("selfextract.exe" if _sys.platform == "win32" else "selfextract")
+        exe.write_bytes(b"MZnative" + buf.getvalue())
+        exe.chmod(0o755)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        cfg = resolve_stdio_command(
+            {"command": exe.name}, app_root=tmp_path
+        )
+        assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="shebang launch semantics are POSIX-only; Windows uses the launcher pair",
+    )
+    def test_a_non_python_deps_script_stays_direct(self, tmp_path):
+        """A package can ship arbitrary bin artifacts; runpy on a shell
+        script would break a working launch. Only a python-shebang
+        script is shimmed - everything else executes directly and keeps the
+        PYTHONPATH transport."""
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        deps_bin = app_deps_dir(tmp_path) / "bin"
+        deps_bin.mkdir(parents=True)
+        script = deps_bin / "shtool"
+        script.write_bytes(b"#!/bin/sh\necho hi\n")
+        script.chmod(0o755)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        cfg = resolve_stdio_command({"command": "shtool"}, app_root=tmp_path)
+        assert cfg["command"] == str(script), cfg
+        assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+        pp = cfg["env"]["PYTHONPATH"].split(os.pathsep)
+        assert pp[0] == str(app_deps_dir(tmp_path)), cfg
+
+    def test_a_backendless_app_provisions_deps_at_registration(self, tmp_path, monkeypatch):
+        """An app can ship only stdio MCP servers: with no backend start,
+        nothing else ever runs pip, and the shim/PYTHONPATH transports would
+        reference a forever-empty deps tree. Registration provisions - and
+        only for backend-less apps: with an entry point the backend spawn
+        owns provisioning (module-style builtins must never reach it)."""
+        from types import SimpleNamespace as NS
+
+        import kiro_crew.apps.backend as bkmod
+        import kiro_crew.apps.bridges as brmod
+
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        monkeypatch.setattr(brmod, "app_dir", lambda name: tmp_path)
+        calls: list = []
+        monkeypatch.setattr(
+            bkmod, "provision_app_deps", lambda name, root: calls.append((name, root)) or ""
+        )
+        stdio_manifest = NS(
+            mcpServers={"srv": {"command": "python3", "args": ["s.py"]}},
+            backend=NS(entryPoint=""),
+        )
+        brmod._maybe_provision_backendless_deps("app", stdio_manifest)
+        assert calls == [("app", tmp_path)]
+
+        # A DANGLING requirements.txt must reach the provisioner (whose
+        # failure epilogue surfaces it) - is_file() would skip it silently.
+        import sys as _sys
+
+        if _sys.platform != "win32":
+            calls.clear()
+            (tmp_path / "requirements.txt").unlink()
+            os.symlink(str(tmp_path / "missing.txt"), str(tmp_path / "requirements.txt"))
+            brmod._maybe_provision_backendless_deps("app", stdio_manifest)
+            assert calls == [("app", tmp_path)], "dangling link must reach the provisioner"
+            (tmp_path / "requirements.txt").unlink()
+            # True ABSENCE skips: no lock files for apps without deps.
+            calls.clear()
+            brmod._maybe_provision_backendless_deps("app", stdio_manifest)
+            assert calls == []
+            (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+
+        calls.clear()
+        # a FILE entry point provisions too: a healthy fixed-port backend is
+        # ADOPTED, never spawned, so spawn-path provisioning never ran
+        brmod._maybe_provision_backendless_deps(
+            "app", NS(mcpServers={"srv": {"command": "x"}}, backend=NS(entryPoint="server.py"))
+        )
+        assert calls == [("app", tmp_path)]
+
+        calls.clear()
+        # a MODULE-style entry point is trusted package code: never
+        # provision app-dir requirements for it (backend trust gate)
+        brmod._maybe_provision_backendless_deps(
+            "app",
+            NS(
+                mcpServers={"srv": {"command": "x"}},
+                backend=NS(entryPoint="kiro_crew.apps.builtins.demo"),
+            ),
+        )
+        # url-only servers never import from the deps dir
+        brmod._maybe_provision_backendless_deps(
+            "app", NS(mcpServers={"srv": {"url": "http://127.0.0.1:9/mcp"}}, backend=NS(entryPoint=""))
+        )
+        # a shipped BUILTIN is trusted package code: an agent-planted
+        # requirements.txt in its writable app dir must never have pip
+        # execute build hooks under the gateway (provenance gate)
+        monkeypatch.setattr(brmod, "shipped_builtin_app_root", lambda name: tmp_path)
+        brmod._maybe_provision_backendless_deps("app", stdio_manifest)
+        assert calls == []
+
+    def test_no_deps_dir_leaves_the_manifest_env_untouched(self, tmp_path):
+        from kiro_crew.apps.bridges import resolve_stdio_command
+
+        cfg = resolve_stdio_command(
+            {"command": "python3", "args": ["server.py"]}, app_root=tmp_path
+        )
+        assert "env" not in cfg, cfg
+
+    def test_a_python_launcher_with_deps_routes_through_the_shim(self, tmp_path):
+        """PYTHONPATH never processes .pth files, so a python-launcher stdio
+        server with provisioned deps launches via deps_boot (addsitedir).
+        An interpreter OPTION first-token is left unshimmed (it would be
+        misread as the target) and falls back to the PYTHONPATH transport."""
+        import sys as _sys
+
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        cfg = resolve_stdio_command(
+            {"command": "python3", "args": ["server.py"]}, app_root=tmp_path
+        )
+        assert cfg["command"] == _sys.executable
+        assert cfg["args"][0].endswith("deps_boot.py"), cfg
+        assert cfg["args"][1] == str(app_deps_dir(tmp_path)), cfg
+        assert cfg["args"][2] == "server.py", cfg
+        # interpreter options are WALKED: -u stays consumed by the
+        # interpreter, the shim triple lands at the target token
+        cfg2 = resolve_stdio_command(
+            {"command": "python3", "args": ["-u", "server.py"]}, app_root=tmp_path
+        )
+        assert cfg2["args"][0] == "-u", cfg2
+        assert cfg2["args"][1].endswith("deps_boot.py"), cfg2
+        assert cfg2["args"][2] == str(app_deps_dir(tmp_path)), cfg2
+        assert cfg2["args"][3] == "server.py", cfg2
+        # -c launches shim too (deps_boot has a -c arm): raw PYTHONPATH
+        # would skip .pth hooks and an editable import would die
+        cfg3 = resolve_stdio_command(
+            {"command": "python3", "args": ["-c", "import server"]}, app_root=tmp_path
+        )
+        assert cfg3["args"][0].endswith("deps_boot.py"), cfg3
+        assert cfg3["args"][1:] == [
+            str(app_deps_dir(tmp_path)),
+            "-c",
+            "import server",
+        ], cfg3
+        pp3 = (cfg3.get("env") or {}).get("PYTHONPATH", "")
+        assert str(app_deps_dir(tmp_path)) not in pp3.split(os.pathsep), cfg3
+        # `python -- server.py` is `python server.py`: the separator is
+        # normalized away and the script shims; an operand that needs the
+        # dash-guard stays unshimmable
+        cfg_dd = resolve_stdio_command(
+            {"command": "python3", "args": ["--", "server.py"]}, app_root=tmp_path
+        )
+        assert cfg_dd["args"][0].endswith("deps_boot.py"), cfg_dd
+        assert cfg_dd["args"][1:] == [
+            str(app_deps_dir(tmp_path)),
+            "server.py",
+        ], cfg_dd
+        cfg_dd2 = resolve_stdio_command(
+            {"command": "python3", "args": ["--", "-weird.py"]}, app_root=tmp_path
+        )
+        assert "deps_boot" not in " ".join(cfg_dd2["args"]), cfg_dd2
+        # attached -cCODE is normalized like -mMODULE
+        cfg3b = resolve_stdio_command(
+            {"command": "python3", "args": ["-cimport server"]}, app_root=tmp_path
+        )
+        assert cfg3b["args"][2:] == ["-c", "import server"], cfg3b
+        # -S skips site initialization, so the shim itself could never
+        # import (kiro_crew lives in site-packages) - unshimmable, keep the
+        # PYTHONPATH transport; same for -E/-I and combined spellings
+        # an attached -W VALUE is not a flag cluster: the uppercase letters
+        # inside ignore::ImportWarning must not read as -S/-E/-I
+        cfg6 = resolve_stdio_command(
+            {"command": "python3", "args": ["-Wignore::ImportWarning", "server.py"]},
+            app_root=tmp_path,
+        )
+        assert cfg6["args"][1].endswith("deps_boot.py"), cfg6
+        assert cfg6["args"][2] == str(app_deps_dir(tmp_path)), cfg6
+        # -S/-E/-I make BOTH the -m spelling and PYTHONPATH inert, so those
+        # forms shim via the stdlib-only deps_boot launched BY ABSOLUTE PATH
+        for flags in (["-S"], ["-E"], ["-I"], ["-s"], ["-uS"], ["-us"]):
+            cfg5 = resolve_stdio_command(
+                {"command": "python3", "args": [*flags, "server.py"]}, app_root=tmp_path
+            )
+            assert cfg5["args"][: len(flags)] == flags, cfg5
+            assert cfg5["args"][len(flags)].endswith("deps_boot.py"), cfg5
+            assert cfg5["args"][len(flags) + 1] == str(app_deps_dir(tmp_path)), cfg5
+            assert cfg5["args"][len(flags) + 2] == "server.py", cfg5
+            pp5 = (cfg5.get("env") or {}).get("PYTHONPATH", "")
+            assert str(app_deps_dir(tmp_path)) not in pp5.split(os.pathsep), cfg5
+        # attached -mMODULE is CPython-equivalent to the separate form and is
+        # normalized so it still gets .pth processing through the shim
+        cfg4 = resolve_stdio_command(
+            {"command": "python3", "args": ["-mserver"]}, app_root=tmp_path
+        )
+        assert cfg4["args"][0].endswith("deps_boot.py"), cfg4
+        assert cfg4["args"][1:] == [
+            str(app_deps_dir(tmp_path)),
+            "-m",
+            "server",
+        ], cfg4
+
+    def test_a_stale_deps_tree_without_requirements_is_ignored(self, tmp_path):
+        """data/ survives updates, so an update that REMOVES requirements.txt
+        leaves the provisioned tree behind - a stale tree must neither
+        inject removed dependency code nor route through the shim."""
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)  # tree present, no requirements.txt
+        cfg = resolve_stdio_command(
+            {"command": "python3", "args": ["server.py"]}, app_root=tmp_path
+        )
+        assert "env" not in cfg, cfg
+        assert "deps_boot" not in " ".join(cfg.get("args") or []), cfg
+
+    def test_expected_provisioning_emits_the_deps_path_before_the_dir_exists(self, tmp_path):
+        """First enable registers the MCP config BEFORE the backend spawn
+        provisions the deps dir, and no reconciliation pass is guaranteed to
+        rewrite it. A requirements.txt makes provisioning expected, so the
+        deps path is emitted up front - a missing PYTHONPATH entry is inert
+        to Python, while omitting it strands the first registration without
+        its dependencies."""
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        cfg = resolve_stdio_command(
+            {"command": "python3", "args": ["server.py"]}, app_root=tmp_path
+        )
+        # the shim triple carries the deps path; addsitedir on the
+        # not-yet-existing dir is inert until provisioning fills it
+        assert cfg["args"][0].endswith("deps_boot.py"), cfg
+        assert cfg["args"][1] == str(app_deps_dir(tmp_path)), cfg
+
+    def test_a_symlinked_venv_python_is_abi_matched(self, tmp_path, monkeypatch):
+        """A venv python is normally a SYMLINK to the base interpreter;
+        the location check must validate the unresolved parent (.venv/bin)
+        and leave the interpreter question to the _venv_is_usable probe -
+        dereferencing first made standard venvs silently lose their deps."""
+        import os as _os
+        import sys as _sys
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        import kiro_crew.apps.interpreter as imod
+
+        venv_bin = tmp_path / ".venv" / ("Scripts" if _sys.platform == "win32" else "bin")
+        venv_bin.mkdir(parents=True)
+        link = venv_bin / "python3"
+        try:
+            _os.symlink(_sys.executable, link)
+        except OSError:
+            pytest.skip("symlink not permitted")
+        monkeypatch.setattr(imod, "_venv_is_usable", lambda root: True)
+        assert imod.path_command_is_abi_matched(tmp_path, str(link))
+        # a console script BESIDE the interpreter must not read as one:
+        # interpreter operands injected into it would kill the server
+        worker = venv_bin / "python-worker"
+        worker.write_text("#!/bin/sh\n")
+        assert not imod.path_command_is_abi_matched(tmp_path, str(worker))
+
+    def test_a_foreign_path_interpreter_gets_no_deps_pythonpath(self, tmp_path):
+        """The deps tree is built by the GATEWAY's pip, ABI-bound to the
+        gateway's interpreter. A path-pinned command that is NOT positively
+        matched (gateway executable or the version-probed app venv python)
+        must not receive the deps PYTHONPATH - 3.12-built wheels injected
+        into a foreign 3.11 would kill the server at import. Its env stays
+        exactly the pre-deps status quo."""
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        foreign = tmp_path / "bin" / "python3.11"
+        foreign.parent.mkdir()
+        foreign.write_text("#!/bin/sh\n")
+        foreign.chmod(0o755)
+        cfg = resolve_stdio_command(
+            {"command": str(foreign), "args": ["server.py"], "env": {"PYTHONPATH": "/manifest/own"}},
+            app_root=tmp_path,
+        )
+        assert cfg["command"] == str(foreign), cfg
+        assert cfg["env"]["PYTHONPATH"] == "/manifest/own", cfg
+
+    def test_a_path_based_gateway_module_server_gets_no_deps_env(self, tmp_path):
+        """The gateway-module exclusion survives the hoist: even a path-based
+        command whose args launch a kiro_crew module must not see the app
+        deps dir on PYTHONPATH."""
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        cfg = resolve_stdio_command(
+            {
+                "command": os.path.join("bin", "python3"),
+                "args": ["-m", "kiro_crew.apps.builtins.x"],
+            },
+            app_root=tmp_path,
+        )
+        assert "env" not in cfg, cfg
+
+    def test_a_gateway_module_server_never_gets_the_deps_pythonpath(self, tmp_path):
+        """An app that pip-pins its own kiro_crew copy must not shadow the
+        gateway's code: a `-m kiro_crew...` server runs the gateway's OWN
+        module on the gateway's interpreter, so the app deps dir stays out of
+        its PYTHONPATH entirely."""
+        import sys as _sys
+
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        cfg = resolve_stdio_command(
+            {"command": "python3", "args": ["-m", "kiro_crew.apps.builtins.x"]},
+            app_root=tmp_path,
+        )
+        assert cfg["command"] == _sys.executable
+        assert "env" not in cfg, cfg
+
+    def test_a_deps_dir_console_script_is_rewritten_and_gets_the_env(self, tmp_path):
+        from kiro_crew.apps.bridges import resolve_stdio_command
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        scripts = "Scripts" if platform_compat.IS_WINDOWS else "bin"
+        name = "my-mcp-server.exe" if platform_compat.IS_WINDOWS else "my-mcp-server"
+        script = app_deps_dir(tmp_path) / scripts / name
+        script.parent.mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_deps_stamp(tmp_path, b"requests\n")
+        script.write_text("#!/bin/sh\n")
+        script.chmod(0o755)
+        cfg = resolve_stdio_command({"command": "my-mcp-server"}, app_root=tmp_path)
+        assert cfg["command"] == str(script), cfg
+        # The script's shebang is the INSTALLING interpreter (sys.executable),
+        # which sees the script's own package only through this env.
+        parts = cfg["env"]["PYTHONPATH"].split(os.pathsep)
+        assert parts[0] == str(app_deps_dir(tmp_path)), cfg
 
 
 # ---------------------------------------------------------------------------
@@ -2345,9 +3032,7 @@ class TestCronServiceBridge:
             folder_id="",
         )
 
-    def test_cron_without_timezone_passes_the_empty_sentinel(
-        self, tmp_path, app_env, monkeypatch
-    ):
+    def test_cron_without_timezone_passes_the_empty_sentinel(self, tmp_path, app_env, monkeypatch):
         """A def that names no zone keeps today's config-then-UTC fallback."""
         from unittest.mock import MagicMock, patch
 
@@ -3792,13 +4477,9 @@ class TestRefreshAppAgentsReportsIoFailures:
         # Rewriting a revoked app's agents would make them dispatchable again.
         import kiro_crew.apps.bridges as brmod
         self._wire(monkeypatch, brmod, tmp_path)
-        monkeypatch.setattr(
-            brmod, "_registration_denied", lambda name, action, app_root: "revoked"
-        )
+        monkeypatch.setattr(brmod, "_registration_denied", lambda name, action, app_root: "revoked")
         scrubbed: list[str] = []
-        monkeypatch.setattr(
-            brmod, "_deregister_agents", lambda name: scrubbed.append(name)
-        )
+        monkeypatch.setattr(brmod, "_deregister_agents", lambda name: scrubbed.append(name))
         monkeypatch.setattr(
             brmod, "_register_agents",
             lambda *a, **k: pytest.fail("must not re-register a denied app"),
@@ -3818,9 +4499,7 @@ class TestDemotionKeepsBackendIndependentServers:
     reason that had nothing to do with them.
     """
 
-    def test_the_unhealthy_reconcile_scrubs_http_and_keeps_stdio(
-        self, monkeypatch, tmp_path
-    ):
+    def test_the_unhealthy_reconcile_scrubs_http_and_keeps_stdio(self, monkeypatch, tmp_path):
         import kiro_crew.apps.backend as bmod
         import kiro_crew.apps.bridges as brmod
 
@@ -3835,8 +4514,7 @@ class TestDemotionKeepsBackendIndependentServers:
             calls["app"] = app_name
             return ["app:stdio-tool"]  # the stdio entry survives
         monkeypatch.setattr(brmod, "scrub_backend_mcp_url", _scrub)
-        monkeypatch.setattr(brmod, "refresh_app_agents",
-                            lambda name, io_failures=None: [])
+        monkeypatch.setattr(brmod, "refresh_app_agents", lambda name, io_failures=None: [])
 
         def _blanket(name):
             raise AssertionError("must not blanket-deregister on a health demotion")
@@ -3926,7 +4604,8 @@ class TestLifecycleWritersShareTheHealthSerialization:
         import kiro_crew.apps.bridges as brmod
         held: list[bool] = []
         monkeypatch.setattr(
-            brmod, "_read_mcp_json_unlocked",
+            brmod,
+            "_read_mcp_json_unlocked",
             lambda strict=False: (held.append(self._lock_held()), {"mcpServers": {}})[1],
         )
         monkeypatch.setattr(brmod, "_write_mcp_json_unlocked", lambda data: None)
@@ -3935,7 +4614,11 @@ class TestLifecycleWritersShareTheHealthSerialization:
         # nothing to register, so an empty one would pass this test vacuously.
         monkeypatch.setattr(brmod, "strip_ungoverned_auto_approve", lambda m: m)
         brmod._register_mcp_servers(
-            "app", SimpleNamespace(mcpServers={"srv": {"command": "x"}})
+            "app",
+            SimpleNamespace(
+                mcpServers={"srv": {"command": "x"}},
+                backend=SimpleNamespace(entryPoint="server.py"),
+            ),
         )
         assert held == [True]
 
@@ -3943,7 +4626,8 @@ class TestLifecycleWritersShareTheHealthSerialization:
         import kiro_crew.apps.bridges as brmod
         held: list[bool] = []
         monkeypatch.setattr(
-            brmod, "_read_mcp_json_unlocked",
+            brmod,
+            "_read_mcp_json_unlocked",
             lambda strict=False: (held.append(self._lock_held()), {"mcpServers": {}})[1],
         )
         monkeypatch.setattr(brmod, "_write_mcp_json_unlocked", lambda data: None)
@@ -4014,6 +4698,7 @@ class TestRenderFailureIsClassifiedByCause:
 
     def test_invalid_rendered_json_is_not_collected(self, monkeypatch, tmp_path):
         import kiro_crew.apps.bridges as brmod
+
         src = self._template(tmp_path, '{"name": "a", "root": "{ENGINE_ROOT}"')  # unbalanced
         monkeypatch.setattr(brmod, "_placeholder_values", lambda n: {"{ENGINE_ROOT}": "/x"})
 
@@ -4066,9 +4751,7 @@ class TestScrubNeverDeletesMaterializedAgents:
 
         monkeypatch.setattr(brmod, "_registration_source", lambda n: (None, brmod.Path(".")))
         removed: list[str] = []
-        monkeypatch.setattr(
-            brmod, "_deregister_mcp_servers", lambda n: (removed.append(n), 1)[1]
-        )
+        monkeypatch.setattr(brmod, "_deregister_mcp_servers", lambda n: (removed.append(n), 1)[1])
         monkeypatch.setattr(brmod, "_deregister_agents", lambda n: 0)
 
         brmod.scrub_backend_mcp_url("gone")
@@ -4088,9 +4771,7 @@ class TestUnreadableManifestIsNotASilentRegistration:
         import kiro_crew.apps.bridges as brmod
 
         monkeypatch.setattr(brmod, "_registration_source", lambda n: (None, brmod.Path(".")))
-        monkeypatch.setattr(
-            brmod, "_registration_denied", lambda name, action, app_root: None
-        )
+        monkeypatch.setattr(brmod, "_registration_denied", lambda name, action, app_root: None)
 
         collected: list[str] = []
         assert brmod.reregister_app_mcp_servers("app", io_failures=collected) == []
@@ -4104,9 +4785,7 @@ class TestUnreadableManifestIsNotASilentRegistration:
             brmod, "_registration_source",
             lambda n: (SimpleNamespace(mcpServers={}, agents=[]), brmod.Path(".")),
         )
-        monkeypatch.setattr(
-            brmod, "_registration_denied", lambda name, action, app_root: None
-        )
+        monkeypatch.setattr(brmod, "_registration_denied", lambda name, action, app_root: None)
 
         collected: list[str] = []
         assert brmod.reregister_app_mcp_servers("app", io_failures=collected) == []
@@ -4127,12 +4806,8 @@ class TestScrubDoesNotRematerializeAgents:
         import kiro_crew.apps.bridges as brmod
 
         manifest = SimpleNamespace(mcpServers={"srv": {"command": "x"}}, agents=["a.json"])
-        monkeypatch.setattr(
-            brmod, "_registration_source", lambda n: (manifest, brmod.Path("."))
-        )
-        monkeypatch.setattr(
-            brmod, "_registration_denied", lambda name, action, app_root: None
-        )
+        monkeypatch.setattr(brmod, "_registration_source", lambda n: (manifest, brmod.Path(".")))
+        monkeypatch.setattr(brmod, "_registration_denied", lambda name, action, app_root: None)
         monkeypatch.setattr(
             brmod, "_register_mcp_servers",
             lambda name, m, live_port=None: ["app:srv"],
@@ -4150,16 +4825,10 @@ class TestScrubDoesNotRematerializeAgents:
         import kiro_crew.apps.bridges as brmod
 
         manifest = SimpleNamespace(mcpServers={"srv": {"command": "x"}}, agents=[])
-        monkeypatch.setattr(
-            brmod, "_registration_source", lambda n: (manifest, brmod.Path("."))
-        )
-        monkeypatch.setattr(
-            brmod, "_registration_denied", lambda name, action, app_root: "revoked"
-        )
+        monkeypatch.setattr(brmod, "_registration_source", lambda n: (manifest, brmod.Path(".")))
+        monkeypatch.setattr(brmod, "_registration_denied", lambda name, action, app_root: "revoked")
         removed: list[str] = []
-        monkeypatch.setattr(
-            brmod, "_deregister_mcp_servers", lambda n: (removed.append(n), 1)[1]
-        )
+        monkeypatch.setattr(brmod, "_deregister_mcp_servers", lambda n: (removed.append(n), 1)[1])
         monkeypatch.setattr(
             brmod, "_register_mcp_servers",
             lambda *a, **k: pytest.fail("a denied app must not keep any server"),

--- a/test/test_app_manager.py
+++ b/test/test_app_manager.py
@@ -312,6 +312,181 @@ class TestUninstall:
         # App files removed
         assert not (app_home / "apps" / "test-app" / APP_MANIFEST_FILENAME).exists()
 
+    def test_uninstall_purges_generated_deps_from_preserved_data(self, tmp_path, app_home):
+        """data/ preservation exists for USER data. The gateway-generated
+        dependency trees must not survive an uninstall: a compromised app
+        could plant code there (sitecustomize.py) and a reinstall under the
+        same name would prepend it to PYTHONPATH - revoked code executing in
+        a fresh install."""
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        data_dir = app_home / "apps" / "test-app" / "data"
+        (data_dir / "cache.json").write_text('{"key": "value"}')
+        for gen in (".kirocrew-deps", ".kirocrew-deps-staging", ".kirocrew-deps-prior"):
+            (data_dir / gen).mkdir(parents=True)
+            (data_dir / gen / "sitecustomize.py").write_text("planted = True\n")
+
+        result = uninstall_app("test-app", keep_data=True)
+        assert result.ok
+        preserved = app_home / "apps" / "test-app" / "data"
+        assert (preserved / "cache.json").is_file()  # user data kept
+        for gen in (".kirocrew-deps", ".kirocrew-deps-staging", ".kirocrew-deps-prior"):
+            assert not (preserved / gen).exists(), gen
+
+    def test_uninstall_refuses_a_linked_data_directory(self, tmp_path, app_home):
+        """A linked data dir would make the purge (and the whole preserve
+        dance) operate on the link's TARGET - an app pointing data at
+        another app's tree would have this uninstall move and delete a
+        foreign deps tree. The gateway creates data/ as a real directory, so
+        a link is never legitimate: refuse, leaving the app installed and
+        the target untouched."""
+        import os as _os
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        app_root = app_home / "apps" / "test-app"
+        victim = tmp_path / "victim-data"
+        victim.mkdir()
+        (victim / ".kirocrew-deps").mkdir()
+        (victim / ".kirocrew-deps" / "keepme.py").write_text("x = 1\n")
+        data = app_root / "data"
+        import shutil as _shutil
+
+        _shutil.rmtree(data)
+        try:
+            _os.symlink(victim, data)
+        except OSError:
+            pytest.skip("symlink not permitted")
+
+        result = uninstall_app("test-app", keep_data=True)
+        assert not result.ok
+        # the victim's tree is untouched and the app is still installed
+        assert (victim / ".kirocrew-deps" / "keepme.py").is_file()
+        assert (app_root / APP_MANIFEST_FILENAME).exists()
+
+    def test_suffixed_staging_leftovers_are_purged_at_uninstall(self, tmp_path, app_home):
+        """Staging dirs carry unique per-transaction suffixes; an interrupted
+        install's leftover must not survive uninstall under a name the exact
+        filter never matches."""
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        app_root = app_home / "apps" / "test-app"
+        leftover = app_root / "data" / ".kirocrew-deps-staging-1234-deadbeef"
+        leftover.mkdir()
+        (leftover / "pkg.py").write_text("x = 1\n")
+        result = uninstall_app("test-app", keep_data=True)
+        assert result.ok, result
+        preserved = app_home / "apps" / "test-app" / "data"
+        assert not list(preserved.glob(".kirocrew-deps-staging*"))
+
+    def test_failed_purge_restores_preserved_data_to_its_home(
+        self, tmp_path, app_home, monkeypatch
+    ):
+        """A raise after data/ was moved to its temp name must move it BACK:
+        the app is still installed, and its user data must not be orphaned
+        under a hidden dot-name."""
+        import kiro_crew.apps.manager as mgr
+
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        app_root = app_home / "apps" / "test-app"
+        marker = app_root / "data" / "user-file.txt"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("keep me")
+
+        real_rmtree = mgr.shutil.rmtree
+
+        def failing_rmtree(path, *args, **kwargs):
+            if str(path) == str(app_root):
+                raise OSError("simulated: app dir resists deletion")
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(mgr.shutil, "rmtree", failing_rmtree)
+        result = uninstall_app("test-app", keep_data=True)
+        assert not result.ok
+        assert marker.exists(), "preserved data must be restored to data/"
+        assert not (app_home / "apps" / ".test-app-data-tmp").exists()
+
+    def test_app_owned_names_sharing_the_deps_prefix_survive_uninstall(
+        self, tmp_path, app_home
+    ):
+        """The sweep deletes only the gateway's own generated names: an
+        app-owned entry that merely shares the .kirocrew-deps prefix (a
+        user's backup dir) is preserved data, not a purge target."""
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        app_root = app_home / "apps" / "test-app"
+        backup = app_root / "data" / ".kirocrew-deps-backup"
+        backup.mkdir(parents=True, exist_ok=True)
+        (backup / "precious.txt").write_text("keep me")
+        # A staging-prefix-sharing app name must equally survive: the
+        # quarantine's strict matcher only claims the generated
+        # -<pid>-<8hex> shape.
+        assets = app_root / "data" / ".kirocrew-deps-staging-assets"
+        assets.mkdir(parents=True, exist_ok=True)
+        (assets / "art.bin").write_text("app asset")
+        result = uninstall_app("test-app", keep_data=True)
+        assert result.ok, result.error
+        preserved = app_root / "data" / ".kirocrew-deps-backup" / "precious.txt"
+        assert preserved.exists(), "app-owned prefix-sharing data must survive"
+        assert (
+            app_root / "data" / ".kirocrew-deps-staging-assets" / "art.bin"
+        ).exists(), "app-owned staging-prefix data must survive"
+
+    def test_a_file_shaped_deps_artifact_is_purged_and_does_not_poison(
+        self, tmp_path, app_home
+    ):
+        """rmtree refuses non-directories, so a FILE written at a deps-tree
+        name survives every uninstall and poisons the next quarantine
+        rename. Shape-aware removal purges it - and a second
+        install/uninstall round over the same name stays clean."""
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        app_root = app_home / "apps" / "test-app"
+        (app_root / "data" / ".kirocrew-deps").write_text("not a directory\n")
+        result = uninstall_app("test-app", keep_data=True)
+        assert result.ok, result
+        preserved = app_home / "apps" / "test-app" / "data"
+        assert not (preserved / ".kirocrew-deps").exists()
+        # the poison scenario: same name, directory shape, next round
+        install_app(src)
+        deps = app_home / "apps" / "test-app" / "data" / ".kirocrew-deps"
+        deps.mkdir()
+        (deps / "pkg.py").write_text("x = 1\n")
+        result2 = uninstall_app("test-app", keep_data=True)
+        assert result2.ok, result2
+        assert not (app_home / "apps" / "test-app" / "data" / ".kirocrew-deps").exists()
+
+    def test_uninstall_purge_unlinks_a_planted_deps_symlink(self, tmp_path, app_home):
+        """rmtree refuses a symlink, so a malicious app could plant one at
+        the deps name and its target would ride through the purge; the purge
+        must unlink the LINK (never following it) so the reinstall starts
+        clean while the link's target elsewhere is untouched."""
+        import os as _os
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        data_dir = app_home / "apps" / "test-app" / "data"
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        (target / "sitecustomize.py").write_text("planted = True\n")
+        try:
+            _os.symlink(target, data_dir / ".kirocrew-deps")
+        except OSError:
+            pytest.skip("symlink not permitted")
+
+        result = uninstall_app("test-app", keep_data=True)
+        assert result.ok
+        preserved = app_home / "apps" / "test-app" / "data"
+        assert not (preserved / ".kirocrew-deps").exists()
+        assert not (preserved / ".kirocrew-deps").is_symlink()
+        # the purge removed the LINK, not the linked target's content
+        assert (target / "sitecustomize.py").is_file()
+
     def test_install_preserves_existing_data(self, tmp_path, app_home):
         """Reinstall after default uninstall must preserve user data."""
         src = _make_app_source(tmp_path)
@@ -1276,6 +1451,18 @@ class TestCopyAppTree:
         (src / ".git" / "config").write_text("[core]")
         (src / "__pycache__").mkdir()
         (src / "__pycache__" / "x.pyc").write_bytes(b"\x00")
+        # The gateway's own pip --target provisioning output: machine- and
+        # platform-specific, re-provisioned at the destination on first spawn.
+        # Copying it would put a foreign wheel tree FIRST on the child's
+        # PYTHONPATH, shadowing the correctly provisioned copy. The transient
+        # staging/prior swap directories are denylisted for the same reason.
+        (src / ".kirocrew-deps").mkdir()
+        (src / ".kirocrew-deps" / "requests").mkdir()
+        (src / ".kirocrew-deps" / "requests" / "__init__.py").write_text("x = 1")
+        (src / ".kirocrew-deps-staging").mkdir()
+        (src / ".kirocrew-deps-staging" / "partial.py").write_text("x = 1")
+        (src / ".kirocrew-deps-prior").mkdir()
+        (src / ".kirocrew-deps-prior" / "old.py").write_text("x = 1")
         # A real `build/` dir is NOT denylisted: the manifest may reference
         # runtime paths anywhere under the app root, so it must survive.
         # (A `build` *symlink* is neutralized by symlinks=True instead.)
@@ -1291,6 +1478,9 @@ class TestCopyAppTree:
         assert not (dest / "ui" / "node_modules").exists()
         assert not (dest / ".git").exists()
         assert not (dest / "__pycache__").exists()
+        assert not (dest / ".kirocrew-deps").exists()
+        assert not (dest / ".kirocrew-deps-staging").exists()
+        assert not (dest / ".kirocrew-deps-prior").exists()
         assert (dest / "build" / "artifact.txt").is_file()
         assert (dest / "ui" / "dist" / "index.mjs").is_file()
 

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -5,7 +5,7 @@ and ``test_app_backend_stale_reap.py`` (pidfile reap safety) by exercising the
 branches those files leave untouched:
 
 * the adopt-an-already-healthy-instance path and its refusals,
-* the per-app venv / pip and npm dependency-install branches,
+* the per-app pip --target / npm dependency-install branches,
 * the Node and ASGI dispatch branches,
 * ``stop_app_backend``'s adopted-PID revalidation and SIGKILL escalation,
 * the pidfile helpers' error paths and ``_proc_start_time``'s two platforms,
@@ -18,10 +18,13 @@ asserted. ``subprocess.Popen`` / ``subprocess.run``, the ``socket`` module,
 and ``loopback_urlopen`` are stubbed, and the spawn body is frozen at the
 ``Popen`` seam with a sentinel exception.
 """
+
 from __future__ import annotations
 
+import importlib
 import json
 import logging
+import os
 import subprocess
 import sys
 import urllib.error
@@ -610,9 +613,7 @@ class TestSpawnPortResolution:
     ) -> None:
         (spawn_root / "server.py").write_text("x = 1\n")
         with caplog.at_level(logging.ERROR):
-            assert (
-                bmod._start_app_backend_body("ranged", _manifest("server.py", port="1")) is None
-            )
+            assert bmod._start_app_backend_body("ranged", _manifest("server.py", port="1")) is None
         assert any("outside allowed range" in r.message for r in caplog.records)
 
     def test_fixed_port_held_by_another_app_is_refused(
@@ -802,9 +803,7 @@ class TestAdoptExistingInstance:
             [bmod.platform_compat.PortListener(111, "127.0.0.1", "4")],
             [bmod.platform_compat.PortListener(999, "*", "6")],
         ]
-        monkeypatch.setattr(
-            bmod.platform_compat, "find_port_listeners", lambda _port: seqs.pop(0)
-        )
+        monkeypatch.setattr(bmod.platform_compat, "find_port_listeners", lambda _port: seqs.pop(0))
         with caplog.at_level(logging.WARNING):
             assert self._run(bmod._MIN_PORT + 18) is None
         assert any("owners changed" in r.message for r in caplog.records)
@@ -858,64 +857,1387 @@ class TestAdoptExistingInstance:
 
 
 class TestDependencyInstall:
-    def test_requirements_txt_provisions_a_per_app_venv_then_pip_installs(
+    def test_requirements_txt_provisions_the_deps_dir_without_a_venv(
         self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Provisioning is a single `pip install --target` into a staging dir
+        that is swapped live on success (with the requirements hash stamped).
+
+        Never `-m venv`: a packaged install's bundled interpreter ships pip
+        but no ensurepip, so venv creation dies after building the directory
+        skeleton - which the venv-first interpreter policy then prefers while
+        it holds none of the app's dependencies."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
         (spawn_root / "server.py").write_text("x = 1\n")
-        (spawn_root / "requirements.txt").write_text("requests\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
         runs = _record_runs(monkeypatch)
         _capture_popen(monkeypatch)
         with pytest.raises(_StopSpawn):
             bmod._start_app_backend_body("deps", _manifest("server.py"))
-        assert any("venv" in argv for argv in runs), runs
+        assert not any("venv" in argv for argv in runs), runs
+        pip_argv = next(argv for argv in runs if "install" in argv)
+        target_idx = pip_argv.index("--target")
+        # staging names are UNIQUE per transaction (pid+nonce suffix), so a
+        # data/ swap can never redirect a fixed name's cleanup or fill
+        _target = pip_argv[target_idx + 1]
+        assert _target.startswith(str(spawn_root / "data" / bmod._DEPS_STAGING_NAME)), pip_argv
+        # Success swapped the staging dir live and stamped the requirements
+        # hash, so the next start with an unchanged file can skip pip.
+        deps_dir = app_deps_dir(spawn_root)
+        assert deps_dir.is_dir()
+        assert not list((spawn_root / "data").glob(f"{bmod._DEPS_STAGING_NAME}*"))
+        assert (deps_dir / bmod._DEPS_STAMP_NAME).read_text() == bmod._deps_digest(b"requests\n")
+
+    def test_an_out_of_root_requirements_symlink_is_refused_without_reading_it(
+        self, spawn_root: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The app dir is app-writable, so requirements.txt can be a planted
+        symlink to a file outside the app root. Provisioning must refuse it:
+        hashing the target's bytes would turn the on-disk stamp into a
+        sha256 content oracle for that file, and pip would install from a
+        path the app cannot otherwise reach. The refusal is surfaced as a
+        provisioning error, not swallowed."""
+        import os as _os
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        outside = tmp_path / "outside-secret.txt"
+        outside.write_bytes(b"host-secret==1.0\n")
+        (spawn_root / "server.py").write_text("x = 1\n")
+        try:
+            _os.symlink(outside, spawn_root / "requirements.txt")
+        except OSError:
+            pytest.skip("symlink not permitted")
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps", _manifest("server.py"))
+        # No pip ran, no deps dir was created, and no stamp exists anywhere
+        # that could disclose a digest of the outside file's bytes.
+        assert not any("install" in argv for argv in runs), runs
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        assert not app_deps_dir(spawn_root).exists()
+        assert not list((spawn_root / "data").glob(f"{bmod._DEPS_STAGING_NAME}*"))
+
+    def test_an_in_tree_requirements_symlink_provisions_normally(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """requirements.txt -> requirements/prod.txt is legitimate app
+        layout: a link whose strict resolution stays inside the app root is
+        accepted, read via its resolved target (itself no-follow-bound), and
+        provisions normally."""
+        import os as _os
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        (spawn_root / "server.py").write_text("x = 1\n")
+        reqs = spawn_root / "requirements"
+        reqs.mkdir()
+        (reqs / "prod.txt").write_bytes(b"requests\n")
+        try:
+            _os.symlink(
+                _os.path.join("requirements", "prod.txt"),
+                spawn_root / "requirements.txt",
+            )
+        except OSError:
+            pytest.skip("symlink not permitted")
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-inlink", _manifest("server.py"))
         assert any("install" in argv for argv in runs), runs
+
+    def test_pip_runs_from_the_app_root_on_the_apps_own_requirements(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pip runs with cwd=app root, so a relative reference (`-e ./lib`)
+        resolves inside the app dir rather than the gateway's working
+        directory - and for VOLATILE requirements (the only kind that can
+        carry file references) -r points at the app's OWN requirements.txt,
+        so a nested include resolves beside it (a relocated copy would
+        break includes)."""
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "base.txt").write_bytes(b"requests\n")
+        (spawn_root / "requirements.txt").write_bytes(b"-r base.txt\n")
+        _record_runs(monkeypatch)
+        seen: dict[str, Any] = {}
+
+        def _spy_run(argv: Any, **kwargs: Any) -> Any:
+            if "install" in argv:
+                seen["cwd"] = kwargs.get("cwd")
+                seen["r_path"] = argv[list(argv).index("-r") + 1]
+            return SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(bmod, "run_limited", _spy_run)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps", _manifest("server.py"))
+        assert seen["cwd"] == str(spawn_root), seen
+        assert seen["r_path"] == str(spawn_root / "requirements.txt"), seen
+
+    def test_an_editable_install_is_retained_and_swapped_live(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Editable installs materialise as __editable__*.pth hooks, which
+        the deps_boot shim processes via site.addsitedir - so provisioning
+        RETAINS them and swaps the tree live (the refusal that predated the
+        shim is gone)."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"-e ./lib\n")
+        _record_runs(monkeypatch)
+
+        def _fake_pip(argv: Any, **kwargs: Any) -> Any:
+            if "install" in argv:
+                argv = list(argv)
+                staging = argv[argv.index("--target") + 1]
+                (__import__("pathlib").Path(staging) / "__editable__.lib-1.0.pth").write_text(
+                    "hook\n"
+                )
+            return SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(bmod, "run_limited", _fake_pip)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-editable", _manifest("server.py"))
+        deps_dir = app_deps_dir(spawn_root)
+        assert (deps_dir / "__editable__.lib-1.0.pth").is_file()
+        log_path = spawn_root / "data" / "logs" / "backend.log"
+        if log_path.exists():
+            assert "editable requirements" not in log_path.read_text()
+
+    def test_volatile_requirement_forms_disable_the_stamp(self) -> None:
+        """Any line whose resolution can change while the line does not
+        (file refs attached or spaced, editables, local paths, VCS/URL,
+        direct references) must disable stamp reuse - the digest cannot
+        prove the resolved set unchanged for them."""
+        vol = bmod._requirements_volatile
+        assert vol(b"-rbase.txt\n")
+        assert vol(b"-r base.txt\n")
+        assert vol(b"-c pins.txt\n")
+        assert vol(b"--requirement=base.txt\n")
+        assert vol(b"-e ./lib\n")
+        assert vol(b"./lib\n")
+        assert vol(b"~/wheels/pkg.whl\n")
+        assert vol(b"pkg @ https://host/pkg.whl\n")
+        assert vol(b"git+https://host/repo.git#egg=pkg\n")
+        assert vol(b"wheels/pkg.whl\n")  # bare relative path, no ./ prefix
+        assert vol(b"vendor.whl\n")  # bare archive FILENAME, no separator
+        assert vol(b"-f wheelhouse\n")  # find-links: local wheel content can change
+        assert vol(b"--find-links wheelhouse\n")
+        assert vol(b"--no-index\n")  # resolution-location options
+        assert vol(b"Vendor-1.0.TAR.GZ\n")  # case-insensitive suffix
+        assert not vol(b"requests==2.31.0\n")  # index spec stays stampable
+        assert vol(b"wheels\\pkg.whl\n")
+        assert not vol(b"requests==2.32.0\n# -r not-a-directive in a comment\n")
+        assert not vol(b"")
+
+    def test_deps_boot_pth_imports_resolve_deps_first(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A .pth import line executes DURING site processing and caches its
+        resolution in sys.modules - so the deps dir must already sit at its
+        final front position when addsitedir runs. A gateway copy of a
+        colliding name earlier on sys.path must NOT win (no later reordering
+        can evict a wrongly cached module)."""
+        from kiro_crew.apps import deps_boot
+
+        gateway = tmp_path / "gateway"
+        gateway.mkdir()
+        (gateway / "collide_probe_7901.py").write_text("MARKER = 'gateway'\n")
+        deps = tmp_path / "deps"
+        deps.mkdir()
+        (deps / "collide_probe_7901.py").write_text("MARKER = 'dep'\n")
+        pth_proof = tmp_path / "pth_proof.txt"
+        (deps / "hook.pth").write_text(
+            "import collide_probe_7901, pathlib; "
+            f"pathlib.Path({str(pth_proof)!r}).write_text(collide_probe_7901.MARKER)\n"
+        )
+        script = tmp_path / "noop.py"
+        script.write_text("pass\n")
+        patched = [str(gateway), *sys.path]  # gateway-like entry ahead of the shim's work
+        monkeypatch.setattr(sys, "path", patched)
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        importlib.invalidate_caches()
+        try:
+            deps_boot.main([str(deps), str(script)])
+        finally:
+            sys.modules.pop("collide_probe_7901", None)
+        assert pth_proof.read_text() == "dep", pth_proof.read_text()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX arm of the exe gate")
+    def test_deps_boot_posix_exe_named_script_keeps_deps(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On POSIX a *.exe name is just a python script (only python targets
+        reach the shim): it must take the script dispatch - the embedded-
+        launcher arm's execv fallback would restart its shebang interpreter
+        WITHOUT the deps path."""
+        from kiro_crew.apps import deps_boot
+
+        deps = tmp_path / "deps"
+        deps.mkdir()
+        (deps / "exe_dep_7901.py").write_text("MARKER = 'dep'\n")
+        exe_proof = tmp_path / "exe_proof.txt"
+        exe = tmp_path / "tool.exe"
+        exe.write_text(
+            "#!/usr/bin/env python3\n"
+            "import pathlib\n"
+            "import exe_dep_7901\n"
+            f"pathlib.Path({str(exe_proof)!r}).write_text(exe_dep_7901.MARKER)\n"
+        )
+        execvs: list = []
+        monkeypatch.setattr(deps_boot.os, "execv", lambda *a: execvs.append(a))
+        monkeypatch.setattr(sys, "path", list(sys.path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        importlib.invalidate_caches()
+        try:
+            deps_boot.main([str(deps), str(exe)])
+        finally:
+            sys.modules.pop("exe_dep_7901", None)
+        assert execvs == [], "POSIX exe-named script must not be handed to execv"
+        assert exe_proof.read_text() == "dep"
+
+    def test_deps_boot_windows_launcher_arm(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pip embedded-launcher arm behind the Windows gate, driven on
+        any platform through an os proxy: a zip-appended exe's __main__.py
+        stub runs in-process with the deps placed, and a non-zip exe is
+        handed to execv exactly as an unshimmed launch would."""
+        import zipfile as _zf
+
+        from kiro_crew.apps import deps_boot
+
+        class _ExecvCalled(Exception):
+            pass
+
+        class _NtOs:
+            name = "nt"
+
+            @staticmethod
+            def execv(path: str, args: list) -> None:
+                raise _ExecvCalled(path)
+
+            def __getattr__(self, attr: str) -> Any:
+                return getattr(os, attr)
+
+        deps = tmp_path / "deps"
+        deps.mkdir()
+        (deps / "zip_dep_7901.py").write_text("MARKER = 'dep'\n")
+        proof = tmp_path / "zip_proof.txt"
+        exe = tmp_path / "console.exe"
+        with _zf.ZipFile(exe, "w") as z:
+            z.writestr(
+                "__main__.py",
+                "import pathlib, sys\n"
+                "import zip_dep_7901\n"
+                f"pathlib.Path({str(proof)!r}).write_text(zip_dep_7901.MARKER + sys.argv[1])\n",
+            )
+        monkeypatch.setattr(deps_boot, "os", _NtOs())
+        monkeypatch.setattr(sys, "path", list(sys.path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        monkeypatch.setitem(sys.modules, "__main__", sys.modules["__main__"])
+        importlib.invalidate_caches()
+        try:
+            deps_boot.main([str(deps), str(exe), "zargv"])
+        finally:
+            sys.modules.pop("zip_dep_7901", None)
+        assert proof.read_text() == "depzargv"
+
+        # Not a zip after all (the resolver gates on is_zipfile but the file
+        # can change between resolution and launch): handed straight to
+        # execv, never dispatched as python.
+        native = tmp_path / "native.exe"
+        native.write_bytes(b"MZx90")
+        monkeypatch.setattr(sys, "path", list(sys.path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        with pytest.raises(_ExecvCalled):
+            deps_boot.main([str(deps), str(native), "n"])
+
+    def test_deps_boot_drops_its_own_script_dir(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Path-launch shape: CPython puts the shim script's OWN directory at
+        sys.path[0], which would let an app import gateway modules by bare
+        name - the shim must drop it before anything resolves."""
+        from kiro_crew.apps import deps_boot
+
+        own = os.path.dirname(os.path.abspath(deps_boot.__file__))
+        deps = tmp_path / "deps"
+        deps.mkdir()
+        script = tmp_path / "noop2.py"
+        script.write_text("pass\n")
+        monkeypatch.setattr(sys, "path", [own, *sys.path])
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        deps_boot.main([str(deps), str(script)])
+        assert sys.path[0] != own
+
+    def test_deps_boot_main_runs_a_script_and_a_module_in_process(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In-process coverage of the shim's three arms: script dispatch
+        (with the script dir at sys.path[0]), -m module dispatch (module
+        resolved through the addsitedir'd deps dir, moved to the front),
+        and the usage error."""
+        from kiro_crew.apps import deps_boot
+
+        _clean_path = list(sys.path)  # arms mutate the patched list; reset from this
+        deps = tmp_path / "deps"
+        deps.mkdir()
+        (deps / "dep_mod.py").write_text("MARKER = 'dep'\n")
+        proof = tmp_path / "proof.txt"
+        script = tmp_path / "sub" / "entry.py"
+        script.parent.mkdir()
+        (script.parent / "sib.py").write_text("S = 'sib'\n")
+        script.write_text(
+            "import pathlib, sys\n"
+            "import dep_mod, sib\n"
+            f"pathlib.Path({str(proof)!r}).write_text("
+            "dep_mod.MARKER + sib.S + sys.argv[1])\n"
+        )
+        monkeypatch.setattr(sys, "path", list(sys.path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        deps_boot.main([str(deps), str(script), "argved"])
+        assert proof.read_text() == "depsibargved"
+        assert sys.path[0] == str(script.parent)
+
+        mod_proof = tmp_path / "mod_proof.txt"
+        (deps / "runnable_mod.py").write_text(
+            "import pathlib, sys\n"
+            f"pathlib.Path({str(mod_proof)!r}).write_text('ran' + sys.argv[1])\n"
+        )
+        # The first arm's import built a FileFinder for the deps dir whose
+        # listing cache has mtime granularity - a module written within the
+        # same granule is invisible to the second arm without this.
+        importlib.invalidate_caches()
+        monkeypatch.setattr(sys, "path", list(sys.path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        deps_boot.main([str(deps), "-m", "runnable_mod", "x"])
+        assert mod_proof.read_text() == "ranx"
+
+        # -c arm: python -c parity (argv[0] is "-c", cwd at sys.path[0]),
+        # module resolved through the addsitedir'd deps dir. The arm
+        # installs a fresh __main__ module (production runs in a dedicated
+        # process); restore the test runner's afterwards.
+        c_proof = tmp_path / "c_proof.txt"
+        monkeypatch.setitem(sys.modules, "__main__", sys.modules["__main__"])
+        monkeypatch.setattr(sys, "path", list(sys.path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        deps_boot.main(
+            [
+                str(deps),
+                "-c",
+                "import pathlib, sys\n"
+                "import dep_mod\n"
+                f"pathlib.Path({str(c_proof)!r}).write_text(dep_mod.MARKER + sys.argv[1])",
+                "cargv",
+            ]
+        )
+        assert c_proof.read_text() == "depcargv"
+
+        # PLACEMENT parity: the launch entry precedes the deps entries, so
+        # an app-local module colliding with a dependency name resolves to
+        # the app's own file exactly like a plain launch
+        (deps / "sib.py").write_text("S = 'DEPSIB'\n")  # collides with app sib.py
+        order_proof = tmp_path / "order_proof.txt"
+        script2 = tmp_path / "sub" / "entry2.py"
+        script2.write_text(
+            "import pathlib\n"
+            "import sib\n"
+            f"pathlib.Path({str(order_proof)!r}).write_text(sib.S)\n"
+        )
+        monkeypatch.setattr(sys, "path", list(_clean_path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        importlib.invalidate_caches()
+        deps_boot.main([str(deps), str(script2)])
+        assert order_proof.read_text() == "sib", order_proof.read_text()
+
+        # safe_path (-P/-I): the shim must not restore the launch entry.
+        # A proxy, not a bare object: sys.flags is process-global and other
+        # code (runpy) reads .verbose etc. during the run.
+        _real_flags = sys.flags
+
+        class _Flags:
+            safe_path = True
+
+            def __getattr__(self, attr):
+                return getattr(_real_flags, attr)
+
+        monkeypatch.setattr(sys, "path", list(_clean_path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        monkeypatch.setattr(deps_boot.sys, "flags", _Flags())
+        monkeypatch.setitem(sys.modules, "__main__", sys.modules["__main__"])
+        sp_proof = tmp_path / "sp_proof.txt"
+        deps_boot.main(
+            [
+                str(deps),
+                "-c",
+                "import pathlib, sys\n"
+                f"pathlib.Path({str(sp_proof)!r}).write_text("
+                "'|'.join(sys.path[:2]))",
+            ]
+        )
+        parts = sp_proof.read_text().split("|")
+        assert parts[0] == str(deps), parts  # deps first, NO '' cwd entry
+        monkeypatch.setattr(deps_boot.sys, "flags", _real_flags)
+
+        # embedded-exe arm: pip's Windows launcher carries the console
+        # script as an appended ZIP; the shim extracts __main__.py and
+        # dispatches it after addsitedir
+        import zipfile as _zipfile
+
+        exe_proof = tmp_path / "exe_proof.txt"
+        fake_exe = tmp_path / "embtool.exe"
+        with open(fake_exe, "wb") as fh:
+            fh.write(b"MZ fake native prefix\n")
+            with _zipfile.ZipFile(fh, "a") as zf:
+                zf.writestr(
+                    "__main__.py",
+                    "import pathlib, sys\n"
+                    "import dep_mod\n"
+                    f"pathlib.Path({str(exe_proof)!r}).write_text(dep_mod.MARKER + sys.argv[1])\n",
+                )
+        monkeypatch.setitem(sys.modules, "__main__", sys.modules["__main__"])
+        monkeypatch.setattr(sys, "path", list(_clean_path))
+        monkeypatch.setattr(sys, "argv", list(sys.argv))
+        importlib.invalidate_caches()
+        deps_boot.main([str(deps), str(fake_exe), "exearg"])
+        assert exe_proof.read_text() == "depexearg"
+
+        with pytest.raises(SystemExit) as exc1:
+            deps_boot.main([])
+        assert exc1.value.code == 2
+        with pytest.raises(SystemExit) as exc2:
+            deps_boot.main([str(deps), "-m"])
+        assert exc2.value.code == 2
+
+    def test_the_deps_boot_shim_processes_pth_files_with_deps_first(self, tmp_path: Any) -> None:
+        """The whole reason the shim exists: PYTHONPATH never processes .pth
+        files, site.addsitedir does. A deps tree whose package arrives ONLY
+        via a .pth redirect must import under the shim - and the deps
+        entries must sit ahead of the gateway env on sys.path (the
+        precedence the PYTHONPATH transport had)."""
+        deps = tmp_path / "deps"
+        hidden = deps / "hidden"
+        hidden.mkdir(parents=True)
+        (hidden / "pth_only_pkg.py").write_text("VIA_PTH = True\n")
+        (deps / "redirect.pth").write_text("hidden\n")
+        subdir = tmp_path / "app"
+        subdir.mkdir()
+        (subdir / "sibling.py").write_text("S = 1\n")
+        script = subdir / "entry.py"
+        script.write_text(
+            "import json, sys\n"
+            "import pth_only_pkg\n"
+            "import sibling  # direct-script parity: script dir on sys.path[0]\n"
+            "print(json.dumps({'via_pth': pth_only_pkg.VIA_PTH,"
+            " 'sibling': sibling.S}))\n"
+        )
+        proc = subprocess.run(
+            [
+                sys.executable,
+                # Absolute SCRIPT path, not -m: the -m spelling imports the
+                # kiro_crew package and Python writes __pycache__ into the
+                # CHECKOUT - a test must not leave artifacts outside
+                # tmp_path. (Production spells it by path for its own
+                # reason: session-cwd shadowing.)
+                os.path.abspath(bmod._deps_boot_module.__file__),
+                str(deps),
+                str(script),
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+            cwd=str(tmp_path),
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert '"via_pth": true' in proc.stdout, proc.stdout
+        assert '"sibling": 1' in proc.stdout, proc.stdout
+
+    def test_a_python_backend_with_deps_launches_through_the_shim(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A provisioned backend spawns via deps_boot (which addsitedir()s
+        the deps dir, processing .pth) rather than a raw interpreter+entry
+        argv - and only for the gateway interpreter."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        deps_dir = app_deps_dir(spawn_root)
+        deps_dir.mkdir(parents=True)
+        (deps_dir / bmod._DEPS_STAMP_NAME).write_text(bmod._deps_digest(b"requests\n"))
+        _record_runs(monkeypatch)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-shim", _manifest("server.py"))
+        argv = seen["argv"]
+        assert argv[0] == sys.executable, argv
+        # absolute-path spelling: an app-root kiro_crew.py must not be able
+        # to shadow the shim for -m resolution under cwd=app root
+        assert argv[1].endswith("deps_boot.py"), argv
+        assert argv[2] == str(deps_dir), argv
+        assert argv[3].endswith("server.py"), argv
+
+    def test_non_volatile_requirements_install_from_a_snapshot(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pip re-opens the requirements path; a concurrent rewrite after
+        hashing would install replacement contents under the ORIGINAL
+        digest's stamp. When the stamp will be trusted, pip installs from an
+        immutable snapshot of the very bytes the digest covers."""
+        (spawn_root / "server.py").write_text("x = 1\n")
+        req = b"requests==2.31.0\n"
+        (spawn_root / "requirements.txt").write_bytes(req)
+        _record_runs(monkeypatch)
+        seen: dict[str, Any] = {}
+
+        def _spy_run(argv: Any, **kwargs: Any) -> Any:
+            if "install" in argv:
+                argv = list(argv)
+                r_path = argv[argv.index("-r") + 1]
+                seen["r_path"] = r_path
+                seen["r_bytes"] = __import__("pathlib").Path(r_path).read_bytes()
+            return SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(bmod, "run_limited", _spy_run)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-snap", _manifest("server.py"))
+        assert "snapshot" in seen["r_path"], seen
+        assert str(spawn_root / "data") in seen["r_path"], seen
+        assert seen["r_bytes"] == req, seen
+
+    def test_pip_reads_the_resolved_target_of_an_in_tree_symlink(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pip resolves a nested include (`-r base.txt`) relative to the
+        requirements FILE - handing it the symlink path would resolve
+        includes beside the LINK instead of its target. The -r argument must
+        be the validated resolved path."""
+        import os as _os
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        (spawn_root / "server.py").write_text("x = 1\n")
+        real = spawn_root / "config"
+        real.mkdir()
+        (real / "base.txt").write_bytes(b"requests\n")
+        # an include makes the requirements VOLATILE, so pip reads the live
+        # validated path (where the include resolves) instead of a snapshot
+        (real / "requirements.txt").write_bytes(b"-r base.txt\n")
+        try:
+            _os.symlink(real / "requirements.txt", spawn_root / "requirements.txt")
+        except OSError:
+            pytest.skip("symlink not permitted")
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-reqlink", _manifest("server.py"))
+        pip_argv = next(argv for argv in runs if "install" in argv)
+        r_val = pip_argv[pip_argv.index("-r") + 1]
+        assert r_val == str(real / "requirements.txt"), pip_argv
+
+    def test_concurrent_provisioning_is_serialized_by_the_deps_lock(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The backend spawn and a backend-less registration (or two
+        registrations) can provision the same app concurrently; unserialized
+        they delete each other's staging tree and both fail. The per-app
+        file lock admits one transaction at a time - and the stamp check
+        runs inside it, so the waiter skips pip on the winner's stamp."""
+        import threading
+        import time as _time
+
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        inside = []
+        overlap = []
+
+        def _fake_pip(argv: Any, **kwargs: Any) -> Any:
+            if "install" in argv:
+                if inside:
+                    overlap.append(True)
+                inside.append(True)
+                _time.sleep(0.15)
+                argv = list(argv)
+                staging = argv[argv.index("--target") + 1]
+                (__import__("pathlib").Path(staging) / "pkg.py").write_text("x = 1\n")
+                inside.pop()
+            return SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(bmod, "run_limited", _fake_pip)
+        errs: list[str] = []
+
+        def _call() -> None:
+            errs.append(bmod.provision_app_deps("deps-race", spawn_root))
+
+        threads = [threading.Thread(target=_call) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert errs == ["", ""], errs
+        assert not overlap, "two pip transactions ran concurrently"
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        assert (app_deps_dir(spawn_root) / "pkg.py").is_file()
+
+    def test_the_pinned_dir_detects_a_mid_transaction_swap(self, tmp_path: Any) -> None:
+        """The link pre-check is a TOCTOU window: a running app can swap
+        data/ AFTER validation. The pin holds the directory open and verify()
+        refuses once the path names a different inode - the renames go
+        through the held fd and cannot be redirected at all."""
+        if bmod.platform_compat.IS_WINDOWS:
+            pytest.skip("dir pinning is POSIX-only (symlink creation is privileged on Windows)")
+        real = tmp_path / "data"
+        real.mkdir()
+        pin = bmod._PinnedDir(real)
+        try:
+            pin.verify()  # untouched: passes
+            real.rename(tmp_path / "moved-away")
+            (tmp_path / "other").mkdir()
+            (tmp_path / "other").rename(real)
+            with pytest.raises(OSError, match="replaced mid-provisioning"):
+                pin.verify()
+        finally:
+            pin.close()
+
+    def test_provisioning_refuses_a_linked_data_directory(
+        self, spawn_root: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every provisioning operation under data/ would FOLLOW a planted
+        link - an app pointing data/ at another app's tree would have the
+        swap install attacker-chosen dependencies into the victim's dir.
+        Refused before anything is touched through it, same shape as the
+        uninstall purge's guard."""
+        import os as _os
+        import shutil as _shutil
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        victim = tmp_path / "victim-data"
+        victim.mkdir()
+        data = spawn_root / "data"
+        if data.exists():
+            _shutil.rmtree(data)
+        try:
+            _os.symlink(victim, data)
+        except OSError:
+            pytest.skip("symlink not permitted")
+        runs = _record_runs(monkeypatch)
+        err = bmod.provision_app_deps("deps-datalink", spawn_root)
+        assert "symlink/junction" in err, err
+        assert not any("install" in argv for argv in runs), runs
+        assert not any(victim.iterdir()), list(victim.iterdir())
+
+    def test_an_oversized_requirements_file_is_refused_bounded(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gateway buffers app-controlled inputs in its own memory: an
+        oversized requirements.txt reads at most cap+1 bytes and refuses -
+        it must never be slurped whole or handed to pip."""
+        (spawn_root / "requirements.txt").write_bytes(b"#" + b"x" * (bmod._DEPS_REQ_MAX_BYTES + 10))
+        runs = _record_runs(monkeypatch)
+        err = bmod.provision_app_deps("deps-huge", spawn_root)
+        assert "Refusing requirements.txt" in err, err
+        assert not any("install" in argv for argv in runs), runs
+
+    def test_every_provisioning_failure_arm_emits_the_sel_event(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """deps_provision_failed is the audit contract for provisioning
+        failures; the requirements-read refusal (out-of-root symlink) and
+        lock failures go through the same wrapper emit as pip failures."""
+        import os as _os
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        outside = spawn_root.parent / "outside-req.txt"
+        outside.write_bytes(b"requests\n")
+        try:
+            _os.symlink(outside, spawn_root / "requirements.txt")
+        except OSError:
+            pytest.skip("symlink not permitted")
+        events: list = []
+        monkeypatch.setattr(
+            bmod,
+            "sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        _record_runs(monkeypatch)
+        err = bmod.provision_app_deps("deps-selpin", spawn_root)
+        assert "Refusing requirements.txt" in err, err
+        assert [e.get("outcome") for e in events] == ["deps_provision_failed"], events
+
+    def test_a_planted_stamp_symlink_reads_as_unprovisioned(
+        self, spawn_root: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The stamp lives in the app-writable tree, so its read is
+        no-follow-bound like the requirements read: a planted symlink at the
+        stamp name must never make the gateway read an arbitrary path - it
+        reads as "unprovisioned" and pip simply runs (safe direction)."""
+        import os as _os
+
+        if not hasattr(_os, "symlink"):
+            pytest.skip("no symlink support")
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        req = b"requests\n"
+        (spawn_root / "requirements.txt").write_bytes(req)
+        deps_dir = app_deps_dir(spawn_root)
+        deps_dir.mkdir(parents=True)
+        target = tmp_path / "protected.txt"
+        target.write_text(bmod._deps_digest(req))  # even a matching target
+        try:
+            _os.symlink(target, deps_dir / bmod._DEPS_STAMP_NAME)
+        except OSError:
+            pytest.skip("symlink not permitted")
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-stamplink", _manifest("server.py"))
+        assert any("install" in argv for argv in runs), runs
+
+    def test_include_bearing_requirements_never_skip_pip(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The stamp digest covers the top-level file's bytes only, so a
+        change confined to an included file (-r base.txt) would preserve the
+        stamp and serve stale dependencies. Include-bearing requirements
+        therefore disable the skip: pip runs even when the stamp matches."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        req = b"-r base.txt\n"
+        (spawn_root / "requirements.txt").write_bytes(req)
+        (spawn_root / "base.txt").write_bytes(b"requests\n")
+        deps_dir = app_deps_dir(spawn_root)
+        deps_dir.mkdir(parents=True)
+        (deps_dir / bmod._DEPS_STAMP_NAME).write_text(bmod._deps_digest(req))
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-inc", _manifest("server.py"))
+        assert any("install" in argv for argv in runs), runs
+
+    def test_an_unchanged_requirements_file_skips_the_pip_call(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pip --target cannot answer "already satisfied" the way a venv
+        install could, so the stamp is what keeps a restart with unchanged
+        requirements off the network - and keeps an OFFLINE restart of a
+        healthy backend from raising a false provisioning alarm."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        deps_dir = app_deps_dir(spawn_root)
+        deps_dir.mkdir(parents=True)
+        (deps_dir / bmod._DEPS_STAMP_NAME).write_text(bmod._deps_digest(b"requests\n"))
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-skip", _manifest("server.py"))
+        assert not any("install" in argv for argv in runs), runs
+
+    def test_a_changed_requirements_file_reinstalls(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests==2.32.0\n")
+        deps_dir = app_deps_dir(spawn_root)
+        deps_dir.mkdir(parents=True)
+        (deps_dir / bmod._DEPS_STAMP_NAME).write_text(
+            bmod._deps_digest(b"requests\n")  # stamp of the OLD file
+        )
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-changed", _manifest("server.py"))
+        assert any("install" in argv for argv in runs), runs
+
+    def test_the_stamp_digest_changes_with_the_interpreter_abi(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Wheels installed by pip --target are ABI-specific, so a gateway
+        Python upgrade must reprovision even when requirements.txt is
+        byte-identical - a requirements-only stamp would skip pip and leave
+        old-ABI wheels live. A PATCH upgrade must reprovision too:
+        requirements can carry python_full_version markers that flip on it."""
+        before = bmod._deps_digest(b"requests\n")
+        monkeypatch.setattr(
+            bmod.sys,
+            "implementation",
+            SimpleNamespace(
+                cache_tag="cpython-399",
+                name=sys.implementation.name,
+                version=sys.implementation.version,
+            ),
+        )
+        assert bmod._deps_digest(b"requests\n") != before
+        monkeypatch.undo()
+        monkeypatch.setattr(bmod.platform, "python_version", lambda: "3.99.99")
+        assert bmod._deps_digest(b"requests\n") != before
+
+    def test_an_interrupted_swap_is_recovered_on_the_next_start(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash between the two swap renames leaves the good tree under the
+        prior name only. The next start must put it back - and, with a
+        matching stamp inside, skip pip - so an offline restart keeps its
+        dependencies instead of spawning bare."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        prior = spawn_root / "data" / bmod._DEPS_PRIOR_NAME
+        prior.mkdir(parents=True)
+        (prior / bmod._DEPS_STAMP_NAME).write_text(bmod._deps_digest(b"requests\n"))
+        (prior / "marker.py").write_text("recovered = True\n")
+        runs = _record_runs(monkeypatch)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-recover", _manifest("server.py"))
+        deps_dir = app_deps_dir(spawn_root)
+        assert (deps_dir / "marker.py").is_file()
+        assert not prior.exists()
+        assert not any("install" in argv for argv in runs), runs
+        assert any(str(a).endswith("deps_boot.py") for a in seen["argv"]), seen["argv"]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="dir_fd staging pin is POSIX-only")
+    def test_a_staging_swap_after_pip_cannot_redirect_marker_writes_or_publish(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """A build hook that replaces staging with a symlink after pip exits
+        must neither have the gateway's marker writes land in its target nor
+        get its tree PUBLISHED as the live install: the staging descriptor
+        pinned at creation makes the writes un-redirectable and the
+        pre-publish identity verify refuses the swapped entry."""
+        import os as _os
+        from pathlib import Path
+
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        victim = tmp_path / "victim-outside-app"
+        victim.mkdir()
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests==2.32.0\n")
+
+        def swapping_run(cmd: Any, **kwargs: Any) -> Any:
+            target = None
+            for i, tok in enumerate(cmd):
+                if str(tok) == "--target" and i + 1 < len(cmd):
+                    target = Path(str(cmd[i + 1]))
+                    break
+            assert target is not None, cmd
+            aside = target.parent / (target.name + "-aside")
+            _os.rename(str(target), str(aside))
+            _os.symlink(str(victim), str(target))
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        monkeypatch.setattr(bmod, "run_limited", swapping_run)
+        err = bmod.provision_app_deps("swap-app", spawn_root)
+        assert err, "provisioning must FAIL when staging identity is lost"
+        assert not (victim / bmod._DEPS_STAMP_NAME).exists(), "marker escaped!"
+        assert not (victim / bmod._DEPS_ABI_NAME).exists(), "marker escaped!"
+        deps_dir = app_deps_dir(spawn_root)
+        assert not deps_dir.is_symlink(), "the swapped tree must not be published"
+
+    def test_a_failed_reinstall_leaves_the_prior_deps_dir_intact(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pip fills a staging dir that is swapped in only on success, so a
+        failed or interrupted (re)install can never corrupt the live deps dir
+        in place - the prior good install keeps serving the spawn."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests==2.32.0\n")
+        deps_dir = app_deps_dir(spawn_root)
+        (deps_dir / "requests").mkdir(parents=True)
+        (deps_dir / "requests" / "__init__.py").write_text("prior = True\n")
+        # A REAL prior good install carries its stamp (written at swap time);
+        # activation requires it to name the current interpreter's digest,
+        # so the fixture plants it too. A stampless (or stale-ABI) tree is
+        # deliberately NOT activated - see _deps_tree_stamp_current.
+        (deps_dir / bmod._DEPS_STAMP_NAME).write_text(bmod._deps_digest(b"requests==2.32.0\n"))
+        _record_runs(monkeypatch, exc=RuntimeError("no network"))
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-keep", _manifest("server.py"))
+        assert (deps_dir / "requests" / "__init__.py").read_text() == "prior = True\n"
+        assert not list((spawn_root / "data").glob(f"{bmod._DEPS_STAGING_NAME}*"))
+        # And the surviving install still reaches the child.
+        assert any(str(a).endswith("deps_boot.py") for a in seen["argv"]), seen["argv"]
 
     def test_the_installer_never_shells_out_to_a_bare_interpreter(
         self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Venv creation must use sys.executable and pip must run as
-        `<venv python> -m pip` — `.venv/bin/pip` is POSIX-only and a bare
-        `python3` relies on PATH. Anything else leaves a Windows venv created
-        but never provisioned, which the venv-first interpreter policy would
-        then prefer while it holds none of the app's dependencies."""
-        import sys
-
-        from kiro_crew.apps.interpreter import venv_python_path
-
+        """pip must run as `sys.executable -m pip` - a bare `python3` relies
+        on PATH (absent on some hosts, a Store stub on Windows), and any
+        venv-relative pip path is POSIX-only."""
         (spawn_root / "server.py").write_text("x = 1\n")
-        (spawn_root / "requirements.txt").write_text("requests\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
         runs = _record_runs(monkeypatch)
         _capture_popen(monkeypatch)
         with pytest.raises(_StopSpawn):
             bmod._start_app_backend_body("deps-argv", _manifest("server.py"))
-        venv_argv = next(argv for argv in runs if "venv" in argv)
+        pip_argv = next(argv for argv in runs if "install" in argv)
         # Assert on the argv TOKEN, never on a substring of the joined command.
         # sys.executable's own basename is frequently `python3` (any mise- or
         # pyenv-managed interpreter, and /usr/bin/python3 itself), so a
-        # substring check for "python3 -m venv" matches the correct absolute
-        # form and fails on exactly the hosts it is meant to pass on.
-        assert venv_argv[0] == sys.executable, venv_argv
-        assert venv_argv[0] != "python3", venv_argv
-        assert venv_argv[1:3] == ["-m", "venv"], venv_argv
-        pip_argv = next(argv for argv in runs if "install" in argv)
-        assert pip_argv[0] == str(venv_python_path(spawn_root)), pip_argv
+        # substring check matches the correct absolute form and fails on
+        # exactly the hosts it is meant to pass on.
+        assert pip_argv[0] == sys.executable, pip_argv
+        assert pip_argv[0] != "python3", pip_argv
         assert pip_argv[1:3] == ["-m", "pip"], pip_argv
         # `.venv/bin/pip` is POSIX-only; the interpreter must run pip as a module.
         assert not pip_argv[0].replace("\\", "/").endswith("/bin/pip"), pip_argv
 
+    def test_a_nonzero_pip_exit_is_checked_not_discarded(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pip call passes check=True: a non-zero exit must raise into the
+        failure path rather than being silently discarded (the original defect
+        left the backend to die on an import error pointing away from
+        provisioning)."""
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        kwargs_seen: list[dict[str, Any]] = []
+
+        def _run(argv: Any, **kwargs: Any) -> Any:
+            kwargs_seen.append(kwargs)
+            return SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(bmod, "run_limited", _run)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-check", _manifest("server.py"))
+        assert kwargs_seen and kwargs_seen[0].get("check") is True, kwargs_seen
+
     def test_a_failed_dependency_install_does_not_block_the_spawn(
         self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Deps are best-effort: an offline host must still get its backend tried."""
+        """The spawn is still attempted (the deps dir may hold a previous
+        successful install, and an offline host must not lose a working
+        backend to a failed refresh) - but the failure now surfaces as an
+        ERROR naming provisioning, not a swallowed warning."""
 
         (spawn_root / "server.py").write_text("x = 1\n")
-        (spawn_root / "requirements.txt").write_text("requests\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
         _record_runs(monkeypatch, exc=RuntimeError("no network"))
         _capture_popen(monkeypatch)
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.ERROR):
             with pytest.raises(_StopSpawn):
                 bmod._start_app_backend_body("deps-fail", _manifest("server.py"))
-        assert any("Failed to install deps" in r.message for r in caplog.records)
+        assert any(
+            "Failed to install requirements.txt dependencies" in r.message
+            and r.levelno == logging.ERROR
+            for r in caplog.records
+        )
+
+    def test_a_provisioning_failure_is_written_into_the_backend_log(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The user-visible surface: the backend's own log opens with the
+        provisioning failure, so the import error the missing deps produce
+        points back at the real cause instead of reading as an app bug."""
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        err = subprocess.CalledProcessError(
+            1, ["pip"], stderr=b"No matching distribution found for requests"
+        )
+        _record_runs(monkeypatch, exc=err)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-log", _manifest("server.py"))
+        log_text = (spawn_root / "data" / "logs" / "backend.log").read_text()
+        assert "Failed to install requirements.txt dependencies" in log_text
+        assert "No matching distribution found" in log_text
+
+    def test_tokenized_url_query_strings_are_stripped_from_pip_stderr(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """redact_credentials catches user:pass@ forms; a signed or
+        tokenized URL carries its secret in the query string, which pip
+        echoes verbatim. The strip runs on the FULL stderr before the tail
+        cut, so a truncation can never split the URL from its query and let
+        the token's tail through."""
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        token = "X-Amz-Signature=" + "s" * 32
+        stderr = (
+            "x" * 380 + f"ERROR: fetch https://bucket.example/pkg.whl?{token} failed"
+        ).encode()
+        err = subprocess.CalledProcessError(1, ["pip"], stderr=stderr)
+        _record_runs(monkeypatch, exc=err)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-qs", _manifest("server.py"))
+        log_text = (spawn_root / "data" / "logs" / "backend.log").read_text()
+        assert token not in log_text
+        assert "s" * 32 not in log_text
+        # WHICH layer catches it is not the contract (the exfiltration-URL
+        # pass now runs first and can swallow the whole URL); the property
+        # is that some redaction fired and the secret is gone.
+        assert "<redacted-query>" in log_text or "[REDACTED" in log_text
+
+    def test_pip_stderr_is_redacted_before_the_tail_truncation(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redaction runs on the FULL stderr, then the tail is taken: a
+        suffix cut applied first can split a credential from the marker the
+        redactor matches on, letting the secret's tail reach the logs."""
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        secret = "AKIA" + "X" * 16
+        # Position the credential so a truncate-first implementation would
+        # cut through it: padding pushes all but the secret's tail out of the
+        # final 400 characters.
+        stderr = (
+            "x" * 380 + f"ERROR: fetch https://user:{secret}@pypi.example/simple failed"
+        ).encode()
+        err = subprocess.CalledProcessError(1, ["pip"], stderr=stderr)
+        _record_runs(monkeypatch, exc=err)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-redact", _manifest("server.py"))
+        log_text = (spawn_root / "data" / "logs" / "backend.log").read_text()
+        assert secret not in log_text
+        assert "Failed to install requirements.txt dependencies" in log_text
+
+    def test_a_shimmed_child_gets_no_deps_pythonpath(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shim XOR PYTHONPATH: `python -m kiro_crew.apps.deps_boot` resolves
+        kiro_crew through sys.path, so a deps-provided kiro_crew copy on
+        PYTHONPATH would SHADOW the gateway's shim - app code running as the
+        "shim". A shimmed child therefore launches WITHOUT the deps dir on
+        PYTHONPATH; addsitedir supplies the deps only after the trusted shim
+        has imported. The operator's own PYTHONPATH still passes through."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        deps_dir = app_deps_dir(spawn_root)
+        deps_dir.mkdir(parents=True)
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        (spawn_root / "server.py").write_text("x = 1\n")
+        monkeypatch.setenv("PYTHONPATH", "/operator/own")
+        _record_runs(monkeypatch)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-env", _manifest("server.py"))
+        assert any(str(a).endswith("deps_boot.py") for a in seen["argv"]), seen["argv"]
+        child_pp = seen["kwargs"]["env"].get("PYTHONPATH", "")
+        assert str(deps_dir) not in child_pp.split(os.pathsep), child_pp
+        assert "/operator/own" in child_pp.split(os.pathsep), child_pp
+
+    def test_no_deps_dir_means_no_pythonpath_injection(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        monkeypatch.delenv("PYTHONPATH", raising=False)
+        _record_runs(monkeypatch)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-none", _manifest("server.py"))
+        assert "PYTHONPATH" not in seen["kwargs"]["env"]
+
+
+# ---------------------------------------------------------------------------
+# Shared interpreter resolution (apps/interpreter.py)
+# ---------------------------------------------------------------------------
+
+
+def _write_runnable(path: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n")
+    path.chmod(0o755)
+
+
+@pytest.fixture()
+def probe_sandbox_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the interpreter usability probe without OS confinement.
+
+    The probe's sandbox wrapping is a host capability (absent on Windows CI
+    and fail-closed there by design); these tests pin the probe's LOGIC -
+    sys.prefix ownership and ABI match against a real venv interpreter - so
+    the seams are passed through and the child runs directly.
+    """
+    from kiro_crew.apps import interpreter as imod
+
+    monkeypatch.setattr(imod.sandbox, "wrap_argv", lambda argv, **_k: (list(argv), None))
+    monkeypatch.setattr(imod.sandbox, "cgroup_scope_argv", lambda argv: list(argv))
+    monkeypatch.setattr(imod.sandbox, "run_limited", lambda argv, **kw: subprocess.run(argv, **kw))
+
+
+def _plant_stamp(app_root: Any) -> None:
+    """Command selection requires a CURRENT stamp (stale trees crash at
+    import); fixtures that expect deps-dir scripts to resolve plant one."""
+    from kiro_crew.apps.interpreter import app_deps_dir as _add
+
+    d = _add(app_root)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / bmod._DEPS_STAMP_NAME).write_text(bmod._deps_digest(b"requests\n"))
+
+
+class TestInterpreterResolution:
+    def _venv_python(self, root: Any) -> Any:
+        from kiro_crew.apps.interpreter import venv_python_path
+
+        return venv_python_path(root)
+
+    def _real_venv(self, root: Any) -> Any:
+        """Build a REAL .venv under root (the resolver now probes the
+        interpreter, so a stub file fails _venv_is_usable)."""
+        import venv as _venv
+
+        _venv.create(root / ".venv", with_pip=False)
+        return self._venv_python(root)
+
+    def test_a_real_venv_is_preferred(self, tmp_path: Any, probe_sandbox_passthrough: Any) -> None:
+        from kiro_crew.apps.interpreter import resolve_app_python
+
+        py = self._real_venv(tmp_path)
+        assert resolve_app_python(tmp_path) == str(py)
+
+    def test_a_bootstrap_skeleton_is_not_preferred(
+        self, tmp_path: Any, probe_sandbox_passthrough: Any
+    ) -> None:
+        """The defect the probe fixes: a failed `python -m venv` leaves a
+        skeleton whose bin/python3 is the fully-runnable system interpreter
+        and whose pyvenv.cfg names the current minor version - a version
+        check ACCEPTS it, but its sys.prefix is not this venv (no working
+        environment), so the probe rejects it."""
+        from kiro_crew.apps.interpreter import resolve_app_python
+
+        # A stub interpreter that starts but is NOT the venv's own python
+        # (its sys.prefix will not point inside <root>/.venv).
+        py = self._venv_python(tmp_path)
+        py.parent.mkdir(parents=True)
+        py.write_text("#!/bin/sh\nexit 0\n")
+        py.chmod(0o755)
+        (tmp_path / ".venv" / "pyvenv.cfg").write_text(
+            f"version = {sys.version_info[0]}.{sys.version_info[1]}.0\n"
+        )
+        assert resolve_app_python(tmp_path) == sys.executable
+
+    def test_a_venv_without_an_interpreter_is_not_preferred(self, tmp_path: Any) -> None:
+        from kiro_crew.apps.interpreter import resolve_app_python
+
+        (tmp_path / ".venv").mkdir()
+        assert resolve_app_python(tmp_path) == sys.executable
+
+    def test_the_probe_runs_with_the_sanitized_app_env(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, probe_sandbox_passthrough: Any
+    ) -> None:
+        """The probe executable is app-controlled, so it must receive the
+        same sanitized environment every app subprocess gets - never the
+        gateway's own, which can carry credentials."""
+        import venv as _venv
+
+        from kiro_crew.apps import interpreter as imod
+
+        _venv.create(tmp_path / ".venv", with_pip=False)
+        monkeypatch.setenv("GATEWAY_SECRET_CANARY", "leak-me")
+        seen: dict[str, Any] = {}
+        real_run = imod.sandbox.run_limited
+
+        def _spy(argv: Any, **kwargs: Any) -> Any:
+            seen["env"] = kwargs.get("env")
+            return real_run(argv, **kwargs)
+
+        monkeypatch.setattr(imod.sandbox, "run_limited", _spy)
+        imod._venv_is_usable(tmp_path)
+        assert seen["env"] is not None, "probe ran with the inherited gateway env"
+        assert "GATEWAY_SECRET_CANARY" not in seen["env"]
+
+    def test_the_probe_fails_closed_when_no_sandbox_is_available(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The probe executes app-controlled code, so it runs ONLY under the
+        OS sandbox; a host where wrap_argv fail-closes (no backend) gets no
+        positive evidence and falls back to sys.executable - the exception
+        must never propagate into spawn or registration."""
+        import venv as _venv
+
+        from kiro_crew.apps import interpreter as imod
+
+        _venv.create(tmp_path / ".venv", with_pip=False)
+
+        def _raise(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("no sandbox backend")
+
+        monkeypatch.setattr(imod.sandbox, "wrap_argv", _raise)
+        assert imod.resolve_app_python(tmp_path) == sys.executable
+
+    def test_hostile_probe_output_reads_as_not_usable(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, probe_sandbox_passthrough: Any
+    ) -> None:
+        """The probe output is app-controlled: a venv whose interpreter prints
+        a null prefix (valid JSON, wrong shape) must read as "not usable" -
+        Path(None) raising TypeError out of the probe would break spawn and
+        registration."""
+        py = self._venv_python(tmp_path)
+        py.parent.mkdir(parents=True)
+        py.write_text("#!/bin/sh\necho '[null, %d, %d]'\n" % sys.version_info[:2])
+        py.chmod(0o755)
+        from kiro_crew.apps import interpreter as imod
+
+        assert imod._venv_is_usable(tmp_path) is False
+        assert imod.resolve_app_python(tmp_path) == sys.executable
+
+    def test_interpreter_choice_follows_the_active_tree(self, tmp_path: Any) -> None:
+        """With an ACTIVE provisioned tree the gateway interpreter owns the
+        launch (the wheels are ABI-bound to it). WITHOUT one - never
+        provisioned or provisioning failed - a POSITIVELY usable venv is
+        preferred even when requirements are declared: the bare gateway
+        interpreter holds none of the declared deps either, and a failed
+        provisioning must not also take a working legacy venv away."""
+        import sys as _sys
+        from unittest import mock
+
+        from kiro_crew.apps import interpreter as imod
+
+        (tmp_path / "requirements.txt").write_bytes(b"uvicorn\n")
+        # No tree + usable venv: the venv wins (the F2 fallback).
+        with mock.patch.object(imod, "_venv_is_usable", return_value=True):
+            assert imod.resolve_app_python(tmp_path) != _sys.executable
+        # No tree + NO usable venv: the gateway interpreter.
+        with mock.patch.object(imod, "_venv_is_usable", return_value=False):
+            assert imod.resolve_app_python(tmp_path) == _sys.executable
+        # ACTIVE tree (current-interpreter stamp planted): the gateway
+        # interpreter reclaims the launch, even with a usable venv present.
+        deps = imod.app_deps_dir(tmp_path)
+        deps.mkdir(parents=True)
+        (deps / bmod._DEPS_STAMP_NAME).write_text(bmod._deps_digest(b"uvicorn\n"))
+        with mock.patch.object(imod, "_venv_is_usable", return_value=True):
+            assert imod.resolve_app_python(tmp_path) == _sys.executable
+        # STALE tree (no stamp, foreign/absent ABI tag): the spawn would
+        # refuse to inject it, so it must not suppress the venv fallback
+        # either - a dead tree that delivers nothing cannot also take the
+        # working environment away.
+        (deps / bmod._DEPS_STAMP_NAME).unlink()
+        with mock.patch.object(imod, "_venv_is_usable", return_value=True):
+            assert imod.resolve_app_python(tmp_path) != _sys.executable
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="dangling-symlink semantics are POSIX-only")
+    def test_a_dangling_requirements_symlink_surfaces_as_a_failure(self, spawn_root: Any) -> None:
+        """is_file() answers False for a DANGLING requirements.txt link the
+        same as for absence - but a present-yet-unreadable entry must NOT be
+        silently skipped, or the backend spawns importing deps that were
+        never installed. Absence returns "" (nothing to do); a broken link
+        returns a provisioning-failure string."""
+        import os as _os
+
+        # Genuine absence: no error.
+        assert bmod.provision_app_deps("noreq-app", spawn_root) == ""
+        # Present but dangling: a failure string routed through the common
+        # failure epilogue (SEL audit + ERROR log), not a silent skip.
+        _os.symlink(str(spawn_root / "does-not-exist.txt"), str(spawn_root / "requirements.txt"))
+        events: list = []
+
+        class _Sel:
+            def log_api_access(self, **kw: Any) -> None:
+                events.append(kw)
+
+        from unittest.mock import patch
+
+        with patch.object(bmod, "sel", lambda: _Sel()):
+            err = bmod.provision_app_deps("dangling-app", spawn_root)
+        assert err and "requirements.txt" in err, err
+        assert events and events[0]["outcome"] == "deps_provision_failed", events
+
+    def test_the_spill_cap_truncates_a_flooding_child(self, tmp_path: Any) -> None:
+        """The output spill is bounded on disk: when it crosses the cap the
+        watchdog truncates it back to empty, so a flooding child cannot fill
+        the host. Drive the watchdog directly against a real temp file."""
+        import tempfile as _tf
+        import time as _time
+
+        with _tf.TemporaryFile() as f:
+            with bmod._capped_spill(f, hard_cap_bytes=4096, poll_secs=0.05) as tripped:
+                f.write(b"x" * (4096 * 4))
+                f.flush()
+                deadline = _time.monotonic() + 3
+                while _time.monotonic() < deadline and not tripped.is_set():
+                    _time.sleep(0.05)
+            assert tripped.is_set(), "watchdog must trip on a spill over the cap"
+            import os as _os
+
+            assert _os.fstat(f.fileno()).st_size <= 4096, "spill must be truncated"
+
+    def test_a_deps_dir_console_script_is_resolvable(self, tmp_path: Any) -> None:
+        """pip --target puts console scripts in <target>/bin (Scripts on
+        Windows); the resolver must find them there now that the gateway never
+        creates the venv layout that carries them on real installs."""
+        from kiro_crew import platform_compat as _pc
+        from kiro_crew.apps.interpreter import app_deps_dir, venv_provided_command
+
+        scripts = "Scripts" if _pc.IS_WINDOWS else "bin"
+        name = "my-tool.exe" if _pc.IS_WINDOWS else "my-tool"
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_stamp(tmp_path)
+        script = app_deps_dir(tmp_path) / scripts / name
+        _write_runnable(script)
+        assert venv_provided_command(tmp_path, "my-tool") == str(script)
+
+    def test_provisioned_deps_pin_the_gateway_interpreter(self, tmp_path: Any) -> None:
+        """Once the gateway provisioned .kirocrew-deps, those wheels were
+        built by sys.executable, so the venv is not consulted at all."""
+        from kiro_crew.apps.interpreter import app_deps_dir, resolve_app_python
+
+        self._real_venv(tmp_path)
+        app_deps_dir(tmp_path).mkdir(parents=True)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_stamp(tmp_path)
+        assert resolve_app_python(tmp_path) == sys.executable
+
+    def test_a_venv_console_script_wins_only_without_provisioned_deps(
+        self, tmp_path: Any, probe_sandbox_passthrough: Any
+    ) -> None:
+        from kiro_crew import platform_compat as _pc
+        from kiro_crew.apps.interpreter import app_deps_dir, venv_provided_command
+
+        scripts = "Scripts" if _pc.IS_WINDOWS else "bin"
+        name = "my-tool.exe" if _pc.IS_WINDOWS else "my-tool"
+        self._real_venv(tmp_path)
+        venv_script = tmp_path / ".venv" / scripts / name
+        _write_runnable(venv_script)
+        # No deps dir: the usable venv's script is the answer.
+        assert venv_provided_command(tmp_path, "my-tool") == str(venv_script)
+        # Provisioned deps present: the deps-dir script (shebang:
+        # sys.executable, ABI-consistent with the provisioned wheels) wins.
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_stamp(tmp_path)
+        deps_script = app_deps_dir(tmp_path) / scripts / name
+        _write_runnable(deps_script)
+        assert venv_provided_command(tmp_path, "my-tool") == str(deps_script)
+
+    def test_a_skeleton_venv_console_script_is_bypassed(self, tmp_path: Any) -> None:
+        """A console script under a NON-usable venv (skeleton / no working
+        interpreter) is skipped: its shebang interpreter would not carry the
+        app's environment. The deps-dir script is used instead."""
+        from kiro_crew import platform_compat as _pc
+        from kiro_crew.apps.interpreter import app_deps_dir, venv_provided_command
+
+        scripts = "Scripts" if _pc.IS_WINDOWS else "bin"
+        name = "my-tool.exe" if _pc.IS_WINDOWS else "my-tool"
+        # venv dir exists but has no runnable interpreter -> not usable.
+        _write_runnable(tmp_path / ".venv" / scripts / name)
+        (tmp_path / "requirements.txt").write_bytes(b"requests\n")
+        _plant_stamp(tmp_path)
+        deps_script = app_deps_dir(tmp_path) / scripts / name
+        _write_runnable(deps_script)
+        assert venv_provided_command(tmp_path, "my-tool") == str(deps_script)
 
 
 # ---------------------------------------------------------------------------
@@ -1028,26 +2350,47 @@ class TestAsgiDispatch:
         assert seen["kwargs"]["cwd"] == str(spawn_root / "src")
 
     def test_the_app_venv_interpreter_is_preferred_when_present(
-        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, probe_sandbox_passthrough: Any
     ) -> None:
-        # Real venv layout per platform: POSIX ships bin/python3, native Windows
-        # ships Scripts\python.exe (and no python3). The shared resolver honours
-        # both and requires the file to be runnable, so a permission-stripped
-        # interpreter cannot become a guaranteed-EACCES spawn target.
-        from kiro_crew import platform_compat as _pc
+        # A REAL venv: resolve_app_python now probes the interpreter (runs it
+        # and checks sys.prefix + ABI), so a stub file fails the probe. A
+        # bootstrap skeleton or wrong-ABI copy is rejected by that probe;
+        # provisioned deps (absent here) would pin sys.executable instead.
+        import venv as _venv
 
-        if _pc.IS_WINDOWS:
-            venv_py = spawn_root / ".venv" / "Scripts" / "python.exe"
-        else:
-            venv_py = spawn_root / ".venv" / "bin" / "python3"
-        venv_py.parent.mkdir(parents=True)
-        venv_py.write_text("#!/bin/sh\n")
-        venv_py.chmod(0o755)
+        from kiro_crew.apps.interpreter import venv_python_path
+
+        _venv.create(spawn_root / ".venv", with_pip=False)
+        venv_py = venv_python_path(spawn_root)
         (spawn_root / "app.py").write_text(self._ASGI_SRC)
         seen = _capture_popen(monkeypatch)
         with pytest.raises(_StopSpawn):
             bmod._start_app_backend_body("asgi-venv", _manifest("app.py"))
         assert seen["argv"][0] == str(venv_py)
+
+    def test_a_module_builtin_never_provisions_or_injects_app_deps(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A module-style builtin (entry is None) runs TRUSTED package code.
+        A requirements.txt or .kirocrew-deps sitting in its writable app dir
+        must NOT be provisioned or prepended to its PYTHONPATH - that would
+        let agent-authored wheels load ahead of the trusted module."""
+        from kiro_crew.apps.interpreter import app_deps_dir
+
+        # Both attack surfaces present in the writable app dir:
+        (spawn_root / "requirements.txt").write_bytes(b"requests\n")
+        app_deps_dir(spawn_root).mkdir(parents=True)
+        (app_deps_dir(spawn_root) / "evil.py").write_text("x = 1\n")
+        runs = _record_runs(monkeypatch)
+        seen = _capture_popen(monkeypatch)
+        # A module-style entry point: dotted, no separator, no extension, and
+        # no such file under the app root.
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("mod-builtin", _manifest("kiro_crew.apps.builtins.demo"))
+        # No pip install ran, and the deps dir is NOT on the child PYTHONPATH.
+        assert not any("install" in argv for argv in runs), runs
+        child_pp = seen["kwargs"]["env"].get("PYTHONPATH", "")
+        assert str(app_deps_dir(spawn_root)) not in child_pp, child_pp
 
 
 # ---------------------------------------------------------------------------
@@ -1196,9 +2539,7 @@ class TestStopSpawnedBackend:
             )
         assert bmod.stop_app_backend("gone") is True
 
-    def test_a_failing_log_handle_close_is_swallowed(
-        self, kills: list[tuple[int, int]]
-    ) -> None:
+    def test_a_failing_log_handle_close_is_swallowed(self, kills: list[tuple[int, int]]) -> None:
         handle = MagicMock()
         handle.close.side_effect = OSError("already closed")
         with bmod._lock:
@@ -1268,7 +2609,10 @@ class TestStopAdoptedBackend:
         assert kills == [(111, bmod.platform_compat.SIGTERM)]
 
     def test_a_recycled_pid_is_not_signalled_even_when_it_listens(
-        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        kills: list[tuple[int, int]],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """The exact residual the identity guard closes: the adopted backend
         exits, the OS recycles its PID onto ANOTHER listener of the same port
@@ -1327,9 +2671,7 @@ class TestStopAdoptedBackend:
 
         self._track(adopted_pids=[111], adopted_start_times={111: "st"}, healthy=True)
         monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st")
-        monkeypatch.setattr(
-            bmod.platform_compat, "kill_pid_pinned", lambda _pid, _st, _sig: False
-        )
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid_pinned", lambda _pid, _st, _sig: False)
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
         with caplog.at_level(logging.INFO):
             assert bmod.stop_app_backend("ext") is True
@@ -1338,8 +2680,8 @@ class TestStopAdoptedBackend:
     def test_an_unreadable_identity_is_never_signalled(
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No token was recorded at adoption (identity unreadable): the PID can
-        no longer be positively named, so it is skipped — fail toward not
+        """No token was recorded at adoption (identity unreadable): the PID
+        cannot be positively named, so it is skipped - fail toward not
         killing, per the process_start_time contract."""
 
         self._track(adopted_pids=[111], adopted_start_times={}, healthy=True)
@@ -1360,9 +2702,7 @@ class TestStopAdoptedBackend:
         assert bmod.stop_app_backend("ext") is True
         assert kills == []
 
-    def test_a_survivor_is_escalated_to_sigkill(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_a_survivor_is_escalated_to_sigkill(self, monkeypatch: pytest.MonkeyPatch) -> None:
         recorded: list[tuple[int, int]] = []
 
         def _pinned_kill(pid: int, _start_time: str, sig: int) -> bool:
@@ -1423,9 +2763,7 @@ class TestWaitForPids:
         bmod._wait_for_pids([111], timeout=5.0)
         assert states == []
 
-    def test_an_unsignalable_pid_counts_as_done(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_an_unsignalable_pid_counts_as_done(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """EPERM means 'not ours' — waiting the full deadline on it is pure latency."""
 
         monkeypatch.setattr(
@@ -1484,18 +2822,14 @@ class TestPidfileHelpers:
         bmod._pidfile_path().write_text("[1, 2, 3]")
         assert bmod._read_pidfile() == {}
 
-    def test_an_unwritable_pidfile_never_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_an_unwritable_pidfile_never_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _boom(*_a: Any, **_k: Any) -> None:
             raise OSError("read-only filesystem")
 
         monkeypatch.setattr(bmod, "atomic_write", _boom)
         bmod._write_pidfile({"app": {"pid": 1}})  # must not raise
 
-    def test_recording_a_pid_never_breaks_a_spawn(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_recording_a_pid_never_breaks_a_spawn(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _boom(_pid: int) -> str:
             raise RuntimeError("ps exploded")
 
@@ -1503,9 +2837,7 @@ class TestPidfileHelpers:
         bmod._record_app_pid("app", 4321, 9100)  # must not raise
         assert bmod._read_pidfile() == {}
 
-    def test_forgetting_a_pid_never_breaks_a_stop(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_forgetting_a_pid_never_breaks_a_stop(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _boom() -> dict[str, dict[str, Any]]:
             raise RuntimeError("disk gone")
 
@@ -1594,7 +2926,9 @@ class TestHealthCheckLoop:
         monkeypatch.setattr(bmod, "loopback_urlopen", _urlopen)
         with bmod._lock:
             bmod._processes["sick"] = AppProcess(app_name="sick", port=9134)
-        bmod._health_check_loop(bmod._processes.get("sick") or bmod.AppProcess(app_name="sick", port=9134), "/health")
+        bmod._health_check_loop(
+            bmod._processes.get("sick") or bmod.AppProcess(app_name="sick", port=9134), "/health"
+        )
         assert attempts["n"] == 2
         assert gate == [("sick", 9134, False)]
 
@@ -1619,7 +2953,9 @@ class TestHealthCheckLoop:
         monkeypatch.setattr(bmod, "loopback_urlopen", _urlopen)
         with bmod._lock:
             bmod._processes["racy"] = AppProcess(app_name="racy", port=9135)
-        bmod._health_check_loop(bmod._processes.get("racy") or bmod.AppProcess(app_name="racy", port=9135), "/health")
+        bmod._health_check_loop(
+            bmod._processes.get("racy") or bmod.AppProcess(app_name="racy", port=9135), "/health"
+        )
         assert gate == []
 
 
@@ -1656,9 +2992,7 @@ class TestBootMcpReconcile:
     def test_a_disabled_app_without_mcp_servers_is_left_alone(
         self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(
-            bmod, "list_apps", lambda: [_app("off", enabled=False, manifest={})]
-        )
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("off", enabled=False, manifest={})])
         bmod.start_enabled_app_backends()
         assert boot_env["dereg_mcp"] == []
 
@@ -1750,9 +3084,7 @@ class TestBootResourceReconcile:
             raise RuntimeError("agents dir read-only")
 
         monkeypatch.setattr("kiro_crew.apps.bridges._deregister_agents", _boom)
-        monkeypatch.setattr(
-            "kiro_crew.apps.manager._app_activation_denied", lambda _n: "banned"
-        )
+        monkeypatch.setattr("kiro_crew.apps.manager._app_activation_denied", lambda _n: "banned")
         monkeypatch.setattr(bmod, "list_apps", lambda: [_app("banned")])
         with caplog.at_level(logging.ERROR):
             bmod.start_enabled_app_backends()
@@ -1868,9 +3200,7 @@ class TestPreclaimFixedPorts:
 
 
 class TestDefensiveBranches:
-    def test_an_unreadable_extensionless_entry_is_not_a_shell_launcher(
-        self, tmp_path: Any
-    ) -> None:
+    def test_an_unreadable_extensionless_entry_is_not_a_shell_launcher(self, tmp_path: Any) -> None:
         """A directory passes the executable check but cannot be sniffed."""
 
         candidate = tmp_path / "launcher"
@@ -1950,9 +3280,7 @@ class TestDefensiveBranches:
         proc = _fake_proc(pid=600)
         proc.wait_raises = True
         with bmod._lock:
-            bmod._processes["audit"] = AppProcess(
-                app_name="audit", port=9100, pid=600, proc=proc
-            )
+            bmod._processes["audit"] = AppProcess(app_name="audit", port=9100, pid=600, proc=proc)
         assert bmod.stop_app_backend("audit") is True
         assert signals == [
             bmod.platform_compat.SIGTERM,
@@ -1992,8 +3320,13 @@ class TestDefensiveBranches:
         monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st")
         with bmod._lock:
             bmod._processes["ext"] = AppProcess(
-                app_name="ext", port=9100, pid=0, proc=None, adopted_pids=[111],
-                adopted_start_times={111: "st"}, healthy=True
+                app_name="ext",
+                port=9100,
+                pid=0,
+                proc=None,
+                adopted_pids=[111],
+                adopted_start_times={111: "st"},
+                healthy=True,
             )
         assert bmod.stop_app_backend("ext") is True
         assert killed == [


### PR DESCRIPTION
## Problem / Motivation

On a packaged install, provisioning an app's `requirements.txt` can never succeed: the bundled interpreter ships pip but no `ensurepip`, so the per-app `python -m venv` dies right after creating the directory skeleton. Neither half of the failure reaches the user -- venv creation collapses into a `logger.warning`, and the `pip install` call passes no `check` at all, so a non-zero pip exit is discarded without even a log line. The backend then spawns without its dependencies and dies on a `ModuleNotFoundError` that points at the app, not at provisioning. Worse, the half-built `.venv` skeleton is runnable enough that `resolve_app_python` prefers it afterwards, so a failed attempt actively degrades interpreter selection and never self-heals (the directory now exists, so creation is skipped forever).

## Why it matters

Every third-party app that declares a `requirements.txt` alongside a spawned backend is dead on arrival on packaged installs -- the mainstream install path -- and the visible symptom (an import error inside the app) sends both the user and the app author debugging the wrong code. The second-order effect means even a later gateway upgrade that fixes provisioning inherits the poisoned `.venv`.

## What changed (motivation -> approach -> change)

Symptom -> root cause: the provisioning mechanism itself requires `ensurepip`, which packaged interpreters do not carry, and its two error paths (checked venv, unchecked pip) both fail silent. The bundled runtime does carry a working importable pip, so `pip install --target` sidesteps the bootstrap entirely.

- **`apps/backend.py`** -- the venv+pip pair becomes one `sys.executable -m pip install --target <app>/.kirocrew-deps -r requirements.txt` with `check=True`. The deps dir is prepended to the child's `PYTHONPATH` (honored identically by any interpreter, any platform). A provisioning failure now surfaces three ways: an ERROR log with the credential-redacted pip stderr tail, a SEL `deps_provision_failed` event, and a header line written into the backend's own (user-visible) log so the subsequent import error points back at provisioning. The spawn is still attempted -- the deps dir may hold a previous good install, and an offline host must not lose a working backend to a failed refresh.
- **Stamp-gated, staged install** -- `pip --target` cannot answer "already satisfied", so a digest of `requirements.txt` plus the installing interpreter's ABI tag is stamped into the deps dir on success and a matching stamp skips pip entirely (a gateway Python upgrade therefore reprovisions even with an unchanged file) (no network work on restart, no false alarm on an offline restart of a healthy backend). pip fills a staging dir that is swapped live only on success, so a failed or interrupted refresh can never corrupt the prior good install in place; a crash inside the swap window itself is recovered on the next start (the outgoing tree is restored from its transient name before the stamp check).
- **`apps/interpreter.py`** -- `app_deps_dir()` names the layout for both spawn paths. When the gateway has provisioned deps, `resolve_app_python` returns `sys.executable` unconditionally (those wheels are ABI-bound to it). Without provisioned deps it prefers an app-shipped `.venv` only on a probe that positively confirms the venv is usable -- its interpreter starts, reports a `sys.prefix` inside the venv, and matches the gateway's Python minor version. A `pyvenv.cfg` version check was not enough in either direction (a failed `venv` skeleton passes it; a working cross-minor venv fails it), so the probe is positive evidence, not a heuristic. `venv_provided_command` mirrors that precedence and probes `<deps dir>/bin` (`Scripts` on Windows) where `--target` places console scripts, so bare console-script commands in app manifests stay resolvable.
- **Module-style builtins are outside the boundary.** A builtin whose backend runs `kiro_crew` package code is spawned from a writable app dir; it never provisions a `requirements.txt` found there and never gets `.kirocrew-deps` on its `PYTHONPATH`, so agent-authored wheels cannot load ahead of the trusted module.
- **`apps/bridges.py`** -- stdio MCP server registration exposes the deps dir through `PYTHONPATH` the same way the backend spawn env does; a `--target` install carries no interpreter, so the env is the only bridge for python-launcher servers and deps-provided console scripts (whose shebang is the installing interpreter).
- **`apps/manager.py`** -- `.kirocrew-deps` (and its transient staging/prior siblings) join the app-copy denylist next to `.venv`, so install/update never drags a machine-specific wheel tree along to shadow the destination's own provisioning.
- **Docs** -- `docs/app-kit/manifest-reference.md` (stdio command resolution) and `docs/app-kit/publishing-guide.md` (excluded directories) updated in step with the behavior.

## Tests

All in existing suites, exercising the spawn body hermetically (no real pip, no real processes):

- `test_apps_backend_coverage.py::TestDependencyInstall` -- provisioning is a single `pip --target` into staging with no `-m venv` anywhere; the pip argv is `sys.executable -m pip` (never a bare or venv-relative interpreter); `check=True` is actually passed; success swaps staging live and stamps the digest; the digest changes with the interpreter ABI tag; an interrupted swap is recovered on the next start (pip skipped, prior tree back on PYTHONPATH); an unchanged requirements file skips pip; a changed one reinstalls; a failed reinstall leaves the prior deps dir intact and still on the child's `PYTHONPATH`; a failure logs at ERROR and writes the header into the backend log; the deps dir lands first on the child's `PYTHONPATH`, and no dir means no injection.
- `test_apps_backend_coverage.py::TestInterpreterResolution` -- a real venv is preferred; a bootstrap skeleton (runnable system-python interpreter, current-minor `pyvenv.cfg`) is rejected by the probe; a venv with no interpreter falls back to `sys.executable`; provisioned deps pin `sys.executable`; deps-dir console scripts resolve, with a usable venv winning on a name collision only when no deps dir was provisioned. `TestDependencyInstall` adds a module-builtin case asserting no provisioning and no deps-dir `PYTHONPATH` injection.
- `test_app_bridges.py::TestStdioDepsDirExposure` -- stdio registrations get the deps dir prepended to `PYTHONPATH` (manifest env preserved), only when the dir exists; a deps-provided console script is rewritten to its absolute path and gets the env.
- `test_app_manager.py` -- the copy denylist drops `.kirocrew-deps` while runtime payload survives.

Local gates: isort, flake8, black/brand/encoding/docs-lint scripts, mypy (clean on changed files), and the full related pytest files (897 tests) all green.

## Manual verification

Verified empirically that `pip install --target` places console scripts in `<target>/bin` with a shebang pointing at the installing interpreter (the fact the PYTHONPATH bridging and script resolution rest on). A live packaged-install run was not performed in this environment; the issue's own reproduction (`import ensurepip` failing in the bundled interpreter, pip importable) pins the platform facts the fix relies on.

## Pattern harvest

Rule candidate: semgrep
Pattern: a subprocess call on a provisioning/setup path with `capture_output=True`, no `check=`, and an unused result -- the non-zero exit silently reads as success and the failure surfaces later as an unrelated error (here: pip's exit was discarded and the symptom was an import error inside the app).

Rule candidate: recurring-defect-patterns (AUTOSDE)
Pattern: an "is provisioned/ready" predicate satisfied by an artifact a FAILED bootstrap also creates (the half-built venv skeleton was runnable, so the venv-first interpreter policy preferred it). The fix shape is a positive success marker written only after the operation completes (the stamp file this PR adds), never existence/runnability of the output directory.

Closes #7878


---

## Transport and lifecycle details (per First Principles review)

- **Transport is a launch shim, not bare PYTHONPATH.** Python launches route through `deps_boot` (a stdlib-only shim that `site.addsitedir`s the deps dir before dispatching the real target), because PYTHONPATH never processes `.pth` files - editable installs and console scripts require it. The shim strips the deps dir from PYTHONPATH it injects elsewhere (shim XOR PYTHONPATH). Non-python and foreign-interpreter launches keep the plain PYTHONPATH transport or none at all (ABI-gated). Windows launcher pairs and embedded-ZIP console scripts have dedicated shim arms.
- **Provisioning timing.** pip runs in the backend spawn path; for apps with NO backend (stdio-only MCP servers) and for adopted file-entry backends, provisioning runs at MCP registration - otherwise nothing would ever install their requirements.
- **Uninstall quarantine apparatus.** The generated deps tree lives under app-writable `data/` (so app updates keep the last good install). That placement makes uninstall's sweep of GENERATED artifacts a security boundary: the sweep quarantines and removes exactly the gateway-generated names (strict matcher), through pinned descriptors, and preserves everything app-owned. The stop/pidfile lifecycle machinery that previously accompanied this was extracted to issue #9396.
- **Uninstall path-safety guard**: `uninstall_app` validates the app name before any metadata read (`_check_path_safety`), unchanged from main.
