### PR TITLE
feat: show a file tab's full path as its hover tooltip

### DIFF
--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -1283,7 +1283,13 @@ function TabChip({ tab, active, onSelect, onClose, closable = true, pinned = fal
       // accessible name + hover tooltip. Harmless (and a nice tooltip) when the
       // label is also shown.
       aria-label={pinned ? tab.title : undefined}
-      title={pinned && !showLabel ? tab.title : undefined}
+      // A file/diff/folder tab's label is `basename(path)` inside a truncating
+      // 240px chip, so a long name and a deep directory are both unreadable and
+      // two same-named files in different directories are indistinguishable.
+      // Prefer the full path as the tooltip whenever the tab carries one; fall
+      // back to the title for the tabs that have no path (terminal, app) and for
+      // the icon-only pinned chips that need a name for their glyph.
+      title={tab.path ?? (pinned && !showLabel ? tab.title : undefined)}
       // Browser-tab chip: 32px tall, top corners only (8px), bottom edge fused
       // into the panel body. Active = the body's own background (--bg) plus a
       // top/side hairline (--border, bottom open) so the silhouette survives a

--- a/website/src/test/sidePanelTabChipPathTooltip.test.tsx
+++ b/website/src/test/sidePanelTabChipPathTooltip.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * A side-panel tab chip must expose the full path of the file it holds as its
+ * hover tooltip.
+ *
+ * The chip's visible label is `basename(path)` inside a `max-w-[240px]`
+ * truncating span, so on its own it answers neither "what is this file called"
+ * for a long name nor "which of these two `index.ts` tabs is which" for a deep
+ * tree. The breadcrumb bar in the panel body already carries the full path;
+ * the chip is the surface a user hovers first, and it carried no tooltip at all
+ * for a non-pinned tab.
+ *
+ * The ratchet has two halves: a tab that HAS a path must advertise that path,
+ * and the icon-only pinned chips must keep the accessible name they need for a
+ * glyph with no visible text.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+
+// Heavy tab bodies are not what this drives — only the strip's chips.
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DiffPanel', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/ArtifactPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/FolderPanel', () => ({ default: () => null }))
+vi.mock('../components/WebPreviewPanel', () => ({ default: () => null }))
+vi.mock('../components/McpAppFrame', () => ({ default: () => null }))
+vi.mock('../components/CliPanel', () => ({
+  default: () => null,
+  disposeTerminalSession: vi.fn(),
+  useDeleteTerminalSession: () => ({ mutate: vi.fn() }),
+}))
+vi.mock('../utils/terminalRegistry', () => ({
+  useTerminalEnabled: () => false,
+  useTerminalTitle: () => 'Terminal',
+}))
+vi.mock('../hooks/useDevMode', () => ({ useDevMode: () => false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+
+globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as never
+
+import SidePanel from '../pages/chat/SidePanel'
+import { usePanelTabs } from '../hooks/usePanelTabs'
+
+type TabsCtl = ReturnType<typeof usePanelTabs>
+
+function Harness({ onReady }: { onReady: (ctl: TabsCtl) => void }) {
+  const tabsCtl = usePanelTabs('slot-a')
+  onReady(tabsCtl)
+  return (
+    <SidePanel
+      tabsCtl={tabsCtl}
+      slot="slot-a"
+      pins={[]}
+      onFileSave={async () => {}}
+      onClose={() => {}}
+    />
+  )
+}
+
+function renderPanel() {
+  let ctl: TabsCtl | undefined
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Provider store={createTestStore()}>
+        <Harness onReady={c => { ctl = c }} />
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return () => ctl as TabsCtl
+}
+
+describe('side panel tab chip exposes the full path as its tooltip', () => {
+  beforeEach(() => { localStorage.clear() })
+
+  it('titles a file tab with the absolute path, not the basename', () => {
+    const ctl = renderPanel()
+    const path = '/Users/dev/workspace/src/very/deeply/nested/package/notes.md'
+    act(() => { ctl().openFile(path, '# hi', 'slot-a') })
+
+    const chip = screen.getByRole('tab', { name: /notes\.md/ })
+    // The whole point: the truncated label says `notes.md`, the tooltip says
+    // which `notes.md`.
+    expect(chip.getAttribute('title')).toBe(path)
+  })
+
+  it('distinguishes two same-named files in different directories', () => {
+    const ctl = renderPanel()
+    const a = '/repo/alpha/index.ts'
+    const b = '/repo/beta/index.ts'
+    act(() => { ctl().openFile(a, 'a', 'slot-a') })
+    act(() => { ctl().openFile(b, 'b', 'slot-a') })
+
+    // Both chips carry the identical visible label, so the tooltip is the only
+    // thing that tells them apart.
+    const titles = screen.getAllByRole('tab')
+      .map(el => el.getAttribute('title'))
+      .filter((t): t is string => t != null)
+    expect(titles).toContain(a)
+    expect(titles).toContain(b)
+  })
+
+  it('titles a folder tab with its path', () => {
+    const ctl = renderPanel()
+    const path = '/repo/packages/design-system/src'
+    act(() => { ctl().openFolder(path, 'slot-a') })
+
+    expect(screen.getByRole('tab', { name: /src/ }).getAttribute('title')).toBe(path)
+  })
+
+  it('keeps a name on the icon-only pinned chips', () => {
+    // Pinned views are icon-only while inactive and have no path, so they must
+    // still fall back to their title — otherwise this change would strip the
+    // only name a glyph-only chip has.
+    renderPanel()
+    const files = screen.getByRole('tab', { name: 'Files' })
+    expect(files.getAttribute('title') || files.getAttribute('aria-label')).toBe('Files')
+  })
+})


### PR DESCRIPTION
## What

A side panel tab chip now exposes the full path of the file it holds as its hover tooltip.

The chip labels itself with the file's `basename` inside a 240px truncating span, and carried no `title` at all unless it was one of the icon-only pinned view chips. Two consequences:

- a long filename truncates with no way to read the rest
- two tabs holding a same-named file from different directories (`alpha/index.ts` and `beta/index.ts`) are impossible to tell apart without clicking each one

The chip already receives the tab, and file, diff and folder tabs all carry the absolute path on it, so this is a one-line change: prefer `tab.path` as the tooltip, falling back to `tab.title` for tabs that have no path (terminal, app) and for the icon-only pinned chips whose glyph needs a name.

The breadcrumb bar in the panel body already carries the full path this way. This brings the chip, which is the surface a user hovers first, to the same behaviour.

No new user-facing strings, so no i18n catalog changes.

## Why

Reported in #7900. The truncated label is frequently ambiguous — repos contain many same-named files (`index.ts`, `config.json`, `AGENTS.md`), and today the only way to confirm which one a tab holds is to click it and read the breadcrumb.

## Testing

New `website/src/test/sidePanelTabChipPathTooltip.test.tsx`, four cases:

- a file tab is titled with the absolute path rather than the basename
- two same-named files in different directories are distinguishable by tooltip
- a folder tab is titled with its path
- the icon-only pinned chips keep their accessible name (regression guard, so this change cannot strip the only name a glyph-only chip has)

Verified as a real ratchet: with the source change stashed, the first three assertions fail with `expected null`, while the pinned-chip guard passes both ways.

Gates run locally in a dedicated worktree:

- `npx tsc -b` — clean
- `npx vitest run` (full frontend suite) — 1764 files, 27,706 passed, 1 expected-fail, 2 skipped
- `npm run jscpd` — 0 clones
- backend cross-surface guards (the 416 files `scripts/ci-surface-tests.py --surface backend` selects for a frontend-only diff)

Two pre-existing failures on this host, both confirmed identical on a pristine `origin/main` tree with the change stashed and the new test file moved out, so neither is introduced here:

- `website/electron` node suite: exit 1 with 1552 tests, 1525 pass, 0 fail, 26 `cancelledByParent` in `test/gateway-stop.test.js`
- backend guards: 40 failures across 8 files, same distribution on main — `ops_mission_control/tests/test_routes.py`, `test_sandbox_argv.py`, `test_acp_client.py`, `test_acp_runtime.py`, `test_browser_cli_install.py`, `test_terminal_handler.py`, `test_host_isolation_floor.py`, `auto_improvement/tests/test_dogfood_learnings.py`. These look environment-specific (this host clamped pytest to 2 of 12 workers on available memory, which is itself what the worker-budget assertion checks)

No Python source is touched, so `isort`, `flake8` and `mypy` have nothing in this diff to act on.

## Note on CI

Opened from a fork, so the three Bedrock-credentialed AI review checks are skipped by design per CONTRIBUTING.
