### PR TITLE
fix(deps): unpin fast-uri so the patched 3.1.7 can resolve

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kirocrew-desktop",
-      "version": "0.4.0",
+      "version": "0.6.0",
+      "hasInstallScript": true,
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.9"
@@ -1844,9 +1845,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -23,7 +23,7 @@
     "electron-builder": "26.15.3"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "js-yaml": "4.3.1"
   },
   "build": {


### PR DESCRIPTION
## Problem / Motivation

`scripts/check_npm_audit.py` fails on every PR that runs the production dependency gate:

```
ERROR: unexcepted high/critical production vulnerabilities:
  website/electron/package-lock.json: fast-uri GHSA-5jgf-p345-68v8 (high) - fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references
  website/electron/package-lock.json: fast-uri GHSA-f65p-4m7j-42xc (high) - fast-uri vulnerable to server-side request forgery via malformed IPv6 normalization
  website/electron/package-lock.json: fast-uri GHSA-fph4-wmhf-6fwf (high) - fast-uri vulnerable to server-side request forgery via repeated hostname percent-decoding
  website/electron/package-lock.json: fast-uri GHSA-jqff-g426-hqxp (high) - fast-uri vulnerable to host confusion via percent-encoded scheme normalization
```

Four advisories published against `fast-uri` cover `3.0.0 - 3.1.5`. `website/electron/package.json` pinned `fast-uri` to **exactly** `3.1.5` in its `overrides` block, so the desktop tree was held on the last vulnerable release and could not resolve the patched one.

## Why it matters

The gate is repo-wide and unrelated to any individual author's diff, so every open PR that runs it reds out on this. It is a shared blocker, not a per-PR defect, and it also means the desktop app ships a `fast-uri` with four known high-severity SSRF / host-confusion advisories.

## What changed (motivation → approach → change)

Observed symptom: the audit gate reports four high `fast-uri` advisories against `website/electron/package-lock.json`.

Root cause: the `overrides` entry was an **exact** pin (`"fast-uri": "3.1.5"`), added by #1001 to hold the tree off the then-vulnerable versions. When the new advisories extended the vulnerable range through `3.1.5`, that same pin became the thing preventing the fix from resolving. `fast-uri`'s only consumer in this tree is `ajv` (range `^3.0.1`), which would otherwise have floated to a patched release on its own.

Change: bump the override to `3.1.7` — the latest `3.x`, still inside `ajv`'s `^3.0.1` range, so no `major` jump and no other resolution changes — and regenerate `website/electron/package-lock.json`.

Two pieces of pre-existing lockfile drift came along with the regeneration and are worth naming so they are not read as unexplained edits:

- `version` `0.4.0` → `0.6.0` — the lockfile's copy of the root version was stale; `package.json` already declares `0.6.0`.
- `hasInstallScript: true` — reflects the `postinstall` (`node scripts/patch-nsis-template.js`) already declared in the committed `package.json`. No new install code is introduced.

Dependency/manifest summary: no dependency added or removed. One `overrides` version bump; the only resolution change in the lockfile is the `fast-uri` node itself.

## Tests

No new automated tests. The invariant this change restores is already enforced by an existing gate — `scripts/check_npm_audit.py`, which is exactly what was failing — so a new test would duplicate it. There is no unit-testable behavior change: the diff contains no executable code.

## Manual verification

- `python3 scripts/check_npm_audit.py` → `Production dependency audit passed: 3 lockfiles, 0 governed exception(s).` (fails on `main` with the four advisories above).
- `npm ci --ignore-scripts` in `website/electron` succeeds against the regenerated lockfile, so lockfile integrity holds for CI's install path.
- `npm test --prefix website/electron` → `0 fail`. 26 tests in `test/gateway-stop.test.js` are cancelled locally with `Promise resolution is still pending but the event loop has already resolved`; that file imports only Node builtins and `../gateway-stop` (no `node_modules`), it reproduces in isolation, and it is a local Node 20 vs CI Node 22/24 `node:test` artifact — unrelated to this diff.
- `pytest test/test_brand_name_gate.py test/test_desktop_icns_assets.py test/test_platform_compat.py` (the three test files that read `website/electron/package.json`) → 354 passed, 22 skipped.
- Brand gate on the added lines → clean.

## Related Issues

no linked issue: the failure surfaced directly in CI on unrelated PRs rather than through a tracked issue.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: an **exact** version pin added as a vulnerability remediation becomes the blocker for the *next* advisory in the same package, because the pinned version eventually falls inside the vulnerable range and the range-satisfying consumer can no longer float past it. A remediation pin should be the floor (`>=`/`^` on the patched line) rather than an equality, or it needs an owner who re-bumps it when new advisories land.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
