### PR TITLE
fix: drop inherited browser lifecycle root to stop namespace nesting (#7909)

### DIFF
--- a/src/kiro_crew/browser_cli/launch.py
+++ b/src/kiro_crew/browser_cli/launch.py
@@ -127,12 +127,32 @@ def browser_socket_env(env: Mapping[str, str]) -> dict[str, str]:
     executing the user-writable CLI wrapper.
 
     This helper is called only when Kiro Crew generated ``SESSION_ENV``.
-    Existing location variables are treated as operator-selected BASE roots,
-    then namespaced by the generated session; non-generated operator sessions
-    never call this helper. Both final directories are owner-restricted. If
-    validation or preparation fails, no partial additions are returned and the
-    current TMPDIR/default-registry behavior remains. This helper performs
-    filesystem I/O and event-loop callers MUST offload it.
+
+    A configured location variable is treated as an operator-selected BASE
+    root and namespaced by the generated session -- UNLESS it already lives
+    under ``config_dir()/_LIFECYCLE_DIR``, in which case it is one of OURS
+    arriving by INHERITANCE and is dropped in favor of the default root. Both
+    spawn sites build the child env as ``{**os.environ, **browser_env}``, so a
+    gateway started from inside an agent process -- which this repo's own
+    ``kirocrew-worktree-dev`` skill tells an agent to do via
+    ``./dev-backend.sh`` -- passes its own generated ``<8hex>/s`` and
+    ``<8hex>/d`` roots down to every session it hosts. Namespacing under an
+    inherited root would nest each generation one level deeper (``pw/<a>/s``,
+    then ``pw/<a>/s/<b>/s``, ...), growing the socket path toward
+    :data:`_UNIX_SOCKET_PATH_MAX_BYTES` until this very function starts
+    refusing the root, and littering the config dir with unbounded empty
+    namespaces (issue #7909). Dropping an inherited root keeps every session a
+    SIBLING at depth 1. This mirrors the guard in :func:`browser_session_env`,
+    which regenerates a ``kc-`` session name that arrived by the same
+    inheritance vector rather than preserving it. Each of the two variables is
+    decided independently, since only one may be inherited. A genuinely
+    operator-chosen absolute root ANYWHERE ELSE is still honored as a base, and
+    non-generated operator sessions never reach this helper at all.
+
+    Both final directories are owner-restricted. If validation or preparation
+    fails, no partial additions are returned and the current
+    TMPDIR/default-registry behavior remains. This helper performs filesystem
+    I/O and event-loop callers MUST offload it.
     """
     session_name = env.get(SESSION_ENV, "").strip()
     if not _session_leaf(session_name):
@@ -153,12 +173,29 @@ def browser_socket_env(env: Mapping[str, str]) -> dict[str, str]:
     ):
         logger.warning("Playwright lifecycle root overrides must be absolute paths")
         return {}
-    sockets_path = socket_dir(
-        session_name, Path(configured_sockets) if configured_sockets else None
-    )
-    daemons_path = daemon_dir(
-        session_name, Path(configured_daemons) if configured_daemons else None
-    )
+    # A configured root that already lives under our own lifecycle dir is one
+    # of ours arriving by inheritance, not an operator's base (see #7909 and
+    # the docstring). Drop it -- pass base=None -- so the session lands at
+    # depth 1 as a sibling instead of nesting one level deeper each generation.
+    # Resolve both sides so a symlinked data home cannot slip past the ancestry
+    # test, matching :func:`kiro_crew.config.paths._in_ephemeral_tree`. Decided
+    # per variable, since only one of the two may have been inherited.
+    lifecycle_root = (config_dir() / _LIFECYCLE_DIR).resolve()
+
+    def _base_for(configured: str) -> Path | None:
+        if not configured:
+            return None
+        root = Path(configured)
+        try:
+            resolved = root.resolve()
+        except OSError:
+            return root
+        if resolved == lifecycle_root or lifecycle_root in resolved.parents:
+            return None
+        return root
+
+    sockets_path = socket_dir(session_name, _base_for(configured_sockets))
+    daemons_path = daemon_dir(session_name, _base_for(configured_daemons))
     additions: dict[str, str] = {}
     # Upstream builds `<root>/cli/<16-char-workspace>-<11-char-session>.sock`.
     # Check the complete shortest non-trimmed form; if even that cannot fit,

--- a/test/test_browser_cli_launch.py
+++ b/test/test_browser_cli_launch.py
@@ -241,9 +241,7 @@ def test_launch_config_shell_protection_matches_an_existing_protected_leaf() -> 
         "tee ~/.kiro/crew/{leaf}",
         "cd ~/.kiro/crew && printf x > {leaf}",
     ):
-        assert (
-            security.is_sensitive_bash_command(form.format(leaf=ours)) is not None
-        ) == (
+        assert (security.is_sensitive_bash_command(form.format(leaf=ours)) is not None) == (
             security.is_sensitive_bash_command(form.format(leaf=existing)) is not None
         ), form
 
@@ -486,3 +484,130 @@ def test_browser_socket_env_refuses_relative_configured_roots(
     }
 
     assert mod.browser_socket_env(env) == {}
+
+
+def _stub_socket_prep(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Common lifecycle stubs so the real path math runs unmodified.
+
+    Leaves ``socket_dir``/``daemon_dir`` intact (the fix lives in how their
+    ``base`` is chosen), lifts the AF_UNIX guard, and records prepared dirs.
+    """
+    prepared: list[Path] = []
+    monkeypatch.setattr(mod, "_UNIX_SOCKET_PATH_MAX_BYTES", 10_000)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    monkeypatch.setattr(
+        mod.platform_compat, "make_owner_only_dir", lambda path: prepared.append(Path(path))
+    )
+    monkeypatch.setattr(mod.platform_compat, "restrict_dir_to_owner", lambda _path: None)
+    return prepared
+
+
+def test_browser_socket_env_drops_an_inherited_root_to_stay_a_sibling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An inherited root under ``config_dir()/pw`` falls back to the default.
+
+    Both spawn sites build the child env as ``{**os.environ, **browser_env}``,
+    so a gateway started inside an agent process (``./dev-backend.sh``) passes
+    its own ``pw/<hex>/s`` and ``pw/<hex>/d`` roots down. Namespacing under
+    them would nest one level deeper every generation (#7909); the fix drops a
+    root that already lives under our lifecycle dir so the new session sits at
+    depth 1 as a SIBLING -- ``pw/<leaf>/s`` and ``pw/<leaf>/d``, NOT nested.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    _stub_socket_prep(monkeypatch)
+    lifecycle_root = mod.config_dir() / mod._LIFECYCLE_DIR
+    # The value a parent gateway would inherit: its own generated subtree.
+    inherited_sockets = lifecycle_root / "deadbeef" / "s"
+    inherited_daemons = lifecycle_root / "deadbeef" / "d"
+
+    env = {
+        mod.SESSION_ENV: "kc-a1b2c3d4",
+        mod.SOCKETS_ENV: str(inherited_sockets),
+        mod.DAEMON_DIR_ENV: str(inherited_daemons),
+    }
+    assert mod.browser_socket_env(env) == {
+        mod.SOCKETS_ENV: str(lifecycle_root / "a1b2c3d4" / "s"),
+        mod.DAEMON_DIR_ENV: str(lifecycle_root / "a1b2c3d4" / "d"),
+    }
+
+
+def test_browser_socket_env_drops_the_lifecycle_root_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ancestry test also matches the lifecycle root exactly, not just below."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    _stub_socket_prep(monkeypatch)
+    lifecycle_root = mod.config_dir() / mod._LIFECYCLE_DIR
+
+    env = {
+        mod.SESSION_ENV: "kc-a1b2c3d4",
+        mod.SOCKETS_ENV: str(lifecycle_root),
+        mod.DAEMON_DIR_ENV: str(lifecycle_root),
+    }
+    assert mod.browser_socket_env(env) == {
+        mod.SOCKETS_ENV: str(lifecycle_root / "a1b2c3d4" / "s"),
+        mod.DAEMON_DIR_ENV: str(lifecycle_root / "a1b2c3d4" / "d"),
+    }
+
+
+def test_browser_socket_env_decides_each_inherited_root_independently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only one of the two variables may be inherited; each is judged alone.
+
+    Here SOCKETS_ENV arrives by inheritance (under ``pw``) and is dropped,
+    while DAEMON_DIR_ENV is a genuine operator root elsewhere and stays a base.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    _stub_socket_prep(monkeypatch)
+    lifecycle_root = mod.config_dir() / mod._LIFECYCLE_DIR
+    inherited_sockets = lifecycle_root / "deadbeef" / "s"
+    operator_daemons = tmp_path / "operator-daemons"
+
+    env = {
+        mod.SESSION_ENV: "kc-a1b2c3d4",
+        mod.SOCKETS_ENV: str(inherited_sockets),
+        mod.DAEMON_DIR_ENV: str(operator_daemons),
+    }
+    assert mod.browser_socket_env(env) == {
+        mod.SOCKETS_ENV: str(lifecycle_root / "a1b2c3d4" / "s"),
+        mod.DAEMON_DIR_ENV: str(operator_daemons / "a1b2c3d4" / "d"),
+    }
+
+
+def test_browser_socket_env_nesting_cannot_grow_depth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: chaining our output back in does not increase depth.
+
+    Mirrors ``test_nesting_cannot_collapse_two_processes_onto_one_browser`` for
+    the socket root. A first session's output, fed back as the inherited env of
+    a gateway spawned inside that process, must produce a socket root at the
+    SAME depth -- both siblings under ``config_dir()/pw`` -- not one deeper.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    _stub_socket_prep(monkeypatch)
+    lifecycle_root = mod.config_dir() / mod._LIFECYCLE_DIR
+
+    first = mod.browser_socket_env({mod.SESSION_ENV: "kc-a1b2c3d4"})
+    # A gateway spawned inside that process inherits the first session's env.
+    inherited_env = {
+        mod.SESSION_ENV: "kc-11112222",
+        mod.SOCKETS_ENV: first[mod.SOCKETS_ENV],
+        mod.DAEMON_DIR_ENV: first[mod.DAEMON_DIR_ENV],
+    }
+    second = mod.browser_socket_env(inherited_env)
+
+    assert first == {
+        mod.SOCKETS_ENV: str(lifecycle_root / "a1b2c3d4" / "s"),
+        mod.DAEMON_DIR_ENV: str(lifecycle_root / "a1b2c3d4" / "d"),
+    }
+    assert second == {
+        mod.SOCKETS_ENV: str(lifecycle_root / "11112222" / "s"),
+        mod.DAEMON_DIR_ENV: str(lifecycle_root / "11112222" / "d"),
+    }
+    # Same depth in both generations: siblings, not nested.
+    first_depth = len(Path(first[mod.SOCKETS_ENV]).parts)
+    second_depth = len(Path(second[mod.SOCKETS_ENV]).parts)
+    assert first_depth == second_depth


### PR DESCRIPTION
## Summary

Fixes #7909. `browser_socket_env` treated an **inherited** `PWTEST_SOCKETS_DIR` / `PWTEST_DAEMON_SESSION_DIR` as an operator-chosen base root and namespaced the new session *under* it. Because both spawn sites build the child env as `{**os.environ, **browser_env}`, a gateway started from inside an agent process (e.g. via the `kirocrew-worktree-dev` skill's `./dev-backend.sh` flow) passed its own generated `pw/<8hex>/s` root down to every session it hosted, nesting each generation one level deeper. This walks the socket path toward the `_UNIX_SOCKET_PATH_MAX_BYTES` guard the same function enforces and litters the config dir with unbounded empty namespaces.

The sibling `browser_session_env` in the same file already distinguishes inherited-from-us from operator-chosen and regenerates the former; `browser_socket_env` did not. That asymmetry was the bug.

## Change

- `src/kiro_crew/browser_cli/launch.py`, `browser_socket_env`: adds a per-variable `_base_for` guard. A configured root that resolves to `config_dir()/_LIFECYCLE_DIR` or below is recognized as ours-by-inheritance and dropped (base `None`, so the session lands at depth 1 as a sibling); a genuinely operator-chosen absolute root anywhere else is namespaced exactly as before. Both operands are resolved so a symlinked data home cannot slip past the ancestry test. Each of the two variables is decided independently, since only one may be inherited. Docstring rewritten to describe the new behavior and reference #7909.
- The two spawn sites in `acp/runtime.py` and `acp/client.py` are intentionally unchanged (their env shape is pinned by an existing wiring test; the fix in launch.py covers both paths).

## Testing

- `pytest test/test_browser_cli_launch.py -q` => 35 passed (baseline 31, +4 regression tests): inherited-under-`pw` drop, exact-lifecycle-root match, asymmetric one-inherited/one-operator case, and an end-to-end no-deeper-nesting property.
- `black --check`, `isort --check-only`, `flake8`, `mypy` on the changed files: clean.
- Test-quality proof: reverting the guard in place makes the 3 inheritance/depth regression tests FAIL (they get nested `pw/<parent>/s/<leaf>/s` paths) and PASS with the fix.

## Out of scope

The pre-existing empty-namespace prune/cleanup (`pw/<hex>` directories are no longer created unboundedly, but existing ones are never reaped) is left as follow-up per the issue author's note, at reviewer discretion.