### PR TITLE
chore(test): remove dead dashboard/chat/slot tests (B2)

### DIFF
--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -889,34 +889,6 @@ class TestDenyOnce:
         assert slot._batch_rejected is False
 
     @pytest.mark.asyncio
-    async def test_deny_all_still_cascades(self, tmp_path):
-        """Full 'rejected' still cascades to remaining batch tools."""
-        state, client = _make_state(tmp_path, context_builder=_context_builder())
-        slot = _make_slot()
-        evt1 = _permission_event(title="tool_a")
-        evt1.request_id = "req-1"
-        evt1.tool_call_id = "tc-1"
-        evt2 = _permission_event(title="tool_b")
-        evt2.request_id = "req-2"
-        evt2.tool_call_id = "tc-2"
-        _set_stream(client, [evt1, evt2, _complete_event()])
-
-        async def _reject_first() -> None:
-            await _answer_approval(slot, "req-1", "rejected")
-
-        rejecter = asyncio.get_event_loop().create_task(_reject_first())
-
-        with _patch_stats():
-            await _run_chat(state, slot, "hello")
-        await _drain(rejecter)
-
-        # Both tools rejected (second via batch cascade)
-        client.reject_tool.assert_any_call("req-1")
-        client.reject_tool.assert_any_call("req-2")
-        # Reset in finally block
-        assert slot._batch_rejected is False
-
-    @pytest.mark.asyncio
     async def test_decision_override_reaches_slot_future(self, tmp_path):
         """``rejected_once=True`` is what the slot future receives, not "rejected"."""
         state, _ = _make_state(tmp_path)

--- a/test/test_dashboard_origin.py
+++ b/test/test_dashboard_origin.py
@@ -450,11 +450,6 @@ class TestCheckOriginLoopbackTrust:
         request = self._make_request("http://evil.com:7779", host="evil.com:7779")
         assert check_origin(request) is False
 
-    def test_same_origin_missing_host_header_rejected(self) -> None:
-        """No Host header -> the same-origin fallback cannot confirm a match."""
-        request = self._make_request("http://localhost:8777")
-        assert check_origin(request) is False
-
 
 class TestAllowedLoopbackPortsEnv:
     """KIROCREW_ALLOWED_LOOPBACK_PORTS opts specific loopback ports into the allowed set."""


### PR DESCRIPTION
## Problem / Motivation

The dashboard/chat/slot backend suite (`test/test_dashboard*.py`, `test/test_chat*.py`, `test/test_slot*.py` — 100 files, 3487 collected tests) carries two tests that are byte-identical duplicates of a sibling in the same file. They run the same scenario a second time under a different name: no new input, no new assertion, no new branch. That is suite runtime and reader attention spent on nothing.

## Why it matters

A duplicate test is worse than a missing one: it doubles the maintenance cost of the scenario (both copies must be updated together) and it inflates the apparent coverage of a class, which is how a real gap stays hidden. In `test_dashboard_origin.py` in particular, a test named for the "missing Host header" fallback shares its body verbatim with the port-rejection test next to it — so the class reads as if two distinct branches are pinned when one input is exercised twice.

## What changed (motivation → approach → change)

Goal: remove only tests I can prove are dead, and prove it mechanically rather than by judgement.

Approach: audited all 100 in-scope files with AST scanners against four conservative rules — (1) asserts nothing, (2) tautological (asserts only on a mock/constant it set itself), (3) unconditionally skipped with no reason, (4) exact duplicate of another test. Rule 4 was checked by normalising each test body (docstring and name stripped) to a hash and grouping collisions, then hand-verifying every group: same class, same decorators, no autouse fixture that could make identical bodies behave differently. I also scanned for shadowed (redefined) test names, empty bodies, body-level `pytest.skip` calls, and tests that reference no product symbol at all.

Change: deleted the two tests that survived that verification. Nothing else in scope qualified.

### Removed (2)

| File | Test | Rule | Justification |
|---|---|---|---|
| `test/test_dashboard_approval.py` | `TestDenyOnce::test_deny_all_still_cascades` | 4 — exact duplicate | Body identical to `TestBatchRejection::test_batch_rejection_auto_rejects_remaining` (same two permission events, same `_reject_first` task, same three assertions incl. `slot._batch_rejected is False`). Same `@pytest.mark.asyncio` decorator; neither class has an autouse fixture, so both ran the identical scenario. |
| `test/test_dashboard_origin.py` | `TestCheckOriginLoopbackTrust::test_same_origin_missing_host_header_rejected` | 4 — exact duplicate | Body identical to `test_localhost_different_port_rejected_by_default` in the **same class**: both call `self._make_request("http://localhost:8777")` (the helper's `host` defaults to `""`, so neither sets a Host header) then `assert check_origin(request) is False`. |

Note for a follow-up, not addressed here: the second test's docstring names the same-origin/missing-Host fallback, but its body never distinguished that path from the plain port rejection it duplicated. The named branch is still reached by the surviving sibling; asserting it *distinctly* would need a different input (`host=` set) and is a test-writing change, out of scope for a deletion-only pass.

### Kept — every other candidate, and why

- **39 tests with no `assert` statement** — these are "does not raise" / no-op-path regression tests (`test_broadcast_noop_when_empty`, `test_recorder_failure_is_swallowed`, `test_absent_path_is_not_an_error`, the `_enqueues_recovery` and `_redacts` families, …). Each carries a real expectation: the call must not propagate an exception, and several delegate their assertions to `_assert_*` helper functions. Rule 1 requires *no* expectation; these have one.
- **8 skip-decorated tests** — all `skipif` on `os.name == "nt"` / `IS_WINDOWS` with a stated reason (AF_UNIX is POSIX-only, symlink creation needs elevation). Rule 3 requires unconditional and reasonless.
- **2 body-level `pytest.skip` calls** — both conditional host-capability guards (`website/public` absent on a python-only checkout; `expanduser` not honouring `HOME`), each followed by real assertions.
- **2 further exact-body hash collisions in `test_chat_title.py`** — false positives from my own normaliser, which strips decorators: `test_prose_replies_rejected` / `test_unspaced_script_prose_rejected` (and the accepted pair) share a one-line body but carry **different `@pytest.mark.parametrize` data** (Latin vs CJK/Thai inputs). Distinct coverage; kept.
- **12 rule-2 heuristic hits** — all invoke real product code (e.g. `test_returns_true_when_slot_exists` binds the genuine `DashboardState.has_slot` onto a spec'd mock; `test_returning_an_existing_slot_does_not_republish` exercises the real early-return in `get_or_create_slot`). Not tautological.
- **8 tests referencing no product symbol** — source-level invariant guards that assert real things about the repo (legacy dashboard assets stay deleted, a banned `_TURN_DEADLINE.reset(` pattern stays absent, refusal-code spellings agree across modules). Kept.
- **0 shadowed test names, 0 empty/`pass`-only bodies, 0 module-level unconditional `pytestmark` skips** in scope.

## Tests

No tests added — this PR only deletes. The two deletions are provably coverage-neutral because each removed body was byte-identical to a body that remains, and both removed tests are non-parametrized, so the collected-item delta is exactly −2.

Verification (re-run after rebasing onto `main` @ `1a765b88ceb7`):

- **Collection:** `pytest test/test_dashboard*.py test/test_chat*.py test/test_slot*.py --collect-only` → **3487 on base → 3485 on this branch**, exactly −2.
- **Affected files:** `pytest test/test_dashboard_approval.py test/test_dashboard_origin.py -q` → **180 passed**, exit 0.
- **Full scope:** `pytest test/test_dashboard*.py test/test_chat*.py test/test_slot*.py -q -n 4` → **3479 passed, 4 failed, 2 errors**. All 6 are `test_dashboard_peer_auth.py` / `OSError: AF_UNIX path too long`, an artefact of the long worktree path used for this branch. **Proven inherited:** stashing the diff and rerunning that file on the pristine base gives the identical failure set (4 failed, 2 errors). The diff touches neither that file nor any source it imports.
- **Gates:** `scripts/check_black_formatting.py` passes on the 2-file scope; `isort --check-only src/kiro_crew test` clean; `flake8 src/kiro_crew test` clean; `mypy src/kiro_crew/` clean (1264 files); `scripts/check_testpaths_coverage.py` clean.

## Manual verification

N/A — test-only deletion with no product diff; collection count and per-file runs are the complete signal.

## Related Issues

no linked issue: part of a repo-wide test-suite cleanup effort (group B2 — dashboard/chat/slot backend tests), not tracked as an issue.
