### PR TITLE
fix(acp): stop error guidance naming commands that do not exist

### DIFF
--- a/docs/system-specs/common/error-handling.md
+++ b/docs/system-specs/common/error-handling.md
@@ -35,7 +35,15 @@ never drift. Notable terminal (non-retryable) classes:
 - **Malformed request**: a structural rejection (backend "Improperly formed
   request", #6022). Classified TERMINAL: the identical payload cannot succeed on
   retry, so the message states the request was malformed and points at a repair
-  affordance (`/compact` to shrink and repair the conversation, or `/chat new`)
-  rather than suggesting a retry.
+  affordance (`/compact` to shrink and repair the conversation, or starting a new
+  conversation) rather than suggesting a retry. The reset affordance is PROSE,
+  not a command: this formatter does not know which surface renders the string,
+  and the reset command differs per surface (`/new` on Telegram and Discord, a
+  new tab on the dashboard), so naming one spelling hands every other surface's
+  user a command that does nothing (#7213). A command may be named here only if
+  every surface UNDERSTANDS it: `/compact` qualifies because it reaches the
+  backend through the prompt transport everywhere, even on Slack, which also
+  offers `!compact` as its own alias. The same rule governs the sibling
+  prompt-busy branch, which for the same reason now names no command at all.
 - **Usage limit** and **model not entitled**: allowance spent, or the plan lacks
   the model; also terminal, with guidance to switch model or tier.

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -340,7 +340,7 @@ Triggers in-place ACP `/compact` on the current thread's session:
 
 ## Wedged-Session Recovery (`AcpPromptBusy`)
 
-When kiro-cli reports a prompt is still in flight ("already in progress" — a tool stall, timeout, or message race), `AcpClient` raises `AcpPromptBusy` (`acp/client.py`) with a friendly "I'm still processing a previous request… if it persists, send `!restart`" message. `handle_message` catches it and auto-resets the wedged session via `sessions.reset(session_key)` so the next message cold-starts cleanly, then records the failure (the reset itself is best-effort — a reset failure is logged, not raised).
+When kiro-cli reports a prompt is still in flight ("already in progress" — a tool stall, timeout, or message race), `AcpClient` raises `AcpPromptBusy` (`acp/client.py`) with a friendly "I'm still processing a previous request… it clears on its own once the stale turn expires" message. `handle_message` catches it and auto-resets the wedged session via `sessions.reset(session_key)` so the next message cold-starts cleanly, then records the failure (the reset itself is best-effort — a reset failure is logged, not raised). The message deliberately names no command: the auto-reset above is what recovers the session, so the text has nothing to ask the user for (it used to say `!restart`, which is Slack-only, owner-gated, and restarts the gateway rather than the session -- see `common/error-handling.md`).
 
 ## OPTIONS Buttons (`format.py`)
 

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1778,16 +1778,20 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
             # because of its shape, not a momentary fault. Retrying the same
             # payload will be rejected identically, so the guidance is to REPAIR
             # or reset the conversation rather than retry. /compact shrinks and
-            # rebuilds the conversation; a fresh chat (/chat new) drops whatever
-            # in the accumulated context tripped the parser. Kept plain and
+            # rebuilds the conversation; a new conversation drops whatever in the
+            # accumulated context tripped the parser. Kept plain and
             # non-alarmist, matching the other branches. Matched against `data`
             # only via the shared _RE_MALFORMED_REQUEST, so a phrase echo in the
             # JSON-RPC `message` can't flip an unrelated error into this branch.
+            #
+            # Only `/compact` is named, because this formatter does not know
+            # which surface renders its output and the reset command differs per
+            # surface -- see docs/system-specs/common/error-handling.md (#7213).
             formatted = (
                 "The request was rejected as malformed. This is a structural "
                 "problem with the request, so retrying it as-is will not help. "
                 "Try `/compact` to shrink and repair the conversation, or start "
-                "a fresh chat (`/chat new`)."
+                "a new conversation."
                 f"{req_id_suffix}"
             )
         elif _PROMPT_BUSY_RE.search(data):
@@ -1795,9 +1799,18 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
             # This means a previous turn didn't complete cleanly (tool stall,
             # timeout, or race between messages). The session will auto-recover
             # on the next attempt once the stale turn expires.
+            #
+            # Names no command, for the reason given in the malformed-request
+            # branch above: this formatter is surface-blind. The text used to say
+            # "send `!restart`", which was wrong three ways -- it is a Slack-only
+            # bang alias, it is owner-gated even there, and it restarts the
+            # GATEWAY rather than the session. It was also unnecessary: the
+            # handlers reset and re-queue on AcpPromptBusy by themselves (see
+            # dashboard/chat_runner.py's retry-eligible branch).
             formatted = (
                 "I'm still processing a previous request. Please wait a moment "
-                "and try again — if it persists, send `!restart` to reset the session."
+                "and try again; it clears on its own once the stale turn "
+                "expires. If it persists, start a new conversation."
             )
         else:
             # Unrecognised failure mode. Show the PROVIDER'S OWN message when

--- a/test/test_acp_error_surface.py
+++ b/test/test_acp_error_surface.py
@@ -150,6 +150,24 @@ class TestNoRawDictInUserFacingError:
         assert "still processing a previous request" in str(exc)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_prompt_busy_guidance_names_no_unknown_command(self, driver):
+        """The busy branch must not name `!restart` either.
+
+        Same defect class as the malformed-request branch, in the same
+        surface-blind formatter: `!restart` is a Slack-only bang alias, it is
+        owner-gated even there, and it restarts the GATEWAY rather than the
+        session -- so on every other surface it is an inert instruction. It was
+        also unnecessary, because the handlers reset and re-queue on
+        AcpPromptBusy on their own. Asserted as an absence, and paired with a
+        positive check that the recovery advice survived (#7213).
+        """
+        msg = str(await driver(_PROMPT_BUSY))
+
+        assert "!restart" not in msg
+        assert "clears on its own" in msg
+
+    @pytest.mark.asyncio
     async def test_unknown_shape_still_preserved(self):
         """An unrecognised frame must not be swallowed — the raw shape is kept."""
         msg = str(await _raise_via_wait({"code": -32602, "message": "Invalid params"}))
@@ -366,9 +384,35 @@ class TestMalformedRequestReachesTheHandlePath:
         assert "Internal error" not in msg
         # It names the failure class and offers a repair affordance.
         assert "malformed" in msg.lower()
-        assert "/compact" in msg or "/chat new" in msg
+        assert "/compact" in msg
         # request_id survives for support correlation.
         assert "863ae6fe-de1d-4149-b3ff-6ee02d8d58a2" in msg
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_malformed_request_guidance_names_no_unknown_command(self, driver):
+        """Every command the guidance names must exist on the reader's surface.
+
+        This error is TERMINAL, so a channel dispatcher hands the formatted
+        string straight to the user (telegram's ``_user_safe_failure_reason``
+        only surfaces ``transient is False``). The formatter does not know which
+        surface will render it, so it may name only commands spelled the same
+        everywhere. ``/chat new`` was not one: it exists nowhere in the product
+        (``/new`` on Telegram and Discord, a new tab on the dashboard), so the
+        one actionable instruction a stuck user received was inert -- and on a
+        session this broken the non-command is forwarded as a prompt and
+        re-fails with this same error (#7213).
+
+        Asserted as an absence rather than by re-stating the sentence, so the
+        test constrains the CLASS of mistake (a fabricated command) instead of
+        pinning wording a later copy edit is entitled to change.
+        """
+        msg = str(await driver(_MALFORMED_REQUEST))
+
+        assert "/chat new" not in msg
+        # The reset affordance survives as prose, so the guidance still tells the
+        # user what to do -- deleting the wrong command must not delete the advice.
+        assert "new conversation" in msg.lower()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])

--- a/test/test_acp_true_provider_error.py
+++ b/test/test_acp_true_provider_error.py
@@ -166,8 +166,11 @@ class TestMalformedRequestIsTerminalAndActionable:
         assert "structural" in out.lower()
         # It says retrying as-is won't help.
         assert "will not help" in out.lower()
-        # It offers a concrete repair affordance (#6022).
-        assert "/compact" in out or "/chat new" in out
+        # It offers a concrete repair affordance (#6022). Only `/compact` is
+        # accepted, and the disjunction that once also accepted the non-existent
+        # `/chat new` is why the defect passed -- see
+        # docs/system-specs/common/error-handling.md (#7213).
+        assert "/compact" in out
 
     def test_request_id_is_preserved(self):
         out = _format_acp_error(self._MALFORMED)


### PR DESCRIPTION
## Problem / Motivation

Two branches of `_format_acp_error` told users to run commands that are not
available to them.

**Malformed request** ended: start "a fresh chat (`/chat new`)". `/chat new`
exists nowhere in the product. The command to start a fresh conversation is
`/new` on Telegram and Discord, and a new tab on the dashboard; `/chat` in the
frontend is a router path (`<Navigate to="/chat">`), not a slash command.

**Prompt busy** said to "send `!restart`". That is wrong three ways: it is a
Slack-only bang alias (`slack/handler.py:159`, `slack/events.py:2555`), it is
owner-gated even there ("Only the owner can restart the gateway",
`slack/events.py:745`), and it restarts the GATEWAY rather than the session --
it is registered as "restart the gateway (owner-only)" at `slack/events.py:829`.

So on both branches the actionable instruction a stuck user receives is inert.

## Why it matters

The malformed-request class is TERMINAL (`_is_transient_raw_error` returns False
for it), which is exactly why its text reaches the user verbatim: a channel
dispatcher surfaces a permanent ACP failure's own message instead of the generic
"please try again". Telegram's `_user_safe_failure_reason` is gated on
`transient is False` and does precisely this.

That reader is, by construction, in a session that cannot build a valid request.
Typing `/chat new` there is not a no-op: it is not a command on any surface, so
it is forwarded to the model as prompt text through the same broken session and
returns the identical `Improperly formed request`. Following the guidance
reproduces the failure. `/chat new` appears in #7213's own "What did NOT fix it"
list.

The `!restart` advice was also redundant: both the dashboard
(`dashboard/chat_runner.py`, retry-eligible branch) and Slack already reset and
re-queue the session on `AcpPromptBusy` by themselves. The user was being asked
to intervene in a recovery that is automatic.

## What changed (motivation -> approach -> change)

Symptom: repair guidance names commands that do not exist for the reader, on the
paths whose text is handed to users unmodified.

Root cause: `_format_acp_error` lives in `acp/client.py` and cannot know which
surface will render its output, but both branches were written as if the reader
were on a particular one.

Change: name a command only if every surface understands it, and otherwise use
prose. `/compact` qualifies -- it reaches the backend through the prompt
transport everywhere, including Slack, which additionally offers `!compact` as
its own alias. The malformed-request branch keeps `/compact` and drops
`/chat new` for "start a new conversation". The prompt-busy branch names nothing
and says the condition clears itself. The spec states the rule so the next edit
does not reintroduce a surface-specific spelling, and the comments point at it
rather than restating it.

Scope note, since #7213 stacks two defects: this PR fixes **only the guidance**,
not the malformation and not the retry policy. The retry half was already fixed
and merged by #7218, which classifies the string as terminal so the identical
payload is never re-sent -- that is why this text now reaches users at all. The
residue #7213 still carries is untouched here, which is why this PR uses `Refs`
rather than a closing keyword:

1. what a session whose persisted model id is no longer advertised should do
   (silent fallback to the default vs. an explicit "pick a new model" prompt) --
   a product decision, recorded as such by three triage passes on the issue;
2. releasing or recovering a channel-bound slot without deleting the session;
3. why the ACP runtime dies on this error at all.

## Tests

Both pre-existing tests of the malformed branch asserted
`"/compact" in out or "/chat new" in out`. That disjunction is why the defect
survived: the fabricated command satisfied the assertion on its own, so neither
test would have reddened on a reintroduction. Both are tightened to `/compact`.

- `test/test_acp_error_surface.py` --
  `test_malformed_request_guidance_names_no_unknown_command` and
  `test_prompt_busy_guidance_names_no_unknown_command`, each over both handle
  raise sites (`_wait_for_response` and `_dispatch_events`). Each asserts the
  fabricated command is absent AND that the branch's advice survived, so deleting
  a command cannot silently delete the guidance.
- `test/test_acp_true_provider_error.py` --
  `test_rewrites_into_actionable_prose`, the same disjunction, tightened the same
  way. It drives `_format_acp_error` directly, so the two files cover the
  formatter and both raise sites.

Mutation-verified in both directions: restoring `a fresh chat (/chat new).`
reddens both parametrizations of the malformed test, and restoring
`send \`!restart\`` reddens both parametrizations of the busy test; each returns
green on revert. 34 passed in `test_acp_error_surface.py`, 24 in
`test_acp_true_provider_error.py`. `flake8` and `isort` clean on every touched
Python file.

`docs/system-specs/modules/slack-gateway.md` quoted the busy string verbatim and
moves with it, so no spec describes a message that no longer exists.

## Manual verification

N/A -- unit coverage is the right bar. The change is two user-facing strings
built by a pure formatter, and the tests drive that formatter through both real
raise sites plus the direct entry point. Reproducing a live
`Improperly formed request` on a Telegram-bound session is not available in this
repo's test environment: pod security forces `telegram.enabled=False`, so no live
Telegram round trip was attempted and none is claimed.

## Related Issues

Refs #7213
Refs #6022

## Pattern harvest

Rule candidate: review-prompt
Pattern: user-facing guidance names a command, flag, or path that does not exist
for the reader -- and a test disjunction (`assert A in out or B in out`) lets the
fabricated half satisfy the assertion by itself. Invisible to every automated
gate: these strings type-check, lint, and here satisfied two separate tests
through the `or` branch. Three generalizable checks: when a diff adds a command
name to user-facing prose, grep the product for that command AND confirm it is
available on every surface that can render the string (not just that it exists);
treat `or` in an assertion about a single required affordance as a smell, since
it makes the weaker half sufficient; and when a string is built somewhere with no
surface context, prefer prose over any one surface's spelling.
