### PR TITLE
fix(virtualizer): follow re-pins through an animated viewport shrink

### DIFF
--- a/website/src/app-sdk/useChatScrollFollow.ts
+++ b/website/src/app-sdk/useChatScrollFollow.ts
@@ -70,6 +70,14 @@ export function useChatScrollFollow(opts: {
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null)
   const stickRef = useRef(true)
   const lastWriteTopRef = useRef(-1)
+  // The scroller's `clientHeight` at the moment `lastWriteTopRef` was recorded
+  // — the viewport box that value was a bottom FOR. Kept in lockstep with it
+  // (`-1` alongside `-1`) so the pin evaluation can tell how much of the
+  // current distance-from-bottom is our own viewport shrink rather than the
+  // user's move (see evaluateAutoPin's `viewportShrink`). This observer watches
+  // the scroller's own box as well as the content wrapper, so a pane drag or a
+  // keyboard opening below the transcript shrinks it with no user input.
+  const lastWriteClientHRef = useRef(-1)
   const prevScrollTopRef = useRef(-1)
   const [isAtBottom, setIsAtBottom] = useState(true)
   // Effect-stable mirror so the callbacks read the live value without
@@ -80,6 +88,7 @@ export function useChatScrollFollow(opts: {
   const writePin = useCallback((el: HTMLElement, target: number) => {
     el.scrollTop = target
     lastWriteTopRef.current = target
+    lastWriteClientHRef.current = el.clientHeight
     prevScrollTopRef.current = target
   }, [])
 
@@ -89,7 +98,19 @@ export function useChatScrollFollow(opts: {
     const el = scrollerRef.current
     if (!el) return
     const geom = readGeom(el)
-    const result = evaluateAutoPin({ stick: stickRef.current, geom, lastWriteTop: lastWriteTopRef.current })
+    const result = evaluateAutoPin({
+      stick: stickRef.current,
+      geom,
+      lastWriteTop: lastWriteTopRef.current,
+      // Measure the scroll-up guard against the box our reference was a bottom
+      // for, never the box that just shrank. A turn-collapse SHRINK clamps
+      // scrollTop below our last write while leaving us at the new bottom; if
+      // the scroller's own box shrinks in the SAME tick, the clamp plus the
+      // shrink-inflated distance together look exactly like a user scrolling
+      // up, and follow releases for good with nothing to re-arm it.
+      viewportShrink:
+        lastWriteClientHRef.current >= 0 ? lastWriteClientHRef.current - geom.clientHeight : 0,
+    })
     stickRef.current = result.stick
     if (result.pin) {
       writePin(el, result.target)
@@ -97,6 +118,7 @@ export function useChatScrollFollow(opts: {
       // Following and already at the bottom — keep the self-scroll reference
       // aligned so the next scroll event is not misread as the user's.
       lastWriteTopRef.current = result.target
+      lastWriteClientHRef.current = geom.clientHeight
     }
     // Content growth while the user is scrolled up must reveal the jump pill
     // even though no scroll event fires.
@@ -120,7 +142,10 @@ export function useChatScrollFollow(opts: {
       })
       // A user scroll invalidates the self-scroll reference: keeping it would
       // let a later user move back to the same offset read as ours.
-      if (!stickRef.current) lastWriteTopRef.current = -1
+      if (!stickRef.current) {
+        lastWriteTopRef.current = -1
+        lastWriteClientHRef.current = -1
+      }
     }
     prevScrollTopRef.current = geom.scrollTop
   }, [])
@@ -140,6 +165,7 @@ export function useChatScrollFollow(opts: {
     if (!enabled) return
     stickRef.current = true
     lastWriteTopRef.current = -1
+    lastWriteClientHRef.current = -1
     prevScrollTopRef.current = -1
     setIsAtBottom(true)
     const el = scrollerRef.current

--- a/website/src/hooks/virtualizer/FollowController.ts
+++ b/website/src/hooks/virtualizer/FollowController.ts
@@ -173,15 +173,31 @@ export interface AutoPinResult {
  *
  * `lastWriteTop < 0` disables the scroll-up guard (used right after a slot
  * switch, before we have written anything this session).
+ *
+ * `viewportShrink` (px, default 0) is how much the SCROLLER'S OWN BOX has
+ * shrunk since that reference was recorded — chrome mounting below the
+ * transcript (a queue band, an attachment strip, a tip card), often
+ * spring-animated over several frames. Our own shrink inflates
+ * `distanceFromBottom` with no user input, so without this allowance the
+ * distance guard reads it as "meaningfully away from the bottom". Paired with
+ * a content SHRINK in the same commit window — a tail-row remount clamping
+ * scrollTop below `lastWriteTop` — that produced a full user-scroll-up
+ * signature out of two of our own layout changes: follow released mid
+ * animation and the content settled a card-height low. Judging the distance
+ * against the box we were last a bottom FOR keeps the guard measuring the
+ * user's move rather than our own. Only the shrink's own pixels are forgiven,
+ * so a genuine drag inside the same tick still releases.
  */
 export function evaluateAutoPin(args: {
   stick: boolean
   geom: ScrollGeom
   lastWriteTop: number
   epsilon?: number
+  viewportShrink?: number
 }): AutoPinResult {
   const { stick, geom, lastWriteTop } = args
   const epsilon = args.epsilon ?? SELF_SCROLL_EPSILON
+  const viewportShrink = Math.max(0, args.viewportShrink ?? 0)
   const target = bottomTarget(geom)
   if (!stick) return { pin: false, stick: false, target }
   // Release only on a genuine user scroll-UP: scrollTop dropped below our last
@@ -194,7 +210,7 @@ export function evaluateAutoPin(args: {
   if (
     lastWriteTop >= 0 &&
     geom.scrollTop < lastWriteTop - epsilon &&
-    distanceFromBottom(geom) > epsilon
+    distanceFromBottom(geom) - viewportShrink > epsilon
   ) {
     return { pin: false, stick: false, target }
   }

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -430,6 +430,13 @@ export function useVirtualChat<T>(
   // beating the RO-vs-scroll-event race.
   const stickRef = useRef<boolean>(followOutput)
   const lastWriteTopRef = useRef<number>(-1)
+  // `lastWriteClientHRef`: the scroller's `clientHeight` at the moment
+  // `lastWriteTopRef` was recorded — i.e. the viewport box that value was a
+  // bottom FOR. Kept in lockstep with it (`-1` alongside `-1`) so the pin
+  // evaluation can tell how much of the current distance-from-bottom is our
+  // own viewport shrink rather than the user's move (see evaluateAutoPin's
+  // `viewportShrink`).
+  const lastWriteClientHRef = useRef<number>(-1)
   // True while a smooth scrollTo animation (from pinAuto) is in flight.
   // During this period, scroll events are NOT treated as user-scrolls — they
   // are intermediate frames of our own programmatic smooth-pin.
@@ -926,6 +933,7 @@ export function useVirtualChat<T>(
         : { start: Math.max(0, itemCount - tailSize), end: itemCount },
     )
     lastWriteTopRef.current = -1
+    lastWriteClientHRef.current = -1
     setIsAtBottom(true)
     // A pending debounced save belongs to the OUTGOING session: flush it NOW,
     // synchronously, instead of dropping it — a scroll-then-switch inside the
@@ -1322,6 +1330,7 @@ export function useVirtualChat<T>(
       if (typeof el.scrollTo === 'function') el.scrollTo({ top, behavior })
       else el.scrollTop = top
       lastWriteTopRef.current = accounting === 'pin' ? top : -1
+      lastWriteClientHRef.current = accounting === 'pin' ? el.clientHeight : -1
       // The direction reference must move WITH our own writes, synchronously.
       // A programmatic scroll's event lands asynchronously (and a fake scroller
       // in tests dispatches none), so leaving the reference to the scroll
@@ -1369,6 +1378,7 @@ export function useVirtualChat<T>(
           // they are. lastWriteTop is reset because we are releasing follow.
           if (typeof el.scrollTo === 'function') el.scrollTo({ top: el.scrollTop, behavior: 'auto' })
           lastWriteTopRef.current = -1
+          lastWriteClientHRef.current = -1
           detachSmoothAbort()
         }
         // Replace any previous glide's listeners rather than stacking them:
@@ -1404,10 +1414,17 @@ export function useVirtualChat<T>(
     // pinAuto(), which then snaps instantly to the new bottom.
     if (smoothPinActiveRef.current) return
     const geom = { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }
+    const viewportShrink =
+      lastWriteClientHRef.current >= 0 ? lastWriteClientHRef.current - geom.clientHeight : 0
     const result = evaluateAutoPin({
       stick: stickRef.current,
       geom,
       lastWriteTop: lastWriteTopRef.current,
+      // Chrome mounting below the transcript shrinks this box, often
+      // spring-animated across many frames. Measure the scroll-up guard
+      // against the box our reference was a bottom for, never the box the
+      // animation just applied.
+      viewportShrink,
     })
     stickRef.current = result.stick
     if (result.pin) {
@@ -1416,6 +1433,7 @@ export function useVirtualChat<T>(
       // Still following but already at the bottom (no write needed) — keep the
       // self-scroll reference aligned with the current bottom.
       lastWriteTopRef.current = result.target
+      lastWriteClientHRef.current = geom.clientHeight
     }
   }, [scrollerRef, writeScrollTop])
 
@@ -1497,7 +1515,18 @@ export function useVirtualChat<T>(
         }
         prevSmoothTopRef.current = el.scrollTop
       } else if (!isSelfScroll(el.scrollTop, lastWriteTopRef.current)) {
-        lastUserScrollAtRef.current = performance.now()
+        // A scroll we did not write that leaves us EXACTLY at the bottom was the
+        // layout engine's: the browser clamps scrollTop when a shrinking
+        // scrollHeight drops the maximum below it, and a spacer re-estimate does
+        // the same.
+        //
+        // The test is the CLAMP — distance within SELF_SCROLL_EPSILON — and NOT
+        // the 100px `atBottom` UI band. resolveUserScrollStick's bottom-epsilon
+        // branch is what keeps `stick` armed across the clamp; widening this to
+        // the 100px band would erase the only evidence evaluateAutoPin has of a
+        // real 3-100px scroll-up.
+        const clampedAtBottom =
+          geom.scrollHeight - (geom.scrollTop + geom.clientHeight) <= SELF_SCROLL_EPSILON
         stickRef.current = resolveUserScrollStick({
           stick: stickRef.current,
           followOutput,
@@ -1505,23 +1534,37 @@ export function useVirtualChat<T>(
           prevScrollTop: lastObservedTopRef.current,
           geom,
         })
-        // A scroll we did not write that leaves us EXACTLY at the bottom was the
-        // layout engine's: the browser clamps scrollTop when a shrinking
-        // scrollHeight drops the maximum below it, and a spacer re-estimate does
-        // the same. Re-baseline the self-scroll reference to where we now are —
+        const layoutClamp = stickRef.current && clampedAtBottom
+        // A clamp is OUR layout change, so it must not be stamped as input.
+        // `lastUserScrollAtRef` arms the SCROLL_SETTLE_MS gate that holds
+        // automatic pins off while a gesture is in flight, so stamping it for a
+        // clamp spent the whole window on our own reflow. A send that queues
+        // behind a busy turn does both halves at once: the queued row regroups
+        // the turn and remounts tail rows (content shrinks — the clamp), and the
+        // queue band mounts below the transcript and spring-animates the
+        // scroller's box smaller over the following frames. Every one of those
+        // viewport re-pins was then suppressed, so the transcript sat up to a
+        // card-height below the bottom until the gate expired — measured on the
+        // real build: the box shrank 617 -> 588 across 130ms with scrollTop
+        // frozen, and the first pin landed at 154ms, one frame AFTER the last
+        // shrink step. Whether the animation outlived the gate is what made the
+        // defect intermittent.
+        //
+        // Genuine input keeps its own signal: the persistent intent listeners
+        // below stamp at wheel/touch/key/scrollbar time, which is EARLIER than
+        // the scroll event this branch handles, so nothing is lost by declining
+        // to stamp here. `stick` and `lastWriteTop` already treat the clamp as
+        // ours; the gate now agrees with them.
+        if (!layoutClamp) lastUserScrollAtRef.current = performance.now()
+        // Re-baseline the self-scroll reference to where the clamp left us —
         // otherwise it keeps pointing at our last write, and the next pin
         // evaluation reads that gap as a user scroll-up, releasing follow for the
         // rest of the turn with only a manual scroll back to the bottom able to
         // re-arm it.
-        //
-        // The test is the CLAMP — distance within SELF_SCROLL_EPSILON — and NOT
-        // the 100px `atBottom` UI band. resolveUserScrollStick's bottom-epsilon
-        // branch is what keeps `stick` armed across the clamp; re-baselining
-        // across the wider band would erase the only evidence evaluateAutoPin
-        // has of a real 3-100px scroll-up.
-        const clampedAtBottom =
-          geom.scrollHeight - (geom.scrollTop + geom.clientHeight) <= SELF_SCROLL_EPSILON
-        if (stickRef.current && clampedAtBottom) lastWriteTopRef.current = el.scrollTop
+        if (layoutClamp) {
+          lastWriteTopRef.current = el.scrollTop
+          lastWriteClientHRef.current = geom.clientHeight
+        }
       }
       // Direction reference for the next event — updated for self-scrolls too,
       // so a user move right after our own pin is measured against where the
@@ -2023,6 +2066,7 @@ export function useVirtualChat<T>(
       // resulting scroll event is classified as ours, not user input (which
       // would trip the settle frames' user-scroll abort below).
       lastWriteTopRef.current = el.scrollTop
+      lastWriteClientHRef.current = el.clientHeight
       // Settle: for a few frames, correct against the anchor row's LIVE DOM
       // position as measurements land (rows above it refine from estimates).
       // Aborts on a genuine user scroll (lastUserScrollAtRef — restore writes

--- a/website/src/test/FollowController.test.ts
+++ b/website/src/test/FollowController.test.ts
@@ -249,6 +249,42 @@ describe('evaluateAutoPin — the race-proof core', () => {
     const r = evaluateAutoPin({ stick: true, geom, lastWriteTop: 600 })
     expect(r.stick).toBe(true)
   })
+
+  it('OUR OWN viewport shrink does not read as a scroll-up, even on top of a clamp', () => {
+    // Both halves of the queue-band race in one geometry: a tail-row remount
+    // shrank content by 4px (so the browser clamped scrollTop from 600 to 596,
+    // below our last write) AND the band's animation shrank the box by 29px
+    // (400 -> 371). Distance is now 29px, which without the allowance is
+    // "meaningfully away from the bottom" — a full scroll-up signature built
+    // from two of our own layout changes. Forgiving the box's own 29px keeps
+    // follow armed and re-pins to the new bottom (996 - 371 = 625).
+    const geom = { scrollTop: 596, scrollHeight: 996, clientHeight: 371 }
+    expect(distanceFromBottom(geom)).toBe(29)
+    expect(evaluateAutoPin({ stick: true, geom, lastWriteTop: 600 }).stick).toBe(false)
+    const r = evaluateAutoPin({ stick: true, geom, lastWriteTop: 600, viewportShrink: 29 })
+    expect(r.stick).toBe(true)
+    expect(r.pin).toBe(true)
+    expect(r.target).toBe(625)
+  })
+
+  it('the allowance forgives only its own pixels — a real drag inside it still releases', () => {
+    // Same 29px shrink, but the user also dragged 200px up: distance 229, of
+    // which only 29 is ours. The remaining 200 is still user input.
+    const geom = { scrollTop: 396, scrollHeight: 996, clientHeight: 371 }
+    const r = evaluateAutoPin({ stick: true, geom, lastWriteTop: 600, viewportShrink: 29 })
+    expect(r.stick).toBe(false)
+    expect(r.pin).toBe(false)
+  })
+
+  it('a viewport GROW never widens the guard (negative shrink is clamped to 0)', () => {
+    // The box grew (chrome unmounted), so the caller passes a negative value.
+    // Treating it as an allowance would be a subtraction the wrong way; a
+    // genuine 100px scroll-up must still release.
+    const geom = { scrollTop: 500, scrollHeight: 1000, clientHeight: 400 }
+    const r = evaluateAutoPin({ stick: true, geom, lastWriteTop: 600, viewportShrink: -60 })
+    expect(r.stick).toBe(false)
+    expect(r.pin).toBe(false)
+  })
 })
 
 // Feature: chat-virtualizer — DPR-aware "at bottom" epsilon.

--- a/website/src/test/useChatScrollFollow.test.tsx
+++ b/website/src/test/useChatScrollFollow.test.tsx
@@ -116,6 +116,49 @@ describe('useChatScrollFollow', () => {
     expect(state.scrollTop).toBe(BOTTOM)
   })
 
+  it('a turn-collapse SHRINK in the same tick as a viewport shrink keeps following', () => {
+    // The sibling of the virtualizer's queue-band defect, on the plain
+    // scroller: this hook's single observer watches the scroller's own box as
+    // well as the content wrapper, so one tick can carry both a turn-collapse
+    // content shrink (which clamps scrollTop below our last write) and a
+    // viewport shrink (a pane drag, a keyboard, chrome mounting below). Judged
+    // against the just-shrunk box the pair reads as a user scroll-up, and this
+    // hook has no clamp re-baseline to fall back on, so follow released for
+    // good and later growth never pinned again.
+    const { state } = mount()
+    act(() => { FakeResizeObserver.fireAll() })
+    expect(state.scrollTop).toBe(BOTTOM)
+
+    act(() => {
+      state.scrollHeight = SH - 200
+      state.scrollTop = BOTTOM - 200 // the layout engine's clamp, NOT a user scroll
+      state.clientHeight = CH - 29 // the box shrinks in the same tick
+      FakeResizeObserver.fireAll()
+    })
+    expect(state.scrollTop).toBe(SH - 200 - (CH - 29))
+
+    // Follow is still armed, so the next growth pins.
+    act(() => { state.scrollHeight = SH; FakeResizeObserver.fireAll() })
+    expect(state.scrollTop).toBe(SH - (CH - 29))
+  })
+
+  it('a real scroll-up inside a viewport shrink still releases follow', () => {
+    // The boundary: the allowance forgives only the box's own pixels.
+    const { scroller, state } = mount()
+    act(() => { FakeResizeObserver.fireAll() })
+    expect(state.scrollTop).toBe(BOTTOM)
+
+    act(() => {
+      state.clientHeight = CH - 29
+      state.scrollTop = BOTTOM - 200
+      FakeResizeObserver.fireAll()
+    })
+    expect(state.scrollTop).toBe(BOTTOM - 200)
+    act(() => { scroller.dispatchEvent(new Event('scroll')) })
+    act(() => { state.scrollHeight = SH + 500; FakeResizeObserver.fireAll() })
+    expect(state.scrollTop).toBe(BOTTOM - 200)
+  })
+
   it('releases on user scroll up: growth no longer moves the viewport, pill shows', () => {
     const { scroller, state } = mount()
     act(() => { FakeResizeObserver.fireAll() })

--- a/website/src/test/useVirtualChat.viewportResize.test.tsx
+++ b/website/src/test/useVirtualChat.viewportResize.test.tsx
@@ -123,6 +123,96 @@ describe('useVirtualChat: viewport-box resize re-pin', () => {
     expect(el.scrollTop).toBe(600)
   })
 
+  it('re-pins through the shrink animation when a content clamp preceded it', () => {
+    // The measured cause of the queue-band dip. A send that queues behind a
+    // busy turn regroups the turn and remounts tail rows, so the content
+    // shrinks and the browser clamps scrollTop; the queue band then mounts
+    // below the transcript and spring-animates the scroller's box smaller over
+    // the following frames. The clamp's scroll event used to be stamped as user
+    // input, which armed the SCROLL_SETTLE_MS gate and suppressed EVERY
+    // viewport re-pin of that animation.
+    const { el, state } = mount('viewport-clamp-gate', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
+    expect(el.scrollTop).toBe(1600)
+
+    // The remount: content shrinks 125px, the layout engine clamps scrollTop by
+    // the same amount, and the resulting scroll event dispatches. Still exactly
+    // at the bottom (1875 - 1475 - 400 === 0), so this is a clamp, not input.
+    act(() => {
+      state.scrollHeight = 1875
+      state.scrollTop = 1475
+      el.dispatchEvent(new Event('scroll'))
+    })
+
+    // First frame of the band's animation, well inside the settle window.
+    act(() => {
+      state.clientHeight = 371
+      fireViewport(el)
+    })
+    expect(el.scrollTop).toBe(1875 - 371)
+  })
+
+  it('a genuine gesture still holds pins off for the settle window', () => {
+    // The boundary the fix must not move: real input is stamped by the intent
+    // listeners at wheel/touch/key time, and a viewport shrink inside that
+    // window must not write scrollTop out from under the gesture.
+    const { el, state, writes } = mount('viewport-gesture-gate', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
+    expect(el.scrollTop).toBe(1600)
+    const before = writes.n
+
+    act(() => { el.dispatchEvent(new Event('wheel')) })
+    act(() => {
+      state.clientHeight = 371
+      fireViewport(el)
+    })
+    expect(writes.n).toBe(before)
+
+    // Once the window expires, follow resumes. (SCROLL_SETTLE_MS is 150ms and
+    // module-private; followDisengage's gate test uses the same literal.)
+    act(() => { vi.advanceTimersByTime(151); fireViewport(el) })
+    expect(el.scrollTop).toBe(2000 - 371)
+  })
+
+  it('re-pins when a tail-row remount clamps scrollTop in the same tick as the shrink', () => {
+    const { el, state } = mount('viewport-clamp-shrink', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
+    expect(el.scrollTop).toBe(1600)
+
+    // A send that queues behind a busy turn does two things in one commit
+    // window: the queued row appends, which regroups the turn and REMOUNTS
+    // tail rows (content transiently shrinks — here by 28px, so the browser
+    // clamps scrollTop to the new maximum 1972 - 400 = 1572), and the queue
+    // band mounts below the transcript and spring-animates the scroller's box
+    // smaller (here by 29px). Scroll events dispatch asynchronously, so this
+    // RO callback is the first code to see either change.
+    act(() => {
+      state.scrollHeight = 1972
+      state.scrollTop = 1572 // the layout engine's clamp, NOT a user scroll
+      state.clientHeight = 371
+      fireViewport(el)
+    })
+
+    // The whole gap is ours — a clamp plus our own viewport shrink — so follow
+    // must hold and the pin must land on the new bottom. Judged against the
+    // just-applied box instead, the clamp (scrollTop below our last write) and
+    // the shrink-inflated distance together carried a user-scroll-up
+    // signature: follow released, no re-pin ran, and the content settled a
+    // card-height low for the rest of the animation.
+    expect(el.scrollTop).toBe(1972 - 371)
+  })
+
+  it('still releases follow when the user scrolls up during a viewport shrink', () => {
+    const { el, state } = mount('viewport-shrink-userup', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
+    expect(el.scrollTop).toBe(1600)
+
+    // Same tick, but 200px of the gap is a real drag. The allowance covers
+    // only the box's own 29px, so the remainder still reads as user input.
+    act(() => {
+      state.clientHeight = 371
+      state.scrollTop = 1400
+      fireViewport(el)
+    })
+    expect(el.scrollTop).toBe(1400)
+  })
+
   it('defers per-frame writes during the rail collapse and re-pins once at settle', () => {
     const { el, state, writes } = mount('viewport-rail', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
     expect(el.scrollTop).toBe(1600)


### PR DESCRIPTION
## Problem / Motivation

When a send queues behind a busy turn, the transcript settles up to a
card-height (about 20px, one collapsed queue card) BELOW where "at bottom"
should put it, for the length of the queue band's spring animation. It eats the
transcript's tail clearance, so wherever the remaining budget is thinner than
the offset the last line lands under the clip edge and renders as sliced glyphs
directly above the queue card. Whether it recovered depended on which
re-render landed last, which is why it read as intermittent.

PR #7764 shipped a page-level mitigation (a ResizeObserver on
`composer-status-stack` that re-anchors while FOLLOW holds) and deliberately
did not touch the virtualizer. This fixes it inside the virtualizer's own
follow mechanism, which is what #7769 asks for.

## Why it matters

The mitigation only covers the bands ChatPage happens to observe. Three
animated bands are covered by neither it nor the `[activeTip,
surveyLayoutTick]` compensation effect: FolderSuggestionCard's animated mount
in the tip slot, the follow-up options row, and the knowledge-fetch card. Any
chrome that animates its height below the transcript hits the same defect, so
fixing the follow mechanism covers all of them at once instead of adding a
per-band observer each time.

## What changed (motivation -> approach -> change)

The issue left the root cause open (height-cache redistribution on regroup, or
spacer-sync ordering versus the pin write). It is neither. Instrumenting the
real built SPA frame by frame shows the viewport re-pin is not landing short -
it is not running at all:

```
t=108  st=1295 sh=1912 ch=617 d=0     <- content shrank 125px, scrollTop clamped
t=130  st=1295 sh=1912 ch=611 d=6     <- RO tick: viewportResized, stick=true,
t=157  st=1295 sh=1912 ch=603 d=14       shouldFollow=true ... and no pinAuto
t=193  st=1295 sh=1912 ch=597 d=20
t=243  st=1295 sh=1912 ch=589 d=27
t=262  st=1295 sh=1912 ch=588 d=28    <- sinceInput crosses 150ms; pin finally runs
t=275  st=1324 sh=1912 ch=588 d=0
```

Two of our own layout changes were being attributed to the user, and each has
its own fix:

1. **The settle gate.** A send that queues regroups the turn and remounts tail
   rows, so the content shrinks and the layout engine clamps scrollTop. The
   passive scroll listener stamped that clamp's scroll event into
   `lastUserScrollAtRef`, which arms the 150ms `SCROLL_SETTLE_MS` gate whose
   job is to hold RO-driven pins off while a gesture is in flight. The whole
   window was therefore spent on our own reflow, and every viewport re-pin of
   the band's animation was suppressed - the pin resumed at 154ms, one frame
   after the last shrink step. `stick` and `lastWriteTop` already treat this
   clamp as ours (the `clampedAtBottom` branch immediately below); the gate now
   agrees with them. Genuine input is unaffected: the persistent
   wheel/touch/key/scrollbar intent listeners stamp at input time, which is
   EARLIER than the scroll event this branch handles.

2. **The scroll-up release.** `evaluateAutoPin` compared
   `distanceFromBottom` against the box the animation had just applied. Our own
   shrink inflates that distance with no user input, so a clamp (scrollTop
   below our last write) plus a shrink formed a complete user-scroll-up
   signature out of two of our own changes - releasing follow mid-animation
   with nothing able to re-arm it. It now takes a `viewportShrink` allowance
   and judges against the box `lastWriteTop` was a bottom FOR. Only the
   shrink's own pixels are forgiven, so a genuine drag in the same tick still
   releases. This one is ordering-dependent (the clamp's re-baseline needs its
   scroll event to have dispatched first), which is exactly the RO-versus-
   scroll-event race FollowController's header says the design must not rely
   on.

The new `lastWriteClientHRef` is kept in lockstep with `lastWriteTopRef` at
every site that writes it, `-1` alongside `-1`.

`evaluateAutoPin` is shared, so **both** of its consumers get the allowance.
`useChatScrollFollow` - the plain non-virtualized scroller behind ChatPane,
ChatEmbed and SideChat - runs one observer over the content wrapper AND the
scroller's own box, and names turn-collapse shrink as a first-class event, so
one tick there can carry the same clamp plus the same viewport shrink (a pane
drag, a keyboard, chrome mounting below). It is in fact more exposed than the
virtualizer was: it has no clamp re-baseline to fall back on, so the release
was permanent rather than ordering-dependent. Its header promises every chat
surface follows and releases with identical semantics; wiring both keeps that
promise true instead of leaving one caller on the old behavior. Its settle-gate
half does not apply - that hook has no gesture gate.

Not in this PR: deleting the `composer-status-stack` observer and the
`[activeTip, surveyLayoutTick]` effect. The measurement below shows both are
now redundant, but removing them also means rewriting
`ChatPage.queueBandReanchor.test.tsx`, which is CI's only guard on this
behavior - worth its own reviewable change rather than riding along here.

## Tests

Three cases that fail on `main` and pass here, plus three that pin the
boundaries:

- `useVirtualChat.viewportResize`: "re-pins through the shrink animation when a
  content clamp preceded it" - the measured cause. A clamp scroll event, then a
  viewport shrink well inside the settle window. Fails on main (`expected 1475
  to be 1504`).
- `useVirtualChat.viewportResize`: "re-pins when a tail-row remount clamps
  scrollTop in the same tick as the shrink" - the release guard, both halves in
  one RO tick. Fails on main (`expected 1572 to be 1601`).
- `FollowController`: "OUR OWN viewport shrink does not read as a scroll-up,
  even on top of a clamp" - the same case at the pure-function level, asserting
  the old behavior inline for contrast. Fails on main.
- `useVirtualChat.viewportResize`: "a genuine gesture still holds pins off for
  the settle window" - a `wheel` event still suppresses the pin, and follow
  resumes once 150ms elapses. Passes on main and here.
- `FollowController`: "the allowance forgives only its own pixels" - a 200px
  drag inside a 29px shrink still releases.
- `FollowController`: "a viewport GROW never widens the guard" - a negative
  shrink is clamped to 0.
- `useChatScrollFollow`: "a turn-collapse SHRINK in the same tick as a viewport
  shrink keeps following" - the sibling case on the plain scroller. Fails
  without the hook change (`expected 400 to be 429`, the same card-height low
  settle), and asserts follow is still armed by pinning the next growth.
- `useChatScrollFollow`: "a real scroll-up inside a viewport shrink still
  releases follow" - the matching boundary on that surface.

19 files / 213 tests green across every suite covering the three changed
sources (`FollowController`, all `useVirtualChat.*`, `UseVirtualChatCoverage`,
`virtualizerHeightOwner`, `useChatScrollFollow`, `ChatPane.scrollChrome`,
`ChatPage.queueBandReanchor`). `tsc -b` and eslint clean.

## Manual verification

`website/scripts/capture-queue-band-reanchor.mjs` against the real built SPA,
run with the ChatPage `composer-status-stack` mitigation removed so the
virtualizer is isolated (the repro recipe the issue names). Deepest dip across
the band's spring animation, desktop-dark / desktop-light / phone-dark:

| build | deepest dip |
| --- | --- |
| main virtualizer, mitigation removed | 20.2 / 19.8 / 17.2 px (`--expect offset` passes) |
| this fix, mitigation removed | 0.0 / 1.5 / 0.0 px (`--expect anchored` passes) |
| this fix, mitigation in place (shipped config) | 3.4 / 0.0 / 0.0 px (`--expect anchored` passes) |

The middle row is the load-bearing one: the virtualizer now holds the anchor by
itself, at least as well as #7764's measured 3px. The third row confirms the
two mechanisms do not fight - both drive to the same target.

The frame-by-frame trace in "What changed" came from a temporary probe build
that recorded every RO tick and `pinAuto` evaluation; the probe is not part of
this diff.

## Related Issues

Closes #7769

## Pattern harvest

Rule candidate: review-prompt

Pattern: a scroll/follow guard that infers user intent from geometry must
measure against the geometry as of its own last write, never the geometry the
current frame just applied - and a layout clamp must not be stamped as input on
any path that already recognises it as a clamp somewhere else. Both bugs here
are the same shape: the code had already special-cased the clamp for two of
three consumers (`stick`, `lastWriteTop`) and missed the third (the settle-gate
timestamp), and had a distance test whose denominator our own animation moves.
