### PR TITLE
fix(dashboard): tear down theme overlays when a remote Crew is active

### DIFF
--- a/website/src/components/ThemeExperienceLayer.tsx
+++ b/website/src/components/ThemeExperienceLayer.tsx
@@ -35,6 +35,7 @@ import { grantConsent, getStoredConsent, revokeConsent } from '../utils/themeCon
 import { MC_THEME_SOUND_EVENT, type ThemeSoundDetail } from '../hooks/themeSound'
 import { MC_NOTIFICATION_EVENT } from '../hooks/notificationEvent'
 import { useIsNarrowViewport } from '../hooks/useIsMobile'
+import { useAppSelector } from '../store'
 
 import { i18nT } from '../i18n/t'
 // postMessage types accepted from theme iframes — everything else is ignored.
@@ -169,6 +170,15 @@ function parseIdleSeconds(trigger: string): number | null {
 
 export default function ThemeExperienceLayer() {
   const { theme: mode, colorTheme, customThemeDataMap, setColorTheme } = useTheme()
+
+  // A remote Crew is a separate SPA in a full-bleed iframe; switching Crews only
+  // toggles `display` on the local dashboard's wrapper inside `App`. This layer is
+  // a SIBLING of `<App />` (mounted in main.tsx) and its overlay/topbar iframes are
+  // `position: fixed` at up to OVERLAY_Z_MAX — so App's own `display: none` wrapper
+  // cannot hide them, and z-45 composites above the remote pane stack at z-1. Read
+  // the active remote-Crew id here so the render gate below can unmount the whole
+  // layer, mirroring how App hides the local dashboard.
+  const activeInstanceId = useAppSelector((s) => s.instances.activeId)
 
   const active = colorTheme.startsWith('custom-')
     ? customThemeDataMap.get(colorTheme.slice('custom-'.length))
@@ -425,6 +435,16 @@ export default function ThemeExperienceLayer() {
     }
   }, [audioEnabled, stopAllSounds])
   useEffect(() => stopAllSounds, [stopAllSounds])
+  // Switching to a remote Crew unmounts this layer (see the render gate below),
+  // but React runs that teardown only after the commit — and themed audio lives in
+  // refs, not in the tree. Stop it as soon as a remote Crew becomes active so its
+  // ambient bed can't keep playing over another Crew's dashboard.
+  useEffect(() => {
+    if (activeInstanceId !== null) {
+      stopAllSounds()
+      activatedForSlugRef.current = undefined
+    }
+  }, [activeInstanceId, stopAllSounds])
 
   // Dashboard-side trigger emission. On activation of an enabled audio theme:
   // play the `activate` cue and start the ambient bed (fade-in). On switch-away:
@@ -671,6 +691,10 @@ export default function ThemeExperienceLayer() {
     return () => window.removeEventListener('keydown', onKey)
   }, [showConsent, declineExperience])
 
+  // A remote Crew owns the viewport: unmount every overlay/topbar iframe, the mute
+  // button and the consent modal. `display: none` on App's local-dashboard wrapper
+  // cannot reach a fixed-position sibling, so unmounting is the only real teardown.
+  if (activeInstanceId !== null) return null
   if (!anyExperience || !slug) return null
 
   // First-activation consent gate for persona/audio packs.

--- a/website/src/test/ThemeExperienceLayer.crewSwitch.test.tsx
+++ b/website/src/test/ThemeExperienceLayer.crewSwitch.test.tsx
@@ -1,0 +1,93 @@
+import type React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { createTestStore } from './helpers'
+import { setActiveId } from '../store/instancesSlice'
+
+// Controllable useTheme mock — mirrors ThemeExperienceLayer.test.tsx so this file
+// can put the layer into a level-2 (Experience) theme without a real theme pack.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockTheme: any
+const setColorTheme = vi.fn()
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => mockTheme,
+}))
+
+import ThemeExperienceLayer from '../components/ThemeExperienceLayer'
+
+function setL2Theme() {
+  const slug = 'bikini-bottom'
+  const map = new Map<string, unknown>()
+  map.set(slug, {
+    slug,
+    name: 'Bikini Bottom',
+    emoji: '🫧',
+    level: 2,
+    assets: {
+      overlays: ['bubbles'],
+      topbar: { dark: true, light: true },
+      hasAudio: false,
+      hasPersona: false,
+      branding: { botName: 'Bubbles' },
+    },
+  })
+  mockTheme = {
+    theme: 'dark',
+    colorTheme: `custom-${slug}`,
+    customThemeDataMap: map,
+    setColorTheme,
+  }
+}
+
+const themeFrames = () =>
+  Array.from(document.querySelectorAll<HTMLIFrameElement>('iframe[data-theme-frame="1"]'))
+
+describe('ThemeExperienceLayer — remote Crew switch', () => {
+  let store: ReturnType<typeof createTestStore>
+
+  beforeEach(() => {
+    localStorage.clear()
+    setColorTheme.mockReset()
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as unknown as typeof window.matchMedia
+    store = createTestStore()
+    setL2Theme()
+  })
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  )
+
+  it('tears the overlay iframes down when a remote Crew becomes active', () => {
+    render(<ThemeExperienceLayer />, { wrapper: Wrapper })
+
+    // Baseline: local Crew (activeId === null) → L2 overlays are mounted.
+    expect(store.getState().instances.activeId).toBeNull()
+    expect(themeFrames().length).toBeGreaterThan(0)
+
+    // Switching the active Crew to a remote one must unmount the whole layer —
+    // App's `display: none` wrapper cannot hide these fixed-position siblings.
+    act(() => {
+      store.dispatch(setActiveId('cd-1'))
+    })
+    expect(themeFrames()).toHaveLength(0)
+  })
+
+  it('remounts the overlay iframes when the local Crew is reselected', () => {
+    render(<ThemeExperienceLayer />, { wrapper: Wrapper })
+
+    act(() => {
+      store.dispatch(setActiveId('cd-1'))
+    })
+    expect(themeFrames()).toHaveLength(0)
+
+    act(() => {
+      store.dispatch(setActiveId(null))
+    })
+    expect(themeFrames().length).toBeGreaterThan(0)
+  })
+})

--- a/website/src/test/ThemeExperienceLayer.test.tsx
+++ b/website/src/test/ThemeExperienceLayer.test.tsx
@@ -1,5 +1,8 @@
+import type React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { createTestStore } from './helpers'
+import { render as rtlRender, screen, act, type RenderOptions } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 // Controllable useTheme mock — each test sets `mockTheme` before rendering.
@@ -11,6 +14,17 @@ vi.mock('../hooks/useTheme', () => ({
 }))
 
 import ThemeExperienceLayer from '../components/ThemeExperienceLayer'
+
+// The layer reads `instances.activeId` (it unmounts when a remote Crew is active),
+// so every mount needs a Redux Provider. Shim `render` through RTL's `wrapper`
+// option — not a hand-wrapped element — so `rerender(<ThemeExperienceLayer />)`
+// in the cases below keeps the Provider instead of dropping it.
+let testStore = createTestStore()
+const StoreWrapper = ({ children }: { children: React.ReactNode }) => (
+  <Provider store={testStore}>{children}</Provider>
+)
+const render = (ui: React.ReactElement, options: Omit<RenderOptions, 'wrapper'> = {}) =>
+  rtlRender(ui, { wrapper: StoreWrapper, ...options })
 
 function mockMatchMedia(reduced: boolean) {
   const mql = {
@@ -76,6 +90,7 @@ describe('ThemeExperienceLayer', () => {
     localStorage.clear()
     setColorTheme.mockReset()
     mockMatchMedia(false)
+    testStore = createTestStore()
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Problem / Motivation

With a level-2 (Experience) theme pack installed on the local Crew, switching the active Crew to a **remote** Crew via the top switcher leaves the local theme's animation overlays playing on top of the remote Crew's dashboard. The palette follows the switch correctly; only the overlay layer fails to tear down. Themed audio (ambient bed) also keeps playing.

## Why it matters

Anyone running an installed L2 theme pack alongside one or more remote Crews sees the wrong Crew's decoration — animated overlays and a themed topbar strip — composited over a remote Crew they are actively working in. Overlays sit at up to `z-45`, so they are drawn above the remote pane and can occlude or distract from real content, and the audio gives no cue that it belongs to a Crew that is no longer on screen.

## What changed (motivation → approach → change)

**Symptom → root cause.** A remote Crew is a separate SPA in a full-bleed iframe, and switching Crews only toggles `display` on ONE wrapper *inside* `App`:

```tsx
// website/src/App.tsx
<div className="absolute inset-0" style={{ display: activeInstanceId === null ? 'block' : 'none' }}>
```

But `ThemeExperienceLayer` — which mounts the overlay/topbar iframes — is a **sibling** of `<App />`, mounted in `website/src/main.tsx` inside `<Provider store={store}>` → `LanguageProvider` → `ThemeProvider` → `UIModeProvider`, just before `<BrowserRouter>`. Its iframes are `position: 'fixed'` at up to `OVERLAY_Z_MAX = 45`, while the remote-Crew pane stack in `InstancesViewport.tsx` sits at `zIndex: 1`. `display: none` on the local pane cannot hide a fixed-position sibling, and z-45 composites above z-1 — so the overlays survive the switch.

**The change**, all in `website/src/components/ThemeExperienceLayer.tsx`:

- Read the active remote-Crew id from the store the layer already sits under: `useAppSelector((s) => s.instances.activeId)`.
- Return `null` whenever `activeId !== null`, unmounting the topbar iframe, every overlay iframe, the mute button and the consent modal — mirroring how `App.tsx` hides the local dashboard. The gate is placed beside the existing `if (!anyExperience || !slug) return null`, i.e. **after every hook call**, so rules-of-hooks hold; no hook was moved or conditionalised.
- Stop themed audio on the switch via the existing `stopAllSounds` helper, in an effect keyed on `activeId`. Audio elements live in refs rather than in the tree, so unmounting alone would let an ambient bed keep playing over another Crew.

Alternative considered and rejected: moving `ThemeExperienceLayer` inside `App`'s hidden wrapper. That would restructure provider ordering and mounting for every consumer of the layer, for no behavioural gain over the store-driven gate — a much larger diff than the defect warrants.

`website/src/test/ThemeExperienceLayer.test.tsx` mounts the component without a Redux Provider today; since the component now reads the store, the file's `render` was shimmed through RTL's `wrapper` option (not a hand-wrapped element, so its `rerender(<ThemeExperienceLayer />)` cases keep the Provider) plus a fresh store per test. No assertion in that file changed.

## Tests

- **`website/src/test/ThemeExperienceLayer.crewSwitch.test.tsx`** (new):
  - *tears the overlay iframes down when a remote Crew becomes active* — renders the layer with a level-2 theme, asserts `iframe[data-theme-frame="1"]` frames exist while `instances.activeId === null`, dispatches `setActiveId('cd-1')`, then asserts the theme iframes are gone.
  - *remounts the overlay iframes when the local Crew is reselected* — locks in that the gate is not a one-way latch: `setActiveId(null)` brings the overlays back.
- **`website/src/test/ThemeExperienceLayer.test.tsx`** (updated): Provider shim only; its 28 existing cases still pass unchanged, confirming the gate does not alter local-Crew behaviour.

**Mutation verification.** With the `if (activeInstanceId !== null) return null` gate removed, both new tests fail (`expected 0, received 2` theme iframes after the switch). With the gate restored, all 30 tests across the two files pass.

## Manual verification

N/A — unit coverage sufficient: the defect is a pure render-gate condition on `instances.activeId`, and the new test asserts the exact DOM fact that was wrong (theme iframes present after a Crew switch) in both directions.

## Screenshots / video

None. The change adds no surface and alters no layout, panel or theme rendering — it removes an existing layer at a point where it should already have been gone. Capturing the difference would require two live Crews plus an installed L2 theme pack, and the "after" state is the absence of the overlay, which the new test asserts directly on the DOM.

## Related Issues

Closes SIM Mesh-3691 (internal).

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a component that hides a subtree with `display: none` cannot hide a `position: fixed` **sibling** of that subtree — visibility toggles must be checked against every fixed/portal-mounted layer outside the toggled wrapper, not just the wrapper's own children.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe the overlay lifecycle
- [x] No secrets, credentials, or internal references in the diff
