### PR TITLE
chore(test): remove dead session/acp/turn tests (B3)

### DIFF
--- a/test/test_acp_true_provider_error.py
+++ b/test/test_acp_true_provider_error.py
@@ -183,13 +183,6 @@ class TestMalformedRequestIsTerminalAndActionable:
         assert _is_transient_raw_error(err) is False
         assert "malformed" in _format_acp_error(err).lower()
 
-    def test_genuine_transient_neighbour_is_unaffected(self):
-        """Regression guard: a real transient error near this branch still
-        classifies transient and is not swallowed by the new branch."""
-        err = _err(f"{_ENVELOPE}InternalServerError ... please try again.")
-        assert _is_transient_raw_error(err) is True
-        assert "transient error" in _format_acp_error(err).lower()
-
     def test_phrase_in_message_field_alone_does_not_trigger(self):
         """Scoping guard (mirrors the message-field-echo tests): the phrase
         appearing only in the JSON-RPC ``message`` — never the provider

--- a/test/test_acp_usage_cost.py
+++ b/test/test_acp_usage_cost.py
@@ -78,9 +78,6 @@ class TestParseUsageCost:
         # Adapters that omit currency keep working; USD is assumed.
         assert parse_usage_cost({"cost": {"amount": 0.42}}) == 0.42
 
-    def test_explicit_usd_currency_accepted(self):
-        assert parse_usage_cost({"cost": {"amount": 0.42, "currency": "USD"}}) == 0.42
-
     def test_currency_match_is_case_sensitive_exact_usd(self):
         # ISO 4217 codes are uppercase; a lowercase "usd" is treated as
         # not-USD and drops the cost (exact-match posture, pinned).


### PR DESCRIPTION
## Problem / Motivation

Part of a repo-wide test-suite cleanup. This PR covers group **B3 — session/acp/turn backend tests** (`test/test_session*.py`, `test/test_acp*.py`, `test/test_turn*.py`, 100 files, 4127 tests) and removes only tests that are provably dead: exact duplicates whose bodies and assertions are byte-identical to another test in the suite.

Two such tests exist. Each pays full collection and execution cost on every CI run while asserting nothing that a surviving test does not already assert, and each carries a name that misdescribes what its body exercises — so a reader trusting the name believes a branch is covered when it is not.

## Why it matters

A duplicate test is worse than a missing one: it costs CI time on every run, and its name advertises coverage that does not exist. `test_genuine_transient_neighbour_is_unaffected` in particular reads as a regression guard on the malformed-request branch, but its input never reaches that branch — anyone relying on it as the guard for that branch is relying on nothing.

## What changed (motivation → approach → change)

**Goal:** delete dead tests without dropping a single real assertion.

**Approach.** All 100 files in scope were audited by AST against four conservative rules, with "when in doubt, keep" as the tiebreaker:

1. asserts nothing at all;
2. only asserts on a mock or constant the test itself just set (tautological);
3. unconditionally skipped/xfail with no reason and no path to run;
4. an exact duplicate of another test.

Only rule 4 produced hits. What the other three surfaced and why each was kept:

- **Rule 1 — 38 candidates, all kept.** Every one is a deliberate `# should not raise` exception-safety or no-deadlock contract (`_kill_process()` on a `None` process, `release("nonexistent")`, a swallowed sweep crash, `bt.close()` after its loop is gone). Pytest fails these on any raise, and two are bounded by `asyncio.wait_for`, so a regression makes them go red. That is a real expectation, not an absent one.
- **Rule 2 — 0 confident hits.** Three successively narrower detectors each returned only false positives: the flagged "constants" were spy collectors that product code populates, so `assert calls == []` proves a call did *not* happen rather than restating a literal. No test in scope asserts solely on something it set itself.
- **Rule 3 — 12 candidates, all kept.** Every one is a conditional `skipif` on `os.name` or `IS_POSIX` with a stated platform reason; each runs on the platforms it applies to. No unconditional `skip`/`xfail` exists anywhere in scope.

**Change.** Two test functions deleted, nothing else touched.

### Removed tests

| File | Test | Rule | Justification |
|---|---|---|---|
| `test/test_acp_true_provider_error.py` | `TestMalformedRequestIsTerminalAndActionable::test_genuine_transient_neighbour_is_unaffected` | 4 — exact duplicate | Byte-identical body and both assertions to `TestEnvelopeIsNotATransientSignal::test_genuine_5xx_inside_envelope_still_transient`, which stays. Its input (`{envelope}InternalServerError ... please try again.`) carries no "improperly formed request" phrase, so it never reaches the malformed-request branch its name claims to guard — it exercises exactly the same classifier path as the surviving test. |
| `test/test_acp_usage_cost.py` | `TestParseUsageCost::test_explicit_usd_currency_accepted` | 4 — exact duplicate | Byte-identical single assertion to `TestParseUsageCost::test_flat_cost_amount` in the same class, which stays. The explicit-`USD` acceptance path remains covered by that test, plus `test_absent_currency_is_lenient` for the omitted-currency path and `test_non_usd_currency_drops_cost` / `test_currency_match_is_case_sensitive_exact_usd` / `test_non_string_currency_drops_cost` / `test_explicit_null_currency_treated_as_absent` for the negative cases.

No test carrying an assertion absent elsewhere was removed, and no file was deleted.

## Tests

No tests added — this PR only removes two exact duplicates. Verification is that the surviving suite is unchanged in behaviour:

- **Before:** 4127 tests collected in scope on `main` at `6581a04ee`.
- **After:** 4125 collected — **4124 passed, 1 skipped, 0 failed** (85s).
- The duplicate detector reports **2 duplicate groups on base, 0 on this branch**, confirming both were removed and no others were introduced.
- The surviving counterpart of each removed test passes, so both assertions the duplicates carried are still enforced.
- `isort` and `flake8` clean on both touched files.

Rebased onto `main` at `6581a04ee` (25 commits, which touched `test/test_acp_client.py` and `test/test_session_control.py` in scope); the audit was re-run against the new base and found no new dead tests.

## Manual verification

N/A — the change is a pure deletion of duplicated test code with no product-code diff, so the test run above is the complete verification.

## Screenshots / video

N/A — no user-visible change; the diff touches only `test/`.

## Related Issues

no linked issue: part of an internal repo-wide test-cleanup sweep, tracked outside the issue tracker.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
