### PR TITLE
chore(test): remove dead mcp tests (B1)

### DIFF
--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -2225,17 +2225,6 @@ class TestUnresolvedSessionsAreNamespaced:
         mcp_computer._call_tool_inner(TOOL_LIST_APPS, {})
         assert posted and posted[0][0] == "dashboard:main"
 
-    def test_the_fix_added_no_refusal(self):
-        """The constraint this had to be solved under, asserted directly.
-
-        The obvious fix — and the one prescribed — is ``if not key: refuse``. That
-        line is why the feature did not work on macOS at all, so it must not return
-        under a different justification.
-        """
-        src = inspect.getsource(mcp_computer)
-        assert "could not be identified" not in src
-        assert "ERR_NO_SESSION" not in src
-
 
 class TestTheDriftWalkHonoursTheSnapshotBudget:
     """A raised ``max_tree_nodes`` must not make its own elements un-actionable.


### PR DESCRIPTION
## Problem / Motivation

Part of a repo-wide test-suite cleanup. Group **B1** owns the mcp backend tests:
all 107 `test/test_mcp*.py` files, 3255 test functions / ~3870 collected cases.

Some of that surface may be dead weight — tests that assert nothing, tests that
only echo a mock they set themselves, tests parked behind an unconditional skip,
and exact duplicates. Dead tests cost CI time on every run and, worse, read as
coverage that does not exist.

## Why it matters

A test that cannot fail is a false signal. Anyone reading the file believes the
invariant is guarded when nothing guards it, and the suite pays the runtime
anyway. Removing them makes the remaining coverage honest.

## What changed (motivation → approach → change)

Every one of the 107 files was read in full and every test function judged
against a deliberately conservative bar. A test qualified for removal only if it
clearly hit one of four rules:

1. asserts nothing at all — no `assert`, no `pytest.raises`, no expectation
2. only asserts on a mock or constant it set itself in the same body (tautological)
3. unconditionally skipped/xfailed, no reason given, no path to ever run
4. an exact duplicate of another test — same body, same assertions

When in doubt, keep. "Low-value" and "redundant-ish" were explicitly out of
scope. The audit was run two independent ways — a full read of every file, plus
an AST pass over all 107 files at once so cross-file duplicates could not hide —
and both converged on the same single answer.

**Exactly one test qualified.**

| File | Test | Rule | Justification |
|---|---|---|---|
| `test/test_mcp_computer.py` | `TestUnresolvedSessionsAreNamespaced.test_the_fix_added_no_refusal` | 4 | Body and both assertions are byte-identical to the module-level `test_the_shim_carries_no_identity_refusal_at_all` earlier in the same file. |

Both tests read `inspect.getsource(mcp_computer)` and assert the same two strings
(`"could not be identified"`, `"ERR_NO_SESSION"`) are absent. Only the docstring
differed. Neither uses its own parameter (`keystone` / `self`) in the body, and
the enclosing class carries no markers or autouse fixtures, so the two are
indistinguishable at runtime. The surviving copy is the module-level one, because
its docstring explains the guard in terms of the behavioural test it sits beside
("the behavioural test above passes just as well with a refusal that happens to
be unreachable").

### What was deliberately kept

Three findings looked like hits and are not. Recording them so the next pass over
this surface does not re-litigate them:

- **16 tests with no literal `assert`.** Each names a no-raise or no-hang
  contract that the call under test would violate by raising —
  `test_audit_failure_never_breaks_the_caller`,
  `test_unwritable_path_is_silently_dropped`,
  `test_wire_is_noop_when_dashboard_absent`,
  `test_teardown_tolerates_a_missing_endpoint`, and similar — or is bounded by
  `asyncio.wait_for` so a hang fails it. They assert real behaviour; only the
  assertion is structural.
- **Three pairs with identical bodies but different `@pytest.mark.parametrize`
  data sets**, so they exercise genuinely different inputs:
  `test_vet_shell_command_allows_benign` / `..._allows_smuggling_lookalikes`,
  `test_genuine_absence_allows_both` /
  `test_null_container_is_absence_not_malformation`,
  `test_undecodable_or_invalid_json_returns_none` /
  `test_non_object_json_is_refused`. A body-only duplicate check flags all three;
  folding decorators into the identity clears them.
- **Rule 3 had zero hits.** Every skip/xfail in scope is a conditional `skipif`
  with a stated reason (POSIX/Windows/real-CLI gating).

No speed-up work is in this PR — that is a later phase. Nothing outside
`test/test_mcp*.py` was touched.

## Tests

No tests added; this PR only removes one. The surviving
`test_the_shim_carries_no_identity_refusal_at_all` still locks in the exact same
invariant (no identity-refusal string may reappear in `mcp_computer`), so the
guard is intact — re-verified on the current base after rebase.

Before → after, `pytest test/test_mcp*.py` (rebased onto `main` @ `6581a04ee`):

| | Collected | Passed | Skipped | Failed |
|---|---|---|---|---|
| Before | 3870 | — | — | — |
| After | 3869 | 3854 | 15 | 0 |

`inspect` is still used 7 times in that file, so no import went stale.

## Manual verification

N/A — this is a test-only deletion; the suite run above is the verification.
Local gates on the diff: `black --check`, `isort --check-only`, and `flake8` all
clean.

## Related Issues

no linked issue: part of a repo-wide test-cleanup effort tracked outside GitHub.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
