### PR TITLE
fix: order the config write-back migration against concurrent writes

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -480,35 +480,62 @@ def config_local_path() -> Path:
     return config_dir() / "config.local.json"
 
 
+def _inside_data_home(path: Path) -> bool:
+    """Whether *path* lives in ``config_dir()``, the one directory we own.
+
+    ``load()`` reads whatever ``config_path()`` resolves to, and callers can
+    redirect that at a file they own -- tests and embedders point it at a
+    ``tempfile`` entry in the shared ``TMPDIR``. Anything the loader drops beside
+    such a path is a file nobody collects: the caller unlinks the path it created
+    and never learns a sibling appeared. One dev host accumulated 72k orphaned
+    ``tmpXXXXXXXX.json.bak`` files this way, 7% of a tmpfs inode budget whose
+    exhaustion fails every process on the box.
+
+    Ask about the path the sibling will ACTUALLY be written beside, which is not
+    always the one you started from: ``<path>.bak`` lands beside the path as
+    given, but ``update_config_locked`` resolves a symlinked config first, so its
+    ``<path>.lock`` lands beside the TARGET. A ``config.json`` inside the data
+    home that symlinks out of it is contained by one question and foreign by the
+    other -- see :func:`_lock_target`.
+
+    Containment is unprovable for a symlink loop or a vanished parent; treat that
+    as foreign, since acting on a failed check is the worse error.
+    """
+    try:
+        return path.parent.resolve() == config_dir().resolve()
+    except OSError:
+        return False
+
+
+def _lock_target(path: Path) -> Path:
+    """The path ``update_config_locked`` would put its lock sidecar beside.
+
+    It resolves a symlinked config before locking, so that -- not *path* -- is
+    what the containment question has to be asked about. Returns *path* unchanged
+    when it is not a symlink or cannot be resolved, which is the conservative
+    answer either way: an unresolvable path fails the containment check.
+    """
+    try:
+        return path.resolve() if path.is_symlink() else path
+    except OSError:
+        return path
+
+
 def _write_migration_backup(path: Path) -> None:
     """Copy the pre-migration config aside, but ONLY inside our own data home.
 
-    ``load()`` reads whatever ``config_path()`` resolves to, and callers can
-    redirect that at a file they own — tests and embedders point it at a
-    ``tempfile`` entry in the shared ``TMPDIR``. Writing ``<path>.bak`` beside
-    such a path leaks a file nobody collects: the caller unlinks the path it
-    created and never learns a sibling appeared. One dev host accumulated 72k
-    orphaned ``tmpXXXXXXXX.json.bak`` files this way, 7% of a tmpfs inode
-    budget whose exhaustion fails every process on the box.
-
-    So the copy is gated on the config living in ``config_dir()``, the one
-    directory whose contents we own. In production that is always true
-    (``config_path()`` is ``config_dir() / "config.json"``), which keeps the
-    real backup exactly where it has always been; for a redirected path we
-    write nothing rather than litter a directory belonging to someone else.
+    The copy is gated on :func:`_inside_data_home`, which explains the orphan
+    problem the gate exists for. In production the config always lives there
+    (``config_path()`` is ``config_dir() / "config.json"``), which keeps the real
+    backup exactly where it has always been; for a redirected path we write
+    nothing rather than litter a directory belonging to someone else.
 
     Only the LOCATION decision is contained here. A failing copy still
     propagates, because the caller's ``except`` is what skips the migration
-    ``save()`` -- so a config we could not copy aside is not rewritten either,
+    write -- so a config we could not copy aside is not rewritten either,
     and the migration retries on the next load.
     """
-    try:
-        inside_data_home = path.parent.resolve() == config_dir().resolve()
-    except OSError:
-        # Containment is unprovable (symlink loop, vanished parent): treat the
-        # path as foreign, since writing on a failed check is the worse error.
-        inside_data_home = False
-    if not inside_data_home:
+    if not _inside_data_home(path):
         # info, not debug: the migration save that follows rewrites this
         # caller-owned file in place, and that now happens with no backup.
         logger.info("Config migrated; no backup written for %s (outside the data home)", path)
@@ -518,6 +545,249 @@ def _write_migration_backup(path: Path) -> None:
     backup = Path(str(path) + ".bak")
     shutil.copy2(path, backup)
     logger.info("Config migrated — backup saved to %s", backup)
+
+
+#: The write-back migrations a load can find pending, as recorded by
+#: :meth:`KiroCrewConfig._load_resolved` and re-checked against the on-disk
+#: document by :func:`_apply_document_migrations`.
+MIGRATE_WORKSPACES = "workspaces"
+MIGRATE_AGENTS = "agents"
+MIGRATE_DEFAULT_AGENT = "default_agent"
+
+
+def _apply_document_migrations(
+    data: dict,
+    pending: frozenset[str],
+    *,
+    overlay_kiro_agent: str | None,
+    default_kiro_agent: str,
+) -> bool:
+    """Apply the pending write-back migrations to a raw config document in place.
+
+    *data* is ``config.json`` as read **inside the write lock**, not the merged
+    snapshot the calling load parsed. That is the whole point: the migration is
+    expressed as a delta against the document that is actually on disk right now,
+    so a config write that landed after this load's read survives instead of being
+    replaced by a re-serialization of the older snapshot.
+
+    *pending* names the migrations the load decided on, so this never widens what
+    the migration writes. The load's decisions are taken against the MERGED
+    base+overlay view; the overlay is user-owned and never written back, so a
+    migration the merged view did not ask for must not be invented here.
+
+    The seeded agent's kiro agent resolves the same three-way precedence the
+    loader itself applies, because it has to be the MERGED effective value (that
+    is what the default crew dispatched before the migration) computed against a
+    CURRENT base: *overlay_kiro_agent* first, since ``config.local.json`` wins the
+    deep-merge and the base can say nothing about it; then the base document's own
+    ``agent.default_agent`` as read here, so a ``config set`` that landed after
+    the load's read is honored rather than reverted; then *default_kiro_agent*,
+    the value the load resolved, which is the only one carrying the dataclass
+    default. Taking any single one of the three is wrong in a different direction.
+
+    Every entry is re-checked against *data* before it is applied, which makes the
+    function idempotent and makes a concurrent writer that already migrated a
+    no-op rather than a second rewrite. Returns True when anything changed; the
+    caller skips the write entirely when it returns False.
+    """
+    changed = False
+
+    # Flat workspace strings -> {"dir": ...}. Per entry, and only for entries the
+    # document still holds as a string: a workspace added or rewritten by another
+    # writer since this load's read is left exactly as that writer left it.
+    if MIGRATE_WORKSPACES in pending:
+        raw_workspaces = data.get("workspaces")
+        if isinstance(raw_workspaces, dict):
+            for name, value in list(raw_workspaces.items()):
+                if isinstance(value, str):
+                    raw_workspaces[name] = asdict(WorkspaceConfig(dir=value))
+                    changed = True
+
+    # Seed the default agent when the document still has none.
+    if MIGRATE_AGENTS in pending:
+        stored_agents = data.get("agents")
+        if not isinstance(stored_agents, dict) or not stored_agents:
+            stored_agent_section = data.get("agent")
+            stored_kiro = (
+                stored_agent_section.get("default_agent")
+                if isinstance(stored_agent_section, dict)
+                else None
+            )
+            base_kiro = stored_kiro if isinstance(stored_kiro, str) and stored_kiro else None
+            data["agents"] = {
+                "default": asdict(
+                    KiroCrewAgentConfig(
+                        kiro_agent=overlay_kiro_agent or base_kiro or default_kiro_agent,
+                        workspace="default",
+                        memory_store="default",
+                    )
+                )
+            }
+            changed = True
+
+    # Point default_agent at an agent that exists. Resolved against the
+    # document's OWN agents (after any seeding above), so a concurrent writer's
+    # newly added agent is a valid target rather than something we overwrite.
+    if MIGRATE_DEFAULT_AGENT in pending:
+        stored_agents = data.get("agents")
+        known = stored_agents if isinstance(stored_agents, dict) else {}
+        stored_default = data.get("default_agent")
+        if not isinstance(stored_default, str) or not stored_default or stored_default not in known:
+            if "default" in known:
+                data["default_agent"] = "default"
+            elif known:
+                data["default_agent"] = next(iter(known))
+            else:
+                data["default_agent"] = "default"
+            changed = data["default_agent"] != stored_default or changed
+
+    return changed
+
+
+def _overlay_kiro_agent() -> str | None:
+    """``agent.default_agent`` as ``config.local.json`` states it, if it does.
+
+    The overlay is deep-merged OVER the base at load time, so where it names this
+    field the base cannot be the effective value. The seeded agent has to carry
+    the effective one -- that is what the default crew dispatched before the
+    migration existed -- so the seed consults this first.
+
+    Best-effort by design: an unreadable or malformed overlay means "the overlay
+    says nothing here", which lets the base value stand. It must not abort the
+    migration, because the loader itself already tolerates a bad overlay (it warns
+    and marks the file degraded) and a stricter rule here would make one broken
+    user-owned file block a write that is correct without it.
+    """
+    try:
+        local_path = config_local_path()
+        if not local_path.is_file():
+            return None
+        raw = json.loads(local_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    section = raw.get("agent")
+    if not isinstance(section, dict):
+        return None
+    value = section.get("default_agent")
+    return value if isinstance(value, str) and value else None
+
+
+def _persist_config_migration(
+    path: Path,
+    pending: frozenset[str],
+    *,
+    default_kiro_agent: str,
+) -> bool:
+    """Write the pending migrations to *path* as a read-modify-write.
+
+    Replaces the ``cfg.save()`` this used to be. ``save()`` re-serializes the
+    WHOLE snapshot the load parsed, and that snapshot was read before this call:
+    a dashboard PATCH or ``kirocrew config set`` landing in between was silently
+    dropped, because nothing ordered the two (#7793). ``load()`` already runs off
+    the event loop in places (``chat_runner``'s stop-hook nudge-cap site awaits
+    ``asyncio.to_thread(KiroCrewConfig.load)``), so the interleave is reachable.
+
+    Two parts carry the fix, and they are worth separating because only one of
+    them can be applied everywhere:
+
+    * **The write is a delta.** Only the keys *pending* names are touched, and
+      each is re-decided against the document as read HERE rather than against
+      the load's older snapshot. A concurrent write to any other setting is
+      therefore not merely ordered but untouchable -- those bytes are never part
+      of our write. This part always applies.
+    * **The read and the write are one critical section**, via
+      :func:`update_config_locked`, so the migration's own keys are decided from
+      current state and cannot interleave with another locked writer.
+
+    The ordering the loader uses next door -- ``publish_autocompact_pct``'s
+    monotonic ticket -- cannot close this. A ticket orders load against load, and
+    the writer being lost here is not a load: no config writer outside this module
+    draws a ticket, so the comparison never sees the PATCH at all. Nor is it
+    enough to take a lock around the write alone, since the snapshot was read
+    before the lock; the read has to move inside it.
+
+    ``update_config_locked`` takes its advisory lock on a ``<path>.lock`` sidecar,
+    which for a config path we do not own is the orphan the backup gate above
+    exists to prevent -- and ``TestMigrationBackupContainment`` pins that a
+    migrating ``load()`` leaves a caller-owned directory exactly as it found it.
+    So the same containment predicate decides the lock, asked about the path the
+    lock will actually land beside: ``update_config_locked`` resolves a symlinked
+    config first, so a ``config.json`` inside the data home that points OUT of it
+    would otherwise be classified as contained and drop its sidecar in a directory
+    belonging to someone else. Contained, take the lock; foreign, do the delta off
+    an immediate fresh read and skip the sidecar. What the foreign path gives up is
+    ordering on the migration's OWN keys against an unlocked writer of those same
+    keys -- and a redirected config has no gateway writing it, since the dashboard
+    and CLI paths write ``config_path()``.
+
+    The lock is taken WITHOUT waiting. ``load()`` is called from the event loop
+    all over the tree, and a POSIX ``flock`` wait there would stall the gateway
+    for as long as the holder keeps the lock -- so this asks once and gives up.
+    Giving up costs nothing, because a held lock means another writer is mid-write
+    and that writer's bytes are precisely what must not be clobbered: declining is
+    the correct outcome, not a compromise. The migration is already
+    retry-on-next-load by construction (the degraded-sections branch in
+    ``_load_resolved`` relies on the same property), so the next uncontended load
+    performs it. The remaining file I/O on the loop -- one read, one atomic
+    rename -- is what ``cfg.save()`` did here before, unchanged.
+
+    The backup is taken immediately before the write -- inside the lock hold where
+    there is one -- so it is the bytes being replaced rather than whatever was
+    there when the load started. A failing copy still propagates and aborts the
+    write, keeping :func:`_write_migration_backup`'s contract: a config we could
+    not copy aside is not rewritten, and the migration retries on the next load.
+
+    Returns True when a write happened.
+    """
+    wrote = False
+    # The overlay is user-owned and never written back, so it is read OUTSIDE the
+    # lock: there is no update of ours to lose against it, and a concurrent edit
+    # to it is the operator's own action rather than a race. Read here rather than
+    # taken from the load's snapshot so the seed reflects the file as it is now.
+    overlay_kiro_agent = _overlay_kiro_agent()
+
+    def _mutate(current: dict) -> dict | None:
+        nonlocal wrote
+        if not _apply_document_migrations(
+            current,
+            pending,
+            overlay_kiro_agent=overlay_kiro_agent,
+            default_kiro_agent=default_kiro_agent,
+        ):
+            # Nothing left to migrate -- another writer got here first. Returning
+            # None skips the write, so we do not rewrite a file we agree with.
+            return None
+        _write_migration_backup(path)
+        wrote = True
+        return current
+
+    if _inside_data_home(_lock_target(path)):
+        try:
+            update_config_locked(path, mutate=_mutate, wait_for_lock=False)
+        except BlockingIOError:
+            # POSIX reports a contended single-shot acquire this way. Not a
+            # failure worth a warning: info, because the migration simply moves
+            # to the next load and nothing was written or lost.
+            logger.info(
+                "config: migration deferred -- another writer holds %s.lock; "
+                "the next load will migrate",
+                path.name,
+            )
+            return False
+    else:
+        # read_config_for_update fails CLOSED on an unreadable or non-object
+        # file, and that exception reaches load()'s except: the file is left
+        # alone and the migration retries. Same contract as the locked path.
+        result = _mutate(read_config_for_update(path))
+        if result is not None:
+            write_config_atomically(path, stamp_config_meta(result))
+    if wrote:
+        # Same reason save() did: drop the validated-data cache so the next load
+        # re-reads this write even where the filesystem mtime resolution is coarse.
+        _invalidate_config_cache()
+    return wrote
 
 
 def denied_commands_path() -> Path:
@@ -847,6 +1117,7 @@ def update_config_locked(
     fsync: bool = False,
     stamp_meta: bool = True,
     on_corrupt: Literal["fail", "reset"] = "fail",
+    wait_for_lock: bool = True,
 ) -> dict:
     """Perform an atomic read-modify-write of a config file under an advisory lock.
 
@@ -910,6 +1181,14 @@ def update_config_locked(
         update.  ``"reset"`` catches the error inside the lock hold and invokes
         *mutate* with ``{}``; the caller's write proceeds in the same critical
         section so no concurrent writer can land between.
+    wait_for_lock : bool
+        If True (default), block until the advisory lock is free -- correct for
+        a caller whose update must happen.  If False, the acquire is single-shot
+        and raises :class:`OSError` when another writer holds the lock; for a
+        caller whose write is OPTIONAL and retried later, and which may run on
+        the event-loop thread, where a POSIX ``flock`` wait would stall the
+        gateway for as long as the holder keeps it.  It never relaxes the
+        serialization -- a contended acquire declines instead of proceeding.
 
     Returns
     -------
@@ -922,7 +1201,8 @@ def update_config_locked(
         If the existing config is unreadable or malformed and
         ``on_corrupt="fail"``.
     OSError
-        If the lockfile cannot be opened/created or the lock cannot be acquired.
+        If the lockfile cannot be opened/created or the lock cannot be acquired
+        (including a contended ``wait_for_lock=False`` acquire).
     """
     p = path if path is not None else config_path()
     # Resolve symlinks before locking (same logic as write_config_atomically)
@@ -936,7 +1216,7 @@ def update_config_locked(
     p.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
     try:
-        with platform_compat.file_lock(fd, exclusive=True):
+        with platform_compat.file_lock(fd, exclusive=True, wait=wait_for_lock):
             try:
                 data = read_config_for_update(p)
             except ConfigReadError:
@@ -3232,12 +3512,19 @@ class KiroCrewConfig:
         # (flat workspace strings, missing sections), back up the original
         # and save the migrated version.  One-shot — subsequent loads see
         # the canonical format and skip.
+        #
+        # The in-memory half below mutates `cfg` and RECORDS which migrations it
+        # decided on; the on-disk half re-reads config.json inside the write lock
+        # and applies exactly those as a delta (see _persist_config_migration).
+        # It used to be `cfg.save()`, which re-serialized this load's whole
+        # snapshot and so dropped any config write that landed after this load's
+        # read (#7793).
         try:
-            needs_migration = False
+            pending: set[str] = set()
             # Flat workspace strings → need migration to {"dir": ...}
             for v in raw_workspaces.values():
                 if isinstance(v, str):
-                    needs_migration = True
+                    pending.add(MIGRATE_WORKSPACES)
                     break
 
             # One-time migration: create default agent when none exists
@@ -3248,7 +3535,7 @@ class KiroCrewConfig:
                     workspace="default",
                     memory_store="default",
                 )
-                needs_migration = True
+                pending.add(MIGRATE_AGENTS)
             if not cfg.default_agent or cfg.default_agent not in cfg.agents:
                 # Prefer "default" if it exists, otherwise use first available agent
                 if "default" in cfg.agents:
@@ -3257,14 +3544,19 @@ class KiroCrewConfig:
                     cfg.default_agent = next(iter(cfg.agents))
                 else:
                     cfg.default_agent = "default"
-                needs_migration = True
+                pending.add(MIGRATE_DEFAULT_AGENT)
+
+            needs_migration = bool(pending)
 
             if needs_migration and not cfg._degraded_sections:
-                _write_migration_backup(path)
-                cfg.save()
+                _persist_config_migration(
+                    path,
+                    frozenset(pending),
+                    default_kiro_agent=cfg.agent.default_agent or "kirocrew",
+                )
             elif needs_migration:
                 # This load DISCARDED something (a malformed section, an
-                # unreadable file). cfg.save() serializes only the parsed
+                # unreadable file). The write-back serializes only the parsed
                 # fields, so writing back here would replace the operator's
                 # malformed narrowing with clean defaults — erasing the only
                 # on-disk evidence and turning the denial into silent

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -535,6 +535,7 @@ def file_lock(
     *,
     exclusive: bool = True,
     required: bool = False,
+    wait: bool = True,
 ) -> Iterator[None]:
     """Acquire an advisory lock on ``fd`` for the duration of the block.
 
@@ -557,12 +558,28 @@ def file_lock(
     the outcome (both paths refuse to proceed without the lock). On POSIX the
     acquire blocks until the lock is free, as before.
 
+    *wait* is for a caller whose work is OPTIONAL and retried later, and which
+    may run on the event-loop thread: with ``wait=False`` the acquire is
+    single-shot on every platform and raises :class:`BlockingIOError` at once
+    when the lock is held, instead of blocking the loop for as long as the holder
+    keeps it. POSIX gets that from ``LOCK_NB``; Windows already behaves this way
+    on the loop thread, and a zero timeout makes it uniform off the loop too.
+    ``BlockingIOError`` is an ``OSError``, so it is a NARROWING of what a caller
+    already had to handle, and it separates "someone else is writing right now"
+    from the stuck-holder ceiling above. It changes only how long we are willing
+    to wait, never whether the critical section is serialized -- a contended
+    ``wait=False`` acquire raises rather than proceeding.
+
     Note: on Windows, ``msvcrt.locking`` requires seeking to byte 0, so the
     ``fd`` must be a dedicated lock file; callers must not rely on the file
     offset being preserved across the context manager boundary.
     """
     if IS_POSIX:
         mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        if not wait:
+            # BlockingIOError (an OSError) when held: same fail-closed contract
+            # as the Windows branch, reported by the platform rather than by us.
+            mode |= fcntl.LOCK_NB
         fcntl.flock(fd, mode)
         try:
             yield
@@ -579,9 +596,17 @@ def file_lock(
         # strictly safer, and callers already run under `with`, so the fd is
         # cleaned up. `required` is retained for call-site intent but no longer
         # changes the outcome — both paths now refuse to proceed lock-less.
-        if not _win_acquire_blocking(fd):
+        timeout = _WIN_LOCK_TIMEOUT_SECS if wait else 0.0
+        # Called with no keyword on the waiting path, so the default-argument
+        # call shape existing tests stub out stays exactly as it was.
+        acquired = _win_acquire_blocking(fd) if wait else _win_acquire_blocking(fd, timeout=0.0)
+        if not acquired:
+            if not wait:
+                # Held right now. BlockingIOError so the caller can tell this
+                # from the stuck-holder ceiling below, matching POSIX LOCK_NB.
+                raise BlockingIOError("file lock is held; not waiting for it")
             raise OSError(
-                f"could not acquire exclusive file lock within {_WIN_LOCK_TIMEOUT_SECS:g}s "
+                f"could not acquire exclusive file lock within {timeout:g}s "
                 "(a holder is stuck); refusing to proceed unserialized"
             )
         try:

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -14,6 +14,7 @@ import os
 import platform
 import re
 import tempfile
+import threading
 import unittest.mock
 from pathlib import Path
 
@@ -22,6 +23,7 @@ from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 import kiro_crew.config.loader as loader_module
+from kiro_crew import platform_compat
 from kiro_crew.config.loader import (
     _HAS_JSONSCHEMA,
     STT_PROVIDER_LOCAL,
@@ -6069,3 +6071,402 @@ class TestSameDispatchBindingDriftPin:
                 f"exempt field {name!r} — restore the exclusion rationale or "
                 "reclassify the field"
             )
+
+
+class TestMigrationWriteBackOrdering:
+    """The write-back migration must not lose a concurrent config write (#7793).
+
+    ``load()``'s migration used to call ``cfg.save()``, which re-serializes the
+    whole snapshot this load parsed. A config write landing after that read and
+    before the save was silently replaced by the older snapshot. ``load()`` runs
+    off the event loop in places (``chat_runner``'s stop-hook nudge-cap site
+    awaits ``asyncio.to_thread(KiroCrewConfig.load)``), so the interleave is
+    reachable rather than theoretical.
+    """
+
+    #: Bounded so a regression fails the test instead of hanging the suite.
+    _TIMEOUT = 30.0
+
+    @staticmethod
+    def _legacy_config() -> dict:
+        """A config whose only legacy shape is the missing ``agents`` section.
+
+        Deliberately NOT the flat-workspace shape: advisory schema validation
+        normalizes ``workspaces.<name>`` from a string to the structured form
+        before the migration block reads it, so that trigger only fires where
+        jsonschema is unavailable. The missing-``agents`` trigger fires either
+        way, so it is the one the interleave can be pinned on.
+
+        Carries no ``session`` section, so the setting the concurrent writer adds
+        below is genuinely absent from the migrating load's snapshot.
+        """
+        return {"workspaces": {"default": {"dir": "workspace"}}}
+
+    @staticmethod
+    def _owned_config(tmp_path: Path) -> Path:
+        """A config inside the loader's own data home, as in production.
+
+        ``config_dir()`` is redirected at the same directory, because the
+        migration's advisory lock is gated on containment there -- a config we do
+        not own gets no sidecar (see ``TestMigrationBackupContainment``).
+        """
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+        return home / "config.json"
+
+    def test_a_write_landing_mid_migration_survives(self, tmp_path: Path) -> None:
+        """Two writers, deterministically interleaved: neither may lose the other.
+
+        Writer A is a migrating ``load()``, suspended after it has decided to
+        migrate but before its bytes reach the file. Writer B is an ordinary
+        locked config write (the shape the dashboard PATCH and ``kirocrew config
+        set`` both use) carrying a setting the operator just changed.
+
+        Both must be observable afterwards: the seeded default agent, and B's
+        ``autocompact_pct``. Before the fix, A re-serialized its whole snapshot --
+        which predates B's write and so carries the default threshold -- over the
+        file, and B's setting was gone.
+        """
+        cfg_path = self._owned_config(tmp_path)
+        cfg_path.write_text(json.dumps(self._legacy_config()), encoding="utf-8")
+
+        reached_write = threading.Event()
+        release_write = threading.Event()
+        real_backup = loader_module._write_migration_backup
+
+        def _suspend_then_backup(path: Path) -> None:
+            # Called on the migration's write path in both the old and the new
+            # shape, which is what makes one test able to fail before the fix and
+            # pass after it.
+            reached_write.set()
+            assert release_write.wait(self._TIMEOUT), "migration release timed out"
+            real_backup(path)
+
+        errors: list[BaseException] = []
+
+        def _migrating_load() -> None:
+            try:
+                KiroCrewConfig.load()
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        def _concurrent_setting_write() -> None:
+            try:
+
+                def _mutate(data: dict) -> dict:
+                    data.setdefault("session", {})["autocompact_pct"] = 42.0
+                    return data
+
+                loader_module.update_config_locked(cfg_path, mutate=_mutate)
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        with (
+            unittest.mock.patch.object(loader_module, "config_dir", return_value=cfg_path.parent),
+            unittest.mock.patch.object(loader_module, "config_path", return_value=cfg_path),
+            unittest.mock.patch.object(
+                loader_module, "_write_migration_backup", _suspend_then_backup
+            ),
+        ):
+            writer_a = threading.Thread(target=_migrating_load, daemon=True)
+            writer_b = threading.Thread(target=_concurrent_setting_write, daemon=True)
+            # try/finally, not a bare sequence: an assertion or a timeout below
+            # would otherwise exit the test with a writer still running against
+            # this test's paths and patched state, and leak it into later tests.
+            try:
+                writer_a.start()
+                assert reached_write.wait(self._TIMEOUT), "migration never reached its write"
+
+                # B starts while A is mid-migration. Under the fix A holds the
+                # config lock, so B waits for it; without the fix B writes
+                # straight away and A's snapshot rewrite replaces the result.
+                writer_b.start()
+                # Give B a chance to reach (or block on) the write before A
+                # resumes. A short join, not a bare sleep: it returns as soon as
+                # B is done in the unlocked case, and simply times out while B is
+                # blocked.
+                writer_b.join(timeout=1.0)
+
+                release_write.set()
+                writer_a.join(timeout=self._TIMEOUT)
+                writer_b.join(timeout=self._TIMEOUT)
+                assert not writer_a.is_alive(), "migrating load did not finish"
+                assert not writer_b.is_alive(), "concurrent config write did not finish"
+            finally:
+                # Idempotent: releases a writer still parked on the event and
+                # drains both threads before the patches come off, whether we got
+                # here by success or by assertion.
+                release_write.set()
+                for writer in (writer_a, writer_b):
+                    if writer.is_alive():
+                        writer.join(timeout=self._TIMEOUT)
+
+        assert not errors, f"writer raised: {errors!r}"
+
+        on_disk = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert on_disk["default_agent"] == "default", "the migration did not reach disk"
+        assert "default" in on_disk["agents"], "the migration did not reach disk"
+        assert on_disk.get("session", {}).get("autocompact_pct") == 42.0, (
+            "the config write that landed while the migration was in flight was "
+            "lost -- the write-back is not ordered against concurrent writers"
+        )
+
+    @pytest.mark.parametrize("owned", [True, False], ids=["data-home", "redirected"])
+    def test_the_migration_only_rewrites_the_keys_it_owns(
+        self, tmp_path: Path, owned: bool
+    ) -> None:
+        """The write is a delta, not a whole-snapshot re-serialization.
+
+        That is the property the ordering rests on, and the half that holds
+        wherever the config lives: a write confined to the keys the migration
+        decided on cannot carry a stale value for anything else, whoever wrote it
+        and whenever. So it is pinned on BOTH the data-home path (which also takes
+        the advisory lock) and a redirected path (which cannot, without leaving a
+        sidecar orphan). Asserted on the top-level key set, because a snapshot
+        rewrite materializes every section in the schema.
+        """
+        cfg_path = self._owned_config(tmp_path) if owned else tmp_path / "caller" / "cfg.json"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        stored = self._legacy_config()
+        cfg_path.write_text(json.dumps(stored), encoding="utf-8")
+        data_home = cfg_path.parent if owned else tmp_path / "elsewhere"
+
+        with (
+            unittest.mock.patch.object(loader_module, "config_dir", return_value=data_home),
+            unittest.mock.patch.object(loader_module, "config_path", return_value=cfg_path),
+        ):
+            KiroCrewConfig.load()
+
+        on_disk = json.loads(cfg_path.read_text(encoding="utf-8"))
+        # "meta" is stamped by the shared writer, not by the migration.
+        assert set(on_disk) == set(stored) | {"agents", "default_agent", "meta"}, (
+            "the migration wrote sections it did not migrate -- it is "
+            "re-serializing a snapshot rather than applying its own delta"
+        )
+        assert on_disk["workspaces"] == stored["workspaces"]
+        assert on_disk["default_agent"] == "default"
+
+    def test_a_held_lock_defers_the_migration_instead_of_waiting(self, tmp_path: Path) -> None:
+        """A contended lock must not park the caller -- ``load()`` runs on the loop.
+
+        ``load()`` is reached from the event loop all over the tree, so a POSIX
+        ``flock`` wait here would stall the gateway for as long as the holder
+        keeps the lock. The acquire is single-shot instead: it declines, writes
+        nothing, and the next uncontended load migrates.
+
+        Run on a thread with a bounded join, so a regression that goes back to
+        waiting FAILS here rather than hanging the suite -- a waiting acquire
+        would block until the holder below releases, which is forever from this
+        test's point of view.
+        """
+        cfg_path = self._owned_config(tmp_path)
+        stored = self._legacy_config()
+        cfg_path.write_text(json.dumps(stored), encoding="utf-8")
+
+        outcome: list[object] = []
+
+        def _migrate() -> None:
+            with unittest.mock.patch.object(
+                loader_module, "config_dir", return_value=cfg_path.parent
+            ):
+                outcome.append(
+                    loader_module._persist_config_migration(
+                        cfg_path,
+                        frozenset({loader_module.MIGRATE_AGENTS}),
+                        default_kiro_agent="kirocrew",
+                    )
+                )
+
+        lock_fd = os.open(str(cfg_path) + ".lock", os.O_RDWR | os.O_CREAT, 0o600)
+        migrator = threading.Thread(target=_migrate, daemon=True)
+        try:
+            with platform_compat.file_lock(lock_fd, exclusive=True):
+                migrator.start()
+                migrator.join(timeout=10.0)
+                parked = migrator.is_alive()
+                # Assert INSIDE the hold, before the file can be touched: with a
+                # waiting acquire the migration is still parked here, and what it
+                # would eventually write is not the question.
+                assert not parked, "migration waited on a held lock instead of deferring"
+                assert outcome == [False]
+                assert json.loads(cfg_path.read_text(encoding="utf-8")) == stored
+                assert not Path(str(cfg_path) + ".bak").exists()
+        finally:
+            # Releasing the hold above lets a parked migrator (the regression
+            # case) drain instead of surviving this test.
+            if migrator.is_alive():
+                migrator.join(timeout=self._TIMEOUT)
+            os.close(lock_fd)
+
+    def test_a_symlink_out_of_the_data_home_gets_no_lock_sidecar(self, tmp_path: Path) -> None:
+        """Containment is about where the sidecar LANDS, not where the path sits.
+
+        ``update_config_locked`` resolves a symlinked config before locking, so a
+        ``config.json`` inside the data home that points out of it would drop its
+        ``.lock`` beside the external target -- the same orphan the backup gate
+        exists to prevent, one indirection further out.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        target = outside / "real-config.json"
+        target.write_text(json.dumps(self._legacy_config()), encoding="utf-8")
+        link = home / "config.json"
+        link.symlink_to(target)
+
+        before = {p.name for p in outside.iterdir()}
+        with unittest.mock.patch.object(loader_module, "config_dir", return_value=home):
+            wrote = loader_module._persist_config_migration(
+                link,
+                frozenset({loader_module.MIGRATE_AGENTS}),
+                default_kiro_agent="kirocrew",
+            )
+
+        assert wrote is True, "the migration should still reach the symlinked config"
+        assert "default" in json.loads(target.read_text(encoding="utf-8"))["agents"]
+        assert {
+            p.name for p in outside.iterdir()
+        } == before, "the migration left a sidecar beside the symlink's external target: %s" % sorted(
+            {p.name for p in outside.iterdir()} - before
+        )
+
+    def test_the_overlay_wins_the_seed_over_the_base_document(self, tmp_path: Path) -> None:
+        """``config.local.json`` decides the effective agent, so it decides the seed.
+
+        The overlay is deep-merged over the base at load time, so where it names
+        ``agent.default_agent`` the base value is not what anything dispatches.
+        Seeding from the base there would silently switch the default crew's agent
+        on the next load.
+        """
+        cfg_path = self._owned_config(tmp_path)
+        cfg_path.write_text(
+            json.dumps({"agent": {"default_agent": "base-agent"}}), encoding="utf-8"
+        )
+        local_path = cfg_path.parent / "config.local.json"
+        local_path.write_text(
+            json.dumps({"agent": {"default_agent": "overlay-agent"}}), encoding="utf-8"
+        )
+
+        with (
+            unittest.mock.patch.object(loader_module, "config_dir", return_value=cfg_path.parent),
+            unittest.mock.patch.object(loader_module, "config_local_path", return_value=local_path),
+        ):
+            wrote = loader_module._persist_config_migration(
+                cfg_path,
+                frozenset({loader_module.MIGRATE_AGENTS, loader_module.MIGRATE_DEFAULT_AGENT}),
+                default_kiro_agent="base-agent",
+            )
+
+        assert wrote is True
+        on_disk = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert on_disk["agents"]["default"]["kiro_agent"] == "overlay-agent", (
+            "the seed took the base document's agent while the overlay named a "
+            "different one -- the effective agent silently changed"
+        )
+        # The overlay itself is user-owned and must come back untouched.
+        assert json.loads(local_path.read_text(encoding="utf-8")) == {
+            "agent": {"default_agent": "overlay-agent"}
+        }
+
+    def test_a_malformed_overlay_lets_the_base_value_stand(self, tmp_path: Path) -> None:
+        """A broken user-owned overlay must not block a write correct without it."""
+        cfg_path = self._owned_config(tmp_path)
+        cfg_path.write_text(
+            json.dumps({"agent": {"default_agent": "base-agent"}}), encoding="utf-8"
+        )
+        local_path = cfg_path.parent / "config.local.json"
+        local_path.write_text("{ not json", encoding="utf-8")
+
+        with (
+            unittest.mock.patch.object(loader_module, "config_dir", return_value=cfg_path.parent),
+            unittest.mock.patch.object(loader_module, "config_local_path", return_value=local_path),
+        ):
+            wrote = loader_module._persist_config_migration(
+                cfg_path,
+                frozenset({loader_module.MIGRATE_AGENTS}),
+                default_kiro_agent="resolved-by-the-load",
+            )
+
+        assert wrote is True
+        on_disk = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert on_disk["agents"]["default"]["kiro_agent"] == "base-agent"
+
+    def test_the_seeded_agent_takes_its_kiro_agent_from_the_reread(self, tmp_path: Path) -> None:
+        """The seed must not carry a value the document has since moved past.
+
+        ``agent.default_agent`` decides which kiro agent the seeded crew
+        dispatches. The load's snapshot is read before the lock, so a
+        ``kirocrew config set agent.default_agent`` landing in between would
+        otherwise be ignored and every default session would dispatch the
+        superseded agent.
+        """
+        cfg_path = self._owned_config(tmp_path)
+        # What the document says NOW -- the concurrent writer's value.
+        cfg_path.write_text(
+            json.dumps({"agent": {"default_agent": "newer-agent"}}), encoding="utf-8"
+        )
+
+        with unittest.mock.patch.object(loader_module, "config_dir", return_value=cfg_path.parent):
+            wrote = loader_module._persist_config_migration(
+                cfg_path,
+                frozenset({loader_module.MIGRATE_AGENTS, loader_module.MIGRATE_DEFAULT_AGENT}),
+                # What the load's older snapshot said.
+                default_kiro_agent="stale-agent",
+            )
+
+        assert wrote is True
+        on_disk = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert on_disk["agents"]["default"]["kiro_agent"] == "newer-agent", (
+            "the seeded agent carried the snapshot's kiro agent instead of the "
+            "one the document holds now"
+        )
+
+    def test_the_seed_falls_back_when_the_document_names_no_kiro_agent(
+        self, tmp_path: Path
+    ) -> None:
+        """With nothing stored, the load's resolved value is still the best answer.
+
+        It carries the overlay and the dataclass default, which a raw document
+        read cannot see -- so the fallback is the caller's value, not a literal.
+        """
+        cfg_path = self._owned_config(tmp_path)
+        cfg_path.write_text(json.dumps(self._legacy_config()), encoding="utf-8")
+
+        with unittest.mock.patch.object(loader_module, "config_dir", return_value=cfg_path.parent):
+            wrote = loader_module._persist_config_migration(
+                cfg_path,
+                frozenset({loader_module.MIGRATE_AGENTS, loader_module.MIGRATE_DEFAULT_AGENT}),
+                default_kiro_agent="resolved-by-the-load",
+            )
+
+        assert wrote is True
+        on_disk = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert on_disk["agents"]["default"]["kiro_agent"] == "resolved-by-the-load"
+
+    def test_a_migration_another_writer_already_did_writes_nothing(self, tmp_path: Path) -> None:
+        """When the re-read shows the work already done, skip the write.
+
+        The migration decision is taken from this load's snapshot, so a writer
+        that migrated in between leaves us holding a stale reason to write. The
+        re-read before the write is what turns that into a no-op instead of a
+        redundant rewrite (and, with it, a redundant ``.bak``).
+        """
+        cfg_path = self._owned_config(tmp_path)
+        already_migrated = {
+            "workspaces": {"default": {"dir": "workspace"}},
+            "agents": {"default": {"kiro_agent": "kirocrew"}},
+            "default_agent": "default",
+        }
+        cfg_path.write_text(json.dumps(already_migrated), encoding="utf-8")
+
+        with unittest.mock.patch.object(loader_module, "config_dir", return_value=cfg_path.parent):
+            wrote = loader_module._persist_config_migration(
+                cfg_path,
+                frozenset({loader_module.MIGRATE_AGENTS, loader_module.MIGRATE_DEFAULT_AGENT}),
+                default_kiro_agent="kirocrew",
+            )
+
+        assert wrote is False
+        assert not Path(str(cfg_path) + ".bak").exists()
+        assert json.loads(cfg_path.read_text(encoding="utf-8")) == already_migrated

--- a/test/test_dashboard_config_gitlab_hosts.py
+++ b/test/test_dashboard_config_gitlab_hosts.py
@@ -103,10 +103,13 @@ async def test_put_cannot_add_a_gitlab_host(handler_app, cfg_file):
     cfg = KiroCrewConfig.load()
     assert cfg.dashboard.quick_send is True
     assert cfg.dashboard.gitlab_hosts == []
-    # cfg.save() serializes every dataclass field, so the key is present -- what
-    # matters is that the caller-supplied host was never adopted.
+    # Asserted on the stored VALUE, not on the key being present: nothing in the
+    # write path is obliged to materialize a field the caller never legitimately
+    # set, and the loader resolves a missing key to the dataclass default -- which
+    # is exactly what the assertion above proves. What matters is that the
+    # caller-supplied host was never adopted.
     raw = json.loads(cfg_file.read_text(encoding="utf-8"))
-    assert raw["dashboard"]["gitlab_hosts"] == []
+    assert raw.get("dashboard", {}).get("gitlab_hosts", []) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

`KiroCrewConfig.load()`'s write-back migration called `cfg.save()`, which
re-serializes the whole snapshot that load had already parsed. Nothing ordered
that write against any other config writer, so:

1. worker thread: `load()` reads `config.json`, sees a legacy shape, decides to
   migrate
2. event loop: a dashboard PATCH (or `kirocrew config set`) writes a newer config
3. worker thread: `cfg.save()` writes the snapshot from step 1

ends with step 2's edit gone. The loss is silent and the lost data is user
configuration.

The migration is one-shot per process, so the window is the first load in a
process whose stored config still has a legacy shape (no `agents`, a
`default_agent` not present in `agents`, or -- where jsonschema is unavailable --
flat workspace strings).

## Why it matters

This is pre-existing on `main`, not introduced by any open PR: `chat_runner.py`
already runs `await asyncio.to_thread(KiroCrewConfig.load)` at the stop-hook
nudge-cap site, so a worker-thread migration write is reachable today. It becomes
materially more likely as more latency-sensitive reads move off the loop, which
is the right direction for those reads (#4117 / #4118) -- a fix that is correct
for the event loop should not have to carry an argument about a loader-level
write race. #7734's proposed subtraction would make an offloaded load the
process's first load, and so depends on this.

The tell is a strong one: inside one function, `load()`, three publishes and one
write-back all mutate shared state, and exactly one of the four --
`publish_autocompact_pct` -- is ordered, with a docstring that spells out the
hazard ("a load that began earlier cannot overwrite a newer one"). The heaviest
mutation of the four had no equivalent.

## What changed (motivation -> approach -> change)

Root cause: a read-modify-write with no precondition. `cfg` is read at the top of
`_load_resolved`; `save()` writes it back at the bottom, unconditionally and in
full. Anything that landed in between is replaced.

The issue proposed two shapes. Both were checked against the code and neither is
sufficient on its own:

* **An ordering ticket like `publish_autocompact_pct`'s** orders load against
  load. The writer being lost here is not a load -- `next_config_load_ticket` has
  no caller outside `config/loader.py`, so a dashboard PATCH never draws a ticket
  and the comparison never sees it.
* **A lock around the write** does not help either, because the read happened
  before the lock. The read has to move inside it.

So the migration write now has two properties, separated because only one of them
can be applied everywhere:

* **The write is a delta.** `_apply_document_migrations` applies only the keys the
  load decided on, to the document as read at write time, re-deciding each one
  against that document. A concurrent write to any other setting is not merely
  ordered but untouchable -- those bytes are never part of our write. Verified: a
  migrating load now rewrites 4 top-level keys instead of materializing every
  section in the schema.
* **The read and the write are one critical section**, via the repo's
  `update_config_locked` -- the required path for `config.json` mutations, which
  re-reads inside an advisory lock and writes through
  `write_config_atomically`. So the migration's own keys are decided from current
  state and cannot interleave with another locked writer.

The load keeps deciding *whether* to migrate, and now records *which* migrations
it decided on (`pending`), so the write never widens beyond what the merged
base+overlay view asked for. Re-checking each entry at write time also makes the
write idempotent: a migration another writer already performed returns "nothing
to do" and skips the write entirely, rather than rewriting a file we agree with.

One containment detail. `update_config_locked` takes its lock on a `<path>.lock`
sidecar, and `load()` reads whatever `config_path()` resolves to -- which callers
redirect at their own temp files. A sidecar beside such a path is exactly the
orphan class that produced 72k stray `.bak` files on one dev host, and
`TestMigrationBackupContainment` pins that a migrating `load()` leaves a
caller-owned directory as it found it. So the same containment predicate that
already gated the backup now also gates the lock, extracted as
`_inside_data_home`: contained (always true in production, where `config_path()`
is `config_dir() / "config.json"`), take the lock; redirected, do the delta off an
immediate fresh read and leave no sidecar. What the redirected path gives up is
ordering on the migration's own keys against an unlocked writer of those same
keys -- and a redirected config has no gateway writing it, since the dashboard and
CLI paths write `config_path()`.

The lock is taken WITHOUT waiting, which is the second thing to get right:
`load()` is reached from the event loop all over the tree, so a POSIX `flock` wait
here would trade a rare data-loss race for a gateway stall lasting as long as the
holder keeps the lock. Giving up costs nothing, because a held lock means another
writer is mid-write and that writer's bytes are precisely what must not be
clobbered -- declining is the correct outcome, not a compromise, and the migration
is already retry-on-next-load by construction. So `platform_compat.file_lock`
gains `wait=False` (POSIX `LOCK_NB`; Windows already behaves this way on the loop
thread, and a zero timeout makes it uniform) raising `BlockingIOError`, which
`update_config_locked` exposes as `wait_for_lock`. Both default to the existing
waiting behavior, so all 69 existing call sites are unchanged. `BlockingIOError`
is an `OSError`, so it narrows rather than widens what a caller must handle, and
it separates "someone is writing right now" from that function's existing
stuck-holder ceiling. The remaining file I/O on the loop -- one read, one atomic
rename -- is what `cfg.save()` did here before, unchanged.

The backup now happens immediately before the write (inside the lock hold where
there is one), so it captures the bytes actually being replaced rather than
whatever was there when the load started. A failing copy still propagates and
aborts the write, preserving the existing contract: a config we could not copy
aside is not rewritten, and the migration retries on the next load.

One consequence worth stating plainly, because it is visible on disk: a migrating
load no longer materializes every section of the schema into `config.json`. Only
the keys it migrates are written. That is the delta property, and it is also
strictly better for the separate defect where a materialized key pins a shipped
default forever (#5244) -- fewer keys are pinned. One existing test asserted on
the old side effect rather than on its own subject: `test_put_cannot_add_a_gitlab_
host` read `raw["dashboard"]["gitlab_hosts"]` back out of the file, with a comment
explaining the key was present only because "cfg.save() serializes every dataclass
field". Its security property -- a dashboard caller cannot authorize a new GitLab
instance -- is unchanged and still asserted; the raw-file assertion now reads the
stored VALUE (absent or empty are the same thing to the loader, which the sibling
`cfg.dashboard.gitlab_hosts == []` assertion proves) instead of requiring the key
to exist.

Deliberately out of scope: the issue's optional `load(migrate=False)` read-only
path. It is a new public API surface, not part of the ordering defect.

Also out of scope, and worth naming because a reviewer raised it: the migration's
lock does not serialize against the legacy config writers that call
`write_config_atomically` directly under the in-process asyncio `_get_config_lock`
(the dashboard agents endpoint, `updates.py`, `security.py`, `messaging.py`,
`mcp.py`, `core.py` STT). `update_config_locked`'s own docstring names them as
pending conversion. That gap is shared by every one of its ~69 existing call
sites, it predates this change, and this change strictly narrows it -- before, the
migration took no lock at all and rewrote the whole document; now it holds the
sidecar lock and writes three keys. Closing it properly means converting those
writers, not special-casing this one caller, so it is filed as #8032 with the
sites named.

Accepted residue, recorded so the merge carries it: the seeded agent's kiro agent
is the merged value of `agent.default_agent`, which comes from two independently
written files. `config.local.json` is read outside the base lock, so a
`config set --local agent.default_agent` landing between that read and the base
write leaves the seed one write stale. Closing it needs a two-file critical
section that does not exist today and that no other writer participates in;
#8032 is the path that makes one possible. Seeding empty and resolving live is not
an alternative -- `resolve_agent_bindings` computes
`kiro_agent = passthrough or agent_cfg.kiro_agent` with no fallback to
`agent.default_agent`, so an empty seed yields an empty binding.

## Tests

`TestMigrationWriteBackOrdering` in `test/test_config_loader.py`:

* `test_a_write_landing_mid_migration_survives` -- the deterministic two-writer
  interleave. Writer A is a migrating `load()` suspended after it has decided to
  migrate but before its bytes reach the file; writer B is an ordinary
  `update_config_locked` write (the shape the dashboard PATCH and `kirocrew
  config set` both use) setting `session.autocompact_pct`. Both must be
  observable afterwards. Threads are started and drained in a `try/finally` so a
  timeout or assertion cannot leave a writer running against this test's paths.
* `test_the_migration_only_rewrites_the_keys_it_owns` -- parametrized over the
  data-home path (which also takes the lock) and a redirected path (which cannot,
  without leaving a sidecar). Asserted on the top-level key set, because a
  snapshot rewrite materializes every section in the schema.
* `test_a_held_lock_defers_the_migration_instead_of_waiting` -- with the lock held
  by another descriptor, the migration returns without writing. Run on a thread
  with a bounded join and asserted inside the hold, so a regression to a waiting
  acquire FAILS on an assertion instead of hanging the suite.
* `test_a_migration_another_writer_already_did_writes_nothing` -- the re-read
  turns a stale reason to write into a no-op, with no redundant `.bak`.
* `test_the_seeded_agent_takes_its_kiro_agent_from_the_reread` -- the seeded
  agent's `kiro_agent` comes from the document read inside the lock, not from the
  load's older snapshot, so an `agent.default_agent` change landing in between is
  honored rather than silently reverted for every default session.
* `test_the_seed_falls_back_when_the_document_names_no_kiro_agent` -- with nothing
  stored, the fallback is the load's resolved value (which carries the overlay and
  the dataclass default) rather than a literal.

RED verified against the base commit with the source reverted and the tests kept:
the interleave test fails on "the config write that landed while the migration was
in flight was lost", and the delta tests on "the migration wrote sections it did
not migrate". Two fixes are mutation-verified individually: flipping
`wait_for_lock=False` to `True` reddens the held-lock test on its assertion, and
seeding from the snapshot instead of the re-read reddens the seed test. The
pre-existing `TestMigrationBackupContainment` guards pass unchanged -- the lock
containment above is there because the first draft broke them.

Run: `test_config_loader.py` + `test_dashboard_config_gitlab_hosts.py` 510 passed;
`test_platform_compat*.py` + `test_no_blocking_call_on_loop.py` +
`test_loop_lock.py` 585 passed / 22 skipped; 20 further `test_config*` /
`test_atomic_write*` / `test_autocompact_default` / lock-regression files 586
passed / 1 skipped. black, flake8 and isort clean on all four changed files; mypy
clean on both source files.

## Manual verification

N/A -- the defect is a thread interleave with no user-visible surface, and the
interleave is reproduced deterministically in the test above rather than by hand.

## Related Issues

Closes #7793

Follow-up filed from this review: #8032 (legacy config writers bypass the advisory
lock), which carries the accepted residue named above.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a function that both READS shared state and WRITES it back must carry
the same ordering guard as its siblings, or say in-comment why it does not need
one. The specific tell is checkable by a reviewer rather than a linter: in one
function, several mutations of the same shared state where exactly one is ordered
and its docstring names the hazard -- an unguarded sibling doing a heavier
mutation is a defect, not a deliberate asymmetry.

Second, narrower rule: when the guard you add is a lock, check two things about
it. Where its lockfile lands -- an advisory-lock sidecar is a file, and a file
beside a path the process does not own is litter, the same containment question
the backup in this very function had already been fixed for. And whether the
acquire can WAIT on a thread that must not block: converting an unordered write
into a correctly ordered one is not a win if the ordering is bought with a
blocking wait on the event loop. For work that is optional and retried, the
answer is a single-shot acquire that declines.
