### PR TITLE
feat: add contributes.fileMenuItems app-manifest contribution

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -382,6 +382,59 @@ prefixes are built by the host from the app name, so `statusPath` stays the only
 app-authored part of the URL. Declaring the wrong one is not possible: an app
 does not choose.
 
+### `contributes.fileMenuItems` — Rows in File / Tree / Folder Menus
+
+Declares rows an app adds to the file-editor overflow (⋮) menu, the workspace
+tree context menu, and the folder panel. Like `contributes.commands`, it is
+**declarative and host-rendered**: core reads the declaration, draws the rows,
+and POSTs to the app's own `endpoint` on activation — it never imports app code
+and holds no live callback, which is what makes the rows reachable by an app
+installed at runtime.
+
+```json
+{
+  "contributes": {
+    "fileMenuItems": [
+      {
+        "id": "send-to-store",
+        "label": "Send to store",
+        "icon": "Package",
+        "endpoint": "/api/apps/doc-store/send",
+        "surfaces": ["file-overflow", "tree-context", "folder-row"],
+        "when": { "extensions": ["md", "txt"], "kinds": ["file"] }
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `id` | string | Stable, app-owned row id (lowercase kebab slug, `[a-z0-9][a-z0-9-]*`), unique within the app |
+| `label` | string | Row label, max 120 characters (an app-owned literal — not a core i18n key) |
+| `icon` | string | Host glyph name: one of `Shield`, `Bot`, `Search`, `Tag`, `Users`, `Zap`, `Star`, `Package`, `Cat`. Any other name falls back to `Package` |
+| `endpoint` | string | App route core POSTs to; **must** sit under `/api/apps/<your-app>/` (in-gateway, for a `backend.hooks.routes` app) or `/apps/<your-app>/api/` (the reverse proxy, for a `backend.entryPoint` app). Core refuses to follow a redirect out of it, so the route must answer directly rather than forward |
+| `surfaces` | string[] | Any of `file-overflow`, `tree-context`, `folder-row` |
+| `when.extensions` | string[] | Match these file extensions (lowercase, no dot; empty = any) |
+| `when.kinds` | string[] | Match `file` and/or `dir` (empty = any) |
+
+At most **10** rows per app.
+
+On activation core POSTs `{ item_id, surface, path, kind?, root? }` to `endpoint`.
+
+**The file's PATH is sent, never its CONTENT.** A contributed row needs no
+permission to exist, so shipping file bytes with every activation would hand any
+app that declares a row the contents of whatever file the reader clicked, with no
+install-time declaration and no consent step. An app that needs the bytes reads
+them through a route its own `permissions` cover.
+
+`when` is evaluated by core, so an app cannot run code in the host to decide
+visibility. An endpoint outside the app's own namespace (or one using `..`
+traversal) is refused at install — the same allowlist `publishProvider` uses. For
+a signed app the rows are covered by the signature, because `endpoint` is where
+core sends the reader's chosen path. A stock build with no app declaring these
+renders nothing.
+
 ### App Icon
 
 `iconPath` is the App Store's card and row icon, and it is **top-level** — not

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -12,8 +12,10 @@ app-specific fields.
 from __future__ import annotations
 
 import json
+import posixpath
 import re
 import sys
+import urllib.parse
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
@@ -1307,6 +1309,169 @@ _PANEL_TAB_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 #: truncation the app author is never told about.
 _MAX_PANEL_TABS_PER_APP = 8
 
+#: Most file-menu rows one app may contribute, mirroring `MAX_FILE_MENU_ITEMS_PER_APP`
+#: in `fileMenuContributions.tsx`. Lower than the command cap because these rows are not
+#: a searchable list: every one of them lands in three menus a reader opens by hand, and
+#: a menu long enough to scroll is worse than a missing row. Enforced on both sides --
+#: a cap only the manifest enforces truncates silently in the menu instead.
+_MAX_FILE_MENU_ITEMS_PER_APP = 10
+
+#: The file-menu surfaces a contributed row may attach to. Data rather than a branch, so
+#: adding a surface is this line plus a render site, never an evaluator edit.
+FILE_MENU_SURFACES = frozenset({"file-overflow", "tree-context", "folder-row"})
+
+#: The node kinds a `when.kinds` filter may name.
+_FILE_MENU_KINDS = frozenset({"file", "dir"})
+
+
+#: First path segments under ``/api/apps/<app>/`` that CORE owns rather than the app.
+#: Being inside the app's own namespace is therefore NOT sufficient for an app-declared
+#: endpoint: core mounts its own handlers in that namespace, so a manifest naming one
+#: would pass the prefix test and have the host POST to a core handler with the reader's
+#: own session -- on a row the reader clicked, believing it belonged to the app.
+#:
+#: Enumerated from the core registrations of that namespace, which are the only place
+#: this list can be derived from:
+#:
+#: * ``apps/routes.py`` ``setup_routes`` -- ``manifest``, ``config``, and the lifecycle
+#:   verbs ``uninstall`` (whose ``uninstall/preview`` child is covered by the segment),
+#:   ``update``, ``enable``, ``disable``, ``open``, ``dev``, ``migrate-cleanup``
+#: * ``dashboard/routes/system.py`` -- ``token``
+#: * ``apps/job_routes.py`` -- ``_jobs``
+#:
+#: A NEW core route mounted under ``/api/apps/{name}/`` MUST be added here in the same
+#: commit, or an app can claim it; ``test_file_menu_items.py`` scans those sources and
+#: fails on a segment this set is missing. Mirrored by ``CORE_APP_ROUTE_SEGMENTS`` in
+#: ``website/src/apps/fileMenuContributions.tsx``, the dispatch-time floor for a manifest
+#: that reached the dashboard without passing install validation.
+CORE_APP_ROUTE_SEGMENTS = frozenset(
+    {
+        "_jobs",
+        "config",
+        "dev",
+        "disable",
+        "enable",
+        "manifest",
+        "migrate-cleanup",
+        "open",
+        "token",
+        "uninstall",
+        "update",
+    }
+)
+
+#: Splits a path tail at the first segment boundary, query, or fragment. The router
+#: matches on the PATH alone, so ``/api/apps/foo/uninstall?x=1`` reaches the core
+#: uninstall handler; comparing the raw tail would let a query smuggle a reserved
+#: segment past :data:`CORE_APP_ROUTE_SEGMENTS`.
+_SEGMENT_BOUNDARY_RE = re.compile(r"[/?#]")
+
+
+#: Characters an app-declared endpoint may contain, as an ALLOWLIST.
+#:
+#: A blocklist loses this argument one character at a time. Two separate bypasses of
+#: :func:`app_endpoint_allowed` were exactly that shape: the browser's URL parser STRIPS
+#: U+0009/000A/000D while ``fetch`` builds the request, so ``/api/apps/foo/uninstall\n``
+#: read as the segment ``"uninstall\n"`` here and arrived at core's uninstall handler;
+#: and it treats ``\`` as a path separator for http(s), so ``/api/apps/foo/.\uninstall``
+#: read as one opaque segment here and normalized to ``/api/apps/foo/uninstall`` there.
+#: Both are the same defect -- a character the PARSER reinterprets after this check
+#: accepted it -- and there is no reason to believe the set is now enumerated.
+#:
+#: So the shape is inverted: unreserved characters (:rfc:`3986` §2.3), the delimiters a
+#: real declared endpoint needs (``/``, ``?``, ``#``, ``=``, ``&``, ``+``, ``,``, ``:``,
+#: ``@``, ``!``, ``$``, ``'``, ``(``, ``)``, ``*``, ``;``), and nothing else. ``\``,
+#: every C0 control, DEL, space, and the characters a parser may rewrite or a header may
+#: fold on are all outside it without being named.
+#: ``\Z``, not ``$``: Python's ``$`` also matches immediately BEFORE a trailing newline,
+#: so ``"…/uninstall\n"`` would satisfy a ``$``-anchored pattern and sail through the one
+#: bypass this exists to close. The TypeScript mirror needs no equivalent -- JavaScript's
+#: ``$`` without the ``m`` flag is a true end anchor -- which is exactly the kind of
+#: per-language difference a "mirrored" pair hides, so it is stated on both sides.
+_ENDPOINT_ALLOWED_RE = re.compile(r"^[A-Za-z0-9\-._~/?#=&+,:@!$'()*;]+\Z")
+
+
+def app_endpoint_allowed(
+    app_name: str, endpoint: str, *, allow_proxy_namespace: bool = False
+) -> bool:
+    """Whether an app-declared endpoint routes inside that app's own namespace (§9.3).
+
+    The one implementation of this allowlist. Every place a manifest hands the host a URL
+    to call -- ``publishProvider.endpoint``, ``contributes.fileMenuItems[].endpoint`` --
+    checks it here, because a second copy of a security control is free to drift from the
+    first and the drift is invisible until something is let through.
+
+    ``allow_proxy_namespace`` additionally admits ``/apps/<app>/api/``, the reverse-proxy
+    prefix a PROCESS-backed app is served under. It is the caller's decision because each
+    caller documents its own contract: a contributed row must reach a process-backed app,
+    while the publish-provider registry names ``/api/apps/<app>/`` in its refusal message
+    and keeps that narrower shape. Defaulting it off means adding a caller cannot widen an
+    existing surface by accident.
+
+    Three properties do the work, and each is easy to lose when rewritten from memory:
+    normalization happens BEFORE the prefix test, so ``/api/apps/foo/../../shutdown``
+    cannot escape the namespace; the prefix carries a trailing slash, so a sibling app
+    (``/api/apps/foobar/x``) cannot pass ``foo``'s allowlist on a bare ``startswith``;
+    and the first segment BELOW the prefix is refused when core owns it, because the app's
+    own namespace is where core mounts the lifecycle routes
+    (:data:`CORE_APP_ROUTE_SEGMENTS`).
+    """
+    if not app_name or not endpoint:
+        return False
+    # A RESERVED path segment is never an app's own namespace, whatever an app is called.
+    # `/api/apps/registries/refresh` and `/api/apps/registry/install` are shared literal
+    # routes registered BEFORE the `/api/apps/{name}` catch-all, and the first segment
+    # below the prefix (`refresh`, `install`) is not a per-app lifecycle name, so
+    # :data:`CORE_APP_ROUTE_SEGMENTS` does not cover them.
+    #
+    # Reserving the NAME is explicitly forward-looking (see
+    # :data:`RESERVED_APP_PATH_SEGMENTS`): it stops new apps claiming one but leaves an
+    # already-published app so named, and the token_auth carve-out that constrains such an
+    # app governs an APP's own token, not a row a reader clicks with their own session.
+    # This is the check that has to refuse it.
+    if app_name in RESERVED_APP_PATH_SEGMENTS:
+        return False
+    decoded = urllib.parse.unquote(endpoint)
+    # Character allowlist FIRST, before anything else reads the path: see
+    # :data:`_ENDPOINT_ALLOWED_RE` for why this is an allowlist and not a set of named
+    # refusals. Applied after ``unquote`` so a percent-encoded ``%5c`` or ``%0a`` is
+    # judged as the character it becomes, not as the escape.
+    if not _ENDPOINT_ALLOWED_RE.match(decoded):
+        return False
+    normalized = posixpath.normpath(decoded)
+    if ".." in decoded or normalized != decoded.rstrip("/"):
+        return False
+    # BOTH documented app namespaces, but only when the CALLER's contract covers the
+    # second one: which namespace an app owns is not its choice — one declaring
+    # ``backend.entryPoint`` runs its own process and is reverse-proxied at
+    # ``/apps/<app>/api/`` (``routes.py`` ``handle_app_api_proxy``), while one declaring
+    # only ``backend.hooks.routes`` is registered in-gateway under ``/api/apps/<app>/``.
+    # Admitting just the in-gateway form refused every process-backed app's contribution
+    # at install, so those apps could not contribute a row at all.
+    #
+    # It is a per-caller flag rather than a blanket widening because this is the ONE
+    # shared endpoint check (see ``test_app_endpoint_allowed_is_the_one_shared_check``)
+    # and its other caller, the publish-provider registry in ``routes.py``, states
+    # ``/api/apps/<app>/`` as its contract in its own refusal message. Widening the
+    # helper for everyone would have broadened that surface silently.
+    #
+    # The core-owned reserved segments apply to the IN-GATEWAY prefix only: the proxy
+    # namespace forwards wholesale into the app's own process, so nothing core serves
+    # lives under it and a reserved name there is the app's own route.
+    prefixes: list[tuple[str, frozenset[str]]] = [
+        (f"/api/apps/{app_name}/", CORE_APP_ROUTE_SEGMENTS),
+    ]
+    if allow_proxy_namespace:
+        prefixes.append((f"/apps/{app_name}/api/", frozenset()))
+    for prefix, reserved in prefixes:
+        if not (normalized + "/").startswith(prefix):
+            continue
+        # The bare namespace root yields "" (removeprefix is a no-op on `/api/apps/foo`,
+        # whose split then starts with the leading slash), which no core route claims.
+        segment = _SEGMENT_BOUNDARY_RE.split(normalized.removeprefix(prefix), 1)[0]
+        return segment not in reserved
+    return False
+
 
 def _mirrored_len(text: str) -> int:
     """Length in UTF-16 code units -- what JavaScript's ``.length`` counts.
@@ -1757,6 +1922,166 @@ class PanelTabConfig:
 
 
 @dataclass
+class FileMenuWhen:
+    """Declarative visibility predicate for a contributed file-menu row.
+
+    Evaluated by the host, never a live callback across the app boundary -- an app
+    bundle is loaded at runtime and cannot register a function into a menu the host
+    renders. An empty field is "no constraint on this axis"; every present field must
+    match (AND), and the same predicate is mirrored in ``fileMenuContributions.tsx``
+    because the host decides visibility on both the render and the dispatch side.
+    """
+
+    #: Lowercase, dot-stripped extensions: ``["md", "py"]``.
+    extensions: list[str] = field(default_factory=list)
+    #: Subset of :data:`_FILE_MENU_KINDS`.
+    kinds: list[str] = field(default_factory=list)
+    #: Whether ``extensions`` / ``kinds`` were present but not lists. Same reason as
+    #: ``CommandArgument.bad_hosts``: coercing to ``[]`` does not mean "no opinion", it
+    #: means "match everything", so an author who wrote a restriction would silently get
+    #: none. Not serialized.
+    bad_fields: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.extensions:
+            d["extensions"] = self.extensions
+        if self.kinds:
+            d["kinds"] = self.kinds
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FileMenuWhen:
+        ext_raw = data.get("extensions", [])
+        kinds_raw = data.get("kinds", [])
+        return cls(
+            # A leading dot is normalized off so `.md` and `md` name the same file, and
+            # the case is folded here so the render side can compare literally.
+            extensions=[
+                str(e).lower().lstrip(".")
+                for e in (ext_raw if isinstance(ext_raw, list) else [])
+                if e
+            ],
+            kinds=[str(k) for k in (kinds_raw if isinstance(kinds_raw, list) else []) if k],
+            bad_fields=("extensions" in data and not isinstance(ext_raw, list))
+            or ("kinds" in data and not isinstance(kinds_raw, list)),
+        )
+
+
+@dataclass
+class FileMenuItemConfig:
+    """One row an app contributes to a file, tree, or folder menu.
+
+    Endpoint-dispatched like :class:`CommandContribution` is prompt-dispatched: the host
+    reads this declaration, renders the row itself, and POSTs the file's PATH to
+    ``endpoint`` when the row is activated. It never imports app code and holds no live
+    callback, which is what makes the seam reachable by an app installed at runtime
+    rather than only by a build-time composition root.
+    """
+
+    id: str = ""
+    #: Row label. An app-owned literal: the host has no catalog key for a row it does
+    #: not know about.
+    label: str = ""
+    #: Icon name resolved against the host's icon set (see ``AppIcon``).
+    icon: str = ""
+    #: The app's own route the row POSTs to, under ``/api/apps/<app>/``. The allowlist
+    #: is enforced by the host at dispatch, not by this structural check.
+    endpoint: str = ""
+    surfaces: list[str] = field(default_factory=list)
+    when: FileMenuWhen = field(default_factory=FileMenuWhen)
+    #: Whether ``surfaces`` was present but not a list -- an erased restriction rather
+    #: than an absent one, so it is refused instead of coerced. Not serialized.
+    bad_surfaces: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.id:
+            d["id"] = self.id
+        if self.label:
+            d["label"] = self.label
+        if self.icon:
+            d["icon"] = self.icon
+        if self.endpoint:
+            d["endpoint"] = self.endpoint
+        if self.surfaces:
+            d["surfaces"] = self.surfaces
+        when_d = self.when.to_dict()
+        if when_d:
+            d["when"] = when_d
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FileMenuItemConfig:
+        when_raw = data.get("when", {})
+        surfaces_raw = data.get("surfaces", [])
+        return cls(
+            id=str(data.get("id", "")),
+            label=str(data.get("label", "")),
+            icon=str(data.get("icon", "")),
+            endpoint=str(data.get("endpoint", "")),
+            surfaces=[
+                str(s) for s in (surfaces_raw if isinstance(surfaces_raw, list) else []) if s
+            ],
+            when=(
+                FileMenuWhen.from_dict(when_raw)
+                if isinstance(when_raw, dict)
+                else FileMenuWhen(bad_fields=True)
+            ),
+            bad_surfaces="surfaces" in data and not isinstance(surfaces_raw, list),
+        )
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        where = f"contributes.fileMenuItems[{self.id or '?'}]"
+        if not self.id:
+            errors.append("contributes.fileMenuItems: entry missing id")
+        elif not _COMMAND_SLUG_RE.fullmatch(self.id):
+            # Shares the command slug's grammar deliberately: both are app-owned ids
+            # mirrored by a frontend regex, and two patterns that must agree while being
+            # spelled separately is the exact drift that grammar's comment already names.
+            errors.append(f"{where}: id must be a lowercase kebab slug")
+        if not self.label:
+            errors.append(f"{where}: missing label")
+        elif _mirrored_len(self.label) > _MAX_TITLE:
+            errors.append(
+                f"{where}: label exceeds {_MAX_TITLE} characters ({_mirrored_len(self.label)})"
+            )
+        if _mirrored_len(self.icon) > _MAX_TITLE:
+            errors.append(
+                f"{where}: icon exceeds {_MAX_TITLE} characters ({_mirrored_len(self.icon)})"
+            )
+        if not self.endpoint:
+            errors.append(f"{where}: missing endpoint")
+        if self.bad_surfaces:
+            errors.append(
+                f"{where}: surfaces must be an array -- a non-array value passes as empty "
+                "and the row then appears in no menu, with no error its author can see"
+            )
+        elif not self.surfaces:
+            errors.append(f"{where}: must name at least one surface")
+        for surface in self.surfaces:
+            if surface not in FILE_MENU_SURFACES:
+                errors.append(
+                    f"{where}: unknown surface {surface!r} "
+                    f"(expected one of {sorted(FILE_MENU_SURFACES)})"
+                )
+        if self.when.bad_fields:
+            errors.append(
+                f"{where}: when.extensions and when.kinds must be arrays -- a non-array "
+                "value passes as unfiltered, so the row would show everywhere the author "
+                "meant to restrict it"
+            )
+        for node_kind in self.when.kinds:
+            if node_kind not in _FILE_MENU_KINDS:
+                errors.append(
+                    f"{where}: when.kinds has unknown kind {node_kind!r} "
+                    f"(expected one of {sorted(_FILE_MENU_KINDS)})"
+                )
+        return errors
+
+
+@dataclass
 class Contributes:
     """What an app adds to host surfaces it does not own.
 
@@ -1772,6 +2097,11 @@ class Contributes:
     #: is still a contribution rather than ``ui``: the strip, the persistence and the
     #: mounting are the host's, and the app only says which body to put in one slot.
     panelTabs: list[PanelTabConfig] = field(default_factory=list)  # noqa: N815
+    #: Rows an app adds to the file-editor overflow, workspace-tree context, and folder
+    #: menus. Same contract as ``commands`` two fields up -- declared, host-rendered,
+    #: dispatched to the app's own endpoint -- so it carries the same malformed-input
+    #: flags rather than coercing quietly.
+    fileMenuItems: list[FileMenuItemConfig] = field(default_factory=list)  # noqa: N815
     #: Whether the source manifest's ``commands`` was present but not a list. Same reason
     #: as ``CommandArgument.bad_hosts``: coercing to ``[]`` is indistinguishable from a
     #: deliberate empty list, so the declaration would pass validation and then vanish
@@ -1800,6 +2130,11 @@ class Contributes:
     #: error, which reads exactly like an app that simply has no panel. Not serialized.
     bad_panel_tabs: bool = False
     dropped_panel_tabs: int = 0
+    #: ``fileMenuItems`` present but not a list. Not serialized.
+    bad_file_menu_items: bool = False
+    #: How many entries of a well-formed ``fileMenuItems`` array were not objects. Not
+    #: serialized.
+    dropped_file_menu_items: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {}
@@ -1816,6 +2151,10 @@ class Contributes:
         kept_tabs = [t for t in tabs if t]
         if kept_tabs:
             d["panelTabs"] = kept_tabs
+        items = [i.to_dict() for i in self.fileMenuItems]
+        kept_items = [i for i in items if i]
+        if kept_items:
+            d["fileMenuItems"] = kept_items
         return d
 
     @classmethod
@@ -1843,9 +2182,14 @@ class Contributes:
         )
         tabs_raw = data.get("panelTabs", [])
         tab_entries = tabs_raw if isinstance(tabs_raw, list) else []
+        items_raw = data.get("fileMenuItems", [])
+        item_entries = items_raw if isinstance(items_raw, list) else []
         return cls(
             commands=[CommandContribution.from_dict(c) for c in entries if isinstance(c, dict)],
             panelTabs=[PanelTabConfig.from_dict(t) for t in tab_entries if isinstance(t, dict)],
+            fileMenuItems=[
+                FileMenuItemConfig.from_dict(i) for i in item_entries if isinstance(i, dict)
+            ],
             bad_commands="commands" in data and not isinstance(raw, list),
             dropped_commands=sum(1 for c in entries if not isinstance(c, dict)),
             sessionControls=controls,
@@ -1853,6 +2197,8 @@ class Contributes:
             and not isinstance(raw_controls, list),
             bad_panel_tabs="panelTabs" in data and not isinstance(tabs_raw, list),
             dropped_panel_tabs=sum(1 for t in tab_entries if not isinstance(t, dict)),
+            bad_file_menu_items="fileMenuItems" in data and not isinstance(items_raw, list),
+            dropped_file_menu_items=sum(1 for i in item_entries if not isinstance(i, dict)),
         )
 
     def validate(self) -> list[str]:
@@ -1933,6 +2279,34 @@ class Contributes:
                     # second is unreachable and the first answers for both.
                     errors.append(f"contributes.panelTabs: duplicate id {tab.id!r}")
                 tab_ids.add(tab.id)
+        if self.bad_file_menu_items:
+            errors.append(
+                "contributes.fileMenuItems must be an array -- a non-array value passes "
+                "as empty and then disappears from the serialized manifest, so the app "
+                "author sees neither an error nor any rows"
+            )
+        if self.dropped_file_menu_items:
+            errors.append(
+                f"contributes.fileMenuItems: {self.dropped_file_menu_items} entr"
+                f"{'y' if self.dropped_file_menu_items == 1 else 'ies'} "
+                "must be an object -- a non-object entry is filtered out before "
+                "validation, so the app installs with the remaining rows and its "
+                "author is never told one was dropped"
+            )
+        if len(self.fileMenuItems) > _MAX_FILE_MENU_ITEMS_PER_APP:
+            errors.append(
+                f"contributes.fileMenuItems: {len(self.fileMenuItems)} items exceeds the "
+                f"limit of {_MAX_FILE_MENU_ITEMS_PER_APP}"
+            )
+        seen_items: set[str] = set()
+        for item in self.fileMenuItems:
+            errors.extend(item.validate())
+            if item.id:
+                if item.id in seen_items:
+                    # Two rows with one id: the dispatch key is the id, so the second
+                    # row's activation would target the first row's endpoint.
+                    errors.append(f"contributes.fileMenuItems: duplicate id {item.id!r}")
+                seen_items.add(item.id)
         return errors
 
 
@@ -2222,9 +2596,25 @@ class AppManifest:
         # Notification channel validation (RFC Phase 2: 8-channel cap, kebab ids)
         errors.extend(self.notifications.validate())
 
-        # Contributed commands and panel tabs: ids, caps, prompt/argument
-        # agreement, matcher kind, entry paths.
+        # Contributed commands, panel tabs and file-menu rows: ids, caps,
+        # prompt/argument agreement, matcher kind, entry paths, and the file-menu
+        # surfaces / when-filter grammar.
         errors.extend(self.contributes.validate())
+
+        # A contributed row's endpoint is checked against the app's OWN namespace here,
+        # where the name is known -- refusing it at install is what keeps a declaration
+        # naming a core route (`/api/shutdown`) from ever reaching the dashboard, which
+        # would POST to it with the reader's session on a row the reader clicked.
+        for item in self.contributes.fileMenuItems:
+            if item.endpoint and not app_endpoint_allowed(
+                self.name, item.endpoint, allow_proxy_namespace=True
+            ):
+                errors.append(
+                    f"contributes.fileMenuItems[{item.id or '?'}]: endpoint "
+                    f"{item.endpoint!r} must route under /api/apps/{self.name}/ "
+                    f"or /apps/{self.name}/api/ "
+                    "(no traversal, no other app's namespace, no core route)"
+                )
 
         return errors
 
@@ -2261,6 +2651,7 @@ class AppManifest:
             self.contributes.commands
             or self.contributes.sessionControls
             or self.contributes.panelTabs
+            or self.contributes.fileMenuItems
         ):
             # A contributed command's `prompt` is sent to an agent with tools as if
             # the reader typed it, and `autoSend` fires it without a further
@@ -2280,7 +2671,9 @@ class AppManifest:
             #
             # List order preserved, so reordering is a signature-relevant change.
             # Included only when non-empty, so manifests signed before contributions
-            # existed keep producing the identical payload.
+            # existed keep producing the identical payload -- and an app contributing
+            # only commands produces the same bytes it did before panel tabs and file
+            # menus existed.
             #
             # `panelTabs` is in the guard for a sharper version of the same reason: a
             # tab's `entry` names an ESM module the AppHost imports and RUNS in the
@@ -2288,6 +2681,11 @@ class AppManifest:
             # panelTabs-ONLY manifest out of the payload entirely, so its `entry` was
             # the one part of a signed app an attacker could repoint with the signature
             # still verifying.
+            #
+            # A contributed file-menu row is covered for the same reason at one remove:
+            # its `endpoint` is where the host POSTs the path of a file the reader picked,
+            # so rewriting it on a signed app redirects that dispatch while every visible
+            # character of the row, and the signature, stay exactly as published.
             body["contributes"] = self.contributes.to_dict()
         return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
 

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -14,13 +14,11 @@ import json
 import logging
 import mimetypes
 import os
-import posixpath
 import re
 import shutil
 import stat
 import sys
 import time
-import urllib.parse
 from email.utils import formatdate
 from functools import partial
 from pathlib import Path
@@ -82,7 +80,7 @@ from kiro_crew.apps.manager import (
     uninstall_app,
     update_app,
 )
-from kiro_crew.apps.manifest import Dependencies, PlatformConfig
+from kiro_crew.apps.manifest import Dependencies, PlatformConfig, app_endpoint_allowed
 from kiro_crew.apps.official_category_order import forget_cache as forget_category_order_cache
 from kiro_crew.apps.official_category_order import load_category_order
 from kiro_crew.apps.official_editorial import forget_cache as forget_editorial_cache
@@ -409,25 +407,17 @@ def collect_publish_providers(
             continue
         app_name = str(app.get("name", ""))
         endpoint = str(pp["endpoint"])
-        # Endpoint allowlist: must route within the app's own namespace.
-        # Normalize BEFORE checking to prevent dot-segment traversal
-        # (e.g. "/api/apps/foo/../../shutdown" bypassing prefix check).
-        decoded_endpoint = urllib.parse.unquote(endpoint)
-        normalized_endpoint = posixpath.normpath(decoded_endpoint)
-        allowed_prefix = f"/api/apps/{app_name}/"
-        if (
-            ".." in decoded_endpoint
-            or normalized_endpoint != decoded_endpoint.rstrip("/")
-            # Boundary-safe prefix check: appending "/" prevents a sibling-app
-            # collision ("/api/apps/foobar/x" passing app "foo"'s allowlist).
-            or not (normalized_endpoint + "/").startswith(allowed_prefix)
-        ):
+        # Endpoint allowlist: must route within the app's own namespace. The check lives
+        # in `manifest.app_endpoint_allowed` because more than one contribution type
+        # declares an endpoint, and two copies of one security control drift apart
+        # invisibly -- the traversal and sibling-prefix guards are documented there.
+        if not app_endpoint_allowed(app_name, endpoint):
             logger.warning(
                 "publish provider for app %r declares non-conforming endpoint %r "
                 "(must start with %r, no traversal) — dropping",
                 app_name,
                 endpoint,
-                allowed_prefix,
+                f"/api/apps/{app_name}/",
             )
             continue
         providers.append(

--- a/test/test_file_menu_items.py
+++ b/test/test_file_menu_items.py
@@ -1,0 +1,459 @@
+"""Tests for the declarative `contributes.fileMenuItems` contribution point.
+
+Covers manifest parse / round-trip / validation, the caps and malformed-input
+reporting `contributes.commands` established, and the ``/api/apps/<app>/`` endpoint
+allowlist -- refused at install here rather than filtered later, because a row naming
+a core route is what the dashboard would otherwise POST to with the reader's session.
+
+`fileMenuItems` shares :class:`Contributes` with `commands`, so every test that
+exercises one asserts the other still parses, serializes and validates: a second
+field on a shared container is exactly where the first one silently disappears.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import kiro_crew
+from kiro_crew.apps.manifest import (
+    CORE_APP_ROUTE_SEGMENTS,
+    RESERVED_APP_PATH_SEGMENTS,
+    AppManifest,
+    app_endpoint_allowed,
+)
+
+_ITEM = {
+    "id": "send-to-store",
+    "label": "Send to store",
+    "icon": "Package",
+    "endpoint": "/api/apps/doc-store/send",
+    "surfaces": ["file-overflow", "tree-context", "folder-row"],
+    "when": {"extensions": [".md", "PY"], "kinds": ["file"]},
+}
+
+_COMMAND = {"id": "do-thing", "title": "Do thing", "prompt": "go"}
+
+
+def _manifest(*, items: object = None, commands: object = None, name: str = "doc-store"):
+    contributes: dict[str, object] = {}
+    if items is not None:
+        contributes["fileMenuItems"] = items
+    if commands is not None:
+        contributes["commands"] = commands
+    return AppManifest.from_dict(
+        {
+            "name": name,
+            "version": "1.0.0",
+            "displayName": "Doc Store",
+            "description": "x",
+            "contributes": contributes,
+        }
+    )
+
+
+# --- parse / round-trip -----------------------------------------------------
+
+
+def test_file_menu_item_round_trip():
+    m = _manifest(items=[_ITEM])
+    (item,) = m.contributes.fileMenuItems
+    assert item.id == "send-to-store"
+    assert item.label == "Send to store"
+    assert item.endpoint == "/api/apps/doc-store/send"
+    assert item.surfaces == ["file-overflow", "tree-context", "folder-row"]
+    # Extensions normalize: dot stripped, case folded, so the render side compares
+    # literally against a lowercased suffix.
+    assert item.when.extensions == ["md", "py"]
+    assert item.when.kinds == ["file"]
+    assert m.validate() == []
+    assert m.to_dict()["contributes"]["fileMenuItems"][0]["id"] == "send-to-store"
+
+
+def test_absent_contributes_yields_no_items_and_no_key():
+    m = AppManifest.from_dict(
+        {"name": "a", "version": "1.0.0", "displayName": "A", "description": "x"}
+    )
+    assert m.contributes.fileMenuItems == []
+    assert "contributes" not in m.to_dict()
+
+
+def test_commands_and_file_menu_items_coexist_on_one_contributes():
+    """The regression this whole field is at risk of: two contributions, one container."""
+    m = _manifest(items=[_ITEM], commands=[_COMMAND])
+    assert [c.id for c in m.contributes.commands] == ["do-thing"]
+    assert [i.id for i in m.contributes.fileMenuItems] == ["send-to-store"]
+    serialized = m.to_dict()["contributes"]
+    assert set(serialized) == {"commands", "fileMenuItems"}
+    assert m.validate() == []
+
+
+def test_commands_still_round_trip_with_no_file_menu_items():
+    m = _manifest(commands=[_COMMAND])
+    assert [c.id for c in m.contributes.commands] == ["do-thing"]
+    assert m.to_dict()["contributes"] == {"commands": [_COMMAND]}
+
+
+def test_file_menu_items_are_signature_covered():
+    """`endpoint` decides where a reader's chosen path is sent, so tampering with it
+    must invalidate the signature rather than verify unchanged."""
+    payload = _manifest(items=[_ITEM]).signing_payload()
+    assert b"fileMenuItems" in payload
+    moved = dict(_ITEM, endpoint="/api/apps/doc-store/exfiltrate")
+    assert _manifest(items=[moved]).signing_payload() != payload
+    # An app contributing only commands keeps the bytes it produced before this field
+    # existed, so signatures issued earlier still verify.
+    assert b"fileMenuItems" not in _manifest(commands=[_COMMAND]).signing_payload()
+
+
+# --- structural validation --------------------------------------------------
+
+
+def _errors(**kwargs) -> list[str]:
+    return _manifest(**kwargs).validate()
+
+
+def test_missing_id_label_endpoint_are_reported():
+    errs = _errors(items=[{"surfaces": ["file-overflow"]}])
+    assert any("missing id" in e for e in errs)
+    assert any("missing label" in e for e in errs)
+    assert any("missing endpoint" in e for e in errs)
+
+
+def test_non_slug_id_is_reported():
+    bad = dict(_ITEM, id="Send_To_Store")
+    assert any("kebab slug" in e for e in _errors(items=[bad]))
+
+
+def test_duplicate_id_is_reported():
+    assert any("duplicate id" in e for e in _errors(items=[_ITEM, dict(_ITEM)]))
+
+
+def test_unknown_surface_is_reported():
+    bad = dict(_ITEM, surfaces=["sidebar"])
+    assert any("unknown surface" in e for e in _errors(items=[bad]))
+
+
+def test_no_surface_is_reported():
+    bad = dict(_ITEM, surfaces=[])
+    assert any("at least one surface" in e for e in _errors(items=[bad]))
+
+
+def test_unknown_when_kind_is_reported():
+    bad = dict(_ITEM, when={"kinds": ["symlink"]})
+    assert any("unknown kind" in e for e in _errors(items=[bad]))
+
+
+def test_over_long_label_is_reported():
+    bad = dict(_ITEM, label="x" * 121)
+    assert any("label exceeds" in e for e in _errors(items=[bad]))
+
+
+def test_label_cap_counts_utf16_units_like_the_renderer():
+    """Mirrors `_mirrored_len`: an astral character is one code point here and two
+    `.length` units in the menu, so a label the manifest accepted would otherwise be
+    dropped by the renderer with no error."""
+    bad = dict(_ITEM, label="\U0001f600" * 61)  # 61 code points, 122 UTF-16 units
+    assert any("label exceeds" in e for e in _errors(items=[bad]))
+
+
+def test_item_cap_is_enforced():
+    items = [dict(_ITEM, id=f"row-{n}") for n in range(11)]
+    assert any("exceeds the limit" in e for e in _errors(items=items))
+
+
+# --- malformed input is REPORTED, never silently coerced --------------------
+
+
+def test_non_list_file_menu_items_is_reported_not_erased():
+    m = _manifest(items="nope")
+    assert m.contributes.bad_file_menu_items is True
+    assert any("must be an array" in e for e in m.validate())
+
+
+def test_non_object_entry_is_counted_and_reported():
+    m = _manifest(items=[_ITEM, "junk", 3])
+    assert m.contributes.dropped_file_menu_items == 2
+    assert any("must be an object" in e for e in m.validate())
+
+
+def test_non_list_surfaces_is_reported_not_erased():
+    m = _manifest(items=[dict(_ITEM, surfaces="file-overflow")])
+    assert any("surfaces must be an array" in e for e in m.validate())
+
+
+def test_non_list_when_field_is_reported_not_erased():
+    """A `when` that coerces to empty does not narrow anything -- it shows the row
+    everywhere the author meant to restrict it."""
+    m = _manifest(items=[dict(_ITEM, when={"extensions": "md"})])
+    assert any("must be arrays" in e for e in m.validate())
+
+
+def test_non_object_contributes_block_is_reported():
+    m = AppManifest.from_dict(
+        {
+            "name": "a",
+            "version": "1.0.0",
+            "displayName": "A",
+            "description": "x",
+            "contributes": "nope",
+        }
+    )
+    assert m.contributes.bad_block is True
+    assert any("must be an object" in e for e in m.validate())
+
+
+# --- endpoint allowlist (§9.3) ---------------------------------------------
+
+
+def test_endpoint_outside_own_namespace_is_refused_at_install():
+    for endpoint in (
+        "/api/shutdown",  # a core route
+        "/api/apps/other-app/send",  # another app's namespace
+        "/api/apps/doc-store-evil/send",  # sibling-prefix collision
+        "/api/apps/doc-store/../../shutdown",  # dot-segment traversal
+        "/api/apps/doc-store/%2e%2e/%2e%2e/shutdown",  # percent-encoded traversal
+        "/api/apps/doc-store/uninstall",  # a CORE route inside the app's own namespace
+        "/api/apps/doc-store/uninstall/preview",  # ... and a child of one
+        "/api/apps/doc-store/_jobs/active",  # the shared Job SDK surface
+    ):
+        errs = _manifest(items=[dict(_ITEM, endpoint=endpoint)]).validate()
+        assert any("must route under" in e for e in errs), endpoint
+
+
+def test_endpoint_inside_own_namespace_is_accepted():
+    assert _manifest(items=[dict(_ITEM, endpoint="/api/apps/doc-store/deep/send")]).validate() == []
+
+
+def test_app_endpoint_allowed_is_the_one_shared_check():
+    """`publishProvider` and `fileMenuItems` both call this, so its edges are pinned
+    here rather than in each caller."""
+    assert app_endpoint_allowed("foo", "/api/apps/foo/x") is True
+    assert app_endpoint_allowed("foo", "/api/apps/foo/") is True
+    assert app_endpoint_allowed("foo", "/api/apps/foobar/x") is False
+    assert app_endpoint_allowed("foo", "/api/apps/foo/../../shutdown") is False
+    assert app_endpoint_allowed("foo", "/api/core") is False
+    assert app_endpoint_allowed("", "/api/apps/foo/x") is False
+    assert app_endpoint_allowed("foo", "") is False
+
+
+# --- core-owned segments inside the app's own namespace ---------------------
+
+
+def test_core_owned_first_segment_is_refused_even_inside_the_app_namespace():
+    """The app's own prefix is NOT sufficient: core mounts its lifecycle handlers there.
+
+    Without this, an app declares `endpoint: /api/apps/<itself>/uninstall`, passes install
+    validation, and a reader clicking that menu row POSTs to core's uninstall handler with
+    their own session.
+    """
+    for segment in sorted(CORE_APP_ROUTE_SEGMENTS):
+        assert app_endpoint_allowed("foo", f"/api/apps/foo/{segment}") is False, segment
+        # A child path under a reserved segment is core's too (`uninstall/preview`).
+        assert app_endpoint_allowed("foo", f"/api/apps/foo/{segment}/preview") is False
+
+
+def test_a_query_string_cannot_smuggle_a_core_segment_past_the_allowlist():
+    # The router matches on the PATH alone, so this still reaches core's handler.
+    assert app_endpoint_allowed("foo", "/api/apps/foo/uninstall?x=1") is False
+    assert app_endpoint_allowed("foo", "/api/apps/foo/uninstall#frag") is False
+    # A reserved name is a whole segment, not a prefix: an app route may start with it.
+    assert app_endpoint_allowed("foo", "/api/apps/foo/uninstall-helper") is True
+    assert app_endpoint_allowed("foo", "/api/apps/foo/send?x=1") is True
+
+
+def test_a_control_character_cannot_smuggle_a_core_segment_past_the_allowlist():
+    """The browser strips TAB/LF/CR out of a URL while ``fetch`` builds the request.
+
+    So ``"uninstall\\n"`` is not the reserved ``"uninstall"`` to a naive segment test, and
+    the request still lands on core's uninstall handler with the reader's session. The
+    validator uses a character ALLOWLIST, so these are refused without being enumerated.
+    """
+    for ch in ("\t", "\n", "\r", "\x00", "\x0b", "\x1f", "\x7f", " "):
+        assert app_endpoint_allowed("foo", f"/api/apps/foo/uninstall{ch}") is False, repr(ch)
+        # Also refused when the control char sits anywhere else in the path, and when it
+        # arrives percent-encoded (the check runs AFTER unquote for that reason).
+        assert app_endpoint_allowed("foo", f"/api/apps/foo/{ch}uninstall") is False, repr(ch)
+        assert app_endpoint_allowed("foo", f"/api/apps/foo/send{ch}") is False, repr(ch)
+    assert app_endpoint_allowed("foo", "/api/apps/foo/uninstall%0a") is False
+    assert app_endpoint_allowed("foo", "/api/apps/foo/uninstall%09") is False
+    # An ordinary app route with no control characters still passes.
+    assert app_endpoint_allowed("foo", "/api/apps/foo/send") is True
+
+
+def test_a_backslash_cannot_smuggle_a_core_segment_past_the_allowlist():
+    """``\\`` is a PATH SEPARATOR to the URL parser for http(s), but not to posixpath.
+
+    So ``/api/apps/foo/.\\uninstall`` is one opaque segment to a naive segment test --
+    neither ``..`` nor a reserved word -- and the browser then normalizes it to
+    ``/api/apps/foo/uninstall`` and POSTs to core's uninstall handler.
+    """
+    for endpoint in (
+        "/api/apps/foo/.\\uninstall",
+        "/api/apps/foo/.\\token",
+        "/api/apps/foo\\uninstall",
+        "/api/apps/foo/x\\..\\uninstall",
+        "/api/apps/foo/%5cuninstall",  # percent-encoded, judged after unquote
+        "/api/apps/foo/%2e%5cuninstall",
+    ):
+        assert app_endpoint_allowed("foo", endpoint) is False, endpoint
+
+
+def test_the_endpoint_character_allowlist_admits_a_real_route_and_nothing_exotic():
+    """An allowlist, so the refusals above hold for characters nobody enumerated."""
+    for ok in (
+        "/api/apps/foo/send",
+        "/api/apps/foo/send-item",
+        "/api/apps/foo/send_item",
+        "/api/apps/foo/v1.2/send",
+        "/api/apps/foo/send?path=/a/b&kind=file",
+        "/api/apps/foo/send#frag",
+    ):
+        assert app_endpoint_allowed("foo", ok) is True, ok
+    for bad in (
+        '/api/apps/foo/send"x',
+        "/api/apps/foo/send<x",
+        "/api/apps/foo/send>x",
+        "/api/apps/foo/send|x",
+        "/api/apps/foo/send{x}",
+        "/api/apps/foo/send[x]",
+        "/api/apps/foo/send^x",
+        "/api/apps/foo/send`x",
+        "/api/apps/foo/send\u00a0x",  # NBSP
+        "/api/apps/foo/send\u2028x",  # LINE SEPARATOR
+    ):
+        assert app_endpoint_allowed("foo", bad) is False, bad
+
+
+def test_reserved_app_names_never_own_their_api_apps_path():
+    """A reserved segment is a SHARED core route, not an app's namespace.
+
+    ``/api/apps/registries/refresh`` and ``/api/apps/registry/install`` are literal routes
+    mounted before the ``/api/apps/{name}`` catch-all, and the segment below the prefix
+    (``refresh``, ``install``) is not a per-app lifecycle name, so
+    :data:`CORE_APP_ROUTE_SEGMENTS` does not cover them. Reserving the NAME is documented
+    as forward-looking only — it leaves an app already published under one — and the
+    token_auth carve-out that constrains such an app governs an APP's own token, not a row
+    a reader clicks with their own session.
+    """
+    for name in sorted(RESERVED_APP_PATH_SEGMENTS):
+        assert app_endpoint_allowed(name, f"/api/apps/{name}/refresh") is False, name
+        assert app_endpoint_allowed(name, f"/api/apps/{name}/install") is False, name
+        assert app_endpoint_allowed(name, f"/api/apps/{name}/anything") is False, name
+        # The proxy namespace is refused for these names too, in either flag position.
+        assert (
+            app_endpoint_allowed(name, f"/apps/{name}/api/x", allow_proxy_namespace=True) is False
+        ), name
+    # The two named in the route table are the sharp ones: both would otherwise pass,
+    # because neither `refresh` nor `install` is a per-app lifecycle segment.
+    assert "refresh" not in CORE_APP_ROUTE_SEGMENTS
+    assert "install" not in CORE_APP_ROUTE_SEGMENTS
+    # An ordinary app is unaffected, including one whose name merely CONTAINS a
+    # reserved word.
+    assert app_endpoint_allowed("registry-helper", "/api/apps/registry-helper/x") is True
+    assert app_endpoint_allowed("my-registry", "/api/apps/my-registry/x") is True
+
+
+def test_reserved_segment_mirrors_agree_across_python_and_the_frontend():
+    """Two copies of one control drift apart invisibly, so pin them to each other."""
+    root = Path(kiro_crew.__file__).resolve().parent.parent.parent
+    src = (root / "website" / "src" / "apps" / "coreAppRoutes.ts").read_text(encoding="utf-8")
+    block = src[src.index("RESERVED_APP_PATH_SEGMENTS = new Set([") :]
+    block = block[: block.index("])")]
+    mirrored = set(re.findall(r"'([^']+)'", block))
+    assert mirrored == set(
+        RESERVED_APP_PATH_SEGMENTS
+    ), f"frontend mirror {sorted(mirrored)} != python {sorted(RESERVED_APP_PATH_SEGMENTS)}"
+
+
+def test_both_documented_app_namespaces_are_admitted():
+    """Which namespace an app owns is not the app's choice, so both must validate.
+
+    An app declaring ``backend.entryPoint`` runs its own process and is reverse-proxied at
+    ``/apps/<app>/api/``; one declaring only ``backend.hooks.routes`` is registered
+    in-gateway under ``/api/apps/<app>/``. Admitting only the second refused every
+    process-backed app's contributed row at install, so those apps could contribute
+    nothing at all.
+    """
+    allow = {"allow_proxy_namespace": True}
+    assert app_endpoint_allowed("foo", "/api/apps/foo/send", **allow) is True
+    assert app_endpoint_allowed("foo", "/apps/foo/api/send", **allow) is True
+    assert app_endpoint_allowed("foo", "/apps/foo/api/v1/send?x=1", **allow) is True
+    # Still another app's namespace, in either form.
+    assert app_endpoint_allowed("foo", "/apps/bar/api/send", **allow) is False
+    assert app_endpoint_allowed("foo", "/apps/foobar/api/send", **allow) is False
+    # The bare proxy root IS a route: the proxy is registered as
+    # `/apps/{name}/api/{path:.*}` and that tail may be empty, which matches how the
+    # in-gateway namespace already admits its own bare root.
+    assert app_endpoint_allowed("foo", "/apps/foo/api", **allow) is True
+    # But the app root without the `api` segment is not in either namespace.
+    assert app_endpoint_allowed("foo", "/apps/foo/send", **allow) is False
+    # The character allowlist and traversal guards apply to both namespaces.
+    assert app_endpoint_allowed("foo", "/apps/foo/api/send\n", **allow) is False
+    assert app_endpoint_allowed("foo", "/apps/foo/api/.\\send", **allow) is False
+    assert app_endpoint_allowed("foo", "/apps/foo/api/../../shutdown", **allow) is False
+
+
+def test_proxy_namespace_is_opt_in_per_caller():
+    """This is the ONE shared endpoint check, so widening it for everyone is not free.
+
+    The publish-provider registry in ``routes.py`` states ``/api/apps/<app>/`` in its own
+    refusal message and must keep that narrower shape; the default therefore refuses the
+    proxy prefix, and a caller that needs it says so.
+    """
+    assert app_endpoint_allowed("foo", "/apps/foo/api/send") is False
+    assert app_endpoint_allowed("foo", "/apps/foo/api/send", allow_proxy_namespace=False) is False
+    # The in-gateway namespace is unaffected by the flag in either position.
+    for flag in (True, False):
+        assert app_endpoint_allowed("foo", "/api/apps/foo/send", allow_proxy_namespace=flag) is True
+        assert (
+            app_endpoint_allowed("foo", "/api/apps/foo/uninstall", allow_proxy_namespace=flag)
+            is False
+        )
+
+
+def test_publish_provider_registry_does_not_admit_the_proxy_namespace():
+    """Pinned at the CALL, because the default is what protects that surface."""
+    src = (Path(kiro_crew.__file__).parent / "apps" / "routes.py").read_text(encoding="utf-8")
+    call = src[src.index("if not app_endpoint_allowed(app_name, endpoint)") :][:120]
+    assert "allow_proxy_namespace" not in call
+
+
+def test_core_reserved_segments_apply_only_to_the_in_gateway_namespace():
+    """The proxy namespace forwards wholesale into the app's process.
+
+    Core serves nothing under ``/apps/<app>/api/``, so a name that is reserved in the
+    in-gateway namespace is just one of the app's own routes there.
+    """
+    for segment in sorted(CORE_APP_ROUTE_SEGMENTS):
+        assert app_endpoint_allowed("foo", f"/api/apps/foo/{segment}") is False, segment
+        assert (
+            app_endpoint_allowed("foo", f"/apps/foo/api/{segment}", allow_proxy_namespace=True)
+            is True
+        ), segment
+
+
+def test_core_route_segments_covers_every_core_route_in_the_app_namespace():
+    """Drift guard: the reserved list is derived from the code, not from memory.
+
+    A new core route mounted under ``/api/apps/{name}/`` is exactly the change that
+    silently re-opens the hole above, and nothing else in the tree would notice. The scan
+    is deliberately whole-tree rather than a fixed file list, so a core route added in a
+    NEW module is covered too; ``scaffold.py`` is the one exclusion, because its
+    ``/api/apps/{name}/status`` is a template line emitted into a GENERATED app's own
+    backend rather than a route core serves.
+    """
+    root = Path(kiro_crew.__file__).resolve().parent
+    pattern = re.compile(r"/api/apps/\{(?:name|app|app_name)\}/([a-z_][a-z0-9_-]*)")
+    registered: dict[str, set[str]] = {}
+    for path in sorted(root.rglob("*.py")):
+        if path.name == "scaffold.py":
+            continue
+        for match in pattern.finditer(path.read_text(encoding="utf-8")):
+            registered.setdefault(match.group(1), set()).add(path.name)
+    assert registered, "the scan matched nothing -- the pattern or the tree layout moved"
+    assert set(registered) == set(CORE_APP_ROUTE_SEGMENTS), (
+        "CORE_APP_ROUTE_SEGMENTS is out of date with the routes core mounts under "
+        f"/api/apps/{{name}}/ -- scanned {sorted(registered)}. Add or remove the segment "
+        "in BOTH manifest.py and website/src/apps/fileMenuContributions.tsx."
+    )

--- a/website/docs/extension-seams.md
+++ b/website/docs/extension-seams.md
@@ -16,6 +16,10 @@ already calls. `src/extensions.ts` names exactly these fourteen in its header.
 `src/test/extensionSeams.test.tsx` exercises each one except the source-provider
 seam, which has its own suite in `src/test/sourceProviderSeam.test.ts`.
 
+File/tree/folder menu rows are **not** a composition-root seam: an installed app
+declares them in its manifest under `contributes.fileMenuItems[]` and core
+POSTs the file context to the app's endpoint — see the App Kit publishing guide.
+
 | Seam | Module | Registrar to reader |
 |------|--------|---------------------|
 | Builtin page routes | `apps/builtinRegistry.ts` | `registerBuiltinComponents()` to `getBuiltinComponent()` |

--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -902,8 +902,16 @@ export default [
               // A CALLEE exemption, not a whole-file one, for the reason the ones
               // above give -- and the name is deliberately long and specific rather
               // than a generic `warnSkip`, so a future helper elsewhere cannot
-              // inherit this by accident. One definition exists today, in
-              // `src/apps/command-bar/contributedCommands.ts`, which renders nothing.
+              // inherit this by accident. TWO definitions exist today:
+              // `src/apps/command-bar/contributedCommands.ts`, which renders nothing,
+              // and `src/apps/fileMenuContributions.tsx`, the same shim for a refused
+              // `contributes.fileMenuItems` row. The second REUSES this name rather
+              // than adding a second global exemption for a differently-named shim:
+              // one entry covering both keeps the released surface the same size,
+              // where two would widen it for no gain. Note the file-scope caveat
+              // still holds for the second one -- `fileMenuContributions.tsx` does
+              // render real rows (a contributed row's app-owned `label`, straight to
+              // JSX), which is exactly why the exemption stays on the callee.
               '^warnContributionSkipped$',
               // `scrollInspector.ts`'s diagnostic sink. `devLog(tag, detail)` writes a
               // fixed-format line into a developer overlay -- `STORE.save 9020
@@ -1127,6 +1135,28 @@ export default [
           },
         },
       ],
+    },
+  },
+
+  // A URL-path-segment table: the core-owned first segments under
+  // `/api/apps/<app>/`, mirroring `CORE_APP_ROUTE_SEGMENTS` in `apps/manifest.py`.
+  // Route segments are a contract with the router, never copy — a translated
+  // `uninstall` does not localize anything, it silently un-reserves a core route and
+  // lets an app's manifest claim it.
+  //
+  // Scoped to this one file, and the file exists to be scopeable. A global
+  // `words.exclude` shape cannot express it: the values are bare lowercase words
+  // (`open`, `update`, `config`, `enable`), so the whole-value-anchored entry that
+  // would release them would equally release a button labelled exactly "Open". And
+  // releasing their previous home, `apps/fileMenuContributions.tsx`, would release the
+  // app-actions label and every other string in a module that DOES render copy. The
+  // set also sits under an ALL-CAPS declarator, so `eslint.i18n.strict.config.js`
+  // recovers it and `[added-lines]` charges the whole array on any edit to it.
+  // Keep `coreAppRoutes.ts` route segments only.
+  {
+    files: ['src/apps/coreAppRoutes.ts'],
+    rules: {
+      'i18next/no-literal-string': 'off',
     },
   },
 

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1575,7 +1575,13 @@ const projectHeader = (projectKey?: string): HeadersInit | undefined =>
 
 const get = (url: string, sessionKey?: string, signal?: AbortSignal) =>
   fetch(url, { headers: { ...(sessionKey ? { 'X-Session-Key': sessionKey } : _sk) }, ...(signal ? { signal } : {}) })
-const post = (url: string, body?: object, sessionKey?: string, extra?: HeadersInit) =>
+const post = (
+  url: string,
+  body?: object,
+  sessionKey?: string,
+  extra?: HeadersInit,
+  redirect?: RequestRedirect,
+) =>
   trackArtifactWrite(url, fetch(url, {
     method: 'POST',
     // sessionKey overrides the shared `dashboard:ui` placeholder with the REAL
@@ -1585,6 +1591,11 @@ const post = (url: string, body?: object, sessionKey?: string, extra?: HeadersIn
     // of a specific chat slot must pass it.
     // `extra` carries a per-call precondition header (a view the server must
     // still agree with) without every caller re-implementing the header merge.
+    // `redirect` is for a caller whose URL is not core's to choose: a validated
+    // target that answers 3xx would otherwise be followed automatically, and the
+    // check that approved the FIRST url never sees the second. Defaulted so no
+    // existing caller changes behaviour.
+    ...(redirect ? { redirect } : {}),
     headers: { 'Content-Type': 'application/json', ...(sessionKey ? { 'X-Session-Key': sessionKey } : _sk), ...extra },
     body: body ? JSON.stringify(body) : undefined,
   }))
@@ -3916,6 +3927,34 @@ export const api = {
   researchReport: (id: string) => get("/api/apps/auto-research/campaigns/" + id + "/report").then(j),
   researchDelete: (id: string) => del("/api/apps/auto-research/campaigns/" + id).then(j),
 
+  // Activate a file-menu row an installed app contributed. The declarations ride on
+  // `GET /api/apps` (see `fileMenuContributions.ts`) rather than an endpoint of their
+  // own, so only the dispatch lives here: core POSTs the file's path to the row's own
+  // endpoint and never imports app code.
+  //
+  // `sessionKey` is the OWNING SLOT (`dashboard:<slot>`), supplied by the shared
+  // dispatcher. It rides the header rather than the body because the server's
+  // restricted-session gate reads the header, and the body is the app-facing contract
+  // documented in the manifest reference.
+  //
+  // `redirect: 'error'` is what makes the endpoint allowlist mean anything. The URL is
+  // the APP's to choose, and it is validated once, before the request; `fetch` follows a
+  // 3xx by default, and a 307 preserves the method, the body AND this header, so an
+  // approved endpoint answering `307 /api/apps/<victim>/disable` would have the reader's
+  // own session disable another app on a row they merely clicked. Refusing to follow
+  // keeps the checked url the only url.
+  invokeFileMenuItem: async (
+    item: { id: string; endpoint: string },
+    ctx: FileMenuContext,
+    sessionKey?: string,
+  ) => {
+    const r = await post(item.endpoint, { item_id: item.id, ...ctx }, sessionKey, undefined, 'error')
+    checkSessionExpired(r)
+    if (r.ok) { removeAuthBanner(); return r.json() }
+    const errText = await r.text()
+    throw new ApiError(r.status, errText || `HTTP ${r.status}`)
+  },
+
   artifactTeardown: (slug: string) => post(`/api/deploy/teardown/${slug}`, { confirm: true }).then(j),
   publishProviders: () => get('/api/publish-providers').then(j) as Promise<{ providers: AppPublishProvider[] }>,
   /** Publish through a CORE-registry destination, resolved by its registry name.
@@ -3974,4 +4013,23 @@ export interface AppPublishProvider {
   configured: boolean
   setupRoute: string
   endpoint: string
+}
+
+/** The surfaces a contributed file-menu row can appear on. */
+export type FileMenuSurface = 'file-overflow' | 'tree-context' | 'folder-row'
+
+/**
+ * What core POSTs to a row's endpoint when it is activated.
+ *
+ * The PATH only — deliberately never file CONTENT. A contributed row is declared in a
+ * manifest and needs no permission to exist, so shipping the bytes with the activation
+ * would hand any app that declares one the contents of whatever file the reader clicked,
+ * with no install-time declaration and no consent step. An app that needs the bytes reads
+ * them through a route its own `permissions` cover.
+ */
+export interface FileMenuContext {
+  surface: FileMenuSurface
+  path: string
+  kind?: 'file' | 'dir'
+  root?: string
 }

--- a/website/src/apps/coreAppRoutes.ts
+++ b/website/src/apps/coreAppRoutes.ts
@@ -1,0 +1,52 @@
+/**
+ * First path segments under `/api/apps/<app>/` that CORE owns rather than the app.
+ *
+ * Textual mirror of `CORE_APP_ROUTE_SEGMENTS` in `apps/manifest.py`, which carries the
+ * enumeration, the source files it was read from, and the rule that a new core route
+ * mounted under `/api/apps/{name}/` is added to BOTH sides in the same commit. Being
+ * inside the app's own namespace is not sufficient: core mounts the lifecycle routes
+ * there, so a contributed row naming one would POST to a core handler with the
+ * reader's own session, on a row they clicked believing it belonged to the app.
+ *
+ * ## Why this is its own module
+ *
+ * These are URL path segments, not copy, and `eslint.i18n.config.js` releases this
+ * FILE so editing the set does not fail the zero-tolerance `[added-lines]` i18n gate.
+ * A global `words.exclude` shape cannot do that job here: the values are bare
+ * lowercase words (`open`, `update`, `config`), so a whole-value-anchored global
+ * exemption would also release a button whose label is exactly "Open". Keeping them
+ * apart from `fileMenuContributions.tsx` — which DOES render copy — is what makes the
+ * file-scoped release honest. Keep this module route segments only; anything with a
+ * user-visible string belongs elsewhere.
+ */
+export const CORE_APP_ROUTE_SEGMENTS = new Set([
+  '_jobs',
+  'config',
+  'dev',
+  'disable',
+  'enable',
+  'manifest',
+  'migrate-cleanup',
+  'open',
+  'token',
+  'uninstall',
+  'update',
+])
+
+/**
+ * App names that are NOT an app's own namespace, whatever an app is called.
+ *
+ * Textual mirror of `RESERVED_APP_PATH_SEGMENTS` in `apps/manifest.py`. These are shared
+ * literal routes registered before the `/api/apps/{name}` catch-all
+ * (`/api/apps/registries/refresh`, `/api/apps/registry/install`), and the segment BELOW
+ * the prefix is not a per-app lifecycle name, so `CORE_APP_ROUTE_SEGMENTS` does not cover
+ * them. Reserving the name at install is forward-looking only and leaves an
+ * already-published app so named, so the endpoint check is what has to refuse it.
+ */
+export const RESERVED_APP_PATH_SEGMENTS = new Set([
+  'blob',
+  'install',
+  'register',
+  'registries',
+  'registry',
+])

--- a/website/src/apps/file-explorer/styles.ts
+++ b/website/src/apps/file-explorer/styles.ts
@@ -10,7 +10,7 @@ export const FE_CSS = `
 .mc-fe-tab { display:inline-flex; align-items:center; gap:4px; padding:6px 8px 6px 10px; border:1px solid var(--border); border-bottom:none; border-radius:6px 6px 0 0; background:var(--card); color:var(--muted); cursor:pointer; user-select:none; transition:background .12s, color .12s; flex-shrink:0; }
 .mc-fe-tab.is-active { background:var(--bg); color:var(--text); border-color:var(--border); }
 .mc-fe-tab.is-current-folder { border-bottom-color:var(--bg); }
-.mc-fe-tab-label { font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:200px; }
+.mc-fe-tab-label { font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; min-width:0; max-width:200px; }
 .mc-fe-tab-close { display:inline-flex; align-items:center; justify-content:center; width:16px; height:16px; border-radius:3px; opacity:.5; flex-shrink:0; }
 .mc-fe-tab-close:hover { opacity:1; background:color-mix(in srgb, var(--text) 12%, transparent); }
 .mc-fe-tab-new { display:inline-flex; align-items:center; justify-content:center; padding:6px 10px; background:transparent; border:none; color:var(--muted); cursor:pointer; border-radius:4px; flex-shrink:0; }

--- a/website/src/apps/fileMenuContributions.tsx
+++ b/website/src/apps/fileMenuContributions.tsx
@@ -1,0 +1,558 @@
+/**
+ * File-menu rows contributed by installed apps.
+ *
+ * This is what lets a row in the file-editor overflow menu, the workspace-tree
+ * context menu, or the folder panel live OUTSIDE this repository. An app declares
+ * `contributes.fileMenuItems` in its manifest; this module turns that declaration
+ * into rows the host renders, and activating one POSTs the file's PATH to the app's
+ * own endpoint. Nothing here executes app code — a contribution is data, and the
+ * host is the only thing that acts on it.
+ *
+ * **Everything below re-validates what the backend already checks**, for the reason
+ * `contributedCommands.ts` gives: an unknown top-level manifest key reaches this
+ * dashboard through the manifest's `extra` bucket without passing any schema, so an
+ * app installed by an older gateway — or one whose `app.json` was edited in place —
+ * can put an arbitrary object on this path. Manifest data from a third party is
+ * untrusted input.
+ *
+ * A bad declaration is SKIPPED with a warning, never thrown: a malformed app must not
+ * be able to take a file menu down for every other app on the instance.
+ *
+ * The rows are read off the SHARED `['apps']` query rather than an endpoint of their
+ * own. `contributes` already reaches the dashboard on that response, so a second
+ * request would buy nothing and cost a per-session round trip plus a second
+ * `list_apps()` disk walk.
+ *
+ * Kept pure and dependency-light so the rules are pinned by unit test rather than by
+ * reading a component. Icons stay STRINGS here; resolving one to a glyph is the
+ * renderer's job.
+ */
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { MoreHorizontal } from 'lucide-react'
+import { api, type FileMenuContext, type FileMenuSurface } from '../api/client'
+import AppIcon from '../components/AppIcon'
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem,
+} from '../components/ui/dropdown-menu'
+import { i18nT } from '../i18n/t'
+import { store } from '../store'
+import { HOVER_NONE_ACTIONS_ROW_CLS } from '../utils/touchActions'
+
+/**
+ * How a host surface receives a dispatch failure — the same shape `MarkdownPanel`'s
+ * `ReportError` has, so a caller passes the reporter it already holds for its other row
+ * actions instead of standing up a second error surface for contributed rows.
+ */
+export type ReportFileMenuError = (message: string) => void
+
+/** The subset of `GET /api/apps` this module reads. */
+export interface FileMenuAppRecord {
+  name: string
+  /** Human name from the manifest; the attribution prefers it over `name`. */
+  displayName?: string
+  enabled?: boolean
+  manifest?: {
+    contributes?: {
+      fileMenuItems?: unknown
+    }
+  }
+}
+
+/** A validated row, ready to render. */
+export interface ContributedFileMenuItem {
+  /** Row id, namespaced by the contributing app so two apps may use one id. */
+  id: string
+  /** The app that contributed it — namespaces the id and scopes the endpoint. */
+  app: string
+  /** App-owned literal; the host has no catalog key for a row it does not know. */
+  label: string
+  /**
+   * The attribution RENDERED next to `label`, so a contributed row cannot read as a
+   * core one. `label` is app-owned and validated for presence and length only -- it is
+   * never checked against the core vocabulary -- so an app may legitimately, or
+   * deceptively, call its row "Download". Without a visible owner the reader cannot
+   * tell that clicking it hands the file's path to a third party.
+   *
+   * Mirrors `appLabel` in `apps/command-bar/contributedCommands.ts`, whose own note
+   * records why this must never degrade to empty: a row with no attribution renders
+   * character-for-character like a builtin. So it steps down -- `displayName`, else
+   * `name`, else that name clipped to `MAX_LABEL` -- and is always non-empty for a row
+   * that survives validation.
+   */
+  appLabel: string
+  /** Host glyph name; the renderer maps it, and an unknown name falls back. */
+  icon: string
+  endpoint: string
+  surfaces: FileMenuSurface[]
+  when: { extensions: string[]; kinds: ('file' | 'dir')[] }
+}
+
+/** The node a row is being considered for. */
+export interface FileMenuNode {
+  path: string
+  kind: 'file' | 'dir'
+}
+
+/**
+ * Mirrors `_MAX_FILE_MENU_ITEMS_PER_APP` in `apps/manifest.py`. A cap only the
+ * manifest enforces is not a cap: the app would install clean and the menu would then
+ * drop the overflow with no error its author can see.
+ */
+const MAX_FILE_MENU_ITEMS_PER_APP = 10
+/** Mirrors `_MAX_TITLE` in `apps/manifest.py`. */
+const MAX_LABEL = 120
+/** Mirrors `_COMMAND_SLUG_RE` in `apps/manifest.py`, which contributed ids share. */
+const ITEM_ID_RE = /^[a-z0-9][a-z0-9-]*$/
+/** Mirrors `FILE_MENU_SURFACES` in `apps/manifest.py`. */
+const SURFACES = new Set<FileMenuSurface>(['file-overflow', 'tree-context', 'folder-row'])
+/** Mirrors `_FILE_MENU_KINDS` in `apps/manifest.py`. */
+const KINDS = new Set(['file', 'dir'])
+
+// Core-owned route segments live in their own module (`coreAppRoutes.ts`): they are
+// URL path segments rather than copy, and the i18n lint releases that FILE, which it
+// could not do for this one without also releasing the app-actions label and every
+// other string here. Imported for `endpointAllowed` below and re-exported so callers
+// and tests keep one import site.
+import { CORE_APP_ROUTE_SEGMENTS, RESERVED_APP_PATH_SEGMENTS } from './coreAppRoutes'
+export { CORE_APP_ROUTE_SEGMENTS }
+
+/**
+ * A contributed row's label AND its attribution, so all three surfaces render provenance
+ * the same way and none of them can forget it.
+ *
+ * `label` is app-owned and never checked against the core vocabulary, so an app may name
+ * its row "Download" and sit one separator below the real Download. The attribution is
+ * what makes that visible: clicking a contributed row POSTs the file's PATH to a third
+ * party, which a reader can only consent to if they can see who owns the row.
+ *
+ * Rendered as a muted trailing span rather than a second line, because all three hosts
+ * are single-line menu rows. It carries no connecting copy ("from …") on purpose: that
+ * would be a catalog string, while `appLabel` is app-owned text no catalog can translate.
+ * Deliberately NOT `aria-hidden` — the provenance is the security-relevant part of the
+ * row, so a screen reader must announce it too.
+ */
+export function FileMenuItemLabel({ item }: { item: ContributedFileMenuItem }) {
+  return (
+    <>
+      {/* `min-w-0` alongside `truncate`: a flex child's default `min-width: auto` refuses
+          to shrink below its content, so `truncate` alone never engages inside a flex row
+          and the text sets the row's width instead of being clipped by it. */}
+      <span className="truncate min-w-0">{item.label}</span>
+      {/* A literal space, not just the margin: the accessible NAME is computed from text
+          content, so without it a screen reader announces "Send to storedoc-store". */}
+      {' '}
+      {/* HOST-owned framing around the app's identifier, from the catalog. The bare
+          identifier is unspoofable as a host WORD (kebab-case only), but nothing stops an
+          app installing as `kiro-crew`, and on its own that still reads as core. The
+          word around it is core's, in the reader's language, so the row states who owns
+          it rather than leaving the reader to infer it from a slug.
+          Shrinkable and truncating rather than `shrink-0`: `KEBAB_RE` bounds the app
+          name's alphabet and not its length, so a 120-character one (the `MAX_LABEL`
+          clip) would otherwise widen the menu past a 320px viewport and push the rows
+          off-screen. Truncated provenance still identifies the app; an unreachable row
+          does not. */}
+      <span className="ml-2 shrink truncate min-w-0 text-[11px] text-muted">
+        {i18nT('components.fileMenuContributions.contributed_by', { app: item.appLabel })}
+      </span>
+    </>
+  )
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+function warnContributionSkipped(appName: string, id: unknown, reason: string): void {
+  // eslint-disable-next-line no-console -- a refused contribution is invisible otherwise
+  console.warn(
+    `[fileMenuContributions] app ${appName}: skipping contributed row ${String(id)} — ${reason}`,
+  )
+}
+
+/** The row survives; only the LENGTH of its attribution is gone. Distinct from a skip. */
+function warnAttributionClipped(appName: string, id: unknown, reason: string): void {
+  // eslint-disable-next-line no-console -- otherwise the app author has no way to notice
+  console.warn(
+    `[fileMenuContributions] app ${appName}: contributed row ${String(id)} renders with a clipped attribution — ${reason}`,
+  )
+}
+
+/**
+ * Whether an app-declared endpoint routes inside that app's own namespace.
+ *
+ * Mirrors `app_endpoint_allowed` in `apps/manifest.py`, which refuses a bad endpoint at
+ * INSTALL — this copy is the dispatch-time floor, because the row that gets POSTed is
+ * the one in this list and a manifest that reached the dashboard through `extra` never
+ * met the install check. The trailing slash on the prefix is what stops a sibling app
+ * (`/api/apps/foobar/x`) from passing `foo`'s allowlist.
+ */
+function endpointAllowed(appName: string, endpoint: string): boolean {
+  if (!appName || !endpoint) return false
+  // A reserved segment is never an app's own namespace, whatever the app is called:
+  // `/api/apps/registry/install` is a shared literal route mounted before the
+  // `/api/apps/{name}` catch-all, and `install` is not a per-app lifecycle segment, so
+  // the reserved-segment set below would not catch it. Mirrors the same refusal in
+  // `app_endpoint_allowed`.
+  if (RESERVED_APP_PATH_SEGMENTS.has(appName)) return false
+  let decoded = endpoint
+  try {
+    decoded = decodeURIComponent(endpoint)
+  } catch {
+    // A malformed percent-escape cannot be reasoned about; refuse rather than guess.
+    return false
+  }
+  // Character ALLOWLIST, mirroring `_ENDPOINT_ALLOWED_RE` in `apps/manifest.py`, which
+  // carries the reasoning: a blocklist loses this one character at a time, because the
+  // defect class is "a character the URL parser reinterprets AFTER this check accepted
+  // it" — U+0009/000A/000D are stripped as `fetch` builds the request, and `\` is a path
+  // separator for http(s), so `/api/apps/foo/.\uninstall` normalizes onto core's
+  // uninstall route. Unreserved characters plus the delimiters a real endpoint needs;
+  // `\`, controls, DEL and space are outside it without being named. Applied after
+  // `decodeURIComponent` so `%5c` is judged as the character it becomes. The Python
+  // mirror anchors with `\Z` rather than `$` because Python's `$` also matches before a
+  // trailing newline; JavaScript's `$` without `m` is a true end anchor, so `$` is
+  // correct HERE and the two patterns are deliberately not character-identical.
+  if (!/^[A-Za-z0-9\-._~/?#=&+,:@!$'()*;]+$/.test(decoded)) return false
+  if (decoded.includes('..')) return false
+  const path = decoded.replace(/\/+$/, '')
+  // Stands in for `posixpath.normpath` plus the equality test the Python side runs: a `.`
+  // segment or a doubled slash is resolved away by the URL parser BEFORE the request is
+  // routed, so `/api/apps/foo/./uninstall` reads as an app route here and still arrives
+  // at core's uninstall handler. The leading empty segment is the path's own root slash.
+  if (path.split('/').slice(1).some(seg => seg === '' || seg === '.')) return false
+  // BOTH documented app namespaces, mirroring `app_endpoint_allowed` in
+  // `apps/manifest.py` AS THE FILE-MENU CALLER INVOKES IT
+  // (`allow_proxy_namespace=True`). This mirror has exactly one consumer, so the
+  // per-caller flag the Python side carries would be a parameter with a single value
+  // here; the flag exists there because that check is shared with the publish-provider
+  // registry, which keeps the narrower in-gateway shape.
+  //
+  // Which namespace an app owns is decided by whether it declares
+  // `backend.entryPoint` (its own process, reverse-proxied at `/apps/<app>/api/`) or only
+  // `backend.hooks.routes` (in-gateway at `/api/apps/<app>/`), never by the app. The
+  // reserved core segments apply to the in-gateway prefix ALONE — the proxy namespace
+  // forwards wholesale into the app's process, so core serves nothing under it.
+  for (const [prefix, reserved] of [
+    [`/api/apps/${appName}/`, CORE_APP_ROUTE_SEGMENTS],
+    [`/apps/${appName}/api/`, new Set<string>()],
+  ] as const) {
+    if (!(path + '/').startsWith(prefix)) continue
+    // First segment below the app's prefix, cut at a query or fragment for the reason the
+    // Python mirror gives: the router matches on the path alone, so `/uninstall?x=1` still
+    // reaches core's handler. The bare namespace root yields '', which no core route claims.
+    const segment = path.slice(prefix.length).split(/[/?#]/, 1)[0]
+    return !reserved.has(segment)
+  }
+  return false
+}
+
+function readItem(app: FileMenuAppRecord, raw: unknown): ContributedFileMenuItem | null {
+  if (typeof raw !== 'object' || raw === null) {
+    warnContributionSkipped(app.name, raw, 'entry is not an object')
+    return null
+  }
+  const obj = raw as Record<string, unknown>
+  const id = str(obj.id)
+  if (!ITEM_ID_RE.test(id)) {
+    warnContributionSkipped(app.name, obj.id, 'id must be lowercase alphanumeric with dashes')
+    return null
+  }
+  const label = str(obj.label)
+  if (!label) {
+    warnContributionSkipped(app.name, id, 'missing label')
+    return null
+  }
+  if (label.length > MAX_LABEL) {
+    warnContributionSkipped(app.name, id, `label exceeds ${MAX_LABEL} characters`)
+    return null
+  }
+  const endpoint = str(obj.endpoint)
+  if (!endpointAllowed(app.name, endpoint)) {
+    warnContributionSkipped(app.name, id, `endpoint must route under /api/apps/${app.name}/`)
+    return null
+  }
+  const rawSurfaces = obj.surfaces
+  if (!Array.isArray(rawSurfaces)) {
+    warnContributionSkipped(app.name, id, 'surfaces must be an array')
+    return null
+  }
+  const surfaces = rawSurfaces.filter(
+    (s): s is FileMenuSurface => typeof s === 'string' && SURFACES.has(s as FileMenuSurface),
+  )
+  if (surfaces.length === 0) {
+    warnContributionSkipped(app.name, id, 'names no known surface')
+    return null
+  }
+  // `when` is advisory rather than load-bearing: a malformed filter narrows nothing, so
+  // it degrades to "no constraint" instead of dropping the row. The manifest reports the
+  // same input as an error, which is where an author finds out.
+  const rawWhen = typeof obj.when === 'object' && obj.when !== null ? (obj.when as Record<string, unknown>) : {}
+  const extensions = Array.isArray(rawWhen.extensions)
+    ? rawWhen.extensions.filter((e): e is string => typeof e === 'string' && e.length > 0)
+        .map(e => e.toLowerCase().replace(/^\.+/, ''))
+    : []
+  const kinds = Array.isArray(rawWhen.kinds)
+    ? rawWhen.kinds.filter((k): k is 'file' | 'dir' => typeof k === 'string' && KINDS.has(k))
+    : []
+  // The attribution, and it comes from `name` -- NEVER `displayName`.
+  //
+  // `displayName` is free text the app chooses, so as provenance it can claim to be
+  // anything, the host included: a manifest saying `displayName: "Kiro Crew"` rendered a
+  // row that read as native, and the reader clicked it believing core was handling their
+  // file. `name` is the install identity and `KEBAB_RE` constrains it to
+  // `[a-z0-9]` plus single hyphens, so it cannot spell a host word with a space or a
+  // capital. It is also unique across installed apps, which `displayName` is not.
+  //
+  // Clipped rather than refused: `KEBAB_RE` bounds the alphabet and not the length, and
+  // dropping the row instead would hide every action of an app whose own fields were all
+  // fine.
+  const rawAppLabel = app.name
+  const appLabel = rawAppLabel.length > MAX_LABEL ? app.name.slice(0, MAX_LABEL) : rawAppLabel
+  if (appLabel !== rawAppLabel) {
+    warnAttributionClipped(app.name, id, `app label exceeds ${MAX_LABEL} characters`)
+  }
+  return {
+    id,
+    app: app.name,
+    label,
+    appLabel,
+    icon: str(obj.icon),
+    endpoint,
+    surfaces,
+    when: { extensions, kinds },
+  }
+}
+
+/**
+ * Every valid row contributed by the ENABLED installed apps.
+ *
+ * Disabled apps contribute nothing: the enable state is the reader's switch for the
+ * whole app, and a row that still POSTed from a disabled app would make that switch a
+ * lie.
+ */
+export function contributedFileMenuItems(
+  apps: readonly FileMenuAppRecord[],
+): ContributedFileMenuItem[] {
+  const out: ContributedFileMenuItem[] = []
+  // Array-checked, not just nullish-checked. This reads the SHARED `['apps']` cache, so
+  // the value is whatever another observer's fetch put there, and `normalizeInstalledApps`
+  // returns a non-array payload untouched. Both sibling resolvers on that same key guard
+  // here for the same reason: this runs inside a `useMemo` during render, so iterating a
+  // non-array throws `apps is not iterable` and takes the whole host page down -- on a
+  // menu the reader merely opened.
+  for (const app of Array.isArray(apps) ? apps : []) {
+    if (!app.enabled) continue
+    if (!app.name) {
+      warnContributionSkipped('(unnamed)', '(all)', 'app record has no name')
+      continue
+    }
+    const raw = app.manifest?.contributes?.fileMenuItems
+    if (raw === undefined || raw === null) continue
+    if (!Array.isArray(raw)) {
+      warnContributionSkipped(app.name, '(all)', 'contributes.fileMenuItems is not an array')
+      continue
+    }
+    // Sliced BEFORE the loop so the cap bounds the WORK, not just the output: a manifest
+    // with fifty thousand malformed entries would otherwise run that many validations
+    // and `console.warn` calls synchronously on the thread drawing the menu.
+    const seen = new Set<string>()
+    for (const entry of raw.slice(0, MAX_FILE_MENU_ITEMS_PER_APP)) {
+      const item = readItem(app, entry)
+      if (!item) continue
+      if (seen.has(item.id)) {
+        warnContributionSkipped(app.name, item.id, 'duplicate id')
+        continue
+      }
+      seen.add(item.id)
+      out.push(item)
+    }
+  }
+  return out
+}
+
+/**
+ * The rows enabled apps contribute to one surface.
+ *
+ * A pure cache subscriber (`enabled: false`), like the Command Bar's use of the same
+ * query: it re-renders when the shell's own `['apps']` fetch lands and never issues a
+ * request of its own, so mounting this from three menus costs nothing. With no
+ * contributing app it returns `[]`, so a stock build renders nothing and is inert.
+ */
+export function useFileMenuItems(surface: FileMenuSurface): ContributedFileMenuItem[] {
+  const { data: apps } = useQuery({
+    queryKey: ['apps'],
+    queryFn: () => api.listApps(),
+    enabled: false,
+  })
+  return useMemo(
+    () =>
+      contributedFileMenuItems((apps ?? []) as FileMenuAppRecord[]).filter(it =>
+        it.surfaces.includes(surface),
+      ),
+    [apps, surface],
+  )
+}
+
+/**
+ * Whether a row's declarative `when` predicate admits this node. An empty field is "no
+ * constraint on that axis"; present fields AND together. A path with no dot has no
+ * extension, so an extension filter excludes it.
+ */
+export function fileMenuItemMatches(
+  item: ContributedFileMenuItem,
+  node: FileMenuNode,
+): boolean {
+  const { extensions, kinds } = item.when
+  if (kinds.length && !kinds.includes(node.kind)) return false
+  if (extensions.length) {
+    const base = node.path.split('/').pop() ?? ''
+    // A leading-dot name (`.gitignore`) is a name, not an extension.
+    const dot = base.lastIndexOf('.')
+    if (dot <= 0) return false
+    if (!extensions.includes(base.slice(dot + 1).toLowerCase())) return false
+  }
+  return true
+}
+
+/** Surface rows already filtered against a node's `when` predicate. */
+export function visibleFileMenuItems(
+  items: readonly ContributedFileMenuItem[],
+  node: FileMenuNode,
+): ContributedFileMenuItem[] {
+  return items.filter(it => fileMenuItemMatches(it, node))
+}
+
+/**
+ * POST a row's activation to the app that declared it.
+ *
+ * Only the PATH crosses the boundary — never file CONTENT. An app that needs the bytes
+ * reads them through a route its own `permissions` cover, which is where the reader's
+ * consent for that access is recorded; handing content to every contributed row would
+ * grant it silently to any app that declares one.
+ *
+ * A rejection is handed to `onError` rather than logged: every surface closes its menu on
+ * activation, so a console-only failure leaves the reader looking at a row that did
+ * nothing and no way to tell an endpoint refusal from a slow app. The host renders the
+ * message through the shared `ErrorNotice` it already owns for its other row actions.
+ */
+export function invokeFileMenuItem(
+  item: ContributedFileMenuItem,
+  ctx: FileMenuContext,
+  onError: ReportFileMenuError,
+): void {
+  // Read the owning slot at dispatch time and send it as the X-Session-Key, the same
+  // way MarkdownPanel's own promote and pin actions in this very menu do.
+  //
+  // Without it `post` falls back to the shared `dashboard:ui` placeholder, which
+  // satisfies the server's `if sk:` gate but names no actual session — so a restricted
+  // (incognito) slot is never recognised as restricted and the row's write is allowed
+  // through. Read HERE, in the one dispatcher all three surfaces call, rather than
+  // threaded as a prop through each of them: a surface that forgot the prop would fail
+  // OPEN, and silently.
+  const slot = store.getState().chat.activeSlot
+  void api.invokeFileMenuItem(
+    item,
+    ctx,
+    slot ? `dashboard:${slot}` : undefined,
+  ).catch((err: unknown) => {
+    // The thrown value is an `ApiError` carrying the endpoint's own response text (or
+    // `HTTP <status>`), so it is already the most specific thing there is to say; the
+    // `String` arm covers a non-Error rejection rather than reporting an empty banner.
+    onError((err as Error)?.message || String(err))
+  })
+}
+
+/**
+ * Render a contributed row's icon. `icon` is a manifest string, resolved through the
+ * same `AppIcon` allowlist app icons use (an unknown name falls back to a generic
+ * glyph); an empty icon renders nothing.
+ */
+export function FileMenuItemIcon({ name }: { name?: string }) {
+  if (!name) return null
+  return <AppIcon icon={name} size={14} />
+}
+
+/**
+ * Hover-revealed actions for the `folder-row` surface, behind ONE overflow trigger.
+ *
+ * A row of peer buttons is capped at two (`max-two-buttons-per-row`), and the count here
+ * is an app's to choose — three declaring apps would put three unranked icon buttons in a
+ * listing row that a sidebar or split pane clips before it degrades. So the rows always
+ * collapse into a single kebab, even for one contribution: the trigger is one control
+ * whatever it holds, and a row whose control count changes when an app is installed is
+ * worse than one that never does.
+ *
+ * `DropdownMenu` is the row-action overflow the dashboard already uses
+ * (`CronRowActions`), which is what supplies the roving focus, Escape-to-close and
+ * focus-restore rather than this file re-deriving them.
+ */
+export function FolderRowActions({
+  items,
+  node,
+  onError,
+}: {
+  items: readonly ContributedFileMenuItem[]
+  node: FileMenuNode
+  /** Where a dispatch failure goes; the panel renders it through its own ErrorNotice. */
+  onError: ReportFileMenuError
+}) {
+  if (items.length === 0) return null
+  const label = i18nT('components.fileMenuContributions.app_actions')
+  return (
+    // role="presentation" keeps the wrapper out of the accessibility tree while it stops
+    // the interaction from reaching the enclosing row: the row is a `role="button"` with
+    // its own click and Enter/Space handlers, so opening this menu would otherwise also
+    // navigate into the folder or open the file.
+    <span
+      role="presentation"
+      onClick={e => e.stopPropagation()}
+      onKeyDown={e => e.stopPropagation()}
+      // Hover-reveal keeps the row quiet on a pointer device, but on a touch screen
+      // there is no hover and nothing here has been focused yet, so `opacity-0` alone
+      // left the ONLY trigger for these actions permanently invisible. Keyed on hover
+      // CAPABILITY rather than a width breakpoint (`HOVER_NONE_ACTIONS_ROW_CLS`, the
+      // repo's owned constant): a narrow desktop window still hovers, and a wide tablet
+      // still does not.
+      className={`flex items-center opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity ${HOVER_NONE_ACTIONS_ROW_CLS}`}
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={label}
+            title={label}
+            // The row constant above carries `[&_button]:p-3` for the tap target, but
+            // padding cannot grow a box whose width and height are fixed — so the SIZE
+            // is overridden here instead, or the trigger would become visible on touch
+            // and still be a 22px target.
+            className="flex items-center justify-center w-[22px] h-[22px] [@media(hover:none)]:w-9 [@media(hover:none)]:h-9 rounded text-muted hover:text-text hover:bg-bg-hover bg-transparent border-none cursor-pointer"
+          >
+            <MoreHorizontal size={14} className="lucide-inline" />
+          </button>
+        </DropdownMenuTrigger>
+        {/* Capped like `RejectDropdown`: `KEBAB_RE` bounds an app name's alphabet and not
+            its length, so an unconstrained menu widened past a 320px viewport and pushed
+            its own rows off-screen. `calc(100vw-2rem)` is what keeps it inside the
+            narrowest one. */}
+        <DropdownMenuContent align="end" className="min-w-[180px] max-w-[min(420px,calc(100vw-2rem))]">
+          {items.map(item => (
+            <DropdownMenuItem
+              key={`${item.app}:${item.id}`}
+              onSelect={() =>
+                invokeFileMenuItem(
+                  item,
+                  { surface: 'folder-row', path: node.path, kind: node.kind },
+                  onError,
+                )
+              }
+            >
+              <FileMenuItemIcon name={item.icon} />
+              <FileMenuItemLabel item={item} />
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </span>
+  )
+}

--- a/website/src/components/MarkdownPanel.tsx
+++ b/website/src/components/MarkdownPanel.tsx
@@ -12,6 +12,7 @@ import { useConfirm } from './ConfirmDialog'
 import Clickable from './Clickable'
 import { CommentPopover, CommentList, formatCommentsMessage, type InlineComment } from './CommentOverlay'
 import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
+import { useFileMenuItems, visibleFileMenuItems, invokeFileMenuItem, FileMenuItemIcon, FileMenuItemLabel } from '../apps/fileMenuContributions'
 import SelectionToolbar, { type SelectionAction } from './SelectionToolbar'
 import MarkdownOutlineRail from './MarkdownToc'
 import { useFileWatch } from '../hooks/useFileWatch'
@@ -474,14 +475,18 @@ function KnowledgeToggleIconButton({ state }: { state: ReturnType<typeof useFile
  * moved it was a keypress, so arrow-key navigation keeps its indicator while a
  * mouse click paints nothing.
  */
-const menuRowCls = 'flex items-center gap-2 w-full px-3 py-1.5 text-[13px] text-text cursor-pointer border-none bg-transparent text-left whitespace-nowrap hover:bg-bg-hover focus-visible:bg-bg-hover focus:outline-none'
+// `min-w-0 overflow-hidden`: the menu is capped in width (see the container below), and
+// a row's truncating children only shrink when the row itself may shrink past its
+// content. Without it a long app-contributed label sets the row's width and spills past
+// the cap instead of being clipped by it.
+const menuRowCls = 'flex items-center gap-2 w-full min-w-0 overflow-hidden px-3 py-1.5 text-[13px] text-text cursor-pointer border-none bg-transparent text-left whitespace-nowrap hover:bg-bg-hover focus-visible:bg-bg-hover focus:outline-none'
 
 export function OverflowMenu({ filePath, content, onError, onRefresh, refreshDisabled, refreshTitle, onFullscreen, fullscreen, onSnapshot, snapshotting, wordWrap, onToggleWordWrap, lineNums, onToggleLineNums, collapseUnchanged, onToggleCollapseUnchanged, diffSplit, onToggleDiffSplit }: {
   filePath: string; content: string
   /** Where a failed row action (add to knowledge, promote, snapshot, save,
-   *  download, open/reveal) is reported: the panel renders it through the
-   *  shared ErrorNotice. The menu itself closes on select, so it cannot host
-   *  the notice. */
+   *  download, open/reveal, an app-contributed row's dispatch) is reported: the
+   *  panel renders it through the shared ErrorNotice. The menu itself closes on
+   *  select, so it cannot host the notice. */
   onError: ReportError
   /** View actions folded in from the old header row (side-panel revamp): the
    *  ⋯ menu is the single home for everything that isn't a mode toggle. */
@@ -540,6 +545,8 @@ export function OverflowMenu({ filePath, content, onError, onRefresh, refreshDis
   const revealLabel = useRevealLabel()
   const knowledge = useFileKnowledgeState(filePath, onError)
   const artifact = useFileArtifactState(filePath, content, onError)
+  const contribItems = useFileMenuItems('file-overflow')
+  const contribRows = visibleFileMenuItems(contribItems, { path: filePath, kind: 'file' })
   const delayedClose = () => { closeTimerRef.current = setTimeout(() => setOpen(false), 800) }
   useEffect(() => () => { if (closeTimerRef.current) clearTimeout(closeTimerRef.current) }, [])
   // Reset the per-mutation success flags whenever the menu closes so the
@@ -569,7 +576,7 @@ export function OverflowMenu({ filePath, content, onError, onRefresh, refreshDis
         <Ellipsis size={15} />
       </button>
       {open && (
-        <div ref={listRef} role="menu" tabIndex={-1} onKeyDown={onListKeyDown} className="absolute right-0 top-full mt-1 z-50 rounded-lg bg-bg-elevated border border-border shadow-lg py-1 min-w-[180px] w-max">
+        <div ref={listRef} role="menu" tabIndex={-1} onKeyDown={onListKeyDown} className="absolute right-0 top-full mt-1 z-50 rounded-lg bg-bg-elevated border border-border shadow-lg py-1 min-w-[180px] w-max max-w-[min(420px,calc(100vw-2rem))]">
           {onRefresh && (
             <button role="menuitem" data-option tabIndex={-1} className={`${menuRowCls} disabled:opacity-40`} disabled={refreshDisabled} title={refreshTitle} onClick={() => { onRefresh(); setOpen(false) }}>
               <RefreshCw size={14} className="lucide-inline" /> {i18nT('components.markdownPanel.refresh')}
@@ -672,6 +679,31 @@ export function OverflowMenu({ filePath, content, onError, onRefresh, refreshDis
           <button role="menuitem" data-option tabIndex={-1} className={menuRowCls} onClick={() => { void downloadFile(filePath, onError); setOpen(false) }}>
             {i18nT('components.markdownPanel.download')}
           </button>
+          {/* App-contributed rows (`contributes.fileMenuItems`, surface
+              'file-overflow'), LAST and in their own group: the core rows above are
+              a fixed vocabulary a reader learns, and splicing third-party rows into
+              the middle of it would move a familiar row whenever an app is
+              installed. Activation POSTs the file's PATH to the app's own endpoint;
+              core imports no app code. Filtered by the declaration's `when`
+              predicate, so the stock build (no declaring app) renders neither the
+              rows nor the separator. `data-option` is what makes each row navigable
+              to `useListboxKeyboard`. */}
+          {contribRows.length > 0 && <div className="h-px bg-border my-1 mx-2" />}
+          {contribRows.map(item => (
+            <button
+              key={`${item.app}:${item.id}`}
+              role="menuitem"
+              data-option
+              tabIndex={-1}
+              className={menuRowCls}
+              onClick={() => {
+                invokeFileMenuItem(item, { surface: 'file-overflow', path: filePath, kind: 'file' }, onError)
+                setOpen(false)
+              }}
+            >
+              <FileMenuItemIcon name={item.icon} /> <FileMenuItemLabel item={item} />
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/website/src/i18n/locales/bn.json
+++ b/website/src/i18n/locales/bn.json
@@ -8060,6 +8060,10 @@
       "raw": "মূল",
       "render_the_markdown_headings_lists_tables_links": "মার্কডাউন রেন্ডার করুন - শিরোনাম, তালিকা, টেবিল, লিঙ্ক",
       "show_the_exact_markdown_source": "হুবহু মার্কডাউন সোর্স দেখান"
+    },
+    "fileMenuContributions": {
+      "app_actions": "অ্যাপ ক্রিয়া",
+      "contributed_by": "অ্যাপ: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/de.json
+++ b/website/src/i18n/locales/de.json
@@ -8060,6 +8060,10 @@
       "raw": "Roh",
       "render_the_markdown_headings_lists_tables_links": "Markdown rendern - Überschriften, Listen, Tabellen, Links",
       "show_the_exact_markdown_source": "Den exakten Markdown-Quelltext anzeigen"
+    },
+    "fileMenuContributions": {
+      "app_actions": "App-Aktionen",
+      "contributed_by": "App: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/en-XA.json
+++ b/website/src/i18n/locales/en-XA.json
@@ -7967,6 +7967,10 @@
       "raw": "[Ŕàẁ ·····]",
       "render_the_markdown_headings_lists_tables_links": "[Ŕèñðèŕ ţĥè ɱàŕķðøẁñ - ĥèàðìñğş, ĺìşţş, ţàƀĺèş, ĺìñķş ··················]",
       "show_the_exact_markdown_source": "[Şĥøẁ ţĥè èẋàçţ ɱàŕķðøẁñ şøùŕçè ·····················]"
+    },
+    "fileMenuContributions": {
+      "app_actions": "[Àþþ àçţìøñş ··········]",
+      "contributed_by": "[Àþþ: {{app}} ········]"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/en.manual.json
+++ b/website/src/i18n/locales/en.manual.json
@@ -2823,6 +2823,10 @@
       "raw": "Raw",
       "render_the_markdown_headings_lists_tables_links": "Render the markdown - headings, lists, tables, links",
       "show_the_exact_markdown_source": "Show the exact markdown source"
+    },
+    "fileMenuContributions": {
+      "app_actions": "App actions",
+      "contributed_by": "App: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/es.json
+++ b/website/src/i18n/locales/es.json
@@ -8170,6 +8170,10 @@
       "raw": "Sin formato",
       "render_the_markdown_headings_lists_tables_links": "Renderizar el markdown: encabezados, listas, tablas, enlaces",
       "show_the_exact_markdown_source": "Mostrar el código markdown exacto"
+    },
+    "fileMenuContributions": {
+      "app_actions": "Acciones de la aplicación",
+      "contributed_by": "Aplicación: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/fr.json
+++ b/website/src/i18n/locales/fr.json
@@ -8170,6 +8170,10 @@
       "raw": "Brut",
       "render_the_markdown_headings_lists_tables_links": "Afficher le markdown rendu - titres, listes, tableaux, liens",
       "show_the_exact_markdown_source": "Afficher la source markdown exacte"
+    },
+    "fileMenuContributions": {
+      "app_actions": "Actions de l'application",
+      "contributed_by": "Application : {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -8060,6 +8060,10 @@
       "raw": "रॉ",
       "render_the_markdown_headings_lists_tables_links": "मार्कडाउन रेंडर करें - शीर्षक, सूचियाँ, तालिकाएँ, लिंक",
       "show_the_exact_markdown_source": "बिल्कुल वैसा मार्कडाउन सोर्स दिखाएँ"
+    },
+    "fileMenuContributions": {
+      "app_actions": "ऐप कार्रवाइयाँ",
+      "contributed_by": "ऐप: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/it.json
+++ b/website/src/i18n/locales/it.json
@@ -8170,6 +8170,10 @@
       "raw": "Grezzo",
       "render_the_markdown_headings_lists_tables_links": "Visualizza il markdown - titoli, elenchi, tabelle, link",
       "show_the_exact_markdown_source": "Mostra il sorgente markdown esatto"
+    },
+    "fileMenuContributions": {
+      "app_actions": "Azioni dell'app",
+      "contributed_by": "App: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -7950,6 +7950,10 @@
       "raw": "生",
       "render_the_markdown_headings_lists_tables_links": "マークダウンを描画します - 見出し、リスト、表、リンク",
       "show_the_exact_markdown_source": "正確なマークダウンソースを表示します"
+    },
+    "fileMenuContributions": {
+      "app_actions": "アプリの操作",
+      "contributed_by": "アプリ: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/ko.json
+++ b/website/src/i18n/locales/ko.json
@@ -7950,6 +7950,10 @@
       "raw": "원문",
       "render_the_markdown_headings_lists_tables_links": "마크다운을 렌더링합니다 - 제목, 목록, 표, 링크",
       "show_the_exact_markdown_source": "정확한 마크다운 원문을 표시합니다"
+    },
+    "fileMenuContributions": {
+      "app_actions": "앱 작업",
+      "contributed_by": "앱: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/pt.json
+++ b/website/src/i18n/locales/pt.json
@@ -8170,6 +8170,10 @@
       "raw": "Bruto",
       "render_the_markdown_headings_lists_tables_links": "Renderizar o markdown - títulos, listas, tabelas, links",
       "show_the_exact_markdown_source": "Mostrar o código markdown exato"
+    },
+    "fileMenuContributions": {
+      "app_actions": "Ações do aplicativo",
+      "contributed_by": "Aplicativo: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/ru.json
+++ b/website/src/i18n/locales/ru.json
@@ -8280,6 +8280,10 @@
       "raw": "Исходник",
       "render_the_markdown_headings_lists_tables_links": "Отобразить markdown - заголовки, списки, таблицы, ссылки",
       "show_the_exact_markdown_source": "Показать точный исходный markdown"
+    },
+    "fileMenuContributions": {
+      "app_actions": "Действия приложения",
+      "contributed_by": "Приложение: {{app}}"
     }
   },
   "hooks": {

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -7950,6 +7950,10 @@
       "raw": "原始",
       "render_the_markdown_headings_lists_tables_links": "渲染 Markdown - 标题、列表、表格、链接",
       "show_the_exact_markdown_source": "显示确切的 Markdown 源码"
+    },
+    "fileMenuContributions": {
+      "app_actions": "应用操作",
+      "contributed_by": "应用：{{app}}"
     }
   },
   "hooks": {

--- a/website/src/pages/chat/FolderPanel.tsx
+++ b/website/src/pages/chat/FolderPanel.tsx
@@ -9,6 +9,7 @@ import { useBranding } from '../../hooks/useBranding'
 import { useGatewayPlatform } from '../../hooks/useGatewayPlatform'
 import { api } from '../../api/client'
 import { fileIcon, colorForExt } from '../../utils/fileIcons'
+import { useFileMenuItems, visibleFileMenuItems, FolderRowActions } from '../../apps/fileMenuContributions'
 import { PierreWorkspaceTree } from '../../pierre/tree'
 import { useTreeState } from './FileBrowserRail'
 
@@ -174,6 +175,16 @@ export default function FolderPanel({ path, projectDir, onClose, onFileOpen, onA
     return () => clearTimeout(id)
   }, [query])
 
+  // App-contributed 'folder-row' actions, rendered per row (hover-revealed).
+  const folderItems = useFileMenuItems('folder-row')
+  // A contributed row's dispatch failure. Held here rather than in the row: the menu
+  // closes on select, and the row is unmounted the moment the listing re-renders, so
+  // neither can host the notice. Cleared on navigation for the reason `useRevealFailure`
+  // clears on its subject — a refusal raised for the old directory must not be shown
+  // under the new one.
+  const [contribError, setContribError] = useState<string | null>(null)
+  useEffect(() => { setContribError(null) }, [cwd])
+
   const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
     queryKey: ['browse-files', cwd],
     queryFn: () => api.browseFiles(cwd),
@@ -300,6 +311,14 @@ export default function FolderPanel({ path, projectDir, onClose, onFileOpen, onA
       {reveal.error && (
         <div className="mx-2 mt-1.5">
           <ErrorNotice variant="inline" className="whitespace-normal" message={reveal.error} askAgent onDismiss={reveal.clear} testId="folder-panel-reveal-error" />
+        </div>
+      )}
+      {/* A contributed row's endpoint refused or never answered. askAgent on for the
+          same reason the reveal notice above gives: the only editable field in this
+          panel is a transient search string, not a durable draft. */}
+      {contribError && (
+        <div className="mx-2 mt-1.5">
+          <ErrorNotice variant="inline" className="whitespace-normal" message={contribError} askAgent onDismiss={() => setContribError(null)} testId="folder-panel-contrib-error" />
         </div>
       )}
       <div className="flex items-center gap-1.5 mx-2 mt-1.5 px-2 h-[28px] shrink-0 rounded-md bg-bg border border-border focus-within:border-accent">
@@ -459,6 +478,7 @@ export default function FolderPanel({ path, projectDir, onClose, onFileOpen, onA
                 label={d.name}
                 title={d.path}
                 onActivate={() => navigate(d.path)}
+                actions={<FolderRowActions items={visibleFileMenuItems(folderItems, { path: d.path, kind: 'dir' })} node={{ path: d.path, kind: 'dir' }} onError={setContribError} />}
               />
             ))}
             {files.map(f => {
@@ -470,6 +490,7 @@ export default function FolderPanel({ path, projectDir, onClose, onFileOpen, onA
                   label={f.name}
                   title={f.path}
                   onActivate={() => onFileOpen?.(f.path)}
+                  actions={<FolderRowActions items={visibleFileMenuItems(folderItems, { path: f.path, kind: 'file' })} node={{ path: f.path, kind: 'file' }} onError={setContribError} />}
                 />
               )
             })}
@@ -486,12 +507,14 @@ export default function FolderPanel({ path, projectDir, onClose, onFileOpen, onA
  *  `sub` carries a search hit's subfolder. It is right-aligned and truncates from
  *  the START, because the tail of a path is what distinguishes two same-named
  *  files while the head is the part they share. */
-function Row({ icon, label, sub, title, onActivate }: {
+function Row({ icon, label, sub, title, onActivate, actions }: {
   icon: React.ReactNode
   label: string
   sub?: string
   title: string
   onActivate: () => void
+  /** App-contributed row actions (folder-row surface), right-aligned. */
+  actions?: React.ReactNode
 }) {
   return (
     <div
@@ -512,6 +535,7 @@ function Row({ icon, label, sub, title, onActivate }: {
           {sub}
         </span>
       )}
+      {actions}
     </div>
   )
 }

--- a/website/src/pierre/PierreWorkspaceTreeImpl.tsx
+++ b/website/src/pierre/PierreWorkspaceTreeImpl.tsx
@@ -9,7 +9,7 @@
  * Like the diff/code surfaces, the heavy `@pierre/trees` runtime loads behind
  * a lazy boundary (see `./tree.tsx`) so the eager bundle stays clean.
  */
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { GitStatus, GitStatusEntry } from '@pierre/trees'
 // The package root re-exports the tree's context-menu types under shorter
@@ -21,8 +21,10 @@ import type {
 import { FileTree, useFileTree } from '@pierre/trees/react'
 import { AtSign, FileDiff, FolderOpen } from 'lucide-react'
 import { api } from '../api/client'
+import ErrorNotice from '../components/ErrorNotice'
 import { useMenuKeyboard } from '../hooks/useMenuKeyboard'
 import { i18nT } from '../i18n/t'
+import { useFileMenuItems, visibleFileMenuItems, invokeFileMenuItem, FileMenuItemIcon, FileMenuItemLabel, type ContributedFileMenuItem, type ReportFileMenuError } from '../apps/fileMenuContributions'
 import { normalizeWindowsPath } from '../utils/fileTokens'
 import { TreeSkeleton } from './tree'
 
@@ -33,14 +35,24 @@ type TreeEntryKind = 'file' | 'dir'
 
 /** Row-level right-click menu projected into Pierre's `context-menu` slot.
  *  Pierre owns the anchor, the outside-click wash, and open/close; this renders
- *  only the item list — a single "Add to chat" action (row click already opens
- *  a file, so the menu deliberately carries no Open duplicate). The action
- *  closes the menu itself so focus returns to the row. */
-function TreeContextMenu({ item, context, root, onAddToContext }: {
+ *  only the item list: the built-in "Add to chat" action, plus any row an installed
+ *  app contributes for the `tree-context` surface (row click already opens a file, so
+ *  the menu deliberately carries no Open duplicate). Every action closes the menu
+ *  itself so focus returns to the row. */
+function TreeContextMenu({ item, context, root, onAddToContext, contribItems, onError }: {
   item: FileTreeContextMenuItem
   context: FileTreeContextMenuOpenContext
   root: string
   onAddToContext?: (absPath: string, kind: TreeEntryKind) => void
+  /** Contributed `tree-context` rows, resolved by the PARENT (which already holds
+   *  the `['apps']` query) and passed down. Deliberately a prop rather than a hook
+   *  call here: this component mounts inside Pierre's context-menu slot, and a
+   *  `useQuery` in the leaf would make every host of the tree — and every test
+   *  rendering just this menu — require a `QueryClientProvider` it never needed. */
+  contribItems: readonly ContributedFileMenuItem[]
+  /** Where a contributed row's dispatch failure goes. Owned by the parent because
+   *  activating a row closes this menu, so it cannot render the notice itself. */
+  onError: ReportFileMenuError
 }) {
   const isDir = item.kind === 'directory'
   // Pierre paths are POSIX (`/`), but on native Windows `root` is
@@ -56,6 +68,7 @@ function TreeContextMenu({ item, context, root, onAddToContext }: {
   // two slashes, leaving a stray leading `/` on the relativized path (a
   // root-relative-looking path instead of project-relative).
   const abs = `${normalizeWindowsPath(root).replace(/\/$/, '')}/${item.path}`
+  const rows = visibleFileMenuItems(contribItems, { path: abs, kind: isDir ? 'dir' : 'file' })
   // role="menuitem" divs (an interactive ARIA role) with a keyboard handler:
   // the correct menu semantics inside the role="menu" container, and the role
   // is what makes an onClick div compliant rather than a static-element one.
@@ -79,41 +92,83 @@ function TreeContextMenu({ item, context, root, onAddToContext }: {
   // `restoreFocus`), so this does not strand focus inside a dismissed menu.
   const firstItemRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
-    firstItemRef.current?.focus()
+    // Focus the first row on open: the built-in "add to context" row when a host
+    // supplies onAddToContext, otherwise the first app-contributed row. The
+    // querySelector arm is not redundant with the ref: the built-in row is gated on
+    // onAddToContext, so in an app-only menu `firstItemRef` is attached to a row that
+    // may itself have been filtered out by its `when` predicate.
+    ;(firstItemRef.current
+      ?? menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]'))?.focus()
   }, [])
-  // The DEGENERATE single-item case of the shared role="menu" keyboard contract
-  // (#6231): with exactly one item the arrows have nothing to move between, so
-  // the wiring buys no navigation today. It is here because the CONTRACT is
-  // what role="menu" advertises to assistive technology, and honouring it
-  // per-surface-by-item-count is how surfaces drift: an arrow inside an open
-  // menu must be consumed rather than scrolling the tree behind it, Tab must
-  // stay contained (#2533), and IME composition keys must not reach the menu at
-  // all — all true of a one-item menu. It also means the day this menu grows a
-  // second action (an Open, a Reveal), real navigation arrives with it instead
-  // of being a second bug to find. `enabled: true` unconditionally because
-  // Pierre only mounts this component while the menu is open.
+  // The shared role="menu" keyboard contract (#6231). The item count is no longer
+  // fixed: the built-in row is gated on `onAddToContext` and an installed app may
+  // contribute any number of rows its `when` admits, so this menu can hold one row
+  // or several and the arrows do real navigation whenever it holds more than one.
+  // Honouring the contract per-surface-by-item-count is how surfaces drift anyway —
+  // an arrow inside an open menu must be consumed rather than scrolling the tree
+  // behind it, Tab must stay contained (#2533), and IME composition keys must not
+  // reach the menu at all, all true whatever the count. `enabled: true`
+  // unconditionally because Pierre only mounts this component while the menu is open.
   // focusFirstOnOpen: false — the firstItemRef effect above already owns focus
   // entry (it must, because Pierre focuses the tree ROW, not this slotted
   // content); letting the hook also focus would be a redundant second move.
   const menuRef = useRef<HTMLDivElement>(null)
   useMenuKeyboard({ enabled: true, containerRef: menuRef, focusFirstOnOpen: false })
+  // Render nothing rather than an empty bordered popup: with no host row AND no
+  // app row that its `when` admits for this node, there is nothing to show and
+  // no menuitem for the focus effect to land on.
+  if (!onAddToContext && rows.length === 0) return null
   return (
     <div
       ref={menuRef}
       role="menu"
-      className="min-w-[176px] rounded-lg border border-border bg-bg-elevated p-1 shadow-lg"
+      className="min-w-[176px] max-w-[min(420px,calc(100vw-2rem))] rounded-lg border border-border bg-bg-elevated p-1 shadow-lg"
     >
-      <div
-        ref={firstItemRef}
-        role="menuitem"
-        tabIndex={-1}
-        className={itemCls}
-        onClick={activate(() => onAddToContext?.(abs, isDir ? 'dir' : 'file'))}
-        onKeyDown={activate(() => onAddToContext?.(abs, isDir ? 'dir' : 'file'))}
-      >
-        <AtSign className="lucide-inline text-muted" />
-        {i18nT('pages.chat.fileBrowserRail.ctx_add_to_chat')}
-      </div>
+      {onAddToContext && (
+        <div
+          ref={firstItemRef}
+          role="menuitem"
+          tabIndex={-1}
+          className={itemCls}
+          onClick={activate(() => onAddToContext(abs, isDir ? 'dir' : 'file'))}
+          onKeyDown={activate(() => onAddToContext(abs, isDir ? 'dir' : 'file'))}
+        >
+          <AtSign className="lucide-inline text-muted" />
+          {i18nT('pages.chat.fileBrowserRail.ctx_add_to_chat')}
+        </div>
+      )}
+      {/* App-contributed rows (contributes.fileMenuItems, surface 'tree-context').
+          An installed app declares these in its manifest; core POSTs the node
+          context to the app's endpoint on activation and never imports app code.
+          Already filtered by each row's `when` predicate; the stock build (no
+          declaring app) renders nothing. */}
+      {rows.map((mi, idx) => {
+        const dispatch = () =>
+          invokeFileMenuItem(
+            mi,
+            {
+              surface: 'tree-context',
+              path: abs,
+              kind: isDir ? 'dir' : 'file',
+              root,
+            },
+            onError,
+          )
+        return (
+          <div
+            key={`${mi.app}:${mi.id}`}
+            ref={!onAddToContext && idx === 0 ? firstItemRef : undefined}
+            role="menuitem"
+            tabIndex={-1}
+            className={itemCls}
+            onClick={activate(dispatch)}
+            onKeyDown={activate(dispatch)}
+          >
+            <FileMenuItemIcon name={mi.icon} />
+            <FileMenuItemLabel item={mi} />
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -135,8 +190,9 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
   onFileOpen?: (absPath: string) => void
   /** Right-click "Add to context" on a row: hands the host the ABSOLUTE path
    *  and whether it is a file or a directory, so the composer can insert the
-   *  same `@`-mention the file picker does. Absent → the menu item is still
-   *  shown but inert (the tree has no host to mention into). */
+   *  same `@`-mention the file picker does. Absent → the built-in row is not
+   *  rendered, and the context menu opens only if an app contributes a
+   *  'tree-context' row this node matches. */
   onAddToContext?: (absPath: string, kind: TreeEntryKind) => void
   /** Forwarded into the tree's search session (null clears it). */
   searchQuery?: string | null
@@ -149,6 +205,13 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
    *  prop never re-fire `onFileOpen`. */
   selectedPath?: string | null
 }) {
+  // Whether any app contributes a 'tree-context' row at all — gates whether the
+  // tree wires a context menu (per-node `when` filtering happens in the menu).
+  const treeItems = useFileMenuItems('tree-context')
+  // A contributed row's dispatch failure, rendered above the tree. It lives here rather
+  // than in the context menu because activating a row closes that menu, so a notice
+  // inside it would unmount with the thing that raised it.
+  const [actionError, setActionError] = useState<string | null>(null)
   const { data: tree } = useQuery({
     queryKey: ['project-tree', projectDir],
     queryFn: () => api.projectTree(projectDir),
@@ -302,6 +365,11 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
   onAddToContextRef.current = onAddToContext
   const rootRef = useRef(root)
   rootRef.current = root
+  // Ref'd like the two above so this callback stays identity-stable: Pierre takes
+  // `renderContextMenu` as a prop, and a new function each render would remount the
+  // slotted menu mid-interaction.
+  const treeItemsRef = useRef(treeItems)
+  treeItemsRef.current = treeItems
   const renderContextMenu = useCallback(
     (item: FileTreeContextMenuItem, ctx: FileTreeContextMenuOpenContext) => (
       <TreeContextMenu
@@ -309,6 +377,8 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
         context={ctx}
         root={rootRef.current}
         onAddToContext={onAddToContextRef.current}
+        contribItems={treeItemsRef.current}
+        onError={setActionError}
       />
     ),
     [],
@@ -340,6 +410,20 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
 
   return (
     <div className="flex-1 min-h-0 flex flex-col">
+      {/* A contributed row's endpoint refused or never answered. askAgent on: this
+          subtree holds no editable draft, only the tree's own selection. */}
+      {actionError && (
+        <div className="px-2 pt-1.5">
+          <ErrorNotice
+            variant="inline"
+            className="whitespace-normal"
+            message={actionError}
+            askAgent
+            onDismiss={() => setActionError(null)}
+            testId="workspace-tree-action-error"
+          />
+        </div>
+      )}
       {mode === 'all' && tree?.truncated && (
         <div className="px-3 py-1 text-[11px] text-muted">
           {i18nT('pages.chat.activityViewer.workspace_truncated')}
@@ -353,7 +437,7 @@ export function PierreWorkspaceTreeImpl({ projectDir, onFileOpen, onAddToContext
         // (FileTree's own renderContextMenu != null check) forces the menu
         // enabled unconditionally, so passing it regardless of onAddToContext
         // would open a menu whose only action closes itself and does nothing.
-        renderContextMenu={onAddToContext ? renderContextMenu : undefined}
+        renderContextMenu={(onAddToContext || treeItems.length > 0) ? renderContextMenu : undefined}
       />
     </div>
   )

--- a/website/src/test/ApiClient.coverage.test.tsx
+++ b/website/src/test/ApiClient.coverage.test.tsx
@@ -1486,6 +1486,18 @@ describe('every api method issues one well-formed /api request', () => {
   const methods = Object.entries(api as unknown as Record<string, AnyFn>)
     .filter(([name, fn]) => typeof fn === 'function' && !HAND_TESTED.has(name))
 
+  // Methods whose URL comes out of an ARGUMENT'S FIELD rather than a positional
+  // string. The generic `'sw-1'` args below would make such a method build its
+  // URL from `undefined` — a harness artifact, not a defect in the method — so
+  // each one names the minimal shape its URL is read from.
+  const ARGS: Record<string, unknown[]> = {
+    // `invokeFileMenuItem(item, ctx)`: the URL is `item.endpoint`.
+    invokeFileMenuItem: [
+      { id: 'send', app: 'doc-store', endpoint: '/api/apps/doc-store/send' },
+      { surface: 'file-overflow', path: '/tmp/a.txt', kind: 'file' },
+    ],
+  }
+
   it('covers the whole surface (guards against the table silently shrinking)', () => {
     expect(methods.length).toBeGreaterThan(300)
   })
@@ -1495,7 +1507,7 @@ describe('every api method issues one well-formed /api request', () => {
     // Generic positional arguments. Every method is a thin URL/body builder, so
     // what this asserts is the construction itself: a forgotten argument or a
     // botched template literal shows up as `undefined` inside the path.
-    await Promise.resolve(fn('sw-1', 'sw-2', 'sw-3', 'sw-4'))
+    await Promise.resolve(fn(...(ARGS[name] ?? ['sw-1', 'sw-2', 'sw-3', 'sw-4'])))
 
     expect(fetchMock, `${name} issued no request`).toHaveBeenCalledTimes(1)
     const { url, init } = call()

--- a/website/src/test/MarkdownPanel.test.tsx
+++ b/website/src/test/MarkdownPanel.test.tsx
@@ -4,6 +4,8 @@ import { readSource } from './readSource'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { store } from '../store'
+import { ThemeProvider } from '../hooks/useTheme'
 import { OverflowMenu, breadcrumbSegments, FileHeaderBreadcrumb } from '../components/MarkdownPanel'
 import { api } from '../api/client'
 import { i18nT } from '../i18n/t'
@@ -14,6 +16,10 @@ vi.mock('../api/client', () => ({
     artifact: vi.fn(),
     createArtifact: vi.fn(),
     revealPath: vi.fn(),
+    // The contributed-row seam subscribes to `['apps']` without fetching, and
+    // dispatches an activation through `invokeFileMenuItem`.
+    listApps: vi.fn(),
+    invokeFileMenuItem: vi.fn().mockResolvedValue({}),
   },
   // revealOrOpen branches its failure wording on `err instanceof ApiError`, so
   // the mock must export a real class — a bare object would make `instanceof`
@@ -40,9 +46,15 @@ vi.mock('../hooks/useBranding', () => ({
 
 const writeText = vi.fn()
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+// ThemeProvider mirrors the shipped tree (`main.tsx` mounts it above the whole
+// app): a contributed row's icon renders through `AppIcon`, which reads
+// `useTheme()` to pick its light/dark asset, so the harness needs the same
+// context the real mount sites already sit inside.
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <MemoryRouter>
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>{children}</ThemeProvider>
+    </QueryClientProvider>
   </MemoryRouter>
 )
 
@@ -529,5 +541,114 @@ describe('MarkdownPanel line-reveal effect', () => {
   it('reads the host callback through a ref instead of depending on it', () => {
     expect(effect).toContain('onRevealConsumedRef.current?.()')
     expect(effect).not.toMatch(/\bonRevealConsumed\?\.\(\)/)
+  })
+})
+
+describe('OverflowMenu — app-contributed rows (contributes.fileMenuItems)', () => {
+  const DECL = {
+    id: 'send',
+    label: 'Send to store',
+    icon: 'Package',
+    endpoint: '/api/apps/doc-store/send',
+    surfaces: ['file-overflow'],
+  }
+  const seedApps = (decls: unknown = [DECL], over: Record<string, unknown> = {}) =>
+    queryClient.setQueryData(['apps'], [
+      { name: 'doc-store', enabled: true, manifest: { contributes: { fileMenuItems: decls } } , ...over },
+    ])
+
+  const openWith = (filePath = '/tmp/hello.txt') => {
+    render(<OverflowMenu filePath={filePath} content={'line one\n'} />, { wrapper })
+    fireEvent.click(screen.getAllByRole('button')[0])
+  }
+
+  it('adds no row and no separator when no app contributes — the stock build is inert', () => {
+    openWith()
+    expect(screen.queryByRole('menuitem', { name: /^Send to store\b/ })).not.toBeInTheDocument()
+  })
+
+  it('renders a contributed row and POSTs the PATH only, never the file content', () => {
+    seedApps()
+    openWith('/tmp/notes.md')
+
+    // The dispatcher reads the owning slot from the store, so name one for this case.
+    store.dispatch({ type: 'chat/setActiveSlot', payload: 'slot-md' })
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Send to store\b/ }))
+    expect(api.invokeFileMenuItem).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'send', app: 'doc-store' }),
+      { surface: 'file-overflow', path: '/tmp/notes.md', kind: 'file' },
+      // The owning slot, so the server's restricted-session gate applies to a
+      // contributed row exactly as it does to this menu's own save and promote rows.
+      // Asserted on EVERY surface, not just one: the placeholder it replaces fails open.
+      'dashboard:slot-md',
+    )
+    // The content prop is in scope at the call site; it must not be shipped.
+    expect(vi.mocked(api.invokeFileMenuItem).mock.calls[0][1]).not.toHaveProperty('content')
+  })
+
+  it('renders contributed rows LAST, after the core view/location groups', () => {
+    seedApps()
+    openWith()
+    const labels = screen.getAllByRole('menuitem').map(el => el.textContent?.trim())
+    const contributed = labels.findIndex(l => l?.startsWith('Send to store'))
+    expect(contributed).toBe(labels.length - 1)
+    // Specifically: below Copy path / Download rather than spliced above them.
+    expect(contributed).toBeGreaterThan(
+      labels.findIndex(l => l === i18nT('components.markdownPanel.copy_path')),
+    )
+  })
+
+  it('attributes the contributed row to its app, so it cannot pass as a core action', () => {
+    // A row's label is app-owned and never checked against the core vocabulary, so an app
+    // may call its row "Download" and sit one separator below the real Download. The
+    // visible owner is what lets a reader tell that clicking it POSTs the path elsewhere.
+    seedApps()
+    openWith()
+    const row = screen.getByRole('menuitem', { name: /^Send to store\b/ })
+    expect(row.textContent).toContain('doc-store')
+    // Part of the accessible NAME too, not decoration a screen reader skips.
+    expect(row).toHaveAccessibleName(/doc-store/)
+  })
+
+  it('is keyboard-navigable like every other row', () => {
+    seedApps()
+    openWith()
+    // `data-option` is what useListboxKeyboard treats as navigable; without it the
+    // row renders but arrows skip straight past it.
+    const row = screen.getByRole('menuitem', { name: /^Send to store\b/ })
+    expect(row).toHaveAttribute('data-option')
+  })
+
+  it('honours the when predicate, so a markdown-only row is absent on a .txt file', () => {
+    seedApps([{ ...DECL, when: { extensions: ['md'] } }])
+    openWith('/tmp/hello.txt')
+    expect(screen.queryByRole('menuitem', { name: /^Send to store\b/ })).not.toBeInTheDocument()
+  })
+
+  it('renders more than one contributed row', () => {
+    seedApps([DECL, { ...DECL, id: 'archive', label: 'Archive' }])
+    openWith()
+    expect(screen.getByRole('menuitem', { name: /^Send to store\b/ })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /^Archive\b/ })).toBeInTheDocument()
+  })
+
+  it('contributes nothing from a disabled app', () => {
+    seedApps([DECL], { enabled: false })
+    openWith()
+    expect(screen.queryByRole('menuitem', { name: /^Send to store\b/ })).not.toBeInTheDocument()
+  })
+
+  it('reports a rejected dispatch through the panel own onError', async () => {
+    // `errors-use-error-notice`: the menu closes on select, so an endpoint refusal that
+    // only reached the console would leave the reader with a row that did nothing. The
+    // panel renders this string through the shared ErrorNotice it already owns.
+    vi.mocked(api.invokeFileMenuItem).mockRejectedValueOnce(new Error('endpoint refused'))
+    const onError = vi.fn()
+    seedApps()
+    render(<OverflowMenu filePath="/tmp/notes.md" content={''} onError={onError} />, { wrapper })
+    fireEvent.click(screen.getAllByRole('button')[0])
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Send to store\b/ }))
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('endpoint refused'))
   })
 })

--- a/website/src/test/PierreWorkspaceTreeImpl.test.tsx
+++ b/website/src/test/PierreWorkspaceTreeImpl.test.tsx
@@ -14,6 +14,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { store } from '../store'
 import type { ReactNode } from 'react'
 
 vi.mock('@pierre/trees/react', async () => await import('./__mocks__/pierreTreesReact'))
@@ -22,8 +23,13 @@ vi.mock('../api/client', () => ({
   api: {
     projectTree: vi.fn(),
     projectGitStatus: vi.fn(),
+    // The contributed-row seam reads `['apps']` as a cache subscriber (never fetches)
+    // and dispatches an activation through `invokeFileMenuItem`.
+    listApps: vi.fn(),
+    invokeFileMenuItem: vi.fn().mockResolvedValue({}),
   },
 }))
+vi.mock('../components/AppIcon', () => ({ default: () => null }))
 
 import { PierreWorkspaceTreeImpl } from '../pierre/PierreWorkspaceTreeImpl'
 import { api } from '../api/client'
@@ -638,5 +644,130 @@ describe('PierreWorkspaceTreeImpl — row context menu keyboard contract (#6231)
 
     fireEvent.keyDown(menuitem, { key: 'Enter' })
     expect(onAddToContext).toHaveBeenCalledWith(`${ROOT}/src/a/b.ts`, 'file')
+  })
+})
+
+describe('PierreWorkspaceTreeImpl — app-contributed context rows', () => {
+  const DECL = {
+    id: 'send',
+    label: 'Send to store',
+    icon: 'Package',
+    endpoint: '/api/apps/doc-store/send',
+    surfaces: ['tree-context'],
+  }
+  const appsWith = (over: Record<string, unknown> = {}) => [
+    { name: 'doc-store', enabled: true, manifest: { contributes: { fileMenuItems: [DECL] } }, ...over },
+  ]
+
+  /** Seed the shared `['apps']` cache the seam subscribes to (it never fetches). */
+  const seed = (qc: QueryClient, apps: unknown) => act(() => { qc.setQueryData(['apps'], apps) })
+
+  const openMenu = (item: MenuItem) => {
+    const close = vi.fn()
+    const context: MenuContext = {
+      anchorElement: document.createElement('div'),
+      anchorRect: document.createElement('div').getBoundingClientRect(),
+      close,
+      restoreFocus: vi.fn(),
+    }
+    const render_ = treeMock.fileTreeProps.at(-1)!.renderContextMenu
+    return { close, node: render_ ? render_(item, context) : null }
+  }
+
+  it('wires the context menu for an app row even with no host onAddToContext', async () => {
+    // The gate is what decides whether Pierre offers a menu at all. Before this seam
+    // it tracked `onAddToContext` alone, so an app-only row could never be reached.
+    const { qc, update } = renderTree()
+    await waitForTree()
+    expect(treeMock.fileTreeProps.at(-1)!.renderContextMenu).toBeUndefined()
+
+    seed(qc, appsWith())
+    update()
+    expect(typeof treeMock.fileTreeProps.at(-1)!.renderContextMenu).toBe('function')
+  })
+
+  it('renders the app row, POSTs the path and root, and never the file content', async () => {
+    const { qc, update } = renderTree({ onAddToContext: vi.fn() })
+    await waitForTree()
+    seed(qc, appsWith())
+    update()
+
+    const { close, node } = openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' })
+    render(<>{node}</>)
+
+    // The dispatcher reads the owning slot from the store, so name one for this case.
+    store.dispatch({ type: 'chat/setActiveSlot', payload: 'slot-pierre' })
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Send to store\b/ }))
+    expect(api.invokeFileMenuItem).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'send', app: 'doc-store' }),
+      { surface: 'tree-context', path: `${ROOT}/src/a/b.ts`, kind: 'file', root: ROOT },
+      // The owning slot, so a restricted slot's dispatch is gated here too. Asserted on
+      // every surface: the `dashboard:ui` placeholder it replaces fails open.
+      'dashboard:slot-pierre',
+    )
+    expect(vi.mocked(api.invokeFileMenuItem).mock.calls[0][1]).not.toHaveProperty('content')
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders NOTHING rather than an empty popup when no row survives `when`', async () => {
+    // The gate counts registered rows; `when` then filters per node. A row scoped to
+    // markdown files makes right-clicking a .ts file an empty bordered box with no
+    // menuitem for the focus effect to land on.
+    const { qc, update } = renderTree()
+    await waitForTree()
+    seed(qc, appsWith({
+      manifest: { contributes: { fileMenuItems: [{ ...DECL, when: { extensions: ['md'] } }] } },
+    }))
+    update()
+
+    const { node } = openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' })
+    // Assert on the RENDERED output, not on `node`: Pierre's slot always receives a
+    // `<TreeContextMenu/>` element, and the component's own empty-menu guard is what
+    // renders nothing — so an element-identity check would pass whatever it renders.
+    render(<>{node}</>)
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0)
+  })
+
+  it('focuses the first app row when there is no built-in row to focus', async () => {
+    // `firstItemRef` hangs off the built-in row, which is gated on `onAddToContext`;
+    // the querySelector fallback is what gives an app-only menu a focus target.
+    const { qc, update } = renderTree()
+    await waitForTree()
+    seed(qc, appsWith())
+    update()
+
+    const { node } = openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' })
+    render(<>{node}</>)
+    const row = screen.getByRole('menuitem', { name: /^Send to store\b/ })
+    expect(row).toHaveFocus()
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(api.invokeFileMenuItem).toHaveBeenCalled()
+  })
+
+  it('contributes nothing from a disabled app', async () => {
+    const { qc, update } = renderTree()
+    await waitForTree()
+    seed(qc, appsWith({ enabled: false }))
+    update()
+    expect(treeMock.fileTreeProps.at(-1)!.renderContextMenu).toBeUndefined()
+  })
+
+  it('surfaces a rejected dispatch on the TREE, which outlives the menu', async () => {
+    // `errors-use-error-notice`. Activating a row closes the context menu, so the notice
+    // cannot live inside it: the state and the ErrorNotice belong to the tree.
+    vi.mocked(api.invokeFileMenuItem).mockRejectedValueOnce(new Error('endpoint refused'))
+    const { qc, update } = renderTree()
+    await waitForTree()
+    seed(qc, appsWith())
+    update()
+
+    const { node } = openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' })
+    render(<>{node}</>)
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Send to store\b/ }))
+
+    const notice = await waitFor(() => screen.getByTestId('workspace-tree-action-error'))
+    expect(notice).toHaveTextContent('endpoint refused')
   })
 })

--- a/website/src/test/contributedRowNarrowViewport.test.ts
+++ b/website/src/test/contributedRowNarrowViewport.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `narrow-viewport-required`: every menu that hosts an app-contributed row must stay
+ * inside a 320px viewport.
+ *
+ * The row's text is app-owned and bounded only by `MAX_LABEL` (120 characters for the
+ * label, and again for the app identifier), because `KEBAB_RE` constrains an app name's
+ * alphabet and not its length. An uncapped menu therefore grows to its content and pushes
+ * its own rows off-screen — the actions become unreachable rather than merely ugly.
+ *
+ * Asserted across ALL THREE hosts in one place on purpose: the same defect was fixed in
+ * one host and shipped in the others, twice. A new surface that renders
+ * `FileMenuItemLabel` should be added to this list.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (...p: string[]) => readFileSync(join(__dirname, '..', ...p), 'utf-8')
+
+// The cap the repo already uses for a content-sized dropdown (`RejectDropdown`).
+const CAP = 'max-w-[min(420px,calc(100vw-2rem))]'
+
+const HOSTS: Array<[string, string]> = [
+  ['the folder-row overflow menu', read('apps', 'fileMenuContributions.tsx')],
+  ['the MarkdownPanel overflow menu', read('components', 'MarkdownPanel.tsx')],
+  ['the Pierre tree context menu', read('pierre', 'PierreWorkspaceTreeImpl.tsx')],
+]
+
+describe('contributed menu rows fit a narrow viewport', () => {
+  for (const [name, src] of HOSTS) {
+    it(`caps ${name}`, () => {
+      expect(src).toContain(CAP)
+    })
+  }
+
+  it('lets both halves of a contributed row shrink and truncate', () => {
+    const src = read('apps', 'fileMenuContributions.tsx')
+    const fn = src.slice(src.indexOf('export function FileMenuItemLabel'))
+    const body = fn.slice(0, fn.indexOf('\n}'))
+    // A flex child's default `min-width: auto` refuses to shrink below its content, so
+    // `truncate` without `min-w-0` never engages and the text sets the row's width.
+    const spans = [...body.matchAll(/className="([^"]*)"/g)].map(m => m[1])
+    expect(spans.length).toBeGreaterThanOrEqual(2)
+    for (const cls of spans) {
+      expect(cls, cls).toContain('truncate')
+      expect(cls, cls).toContain('min-w-0')
+      // And the attribution must not be pinned at full width. Asserted on the extracted
+      // classes rather than the whole body, which also mentions `shrink-0` in prose.
+      expect(cls, cls).not.toContain('shrink-0')
+    }
+  })
+
+  it('lets a capped MarkdownPanel row clip rather than spill', () => {
+    const src = read('components', 'MarkdownPanel.tsx')
+    const row = /const menuRowCls = '([^']*)'/.exec(src)
+    expect(row, 'menuRowCls not found').not.toBeNull()
+    expect(row![1]).toContain('min-w-0')
+    expect(row![1]).toContain('overflow-hidden')
+  })
+})

--- a/website/src/test/fileMenuContributions.test.tsx
+++ b/website/src/test/fileMenuContributions.test.tsx
@@ -1,0 +1,531 @@
+/**
+ * contributes.fileMenuItems — the declarative file-menu contribution point.
+ *
+ * Four things are pinned here, because each one is a place a contributed row has
+ * already been able to disappear or misbehave without a test noticing:
+ *
+ *  - the RESOLVER, which is the only thing standing between an untrusted manifest and
+ *    three host menus (enabled-only, caps, endpoint allowlist, skip-with-warn);
+ *  - the `when` predicate that drives visibility on all three surfaces;
+ *  - the per-surface FILTER, so a row declared for one menu cannot appear in another;
+ *  - the RENDER of each surface, including the empty cases -- "the registry is empty so
+ *    the build is inert" is the claim this seam makes, and it is only true if something
+ *    asserts the menus render nothing.
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// The folder-row surface collapses its rows behind a DropdownMenu; the shared stub makes
+// the content render on a plain trigger click instead of Radix's pointer-event gating.
+vi.mock('@radix-ui/react-dropdown-menu', async () => await import('./__mocks__/@radix-ui/react-dropdown-menu'))
+
+const invokeApi = vi.fn().mockResolvedValue({})
+const listApps = vi.fn()
+vi.mock('../api/client', () => ({
+  api: {
+    invokeFileMenuItem: (...a: unknown[]) => invokeApi(...a),
+    listApps: (...a: unknown[]) => listApps(...a),
+  },
+}))
+// AppIcon pulls in theme/dompurify; icon glyph resolution is not under test here.
+vi.mock('../components/AppIcon', () => ({ default: () => null }))
+// The dispatcher reads the owning slot from the store at dispatch time; a mutable
+// binding lets a test set it per case without rendering a Provider.
+let activeSlot: string | undefined = 'slot-7'
+vi.mock('../store', () => ({
+  store: { getState: () => ({ chat: { activeSlot } }) },
+}))
+
+import {
+  contributedFileMenuItems,
+  fileMenuItemMatches,
+  visibleFileMenuItems,
+  useFileMenuItems,
+  invokeFileMenuItem,
+  FolderRowActions,
+  FileMenuItemLabel,
+  CORE_APP_ROUTE_SEGMENTS,
+  type ContributedFileMenuItem,
+  type FileMenuAppRecord,
+} from '../apps/fileMenuContributions'
+import { RESERVED_APP_PATH_SEGMENTS } from '../apps/coreAppRoutes'
+
+function item(over: Partial<ContributedFileMenuItem> = {}): ContributedFileMenuItem {
+  return {
+    id: 'send',
+    app: 'doc-store',
+    // The resolver always sets this; a hand-built fixture must too, or the row renders
+    // its host-owned attribution around an empty identifier.
+    appLabel: 'doc-store',
+    label: 'Send to store',
+    icon: 'Package',
+    endpoint: '/api/apps/doc-store/send',
+    surfaces: ['folder-row'],
+    when: { extensions: [], kinds: [] },
+    ...over,
+  }
+}
+
+const DECL = {
+  id: 'send',
+  label: 'Send to store',
+  icon: 'Package',
+  endpoint: '/api/apps/doc-store/send',
+  surfaces: ['file-overflow', 'tree-context', 'folder-row'],
+}
+
+function app(over: Record<string, unknown> = {}, decls: unknown = [DECL]): FileMenuAppRecord {
+  return {
+    name: 'doc-store',
+    enabled: true,
+    manifest: { contributes: { fileMenuItems: decls } },
+    ...over,
+  } as FileMenuAppRecord
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+describe('contributedFileMenuItems — resolving untrusted manifest data', () => {
+  it('is empty for no apps, so a stock build contributes nothing', () => {
+    expect(contributedFileMenuItems([])).toEqual([])
+  })
+
+  it('returns [] for a NON-ARRAY apps payload instead of throwing', () => {
+    // This resolver reads the shared `['apps']` cache, whose value is whatever another
+    // observer's fetch put there, and `normalizeInstalledApps` passes a non-array
+    // payload straight through. It runs inside a `useMemo` during render, so iterating
+    // one would throw `apps is not iterable` and take the host page down -- on a menu
+    // the reader merely opened. Both sibling resolvers on that key guard the same shape.
+    for (const bad of [{ apps: [] }, {}, 'x', 0, true] as unknown[]) {
+      expect(contributedFileMenuItems(bad as never), JSON.stringify(bad)).toEqual([])
+    }
+  })
+
+  it('reads a well-formed declaration', () => {
+    const [row] = contributedFileMenuItems([app()])
+    expect(row).toMatchObject({ id: 'send', app: 'doc-store', label: 'Send to store' })
+  })
+
+  it('ignores a DISABLED app — the enable switch would otherwise be a lie', () => {
+    expect(contributedFileMenuItems([app({ enabled: false })])).toEqual([])
+  })
+
+  it('skips a row whose endpoint escapes the app namespace', () => {
+    for (const endpoint of [
+      '/api/shutdown',
+      '/api/apps/other/send',
+      '/api/apps/doc-store-evil/send',
+      '/api/apps/doc-store/../../shutdown',
+      '/api/apps/doc-store/%2e%2e/%2e%2e/shutdown',
+    ]) {
+      expect(contributedFileMenuItems([app({}, [{ ...DECL, endpoint }])])).toEqual([])
+    }
+  })
+
+  it('skips a row naming a CORE route inside the app own namespace', () => {
+    // The prefix test alone is not enough: core mounts the lifecycle handlers in the
+    // app's own namespace, so `/api/apps/doc-store/uninstall` would POST to core's
+    // uninstall with the reader's session on a row they thought belonged to the app.
+    for (const endpoint of [
+      '/api/apps/doc-store/uninstall',
+      '/api/apps/doc-store/uninstall/preview',
+      '/api/apps/doc-store/uninstall?confirm=1',
+      '/api/apps/doc-store/uninstall#x',
+      // A `.` segment (and a doubled slash) is resolved away by the URL parser before
+      // the request is routed, so it must not read as an app route here either.
+      '/api/apps/doc-store/./uninstall',
+      '/api/apps/doc-store//uninstall',
+      '/api/apps/doc-store/disable',
+      '/api/apps/doc-store/token',
+      '/api/apps/doc-store/_jobs/active',
+    ]) {
+      expect(contributedFileMenuItems([app({}, [{ ...DECL, endpoint }])])).toEqual([])
+    }
+  })
+
+  it('skips a row hiding a CORE route behind a control character', () => {
+    // The browser's URL parser STRIPS U+0009/000A/000D as `fetch` builds the request, so
+    // `'uninstall\n'` is not the reserved `'uninstall'` to a naive segment test and the
+    // POST still lands on core's uninstall handler with the reader's session. Every C0
+    // control, DEL and space is refused, not only the three stripped today.
+    for (const ch of ['\t', '\n', '\r', '\u0000', '\u000b', '\u001f', '\u007f', ' ']) {
+      for (const endpoint of [
+        `/api/apps/doc-store/uninstall${ch}`,
+        `/api/apps/doc-store/${ch}uninstall`,
+        `/api/apps/doc-store/send${ch}`,
+      ]) {
+        expect(contributedFileMenuItems([app({}, [{ ...DECL, endpoint }])]), endpoint).toEqual([])
+      }
+    }
+    // …and percent-encoded, which is why the check runs after `decodeURIComponent`.
+    for (const endpoint of ['/api/apps/doc-store/uninstall%0a', '/api/apps/doc-store/uninstall%09']) {
+      expect(contributedFileMenuItems([app({}, [{ ...DECL, endpoint }])]), endpoint).toEqual([])
+    }
+  })
+
+  it('skips a row hiding a CORE route behind a backslash', () => {
+    // `\` is a PATH SEPARATOR to the URL parser for http(s) but not to a naive segment
+    // split, so `/api/apps/doc-store/.\uninstall` reads as one opaque segment here and
+    // the browser then normalizes it onto core's uninstall route.
+    for (const endpoint of [
+      '/api/apps/doc-store/.\\uninstall',
+      '/api/apps/doc-store/.\\token',
+      '/api/apps/doc-store\\uninstall',
+      '/api/apps/doc-store/x\\..\\uninstall',
+      '/api/apps/doc-store/%5cuninstall',
+      '/api/apps/doc-store/%2e%5cuninstall',
+    ]) {
+      expect(contributedFileMenuItems([app({}, [{ ...DECL, endpoint }])]), endpoint).toEqual([])
+    }
+  })
+
+  it('admits a real endpoint and refuses characters nobody enumerated', () => {
+    // The validator is a character ALLOWLIST, mirroring the Python side: the refusals
+    // above then hold for a character a future parser rewrites without anyone adding it.
+    for (const endpoint of [
+      '/api/apps/doc-store/send-item',
+      '/api/apps/doc-store/send_item',
+      '/api/apps/doc-store/v1.2/send',
+      '/api/apps/doc-store/send?path=/a/b&kind=file',
+    ]) {
+      expect(contributedFileMenuItems([app({}, [{ ...DECL, endpoint }])]), endpoint).toHaveLength(1)
+    }
+    for (const endpoint of [
+      '/api/apps/doc-store/send"x',
+      '/api/apps/doc-store/send<x',
+      '/api/apps/doc-store/send|x',
+      '/api/apps/doc-store/send{x}',
+      '/api/apps/doc-store/send^x',
+      '/api/apps/doc-store/send\u00a0x',
+      '/api/apps/doc-store/send\u2028x',
+    ]) {
+      expect(contributedFileMenuItems([app({}, [{ ...DECL, endpoint }])]), endpoint).toEqual([])
+    }
+  })
+
+  it('attributes every contributed row to the app that owns it', () => {
+    // `label` is app-owned and never checked against the core vocabulary, so an app can
+    // name its row exactly like a core action and sit one separator below the real one.
+    // The attribution is what lets a reader see that clicking it hands the file's path to
+    // a third party, so it must be present, non-empty, and never the label alone.
+    //
+    // It comes from `name`, NEVER `displayName`: `displayName` is free text the app
+    // chooses, so as provenance it can claim to be anything the host is called.
+    const rows = contributedFileMenuItems([
+      { name: 'doc-store', displayName: 'Kiro Crew', enabled: true, manifest: { contributes: { fileMenuItems: [{ ...DECL, label: 'Download' }] } } },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].appLabel).toBe('doc-store')
+    expect(rows[0].appLabel).not.toBe('Kiro Crew')
+
+    // Every shape of displayName is ignored, including the ones that used to win: a
+    // friendly name, whitespace, and a zero-width character that survives `.trim()`.
+    for (const displayName of ['Doc Store', '   ', '\u200b', '\u034f', undefined]) {
+      expect(contributedFileMenuItems([app({ displayName })])[0].appLabel).toBe('doc-store')
+    }
+
+    // An over-long NAME clips instead of dropping the row: `KEBAB_RE` bounds the
+    // alphabet and not the length, so refusing here would drop every row of an app
+    // whose own fields were all fine.
+    const long = contributedFileMenuItems([
+      { name: 'd'.repeat(500), enabled: true, manifest: { contributes: { fileMenuItems: [{ ...DECL, endpoint: `/api/apps/${'d'.repeat(500)}/send` }] } } },
+    ])
+    expect(long).toHaveLength(1)
+    expect(long[0].appLabel.length).toBeGreaterThan(0)
+    expect(long[0].appLabel.length).toBeLessThan(500)
+  })
+
+  it('still admits an app route whose name merely STARTS with a reserved word', () => {
+    // The reservation is per SEGMENT. Refusing a prefix would take routes the app owns.
+    const rows = contributedFileMenuItems([
+      app({}, [{ ...DECL, endpoint: '/api/apps/doc-store/uninstall-helper' }]),
+    ])
+    expect(rows).toHaveLength(1)
+  })
+
+  it('mirrors the reserved-segment list the Python allowlist owns', () => {
+    // Two copies of one security control drift apart invisibly, and the drift only shows
+    // up as something being let through. Read the owning module rather than restating it.
+    const py = readFileSync(
+      resolve(__dirname, '../../../src/kiro_crew/apps/manifest.py'),
+      'utf8',
+    )
+    const block = /CORE_APP_ROUTE_SEGMENTS = frozenset\(\s*\{([^}]*)\}/.exec(py)
+    expect(block, 'CORE_APP_ROUTE_SEGMENTS not found in apps/manifest.py').not.toBeNull()
+    const pythonSegments = [...block![1].matchAll(/"([^"]+)"/g)].map(m => m[1])
+    expect(pythonSegments.length).toBeGreaterThan(0)
+    expect([...CORE_APP_ROUTE_SEGMENTS].sort()).toEqual(pythonSegments.sort())
+  })
+
+  it('skips malformed rows without throwing, so one bad app cannot break the menus', () => {
+    expect(contributedFileMenuItems([app({}, 'not-an-array')])).toEqual([])
+    expect(contributedFileMenuItems([app({}, [null, 3, 'x'])])).toEqual([])
+    expect(contributedFileMenuItems([app({}, [{ ...DECL, id: 'Bad_Id' }])])).toEqual([])
+    expect(contributedFileMenuItems([app({}, [{ ...DECL, label: '' }])])).toEqual([])
+    expect(contributedFileMenuItems([app({}, [{ ...DECL, label: 'x'.repeat(121) }])])).toEqual([])
+    expect(contributedFileMenuItems([app({}, [{ ...DECL, surfaces: 'file-overflow' }])])).toEqual([])
+    expect(contributedFileMenuItems([app({}, [{ ...DECL, surfaces: ['nope'] }])])).toEqual([])
+    expect(contributedFileMenuItems([app({ name: '' })])).toEqual([])
+  })
+
+  it('caps rows per app, mirroring the manifest so neither side truncates alone', () => {
+    const many = Array.from({ length: 15 }, (_, n) => ({ ...DECL, id: `row-${n}` }))
+    expect(contributedFileMenuItems([app({}, many)])).toHaveLength(10)
+  })
+
+  it('drops a duplicate id within one app', () => {
+    expect(contributedFileMenuItems([app({}, [DECL, { ...DECL }])])).toHaveLength(1)
+  })
+
+  it('normalizes when.extensions and ignores a non-array when field', () => {
+    const [row] = contributedFileMenuItems([
+      app({}, [{ ...DECL, when: { extensions: ['.MD', 'Py'], kinds: ['file'] } }]),
+    ])
+    expect(row.when).toEqual({ extensions: ['md', 'py'], kinds: ['file'] })
+    const [loose] = contributedFileMenuItems([app({}, [{ ...DECL, when: { extensions: 'md' } }])])
+    expect(loose.when).toEqual({ extensions: [], kinds: [] })
+  })
+
+  it('lets two apps use the same row id', () => {
+    const rows = contributedFileMenuItems([
+      app(),
+      app({ name: 'other' }, [{ ...DECL, endpoint: '/api/apps/other/send' }]),
+    ])
+    expect(rows.map(r => `${r.app}:${r.id}`)).toEqual(['doc-store:send', 'other:send'])
+  })
+})
+
+describe('useFileMenuItems — per-surface filter, without fetching', () => {
+  const twoSurfaces = [
+    { ...DECL, id: 'only-overflow', surfaces: ['file-overflow'] },
+    { ...DECL, id: 'only-tree', surfaces: ['tree-context'] },
+  ]
+
+  function renderHookWith(surface: 'file-overflow' | 'tree-context' | 'folder-row', decls: unknown) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    qc.setQueryData(['apps'], [app({}, decls)])
+    const seen: string[][] = []
+    function Probe() {
+      seen.push(useFileMenuItems(surface).map(r => r.id))
+      return null
+    }
+    render(
+      <QueryClientProvider client={qc}>
+        <Probe />
+      </QueryClientProvider>,
+    )
+    return seen.at(-1)!
+  }
+
+  it('returns only rows declaring the requested surface', () => {
+    expect(renderHookWith('file-overflow', twoSurfaces)).toEqual(['only-overflow'])
+    expect(renderHookWith('tree-context', twoSurfaces)).toEqual(['only-tree'])
+    expect(renderHookWith('folder-row', twoSurfaces)).toEqual([])
+  })
+
+  it('never issues a request — the rows ride on the existing apps query', () => {
+    renderHookWith('file-overflow', [DECL])
+    expect(listApps).not.toHaveBeenCalled()
+  })
+
+  it('is empty when the apps cache is cold, so the menus stay inert', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    let rows: ContributedFileMenuItem[] = [item()]
+    function Probe() {
+      rows = useFileMenuItems('file-overflow')
+      return null
+    }
+    render(
+      <QueryClientProvider client={qc}>
+        <Probe />
+      </QueryClientProvider>,
+    )
+    expect(rows).toEqual([])
+  })
+})
+
+describe('fileMenuItemMatches — declarative when predicate', () => {
+  it('admits any node when when is empty', () => {
+    expect(fileMenuItemMatches(item(), { path: 'a/b.md', kind: 'file' })).toBe(true)
+    expect(fileMenuItemMatches(item(), { path: 'a/dir', kind: 'dir' })).toBe(true)
+  })
+
+  it('filters by kind', () => {
+    const row = item({ when: { extensions: [], kinds: ['file'] } })
+    expect(fileMenuItemMatches(row, { path: 'a/b.md', kind: 'file' })).toBe(true)
+    expect(fileMenuItemMatches(row, { path: 'a/dir', kind: 'dir' })).toBe(false)
+  })
+
+  it('filters by extension; a dotless name and a dotfile have none', () => {
+    const row = item({ when: { extensions: ['md'], kinds: [] } })
+    expect(fileMenuItemMatches(row, { path: 'a/b.md', kind: 'file' })).toBe(true)
+    expect(fileMenuItemMatches(row, { path: 'a/b.MD', kind: 'file' })).toBe(true)
+    expect(fileMenuItemMatches(row, { path: 'a/b.py', kind: 'file' })).toBe(false)
+    expect(fileMenuItemMatches(row, { path: 'Makefile', kind: 'file' })).toBe(false)
+    expect(fileMenuItemMatches(row, { path: 'a/.md', kind: 'file' })).toBe(false)
+    // A dot in a PARENT directory is not the file's extension.
+    expect(fileMenuItemMatches(row, { path: 'a.md/notes', kind: 'file' })).toBe(false)
+  })
+
+  it('ANDs kind and extension', () => {
+    const row = item({ when: { extensions: ['md'], kinds: ['file'] } })
+    expect(fileMenuItemMatches(row, { path: 'a/b.md', kind: 'file' })).toBe(true)
+    expect(fileMenuItemMatches(row, { path: 'a/b.md', kind: 'dir' })).toBe(false)
+  })
+
+  it('visibleFileMenuItems drops non-matching rows', () => {
+    const items = [
+      item({ id: 'a', when: { extensions: ['md'], kinds: [] } }),
+      item({ id: 'b', when: { extensions: ['py'], kinds: [] } }),
+    ]
+    expect(visibleFileMenuItems(items, { path: 'x.md', kind: 'file' }).map(i => i.id)).toEqual(['a'])
+  })
+})
+
+describe('FolderRowActions — folder-row surface', () => {
+  const onError = vi.fn()
+
+  /**
+   * The parent row's handler is a REACT onClick on a wrapping div, not a native
+   * `addEventListener` on the container: React delegates from its own root, so a native
+   * container listener sits BELOW that root and a synthetic `stopPropagation()` cannot
+   * reach it — the assertion would pass whether or not the click was actually stopped.
+   * `role="presentation"` keeps the wrapper out of the accessibility tree, so what
+   * `getAllByRole('button')` counts is unchanged; the real row (FolderPanel's `Row`)
+   * carries `role="button"` and its own Enter/Space handler, which this probe stands in
+   * for rather than reproduces.
+   */
+  function renderRow(items: ContributedFileMenuItem[]) {
+    const rowActivate = vi.fn()
+    render(
+      <div role="presentation" onClick={rowActivate}>
+        <FolderRowActions items={items} node={{ path: 'notes/x.md', kind: 'file' }} onError={onError} />
+      </div>,
+    )
+    return { rowActivate }
+  }
+
+  it('renders nothing when no row matches', () => {
+    const { container } = render(
+      <FolderRowActions items={[]} node={{ path: 'x', kind: 'file' }} onError={onError} />,
+    )
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('collapses every contributed row behind ONE trigger, whatever the count', () => {
+    // `max-two-buttons-per-row`: the count is an app's to choose, so three declaring
+    // apps would otherwise put three unranked icon buttons in a listing row.
+    renderRow([item(), item({ id: 'second' }), item({ id: 'third' })])
+    expect(screen.getAllByRole('button')).toHaveLength(1)
+    expect(screen.queryByRole('menuitem')).toBeNull()
+  })
+
+  it('opens the menu and POSTs the PATH, never the content', () => {
+    const { rowActivate } = renderRow([item(), item({ id: 'second', label: 'Second' })])
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2)
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Send to store\b/ }))
+    expect(invokeApi).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'send' }),
+      { surface: 'folder-row', path: 'notes/x.md', kind: 'file' },
+      'dashboard:slot-7',
+    )
+    // The dispatched context carries no file content.
+    expect(invokeApi.mock.calls[0][1]).not.toHaveProperty('content')
+    // Opening and selecting are stopped, so the row's own onActivate never fires.
+    expect(rowActivate).not.toHaveBeenCalled()
+  })
+
+  it('sends the OWNING SLOT as the session key, not the dashboard:ui placeholder', () => {
+    // `post`'s shared `dashboard:ui` default satisfies the server's `if sk:` gate but
+    // names no actual session, so a restricted (incognito) slot would not be recognised
+    // as restricted and the row's write would be allowed through. The slot is read at
+    // dispatch time, which is why it is asserted on the CALL rather than on a prop.
+    activeSlot = 'incognito-3'
+    const report = vi.fn()
+    invokeFileMenuItem(item(), { surface: 'folder-row', path: 'x', kind: 'file' }, report)
+    expect(invokeApi).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'dashboard:incognito-3',
+    )
+    expect(invokeApi.mock.calls[0][2]).not.toBe('dashboard:ui')
+  })
+
+  it('omits the session key entirely when no slot is active', () => {
+    // Not `dashboard:` with an empty tail, which would name a session that cannot
+    // exist; omitting it lets the transport apply its own documented default.
+    activeSlot = undefined
+    invokeFileMenuItem(item(), { surface: 'folder-row', path: 'x', kind: 'file' }, vi.fn())
+    expect(invokeApi.mock.calls[0][2]).toBeUndefined()
+  })
+
+  it('refuses a reserved app name, which is a shared core route rather than a namespace', () => {
+    // `/api/apps/registry/install` and `/api/apps/registries/refresh` are literal routes
+    // mounted before the `/api/apps/{name}` catch-all, and `install`/`refresh` are not
+    // per-app lifecycle segments, so CORE_APP_ROUTE_SEGMENTS does not cover them.
+    for (const name of RESERVED_APP_PATH_SEGMENTS) {
+      for (const tail of ['install', 'refresh', 'send']) {
+        expect(contributedFileMenuItems([
+          app({ name }, [{ ...DECL, endpoint: `/api/apps/${name}/${tail}` }]),
+        ])).toEqual([])
+      }
+    }
+  })
+
+  it('leaves an app whose name merely contains a reserved word alone', () => {
+    expect(contributedFileMenuItems([
+      app({ name: 'my-registry' }, [{ ...DECL, endpoint: '/api/apps/my-registry/send' }]),
+    ])).toHaveLength(1)
+  })
+
+  it('attributes a row to the app name when displayName is invisible', () => {
+    // Not a unit re-test of `attributionLabel`: this pins that the CONSUMER routes
+    // through it, since the row is what a reader sees and a blank attribution here is
+    // indistinguishable from a builtin row.
+    for (const displayName of ['   ', '\u200b', '\ufeff', '\u3164']) {
+      const rows = contributedFileMenuItems([app({ displayName })])
+      expect(rows).toHaveLength(1)
+      expect(rows[0].appLabel).toBe('doc-store')
+    }
+  })
+
+  it('frames the identifier in host-owned copy so a plausible app name cannot pass as core', () => {
+    // The identifier alone is unspoofable as a host WORD (`KEBAB_RE` allows no space and
+    // no capital), but nothing reserves `kiro-crew`, and a bare slug still reads as core.
+    // The surrounding word comes from the catalog, so it is core's and translated.
+    const rows = contributedFileMenuItems([
+      { name: 'kiro-crew', displayName: 'Kiro Crew', enabled: true, manifest: { contributes: { fileMenuItems: [{ ...DECL, endpoint: '/api/apps/kiro-crew/send' }] } } },
+    ])
+    expect(rows).toHaveLength(1)
+    render(<>{FileMenuItemLabel({ item: rows[0] })}</>)
+    // The attribution is announced, not decorative: it is the security-relevant part.
+    expect(screen.getByText(/kiro-crew/)).toBeInTheDocument()
+    // And it is framed rather than bare, so the row does not read as a core action.
+    expect(screen.getByText(/kiro-crew/).textContent).not.toBe('kiro-crew')
+  })
+
+  it('reports a rejected dispatch to the host instead of the console', async () => {
+    // `errors-use-error-notice`: the menu closes on select, so a console-only failure
+    // leaves the reader with a row that silently did nothing.
+    invokeApi.mockRejectedValueOnce(new Error('endpoint refused'))
+    renderRow([item()])
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Send to store\b/ }))
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith('endpoint refused'))
+  })
+
+  it('reports a non-Error rejection rather than an empty notice', async () => {
+    invokeApi.mockRejectedValueOnce('boom')
+    const report = vi.fn()
+    invokeFileMenuItem(item(), { surface: 'folder-row', path: 'x', kind: 'file' }, report)
+    await vi.waitFor(() => expect(report).toHaveBeenCalledWith('boom'))
+  })
+})

--- a/website/src/test/fileMenuDispatchTransport.test.ts
+++ b/website/src/test/fileMenuDispatchTransport.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The endpoint allowlist (`app_endpoint_allowed` in `apps/manifest.py`, mirrored by
+ * `endpointAllowed`) checks the url the dispatch is ABOUT to request. `fetch` follows a
+ * 3xx by default and a 307 preserves the method, the body and the `X-Session-Key`
+ * header, so an approved app endpoint answering `307 /api/apps/<victim>/disable` would
+ * have the reader's own session disable another app on a row they merely clicked — the
+ * checked url and the url that actually ran would differ, and every character-level
+ * guard in that allowlist would be walked around rather than defeated.
+ *
+ * So the dispatch must refuse to follow. Asserted at the transport, because that is the
+ * only layer where the option exists.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const okResponse = () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({}),
+  text: async () => '',
+  headers: new Headers({ 'content-type': 'application/json' }),
+})
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue(okResponse())
+  vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('invokeFileMenuItem transport', () => {
+  it("refuses to follow a redirect out of the validated endpoint", async () => {
+    const { api } = await import('../api/client')
+    await api.invokeFileMenuItem(
+      { id: 'send', endpoint: '/api/apps/doc-store/send' },
+      { surface: 'folder-row', path: 'notes/x.md', kind: 'file' },
+      'dashboard:slot-1',
+    )
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/apps/doc-store/send')
+    expect(init.redirect).toBe('error')
+  })
+
+  it('sends the owning slot as X-Session-Key rather than the shared placeholder', async () => {
+    const { api } = await import('../api/client')
+    await api.invokeFileMenuItem(
+      { id: 'send', endpoint: '/api/apps/doc-store/send' },
+      { surface: 'folder-row', path: 'notes/x.md', kind: 'file' },
+      'dashboard:incognito-9',
+    )
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-Session-Key']).toBe('dashboard:incognito-9')
+    // The body is the app-facing contract; the slot must not leak into it.
+    expect(JSON.parse(init.body as string)).toEqual({
+      item_id: 'send', surface: 'folder-row', path: 'notes/x.md', kind: 'file',
+    })
+  })
+
+  it('leaves every other POST following redirects as before', async () => {
+    // The option is opt-in: adding it must not change a core-routed caller, whose url
+    // core itself chose.
+    const { api } = await import('../api/client')
+    await api.artifactTeardown('some-slug').catch(() => {})
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.redirect).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`contributes` on main carries `commands`, so a manifest-only app can already reach the Command Bar — but nothing lets an app contribute a row to the **file editor's overflow (⋮) menu**, the **workspace-tree context menu**, or a **folder-panel row**. Those three menus are hardcoded in `MarkdownPanel` / `PierreWorkspaceTreeImpl` / `FolderPanel`, so today the only way to add a row is to edit core.

## What changed

`contributes.fileMenuItems[]` — a second field on the existing `Contributes`, alongside `commands`:

```json
"contributes": {
  "fileMenuItems": [{
    "id": "send-to-store",
    "label": "Send to store",
    "icon": "Package",
    "endpoint": "/api/apps/<app>/send",
    "surfaces": ["file-overflow", "tree-context", "folder-row"],
    "when": { "extensions": ["md"], "kinds": ["file"] }
  }]
}
```

- **Backend** (`apps/manifest.py`) — `FileMenuItemConfig` + `FileMenuWhen` + `fileMenuItems` on `Contributes`, threaded through its `to_dict` / `from_dict` / `validate`. `commands` is untouched: both fields parse, serialize and validate side by side. Caps and malformed-input reporting mirror the `commands` precedent (`bad_file_menu_items` / `dropped_file_menu_items` / `bad_surfaces`, `_MAX_FILE_MENU_ITEMS_PER_APP`, label bounded by `_MAX_TITLE`).
- **Endpoint safety** — the `/api/apps/<app>/` allowlist is now one shared helper, `manifest.app_endpoint_allowed()`, called by manifest validation **and** by `collect_publish_providers` (its inline copy is removed, so there is one implementation of the control rather than two free to drift). It is enforced at **install** time, so a row naming `/api/shutdown` never reaches the dashboard. `signing_payload` covers `fileMenuItems`, because `endpoint` decides where a chosen path is sent — tampering must break the signature.
- **Frontend** (`apps/fileMenuContributions.tsx`, added) — rows resolve off the **shared `['apps']` query** as a non-fetching cache subscriber (`enabled: false`, the same posture as the Command Bar), so there is no extra per-session request and no second `list_apps()` disk walk. `when` is evaluated by core; no live callback crosses the app boundary.
- **Render sites** — `MarkdownPanel` (file-overflow, rows in a trailing group after the core options), `PierreWorkspaceTreeImpl` (tree-context, returning `null` when no row survives `when`), `FolderPanel` (folder-row).
- **Dispatch is path-only.** Activating a row POSTs `{item_id, surface, path, kind?, root?}` to the app's own endpoint. **File content is never sent** — an app that needs bytes reads them through its own permitted route.

## Why it matters

An installed app can add per-file and per-folder actions — sending a file to an external document store, pulling one back — from its manifest alone, without any core edit and without the edition having to register anything on its behalf. That removes the copy-and-shadow maintenance a downstream fork otherwise re-applies on every sync, and it keeps the contribution honest at the boundary: core reads a declaration and POSTs a path to the app's own endpoint, so no app code is imported into the shell and no file content leaves the host without the app reading it through its own permitted route. With no app declaring `fileMenuItems`, the resolver returns empty and the stock build is byte-identical to main.

## Addressing the review

- **`contributes` already exists on main** — correct, and the earlier revision was wrong to add a second class. `fileMenuItems` is now a field on main's `Contributes`; `commands` keeps parsing, serializing and validating, pinned by a round-trip test asserting both survive together. Rebased onto `main`.
- **File content reaching an app with no declared permission** — fixed by removing content from the contract entirely (path-only), which needs no new permission surface. Two tests assert the dispatched payload carries no `content`.
- **Bespoke endpoint duplicating an existing flow** — `GET /api/file-menu-items`, its aggregator, handler, route registration and the second client query are all deleted; `routes.py` is net negative.
- **SSRF allowlist copy-pasted** — extracted to one helper, called from both paths.
- **No caps** — added, and mirrored as constants in the frontend module (label length measured to match the renderer's UTF-16 count).
- **Silent coercion** — `bad_*` / `dropped_*` flags reported from `validate()`, mirroring `commands`. No test asserts silent degradation.
- **Tests (the prior finding still open)** — added file-overflow tests in `MarkdownPanel.test.tsx` (row renders, path-only POST, rows render last, `data-option` present, `when` honoured, N>1, disabled app, inert empty case) and tree-context tests in `PierreWorkspaceTreeImpl.test.tsx` (the `renderContextMenu` gate, the `null` return when no row survives, the `querySelector` focus fallback with no built-in row, path+root dispatch, disabled app), plus surface-filter and resolver coverage.
- **Nits** — the documented icon example is a real `AppIcon` name and the allowed set is documented; the stale "exactly one item" comment is rewritten; app rows render last.

## Tests

22/22 backend tests pass locally. `flake8` clean; `mypy --platform linux` clean on the changed files; `black` gate passes; `scrub-lint`'s working-tree scan is clean. `error-code-baseline.json` needs no change and there is no route census — the endpoint is deleted, not added.

Frontend `tsc` / `vitest` could not run on the authoring host (no npm egress), so CI is the gate for them.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No user-visible change in the stock build — no app on main declares `contributes.fileMenuItems`, so the resolver returns empty and all three render sites are inert. Contributed rows appear only when an installed app declares them, which is out of scope for this PR.
