### PR TITLE
fix(dashboard): recognise Windows paths in the markdown path chip

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -75,14 +75,99 @@ export function artifactSlugFromHref(href: string | null | undefined): string | 
  * Character-level shape of a local filesystem path: letters and digits in any
  * script (`\p{L}\p{N}` — filenames are not ASCII-only), combining marks
  * (`\p{M}` — macOS stores NFD-decomposed forms, and Indic/Thai/Arabic scripts
- * need marks even under NFC), underscore, dot, dash, @, ~, colon and space,
- * separated by slashes. Anchored at both ends, so anything carrying a URL
+ * need marks even under NFC), underscore, dot, dash, @, ~, colon, space and
+ * PARENTHESES, separated by slashes — EITHER kind, because a Windows gateway
+ * names its files with `\`. Anchored at both ends, so anything carrying a URL
  * scheme (`https://…`) or shell punctuation fails outright.
+ *
+ * The punctuation set is a DECIDED boundary, not an accumulation. Two review
+ * rounds each found one more character that is legal in a real filename —
+ * parentheses (`C:\Program Files (x86)`, the most-trodden directory on Windows)
+ * and then an apostrophe (`C:\Users\O'Neil`) — which is the signature of an
+ * allowlist being discovered one bug report at a time. So the rule is stated once
+ * instead: admit every character that is legal in a filename on BOTH platforms
+ * and is not a shell control operator, on both shapes, since the two describe one
+ * filesystem convention and an asymmetry is only a later bug report.
+ *
+ * IN: letters, marks, digits, `_ . @ ~ - space` and `' ! # % = + , ( ) [ ] { }`.
+ * A closing bracket may also END a path, so `App (old)` and `data [2026]`
+ * classify as directories.
+ *
+ * OUT, deliberately — these are what keep the anchored shape from matching a
+ * command or a URL: `$` and a backtick (expansion), `&` `;` `|` (chaining),
+ * `<` `>` (redirection), `"` (quoting), `?` `*` (globbing), and `:` anywhere but
+ * the last segment, where it serves `file:447`. Windows forbids `< > : " / \ | ?
+ * *` in a filename outright, so excluding them costs nothing there and buys the
+ * prose rejection everywhere.
+ *
+ * Widening the repertoire never widens the positive-signal rule, so punctuated
+ * prose (`foo/bar (baz)`, `a&&b/c.sh`) still carries neither a root nor an
+ * extension and is still refused below.
+ *
+ * Admitting `\` as a separator here is what lets a relative Windows path
+ * (`src\main.py`, `.\src\main.py`) reach the probe. It cannot express a
+ * DRIVE-rooted path, whose colon sits before the first separator while this
+ * shape allows a colon only in the last segment (where it serves `file:447`),
+ * so that form has its own shape below.
  *
  * Shape alone is NOT sufficient to linkify — see `isPathCandidate`.
  */
 const PATH_SHAPE_RE =
-  /^~?(?:\.{0,2}\/)?[\p{L}\p{M}\p{N}_.@~/ -]*\/[\p{L}\p{M}\p{N}_.@~: -]*[\p{L}\p{M}\p{N}_.]$/u
+  /^~?(?:\.{0,2}[/\\])?[\p{L}\p{M}\p{N}_.@~'!#%=+,()[\]{}/\\ -]*[/\\][\p{L}\p{M}\p{N}_.@~'!#%=+,()[\]{}: -]*[\p{L}\p{M}\p{N}_.)\]}]$/u
+
+/**
+ * Character-level shape of a DRIVE-rooted Windows path (`C:\x`, `c:/x`), whose
+ * root `PATH_SHAPE_RE` cannot carry: the colon precedes the first separator.
+ *
+ * The trailing segment may be empty so a bare drive root (`C:\`) — a real
+ * directory the file manager can reveal — still classifies, and segments carry
+ * the same repertoire `PATH_SHAPE_RE` allows, so both
+ * `C:\Program Files (x86)\app.txt` and `C:\Users\O'Neil\notes.md` resolve.
+ */
+const WIN_DRIVE_PATH_SHAPE_RE =
+  /^[A-Za-z]:[/\\](?:[\p{L}\p{M}\p{N}_.@~'!#%=+,()[\]{} -]+[/\\])*[\p{L}\p{M}\p{N}_.@~'!#%=+,()[\]{} -]*$/u
+
+/**
+ * A UNC prefix in EITHER spelling — `\\host\share\…` or `//host/share/…` —
+ * refused outright below.
+ *
+ * NOT an oversight that the Windows support here stops at drive letters. A UNC
+ * path names a HOST, and this pre-filter classifies markdown that may be
+ * attacker-authored (a rendered web page, a quoted file, any untrusted text a
+ * message carries), so admitting one would let that text make the dashboard ask
+ * the gateway to stat `\\attacker.example\share\x`. On Windows that stat is an
+ * outbound SMB connection, which offers the host's NTLM credentials — a
+ * credential-leak vector, from nothing but rendering a message.
+ *
+ * Windows reads ANY two leading separators as a UNC root, of either kind and in
+ * either order, so the character class is the whole point: matching two of the
+ * SAME kind (`\\\\` or `//`) leaves `\\/attacker.example\\share\\x` and its `/\\`
+ * mirror admitted, and those resolve to the same share. A mixed pair is the same
+ * vector under a different coat of paint, and unlike the `//` spelling it is a
+ * shape no pre-diff predicate here could even form.
+ *
+ * Three places in this codebase already hold exactly this line, and this is the
+ * fourth: `WINDOWS_ABS_PATH_RE` (utils/urlTransform.ts) excludes UNC for image
+ * `src` values, `MdAnchor` refuses a decoded `//`-prefixed link destination, and
+ * `WIN_PRODUCER_PATH_RE` (utils/fileTokens.ts) documents the producer/consumer
+ * asymmetry that makes all of them deliberate — our own upload endpoint may emit
+ * a UNC path because we trust it, while every consumer-side predicate over
+ * authorable text must refuse the host-naming shape.
+ *
+ * Cost on POSIX is nil: `//tmp/x` names the same file as `/tmp/x`, which is
+ * still a candidate. Cost on Windows is that a network-share path renders as a
+ * copy chip rather than an open chip — the same trade `MdAnchor` already makes.
+ */
+const UNC_PREFIX_RE = /^[/\\]{2}/
+
+/** The last path segment, split on EITHER separator so a Windows path yields its
+ *  real basename. `lastIndexOf('/')` alone returns -1 for `C:\a\notes` and hands
+ *  the whole string to `EXT_RE`, which then reads a dotted DIRECTORY name
+ *  (`project\v1.2\notes`) as an extension on the file. */
+function basenameOf(s: string): string {
+  const cut = Math.max(s.lastIndexOf('/'), s.lastIndexOf('\\'))
+  return s.slice(cut + 1)
+}
 
 /** A trailing `.ext` on the last segment, 1-8 chars — the only positive path
  *  signal available to a path that is neither rooted nor explicitly relative.
@@ -91,6 +176,9 @@ const PATH_SHAPE_RE =
  *  Unicode basename with an ASCII extension (`产品文档-v1.0.md`) still passes,
  *  because only the trailing `.ext` is matched. */
 const EXT_RE = /\.[A-Za-z0-9]{1,8}$/
+
+/** Explicitly relative, either separator: `./x`, `../x`, `.\x`, `..\x`. */
+const REL_PREFIX_RE = /^\.{1,2}[/\\]/
 
 /**
  * Could this inline-code text denote a local filesystem path?
@@ -106,18 +194,35 @@ const EXT_RE = /\.[A-Za-z0-9]{1,8}$/
  * of which then rendered as a clickable "file" that could only ever 404. So a
  * candidate must carry a positive signal that it names a location:
  *
- *   - rooted (`/x`, `~/x`), or
- *   - explicitly relative (`./x`, `../x`), or
- *   - a file extension on the last segment (`src/main.py`).
+ *   - rooted — POSIX (`/x`, `~/x`) or a Windows drive (`C:\x`, `C:/x`), or
+ *   - explicitly relative (`./x`, `../x`, `.\x`, `..\x`), or
+ *   - a file extension on the last segment (`src/main.py`, `src\main.py`).
  *
- * A bare two-segment identifier with no extension is rejected. Note the third
- * rule still admits `origin/feature/x.ts`; that is intentional — syntax cannot
- * settle it, and the stat probe will.
+ * A bare two-segment identifier with no extension is rejected. That rejection is
+ * what keeps the backslash separator safe on every platform: a `\`-joined
+ * non-path carries no extension, so an escape sequence (`\n`), a registry key
+ * (`HKEY_LOCAL_MACHINE\Software\Foo`) and a domain-qualified login
+ * (`CORP\alice`) all still fail here rather than becoming a chip that could only
+ * 404. Note the third rule still admits `origin/feature/x.ts`; that is
+ * intentional — syntax cannot settle it, and the stat probe will.
+ *
+ * UNC is refused FIRST, ahead of every shape and signal test, because the other
+ * rules would otherwise readmit it: the extension rule matches
+ * `\\host\share\x.txt`, and the leading-`/` rule matches `//host/share/x`.
+ * See `UNC_PREFIX_RE` for why that shape must never reach the probe.
  */
 export function isPathCandidate(s: string): boolean {
-  if (!PATH_SHAPE_RE.test(s)) return false
-  if (s.startsWith('/') || s.startsWith('~') || s.startsWith('./') || s.startsWith('../')) return true
-  return EXT_RE.test(s.slice(s.lastIndexOf('/') + 1))
+  if (UNC_PREFIX_RE.test(s)) return false
+  if (!PATH_SHAPE_RE.test(s) && !WIN_DRIVE_PATH_SHAPE_RE.test(s)) return false
+  if (s.startsWith('/') || s.startsWith('~') || REL_PREFIX_RE.test(s)) return true
+  // Rootedness is the positive signal, exactly as a leading `/` is on POSIX, so
+  // a drive-rooted path needs no extension: `C:\Windows` is a real directory.
+  // Reuses the consumer-side predicate `urlTransform` already applies to image
+  // `src` values rather than restating it, so the chip and the request it issues
+  // cannot drift on what "absolute" means — and this pre-filter inherits that
+  // predicate's deliberate exclusion of host-naming shapes.
+  if (WINDOWS_ABS_PATH_RE.test(s)) return true
+  return EXT_RE.test(basenameOf(s))
 }
 
 /**

--- a/website/src/test/MarkdownRenderer.test.tsx
+++ b/website/src/test/MarkdownRenderer.test.tsx
@@ -270,6 +270,142 @@ describe('isPathCandidate — path chip pre-filter', () => {
     expect(isPathCandidate('4a72aec5f04d3f44ba8042931226db051242d48a')).toBe(false)
     expect(isPathCandidate('someIdentifier')).toBe(false)
   })
+
+  it('accepts drive-rooted Windows paths, either separator', () => {
+    // A Windows gateway names its files with `\` and roots them on a drive
+    // letter, so the POSIX-only shape rejected every absolute Windows path
+    // before the stat probe. The chip then degraded to the click-to-copy
+    // fallback, which is what a Windows user reported as "clicking only copies
+    // the address instead of opening the sidebar".
+    expect(isPathCandidate('C:\\Users\\me\\Documents\\notes.md')).toBe(true)
+    expect(isPathCandidate('C:/Users/me/Documents/notes.md')).toBe(true)
+    expect(isPathCandidate('c:\\temp\\a.txt')).toBe(true) // lowercase drive letter
+    expect(isPathCandidate('D:\\repo\\file.ts')).toBe(true)
+  })
+
+  it('accepts a drive-rooted Windows path with no extension — rootedness is the signal', () => {
+    // Exactly the POSIX rule: `/Users` needs no extension because it is rooted,
+    // so `C:\Windows` must not need one either. A bare drive root is a real
+    // directory and the file manager can reveal it.
+    expect(isPathCandidate('C:\\Windows')).toBe(true)
+    expect(isPathCandidate('C:\\')).toBe(true)
+  })
+
+  it('REFUSES UNC in either spelling — a stat on one is an outbound SMB credential probe', () => {
+    // Security boundary, not a gap. This pre-filter classifies markdown that may
+    // be attacker-authored, and a UNC path names a HOST: admitting one would let
+    // that text make the gateway stat `\\\\attacker.example\\share\\x`, which on
+    // Windows opens an SMB connection offering the host's NTLM credentials. The
+    // same line `WINDOWS_ABS_PATH_RE` (utils/urlTransform.ts) holds for image
+    // `src` values. Refused ahead of every other test, because the extension
+    // rule below would otherwise readmit it — `report.txt` has one.
+    expect(isPathCandidate('\\\\server\\share\\report.txt')).toBe(false)
+    expect(isPathCandidate('\\\\server\\share')).toBe(false)
+    expect(isPathCandidate('\\\\attacker.example\\share\\x.txt')).toBe(false)
+    // The Win32 extended-length prefix is the same leading shape, so it is
+    // refused too rather than being special-cased into the drive rule.
+    expect(isPathCandidate('\\\\?\\C:\\Users\\me\\notes.md')).toBe(false)
+    // The forward-slash spelling resolves to the SAME share on Windows, so it is
+    // refused too. `MdAnchor` already holds this line for a decoded `//` link
+    // destination; leaving it open here would be the same vector under a
+    // different coat of paint.
+    expect(isPathCandidate('//server/share/report.txt')).toBe(false)
+    // MIXED pairs, both orders. Windows reads any two leading separators as a
+    // UNC root regardless of kind, so a regex matching two of the SAME kind
+    // admitted these -- and the leading separator is then eaten by the relative
+    // prefix group, leaving `.txt` to satisfy the extension rule and send a real
+    // stat probe to the gateway. Refusing per-character rather than per-spelling
+    // is what closes the shape instead of enumerating it.
+    expect(isPathCandidate('\\/attacker.example\\share\\evil.txt')).toBe(false)
+    expect(isPathCandidate('/\\attacker.example\\share\\evil.txt')).toBe(false)
+    expect(isPathCandidate('\\/server/share/report.txt')).toBe(false)
+    expect(isPathCandidate('/\\server/share/report.txt')).toBe(false)
+    expect(isPathCandidate('//attacker.example/share/x.txt')).toBe(false)
+    // Nothing is lost on POSIX: one slash names the same file and still passes.
+    expect(isPathCandidate('/server/share/report.txt')).toBe(true)
+  })
+
+  it('accepts the decided filename punctuation on Windows', () => {
+    // Two review rounds each found one more legal character (parentheses, then
+    // the apostrophe in `C:\\Users\\O'Neil`), which is an allowlist being
+    // discovered one bug report at a time. These pin the whole decided set so a
+    // third round has nothing left to find.
+    expect(isPathCandidate('C:\\Program Files (x86)\\app.txt')).toBe(true)
+    expect(isPathCandidate('C:\\Program Files (x86)')).toBe(true)
+    expect(isPathCandidate('C:/Program Files (x86)/node/node.exe')).toBe(true)
+    expect(isPathCandidate("C:\\Users\\O'Neil\\notes.md")).toBe(true)
+    expect(isPathCandidate('C:\\data\\report [final].csv')).toBe(true)
+    expect(isPathCandidate('C:\\logs\\run#42.txt')).toBe(true)
+    expect(isPathCandidate('C:\\etc\\x={y}\\conf.ini')).toBe(true)
+  })
+
+  it('accepts the same punctuation on POSIX — one filesystem convention', () => {
+    // Admitted on both shapes deliberately: an asymmetry that fixed Windows and
+    // left the POSIX spelling failing would just be the next bug report.
+    expect(isPathCandidate('/Users/me/App (old).md')).toBe(true)
+    expect(isPathCandidate('/Users/me/Screenshot (1).png')).toBe(true)
+    expect(isPathCandidate("/Users/o'neil/notes.md")).toBe(true)
+    expect(isPathCandidate('/var/tmp/a+b.tar.gz')).toBe(true)
+    expect(isPathCandidate('/opt/app/v1,2/notes.md')).toBe(true)
+    expect(isPathCandidate('/srv/100%/index.html')).toBe(true)
+    expect(isPathCandidate('~/docs/report (final).pdf')).toBe(true)
+    expect(isPathCandidate("src/O'Brien (draft).md")).toBe(true)
+    // A closing bracket may END a path, so these classify as directories.
+    expect(isPathCandidate('/Users/me/App (old)')).toBe(true)
+    expect(isPathCandidate('/Users/me/data [2026]')).toBe(true)
+  })
+
+  it('keeps shell control operators OUT of the repertoire', () => {
+    // The exclusions are what keep the anchored shape from matching a command.
+    // Each of these carries an extension, so only the character class refuses it.
+    expect(isPathCandidate('$HOME/x.txt')).toBe(false)
+    expect(isPathCandidate('a&&b/c.sh')).toBe(false)
+    expect(isPathCandidate('cmd;rm/x.sh')).toBe(false)
+    expect(isPathCandidate('a|b/c.txt')).toBe(false)
+    expect(isPathCandidate('a>b/c.txt')).toBe(false)
+    expect(isPathCandidate('glob*/x.txt')).toBe(false)
+    expect(isPathCandidate('what?/x.txt')).toBe(false)
+  })
+
+  it('still refuses punctuated prose and a punctuated UNC share', () => {
+    // Widening the repertoire never widens the positive-signal rule: prose with
+    // neither a root nor an extension is still not a candidate, and the UNC
+    // refusal runs ahead of the shape tests.
+    expect(isPathCandidate('foo/bar (baz)')).toBe(false)
+    expect(isPathCandidate('and/or (maybe)')).toBe(false)
+    expect(isPathCandidate('\\\\server\\Program Files (x86)\\x.txt')).toBe(false)
+  })
+
+  it('accepts explicitly relative and extension-bearing backslash paths', () => {
+    expect(isPathCandidate('.\\src\\main.py')).toBe(true)
+    expect(isPathCandidate('..\\sibling\\file.json')).toBe(true)
+    expect(isPathCandidate('src\\main.py')).toBe(true)
+  })
+
+  it('accepts Unicode segments in a rooted Windows path', () => {
+    expect(isPathCandidate('C:\\Users\\me\\产品文档-v1.0.md')).toBe(true)
+    expect(isPathCandidate('C:\\Пользователи\\отчёт.txt')).toBe(true)
+  })
+
+  it('rejects backslash-joined text that is not a path — no positive signal', () => {
+    // Admitting `\` as a separator must not turn every backslash-joined token
+    // into a chip. Each of these lacks a root, an explicit-relative prefix and
+    // an extension, so the same rule that rejects `owner/repo` rejects them —
+    // on every platform, since the pre-filter cannot know the gateway's OS.
+    expect(isPathCandidate('\\n')).toBe(false) // escape sequence in inline code
+    expect(isPathCandidate('\\t')).toBe(false)
+    expect(isPathCandidate('HKEY_LOCAL_MACHINE\\Software\\Foo')).toBe(false) // registry key
+    expect(isPathCandidate('CORP\\alice')).toBe(false) // domain-qualified login
+    expect(isPathCandidate('domain\\user')).toBe(false)
+  })
+
+  it('reads the basename across either separator when applying the extension gate', () => {
+    // `lastIndexOf('/')` returns -1 for a backslash path and hands the whole
+    // string to the extension test, so a dotted DIRECTORY name would be read as
+    // an extension on the file. The basename here is `notes`, which has none.
+    expect(isPathCandidate('project\\v1.2\\notes')).toBe(false)
+    expect(isPathCandidate('project\\v1.2\\notes.md')).toBe(true)
+  })
 })
 
 /**
@@ -933,6 +1069,143 @@ describe('MarkdownRenderer path chips — file:line references', () => {
     await Promise.resolve()
     expect(globalThis.fetch).not.toHaveBeenCalled()
     expect(container.querySelector('code[data-path-kind]')).toBeNull()
+  })
+})
+
+
+/**
+ * Windows paths, end to end through the chip: pre-filter -> stat probe -> chip.
+ *
+ * The pre-filter cases above pin the syntax decision in isolation; these pin the
+ * RENDERED consequence, which is what the bug report was actually about. Before
+ * this fix a Windows absolute path failed `isPathCandidate`, so no probe was ever
+ * issued and `InlineCode` fell through to the click-to-copy `CopyableCode`
+ * fallback — a Windows user clicking a path the agent had just written got the
+ * address on their clipboard instead of the file in the sidebar.
+ */
+describe('MarkdownRenderer path chips — Windows paths', () => {
+  const realFetch = globalThis.fetch
+
+  /** Answers `file` only for the paths listed, 404 otherwise, and records every
+   *  path the component actually asked about — the absence of a probe is the
+   *  pre-fix symptom, so the call list is itself an assertion target. */
+  function stubPaths(known: string[]): string[] {
+    const asked: string[] = []
+    globalThis.fetch = vi.fn((url: unknown) => {
+      const p = decodeURIComponent(new URL(String(url), 'http://x').searchParams.get('path') || '')
+      asked.push(p)
+      const hit = known.includes(p)
+      return Promise.resolve({
+        ok: hit,
+        status: hit ? 200 : 404,
+        headers: new Headers(hit ? { 'X-Path-Kind': 'file' } : {}),
+      } as Response)
+    }) as unknown as typeof fetch
+    return asked
+  }
+
+  beforeEach(() => { __resetPathKindCache() })
+  afterEach(() => { globalThis.fetch = realFetch; vi.restoreAllMocks() })
+
+  it('renders a drive-qualified path as a chip and opens it, instead of copying', async () => {
+    const win = 'C:\\Users\\me\\Documents\\notes.md'
+    stubPaths([win])
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <MarkdownRenderer content={'`' + win + '`'} onFileOpen={onFileOpen} />,
+    )
+    const chip = await waitFor(() => {
+      const c = container.querySelector('code[data-path-kind="file"]') as HTMLElement | null
+      expect(c).not.toBeNull()
+      return c!
+    })
+    expect(chip.getAttribute('data-path')).toBe(win)
+    fireEvent.click(chip)
+    expect(onFileOpen).toHaveBeenCalledWith(win)
+  })
+
+  it('probes both drive spellings, and never probes a backslash UNC path', async () => {
+    const back = 'C:\\Users\\me\\notes.md'
+    const fwd = 'D:/repo/main.ts'
+    const unc = '\\\\server\\share\\report.txt'
+    const asked = stubPaths([back, fwd, unc])
+    const { container } = render(
+      <MarkdownRenderer content={'`' + back + '`, `' + fwd + '` and `' + unc + '`'} />,
+    )
+    await waitFor(() => {
+      expect(container.querySelectorAll('code[data-path-kind="file"]')).toHaveLength(2)
+    })
+    expect(asked).toContain(back)
+    expect(asked).toContain(fwd)
+    // The stub would have answered `file` for the UNC path, so a chip for it
+    // would have rendered. It never resolved because it was never asked — that
+    // absent request IS the SMB-probe guard.
+    expect(asked).not.toContain(unc)
+  })
+
+  it("renders `C:\\Users\\O'Neil` as a chip and opens it", async () => {
+    const win = "C:\\Users\\O'Neil\\notes.md"
+    stubPaths([win])
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <MarkdownRenderer content={'`' + win + '`'} onFileOpen={onFileOpen} />,
+    )
+    const chip = await waitFor(() => {
+      const c = container.querySelector('code[data-path-kind="file"]') as HTMLElement | null
+      expect(c).not.toBeNull()
+      return c!
+    })
+    expect(chip.getAttribute('data-path')).toBe(win)
+    fireEvent.click(chip)
+    expect(onFileOpen).toHaveBeenCalledWith(win)
+  })
+
+  it('renders `C:\\Program Files (x86)` as a chip and opens it', async () => {
+    const win = 'C:\\Program Files (x86)\\app\\config.json'
+    stubPaths([win])
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <MarkdownRenderer content={'`' + win + '`'} onFileOpen={onFileOpen} />,
+    )
+    const chip = await waitFor(() => {
+      const c = container.querySelector('code[data-path-kind="file"]') as HTMLElement | null
+      expect(c).not.toBeNull()
+      return c!
+    })
+    expect(chip.getAttribute('data-path')).toBe(win)
+    fireEvent.click(chip)
+    expect(onFileOpen).toHaveBeenCalledWith(win)
+  })
+
+  it('carries the line number from a Windows file:line citation', async () => {
+    const win = 'C:\\repo\\src\\main.ts'
+    stubPaths([win])
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <MarkdownRenderer content={'`' + win + ':42`'} onFileOpen={onFileOpen} />,
+    )
+    const chip = await waitFor(() => {
+      const c = container.querySelector('code[data-path-kind="file"]') as HTMLElement | null
+      expect(c).not.toBeNull()
+      return c!
+    })
+    fireEvent.click(chip)
+    expect(onFileOpen).toHaveBeenCalledWith(win, { line: 42 })
+  })
+
+  it('issues NO probe for backslash text that is not a path, and leaves it a copy chip', async () => {
+    // The guard on widening the separator: a registry key and an escape sequence
+    // must not become chips, and must not even cost a request. `data-path-kind`
+    // absent is the click-to-copy fallback still being in charge.
+    const asked = stubPaths([])
+    const { container } = render(
+      <MarkdownRenderer content={'`HKEY_LOCAL_MACHINE\\Software\\Foo` and `\\n`'} />,
+    )
+    await waitFor(() => {
+      expect(container.querySelectorAll('code').length).toBeGreaterThan(0)
+    })
+    expect(container.querySelector('code[data-path-kind]')).toBeNull()
+    expect(asked).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Problem / Motivation

On a Windows gateway, clicking a file path the agent just wrote in chat copies the
path to the clipboard instead of opening the file in the sidebar viewer. Reported
by a Windows desktop user on the latest version.

It affects **every** Windows absolute path, so on Windows the path chip — the
normal route from "the agent mentioned this file" to "the file is open in front of
me" — has never worked. Nothing looked broken, which is why it went unreported for
so long: the span still rendered as a chip and still did something on click, just
the wrong thing.

## Why it matters

Two costs, one of them silent.

The visible one: every Windows user loses the click-to-open affordance entirely and
gets a clipboard write they did not ask for, with no way to tell that a different
behaviour was intended.

The silent one: the same pre-filter admitted `//host/share/x.txt` as a path
candidate, so rendering a message containing one made the dashboard ask the gateway
to stat it. On Windows that stat is an outbound SMB connection offering the host's
NTLM credentials. Since chat markdown can carry untrusted text (a fetched page, a
quoted file), that was a credential-leak vector reachable from rendering alone. It
is closed here — see the fourth bullet under *What changed*.

## What changed (motivation → approach → change)

**Symptom** — a Windows path chip copies instead of opening.

**Root cause** — `isPathCandidate` in `website/src/components/MarkdownRenderer.tsx`
is the pre-filter that decides whether an inline-code span is worth spending a stat
probe on. Its `PATH_SHAPE_RE` required a forward slash and admitted neither a
backslash separator nor the colon in a drive prefix, so `C:\Users\me\notes.md`,
`C:/Users/me/notes.md` and `src\main.py` all failed it. No candidate means no
probe; no probe means `usePathKind` never reports `file`/`dir`; and `InlineCode`
then falls through to the `CopyableCode` branch, whose click handler copies. The
copy was never a fallback for a *failed* path — it is the generic inline-code
affordance, and Windows paths were never recognised as paths at all.

The rest of the chain was already Windows-aware, which is what makes this a
one-place fix: `fileReadUrl.ts::isAbsolute` already classifies drive and UNC
shapes, `MdImage` already routes a drive-qualified `src` through
`WINDOWS_ABS_PATH_RE` (issue #3497), and `splitLineRef`, `activatePath`,
`FilePathMenu` and `/api/reveal` are all separator-agnostic. Only the pre-filter
was POSIX-only.

**Change** — five parts, all in the pre-filter:

- `PATH_SHAPE_RE` accepts **either** separator, which is what lets a relative
  Windows path (`src\main.py`, `.\src\main.py`) reach the probe.
- A new `WIN_DRIVE_PATH_SHAPE_RE` carries the drive-rooted form the general shape
  structurally cannot: a drive prefix puts its colon *before* the first separator,
  while the general shape allows a colon only in the last segment, where it serves
  `file:447`.
- **Parentheses are admitted in a path segment, on both platforms.** `C:\Program
  Files (x86)` is one of the most-trodden directories on Windows, so excluding it
  would have left the defect in place for a large share of real paths — the first
  revision of this PR did exactly that, and the GPT review lane caught it.
  `/Users/me/App (old).md` is the same filesystem convention, so it is admitted
  too rather than shipping an asymmetry that would just be the next report. A
  closing paren may also end a path, so a directory named `App (old)` classifies.
  This widens the character repertoire, not the positive-signal rule, so
  parenthesised prose (`foo/bar (baz)`) is still refused.
- A new `UNC_PREFIX_RE` (`/^[/\\]{2}/`) **refuses any two leading separators**,
  checked before every other rule because the others would readmit it — the
  extension rule matches `\\\\host\share\x.txt` and the leading-`/` rule matches
  `//host/share/x`. Per-CHARACTER, not per-spelling: Windows reads any two leading
  separators as a UNC root regardless of kind or order, so enumerating `\\\\` and
  `//` would leave the mixed pairs `\\/host\share\x.txt` and `/\\host\share\x.txt`
  admitted, and those resolve to the same share. This is the same line three other places in the
  codebase already hold (`WINDOWS_ABS_PATH_RE` for image `src`, `MdAnchor` for a
  decoded `//` link destination, and the producer/consumer asymmetry documented on
  `WIN_PRODUCER_PATH_RE`); the chip was the one consumer-side predicate that had
  not adopted it.
- Rootedness becomes a positive signal for Windows too, reusing the **existing**
  `WINDOWS_ABS_PATH_RE` rather than restating it, so `C:\Windows` needs no
  extension exactly as `/Users` does not. The extension gate now takes the
  basename across either separator, so a dotted *directory* (`project\v1.2\notes`)
  is no longer misread as an extension on the file.

**Why widening the separator is safe.** The existing "a bare two-segment
identifier with no extension is rejected" rule does the work: a `\`-joined
non-path carries no extension, so `\n`, `HKEY_LOCAL_MACHINE\Software\Foo` and
`CORP\alice` are all still refused — on every platform, since the pre-filter
cannot know the gateway's OS — and no request is issued for them. The probe
remains the decision; this only widens what is worth asking about.

**Deliberately not in scope.** `utils/terminalCompletion.ts` and
`MarkdownPanel.tsx`'s `isAbs` carry the same POSIX-only assumption on other
surfaces. They are separate behaviours with their own tests and are left alone
rather than folded in here; see *Pattern harvest*.

## Tests

15 new tests in `website/src/test/MarkdownRenderer.test.tsx`, 122 passing in that
file (was 107).

Ten pin the pre-filter decision in isolation: drive-rooted paths in both separator
spellings; a drive-rooted path with no extension (and a bare `C:\` root); UNC
refused in every spelling — both same-kind pairs, both MIXED pairs, and the Win32
extended-length prefix — with `/server/share/report.txt` still accepted to show one
slash is unaffected;
explicitly-relative and extension-bearing backslash paths; Unicode segments under
a drive root; backslash-joined non-paths still refused; the basename read across
either separator (`project\v1.2\notes` vs `project\v1.2\notes.md`); parenthesised
segments on Windows and on POSIX; and parenthesised prose plus a parenthesised UNC
share still refused.

Five pin the rendered consequence, which is what the report was actually about: a
drive-qualified path renders as a `data-path-kind="file"` chip and routes a click
to `onFileOpen`; `C:\Program Files (x86)\app\config.json` does the same; both drive
spellings get probed while a backslash UNC path never does — the stub would have
answered `file` for it, so the **absent request** is the SMB guard's assertion; a
Windows `file:line` citation carries its line through; and backslash text that is
not a path issues no probe at all and stays a copy chip.

Reverting only the component hunks and re-running turns **12 of the 15 red**. The
three that stay green are pure negative guards, which held before the change too.

Five neighbouring suites that render chips or resolve Windows paths
(`MarkdownRendererCoverage`, `MarkdownRenderer.contextmenu`,
`MarkdownRenderer.windowsImagePath`, `usePathKind`, `fileTokens`) pass unchanged:
115 tests. `tsc -b` clean; eslint at its existing 597-warning ceiling, unchanged.

## Manual verification

**Not performed — it is not reachable from a macOS host, and that is inherent to
the bug rather than a shortcut.** The chip's affordance is gated on the *gateway's*
filesystem answering the stat probe, so confirming the fix end to end requires a
Windows gateway: on macOS no Windows path resolves, and the chip correctly stays
inert. The 15 tests above stand in by driving the same
pre-filter → probe → chip → `onFileOpen` chain with the probe stubbed.

What still wants a human on Windows: open a chat, have the agent write an absolute
path, and confirm a left click opens the sidebar viewer at that file (and at the
right line for a `path:42` citation) rather than copying.

## Screenshots / video

Waived by the `no-screenshots` label, applied by the maintainer.

There *is* a rendered delta — on a Windows gateway the span gains the file glyph
and the confirmed-chip styling — but it is unreachable from the authoring host for
the same reason manual verification is: the chip only renders confirmed once the
gateway stats the path, and a macOS gateway stats no Windows path. Booting an
isolated instance to capture it was attempted twice (the repo dev stack and
`kirocrew pod up`) and both are blocked by sandbox permission errors on this host.
Nothing about the chip's *appearance* is new; it is the existing confirmed-path
chip, already visible throughout the product for POSIX paths.

## Related Issues

no linked issue: reported directly as customer feedback; no matching open issue
found (searched open issues for the windows/path/chip/copy terms).

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a syntactic pre-filter over filesystem paths written against one
separator convention, in a codebase whose gateway can be Windows.

This one does generalize, and it has a specific shape worth catching: the *shape*
predicate was POSIX-only while every consumer downstream of it was already
Windows-aware, so the bug hid behind a chain that otherwise handled Windows
correctly. `utils/terminalCompletion.ts:238` and `MarkdownPanel.tsx:74` carry the
same assumption today on other surfaces.

The second half is the one I would actually encode as a rule: **when a
path-shaped predicate is widened, check whether a sibling predicate narrowed it on
purpose.** Adding Windows support here naturally admitted UNC, and UNC is excluded
elsewhere in this codebase for a documented security reason — the widening would
have quietly reopened an SMB credential-probe vector that the image and link paths
both defend against.

A third, smaller lesson from the review round: a character-class allowlist over
real filenames is easy to under-build. Parentheses were missing from the first
revision, and `C:\Program Files (x86)` is common enough that the fix would have
read as still broken to the very user who reported it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — behaviour is documented in the predicate's own comments, which is where the existing rationale lives
- [x] No secrets, credentials, or internal references in the diff

