### PR TITLE
fix(security): derive the UNC path-token boundary from whitespace

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -8163,9 +8163,18 @@ _REDIR_PREFIX_RE = re.compile(r"^\d*(?:>>?|<(?!<))")
 
 
 _SEPARATOR_RUN_RE = re.compile(r"[\\/]{2,}")
-#: What a path token may start after, used to recognise a LEADING separator run
-#: (a UNC prefix) as opposed to an interior one.
-_PATH_TOKEN_BOUNDARY = " \t\"'=:,;(<>|&`"
+#: The PUNCTUATION a path token may start after, used together with
+#: ``str.isspace()`` to recognise a LEADING separator run (a UNC prefix) as
+#: opposed to an interior one. Whitespace is derived rather than enumerated:
+#: the hand-written class here used to spell out only space and tab, so a UNC
+#: path on a CONTINUATION LINE (newline before it, as in a multi-line
+#: PowerShell command) was read as interior, every emitted variant destroyed
+#: the UNC anchor, and the doubled spelling of a fenced file was permitted
+#: while its single-separator spelling was blocked -- the #6350 class surviving
+#: at a newline boundary. ``isspace()`` is exactly the class the patterns
+#: themselves accept before a path operand, so the two cannot drift apart
+#: again (\r, \v and \f were missing for the same reason).
+_PATH_TOKEN_BOUNDARY_PUNCTUATION = "\"'=:,;(<>|&`"
 
 
 def _separator_collapsed_variants(command: str) -> tuple[str, ...]:
@@ -8215,7 +8224,8 @@ def _separator_collapsed_variants(command: str) -> tuple[str, ...]:
                 keep_leading_pair: bool = keep_leading_pair,
             ) -> str:
                 start = match.start()
-                leading = start == 0 or command[start - 1] in _PATH_TOKEN_BOUNDARY
+                prev = command[start - 1] if start else ""
+                leading = start == 0 or prev.isspace() or prev in _PATH_TOKEN_BOUNDARY_PUNCTUATION
                 return sep * 2 if (keep_leading_pair and leading) else sep
 
             variant = _SEPARATOR_RUN_RE.sub(_replace, command)

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -6792,6 +6792,43 @@ class TestWindowsSeparatorRuns:
         ):
             assert is_sensitive_bash_command(cmd) is not None, cmd
 
+    @pytest.mark.parametrize("gap", ("\n", "\r", "\r\n", "\v", "\f", " ", "\t"))
+    def test_a_unc_path_after_any_whitespace_boundary_is_still_fenced(self, gap: str) -> None:
+        # The leading-run test above quotes the path, so the character before
+        # the UNC prefix is always ``"``. A multi-line command puts it after a
+        # NEWLINE instead, and the boundary class used to enumerate only space
+        # and tab -- so the prefix read as interior, every variant destroyed the
+        # UNC anchor, and the doubled spelling was permitted while the single
+        # one was blocked. Asserted over the whole whitespace class, both the
+        # read fence and the agents-directory WRITE gate, because enumerating
+        # is what produced the gap: \r, \v and \f were missing for the same reason.
+        for cmd in (
+            f"Get-Content `{gap}\\\\server\\share\\.kiro\\\\crew\\security_policy.json",
+            f"Get-Content `{gap}//server//share//.kiro//crew//security_policy.json",
+            f"Set-Content `{gap}\\\\server\\share\\.kiro\\\\agents\\evil.json -Value x",
+            f"cat `{gap}\\\\srv\\homes\\u\\\\.ssh\\id_rsa",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, repr(cmd)
+        # The control: the single-separator spelling of the same file at the
+        # same boundary was ALWAYS blocked. Pinned so a future change cannot
+        # close the gap by relaxing this side instead.
+        for cmd in (
+            f"Get-Content `{gap}\\\\server\\share\\.kiro\\crew\\security_policy.json",
+            f"Set-Content `{gap}\\\\server\\share\\.kiro\\agents\\evil.json -Value x",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, repr(cmd)
+
+    @pytest.mark.parametrize("gap", ("\n", "\r", "\v", "\f"))
+    def test_a_benign_unc_path_after_a_whitespace_boundary_stays_allowed(self, gap: str) -> None:
+        # The fence must not widen past the boundary gap: an unfenced UNC path
+        # on a continuation line keeps being allowed in both spellings.
+        for cmd in (
+            f"Get-Content `{gap}\\\\server\\share\\project\\readme.md",
+            f"Get-Content `{gap}\\\\server\\share\\project\\\\readme.md",
+            f"Get-Content `{gap}//server//share//project//readme.md",
+        ):
+            assert is_sensitive_bash_command(cmd) is None, repr(cmd)
+
     def test_the_unchanged_unc_spelling_still_matches(self) -> None:
         # The control: a UNC path with no interior run needs no collapsing and
         # must keep matching on the original command.


### PR DESCRIPTION
## Problem / Motivation

`_PATH_TOKEN_BOUNDARY` in `src/kiro_crew/security.py` spelled out the whitespace a path operand may start after as `" \t"` and stopped there, while the sensitive-path patterns accept the whole whitespace class.

`_separator_collapsed_variants` used that constant to decide whether a separator run is **LEADING** (a UNC prefix, which must survive as a pair for the UNC anchor to match) or **interior** (collapsed to one). So a UNC path on a **continuation line** — newline immediately before it, as in a multi-line PowerShell command — was misclassified as interior. Every emitted variant then destroyed the UNC anchor, while the original command still missed because of its interior doubled run.

Net effect: the **doubled** spelling of a fenced path was permitted where the **single-separator** spelling of the same file was blocked. That is the #6350 defect class surviving at a newline boundary. `\r`, `\v` and `\f` were missing for the same reason.

## Why it matters

Two reachable surfaces, both governance-critical:

- the crew-directory read fence over `security_policy.json`
- the `~/.kiro/agents` **write** gate, where a planted agent spec becomes a gateway-exec'd MCP server command outside the per-session sandbox

Post-merge patrol finding from #6993, verified live on `origin/main` before this fix.

## What changed

The boundary is now **derived** rather than enumerated: `str.isspace()` plus the punctuation set, which is exactly the class the patterns themselves accept before a path operand, so the two cannot drift apart again. The constant is renamed to `_PATH_TOKEN_BOUNDARY_PUNCTUATION` to say what it now holds — it had no consumer outside this function.

```python
leading = start == 0 or prev.isspace() or prev in _PATH_TOKEN_BOUNDARY_PUNCTUATION
```

Deliberately minimal: two lines of logic, one constant, one docstring. No pattern was widened.

### Before / after

`is_sensitive_bash_command` against a continuation-line UNC read of `\\server\share\.kiro\crew\security_policy.json` — measured on the `origin/main` blob, then on this branch:

| boundary | spelling | before | after |
|---|---|---|---|
| `\n` | single separator | BLOCKED | BLOCKED |
| `\n` | **doubled separator** | **ALLOWED** | **BLOCKED** |
| `\r` | **doubled separator** | **ALLOWED** | **BLOCKED** |
| `\v` | **doubled separator** | **ALLOWED** | **BLOCKED** |
| `\f` | **doubled separator** | **ALLOWED** | **BLOCKED** |
| space | doubled separator | BLOCKED | BLOCKED (control) |

The `~/.kiro/agents` write gate leaked identically:

| command | before | after |
|---|---|---|
| `Set-Content \`\n\\server\share\.kiro\\agents\evil.json -Value x` | **ALLOWED** | **BLOCKED** |
| `Set-Content \`\n\\server\share\.kiro\agents\evil.json -Value x` | BLOCKED | BLOCKED (control) |

## Tests

`TestWindowsSeparatorRuns` gains two cases, both parametrized over the whitespace class rather than the newline alone — enumerating is what produced this gap:

- `test_a_unc_path_after_any_whitespace_boundary_is_still_fenced` — the doubled spelling across `\n \r \r\n \v \f` space tab, on both the read fence and the agents write gate, **plus** the single-separator control on the same commands so a future change cannot close the gap by relaxing that side instead.
- `test_a_benign_unc_path_after_a_whitespace_boundary_stays_allowed` — holds the allow side: an unfenced UNC path on a continuation line stays allowed in both spellings.

**Revert-verified.** With the fix mutated back to the pre-fix boundary, 5 of the 11 new cases fail (`\n`, `\r`, `\r\n`, `\v`, `\f`) and the space, tab and benign-allow cases still pass. Restoring the fix returns all 11 to green. Re-run after the rebase onto current `main`.

**No false positives.** A 17-command benign corpus — multi-line PowerShell/POSIX commands with separator runs at a newline boundary (`robocopy`, `Copy-Item`, `grep -r` over a UNC share, `cd node_modules//pkg`, `cat /etc//hostname`) — returns byte-identical verdicts before and after this change. Widening the fence is the failure mode here, so this was checked as a diff of the two verdict sets rather than by inspection.

| gate | result |
|---|---|
| `test/test_security.py` | 1261 passed, 1 skipped |
| flake8 | clean |
| isort | clean |
| mypy (`security.py`) | clean |
| brand-name (`BRAND_BASE_REF` set) | PASS |
| focus-cue (base ref set) | PASS |
| changelog-history (base ref set) | PASS |
| harness-parity (base ref set) | PASS |
| docs-lint | PASS |

Diff-scoped gates were run with `BASE_REF=$(git merge-base HEAD origin/main)` exported — without it they report a false green.

## Related Issues

Follows #6350 (the separator-run collapse this boundary belongs to). Patrol finding from #6993.

## Pattern harvest

Rule candidate: semgrep
Pattern: hand-enumerated character class standing in for a derivable one (`" \t"` where `str.isspace()` is meant) on a security-matching path — the enumeration and the pattern it mirrors drift apart silently, and the drift is only observable as a boundary the fence stops covering.

The same shape is worth flagging wherever a gate compares against a literal string of separator/whitespace characters instead of the classifier the regexes use; a review-prompt line asking "is this class derivable?" would have caught it at the original #6350 review.
