### PR TITLE
fix(dashboard): scope a tool denial to its own tool group, not the whole turn

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -1552,6 +1552,26 @@ def _redact_acp_string(s: str) -> str:
 _MAX_NATIVE_CARD_ERROR = 200
 _RE_TRAILING_REQUEST_ID = re.compile(r"\(request_id:\s*[0-9a-fA-F-]+\)\s*$")
 
+# Events that end a denied tool group, clearing ``slot._batch_rejected``.
+#
+# A plain "Deny" suppresses the REST OF THE GROUP the user just refused: the
+# other tool calls the model dispatched from the same assistant message are part
+# of the same action, so re-prompting for each is nagging. The flag used to be
+# cleared only in the turn runner's ``finally``, which made its lifetime the
+# whole TURN — so a call the model issued LATER in that turn, after taking the
+# denial as feedback and revising, was auto-denied without ever being shown
+# (issue #7681). That silently broke deny -> discuss -> revise -> retry.
+#
+# Model-authored output is the boundary: a group's text/reasoning is streamed
+# BEFORE its tool_use blocks, so neither of these events ever falls between two
+# members of one group, while a revised retry necessarily follows fresh model
+# output. Deliberately NOT included is ``EVENT_TOOL_RESULT`` — the denied call's
+# own result can arrive as one, which would end the group the user just refused.
+#
+# Clearing only ever restores the interactive prompt; it never auto-approves. A
+# denial still denies, and only its blast radius changes.
+_BATCH_REJECT_CLEARED_BY = frozenset({EVENT_TEXT_CHUNK, EVENT_THINKING_CHUNK})
+
 
 def _clip_card_error(text: str, limit: int = _MAX_NATIVE_CARD_ERROR) -> str:
     """Clip *text* to *limit* characters, keeping any trailing request id."""
@@ -6389,6 +6409,18 @@ async def _run_chat(
             # credential split across thinking chunks can't cross the wire raw.
             if event.kind != EVENT_THINKING_CHUNK:
                 _flush_thinking_stream()
+
+            # The model produced new output, so the tool group the user denied is
+            # over: end the batch-rejection suppression instead of letting it run
+            # to the end of the turn and swallow a revised call the user never
+            # saw (#7681). See _BATCH_REJECT_CLEARED_BY.
+            if event.kind in _BATCH_REJECT_CLEARED_BY and getattr(slot, "_batch_rejected", False):
+                slot._batch_rejected = False
+                logger.info(
+                    "batch rejection cleared on %s — later tool calls in this "
+                    "turn are approved independently",
+                    event.kind,
+                )
 
             if event.kind == EVENT_TEXT_CHUNK:
                 # If we just exited a tool group, finalize the streaming

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -26,6 +26,8 @@ from kiro_crew.hooks import HOOK_EVENT_PRE_TOOL_USE, ToolHookResult
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    EVENT_THINKING_CHUNK,
     LLMEvent,
 )
 
@@ -854,6 +856,82 @@ class TestBatchRejection:
                 pass
 
         assert slot._batch_rejected is False
+
+
+class TestDenialCascadeLifetime:
+    """The batch-rejection suppression must not outlive the group it belongs to.
+
+    Issue #7681: ``_batch_rejected`` was only cleared in the turn runner's
+    ``finally``, so it lived for the whole TURN. A user who denied one call had
+    every later call in that turn auto-denied without ever being shown a card —
+    breaking deny → discuss → agent revises → agent retries, and reporting the
+    phantom denial to the model as "User denied tool execution".
+    """
+
+    @pytest.mark.parametrize("resume_kind", [EVENT_TEXT_CHUNK, EVENT_THINKING_CHUNK])
+    @pytest.mark.asyncio
+    async def test_later_sequential_call_is_evaluated_independently(
+        self, tmp_path, resume_kind
+    ):
+        """Call N+1 gets its own prompt once the model resumed after N was denied."""
+        state, client = _make_state(tmp_path, context_builder=_context_builder())
+        slot = _make_slot()
+        denied = _permission_event(title="tool_a")
+        denied.request_id = "req-1"
+        denied.tool_call_id = "tc-1"
+        # Model-authored output between the two calls: the denied group is over
+        # and req-2 is a NEW decision, not a remaining member of that group.
+        resumed = LLMEvent(kind=resume_kind, text="Understood - trying a different edit.")
+        revised = _permission_event(title="tool_b")
+        revised.request_id = "req-2"
+        revised.tool_call_id = "tc-2"
+        _set_stream(client, [denied, resumed, revised, _complete_event()])
+
+        async def _answer_both() -> None:
+            await _answer_approval(slot, "req-1", "rejected")
+            await _answer_approval(slot, "req-2", "approved")
+
+        answerer = asyncio.get_event_loop().create_task(_answer_both())
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+        await _drain(answerer)
+
+        # The denial itself still denies.
+        client.reject_tool.assert_any_call("req-1")
+        # The revised call was PROMPTED and could be approved — never swallowed.
+        client.approve_tool.assert_any_call("req-2")
+        assert ("req-2",) not in [c.args for c in client.reject_tool.call_args_list]
+
+    @pytest.mark.asyncio
+    async def test_same_group_still_cascades_after_the_fix(self, tmp_path):
+        """No model output between the calls → the remaining member stays denied.
+
+        Pins the blast-radius reduction as a LIFETIME change only: suppression
+        of the group the user actually refused is preserved.
+        """
+        state, client = _make_state(tmp_path, context_builder=_context_builder())
+        slot = _make_slot()
+        evt1 = _permission_event(title="tool_a")
+        evt1.request_id = "req-1"
+        evt1.tool_call_id = "tc-1"
+        evt2 = _permission_event(title="tool_b")
+        evt2.request_id = "req-2"
+        evt2.tool_call_id = "tc-2"
+        _set_stream(client, [evt1, evt2, _complete_event()])
+
+        async def _reject_first() -> None:
+            await _answer_approval(slot, "req-1", "rejected")
+
+        rejecter = asyncio.get_event_loop().create_task(_reject_first())
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+        await _drain(rejecter)
+
+        client.reject_tool.assert_any_call("req-1")
+        client.reject_tool.assert_any_call("req-2")
+        client.approve_tool.assert_not_called()
 
 
 class TestDenyOnce:


### PR DESCRIPTION
## Problem / Motivation

Denying one tool call on the dashboard auto-denies every *later* tool call in
the same turn. The later calls are never presented for approval: the user sees
no card, and the model is told `User denied tool execution` for a denial the
user never issued.

The reporter's sequence (#7681): deny a file edit for a legitimate reason; the
agent takes the feedback, does read-only work that succeeds, and issues a
*different* edit addressing the feedback; that edit is silently rejected.

## Why it matters

This breaks the core iterative loop of deny -> discuss -> agent revises ->
agent retries. A denial is the user's highest-signal steering input, and today
it costs them the rest of the turn: the agent's corrected follow-up is blocked
by a phantom denial, and neither side can tell a real denial from a cascaded
one. It teaches users that denying anything wedges the agent until they send a
new message.

It also makes an approval outage indistinguishable from a policy refusal, since
every later call in the turn reports the same user-denial text.

## What changed (motivation -> approach -> change)

Observed symptom: one deny becomes a rest-of-turn deny, with no card for the
later calls.

Root cause: `slot._batch_rejected`. A plain `reject` sets it
(`chat_runner.py`, the interactive-decision block), and the top of the
`EVENT_PERMISSION_REQUEST` branch auto-rejects while it is set - *above* the
code that builds the approval card, so nothing is shown and no future is
awaited. The flag is only cleared in the turn runner's `finally`, which makes
its **lifetime the whole turn** while its **purpose is one tool group**: the
sibling calls the model dispatched from the same assistant message, which are
part of the same action the user just refused. A call issued later in the turn
is a new decision, but inherits the group's denial.

The fix is to the flag's lifetime, not to the auto-reject site: clear
`_batch_rejected` when the model produces new output, which is what ends the
denied group. One clearing site at the top of the event loop, driven by
`_BATCH_REJECT_CLEARED_BY = {EVENT_TEXT_CHUNK, EVENT_THINKING_CHUNK}`.

Why those two events, and only those:

- A group's text and reasoning are streamed *before* its `tool_use` blocks, so
  neither event ever falls between two members of one group - suppression of
  the group the user actually refused is preserved.
- A revised retry always follows fresh model output, so the reported repro is
  covered.
- `EVENT_TOOL_RESULT` is deliberately excluded: the denied call's own result
  can arrive as one, which would end the group the user just refused.

Clearing only ever restores the interactive prompt - it never auto-approves.
A denial still denies; only its blast radius changes.

Known residual, not addressed here: a model that issues a revised call with no
text or reasoning preamble at all emits none of the clearing events, so that
call is still suppressed. Closing that needs a per-group identifier on the
permission request rather than a slot flag, which is a larger change than this
defect warrants.

Telling this bug apart from an approval-system failure, since both surface the
same `User denied tool execution` text on unrelated later calls: time the
denials. This bug returns them INSTANTLY - the gate short-circuits before an
approval card is built, so nothing is ever awaited. An approval-path failure
(an expired trust grant, or an operator-side outage with nobody to answer the
prompt) costs a full approval timeout PER CALL, so the same run takes minutes
per denial rather than milliseconds. A second discriminator: this bug is scoped
to one turn and one session, so a denial storm spanning several sessions at once
is the approval path, not this cascade.

Relationship to #7694: that PR fixes a *sibling, non-overlapping* cause in the
ACP layer - `reject_tool` answering `cancelled` (turn-scoped in the backend)
when no deny-shaped option is recognised. This PR fixes the dashboard-layer
cascade, which fires before any ACP answer is chosen: with #7694 landed, the
`_batch_rejected` gate would still auto-reject the later call. The two diffs
touch disjoint files.

## Tests

`test/test_dashboard_approval.py::TestDenialCascadeLifetime`

- `test_later_sequential_call_is_evaluated_independently` (parametrized over
  `text_chunk` and `thinking_chunk`) - after call N is denied and the model
  resumes, call N+1 is prompted and can be approved, and is never passed to
  `reject_tool`. **Red before the change** on both parameters with
  `AssertionError: approve_tool('req-2') call not found`, which is exactly the
  reported symptom.
- `test_same_group_still_cascades_after_the_fix` - with no model output between
  the two calls, the remaining member stays auto-denied and nothing is
  approved. Pins this as a lifetime change only.

The pre-existing `TestBatchRejection` and `TestDenyOnce` guards (including
`test_deny_all_still_cascades`) are unchanged and still pass.

Scoped runs: `test/test_dashboard_approval.py` 77 passed;
`test_chat_runner_coverage.py`, `test_dashboard_chat.py`,
`test_dashboard_approval_window.py`, `test_chat_turn_timeout_consistency.py`
1045 passed. `ruff check` clean on both changed files. (`ruff format --check`
reports pre-existing drift on both files at the base commit too - verified
against `origin/main` - so no reformatting is included here; the added lines
are themselves format-clean.)

## Manual verification

N/A - unit coverage sufficient: the defect is entirely in the event loop's
approval-suppression state, and both the fixed behaviour and the preserved
same-group suppression are pinned end-to-end through `_run_chat`. No UI or
rendering change.

## Related Issues

Closes #7681

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a suppression flag whose clear site is a turn/request teardown while
its purpose is a narrower sub-scope silently widens blast radius - when adding
state that suppresses a user prompt, name the scope it belongs to and clear it
at that scope's boundary, not at the outermost one"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
