### PR TITLE
fix(artifacts): stop flagging healthy artifacts as no longer showing

### DIFF
--- a/website/src/components/ArtifactBody.tsx
+++ b/website/src/components/ArtifactBody.tsx
@@ -43,7 +43,10 @@ const NO_DOCUMENT_BOX_HEIGHT = 480
  * fires `load` like any other navigation, so without this the user is left with
  * a silent empty box and no affordance, while `failed` stays false because the
  * mint itself succeeded. Every document this surface builds carries the injected
- * height reporter, so silence past this window means the frame is showing
+ * height reporter, and the reporter re-posts unconditionally after its own
+ * window `load` (see HEIGHT_REPORTER_BODY) precisely so that a report racing
+ * ahead of the load event -- layout settles before images finish -- cannot be
+ * the last one; silence past this window therefore means the frame is showing
  * something that is not ours.
  *
  * Deliberately NOT an automatic re-mint: a second `load` also happens when a

--- a/website/src/lib/widgetSrcdoc.ts
+++ b/website/src/lib/widgetSrcdoc.ts
@@ -125,7 +125,10 @@ const TW_ERROR_INLINE_HANDLER =
  * growth eagerly, and defers/cancels shrinks. The net effect is that a
  * continuously animating widget (lava lamp, starry night) reports its height
  * once and then stops posting, instead of feeding a per-frame resize loop back
- * to the parent. */
+ * to the parent. The one deliberate exception is the window `load` re-report
+ * below: quietness must never extend across a load event the parent can
+ * observe, because parent surfaces treat post-load silence as the frame no
+ * longer showing this document. */
 const HEIGHT_REPORTER_BODY = `(function(){
   var EPS = ${HEIGHT_REPORT_EPSILON_PX};
   var SHRINK_MS = ${HEIGHT_REPORT_SHRINK_MS};
@@ -190,7 +193,21 @@ const HEIGHT_REPORTER_BODY = `(function(){
     rafId = raf(evaluate);
   }
   new ResizeObserver(schedule).observe(document.body);
-  window.addEventListener('load', function(){ setTimeout(schedule, 100); });
+  window.addEventListener('load', function(){
+    // Re-report UNCONDITIONALLY after load, bypassing the deadband. The parent
+    // surface re-arms its silence window on EVERY iframe load event (an engine
+    // renavigation onto a spent single-use url fires load with no reporter
+    // behind it, and silence within the grace window is its only signal -- see
+    // DOC_REPORT_GRACE_MS in ArtifactBody). A first measurement that raced
+    // ahead of the load event -- layout settles before images and fonts finish
+    // -- would otherwise be the LAST post this document ever makes: the parent
+    // discards it at load, the deadband swallows this re-check because the
+    // height is unchanged, and three seconds later a healthy, rendering
+    // document is flagged as no longer showing. Resetting lastSent routes the
+    // scheduled measurement through the first-measurement path, so every load
+    // the parent can observe is followed by a report.
+    setTimeout(function(){ lastSent = -1; schedule(); }, 100);
+  });
   schedule();
   document.addEventListener('click', function(e){
  // NOTE: this isTrusted check runs INSIDE the sandboxed iframe

--- a/website/src/test/widgetSrcdocReporter.test.tsx
+++ b/website/src/test/widgetSrcdocReporter.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { buildSrcdoc } from '../lib/widgetSrcdoc'
+
+// Executes the REAL height-reporter script — extracted from buildSrcdoc's own
+// output, not a copy — inside a stub document, and pins the one cross-boundary
+// contract the parent surfaces depend on:
+//
+//   every window `load` event is followed by a height report, even when the
+//   height has not changed since the last post.
+//
+// Why this matters: ArtifactBody re-arms its DOC_REPORT_GRACE_MS silence window
+// on EVERY iframe `load` and discards any report received before it (an engine
+// renavigation onto a spent single-use url fires `load` with no reporter behind
+// it — post-load silence is the only signal). A document whose layout settles
+// before its images finish posts its first measurement BEFORE `load`; if the
+// reporter's deadband then swallowed the load-time re-check (same height, no
+// post), that healthy, rendering document would be flagged "no longer showing"
+// three seconds after every open — the false positive this test locks out.
+
+type Listener = (ev?: unknown) => void
+
+function extractReporterScript(): string {
+  const out = buildSrcdoc({
+    html: '<p>probe</p>',
+    themeVars: {},
+    mode: 'dark',
+    includeHeightReporter: true,
+  })
+  const doc = new DOMParser().parseFromString(out, 'text/html')
+  const script = Array.from(doc.querySelectorAll('script'))
+    .map((s) => s.textContent ?? '')
+    .find((t) => t.includes('mc-widget-height'))
+  if (!script) throw new Error('height reporter script not found in srcdoc')
+  return script
+}
+
+function runReporter(scrollHeight: () => number) {
+  const posts: Array<{ type: string; height: number }> = []
+  const rafQueue: Listener[] = []
+  const windowListeners: Record<string, Listener[]> = {}
+
+  const fakeWindow = {
+    requestAnimationFrame: (cb: Listener) => { rafQueue.push(cb); return rafQueue.length },
+    cancelAnimationFrame: (id: number) => { rafQueue[id - 1] = () => {} },
+    addEventListener: (type: string, fn: Listener) => {
+      ;(windowListeners[type] ??= []).push(fn)
+    },
+  }
+  const fakeDocument = {
+    body: { get scrollHeight() { return scrollHeight() } },
+    addEventListener: () => {},
+    querySelectorAll: () => [],
+  }
+  const fakeParent = {
+    postMessage: (msg: { type: string; height: number }) => {
+      if (msg?.type === 'mc-widget-height') posts.push(msg)
+    },
+  }
+  let roCallback: Listener = () => {}
+  class FakeResizeObserver {
+    constructor(cb: Listener) { roCallback = cb }
+    observe() { /* initial layout is driven by the script's own schedule() */ }
+    disconnect() {}
+  }
+
+  // Shadow the globals the reporter body reaches for. It uses window.*,
+  // document.*, parent.postMessage, bare ResizeObserver, and bare
+  // setTimeout/clearTimeout (left as the real — fake-timer-patched — globals).
+  new Function('window', 'document', 'parent', 'ResizeObserver', extractReporterScript())(
+    fakeWindow, fakeDocument, fakeParent, FakeResizeObserver,
+  )
+
+  return {
+    posts,
+    flushRaf() {
+      const q = rafQueue.splice(0)
+      for (const cb of q) cb()
+    },
+    fireLoad() {
+      for (const fn of windowListeners['load'] ?? []) fn()
+    },
+    resize() { roCallback() },
+  }
+}
+
+describe('height reporter load re-report contract', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('posts an initial measurement on execution', () => {
+    const r = runReporter(() => 400)
+    r.flushRaf()
+    expect(r.posts).toEqual([{ type: 'mc-widget-height', height: 400 }])
+  })
+
+  it('re-posts after window load even when the height is unchanged', () => {
+    // The regression case: first measurement raced ahead of `load` (images
+    // still fetching), height never changes again. Without the unconditional
+    // load re-report the deadband keeps the reporter quiet, the parent — which
+    // reset its record at `load` — sees silence, and a rendering artifact is
+    // flagged "no longer showing".
+    const r = runReporter(() => 400)
+    r.flushRaf()
+    expect(r.posts).toHaveLength(1)
+
+    r.fireLoad()
+    vi.advanceTimersByTime(150) // the reporter defers its load re-check ~100ms
+    r.flushRaf()
+
+    expect(r.posts).toHaveLength(2)
+    expect(r.posts[1]).toEqual({ type: 'mc-widget-height', height: 400 })
+  })
+
+  it('stays quiet on jitter within the deadband outside of load', () => {
+    // The re-report must not weaken the quietness contract everywhere else: an
+    // animating widget still locks to its height and stops posting.
+    let h = 400
+    const r = runReporter(() => h)
+    r.flushRaf()
+    expect(r.posts).toHaveLength(1)
+
+    h = 401 // within HEIGHT_REPORT_EPSILON_PX of the last post
+    r.resize()
+    r.flushRaf()
+    vi.advanceTimersByTime(1000)
+    r.flushRaf()
+    expect(r.posts).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The artifact detail page repeatedly overlays a healthy, fully rendered artifact with the cause-neutral notice "This artifact is no longer showing" (and its Show artifact re-mint action) — while the user is looking straight at the rendered content. It reappears on every open and every re-mint (theme change, refetch), so for affected artifacts the page is effectively always wearing a false warning banner.

## Why it matters

The notice exists to be the reader's only signal that the sandboxed frame silently lost its document (an engine renavigation onto a spent single-use URL lands on a 404 that fires `load` like any other navigation). A detector that cries wolf on every artifact with images trains users to ignore it, which defeats the one recovery affordance the surface has — and it makes the artifact library feel broken.

## What changed (motivation → approach → change)

**Symptom:** the notice fires ~3 seconds after every load of an artifact whose layout settles before its subresources finish (any widget with images/fonts).

**Root cause — a race between two deliberate behaviors:**

1. `ArtifactBody`'s `onLoad` re-arms the `DOC_REPORT_GRACE_MS` (3s) silence window and discards the current height report on **every** iframe `load` — by design, because a renavigation onto a spent URL fires `load` with no reporter behind it, and post-load silence is the only observable signal (#6461).
2. The injected height reporter (`HEIGHT_REPORTER_BODY`) posts its first measurement as soon as layout settles — **before** the `load` event whenever images or fonts are still fetching — and is then deliberately quiet: its own load-time re-check measures the same height and is swallowed by the 2px deadband.

Net: the parent wipes the pre-load report at `load`, the deadband guarantees no re-report ever arrives, and a healthy document is flagged as "no longer showing".

**Change:** fix in the reporter, where the quietness contract lives. On window `load`, re-report **unconditionally** — reset `lastSent` before the scheduled re-check so it routes through the first-measurement path. Every `load` event the parent can observe is now followed by a report. The real detection case is preserved (a 404 on a spent URL carries no reporter and stays correctly silent), and quietness is untouched everywhere else (the animated-widget lock-and-stop behavior is unchanged). `ArtifactBody.tsx` gets a comment-only update pointing its silence-window invariant at the reporter's re-report as the other half of the contract.

## Tests

New `website/src/test/widgetSrcdocReporter.test.tsx` — executes the **actual reporter script extracted from `buildSrcdoc` output** (not a copy) inside a stub document:

- `posts an initial measurement on execution` — baseline contract.
- `re-posts after window load even when the height is unchanged` — the regression case; **proven red against the pre-fix reporter** (deadband swallowed the load re-check) and green with the fix.
- `stays quiet on jitter within the deadband outside of load` — pins that the fix does not weaken the quietness contract that keeps animated widgets from feeding a per-frame resize loop back to the parent.

Existing neighboring suites (`widgetSrcdoc.test.ts`, `ArtifactBody.iframeBlob.test.tsx`, `ArtifactsPage.test.tsx`, `widgetHeights.test.ts`) all pass: 84/84.

## Manual verification

Root cause and fix traced against the live repro on the reporting user's dashboard (artifact with avatar images flagged on every open). The false positive requires subresources that outlive first layout plus real browser load-event timing, which the executed-reporter unit test captures deterministically at the contract boundary.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no styled surface changes — the notice component, its copy, and all layout are byte-identical; the diff changes only *when* the injected reporter script posts (plus comments and a test), so the "after" frame is indistinguishable from a healthy artifact page.

Closes #7915

## Pattern harvest

Rule candidate: review-prompt pattern — when a frame-load observer treats
post-load silence as a failure signal, any in-frame reporter it depends on must
re-post unconditionally on `load`; a reporter that dedups by last-sent value
(deadband/ratchet) silently starves the observer whenever its first report
races ahead of the load event. Grep shape: a `load` listener that resets a
"reported" flag paired with a postMessage sender guarded by
`Math.abs(next - lastSent) <= EPS`.
