### PR TITLE
fix(desktop): honour the local-gateway opt-out when picking the launch target

### DIFF
--- a/website/electron/gateway-supervisor.js
+++ b/website/electron/gateway-supervisor.js
@@ -423,7 +423,20 @@ function createGatewaySupervisor({
         }
         glog(`no gateway on :${PORT} and local gateway is off — not starting one`);
         sendStatus("No gateway is answering…");
-        gatewayStartFailure = { disabled: true, port: PORT };
+        // The host is part of the state, not decoration: on a remote crew's port
+        // a local gateway would shadow that crew's identity, so the dialog needs
+        // to name the target and withhold the start-one-here offer. `remotePort`
+        // travels with it because the crew binds THAT port on its own machine
+        // (see effectivePort in fetchRemoteToken) while PORT is only the local
+        // end of the connection -- naming the local one sends the user to check
+        // a port nothing was ever expected to serve over there.
+        const remoteConfig = getRemoteHostConfig(store, PORT);
+        gatewayStartFailure = {
+          disabled: true,
+          port: PORT,
+          remoteHost: remoteConfig?.host || "",
+          remotePort: remoteConfig?.remotePort || "",
+        };
         resolve(false);
       };
 
@@ -837,20 +850,27 @@ function createGatewaySupervisor({
       portConflict,
       noRetry = false,
       localGatewayOff = false,
+      offerLocalStart = false,
       primaryAction: configuredPrimaryAction,
       primaryLabel: configuredPrimaryLabel,
       showQuitButton: configuredShowQuitButton,
     } = options;
     const showQuitButton = configuredShowQuitButton ?? !noRetry;
+    // Client-only mode launched nothing, so there is no launch to diagnose:
+    // the log on disk belongs to earlier runs, and rendering that tail is what
+    // made a state the user asked for read as a crash report.
+    const showLog = !localGatewayOff;
 
     return new Promise((resolve) => {
       const dark = nativeTheme.shouldUseDarkColors;
       const hasParent = parentWindow && !parentWindow.isDestroyed();
       const errorWindow = new BrowserWindow({
         width: 620,
-        height: 460,
+        // Without the log pane there is nothing to scroll, so the tall window
+        // would open mostly empty under a two-line message.
+        height: showLog ? 460 : 260,
         minWidth: 460,
-        minHeight: 320,
+        minHeight: showLog ? 320 : 200,
         resizable: true,
         useContentSize: true,
         parent: hasParent ? parentWindow : undefined,
@@ -869,12 +889,22 @@ function createGatewaySupervisor({
       const primaryLabel = configuredPrimaryLabel
         || (noRetry ? "Quit" : (portConflict ? "Force-stop & Retry" : "Retry"));
       // Client-only mode cannot reach dashboard Settings to reverse the choice.
-      // Keep the explicit local-gateway escape hatch in this pre-dashboard UI.
-      const enableButton = localGatewayOff && !noRetry
+      // Keep the explicit local-gateway escape hatch in this pre-dashboard UI --
+      // but only where starting one here is coherent. The spawn binds THIS
+      // port, so on a remote crew's port the button would stand up a local
+      // gateway shadowing that crew's identity on a port the user never chose.
+      const enableButton = offerLocalStart && !noRetry
         ? "<button class=\"cancel\" onclick=\"act('enable-retry')\">Start Local Gateway</button>"
         : "";
       const foreground = dark ? "#e2e8f0" : "#1e293b";
       const muted = dark ? "#94a3b8" : "#64748b";
+      const logPane = showLog
+        ? `<div class="pathline">${escapeHtml(displayedLogPath)}</div>`
+          + `<pre class="log">${escapeHtml(logTail || "(launch log is empty)")}</pre>`
+        : "";
+      const revealButton = showLog
+        ? "<button class=\"cancel\" onclick=\"act('reveal')\">Reveal Log</button>"
+        : "";
       const html = `<!DOCTYPE html><html><head><style>
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,sans-serif; padding:20px; background:${dark ? "#1e293b" : "#f8fafc"}; color:${foreground};
@@ -894,12 +924,11 @@ function createGatewaySupervisor({
       </style></head><body>
         <div class="title">${escapeHtml(title)}</div>
         <div class="msg">${escapeHtml(message)}</div>
-        <div class="pathline">${escapeHtml(displayedLogPath)}</div>
-        <pre class="log">${escapeHtml(logTail || "(launch log is empty)")}</pre>
+        ${logPane}
         <div class="row">
           <button class="ok" onclick="act('${primaryAction}')">${escapeHtml(primaryLabel)}</button>
           ${enableButton}
-          <button class="cancel" onclick="act('reveal')">Reveal Log</button>
+          ${revealButton}
           ${showQuitButton ? "<button class=\"cancel\" onclick=\"act('quit')\">Quit</button>" : ""}
         </div>
         <script>
@@ -1340,6 +1369,9 @@ function createGatewaySupervisor({
         portInUseInLog: isPortInUse(logTail),
       });
       const localGatewayOff = failureKind === "client-only";
+      const remoteTarget = localGatewayOff ? (failureRecord?.remoteHost || "") : "";
+      // The crew's own port when it has one; PORT is only this end of the link.
+      const remoteTargetPort = (localGatewayOff && failureRecord?.remotePort) || PORT;
       const portConflict = failureKind === "port-conflict";
 
       let title;
@@ -1350,7 +1382,9 @@ function createGatewaySupervisor({
           ? error.message
           : describeIncompleteBundle([]);
       } else if (localGatewayOff) {
-        title = `Kiro Crew — no gateway on port ${PORT}`;
+        title = remoteTarget
+          ? `Kiro Crew — nothing answering at ${remoteTarget}:${remoteTargetPort}`
+          : `Kiro Crew — no gateway on port ${PORT}`;
         message = error.message;
       } else if (portConflict) {
         title = `Kiro Crew — port ${PORT} already in use`;
@@ -1378,6 +1412,7 @@ function createGatewaySupervisor({
           portConflict,
           port: PORT,
           localGatewayOff,
+          offerLocalStart: localGatewayOff && !remoteTarget,
         });
         if (window.isDestroyed()) return;
         if (action === "reveal") {

--- a/website/electron/gateway-wait.js
+++ b/website/electron/gateway-wait.js
@@ -101,7 +101,7 @@ function waitForGateway({
  * carries the Gatekeeper hint because an unsigned/quarantined nested executable
  * being killed on launch is the most common "works for me, not my friend" mode.
  *
- * @param {{code?: number|null, signal?: string|null, error?: string, disabled?: boolean, port?: number}|null} failure
+ * @param {{code?: number|null, signal?: string|null, error?: string, disabled?: boolean, port?: number, remoteHost?: string, remotePort?: string}|null} failure
  * @returns {string}
  */
 function describeGatewayFailure(failure) {
@@ -112,8 +112,31 @@ function describeGatewayFailure(failure) {
   //
   // Deliberately does NOT send the user to Settings: the page holding that
   // switch is served by a gateway, which is the thing not running. The error
-  // dialog carries a button instead.
+  // dialog carries a button instead -- except on a remote crew's port, where
+  // starting one here would shadow that crew, so this names the host to check
+  // and withholds the offer the dialog is also hiding.
   if (failure.disabled) {
+    if (failure.remoteHost) {
+      // The crew binds its own port on its own machine; this app only holds the
+      // local end of the link. Naming the local port here would send the user to
+      // check a port nothing over there was ever expected to serve.
+      const target = failure.remotePort
+        ? `${failure.remoteHost}:${failure.remotePort}, reached through local port ${failure.port},`
+        : `${failure.remoteHost} on port ${failure.port},`;
+      // The last sentence is the only exit this state has. The dialog withholds
+      // its start-a-gateway button here (that spawn would bind the crew's own
+      // port and shadow it), and the settings page that owns the choice is
+      // served by a gateway -- so without naming this the user is left with a
+      // Retry that cannot succeed. Both steps are named: an explicit port
+      // outranks stored config, but the opt-out is still in force, so that
+      // launch stops at this same state on a port where the button comes back.
+      return `Nothing is answering at ${target} and Kiro Crew is set not to `
+        + `start a gateway on this machine. Start the gateway on `
+        + `${failure.remoteHost}, or re-establish the tunnel or port-forward that `
+        + "reaches it, and retry. To run one on this machine instead, relaunch "
+        + "with KIROCREW_PORT set to a port that has no remote host configured, "
+        + "then choose Start Local Gateway when prompted.";
+    }
     return `No gateway is answering on port ${failure.port}, and Kiro Crew is set `
       + "not to start one on this machine. Start the gateway you connect to (or "
       + "the connection that reaches it) and retry, or start one here.";

--- a/website/electron/host-config.js
+++ b/website/electron/host-config.js
@@ -18,6 +18,62 @@ function migrateRemoteHostConfig(store, port) {
   return false;
 }
 
+/**
+ * The one port this app must never SELECT as a launch target.
+ *
+ * The shell reaches its gateway over `http://localhost:<port>`, and
+ * `new URL("http://localhost:80").port` is `""` -- the URL API strips a scheme's
+ * default port. Every per-port lookup that derives its key from that URL then
+ * misses: `isGatewayLocalForWindow` reads `remoteHosts[""]`, finds no host, and
+ * reports a tunnelled crew as a gateway on this machine, after which the
+ * host-presence heartbeat sends this machine's internal secret over the tunnel.
+ *
+ * The classifier is where that belongs fixed, and it is wrong on port 80
+ * independently of this module. Until it is, selecting 80 from stored config is
+ * a target this app cannot classify, so it is not offered.
+ */
+const UNSELECTABLE_PORT = 80;
+
+/**
+ * Whether a port may be chosen as this launch's target.
+ *
+ * @param {unknown} port
+ * @returns {boolean}
+ */
+function isSelectablePort(port) {
+  return Number.isInteger(port)
+    && port >= 1
+    && port <= 65535
+    && port !== UNSELECTABLE_PORT;
+}
+
+/**
+ * Port of a remote crew this app is configured to reach, or null when none is
+ * configured. Entries holding only a `defaultName` are window-title settings
+ * rather than a remote target, so they are skipped.
+ *
+ * Ports are compared numerically and the lowest wins, so the answer is stable
+ * for a given store instead of depending on key insertion order.
+ *
+ * @param {{get: (key: string) => unknown}} store
+ * @returns {number|null}
+ */
+function remoteHostPort(store) {
+  const hosts = store.get("remoteHosts") || {};
+  let lowest = null;
+  for (const [key, config] of Object.entries(hosts)) {
+    if (!config || typeof config.host !== "string" || config.host === "") continue;
+    // Only a canonical decimal key names a port. parseInt alone reads
+    // "5477-old" as 5477, which would dial a port whose own entry does not
+    // exist -- so the launch would carry no host for the port it targeted.
+    const port = Number.parseInt(key, 10);
+    if (!isSelectablePort(port)) continue;
+    if (String(port) !== key) continue;
+    if (lowest === null || port < lowest) lowest = port;
+  }
+  return lowest;
+}
+
 function getRemoteHostConfig(store, port) {
   const hosts = store.get("remoteHosts") || {};
   return hosts[String(port)] || null;
@@ -45,4 +101,10 @@ function setRemoteHostConfig(store, port, { host, binPath, remotePort, remotePat
   store.set("remoteHosts", hosts);
 }
 
-module.exports = { migrateRemoteHostConfig, getRemoteHostConfig, setRemoteHostConfig };
+module.exports = {
+  isSelectablePort,
+  migrateRemoteHostConfig,
+  remoteHostPort,
+  getRemoteHostConfig,
+  setRemoteHostConfig,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -22,7 +22,13 @@ const {
   describeLocation,
 } = require("./bundle-location");
 const { DEFAULT_REMOTE_BIN } = require("./remote-token");
-const { migrateRemoteHostConfig } = require("./host-config");
+const {
+  migrateRemoteHostConfig,
+  remoteHostPort,
+  getRemoteHostConfig,
+  isSelectablePort,
+} = require("./host-config");
+const { isLocalGatewayEnabled } = require("./local-gateway");
 const { seedRenamedStore } = require("./store-rename");
 const { resolveHome, secretCandidates } = require("./home-dir");
 const { identityFamily } = require("./instance-guard");
@@ -77,6 +83,33 @@ function resolvePort() {
 
   // dashboard.url in the resolved data home is the backend source of truth.
   const configuredPort = findConfiguredDashboardPort(fs, path, [KIROCREW_HOME]);
+
+  // With "Run a local gateway" off, a dashboard.url naming a port that has no
+  // remote host of its own records a backend which will not run here: nothing
+  // binds it and there is no host to mint a token from. A machine switched from
+  // local to remote-only keeps exactly that record, so honouring it would
+  // rebuild the dead end the opt-out is meant to avoid. A dashboard.url that
+  // DOES name a configured crew still wins -- that is the user choosing between
+  // crews rather than a leftover.
+  if (!isLocalGatewayEnabled(store)) {
+    if (
+      configuredPort
+      && isSelectablePort(configuredPort)
+      && getRemoteHostConfig(store, configuredPort)?.host
+    ) {
+      return configuredPort;
+    }
+    const remotePort = remoteHostPort(store);
+    if (remotePort) {
+      console.log(
+        "Local gateway is off; targeting the configured remote crew on port " + remotePort,
+      );
+      return remotePort;
+    }
+    // No crew is configured, so there is no better target than the local
+    // record: naming the port the user configured beats naming the default.
+  }
+
   if (configuredPort) return configuredPort;
   console.debug("No usable dashboard.url port in the data home, falling back to 5476");
   return 5476;

--- a/website/electron/test/gateway-wait.test.js
+++ b/website/electron/test/gateway-wait.test.js
@@ -172,6 +172,88 @@ test("describeGatewayFailure: the disabled case names the port and both ways out
   assert.doesNotMatch(s, /could not be launched|exited on launch|failed to start/);
 });
 
+// #6138: with the launch aimed at a configured remote crew, this text must name
+// that target and must NOT offer to start a gateway here -- the spawn binds the
+// crew's own port, so the offer the dialog hides cannot be promised in words.
+test("describeGatewayFailure: a remote target is named and no local start offered", () => {
+  const s = describeGatewayFailure({ disabled: true, port: 7778, remoteHost: "a.example.com" });
+  assert.match(s, /a\.example\.com/);
+  assert.match(s, /7778/);
+  assert.match(s, /set not to start a gateway on this machine/);
+  assert.doesNotMatch(s, /start one here/);
+  assert.doesNotMatch(s, /Settings/);
+  assert.doesNotMatch(s, /could not be launched|exited on launch|failed to start/);
+});
+
+// The dialog withholds its start-a-gateway button on a crew's port, and the page
+// that owns the choice is served by a gateway, so this sentence is the only exit
+// the state has. Without it the user is left with a Retry that cannot succeed.
+test("describeGatewayFailure: a remote target names a way to run one here anyway", () => {
+  const s = describeGatewayFailure({ disabled: true, port: 7778, remoteHost: "a.example.com" });
+  assert.match(s, /KIROCREW_PORT/);
+  assert.match(s, /no remote host configured/);
+  // BOTH steps, or the instruction under-promises: an explicit port re-aims the
+  // launch, but the opt-out is still in force, so that launch stops at this same
+  // state -- on a port where the withheld button is offered again. A user told
+  // only the first step reads the second dialog as "it did not work".
+  assert.match(s, /then choose Start Local Gateway when prompted/);
+});
+
+test("describeGatewayFailure: the remote-side instruction names the tunnel", () => {
+  // "the connection that reaches it" is vague at the moment of failure.
+  const s = describeGatewayFailure({ disabled: true, port: 7778, remoteHost: "a.example.com" });
+  assert.match(s, /tunnel or port-forward/);
+});
+
+test("describeGatewayFailure: title and body agree on 'answering at'", () => {
+  // The dialog title reads "nothing answering at host:port"; the body said
+  // "for", which reads as two different facts about the same target.
+  const s = describeGatewayFailure({ disabled: true, port: 7778, remoteHost: "a.example.com" });
+  assert.match(s, /answering at a\.example\.com/);
+  assert.doesNotMatch(s, /answering for/);
+});
+
+test("describeGatewayFailure: an empty remoteHost keeps the local-start wording", () => {
+  // The field is absent on every pre-existing caller, and a cleared host entry
+  // stores "", so neither may change which of the two texts is chosen.
+  for (const failure of [
+    { disabled: true, port: 5476 },
+    { disabled: true, port: 5476, remoteHost: "" },
+  ]) {
+    assert.match(describeGatewayFailure(failure), /start one here/);
+  }
+});
+
+// #6138: the crew binds its OWN port on its own machine (effectivePort =
+// remotePort || tokenPort || PORT), so naming the local end would send the user
+// to check a port nothing over there was ever expected to serve.
+test("describeGatewayFailure: a distinct remote port is the one to go and check", () => {
+  const s = describeGatewayFailure({
+    disabled: true,
+    port: 5477,
+    remoteHost: "a.example.com",
+    remotePort: "9000",
+  });
+  assert.match(s, /a\.example\.com:9000/);
+  // The local end stays visible, because that is the port the tunnel must land on.
+  assert.match(s, /local port 5477/);
+  assert.doesNotMatch(s, /a\.example\.com:5477/);
+  assert.doesNotMatch(s, /start one here/);
+});
+
+test("describeGatewayFailure: no remotePort falls back to the shared port form", () => {
+  // The field is optional and a cleared entry stores "", so both must read as
+  // "the crew is on this same port" rather than rendering an empty target.
+  for (const remotePort of [undefined, ""]) {
+    const s = describeGatewayFailure({
+      disabled: true, port: 7778, remoteHost: "a.example.com", remotePort,
+    });
+    assert.match(s, /a\.example\.com on port 7778/);
+    assert.doesNotMatch(s, /local port/);
+    assert.doesNotMatch(s, /:undefined|: ,|::/);
+  }
+});
+
 test("describeGatewayFailure: disabled wins over a stale error field", () => {
   // waitForGateway hands over whatever record it was given; the deliberate
   // no-spawn reason must not be reported as a launch failure.

--- a/website/electron/test/host-config.test.js
+++ b/website/electron/test/host-config.test.js
@@ -1,6 +1,12 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
-const { migrateRemoteHostConfig, getRemoteHostConfig, setRemoteHostConfig } = require("../host-config");
+const {
+  isSelectablePort,
+  migrateRemoteHostConfig,
+  remoteHostPort,
+  getRemoteHostConfig,
+  setRemoteHostConfig,
+} = require("../host-config");
 
 // Minimal mock of electron-store (get/set/delete on a plain object)
 function mockStore(initial = {}) {
@@ -91,5 +97,132 @@ describe("setRemoteHostConfig", () => {
     const store = mockStore({ remoteHosts: {} });
     setRemoteHostConfig(store, 7777, { host: "h.com" });
     assert.equal(store._data.remoteHosts["7777"].binPath, "~/.local/bin/kirocrew");
+  });
+});
+
+// #6138: with "Run a local gateway" off, the launch has to aim at the remote
+// crew the user configured instead of the local default nothing will bind.
+describe("remoteHostPort", () => {
+  it("returns null when nothing is configured", () => {
+    assert.equal(remoteHostPort(mockStore()), null);
+    assert.equal(remoteHostPort(mockStore({ remoteHosts: {} })), null);
+  });
+
+  it("returns the port of the only configured remote host", () => {
+    const store = mockStore({ remoteHosts: { "7778": { host: "a.example.com" } } });
+    assert.equal(remoteHostPort(store), 7778);
+  });
+
+  it("picks the lowest port, whatever order the keys were written in", () => {
+    const store = mockStore({
+      remoteHosts: {
+        "9001": { host: "c.example.com" },
+        "5477": { host: "a.example.com" },
+        "7778": { host: "b.example.com" },
+      },
+    });
+    assert.equal(remoteHostPort(store), 5477);
+  });
+
+  it("skips entries that carry only a window name", () => {
+    const store = mockStore({
+      remoteHosts: {
+        "5477": { defaultName: "Laptop" },
+        "7778": { host: "a.example.com" },
+      },
+    });
+    assert.equal(remoteHostPort(store), 7778);
+  });
+
+  it("skips an entry whose host was cleared", () => {
+    const store = mockStore({
+      remoteHosts: {
+        "5477": { host: "", binPath: "~/.local/bin/kirocrew" },
+        "7778": { host: "a.example.com" },
+      },
+    });
+    assert.equal(remoteHostPort(store), 7778);
+  });
+
+  it("skips keys that are not usable port numbers", () => {
+    const store = mockStore({
+      remoteHosts: {
+        "0": { host: "a.example.com" },
+        "70000": { host: "b.example.com" },
+        "not-a-port": { host: "c.example.com" },
+        "7778": { host: "d.example.com" },
+      },
+    });
+    assert.equal(remoteHostPort(store), 7778);
+  });
+
+  it("skips a key that only STARTS with digits", () => {
+    // parseInt would read "5477-old" as 5477 and dial a port whose own entry
+    // does not exist, so the launch would carry no host for that port.
+    const store = mockStore({
+      remoteHosts: {
+        "5477-old": { host: "a.example.com" },
+        "7778": { host: "b.example.com" },
+      },
+    });
+    assert.equal(remoteHostPort(store), 7778);
+  });
+
+  it("skips non-canonical spellings of a port number", () => {
+    for (const key of ["05477", " 5477", "5477 ", "+5477", "5477.0", "0x1565"]) {
+      const store = mockStore({ remoteHosts: { [key]: { host: "a.example.com" } } });
+      assert.equal(remoteHostPort(store), null, key);
+    }
+  });
+
+  it("returns null when every entry is unusable", () => {
+    const store = mockStore({
+      remoteHosts: { "5477": { defaultName: "Laptop" }, "70000": { host: "a.example.com" } },
+    });
+    assert.equal(remoteHostPort(store), null);
+  });
+
+  it("tolerates a malformed entry instead of throwing", () => {
+    const store = mockStore({ remoteHosts: { "5477": null, "7778": { host: "a.example.com" } } });
+    assert.equal(remoteHostPort(store), 7778);
+  });
+
+  // Security: `new URL("http://localhost:80").port` is "", so a target of 80
+  // defeats every per-port lookup keyed off that URL -- including the
+  // host-presence classifier, which would then read a tunnelled crew as local
+  // and send this machine's internal secret over the tunnel.
+  it("never selects port 80, even as the only configured crew", () => {
+    const store = mockStore({ remoteHosts: { "80": { host: "a.example.com" } } });
+    assert.equal(remoteHostPort(store), null);
+  });
+
+  it("skips port 80 and takes the next selectable crew", () => {
+    const store = mockStore({
+      remoteHosts: {
+        "80": { host: "a.example.com" },
+        "7778": { host: "b.example.com" },
+      },
+    });
+    assert.equal(remoteHostPort(store), 7778);
+  });
+});
+
+describe("isSelectablePort", () => {
+  it("refuses port 80 and accepts its neighbours", () => {
+    assert.equal(isSelectablePort(80), false);
+    assert.equal(isSelectablePort(79), true);
+    assert.equal(isSelectablePort(81), true);
+  });
+
+  it("refuses anything that is not a port number in range", () => {
+    for (const value of [0, -1, 65536, 1.5, NaN, null, undefined, "5476"]) {
+      assert.equal(isSelectablePort(value), false, String(value));
+    }
+  });
+
+  it("accepts the ordinary gateway ports", () => {
+    for (const value of [1, 443, 5476, 7778, 65535]) {
+      assert.equal(isSelectablePort(value), true, String(value));
+    }
   });
 });

--- a/website/electron/test/local-gateway.test.js
+++ b/website/electron/test/local-gateway.test.js
@@ -1,5 +1,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   LOCAL_GATEWAY_KEY,
   isLocalGatewayEnabled,
@@ -129,4 +131,32 @@ test("classifyStartFailure: a plain spawn failure and a timeout stay distinct", 
   assert.equal(classifyStartFailure({ failedToStart: true }), "failed");
   assert.equal(classifyStartFailure({ failedToStart: false }), "unreachable");
   assert.equal(classifyStartFailure(), "unreachable");
+});
+
+// #6138: the client-only dialog must not dress an expected state as a crash.
+test("client-only: the failure dialog derives its log pane from that one bit", () => {
+  // Source-level pin. The log pane is exactly the client-only condition, so a
+  // second flag for it would be a duplicate spelling that can drift.
+  const source = fs.readFileSync(
+    path.join(__dirname, "..", "gateway-supervisor.js"),
+    "utf8",
+  );
+  assert.match(source, /const showLog = !localGatewayOff;/);
+  assert.doesNotMatch(source, /showLog:/);
+});
+
+test("client-only: the local-start offer is withheld on a remote crew's port", () => {
+  // The spawn binds THIS port (`"--port", String(PORT)`), so on a port that
+  // names a remote crew the escape hatch would stand up a local gateway
+  // shadowing that crew. The button is therefore gated on its own condition,
+  // not on client-only mode -- these are genuinely different questions.
+  const source = fs.readFileSync(
+    path.join(__dirname, "..", "gateway-supervisor.js"),
+    "utf8",
+  );
+  assert.match(source, /const enableButton = offerLocalStart && !noRetry/);
+  assert.match(source, /offerLocalStart: localGatewayOff && !remoteTarget/);
+  assert.match(source, /remotePort: remoteConfig\?\.remotePort \|\| ""/);
+  // The title must name the crew's own port, not this end of the link.
+  assert.match(source, /nothing answering at \$\{remoteTarget\}:\$\{remoteTargetPort\}/);
 });


### PR DESCRIPTION
## Problem / Motivation

With the desktop setting **"Run a local gateway"** turned off, the next launch lands on a gateway-failure window saying nothing is answering on the local default port, instead of reaching the remote crew the user configured. The setting is honoured where the gateway is started and ignored where the launch target is chosen.

## Why it matters

Remote-only is the supported way to run the desktop app against a gateway on another machine (for example over a port-forward), and the app already knows the user opted out of a local gateway. Treating "the local default port is silent" as a failure in that mode is a dead end at launch: the app is set never to bind that port, so retrying cannot help, and the surface the user is shown is dressed as a crash report rather than as the state they asked for.

## What changed (motivation -> approach -> change)

**The target.** `resolvePort()` in `main.js` chose the launch target from `KIROCREW_PORT` and `dashboard.url` in the local data home, then fell back to the local default. The per-port `remoteHosts` map -- the only record the shell keeps of a remote crew -- was never consulted. Both of those local-record branches aim the launch at a port nothing will ever bind once the setting is off:

- the blind default is the branch a *fresh* remote-only install hits, because a machine that never ran a local gateway has no `dashboard.url` to read;
- a persisted `dashboard.url` is the branch a machine *switched* from local to remote-only hits, and it outranked the default, so honouring it rebuilt the same dead end.

With the local gateway off, a configured remote crew now outranks both. A `dashboard.url` that itself names a configured crew still wins, because that is the user choosing between crews rather than a leftover; with no crew configured at all the local record is still preferred over the default, so the dialog names the port the user configured. `KIROCREW_PORT` keeps absolute precedence, and nothing changes while the local gateway is on.

`remoteHostPort()` (new, in `host-config.js`) returns the lowest configured port whose entry carries a real host, so entries holding only a window `defaultName` are skipped and the answer does not depend on key insertion order. Only a canonical decimal key names a port: `parseInt` alone would read `"5477-old"` as 5477 and dial a port whose own entry does not exist, leaving the launch with no host for the port it targeted.

**Why 80 is not selectable.** Both remote-selection branches refuse port 80, through a shared `isSelectablePort()` guard. `new URL("http://localhost:80").port` is `""` -- the URL API strips a scheme's default port -- so every per-port lookup keyed off that URL misses. In particular `isGatewayLocalForWindow` (`window-lifecycle.js`) reads `remoteHosts[""]`, finds no host, and reports a tunnelled crew as a gateway on this machine, after which the host-presence heartbeat attaches `X-Internal-Secret` and sends it over the tunnel. That classifier is wrong on port 80 independently of this PR (a launch already lands there via `KIROCREW_PORT=80` or a `dashboard.url` naming 80), and fixing it belongs with the classifier -- it should reuse the supervisor's existing `defaultedPort()` normalizer. What this PR must not do is widen the reach: without the guard, a bare `remoteHosts["80"]` entry plus the opt-out would select 80 with no other user action. Recorded as Finding 3 on #8056.

**The dialog.** It no longer renders the persisted launch-log tail or Reveal Log. In client-only mode nothing was launched, so that log belongs to earlier runs; `classifyStartFailure` already refuses to read it as a port conflict for exactly this reason, yet the dialog still displayed it in a monospace pane, which is what made an expected state read as a crash. The pane is derived from the `localGatewayOff` flag the call already carries rather than a second flag for the same bit, and the window shrinks to fit when it is absent.

**Naming the target.** Where the launch aims at a crew, the dialog says so: the title reads `nothing answering at <host>:<port>` and the message names the host to start. The port shown is the crew's own `remotePort` when its entry sets one, because that is what the gateway binds on the remote machine (`effectivePort = remotePort || tokenPort || PORT` in `fetchRemoteToken`) while the local key port is only this end of the link; the local end stays visible as "reached through local port N" so a broken tunnel is still diagnosable. Naming the local port as if it were the crew's would send the user to check a port nothing over there was ever expected to serve.

**The escape hatch.** `enable-retry` spawns `["gateway", "--no-open", "--port", String(PORT)]`, so once the target can be a crew's port, "Start Local Gateway" could stand up a local gateway shadowing that crew's identity on a port the user never chose -- and `resolveGatewayConflict` treats that port's holder as non-local, so the two halves of the app would disagree about what lives there. The offer is therefore gated on its own condition (`offerLocalStart`) rather than on client-only mode. Where no remote host is configured the button, wording and behaviour are exactly as before.

## Known gap left by this PR

Gating that button closes the shadowing spawn but removes the only in-app way to reverse the opt-out: the setting is written through the `local-gateway:set` IPC handler, and the settings page that calls it is served by a gateway -- the thing not running. So a user whose configured crew is decommissioned gets a dialog offering a Retry that cannot succeed and Quit, and recovery means hand-editing the electron store. **Filed as #8056**, together with a pre-existing incoherence on main that blocks the obvious fix (a `dashboard.url` naming a configured crew's port while the local gateway is on: the app spawns a gateway and then classifies the holder as non-local), the default-port classifier bug above, and all three rejected approaches with their reasons.

This is deliberate, not overlooked. It is not a regression in kind: before this change that same user -- opted out, crew configured, crew gone -- got the default-port failure page this PR exists to remove. They now get a dialog that names the real target and does not read as a crash. Every complete fix leaves obvious-bug scope: spawning on the local default leaves the supervisor's ownership, liveness and lock state keyed to a port it no longer uses; retargeting `PORT`/`BACKEND_URL` mid-session is a refactor of a core invariant; and the narrow relaunch option has a failure mode -- the `dashboard.url` case above -- that could not be exercised where this was written.

Scope note: the issue also asks for a remote-crew selection page and a setup/empty-state flow as new pre-dashboard landing surfaces. Those are new UI and are deliberately not here; the remaining scope is tracked in #8002, including the review suggestion to persist the last successfully-reached crew instead of the lowest-port tie-break.

## Tests

`website/electron/test/host-config.test.js` -- 12 cases for `remoteHostPort` and 3 for `isSelectablePort`: none configured, single host, lowest-port selection across out-of-order keys, skipping a `defaultName`-only entry, skipping a cleared host, skipping keys that are not usable port numbers, skipping a key that only starts with digits (`"5477-old"`), skipping non-canonical spellings (`"05477"`, `" 5477"`, `"5477 "`, `"+5477"`, `"5477.0"`, `"0x1565"`), all-unusable returning null, a malformed entry not throwing, port 80 refused as the only configured crew, port 80 skipped in favour of the next selectable one, and the guard itself refusing 80 while accepting 79, 81, 1, 443, 5476, 7778 and 65535 and rejecting out-of-range, non-integer and string inputs.

`website/electron/test/gateway-wait.test.js` -- 5 cases for the client-only description: a remote target names the host and withholds "start one here"; a distinct `remotePort` is the port named, with the local end still shown; an absent and an empty-string `remotePort` both fall back to the shared-port form without rendering an empty target; an absent and an empty-string `remoteHost` both keep the original local-start wording (the field is absent on every pre-existing caller, and a cleared entry stores `""`).

`website/electron/test/local-gateway.test.js` -- source-level pins that the dialog derives its log pane from the single `localGatewayOff` bit with no second `showLog` option, that the local-start offer is gated on `offerLocalStart` fed from the failure record, and that the title uses the crew's own port rather than this end of the link.

Run in `website/electron`, one file at a time: `host-config.test.js` 27/27, `gateway-wait.test.js` 28/28, `local-gateway.test.js` 15/15, plus the neighbouring source-shape suites over the same file, `gateway-supervisor.test.js` 7/7 and `reconnect-focus.test.js` 13/13. All 0 failures.

## Manual verification

Not performed: these are desktop-shell launch paths, which need a packaged Electron app plus a second machine with a reachable gateway to exercise end to end. Each decision the change introduces was extracted into a pure, injected helper -- port selection into `remoteHostPort` and `isSelectablePort`, the failure wording into `describeGatewayFailure` -- and covered by unit tests, with the remaining wiring pinned at the source level.

## Related Issues

Closes #6138
Follow-up: #8056 (reversing the opt-out once the configured crew is gone; the port-classification disagreement; the default-port classifier bug that gates the internal secret)
Follow-up: #8002 (remote-crew selection and first-run setup surfaces)

## Pattern harvest

Rule candidate: review-prompt
Pattern: a user-facing mode switch is enforced at the action site but the values it invalidates are still used as defaults elsewhere. When a setting means "never do X", every fallback derived from X needs re-examining; so does every button that would perform X, since the port it binds may no longer be the port it used to, and withdrawing that button may remove the only way back out of the mode; and so does every downstream consumer that re-derives a key from the new value -- a port that `new URL()` normalizes away turns a per-port security lookup into a silent miss.
