### PR TITLE
fix(ci): tell an unreadable permission apart from a real denial in the override handler

### DIFF
--- a/.github/workflows/ai-review-human-override.yml
+++ b/.github/workflows/ai-review-human-override.yml
@@ -91,9 +91,52 @@ jobs:
             is_fork=true
           fi
 
+          # A permission read that FAILED is not a permission read that said
+          # "no". `2>/dev/null || true` discarded both the error text and the
+          # exit status, so a transient 5xx on GET
+          # /collaborators/{actor}/permission collapsed onto the same empty
+          # string as a genuine non-collaborator: the override was refused and
+          # the notice told the actor only a repository writer may override,
+          # sending a writer to hunt an access problem that does not exist
+          # while GitHub is degraded. Both cases still DENY -- an unreadable
+          # permission is not authorization, and this handler must never
+          # record an override it could not authorize -- but they must be
+          # DISTINGUISHABLE, so the two are split:
+          #   HTTP 404 -> the API answering "not a collaborator". A legitimate
+          #     negative; keep the writer-only notice exactly as before.
+          #   any other failure -> unknown. The common case is transient, so
+          #     absorb it here with a bounded three attempts and a short
+          #     backoff (<= 3s added), then refuse while NAMING the read, so
+          #     the actor retries instead of chasing permissions. The bound is
+          #     what keeps a fail-closed read from wedging anything: a
+          #     permanently failing API cannot hold the job open, and the
+          #     override is re-issuable by comment at any time.
           allowed=false
-          permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
-            --jq '.permission' 2>/dev/null || true)"
+          permission=""
+          perm_read_ok=""
+          perm_err="$(mktemp)"
+          for attempt in 1 2 3; do
+            if permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
+              --jq '.permission' 2>"$perm_err")"; then
+              perm_read_ok=1
+              break
+            fi
+            if grep -qiE 'HTTP 404|Not Found' "$perm_err"; then
+              permission=""
+              perm_read_ok=1
+              break
+            fi
+            echo "Reading $ACTOR's collaborator permission failed on attempt $attempt."
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$attempt"
+            fi
+          done
+          rm -f "$perm_err"
+          if [ -z "$perm_read_ok" ]; then
+            echo "::error::Could not read $ACTOR's collaborator permission after 3 attempts, so this handler cannot tell a non-writer from an unreadable permission API. Refusing the override without recording it."
+            post_notice "AI-review override not recorded: your repository permission could not be READ (the collaborator-permission API did not answer after 3 attempts). This is not a permission denial -- re-issue the command once the API is healthy."
+            exit 1
+          fi
           case "$permission" in
             admin|maintain|write) allowed=true ;;
           esac

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -211,6 +211,121 @@ class TestHumanOverrideHandler:
         assert 'if [ "${#reason}" -gt 500 ]; then' in workflow
         assert "only a repository writer" in workflow
 
+    def test_permission_read_no_longer_swallows_its_exit_status(self) -> None:
+        # The authority read that decides whether the actor may override must
+        # not treat "the API did not answer" as "the actor is not a writer".
+        # `2>/dev/null || true` made those two the same empty string.
+        script = _step_script(
+            _workflow("ai-review-human-override.yml"), "Validate and record the decision"
+        )
+        permission_read = _line_containing(script, "collaborators/$ACTOR/permission")
+
+        assert "2>/dev/null" not in permission_read
+        assert "|| true" not in permission_read
+        # An explicit 404 stays a legitimate negative, so it must be matched
+        # by name rather than folded into the unknown-failure arm.
+        assert "HTTP 404|Not Found" in script
+        # Fail-closed on an unknown read must stay BOUNDED: a permanently
+        # failing API cannot be allowed to hold this job open.
+        assert "for attempt in 1 2 3; do" in script
+
+    def _override_step(self) -> str:
+        return _step_script(
+            _workflow("ai-review-human-override.yml"), "Validate and record the decision"
+        )
+
+    @pytest.mark.parametrize(
+        ("perm_mode", "want_rc", "want_notice", "want_error_annotation"),
+        [
+            # The read answered "write": the override is recorded.
+            ("write", 0, "Human judgment recorded", False),
+            # The read answered 404 -- the API saying "not a collaborator".
+            # A real denial: same refusal wording as before, and NOT an
+            # infrastructure error, so no ::error:: annotation.
+            ("notfound", 1, "only a repository writer may override", False),
+            # The read never answered. Also denies -- an unreadable permission
+            # is not authorization -- but it must be DISTINGUISHABLE from the
+            # 404 above, or an operator reads a GitHub outage as having lost
+            # write access to the repository.
+            ("transient", 1, "could not be READ", True),
+        ],
+    )
+    def test_unreadable_permission_denies_but_says_so(
+        self,
+        perm_mode: str,
+        want_rc: int,
+        want_notice: str,
+        want_error_annotation: bool,
+        tmp_path: Path,
+    ) -> None:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the handler step is Bash; skip where Bash is absent")
+        if shutil.which("jq") is None:
+            pytest.skip("the handler step shells out to jq")
+
+        head = "a" * 40
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        notices = tmp_path / "notices.json"
+        notices.touch()
+        # Stub only the two calls this step makes, so a third call is a loud
+        # failure rather than a silent pass.
+        (bin_dir / "gh").write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "${1:-}" = "api" ] && [ "${2:-}" = "--method" ]; then\n'
+            f'  cat >> "{notices}"\n'
+            "  exit 0\n"
+            "fi\n"
+            'case "${2:-}" in\n'
+            f'  */pulls/*) printf \'{{"head":{{"sha":"{head}","repo":{{"full_name":"o/r"}}}}}}\'; exit 0 ;;\n'
+            "  */permission)\n"
+            '    case "$PERM_MODE" in\n'
+            "      write) printf 'write\\n'; exit 0 ;;\n"
+            '      notfound) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;\n'
+            '      transient) echo "gh: Internal Server Error (HTTP 500)" >&2; exit 1 ;;\n'
+            "    esac ;;\n"
+            "esac\n"
+            'echo "unexpected gh call: $*" >&2\n'
+            "exit 9\n",
+            encoding="utf-8",
+        )
+        # Keep the bounded backoff from costing this test its own wall clock.
+        (bin_dir / "sleep").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        for stub in ("gh", "sleep"):
+            (bin_dir / stub).chmod(0o755)
+
+        out_file = tmp_path / "gh-output"
+        out_file.touch()
+        proc = subprocess.run(
+            [bash, "-e", "-c", self._override_step()],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                **os.environ,
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                "PERM_MODE": perm_mode,
+                "GH_TOKEN": "stub",
+                "REPO": "o/r",
+                "PR": "1",
+                "ACTOR": "someone",
+                "COMMENT_ID": "42",
+                "COMMENT_BODY": f"/ai-review override gpt {head}: a stated reason",
+                "GITHUB_OUTPUT": str(out_file),
+            },
+            cwd=tmp_path,
+        )
+
+        assert proc.returncode == want_rc, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        assert want_notice in notices.read_text(encoding="utf-8"), notices.read_text(
+            encoding="utf-8"
+        )
+        assert ("::error::" in proc.stdout) is want_error_annotation, proc.stdout
+        if perm_mode == "write":
+            assert "actor=someone" in out_file.read_text(encoding="utf-8")
+
     def test_handler_records_a_bot_marker_before_changing_checks(self) -> None:
         workflow = _workflow("ai-review-human-override.yml")
         marker = (


### PR DESCRIPTION
## Problem / Motivation

The collaborator-permission read that authorizes `/ai-review override` in
`.github/workflows/ai-review-human-override.yml` swallowed its exit status:

```sh
permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
  --jq '.permission' 2>/dev/null || true)"
```

A transient failure on `GET /collaborators/{actor}/permission` collapses
`permission` to the empty string -- byte-for-byte what a genuine
non-collaborator produces. No `case` arm matches either, `allowed` stays
`false`, and the actor is told:

> AI-review override not recorded: only a repository writer may override an AI finding.

So the two facts "you are not a writer" and "we could not find out whether you
are a writer" are reported with one message. This is the write-side twin of the
read-side drop in #7853 (site 2 of the 2 that issue enumerates).

## Why it matters

The refusal direction is already safe -- an unreadable permission is not
authorization, and this handler must never record an override it could not
authorize. The damage is the misattribution. `/ai-review override` is the only
escape hatch when an AI review gate blocks a PR on a false positive, and it is
reached exactly when someone is trying to unblock work. Told they are not a
repository writer, a repository writer goes looking for a permissions problem
that does not exist, during the window when the permission API is degraded and
several review lanes are failing closed at the same second for the same reason.
Nothing in the run says the read is what failed: no `::error::` annotation, and
the notice actively points away from the cause.

## What changed (motivation -> approach -> change)

Symptom: an unreadable permission is reported as a permissions denial. Root
cause: `2>/dev/null || true` discards both the error text and the exit status,
erasing the distinction between the API answering "no" and the API not
answering. Change: split the two at the read, keeping both denials but making
them tell apart.

- **`HTTP 404`** is the API answering "not a collaborator". A legitimate
  negative: `permission=""`, the writer-only refusal is emitted verbatim as
  before, and no `::error::` is raised because nothing is broken. Matched by
  the `HTTP 404|Not Found` idiom already used in `fork-workflow-guard.yml` and
  `pr-readiness.yml`.
- **Any other failure** is unknown. The common case is transient, so it is
  absorbed here with a bounded three attempts and a short backoff (at most 3s
  added), after which the override is refused with an `::error::` naming the
  read and a notice that says the permission could not be READ and to
  re-issue the command -- not that the actor lacks access.

The bound is the load-bearing half of failing closed: a permanently failing
API cannot hold the job open, the job's own 10-minute timeout is untouched, and
the override is re-issuable by comment at any time, so no legitimate override
is wedged by this.

## Tests

`test/test_ai_review_workflows.py`, in `TestHumanOverrideHandler`:

- `test_unreadable_permission_denies_but_says_so` extracts the handler step and
  runs it under `bash -e` with a stubbed `gh` (and a stubbed `sleep`, so the
  backoff costs no wall clock), across all three arms:
  - `write` -> override recorded, rc 0, `actor=` written to `$GITHUB_OUTPUT`
  - `notfound` (404) -> writer-only refusal, rc 1, **no** `::error::`
  - `transient` (500 on every attempt) -> refusal naming the read, rc 1, with
    `::error::`
  The stub fails loudly on an unexpected call, so a reshaped step cannot pass
  it by accident.
- `test_permission_read_no_longer_swallows_its_exit_status` pins the shape:
  no `2>/dev/null` or `|| true` on that read, the 404 arm is still matched by
  name, and the retry stays bounded at three attempts.

Mutation-verified: with the fix reverted in place, the static pin fails and the
`transient` arm fails on
`assert 'could not be READ' in '{ "body": "AI-review override not recorded: only a repository writer may override an AI finding." }'`
-- the conflation itself, reproduced. The `write` and `notfound` arms stay green
across the revert, which is the evidence this change does not alter either
existing behavior.

## Manual verification

N/A -- the tests execute the real extracted step body against a stubbed API, so
the three arms are covered end-to-end rather than asserted on text. Gates run
locally: `python3 -m yaml` parse OK, `bash -n` on the extracted step clean,
`scripts/check_black_formatting.py` passed in scope.

## Related Issues

Refs #7853

Deliberately `Refs`, not `Closes`. #7853 enumerates **two** sites; PR #7876
(`fix/ledger-permission-read-fail-closed-7853`) already carries `Closes #7853`
for site 1, the ledger writer-gating read in `codex-review.yml`. This PR is
site 2 and touches a different file, so the two do not overlap and can land in
either order. #7853 is only fully addressed once both have merged.

## Pattern harvest

Rule candidate: `semgrep` / shell lint on the review-workflow shell.

Pattern: an authority read captured with `2>/dev/null || true`, where the
empty result is then matched against an allow-list -- the swallowed exit status
makes "the API said no" and "the API did not answer" the same value. Failing
closed is necessary but not sufficient: the two must remain distinguishable in
the operator-visible output, or an outage is reported as a denial. This is a
class in this repo, not a one-off: #7839 fixed the comments/override reads,
#7853 site 1 is in flight as #7876, and `disp_authors` in `codex-review.yml`
still carries the same shape (currently unreachable). The consolidation
candidate noted on #7853 -- lifting `gh_retry` from `pr-readiness.yml:188`
into `.github/scripts/` instead of a third inline spelling -- is the right
home for this and is deliberately out of scope here; this PR matches the
inline shape #7854 establishes so that consolidation is a single later sweep.
