### PR TITLE
fix: say that a CLI app enable cannot load backend hooks

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -301,9 +301,18 @@ root (validated against `HooksConfig._HOOK_PATH_RE`).
 | `backend.hooks.on_startup` | string | `module.path:callable` invoked when the app's hooks are wired up |
 | `backend.hooks.on_shutdown` | string | `module.path:callable` invoked when the app is disabled/torn down |
 
-`hooks.routes` handlers are wired up when the app is enabled (via
-`on_app_enable`, also re-run at gateway startup via `on_gateway_startup`), so
-they go live without waiting for a Gateway restart.
+`hooks.routes` handlers are wired up when the app is enabled **through the
+Gateway** -- the dashboard's enable action (`on_app_enable`), also re-run at
+gateway startup (`on_gateway_startup`) -- so on that path they go live without
+waiting for a Gateway restart.
+
+`kirocrew app enable` is not that path. The CLI is a separate process with no
+handle on a running Gateway's imported modules, so it cannot load or replace
+hooks: a Gateway that is already up keeps executing the hook module it imported
+earlier, even though the command succeeds and `app info` reports the new
+version. Restart the Gateway, or disable and re-enable the app from the
+dashboard, for hook changes to take effect. The CLI prints this reminder after
+enabling any app that declares `backend.hooks`.
 
 **Importing your own modules.** Hook entry files are loaded from their file path
 into a synthetic package named after the app, never via `sys.path`, so use a

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -593,6 +593,49 @@ def _register_app_crons_to_scheduler(app_name: str) -> list[str]:
     return registered
 
 
+def _warn_hooks_need_restart(app_name: str) -> bool:
+    """Say plainly that a running gateway will not pick up this app's backend hooks.
+
+    Everything else a CLI enable writes is re-read by a running gateway:
+    ``enable_app`` writes ``installed.json``, ``register_app`` writes agent and
+    skill files, and ``_register_app_crons_to_scheduler`` writes through the
+    shared cron store that the gateway's timer tick re-syncs by content digest.
+    Backend hooks are the exception -- they are Python modules imported INTO the
+    gateway process, and only the gateway can replace them (``on_app_enable`` ->
+    ``RouteRegistry.register_app_routes`` -> ``load_app_module``, reached by the
+    HTTP enable route and by ``on_gateway_startup``). This process has no handle
+    on that one's ``sys.modules``, so a CLI enable cannot load them.
+
+    Printing only "enabled <app>" reads as though it had. The operator then
+    verifies a hook change against the code the gateway imported earlier and
+    concludes the change did not work -- or that it did, when it never ran
+    (issue #7880).
+
+    Deliberately NOT gated on a live-gateway probe. ``_marker_port`` is the only
+    verified one available here, and it writes its own multi-gateway warning to
+    stderr, which would surface out of context on an app enable. The notice is
+    phrased conditionally instead, so it stays true when no gateway is up.
+
+    Only for apps that declare ``backend.hooks``: there is nothing stale to warn
+    about otherwise. Returns whether the notice was printed.
+    """
+    info = get_app(app_name)
+    manifest = info.get("manifest") if isinstance(info, dict) else None
+    backend = manifest.get("backend") if isinstance(manifest, dict) else None
+    hooks = backend.get("hooks") if isinstance(backend, dict) else None
+    if not isinstance(hooks, dict) or not hooks:
+        return False
+    declared = ", ".join(sorted(str(k) for k in hooks))
+    print(
+        f"  note: this app declares backend hooks ({declared}).\n"
+        "  A gateway that is already running keeps executing the hook code it\n"
+        "  imported earlier; this command cannot replace it. Run `kirocrew\n"
+        "  restart`, or disable and re-enable the app from the dashboard, for\n"
+        "  hook changes to take effect."
+    )
+    return True
+
+
 def _run_app_mcp_server(app_name: str) -> None:
     """Run the named app's stdio MCP server in this process.
 
@@ -676,6 +719,7 @@ def _handle_app(args: argparse.Namespace) -> None:
             if reg.skills:
                 print(f"   Skills registered: {len(reg.skills)}")
             _register_app_crons_to_scheduler(args.name)
+            _warn_hooks_need_restart(args.name)
         else:
             print(f"❌ {result.error}", file=sys.stderr)
             sys.exit(1)

--- a/test/test_app_cli.py
+++ b/test/test_app_cli.py
@@ -12,7 +12,7 @@ from kiro_crew.apps.manager import APP_MANIFEST_FILENAME, install_app
 # ---------------------------------------------------------------------------
 
 
-def _make_app_source(tmp_path, name="cli-test-app", crons=None):
+def _make_app_source(tmp_path, name="cli-test-app", crons=None, hooks=None):
     src = tmp_path / "source" / name
     src.mkdir(parents=True)
     manifest = {
@@ -26,6 +26,8 @@ def _make_app_source(tmp_path, name="cli-test-app", crons=None):
     }
     if crons is not None:
         manifest["crons"] = crons
+    if hooks is not None:
+        manifest["backend"] = {"hooks": hooks}
     (src / APP_MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
     (src / "agents").mkdir()
     (src / "agents" / "test-agent.json").write_text('{"name": "test-agent"}')
@@ -166,6 +168,79 @@ class TestHandleApp:
         _handle_app(ns)
         captured = capsys.readouterr()
         assert "Usage" in captured.out
+
+
+class TestEnableWarnsHooksNeedRestart:
+    """CLI `app enable` must not imply it loaded the app's backend hooks.
+
+    Hooks are Python modules imported INTO the gateway process, and only the
+    gateway replaces them (``on_app_enable`` -> ``register_app_routes`` ->
+    ``load_app_module``). The CLI is a separate process, so a CLI enable leaves a
+    running gateway executing the code it imported earlier -- printing only
+    "enabled <app>" reads as though the new code were live (issue #7880).
+    """
+
+    HOOKS = {
+        "routes": "backend.routes:register_routes",
+        "on_startup": "backend.hooks:on_startup",
+    }
+
+    def _enable(self):
+        import argparse
+
+        from kiro_crew.cli_commands import _handle_app
+
+        _handle_app(argparse.Namespace(app_action="enable", name="cli-test-app"))
+
+    def test_enable_warns_when_the_app_declares_backend_hooks(
+        self, tmp_path, app_env, capsys
+    ):
+        install_app(_make_app_source(tmp_path, hooks=self.HOOKS))
+
+        self._enable()
+
+        out = capsys.readouterr().out
+        assert "backend hooks" in out
+        # Names the declared hooks, so the operator can tell which code is stale.
+        assert "routes" in out and "on_startup" in out
+        # Names the recovery, not just the problem.
+        assert "restart" in out
+        # The enable itself still reports success -- the notice is additive.
+        from kiro_crew.apps.manager import _read_installed
+
+        meta = _read_installed("cli-test-app")
+        assert meta is not None and meta.enabled is True
+
+    def test_enable_says_nothing_for_an_app_without_hooks(
+        self, tmp_path, app_env, capsys
+    ):
+        """No hooks means nothing in-process can be stale -- stay quiet."""
+        install_app(_make_app_source(tmp_path))
+
+        self._enable()
+
+        out = capsys.readouterr().out
+        assert "backend hooks" not in out
+        assert "restart" not in out
+
+    def test_notice_helper_tolerates_a_malformed_backend_block(
+        self, tmp_path, app_env
+    ):
+        """A hand-edited app.json must not turn the notice into a crash.
+
+        ``backend`` and ``backend.hooks`` are user-editable JSON, so either can
+        arrive as a non-dict. The helper reports "nothing to warn about" rather
+        than raising out of a successful enable.
+        """
+        from kiro_crew.cli_commands import _warn_hooks_need_restart
+
+        install_app(_make_app_source(tmp_path))
+        app_json = app_env["home"] / "apps" / "cli-test-app" / APP_MANIFEST_FILENAME
+        data = json.loads(app_json.read_text())
+        data["backend"] = {"hooks": "backend.routes:register_routes"}
+        app_json.write_text(json.dumps(data))
+
+        assert _warn_hooks_need_restart("cli-test-app") is False
 
 
 class TestEnableRegistersCrons:


### PR DESCRIPTION
## Problem / Motivation

`kirocrew app enable` prints `enabled <app>` and nothing else. That is true
about metadata and misleading about the running gateway: the gateway keeps
executing the backend-hook code it imported earlier, while the command reports
success and `app info` shows the new version with `enabled: true`.

Reported in #7880 from a replace cycle (`app disable` -> `app uninstall` ->
`app install` -> `app enable`): every command succeeded, and the gateway was
still running the previous module.

## Why it matters

While iterating on a hooks app you verify a change against code that was never
loaded. The reporter hit it several times in one debugging session before
recognising the pattern, and it presents in a second disguise too: reinstalling
rotates the app's `.app_secret`, so the still-live old module starts failing
with an auth-shaped error, which sends you looking at credentials instead of at
a stale module.

Nothing in the CLI output, and nothing in the manifest reference, said a restart
was needed.

## What changed (motivation -> approach -> change)

**Symptom:** a CLI enable does not make new hook code live, and says nothing.

**Root cause:** backend hooks are Python modules imported *into* the gateway
process, and only the gateway replaces them -- `on_app_enable` ->
`RouteRegistry.register_app_routes` -> `load_app_module`, reached by the HTTP
enable route and by `on_gateway_startup`. The CLI is a separate OS process:
`enable_app` only writes `installed.json`, and nothing on the CLI path calls
`on_app_enable`. It has no handle on the gateway's `sys.modules`, so it cannot
load hooks at all.

Hooks are the *only* exception on this path. Everything else a CLI enable writes
is re-read by a running gateway: `installed.json`, the agent and skill files
`register_app` writes, and the cron store that the gateway's timer tick re-syncs
by content digest (`_register_app_crons_to_scheduler` exists for exactly that
reason, and its docstring already notes the separate-process problem). Hooks
have no equivalent re-sync, and no notice.

**Change:** after a CLI enable of an app that declares `backend.hooks`, print
what the command could not do and how to finish it -- naming the declared hooks
so the operator can tell which code is stale.

Two deliberate choices:

- **Gated on the manifest, not on a live-gateway probe.** `_marker_port` is the
  only verified probe available here, and it writes its own multi-gateway warning
  to stderr, which would surface out of context on an app enable. The notice is
  phrased conditionally ("a gateway that is already running...") so it stays true
  when no gateway is up.
- **`enable` only, not `install`.** `install_app` rejects an already-installed
  app and always writes `enabled=False`, so a notice on install would be either
  dead code or noise on the common fresh-install path; the reporter's
  uninstall -> install -> enable cycle ends at `enable`, which is covered. There
  is no CLI `update` action.

The manifest reference claimed hooks "go live without waiting for a Gateway
restart" without naming which enable path does that -- the claim that misleads.
It now says the Gateway-mediated enable does and the CLI cannot.

**Scope.** #7880 asked for either a notice or an actual reload. Only the notice
is here. The reload is a lifecycle change, not an obvious bug: it has to drain a
startup hook that may be parked in an `await`, order `.app_secret` rotation
against module replacement, and avoid half-reloaded states where routes are
swapped but the old `on_startup` task is still running. A partial reload would be
worse than a documented no-op. Filed with that analysis as #7903. Note that the
gateway's *own* disable -> enable already reloads hooks correctly
(`deregister_app_routes` -> `unload_app_modules`, then `load_app_module` re-execs
the file), so the recovery the notice points at is real.

## Tests

`test/test_app_cli.py::TestEnableWarnsHooksNeedRestart`:

- `test_enable_warns_when_the_app_declares_backend_hooks` -- the notice appears,
  names each declared hook and the recovery, and the enable still succeeds (the
  notice is additive, not a failure).
- `test_enable_says_nothing_for_an_app_without_hooks` -- silent when there is
  nothing in-process to be stale.
- `test_notice_helper_tolerates_a_malformed_backend_block` -- `backend` and
  `backend.hooks` are user-editable JSON, so a non-dict `hooks` reports "nothing
  to warn about" instead of raising out of a successful enable.

Both behavioral tests were confirmed red on the base commit: without the change
the captured output is exactly `enabled cli-test-app` with no notice.

Scoped runs: `test/test_app_cli.py` and `test/test_cli_commands_coverage.py`
(the other file exercising CLI `app enable`) -- 204 passed. flake8 clean on both
touched Python files; `scripts/check_black_formatting.py` passes on the
3-file diff scope.

## Manual verification

N/A -- the change is one CLI print plus a doc correction, and the tests assert on
captured stdout for both the hooks and no-hooks paths.

## Related Issues

Refs #7880 -- fixes the honest-signal half (the CLI and docs not saying a restart
is required). The reload half is split out as #7903 and remains open, so #7880 is
deliberately not closed.

## Pattern harvest

Pattern: a CLI command reports success for a write that a separate long-lived
process must act on, without saying that process has not acted yet.

This generalizes within the app CLI, and the codebase shows both outcomes:
`_cleanup_app_crons_from_scheduler` and `_register_app_crons_to_scheduler` were
each written to close exactly this gap for crons by routing through a store the
gateway re-reads, while hooks -- which have no such store -- were left silent.
Rule candidate: review-prompt -- when a CLI path mirrors a gateway path, ask
whether each resource the gateway path touches is either re-read from disk or
reported as not-yet-applied.
