### PR TITLE
fix(crew-companion): drop the happy-mood eye shift on a successful finish

### DIFF
--- a/website/src/apps/crew-companion/pet.tsx
+++ b/website/src/apps/crew-companion/pet.tsx
@@ -754,6 +754,12 @@ function Companion() {
         if (k === 'session-error') { react('error', 2_000); setMood('scared') }
         else if (k === 'approval' || k === 'session-input') { bumpReaction(); setMood('curious') }
         else if (k === 'break' || k === 'break-breathe' || k === 'reminder') { /* ambient: no reaction */ }
+        // A successful finish is a BODY reaction only — the hop plus a celebrate
+        // prop. setMood('neutral') actively clears any still-live transient mood
+        // (a curious/scared eye pose from an approval or error in the last few
+        // seconds) so the eyes rest at 'primary'; ambient blink and cursor-tracking
+        // still run. 'other'/unknown kinds below keep the old happy reaction.
+        else if (k === 'session-done') { react('done', 2_400); setMood('neutral'); celebrateWithProp() }
         else { react('done', 2_400); setMood('happy'); celebrateWithProp() }
       }) ?? undefined,
     [react, setMood, bumpReaction, celebrateWithProp],


### PR DESCRIPTION
## Problem / Motivation

When a session finishes successfully, the Crew Companion desktop pet was reacting mostly with its **eyes** rather than a body celebration. On a finish the code called `setMood('happy')`, and mood overrides the ghost's eye pose (`happy` → the `'4th'` pose in `ghostEyes.ts`), so the "reaction" read as the eyes sliding to a new position instead of the intended celebrate hop. The user wants a successful finish to be a body reaction — the hop plus a celebrate prop — with the eyes left at rest.

## Why it matters

The eye shift made the celebration feel inconsistent and easy to miss (an eye slide reads very differently from a hop), and it was surprising: a "job done" should look like a small celebration, not a change of expression. It also collided with a stale-mood edge (below) where a finish could inherit a `curious`/`scared` expression from a just-prior approval or error.

## What changed (motivation → approach → change)

- **Symptom:** a successful finish animates the eyes, not the body.
- **Root cause:** `onRenderBubble`'s reaction switch handled `session-done` in the same branch as unknown kinds and called `setMood('happy')`; because mood outranks state for the eye pose, the happy pose (`'4th'`) was drawn during the celebration.
- **Change:** split `session-done` into its own branch that plays the body celebration only — `react('done', …)` (the hop) + `celebrateWithProp()` — and calls `setMood('neutral')` instead of `'happy'`. The neutral reset is deliberate rather than simply omitting the call: a finish arriving within the ~3s transient-mood window of an approval (`curious`) or error (`scared`) would otherwise still show that lingering eye pose. With neutral set, the eyes fall back to their resting `'primary'` pose while ambient blink and cursor-tracking keep running (`celebrate` is not a posed animation, so tracking is not frozen).

Scope is intentionally narrow: the error (`scared`) and approval/needs-input (`curious`) reactions are unchanged, and the `else` branch for `other`/unknown kinds keeps its prior `happy` behavior (real finishes always arrive as `session-done`, so no finish path hits `else`).

## Tests

No new automated test. The new `session-done` branch is already exercised by the existing integration test (`CrewCompanionPet.coverage.test.tsx` — "celebrates a completion that came off the fire queue"), so per-file coverage is satisfied. The intent-specific assertion (eyes at `'primary'`, not the mood pose) is not cleanly expressible: the built-in ghost's eye pose is drawn by `GhostEyeOverlay` from coordinates and is not exposed as a queryable DOM attribute, so a robust assertion would require a refactor wider than this one-line behavioral fix. Behavior was instead validated by two model code-reviews (see Manual verification).

## Manual verification

Not run against the live desktop overlay — the companion runs inside the packaged desktop app, and this repo's dashboard/web-verify flow cannot drive the transparent Electron overlay or trigger a real session finish. Verified by code reasoning plus two independent local model reviews (GPT and Opus lanes) against the diff, which confirmed: the celebrate hop still fires without the happy mood; `celebrate` is excluded from `POSED_ANIMS` so blink/cursor-tracking continue; celebrate-continuity/`animEpoch` and the `useMood` transient-timer cleanup are unaffected; and no AUTOSDE rule is tripped. The GPT lane surfaced the stale-mood edge, which this PR fixes with the neutral reset.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the change is a motion/behavior delta on the native Crew Companion desktop overlay (a transparent always-on-top Electron window), which cannot be captured through the dashboard browser or the standard web-verify flow, and reproducing it requires triggering a real session finish inside the packaged desktop app. This matches the no-screenshots handling used on prior Crew Companion overlay PRs; happy to attach a screen recording if a maintainer can run the desktop build.

## Related Issues

no linked issue: direct user-reported behavior tweak on the companion's finish reaction; no tracking issue exists.

## Pattern harvest

Rule candidate: review-prompt
Pattern: when a reaction is scoped to leave one output channel (here, the eyes) at rest, it must actively RESET that channel, not merely refrain from setting it — a prior transient state on that channel (a mood set 3s earlier) can still be live and will otherwise show through.

## Checklist

- [x] At most two commits (one), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (existing coverage exercises the new branch; see Tests)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
