### PR TITLE
test: drop scaffolding that only existed for the retired Python 3.10 leg

### DIFF
--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -2596,10 +2596,9 @@ class TestATimerOutlivesItsEventLoop:
 
         `cancel()` only SCHEDULES the cancellation, so the flag is not set on the
         calling tick. Polled rather than read after a single `sleep(0)` because the
-        number of ticks it takes is an implementation detail — and `Task.cancelling()`,
-        which would read the request directly, is Python 3.11+ while this repo supports
-        >= 3.10 (CI runs a 3.10 shard). Keeps the assertion; only the waiting is
-        generous.
+        number of ticks it takes is an implementation detail. Deliberately asserts
+        the terminal `cancelled()` flag rather than `Task.cancelling()`, which
+        counts outstanding requests instead. Only the waiting is generous.
         """
         for _ in range(ticks):
             if task.cancelled():

--- a/test/test_credential_prefilter.py
+++ b/test/test_credential_prefilter.py
@@ -21,7 +21,6 @@ import binascii
 import random
 import re
 import string
-import sys
 
 import pytest
 
@@ -1079,13 +1078,9 @@ def test_a_length_short_circuit_would_leak_an_encoded_credential() -> None:
         if real:
             leaked += 1
 
-    if sys.version_info < (3, 12):
-        assert leaked >= 1, (
-            "expected the lenient pre-3.12 decoder to make the length guard a "
-            "redaction bypass on at least one misaligned shape"
-        )
-    else:
-        assert leaked == 0, (
-            "3.12 rejects these shapes outright, which is exactly why the bypass "
-            "was invisible when the change was tested on 3.12 alone"
-        )
+    # The base64 decoder rejects these shapes outright, so nothing leaks through
+    # them here. That is precisely why the length guard read as safe when it was
+    # only ever exercised on this interpreter: the bypass it would have opened is
+    # invisible from 3.12, and the in-loop invariant above -- a guard can never
+    # detect more than no guard -- is what actually rules the guard out.
+    assert leaked == 0

--- a/test/test_dep_sync.py
+++ b/test/test_dep_sync.py
@@ -1103,12 +1103,11 @@ def test_module_imports_stdlib_only():
             roots.update(alias.name.split(".")[0] for alias in node.names)
         elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
             roots.add(node.module.split(".")[0])
-    # Both names of the TOML ladder are allowed, and neither weakens the check:
-    # `tomllib` IS stdlib, but only from 3.11 — on the 3.10 interpreter this
-    # project still supports it is absent from `sys.stdlib_module_names`, so
-    # deriving the allowance from the running interpreter would make this test
-    # pass or fail on the version that happens to run it. `tomli` is the
-    # third-party fallback for exactly that version. Both imports are guarded, so
-    # a missing one degrades a reader rather than breaking the module.
-    third_party = roots - set(sys.stdlib_module_names) - {"tomllib", "tomli"}
+    # `tomllib` needs no allowance: it is stdlib on every interpreter this
+    # project supports, so `sys.stdlib_module_names` already covers it and this
+    # assertion would catch a floor that regressed below 3.11. `tomli` is the
+    # vestigial third-party fallback dep_sync still carries for the retired
+    # pre-3.11 leg; its import is guarded, so a missing one degrades a reader
+    # rather than breaking the module.
+    third_party = roots - set(sys.stdlib_module_names) - {"tomli"}
     assert not third_party, f"dep_sync must import stdlib only; found {sorted(third_party)}"

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -2866,12 +2866,9 @@ class TestKiroPrerequisiteWorkflow:
         release_unlink.set()
         with pytest.raises(asyncio.CancelledError) as exc_info:
             await outer
-        if sys.version_info >= (3, 11):
-            # 3.10's Task rebuilds the awaiter-visible CancelledError from the
-            # task's LAST cancel message (message-less repeats blank it), so
-            # the original's args are only observable from 3.11, where the
-            # coroutine's actual exception object propagates.
-            assert exc_info.value.args == ("original-cancellation-5841",)
+        # The coroutine's actual exception object propagates, so the original
+        # cancel message survives the message-less repeats above.
+        assert exc_info.value.args == ("original-cancellation-5841",)
         assert not cleanup_path.exists()
 
     @pytest.mark.asyncio

--- a/test/test_knowledge_search_upgrade.py
+++ b/test/test_knowledge_search_upgrade.py
@@ -1,7 +1,5 @@
 """Tests for knowledge search upgrade: embedding endpoints + search-for-context."""
 
-import pytest
-
 from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_NORMAL
 from kiro_crew.knowledge.embedder import (
     InProcessEmbedder,
@@ -232,29 +230,23 @@ class TestSearchForContext:
     """search_for_context endpoint logic."""
 
     def test_estimate_tokens(self):
-        try:
-            from kiro_crew.dashboard.handlers.knowledge import _estimate_tokens
-        except TypeError:
-            pytest.skip("requires Python 3.10+ (type union syntax)")
+        from kiro_crew.dashboard.handlers.knowledge import _estimate_tokens
+
         assert _estimate_tokens("hello world") == 2  # 11 chars // 4
         assert _estimate_tokens("") == 0
 
     def test_knowledge_fetch_defaults(self):
-        try:
-            from kiro_crew.dashboard.handlers.knowledge import (
-                KNOWLEDGE_FETCH_MAX_TOKENS,
-                KNOWLEDGE_FETCH_TOP_N,
-            )
-        except TypeError:
-            pytest.skip("requires Python 3.10+ (type union syntax)")
+        from kiro_crew.dashboard.handlers.knowledge import (
+            KNOWLEDGE_FETCH_MAX_TOKENS,
+            KNOWLEDGE_FETCH_TOP_N,
+        )
+
         assert KNOWLEDGE_FETCH_TOP_N == 3
         assert KNOWLEDGE_FETCH_MAX_TOKENS == 4096
 
     def test_context_card_carries_citation_fields(self):
-        try:
-            from kiro_crew.dashboard.handlers.knowledge import _build_context_card
-        except TypeError:
-            pytest.skip("requires Python 3.10+ (type union syntax)")
+        from kiro_crew.dashboard.handlers.knowledge import _build_context_card
+
         result = {
             "id": "i1",
             "title": "Auth Design",
@@ -276,10 +268,8 @@ class TestSearchForContext:
         assert card["chunk_range"] == "10-25"
 
     def test_context_card_artifact_slug(self):
-        try:
-            from kiro_crew.dashboard.handlers.knowledge import _build_context_card
-        except TypeError:
-            pytest.skip("requires Python 3.10+ (type union syntax)")
+        from kiro_crew.dashboard.handlers.knowledge import _build_context_card
+
         result = {
             "id": "i3",
             "title": "OP Vision",
@@ -295,10 +285,8 @@ class TestSearchForContext:
         assert card["artifact_name"] == "OP Vision Plan"
 
     def test_context_card_without_location_degrades(self):
-        try:
-            from kiro_crew.dashboard.handlers.knowledge import _build_context_card
-        except TypeError:
-            pytest.skip("requires Python 3.10+ (type union syntax)")
+        from kiro_crew.dashboard.handlers.knowledge import _build_context_card
+
         result = {"id": "i2", "title": "DB Schema", "source": "src-2"}
         card = _build_context_card(result, content="body", tokens=1)
         # No location / no source meta -> citation fields are None, not errors.
@@ -314,29 +302,23 @@ class TestRedactMeta:
     """_redact_meta security helper."""
 
     def test_redacts_strings(self):
-        try:
-            from kiro_crew.dashboard.chat_utils import _redact_meta
-        except TypeError:
-            pytest.skip("requires Python 3.10+")
+        from kiro_crew.dashboard.chat_utils import _redact_meta
+
         meta = {"title": "safe text", "content": "key is AKIAIOSFODNN7EXAMPLE here"}
         result = _redact_meta(meta)
         assert "AKIAIOSFODNN7EXAMPLE" not in result["content"]
         assert result["title"] == "safe text"
 
     def test_redacts_nested_dicts(self):
-        try:
-            from kiro_crew.dashboard.chat_utils import _redact_meta
-        except TypeError:
-            pytest.skip("requires Python 3.10+")
+        from kiro_crew.dashboard.chat_utils import _redact_meta
+
         meta = {"knowledge": {"content": [{"title": "ok", "text": "AKIAIOSFODNN7EXAMPLE"}]}}
         result = _redact_meta(meta)
         assert "AKIAIOSFODNN7EXAMPLE" not in str(result)
 
     def test_preserves_non_strings(self):
-        try:
-            from kiro_crew.dashboard.chat_utils import _redact_meta
-        except TypeError:
-            pytest.skip("requires Python 3.10+")
+        from kiro_crew.dashboard.chat_utils import _redact_meta
+
         meta = {"items": 3, "tokens": 1054, "titles": ["safe"]}
         result = _redact_meta(meta)
         assert result == {"items": 3, "tokens": 1054, "titles": ["safe"]}

--- a/test/test_mcp_gateway_transport.py
+++ b/test/test_mcp_gateway_transport.py
@@ -20,7 +20,6 @@ import os
 import shutil
 import socket
 import stat
-import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Iterator
@@ -759,15 +758,11 @@ async def test_wait_closed_returns_once_connections_are_cancelled(
     await asyncio.wait_for(started.wait(), timeout=5)
 
     server.close()
-    if sys.version_info >= (3, 12):
-        # Awaiting here first is the bug: prove it would block. Gated because
-        # the semantics are version-dependent -- measured blocking on 3.12.13,
-        # and CI showed 3.10 returning immediately, which matches the CPython
-        # change that made wait_closed() await accepted connections landing in
-        # 3.12.0. On 3.10 the reordering is a harmless no-op, so only the
-        # positive assertion below applies there.
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(asyncio.shield(server.wait_closed()), timeout=0.5)
+    # Awaiting here first is the bug: prove it would block. CPython 3.12.0 made
+    # wait_closed() await accepted connections, so with a stub still attached
+    # this cannot return -- which is why the daemon drains and cancels first.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(server.wait_closed()), timeout=0.5)
 
     for task in handlers:
         task.cancel()

--- a/test/test_pip_deps_consistency.py
+++ b/test/test_pip_deps_consistency.py
@@ -250,10 +250,9 @@ def test_dev_extra_covers_test_imports():
 def _dependency_group_requirements(group: str) -> list[str]:
     """Requirement strings from a pyproject ``[dependency-groups]`` list.
 
-    Text-level, like every other pyproject read in this module: the 3.10 shard
-    has no ``tomllib`` and this gate must run there too. The list items are
-    plain double-quoted strings, so collecting quoted spans between the group's
-    opening ``[`` and its closing ``]`` reads exactly what pip's
+    Text-level, like every other pyproject read in this module. The list items
+    are plain double-quoted strings, so collecting quoted spans between the
+    group's opening ``[`` and its closing ``]`` reads exactly what pip's
     ``--group`` resolver sees.
     """
     lines = _pyproject_text().splitlines()

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -7,9 +7,7 @@ Covers:
     positional-argument stripping that makes it work.
 
 The scripts live under the packaged builtin skill and are NOT importable as a
-package, so we load them by path with importlib. Everything here is stdlib and
-runs on the full CI matrix (3.10 + 3.12); the TOML path is version-guarded
-because tomllib is 3.11+.
+package, so we load them by path with importlib. Everything here is stdlib.
 """
 import json
 import os
@@ -33,20 +31,6 @@ def _load(module_name, filename):
 
 resolve_profile = _load("_pp_resolve_profile", "resolve_profile.py")
 pr_status = _load("_pp_pr_status", "pr_status.py")
-
-
-def _toml_available():
-    try:
-        import tomllib  # noqa: F401
-
-        return True
-    except ImportError:
-        try:
-            import tomli  # noqa: F401
-
-            return True
-        except ImportError:
-            return False
 
 
 # --------------------------------------------------------------------------
@@ -661,29 +645,17 @@ def test_toml_config_path(tmp_path):
         "[readiness]\n"
         'status_context = "My Readiness"\n'
     )
-    if _toml_available():
-        prof = resolve_profile.resolve(str(tmp_path))
-        assert prof["source"] == "config"
-        assert prof["base_branch"] == "trunk"
-        assert prof["setup"] == ["make bootstrap"]
-        assert prof["gates"] == ["make check"]
-        assert prof["rule_files"] == ["AGENTS.md"]
-        assert prof["reviewers"][0]["model"] == "gpt-5.6-sol"
-        assert prof["readiness"]["status_context"] == "My Readiness"
-    else:
-        # No TOML parser (Python < 3.11 without tomli): a present config is a
-        # hard error, never silently ignored.
-        try:
-            resolve_profile.resolve(str(tmp_path))
-        except RuntimeError as exc:
-            assert "TOML parser" in str(exc)
-        else:
-            raise AssertionError("expected RuntimeError when no TOML parser")
+    prof = resolve_profile.resolve(str(tmp_path))
+    assert prof["source"] == "config"
+    assert prof["base_branch"] == "trunk"
+    assert prof["setup"] == ["make bootstrap"]
+    assert prof["gates"] == ["make check"]
+    assert prof["rule_files"] == ["AGENTS.md"]
+    assert prof["reviewers"][0]["model"] == "gpt-5.6-sol"
+    assert prof["readiness"]["status_context"] == "My Readiness"
 
 
 def test_partial_toml_config_fills_gates_from_autodetect(tmp_path):
-    if not _toml_available():
-        return  # parse path only runs on 3.11+; covered on the 3.12 CI leg
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
     (tmp_path / ".prepare-pr.toml").write_text('[project]\nbase_branch = "trunk"\n')
     prof = resolve_profile.resolve(str(tmp_path))


### PR DESCRIPTION
## Problem

[#7780](https://github.com/kirodotdev/KiroCrew/pull/7780) raised `requires-python` to
`>=3.12` and removed the 3.10 CI lane. The suite still carried the accommodations that
lane needed: branches that can no longer be taken, skips that can no longer fire, and
a TOML import ladder whose fallback rung is unreachable.

## Why it matters

Dead version branches are worse than clutter. A `if sys.version_info >= (3, 12):`
around an assertion reads as "this may not run", so the next reader cannot tell whether
the assertion is load-bearing, and an eight-site `pytest.skip("requires Python 3.10+")`
hides whether those tests execute at all. They did not: they were live, just wrapped in
a condition nothing can now falsify.

## What changed

**Dead version branches — the guarded side is now the only side.**

| File | Was | Now |
|---|---|---|
| `test/test_kiro_prerequisite.py` | `if sys.version_info >= (3, 11):` around the `CancelledError` args assertion — 3.10 rebuilt the awaiter-visible exception from the task's *last* cancel message, so message-less repeats blanked it | assertion runs unconditionally |
| `test/test_mcp_gateway_transport.py` | `if sys.version_info >= (3, 12):` around the `wait_closed()` blocking proof — 3.10 returned immediately, before the CPython 3.12.0 change that made it await accepted connections | proof runs unconditionally |
| `test/test_credential_prefilter.py` | a `< (3, 12)` / `else` split expecting the lenient pre-3.12 base64 decoder to leak on a misaligned shape | collapsed onto the 3.12 expectation; the in-loop invariant (a guard can never detect more than no guard) is what rules the rejected length guard out |

**Dead skips.** `X | Y` in an annotation raised `TypeError` at *import* time on 3.9, so
eight imports in `test/test_knowledge_search_upgrade.py` were wrapped in
`try/except TypeError` with a `pytest.skip("requires Python 3.10+")`. Unreachable at a
3.12 floor. All eight now import directly — verified as **8 passed, 0 skipped**, so
they were live tests wearing a skip that could never fire.

**Dead `tomli` ladder.** `tomllib` is stdlib from 3.11, so
`test/test_prepare_pr_profiles.py`'s `_toml_available()` was always `True` and its
"no TOML parser is a hard error" branch unreachable. Helper and branch removed, along
with the `(3.10 + 3.12)` matrix note in the module docstring.
`test/test_dep_sync.py` no longer exempts `tomllib` from its stdlib-only assertion —
`sys.stdlib_module_names` covers it now, so that check would *catch* a floor regressing
below 3.11. `tomli` stays exempt because `dep_sync` still carries the fallback import.

**Stale justifications** in `test/test_pip_deps_consistency.py` and
`test/test_autonudge.py` that cited "the 3.10 shard" as the reason for their code shape.
Both keep their implementation — the text-level pyproject read is consistent with every
other read in that module, and the polled `cancelled()` wait is deliberate — but the
reason given is no longer true. `test_autonudge`'s note now says why it asserts the
terminal `cancelled()` flag rather than `Task.cancelling()`, which counts outstanding
requests instead.

Also drops the three imports (`sys` ×2, `pytest` ×1) the removals left unused.

## What was deliberately left alone

Not every `version_info` in the suite is a 3.10 accommodation, and these four are not:

- `test/conftest.py` — the child-watcher cleanup is keyed on whether the API *exists*, not on a version, and its comment records a real past regression (a `>= (3, 12): return` guard that skipped cleanup on the one version where the second failure mode lives).
- `test/test_installer_distro.py`, `test/test_installer_python_floor.py` — shell stubs and assertions that *test the installer's own 3.12 probe*.
- `test/test_platform_compat.py` — deliberately forces a fake `3.4` to prove the version gate ignores a `sitecustomize` decoy.

## Tests

- `377 passed` across `test_knowledge_search_upgrade`, `test_prepare_pr_profiles`, `test_credential_prefilter`, `test_pip_deps_consistency`, `test_dep_sync`; `148 passed` on `test_mcp_gateway_transport` + `test_autonudge`; the touched `test_kiro_prerequisite` cancellation cases pass.
- The three assertions that became unconditional all execute and pass, and the eight unwrapped imports report 0 skipped — so nothing was quietly disabled by removing a guard.
- `82 passed` on `test_ci_surface_tests` + `test_installer_python_floor` (the gates that police the suite's own shape).
- `flake8`, `isort` clean across `test/`; `black --check` clean on every non-baselined file touched. Three of the eight files are in `.github/black-baseline.txt` and were left unformatted rather than reformatted wholesale, so the diff stays confined to these removals.
- `scripts/docs-lint.sh` and `BRAND_BASE_REF=origin/main scripts/check_brand_name.py` clean.
- Zero `version_info` references remain in `test/` outside the four files listed above.

**Pre-existing failure, not from this change:**
`test_autonudge.py::TestSentinelPathRepair::test_unnormalized_path_escaping_legacy_is_preserved`
fails identically on clean `origin/main` (`d402acdf8`) on this host — the assertion is
`'.kiro/crew' not in <workspace path>`, and this machine's workspace path contains it.
Host-dependent, untouched by this PR.

## Manual verification

N/A — the change only removes test scaffolding, and the suites above are the
verification.

## Follow-up this deliberately does not do

The same retired leg left accommodations in **runtime** code, which belong in their own
PR rather than a test sweep:

- `tomli` fallback imports in `src/kiro_crew/dep_sync.py`, `onboarding_import.py`, and `apps/builtins/meetings/backend/domain/dictionary.py` — dead at a 3.11+ floor.
- Three `str`-mixin enums documented as `"(not StrEnum) for Py3.10 compat"` in `dashboard/chat_utils.py` and `publish_provider.py`. `StrEnum` is available now, but swapping the base class changes `str()`/format behaviour, so it is a behaviour call and not a mechanical cleanup.
- `platform/discovery.py` and `apps/builtins/ops_mission_control/backend/companion.py` carry 3.9 fallbacks for `entry_points(group=...)`, and `src/kiro_crew/__init__.py` still says "we still target 3.9".

no linked issue: follow-on cleanup from #7780, raised in review discussion rather than
tracked as an issue.
