### PR TITLE
docs(skills): fix widget canvas sizing hazard and stale CSP claim

### DIFF
--- a/src/kiro_crew/builtin_skills/widgets/SKILL.md
+++ b/src/kiro_crew/builtin_skills/widgets/SKILL.md
@@ -12,10 +12,11 @@ a sandboxed iframe with Tailwind CSS preloaded. Use this for styled visual
 content plain markdown cannot express: charts, color-coded tables, styled
 cards, visual summaries, simple interactive probes.
 
-The iframe CSP allows `script-src` from three CDNs: `cdn.tailwindcss.com`
-(preloaded), `cdn.jsdelivr.net`, and `cdnjs.cloudflare.com`. Tailwind is
-ready without any setup; other libraries (Chart.js, D3, etc.) need a
-`<script src="…">` tag pulling from one of those two CDNs.
+Tailwind is preloaded and ready without any setup — it is served from the
+dashboard's own origin, not from `cdn.tailwindcss.com`, which the iframe CSP
+does NOT allow. Other libraries (Chart.js, D3, etc.) need a
+`<script src="…">` tag pulling from one of the CSP-allowed CDNs listed under
+Rules below.
 
 ## When to use
 
@@ -102,6 +103,19 @@ Rules:
   <canvas id="c"></canvas>
   <script>new Chart(document.getElementById('c'), { /* config */ })</script>
   ```
+- **Give a responsive canvas a definite height, or leave the aspect ratio
+  alone.** The Chart.js defaults (`responsive: true`,
+  `maintainAspectRatio: true`) are safe exactly as written above. Only set
+  `maintainAspectRatio: false` when the canvas's parent has an explicit pixel
+  height:
+  ```html
+  <div style="height:180px"><canvas id="c"></canvas></div>
+  ```
+  Without one, the canvas and its parent size each other and the self-sizing
+  iframe re-feeds the loop, so the chart never settles and the widget renders
+  blank. Any library that sizes a canvas from its container — Chart.js,
+  ECharts, Plotly's responsive mode — carries the same hazard; inline SVG with
+  a fixed `viewBox` has no feedback path at all.
 - The dashboard sanitizes CSS via `src/lib/cssSanitize.ts` (shared with
   `WidgetFrame.tsx`) — a small allowlist of properties plus a denylist of
   dangerous functions (`expression()`, `javascript:`, `url(` with external


### PR DESCRIPTION
## Problem / Motivation

Two defects in `src/kiro_crew/builtin_skills/widgets/SKILL.md`, both found while root-causing a widget artifact that rendered as a blank white page.

**1. No warning about the canvas sizing hazard.** A widget using Chart.js with `maintainAspectRatio: false` against a content-sized parent renders blank. Setting that option is the standard advice for making a chart fill its box, and the skill said nothing about the extra constraint this iframe imposes.

**2. The intro described a CSP that does not exist.** It claimed `script-src` allows three CDNs including `cdn.tailwindcss.com`, then contradicted itself one sentence later by referring to "those two CDNs". `cspFor()` in `website/src/lib/widgetSrcdoc.ts` allows only `cdn.jsdelivr.net` and `cdnjs.cloudflare.com` externally; Tailwind is served from the dashboard's own origin, pinned to a single vendored runtime file. The code comment there states public `cdn.tailwindcss.com` was deliberately replaced because "locked-down network environments block" it.

## Why it matters

The skill is the instruction set LLM authors follow when emitting a widget, so an inaccuracy in it produces broken widgets at scale rather than one bad page.

For the sizing hazard, the failure mode is maximally expensive to debug: the page is entirely white, so it looks like the renderer, the theme, the CSP, or the data — not like a chart option. Root-causing this one instance took a three-way bisection, and on the way there a plausible-but-wrong theory ("Chart.js is blocked by the CDN") nearly produced a breaking change to the CSP that would have fixed nothing.

For the CSP claim, an author trusting the old text would load Tailwind from a source the CSP blocks, in exactly the locked-down networks the same-origin runtime was introduced to serve.

## What changed (motivation → approach → change)

**Symptom.** A saved widget artifact rendered fully blank. Static markup that preceded the `<script>` tags did not appear either.

**Root cause.** Isolated by bisection: three artifacts differing only in the suspected variable narrowed the failure to the chart block, then a variant identical to the failing one except for its sizing config rendered correctly *with the CDN load intact* — which also disproved the CDN theory.

The mechanism is a feedback loop closed at two levels. With `maintainAspectRatio: false`, Chart.js takes the canvas height *from the parent*; when that parent is content-sized, the parent's height comes from the canvas and the canvas's from the parent. The self-sizing iframe then re-feeds that loop, because the frame resizes to its own reported content height. The chart never reaches a stable size and the widget renders blank. This is the same failure class the height reporter's own comments already name — "a self-sizing frame then feeds its own measurement" — reached through Chart.js instead of viewport-unit CSS.

**Change.** Two edits, both in that one file:

1. A new rule next to the existing Chart.js example: keep the Chart.js defaults (which derive height from width and never consult the parent), or, if you set `maintainAspectRatio: false`, give the canvas's parent an explicit pixel height. It states the mechanism in one sentence so the rule is followable rather than cargo-culted, generalises to any container-sized canvas library (ECharts, Plotly), and points at inline SVG with a fixed `viewBox` as the option with no feedback path at all.

2. The intro paragraph now describes the CSP that `cspFor()` actually emits, which removes the three-CDNs/two-CDNs contradiction — and it no longer re-enumerates the allowlist at all. The list was enumerated twice in this one file, and two copies is *why* the intro copy went stale while the Rules copy stayed correct; the Rules bullet is now the single site, with the intro pointing at it.

Both edits deliberately avoid naming internal frontend symbols. A doc that asserts code internals is the same drift-prone shape that produced the stale CDN claim in the first place — including a stale `MAX_HEIGHT` reference still sitting in a `widgetSrcdoc.ts` comment, where the real constant now lives in `utils/widgetHeights.ts`. Fixing that comment would pull a frontend file into a docs-only diff, so it is left for a follow-up.

Deliberately **not** included: the arguably deeper defect is that the height reporter has no runaway detection, so an author writing ordinary Chart.js code gets a blank page and guidance only helps authors who read the skill. That fix belongs in `widgetSrcdoc.ts` and needs someone who can watch a widget render before and after; this change is documentation-only and carries no such risk.

## Tests

N/A — no automated test added. The diff changes only prose in a skill document; there is no behaviour to assert and no existing test pins doc claims to the code they describe. The absence of such a test is precisely how the `cdn.tailwindcss.com` line went stale, so it is raised as a rule candidate under Pattern harvest rather than silently skipped.

Verified against the existing suite: the five test files that read this skill (`test_builtin_skill_scope.py`, `test_context_widget_block.py`, `test_verbosity_config.py`, `test_config_loader.py`, `test_dashboard_files_coverage.py`) pass — 696 tests. `check_builtin_skill_scope.py`, `docs_lint.py`, `docs-lint.sh`, `scrub-lint.sh`, `check_changelog_history.py`, `check_brand_name.py`, `check_focus_cue.py`, `check_testpaths_coverage.py`, `isort`, and `flake8` all exit 0.

## Manual verification

The root cause was established empirically before this text was written. Three artifacts were saved that differed only in the suspected variable (plain HTML control; the original Chart.js widget; a static inline-SVG version) and rendered by a human: the control and the SVG version rendered, the Chart.js one was blank. A fourth artifact, identical to the blank one except with `maintainAspectRatio` at its default and a fixed-height wrapper per canvas, rendered correctly with the jsDelivr `<script src>` still present — which is what identifies the sizing config as the cause and clears the CDN.

Both factual claims were independently re-verified against the cited source by four reviewers (the two local pre-push lanes plus Design Review and First Principles Review): the growth/shrink asymmetry in the height reporter and the allowlist emitted by `cspFor()`.

No browser was available on the host where this was written (`playwright-cli` absent), so the renders were performed by a human rather than captured by me.

## Related Issues

no linked issue: found while debugging a blank artifact render, not tracked as an issue.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: a doc asserts a security allowlist (CSP sources, permitted hosts) that the code later narrowed, and nothing fails when the two diverge — made worse when the doc enumerates the same allowlist in two places, so one copy can be corrected while the other rots. `cdn.tailwindcss.com` was removed from `script-src` when Tailwind moved same-origin, but the skill that instructs authors to use it kept saying it was allowed, in the one of its two enumerations that nobody updated. The generalisable guards are: a change narrowing an allowlist should require updating every doc that enumerates it, and a doc should enumerate it exactly once. A test asserting the skill's CDN list matches `cspFor()` would have caught this mechanically, and the same shape applies to any enumerated-hosts doc.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
