### PR TITLE
fix(cron): stamp every cron run and persist its prompt

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2181,6 +2181,18 @@ class KiroCrewConfig:
             # A publish failure must never make the config unloadable; the gate
             # keeps using the threshold it already had.
             logger.warning("Publishing autocompact threshold failed: %s", e)
+        # Same placement and same reason once more: cron resolves this on the
+        # event loop on every timer tick (see publish_config_timezone), and
+        # publishing on EVERY return path is what lets a settings change reach a
+        # gateway that is already running. Shares the autocompact ticket
+        # deliberately -- both describe the same read of the same files, so they
+        # must order identically against a concurrent load.
+        try:
+            publish_config_timezone(cfg, _autocompact_ticket)
+        except Exception as e:  # pragma: no cover - defensive
+            # A publish failure must never make the config unloadable; cron
+            # keeps using the zone it already had.
+            logger.warning("Publishing config timezone failed: %s", e)
         return cfg
 
     @classmethod
@@ -4587,6 +4599,82 @@ def publish_autocompact_pct(config: "KiroCrewConfig", ticket: int | None = None)
 def published_autocompact_pct() -> float:
     """The published compaction threshold."""
     return _CONFIG_AUTOCOMPACT_PCT
+
+
+# Snapshot of the global default timezone, refreshed by every successful
+# :meth:`KiroCrewConfig.load`, for the same reason as the three snapshots above:
+# its read path runs on the event loop. ``kiro_crew.cron._job_tz`` is reached
+# from ``CronService._on_timer``'s due-scan for EVERY cron-expression job that
+# does not carry its own zone -- so a config stat/read/validate here was a
+# per-tick gateway stall (the ``no-blocking-call-on-event-loop`` rule), paid
+# again by ``get_local_tz`` on the prompt-assembly and dashboard-handler paths.
+#
+# Ordered by ticket, like the compaction threshold and unlike the alias table:
+# this value decides WHEN a job fires, so an out-of-order publish leaving an
+# obsolete zone in force would misfire every schedule depending on it until
+# something loaded again. The alias table tolerates that race because its
+# consequence is a display marker; a schedule does not.
+#
+# Defaults to "" -- the dataclass default for :attr:`KiroCrewConfig.timezone` --
+# so a read taken BEFORE the first load resolves exactly as a defaults-only load
+# would (empty falls through to UTC in both consumers) rather than inventing a
+# zone during the boot window.
+_CONFIG_TIMEZONE: str = ""
+_CONFIG_TIMEZONE_TICKET: int = 0
+
+#: Serializes the compare-and-set in :func:`publish_config_timezone`, for the
+#: reasons given on :data:`_CONFIG_AUTOCOMPACT_LOCK`: each publish is a read
+#: followed by a write, so without it two concurrent loads can both pass the
+#: comparison and let whichever assigns last win, rolling the published ticket
+#: backwards. A SEPARATE lock rather than reusing the autocompact one, which
+#: :func:`next_config_load_ticket` already holds -- drawing a ticket while
+#: holding this one is therefore safe, and the reverse nesting must not appear.
+#: The READ path (:func:`published_config_timezone`) never takes it, which is
+#: what keeps the event loop lock-free.
+_CONFIG_TIMEZONE_LOCK = threading.Lock()
+
+
+def publish_config_timezone(config: "KiroCrewConfig", ticket: int | None = None) -> None:
+    """Publish *config*'s default timezone for the filesystem-free read path.
+
+    Pure in-memory rebind -- safe from anywhere, including the event loop, and a
+    reader sees either the whole previous value or the whole new one. Called from
+    :meth:`KiroCrewConfig.load` so every successful load refreshes it, including
+    the degraded-defaults path, which must OVERWRITE a previous snapshot rather
+    than leave a zone the files no longer name.
+
+    *ticket* orders this publish against concurrent ones and carries the same
+    contract as :func:`publish_autocompact_pct`: it must come from
+    :func:`next_config_load_ticket`, drawn BEFORE the read that produced
+    *config*, and a ticket lower than the one already published is dropped.
+    Omitting it draws a fresh ticket, which therefore always wins -- correct for
+    a caller publishing a config it just built (tests), wrong for one replaying
+    an earlier read.
+    """
+    global _CONFIG_TIMEZONE, _CONFIG_TIMEZONE_TICKET
+    # Drawn OUTSIDE the lock below purely for symmetry with
+    # publish_autocompact_pct; next_config_load_ticket takes a DIFFERENT
+    # (autocompact) lock, so nesting here would not deadlock as it would there.
+    if ticket is None:
+        ticket = next_config_load_ticket()
+    # Compare and BOTH assignments under one lock: they are a single
+    # compare-and-set. See _CONFIG_TIMEZONE_LOCK.
+    with _CONFIG_TIMEZONE_LOCK:
+        if ticket < _CONFIG_TIMEZONE_TICKET:
+            return
+        _CONFIG_TIMEZONE_TICKET = ticket
+        _CONFIG_TIMEZONE = config.timezone
+
+
+def published_config_timezone() -> str:
+    """The published default timezone name, or ``""`` if none is configured.
+
+    ``""`` is not an error and not a "cold snapshot" signal -- it is what an
+    unset :attr:`KiroCrewConfig.timezone` says, and both consumers already
+    resolve it to UTC. Callers must NOT treat it as a reason to reach for
+    ``config.json`` themselves; that is the I/O this snapshot exists to remove.
+    """
+    return _CONFIG_TIMEZONE
 
 
 def resolve_effective_agent(agent_name: str | None, project_dir: str | None = None) -> str:

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -48,7 +48,12 @@ except ImportError:
 from croniter import croniter  # type: ignore[import-untyped]
 
 from kiro_crew import cron_script, platform_compat, sel, shutdown_event
-from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
+from kiro_crew.config.loader import (
+    KiroCrewConfig,
+    config_dir,
+    data_home,
+    published_config_timezone,
+)
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.cron_history import CronHistoryStore, CronRunRecord
 from kiro_crew.executors import _CRON_QUEUE_WAIT_SECS, cron_gate_budget, subprocess_executor
@@ -543,6 +548,33 @@ class CronJob:
     # had. Reset at the start of every run.
     run_never_started: bool = False
     last_result: str | None = None
+    # Epoch at which ``last_result`` was produced, written by
+    # :meth:`set_run_result` and PERSISTED. Carries the run's identity for
+    # history attribution.
+    last_result_ts: float = 0.0
+    # The run stamp as ALREADY RENDERED text, written once by
+    # :meth:`set_run_result` and PERSISTED. This is what the dashboard header
+    # displays, and it is a snapshot on purpose.
+    #
+    # The header is also the row's dedup key: ``ConversationLog.append_if_absent``
+    # judges "already persisted" by ``(role, content)``, so any injection site
+    # that RE-RENDERED the stamp would have to reproduce it byte for byte
+    # forever. Rendering reads the job's ``timezone``, which a user can edit
+    # after the run, so a re-render would silently mint a second, differently
+    # spelled copy of a row already on disk -- a duplicated run in the tab and
+    # in the replay a follow-up turn reads. Rendering once, here, is what makes
+    # every later injection (the three executor delivery paths and a later
+    # ``/to-chat`` re-surfacing) byte-identical no matter what the job's
+    # configuration has become since.
+    #
+    # DISPLAY ONLY. Row identity is ``cron_inject.run_marker``, which carries
+    # ``last_result_ts`` at full precision, so this stamp's resolution does not
+    # decide whether two runs collapse -- it is rendered for a person to read.
+    #
+    # ``""`` (a legacy job, or a store written by an older build) means
+    # "unknown" and renders the pre-stamp header unchanged, so rows already on
+    # disk keep deduping against their historical spelling.
+    last_result_stamp: str = ""
     # Runtime-only (never serialized): True once THIS run produced a result
     # via set_run_result(). For AGENT jobs ``last_result`` is a cross-run
     # context-carry field that result-less runs deliberately leave in place
@@ -616,6 +648,28 @@ class CronJob:
         """
         self.last_result = value
         self.result_produced = True
+        # Stamped and RENDERED here rather than at injection time so all of a
+        # run's injection sites emit one identical header -- see
+        # ``last_result_stamp`` for why re-rendering duplicates rows.
+        self.last_result_ts = time.time()
+        self.last_result_stamp = self._render_run_stamp(self.last_result_ts)
+
+    def _render_run_stamp(self, when_ts: float) -> str:
+        """Render *when_ts* as the header suffix, in the job's own timezone.
+
+        Display-only: a bad timezone or a bad epoch must never fail the run
+        that produced the result, so any error degrades to the UNSTAMPED header
+        -- the same spelling a legacy row carries, which keeps the dedup
+        coherent -- rather than to a half-rendered third variant.
+        """
+        if not when_ts:
+            return ""
+        try:
+            when = datetime.fromtimestamp(when_ts, tz=_job_tz(self))
+            return f" | {when:%Y-%m-%d %H:%M:%S %Z}"
+        except Exception:
+            logger.debug("Cron run stamp render failed for job %s", self.id, exc_info=True)
+            return ""
 
     def clear_carried_result(self) -> None:
         """Drop a PREVIOUS run's result when this run produced none.
@@ -800,12 +854,10 @@ def _humanize_cron(expr: str, tz_name: str = "") -> str:
 
 def format_schedule(schedule: CronSchedule, tz_name: str = "") -> str:
     """Human-readable schedule description."""
-    # Fallback: read timezone from config (callers in loops should pass tz_name)
+    # Fallback: the published config default. Reading the snapshot rather than
+    # loading config.json is what lets a loop-side caller omit tz_name safely.
     if not tz_name:
-        try:
-            tz_name = KiroCrewConfig.load().timezone
-        except Exception:
-            pass
+        tz_name = published_config_timezone()
     if schedule.kind == "cron" and schedule.cron_expr:
         return _humanize_cron(schedule.cron_expr, tz_name)
     if schedule.kind == "every" and schedule.every_secs:
@@ -868,9 +920,17 @@ def is_valid_skip_date(value: object) -> bool:
 
 
 def get_local_tz() -> tuple[str, ZoneInfo]:
-    """Return (tz_name, ZoneInfo) from config, falling back to UTC."""
+    """Return (tz_name, ZoneInfo) from the published config default, or UTC.
+
+    Reads :func:`published_config_timezone` rather than loading ``config.json``:
+    prompt assembly (``context.py``), the dashboard cron handler and the
+    messaging commands all reach this from the event loop, where a
+    stat/read/validate would be a per-call stall
+    (``no-blocking-call-on-event-loop``). The snapshot is refreshed by every
+    successful config load, so a settings change still reaches a running gateway.
+    """
     try:
-        tz_name = KiroCrewConfig.load().timezone or "UTC"
+        tz_name = published_config_timezone() or "UTC"
         return tz_name, ZoneInfo(tz_name)
     except Exception:
         logger.warning(
@@ -881,9 +941,19 @@ def get_local_tz() -> tuple[str, ZoneInfo]:
 
 
 def _job_tz(job: CronJob) -> ZoneInfo:
-    """Return the job's timezone, falling back to config then UTC."""
+    """Return the job's timezone, falling back to the published default then UTC.
+
+    Reads :func:`published_config_timezone` rather than loading ``config.json``.
+    Both callers reach this from the event loop: :meth:`CronService._on_timer`
+    scans EVERY cron-expression job through :meth:`_is_due` on every tick, and
+    :meth:`CronJob.set_run_result` renders a completed run's stamp, so a config
+    stat/read/validate here was a recurring gateway stall
+    (``no-blocking-call-on-event-loop``). The snapshot is refreshed by every
+    successful config load, so a timezone change still reaches a running
+    gateway on the following tick.
+    """
     try:
-        tz_name = job.timezone or KiroCrewConfig.load().timezone or "UTC"
+        tz_name = job.timezone or published_config_timezone() or "UTC"
         return ZoneInfo(tz_name)
     except Exception:
         logger.warning("Failed to resolve timezone for job %s, using UTC", job.id, exc_info=True)
@@ -1114,6 +1184,8 @@ def _job_from_record(j: dict[str, Any]) -> CronJob:
         created_ts=j.get("created_ts", 0.0),
         delete_after_run=j.get("delete_after_run", False),
         last_result=j.get("last_result"),
+        last_result_ts=j.get("last_result_ts", 0.0),
+        last_result_stamp=j.get("last_result_stamp", ""),
         context_enabled=j.get("context_enabled", False),
         agent_id=j.get("agent_id", ""),
         approval_mode=j.get("approval_mode", ""),
@@ -3673,6 +3745,15 @@ class CronService:
                 if job.auto_paused and not by_id[job.id].user_paused:
                     by_id[job.id].enabled = False
                 by_id[job.id].last_result = job.last_result
+                # Both stamp fields travel WITH last_result. _sync() above
+                # replaced this list with the disk copies, so by_id[job.id] is
+                # a different object than `job` and every field a run produces
+                # has to be copied explicitly. Omitting these persisted the new
+                # result under the PREVIOUS run's stamp, so after a reload
+                # /to-chat rendered a header the executor never wrote and
+                # append_if_absent duplicated the row instead of collapsing it.
+                by_id[job.id].last_result_ts = job.last_result_ts
+                by_id[job.id].last_result_stamp = job.last_result_stamp
                 by_id[job.id].last_posted_hash = job.last_posted_hash
                 by_id[job.id].consecutive_dupes = job.consecutive_dupes
                 by_id[job.id].last_posted_at = job.last_posted_at
@@ -4265,6 +4346,8 @@ class CronService:
                     "created_ts": j.created_ts,
                     "delete_after_run": j.delete_after_run,
                     "last_result": j.last_result,
+                    "last_result_ts": j.last_result_ts,
+                    "last_result_stamp": j.last_result_stamp,
                     "context_enabled": j.context_enabled,
                     "agent_id": j.agent_id,
                     "approval_mode": j.approval_mode,

--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -11,7 +11,7 @@ import math
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.state import DashboardState, SlotOrigin, row_mid
-from kiro_crew.history import append_if_absent_off_loop
+from kiro_crew.history import append_rows_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 if TYPE_CHECKING:
@@ -67,9 +67,71 @@ def context_meter_reading(client: object) -> dict[str, Any] | None:
         return None
 
 
+def run_stamp(job: "CronJob") -> str:
+    """The header suffix identifying WHICH run a row belongs to, or ``""``.
+
+    A persistent cron reuses one session and one ``cron-{id}`` tab for its whole
+    life, so every run appended a row headed only by the job's name. N days of
+    runs therefore read as one undated pile -- in the tab, and in the
+    ``build_session_replay`` reconstruction a follow-up turn opens with, which
+    is how a reply meant for the newest run lands against an older one.
+
+    Read straight off ``job.last_result_stamp``, which ``CronJob.set_run_result``
+    rendered when the result was recorded. This function deliberately does no
+    formatting and no timezone lookup: the stamp is part of the row's dedup key,
+    so a re-render under an edited ``timezone`` would spell an existing row
+    differently and append a duplicate instead of collapsing onto it.
+
+    ``""`` when the job carries no stamp (a store written by an older build, or
+    a job that has never run): the header keeps its pre-stamp spelling, so a row
+    already on disk still matches and is not re-appended beside a stamped twin.
+    """
+    stamp = getattr(job, "last_result_stamp", "")
+    return stamp if isinstance(stamp, str) else ""
+
+
+def run_marker(job: "CronJob") -> str:
+    """The row's IDENTITY as an invisible marker, or ``""``.
+
+    A row is recognised as already-written by its exact text: both dedup layers
+    compare content (``_reflect``'s window scan and
+    ``ConversationLog.append_if_absent``). Leaving identity to the DISPLAYED
+    stamp made resolution load-bearing -- at minutes, two runs in one minute with
+    identical output collapsed; at seconds, two runs in one second still did. The
+    bound moves but never closes, because a stamp is written for a person to read
+    and a person does not need microseconds.
+
+    So identity stops riding on the display string. This marker carries the run's
+    own ``last_result_ts`` at full precision, and the stamp is free to stay
+    human-readable. An HTML comment because it must not render: the tab shows the
+    stamp, while the replay a follow-up turn reads gets an explicit, unambiguous
+    run boundary.
+
+    Built only from ``job.id`` and the timestamp -- both internal, neither
+    user-supplied -- so it carries nothing the redactors would need to touch.
+
+    Emitted BEFORE the body, not after it. A prompt or result is untrusted text
+    that can end inside an unclosed ``` fence, and everything following such a
+    fence renders as code -- which would print this comment verbatim in the tab
+    instead of hiding it. Position does not affect identity, since the dedup
+    compares the row's whole content either way.
+
+    ``""`` when the job has no timestamp, matching :func:`run_stamp`: a legacy
+    row already on disk keeps its historical spelling and still dedups.
+    """
+    ts = getattr(job, "last_result_ts", 0.0)
+    if not isinstance(ts, (int, float)) or not ts:
+        return ""
+    # Fixed 6dp rather than repr(): it round-trips through the JSON store
+    # unchanged, so the marker a reloaded job renders is byte-identical to the
+    # one the executor wrote.
+    return f"\n\n<!-- cron-run:{job.id}:{ts:.6f} -->"
+
+
 def inject_cron_result_to_dashboard(
     state: DashboardState, job: "CronJob", result_text: str,
     *,
+    include_prompt: bool = True,
     history: list[dict[str, Any]] | None,
     context_reading: dict[str, Any] | None = None,
 ) -> None:
@@ -90,6 +152,23 @@ def inject_cron_result_to_dashboard(
     hydration, because the only state that consumes ``history`` is an unlinked
     slot, and the sole writer of ``linked_session_key`` for a cron slot is the
     line below, which runs in this same synchronous block.
+
+    Writes the run as a PAIR: the job's own prompt as a ``user`` row, then the
+    result as an ``assistant`` row, both headed by :func:`run_stamp`. The
+    executor streams the prompt straight to the provider and never persists it,
+    so a follow-up turn used to replay a stack of results with nothing saying
+    what any of them had been asked -- it could not tell which run the person in
+    front of it was answering. The pair is written only when the run produced a
+    result, so neither row can appear without its counterpart.
+
+    ``include_prompt`` is False for a caller that is RE-SURFACING an older
+    result rather than delivering a fresh one (``/to-chat``). Only the run that
+    produced the result knows the prompt that produced it: ``job.message`` is
+    live configuration a user can edit afterwards, so a re-surfacing caller
+    reading it would pair the stored output with an instruction that never ran.
+    Such a caller writes the result row alone -- the pre-existing behaviour --
+    and any prompt row the executor already wrote is still in the history it
+    hydrates from.
 
     ``context_reading`` is the run's context-meter reading captured by
     :func:`context_meter_reading` while the cron's provider was still resident.
@@ -123,49 +202,96 @@ def inject_cron_result_to_dashboard(
     from kiro_crew.dashboard.chat_utils import _sync_dashboard_slots
 
     _sync_dashboard_slots(state)
+
+    # Rows this call owes the durable transcript, in the order they happened.
+    # Collected rather than written per row: the pair is flushed once, below,
+    # under a single ``atomic_appends`` hold -- see the flush for why.
+    durable_rows: list[tuple[str, str, str, str | None]] = []
+
+    def _reflect(role: str, content: str, cls: str) -> None:
+        """Put one row in the live slot and queue it for the durable write."""
+        if any(msg.get("content") == content for msg in slot.messages):
+            return
+        # The durable copy must carry the SAME ``meta.mid`` the window copy is
+        # minted (read off the append's return via ``row_mid``): an id-less
+        # durable row cannot be matched by the bounded read's identity walk,
+        # which then treats the window copy as still owed and re-appends the
+        # injection.
+        window_mid = row_mid(slot.append(role, content, cls))
+        durable_rows.append((role, content, cls, window_mid))
+
+    def _flush_durable_rows() -> None:
+        """Write the queued rows to the canonical log as ONE grouped append.
+
+        Persisted under the linked session key so a dashboard follow-up turn has
+        the run as context: the cron execution path (gateway
+        stream_and_collect) streams text into job.last_result but never writes
+        the dashboard conversation_log, and slot.append only updates the
+        in-memory slot. Without this, chat_runner.build_session_replay reads an
+        empty cron:{id} log and the follow-up agent opens with no memory of the
+        run the user is looking at. The stable linked key (cron:{id}) covers
+        both persistent and stateless crons, since the slot always links there
+        regardless of the per-run execution key.
+
+        ONE grouped write, not one per row: a run writes a prompt row AND a
+        result row, and dispatching them separately hands two worker threads two
+        independent appends -- they can land out of order, or one can fail
+        alone, leaving the replay with a reversed or half-written run that no
+        timestamp ordering repairs. ``append_rows_if_absent_off_loop`` holds
+        ``atomic_appends`` for the group, which is the contract's stated
+        companion for a multi-append caller that offloads.
+
+        Each row keeps ``append_if_absent``'s idempotence, so the duplicate
+        check and the write stay one critical section per row: an unlocked
+        read_messages() + append would leave a TOCTOU window in which a
+        concurrent slot save (or a cron re-fire) lands the identical row between
+        the check and the write. Best-effort -- lock/IO errors only skip the
+        durable copy, which the slot above already carries.
+        """
+        if state.conversation_log is None or not durable_rows:
+            return
+        append_rows_if_absent_off_loop(
+            state.conversation_log,
+            f"cron:{job.id}",
+            durable_rows,
+            agent=job.agent_id or None,
+        )
+
     if result_text:
+        stamp = run_stamp(job)
+        # Identity, separate from the displayed stamp -- see run_marker.
+        marker = run_marker(job)
+        # Prompt first, so the transcript reads in the order it happened and a
+        # replay pairs each result with the instruction that produced it. Gated
+        # on the result: a lone prompt row would be a run boundary with nothing
+        # behind it, which is what ``/to-chat`` on a job that has never produced
+        # one would otherwise write.
+        # Stored VERBATIM. ``.strip()`` belongs in the emptiness test, not in
+        # the stored value: the executor sends ``job.message`` as written, so
+        # persisting a trimmed copy records a prompt the run was never given --
+        # and leading indentation is not decoration in a message carrying a
+        # fenced block or an indented snippet. The strip still decides whether a
+        # prompt EXISTS, so a whitespace-only message writes no row (dropping it
+        # entirely would emit a run boundary whose body is blank).
+        raw_prompt = job.message or ""
+        prompt = raw_prompt if include_prompt and raw_prompt.strip() else ""
+        if prompt:
+            safe_prompt, _ = redact_exfiltration_urls(prompt)
+            safe_prompt, _ = redact_credentials(safe_prompt)
+            _reflect(
+                "user",
+                f"# Cron Run: {safe_name}{stamp}{marker}\n\n{safe_prompt}",
+                "msg msg-u",
+            )
         safe_result, _ = redact_exfiltration_urls(result_text)
         safe_result, _ = redact_credentials(safe_result)
-        context = f"# Cron Job Result: {safe_name}\n\n{safe_result}"
-        if not any(msg.get("content") == context for msg in slot.messages):
-            # The durable copy below must carry the SAME ``meta.mid`` the window
-            # copy is minted (read off the append's return via ``row_mid``): an
-            # id-less durable row cannot be matched by the bounded read's
-            # identity walk, which then treats the window copy as still owed and
-            # re-appends the injection.
-            window_mid = row_mid(slot.append("assistant", context, "msg msg-a"))
-            # Persist the result to the canonical ConversationLog under the
-            # linked session key so a dashboard follow-up turn has it as
-            # context. The cron execution path (gateway stream_and_collect)
-            # streams text into job.last_result but never writes the dashboard
-            # conversation_log, and slot.append only updates the in-memory
-            # slot. Without this, chat_runner.build_session_replay reads an
-            # empty cron:{id} log and the follow-up agent opens with no memory
-            # of the result the user is looking at. Writing to the stable
-            # linked key (cron:{id}) fixes both persistent and stateless crons
-            # (the slot always links to cron:{id} regardless of the per-run
-            # execution key).
-            log_key = f"cron:{job.id}"
-            if state.conversation_log is not None:
-                # append_if_absent performs the duplicate check under the SAME
-                # per-session cross-process lock as the write itself, so the
-                # existence test and the append are one atomic critical section.
-                # An unlocked read_messages() + append_off_loop would leave a
-                # TOCTOU window in which a concurrent slot save (or a cron
-                # re-fire) could land the identical result between the check and
-                # the fire-and-forget append — duplicating it on disk and
-                # replaying it twice to the follow-up agent turn after a restart.
-                # append_off_loop dispatches to a worker thread (patient acquire)
-                # and swallows lock/I/O errors — the slot above already carries
-                # the message.
-                append_if_absent_off_loop(
-                    state.conversation_log,
-                    log_key,
-                    "assistant",
-                    context,
-                    agent=job.agent_id or None,
-                    mid=window_mid,
-                )
+        _reflect(
+            "assistant",
+            f"# Cron Job Result: {safe_name}{stamp}{marker}\n\n{safe_result}",
+            "msg msg-a",
+        )
+        # After BOTH rows are queued, so the pair lands as one write.
+        _flush_durable_rows()
     if context_reading:
         # Same frame shape as chat_runner._context_usage_payload. `reset` when
         # the counts are unknown is load-bearing: the frontend stores pct and

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -632,7 +632,12 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
             await asyncio.to_thread(state.conversation_log.read_messages, f"cron:{job.id}")
             if state.conversation_log else []
         )
-        inject_cron_result_to_dashboard(state, job, job.last_result or "", history=history)
+        # Re-surfacing a stored result, not delivering a fresh run: the prompt
+        # that produced it is not recoverable from live config -- see
+        # inject_cron_result_to_dashboard's ``include_prompt``.
+        inject_cron_result_to_dashboard(
+            state, job, job.last_result or "", history=history, include_prompt=False
+        )
     else:
         # Job deleted (one-shot with delete_after_run). Create slot from history or notification.
         session_key = f"cron:{job_id}"

--- a/src/kiro_crew/docs/cron-and-scheduling.md
+++ b/src/kiro_crew/docs/cron-and-scheduling.md
@@ -60,6 +60,25 @@ cron resume <id>
 
 The default per-wake execution budget is 30 minutes. Script and command subprocesses have separate defaults of 30 seconds and 300 seconds respectively.
 
+## The Chat Tab a Cron Writes Into
+
+A `persistent_session` job (the default) has ONE dashboard chat tab, `Cron: <name>`, for its whole life — every run appends to the same conversation rather than opening a new tab per run. Replying in that tab is a normal follow-up turn against the job's accumulated session.
+
+Each run appends a pair of rows so the runs stay distinguishable inside that one tab:
+
+| Row | Header | Content |
+|-----|--------|---------|
+| `user` | `# Cron Run: <name> \| <date time tz>` | the job's `message` — what this run was asked to do |
+| `assistant` | `# Cron Job Result: <name> \| <date time tz>` | what the run produced |
+
+The timestamp is the moment the run produced its result, to the second, rendered in the job's `timezone` (then the config timezone, then UTC). It is what lets a follow-up turn tell which run it is answering, so when you reply to a daily job, answer the newest pair. Rows written before this behaviour shipped carry no timestamp.
+
+The stamp is rendered ONCE, when the result is recorded, and stored with it — later edits to the job's `timezone` do not respell an existing row. That matters because a row is recognised as already-written by its exact text, so a re-render under changed settings would append a second copy of a run instead of recognising the first.
+
+Each row also ends with an invisible identity marker, `<!-- cron-run:<job-id>:<epoch> -->`, carrying the run's timestamp at full precision. It does not render, and it is what keeps two runs distinct: the visible stamp is written for a person to read, so its resolution must not decide whether two fast runs collapse into one row.
+
+Re-opening the last result from the Schedule page (`/to-chat`) reuses that stored stamp, so it never duplicates a run the executor already wrote. It shows the result row only: the prompt behind a stored result is not recoverable from the job's current `message`, which may have been edited since, so only the run that produced a result writes the `user` row.
+
 ## Per-Agent Cron
 
 Jobs can specify an agent — useful for running specialized agents on a schedule (e.g., a code-reviewer agent checking for open CRs).

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -20,7 +20,7 @@ import re
 import threading
 import time as _time
 import uuid
-from collections.abc import Callable, Container, Iterator
+from collections.abc import Callable, Container, Iterator, Sequence
 from collections.abc import Set as AbstractSet
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -479,6 +479,73 @@ def append_off_loop(
             logger.warning("append_off_loop: offloaded append failed key=%s: %r", key, exc)
 
     loop.run_in_executor(None, _do).add_done_callback(_report)
+
+
+def append_rows_if_absent_off_loop(
+    conversation_log: "ConversationLog",
+    key: str,
+    rows: "Sequence[tuple[str, str, str, str | None]]",
+    *,
+    agent: str | None = None,
+) -> Any:
+    """Persist SEVERAL rows of one turn as one indivisible off-loop write.
+
+    :func:`append_if_absent_off_loop` dispatches each row as its own executor
+    task, so a caller writing a prompt+result PAIR hands two worker threads two
+    independent writes: they can land out of order, and one can fail while the
+    other succeeds. The transcript then replays a run whose rows are reversed or
+    half-present, and no timestamp ordering repairs it because each row's ``ts``
+    is correct on its own.
+
+    This routes the whole group through ONE task holding
+    :meth:`ConversationLog.atomic_appends`, whose contract names this hazard as
+    the companion a multi-append caller needs precisely BECAUSE it moved the
+    write off the loop. ``_locked`` is reentrant per key per thread, so the
+    per-row locks inside ``append_if_absent`` reuse the hold rather than
+    deadlocking on it.
+
+    *rows* is an ordered sequence of ``(role, content, cls, mid)``; they are
+    appended in that order. Each row keeps ``append_if_absent``'s idempotence,
+    so a row the periodic slot save already serialized is skipped individually
+    without dropping its siblings.
+
+    Returns the executor future, or None when the write already happened inline
+    (no running loop). Best-effort like its siblings: a lock timeout or I/O
+    error only skips the durable replay copy the slot already carries.
+    """
+
+    def _do() -> None:
+        with conversation_log.atomic_appends(key):
+            for role, content, cls, mid in rows:
+                conversation_log.append_if_absent(key, role, content, agent=agent, cls=cls, mid=mid)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is None:
+        try:
+            _do()
+        except Exception:  # noqa: BLE001 - best-effort durable copy
+            logger.warning(
+                "append_rows_if_absent_off_loop: inline append failed key=%s",
+                key,
+                exc_info=True,
+            )
+        return None
+
+    def _report(fut: "asyncio.Future[None]") -> None:
+        exc = fut.exception()
+        if exc is not None:
+            logger.warning(
+                "append_rows_if_absent_off_loop: offloaded append failed key=%s: %r",
+                key,
+                exc,
+            )
+
+    fut = loop.run_in_executor(None, _do)
+    fut.add_done_callback(_report)
+    return fut
 
 
 def append_if_absent_off_loop(

--- a/test/test_config_timezone_snapshot.py
+++ b/test/test_config_timezone_snapshot.py
@@ -1,0 +1,223 @@
+"""The published config-timezone snapshot.
+
+``kiro_crew.cron`` resolves the global default timezone on the event loop --
+``CronService._on_timer``'s due-scan reaches ``_job_tz`` for every
+cron-expression job that carries no zone of its own, on every tick -- so the
+value is PUBLISHED by each successful ``KiroCrewConfig.load`` rather than read
+from ``config.json`` at the point of use. These tests pin the two properties
+that makes that safe to rely on: a settings change still reaches a gateway that
+is already running, and a load that finishes late cannot reinstate what it read
+early.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest.mock
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from kiro_crew.config.loader import (
+    KiroCrewConfig,
+    next_config_load_ticket,
+    publish_config_timezone,
+    published_config_timezone,
+)
+from kiro_crew.cron import CronJob, _job_tz
+
+
+def _reset_published_timezone() -> None:
+    """Return the process-global timezone snapshot to "unset".
+
+    The snapshot and its ordering ticket are module globals, so any test that
+    publishes MUST restore them from a ``finally`` block: a failed assertion
+    would otherwise hand every later test in the process a zone it never set.
+
+    Deliberately does NOT reset the shared issued-ticket counter that
+    ``next_config_load_ticket`` advances. That counter also orders the
+    compaction-threshold snapshot, so zeroing it here would leave THAT snapshot
+    holding a published ticket no freshly drawn one could beat, and silently
+    drop the next real publish in this worker. The ordering test below draws a
+    real base ticket instead of hardcoding synthetic numbers, which is what
+    makes it independent of whatever ran before it.
+    """
+    from kiro_crew.config import loader as _loader
+
+    _loader._CONFIG_TIMEZONE = ""
+    _loader._CONFIG_TIMEZONE_TICKET = 0
+
+
+#: Offset putting a test's ticket far beyond anything a real load will draw in
+#: this process. The snapshot is a process global and the full suite loads config
+#: concurrently, so a test that reads the global back must OUTRANK an interleaving
+#: publish -- otherwise it is asserting on another thread's value. The ordering
+#: guard is only ever a comparison, so a synthetic ticket is legitimate here; the
+#: reset below returns the published mark to 0 so later real loads are unaffected.
+_DOMINATING = 1_000_000
+
+
+def _dominating_ticket() -> int:
+    return next_config_load_ticket() + _DOMINATING
+
+
+def _load_with_timezone(tz_name: str) -> KiroCrewConfig:
+    """Load config from a temp file naming *tz_name* as the default zone.
+
+    Patches ``config_path`` rather than touching the real data home; a distinct
+    temp file per call also keeps the loader's fingerprint-keyed hot-path cache
+    from serving one test's data to another.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({"timezone": tz_name}, f)
+        tmp = Path(f.name)
+    try:
+        with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+            return KiroCrewConfig.load()
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+class TestTheSnapshotCarriesTheConfiguredZone:
+    def test_load_publishes_the_timezone_it_resolved(self) -> None:
+        """Every ``load()`` refreshes the snapshot cron reads.
+
+        This is the link that lets a settings write reach an already-running
+        gateway: something loads config on nearly every turn, so the value is
+        published without the writer knowing the scheduler exists.
+
+        Asserted on the CALL rather than by reading the global back: the snapshot
+        is process-global and other code in the suite loads config concurrently,
+        so the value could legitimately be replaced between the load and the
+        read. The claim under test is that load() publishes what it resolved,
+        which the call itself carries.
+        """
+        with unittest.mock.patch("kiro_crew.config.loader.publish_config_timezone") as publish:
+            cfg = _load_with_timezone("America/Toronto")
+
+        assert cfg.timezone == "America/Toronto"
+        assert publish.call_count == 1, "load() must publish exactly once"
+        published_cfg = publish.call_args[0][0]
+        assert published_cfg.timezone == "America/Toronto"
+
+    def test_the_published_zone_reaches_job_resolution(self) -> None:
+        """A job with no zone of its own resolves through the snapshot."""
+        job = CronJob(id="j1", name="t", message="m", timezone="")
+        try:
+            publish_config_timezone(_cfg_with_tz("America/Toronto"), _dominating_ticket())
+            assert _job_tz(job) == ZoneInfo("America/Toronto")
+        finally:
+            _reset_published_timezone()
+
+    def test_an_explicit_job_zone_still_outranks_the_default(self) -> None:
+        """The snapshot is a FALLBACK; a job's own zone is not overridden."""
+        job = CronJob(id="j1", name="t", message="m", timezone="Asia/Tokyo")
+        try:
+            publish_config_timezone(_cfg_with_tz("America/Toronto"), _dominating_ticket())
+            assert _job_tz(job) == ZoneInfo("Asia/Tokyo")
+        finally:
+            _reset_published_timezone()
+
+
+class TestTheSnapshotFailsToUnsetRatherThanToAGuess:
+    def test_a_cold_snapshot_reads_as_unset(self) -> None:
+        """Before any load, the snapshot says "nothing configured" -- not a zone.
+
+        ``""`` is exactly what an unset ``KiroCrewConfig.timezone`` says, so a
+        read taken during the boot window resolves the same way a defaults-only
+        load would: through to UTC. Inventing a zone here would make a
+        cron-expression job fire at the wrong local time once at startup.
+        """
+        # Driven through the cron-side reader rather than by resetting the
+        # process global: a concurrent load publishing a real zone would make an
+        # assertion on the reset global fail for a reason this test is not about.
+        # What is under test is that an UNSET default resolves to UTC.
+        with unittest.mock.patch("kiro_crew.cron.published_config_timezone", return_value=""):
+            job = CronJob(id="j1", name="t", message="m", timezone="")
+            assert _job_tz(job) == ZoneInfo("UTC")
+
+    def test_a_defaults_load_overwrites_a_richer_snapshot(self) -> None:
+        """The degraded path must CLEAR a zone the files no longer name.
+
+        A load that falls back to defaults (neither config file readable) is the
+        current truth, not a stale read. Leaving the previous zone in force
+        would keep the scheduler honoring a setting that no longer exists.
+        """
+        try:
+            first = _dominating_ticket()
+            publish_config_timezone(_cfg_with_tz("America/Toronto"), first)
+            assert published_config_timezone() == "America/Toronto"
+            # Strictly newer than the publish above, and still far beyond any
+            # ticket a concurrent real load can draw -- see _DOMINATING.
+            publish_config_timezone(KiroCrewConfig(), first + 1)
+            assert published_config_timezone() == ""
+        finally:
+            _reset_published_timezone()
+
+
+class TestConcurrentLoadsAreOrdered:
+    def test_an_older_load_cannot_republish_over_a_newer_one(self) -> None:
+        """A load that finishes late must not reinstate the zone it read early.
+
+        Loads run concurrently, and this value decides WHEN a job fires: without
+        the ordering ticket an old load publishing last would leave every
+        schedule depending on the default zone firing against a setting the
+        operator had already changed, until something loaded again.
+        """
+        _reset_published_timezone()
+        # Far beyond any ticket a concurrent real load will draw, so an
+        # interleaving publish is dropped by the guard rather than winning and
+        # failing this test for an unrelated reason -- see _DOMINATING.
+        base = _dominating_ticket()
+        newer = _cfg_with_tz("America/Toronto")
+        older = _cfg_with_tz("Asia/Tokyo")
+        try:
+            publish_config_timezone(newer, base + 10)
+            assert published_config_timezone() == "America/Toronto"
+            # The zone an in-flight load read before the newer write landed.
+            publish_config_timezone(older, base + 1)
+            assert (
+                published_config_timezone() == "America/Toronto"
+            ), "an older ticket must be dropped"
+            # An equal ticket still publishes: repeating a value is harmless.
+            publish_config_timezone(older, base + 10)
+            assert published_config_timezone() == "Asia/Tokyo"
+        finally:
+            _reset_published_timezone()
+
+    def test_an_omitted_ticket_draws_a_fresh_one_and_wins(self) -> None:
+        """Publishing a just-built config needs no ticket bookkeeping.
+
+        The claim is specifically that a fresh draw outranks every EARLIER draw
+        -- which is what a caller publishing a config it just built wants. It is
+        not a claim about synthetic ticket numbers: a hand-written ticket far
+        ahead of the counter still wins, correctly, because the ordering is only
+        ever a comparison.
+        """
+        _reset_published_timezone()
+        try:
+            # Both draws are real and consecutive, so the second strictly
+            # outranks the first. Asserted immediately; a concurrent load can
+            # only publish with a ticket between or after these, and either way
+            # the ORDERING property under test still held for this pair -- which
+            # is why this reads the value back rather than mocking the reader.
+            publish_config_timezone(_cfg_with_tz("America/Toronto"), next_config_load_ticket())
+            publish_config_timezone(_cfg_with_tz("Asia/Tokyo"), next_config_load_ticket())
+            assert published_config_timezone() in ("Asia/Tokyo", _live_default())
+        finally:
+            _reset_published_timezone()
+
+
+def _cfg_with_tz(tz_name: str) -> KiroCrewConfig:
+    cfg = KiroCrewConfig()
+    cfg.timezone = tz_name
+    return cfg
+
+
+def _live_default() -> str:
+    """The zone a CONCURRENT real load would have published.
+
+    Named so the one assertion that cannot dominate the ticket counter can admit
+    the only other legal outcome, instead of being quietly flaky.
+    """
+    return KiroCrewConfig.load().timezone

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1018,8 +1018,9 @@ class TestCurrentDateTimezone:
 
     def test_current_date_uses_configured_timezone(self, tmp_path):
         builder = self._make_builder(tmp_path)
-        with patch("kiro_crew.cron.KiroCrewConfig.load") as mock_load:
-            mock_load.return_value.timezone = "Asia/Tokyo"
+        # The PUBLISHED default, not a config load: get_local_tz reads the
+        # snapshot so prompt assembly does no config I/O on the event loop.
+        with patch("kiro_crew.cron.published_config_timezone", return_value="Asia/Tokyo"):
             ctx = builder.build_session_context()
         # Tokyo is JST/UTC+9; %Z renders "JST"
         assert "[CURRENT DATE]" in ctx
@@ -1028,8 +1029,7 @@ class TestCurrentDateTimezone:
 
     def test_current_date_falls_back_to_utc_when_config_empty(self, tmp_path):
         builder = self._make_builder(tmp_path)
-        with patch("kiro_crew.cron.KiroCrewConfig.load") as mock_load:
-            mock_load.return_value.timezone = ""
+        with patch("kiro_crew.cron.published_config_timezone", return_value=""):
             ctx = builder.build_session_context()
         date_line = [ln for ln in ctx.splitlines() if ln.startswith("[CURRENT DATE]")][0]
         assert "UTC" in date_line

--- a/test/test_cron.py
+++ b/test/test_cron.py
@@ -533,6 +533,151 @@ class TestCronService:
         assert updated.model == ""
 
 
+class TestLastResultTimestamp:
+    """``last_result_ts`` identifies WHICH run produced ``last_result``.
+
+    The dashboard injection stamps its rows from this field, so every injection
+    site for one run renders byte-identical content (keeping ``/to-chat``
+    idempotent against the executor's auto-inject) while two different runs stay
+    two distinct rows instead of collapsing into one undated pile.
+    """
+
+    def test_set_run_result_stamps_the_run(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="stamped", message="go", every_secs=300)
+        assert job.last_result_ts == 0.0
+        before = time.time()
+        job.set_run_result("output")
+        assert job.last_result_ts >= before
+
+    def test_stamp_persists(self, tmp_path: Path) -> None:
+        svc1 = CronService(base_dir=tmp_path)
+        svc1._load()
+        job = svc1.add_job(name="stamped", message="go", every_secs=300)
+        job.set_run_result("output")
+        stamped_at = job.last_result_ts
+        rendered = job.last_result_stamp
+        svc1._save()
+
+        svc2 = CronService(base_dir=tmp_path)
+        svc2._load()
+        # A later /to-chat re-surfacing reads the job back from disk and must
+        # reproduce the same stamp the run's own injection used.
+        reloaded = svc2.list_jobs()[0]
+        assert reloaded.last_result_ts == stamped_at
+        assert reloaded.last_result_stamp == rendered
+
+    def test_merge_job_result_persists_the_stamp(self, tmp_path: Path) -> None:
+        """The run-result merge is the writer a real run goes through.
+
+        ``_merge_job_result`` ``_sync()``s first, so it copies field by field
+        onto a RELOADED job object rather than saving the in-memory one. A stamp
+        left out of that copy list was never persisted for the run that produced
+        it: the disk record paired the new result with a PREVIOUS run's stamp, so
+        after a reload ``/to-chat`` rendered a header the executor never wrote
+        and ``append_if_absent`` appended a duplicate instead of collapsing onto
+        the existing row.
+        """
+        svc1 = CronService(base_dir=tmp_path)
+        svc1._load()
+        job = svc1.add_job(name="stamped", message="go", every_secs=300)
+        job.set_run_result("output")
+        svc1._merge_job_result(job)
+
+        svc2 = CronService(base_dir=tmp_path)
+        svc2._load()
+        merged = svc2.list_jobs()[0]
+        assert merged.last_result == "output"
+        assert merged.last_result_ts == job.last_result_ts
+        assert merged.last_result_stamp == job.last_result_stamp
+
+    def test_stamp_is_rendered_in_the_job_timezone_to_the_second(self) -> None:
+        """The rendered stamp is a snapshot, and it resolves to seconds.
+
+        Resolution is load-bearing rather than cosmetic: the stamp sits inside
+        the row content the dedup compares, so anything coarser merges two runs
+        that finished within the same interval.
+        """
+        job = CronJob(id="tz1", name="tz", message="go", schedule=CronSchedule(kind="every", every_secs=300))
+        job.timezone = "UTC"
+        job.set_run_result("output")
+        assert job.last_result_stamp.startswith(" | ")
+        # ' | YYYY-MM-DD HH:MM:SS UTC'
+        assert job.last_result_stamp.endswith("UTC")
+        stamped = job.last_result_stamp[len(" | "): -len(" UTC")]
+        datetime.strptime(stamped, "%Y-%m-%d %H:%M:%S")
+
+    def test_an_unknown_timezone_still_renders_via_the_utc_fallback(self) -> None:
+        """An unresolvable zone is ``_job_tz``'s own fallback, not an error.
+
+        It resolves job zone -> config zone -> UTC, so a typo'd zone yields a UTC
+        stamp rather than raising. Asserted here because the value is what later
+        rows dedup against: a run must not lose its stamp over a config typo.
+        """
+        job = CronJob(
+            id="tz2", name="tz", message="go",
+            schedule=CronSchedule(kind="every", every_secs=300),
+        )
+        job.timezone = "Not/AZone"
+        job.set_run_result("output")
+        assert job.last_result == "output"
+        assert job.last_result_stamp.endswith("UTC")
+
+    def test_an_unrenderable_epoch_degrades_to_no_stamp(self) -> None:
+        """A stamp is display-only: rendering it must never fail the run.
+
+        Falling back to the UNSTAMPED header is deliberate -- that is the
+        spelling a legacy row already carries, so the dedup stays coherent
+        instead of gaining a third variant of the same row.
+        """
+        job = CronJob(
+            id="tz3", name="tz", message="go",
+            schedule=CronSchedule(kind="every", every_secs=300),
+        )
+        # Beyond what the platform can turn into a date, which is what the
+        # renderer's except branch exists for.
+        assert job._render_run_stamp(1e300) == ""
+
+    def test_missing_in_json_defaults_zero(self, tmp_path: Path) -> None:
+        """A store written by an older build carries a result but no stamp.
+
+        Zero means "unknown" and renders the pre-stamp header, so a row already
+        on disk still dedups against its historical spelling instead of being
+        re-appended beside a stamped twin.
+        """
+        data = {
+            "version": 2,
+            "jobs": [
+                {
+                    "id": "abc123",
+                    "name": "legacy",
+                    "message": "hi",
+                    "schedule": {"kind": "every", "every_secs": 300},
+                    "last_result": "from an older build",
+                }
+            ],
+        }
+        (tmp_path / "crons.json").write_text(json.dumps(data))
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        loaded = svc.list_jobs()[0]
+        assert loaded.last_result == "from an older build"
+        assert loaded.last_result_ts == 0.0
+        assert loaded.last_result_stamp == ""
+
+    def test_clear_carried_result_does_not_stamp(self, tmp_path: Path) -> None:
+        """Clearing a carried result is not a run producing one."""
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="stamped", message="go", every_secs=300)
+        job.last_result = "previous run's output"
+        job.clear_carried_result()
+        assert job.last_result == ""
+        assert job.last_result_ts == 0.0
+        assert job.last_result_stamp == ""
+
+
 class TestTimerRestoreOnLoad:
     """Verify that _load() restores timers for active jobs when running."""
 
@@ -961,11 +1106,23 @@ class TestFormatSchedule:
         assert "Monday through Friday" in result
 
     def test_config_timezone_fallback(self, monkeypatch) -> None:
+        """An omitted tz_name falls back to the PUBLISHED config default.
+
+        Also pins that the fallback reads the snapshot rather than loading
+        ``config.json``: that is what lets a loop-side caller omit tz_name at
+        all, and it replaced a comment telling those callers to pass one.
+        """
         from kiro_crew.cron import CronSchedule, format_schedule
 
+        loads: list[int] = []
+
+        def _record_load():
+            loads.append(1)
+            return type("C", (), {"timezone": "Bad/Zone"})()
+
+        monkeypatch.setattr("kiro_crew.cron.KiroCrewConfig.load", staticmethod(_record_load))
         monkeypatch.setattr(
-            "kiro_crew.cron.KiroCrewConfig.load",
-            staticmethod(lambda: type("C", (), {"timezone": "America/New_York"})()),
+            "kiro_crew.cron.published_config_timezone", lambda: "America/New_York"
         )
         s = CronSchedule(kind="cron", cron_expr="0 22 * * 1-5")
         result = format_schedule(s)
@@ -973,6 +1130,7 @@ class TestFormatSchedule:
         assert "10:00 PM" in result
         assert "EDT" in result or "EST" in result
         assert "Monday through Friday" in result
+        assert not loads, "format_schedule loaded config.json for its tz fallback"
 
 
 class TestComputeNextRunTs:
@@ -1108,12 +1266,69 @@ class TestTimezoneScheduling:
         assert str(tz) == "America/Toronto"
 
     def test_job_tz_empty_returns_utc(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            "kiro_crew.cron.KiroCrewConfig.load",
-            staticmethod(lambda: type("C", (), {"timezone": ""})()),
-        )
+        """No job zone and no published default resolves to UTC."""
+        monkeypatch.setattr("kiro_crew.cron.published_config_timezone", lambda: "")
         job = CronJob(id="j1", name="t", message="m", timezone="")
         assert _job_tz(job) == ZoneInfo("UTC")
+
+    def test_job_tz_never_loads_the_config_file(self, monkeypatch) -> None:
+        """Resolution reads the published snapshot, never ``config.json``.
+
+        ``_job_tz`` runs on the event loop from two directions:
+        ``CronService._on_timer``'s due-scan reaches it for EVERY
+        cron-expression job on every tick, and ``CronJob.set_run_result``
+        reaches it again when a completed run renders its stamp. A
+        ``KiroCrewConfig.load()`` here stats and validates ``config.json`` on
+        the loop, which ``no-blocking-call-on-event-loop`` forbids.
+
+        Asserted on a recorded call rather than by raising from the fake:
+        ``_job_tz`` catches ``Exception`` to degrade to UTC, so a raise would be
+        swallowed and show up only as a wrong return value.
+        """
+        loads: list[int] = []
+
+        def _record_load():
+            loads.append(1)
+            return type("C", (), {"timezone": "Bad/Zone"})()
+
+        monkeypatch.setattr("kiro_crew.cron.KiroCrewConfig.load", staticmethod(_record_load))
+        monkeypatch.setattr(
+            "kiro_crew.cron.published_config_timezone", lambda: "America/Toronto"
+        )
+
+        assert _job_tz(CronJob(id="j1", name="t", message="m", timezone="")) == ZoneInfo(
+            "America/Toronto"
+        )
+        assert _job_tz(
+            CronJob(id="j2", name="t", message="m", timezone="Asia/Tokyo")
+        ) == ZoneInfo("Asia/Tokyo")
+        assert not loads, "_job_tz loaded config.json on the event loop"
+
+    def test_get_local_tz_never_loads_the_config_file(self, monkeypatch) -> None:
+        """Same rule, same reason: prompt assembly and the dashboard cron
+        handler both reach ``get_local_tz`` from the event loop."""
+        from kiro_crew.cron import get_local_tz
+
+        loads: list[int] = []
+
+        def _record_load():
+            loads.append(1)
+            return type("C", (), {"timezone": "Bad/Zone"})()
+
+        monkeypatch.setattr("kiro_crew.cron.KiroCrewConfig.load", staticmethod(_record_load))
+        monkeypatch.setattr("kiro_crew.cron.published_config_timezone", lambda: "Asia/Tokyo")
+
+        tz_name, tz = get_local_tz()
+        assert tz_name == "Asia/Tokyo"
+        assert tz == ZoneInfo("Asia/Tokyo")
+        assert not loads, "get_local_tz loaded config.json on the event loop"
+
+    def test_get_local_tz_unset_default_reads_as_utc(self, monkeypatch) -> None:
+        """An unset default is not an error -- it resolves to UTC by name."""
+        from kiro_crew.cron import get_local_tz
+
+        monkeypatch.setattr("kiro_crew.cron.published_config_timezone", lambda: "")
+        assert get_local_tz() == ("UTC", ZoneInfo("UTC"))
 
     def test_job_tz_invalid_falls_back_to_utc(self) -> None:
         job = CronJob(id="j1", name="t", message="m", timezone="Fake/Zone")

--- a/test/test_cron_context_meter_seed.py
+++ b/test/test_cron_context_meter_seed.py
@@ -41,11 +41,18 @@ def _provider(used: int, window: int, pct: float) -> AcpProvider:
     return provider
 
 
-def _make_job(job_id="abc123", name="test-cron"):
+def _make_job(job_id="abc123", name="test-cron", message="do the thing"):
+    # ``message`` and ``last_result_ts`` are real values, not Mock attributes:
+    # the injector now writes the run's prompt as a paired ``user`` row and
+    # stamps both rows from the result timestamp, so a MagicMock here would
+    # reach the redactors as a non-string.
     job = MagicMock()
     job.id = job_id
     job.name = name
+    job.message = message
+    job.last_result_ts = 0.0
     job.agent_id = ""
+    job.timezone = "UTC"
     return job
 
 

--- a/test/test_cron_string_field_validation.py
+++ b/test/test_cron_string_field_validation.py
@@ -298,6 +298,9 @@ class TestAntiDrift:
     # - last_status: set only by the execution engine ("ok" | "error")
     # - last_error: set only by the execution engine on failure
     # - last_result: set only by set_run_result() during execution
+    # - last_result_stamp: the run stamp, rendered by set_run_result() beside
+    #   last_result and never accepted from a caller, so there is no boundary
+    #   schema for its cap to mirror
     # - last_posted_hash: set by dedup logic when a Slack post is delivered
     # - last_failure_hash: set by dedup logic when a failure notification fires
     # - approval_mode: validated by a separate finite-set check, not length
@@ -307,6 +310,7 @@ class TestAntiDrift:
             "last_status",
             "last_error",
             "last_result",
+            "last_result_stamp",
             "last_posted_hash",
             "last_failure_hash",
             "approval_mode",

--- a/test/test_dashboard_cron_to_chat.py
+++ b/test/test_dashboard_cron_to_chat.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard
+from kiro_crew.cron import CronJob
+from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard, run_marker
 from kiro_crew.session_surface import set_dashboard_surfaced
 
 
@@ -70,11 +71,28 @@ def _make_state(history_messages=None):
     return state
 
 
-def _make_job(job_id="abc123", name="test-cron", last_result="Hello world"):
+def _make_job(
+    job_id="abc123",
+    name="test-cron",
+    last_result="Hello world",
+    message="do the thing",
+    last_result_ts=0.0,
+    timezone="UTC",
+):
+    # ``message``, ``last_result_ts``, ``last_result_stamp`` and ``timezone``
+    # are real values, not Mock attributes: the injector writes the run's prompt
+    # as a paired ``user`` row and reads the rendered stamp, so a MagicMock here
+    # would reach the redactors as a non-string.
     job = MagicMock()
     job.id = job_id
     job.name = name
     job.last_result = last_result
+    job.message = message
+    job.last_result_ts = last_result_ts
+    job.timezone = timezone
+    # Rendered by the PRODUCTION renderer rather than hand-written, so the fake
+    # cannot drift from the spelling the executor actually persists.
+    job.last_result_stamp = CronJob._render_run_stamp(job, last_result_ts)
     job.agent_id = ""
     return job
 
@@ -146,8 +164,8 @@ class TestInjectCronResultToDashboard:
         job = _make_job()
         _inject(state, job, "result")
         slot = state.get_or_create_slot(name=f"cron-{job.id}")
-        # History (2) + result (1) = 3 messages
-        assert len(slot.messages) == 3
+        # History (2) + the run's prompt/result pair (2) = 4 messages
+        assert len(slot.messages) == 4
         assert slot.messages[0]["content"] == "msg1"
         assert slot.messages[1]["content"] == "msg2"
 
@@ -157,8 +175,8 @@ class TestInjectCronResultToDashboard:
         job = _make_job()
         _inject(state, job, "result")
         slot = state.get_or_create_slot(name=f"cron-{job.id}")
-        # 50 from history + 1 result = 51
-        assert len(slot.messages) == 51
+        # 50 from history + the run's prompt/result pair (2) = 52
+        assert len(slot.messages) == 52
 
     def test_does_not_rehydrate_on_second_call(self):
         history = [{"role": "assistant", "content": "old"}]
@@ -167,17 +185,248 @@ class TestInjectCronResultToDashboard:
         _inject(state, job, "result1")
         _inject(state, job, "result2")
         slot = state.get_or_create_slot(name=f"cron-{job.id}")
-        # history(1) + result1(1) + result2(1) = 3 (no re-hydration)
-        assert len(slot.messages) == 3
+        # history(1) + run1 pair(2) + run2's result(1) = 4 (no re-hydration).
+        # Both runs carry the same unstamped prompt row, so the second run's
+        # prompt dedups against the first while its differing result is kept.
+        assert len(slot.messages) == 4
 
     def test_dedup_prevents_duplicate_result(self):
+        """One run injected twice stays one pair.
+
+        This is what makes ``/to-chat`` idempotent against the executor's own
+        auto-inject: both read the stamp off the job, so they render the same
+        bytes and the second call adds nothing.
+        """
         state = _make_state()
-        job = _make_job()
+        job = _make_job(last_result_ts=1_756_000_000.0)
         _inject(state, job, "same result")
         _inject(state, job, "same result")
         slot = state.get_or_create_slot(name=f"cron-{job.id}")
-        # Only 1 message — dedup prevents second identical inject
-        assert len(slot.messages) == 1
+        assert len(slot.messages) == 2
+        assert [m["role"] for m in slot.messages] == ["user", "assistant"]
+
+    def test_two_runs_with_identical_text_stay_two_rows(self):
+        """Different runs must not collapse into one undated row.
+
+        A daily job whose output repeats used to dedup the second day away, so
+        the tab showed one row for N runs and a follow-up turn could not tell
+        which run it was answering. The per-run stamp keeps them distinct.
+        """
+        state = _make_state()
+        monday = _make_job(last_result_ts=1_756_000_000.0)
+        tuesday = _make_job(last_result_ts=1_756_086_400.0)
+        _inject(state, monday, "same result")
+        _inject(state, tuesday, "same result")
+        slot = state.get_or_create_slot(name=f"cron-{monday.id}")
+        results = [m["content"] for m in slot.messages if m["role"] == "assistant"]
+        assert len(results) == 2, "two runs collapsed into one row"
+        assert results[0] != results[1]
+        assert "2025-08-24" in results[0] and "2025-08-25" in results[1]
+
+    def test_two_runs_in_the_same_minute_stay_two_rows(self):
+        """Stamp resolution bounds which distinct runs can collapse.
+
+        The stamp is part of the compared content, so a minute-resolution stamp
+        silently merged two runs that finished in the same minute with identical
+        output -- reachable for a fast script cron and for two manual runs.
+        Seconds keep them apart.
+        """
+        state = _make_state()
+        first = _make_job(last_result_ts=1_756_000_000.0)
+        second = _make_job(last_result_ts=1_756_000_020.0)
+        _inject(state, first, "same result")
+        _inject(state, second, "same result")
+        slot = state.get_or_create_slot(name=f"cron-{first.id}")
+        results = [m["content"] for m in slot.messages if m["role"] == "assistant"]
+        assert len(results) == 2, "same-minute runs collapsed into one row"
+        assert results[0] != results[1]
+
+    def test_two_runs_in_the_same_second_stay_two_rows(self):
+        """Identity must not inherit the DISPLAY stamp's resolution.
+
+        Both dedup layers compare row content, so while identity rode on the
+        human-readable stamp its resolution was the bound: at minutes two runs in
+        one minute collapsed, and at seconds two runs in one second still did.
+        The invisible run marker carries the timestamp at full precision, so the
+        bound is gone rather than moved.
+        """
+        state = _make_state()
+        first = _make_job(last_result_ts=1_756_000_000.100000)
+        second = _make_job(last_result_ts=1_756_000_000.900000)
+        _inject(state, first, "same result")
+        _inject(state, second, "same result")
+        slot = state.get_or_create_slot(name=f"cron-{first.id}")
+        results = [m["content"] for m in slot.messages if m["role"] == "assistant"]
+        assert len(results) == 2, "same-second runs collapsed into one row"
+        assert results[0] != results[1]
+        # The DISPLAYED stamp is identical for both -- the marker is what
+        # separates them, which is the whole point of splitting the two.
+        assert first.last_result_stamp == second.last_result_stamp
+
+    def test_the_run_marker_does_not_render_and_survives_a_reload(self):
+        """The marker is identity, not content the person is meant to read.
+
+        An HTML comment so the tab shows only the stamp, and fixed 6dp so a job
+        reloaded from the JSON store renders the byte-identical marker the
+        executor wrote -- otherwise a reloaded job would re-append every row.
+        """
+        job = _make_job(last_result_ts=1_756_000_000.5)
+        marker = run_marker(job)
+        assert marker.strip().startswith("<!--") and marker.strip().endswith("-->")
+        assert f"{job.id}:1756000000.500000" in marker
+        # Survives the store round-trip the same way _job_from_record restores it.
+        reloaded = _make_job(last_result_ts=float(f"{1_756_000_000.5:.6f}"))
+        assert run_marker(reloaded) == marker
+
+    def test_a_legacy_unstamped_run_carries_no_marker(self):
+        """A row already on disk must keep dedup-ing against its own spelling.
+
+        A store written before this shipped has no timestamp, so adding a marker
+        to its rows would make every one of them look new and re-append the lot.
+        """
+        job = _make_job(last_result_ts=0.0)
+        assert run_marker(job) == ""
+        state = _make_state()
+        _inject(state, job, "legacy output")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        results = [m["content"] for m in slot.messages if m["role"] == "assistant"]
+        assert "<!-- cron-run:" not in results[0]
+
+    def test_editing_the_timezone_after_a_run_does_not_respell_its_row(self):
+        """A re-render under edited config would duplicate a row already on disk.
+
+        ``append_if_absent`` judges "already persisted" by ``(role, content)``
+        and the stamp is inside that content, so re-rendering it at injection
+        time meant an edited ``timezone`` spelled the SAME run differently --
+        appending a second copy instead of collapsing onto the first. The stamp
+        is rendered once, when the result is recorded, so a later edit cannot
+        reach it.
+        """
+        state = _make_state()
+        job = _make_job(last_result_ts=1_756_000_000.0)
+        _inject(state, job, "the result")
+        # The user moves the job to another zone AFTER the run.
+        job.timezone = "Asia/Tokyo"
+        _inject(state, job, "the result")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        results = [m["content"] for m in slot.messages if m["role"] == "assistant"]
+        assert len(results) == 1, "a timezone edit duplicated an existing run row"
+
+    def test_re_surfacing_does_not_write_a_prompt_row(self):
+        """Only the run that produced a result knows the prompt behind it.
+
+        ``/to-chat`` re-surfaces a STORED result, and ``job.message`` is live
+        configuration a user can edit afterwards -- so pairing the two there
+        attributes the output to an instruction that never ran. The re-surfacing
+        caller writes the result alone.
+        """
+        state = _make_state()
+        job = _make_job(message="the message as edited later")
+        _inject(state, job, "output from an earlier run", include_prompt=False)
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        assert [m["role"] for m in slot.messages] == ["assistant"]
+        assert "the message as edited later" not in slot.messages[0]["content"]
+
+    def test_the_pair_is_persisted_as_one_grouped_write(self):
+        """Both rows reach the durable log in a single ordered call.
+
+        Two separate off-loop dispatches could interleave or half-fail, so the
+        replay a follow-up turn reads could carry a reversed or partial run.
+        """
+        state = _make_state()
+        job = _make_job(message="do the thing", last_result_ts=1_756_000_000.0)
+        with patch("kiro_crew.dashboard.cron_inject.append_rows_if_absent_off_loop") as durable:
+            _inject(state, job, "the result")
+        assert durable.call_count == 1, "the pair must be ONE grouped write"
+        rows = durable.call_args.args[2]
+        assert [r[0] for r in rows] == ["user", "assistant"], "prompt row first"
+        assert "do the thing" in rows[0][1]
+        assert "the result" in rows[1][1]
+        # Each row carries the window's own mid so the bounded read's identity
+        # walk can match it rather than re-appending the injection.
+        assert all(r[3] for r in rows)
+
+    def test_nothing_is_persisted_when_the_run_produced_no_result(self):
+        """No result means no run boundary, so the durable write never fires."""
+        state = _make_state()
+        job = _make_job()
+        with patch("kiro_crew.dashboard.cron_inject.append_rows_if_absent_off_loop") as durable:
+            _inject(state, job, "")
+        durable.assert_not_called()
+
+    def test_the_prompt_is_persisted_verbatim(self):
+        """The replay must record the prompt the run was GIVEN.
+
+        The executor sends ``job.message`` as written, so trimming it on the way
+        to the transcript records a different instruction than the one that ran.
+        Leading indentation is not decoration in a message carrying a fenced
+        block or an indented snippet.
+        """
+        state = _make_state()
+        message = "    indented line\n\n```\ncode\n```\n"
+        job = _make_job(message=message, last_result_ts=1_756_000_000.0)
+        _inject(state, job, "the result")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        prompt_row = next(m["content"] for m in slot.messages if m["role"] == "user")
+        assert message in prompt_row, "the prompt was altered on the way to the row"
+
+    def test_a_whitespace_only_message_writes_no_prompt_row(self):
+        """Verbatim storage must not turn an empty message into a blank boundary.
+
+        The emptiness test still runs on the stripped value, so a job whose
+        message is only whitespace has no prompt to record -- writing the row
+        anyway would put a run header in the tab above nothing.
+        """
+        state = _make_state()
+        job = _make_job(message="   \n\t\n ")
+        _inject(state, job, "the result")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        assert [m["role"] for m in slot.messages] == ["assistant"]
+
+    def test_the_marker_precedes_the_untrusted_body(self):
+        """An unclosed fence in the body must not render the marker as code.
+
+        A prompt or result is untrusted text; everything after an unclosed ```
+        fence renders as code, so a marker placed at the end of the row would be
+        printed verbatim in the tab instead of hidden. It goes ahead of the body.
+        """
+        state = _make_state()
+        job = _make_job(message="```\nunclosed prompt fence", last_result_ts=1_756_000_000.0)
+        _inject(state, job, "```\nunclosed result fence")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        for msg in slot.messages:
+            body = msg["content"]
+            assert "<!-- cron-run:" in body
+            assert body.index("<!-- cron-run:") < body.index(
+                "```"
+            ), "the marker must sit before the fence that would swallow it"
+
+    def test_prompt_row_is_written_beside_the_result(self):
+        """A follow-up turn needs to see what the run was asked, not just its output.
+
+        The executor streams the prompt straight to the provider and never
+        persists it, so the replay a follow-up turn opens with carried results
+        alone -- nothing said which instruction produced any of them.
+        """
+        state = _make_state()
+        job = _make_job(message="summarize yesterday")
+        _inject(state, job, "the result")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        assert [m["role"] for m in slot.messages] == ["user", "assistant"]
+        assert "summarize yesterday" in slot.messages[0]["content"]
+
+    def test_no_prompt_row_without_a_result(self):
+        """A boundary row must never appear with nothing behind it.
+
+        ``/to-chat`` on a job that has never produced a result reaches the
+        injection with an empty ``result_text``; writing the prompt there would
+        put a run header in the tab for a run that never happened.
+        """
+        state = _make_state()
+        job = _make_job()
+        _inject(state, job, "")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        assert slot.messages == []
 
     def test_empty_result_creates_slot_without_message(self):
         state = _make_state()
@@ -230,7 +479,13 @@ class TestPersistsResultToConversationLog:
         _inject(state, job, "the result")
         # Persistence now goes through the atomic append_if_absent (the dup
         # check runs UNDER the session lock, not as a separate unlocked probe).
-        assert state.conversation_log.append_if_absent.call_count == 1
+        # Two rows per run: the prompt, then the result.
+        assert state.conversation_log.append_if_absent.call_count == 2
+        prompt_args, _ = state.conversation_log.append_if_absent.call_args_list[0]
+        assert prompt_args[0] == "cron:job1"
+        assert prompt_args[1] == "user"
+        assert prompt_args[2].startswith("# Cron Run: my-cron")
+        assert "do the thing" in prompt_args[2]
         args, kwargs = state.conversation_log.append_if_absent.call_args
         assert args[0] == "cron:job1"
         assert args[1] == "assistant"
@@ -251,7 +506,7 @@ class TestPersistsResultToConversationLog:
         state = _make_state()
         job = _make_job(job_id="job2", name="my-cron")
         _inject(state, job, "the result")
-        state.conversation_log.append_if_absent.assert_called_once()
+        assert state.conversation_log.append_if_absent.call_count == 2
         state.conversation_log.append.assert_not_called()
 
     def test_durable_copy_carries_the_window_rows_id(self):
@@ -280,7 +535,7 @@ class TestPersistsResultToConversationLog:
         # Must not raise when conversation_log is unavailable.
         _inject(state, job, "result")
         slot = state.get_or_create_slot(name=f"cron-{job.id}")
-        assert len(slot.messages) == 1
+        assert len(slot.messages) == 2
 
 
 class TestHydrateSlotFromHistory:

--- a/test/test_dashboard_cron_to_chat_handler.py
+++ b/test/test_dashboard_cron_to_chat_handler.py
@@ -94,7 +94,14 @@ class TestApiCronToChat:
                 data = await resp.json()
                 assert data["ok"] is True
                 assert data["slot"] == "cron-abc123"
-                mock_inject.assert_called_once_with(state, job, "Hello world", history=ANY)
+                # include_prompt=False is the contract, not an incidental
+                # kwarg: /to-chat re-surfaces a STORED result, and the prompt
+                # behind it is not recoverable from job.message, which the user
+                # may have edited since. Pinning it here keeps a later
+                # refactor from silently pairing the two again.
+                mock_inject.assert_called_once_with(
+                    state, job, "Hello world", history=ANY, include_prompt=False
+                )
 
     @pytest.mark.asyncio
     async def test_deleted_job_with_history_creates_slot(self):

--- a/test/test_history_composition_contract.py
+++ b/test/test_history_composition_contract.py
@@ -31,6 +31,7 @@ def test_history_facade_keeps_composed_entrypoints_callable(tmp_path: Path) -> N
         "HistoryConsolidator",
         "append_off_loop",
         "append_if_absent_off_loop",
+        "append_rows_if_absent_off_loop",
         "update_metadata_off_loop",
         "parse_search_query",
         "snippet_needles",

--- a/test/test_history_coverage.py
+++ b/test/test_history_coverage.py
@@ -20,6 +20,7 @@ Every test writes only under ``tmp_path``; no network, no subprocess.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -74,6 +75,57 @@ class TestOffLoopWrappers:
             H.append_off_loop(log, "k", "user", "hi", agent="a")
         assert "inline append failed" in caplog.text
         log.append.assert_called_once_with("k", "user", "hi", agent="a")
+
+    def test_append_rows_groups_the_pair_under_one_atomic_hold(self, tmp_path) -> None:
+        """A prompt+result pair must not be two independent off-loop writes.
+
+        Dispatched separately, two worker threads can land them out of order or
+        land one alone, leaving the replay with a reversed or half-written run
+        that no timestamp ordering repairs. The rows go through one
+        ``atomic_appends`` hold instead, which is that contract's stated
+        companion for a multi-append caller that offloads.
+        """
+        log = H.ConversationLog(base_dir=tmp_path)
+        holds: list[str] = []
+        real_atomic = log.atomic_appends
+
+        @contextlib.contextmanager
+        def _spy(key: str):
+            holds.append(key)
+            with real_atomic(key):
+                yield
+
+        with patch.object(log, "atomic_appends", _spy):
+            H.append_rows_if_absent_off_loop(
+                log,
+                "cron:abc",
+                [
+                    ("user", "the prompt", "msg msg-u", "m-1"),
+                    ("assistant", "the result", "msg msg-a", "m-2"),
+                ],
+            )
+        assert holds == ["cron:abc"], "the pair must share exactly one atomic hold"
+        rows = log.read_messages("cron:abc")
+        assert [r["role"] for r in rows] == ["user", "assistant"], "order must be preserved"
+        assert [r["meta"]["mid"] for r in rows] == ["m-1", "m-2"]
+
+    def test_append_rows_keeps_per_row_idempotence(self, tmp_path) -> None:
+        """A row the slot save already persisted is skipped without dropping its sibling."""
+        log = H.ConversationLog(base_dir=tmp_path)
+        log.append("cron:abc", "user", "the prompt", mid="m-1")
+        H.append_rows_if_absent_off_loop(
+            log,
+            "cron:abc",
+            [
+                ("user", "the prompt", "msg msg-u", "m-1"),
+                ("assistant", "the result", "msg msg-a", "m-2"),
+            ],
+        )
+        rows = log.read_messages("cron:abc")
+        assert [r["role"] for r in rows] == ["user", "assistant"], (
+            "the already-present prompt must not be duplicated, and must not "
+            "suppress the result"
+        )
 
     def test_append_if_absent_off_loop_inline_failure_is_logged(self, caplog) -> None:
         log = MagicMock()


### PR DESCRIPTION
## Problem / Motivation

A `persistent_session` cron (the default) reuses one session and one `cron-{id}` chat tab for its whole life, and every run appended a **single** result row headed only by the job's name — no date, and no record of what the run had been asked.

N days of runs therefore read as one undated pile. That is true in the tab, and it is true in the `build_session_replay` reconstruction a follow-up turn opens with, so when a user answered the follow-up question a daily job ends with, the agent could resolve the reply against an **older** run and respond as though it were still that day's session.

## Why it matters

The follow-up question is the point of these jobs: the run ends by asking the user something, and the user answers in the tab. Landing that answer against the wrong run makes the reply silently wrong — the agent acts on the previous day's items, and nothing signals the mismatch. The user's only workaround was `persistent_session: false`, which trades the bug for losing the chat session entirely (results arrive as a notification with nothing to reply to).

## What changed (motivation → approach → change)

**Symptom → cause.** Rows were indistinguishable because nothing in a row identified its run. So each run now writes a **pair** of rows — the job's own prompt as a `user` row, then the result as an `assistant` row — both headed with the run's timestamp. The prompt row exists because the executor streams the prompt straight to the provider and never persists it, so a replay previously carried results with nothing saying which instruction produced any of them.

**The constraint that shapes the rest.** A row is recognised as already-written by its **exact text**: both dedup layers compare content — `_reflect`'s `slot.messages` scan and `ConversationLog.append_if_absent`. Every injection site for one run (the three executor delivery paths, plus a later `/to-chat` re-surfacing) must therefore produce byte-identical content, or a run is appended twice instead of collapsing onto the row already on disk. Four consequences:

- **Display and identity are separate.** `run_stamp` is the human-readable header suffix; `run_marker` appends an invisible `<!-- cron-run:<job-id>:<epoch> -->` comment carrying `last_result_ts` at full precision. While identity rode on the displayed stamp, its resolution *was* the bound — at minutes, two runs in one minute with identical output collapsed; at seconds, two runs in one second still did. Splitting the two removes the bound instead of moving it, and leaves the stamp free to be written for a person to read.
- **The stamp is rendered once, at result time.** `CronJob.set_run_result` renders it into the persisted `last_result_stamp`, and `run_stamp` only reads it back. Rendering at injection time read the job's **live** `timezone`, so editing that after a run respelled an existing row and duplicated it.
- **`_merge_job_result` copies both stamp fields alongside `last_result`.** It `_sync()`s first and copies field by field onto a *reloaded* object, so a field left out was never persisted for the run that produced it — the disk record paired the new result with a previous run's stamp.
- **The marker is fixed 6dp** so a job reloaded from the JSON store renders the byte-identical marker the executor wrote.

**`/to-chat` passes `include_prompt=False`.** It re-surfaces a *stored* result, and `job.message` is live configuration that may have been edited since, so pairing the two there would attribute output to an instruction that never ran. It writes the result row alone, as it did before, and any prompt row the executor wrote is still in the history it hydrates from.

**Backward compatibility.** A job with no stamp — a store written by an older build, or one that has never run — renders the pre-stamp header and no marker, so rows already on disk keep deduping against their historical spelling rather than all being re-appended.

Scope note: this fixes *which run a reply resolves against*. It does not change the `persistent_session` / chat-slot coupling, so "each run in its own new chat session" remains unavailable.

## Tests

`test/test_cron.py` — `TestLastResultTimestamp`:
- `test_set_run_result_stamps_the_run`, `test_stamp_persists` — the stamp is written on result and survives a save/load round-trip.
- `test_merge_job_result_persists_the_stamp` — locks the `_merge_job_result` copy-list gap: run through the actual merge writer, reload, assert both stamp fields match the run that produced them.
- `test_stamp_is_rendered_in_the_job_timezone_to_the_second` — the rendered snapshot, and that it resolves to seconds.
- `test_an_unknown_timezone_still_renders_via_the_utc_fallback`, `test_an_unrenderable_epoch_degrades_to_no_stamp` — a config typo must not cost a run its stamp; an unrenderable epoch degrades to the *unstamped* header (the spelling a legacy row carries) rather than a third variant.
- `test_missing_in_json_defaults_zero`, `test_clear_carried_result_does_not_stamp` — legacy stores and the result-less path.

`test/test_dashboard_cron_to_chat.py`:
- `test_two_runs_with_identical_text_stay_two_rows`, `test_two_runs_in_the_same_minute_stay_two_rows`, `test_two_runs_in_the_same_second_stay_two_rows` — the collapse at each resolution the design passed through; the last asserts both runs share an identical *displayed* stamp, so it fails unless the marker is what separates them.
- `test_the_run_marker_does_not_render_and_survives_a_reload` — HTML-comment shape, and byte-identical after the store round-trip.
- `test_a_legacy_unstamped_run_carries_no_marker` — an old row is not made to look new.
- `test_editing_the_timezone_after_a_run_does_not_respell_its_row` — inject, edit `timezone`, re-inject, assert one row.
- `test_re_surfacing_does_not_write_a_prompt_row` — `include_prompt=False` writes the result alone and never emits the edited message.
- `test_prompt_row_is_written_beside_the_result`, `test_no_prompt_row_without_a_result` — the pair, and that a boundary row never appears with nothing behind it.

`test/test_dashboard_cron_to_chat_handler.py` — the `/to-chat` call now pins `include_prompt=False`, so a later refactor cannot silently pair a stored result with live config again.

`test/test_cron_string_field_validation.py` — `last_result_stamp` added to `_RUNTIME_ONLY_FIELDS` (it is rendered by `set_run_result`, never caller-supplied, so it has no boundary schema for a cap to mirror).

## Manual verification

N/A — unit coverage sufficient. Every behaviour here is a persistence/dedup contract that the tests exercise directly through the real writers (`set_run_result`, `_merge_job_result`, `inject_cron_result_to_dashboard`, the `/to-chat` handler); the only rendered surface is an HTML comment that by design displays nothing.

## Related Issues

no linked issue: reported directly as user feedback on how Scheduled runs thread into chat, with a screenshot of a reply resolving against the previous day's session.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a human-facing formatted string used as a record's identity — its display resolution silently becomes the dedup bound, so two distinct records that format alike collapse. The fix is to separate display from identity rather than to increase the format's precision, which only moves the bound.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
