### PR TITLE
fix(dashboard): keep-visible marker exempts mid-turn deliverables from collapse-all

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -151,6 +151,132 @@ OPTIONS_RE_TRAILER = re.compile(
     re.DOTALL,
 )
 
+# CONTROL-TAG HTML COMMENTS — canonical grammar (single source of truth).
+#
+# Agent control tags ride in HTML comments, which the dashboard's markdown
+# pipeline renders as nothing (rehype-raw emits comment nodes the react
+# renderer skips). Three families exist in ``src/``:
+#   * ``<!-- keep-visible -->``       — collapse-all exemption (#7948)
+#   * ``<!-- deliver:<route> -->``    — heartbeat routing
+#   * ``<!-- plan_task_id:<id> -->``  — task-planner Apply-to-Tasks anchor
+#
+# ONE GRAMMAR, TAIL-ANCHORED + FENCE-GUARDED, case-insensitive, both
+# recognizers (this regex and ``website/src/app-sdk/protocol/
+# keepVisibleMarker.ts``): only standalone tag lines at the message tail are
+# control tags, and a tail inside an UNTERMINATED fence is visible code (see
+# ``_in_open_fence``). Message-tail producers: the prompt rule ("as its
+# final line") and the task-planner appender (newline-prefixed). The
+# heartbeat's ``deliver:`` tags are HEARTBEAT.md FILE-format suffixes on
+# checklist lines, not message-tail emissions — echoed into a message body
+# they are mid-body content, which the dashboard renders as nothing and this
+# strip deliberately leaves alone. Position-independent stripping was tried
+# and retired: rounds 5–8 each surfaced another quoted-code dialect it
+# corrupted.
+#
+# Tag-line leading indent is ≤3 (CommonMark: 4+ spaces renders as an
+# indented code block — visible content, never a control tag).
+# ReDoS note: every quantifier is BOUNDED (whitespace ≤16, tag body ≤256 —
+# generous for real emissions like ``<!-- deliver:dashboard -->``), so a
+# failed match attempt does constant work and total matching stays linear
+# even on adversarial repetition input (CodeQL py/polynomial-redos: an
+# UNBOUNDED body with a failing ``-->`` suffix rescans per start position —
+# quadratic). An unterminated ``<!--`` is NOT matched: swallowing to
+# end-of-text on a missing ``-->`` silently deletes visible prose. A tag
+# body over the bound is not a real control tag and stays visible.
+_TRAILING_CONTROL_LINES_RE = re.compile(
+    r"(?:(?:^|\n)[ \t]{0,3}"
+    r"<!--(?:\s{0,16}keep-visible\s{0,16}|\s{0,16}(?:deliver|plan_task_id):[^>\n]{0,256})-->"
+    r"[ \t]{0,16})+\s{0,16}\Z",
+    re.IGNORECASE,
+)
+
+
+# Fence-delimiter lines (CommonMark: 3+ backticks or tildes, ≤3 leading
+# spaces). Used for the open-fence parity guard below.
+_FENCE_DELIM_LINE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+
+# Over-approximate fence-open CANDIDATES the exact walker cannot classify:
+# a fence run preceded only by whitespace and CommonMark container-marker
+# characters — list bullets (``- ```` ``), ordered-list digits/punctuation
+# (``1. ```` ``), blockquote markers (``> ```` ``) — or by 4+ spaces (an
+# indented code block at top level, but a REAL fence inside a list
+# continuation). Classifying these correctly needs full CommonMark
+# container tracking (nesting, lazy continuation, per-container indent
+# budgets); each conformance round surfaced another sibling. Instead of
+# deciding, the walker VETOES: a candidate seen while outside any tracked
+# fence makes the message's fence structure ambiguous and the strip does
+# nothing. Over-matching is safe by construction — the failure modes are
+# asymmetric: wrongly stripping deletes visible fence-interior content,
+# wrongly not stripping leaves an HTML comment the renderer never shows —
+# so a false veto costs at most a feature-miss, never content.
+# Single bounded character class then a literal run: linear, no
+# backtracking (class and fence characters are disjoint).
+_AMBIGUOUS_FENCE_LINE_RE = re.compile(r"^[ \t>+*\-\d.)]{0,40}(`{3,}|~{3,})")
+
+
+def _in_open_fence(text: str, idx: int) -> bool:
+    """True when position *idx* falls inside an UNTERMINATED code fence —
+    or when the fence structure before *idx* is AMBIGUOUS.
+
+    Walks fence-delimiter lines before *idx* with CommonMark's close rule
+    (same character, run at least as long as the opener). Inside an open
+    fence the renderer shows every line as literal code — including a line
+    that lexes like a control tag — so the strip must not touch it.
+
+    STRIP ONLY WHEN PROVABLY OUTSIDE: a container-prefixed or over-indented
+    fence candidate (``_AMBIGUOUS_FENCE_LINE_RE``) encountered while the
+    walker believes it is outside any fence may be a real opener this
+    grammar cannot see, so the walk answers True — do nothing — rather
+    than risk deleting fence-interior content. Inside a tracked fence the
+    same line shape is literal code under every interpretation and does
+    not veto, so a closed plain fence quoting container-fence examples
+    still strips normally.
+    """
+    open_run: str | None = None
+    for line in text[:idx].split("\n"):
+        m = _FENCE_DELIM_LINE_RE.match(line)
+        if not m:
+            if open_run is None and _AMBIGUOUS_FENCE_LINE_RE.match(line):
+                return True
+            continue
+        run = m.group(1)
+        if open_run is None:
+            open_run = run
+        elif (
+            run[0] == open_run[0]
+            and len(run) >= len(open_run)
+            # CommonMark 4.5: a CLOSING fence may not carry an info string —
+            # only whitespace may follow the run. Inside an open fence a
+            # fence-lookalike WITH trailing text (``` python) is literal
+            # code content, not a closer, so the fence stays open.
+            and line[m.end() :].strip() == ""
+        ):
+            open_run = None
+    return open_run is not None
+
+
+def strip_control_comments(text: str) -> str:
+    """Remove trailing control-tag lines from *text* for a plain-text
+    projection (preview, TTS, channel delivery).
+
+    TAIL-ANCHORED with a FENCE-PARITY guard — the same grammar as the
+    frontend recognizer (``keepVisibleMarker.ts``), case-insensitive on
+    both sides: only standalone tag lines ENDING the message are control
+    tags, and a tail that sits inside an UNTERMINATED fence is visible
+    code, not a tag (the renderer shows it literally). Every producer
+    emits at the tail — the prompt rule says "as its final line" and the
+    task-planner appends a newline-prefixed tag — so nothing real is
+    missed, and a tag quoted anywhere in the body (prose, inline code, any
+    fence dialect) is structurally untouchable rather than guarded by a
+    code-span grammar this module would have to keep re-deriving (rounds
+    5–8 each found another dialect). Stacked trailing tags are all
+    removed. This is the ONE backend strip implementation.
+    """
+    m = _TRAILING_CONTROL_LINES_RE.search(text)
+    if m is None or _in_open_fence(text, m.start()):
+        return text
+    return text[: m.start()]
+
 
 def split_trailing_protocol_suffix(text: str) -> tuple[str, str]:
     """Detach protocol trailers before a renderer length-splits ``text``.

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1161,6 +1161,14 @@ _DIFF_RULE_DASHBOARD = (
     "`+++ new_path` headers and an `@@` hunk line; use /dev/null for new "
     "files / deletions — the headers let the dashboard's diff viewer link to "
     "the file), because no card is rendered for those.\n"
+    "When a substantive report, synthesis, or results table is NOT your turn's "
+    "final message (more tool calls or messages follow it), end that message "
+    "with <!-- keep-visible --> as its final line. The dashboard transcript's "
+    "collapse-all mode shows only the turn's last substantive message and folds "
+    "earlier ones into the collapsed steps pane; this marker exempts the "
+    "message so mid-turn deliverables stay visible. The marker is an HTML "
+    "comment and renders as nothing in the dashboard -- do not use it on "
+    "routine progress notes, only on content the user must see.\n"
 )
 _DIFF_RULE_CHANNEL = (
     "After ANY file change (create, edit, append, delete), you MUST show a "

--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -25,6 +25,7 @@ from typing import Any
 from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.constants import strip_control_comments
 from kiro_crew.dashboard.chat_backfill import (
     backfill_content,
     gap_summary,
@@ -381,7 +382,9 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         # without passing a renderer, so a markdown-collapse credential would be
         # reassembled whole by the client. Same floor and same context-aware
         # redactor as the live legs in ``chat_runner``.
-        text, _ = redact_for_display(backfill_content(row), redact_via_context)
+        text, _ = redact_for_display(
+            strip_control_comments(backfill_content(row)), redact_via_context
+        )
         return split_markdown_safe(f"{speaker}: {text}", max_chars)
 
     # Bound the INLINE delivery. Unlike the Slack drain this cannot be

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -50,6 +50,7 @@ from kiro_crew.config.loader import (
     resolve_agent_bindings,
 )
 from kiro_crew.connections import get_visible_providers
+from kiro_crew.constants import strip_control_comments
 from kiro_crew.context_blocks import (
     PHASE_PER_TURN,
     PHASE_SESSION_START,
@@ -3034,7 +3035,11 @@ async def _deliver_cross_surface_reply(state: Any, session_key: str, assistant_t
     # whole on screen) reach the channel. ``redact_via_context`` stays the redactor
     # rather than the neutral ``display_safe``, because it is context-aware and the
     # shared sink's default pair would silently drop that.
-    text, _ = redact_for_display(assistant_text, redact_via_context)
+    #
+    # Strip trailing control-tag lines FIRST (#7948): this leg mirrors a
+    # dashboard turn — a marker-taught session — to a channel whose client
+    # renders HTML comments literally. Strip-then-redact matches display_safe.
+    text, _ = redact_for_display(strip_control_comments(assistant_text), redact_via_context)
     # Split on the channel's max message length so a long reply mirrors in full
     # rather than being hard-truncated by the transport (Telegram caps at 4096,
     # and its client slices at that width), matching the Slack leg's chunking.

--- a/src/kiro_crew/dashboard/chat_slack.py
+++ b/src/kiro_crew/dashboard/chat_slack.py
@@ -9,6 +9,7 @@ from typing import Any
 from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.constants import strip_control_comments
 from kiro_crew.dashboard import state as dashboard_state
 from kiro_crew.dashboard.chat_backfill import (
     backfill_content,
@@ -88,7 +89,9 @@ def _format_backfill_parts(content: str, icon: str) -> list[str]:
     maximally-sized part after the split pushed it past ``SLACK_MSG_LIMIT`` by
     the width of the icon plus its space.
     """
-    return render_for_slack(content, prefix=f"{icon} ", redactor=redact_via_context)
+    return render_for_slack(
+        strip_control_comments(content), prefix=f"{icon} ", redactor=redact_via_context
+    )
 
 
 async def drain_slack_backfill(

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -35,7 +35,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
+from kiro_crew.constants import OPTIONS_RE_TRAILER, strip_control_comments
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.tables import render_tables, render_tables_with_metadata
 from kiro_crew.messaging.transport import TransportCapabilities
@@ -178,8 +178,13 @@ def display_safe_for(text: str, capabilities: TransportCapabilities) -> str:
     uncopyable. Its own renderer already avoids that (``webex_display_safe``); the
     neutral sinks read the declaration instead of importing a channel symbol,
     which is what keeps them neutral.
+
+    Control-tag comments are stripped first, same as :func:`display_safe` —
+    the deterministic backstop against a dashboard-authored control tag
+    reaching channel users as literal text (#7948).
     """
-    safe, _ = redact_for_display(text or "", _default_redactor)
+    text = strip_control_comments(text or "")
+    safe, _ = redact_for_display(text, _default_redactor)
     if not capabilities.mention_grammars:
         return safe
     return safe.replace("@", "@\u200b").replace("<!", "<\u200b!")
@@ -248,8 +253,16 @@ def display_safe(text: str) -> str:
     The defang covers both mention grammars because the callers are
     channel-neutral: ``@`` for Discord/Telegram users and ``@everyone``, ``<!``
     for Slack's ``<!channel>``.
+
+    Control-tag comments are stripped first (fence/inline-code aware): channel
+    formatters render HTML comments literally, so a dashboard-authored
+    ``<!-- keep-visible -->`` (#7948) or ``deliver:``/``plan_task_id:`` tag
+    delivered to a channel would otherwise reach end users as visible text.
+    The prompt rule only contains the emitter; this is the deterministic
+    backstop on the message itself.
     """
-    safe, _ = redact_for_display(text or "", _default_redactor)
+    text = strip_control_comments(text or "")
+    safe, _ = redact_for_display(text, _default_redactor)
     return safe.replace("@", "@\u200b").replace("<!", "<\u200b!")
 
 

--- a/src/kiro_crew/preview_text.py
+++ b/src/kiro_crew/preview_text.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import re
 import unicodedata
 
-from kiro_crew.constants import OPTIONS_RE_LINE
+from kiro_crew.constants import OPTIONS_RE_LINE, strip_control_comments
 
 # Fenced code blocks — ```lang ... ``` (or unterminated, running to the end
 # of the message). Replaced with a short placeholder; the code body would
@@ -26,6 +26,9 @@ from kiro_crew.constants import OPTIONS_RE_LINE
 _FENCE_RE = re.compile(r"```([^\n`]*)\n?[\s\S]*?(?:```|\Z)")
 # <mcwidget> bodies render as an iframe elsewhere; raw HTML is noise here.
 _MCWIDGET_RE = re.compile(r"<mcwidget\b[^>]*>[\s\S]*?(?:</mcwidget>|\Z)", re.IGNORECASE)
+# Control-tag comment stripping lives in ``constants.strip_control_comments``
+# (grammar + recognizer split documented on ``constants._TRAILING_CONTROL_LINES_RE``);
+# this module deliberately has no local spelling to drift.
 _INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
 _IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
@@ -91,6 +94,11 @@ def strip_markdown_preview(text: str) -> str:
     t = drop_format_chars(text)
     t = _FENCE_RE.sub(_fence_placeholder, t)
     t = _MCWIDGET_RE.sub(" (widget) ", t)
+    # Only RECOGNIZED control tags (keep-visible #7948, heartbeat deliver
+    # routing, plan_task_id anchors) — never all comments, and never inside
+    # inline code: a tag an assistant quotes in inline code renders literally
+    # and is visible content. Shared implementation; see constants.py.
+    t = strip_control_comments(t)
     t = _INLINE_CODE_RE.sub(r"\1", t)
     t = _IMAGE_RE.sub(lambda m: m.group(1) or "(image)", t)
     t = _LINK_RE.sub(r"\1", t)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -83,7 +83,7 @@ from kiro_crew.config.loader import (
     data_home,
 )
 from kiro_crew.config.paths import kiro_agents_dir
-from kiro_crew.constants import DATA_WARNING, SUBAGENT_COMPLETION_META_KEY
+from kiro_crew.constants import DATA_WARNING, SUBAGENT_COMPLETION_META_KEY, strip_control_comments
 from kiro_crew.context import ContextBuilder
 from kiro_crew.context_management import summarize_result
 from kiro_crew.cron import (
@@ -2965,7 +2965,12 @@ class GatewayOrchestrator:
             # ``redact_via_context`` stays the redactor rather than the neutral
             # ``display_safe``: it is context-aware, and the shared sink's default
             # pair would silently drop that.
-            safe_text, _ = redact_for_display(text, redact_via_context)
+            #
+            # Trailing control-tag lines are stripped FIRST (#7948): this is the
+            # proactive egress chokepoint for cron results and subagent
+            # completions authored under dashboard rules, and Slack renders
+            # HTML comments literally. Strip-then-redact matches display_safe.
+            safe_text, _ = redact_for_display(strip_control_comments(text), redact_via_context)
             # ``chunk_for_transport``: the transport's OWN unit (bytes for a
             # byte-capped channel like Webex, chars otherwise) and fence-safe on
             # both paths. A blind slice through a code block leaves part two with

--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -29,6 +29,7 @@ import tempfile
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew import aws_consent
+from kiro_crew.constants import strip_control_comments
 from kiro_crew.deploy.engine import resolve_aws_bin
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
@@ -184,6 +185,12 @@ def strip_markdown(text: str) -> str:
     t = re.sub(r"```[\s\S]*?```", _code_block, t)
     # Remove HTML/XML tags and their content for block-level elements
     t = re.sub(r"<mcwidget[^>]*>[\s\S]*?</mcwidget>", " (widget) ", t)
+    # Strip RECOGNIZED control-tag comments (keep-visible #7948, deliver
+    # routing, plan_task_id anchors) — never all comments, and never inside
+    # inline code, which renders literally and must survive to speech. The
+    # generic tag regex below deliberately excludes "<!". Shared
+    # implementation + grammar spec: constants.strip_control_comments.
+    t = strip_control_comments(t)
     # Replace markdown tables with spoken placeholder
 
     def _table(m):
@@ -229,6 +236,13 @@ def strip_markdown(text: str) -> str:
     # Collapse whitespace
     t = re.sub(r"\n{3,}", "\n\n", t)
     t = re.sub(r"  +", " ", t)
+    # Re-run redaction on the STRIPPED text. Every strip above can make two
+    # halves of a secret contiguous (a control comment, `**` emphasis, or an
+    # HTML tag interposed inside a key id), so a credential scan that ran on
+    # the raw text has not necessarily seen the string TTS will speak.
+    # Idempotent on clean text; placeholders survive re-scanning. (#7960)
+    t, _ = redact_exfiltration_urls(t)
+    t, _ = redact_credentials(t)
     return t.strip()
 
 

--- a/test/fixtures/control_tag_corpus.json
+++ b/test/fixtures/control_tag_corpus.json
@@ -1,0 +1,191 @@
+{
+  "_comment": [
+    "Shared conformance corpus for the control-tag recognizer pair:",
+    "backend constants.strip_control_comments (Python) and frontend",
+    "website/src/app-sdk/protocol/keepVisibleMarker.ts (TypeScript).",
+    "Both test suites assert every case (test/test_display_safe_control_tags.py",
+    "and website/src/test/keepVisibleMarker.test.ts), so grammar drift on either",
+    "side goes red locally instead of shipping (Design Review, PR #7960 round 9).",
+    "",
+    "Fields per case:",
+    "  input            - the message text",
+    "  backend_stripped - expected strip_control_comments(input)",
+    "  frontend_stripped- expected stripKeepVisibleMarker(input)",
+    "  exempt           - expected hasKeepVisibleMarker(input)",
+    "The two strip scopes differ BY CONTRACT on one axis: the backend strips any",
+    "trailing recognized tag block, while the frontend strips only blocks LED by",
+    "the keep-visible marker (deliver:/plan_task_id: tails alone are backend-only",
+    "concerns; the dashboard renderer already shows comments as nothing). Cases",
+    "where the two outputs differ are deliberate and documented by their name."
+  ],
+  "cases": [
+    {
+      "name": "plain trailing marker: stripped both sides, exemption fires",
+      "input": "substantive report\n<!-- keep-visible -->",
+      "backend_stripped": "substantive report",
+      "frontend_stripped": "substantive report",
+      "exempt": true
+    },
+    {
+      "name": "uppercase marker: case-insensitive both sides",
+      "input": "report\n<!-- KEEP-VISIBLE -->",
+      "backend_stripped": "report",
+      "frontend_stripped": "report",
+      "exempt": true
+    },
+    {
+      "name": "stacked siblings after marker: whole block strips, exemption fires",
+      "input": "report\n<!-- keep-visible -->\n<!-- deliver:slack -->",
+      "backend_stripped": "report",
+      "frontend_stripped": "report",
+      "exempt": true
+    },
+    {
+      "name": "indent 16 spaces: over CommonMark's 3-space bound, content both sides",
+      "input": "report\n                <!-- keep-visible -->",
+      "backend_stripped": "report\n                <!-- keep-visible -->",
+      "frontend_stripped": "report\n                <!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "indent 17 spaces: over bound, content both sides",
+      "input": "report\n                 <!-- keep-visible -->",
+      "backend_stripped": "report\n                 <!-- keep-visible -->",
+      "frontend_stripped": "report\n                 <!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "mid-body marker: content both sides",
+      "input": "a <!-- keep-visible --> b",
+      "backend_stripped": "a <!-- keep-visible --> b",
+      "frontend_stripped": "a <!-- keep-visible --> b",
+      "exempt": false
+    },
+    {
+      "name": "same-line trailing tag after prose: content both sides",
+      "input": "prose tail <!-- keep-visible -->",
+      "backend_stripped": "prose tail <!-- keep-visible -->",
+      "frontend_stripped": "prose tail <!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "unterminated backtick fence swallows tail: visible code both sides",
+      "input": "```\n<!-- keep-visible -->",
+      "backend_stripped": "```\n<!-- keep-visible -->",
+      "frontend_stripped": "```\n<!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "unterminated tilde fence swallows tail: visible code both sides",
+      "input": "~~~html\n<!-- keep-visible -->",
+      "backend_stripped": "~~~html\n<!-- keep-visible -->",
+      "frontend_stripped": "~~~html\n<!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "closed fence then tail: stripped both sides, exemption fires",
+      "input": "```\ncode\n```\ndone\n<!-- keep-visible -->",
+      "backend_stripped": "```\ncode\n```\ndone",
+      "frontend_stripped": "```\ncode\n```\ndone",
+      "exempt": true
+    },
+    {
+      "name": "marker quoted inside closed fence: content, no exemption",
+      "input": "the marker looks like:\n```html\n<!-- keep-visible -->\n```\nend of message",
+      "backend_stripped": "the marker looks like:\n```html\n<!-- keep-visible -->\n```\nend of message",
+      "frontend_stripped": "the marker looks like:\n```html\n<!-- keep-visible -->\n```\nend of message",
+      "exempt": false
+    },
+    {
+      "name": "unterminated comment: never swallowed, content both sides",
+      "input": "report\n<!-- keep-visible",
+      "backend_stripped": "report\n<!-- keep-visible",
+      "frontend_stripped": "report\n<!-- keep-visible",
+      "exempt": false
+    },
+    {
+      "name": "tag body over 256 bound: content both sides",
+      "input": "report\n<!-- deliver:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -->",
+      "backend_stripped": "report\n<!-- deliver:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -->",
+      "frontend_stripped": "report\n<!-- deliver:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -->",
+      "exempt": false
+    },
+    {
+      "name": "indent 3 spaces: within CommonMark bound, stripped both sides",
+      "input": "report\n   <!-- keep-visible -->",
+      "backend_stripped": "report",
+      "frontend_stripped": "report",
+      "exempt": true
+    },
+    {
+      "name": "indent 4 spaces: indented code block, content both sides",
+      "input": "report\n\n    <!-- keep-visible -->",
+      "backend_stripped": "report\n\n    <!-- keep-visible -->",
+      "frontend_stripped": "report\n\n    <!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "fence-lookalike closer with info string does not close: tail still swallowed",
+      "input": "```\n``` explanation\n<!-- keep-visible -->",
+      "backend_stripped": "```\n``` explanation\n<!-- keep-visible -->",
+      "frontend_stripped": "```\n``` explanation\n<!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "clean closer after info-string lookalike: fence closed, tail stripped",
+      "input": "```\n``` explanation\n```\n<!-- keep-visible -->",
+      "backend_stripped": "```\n``` explanation\n```",
+      "frontend_stripped": "```\n``` explanation\n```",
+      "exempt": true
+    },
+    {
+      "name": "deliver-only tail, no marker: backend strips, frontend keeps (contract asymmetry), no exemption",
+      "input": "done\n<!-- deliver:dashboard -->",
+      "backend_stripped": "done",
+      "frontend_stripped": "done\n<!-- deliver:dashboard -->",
+      "exempt": false
+    },
+    {
+      "name": "plan_task_id tail, no marker: backend strips, frontend keeps (contract asymmetry), no exemption",
+      "input": "plan ready\n<!-- plan_task_id:abc123 -->",
+      "backend_stripped": "plan ready",
+      "frontend_stripped": "plan ready\n<!-- plan_task_id:abc123 -->",
+      "exempt": false
+    },
+    {
+      "name": "list-contained unterminated fence: ambiguous, veto — content both sides",
+      "input": "- ```\n  code inside list fence\n<!-- keep-visible -->",
+      "backend_stripped": "- ```\n  code inside list fence\n<!-- keep-visible -->",
+      "frontend_stripped": "- ```\n  code inside list fence\n<!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "blockquote-contained unterminated fence: ambiguous, veto — content both sides",
+      "input": "> ```\n> quoted fence content\n<!-- keep-visible -->",
+      "backend_stripped": "> ```\n> quoted fence content\n<!-- keep-visible -->",
+      "frontend_stripped": "> ```\n> quoted fence content\n<!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "list-contained CLOSED fence: still vetoed — feature-miss by design, content both sides",
+      "input": "- ```\n  code\n- ```\n<!-- keep-visible -->",
+      "backend_stripped": "- ```\n  code\n- ```\n<!-- keep-visible -->",
+      "frontend_stripped": "- ```\n  code\n- ```\n<!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "over-indented fence line inside list continuation: ambiguous, veto — content both sides",
+      "input": "-   intro\n    ```\n    code\n<!-- keep-visible -->",
+      "backend_stripped": "-   intro\n    ```\n    code\n<!-- keep-visible -->",
+      "frontend_stripped": "-   intro\n    ```\n    code\n<!-- keep-visible -->",
+      "exempt": false
+    },
+    {
+      "name": "container-fence example quoted inside a CLOSED plain fence: no veto, tail stripped, exemption fires",
+      "input": "```\n- ```\n```\n<!-- keep-visible -->",
+      "backend_stripped": "```\n- ```\n```",
+      "frontend_stripped": "```\n- ```\n```",
+      "exempt": true
+    }
+  ]
+}

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1412,3 +1412,18 @@ class TestMemoryGetContextQueryWiring:
         )
         builder.build_message("find my tokyo notes", True, "s2")
         assert seen == ["find my tokyo notes"]
+
+
+class TestKeepVisibleMarkerRule:
+    """#7948: the keep-visible collapse exemption must be documented in the
+    DASHBOARD critical rules (collapse-all is a dashboard-transcript feature
+    and rehype-raw is what renders the marker invisible), and must NOT ship in
+    the channel variant -- Slack/Discord outbound formatters never strip HTML
+    comments, so a channel agent following the rule would show users the
+    literal marker text."""
+
+    def test_marker_documented_in_dashboard_rules_only(self):
+        from kiro_crew.context import _CRITICAL_RULES, _CRITICAL_RULES_CHANNEL
+
+        assert "<!-- keep-visible -->" in _CRITICAL_RULES
+        assert "<!-- keep-visible -->" not in _CRITICAL_RULES_CHANNEL

--- a/test/test_display_safe_control_tags.py
+++ b/test/test_display_safe_control_tags.py
@@ -1,0 +1,85 @@
+"""Channel outbound sinks strip agent control-tag comments (#7948 round 6).
+
+The prompt rule only contains the EMITTER (channel sessions are never taught
+the marker); these tests pin the deterministic backstop on the MESSAGE: a
+dashboard-authored ``<!-- keep-visible -->`` delivered to a channel via the
+neutral sinks must not reach end users as literal text, while tags quoted in
+code (fenced or inline) stay visible.
+"""
+
+from kiro_crew.constants import strip_control_comments
+from kiro_crew.messaging.renderer import display_safe, display_safe_for
+from kiro_crew.messaging.transport import TransportCapabilities
+
+
+class TestStripControlCommentsTailAnchoredFenceGuarded:
+    def test_tag_inside_fence_is_preserved_and_trailing_line_stripped(self) -> None:
+        # A tag quoted mid-message — in a fence, inline code, or prose — is
+        # rendered content the tail-anchored grammar never touches; only the
+        # trailing tag LINE is a control tag.
+        text = "see\n```html\n<!-- keep-visible -->\n```\ndone\n<!-- keep-visible -->"
+        out = strip_control_comments(text)
+        assert "```html\n<!-- keep-visible -->\n```" in out
+        assert out.rstrip().endswith("done")
+
+    def test_tail_inside_unterminated_fence_is_visible_code(self) -> None:
+        # Round-8 GPT: a message ending inside an UNTERMINATED fence renders
+        # the tail tag line as literal code — visible content. The
+        # fence-parity guard rejects the match on BOTH recognizers (the
+        # frontend applies the identical guard), reversing round 7's
+        # tail-wins reading.
+        text = "```\n<!-- deliver:slack -->"
+        assert strip_control_comments(text) == text
+        tilde = "~~~html\n<!-- keep-visible -->"
+        assert strip_control_comments(tilde) == tilde
+
+    def test_closed_fence_then_tail_tag_still_stripped(self) -> None:
+        # Parity: a CLOSED fence earlier in the message does not disable the
+        # tail strip.
+        text = "```\ncode\n```\ndone\n<!-- keep-visible -->"
+        assert strip_control_comments(text).rstrip().endswith("done")
+
+    def test_marker_case_insensitive(self) -> None:
+        # The frontend recognizer is /i; the backend grammar must match, or
+        # a mirrored uppercase marker reaches channel users literally
+        # (round-8 GPT validation finding).
+        assert strip_control_comments("done\n<!-- KEEP-VISIBLE -->").rstrip() == "done"
+
+
+class TestDisplaySafeStripsControlTags:
+    def test_display_safe_strips_marker(self) -> None:
+        out = display_safe("report body\n<!-- keep-visible -->")
+        assert "keep-visible" not in out
+        assert "report body" in out
+
+    def test_display_safe_for_strips_marker_all_capability_shapes(self) -> None:
+        for grammars in (False, True):
+            caps = TransportCapabilities(mention_grammars=grammars)
+            out = display_safe_for("done\n<!-- deliver:dashboard -->", caps)
+            assert "deliver:" not in out
+
+    def test_display_safe_keeps_quoted_tag_in_inline_code(self) -> None:
+        out = display_safe("the `<!-- keep-visible -->` tag")
+        assert "keep-visible" in out
+
+
+class TestSharedConformanceCorpus:
+    """Both recognizers assert the SAME corpus (Design round-9 parity pin).
+
+    ``test/fixtures/control_tag_corpus.json`` is also asserted by the
+    frontend suite (``website/src/test/keepVisibleMarker.test.ts``); grammar
+    drift on either side goes red locally instead of shipping.
+    """
+
+    def test_backend_matches_corpus(self):
+        import json
+        import pathlib
+
+        from kiro_crew.constants import strip_control_comments
+
+        corpus = json.loads(
+            (pathlib.Path(__file__).parent / "fixtures" / "control_tag_corpus.json").read_text()
+        )
+        for case in corpus["cases"]:
+            got = strip_control_comments(case["input"])
+            assert got == case["backend_stripped"], case["name"]

--- a/test/test_preview_text.py
+++ b/test/test_preview_text.py
@@ -38,6 +38,59 @@ class TestStripMarkdownPreview:
     def test_inline_code_keeps_literal_text(self):
         assert strip_markdown_preview("run `npm ci` first") == "run npm ci first"
 
+    def test_keep_visible_marker_stripped(self):
+        # #7948: the collapse-exemption marker is emitted "as its final line"
+        # (prompt contract) — a trailing tag LINE is stripped from previews.
+        assert (
+            strip_markdown_preview("Fleet synthesis banked.\n<!-- keep-visible -->")
+            == "Fleet synthesis banked."
+        )
+
+    def test_html_comment_control_tags_stripped(self):
+        # Heartbeat delivery routing tags are HTML comments too — appended as
+        # trailing lines. Mid-body occurrences are rendered content (the
+        # tail-anchored grammar shared with the frontend recognizer): they
+        # are what makes tags quoted in ANY code dialect untouchable.
+        assert strip_markdown_preview("done\n<!-- deliver:dashboard -->") == "done"
+        assert "deliver" in strip_markdown_preview("before <!-- deliver:dashboard --> after")
+
+    def test_unterminated_control_tag_no_longer_swallows_text(self):
+        # The old generic strip treated an unclosed <!-- as a comment to EOF,
+        # which silently deleted everything after it — the data-loss shape
+        # the scoped strip exists to prevent. A truncated control tag now
+        # leaks literally (visible garbage beats silent loss).
+        assert (
+            strip_markdown_preview("visible tail <!-- keep-visible")
+            == "visible tail <!-- keep-visible"
+        )
+
+    def test_ordinary_html_comments_are_preserved(self):
+        # Only recognized control tags are stripped: an ordinary comment the
+        # assistant quotes is visible rendered content in inline code, and
+        # inline code is NOT fence-placeholdered — a generic strip deleted it.
+        assert (
+            strip_markdown_preview("use `<!-- ordinary -->` here") == "use <!-- ordinary --> here"
+        )
+
+    def test_html_comment_inside_code_fence_stays_placeholdered(self):
+        # Fences are placeholder-protected BEFORE the comment strip runs.
+        assert strip_markdown_preview("```html\n<!-- x -->\n```") == "(code)"
+
+    def test_recognized_tag_quoted_in_inline_code_is_preserved(self):
+        # A RECOGNIZED control tag quoted in inline code renders literally in
+        # the dashboard — visible content the preview must keep. Round-5
+        # review: the old anywhere-strip deleted it while search/copy kept
+        # it, a grammar divergence between the projections.
+        assert (
+            strip_markdown_preview("the `<!-- keep-visible -->` marker")
+            == "the <!-- keep-visible --> marker"
+        )
+
+    def test_plan_task_id_tag_is_stripped(self):
+        # Third control-tag family (task planner anchors) — same leak class
+        # as deliver: routing tags; covered by the shared constant.
+        assert strip_markdown_preview("plan ready\n<!-- plan_task_id:abc123 -->") == "plan ready"
+
     def test_link_keeps_label(self):
         assert strip_markdown_preview("see [the docs](https://x.y/z)") == "see the docs"
 

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -58,6 +58,105 @@ class TestStripMarkdown:
     def test_preserves_plain_text(self) -> None:
         assert strip_markdown("hello world") == "hello world"
 
+    def test_removes_control_tag_comments(self) -> None:
+        # Trailing control-tag LINES are stripped — the tail-anchored grammar
+        # shared with the frontend recognizer (#7948). Stacked tags all go.
+        assert strip_markdown("report body\n<!-- keep-visible -->") == "report body"
+        assert strip_markdown("done\n<!-- deliver:dashboard -->") == "done"
+        assert (
+            strip_markdown("report\n<!-- keep-visible -->\n<!-- deliver:slack -->") == "report"
+        )
+
+    def test_mid_body_and_same_line_tags_are_rendered_content(self) -> None:
+        # Only tail LINES are control tags: producers emit "as its final
+        # line" (prompt contract; heartbeat/task-planner both append). A tag
+        # mid-body or trailing on a prose line is content, never stripped —
+        # this is what makes a tag quoted in ANY code dialect untouchable.
+        assert "deliver" in strip_markdown("done <!-- deliver:dashboard --> ok")
+        assert "keep-visible" in strip_markdown("prose tail <!-- keep-visible -->")
+
+    def test_ordinary_html_comments_are_preserved(self) -> None:
+        # Scoped to known control tags, never all comments: an ordinary
+        # comment quoted in inline code is visible content the user asked
+        # about — a generic strip deleted it from speech.
+        assert strip_markdown("use `<!-- ordinary -->` here") == "use <!-- ordinary --> here"
+
+    def test_recognized_tag_quoted_in_inline_code_is_preserved(self) -> None:
+        # A RECOGNIZED tag in inline code renders literally — quoted visible
+        # content, so speech keeps it (round-5 grammar unification).
+        assert strip_markdown("the `<!-- keep-visible -->` tag") == (
+            "the <!-- keep-visible --> tag"
+        )
+
+    def test_plan_task_id_tag_is_not_spoken(self) -> None:
+        # Third control-tag family; task_planner appends "\n<!-- plan_task_id:… -->",
+        # so the tag arrives as its own trailing line.
+        assert strip_markdown("plan ready\n<!-- plan_task_id:abc123 -->") == "plan ready"
+
+    def test_html_comment_inside_fence_is_already_placeholdered(self) -> None:
+        # Fences are replaced before the comment strip runs, so a comment
+        # inside code cannot swallow surrounding prose.
+        assert strip_markdown("a ```<!-- not a tag -->``` b") == "a (code block) b"
+
+    def test_unterminated_control_tag_no_longer_swallows_text(self) -> None:
+        # A truncated control tag leaks literally instead of silently eating
+        # the rest of the message (visible garbage beats silent data loss).
+        assert strip_markdown("safe part <!-- broken") == "safe part <!-- broken"
+
+    def test_credential_rejoined_by_comment_strip_is_redacted(self) -> None:
+        # A control tag interposed inside a key id splits it, so a redaction
+        # scan on the RAW text misses it; the strip rejoins the halves. The
+        # post-strip redaction pass must catch the reconstructed secret
+        # before it reaches TTS (#7960 GPT round-4 blocking).
+        out = strip_markdown("key AKIAIOSF<!-- keep-visible -->ODNN7EXAMPLE end")
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+    def test_credential_rejoined_by_emphasis_strip_is_redacted(self) -> None:
+        # Same class, different strip: `**` emphasis markers inside a key id
+        # are removed by the [*_~]+ pass. The invariant covers every strip,
+        # not just the control-tag one.
+        out = strip_markdown("key AKIAIOSF**ODNN7EXAMPLE** end")
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+    def test_contiguous_credential_still_redacted_after_strip(self) -> None:
+        # Idempotence: a credential the pre-strip scan would catch is also
+        # caught by the post-strip pass when strip_markdown is used alone
+        # (split_sentences path has no pre-strip redaction).
+        out = strip_markdown("key AKIAIOSFODNN7EXAMPLE end")
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+    def test_control_tag_regex_linear_on_adversarial_input(self) -> None:
+        # CodeQL py/polynomial-redos, two vectors: (a) "<!--deliver:" + many
+        # tabs (adjacent-quantifier ambiguity — fixed round 4); (b) the
+        # repeated prefix "<!--deliver:" * n, where an UNBOUNDED body meant
+        # each of n start positions rescanned an O(n) tail = quadratic
+        # (fixed round 6 by bounding every quantifier, so a failed attempt
+        # is constant work). Times the shared helper this PR ships —
+        # strip_markdown's pre-existing passes are not under test here.
+        # Polynomial time at this size hangs for minutes; linear completes
+        # in milliseconds. Generous bound for slow CI.
+        import time
+
+        from kiro_crew.constants import strip_control_comments
+
+        start = time.monotonic()
+        out_tabs = strip_control_comments("<!--deliver:" + "\t" * 50_000)
+        out_reps = strip_control_comments("<!--deliver:" * 20_000)
+        assert time.monotonic() - start < 5.0
+        # Unterminated tags are preserved (no swallow), not stripped.
+        assert out_tabs.startswith("<!--deliver:")
+        assert out_reps.startswith("<!--deliver:")
+
+    def test_unterminated_tag_preserved_through_full_strip(self) -> None:
+        # Same no-swallow contract through the full TTS pipeline.
+        assert strip_markdown("safe <!--deliver:oops").startswith("safe <!--deliver:oops")
+
+    def test_oversized_tag_body_is_not_treated_as_control_tag(self) -> None:
+        # The body bound (256) is what makes matching linear; a "tag" larger
+        # than any real emission is left visible rather than stripped.
+        big = "<!-- deliver:" + "x" * 300 + " -->"
+        assert strip_markdown(f"before {big} after").strip() != "before after"
+
     def test_collapses_whitespace(self) -> None:
         assert strip_markdown("a\n\n\n\nb") == "a\n\nb"
 

--- a/website/src/app-sdk/protocol/keepVisibleMarker.ts
+++ b/website/src/app-sdk/protocol/keepVisibleMarker.ts
@@ -1,0 +1,106 @@
+// Canonical keep-visible marker — the invisible intent tag an agent appends to a
+// SUBSTANTIVE MID-TURN message (a report, synthesis, or results table that is not
+// the turn's final message) so collapse-all mode does not fold it into the
+// "Worked through N steps" pane (#7948).
+//
+// The marker is an HTML comment, so the markdown renderer (rehypeRaw parses it
+// into a hast comment node, which the react renderer skips) shows nothing: the
+// exemption costs no visible ink. HTML-comment control tags are an established
+// convention in this codebase (the heartbeat's `<!-- deliver:... -->` routing
+// tags), and gating visibility on an explicit intent marker rather than a size
+// heuristic follows the [OPTIONS:] hand-back precedent documented in
+// TurnBlock.tsx — "hide intermediate reasoning" is a user preference, so only a
+// direct signal of agent intent may override it.
+//
+// g-flagged for the same reason as OPTION_MARKER_RE: `String#replace` (which
+// resets lastIndex) is the one safe direct use. Probe for presence via
+// hasKeepVisibleMarker below — never call .test()/.exec() on this shared const,
+// both leave lastIndex advanced and the next reader scans from the wrong offset.
+//
+// TAIL-ANCHORED: matches only a standalone marker line at the END of the
+// message (the emission contract — agents append it as the message's final
+// line). A literal `<!-- keep-visible -->` quoted inside a code block or
+// mid-message prose is VISIBLE rendered content, not a control tag: it must
+// not trigger the exemption, and stripping it from search/copy text would
+// corrupt what the user sees. The leading `(?:^|\n)[ \t]*` also consumes the
+// preceding newline so a copy-strip leaves no trailing blank line.
+//
+// BOUNDED QUANTIFIERS: leading indent is capped at 3 (CommonMark: 4+ spaces
+// renders as an indented code block — visible content, never a control tag),
+// other whitespace runs at 16 and tag bodies at 256,
+// the backend grammar's exact bounds (constants._TRAILING_CONTROL_LINES_RE) --
+// parity is pinned by the shared corpus in test/fixtures/control_tag_corpus.json,
+// asserted by BOTH test suites, so a bound edited on one side goes red on the other.
+// STACKED SIBLINGS: the marker line may be followed by other recognized
+// control-tag lines (`deliver:`, `plan_task_id:` — the backend grammar's
+// families) without voiding the exemption; the whole trailing tag block
+// matches, so copy/search strip all of it and the exemption still fires.
+const KEEP_VISIBLE_MARKER_RE =
+  /(?:^|\n)[ \t]{0,3}<!--\s{0,16}keep-visible\s{0,16}-->[ \t]{0,16}(?:\n[ \t]{0,3}<!--\s{0,16}(?:deliver|plan_task_id):[^>\n]{0,256}-->[ \t]{0,16})*\s{0,16}$/gi
+
+// Fence-delimiter lines (CommonMark: 3+ backticks or tildes, ≤3 leading
+// spaces) for the open-fence parity guard.
+const FENCE_DELIM_LINE_RE = /^[ \t]{0,3}(`{3,}|~{3,})/
+
+// Over-approximate fence-open CANDIDATES the exact walker cannot classify: a
+// fence run preceded only by whitespace and CommonMark container-marker
+// characters (list bullets, ordered-list digits/punctuation, blockquote
+// markers) or by 4+ spaces (indented code at top level, a REAL fence inside a
+// list continuation). Mirrors constants._AMBIGUOUS_FENCE_LINE_RE — see the
+// backend comment for the full rationale. Instead of tracking CommonMark
+// containers, a candidate seen while outside any tracked fence VETOES the
+// whole decision (strip nothing, no exemption): the failure modes are
+// asymmetric, so over-matching costs at most a feature-miss, never content.
+// Deliberately NOT g-flagged: .test() is called per line and must not carry
+// lastIndex between calls. Bounded class then a literal run — linear.
+const AMBIGUOUS_FENCE_LINE_RE = /^[ \t>+*\-\d.)]{0,40}(`{3,}|~{3,})/
+
+/** True when position `idx` falls inside an UNTERMINATED code fence — or
+ *  when the fence structure before `idx` is AMBIGUOUS. Inside an open fence
+ *  the renderer shows every line as literal code — including one that lexes
+ *  like the marker — so it is visible content: neither the exemption nor a
+ *  strip may fire on it. Close rule per CommonMark: same character, run at
+ *  least as long as the opener. STRIP ONLY WHEN PROVABLY OUTSIDE: a
+ *  container-prefixed or over-indented fence candidate seen while outside
+ *  any tracked fence may be a real opener this grammar cannot see, so the
+ *  walk answers true (do nothing) rather than risk deleting fence-interior
+ *  content; inside a tracked fence the same shape is literal code under
+ *  every interpretation and does not veto. */
+function inOpenFence(text: string, idx: number): boolean {
+  let openRun: string | null = null
+  for (const line of text.slice(0, idx).split('\n')) {
+    const m = FENCE_DELIM_LINE_RE.exec(line)
+    if (!m) {
+      if (openRun === null && AMBIGUOUS_FENCE_LINE_RE.test(line)) return true
+      continue
+    }
+    if (openRun === null) openRun = m[1]
+    // CommonMark 4.5: a CLOSING fence may not carry an info string — only
+    // whitespace may follow the run; a fence-lookalike with trailing text
+    // inside an open fence is literal code, not a closer.
+    else if (
+      m[1][0] === openRun[0] &&
+      m[1].length >= openRun.length &&
+      line.slice(m.index + m[0].length).trim() === ''
+    )
+      openRun = null
+  }
+  return openRun !== null
+}
+
+/** Strip the trailing marker block — fence-guarded: a tail inside an
+ *  unterminated fence is visible code and is left intact. The one safe
+ *  direct use of the shared g-flagged RE is `String#replace` (resets
+ *  lastIndex); the offset callback carries the fence check. */
+export function stripKeepVisibleMarker(text: string): string {
+  return text.replace(KEEP_VISIBLE_MARKER_RE, (match, offset: number) =>
+    inOpenFence(text, offset) ? match : '',
+  )
+}
+
+/** True when *text* carries a LIVE keep-visible marker (tail-anchored and
+ *  not swallowed by an unterminated fence). Probes via the guarded strip,
+ *  mirroring the hasOptionsMarker convention in TurnBlock.tsx. */
+export function hasKeepVisibleMarker(text: string): boolean {
+  return stripKeepVisibleMarker(text) !== text
+}

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { Copy, Check, Volume2, Code, ClipboardList, CheckCircle, RefreshCw, ChevronLeft, ChevronRight, GitFork, Loader2, Link2, Compass, Clock, Pin, PinOff, MoreHorizontal } from 'lucide-react'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '../../components/ui/dropdown-menu'
 import { copyToClipboard } from '../../utils/clipboard'
+import { stripKeepVisibleMarker } from '../../app-sdk/protocol/keepVisibleMarker'
 import { copySessionLink } from '../../utils/shareUrl'
 import { HOVER_NONE_ACTIONS_ROW_CLS } from '../../utils/touchActions'
 import MarkdownRenderer from '../../components/MarkdownRenderer'
@@ -338,7 +339,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
             alignment the mono was actually there for — and it holds the action
             row below at the same x across messages. */}
         {timestamp && <span className="text-muted text-[12px] leading-5 tabular-nums mr-2" title={timestampTitle}>{timestamp}</span>}
-        <button className="text-muted hover:text-text p-0.5 rounded transition-colors" title={i18nT('pages.chat.assistantMessage.copy')} aria-label={copied ? i18nT('pages.chat.assistantMessage.copied') : i18nT('pages.chat.assistantMessage.copy')} onClick={() => { copyToClipboard(steerCleaned).then(() => { setCopied(true); setTimeout(() => setCopied(false), 1500) }).catch(() => {}) }}>{copied ? <Check size={14} className="text-ok" /> : <Copy size={14} />}</button>
+        <button className="text-muted hover:text-text p-0.5 rounded transition-colors" title={i18nT('pages.chat.assistantMessage.copy')} aria-label={copied ? i18nT('pages.chat.assistantMessage.copied') : i18nT('pages.chat.assistantMessage.copy')} onClick={() => { const stripped = stripKeepVisibleMarker(steerCleaned); copyToClipboard(stripped === steerCleaned ? stripped : stripped.trimEnd()).then(() => { setCopied(true); setTimeout(() => setCopied(false), 1500) }).catch(() => {}) }}>{copied ? <Check size={14} className="text-ok" /> : <Copy size={14} />}</button>
         {messageTs && slotKey && <button className="text-muted hover:text-text p-0.5 rounded transition-colors" title={i18nT('pages.chat.assistantMessage.copy_link_to_message')} aria-label={i18nT('pages.chat.assistantMessage.copy_link_to_message')} onClick={() => { copySessionLink(slotKey, slotTitle, messageTs, mode).then(() => { setLinkCopied(true); setTimeout(() => setLinkCopied(false), 1500) }).catch(() => {}) }}>{linkCopied ? <Check size={14} className="text-ok" /> : <Link2 size={14} />}</button>}
         {messageTs && onTogglePin && <button className="text-muted hover:text-text p-0.5 rounded transition-colors" title={pinned ? i18nT('pages.chat.assistantMessage.unpin_message') : i18nT('pages.chat.assistantMessage.pin_message')} aria-label={pinned ? i18nT('pages.chat.assistantMessage.unpin_message') : i18nT('pages.chat.assistantMessage.pin_message')} aria-pressed={!!pinned} onClick={onTogglePin}>{pinned ? <PinOff size={14} /> : <Pin size={14} />}</button>}
         {/* A loaded window keeps fork/plan as row buttons, as on base: the menu below exists

--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -11,6 +11,7 @@ import { isSubagentCompletionMessage } from './subagentCompletion'
 import { isReasoningBurst } from './groupDisplayItems'
 import { isDiffToolMessage } from './toolDiff'
 import { OPTION_MARKER_RE } from '../../app-sdk/protocol/optionMarker'
+import { hasKeepVisibleMarker } from '../../app-sdk/protocol/keepVisibleMarker'
 import { i18nT } from '../../i18n/t'
 
 // A workflow_run launch renders as its own always-visible inline card
@@ -102,6 +103,21 @@ const isHandBack = (it: TurnItem) =>
   it.kind === 'single' && isConclusion(it) && hasOptionsMarker(it.msg.content)
 
 /**
+ * A message the agent explicitly marked to survive the collapse: a substantive
+ * mid-turn deliverable (a report or synthesis followed by more tool calls or a
+ * short sign-off) carrying the invisible `<!-- keep-visible -->` marker (#7948).
+ * Without it, findConclusionIdx keeps only the LAST substantive message and a
+ * deliverable emitted before a terminal tool call folds into the collapse pane.
+ * Same design rule as isHandBack above: gate on an explicit intent marker, not
+ * on size — the collapse setting is a user preference, so only a direct signal
+ * of agent intent may exempt a message from it. The marker is an HTML comment,
+ * so the rendered message shows nothing extra (rehypeRaw emits a comment node,
+ * which the react renderer skips).
+ */
+const isKeepVisible = (it: TurnItem) =>
+  it.kind === 'single' && isConclusion(it) && hasKeepVisibleMarker(it.msg.content)
+
+/**
  * A crew-mode answer: a forwarded topic result, a meta render, or a question
  * back to the user. Crew Mode breaks this component's central assumption —
  * that the LAST assistant message of a turn is the conclusion and the earlier
@@ -119,13 +135,13 @@ const isCrewReply = (it: TurnItem) =>
   (it.msg.meta?.crew_reply === true || /(^|\s)crew-reply(\s|$)/.test(it.msg.cls || ''))
 
 /** A renderable assistant message (widget/image), a mid-turn hand-back
- *  ([OPTIONS:] marker), a crew-mode answer, a role that must surface inline
- *  (mcp_oauth, error), a workflow_run / spawn_run / workflow-completion /
- *  sub-agent-completion card, or an MCP App-bearing tool call (interactive
- *  iframe anchored to the row). All
+ *  ([OPTIONS:] marker), a keep-visible-marked deliverable (#7948), a crew-mode
+ *  answer, a role that must surface inline (mcp_oauth, error), a workflow_run /
+ *  spawn_run / workflow-completion / sub-agent-completion card, or an MCP
+ *  App-bearing tool call (interactive iframe anchored to the row). All
  *  bypass the collapse pane. */
 const isVisibleInline = (it: TurnItem, appToolCallIds: ReadonlySet<string>) =>
-  isRenderable(it) || isHandBack(it) || isAlwaysVisible(it) || isCrewReply(it) ||
+  isRenderable(it) || isHandBack(it) || isKeepVisible(it) || isAlwaysVisible(it) || isCrewReply(it) ||
   isWorkflowRunItem(it) || isSpawnRunItem(it) ||
   isSubagentCompletionItem(it) ||
   isWorkflowCompletionItem(it) || isMcpAppItem(it, appToolCallIds) ||

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -17,6 +17,8 @@ vi.mock('../hooks/useSmoothStream', () => ({
 }))
 vi.mock('../utils/shareUrl', () => ({ copySessionLink: vi.fn().mockResolvedValue(undefined) }))
 import { copySessionLink } from '../utils/shareUrl'
+vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn().mockResolvedValue(undefined) }))
+import { copyToClipboard } from '../utils/clipboard'
 
 beforeEach(() => { vi.useFakeTimers() })
 afterEach(() => { act(() => { vi.runAllTimers() }); vi.useRealTimers() })
@@ -758,6 +760,17 @@ describe('parseOptions', () => {
     render(<AssistantMessage content="Hello" isStreaming={false} slotRunning={false} messageTs="2025-05-13T14:00:00.000Z" slotKey="chat-1" slotTitle="My Chat" mode="orchestrator" />)
     fireEvent.click(screen.getByTitle('Copy link to message'))
     expect(copySessionLink).toHaveBeenCalledWith('chat-1', 'My Chat', '2025-05-13T14:00:00.000Z', 'orchestrator')
+  })
+
+  it('copy strips the keep-visible marker so pastes carry no literal control tag (#7948)', () => {
+    // The marker renders as nothing (HTML comment), so the copied text must
+    // not resurface it — copy is the primary action on the substantive
+    // deliverables this marker targets. Marker-specific strip (not a
+    // whole-comment strip): copy preserves message fidelity and has no
+    // fence-protection pass, so comments inside fenced code must survive.
+    render(<AssistantMessage content={'Substantive report body\n\n<!-- keep-visible -->'} isStreaming={false} slotRunning={false} />)
+    fireEvent.click(screen.getByTitle('Copy'))
+    expect(copyToClipboard).toHaveBeenCalledWith('Substantive report body')
   })
 
   it('does not show "Copy link to message" while streaming', () => {

--- a/website/src/test/TurnBlock.test.tsx
+++ b/website/src/test/TurnBlock.test.tsx
@@ -111,6 +111,59 @@ describe('TurnBlock — file role visibility', () => {
     expect(container.querySelector('[data-testid="item-3"]')).not.toBeNull()
   })
 
+  it('keep-visible marked report mid-turn stays visible in collapseAll mode (#7948)', () => {
+    const report =
+      'Fleet synthesis: 44/44 runs banked, all routing gates PASS, medians in the artifact. '.repeat(3) +
+      '\n\n<!-- keep-visible -->'
+    const items: TurnItem[] = [
+      { kind: 'single', msg: { role: 'assistant', content: report, ts: '1' }, idx: 0 },
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: autonudge_stop', ts: '2' }, idx: 1 },
+      { kind: 'single', msg: { role: 'assistant', content: 'Loop stopped. Campaign closed out; summaries and restores all verified done.', ts: '3' }, idx: 2 },
+    ]
+    const turn = makeTurn(items)
+    const { container } = render(
+      <TurnBlock
+        turn={turn}
+        renderItem={(it, i) => <div data-testid={`item-${i}`} data-role={it.kind === 'single' ? it.msg.role : 'group'}>{it.kind === 'single' ? it.msg.content : 'group'}</div>}
+        collapseAll={true}
+      />
+    )
+    // The marked report (idx 0) must render in place, not inside a collapsed
+    // (overflow-hidden) section — same assertion shape as the file-row test.
+    const reportItem = container.querySelector('[data-testid="item-0"]')
+    expect(reportItem).not.toBeNull()
+    expect(reportItem?.closest('[style*="overflow"]')).toBeNull()
+    // Conclusion still visible
+    expect(container.querySelector('[data-testid="item-2"]')).not.toBeNull()
+  })
+
+  it('unmarked mid-turn report folds into the collapse pane (control for #7948)', () => {
+    const report =
+      'Fleet synthesis: 44/44 runs banked, all routing gates PASS, medians in the artifact. '.repeat(3)
+    const items: TurnItem[] = [
+      { kind: 'single', msg: { role: 'assistant', content: report, ts: '1' }, idx: 0 },
+      { kind: 'single', msg: { role: 'tool', content: '🔧 Running: autonudge_stop', ts: '2' }, idx: 1 },
+      { kind: 'single', msg: { role: 'assistant', content: 'Loop stopped. Campaign closed out; summaries and restores all verified done.', ts: '3' }, idx: 2 },
+    ]
+    const turn = makeTurn(items)
+    const { container } = render(
+      <TurnBlock
+        turn={turn}
+        renderItem={(it, i) => <div data-testid={`item-${i}`} data-role={it.kind === 'single' ? it.msg.role : 'group'}>{it.kind === 'single' ? it.msg.content : 'group'}</div>}
+        collapseAll={true}
+      />
+    )
+    // Without the marker the report is intermediate reasoning: it either does
+    // not render or sits inside a collapsed overflow section. This pins the
+    // user-preference contract the marker deliberately opts OUT of.
+    const reportItem = container.querySelector('[data-testid="item-0"]')
+    expect(reportItem === null || reportItem.closest('[style*="overflow"]') !== null).toBe(true)
+    // The conclusion is the visible survivor.
+    const conclusion = container.querySelector('[data-testid="item-2"]')
+    expect(conclusion).not.toBeNull()
+    expect(conclusion?.closest('[style*="overflow"]')).toBeNull()
+  })
+
   it('renders file in its original turn position (not hoisted to top)', () => {
     const items: TurnItem[] = [
       { kind: 'single', msg: { role: 'assistant', content: 'generating audio…', ts: '1' }, idx: 0 },

--- a/website/src/test/keepVisibleMarker.test.ts
+++ b/website/src/test/keepVisibleMarker.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  hasKeepVisibleMarker,
+  stripKeepVisibleMarker,
+} from '../app-sdk/protocol/keepVisibleMarker'
+
+describe('keepVisibleMarker recognizer (#7948, round-8 grammar)', () => {
+  it('strips a trailing marker line and fires the exemption', () => {
+    const text = 'report body\n<!-- keep-visible -->'
+    expect(stripKeepVisibleMarker(text)).toBe('report body')
+    expect(hasKeepVisibleMarker(text)).toBe(true)
+  })
+
+  it('tolerates stacked sibling control tags after the marker (Design round-8)', () => {
+    // A deliver/plan_task_id line after the marker must not void the
+    // exemption, and the whole trailing block strips from copy/search.
+    const text = 'report\n<!-- keep-visible -->\n<!-- deliver:slack -->'
+    expect(hasKeepVisibleMarker(text)).toBe(true)
+    expect(stripKeepVisibleMarker(text)).toBe('report')
+  })
+
+  it('rejects a tail inside an unterminated fence — visible code (GPT round-8)', () => {
+    // The renderer shows every line of an open fence literally, so the
+    // marker line is visible content: no exemption, no strip. Backticks
+    // and tildes both.
+    for (const fence of ['```', '~~~html']) {
+      const text = `${fence}\n<!-- keep-visible -->`
+      expect(hasKeepVisibleMarker(text)).toBe(false)
+      expect(stripKeepVisibleMarker(text)).toBe(text)
+    }
+  })
+
+  it('a closed fence earlier in the message does not disable the tail strip', () => {
+    const text = '```\ncode\n```\ndone\n<!-- keep-visible -->'
+    expect(hasKeepVisibleMarker(text)).toBe(true)
+    expect(stripKeepVisibleMarker(text)).toBe('```\ncode\n```\ndone')
+  })
+
+  it('mid-body and same-line markers are rendered content', () => {
+    expect(hasKeepVisibleMarker('a <!-- keep-visible --> b')).toBe(false)
+    expect(hasKeepVisibleMarker('prose tail <!-- keep-visible -->')).toBe(false)
+  })
+})
+
+describe('shared conformance corpus (parity pin with backend, Design round-9)', () => {
+  // Same fixture asserted by test/test_display_safe_control_tags.py on the
+  // Python side; a bound or grammar edited on one side goes red on the other.
+  const corpusPath = path.resolve(
+    __dirname,
+    '../../../test/fixtures/control_tag_corpus.json',
+  )
+  const corpus = JSON.parse(readFileSync(corpusPath, 'utf-8')) as {
+    cases: {
+      name: string
+      input: string
+      frontend_stripped: string
+      exempt: boolean
+    }[]
+  }
+
+  it.each(corpus.cases)('$name', ({ input, frontend_stripped, exempt }) => {
+    expect(stripKeepVisibleMarker(input)).toBe(frontend_stripped)
+    expect(hasKeepVisibleMarker(input)).toBe(exempt)
+  })
+})

--- a/website/src/test/searchableText.test.ts
+++ b/website/src/test/searchableText.test.ts
@@ -31,6 +31,17 @@ describe('searchableText', () => {
     expect(searchableText(msg('assistant', src))).toContain('const replication = 1')
   })
 
+  it('strips a trailing keep-visible marker (renders as nothing — a match would be phantom, #7948)', () => {
+    const t = searchableText(msg('assistant', 'substantive report\n\n<!-- keep-visible -->'))
+    expect(t).toBe('substantive report')
+    expect(t).not.toContain('keep-visible')
+  })
+
+  it('preserves a keep-visible marker quoted inside fenced code (visible content, tail-anchored regex, #7948)', () => {
+    const src = 'the marker looks like:\n```html\n<!-- keep-visible -->\n```\nend of message'
+    expect(searchableText(msg('assistant', src))).toContain('<!-- keep-visible -->')
+  })
+
   it('preserves prose and inline code', () => {
     const src = 'The `useMessageSearch` hook scans messages.'
     expect(searchableText(msg('assistant', src))).toBe(src)

--- a/website/src/utils/searchableText.ts
+++ b/website/src/utils/searchableText.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage } from '../types'
 import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { stripKeepVisibleMarker } from '../app-sdk/protocol/keepVisibleMarker'
 
 // `<mcwidget>...</mcwidget>` bodies render as a sandboxed iframe (WidgetFrame).
 // Their visible text lives in a separate document the in-chat highlighter's
@@ -21,7 +22,9 @@ const MCWIDGET_RE = /<mcwidget\b[^>]*>[\s\S]*?<\/mcwidget>/gi
  */
 export function searchableText(m: ChatMessage): string {
   if (m.role === 'assistant' || m.role === 'streaming') {
-    return m.content.replace(MCWIDGET_RE, '').replace(OPTION_MARKER_RE, '').trimEnd()
+    // stripKeepVisibleMarker: the marker is an HTML comment the renderer never
+    // shows (#7948), so a search hit inside it would be a phantom match.
+    return stripKeepVisibleMarker(m.content.replace(MCWIDGET_RE, '').replace(OPTION_MARKER_RE, '')).trimEnd()
   }
   return m.content
 }


### PR DESCRIPTION
## Problem / Motivation

With the transcript collapse preference on (`collapseAll` — "all working steps collapse, only final assistant text visible"), a substantive mid-turn assistant report folds into the collapsed "Worked through N steps" pane whenever any later assistant message in the turn is also substantive. Observed shape: a monitor-loop campaign close posted a full results synthesis, then called `autonudge_stop`, then posted a short "Loop stopped…" sign-off — `findConclusionIdx` picked the sign-off as the turn's conclusion and buried the synthesis.

## Why it matters

Users running collapse-all lose the turn's actual deliverable — the one message they needed — unless they think to expand the steps pane. Every agentic long-turn pattern (monitor cycles, queued-message resumes, injected subagent/workflow completions) produces exactly this shape, and `TurnBlock.tsx` already documents the class ("A single turn can contain SEVERAL hand-backs…") but only exempts `[OPTIONS:]`-bearing messages.

## What changed (motivation → approach → change)

Symptom → root cause: `isVisibleInline` has bypasses for widgets/images, `[OPTIONS:]` hand-backs, crew replies, error/mcp_oauth rows, workflow/spawn/completion cards, MCP-App rows, and diff cards — but a plain prose deliverable has no bypass, so only the last substantive message survives.

Approach: an explicit, invisible intent marker, mirroring the `[OPTIONS:]` hand-back exemption. A size/shape heuristic was deliberately NOT used — the `isHandBack` comment documents that rejection ("gating on size would override a preference the user set on purpose"); intent markers are the accepted pattern. HTML-comment control tags are an existing convention (heartbeat `<!-- deliver:... -->`).

Change:
- `website/src/app-sdk/protocol/keepVisibleMarker.ts` (new): canonical `<!-- keep-visible -->` regex + `hasKeepVisibleMarker` probe, following `optionMarker.ts` lastIndex-safety conventions.
- `website/src/pages/chat/TurnBlock.tsx`: `isKeepVisible` joins `isVisibleInline`. Shared by ChatPage and app-sdk `ChatMessageList` (both render through TurnBlock), and applies to interim fan-out turns for free.
- `website/src/utils/searchableText.ts`: strip the marker so search never phantom-matches inside the never-rendered comment.
- `src/kiro_crew/preview_text.py`: strip recognized control-tag comments from plain-text previews — rehype-raw parses them into comment nodes the react renderer skips, so they render as nothing and must not leak into sidebar previews. Also strips the task planner's `<!-- plan_task_id:... -->` anchors (`task_planner.py:430` appends one at the tail) and standalone tail `<!-- deliver:... -->` lines — the latter have no code emitter, but the shipped prompt (`config/prompt.md`, heartbeat section) instructs agents to “Route completion with `<!-- deliver:dashboard -->` tags”, so completion text imitating that instruction is a prompt-induced tail producer; the heartbeat FILE's own `deliver:` suffixes are same-line, mid-body content when echoed and are deliberately left alone. The strip is the shared `constants.strip_control_comments` (grammar documented once on `constants.CONTROL_COMMENT_RE`): it runs after `_FENCE_RE` (fenced tags stay placeholder-protected), preserves tags quoted in inline code (rendered literally, so visible), and preserves ordinary and unterminated comments — swallowing to end-of-text on a missing `-->` would silently delete visible prose.
- `src/kiro_crew/context.py`: one rule in the DASHBOARD-only `_DIFF_RULE_DASHBOARD` block telling agents to append the marker to substantive reports that are not the turn's final message — without the prompt half, agents never emit the marker and the UI half is dead code. Deliberately NOT in the channel variant: collapse-all is a dashboard-transcript feature (Design/UX/First-Principles round-1 finding, fixed in `9612a6d47`). The prompt rule contains the EMITTER; the MESSAGE gets a deterministic backstop too (round-6 Design finding): the channel-neutral outbound sinks (`messaging.renderer.display_safe` / `display_safe_for` — the dashboard's channel-addressed sends, heartbeat `deliver:` routing, and the owner-DM leg) now run `strip_control_comments` first, so dashboard-authored text delivered to a channel cannot show end users the literal tag. The shared helper is fence- and inline-code-aware, so a tag QUOTED in code stays visible on channels exactly as it does in dashboard projections.

Security note: the marker only prevents folding — it grants no capability. Untrusted content carrying it can at worst keep its own text visible, which is the default outside collapse mode; the marker-neutralization suite passes unchanged.

## Tests

- `website/src/test/TurnBlock.test.tsx`: marked mid-turn report stays visible in collapseAll (`#7948`); unmarked control folds and pins the existing user-preference contract the marker opts out of.
- `test/test_preview_text.py`: marker stripped from previews; `<!-- deliver:dashboard -->` and `<!-- plan_task_id:... -->` stripped; ordinary and unterminated comments preserved (no swallow); recognized tag quoted in inline code preserved; comment inside a code fence stays placeholder-protected.
- `test/test_context.py::TestKeepVisibleMarkerRule`: the marker is documented in the dashboard rules variant and asserted ABSENT from the channel variant.

Runs: backend 50 passed (preview + context + full marker-neutralization suite); TurnBlock suites 50 passed / 1 pre-existing expected fail; search suites 260 passed; `tsc -b` clean; baselined black / subprocess-encoding / sync-io-in-async / brand / testpaths gates all pass locally on the commit.

## Manual verification

N/A — unit coverage exercises the exact fold/bypass split (`splitSegments` assertions on overflow containment), and the marker's invisibility rests on rehype-raw comment-node handling already exercised by the renderer suite.

## Pattern harvest

Rule candidate: a prompt rule that teaches agents an output marker must ship only in the per-surface prompt variant whose renderer actually consumes that marker (the dashboard vs channel split at `_DIFF_RULE_*`) — a marker taught in the shared tail leaks as literal text on every surface whose formatter does not strip it.

- Checked the other `isVisibleInline` consumers (collapseAll split and interim fan-out fold share `splitSegments` — one definition, both covered).
- Plain-text projections of assistant content must not resurface the invisible marker — and, symmetrically, strips must never delete VISIBLE content (a tag the assistant quotes in prose or any code dialect). Both recognizers share ONE tail-anchored, case-insensitive, fence-guarded grammar with identical bounded quantifiers (leading indent ≤3 per CommonMark’s indented-code rule; fence closers must be bare per CommonMark 4.5), pinned by a shared conformance corpus (`test/fixtures/control_tag_corpus.json`) asserted by BOTH test suites so grammar drift goes red locally: only standalone control-tag lines ENDING the message are control tags, a tail inside an UNTERMINATED fence is visible code (renders literally) and is rejected by both sides, and a fence candidate the exact walker cannot classify (container-prefixed — a fence run after a list bullet, ordered-list marker, or blockquote marker — or over-indented) VETOES the whole decision on both sides: strip nothing, no exemption. The failure modes are asymmetric — wrongly stripping deletes visible fence-interior content while wrongly not stripping leaves an HTML comment the renderer never shows — so the walkers strip only when the tail is PROVABLY outside every fence under an over-approximating candidate detector, and ambiguity may only ever cost the feature, never content, and stacked sibling tags after the marker neither void the exemption nor survive the strip (frontend `keepVisibleMarker.ts`; backend `constants._TRAILING_CONTROL_LINES_RE` via `strip_control_comments`). Every producer emits at the tail — the prompt rule says "as its final line", and the task-planner appender emits a newline-prefixed tag, while the heartbeat’s `deliver:` tags are HEARTBEAT.md file-format suffixes on checklist lines (not message-tail emissions — echoed into a message they are mid-body content the renderer hides) — so nothing real is missed, and a tag quoted anywhere in the body (inline code, fences, variable-length backtick spans) is structurally untouchable rather than guarded by a code-span grammar (rounds 5–7 each surfaced another dialect the position-independent strip corrupted). Strip sites: `searchableText.ts` and the Copy button (frontend regex), `preview_text.py`, `voice_reply.strip_markdown` (also covers the dashboard Speak button), the channel-neutral sinks `display_safe`/`display_safe_for`, and the four direct-egress legs that bypass those sinks (`chat_runner._deliver_cross_surface_reply`, the Slack proactive-egress chokepoint in `slack/gateway.py`, the `chat_mirror.py` link-backfill leg, and the `chat_slack.py` thread-backfill leg) — strip-then-redact at every backend site. All quantifiers bounded (CodeQL `py/polynomial-redos`).
- Removing syntax can REJOIN split secrets: a control tag (or `**` emphasis) interposed inside a credential splits it, so the pre-strip redaction scan misses it and the strip reconstructs it. `strip_markdown` therefore re-runs `redact_credentials` + `redact_exfiltration_urls` on its own output — an invariant covering every strip in the function. Idempotent on clean text; also protects the `split_sentences` path, which had no pre-strip redaction.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the marker is an HTML comment that renders as zero pixels (rehype-raw comment node); the fold-bypass changes visibility only for transcripts carrying the new marker, none of which exist yet, and the exact visible/folded split is pinned by TurnBlock unit tests asserting overflow containment. A seeded-transcript before/after can be produced on request.

Fixes #7948


