### PR TITLE
fix(prompts): clean up a create whose close fails, and spare a rival's file

### DIFF
--- a/src/kiro_crew/dashboard/handlers/prompts.py
+++ b/src/kiro_crew/dashboard/handlers/prompts.py
@@ -408,6 +408,21 @@ _DIR_FD_SUPPORTED = pinned_fs.supports_pinned_walk() and {os.unlink, os.mkdir}.i
     os.supports_dir_fd
 )
 
+#: True when this interpreter can build a file with NO NAME at all -- Linux's
+#: ``O_TMPFILE`` -- and hand it a name with ``linkat``. That is what lets create
+#: publish a finished prompt without the body ever being reachable under a name,
+#: and without the published inode passing through a two-link state.
+#:
+#: Deliberately only ATTRIBUTE lookups: this module is imported on the gateway
+#: boot path, where every statement is paid on every launch before the socket
+#: accepts requests. The remaining half of the capability -- whether
+#: ``/proc/self/fd`` is actually mounted, which ``linkat``'s unprivileged form
+#: needs -- is a filesystem question, so it is asked inside the write job in the
+#: executor rather than here. A mount that refuses ``O_TMPFILE`` (NFS, some
+#: overlayfs) cannot be probed at all: the capability is per-filesystem, so the
+#: open is attempted and its refusal handled where it happens.
+_UNNAMED_CREATE_SUPPORTED = bool(getattr(os, "O_TMPFILE", 0)) and os.link in os.supports_dir_fd
+
 
 def _pin_prompt_dir(d: Path, *, create: bool = False) -> int:
     """Return a descriptor pinning the prompt directory *d*, via ``pinned_fs``.
@@ -751,18 +766,143 @@ async def api_prompts_create(request: web.Request) -> web.Response:
             # path, so a permission denial is not misdiagnosed as a linked root.
             return "linked_prompt_root"
         try:
+            # This one write has to satisfy four things at once, and every
+            # obvious shape satisfies only three:
+            #
+            #   (1) never publish a partial body;
+            #   (2) never destroy a file another writer holds at the name;
+            #   (3) leave the published inode at ONE link, because the read path
+            #       a few hundred lines below goes through
+            #       safe_read_file_bytes_nolink and refuses st_nlink > 1 -- a
+            #       prompt with two links answers 403 forever, which is a worse
+            #       dead end than the 409 this fixes;
+            #   (4) leave nothing behind when the process dies mid-write.
+            #
+            # O_EXCL straight onto <stem>.md breaks (1): the name holds the body
+            # while it is being written, so a failure strands a partial prompt
+            # and every retry is refused 409 -- the reported defect. A cleanup
+            # cannot fully repair that, because POSIX has no unlink-by-inode:
+            # verify-then-unlink is two syscalls on one NAME, so an atomic save
+            # landing between them destroys the replacement, breaking (2).
+            # Writing a NAMED temp and linking it into place breaks (3) and (4):
+            # between the link and the temp's removal the inode carries two
+            # links, and a process death there leaves the prompt permanently
+            # unreadable. rename would clobber, and renameat2's RENAME_NOREPLACE
+            # is Linux-only and unexposed by CPython -- pinned_fs's
+            # put_back_no_clobber records that same dead end.
+            #
+            # An UNNAMED inode has none of these problems. O_TMPFILE builds the
+            # body with no name at all, so nothing can be observed half-written
+            # and there is nothing to clean up -- a crash drops an inode that was
+            # never linked. linkat then gives it its one and only name, and link
+            # is create-if-absent, so an occupied name is still a 409 and what is
+            # already there is never touched. The inode goes from zero links to
+            # one and is never at two.
+            fd = -1
+            if _UNNAMED_CREATE_SUPPORTED and os.path.isdir("/proc/self/fd"):
+                try:
+                    # Opened THROUGH the pinned descriptor, so the inode is born
+                    # on the filesystem holding the directory the walk
+                    # validated. Mode matches what open("x") would have produced
+                    # (0o666 & ~umask), because this inode is the one published.
+                    fd = os.open(".", os.O_TMPFILE | os.O_WRONLY, 0o666, dir_fd=dir_fd)
+                except OSError:
+                    # O_TMPFILE is a per-FILESYSTEM capability, not a per-OS one:
+                    # a mount without it answers EOPNOTSUPP here. Not a failure
+                    # -- the named fallback below keeps the pinned guarantee
+                    # there, at the cost of the residual it documents.
+                    fd = -1
+            if fd >= 0:
+                try:
+                    # Written on the raw descriptor rather than through
+                    # os.fdopen, so ownership is unambiguous. fdopen's failure
+                    # behaviour is split: an argument error raises BEFORE
+                    # wrapping and leaves the descriptor open, while a late
+                    # failure (a MemoryError building the buffer) runs io.open's
+                    # error path, which closes it. Both are reachable -- probed
+                    # on CPython 3.12 -- so a caller either leaks a descriptor or
+                    # double-closes one, and a double close in this thread pool
+                    # can shut a descriptor another worker just opened. Owning
+                    # the fd here makes the close exactly once. No newline
+                    # translation exists on this path at all: the descriptor is
+                    # binary and handed the encoded bytes, so the file holds
+                    # exactly what was posted.
+                    data = content.encode("utf-8")
+                    written = 0
+                    while written < len(data):
+                        written += os.write(fd, data[written:])
+                    # Flushed BEFORE the name exists. 201 is a promise the prompt
+                    # is on disk, and fsync is where a full or network-backed
+                    # filesystem reports the error it deferred -- the
+                    # reported-success-before-durable half of this bug. It also
+                    # leaves the close below nothing to report, which is why a
+                    # failing close here cannot strand anything.
+                    os.fsync(fd)
+                    try:
+                        # The publish, and the only syscall that touches the
+                        # user-visible name. linkat's AT_EMPTY_PATH form would
+                        # need CAP_DAC_READ_SEARCH; the /proc spelling is the
+                        # unprivileged equivalent, and follow_symlinks=True is
+                        # what makes that entry resolve to the inode instead of
+                        # being linked as a symlink.
+                        os.link(
+                            f"/proc/self/fd/{fd:d}",
+                            filename,
+                            dst_dir_fd=dir_fd,
+                            follow_symlinks=True,
+                        )
+                    except FileExistsError:
+                        return "exists"
+                    # The link made the entry; this makes the ENTRY durable.
+                    # fsync on the file settles its CONTENT, and a directory is a
+                    # separate object -- so without this a power loss after a 201
+                    # can come back with the body intact and no name pointing at
+                    # it, which is the acknowledged-then-vanished case.
+                    #
+                    # It RAISES rather than being logged and swallowed. 201 is a
+                    # claim the prompt is on disk, and a create that cannot flush
+                    # the entry has not established that, so reporting success
+                    # would be the very failure this change exists to close.
+                    # Answering 500 costs little here: the body is already
+                    # written, flushed and linked, so the caller sees a complete
+                    # and readable prompt, and a retry gets a truthful 409 on a
+                    # prompt that really does exist and can still be edited
+                    # through the update path -- nothing like the truncated
+                    # leftover that made the original 409 a dead end.
+                    #
+                    # The entry is deliberately NOT withdrawn on this path. There
+                    # is nothing safe to withdraw it with: removing the leaf would
+                    # mean unlinking the prompt's own name, which is exactly the
+                    # verify-then-unlink hazard the unnamed publish exists to
+                    # avoid. The by-name branch below does withdraw, because it
+                    # already holds an identity-checked cleanup for its own leaf.
+                    os.fsync(dir_fd)
+                finally:
+                    # Swallowed: fsync already settled durability, so after a
+                    # successful publish a failing close must not turn a created
+                    # prompt into a 500. Before the publish the inode has no
+                    # name, so a failed close can leak nothing but the descriptor
+                    # itself, which this reclaims.
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                return None
+            # No O_TMPFILE on this filesystem. The body goes under its own name
+            # and the failure path removes it, bound to the inode this call
+            # created so the removal addresses an object rather than a name. The
+            # residual is the one pinned_fs's _unlink_verified documents as
+            # irreducible and ships: the verify and the unlink are two syscalls
+            # on one name, so a replacement landing between them is lost. It is
+            # accepted here for the reason it is accepted there -- POSIX offers
+            # nothing better -- and it is now confined to filesystems that cannot
+            # build an unnamed inode.
             # O_EXCL keeps create-if-absent atomic; O_NOFOLLOW refuses an
             # existing symlink at the name rather than writing through it. Both
-            # resolve relative to the pinned directory, so a swap after the
-            # check cannot redirect this write. Mode matches what open("x")
-            # would have produced (0o666 & ~umask).
-            # No newline translation exists on this path at all: the descriptor
-            # is opened binary (O_BINARY matters only on Windows, where os.open
-            # defaults to text mode and os.write would expand every \n to
-            # \r\n) and handed the encoded bytes, so the file holds exactly what
-            # was posted. Unreachable on Windows today — that platform has no
-            # openat and takes the by-name branch above — but the flag belongs
-            # on any os.open this code owns, not just the reachable ones.
+            # resolve relative to the pinned directory, so a swap after the check
+            # cannot redirect this write. O_BINARY matters only on Windows, which
+            # has no openat and takes the by-name branch above, but the flag
+            # belongs on any os.open this code owns.
             try:
                 fd = os.open(
                     filename,
@@ -776,35 +916,50 @@ async def api_prompts_create(request: web.Request) -> web.Response:
                 )
             except FileExistsError:
                 return "exists"
+            # Annotated once, in the no-openat branch above: mypy reads both
+            # branches as one scope, so re-annotating here is a [no-redef].
+            created_ident = None
             try:
-                # Written on the raw descriptor rather than through os.fdopen,
-                # so ownership is unambiguous. fdopen's failure behaviour is
-                # split: an argument error raises BEFORE wrapping and leaves the
-                # descriptor open, while a late failure (a MemoryError building
-                # the buffer) runs io.open's error path, which closes it. Both
-                # are reachable — probed on CPython 3.12 — so a caller either
-                # leaks a descriptor or double-closes one, and a double close in
-                # this thread pool can shut a descriptor another worker just
-                # opened. Owning the fd here makes the close exactly once.
+                # Identity of the inode THIS create made, read from the
+                # descriptor while it is provably ours, and unset until then so a
+                # failure before this point forgoes the cleanup rather than
+                # unlinking on a guess.
+                leaf_st = os.fstat(fd)
+                created_ident = (leaf_st.st_dev, leaf_st.st_ino)
                 data = content.encode("utf-8")
                 written = 0
                 while written < len(data):
                     written += os.write(fd, data[written:])
+                os.fsync(fd)
+                # Closed INSIDE the guarded region: close is the other place a
+                # deferred write error surfaces, so a close in a `finally` beside
+                # the cleanup arm would skip the removal below and strand the
+                # partial body. Clearing `fd` first keeps the arm's fallback
+                # close from double-closing; atomic_write uses the same two lines
+                # for the same reason.
+                fd, open_fd = -1, fd
+                os.close(open_fd)
+                # Same reason as the unnamed branch above: the O_EXCL open made
+                # the entry, and the entry needs its own flush before 201 can
+                # claim the prompt is on disk. It raises here too -- and on THIS
+                # path the failure also withdraws the publication, because the
+                # arm below already removes this call's own leaf under an identity
+                # check. A caller that gets the 500 can retry into a clean create.
+                os.fsync(dir_fd)
             except BaseException:
-                # Partial body written under an O_EXCL name: remove it, or every
-                # retry answers 409 forever. Caught broadly rather than on
-                # OSError, because the leftover is just as fatal to the retry
-                # when the write fails for a non-OS reason (a MemoryError, an
-                # interrupt): the file exists either way. Unlinked relative to
-                # the same descriptor, so the cleanup cannot reach a different
-                # file.
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
                 try:
-                    os.unlink(filename, dir_fd=dir_fd)
+                    if created_ident is not None:
+                        st_now = os.stat(filename, dir_fd=dir_fd, follow_symlinks=False)
+                        if (st_now.st_dev, st_now.st_ino) == created_ident:
+                            os.unlink(filename, dir_fd=dir_fd)
                 except OSError:
                     pass
                 raise
-            finally:
-                os.close(fd)
         finally:
             os.close(dir_fd)
         return None

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import errno
 import hashlib
@@ -1663,6 +1664,328 @@ class TestCreateAndDeletePinTheDirectory:
         assert _outcomes(mock_sel)[-1] == "blocked"
         assert (outside / "victim.md").read_text() == "SECRET"
         assert not (outside / "x.md").exists()
+
+    def test_a_create_whose_close_fails_publishes_nothing_and_stays_retryable(
+        self, tmp_path, mock_sel, monkeypatch
+    ):
+        """A DEFERRED write error cannot leave anything behind, named or not.
+
+        ``fsync`` and ``close`` are where a filesystem is entitled to first
+        report a failure it deferred -- ENOSPC once the last block is flushed,
+        EIO on a network mount -- so guarding the write loop alone does not cover
+        it. The injected failure closes the descriptor for real and then raises,
+        which is what the kernel does: POSIX leaves the descriptor's state
+        unspecified after a failed close and Linux releases it either way.
+
+        Retryability is the property under test. Anything left under the
+        prompt's own name answers every later create 409 ``prompt_exists`` over a
+        truncated body, and the API offers no way to remove a file it will not
+        admit it wrote. The empty-directory assertion is exhaustive on purpose:
+        on the unnamed path there is no temp entry to tolerate either.
+        """
+        real_fsync, real_close = os.fsync, os.close
+        failed: list[str] = []
+
+        def _fsync_fails(fd):
+            failed.append("fsync")
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        monkeypatch.setattr(os, "fsync", _fsync_fails)
+        first = asyncio.run(
+            api_prompts_create(_create_request({"name": "half", "content": "abcdefgh"}))
+        )
+        # Restored one name at a time, NOT through ``monkeypatch.undo()``: this
+        # test and the autouse home-isolation fixture share one function-scoped
+        # monkeypatch instance, so an undo here also reverts ``Path.home`` and
+        # the retry below would create the prompt in the developer's REAL
+        # ``~/.kiro/prompts`` while these assertions read ``tmp_path``.
+        monkeypatch.setattr(os, "fsync", real_fsync)
+        monkeypatch.setattr(os, "close", real_close)
+
+        assert failed, "the flush never failed — the test would be vacuous"
+        assert first.status == 500 and json.loads(first.body)["code"] == "write_failed"
+        assert _outcomes(mock_sel)[-1] == "error"
+        assert list((tmp_path / ".kiro" / "prompts").iterdir()) == []
+
+        second = asyncio.run(
+            api_prompts_create(_create_request({"name": "half", "content": "abcdefgh"}))
+        )
+        assert second.status == 201
+        assert (tmp_path / ".kiro" / "prompts" / "half.md").read_text() == "abcdefgh"
+        assert [p.name for p in (tmp_path / ".kiro" / "prompts").iterdir()] == ["half.md"]
+
+    @pytest.mark.skipif(
+        not _prompts_mod._UNNAMED_CREATE_SUPPORTED or not os.path.isdir("/proc/self/fd"),
+        reason="platform cannot build an unnamed inode (O_TMPFILE + /proc/self/fd)",
+    )
+    def test_the_published_prompt_has_exactly_one_link(self, tmp_path, mock_sel):
+        """The prompt this handler creates is readable by its own read path.
+
+        ``safe_read_file_bytes_nolink`` refuses ``st_nlink > 1``, so a publish
+        that routes the body through a second name -- write a temp, link it into
+        place, remove the temp -- leaves a window in which a crash strands a
+        prompt that answers 403 forever. Building the inode UNNAMED and linking
+        it once means the count goes from zero to one and is never two, so there
+        is no such window and no temp to reclaim.
+        """
+        resp = asyncio.run(api_prompts_create(_create_request({"name": "solo", "content": "S"})))
+        assert resp.status == 201
+        d = tmp_path / ".kiro" / "prompts"
+        published = d / "solo.md"
+        assert published.stat().st_nlink == 1
+        assert [p.name for p in d.iterdir()] == ["solo.md"]
+        # Readable through the endpoint that enforces the link count.
+        detail = asyncio.run(api_prompt_detail(_api_request("solo")))
+        assert detail.status == 200 and json.loads(detail.body)["content"] == "S"
+
+    def test_the_capability_constant_touches_no_filesystem(self):
+        """``_UNNAMED_CREATE_SUPPORTED`` is settled by attribute lookups alone.
+
+        This module is imported on the gateway boot path, where every statement
+        runs once on one thread before the dashboard socket accepts requests --
+        so a filesystem probe here is paid by every user on every launch
+        (``no-new-work-on-gateway-boot-path``). The ``/proc/self/fd`` half of the
+        capability is a mount question, so it belongs in the write job, which
+        already runs in the executor.
+
+        Read statically off the module's own source rather than by executing it:
+        the assignment's expression may name only capability attributes and may
+        call only ``getattr``/``bool``, so putting a ``stat`` back into it fails
+        here no matter how the call is spelled.
+        """
+        tree = ast.parse(Path(_prompts_mod.__file__).read_text(encoding="utf-8"))
+        assign = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_UNNAMED_CREATE_SUPPORTED"
+                for t in node.targets
+            )
+        )
+        reads = {
+            ast.unparse(sub) for sub in ast.walk(assign.value) if isinstance(sub, ast.Attribute)
+        }
+        calls = {
+            ast.unparse(sub.func) for sub in ast.walk(assign.value) if isinstance(sub, ast.Call)
+        }
+        assert reads <= {
+            "os.O_TMPFILE",
+            "os.link",
+            "os.supports_dir_fd",
+        }, f"boot-path constant reads more than capability attributes: {sorted(reads)}"
+        assert calls <= {
+            "getattr",
+            "bool",
+        }, f"boot-path constant calls something that may touch the filesystem: {sorted(calls)}"
+
+    def test_the_body_is_durable_before_the_name_appears(self, tmp_path, mock_sel, monkeypatch):
+        """The flush precedes the publish, and the DIRECTORY is flushed too.
+
+        201 says the prompt is on disk. Publishing first and flushing after
+        inverts that: the entry is visible, the lister shows it, and the error a
+        full or network-backed filesystem was deferring arrives afterwards --
+        reported success over a body that never landed.
+
+        Flushing only the file is the subtler half of the same promise. A
+        directory is a separate object, so an inode that is durable under a name
+        that is not comes back from a power loss with the body intact and nothing
+        pointing at it -- acknowledged, then vanished. Both flushes are the
+        contract, so the whole order is what is asserted.
+        """
+        order: list[str] = []
+        real_fsync, real_link = os.fsync, os.link
+
+        def _note_fsync(fd):
+            # Distinguish the file's flush from the directory's by asking the
+            # descriptor what it is, rather than by call order.
+            order.append("fsync_dir" if stat.S_ISDIR(os.fstat(fd).st_mode) else "fsync_file")
+            return real_fsync(fd)
+
+        def _note_link(*a, **kw):
+            order.append("publish")
+            return real_link(*a, **kw)
+
+        monkeypatch.setattr(os, "fsync", _note_fsync)
+        monkeypatch.setattr(os, "link", _note_link)
+        resp = asyncio.run(api_prompts_create(_create_request({"name": "durable", "content": "B"})))
+        monkeypatch.setattr(os, "fsync", real_fsync)
+        monkeypatch.setattr(os, "link", real_link)
+
+        assert resp.status == 201
+        assert order[:2] == ["fsync_file", "publish"], f"flush must precede publish, got {order}"
+        assert "fsync_dir" in order, f"the directory entry was never flushed: {order}"
+        assert order.index("fsync_dir") > order.index(
+            "publish"
+        ), f"the directory flush must follow the publish it is making durable: {order}"
+        assert (tmp_path / ".kiro" / "prompts" / "durable.md").read_text() == "B"
+
+    def test_a_failing_directory_flush_is_reported_not_swallowed(
+        self, tmp_path, mock_sel, monkeypatch
+    ):
+        """A create that cannot flush the ENTRY must not answer 201.
+
+        201 is a claim the prompt is on disk. Flushing the body but only logging a
+        failed directory flush reports a durability this call never established --
+        the same reported-success-before-durable class the whole change exists to
+        close. An earlier revision swallowed it on the theory that 500 would strand
+        the caller in the 409-forever dead end; that was wrong. The body is already
+        written, flushed and linked by this point, so the caller sees a complete
+        readable prompt and a retry gets a truthful 409 on a prompt that genuinely
+        exists and remains editable through the update path -- unlike the truncated
+        leftover that made the original 409 a dead end.
+
+        The directory descriptor is picked out by ``fstat`` rather than by call
+        order, so the injection cannot hit the body's flush by accident.
+        """
+        real_fsync = os.fsync
+        failed = {"dir": False}
+
+        def _dir_flush_fails(fd):
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                failed["dir"] = True
+                raise OSError(errno.EIO, "Input/output error")
+            return real_fsync(fd)
+
+        monkeypatch.setattr(os, "fsync", _dir_flush_fails)
+        resp = asyncio.run(
+            api_prompts_create(_create_request({"name": "unflushed", "content": "BODY"}))
+        )
+        monkeypatch.setattr(os, "fsync", real_fsync)
+
+        assert failed["dir"], "the directory flush never failed — the test would be vacuous"
+        assert resp.status == 500, "a create that could not flush its entry reported success"
+        assert json.loads(resp.body)["code"] == "write_failed"
+        assert _outcomes(mock_sel)[-1] == "error"
+
+    @pytest.fixture()
+    def force_named_fallback(self, monkeypatch):
+        """Run the by-name branch on a filesystem that would take the unnamed one.
+
+        `O_TMPFILE` is present on every Linux runner, so without this the whole
+        fallback -- its `O_EXCL` create, its two flushes, and its identity-checked
+        cleanup -- executes only on filesystems no CI job uses, which is how it
+        came to ship unverified. Forcing the capability off is what lets the same
+        assertions run here as would run on an NFS home.
+        """
+        monkeypatch.setattr(_prompts_mod, "_UNNAMED_CREATE_SUPPORTED", False)
+
+    def test_the_named_fallback_publishes_a_correct_prompt(
+        self, tmp_path, mock_sel, force_named_fallback
+    ):
+        """The path taken where the mount has no O_TMPFILE still creates cleanly."""
+        resp = asyncio.run(
+            api_prompts_create(_create_request({"name": "byname", "content": "FALLBACK"}))
+        )
+
+        assert resp.status == 201
+        path = tmp_path / ".kiro" / "prompts" / "byname.md"
+        assert path.read_text() == "FALLBACK"
+        st = os.stat(path)
+        assert st.st_nlink == 1
+        assert stat.S_IMODE(st.st_mode) == 0o644
+
+    def test_the_named_fallback_still_refuses_an_occupied_name(
+        self, tmp_path, mock_sel, force_named_fallback
+    ):
+        """`O_EXCL` carries the same create-if-absent promise `link` gives the
+        unnamed path, so an occupied name is a 409 and the resident is untouched."""
+        _user_prompt(tmp_path, "byname", "RESIDENT\n")
+
+        resp = asyncio.run(
+            api_prompts_create(_create_request({"name": "byname", "content": "INTRUDER"}))
+        )
+
+        assert resp.status == 409
+        assert (tmp_path / ".kiro" / "prompts" / "byname.md").read_text() == "RESIDENT\n"
+
+    def test_the_named_fallback_withdraws_a_prompt_it_cannot_flush(
+        self, tmp_path, mock_sel, monkeypatch, force_named_fallback
+    ):
+        """A failed directory flush here removes the leaf as well as answering 500.
+
+        This is the half of the asymmetry the unnamed path cannot offer. This
+        branch already holds a cleanup arm bound to the inode it created, so it can
+        take the publication back and leave the caller a clean retry rather than a
+        prompt whose entry may not have landed. The unnamed path deliberately
+        keeps its leaf, because withdrawing there would mean unlinking the
+        prompt's own name -- the hazard that branch exists to avoid.
+        """
+        real_fsync = os.fsync
+        failed = {"dir": False}
+
+        def _dir_flush_fails(fd):
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                failed["dir"] = True
+                raise OSError(errno.EIO, "Input/output error")
+            return real_fsync(fd)
+
+        monkeypatch.setattr(os, "fsync", _dir_flush_fails)
+        resp = asyncio.run(
+            api_prompts_create(_create_request({"name": "withdrawn", "content": "BODY"}))
+        )
+        monkeypatch.setattr(os, "fsync", real_fsync)
+
+        assert failed["dir"], "the directory flush never failed — the test would be vacuous"
+        assert resp.status == 500
+        assert json.loads(resp.body)["code"] == "write_failed"
+        assert not (
+            tmp_path / ".kiro" / "prompts" / "withdrawn.md"
+        ).exists(), "the fallback left behind a prompt whose entry it could not flush"
+        assert _outcomes(mock_sel)[-1] == "error"
+
+    def test_a_create_cannot_disturb_a_prompt_already_at_the_name(
+        self, tmp_path, mock_sel, monkeypatch
+    ):
+        """The publish is create-if-absent, and a failure never reaches the name.
+
+        Both halves matter, because the obvious alternative fails one or the
+        other. Writing O_EXCL straight onto the prompt's own name and unlinking
+        on failure has no way to bind the unlink to the inode it created (POSIX
+        has no unlink-by-inode, so the verify and the unlink are two syscalls on
+        one NAME), so an atomic save landing between them loses the replacement;
+        dropping that cleanup instead strands a partial body and answers every
+        retry 409 forever. Publishing an unnamed inode with ``link`` has neither
+        problem: the name appears only on success, and ``link`` refuses an
+        occupied destination rather than writing through it.
+        """
+        d = tmp_path / ".kiro" / "prompts"
+        d.mkdir(parents=True)
+        rival = d / "rival.md"
+        rival.write_text("NOT YOURS")
+        before = rival.stat()
+
+        # A create losing the race for a name someone else holds is refused, and
+        # the incumbent is untouched -- same inode, same bytes.
+        taken = asyncio.run(
+            api_prompts_create(_create_request({"name": "rival", "content": "MINE"}))
+        )
+        assert taken.status == 409 and json.loads(taken.body)["code"] == "prompt_exists"
+        assert rival.read_text() == "NOT YOURS"
+        assert (rival.stat().st_dev, rival.stat().st_ino) == (before.st_dev, before.st_ino)
+        assert [p.name for p in d.iterdir()] == ["rival.md"]
+
+        # And a create that FAILS mid-write never had the name to lose: the
+        # incumbent survives and no debris is left beside it.
+        real_write = os.write
+        failed = {"done": False}
+
+        def _fail_the_body(fd, data):
+            if data == b"MINE" and not failed["done"]:
+                failed["done"] = True
+                raise OSError(errno.ENOSPC, "No space left on device")
+            return real_write(fd, data)
+
+        monkeypatch.setattr(os, "write", _fail_the_body)
+        broke = asyncio.run(
+            api_prompts_create(_create_request({"name": "rival", "content": "MINE"}))
+        )
+        monkeypatch.setattr(os, "write", real_write)
+
+        assert failed["done"], "the write never failed — the test would be vacuous"
+        assert broke.status == 500 and json.loads(broke.body)["code"] == "write_failed"
+        assert rival.read_text() == "NOT YOURS"
+        assert [p.name for p in d.iterdir()] == ["rival.md"]
 
 
 class TestARefusedUpdateIsNotReportedAsSuccess:


### PR DESCRIPTION
## Problem / Motivation

`api_prompts_create`'s pinned branch created the prompt by opening `<stem>.md`
`O_EXCL` and writing the body straight into it, closing the leaf descriptor in a
`finally` that sat BESIDE its cleanup arm rather than inside it:

```python
        except BaseException:
            try:
                os.unlink(filename, dir_fd=dir_fd)   # the retry-cleanup
            except OSError:
                pass
            raise
        finally:
            os.close(fd)                             # raises AFTER the arm is skipped
```

`close` is where a DEFERRED write error surfaces -- ENOSPC once the last block
is flushed, EIO on a network mount -- so guarding the write loop alone does not
cover it. On a close failure the partial body stayed under the `O_EXCL` name and
every retry answered 409 `prompt_exists` over a truncated prompt.

The cleanup arm carries a second defect, found by review round 11 on #7713 and
grouped here because it is the same arm in the same function: it unlinked BY
NAME under the pinned descriptor. A descriptor pins the DIRECTORY, not the entry
inside it, so a rival that took the name inside the failure window lost its file.

## Why it matters

A prompt create that reports 500 left a file the API would not admit it wrote.
The Prompts tab listed it (the lister globs `*.md`), opening it showed a
truncated body, and creating it again was refused forever with a conflict on a
file the user never successfully created. Nothing in the dashboard removed it;
the only recovery was a shell.

## What changed (motivation -> approach -> change)

This one write has to satisfy four things at once, and every shape that writes
through the prompt's own name satisfies only three:

1. never publish a partial body;
2. never destroy a file another writer holds at the name;
3. leave the published inode at ONE link, because this module's own read path
   goes through `safe_read_file_bytes_nolink` and refuses `st_nlink > 1`;
4. leave nothing behind when the process dies mid-write.

`O_EXCL` onto `<stem>.md` breaks (1) -- the name holds the body while it is
being written, which is the reported defect. A cleanup cannot fully repair that,
because POSIX has no unlink-by-inode: verify-then-unlink is two syscalls on one
NAME, so an atomic save landing between them destroys the replacement, breaking
(2). Writing a NAMED temp and linking it into place breaks (3) and (4): between
the link and the temp's removal the inode carries two links, and a process death
there leaves a prompt its own read path answers 403 on -- a worse dead end than
the 409. `rename` clobbers, and `renameat2`'s `RENAME_NOREPLACE` is Linux-only
and unexposed by CPython, which `pinned_fs.put_back_no_clobber` already records
as a dead end.

An UNNAMED inode has none of these problems, so the create now builds one:

1. `os.open(".", os.O_TMPFILE | os.O_WRONLY, 0o666, dir_fd=dir_fd)` -- through
   the pinned descriptor, so the inode is born on the filesystem the walk
   validated, with the mode `open("x")` produced.
2. Write the encoded bytes on the raw descriptor, then `os.fsync`. 201 claims
   the prompt is on disk, and this is where a full or network-backed filesystem
   reports the error it deferred.
3. `os.link("/proc/self/fd/<fd>", filename, dst_dir_fd=dir_fd,
   follow_symlinks=True)` -- the publish, and the only syscall that touches the
   user-visible name. `linkat`'s `AT_EMPTY_PATH` form needs
   `CAP_DAC_READ_SEARCH`; the `/proc` spelling is the unprivileged equivalent.
4. `os.fsync(dir_fd)` -- the link made the entry, this makes the ENTRY durable.
   A directory is a separate object from the inode it names, so flushing only
   the file leaves a power loss able to return the body with no name pointing at
   it: acknowledged, then vanished. A failure here RAISES, so a create that
   could not establish durability does not answer 201. The named fallback gets
   the same flush, and on that path the failure also withdraws the publication,
   because it already holds an identity-checked cleanup for its own leaf; the
   unnamed path deliberately does not withdraw, since removing the leaf would
   mean unlinking the prompt's own name -- the exact hazard this publish avoids.

Nothing is observable half-written, because the name appears only on success.
Nothing needs cleaning up, because a crash drops an inode that was never linked.
`link` is create-if-absent, so an occupied name is still a 409 and what is
already there is never touched. The inode goes from zero links to one and is
never at two. All four hold, and the cleanup arm is gone rather than made
narrower.

`O_TMPFILE` is a per-FILESYSTEM capability, so a mount without it (NFS, some
overlayfs) answers EOPNOTSUPP at the open and falls back to the in-place `O_EXCL`
shape with `fsync`, the close inside the guarded region, and an
identity-verified unlink. That path keeps the residual `pinned_fs._unlink_verified`
documents as irreducible and ships -- accepted here for the reason it is accepted
there, and now confined to filesystems that cannot build an unnamed inode.

`_UNNAMED_CREATE_SUPPORTED` is settled by attribute lookups alone (`O_TMPFILE`,
`os.link in os.supports_dir_fd`), because this module is imported on the gateway
boot path and `no-new-work-on-gateway-boot-path` forbids adding filesystem work
there. The `/proc/self/fd` half of the capability is a mount question, so it is
asked inside the write job, which already runs in the executor.
`_DIR_FD_SUPPORTED` is unchanged.

Not changed: the no-openat branch. Its `with path.open("x")` sits inside the
guarded `try`, so a close failure from `__exit__` already reaches its cleanup.

## Tests

Four tests in `test/test_prompts.py`, each mutation-verified -- reverting one
piece of the shape reddens its test and nothing else:

* `test_a_create_whose_close_fails_publishes_nothing_and_stays_retryable` -- a
  failing flush answers 500, leaves the prompts directory with NO entries at
  all, and the immediate retry succeeds with 201 and the full body.
* `test_the_published_prompt_has_exactly_one_link` -- the published prompt has
  `st_nlink == 1` and is readable through `api_prompt_detail`, the endpoint that
  enforces the link count. Adding a second link to the published inode reddens
  it. Skipped where the platform cannot build an unnamed inode.
* `test_the_capability_constant_touches_no_filesystem` -- parses the module's own
  source and asserts the `_UNNAMED_CREATE_SUPPORTED` expression names only
  capability attributes and calls only `getattr`/`bool`. Read statically rather
  than executed, so it holds however a probe is spelled. Putting the
  `/proc/self/fd` check back into the constant reddens it.
* `test_the_named_fallback_publishes_a_correct_prompt`,
  `test_the_named_fallback_still_refuses_an_occupied_name` and
  `test_the_named_fallback_withdraws_a_prompt_it_cannot_flush` -- force
  `_UNNAMED_CREATE_SUPPORTED` off so the by-name branch runs where a Linux runner
  would always have taken the unnamed one. That branch was reachable only on
  mounts no CI job uses, so it shipped unverified; these cover its `O_EXCL`
  create, both flushes, its 409 on an occupied name, and its identity-checked
  withdrawal. The third pins the asymmetry: this branch takes the publication
  back when it cannot flush the entry, and skipping the unlink reddens it.
* `test_a_failing_directory_flush_is_reported_not_swallowed` -- injects EIO on
  the DIRECTORY descriptor only, picked out by `fstat` rather than by call order,
  and asserts the create answers 500 rather than 201. Restoring the log-and-
  swallow reddens it.
* `test_the_body_is_durable_before_the_name_appears` -- records the real call
  order, distinguishing the file's flush from the directory's by `fstat`ing the
  descriptor rather than by position, and asserts flush-file, publish,
  flush-directory. Publishing before the flush reddens this AND the retryability
  test above; removing the directory flush reddens it on its own.
* `test_a_create_cannot_disturb_a_prompt_already_at_the_name` -- a create for an
  occupied name answers 409 with the incumbent's bytes and inode identity
  unchanged, and a create that fails mid-write leaves the incumbent and no
  debris. Making the publish clobber reddens it.

`pytest test/test_prompts.py`: 175 passed, 1 skipped. The four other suites that
exercise this module's handlers (`test_skill_browser`, `test_skill_pending_api`,
`test_skill_trust_store`, `test_resolve_skill_root_package`): 250 passed.
`black --check`, the baselined black gate, `flake8` and `isort` clean on both
files.

## Manual verification

The unnamed-inode publish was probed directly before being written into the
handler: a fresh `O_TMPFILE` descriptor reports `st_nlink == 0`, the published
file reports `st_nlink == 1`, mode is `0o644` (`0o666 & ~umask`, unchanged from
the previous shape), a second publish to the same name raises `FileExistsError`
with the first file's content intact, and the same sequence works opened
relative to a pinned `dir_fd`.

The reported second observation -- `O_CREAT|O_EXCL|O_NOFOLLOW` returning EEXIST
against a freshly walked `dir_fd` for a directory `iterdir()` reports as empty
-- is a HARNESS artifact, and it reproduces on demand. Both hypotheses the
triage named are disproven by measurement.

The mechanism: this test class and the autouse home-isolation fixture share one
function-scoped `monkeypatch` instance, so a `monkeypatch.undo()` placed between
the failing create and the retry (mirroring the neighbouring
`test_the_walk_pins_every_level_not_just_the_leaf`) also reverts `Path.home`.
The retry then creates the prompt in the developer's REAL `~/.kiro/prompts`
while the assertions read `tmp_path` -- so `tmp_path` is genuinely empty, and
the EEXIST is genuinely correct, because a previous iteration of the same test
already left a `half.md` in the real home. Watching `~/.kiro/prompts/half.md`
appear is the whole reproduction. The tests here restore the patched `os`
functions one at a time instead, and say why in a comment.

With that removed, instrumenting the retry answered the parked question directly,
measured against the original in-place shape:

```
attempt1 status=500 dir=[]
pinned dir_fd=18 ino=2802628135 dev=66305 | path ino=2802628135 dev=66305 | same=True | entries via fd=[]
attempt2 status=201 dir=['half.md']
```

`_pin_prompt_dir` addresses exactly the directory it appears to (`same=True`),
that directory is empty through the descriptor as well as through the path, and
nothing re-creates the entry. Confirmed on Linux / CPython 3.12.

`Dependency Audit` was red for four `fast-uri` advisories in
`website/electron/package-lock.json` on the two earlier heads. That file is
main-owned and this diff contains zero frontend or lockfile lines; it now reports
green, so main resolved it.

Worth a reviewer's note on scope: main's own `atomic_write` flushes the file when
asked and never flushes the parent directory, so the directory flush added here
is stricter than the repo's established durability helper. It is added because
this endpoint's 201 is an explicit claim the prompt is on disk. If the maintainer
would rather keep create aligned with `atomic_write`, the alternative is to drop
the claim instead of the flush -- say so and I will invert it.

## Accepted residual (maintainer-adjudicated)

GPT round 4 raises the fallback's cleanup: on a filesystem without `O_TMPFILE`,
`os.unlink(filename, dir_fd=dir_fd)` is preceded by a `stat` that verifies the
inode, and a replacement landing between those two syscalls is deleted.

This residual is **accepted, deliberately, and this PR adds none of it.** It is
the residual `pinned_fs._unlink_verified` documents in the module that owns this
discipline: POSIX has no unlink-by-inode, so verify-then-unlink is irreducibly
two syscalls addressing one name. `main` ships it, and `f835dfd98` applied the
same residual to the two sibling trash removals. The delta this change
contributes to that class is zero -- and it is now reached only on filesystems
that cannot build an unnamed inode, which is strictly narrower than the surface
it had before.

The reviewer's prescribed remedy -- propagate the `O_TMPFILE` refusal instead of
falling back -- was rejected on the merits: it makes prompt creation fail
outright on any mount without `O_TMPFILE` (NFS homes, some overlayfs), trading a
rare race for a hard functional regression. Descoping the fallback was rejected
too, because it would leave exactly those filesystems on the partial-prompt bug
this PR exists to fix.

No new issue is filed for the class: it is already documented at the helper.

## Screenshots / video

None -- backend only, no user-visible surface changed beyond the status code a
failed create already returns.

## Related Issues

Closes #7858

Touches the same function as #7713 (open), which migrates this handler to
`pinned_fs`. A textual conflict in `api_prompts_create` is expected; whichever
lands second rebases. #7713's promotion of `_unlink_verified` to public would
now serve only the non-`O_TMPFILE` fallback here.

## Pattern harvest

Rule candidate: a create that writes through the name it is creating cannot be
made crash-safe, race-safe and single-link at once, so do not pick which one to
lose -- build the body as an UNNAMED inode (`O_TMPFILE`) and give it its name
once with `linkat`. Cleaning up on failure means removing an entry by name
(POSIX has no unlink-by-inode, so verify-then-unlink is two syscalls on one name
and a swap between them destroys someone else's file); not cleaning up strands a
partial body that refuses every retry; and routing through a named temp leaves a
two-link window that any `st_nlink > 1` reader gate turns into a permanent
failure. An unnamed inode removes all three: nothing is reachable half-written,
there is nothing to clean up, and the link count goes zero to one.

Second: a `finally` is the wrong home for a close that a cleanup arm depends on,
because `finally` runs after the `except` -- so the close's own failure is
exactly the case the arm never sees.

Third: before adding a publish step, check what the module's own READ path
refuses. This one rejects `st_nlink > 1`, which is what made an otherwise
reasonable link-then-unlink publish a 403 generator.

Fourth: an inode flush is not a publication flush. `fsync` on the file settles
its content; the directory holding the name is a separate object and needs its
own flush, or a power loss returns the body with nothing naming it.

Fifth, on process rather than code: after a RESTRUCTURE, re-run the full local
gate set, not the subset that passed before it. The fallback branch here was
reshaped after the only local `mypy` run, so a duplicate `created_ident`
annotation -- a `[no-redef]` any local run catches in seconds -- reached CI on two
pushed heads. `black`, `flake8` and `isort` all stayed green throughout and gave
false confidence. The expensive part was not the red lane: the fix required a
push, and a push voids a SHA-pinned review override, so a trivially preventable
type error cost an already-granted override its validity.

Sixth, a correction to this PR's own earlier revision, since the reasoning was
wrong in a way worth naming: the directory flush was at first logged and
swallowed, justified by the claim that answering 500 would recreate the
409-forever dead end. Re-checking the behaviour rather than re-reading the
argument showed that cost does not exist -- by the flush the body is already
written, flushed and linked, so a 500 sits over a complete readable prompt and
the retry gets a truthful 409 on a prompt that genuinely exists and stays
editable, unlike the truncated leftover that made the original 409 a dead end.
Swallowing violated this change's own first requirement, never publish a success
you cannot back. A durability step whose failure is only logged is not a
durability step.

Seventh, a gate reading worth recording because the signal was accurate and the
first instinct was to call it someone else's: the per-file coverage gate went red
at 79.6% on `prompts.py`. The branch's copy of the baseline still listed the file
at 64.5%, which looked like an exemption, but `main` had since GRADUATED it and CI
judges the merge commit -- so the floor applied and the added statements had
diluted the file under it. The uncovered block was the by-name fallback, which no
test could reach on a runner that always has `O_TMPFILE`. Covering it was the
gate's own prescription (add tests, do not extend the baseline) and it was the
right change on the merits too: that branch carries both the accepted residual
and the withdraw-on-failure behaviour, and neither had a test.

## Checklist

- [x] One commit
- [x] Tests added and mutation-verified
- [x] `black` / `flake8` / `isort` clean on the touched files
- [x] No public-surface or config change







