### PR TITLE
fix(pod-e2e): probe health before judging the deadline, not after

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -316,7 +316,13 @@ if [ -z "$HEALTH_TIMEOUT" ] || [ "${#HEALTH_TIMEOUT}" -gt 6 ]; then
   HEALTH_TIMEOUT=60
 fi
 HEALTH_DEADLINE=$(( $(date +%s) + 10#$HEALTH_TIMEOUT ))
-while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
+# Probe FIRST, test the deadline after -- a do-while, not a while. `date +%s` has
+# whole-second resolution, so a pre-test loop reads a clock that may already have
+# ticked past the deadline computed one fork earlier, and skips its body. The body
+# is the only place HEALTHY is set, so that zero-probe run reports "never became
+# healthy" about a pod nobody ever asked. The window is one fork wide, which is
+# invisible at the 60s default and near-certain to bite at the 1s a test uses.
+while :; do
   CODE=$("$KIROCREW_CLI" pod status "$NAME" --json 2>/dev/null \
     | python3 -c 'import sys,json;print(json.load(sys.stdin).get("health",0))' 2>/dev/null \
     || echo 0)
@@ -326,6 +332,8 @@ while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
     # the timeout names the conflict instead of blaming the worktree build.
     -2)          FOREIGN=1 ;;
   esac
+  # Deadline reached: stop without burning a final pointless sleep.
+  [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ] || break
   sleep 1
 done
 if [ "$HEALTHY" -eq 0 ]; then

--- a/test/test_pod_e2e_harness_paths.py
+++ b/test/test_pod_e2e_harness_paths.py
@@ -381,3 +381,59 @@ def test_health_accepts_a_valid_timeout_override(stub_cli, tmp_path, good):
     assert "HEALTHY=1" in res.stdout, res.stdout
     assert "ignoring POD_E2E_HEALTH_TIMEOUT" not in res.stderr, res.stderr
     assert "value too great for base" not in res.stderr, res.stderr
+
+
+@pytest.fixture()
+def ticking_date(tmp_path: Path) -> str:
+    """A `date` whose clock advances one whole second on every single call.
+
+    The real flake needed a genuine second boundary to fall in the one-fork gap
+    between the deadline assignment and the loop's own clock read -- a few
+    milliseconds in 1000, so it surfaced as an unreproducible macOS CI failure
+    rather than anything a test could pin. This shim makes that boundary land
+    there every time: call one returns N, call two returns N+1. Nothing else on
+    PATH is replaced, so the stub CLI and python3 still run normally.
+    """
+    bindir = tmp_path / "clockshim"
+    bindir.mkdir()
+    counter = tmp_path / "clock-counter"
+    shim = bindir / "date"
+    shim.write_text(textwrap.dedent(f"""\
+            #!/bin/sh
+            n=$(cat '{counter}' 2>/dev/null || echo 1000)
+            echo $((n + 1)) > '{counter}'
+            echo "$n"
+            """))
+    shim.chmod(0o755)
+    return str(bindir)
+
+
+def test_health_probes_at_least_once_when_the_clock_ticks_past_the_deadline(
+    stub_cli, tmp_path, ticking_date
+):
+    """The poll must be a do-while: probe, THEN judge the deadline.
+
+    `date +%s` is whole-second, so the pre-test form read a clock that could have
+    already ticked past a deadline computed one fork earlier and skipped its body
+    entirely. The body is the only place HEALTHY is set, so a healthy pod was
+    reported as "never became healthy" -- a false red whose message points the
+    operator at a boot log that shows a perfectly healthy boot.
+    """
+    res = _run(_health_snippet(stub_cli("200")), str(tmp_path), extra_path=ticking_date)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "HEALTHY=1" in res.stdout, f"zero probes performed: {res.stdout}"
+    assert "FAIL:" not in res.stdout, res.stdout
+
+
+def test_health_still_gives_up_when_the_clock_runs_away(stub_cli, tmp_path, ticking_date):
+    """Probing first must not cost the deadline -- an unhealthy pod still ends.
+
+    Guards the other side of the same change: a do-while whose exit test was
+    dropped would hang an unattended harness forever on a pod that never answers.
+    With this clock every iteration burns a second, so the 1s deadline is past
+    immediately after the first probe.
+    """
+    res = _run(_health_snippet(stub_cli("0")), str(tmp_path), extra_path=ticking_date)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "HEALTHY=0 FOREIGN=0" in res.stdout, res.stdout
+    assert "never became healthy" in res.stdout, res.stdout


### PR DESCRIPTION
## Problem

`Gateway Tests (macOS)` fails intermittently on PRs whose diff cannot possibly reach it. The most recent example is [PR #7766](https://github.com/kirodotdev/KiroCrew/pull/7766), a Dependabot bump of `postcss-selector-parser` whose entire diff is one file, `website/package-lock.json`:

```
test/test_pod_e2e_harness_paths.py::test_health_accepts_the_pods_own_serving_codes
  AssertionError: code 200: FAIL:health — pod never became healthy
```

`main` is green on the same shard, so it reads as an unattributable flake and gets re-run away.

## Root cause

The health poll in `pod-e2e.sh` computed a deadline from `date +%s` and used it as a **pre-test** while-condition:

```bash
HEALTH_DEADLINE=$(( $(date +%s) + 10#$HEALTH_TIMEOUT ))
while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
  CODE=$(... pod status --json ...)
  case "$CODE" in 200|401|403) HEALTHY=1; break ;; -2) FOREIGN=1 ;; esac
  sleep 1
done
```

Both clock reads are whole-second. When a real second boundary falls in the one-fork gap between the assignment and the first condition, `date +%s` already equals `HEALTH_DEADLINE`, the condition is false, and **the loop body never runs**. That body is the only place `HEALTHY` is set, so the run reports `health — pod never became healthy` about a pod it never asked — and points the operator at a `boot-fail.log` showing a perfectly healthy boot.

The window is one fork wide. Measured locally at mean 2.4ms, so ~0.24% per invocation: invisible against the 60s production default, and a routine failure against the 1s these tests use. Several cases in the file drive the fragment at `timeout=1`, which is why the macOS shard trips every so often.

## Why this way

Making the loop a do-while removes the failure mode structurally rather than widening the test's timeout, which would only make the same race rarer. A deadline loop that can perform zero probes is wrong on its own terms, independent of the test: the 60s default makes it improbable, not impossible, and the symptom it produces is a false red that actively misdirects whoever reads it.

## What changed

- `pod-e2e.sh`: health poll restructured as a do-while — probe, then test the deadline before sleeping. A healthy pod is always seen at least once; an unhealthy one still gives up on time; the trailing pointless `sleep 1` after the final probe is gone.
- `test_pod_e2e_harness_paths.py`: two cases pin both directions, using a `date` shim whose clock advances a whole second per call. That places the boundary in the vulnerable gap deterministically instead of once in a few hundred runs.

## Tests

- `test_health_probes_at_least_once_when_the_clock_ticks_past_the_deadline` — **red on base** with the exact CI string (`AssertionError: zero probes performed: FAIL:health — pod never became healthy`), green with the fix. Proven by stashing only the script change and re-running.
- `test_health_still_gives_up_when_the_clock_runs_away` — guards the other side: a do-while that lost its exit test would hang an unattended harness forever on a pod that never answers.
- `test/test_pod_e2e_harness_paths.py`: 24 passed.
- `test_pod.py`, `test_pod_e2e_video_guard.py`, `test_dev_fleet_app.py`, `test_pod_launchd.py`, `test_pod_e2e_harness_paths.py`: 823 passed, 2 skipped. One failure in `test_dev_fleet_app.py::test_trusted_bin_pins_the_resolved_target_not_the_symlink` is environmental and reproduces identically on base.
- `black`, `isort`, `flake8` clean on the changed test file.


## Pattern harvest

Rule candidate: semgrep

Pattern: a polling loop whose deadline is a **pre-test** condition read from a coarse (whole-second) clock, so the loop can execute its body zero times and report the timeout verdict without ever having probed. Concretely, in shell:

```bash
DEADLINE=$(( $(date +%s) + $TIMEOUT ))
while [ "$(date +%s)" -lt "$DEADLINE" ]; do   # <- flag this shape
  ...probe...
done
```

The two `date +%s` reads are separated by a fork, and `date +%s` has one-second granularity, so any second boundary landing in that gap makes the first condition false. Whether that is harmless or a false verdict depends entirely on where the loop's result variable is assigned: if it is assigned only inside the body (as `HEALTHY` was here), a zero-iteration run silently produces the failure answer.

Two things make this worth a rule rather than a one-off. It is invisible in review — the loop looks obviously correct, and the bug rate scales inversely with the timeout, so it passes every manual test at the production default and only fires at the short timeout a test uses. And it fails in the most expensive direction: a false red on an unrelated PR's CI shard, whose message (`pod never became healthy`) points the reader at a boot log that shows a healthy boot, so it gets re-run away rather than diagnosed.

Suggested rule shape, deliberately narrow to stay false-positive-free: flag a `while`/`until` whose test is a bare comparison against a variable assigned from `$(date +%s)`, and require either a do-while (probe, then test) or a post-loop re-probe. Sweeping this repo for the shape found exactly one instance, the one fixed here — so the rule's value is preventing reintroduction, not clearing a backlog.

Not applicable to the Python polling loops (`while time.monotonic() < deadline:`, ~8 sites): `time.monotonic()` is a float from the same clock the deadline was computed from microseconds earlier, so the zero-iteration window is sub-microsecond rather than up to a full second. The rule should stay scoped to coarse integer-second clocks and not be generalised to those.

<!-- no-visual-delta -->

