### PR TITLE
fix(browser): stop inherited lifecycle roots nesting per-session namespaces

### DIFF
--- a/src/kiro_crew/browser_cli/launch.py
+++ b/src/kiro_crew/browser_cli/launch.py
@@ -96,12 +96,21 @@ _SESSION_PREFIX = "kc-"
 _CONFIG_FILE = "playwright-cli-config.json"
 
 
+#: Leaf names :func:`socket_dir` and :func:`daemon_dir` build under a session dir.
+_LIFECYCLE_LEAVES = frozenset({"s", "d"})
+
+
+def _is_generated_leaf(leaf: str) -> bool:
+    """Whether *leaf* is the 8-hex filesystem leaf of a generated session."""
+    return len(leaf) == 8 and all(c in "0123456789abcdef" for c in leaf)
+
+
 def _session_leaf(session_name: str) -> str:
     """Filesystem leaf for one generated ``kc-<8hex>`` session."""
     if not session_name.startswith(_SESSION_PREFIX):
         return ""
     leaf = session_name.removeprefix(_SESSION_PREFIX)
-    return leaf if len(leaf) == 8 and all(c in "0123456789abcdef" for c in leaf) else ""
+    return leaf if _is_generated_leaf(leaf) else ""
 
 
 def socket_dir(session_name: str, base: Path | None = None) -> Path:
@@ -116,6 +125,43 @@ def daemon_dir(session_name: str, base: Path | None = None) -> Path:
     return root / _session_leaf(session_name) / "d"
 
 
+def _operator_base(configured: str) -> Path | None:
+    """An operator-chosen lifecycle root, or ``None`` to use the default.
+
+    ``None`` for an unset value AND for one of our own roots arriving by
+    INHERITANCE, which is the same distinction :func:`browser_session_env`
+    draws on the session name -- ours-by-inheritance is regenerated, only a
+    foreign value is honoured.
+
+    Both spawn sites build the child environment from ``{**os.environ, ...}``,
+    so a gateway started from inside an agent process hands its own
+    ``SOCKETS_ENV`` down. Treating that as an operator base namespaced EVERY
+    session it hosts one level deeper inside the parent's root, recursively:
+    measured 133 children under a single root and a depth of four, with real
+    socket paths at 79 of the ``_UNIX_SOCKET_PATH_MAX_BYTES`` budget. Nesting
+    spends ~12 bytes a level, so it walks into the AF_UNIX ceiling this module
+    already guards -- and that guard returns ``{}``, which drops the daemon back
+    under reclaimable scratch and reinstates the unreachability the roots exist
+    to prevent.
+
+    Recognition is by SHAPE -- a ``<root>/<8hex>/{s,d}`` tail, which is what
+    :func:`socket_dir` and :func:`daemon_dir` build -- not by location under the
+    current ``config_dir()``. Every trigger flow changes the data home
+    (``dev-backend.sh`` exports ``KIROCREW_HOME``, and a pod runs an isolated
+    one), so an inherited root sits under the PARENT's home and a location test
+    would read it as foreign and keep nesting. Shape is also why the sibling
+    ``kc-`` prefix guard survives crossing installations. The residual cost is
+    an operator root that happens to end in ``<8hex>/s``, which is treated as
+    ours; that is the same collision the reserved prefix already accepts.
+    """
+    if not configured:
+        return None
+    path = Path(configured)
+    if path.name in _LIFECYCLE_LEAVES and _is_generated_leaf(path.parent.name):
+        return None
+    return path
+
+
 def browser_socket_env(env: Mapping[str, str]) -> dict[str, str]:
     """Environment additions keeping daemon sockets reachable and discoverable.
 
@@ -127,8 +173,11 @@ def browser_socket_env(env: Mapping[str, str]) -> dict[str, str]:
     executing the user-writable CLI wrapper.
 
     This helper is called only when Kiro Crew generated ``SESSION_ENV``.
-    Existing location variables are treated as operator-selected BASE roots,
-    then namespaced by the generated session; non-generated operator sessions
+    A location variable holding a FOREIGN value is treated as an
+    operator-selected BASE root and namespaced by the generated session; one
+    holding a value already under our own lifecycle root arrived by inheritance
+    and is ignored in favour of that root, so namespaces stay siblings instead
+    of nesting (see :func:`_operator_base`). Non-generated operator sessions
     never call this helper. Both final directories are owner-restricted. If
     validation or preparation fails, no partial additions are returned and the
     current TMPDIR/default-registry behavior remains. This helper performs
@@ -153,12 +202,8 @@ def browser_socket_env(env: Mapping[str, str]) -> dict[str, str]:
     ):
         logger.warning("Playwright lifecycle root overrides must be absolute paths")
         return {}
-    sockets_path = socket_dir(
-        session_name, Path(configured_sockets) if configured_sockets else None
-    )
-    daemons_path = daemon_dir(
-        session_name, Path(configured_daemons) if configured_daemons else None
-    )
+    sockets_path = socket_dir(session_name, _operator_base(configured_sockets))
+    daemons_path = daemon_dir(session_name, _operator_base(configured_daemons))
     additions: dict[str, str] = {}
     # Upstream builds `<root>/cli/<16-char-workspace>-<11-char-session>.sock`.
     # Check the complete shortest non-trimmed form; if even that cannot fit,

--- a/test/test_browser_cli_launch.py
+++ b/test/test_browser_cli_launch.py
@@ -431,6 +431,117 @@ def test_browser_socket_env_namespaces_configured_bases(
     ]
 
 
+def test_browser_socket_env_ignores_an_inherited_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A root already under ours arrived by inheritance, not by intent.
+
+    Both spawn sites build the child env from ``{**os.environ, ...}``, so a
+    gateway started from inside an agent process passes its own lifecycle roots
+    down. Namespacing under them nested every session one level deeper inside
+    the parent's root instead of beside it.
+    """
+    home = tmp_path / "home"
+    monkeypatch.setattr(mod, "config_dir", lambda: home)
+    monkeypatch.setattr(mod.platform_compat, "make_owner_only_dir", lambda _path: None)
+    monkeypatch.setattr(mod.platform_compat, "restrict_dir_to_owner", lambda _path: None)
+    monkeypatch.setattr(mod, "_UNIX_SOCKET_PATH_MAX_BYTES", 10_000)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    root = home / mod._LIFECYCLE_DIR
+
+    env = {
+        mod.SESSION_ENV: "kc-a1b2c3d4",
+        # what a parent agent process exports
+        mod.SOCKETS_ENV: str(root / "deadbeef" / "s"),
+        mod.DAEMON_DIR_ENV: str(root / "deadbeef" / "d"),
+    }
+    assert mod.browser_socket_env(env) == {
+        mod.SOCKETS_ENV: str(root / "a1b2c3d4" / "s"),
+        mod.DAEMON_DIR_ENV: str(root / "a1b2c3d4" / "d"),
+    }
+
+
+def test_nesting_cannot_deepen_however_long_the_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The end-to-end property: depth stays 1, so the AF_UNIX budget is fixed.
+
+    Feeding each generation's output back in as the next generation's
+    environment is what a gateway-inside-an-agent-inside-a-gateway does.
+    """
+    home = tmp_path / "home"
+    monkeypatch.setattr(mod, "config_dir", lambda: home)
+    monkeypatch.setattr(mod.platform_compat, "make_owner_only_dir", lambda _path: None)
+    monkeypatch.setattr(mod.platform_compat, "restrict_dir_to_owner", lambda _path: None)
+    monkeypatch.setattr(mod, "_UNIX_SOCKET_PATH_MAX_BYTES", 10_000)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    root = home / mod._LIFECYCLE_DIR
+
+    env = {mod.SESSION_ENV: "kc-00000000"}
+    for generation in range(6):
+        env = {mod.SESSION_ENV: f"kc-0000000{generation}", **mod.browser_socket_env(env)}
+        socket_root = Path(env[mod.SOCKETS_ENV])
+        assert socket_root.parent.parent == root, f"generation {generation} nested"
+        assert len(socket_root.relative_to(root).parts) == 2
+
+
+def test_a_foreign_configured_root_is_still_honoured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must not cost an operator their deliberate override."""
+    home = tmp_path / "home"
+    elsewhere = tmp_path / "operator-chosen"
+    monkeypatch.setattr(mod, "config_dir", lambda: home)
+    monkeypatch.setattr(mod.platform_compat, "make_owner_only_dir", lambda _path: None)
+    monkeypatch.setattr(mod.platform_compat, "restrict_dir_to_owner", lambda _path: None)
+    monkeypatch.setattr(mod, "_UNIX_SOCKET_PATH_MAX_BYTES", 10_000)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+
+    env = {mod.SESSION_ENV: "kc-a1b2c3d4", mod.SOCKETS_ENV: str(elsewhere)}
+    additions = mod.browser_socket_env(env)
+    assert additions[mod.SOCKETS_ENV] == str(elsewhere / "a1b2c3d4" / "s")
+    # the unset sibling still falls to the default root
+    assert additions[mod.DAEMON_DIR_ENV] == str(
+        home / mod._LIFECYCLE_DIR / "a1b2c3d4" / "d"
+    )
+
+
+def test_browser_socket_env_ignores_an_inherited_root_from_another_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The trigger flows change ``KIROCREW_HOME``, so identity would miss them.
+
+    ``dev-backend.sh`` exports its own ``KIROCREW_HOME`` and a pod runs an
+    isolated one, so the inherited root sits under the PARENT's home. Testing
+    location against the child's own ``config_dir()`` would read that as a
+    foreign operator base and keep nesting -- and it would also let a pod write
+    its sockets outside its isolated home. Recognition is by shape instead.
+    """
+    parent_home = tmp_path / "parent-home"
+    child_home = tmp_path / "pod-home"
+    monkeypatch.setattr(mod, "config_dir", lambda: child_home)
+    monkeypatch.setattr(mod.platform_compat, "make_owner_only_dir", lambda _path: None)
+    monkeypatch.setattr(mod.platform_compat, "restrict_dir_to_owner", lambda _path: None)
+    monkeypatch.setattr(mod, "_UNIX_SOCKET_PATH_MAX_BYTES", 10_000)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    parent_root = parent_home / mod._LIFECYCLE_DIR
+
+    env = {
+        mod.SESSION_ENV: "kc-a1b2c3d4",
+        mod.SOCKETS_ENV: str(parent_root / "deadbeef" / "s"),
+        mod.DAEMON_DIR_ENV: str(parent_root / "deadbeef" / "d"),
+    }
+    additions = mod.browser_socket_env(env)
+
+    child_root = child_home / mod._LIFECYCLE_DIR
+    assert additions == {
+        mod.SOCKETS_ENV: str(child_root / "a1b2c3d4" / "s"),
+        mod.DAEMON_DIR_ENV: str(child_root / "a1b2c3d4" / "d"),
+    }
+    # and nothing was written into the parent's home
+    assert parent_home not in Path(additions[mod.SOCKETS_ENV]).parents
+
+
 def test_browser_socket_env_fails_without_partial_additions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem / Motivation

`browser_socket_env` treats an **inherited** `PWTEST_SOCKETS_DIR` / `PWTEST_DAEMON_SESSION_DIR` as an operator-chosen base root and namespaces the new session *under* it. A Kiro Crew gateway started from inside an agent process therefore nests every session it hosts one level deeper inside the parent session's socket root, recursively.

Measured on a live gateway data home over ~43 hours (`main` @ `f51e65947`):

| | |
|---|---|
| `pw/<8hex>` top-level namespaces | 238 |
| total directories under `pw/` | 2004 |
| max depth reached | **4** — `pw/e7afb572/s/fe3a1214/s` |
| worst single parent | `pw/929db0e3/s` holding **133** further `<8hex>` children |

Nesting parents observed: `929db0e3` (133 children), `7edeaa60` (72), `c9428841` (72), `e7afb572` (38), plus 7 smaller.

## Why it matters

It spends the AF_UNIX path budget this same function guards. `browser_socket_env` refuses a root whose worst-case socket path would exceed `_UNIX_SOCKET_PATH_MAX_BYTES = 103`, because `makeSocketPath` raises and — per that code's own comment — *"browsing fails before cleanup can help."* Real socket paths on the measured host are already **79 of those 103 bytes**:

```
/home/pevu/.kiro/crew/pw/e7afb572/s/cli/da78a3e3f32e7e2b-kc-e7afb572.sock
```

Each nesting level adds ~12 bytes. On a longer `$HOME`, or two levels deeper, the guard starts refusing — and refusing returns `{}`, which drops the daemon back under reclaimable per-process scratch and reinstates exactly the unreachability (#5986) that these roots were introduced to prevent. So the failure mode is not "untidy directories", it is a silent regression of #6083 under nesting.

## What changed (motivation → approach → change)

**Symptom** → namespaces nest recursively instead of sitting as siblings.

**Root cause** → both spawn sites build the child environment from the spawning process's own environ (`acp/runtime.py`, `acp/client.py`: `lifecycle_env = {**os.environ, **browser_env}`), so a gateway that inherited these variables passes them down, and `browser_socket_env` reads the inherited value as an operator base. The trigger is a documented flow: `kirocrew-worktree-dev/SKILL.md` tells an agent to run `./dev-backend.sh` itself, and `kirocrew pod up` has the same shape.

**Change** → mirror the guard that already exists one function above. `browser_session_env` distinguishes *inherited-from-us* (regenerate) from *chosen-by-an-operator* (honour) on the session name; the new `_operator_base` draws the same line on the lifecycle roots: a configured root already under `config_dir()/pw` arrived by inheritance and is ignored in favour of that root, so namespaces stay siblings at depth 1. A foreign absolute root is still honoured and still namespaced, exactly as today.

That asymmetry between the two helpers — same file, same env block, same inheritance vector, opposite handling — is the argument that the old behaviour was unintended rather than a design choice.

## Tests

Three added to `test/test_browser_cli_launch.py`:

- `test_browser_socket_env_ignores_an_inherited_root` — a root under our own lifecycle root is replaced by the default root rather than namespaced under.
- `test_nesting_cannot_deepen_however_long_the_chain` — the end-to-end property: feeding each generation's output back in as the next generation's environment (what a gateway-inside-an-agent does) keeps depth at 1 for six generations, so the AF_UNIX budget is fixed rather than shrinking.
- `test_a_foreign_configured_root_is_still_honoured` — the guard does not cost an operator their deliberate override, and an unset sibling still falls back to the default root.

`prove.py` reports **PROVEN**: reverting the production hunk and keeping the tests fails at pytest phase `call`, so the tests catch the defect rather than merely covering the line.

## Manual verification

N/A — unit coverage sufficient. The behaviour is a pure path-derivation decision with no I/O beyond the `mkdir` the existing tests already stub; the live evidence that motivated it is the measured directory tree quoted above.

## Related Issues

Fixes #7909

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: an environment variable that a process both **consumes as input** and **exports to its children** must distinguish a value it inherited from one an operator set, or it compounds on every generation. This is the second instance in this same file — `browser_session_env` needed the identical guard for `PLAYWRIGHT_CLI_SESSION` (caught pre-merge in #5960, where inheritance made the fix a silent no-op rather than nesting). A reviewer prompt asking "is this variable also exported to children, and if so what happens when it comes back in?" would have caught both.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the `browser_socket_env` docstring stated the old base-root contract and is corrected in this diff
- [x] No secrets, credentials, or internal references in the diff

## Note on scope

The namespace is still never pruned. #6083 disclosed and deferred that, #7294 disclosed and deferred it again, and #5986 — which both named as its home — closed COMPLETED when #7294 merged, so nothing tracks it today. I kept it out of this diff deliberately: this PR is a correctness fix with a failure mode, and reclamation needs its own liveness argument. #7909 carries the details, including the measurement that makes the dominant case cheap (227 of the 238 namespaces are completely empty, because the directories are created eagerly at spawn before any browser exists — so an empty socket root means no daemon was ever launched). Happy to fold it in here if reviewers prefer one change.
