### PR TITLE
fix(mcp): retry a refused gateway connection and report it actionably

### DIFF
--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -61,7 +61,7 @@ from kiro_crew.mcp_tools import build_tool_list, dispatch
 from kiro_crew.members import record_activity
 from kiro_crew.messaging.link import is_legacy_slack_key, legacy_key
 from kiro_crew.platform import redact_via_context as redact
-from kiro_crew.port_resolution import resolve_client_port_src
+from kiro_crew.port_resolution import port_is_gateway_owned, resolve_client_port_src
 from kiro_crew.security import (
     redact_credentials,
     redact_exfiltration_urls,
@@ -337,6 +337,96 @@ def _replay_target(refused_base: str) -> tuple[str, str] | None:
         return None
     base = f"http://127.0.0.1:{port}"
     if base == refused_base:
+        return None
+    return base, _socket_path_for(port)
+
+
+def _secret_for_base(base: str) -> str:
+    """The internal-API credential belonging to the gateway on *base*.
+
+    ``read_local_secret`` resolves per LISTENER (``run/gateway-<port>.secret``)
+    before the shared file, because the credential identifies ONE gateway
+    GENERATION — its docstring is explicit that authenticating for a different
+    generation than the one owning the dialled port earns a 403 on every
+    internal call. A restarted gateway is a new generation, so a retry that
+    re-proves the target must re-read the credential for it too; carrying the
+    pre-restart secret is the desync that helper exists to close.
+
+    The port comes from the base being dialled rather than a fresh resolution,
+    so the credential and the target cannot name different gateways.
+    """
+    try:
+        return read_local_secret(int(base.rsplit(":", 1)[-1]))
+    except Exception:
+        return ""
+
+
+def _reverify_refused_target(refused_base: str) -> tuple[str, str] | None:
+    """The FRESH pair for *refused_base*, or ``None`` if it is no longer proven.
+
+    :func:`_replay_target`'s sibling, and the inverse test. That one answers
+    "has the gateway MOVED, so is there a new base worth dialling"; this one
+    answers "does re-resolution still positively identify the SAME base, so is
+    re-dialling it still addressed to the gateway proved to own it".
+
+    Why a same-base retry needs this at all: the ownership proof is per
+    ATTEMPT, not per process (see :func:`_resolve_api_target`). A marker
+    resolution is never pinned precisely because the gateway can exit and
+    something else can take the port — and a retry that SLEEPS first is exactly
+    that window. Re-dialling the cached pair would hand the internal secret and
+    the session key to whatever now listens there, which is the same exposure
+    the ``source == "default"`` rule above refuses, for the same reason.
+
+    Three outcomes answer ``None``, so the caller stops instead of dialling:
+
+    * the re-resolution fell through to the DEFAULT port — no evidence at all,
+      so the listener could be any local process.
+    * the re-resolution names a DIFFERENT base. The gateway moved mid-backoff,
+      so the refused base is no longer owned and this retry is over. Chasing the
+      new base is :func:`_replay_target`'s job on the caller's next attempt, not
+      a second replay smuggled into a retry loop.
+    * the port is not PROVEN to be held by this user's gateway. The source
+      label alone cannot carry that proof: ``KIROCREW_BOUND_PORT`` is
+      inherited process state naming the gateway that SPAWNED us, exported
+      once its site was listening (``dashboard.server._export_bound_port``),
+      and it ranks above the marker step — so ``bound``, not ``marker``, is
+      the source for every gateway-spawned process, and it is never
+      ownership-checked. A refusal is affirmative evidence the previous owner
+      is gone, and a retry that SLEEPS first is exactly the window in which
+      another local user can rebind the port, so the proof is re-earned here
+      via :func:`port_is_gateway_owned` before the secret is dialled anywhere.
+      A ``marker`` resolution already ran that proof inside its own step, so it
+      is not re-run for one.
+
+    Gating on the proof rather than on a list of trusted labels is deliberate.
+    Trusting ``bound`` because it is "stable for the process lifetime" (which is
+    what :data:`_STABLE_PORT_SOURCES` means, and all it means) confuses a value
+    that does not change with a gateway that is still there; refusing it instead
+    would have disabled this retry for the deployment it exists to serve, since
+    ``bound`` is the only source that ever fires there. Verifying the port keeps
+    the retry working when the gateway really did come back on it, and refuses
+    only when something else answers.
+
+    On non-POSIX the proof denies outright, so the retry is unavailable rather
+    than approximated — the same trade :func:`_gateway_owns_port` already makes
+    for marker discovery, and for the same reason: the file-permission argument
+    that carries it does not hold there. ``--port`` / ``KIROCREW_PORT`` users on
+    Windows get the actionable exhaustion message instead of a silent re-dial.
+
+    Both halves of the returned pair come from the one resolution whose source
+    was checked, keeping :func:`_resolve_api_target`'s "both transports derive
+    from one resolution" invariant.
+    """
+    _invalidate_api_base()
+    port, source = _resolve_api_port()
+    if source == "default":
+        return None
+    base = f"http://127.0.0.1:{port}"
+    if base != refused_base:
+        return None
+    # Cheapest checks first: the two above are string work, this one forks a
+    # port lookup, and it is only worth paying when a dial is otherwise due.
+    if source != "marker" and not port_is_gateway_owned(port):
         return None
     return base, _socket_path_for(port)
 
@@ -1110,6 +1200,36 @@ def _transport_failure(message: str, mark: bool) -> dict:
     return out
 
 
+# Extra attempts a REFUSED target gets, and the pause before each.
+#
+# A refusal is the one failure where nothing reached the gateway, so re-dialling
+# the identical request cannot double-execute a verb — that invariant is what
+# makes this retry legal (see ``_retry_refused`` inside :func:`_send`). Two extra
+# dials, pausing ~250ms then ~500ms, cover the sub-second window in which a
+# restarting gateway is rebinding its port, without making a genuinely-down
+# gateway feel hung.
+_REFUSED_RETRY_BACKOFFS: tuple[float, ...] = (0.25, 0.5)
+
+
+def _refused_message(refused_base: str, exc: BaseException) -> str:
+    """Actionable text for a base that refused every attempt.
+
+    A bare ``<urlopen error [Errno 61] Connection refused>`` tells the caller
+    nothing it can act on, so name the address that was dialled and the likely
+    reason (the gateway is down, or restarting) together with the advice that
+    follows from it. The raw error is appended so the original diagnostic
+    survives for a bug report.
+
+    The address comes from the base that was actually refused; re-resolving here
+    would name a port nobody dialled.
+    """
+    host = refused_base.split("//", 1)[-1].rstrip("/") or refused_base
+    return (
+        f"Kiro Crew gateway not reachable on {host} — it may be down or "
+        f"restarting; retry shortly ({exc})"
+    )
+
+
 def _send(
     path: str,
     *,
@@ -1119,25 +1239,108 @@ def _send(
     timeout: float = 30,
     mark_transport_error: bool = False,
 ) -> dict:
-    """Send one gateway request, re-resolving the base once if it is refused.
+    """Send one gateway request, recovering from a refused connection.
 
-    A refused connection usually means the resolved base is stale: the gateway
-    came up, or moved to another port, after this tool server booted, and that
-    port is recorded only in the run marker. The replay runs only when
-    re-resolution actually produced a different base — retrying an unchanged
-    dead port just doubles the caller's latency to reach the identical failure.
+    Two layers, in order. A refused connection may mean the resolved base is
+    stale: the gateway came up, or moved to another port, after this tool server
+    booted, and that port is recorded only in the run marker — so the base is
+    re-resolved and the request replayed once, but only when re-resolution
+    actually produced a different base (the rule lives in
+    :func:`_replay_target`). When there is no moved gateway to chase, the base
+    that refused is the only candidate, and a gateway RESTARTING on its own port
+    lands there: it gets a short bounded retry of the same target
+    (``_retry_refused``) before the caller is told, actionably, that the gateway
+    is unreachable.
 
-    Every verb goes through here. Keeping the replay in one place is what stops
+    Every verb goes through here. Keeping both layers in one place is what stops
     PATCH-shaped calls from staying pinned to a base that POST already learned
     was wrong.
     """
 
-    def _once(target: tuple[str, str]) -> dict:
+    def _once(target: tuple[str, str], hdrs: dict[str, str] | None = None) -> dict:
         base, socket_path = target
-        req = urllib.request.Request(f"{base}{path}", data=data, headers=headers, method=method)
+        req = urllib.request.Request(
+            f"{base}{path}", data=data, headers=hdrs if hdrs is not None else headers, method=method
+        )
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_resolve_api_target(): 127.0.0.1 plus a port from config/env or a run-marker whose ownership is re-verified per request) + a fixed internal path; never user-controlled  # noqa: E501
         with _api_urlopen(req, timeout=timeout, unix_socket_path=socket_path) as resp:
             return json.loads(resp.read())
+
+    def _refreshed_headers(base: str) -> dict[str, str]:
+        """*headers* with the credential re-read for *base*, caller's dict intact.
+
+        A copy, never an in-place edit: ``headers`` belongs to the caller and is
+        reused for its own error reporting. An unreadable secret leaves the
+        original value rather than sending an empty one, so a transient read
+        failure cannot turn a retry into a guaranteed 403.
+        """
+        fresh = dict(headers)
+        secret = _secret_for_base(base)
+        if secret:
+            fresh["X-Internal-Secret"] = secret
+        return fresh
+
+    def _retry_refused(refused: tuple[str, str], refusal: urllib.error.URLError) -> dict:
+        """Re-dial the SAME refused target a few times, then report it actionably.
+
+        A refusal is the one failure that is safe to replay: the connect itself
+        never completed, so nothing was handed to the gateway and the request
+        cannot have been executed — an identical retry therefore cannot
+        double-execute a verb. That invariant is why this loop retries ONLY
+        ``ConnectionRefusedError`` / ``socket.gaierror``; every other failure
+        keeps its existing route, because an ``HTTPError`` carries a real
+        response and any post-connect failure leaves acceptance undetermined,
+        and spawn_run's reconcile depends on that ambiguity being reported
+        rather than retried.
+
+        The window this covers is a gateway restarting on its own port, which
+        :func:`_replay_target` deliberately declines to chase — there is no
+        moved base to find, so before this the caller got the raw errno with no
+        retry at all. On exhaustion it gets the port and the restart hypothesis
+        instead, with the raw error appended.
+
+        Sleeping does NOT let the target go unproven. The ownership proof is per
+        ATTEMPT, so every re-dial re-resolves through
+        :func:`_reverify_refused_target` and proceeds only while positive
+        evidence still names this same base — otherwise the port could have been
+        taken by another local process during the backoff, and the retry would
+        hand it the internal secret.
+
+        A check that cannot prove the target consumes one step of the budget
+        rather than ending it. "Not proven" is the EXPECTED reading mid-restart:
+        between the old process releasing the port and the new one binding it
+        nothing is listening, so no ownership can be shown — and that is the very
+        window this retry exists to cover. Abandoning the schedule on the first
+        such reading would have limited recovery to a gateway that rebinds inside
+        the FIRST backoff, discarding the longer half of the budget for the case
+        it was sized for. The schedule stays the bound: when the last step is
+        still unproven, the caller gets the same actionable message as a
+        dialled-and-refused exhaustion.
+        """
+        for backoff in _REFUSED_RETRY_BACKOFFS:
+            time.sleep(backoff)
+            # Re-prove ownership AFTER the sleep, never before it: the whole
+            # point is that the gateway may have gone during the pause.
+            proven = _reverify_refused_target(refused[0])
+            if proven is None:
+                # Spend the next step rather than the whole schedule: a gateway
+                # part-way through rebinding is unprovable but about to be back.
+                continue
+            # The target was re-proven; the CREDENTIAL has to be re-read for it
+            # too. A gateway that restarted on this port is a new generation with
+            # a new per-listener secret, so replaying the header this request was
+            # built with would earn a 403 instead of the retry this exists for.
+            try:
+                return _once(proven, _refreshed_headers(proven[0]))
+            except urllib.error.HTTPError as exc:
+                return _http_error_body(exc)
+            except urllib.error.URLError as exc:
+                if not isinstance(exc.reason, (ConnectionRefusedError, socket.gaierror)):
+                    return _transport_failure(str(exc), mark_transport_error)
+                refusal = exc
+            except Exception as exc:
+                return _transport_failure(str(exc), mark_transport_error)
+        return {"error": _refused_message(refused[0], refusal)}
 
     # ONE resolution for this attempt; both transports derive from it.
     target = _resolve_api_target()
@@ -1156,18 +1359,25 @@ def _send(
         # THE replay rule lives in _replay_target, shared with
         # mcp_computer._invoke: None means "do not replay" (no evidence, or the
         # re-resolution named the same dead base). Nothing was handed to a live
-        # gateway in either case, so the first-attempt refusal stands as a
-        # definite rejection — no transport ambiguity to report.
+        # gateway in either case, so no refusal below carries transport
+        # ambiguity — the outcome is a definite rejection once the retry window
+        # for the refused target is spent.
         retry_target = _replay_target(base)
         if retry_target is None:
-            return {"error": str(e)}
+            # No moved gateway to chase, so the base that refused is the only
+            # candidate — the same-port restart case. Give it the short retry
+            # window rather than surfacing a bare errno.
+            return _retry_refused(target, e)
         try:
             return _once(retry_target)
         except urllib.error.HTTPError as retry_exc:
             return _http_error_body(retry_exc)
         except urllib.error.URLError as retry_exc:
             if isinstance(retry_exc.reason, (ConnectionRefusedError, socket.gaierror)):
-                return {"error": str(e)}
+                # Both bases refused. The re-resolved one is the fresher
+                # evidence of where the gateway lives, so the retry window
+                # applies to it.
+                return _retry_refused(retry_target, retry_exc)
             return _transport_failure(str(retry_exc), mark_transport_error)
         except Exception as retry_exc:
             # The replay reached the gateway and failed afterwards (a read timeout

--- a/src/kiro_crew/port_resolution.py
+++ b/src/kiro_crew/port_resolution.py
@@ -177,6 +177,25 @@ def _gateway_owns_port(port: int) -> bool:
     return _patchable("_is_kirocrew_process")(recorded)
 
 
+def port_is_gateway_owned(port: int) -> bool:
+    """The chain's ownership proof, for a credential-bearing caller outside it.
+
+    :func:`_gateway_owns_port` is step 5's own guard, and step 5 is the only
+    step that has one. A caller whose port arrived through a step carrying NO
+    ownership evidence — an inherited ``KIROCREW_BOUND_PORT``, an operator
+    ``KIROCREW_PORT``, a configured ``dashboard.url`` — and which is about to
+    attach the internal secret to a request needs that same proof on its own
+    account. Exposing it here keeps such a caller from reaching for a private
+    name, and routing through :func:`_patchable` keeps a test that patches
+    ``cli_server._gateway_owns_port`` intercepting as it always has.
+
+    Inherits the underlying proof's contract unchanged: fails closed on every
+    missing or unverifiable step, and denies outright on non-POSIX, where the
+    file-permission argument the proof rests on does not hold.
+    """
+    return bool(_patchable("_gateway_owns_port")(port))
+
+
 def _marker_port() -> int | None:
     """Port of the sole gateway-owned run-marker, or ``None``.
 

--- a/test/test_mcp_api_base_resolution.py
+++ b/test/test_mcp_api_base_resolution.py
@@ -8,6 +8,11 @@ refused connection drops the resolution caches, re-resolves, and replays the
 request exactly once — and only when re-resolution actually produced a
 different base. ``mcp_computer._invoke`` applies the same rule to its one
 request path.
+
+``TestSameBaseRefusalRetry`` covers the case that rule deliberately declines --
+a gateway restarting on its OWN port, where there is no moved base to find. That
+used to fall through to a bare errno; it now gets a short bounded retry of the
+same target and, on exhaustion, an actionable message.
 """
 
 from __future__ import annotations
@@ -168,10 +173,17 @@ def test_every_verb_rediscovers_and_replays(refusing_gateway, verb: str) -> None
 
 
 def test_no_replay_when_rediscovery_returns_the_same_base(mcp: Any, monkeypatch) -> None:
-    """Retrying an unchanged dead base would only double the latency."""
+    """Re-resolution proving the same base earns no REPLAY — only the retry window.
+
+    The replay exists to chase a MOVED gateway, and there is none here. What the
+    unchanged base does get is the short same-target retry
+    (``TestSameBaseRefusalRetry``), for the gateway that is merely restarting on
+    its own port, so the dials stay on that one base.
+    """
     attempts: list[str] = []
     _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
     _retry_resolution(monkeypatch, mcp, 7788, "marker")
+    monkeypatch.setattr(mcp, "_REFUSED_RETRY_BACKOFFS", (0.0, 0.0))
 
     def fake_open(req, timeout=None, unix_socket_path=None):
         attempts.append(req.full_url)
@@ -179,7 +191,8 @@ def test_no_replay_when_rediscovery_returns_the_same_base(mcp: Any, monkeypatch)
 
     monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
     assert "error" in mcp._post("/api/x", {"k": "v"})
-    assert len(attempts) == 1
+    assert len(attempts) == 1 + len(mcp._REFUSED_RETRY_BACKOFFS)
+    assert all(":7788" in u for u in attempts), attempts
 
 
 def test_no_replay_when_rediscovery_falls_through_to_default(mcp: Any, monkeypatch) -> None:
@@ -189,10 +202,16 @@ def test_no_replay_when_rediscovery_falls_through_to_default(mcp: Any, monkeypat
     nothing and falls through to the default port. A listener there is
     unverified — it could be any local process — and the request carries the
     internal secret, so the replay is skipped even though the base differs.
+
+    The SAME evidence rule bounds the same-base retry. Re-resolution proving
+    nothing means the refused port is no longer proven to be ours either, so the
+    retry window is not spent dialling it: one dial in total, and the caller is
+    told the gateway is unreachable.
     """
     attempts: list[str] = []
     _bases(monkeypatch, mcp, ["http://127.0.0.1:9999"])
     _retry_resolution(monkeypatch, mcp, 5476, "default")
+    monkeypatch.setattr(mcp, "_REFUSED_RETRY_BACKOFFS", (0.0, 0.0))
 
     def fake_open(req, timeout=None, unix_socket_path=None):
         attempts.append(req.full_url)
@@ -202,7 +221,11 @@ def test_no_replay_when_rediscovery_falls_through_to_default(mcp: Any, monkeypat
     out = mcp._post("/api/x", {"k": "v"})
     assert "error" in out
     assert "transport_error" not in out
-    assert len(attempts) == 1  # nothing was sent to the unverified default port
+    # Neither the unverified default port NOR the refused base receives a
+    # further secret-bearing dial: re-resolution proved nothing, so ownership of
+    # 9999 is no longer established and the retry stops before sleeping again.
+    assert all(":9999" in u for u in attempts), attempts
+    assert len(attempts) == 1
 
 
 def test_only_post_reports_transport_error(mcp: Any, monkeypatch) -> None:
@@ -547,3 +570,404 @@ class TestOneResolutionPerAttempt:
         replayed = _sock_for(7788)
         assert sock2 == replayed, f"the replay aimed TCP at {url2} and the unix socket at {sock2}"
         assert sock2 != _sock_for(5476), "the replay must not reuse the refused resolution"
+
+
+class TestSameBaseRefusalRetry:
+    """A gateway restarting on its OWN port gets a short bounded retry.
+
+    ``_replay_target`` deliberately answers ``None`` when re-resolution names the
+    base that was just refused — there is no moved gateway to chase. That left
+    ``_send`` with a bare ``return {"error": str(e)}``, so an MCP write issued
+    during the sub-second window a restarting gateway is rebinding its port came
+    back as the raw ``<urlopen error [Errno 61] Connection refused>``: no retry,
+    and an errno the caller cannot act on.
+
+    The retry is legal precisely because the connect never completed, so nothing
+    was handed to the gateway and the request cannot have been executed. These
+    tests pin that it happens for a refusal, that exhaustion is reported
+    actionably, and that no other failure class is retried — an ``HTTPError`` has
+    a real response, and a post-connect failure leaves acceptance undetermined,
+    which spawn_run's reconcile reads off ``transport_error``.
+    """
+
+    @pytest.fixture
+    def unchanged_base(self, mcp: Any, monkeypatch) -> Any:
+        """Resolution and re-resolution both name 7788, so no replay is allowed."""
+        _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
+        monkeypatch.setattr(mcp, "_REFUSED_RETRY_BACKOFFS", (0.0, 0.0))
+        return mcp
+
+    @staticmethod
+    def _refusal() -> urllib.error.URLError:
+        return urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+    @staticmethod
+    def _resolution_sequence(
+        monkeypatch: pytest.MonkeyPatch, mcp: Any, sequence: list[tuple[int, str]]
+    ) -> None:
+        """Script successive ``_resolve_api_port`` answers, last value repeating.
+
+        ``_retry_resolution`` pins ONE answer, which cannot express a gateway
+        that moves BETWEEN the replay decision and a later re-verification {EM}
+        exactly the window these cases are about.
+        """
+        it = iter(sequence)
+        last = sequence[-1]
+        monkeypatch.setattr(mcp, "_resolve_api_port", lambda: next(it, last))
+
+    def test_reverify_demands_positive_evidence_for_this_same_base(
+        self, mcp: Any, monkeypatch
+    ) -> None:
+        """The proof is per attempt, so each re-dial must re-earn it.
+
+        Three outcomes, one helper: the same base still named by a real source is
+        the only one that authorises another dial. A default fall-through proves
+        nothing, and a different base means the port was freed {EM} in both cases
+        the answer is ``None`` and the caller stops.
+        """
+        base = "http://127.0.0.1:7788"
+
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
+        assert mcp._reverify_refused_target(base) == (base, _sock_for(7788))
+
+        _retry_resolution(monkeypatch, mcp, 5476, "default")
+        assert mcp._reverify_refused_target(base) is None
+
+        _retry_resolution(monkeypatch, mcp, 9999, "marker")
+        assert mcp._reverify_refused_target(base) is None
+
+    def test_an_unproven_port_is_never_re_dialled(self, mcp: Any, monkeypatch) -> None:
+        """``bound`` is the NORMAL source, and it carries no ownership evidence.
+
+        ``KIROCREW_BOUND_PORT`` is inherited process state naming the gateway that
+        spawned us, exported once its site was listening, and it ranks ABOVE the
+        marker step -- so every gateway-spawned MCP server resolves ``bound``,
+        never ``marker``. That label says the value has not changed, not that the
+        gateway is still on it, so a re-dial has to prove the port is still held
+        by this user's gateway.
+        """
+        base = "http://127.0.0.1:7788"
+        _retry_resolution(monkeypatch, mcp, 7788, "bound")
+        monkeypatch.setattr(mcp, "port_is_gateway_owned", lambda port: False)
+        assert mcp._reverify_refused_target(base) is None
+
+    def test_a_proven_port_still_gets_its_retry(self, mcp: Any, monkeypatch) -> None:
+        """The proof is a gate, not a ban -- the retry survives where it matters.
+
+        Refusing ``bound`` outright (or trusting only ``marker``) would have
+        disabled this retry for the one deployment it exists to serve. A gateway
+        that really did come back on its own port passes the proof and is dialled.
+        """
+        base = "http://127.0.0.1:7788"
+        _retry_resolution(monkeypatch, mcp, 7788, "bound")
+        asked: list[int] = []
+
+        def owns(port: int) -> bool:
+            asked.append(port)
+            return True
+
+        monkeypatch.setattr(mcp, "port_is_gateway_owned", owns)
+        assert mcp._reverify_refused_target(base) == (base, _sock_for(7788))
+        assert asked == [7788], f"the proof must name the port about to be dialled: {asked}"
+
+    def test_a_marker_resolution_is_not_re_proven(self, mcp: Any, monkeypatch) -> None:
+        """Step 5 already ran the proof, so running it again is pure cost.
+
+        ``_marker_port`` discards every candidate a verified gateway does not
+        hold, so a ``marker`` answer IS an ownership-checked answer. Re-forking a
+        port lookup for it would double the cost of the common recovery path.
+        """
+        base = "http://127.0.0.1:7788"
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
+
+        def boom(port: int) -> bool:
+            raise AssertionError("a marker resolution must not be re-proven")
+
+        monkeypatch.setattr(mcp, "port_is_gateway_owned", boom)
+        assert mcp._reverify_refused_target(base) == (base, _sock_for(7788))
+
+    def test_an_unproven_port_ends_the_retry_instead_of_replaying_the_secret(
+        self, mcp: Any, monkeypatch
+    ) -> None:
+        """End to end: one dial, and the credential is never offered a second time.
+
+        The unit assertions above pin the rule; this pins that ``_send`` obeys it,
+        which is where the exposure would actually land.
+        """
+        _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
+        _retry_resolution(monkeypatch, mcp, 7788, "bound")
+        monkeypatch.setattr(mcp, "_REFUSED_RETRY_BACKOFFS", (0.0, 0.0))
+        monkeypatch.setattr(mcp, "port_is_gateway_owned", lambda port: False)
+        dials: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            dials.append(req.full_url)
+            raise self._refusal()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        result = mcp._post("/api/x", {"k": "v"})
+        assert len(dials) == 1, f"an unproven port must not be re-dialled: {dials}"
+        assert "error" in result, result
+
+    def test_a_gateway_not_back_yet_keeps_its_remaining_budget(self, mcp: Any, monkeypatch) -> None:
+        """An unprovable target is a not-yet, not a stop signal.
+
+        Between the old process releasing the port and the new one binding it,
+        nothing is listening and no ownership can be shown -- which is exactly the
+        window this retry covers. Ending the schedule on the first such reading
+        would limit recovery to a gateway that rebinds inside the first backoff.
+        """
+        _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
+        _retry_resolution(monkeypatch, mcp, 7788, "bound")
+        monkeypatch.setattr(mcp, "_REFUSED_RETRY_BACKOFFS", (0.0, 0.0))
+        proofs = iter([False, True])
+        monkeypatch.setattr(mcp, "port_is_gateway_owned", lambda port: next(proofs, True))
+        dials: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            dials.append(req.full_url)
+            if len(dials) == 1:
+                raise self._refusal()
+            return _Resp()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        assert mcp._post("/api/x", {"k": "v"}) == {"ok": True}
+        assert len(dials) == 2, f"the second backoff must still be spent: {dials}"
+
+    def test_the_retry_re_reads_the_credential_for_the_restarted_gateway(
+        self, unchanged_base, monkeypatch
+    ) -> None:
+        """A restarted gateway is a new GENERATION, so the secret is re-read.
+
+        ``read_local_secret`` resolves ``run/gateway-<port>.secret`` before the
+        shared file because the credential identifies one gateway generation, and
+        authenticating for a different generation than the one owning the dialled
+        port earns a 403. The request was built with the pre-restart secret, so a
+        retry that replays it reaches the gateway this fix exists to reach and is
+        rejected — the credential has to be re-read for the re-proven target.
+        """
+        mcp = unchanged_base
+        # Patched at the credential seam itself. The FIRST dial's header was built
+        # by the caller before this test could reach it, so the property under test
+        # is that the retry re-reads rather than replays -- not a literal for a
+        # value this test never supplied.
+        monkeypatch.setattr(mcp, "read_local_secret", lambda port: "regenerated-secret")
+        sent: list[str | None] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            sent.append(req.get_header("X-internal-secret"))
+            if len(sent) == 1:
+                raise self._refusal()
+            return _Resp()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        assert mcp._post("/api/x", {"k": "v"}) == {"ok": True}
+        # The retry carries the credential belonging to the generation now on
+        # that port, not the one the request was originally built with.
+        assert sent[1] == "regenerated-secret", sent
+        assert sent[1] != sent[0], sent
+
+    def test_a_credential_that_cannot_be_re_read_keeps_the_original(
+        self, unchanged_base, monkeypatch
+    ) -> None:
+        """A failed secret read must not downgrade the retry to a guaranteed 403.
+
+        Sending an empty credential would be strictly worse than replaying the one
+        the request already had, so an unreadable secret leaves the original in
+        place.
+        """
+        mcp = unchanged_base
+
+        def boom(port):
+            raise OSError("unreadable")
+
+        monkeypatch.setattr(mcp, "read_local_secret", boom)
+        sent: list[str | None] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            sent.append(req.get_header("X-internal-secret"))
+            if len(sent) == 1:
+                raise self._refusal()
+            return _Resp()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        assert mcp._post("/api/x", {"k": "v"}) == {"ok": True}
+        assert sent[1] == sent[0], sent
+
+    def test_a_port_freed_mid_backoff_is_never_re_dialled(self, mcp: Any, monkeypatch) -> None:
+        """The security property: sleeping must not outlive the ownership proof.
+
+        Re-resolution names the refused base while ``_replay_target`` runs, so
+        there is no moved gateway to chase and the retry window opens. During the
+        backoff the gateway exits and the port is taken: the next resolution
+        names a DIFFERENT base. Re-dialling 7788 now would hand the internal
+        secret and the session key to whatever bound it, so the retry stops with
+        the unreachable message instead.
+        """
+        attempts: list[str] = []
+        _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
+        # First answer keeps the replay closed; the second is the port moving.
+        self._resolution_sequence(monkeypatch, mcp, [(7788, "marker"), (9999, "marker")])
+        monkeypatch.setattr(mcp, "_REFUSED_RETRY_BACKOFFS", (0.0, 0.0))
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            raise self._refusal()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/x", {"k": "v"})
+
+        assert "error" in out
+        assert "not reachable" in out["error"]
+        assert attempts == ["http://127.0.0.1:7788/api/x"], attempts
+        assert not any(":9999" in u for u in attempts), attempts
+
+    def test_two_refusals_then_success_yields_one_payload(
+        self, unchanged_base, monkeypatch
+    ) -> None:
+        """The restart window closes mid-retry: one payload, no duplicate send."""
+        mcp = unchanged_base
+        attempts: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            if len(attempts) <= 2:
+                raise self._refusal()
+            return _Resp()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/learn", {"rule": "x"})
+        assert out == {"ok": True}
+        assert len(attempts) == 3, f"expected the first dial plus two retries: {attempts}"
+        assert all(":7788" in u for u in attempts), attempts
+
+    def test_exhaustion_names_the_port_the_restart_and_the_errno(
+        self, unchanged_base, monkeypatch
+    ) -> None:
+        """The caller must get something to act on, without losing the diagnostic."""
+        mcp = unchanged_base
+        attempts: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            raise self._refusal()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/learn", {"rule": "x"})
+        assert len(attempts) == 1 + len(mcp._REFUSED_RETRY_BACKOFFS), attempts
+        message = out["error"]
+        assert "127.0.0.1:7788" in message, message
+        assert "restarting" in message, message
+        assert "retry shortly" in message, message
+        assert "[Errno 111]" in message, "the raw errno must survive for a bug report"
+        assert "transport_error" not in out, "nothing reached the gateway"
+
+    def test_the_retry_budget_is_bounded_and_brief(self, mcp: Any, monkeypatch) -> None:
+        """A down gateway must not feel hung: a couple of sub-second pauses.
+
+        Asserted on the SHIPPED backoffs (this one does not stub them), because
+        the budget is the whole reason a retry is acceptable on a hot path — the
+        5s keepalive poll goes through here too.
+        """
+        _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
+        slept: list[float] = []
+        monkeypatch.setattr(mcp.time, "sleep", slept.append)
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            raise self._refusal()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        assert "error" in mcp._post("/api/learn", {"rule": "x"})
+        assert 2 <= len(slept) <= 3, f"retry budget drifted: {slept}"
+        assert sum(slept) <= 2.0, f"a refused gateway blocked the caller for {sum(slept)}s"
+
+    def test_a_refused_replay_also_gets_the_window(self, mcp: Any, monkeypatch) -> None:
+        """Both bases refused: the retry follows the fresher re-resolved base."""
+        _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
+        monkeypatch.setattr(mcp, "_REFUSED_RETRY_BACKOFFS", (0.0,))
+        attempts: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            raise self._refusal()
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/spawn", {"tasks": ["x"]})
+        assert [":5476" in attempts[0], ":7788" in attempts[1], ":7788" in attempts[2]] == [
+            True,
+            True,
+            True,
+        ], attempts
+        assert "127.0.0.1:7788" in out["error"], out
+        assert "transport_error" not in out
+
+    def test_an_http_error_is_never_retried(self, unchanged_base, monkeypatch) -> None:
+        """A 4xx is a real response — retrying it would re-send an accepted write."""
+        mcp = unchanged_base
+        attempts: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            raise urllib.error.HTTPError(
+                req.full_url, 400, "Bad Request", None, None  # type: ignore[arg-type]
+            )
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/learn", {"rule": "x"})
+        assert len(attempts) == 1, attempts
+        assert "transport_error" not in out
+
+    def test_a_post_connect_failure_stays_ambiguous_and_unretried(
+        self, unchanged_base, monkeypatch
+    ) -> None:
+        """Acceptance is undetermined, so a retry could double-execute the verb."""
+        mcp = unchanged_base
+        attempts: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            raise TimeoutError("read timed out after the spawn was accepted")
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/spawn", {"tasks": ["x"]})
+        assert len(attempts) == 1, attempts
+        assert out == {
+            "error": "read timed out after the spawn was accepted",
+            "transport_error": True,
+        }
+        assert "transport_error" not in mcp._get("/api/x"), "mark stays opt-in per verb"
+
+    def test_a_non_refusal_urlerror_is_never_retried(self, unchanged_base, monkeypatch) -> None:
+        """A connect timeout may have reached the gateway; only refusals are safe."""
+        mcp = unchanged_base
+        attempts: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            raise urllib.error.URLError(socket.timeout("slow"))
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/spawn", {"tasks": ["x"]})
+        assert len(attempts) == 1, attempts
+        assert out.get("transport_error") is True
+
+    def test_a_refusal_that_turns_into_a_post_connect_failure_is_ambiguous(
+        self, unchanged_base, monkeypatch
+    ) -> None:
+        """The gateway came back mid-retry and then failed after accepting."""
+        mcp = unchanged_base
+        attempts: list[str] = []
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            attempts.append(req.full_url)
+            if len(attempts) == 1:
+                raise self._refusal()
+            raise TimeoutError("read timed out after the spawn was accepted")
+
+        monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+        out = mcp._post("/api/spawn", {"tasks": ["x"]})
+        assert len(attempts) == 2, "the retry must stop at the first non-refusal"
+        assert out.get("transport_error") is True


### PR DESCRIPTION
## Problem / Motivation

An MCP write tool fails with the raw `Error: <urlopen error [Errno 61] Connection refused>` when the gateway is down or mid-restart (reported on `learn_add`). The user sees an errno with no context, and because nothing is retried, a sub-second gateway restart window turns into a hard tool failure. This is not the `missing X-Session-Key` 400 cluster — here there is no HTTP response at all.

## Why it matters

Every gateway verb goes through `mcp_core._send`, so any MCP tool call that lands in a restart window (self-update, `kirocrew restart`, a config reload) fails outright. The failure is also unactionable: the caller cannot tell "gateway restarting, try again in a second" from "gateway is not installed", so an agent either gives up on real work or retries blindly against the wrong hypothesis.

## What changed (motivation → approach → change)

**Symptom → root cause.** `_send` already recovers from a refusal, but only from a gateway that *moved*. `_replay_target` — which owns the replay rule — answers `None` in two cases: re-resolution fell through to the default port (no evidence, and the request carries the internal secret), or it named the base that was just refused. A gateway restarting on its **own** port is that second case, so `_send` fell to a bare `return {"error": str(e)}`: the raw errno, no retry, no guidance. The same bare return sat on the branch where the replay itself was refused.

**The change.** Both terminal bare returns now go through a new `_retry_refused` closure in `_send`:

- Two extra dials of the **same** target, pausing ~250ms then ~500ms (`_REFUSED_RETRY_BACKOFFS`) — enough to cover a port rebind, bounded so a genuinely-down gateway does not feel hung on a hot path (the 5s keepalive poll goes through here too).
- On exhaustion, `_refused_message(...)` instead of the errno: `Kiro Crew gateway not reachable on 127.0.0.1:5476 — it may be down or restarting; retry shortly (<urlopen error [Errno 111] refused>)`. The address is read off the base that was actually refused (re-resolving would name a port nobody dialled), and the raw error is appended so the diagnostic survives for a bug report.

**Why retrying a refusal is safe.** A refusal means the connect itself never completed, so nothing was handed to the gateway and the request cannot have been executed — an identical retry cannot double-execute a verb. That invariant is stated in the code and is exactly why the retry is scoped to `ConnectionRefusedError` / `socket.gaierror` only. An `HTTPError` carries a real response, and any post-connect failure leaves acceptance undetermined; both keep routing through `_transport_failure` with their `mark_transport_error` semantics unchanged, because spawn_run's batch reconcile reads that ambiguity to avoid reconciling a still-running member down.

The moved-gateway replay is untouched — this is an extra layer for the same-base case only. No restructuring beyond what the retry needs.

## Tests

`test/test_mcp_api_base_resolution.py` (the module that already stubs `_api_urlopen` and owns the refusal harness) gains `TestSameBaseRefusalRetry`:

- **two refusals then success** — one payload, exactly three dials, all on the base that refused (no duplicate send).
- **exhaustion is actionable** — the message names `127.0.0.1:7788`, `restarting`, `retry shortly` *and* still contains `[Errno 111]`; no `transport_error`.
- **the budget is bounded** — asserted against the shipped backoffs: two sub-second pauses, under 2s total.
- **a refused replay also gets the window** — both bases refused; the retry follows the fresher re-resolved base and the message names it.
- **`HTTPError` is never retried** — one dial, structured backend body.
- **a post-connect failure stays ambiguous and unretried** — one dial, `transport_error: True`, and the mark stays opt-in per verb.
- **a non-refusal `URLError` is never retried** — one dial, `transport_error: True`.
- **a refusal that turns into a post-connect failure** — the retry stops at the first non-refusal and reports ambiguity.

Two existing tests encoded "one dial, ever" for the no-replay cases; they now assert the retry dials stay on the base that refused, so the unverified default port still never receives the secret-bearing request.

**Mutation-verified.** With the retry loop removed (`for backoff in ():`), the two-refusals-then-success test fails (5 of 8 fail). With the actionable message reverted to `str(refusal)`, the exhaustion test fails (2 of 8 fail).

## Manual verification

N/A — unit coverage sufficient: the change is entirely inside the transport helper, and the refusal, replay, HTTP-error and post-connect paths are all exercised at the `_api_urlopen`/`loopback_urlopen` seam with the real resolution logic in play.

## Related Issues

Closes SIM Mesh-3678

## Pattern harvest

Rule candidate: review-prompt
Pattern: a recovery path guarded by a "do not retry" sentinel (`_replay_target` returning `None`) whose *else* branch degrades to re-raising the raw transport error — the sentinel correctly rules out one recovery (a moved base) and silently rules out every other, including the safe one.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the `_send` docstring now describes both recovery layers; `_replay_target`'s rule is unchanged and still owns the replay decision
- [x] No secrets, credentials, or internal references in the diff


## Round 2 — GPT blocking finding addressed (`3e9319f53`)

GPT blocked round 1 on `mcp_core.py:1199`: the retry re-dialled the **cached** refused
pair after sleeping, but the ownership proof is per ATTEMPT, so a gateway that exits
during the backoff leaves the port free for another local process — and the re-dial
would hand that listener the internal secret and the session key.

`_replay_target` now has a sibling, `_reverify_refused_target`, with the inverse test
("does re-resolution still positively identify the SAME base" rather than "has the
gateway moved"). The retry re-resolves through it after every backoff and dials only
while that holds, stopping with the same actionable unreachable message when the
source falls through to `default` or names a different base.

One pre-existing test was corrected rather than added to:
`test_no_replay_when_rediscovery_falls_through_to_default` had asserted the retry
window was still spent on the refused base after re-resolution proved nothing — which
is the exposure itself. Two cases added: `_reverify_refused_target`'s three outcomes,
and a port freed mid-backoff never being re-dialled. Mutation-verified by restoring
`_once(refused)`, which fails exactly those while the positive-path retry tests keep
passing.

Full reasoning, including why the fix is scoped to the marker source, is in the
disposition comment on this PR.

no linked issue: tracked internally as SIM Mesh-3678, which has no GitHub issue
