### PR TITLE
fix(deps): bump the fast-uri override to 3.1.7 for four high advisories

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kirocrew-desktop",
-      "version": "0.4.0",
+      "version": "0.6.0",
+      "hasInstallScript": true,
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.9"
@@ -1844,9 +1845,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -23,7 +23,7 @@
     "electron-builder": "26.15.3"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "js-yaml": "4.3.1"
   },
   "build": {


### PR DESCRIPTION
## Problem / Motivation

The `Dependency Audit / Audit Production Dependencies` check fails on `main` — and therefore on every open PR — on four newly-published high-severity advisories against the transitive `fast-uri@3.1.5` pinned by the override in `website/electron/package.json`:

- GHSA-5jgf-p345-68v8 (high, CVSS 7.5) — host confusion via skipped IDN canonicalization (`>=3.1.3 <3.1.6`)
- GHSA-f65p-4m7j-42xc (high, CVSS 7.5) — SSRF via malformed IPv6 normalization (`>=3.0.0 <3.1.6`)
- GHSA-fph4-wmhf-6fwf (high, CVSS 7.5) — SSRF via repeated hostname percent-decoding (`>=3.1.2 <3.1.6`)
- GHSA-jqff-g426-hqxp (high, CVSS 7.5) — host confusion via percent-encoded scheme normalization (`>=3.0.0 <3.1.6`)

## Why it matters

A red audit on main blocks the merge gate for the whole PR queue, and the advisories themselves are SSRF/host-confusion classes in URI parsing.

## What changed (motivation → approach → change)

Same shape as the three precedent bumps for this override (#1336, #1338, #1348): all four advisories are patched at `<3.1.6`, and the latest 3.x release is 3.1.7, so the override is bumped `3.1.5` → `3.1.7` (staying within the same major; exact pin per the override's existing convention) and `package-lock.json` regenerated with `npm install --package-lock-only --ignore-scripts`.

## Tests

No code change — dependency pin only. Verification is the audit itself (below).

## Manual verification

- `npm audit --omit=dev` in `website/electron`: **found 0 vulnerabilities** (was 4 high).
- Lockfile carries exactly one `fast-uri` entry at `3.1.7`.

## Screenshots / video

N/A (CI/deps change).

## Related Issues

Fixes #7933

## Pattern harvest

Rule candidate: recurring "new fast-uri advisory reddens the production audit" (#1336 → #1338/#1348 → this, third recurrence). If the cadence continues, the override may warrant a range (`^3.1.6`) or a scheduled audit-bump job instead of a manual PR per advisory batch — maintainer's call, noted here for the record.

## Checklist

- [x] Lockfile regenerated from the manifest change only
- [x] Production audit clean

## Contribution License Agreement

I confirm my contribution is made under the project's contribution license terms.
