### PR TITLE
fix(design-critique): find the report the critic did produce

### DIFF
--- a/website/src/apps/design-critique/DesignCritiquePage.tsx
+++ b/website/src/apps/design-critique/DesignCritiquePage.tsx
@@ -10,7 +10,7 @@ import { Spinner } from './Motion'
 import { S } from './styles'
 import { designCritiqueApi, fileUrl } from './api'
 import {
-  detectKind, extractJson, lastAssistant, shortLabel, relTime, readableOn, normalizeReport, normalizeScope,
+  detectKind, jsonFromMessages, looksLikeReport, lastAssistant, shortLabel, relTime, readableOn, normalizeReport, normalizeScope,
   loadHistory, saveHistory, beginPendingCritique, dropPendingCritique, loadJobs, saveJob, clearJob, loadSlots, saveSlots, trackSlot, untrackSlot,
   loadLive, markLive, unmarkLive,
 } from './utils'
@@ -170,7 +170,7 @@ export default function DesignCritiquePage() {
       if (!aliveRef.current || isCancelled(slotKey)) throw CANCELLED()
       const c = lastAssistant(d && d.messages)
       if (c && c.trim() && activeSlotRef.current === slotKey) setWriting(true)
-      if (d && !d.running && c) { const p = extractJson<T>(c); if (p) return p; throw new Error('The critic replied but not in a readable format.') }
+      if (d && !d.running && c) { const p = jsonFromMessages<T>(d.messages, looksLikeReport); if (p) return p; throw new Error('The critic replied but not in a readable format.') }
     }
     throw TIMEOUT()
   }
@@ -923,10 +923,10 @@ export default function DesignCritiquePage() {
   if (!isFlow) screenFindings.forEach((f, i) => pinNo.set(f, i + 1))
 
   const stepRange = (f: Finding) => {
-    // `steps` arrives from extractJson<Report>, which is an unchecked cast over
-    // model output — a reply with "steps":"1" would otherwise reach .sort() on a
-    // string and take the whole report down. Trust the shape only when it really
-    // is an array.
+    // `steps` arrives from jsonFromMessages<Report>, which is an unchecked cast
+    // over model output — a reply with "steps":"1" would otherwise reach .sort()
+    // on a string and take the whole report down. Trust the shape only when it
+    // really is an array.
     const st = Array.isArray(f.steps) ? f.steps.slice().sort((a, b) => a - b) : []
     if (!st.length) return 'flow'
     if (st.length === 1) return String(st[0])

--- a/website/src/apps/design-critique/utils.ts
+++ b/website/src/apps/design-critique/utils.ts
@@ -46,12 +46,154 @@ export function recognise(det: Detected | null): { ok: boolean; text: string } |
   }
 }
 
-export function extractJson<T = Record<string, unknown>>(text: string | undefined): T | null {
+/**
+ * Every balanced `{…}` span in `t`, outermost only, in the order they appear.
+ *
+ * Quote- and escape-aware INSIDE an object, so a brace in a string value
+ * (`"fix":"drop the {primary} token"`) does not move the depth counter and
+ * cannot split a span.
+ *
+ * Outside one — at depth 0 — a quote is ignored on purpose. Prose is not JSON,
+ * so its quotes do not pair: a reply opening `Here is "the report:` leaves one
+ * unmatched quote, and tracking it there would put the scanner in string mode
+ * for everything after, swallowing the report's own braces and emitting no span
+ * at all. That is the failure this whole function exists to prevent, so string
+ * mode begins only once an object is open.
+ */
+function braceSpans(t: string): string[] {
+  const out: string[] = []
+  let depth = 0, start = -1, inStr = false, esc = false
+  for (let i = 0; i < t.length; i++) {
+    const ch = t[i]
+    if (inStr) {
+      if (esc) { esc = false; continue }
+      if (ch === '\\') { esc = true; continue }
+      if (ch === '"') inStr = false
+      continue
+    }
+    if (ch === '"') { if (depth > 0) inStr = true; continue }
+    if (ch === '{') { if (depth === 0) start = i; depth++; continue }
+    if (ch === '}' && depth > 0 && --depth === 0 && start >= 0) {
+      out.push(t.slice(start, i + 1)); start = -1
+    }
+  }
+  return out
+}
+
+/**
+ * Pull the critic's JSON out of a reply.
+ *
+ * The contract asks for JSON and nothing else, and a reply that honours it
+ * parses either way. But the tolerance this function already extends to the
+ * usual model wrapping — a ```json fence, a line of prose either side — used to
+ * break on a wrapper that merely CONTAINED a brace, because it sliced from the
+ * first `{` to the last `}` and handed whatever lay between to `JSON.parse`.
+ * A reply that closed with "tweak the `{primary}` token", or opened by naming
+ * the `{schema}` it was given, therefore threw away a complete report and the
+ * run ended on "not in a readable format".
+ *
+ * So consider every balanced span instead of one blind slice, and take the
+ * largest that parses — the report is the substantive object in the reply, not
+ * the aside next to it. This is strictly more tolerant than the slice: any text
+ * the slice accepted still parses. A reply carrying no JSON at all still returns
+ * null, which is the honest case the error message exists for.
+ *
+ * `accept` filters the candidates rather than vetoing the winner, and that
+ * distinction is the whole point of taking it here. Judging only the largest
+ * span and rejecting it outside this function would end the search at the first
+ * unrecognised object, so a reply carrying a bigger unrelated object beside a
+ * real report would lose the report — the same discard this function exists to
+ * prevent. Rejection therefore continues to the next span.
+ */
+export function extractJson<T = Record<string, unknown>>(
+  text: string | undefined,
+  accept?: (value: unknown) => boolean,
+): T | null {
   if (!text) return null
   const t = String(text).replace(/```json\s*/gi, '').replace(/```/g, '').trim()
-  const a = t.indexOf('{'); const b = t.lastIndexOf('}')
-  if (a === -1 || b === -1 || b < a) return null
-  try { return JSON.parse(t.slice(a, b + 1)) as T } catch { return null }
+  const spans = braceSpans(t).sort((a, b) => b.length - a.length)
+  for (const s of spans) {
+    let parsed: T
+    try { parsed = JSON.parse(s) as T } catch { continue }
+    if (!accept || accept(parsed)) return parsed
+  }
+  return null
+}
+
+/**
+ * Does this parsed object look like a critique report, rather than a fragment of
+ * one or something else that happens to share a key name?
+ *
+ * Needed because a JSON object is not self-identifying. A stream cut short right
+ * before a nested object leaves a continuation row that parses PERFECTLY on its
+ * own — split the schema before `{"severity":…}` and the suffix is a complete,
+ * valid finding object — so "it parsed" cannot mean "it is the report". Accepting
+ * one would be worse than the error it replaced: `normalizeReport` coerces the
+ * fragment into a report with nothing in it, `finishReport` writes that blank
+ * critique to history, and `endRun` then deletes the slot holding the real one.
+ *
+ * The test is TYPED, not a key-presence check, and that distinction carries the
+ * guarantee. A key name alone is cheap for unrelated JSON to satisfy — an object
+ * holding `findings` as a long STRING passes a presence test, and being longer
+ * than the real report it would then be preferred over it, losing the critique to
+ * exactly the blank-render path above. So each field must arrive as the type the
+ * UI renders it as, which is the same shape `normalizeReport` coerces to
+ * downstream: prose as a string, lists as arrays, the tally as an object.
+ *
+ * Any ONE correctly-typed field is enough. A real report carries several, while a
+ * sparse one should still render rather than be discarded — requiring a full
+ * schema here would reintroduce the original bug in a stricter disguise.
+ */
+export function looksLikeReport(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const v = value as Record<string, unknown>
+  const isText = (k: string): boolean => typeof v[k] === 'string'
+  const isList = (k: string): boolean => Array.isArray(v[k])
+  const isObj = (k: string): boolean =>
+    !!v[k] && typeof v[k] === 'object' && !Array.isArray(v[k])
+  return isText('overallRead') || isText('health') || isObj('tally')
+    || isList('screens') || isList('findings') || isList('keep') || isList('couldNotSee')
+}
+
+/**
+ * The report from a finished turn, wherever in that turn it landed.
+ *
+ * One turn is not one message. The runner finalizes a segment per text block
+ * (`_flush_segment`), so text either side of a tool group arrives as two
+ * `assistant` rows, and a stream interrupted by a transient backend error is
+ * persisted as a partial row plus a continuation row — the model is told to
+ * carry on where it stopped, which for this prompt means resuming mid-JSON.
+ * Reading only the newest row therefore discarded a report the critic really
+ * did produce: a trailing remark after the JSON, or either half of a split one,
+ * failed to parse and the run ended on "not in a readable format".
+ *
+ * So try each assistant row newest-first, then the rows joined in order, which
+ * is what reassembles a split reply. Order matters: newest-first keeps the last
+ * report authoritative when a turn somehow produced two, and the join is only
+ * reached when no single row carries one.
+ *
+ * `accept` is what makes that order safe. Without it the newest-first pass is a
+ * trap on exactly the split it exists to repair — a continuation beginning at a
+ * nested object parses alone, and would be taken for the whole report before the
+ * join ever ran. It is handed to `extractJson` rather than applied to its result,
+ * so an unrecognised candidate is skipped WITHIN a row's span search and the next
+ * span still gets its turn; vetoing the result here would abandon a row whose
+ * report merely sat behind a larger object.
+ */
+export function jsonFromMessages<T = Record<string, unknown>>(
+  messages: SlotData['messages'],
+  accept?: (value: unknown) => boolean,
+): T | null {
+  if (!Array.isArray(messages)) return null
+  const rows = messages
+    .filter(m => { const role = m.role || m.type; return role === 'assistant' || role === 'msg msg-a' })
+    .map(m => m.content || '')
+    .filter(c => !!c.trim())
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const p = extractJson<T>(rows[i], accept)
+    if (p) return p
+  }
+  return rows.length > 1 ? extractJson<T>(rows.join(''), accept) : null
 }
 
 export function lastAssistant(messages: SlotData['messages']): string {

--- a/website/src/test/DesignCritiquePage.coverage.test.tsx
+++ b/website/src/test/DesignCritiquePage.coverage.test.tsx
@@ -542,6 +542,51 @@ describe('Design Critique — critiquing screenshots', () => {
       .toBeInTheDocument()
   })
 
+  // One turn is not one message: the runner finalizes a segment per text block,
+  // so a report can sit behind a later segment of the same turn. Reading only the
+  // newest row ended a finished critique on the unreadable-reply message.
+  it('renders a report the turn left behind a later segment', async () => {
+    mockApi.getSlot.mockResolvedValue({
+      running: false,
+      messages: [
+        { role: 'user', content: 'critique this' },
+        { role: 'assistant', content: JSON.stringify(ONE_SCREEN_REPORT) },
+        { role: 'tool', content: 'artifact_save' },
+        { role: 'assistant', content: 'Saved the critique for you.' },
+      ],
+    })
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+    await tick(POLL_MS)
+
+    expect(screen.getByText(/the two blue buttons fight each other/)).toBeInTheDocument()
+    expect(screen.queryByText('The critic replied but not in a readable format.')).toBeNull()
+  })
+
+  // A stream cut short by a transient backend error is persisted as a partial plus
+  // a continuation, and the model is told to resume where it stopped — mid-JSON
+  // for this prompt. Neither half parses alone; the whole reply does.
+  it('renders a report split across a partial and its continuation', async () => {
+    const whole = JSON.stringify(ONE_SCREEN_REPORT)
+    mockApi.getSlot.mockResolvedValue({
+      running: false,
+      messages: [
+        { role: 'assistant', content: whole.slice(0, 120) },
+        { role: 'error', content: 'The previous response was interrupted.' },
+        { role: 'assistant', content: whole.slice(120) },
+      ],
+    })
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+    await tick(POLL_MS)
+
+    expect(screen.getByText(/the two blue buttons fight each other/)).toBeInTheDocument()
+  })
+
   it('cancels a run, releases its slot, and returns to the composer', async () => {
     render(<DesignCritiquePage />)
     dropFiles([imageFile('cart.png')])

--- a/website/src/test/DesignCritiqueReplyParse.test.ts
+++ b/website/src/test/DesignCritiqueReplyParse.test.ts
@@ -1,0 +1,234 @@
+// How a critic reply becomes a report — the two steps between a finished slot and
+// a rendered critique, and the shapes that used to fall between them.
+//
+// `DesignCritiquePage` polls a slot and, once it stops running, turns the turn's
+// messages into a `Report`. When that fails the run ends on "The critic replied
+// but not in a readable format." — an honest message for a reply that carries no
+// report, and a wrong one for a reply that carries a report the reader could not
+// find. Everything below is the second case, plus the first case still failing.
+import { describe, expect, it } from 'vitest'
+
+import { extractJson, jsonFromMessages, looksLikeReport } from '../apps/design-critique/utils'
+import type { SlotData } from '../apps/design-critique/types'
+
+/** A contract-shaped report, as the schema in `prompts.ts` asks for it. */
+const REPORT = {
+  overallRead: 'The two blue buttons fight each other.',
+  health: '1 major',
+  tally: { catastrophe: 0, major: 1, minor: 0, cosmetic: 0 },
+  screens: [{ step: 1, label: 'Cart', path: '/tmp/cart.png' }],
+  findings: [{
+    severity: 'major',
+    title: 'Two primary buttons compete',
+    category: 'Hierarchy',
+    scope: 'screen',
+    steps: [1],
+    location: 'Footer action row',
+    evidence: 'Save and Publish are both filled in the same blue.',
+    fix: 'Consider demoting one to a quiet button.',
+    rules: ['Nielsen: consistency'],
+    box: { x: 0.1, y: 0.8, w: 0.8, h: 0.1 },
+  }],
+  keep: ['Generous spacing between the fields.'],
+  couldNotSee: ['Hover states.'],
+}
+const JSON_REPORT = JSON.stringify(REPORT)
+
+const assistant = (content: string) => ({ role: 'assistant', content })
+const msgs = (...rows: Array<{ role: string; content: string }>): SlotData['messages'] => [
+  { role: 'user', content: 'critique this' }, ...rows,
+]
+
+describe('extractJson', () => {
+  it('reads a reply that honours the contract and sends JSON alone', () => {
+    expect(extractJson(JSON_REPORT)).toEqual(REPORT)
+  })
+
+  it('reads a reply wrapped in a json code fence', () => {
+    expect(extractJson('```json\n' + JSON_REPORT + '\n```')).toEqual(REPORT)
+  })
+
+  it('reads a reply introduced by a line of prose', () => {
+    expect(extractJson('Here is the critique.\n\n' + JSON_REPORT)).toEqual(REPORT)
+  })
+
+  // The three shapes a first-`{`-to-last-`}` slice mangled: each one hands
+  // `JSON.parse` a span that starts or ends outside the report.
+  it('reads a report followed by a remark that contains a brace', () => {
+    expect(extractJson(JSON_REPORT + '\n\nTweak the `{primary}` token and re-run.'))
+      .toEqual(REPORT)
+  })
+
+  it('reads a report preceded by a remark that contains a brace', () => {
+    expect(extractJson('I filled the {schema} you gave me.\n\n' + JSON_REPORT))
+      .toEqual(REPORT)
+  })
+
+  it('prefers the report over a smaller object beside it', () => {
+    expect(extractJson('{"note":"draft"}\n\n' + JSON_REPORT)).toEqual(REPORT)
+  })
+
+  // Size decides only among candidates the caller will accept. A reply carrying a
+  // bigger unrelated object must not cost the report: rejecting the largest span
+  // has to continue the search, not end it.
+  it('keeps searching past a rejected span to find the report', () => {
+    const bulky = { debug: 'x'.repeat(JSON_REPORT.length * 2) }
+    const lean = { overallRead: 'Tidy, but the labels crowd each other.', findings: [] }
+    const reply = JSON.stringify(bulky) + '\n\n' + JSON.stringify(lean)
+
+    // Without a filter the bigger object wins, which is why the filter belongs
+    // inside the span search rather than over its result.
+    expect(extractJson(reply)).toEqual(bulky)
+    expect(extractJson(reply, looksLikeReport)).toEqual(lean)
+  })
+
+  // A brace inside a string value must not be read as structure, or the span it
+  // opens swallows the rest of the report.
+  it('ignores braces inside string values', () => {
+    const withBraces = { ...REPORT, overallRead: 'The {primary} and {danger} tokens collide.' }
+    expect(extractJson(JSON.stringify(withBraces))).toEqual(withBraces)
+  })
+
+  // The mirror of that: prose is not JSON, so its quotes do not pair. One
+  // unmatched quote ahead of the report would put a quote-tracking scanner in
+  // string mode for the rest of the reply and hide every brace it contains.
+  it('reads a report behind prose carrying an unmatched quote', () => {
+    expect(extractJson('Here is "the report:\n' + JSON_REPORT)).toEqual(REPORT)
+    expect(extractJson('One screen, one " finding.\n\n' + JSON_REPORT)).toEqual(REPORT)
+  })
+
+  it('reads a report whose own strings contain escaped quotes', () => {
+    const quoted = { ...REPORT, overallRead: 'The button reads "Save" and "Publish".' }
+    expect(extractJson(JSON.stringify(quoted))).toEqual(quoted)
+  })
+
+  it('still returns null for a reply that carries no JSON at all', () => {
+    expect(extractJson('I had a look and it seems fine.')).toBeNull()
+    expect(extractJson('')).toBeNull()
+    expect(extractJson(undefined)).toBeNull()
+  })
+
+  it('still returns null for a report cut off mid-object', () => {
+    expect(extractJson(JSON_REPORT.slice(0, 120))).toBeNull()
+  })
+})
+
+describe('jsonFromMessages', () => {
+  it('reads a turn that finished as one assistant message', () => {
+    expect(jsonFromMessages(msgs(assistant(JSON_REPORT)))).toEqual(REPORT)
+  })
+
+  // Text either side of a tool group arrives as two assistant rows
+  // (`_flush_segment`), so the report is not always the newest one.
+  it('reads a report left behind an earlier segment of the same turn', () => {
+    expect(jsonFromMessages(msgs(
+      assistant(JSON_REPORT),
+      { role: 'tool', content: 'artifact_save' },
+      assistant('Saved the critique for you.'),
+    ))).toEqual(REPORT)
+  })
+
+  it('reads the newest report when a turn produced two', () => {
+    const stale = { ...REPORT, overallRead: 'A first pass.' }
+    expect(jsonFromMessages(msgs(
+      assistant(JSON.stringify(stale)),
+      assistant(JSON_REPORT),
+    ))).toEqual(REPORT)
+  })
+
+  // A stream interrupted by a transient backend error is persisted as a partial
+  // plus a continuation, and the model is told to carry on where it stopped —
+  // which for this prompt means resuming mid-JSON. Neither half parses alone.
+  it('rejoins a report split across a partial and its continuation', () => {
+    expect(jsonFromMessages(msgs(
+      assistant(JSON_REPORT.slice(0, 300)),
+      { role: 'error', content: 'The previous response was interrupted.' },
+      assistant(JSON_REPORT.slice(300)),
+    ), looksLikeReport)).toEqual(REPORT)
+  })
+
+  // The split that makes "it parsed" insufficient: cut immediately before a
+  // nested object and the continuation is a complete, valid finding object on its
+  // own. Taken for the report it would be coerced into a blank critique, written
+  // to history, and the slot holding the real report deleted. The newest-first
+  // pass has to skip it and reach the join.
+  it('does not mistake a continuation that starts at a nested object for the report', () => {
+    const cut = JSON_REPORT.indexOf('{"severity"')
+    expect(cut).toBeGreaterThan(0)
+    const suffix = JSON_REPORT.slice(cut)
+    // The trap is real: that suffix parses, and on its own looks like a finding.
+    expect(extractJson(suffix)).toMatchObject({ title: 'Two primary buttons compete' })
+
+    expect(jsonFromMessages(msgs(
+      assistant(JSON_REPORT.slice(0, cut)),
+      assistant(suffix),
+    ), looksLikeReport)).toEqual(REPORT)
+  })
+
+  it('reads a row carrying the legacy cls role', () => {
+    expect(jsonFromMessages([{ role: 'msg msg-a', content: JSON_REPORT }])).toEqual(REPORT)
+  })
+
+  it('ignores the user prompt, which quotes the schema back at the model', () => {
+    expect(jsonFromMessages([
+      { role: 'user', content: 'Return ONLY JSON matching {"overallRead":"…"}' },
+    ])).toBeNull()
+  })
+
+  it('returns null when no message in the turn carries a report', () => {
+    expect(jsonFromMessages(msgs(assistant('I had a look and it seems fine.')))).toBeNull()
+    expect(jsonFromMessages([])).toBeNull()
+    expect(jsonFromMessages(undefined)).toBeNull()
+  })
+
+  it('returns null when the only JSON in the turn is not a report', () => {
+    expect(jsonFromMessages(msgs(assistant('{"severity":"major","title":"orphan"}')), looksLikeReport))
+      .toBeNull()
+  })
+
+  // Same hazard one layer out: the row holding the report also holds a bigger
+  // object, so the row must not be abandoned on the first rejected span.
+  it('reads a report sharing its row with a bigger unrelated object', () => {
+    const bulky = JSON.stringify({ debug: 'x'.repeat(JSON_REPORT.length * 2) })
+    expect(jsonFromMessages(msgs(assistant(bulky + '\n\n' + JSON_REPORT)), looksLikeReport))
+      .toEqual(REPORT)
+  })
+
+  // And the harder version of it: the bigger object borrows a report FIELD NAME,
+  // so only its type tells the two apart.
+  it('reads the report past a bigger object that only borrows a report key', () => {
+    const impostor = JSON.stringify({ findings: 'draft '.repeat(JSON_REPORT.length / 3) })
+    expect(impostor.length).toBeGreaterThan(JSON_REPORT.length)
+    expect(jsonFromMessages(msgs(assistant(impostor + '\n\n' + JSON_REPORT)), looksLikeReport))
+      .toEqual(REPORT)
+  })
+})
+
+describe('looksLikeReport', () => {
+  it('accepts a report, and one carrying only a single report-level field', () => {
+    expect(looksLikeReport(REPORT)).toBe(true)
+    expect(looksLikeReport({ overallRead: 'Tidy.' })).toBe(true)
+    expect(looksLikeReport({ findings: [] })).toBe(true)
+    expect(looksLikeReport({ tally: { major: 1 } })).toBe(true)
+  })
+
+  it('rejects a finding object, which shares no field with a report', () => {
+    expect(looksLikeReport(REPORT.findings[0])).toBe(false)
+    expect(looksLikeReport({ box: { x: 0, y: 0, w: 1, h: 1 } })).toBe(false)
+  })
+
+  // A key name alone is cheap for unrelated JSON to satisfy, so each field has to
+  // arrive as the type the UI renders it as.
+  it('rejects a report-shaped key holding the wrong type', () => {
+    expect(looksLikeReport({ findings: 'draft notes' })).toBe(false)
+    expect(looksLikeReport({ overallRead: { text: 'Tidy.' } })).toBe(false)
+    expect(looksLikeReport({ keep: 'spacing' })).toBe(false)
+    expect(looksLikeReport({ tally: '1 major' })).toBe(false)
+  })
+
+  it('rejects anything that is not a plain object', () => {
+    expect(looksLikeReport(null)).toBe(false)
+    expect(looksLikeReport([REPORT])).toBe(false)
+    expect(looksLikeReport('overallRead')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A Design Critique run ends on "The critic replied but not in a readable format."
instead of a critique, minutes after the screenshot was dropped (#7868).

That string is the fallback for a reply the app could not read, and it is the
right answer when the critic really did reply in prose. It was also being shown
for replies that carried a complete report, because the two steps between a
finished slot and a rendered critique were each narrower than the replies they
read:

- `extractJson` sliced from the first `{` to the last `}`. The tolerance it
  already extends to the usual model wrapping (a ```json fence, a line of prose
  either side) broke on a wrapper that merely CONTAINED a brace, because the
  slice then starts or ends outside the report. Measured against the function as
  it stands on main, a report followed by "tweak the `{primary}` token", a report
  preceded by a line naming the `{schema}`, and a small scratch object beside the
  report all returned null.
- `lastAssistant` treated the newest assistant row as the whole turn. It is not:
  `_flush_segment` in `chat_runner.py` finalizes one `assistant` row per text
  block, so text either side of a tool group is two rows, and a stream cut short
  by a transient backend error is persisted as a partial row plus a continuation
  row -- the continuation prompt tells the model to carry on where it stopped,
  which for this prompt means resuming mid-JSON. In both shapes the row the app
  read fails to parse while the turn as a whole holds a valid report.

## Why it matters

The run is lost at the last step, after the upload, the render and several
minutes of model time -- the most expensive possible place to fail. The user is
told the critic misbehaved when it did not, and retrying costs the whole run
again with no reason to expect a different outcome.

It is also invisible in the field: a critique slot is opened with
`memory_mode: 'temporary'`, so nothing is persisted, and the unreadable reply is
discarded rather than logged. Nobody can tell a wrapper the parser mis-sliced
from a genuine prose reply, which is why #7868 could not be diagnosed from the
report alone.

## What changed (motivation -> approach -> change)

Symptom: a finished, non-empty reply produces the unreadable-reply error. Root
cause: the reply is read through one blind brace slice on one row. Neither the
prompt contract nor the error message is at fault, and neither is changed here --
the critic is still asked for JSON and nothing else, and a reply with no report
in it still fails exactly as before (the existing test for that case is
untouched and still passes).

- `extractJson` now walks the reply for balanced `{...}` spans -- quote- and
  escape-aware, so a brace inside a string value cannot move the depth counter --
  and returns the largest span that parses. The report is the substantive object
  in a reply, not the aside next to it. This is strictly more tolerant than the
  slice: any text the slice accepted still parses.
- A new `jsonFromMessages` reads the TURN rather than one row: each assistant row
  newest-first, then the rows joined in order, which is what reassembles a reply
  split across a partial and its continuation. Newest-first keeps the last report
  authoritative if a turn ever produced two; the join is only reached when no
  single row carries one. `pollForReport` calls it in place of
  `extractJson(lastAssistant(...))`.

`lastAssistant` itself is unchanged -- it still drives the "the critic is
writing" signal, and `pollForText` still uses it for prose follow-up answers,
where the newest row is the correct one.

## Tests

New `website/src/test/DesignCritiqueReplyParse.test.ts` (16 cases) locks in both
halves:

- `extractJson`: bare JSON, a fenced reply and a prose-introduced reply keep
  working; a report followed by or preceded by a brace-bearing remark, and a
  report beside a smaller object, are now read; a brace inside a string value is
  not read as structure; a prose-only reply and a report cut off mid-object still
  return null.
- `jsonFromMessages`: a single-row turn, a report left behind a later segment, the
  newest of two reports, a report split across a partial and its continuation, and
  the legacy `msg msg-a` role; a user row quoting the schema back is ignored, and a
  turn with no report returns null.

Two page-level cases added to `DesignCritiquePage.coverage.test.tsx`: a run whose
report sits behind a later segment, and one whose report is split across a partial
and a continuation, both now render the critique instead of the error. The
existing "says so when the critic replies with something unreadable" case is
unchanged.

Verified RED on the base commit before the fix: the same file fails 10 of 16 cases
against `origin/main` `3a8dd4d7e` (including the three `extractJson` brace cases,
which fail on assertion rather than on the missing export). GREEN after: 60 passed
across both files.

Gates run on the diff: `tsc --noEmit` clean; `eslint` on the four touched files
clean (0 errors, and the 2 warnings are pre-existing lines this diff does not
touch); `i18n-check.mjs` with `I18N_BASE_REF` set to the merge base passes,
including the diff-scoped added-lines checks; `check-i18n-strings.mjs` at or below
baseline. No user-facing string is added, removed or changed.

## Manual verification

N/A -- no reproduction of the reporter's specific reply was available, and the
change is verified against the reply shapes rather than one sample. The failing
reply is not recoverable: critique slots are temporary and the unparsed text is
discarded, so no captured shape exists on any machine. What the tests assert
instead is that every shape in which a report WAS produced now yields a critique,
and that a reply with no report still yields the same message.

Residual, stated plainly: if the reporter's critic answered in prose or refused,
this does not change what they see. That case is a prompt-adherence question --
whether to retry with a JSON-only nudge, or to surface the raw reply -- which
decides the critic's output contract and is deliberately out of scope here.

## Related Issues

Closes #7868

## Pattern harvest

Rule candidate: review-prompt

Pattern: reading a model turn as its newest message. The runner emits one
`assistant` row per text block (`_flush_segment`), so any consumer that
reconstructs a turn's output from `messages[last]` is correct only for a
single-segment turn and silently wrong after a tool group or a mid-stream
recovery. A second instance of the same class -- a first-delimiter-to-last
-delimiter slice standing in for a parser -- is the other half of this fix.
