### PR TITLE
Add two-axis ratchet for agent-config PUT; document open content-axis ruling (#7470)

### DIFF
--- a/.agents/tasks/task-agent-config-content-axis-ratchet/CONTENT-AXIS-RULING.md
+++ b/.agents/tasks/task-agent-config-content-axis-ratchet/CONTENT-AXIS-RULING.md
@@ -1,0 +1,117 @@
+# Content axis of `PUT /api/agent/config`: open maintainer ruling (#7470)
+
+This brief surfaces a decision that cannot be made from the codebase alone. It
+implements **neither** candidate shape. #7089 shipped the deletion (absent) half
+only and stopped at this same point for exactly this reason.
+
+## The ruling question
+
+`PUT /api/agent/config` makes on-disk state authoritative for the `<app>:<server>`
+region on both directions of *existence*: #6975 stopped it clobbering a bridge the
+submission omits (absent axis), and #7089 stopped it resurrecting one the
+submission still carries (present-drop axis). One axis is left, and it is about
+*content* rather than existence:
+
+> Where the name is on disk **and** in the submission, the submitted row still
+> wins, so a stale editor snapshot can revert a bridge definition the platform had
+> already corrected (e.g. a `backend.port: "auto"` app whose bridge was rewritten
+> to its live allocated port by `_resolve_live_mcp_url`, saved back to the
+> manifest's illustrative port by an editor tab that loaded before the rewrite).
+
+**What needs ruling:** may the content axis be reversed at all, and if so, which of
+the two candidate shapes below closes it? Reversing it undoes the
+editor-snapshot-wins contract kept deliberately in #5899 and re-affirmed for #6664
+(maintainer decision 2026-08-30), so it needs a maintainer ruling rather than a fix
+decided in review.
+
+## Candidate shapes (costs faithful to the issue)
+
+### Shape 1 — substitute on-disk rows
+In `_drop_unbacked_app_entries`, where a submitted namespaced name **is** on disk,
+replace the submitted value with the on-disk one.
+
+- **Size:** mechanically about six lines and one changed test assertion (the
+  assertion in `test_app_owned_entry_present_in_the_snapshot_is_updated`).
+- **Cost:** the contract reversal itself — an app bridge stops being editable
+  through the raw editor. (Arguably already the intent: "an app bridge cannot be
+  removed through this endpoint" is stated in `_merge_unowned_servers`.)
+
+### Shape 2 — optimistic concurrency
+Version/etag the config snapshot and reject a stale `PUT` with a machine-readable
+`code` so the editor reloads.
+
+- **Reach:** closes this axis and the two already-closed ones at their real root —
+  the PUT accepting a snapshot with no staleness signal at all — and would have
+  prevented #6664, #7089 and this one.
+- **Cost:** it is a new API contract plus a client reload path, i.e. feature work,
+  **and it has no client landing path today:**
+  - No `etag`/`If-Match`/version field exists anywhere in the PUT handler
+    (`src/kiro_crew/dashboard/handlers/agents.py` — verified: no `etag`/`If-Match`
+    match).
+  - `saveAgentConfig` sends only `{ config }`
+    (`website/src/api/client.ts:2774`).
+  - `AgentCfgTab.tsx:18` fills its edit buffer once
+    (`useEffect(() => { if (loadedCfg && !cfg) setCfg(loadedCfg) }, ...)`) and
+    never refreshes it, so a stale-PUT rejection has nothing to land on.
+
+## Blast radius (why this is worth a decider's attention)
+
+The blast radius is wider than one app's tools. Writing back a port nobody is
+listening on produces exactly the dead-looking URL the handler's own docstring
+describes: a manifest's illustrative port is a reachable-LOOKING dead URL that
+kiro-cli dials on every request and that **"breaks EVERY kiro session, not just
+that app's"** (`src/kiro_crew/dashboard/handlers/agents.py:285`).
+
+## Self-heal mitigation (why it is separable / less severe than resurrection)
+
+Unlike a resurrected bridge, this axis **self-heals**. An enabled app's bridge is
+re-registered with its live port on the next gateway start via
+`reconcile_enabled_app_resources`, so the window is **until the next restart**
+rather than indefinite. Resurrection did not self-heal because
+`reconcile_enabled_app_resources` only re-registers *enabled* apps. That difference
+is the reason the content axis was separable from the deletion half.
+
+## Ground-truth anchors verified on the current branch
+
+Branch `fix/agent-config-content-axis-ratchet-7470`; HEAD when verified: the
+region-level two-axis ratchet commit `d0fc4f9e5` on top of `6581a04ee`. (The line
+numbers in the issue body are from the older commit `be2ee94`; the anchors below
+are the current file:line locations.)
+
+1. **Handler docstring — the deliberate non-goal.**
+   `src/kiro_crew/dashboard/handlers/agents.py:287-291`, the
+   `_drop_unbacked_app_entries` docstring section
+   **"WHAT THIS DELIBERATELY DOES NOT DO: it never rewrites a submitted value."**
+   It states the submitted row still wins untouched, cites the #5899/#6664
+   editor-snapshot-wins contract and the pinning test, and says
+   *"Reversing it needs a maintainer ruling and is tracked separately."*
+   (Blast-radius sentence at `:285`; self-heal note for the absent axis at
+   `:225-227`.)
+
+2. **Spec decision table — section 1a.**
+   `docs/system-specs/modules/app-kit-platform.md`:
+   - Decision-table row `` `<app>:<server>` on disk `` → **"persisted as
+     submitted — the snapshot still wins where the platform agrees the name
+     exists"** (line 265).
+   - **"Not closed here:"** paragraph at lines 288-292, ending *"…it
+     self-heals on the next gateway start, so it is **left to a separate
+     ruling**."*
+
+3. **Pinning test — submitted-row-wins.**
+   `test/test_agent_config_merge_on_write.py:1034-1047`,
+   `test_app_owned_entry_present_in_the_snapshot_is_updated`, still asserts
+   `written["mcpServers"] == {"demo:notes": {"command": "new"}}` (the submitted
+   `command: "new"` overwrites the on-disk `command: "old"`).
+
+## Disposition
+
+All three markers are present and consistent with the issue, so the codebase
+already reflects the open ruling correctly. **No source change was made** and
+**neither candidate shape was implemented** (no etag/If-Match/version on handler or
+client; no on-disk row substitution in `_drop_unbacked_app_entries`; the pinning
+test's asserted behavior is unchanged). `pytest -q test/test_agent_config_merge_on_write.py`
+→ 47 passed, `test_app_owned_entry_present_in_the_snapshot_is_updated` among them.
+
+The region-level two-axis ratchet the issue also asks for (asserting every key of a
+non-client-owned region is decided by on-disk state on *both* axes) is the
+ruling-independent half and landed separately (commit `d0fc4f9e5`).

--- a/test/test_agent_config_merge_on_write.py
+++ b/test/test_agent_config_merge_on_write.py
@@ -1440,3 +1440,127 @@ async def test_an_unreadable_spec_still_persists_a_namespaced_entry(tmp_path):
         "an unreadable spec deleted what the client submitted: this axis must be "
         "best-effort so the raw editor stays the repair path for a corrupt spec"
     )
+
+
+# ── the region-level two-axis ratchet: existence is on-disk on BOTH axes ───────
+#
+# The gate the #7465 design lanes asked for, worth landing even without the
+# content-axis ruling (#7470): a SINGLE test that holds the app-owned region --
+# the ``mcpServers`` keys that contain ``:`` and are not host-owned -- to on-disk
+# state of *existence* on BOTH axes at once, so the pair reads as complete because
+# it IS complete.
+#
+# The lesson it encodes is #7089's: the absent half alone READS as finished and is
+# not. The absent-axis rule (``_merge_unowned_servers``, #6664) shipped first and
+# its review (#6975) never asked about the mirror direction, so a stale snapshot
+# could still CREATE a namespaced bridge the platform had removed -- the present
+# axis (``_drop_unbacked_app_entries``, #7089) had to be added afterwards. A gate
+# that checks only one direction lets the next owned region repeat that: a future
+# writer's ``:``-keyed region wired into the absent-axis merge but not the
+# present-axis drop would look done and ship a fresh resurrection hole.
+#
+# So this asserts the invariant directly, not a snapshot of today's names: for the
+# app-owned region, EXISTENCE in ``written`` is decided by the on-disk baseline and
+# never by the submission -- an unbacked submitted name is absent (present axis),
+# a backed on-disk name omitted from the submission is present (absent axis). A new
+# owned region that honours only the absent axis makes the present-axis assertion
+# below fail the suite instead of shipping. (Existence only: whether a name PRESENT
+# on both sides may be rewritten is the content axis, deliberately out of scope
+# here and left to #7470's ruling.)
+
+
+@pytest.mark.asyncio
+async def test_app_owned_region_existence_is_decided_on_disk_on_both_axes(tmp_path):
+    """RATCHET: an owned ``:``-region's existence is on-disk on BOTH axes.
+
+    One PUT off one baseline carries both faults an owned region can take on the
+    existence dimension, so neither axis can be satisfied by luck or in isolation:
+
+    * PRESENT axis -- ``demo:custom`` is submitted but has no backing row on disk
+      (``demo`` declares only ``notes``), so the client is trying to CREATE a name
+      in a region it does not author. It must be dropped.
+    * ABSENT axis -- ``demo:notes`` is a backed app bridge on disk that the stale
+      submission OMITS. Its absence from the snapshot is not a deletion the client
+      is entitled to make, so it must be preserved.
+
+    The two verdicts are then re-stated as one region-level rule: after the PUT,
+    every app-owned key in ``written`` (contains ``:``; here ``plainuser`` is the
+    non-namespaced control that both axes must leave alone) exists iff it was on
+    the on-disk baseline -- existence tracks disk, not the submission, in both
+    directions. That whole-region form is the ratchet: a future non-client-owned
+    ``:``-region wired into the absent-axis merge but not the present-axis drop
+    would resurrect an unbacked name here and trip this test, which is exactly the
+    single-direction blind spot that let the #7089 present axis slip through
+    #6975's absent-only review of #6664.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={
+            "name": "kirocrew",
+            "mcpServers": {
+                "demo:notes": {"command": "notes-mcp"},  # backed app bridge on disk
+                "plainuser": {"url": "u"},  # the client's own, on disk
+            },
+        },
+        submitted={
+            "name": "kirocrew",
+            "mcpServers": {
+                # ABSENT axis: demo:notes is omitted here on purpose.
+                "demo:custom": {"command": "c"},  # PRESENT axis: no backing row
+                "plainuser": {"url": "u"},
+            },
+        },
+        apps={"demo": ("notes",)},  # demo:notes is backed; demo:custom is not
+    )
+
+    assert response.status == 200
+
+    written_servers = written["mcpServers"]
+
+    # PRESENT axis: an unbacked submitted namespaced name did not get created.
+    assert "demo:custom" not in written_servers, (
+        "the present axis let a stale snapshot CREATE an unbacked app-owned name "
+        "'demo:custom': existence in the app-namespace region must be decided by "
+        "on-disk state, not by the submission"
+    )
+    # ABSENT axis: a backed on-disk bridge omitted from the submission survived.
+    assert written_servers.get("demo:notes") == {"command": "notes-mcp"}, (
+        "the absent axis dropped a backed on-disk bridge 'demo:notes' the "
+        "submission merely omitted: an app bridge cannot be removed through this "
+        "endpoint"
+    )
+    # The non-namespaced control is untouched by either axis.
+    assert written_servers.get("plainuser") == {"url": "u"}
+
+    # The ratchet, stated once for the whole owned region rather than per name: for
+    # every app-owned key (contains ':', excluding host-owned names) its EXISTENCE
+    # after the PUT equals its existence on the on-disk baseline. A new owned region
+    # honouring only the absent axis breaks the ``created`` clause below.
+    from kiro_crew.dashboard.handlers.agents import emission_eligible_mcp_servers
+
+    host_owned = emission_eligible_mcp_servers()
+    on_disk_names = {"demo:notes", "plainuser"}
+    submitted_names = {"demo:custom", "plainuser"}
+    owned = lambda name: ":" in name and name not in host_owned  # noqa: E731
+
+    resurrected = {
+        name
+        for name in submitted_names
+        if owned(name) and name not in on_disk_names and name in written_servers
+    }
+    assert not resurrected, (
+        "an app-owned name absent from disk survived the PUT, so this region "
+        f"decides existence from the submission on the present axis: {resurrected}. "
+        "A new non-client-owned ':'-region must be wired into "
+        "_drop_unbacked_app_entries, not only _merge_unowned_servers -- the "
+        "absent half alone reads as complete but is not (#7089 vs #6975)."
+    )
+    dropped = {
+        name
+        for name in on_disk_names
+        if owned(name) and name not in submitted_names and name not in written_servers
+    }
+    assert not dropped, (
+        "an app-owned on-disk name the submission merely omitted was deleted, so "
+        f"this region decides existence from the submission on the absent axis: {dropped}"
+    )

--- a/test/test_agent_config_merge_on_write.py
+++ b/test/test_agent_config_merge_on_write.py
@@ -1493,22 +1493,29 @@ async def test_app_owned_region_existence_is_decided_on_disk_on_both_axes(tmp_pa
     single-direction blind spot that let the #7089 present axis slip through
     #6975's absent-only review of #6664.
     """
+    # Bind the two mcpServers maps to locals so the region-level assertion below
+    # derives its name-sets from the very dicts the PUT consumes -- the assertion
+    # ranges and the PUT input cannot drift apart, so a later author adding a name
+    # to either map is swept by the ratchet without editing the loop.
+    on_disk_servers = {
+        "demo:notes": {"command": "notes-mcp"},  # backed app bridge on disk
+        "plainuser": {"url": "u"},  # the client's own, on disk
+    }
+    submitted_servers = {
+        # ABSENT axis: demo:notes is omitted here on purpose.
+        "demo:custom": {"command": "c"},  # PRESENT axis: no backing row
+        "plainuser": {"url": "u"},
+    }
+
     response, written = await _put(
         tmp_path,
         on_disk={
             "name": "kirocrew",
-            "mcpServers": {
-                "demo:notes": {"command": "notes-mcp"},  # backed app bridge on disk
-                "plainuser": {"url": "u"},  # the client's own, on disk
-            },
+            "mcpServers": on_disk_servers,
         },
         submitted={
             "name": "kirocrew",
-            "mcpServers": {
-                # ABSENT axis: demo:notes is omitted here on purpose.
-                "demo:custom": {"command": "c"},  # PRESENT axis: no backing row
-                "plainuser": {"url": "u"},
-            },
+            "mcpServers": submitted_servers,
         },
         apps={"demo": ("notes",)},  # demo:notes is backed; demo:custom is not
     )
@@ -1536,11 +1543,18 @@ async def test_app_owned_region_existence_is_decided_on_disk_on_both_axes(tmp_pa
     # every app-owned key (contains ':', excluding host-owned names) its EXISTENCE
     # after the PUT equals its existence on the on-disk baseline. A new owned region
     # honouring only the absent axis breaks the ``created`` clause below.
+    #
+    # Scope: the sets below are derived from the fixture's own PUT inputs, so the
+    # loop sweeps whatever a later author adds to either map. It still only reaches
+    # the names this fixture actually submits or lands on disk, though -- it does
+    # not conjure an unrelated owned region out of nothing. To make the ratchet
+    # guard a genuinely new owned region, add that region's names to on_disk_servers
+    # / submitted_servers above and the clauses here will cover it automatically.
     from kiro_crew.dashboard.handlers.agents import emission_eligible_mcp_servers
 
     host_owned = emission_eligible_mcp_servers()
-    on_disk_names = {"demo:notes", "plainuser"}
-    submitted_names = {"demo:custom", "plainuser"}
+    on_disk_names = set(on_disk_servers)
+    submitted_names = set(submitted_servers)
     owned = lambda name: ":" in name and name not in host_owned  # noqa: E731
 
     resurrected = {


### PR DESCRIPTION
Addresses #7470 (agent-config PUT: a stale snapshot can revert a live app bridge to a superseded definition).

The issue has two clearly separable halves, with different readiness levels — the maintainer comment calls this out explicitly. This PR lands the half that needs no ruling and surfaces the half that does.

## What landed (ruling-free)

**Region-level two-axis existence ratchet.** The issue's "A gate, either way" section asks for a test asserting that every key of an app-owned `mcpServers` region (keys containing `:`, excluding host-owned names) has its existence decided by on-disk state on **both** the present-drop axis (#7089) and the absent-preserve axis (#6975), so adding a new owned region without a present-axis rule fails the suite instead of shipping. That test genuinely did not exist. It now does: `test_app_owned_region_existence_is_decided_on_disk_on_both_axes`.

- It exercises the real PUT commit path via the `_put` harness (no mocking of the drop / merge / ownership decision).
- The region-level assertions derive their name-sets from the fixture's actual PUT-input dicts, so a future added owned region is swept automatically rather than needing the loop edited.

## What is documented, not implemented (needs a maintainer ruling)

The **content axis** — where an `<app>:<server>` name is on disk **and** in the submission, the submitted row still wins, so a stale editor snapshot can revert a bridge the platform already corrected (e.g. a `backend.port: "auto"` app rewritten to its live port by `_resolve_live_mcp_url`) — reverses the editor-snapshot-wins contract kept deliberately in #5899 and re-affirmed for #6664. Per the issue and the maintainer comment, whether it may be reversed at all, and if so which candidate shape (on-disk row substitution vs. optimistic-concurrency/etag) closes it, needs a maintainer ruling. #7089 shipped only the deletion half for exactly this reason.

No behavioral source change was made. The handler docstring, the spec decision table, and `test_app_owned_entry_present_in_the_snapshot_is_updated` already correctly reflect the open ruling. A decision brief assembling everything the decider needs (both candidate shapes with costs, the "breaks EVERY kiro session" blast radius, the self-heal mitigation, and verified current file:line anchors) is added at `.agents/tasks/task-agent-config-content-axis-ratchet/CONTENT-AXIS-RULING.md`.

## Testing

- `pytest -q test/test_agent_config_merge_on_write.py` → 47 passed (baseline 46, +1 new).
- Related sweep across `test_agent_config_merge_on_write.py`, `test_api_agent_config_put_succeeds.py`, `test_agent_config_owner_gate_invariant.py` → 67 passed.
- Test-quality confirmed: temporarily neutering the present-axis `del submitted[name]` drop in `_drop_unbacked_app_entries` makes the new test FAIL on its present-axis assertion; restoring returns to green with `git diff src/` empty.
- `git diff src/` is empty — the committed diff is exactly two files (the new test and the decision brief).