### PR TITLE
fix(dashboard): promote the widget and remote artifact frames to their own layer

### DIFF
--- a/website/src/components/WidgetFrame.tsx
+++ b/website/src/components/WidgetFrame.tsx
@@ -616,7 +616,19 @@ export default function WidgetFrame({ html, title = 'Widget', slug, messageTs, w
           onLoad={() => setIframeLoaded(true)}
           sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
           className="w-full border-none bg-card transition-opacity duration-200 ease-out motion-reduce:transition-none"
-          style={{ height: expanded ? '100%' : height, opacity: iframeLoaded ? 1 : 0 }}
+          style={{
+            height: expanded ? '100%' : height,
+            // Same compositing promotion the artifact frame carries, for the same
+            // reason: an engine can lay this document out, run its scripts and
+            // report a correct height while never rasterizing it, which presents
+            // as an empty box rather than an error. Promoting the frame to its
+            // own layer is the one remedy that needs no timing — the others have
+            // to be fired after load, which races a slow document. This frame was
+            // left out when the artifact frame was promoted, so the inline-widget
+            // surface still had the gap.
+            transform: 'translateZ(0)',
+            opacity: iframeLoaded ? 1 : 0,
+          }}
           title={title}
         />
       </div>}

--- a/website/src/components/library/ArtifactThumbs.tsx
+++ b/website/src/components/library/ArtifactThumbs.tsx
@@ -171,7 +171,17 @@ export function WidgetThumb({ content, slug }: { content: string; slug: string }
           style={{
             width: BASE_W,
             height: renderH,
-            transform: `scale(${scale})`,
+            // `translateZ(0)` composed onto the scale, not instead of it: the
+            // scale is the thumbnail's whole geometry. A 2D transform makes a
+            // stacking context but does NOT force this frame onto its own
+            // compositing layer, and an engine can then lay the document out,
+            // run its scripts and report a correct height while rasterizing
+            // nothing -- an empty card behind the same opacity-on-load reveal,
+            // which across a grid is the whole gallery blank. The 3D form is
+            // what promotes; it adds no visual offset with no perspective set.
+            // Same remedy as ArtifactBody / WidgetFrame / RemoteArtifactDetail;
+            // keep the four in step.
+            transform: `scale(${scale}) translateZ(0)`,
             transformOrigin: 'top left',
             // Hidden until the document reports load: until then the engine may
             // paint its own WHITE canvas over this element's background, which

--- a/website/src/pages/RemoteArtifactDetailPage.tsx
+++ b/website/src/pages/RemoteArtifactDetailPage.tsx
@@ -360,7 +360,16 @@ export default function RemoteArtifactDetailPage() {
                     src={blobUrl}
                     sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
                     className="w-full border-none bg-card"
-                    style={{ height: 'calc(100vh - 240px)', minHeight: 480 }}
+                    style={{
+                      height: 'calc(100vh - 240px)',
+                      minHeight: 480,
+                      // See ArtifactBody's frame: a laid-out document whose first
+                      // paint is skipped shows an empty box, and promoting the
+                      // frame to its own compositing layer is the remedy that
+                      // needs no post-load timing. The remote detail frame was
+                      // left out when the local one was promoted.
+                      transform: 'translateZ(0)',
+                    }}
                     title={i18nT('pages.remoteArtifactDetailPage.remote_artifact_3', { name: externalId })}
                   />
                 ) : failed ? (

--- a/website/src/test/ArtifactsPage.narrowSingleAxis.test.tsx
+++ b/website/src/test/ArtifactsPage.narrowSingleAxis.test.tsx
@@ -236,6 +236,25 @@ describe('ArtifactsPage keeps the axis on the page at one column', () => {
     expect(text).toMatch(/const THUMB_HEIGHT_SPACE = 'thumb900'/)
   })
 
+  it('gives the thumbnail frame its own compositing layer without losing its scale', async () => {
+    // Fourth consumer of `useSandboxDoc`, and the one a First Principles review
+    // caught this PR miscounting. The thumb loads the same minted document
+    // behind the same opacity-on-load reveal as the other three frames, so it
+    // needs the same promotion -- but its transform is load-bearing geometry,
+    // so the 3D form has to be COMPOSED onto the scale rather than replace it.
+    // A 2D scale alone makes a stacking context and does not promote.
+    //
+    // Asserted at source level like its siblings above, because the regression
+    // is invisible in Chromium and in a jsdom mount: nothing else here would
+    // catch the property being dropped or the scale being clobbered.
+    const text = thumbsSrc()
+    const thumb = text.slice(text.indexOf('function WidgetThumb('), text.indexOf('function ContentThumb('))
+    expect(thumb).toMatch(/transform: `scale\(\$\{scale\}\) translateZ\(0\)`/)
+    // The scale must survive: a bare translateZ(0) here would render every
+    // thumbnail at full width inside a column-width box.
+    expect(thumb).not.toMatch(/transform: `translateZ\(0\)`/)
+  })
+
   it('reserves ONE box for a thumbnail, before and after the iframe exists', async () => {
     // A different placeholder height that is swapped once the blob URL resolves
     // is a SECOND height change per card, on top of the report — and in a

--- a/website/src/test/RemoteArtifactDetailPageCoverage.test.tsx
+++ b/website/src/test/RemoteArtifactDetailPageCoverage.test.tsx
@@ -288,6 +288,10 @@ describe('RemoteArtifactDetailPage', async () => {
       expect(frame).toHaveAttribute('src', '/sandbox-doc/test/tok')
       expect(frame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'))
       expect(URL.createObjectURL).not.toHaveBeenCalled()
+      // Own compositing layer, so a skipped first paint cannot leave the reader
+      // an empty box. Dropping the property looks harmless in Chromium and in
+      // this DOM, so the assertion is the whole guard.
+      expect((frame as HTMLIFrameElement).style.transform).toBe('translateZ(0)')
     })
 
     it('flattens a nested "artifact" payload so content_type still selects the html renderer', async () => {

--- a/website/src/test/WidgetFrame.test.tsx
+++ b/website/src/test/WidgetFrame.test.tsx
@@ -973,6 +973,34 @@ describe('WidgetFrame exists-vs-pinned states', () => {
 // the space below the toolbar. These tests pin that CLASS STRUCTURE only —
 // happy-dom computes no layout, so they cannot observe rendered geometry.
 // Real display regressions need a browser-level geometry assertion.
+describe('WidgetFrame paint contract', () => {
+  it('gives the frame its own compositing layer so a skipped first paint cannot blank it', async () => {
+    // The artifact frame was promoted after an engine was measured laying its
+    // document out, running its scripts and reporting a correct height while
+    // rasterizing nothing — a correctly sized, visible frame painting an empty
+    // box. This frame loads the same kind of document, through the same mint,
+    // behind the same opacity-on-load reveal, and was left un-promoted, so the
+    // inline-widget surface kept the gap the artifact surface had closed.
+    //
+    // Chromium in this DOM paints fine either way, so removing the property
+    // looks completely harmless here: this assertion is the whole guard.
+    const { container } = wrap(<WidgetFrame html="<p>promoted</p>" title="T" />)
+    const iframe = await frameIn(container)
+    expect(iframe.style.transform).toBe('translateZ(0)')
+  })
+
+  it('still reveals on load rather than replacing the reveal with the promotion', async () => {
+    // The promotion is additive. If it had displaced the opacity gate the frame
+    // would show the browser's own canvas for the length of the document fetch,
+    // which some engines paint white regardless of the element background.
+    const { container } = wrap(<WidgetFrame html="<p>reveal</p>" title="T" />)
+    const iframe = await frameIn(container)
+    expect(iframe.style.opacity).toBe('0')
+    act(() => { iframe.dispatchEvent(new Event('load')) })
+    await waitFor(() => expect(iframe.style.opacity).toBe('1'))
+  })
+})
+
 describe('WidgetFrame expanded layout (structural contract)', () => {
   const expandLabel = () => i18nT('components.widgetFrame.expand')
 


### PR DESCRIPTION
## Problem / Motivation

In the desktop app, agent-generated widgets and HTML artifacts render as a blank
area while the same content against the same gateway renders correctly in a
browser opened side by side (#6176). The content is generated correctly; it is
simply not displayed, and nothing surfaces an error.

One hook, `useSandboxDoc`, mints a gateway-served document URL and four
components load it into a sandboxed frame:

| Consumer | Own compositing layer before this PR |
|---|---|
| `ArtifactBody.tsx` (artifact detail, Artifacts tab) | yes, added by #6461 |
| `WidgetFrame.tsx` (inline chat widget) | **no** |
| `RemoteArtifactDetailPage.tsx` (remote artifact detail) | **no** |
| `library/ArtifactThumbs.tsx` (gallery thumbnail) | **no** -- 2D scale only |

That is the scope of this change: the four consumers of that mint, three of
which were missing the promotion. Model-authored HTML also reaches the screen
through frames that build their document inline and never touch the mint, so a
fix here cannot reach them; two such frames are filed separately as #8037.

#6461 promoted the artifact frame with `transform: translateZ(0)` after
measuring an engine that laid a document out, ran its injected scripts and
reported a correct 385px height while rasterizing nothing: a correctly sized,
visible frame painting an empty box, with four unrelated post-load
invalidations each making it appear. Its three siblings load the same kind of
document, through the same mint, behind the same opacity-on-load reveal, and
were left un-promoted -- so the inline-widget surface #6176 names first still
carried the gap the artifact surface had closed.

## Why it matters

All four frames reveal at `opacity: 0` until their own `load` fires, and a
document served with an opaque origin cannot be observed by the parent. A frame
that lays out but never paints is therefore indistinguishable from one still
loading: the reader gets a permanently empty box with no error and no retry
affordance. Inline widgets are the primary way generated visual output is read,
and on the gallery thumbnail the same failure repeats across every card at once.

The desktop shell makes this class of defect more reachable than a browser tab
does. It hosts the dashboard in a `WebContentsView` inside a `BaseWindow`
(`website/electron/window-lifecycle.js`), a different compositing host from an
ordinary tab, which is consistent with the report that a browser against the
same gateway paints what the desktop window does not.

## What changed (motivation -> approach -> change)

Symptom: a sandboxed document frame is laid out and never rasterized, which
presents as an empty box rather than an error. Cause of the remaining instances:
the promotion that fixes it was applied to one of the four frames that share the
mint. Change: apply the identical promotion to the other three.

`transform: translateZ(0)` is the one remedy of the four measured in #6461 that
needs no timing -- the others must fire after `load`, which races a slow
document. The promotion is additive: the opacity-on-load reveal stays, because
removing it would show the browser's own canvas for the length of the document
fetch, which some engines paint white regardless of the element background.

On the gallery thumbnail the promotion is **composed onto** that frame's
existing `scale(...)` transform rather than replacing it. Two reasons the
distinction is load-bearing: the scale is the thumbnail's entire geometry, so
clobbering it would render every card at full width inside a column-width box;
and a 2D transform creates a stacking context but does **not** force a
compositing layer the way the 3D form does, which is why that frame needed the
change at all despite already carrying a transform. `translateZ(0)` adds no
visual offset with no perspective set.

Deliberately not in scope:

- **No change to the isolation boundary.** The sandbox flags, the
  `Content-Security-Policy: sandbox` response header, the `frame-ancestors`
  value, and the single-use document channel are all untouched. Nothing here
  loosens the sandbox, adds `allow-same-origin`, or relaxes a CSP.
- The two inline-`srcDoc` frames outside the mint, filed as #8037. They are a
  different code path in different apps; folding them in would put three app
  surfaces in a channel fix.
- `colorScheme`, which the artifact frame and the thumbnail both already set, is
  not added to `WidgetFrame`: it addresses a first-paint canvas flash, not a
  skipped paint, and that frame already covers the flash with `bg-card` plus the
  opacity gate.
- The silent-failure mode itself (a parent cannot observe an in-frame load
  outcome) is pre-existing and independent of this change.

## Tests

- `website/src/test/WidgetFrame.test.tsx` -- the frame carries the promotion;
  and, separately, it still reveals on load rather than having the promotion
  displace the opacity gate.
- `website/src/test/ArtifactsPage.narrowSingleAxis.test.tsx` -- the thumbnail
  carries the promotion **composed onto** its scale, asserted both ways so a
  future edit cannot drop the scale and keep the promotion.
- `website/src/test/RemoteArtifactDetailPageCoverage.test.tsx` -- extends the
  existing sandboxed-document assertion on the html body with the promotion.

Every new guard is mutation-verified: removing the property turns the suite red
(1 failed of 40 for the widget frame, 1 of 10 for the thumbnail) and restoring
it turns it green again. That verification is the point of the assertions -- as
#6461's own test comment records, dropping the property looks completely
harmless in Chromium, so nothing else in the suite would catch a silent revert.

Run on the touched files only, against the rebased tree:

- `vitest run` on the five touched-surface suites -- 128 passed (the sibling
  artifact-frame suite is included to show its existing guard still holds)
- `tsc --noEmit` -- clean
- `eslint` on the six touched files -- 0 errors; the 3 warnings
  (`RemoteArtifactDetailPage.tsx` x2, `ArtifactThumbs.tsx` x1) are pre-existing
  and byte-identical on the base, with only line numbers shifted by this diff
- `npm run i18n:check` with `I18N_BASE_REF` set to the merge base -- all 10
  checks ok, including the zero-tolerance `added-lines`, `vs-base`,
  `unit-added-lines` and `unit-vs-base`

## Manual verification

**Not performed, and this is a limit worth stating plainly rather than papering
over.** The report in #6176 is on the macOS desktop build; this work was done on
Linux, so the desktop shell that ships was never exercised and no console or CSP
output from a reproducing session was captured. The evidence here is
source-level and test-level.

What this PR establishes: three of the four frames on the sandbox-doc mint
lacked a promotion their sibling has for exactly this symptom class, and they
now carry it. The change cannot regress anything, since a promoted frame renders
identically on any engine that was already painting it.

What remains outstanding: a macOS desktop reproduction, which is what would show
whether a skipped paint is the whole story there. A reviewer with that build can
settle it in one pass with the three evidence items from the triage comment on
the issue -- the status of the `/sandbox-doc/<id>/<token>` request in the desktop
devtools Network tab, any `frame-ancestors` or `sandbox` console line, and
whether the Windows and Linux desktop builds reproduce.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** `translateZ(0)` is a non-rendering compositing hint -- on
any engine that already paints the frame, the rendered output before and after
this change is identical, so a before/after pair would be two identical images.

The change is observable only on an engine that skips the frame's first paint,
and that is the environment this branch could not exercise (see Manual
verification). The repository's own guard for the sibling frame records the same
constraint: `ArtifactBody.iframeBlob.test.tsx` says "only an iOS device can
observe the regression, so this assertion is the whole guard: dropping the
property looks completely harmless in Chromium." A Chromium screenshot pair
would misrepresent the evidence rather than add to it, which is why this uses
the marker instead of attaching one.

## Related Issues

Refs #6176

#8037 covers the two inline-`srcDoc` frames outside this mint, found while
reviewing this PR.

Context, not duplicates: #6461 introduced the promotion this PR extends, #6481
fixed the contradictions #6461 left, and #6184 was an earlier attempt withdrawn
by its author after the spent-URL causal chain was falsified. This PR does not
revive that chain -- it changes nothing about the document channel.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a remedy applied at one consumer of a shared hook while its sibling
consumers keep the defect. `useSandboxDoc` has four call sites; #6461 fixed one.

This PR is its own worked example of why the rule is needed, twice. Its first
revision enumerated three consumers and fixed two, and a First Principles review
caught that the count was wrong -- `library/ArtifactThumbs.tsx` was a fourth
consumer, already carrying a 2D transform that looks like a promotion and is
not. The same review then caught this description overstating its own reach,
which is how #8037 was found. So the generalizable check is mechanical rather
than a reminder to be careful: grep every call site of the shared hook, state for
each whether it is fixed or why it is not, and say plainly which surfaces reach
the same screen WITHOUT going through that hook. The guard matters most when the
defect is invisible in the development engine, because then no local run
distinguishes a fixed consumer from an unfixed one.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
