### PR TITLE
fix(deps): bump fast-uri override to 3.1.7 to unblock the audit gate

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kirocrew-desktop",
-      "version": "0.4.0",
+      "version": "0.6.0",
+      "hasInstallScript": true,
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.9"
@@ -1844,9 +1845,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -23,7 +23,7 @@
     "electron-builder": "26.15.3"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "js-yaml": "4.3.1"
   },
   "build": {


### PR DESCRIPTION
## Problem / Motivation

The required `Dependency Audit / Audit Production Dependencies` gate is red on every PR merge ref since ~2026-09-02 16:30 UTC: four high-severity GHSA advisories (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp — SSRF and host-confusion defects in URI normalization) were published today against `fast-uri <= 3.1.5`, which `website/electron/package-lock.json` pins.

## Why it matters

Every open PR is blocked at a required gate regardless of its own diff (first observed on #7918, which touches no dependencies). Until this lands, nothing can reach readiness.

## What changed (motivation → approach → change)

`fast-uri` is a transitive dependency (via `ajv@^3.0.1`), but `website/electron/package.json` pins it with an exact **`overrides` entry: `"fast-uri": "3.1.5"`**. That override — not registry state or lockfile staleness — is why `npm update fast-uri` and `npm audit fix` both no-op here: every re-resolution snaps back to the pin.

Change: bump the override to `3.1.7` (the advisories are patched in 3.1.6; 3.1.7 is the current `three` dist-tag, published today) and regenerate the lockfile entry under it. Two files, four lines of real delta: the override value plus the lockfile's version/resolved/integrity triplet. The neighboring `js-yaml` override is untouched.

## Tests

N/A — lockfile-only dependency bump; no code paths in this repo change. The gate itself is the regression test: the `Dependency Audit` check on this PR runs the exact audit currently failing fleet-wide.

## Manual verification

- `npm ci --ignore-scripts` in `website/electron` installs the regenerated lockfile cleanly (308 packages).
- `npm audit --omit dev` reports **0 vulnerabilities** (was 4 high).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** dependency lockfile bump; no rendered surface exists.

Closes #7925

## Pattern harvest

Not generalizable: operational one-off — an exact `overrides` version pin froze
a transitive dependency on a version that later grew advisories, and the pin
silently defeats `npm update` / `npm audit fix`. Process note rather than a
code rule: an exact `overrides` pin should carry a comment naming why it
exists and what unblocks removing it.
