### PR TITLE
ci: add non-cancellable Main Ratchet Audit for main (#7511)

### DIFF
--- a/.github/workflows/main-ratchet-audit.yml
+++ b/.github/workflows/main-ratchet-audit.yml
@@ -1,0 +1,404 @@
+name: Main Ratchet Audit
+
+# WHY THIS WORKFLOW EXISTS (issue #7511)
+#
+# main's normal CI run does not reliably render a verdict for the ratchet /
+# ceiling / baseline gates, for two independent reasons:
+#
+#   1. Supersession. ci.yml's concurrency group is keyed on the ref
+#      (`${{ github.workflow }}-${{ github.ref }}`) and, for push, its
+#      `cancel-in-progress` is false -- but GitHub still evicts the single
+#      PENDING run when a newer push queues. On a busy main (a ~1.4min median
+#      merge gap against a ~19min run) each run is superseded before its
+#      slower lanes report, so a commit's check runs end up mostly "cancelled",
+#      never "failure". A cancelled run is not a red X: main looks green-ish
+#      (many successes, zero failures) while drift accumulates unseen.
+#
+#   2. Surface gating. Since PR #7337 the backend and frontend lint lanes are
+#      surface-gated in ci.yml (backend-lint `if: only_frontend != 'true'`,
+#      frontend-lint `if: only_backend != 'true'`). On a single-surface push to
+#      main -- e.g. a backend-only merge -- the eslint ceiling is SKIPPED, not
+#      cancelled, so it is never measured against the integrated tree at all.
+#
+# The consequence is that drift on main surfaces later on an UNRELATED pull
+# request (a PR's CI runs against merge(branch, main), inheriting main's state),
+# and the cheapest way out for that author is to raise the ceiling -- exactly
+# what a ratchet exists to prevent.
+#
+# This workflow separates MEASUREMENT from JUDGMENT. It runs ONLY the cheap
+# ratchet / ceiling / baseline gates, UNCONDITIONALLY (both surfaces, no
+# only_backend/only_frontend guard) and NEVER cancelled, so every push to main
+# gets a ratchet verdict attributed to THAT push. It deliberately does NOT
+# change ci.yml's concurrency or full-run budget (full serialization / a merge
+# queue is a maintainer CI-budget ruling) and does NOT add another full run
+# (test-durations.yml already pays the weekly full-suite runner minutes on
+# main; only the verdict was missing). The added runner minutes here are only
+# the individually-cheap ratchet lanes.
+#
+# The gate commands below are the same commands ci.yml's backend-lint and
+# frontend-lint jobs run, so the audit and the PR gates cannot disagree about
+# what a gate IS. If ci.yml adds or renames a gate script, mirror it here. The
+# eslint ceiling is deliberately NOT transcribed: it is read out of ci.yml at
+# run time, so ci.yml stays the one numeric source
+# (test/test_eslint_warning_ceiling.py pins that) and a burn-down cannot leave a
+# stale copy here that grants slack the PR gate does not.
+#
+# The one thing this lane changes about the gates is their SCOPE, and it has to.
+# Four of the backend gates (black, subprocess-encoding, agent-SDK boundary,
+# sync-IO-in-async) scope their verdict to the files the change in front of them
+# touches, via scripts/ratchet_scope.py. On a push to main that diff is EMPTY --
+# the checkout leaves HEAD, `main` and `origin/main` all at the pushed commit --
+# so an unscoped-by-accident run would judge zero files and report green
+# whatever the tree holds. RATCHET_SCOPE_WHOLE_TREE makes the question explicit:
+# judge the integrated tree, which is the only question a push to main can
+# answer and the reason this lane exists.
+
+on:
+  push:
+    branches: [main]
+  # PRs are deliberately NOT a trigger: a pull request already runs these exact
+  # gates against its own diff in ci.yml. This lane's whole value is evaluating
+  # them on main's INTEGRATED tree, which only a push (or a manual dispatch)
+  # produces.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  # The report job opens / updates / closes a single tracking issue so drift is
+  # visible on main instead of surfacing later on an unrelated PR.
+  issues: write
+
+concurrency:
+  # Keyed on the SHA, NOT the ref. Each push gets its OWN group, so a later
+  # push can never supersede an earlier push's audit -- the per-SHA-on-push
+  # serialization issue #7511's option 1 describes, scoped to the cheap ratchet
+  # lanes only. cancel-in-progress is false so an in-flight audit always
+  # finishes and always renders its verdict.
+  group: main-ratchet-audit-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  ratchet-gates:
+    name: Backend ratchet & baseline gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Judge the integrated tree, not a diff. See the scope note in the header:
+      # a push to main has no diff to scope to, so the diff-scoped gates would
+      # otherwise pass by measuring nothing.
+      RATCHET_SCOPE_WHOLE_TREE: "1"
+    steps:
+      # fetch-depth: 0 for parity with ci.yml backend-lint's checkout: a gate
+      # that falls back to a diff (any run where the override above is not set)
+      # needs parent info a shallow clone truncates.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          # This repo has no uv.lock (pip/pyproject-managed), so point the cache
+          # key at the files that define the dependency set (matches ci.yml).
+          cache-dependency-glob: |
+            pyproject.toml
+            setup.cfg
+
+      - name: Install dependencies
+        # Same install as ci.yml backend-lint: --system targets the setup-python
+        # interpreter (no venv); --group pulls [dependency-groups].dev.
+        run: uv pip install --system -e ".[voice]" --group dev
+
+      # Each gate is a SEPARATE step so a failure names exactly which ratchet
+      # drifted. Same commands as ci.yml backend-lint, whole-tree scoped, and
+      # the set of gate scripts is pinned equal to backend-lint's by
+      # test/test_main_ratchet_audit.py -- a gate ADDED to ci.yml and not
+      # mirrored here would silently never be measured on main's integrated
+      # tree, which is the whole failure this lane exists to close. (A RENAME
+      # already fails loud, since the missing script errors the step.)
+      #
+      # `!cancelled()` on every gate, rather than the default `success()`: a job
+      # whose first drifting gate skipped the remaining five would report which
+      # ratchet drifted FIRST and leave the others unmeasured for as long as it
+      # stayed unfixed -- a partial verdict masquerading as a full one, exactly
+      # the class this lane exists to close. Every gate reports, and the job
+      # still fails if any of them did.
+      - name: Check formatting (black, baselined)
+        if: ${{ !cancelled() }}
+        run: python3 scripts/check_black_formatting.py
+
+      - name: Check subprocess text-mode encoding (gate, baselined)
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/check_subprocess_encoding.py --test
+          python3 scripts/check_subprocess_encoding.py
+
+      - name: Check agent-SDK import boundary (gate, baselined)
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/check_agent_sdk_boundary.py --test
+          python3 scripts/check_agent_sdk_boundary.py
+
+      - name: Check for blocking IO inside async def (gate, baselined)
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/check_sync_io_in_async.py --test
+          python3 scripts/check_sync_io_in_async.py
+
+      - name: Check lockdown-before-publish (secret writers)
+        if: ${{ !cancelled() }}
+        run: python3 scripts/check_lockdown_before_publish.py
+
+      # The census ratchet (TestGateSideLogRedactorSpelling / _BASELINE_LOG_SITE_CENSUS
+      # in test_security_posture.py) and the config-baseline ratchet
+      # (test_config_baseline.py against config-baseline.json) are the two
+      # pytest-side counters. They are the lanes whose whole value is being
+      # evaluated on the integrated tree.
+      - name: Census & config-baseline ratchet tests
+        if: ${{ !cancelled() }}
+        run: |
+          # Same as ci.yml's / test-durations.yml's pytest jobs (#7296): the
+          # `python` problem matcher actions/setup-python registers annotates any
+          # traceback in the log (including one printed inside a pytest warning)
+          # and never matches a pytest failure. conftest.py emits the real
+          # annotations instead.
+          echo "::remove-matcher owner=python::"
+          pytest -q --no-cov test/test_security_posture.py test/test_config_baseline.py
+
+  frontend-ceiling:
+    name: Frontend eslint ceiling
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci --no-audit --no-fund
+
+      # The ceiling is READ out of ci.yml rather than transcribed. ci.yml is the
+      # one numeric source (test/test_eslint_warning_ceiling.py pins that), and a
+      # second copy here would grant slack the PR gate does not the first time
+      # the ceiling is burned down -- a false green on main, which is the very
+      # failure this workflow exists to close. Same extraction the prepare-pr
+      # profile uses (prepare-pr/profiles/kirocrew.json), except that an
+      # unreadable ceiling fails CLOSED here: a gate that cannot find its own
+      # ceiling must not pass. The point of the job is that main's ceiling is
+      # measured unconditionally, including on a backend-only push where ci.yml
+      # skips frontend-lint entirely.
+      - name: Lint (eslint ceiling, read from ci.yml)
+        run: |
+          set -euo pipefail
+          MW="$(grep -oE 'npx eslint src/ --max-warnings [0-9]+' .github/workflows/ci.yml \
+            | grep -oE '[0-9]+$' | head -n 1 || true)"
+          if [ -z "$MW" ]; then
+            echo "::error::could not read the eslint ceiling out of .github/workflows/ci.yml;"\
+              "refusing to guess one" >&2
+            exit 1
+          fi
+          echo "eslint ceiling read from ci.yml: $MW"
+          cd website
+          npx eslint src/ --max-warnings "$MW"
+
+  report:
+    name: Render ratchet verdict
+    needs: [ratchet-gates, frontend-ceiling]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # always() so the verdict is rendered even when a gate job failed; the push
+    # guard keeps a manual workflow_dispatch from mutating the tracking issue.
+    if: ${{ always() && github.event_name == 'push' }}
+    steps:
+      - name: Open, update, or close the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          RATCHET_RESULT: ${{ needs.ratchet-gates.result }}
+          FRONTEND_RESULT: ${{ needs.frontend-ceiling.result }}
+        run: |
+          set -euo pipefail
+
+          RUN_URL="$SERVER_URL/$REPO/actions/runs/$RUN_ID"
+          # A hidden HTML marker in the body is how this job recognises an issue
+          # it wrote itself. The label alone is not proof of authorship -- anyone
+          # can add it to their own issue -- and the reconciliation below both
+          # comments on and CLOSES what it selects, so it must never select a
+          # human's issue.
+          MARKER="<!-- main-ratchet-audit-tracking-issue -->"
+          TITLE="Main ratchet drift detected"
+
+          # Which needed jobs did NOT succeed? (result is
+          # success | failure | cancelled | skipped). Anything other than an
+          # explicit `success` is treated as drift: a `cancelled` result (whole-
+          # workflow cancel, or the timeout-minutes cap firing) is an UNKNOWN
+          # verdict, not a green one, so it must not fall through to the all-
+          # green branch and close an open tracking issue -- that would turn an
+          # unknown into a false all-clear and erase a live drift record. Each
+          # non-success lane is one Markdown bullet, joined with real newlines
+          # via printf so the body is a proper list.
+          FAILED=""
+          if [ "$RATCHET_RESULT" != "success" ]; then
+            FAILED="$(printf '%s\n- `ratchet-gates` (backend black/subprocess/agent-sdk/sync-io/lockdown + census & config-baseline): **%s**' "$FAILED" "$RATCHET_RESULT")"
+          fi
+          if [ "$FRONTEND_RESULT" != "success" ]; then
+            FAILED="$(printf '%s\n- `frontend-ceiling` (eslint warning ceiling): **%s**' "$FAILED" "$FRONTEND_RESULT")"
+          fi
+
+          # The tracking issue is scoped by a dedicated label so the QUERY is
+          # deterministic. Do NOT search for it by the marker: GitHub's issue
+          # SEARCH index is eventually consistent, so two closely-spaced drift
+          # pushes could each miss the other's freshly-created issue.
+          # `gh issue list --label ... --state open` reads the issues API
+          # directly, and the marker then filters that answer locally. The label
+          # must exist first or both this list and the create below error for the
+          # wrong reason; ensure it idempotently. --force makes "already exists" a
+          # no-op so a benign re-create is not fatal.
+          gh label create ratchet-audit --repo "$REPO" --force \
+            --color BFD4F2 \
+            --description "Main Ratchet Audit: tracking issue for ratchet/ceiling/baseline drift on main" \
+            || echo "::notice::Could not ensure the ratchet-audit label (continuing); it may already exist or label writes may be refused."
+
+          # Every open issue this workflow owns, lowest number first. The
+          # concurrency group is per-SHA on purpose, so two drifting pushes CAN
+          # reach this step at once, both see no issue and both create one. A
+          # shared group for the reporters would trade that for a worse failure:
+          # GitHub keeps only ONE pending run per group, so a third push would
+          # evict a queued reporter and lose its verdict entirely. Converge
+          # instead -- the lowest-numbered open issue is canonical and the rest
+          # are closed as duplicates on the next run, so a race costs one
+          # redundant issue for one push rather than a permanently split record.
+          OPEN="$(gh issue list --repo "$REPO" --state open --label ratchet-audit \
+            --json number,body 2>/dev/null \
+            | jq -r --arg marker "$MARKER" \
+              '[.[] | select((.body // "") | contains($marker))] | sort_by(.number) | .[].number' \
+            || true)"
+          EXISTING="$(printf '%s\n' "$OPEN" | head -n 1)"
+          for duplicate in $(printf '%s\n' "$OPEN" | tail -n +2); do
+            gh issue comment "$duplicate" --repo "$REPO" \
+              --body "Duplicate of #$EXISTING, this workflow's single tracking issue. Closing; the drift record lives there." \
+              || true
+            gh issue close "$duplicate" --repo "$REPO" --reason "not planned" || true
+            echo "::notice::Closed duplicate tracking issue #$duplicate (canonical is #$EXISTING)."
+          done
+
+          # Is this run's commit still main's head? The concurrency group is
+          # per-SHA, so audits for DIFFERENT commits run concurrently and can
+          # finish out of order. A superseded run's verdict about its own commit
+          # stays sound -- that is what the per-SHA group buys, and the exit
+          # codes below are deliberately left alone -- but it must not mutate
+          # the SHARED tracking issue in either direction: a slow GREEN run
+          # would close the live drift record a newer push just opened, and a
+          # slow DRIFTING run would open or refresh one against a tree that has
+          # since been fixed. Both make the durable artifact describe a commit
+          # that is no longer main.
+          #
+          # The convergence above is exempt on purpose: closing a redundant
+          # copy while keeping the lowest-numbered one is ordering-independent
+          # and can never remove the last record, so a superseded run may still
+          # self-heal a split record.
+          #
+          # An unreadable head is neither confirmed-superseded nor
+          # confirmed-current, and the two branches below resolve that unknown
+          # in OPPOSITE directions, each failing toward keeping drift visible: a
+          # drifting run still records (worst case a spurious issue, which the
+          # next green push closes), while a green run still declines to close
+          # (worst case the issue stays open one push longer). A single symmetric
+          # default cannot do both.
+          HEAD_SHA="$(gh api "repos/$REPO/commits/main" --jq '.sha' 2>/dev/null || true)"
+          SUPERSEDED=""
+          CONFIRMED_CURRENT=""
+          if [ -n "$HEAD_SHA" ]; then
+            if [ "$HEAD_SHA" = "$COMMIT_SHA" ]; then
+              CONFIRMED_CURRENT="1"
+            else
+              SUPERSEDED="1"
+            fi
+          fi
+
+          if [ -n "$FAILED" ]; then
+            if [ -n "$SUPERSEDED" ]; then
+              echo "::notice::Main ratchet drift at $COMMIT_SHA, but main has moved to $HEAD_SHA; the audit for the current head owns the tracking issue. Failed lanes:$FAILED  Run: $RUN_URL"
+              exit 1
+            fi
+            BODY="$(printf '%s\n\nMain ratchet/ceiling drift was detected on the integrated tree at `%s`.\n\nFailed lanes:%s\n\nRun: %s\n\nWhy this matters: these gates guard against drift that would otherwise surface on an UNRELATED pull request (a PR runs against merge(branch, main) and inherits main'\''s state). Fix the drift on main rather than raising the ceiling in someone else'\''s PR. See CONTRIBUTING.md for the ratchet/ceiling/baseline path.\n\nThis issue is maintained automatically by the Main Ratchet Audit workflow; it will be closed on the next all-green push.' \
+              "$MARKER" "$COMMIT_SHA" "$FAILED" "$RUN_URL")"
+
+            if [ -n "$EXISTING" ]; then
+              COMMENT="$(printf 'Still drifting at `%s`.%s\n\nRun: %s' "$COMMIT_SHA" "$FAILED" "$RUN_URL")"
+              gh issue comment "$EXISTING" --repo "$REPO" --body "$COMMENT"
+              echo "::notice::Updated tracking issue #$EXISTING with fresh drift at $COMMIT_SHA."
+              exit 1
+            fi
+
+            # No open issue yet -- create one. `gh issue create` is refused
+            # outright when a repository disables Actions issue writes for the
+            # GITHUB_TOKEN; treat ONLY that specific refusal as a soft failure,
+            # reported as a ::notice:: carrying the drift, so the reporter does
+            # not go red for a reason no maintainer can act on. Any OTHER failure
+            # is real and must fail loud on its own exit code. Same remedy shape
+            # as test-durations.yml's "Open PR if durations changed".
+            rc=0
+            out="$(gh issue create --repo "$REPO" \
+              --title "$TITLE" \
+              --label ratchet-audit \
+              --body "$BODY" 2>&1)" || rc=$?
+            printf '%s\n' "$out"
+            if [ "$rc" -ne 0 ]; then
+              # The label patterns below cover the guard's OWN failure mode: if
+              # `gh label create` above was genuinely refused (not the benign
+              # "already exists" case), the `|| echo` swallowed it and control
+              # reached here, so `gh issue create --label ratchet-audit` fails
+              # for a missing/unaddable label rather than for issues being
+              # disabled. That is the same class of write refusal, so treat it
+              # the same: emit ::notice:: and exit 1 so drift stays visible on
+              # the commit instead of the job reding on the raw rc.
+              case "$out" in
+                *"not permitted"*|*"Resource not accessible by integration"*|*"issues are disabled"*|*"Issues has been disabled"*|*"could not add label"*|*"label"*"not found"*|*"not found"*"label"*)
+                  echo "::notice::Main ratchet drift detected at $COMMIT_SHA but this workflow may not open issues (or provision the ratchet-audit label) in this repository. Failed lanes:$FAILED  Run: $RUN_URL"
+                  # Still fail the run so the drift verdict is visible on the
+                  # commit even when the durable issue cannot be created.
+                  exit 1
+                  ;;
+                *)
+                  exit "$rc"
+                  ;;
+              esac
+            fi
+            # An issue was created; the gates still drifted, so fail the run.
+            exit 1
+          fi
+
+          # All needed gate jobs are green. Self-heal: if a tracking issue is
+          # open, note the green SHA and close it -- but only while this commit
+          # is still main's head, or a slow green audit closes the drift a newer
+          # push recorded.
+          if [ -z "$CONFIRMED_CURRENT" ]; then
+            echo "::notice::Main ratchet gates green at $COMMIT_SHA, but it is not confirmed to be main's head (head read as '$HEAD_SHA'); leaving the tracking issue alone, since any open drift may belong to a newer commit."
+            exit 0
+          fi
+
+          if [ -n "$EXISTING" ]; then
+            COMMENT="$(printf 'Main is green at `%s` -- all ratchet/ceiling/baseline gates pass. Closing.\n\nRun: %s' "$COMMIT_SHA" "$RUN_URL")"
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$COMMENT"
+            gh issue close "$EXISTING" --repo "$REPO" \
+              --reason completed
+            echo "::notice::Closed tracking issue #$EXISTING; main ratchet gates green at $COMMIT_SHA."
+          else
+            echo "Main ratchet/ceiling/baseline gates all green at $COMMIT_SHA; no tracking issue open."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -521,6 +521,69 @@ depends on *where your branch lives*:
 If your only red checks are the AI reviews on a fork PR, there is nothing for
 you to fix — flag it to a maintainer.
 
+### Ratchet and baseline gates (why a check can fail for something you did not touch)
+
+Some of our checks are not "does this pass or fail" tests but *ratchets*: a gate
+that records the current count of a thing we are burning down and then fails if
+that count grows, so the number is only ever allowed to shrink. The idea is that
+we never make a known problem worse, and every PR either holds the line or pays
+some of it down. A few examples (`.github/workflows/ci.yml` stays canonical for
+the full list, so this is illustration, not an inventory):
+
+- the black formatting **baseline** (`.github/black-baseline.txt`) and the
+  config-baseline snapshot (`config-baseline.json`, checked by
+  `test/test_config_baseline.py`);
+- the gate-side log-site census in `test/test_security_posture.py`, which pins
+  the exact count of sites it expects and fails if the real count drifts;
+- the frontend eslint **ceiling** in the frontend-lint job. This one has already
+  been burned down to a hard zero, which is what a ratchet is aiming at: with
+  nothing recorded there is nothing to drift, and any warning a change
+  introduces fails. `ci.yml` holds the value, and it is the only place that may
+  — see [ci-and-reviews.md](docs/ci/ci-and-reviews.md).
+
+The confusing part is that one of these can go red on a PR whose own diff is
+completely innocent. That happens because your PR's CI does not run against your
+branch in isolation. It runs against `merge(branch, main)`, so it inherits
+main's current state along with your changes. If a ratchet-affecting change
+landed on main (say a cleanup that removed a warning or a log site but left the
+recorded count behind) and main's own CI was superseded or surface-skipped
+before that ratchet lane reported, then your PR is simply the first place the
+verdict actually renders. The gate is red because of drift on main, not because
+of anything in your diff.
+
+The Main Ratchet Audit workflow (`.github/workflows/main-ratchet-audit.yml`)
+runs these gates directly on every push to main, non-cancellable and on both
+surfaces, and opens a tracking issue (labeled `ratchet-audit`, titled "Main
+ratchet drift detected") when it finds drift. It judges the **whole tree**,
+where your PR's copy of the same gate judges only the files your diff touches —
+so the audit can name a file no pull request would ever have flagged, which is
+how the drift got in. That closes most of the gap, but a window still exists
+between a drifting merge and the audit run, so you may still be the first to see
+it.
+
+When a ratchet gate fails, do **not** reach for the fix that looks cheapest:
+raising the ceiling (bumping `--max-warnings`) or widening a baseline so the
+count matches again. That turns someone else's red green by loosening the very
+gate that exists to stop the count from growing, and it hides the real
+regression inside your unrelated change. Instead:
+
+1. Confirm the failure is unrelated to your diff. The gate names the drifted
+   count or file (a warning total, a census site, a baseline entry), so check
+   whether your change could plausibly have moved it.
+2. If it is inherited drift, do not absorb the fix into your PR. Check the Main
+   Ratchet Audit tracking issue (or open a new issue) to see whether the drift
+   is already known, and note it on your PR so a reviewer understands the red is
+   pre-existing.
+3. If you want to fix it, land the one-line ratchet correction as its own small,
+   separate PR that credits the real cause (the merge that introduced the
+   drift). Keep it out of the unrelated change so the history stays honest about
+   what moved the number.
+
+(For maintainers running babysit: its `known_reds`
+(`src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md`) only tells one
+operator's local watch loop to treat a known red as expected. It never makes a
+required check pass, so it is not a substitute for any of the above.)
+
 ## Commit Messages
 
 [Conventional Commits](https://www.conventionalcommits.org/):

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -55,6 +55,37 @@ Out-of-band lanes that never gate a PR:
   builds two real app bundles and performs an actual update swap, because the
   Electron unit suite stops at the `autoUpdater` handoff and never proves a real
   bundle is replaced on disk and relaunches.
+- **The ratchet verdict `main` otherwise never gets:** `main-ratchet-audit.yml`
+  re-runs only the cheap ratchet, ceiling and baseline gates on every push to
+  `main`. Two things make a push to `main` unable to answer for them in `ci.yml`:
+  GitHub keeps one *pending* run per concurrency group, so on a busy `main` each
+  run is evicted before its slower lanes report and a commit's checks end up
+  `cancelled` rather than `failure` — which is not a red X, so `main` looks green
+  while drift accumulates; and the lint lanes are surface-gated, so a
+  backend-only merge *skips* the eslint ceiling outright. This lane's group is
+  keyed on the SHA so no push can supersede an earlier push's audit, it runs both
+  surfaces unconditionally, and it reconciles one `ratchet-audit`-labeled tracking
+  issue — opened on drift, commented on each further drifting push, closed on the
+  next all-green one. Because per-SHA groups let audits for different commits
+  finish out of order, only a run whose commit is still `main`'s head writes to
+  that shared issue: a slow green audit would otherwise close the live drift
+  record a newer push just opened. An unreadable head resolves toward keeping
+  drift visible in both directions — still recorded on drift, still not closed on
+  green. Every gate step runs on `!cancelled()` rather than the default
+  `success()`, so one drifting ratchet does not skip the rest and reduce the
+  verdict to whichever gate is listed first; and the set of gate scripts is
+  pinned equal to `ci.yml`'s `backend-lint`, because a gate *added* there and not
+  mirrored here would never be measured on `main` at all. Two further details are
+  load-bearing. It sets
+  `RATCHET_SCOPE_WHOLE_TREE`, because the four diff-scoped gates
+  (`scripts/ratchet_scope.py`) would otherwise resolve an EMPTY diff on a push to
+  the branch they measure against and pass by judging nothing; and it *reads* the
+  eslint ceiling out of `ci.yml` rather than transcribing it, because a second
+  copy would keep granting the old budget after a burn-down and report green on a
+  tree the PR gate reds. It deliberately does not touch `ci.yml`'s concurrency or
+  add a second full run: full serialization or a merge queue is a runner-budget
+  call, and `test-durations.yml` already pays for a full suite on `main`.
+  Contributor-facing half: [CONTRIBUTING.md](../../CONTRIBUTING.md).
 - **Maintenance:** `ship-report.yml` (a scheduled Slack summary),
   `cleanup-temp-screenshots.yml` (prunes the ephemeral `temp-screenshots/` dir,
   see [its README](../../temp-screenshots/README.md); safe because PR bodies

--- a/scripts/ratchet_scope.py
+++ b/scripts/ratchet_scope.py
@@ -32,11 +32,21 @@ worse than no added-line set at all.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+#: Set to a non-empty value to make :func:`changed_paths` answer "whole tree".
+#:
+#: A diff scope is the right question on a pull request and the WRONG one on a
+#: push to a branch that is already the base: there ``origin/main...HEAD`` is
+#: empty, so every consuming ratchet judges zero files and reports green
+#: whatever the tree holds. A caller that means to measure an integrated tree
+#: says so here rather than relying on a diff that happens to be empty.
+WHOLE_TREE_ENV = "RATCHET_SCOPE_WHOLE_TREE"
 
 _HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
@@ -127,7 +137,15 @@ def changed_paths() -> tuple[set[str] | None, str]:
     None means undeterminable, and the caller must then judge the whole tree
     rather than nothing: a scope that fails open disables the gate exactly when
     its inputs are unusual.
+
+    ``WHOLE_TREE_ENV`` short-circuits to that same None, for a caller whose
+    question really is about a whole tree. It is checked FIRST so the answer
+    cannot depend on which checkout shape a run happens to have -- an empty
+    diff is indistinguishable from a clean change, and that ambiguity is what
+    the override exists to remove.
     """
+    if os.environ.get(WHOLE_TREE_ENV, "").strip():
+        return None, f"whole tree ({WHOLE_TREE_ENV} set)"
     code, out = _git("rev-list", "--parents", "-n", "1", "HEAD")
     is_merge = code == 0 and len(out.split()) >= 3
     attempts: list[tuple[str, list[str]]] = []

--- a/test/test_eslint_warning_ceiling.py
+++ b/test/test_eslint_warning_ceiling.py
@@ -15,6 +15,11 @@ that, and neither shows up as a failing check of its own:
   exists; a stale ceiling in a doc is also what makes the next burn-down look
   already done. That is pinned too, but only while the ceiling can drift --
   see `test_the_ceiling_is_not_transcribed_into_prose`.
+* **A second gate.** The number copied into ANOTHER workflow is not prose that
+  goes stale, it is a ceiling of its own that keeps enforcing the old value: on
+  the first burn-down it reports green on a tree the real gate reds. Pinned
+  unconditionally, because unlike a doc there is no value at which a second copy
+  is harmless -- see `test_no_other_workflow_transcribes_the_ceiling`.
 """
 
 from __future__ import annotations
@@ -71,6 +76,38 @@ def test_the_ceiling_is_zero() -> None:
         "inside unseen. Fix the warning, or suppress the one line it names with "
         "`// eslint-disable-next-line <rule> -- <why the code is correct>`, which is "
         "reviewable in the diff where a lifted ceiling is not"
+    )
+
+
+def test_no_other_workflow_transcribes_the_ceiling() -> None:
+    """One workflow declares the ceiling; the rest read it out of that one.
+
+    A copy in a second workflow is a second *enforced* ceiling, so it cannot be
+    excused the way a doc's stale number can: on the first burn-down the copy
+    still admits the old budget, and the job carrying it reports green on a tree
+    `ci.yml` reds. That is a false all-clear on `main`, which is exactly what a
+    lane auditing `main`'s ratchets exists to prevent. Read the value instead --
+    `main-ratchet-audit.yml` greps it out of `ci.yml` at run time, the same way
+    the prepare-pr profile does.
+
+    Checked at every value, including zero: the early return in
+    `test_the_ceiling_is_not_transcribed_into_prose` turns on a doc quoting the
+    gate's real invocation being accurate prose, and a second gate is never that.
+    """
+    offenders: list[str] = []
+    for path in sorted((_REPO_ROOT / ".github" / "workflows").glob("*.yml")):
+        if path == _CI:
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if _CEILING.search(line):
+                offenders.append(f"{path.relative_to(_REPO_ROOT)}:{lineno}")
+
+    assert offenders == [], (
+        "these workflow lines declare an eslint ceiling of their own instead of "
+        f"reading ci.yml's: {offenders}. A second copy keeps enforcing the old "
+        "value after a burn-down, so the job holding it goes green on a tree the "
+        "real gate fails. Extract the value at run time instead: "
+        "grep -oE 'npx eslint src/ --max-warnings [0-9]+' .github/workflows/ci.yml"
     )
 
 

--- a/test/test_main_ratchet_audit.py
+++ b/test/test_main_ratchet_audit.py
@@ -1,0 +1,455 @@
+"""The Main Ratchet Audit must measure every gate, and describe only main.
+
+The audit's concurrency group is keyed on the SHA, so audits for DIFFERENT
+commits run concurrently and finish in whatever order their runners take. The
+per-commit verdict is exactly what that buys, and it stays sound. The single
+tracking issue is not per-commit though -- it is shared mutable state -- so a
+run that finishes after a newer push must not write its verdict there:
+
+* A slow **green** run would close the drift record a newer push just opened,
+  turning a live ratchet failure on main into no record at all. That is the same
+  false all-clear the whole workflow exists to close, arriving through the
+  reporter instead of through an empty diff scope.
+* A slow **drifting** run would open or refresh a record against a tree that has
+  since been fixed, so main reads as dirty when it is clean.
+
+Two further ways the lane could report a verdict that means less than it looks
+are pinned at the bottom of this module: a gate ADDED to ``ci.yml`` and not
+mirrored here would never be measured on the integrated tree, and a gate step
+left on the default ``success()`` condition would skip every later gate as soon
+as one drifted.
+
+These are behavioural properties of a shell step, not of its prose, so they are
+pinned by running the step itself against a stubbed ``gh``. The alternative --
+grepping the workflow for a comparison -- passes on a step that compares the two
+SHAs and then closes the issue anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "main-ratchet-audit.yml"
+
+_CURRENT = "a" * 40
+_NEWER = "b" * 40
+
+# `gh issue list --json number,body` shape: one open issue this workflow owns,
+# recognised by the same hidden marker the step filters on.
+_MARKER = "<!-- main-ratchet-audit-tracking-issue -->"
+_OPEN_ONE = json.dumps([{"number": 4242, "body": f"{_MARKER}\ndrift"}])
+
+_STUB_GH = """#!/usr/bin/env bash
+# Records every invocation on ONE line -- an issue body is multi-line, and a
+# raw dump would split one call across several log entries -- then answers the
+# reads the step performs.
+printf '%s\\n' "${*//$'\\n'/<NL>}" >> "$GH_LOG"
+case "$1" in
+  api)
+    if [ "$STUB_HEAD_SHA" = "UNREADABLE" ]; then
+      echo "stub: head unreadable" >&2
+      exit 1
+    fi
+    printf '%s\\n' "$STUB_HEAD_SHA"
+    ;;
+  label) ;;
+  issue)
+    case "$2" in
+      list) printf '%s' "$STUB_OPEN_JSON" ;;
+      create) printf 'https://github.example/o/r/issues/4243\\n' ;;
+    esac
+    ;;
+esac
+exit 0
+"""
+
+# A stand-in for `C:\Windows\System32\bash.exe` with no WSL distribution
+# installed: an ASCII sentinel on stdout so the harness's own diagnostic can be
+# checked, and the launcher's real UTF-16LE complaint on stderr.
+_SHELL_THAT_RUNS_NOTHING = (
+    "import sys\n"
+    "sys.stdout.write('shell-refused-to-run')\n"
+    "sys.stderr.buffer.write("
+    "'Windows Subsystem for Linux has no installed distributions.'.encode('utf-16-le'))\n"
+    "sys.exit(1)\n"
+)
+
+
+def _posix_shell() -> str | None:
+    """An ABSOLUTE path to a shell that can run the reporter step, or None.
+
+    Absolute, never the bare name: on Windows ``CreateProcess`` searches
+    ``C:\\Windows\\System32`` BEFORE PATH, so a bare ``bash`` resolves to the WSL
+    launcher living there even when the PATH entry a probe approved is Git Bash.
+    That launcher answers a UTF-16LE "Windows Subsystem for Linux has no
+    installed distributions" on stderr and exits 1, so the stub's call log stays
+    empty -- and an empty log is exactly what some assertions below look for, so
+    one wrong binary scores part of this module green and reds the rest with a
+    message about itself.
+
+    None on Windows outright, which is why resolving is not enough on its own.
+    The step under test is a ``runs-on: ubuntu-latest`` shell block, and running
+    it needs the extensionless ``#!``-shebang ``gh`` stub reachable on PATH --
+    an execute bit ``os.chmod`` cannot grant there. Every sibling module that
+    executes a workflow's shell against a stubbed ``gh`` carries the same
+    precondition.
+    """
+    if os.name == "nt":
+        return None
+    return shutil.which("bash")
+
+
+_BASH = _posix_shell()
+
+# Applied per class rather than module-wide: the workflow-parity classes at the
+# bottom only read YAML, so they stay measured on every platform.
+_needs_posix_shell = pytest.mark.skipif(
+    _BASH is None or shutil.which("jq") is None,
+    reason="the reporter step is shell and needs a POSIX bash + jq, as its runner has",
+)
+
+
+def _report_script() -> str:
+    """The reporter step's own shell, read out of the workflow."""
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["report"]["steps"]
+    runs = [step["run"] for step in steps if "run" in step]
+    assert len(runs) == 1, f"expected one run block in the report job, got {len(runs)}"
+    return runs[0]
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    head_sha: str,
+    ratchet: str,
+    frontend: str = "success",
+    open_json: str = _OPEN_ONE,
+    shell: list[str] | None = None,
+) -> tuple[int, str, list[str]]:
+    """Execute the reporter step with a stubbed ``gh``; return rc, output, calls.
+
+    ``shell`` replaces the interpreter argv, so a test can hand the harness a
+    shell that runs nothing and assert it says so.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "gh"
+    stub.write_text(_STUB_GH, encoding="utf-8")
+    stub.chmod(0o755)
+    log = tmp_path / "gh.log"
+    log.write_text("", encoding="utf-8")
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "GH_LOG": str(log),
+            "STUB_HEAD_SHA": head_sha,
+            "STUB_OPEN_JSON": open_json,
+            "GH_TOKEN": "stub",
+            "REPO": "o/r",
+            "SERVER_URL": "https://github.example",
+            "RUN_ID": "1",
+            "COMMIT_SHA": _CURRENT,
+            "RATCHET_RESULT": ratchet,
+            "FRONTEND_RESULT": frontend,
+        }
+    )
+    if shell is None:
+        assert _BASH is not None, "the POSIX-shell precondition mark did not fire"
+        shell = [_BASH, "-s"]
+
+    proc = subprocess.run(
+        shell,
+        input=_report_script(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        # A shell that is not the one asked for answers in its own encoding --
+        # the WSL launcher uses UTF-16LE -- so decode defensively: a raised
+        # UnicodeDecodeError here would destroy the diagnosis below rather than
+        # report it.
+        errors="replace",
+        cwd=tmp_path,
+        env=env,
+    )
+    calls = [line for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    output = proc.stdout + proc.stderr
+    # The step's first action is always `gh label create`, so an EMPTY call log
+    # means the shell never ran the step -- not a reporter that chose to do
+    # nothing. Some assertions below are SATISFIED by an empty log, so this is
+    # what keeps an unusable shell from being scored as a verdict.
+    assert calls, f"the shell ran no part of the reporter step (rc={proc.returncode}): {output!r}"
+    return proc.returncode, output, calls
+
+
+def _closed_issues(calls: list[str]) -> list[str]:
+    return [c for c in calls if c.startswith("issue close")]
+
+
+def _commented_issues(calls: list[str]) -> list[str]:
+    return [c for c in calls if c.startswith("issue comment")]
+
+
+class TestABrokenShellIsNotAQuietReporter:
+    """An empty call log means the shell never ran, and is never a verdict.
+
+    Some assertions in this module are satisfied by an empty log, so a shell that
+    cannot run the step at all reads as "the reporter correctly did nothing" for
+    those while it reds the rest with a complaint about itself -- a split verdict
+    on the shell rather than on the step. A resolution that yields the wrong
+    binary (a bare ``bash`` on Windows lands on the WSL launcher) is therefore
+    only half the guard: the harness must also refuse the observation rather
+    than score it.
+    """
+
+    def test_a_shell_that_runs_nothing_fails_the_harness(self, tmp_path: Path) -> None:
+        # Not gated on the host: the shell is supplied here rather than
+        # resolved, so the guard is measured on every platform, including the
+        # one whose shim it describes.
+        with pytest.raises(AssertionError, match="ran no part of the reporter step") as excinfo:
+            _run(
+                tmp_path,
+                head_sha=_CURRENT,
+                ratchet="success",
+                shell=[sys.executable, "-c", _SHELL_THAT_RUNS_NOTHING],
+            )
+
+        # The shell's own output must reach the message, or the next reader gets
+        # "no calls" with nothing to say which binary answered.
+        assert "shell-refused-to-run" in str(excinfo.value)
+
+
+@_needs_posix_shell
+class TestSupersededReporter:
+    """A reporter whose commit is no longer main's head leaves the issue alone."""
+
+    def test_a_green_run_at_main_head_closes_the_tracking_issue(self, tmp_path: Path) -> None:
+        # The baseline the guard must not break: the self-heal still fires when
+        # this commit really is the tree the green verdict describes.
+        rc, out, calls = _run(tmp_path, head_sha=_CURRENT, ratchet="success")
+
+        assert rc == 0, out
+        assert _closed_issues(calls) == ["issue close 4242 --repo o/r --reason completed"], out
+
+    def test_a_superseded_green_run_does_not_close_newer_drift(self, tmp_path: Path) -> None:
+        # The finding itself: a slow green audit for an older commit must not
+        # erase the drift record a newer push opened. Losing it means a live
+        # ratchet failure on main has no durable artifact at all.
+        rc, out, calls = _run(tmp_path, head_sha=_NEWER, ratchet="success")
+
+        assert rc == 0, out
+        assert _closed_issues(calls) == [], out
+        assert _commented_issues(calls) == [], out
+
+    def test_a_superseded_drifting_run_does_not_touch_the_issue(self, tmp_path: Path) -> None:
+        # The other direction of the same class: a stale drift verdict must not
+        # refresh a record against a tree that has since been fixed. The run
+        # still fails, so the verdict stays visible on its own commit.
+        rc, out, calls = _run(tmp_path, head_sha=_NEWER, ratchet="failure")
+
+        assert rc == 1, out
+        assert _closed_issues(calls) == [], out
+        assert _commented_issues(calls) == [], out
+        assert [c for c in calls if c.startswith("issue create")] == [], out
+
+    def test_a_drifting_run_at_main_head_still_refreshes_the_issue(self, tmp_path: Path) -> None:
+        # The baseline for the drift branch: the guard must not have disarmed
+        # the lane's actual job of recording drift on the current head.
+        rc, out, calls = _run(tmp_path, head_sha=_CURRENT, ratchet="failure")
+
+        assert rc == 1, out
+        assert len(_commented_issues(calls)) == 1, out
+        assert "Still drifting" in _commented_issues(calls)[0], out
+
+
+@_needs_posix_shell
+class TestUnreadableHead:
+    """An unknown head resolves toward keeping drift VISIBLE, in both branches."""
+
+    def test_an_unreadable_head_still_records_drift(self, tmp_path: Path) -> None:
+        # Failing the other way would let one transient API error swallow a
+        # drift record entirely -- a likelier loss than the race being guarded.
+        rc, out, calls = _run(tmp_path, head_sha="UNREADABLE", ratchet="failure")
+
+        assert rc == 1, out
+        assert len(_commented_issues(calls)) == 1, out
+
+    def test_an_unreadable_head_declines_to_close_on_green(self, tmp_path: Path) -> None:
+        # The opposite default, for the opposite risk: an unconfirmed head must
+        # not authorise closing a record, because that loss is not recoverable
+        # by the next run, whereas a record left open closes on the next green
+        # push. The two branches disagree deliberately.
+        rc, out, calls = _run(tmp_path, head_sha="UNREADABLE", ratchet="success")
+
+        assert rc == 0, out
+        assert _closed_issues(calls) == [], out
+
+
+@_needs_posix_shell
+class TestConvergenceStaysExempt:
+    """Duplicate reconciliation is ordering-independent, so it is not guarded."""
+
+    def test_a_superseded_run_still_collapses_a_split_record(self, tmp_path: Path) -> None:
+        # Closing a redundant copy while keeping the lowest-numbered one can
+        # never remove the last record, so a superseded run may still self-heal
+        # the split that the per-SHA concurrency group makes possible.
+        two_open = json.dumps(
+            [
+                {"number": 4242, "body": f"{_MARKER}\ndrift"},
+                {"number": 4250, "body": f"{_MARKER}\ndrift"},
+            ]
+        )
+        rc, out, calls = _run(tmp_path, head_sha=_NEWER, ratchet="success", open_json=two_open)
+
+        assert rc == 0, out
+        closed = _closed_issues(calls)
+        assert closed == ["issue close 4250 --repo o/r --reason not planned"], out
+
+
+@_needs_posix_shell
+class TestIssueBodyRendering:
+    """The durable artifact is the most-read output, so its Markdown must render."""
+
+    def test_the_created_body_carries_no_literal_backslashes(self, tmp_path: Path) -> None:
+        # The body is built by a single-quoted printf, where a backslash-escaped
+        # backtick is NOT unescaped by bash and reaches the issue verbatim.
+        rc, out, calls = _run(tmp_path, head_sha=_CURRENT, ratchet="failure", open_json="[]")
+
+        assert rc == 1, out
+        created = [c for c in calls if c.startswith("issue create")]
+        assert len(created) == 1, out
+        assert "\\`" not in created[0], created[0]
+        assert f"tree at `{_CURRENT}`" in created[0], created[0]
+
+
+class TestGateParityWithCi:
+    """A ``scripts/check_*.py`` gate in ci.yml is measured here or accounted for.
+
+    Scoped to script-invoking gates on purpose. The lane's two pytest-side
+    ratchets (the redactor census and the config baseline) are an ORIGINAL
+    selection, not a transcription: ci.yml runs them only as part of the sharded
+    full suite and enumerates no "ratchet test" set anywhere, so there is no
+    counterpart to diff against. Pinning them by a source heuristic instead was
+    measured and rejected -- scanning `test/` for a module-level baseline
+    constant matches five modules for the two that are ratchets, so the pin would
+    need a hand-maintained exclusion list: the same bookkeeping with an extra
+    mechanism and more confidence than it earns. A third pytest-side ratchet
+    should bring an explicit registry with it.
+    """
+
+    # A gate script cannot merely be absent from this lane; it must be absent for
+    # a RECORDED reason. Scoping the pin to ci.yml's `backend-lint` would have
+    # missed the repo's dominant shape -- one gate per standalone job -- so the
+    # whole of ci.yml is read and every gate lands in exactly one of the three
+    # sets below. That is what makes a gate added tomorrow a red test rather than
+    # a silent omission.
+
+    # No whole-tree question exists to ask on main: each of these judges a CHANGE
+    # against a base ref (`*_BASE_REF`, the lines a PR adds), diffs the base
+    # branch's own file, or consumes a coverage artifact this lane never produces.
+    _PR_ONLY_BY_CONSTRUCTION: frozenset[str] = frozenset(
+        {
+            "check_brand_name.py",
+            "check_focus_cue.py",
+            "check_harness_parity.py",
+            "check_changelog_history.py",
+            "check_per_file_coverage.py",
+        }
+    )
+
+    # Cheap whole-tree content assertions that DO share the evicted-verdict cause
+    # this lane exists to fix, and are outside its declared ratchet / ceiling /
+    # baseline scope rather than outside the problem. Named here so the boundary
+    # is a reviewed decision instead of an invisible gap; moving one into
+    # `ratchet-gates` is a step plus a deletion from this set.
+    _DEFERRED_WHOLE_TREE_GATES: frozenset[str] = frozenset(
+        {
+            "check_feature_map.py",
+            "check_builtin_skill_scope.py",
+            "check_loop_bound_locks.py",
+            "check_testpaths_coverage.py",
+        }
+    )
+
+    @staticmethod
+    def _gate_scripts(job: dict) -> set[str]:
+        found = set()
+        for step in job.get("steps") or []:
+            found.update(re.findall(r"scripts/(check_[A-Za-z0-9_]+\.py)", step.get("run") or ""))
+        return found
+
+    def test_every_ci_gate_is_mirrored_or_recorded(self) -> None:
+        # The silent direction: a renamed script errors its step loudly, but a
+        # gate ADDED to ci.yml and not mirrored here just never runs on main --
+        # and its drift then surfaces on an unrelated PR, which is #7511's
+        # failure mode reproduced for every future gate.
+        ci = yaml.safe_load((_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text("utf-8"))
+        audit = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+        in_ci: set[str] = set()
+        for job in ci["jobs"].values():
+            in_ci |= self._gate_scripts(job)
+        measured = self._gate_scripts(audit["jobs"]["ratchet-gates"])
+        classified = measured | self._PR_ONLY_BY_CONSTRUCTION | self._DEFERRED_WHOLE_TREE_GATES
+
+        assert in_ci <= classified, (
+            "ci.yml runs gate script(s) this lane neither measures nor accounts for: "
+            f"{sorted(in_ci - classified)}. Mirror the step into ratchet-gates, or record "
+            "the reason in _PR_ONLY_BY_CONSTRUCTION (it judges a diff, not a tree) or "
+            "_DEFERRED_WHOLE_TREE_GATES. An unclassified gate is never measured on main's "
+            "integrated tree and its drift surfaces on an unrelated PR."
+        )
+
+    def test_the_audit_mirrors_the_whole_backend_lint_ratchet_set(self) -> None:
+        # The set this lane claims outright, kept separate from the accounting
+        # above: an omission recorded in either set must never quietly cover a
+        # backend-lint ratchet, which is the set the workflow says it mirrors.
+        ci = yaml.safe_load((_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text("utf-8"))
+        audit = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+        expected = self._gate_scripts(ci["jobs"]["backend-lint"])
+        actual = self._gate_scripts(audit["jobs"]["ratchet-gates"])
+
+        assert expected <= actual, (
+            "ci.yml backend-lint runs ratchet gate(s) the Main Ratchet Audit does not: "
+            f"{sorted(expected - actual)}. This is the set the audit mirrors outright, so "
+            "it must be measured, not excused."
+        )
+
+
+class TestEveryGateReports:
+    """One drifting gate must not skip the gates after it."""
+
+    def test_gate_steps_do_not_stop_at_the_first_failure(self) -> None:
+        # A step defaults to `if: success()`, so the first drifting gate would
+        # skip the rest and the run would name only the gate that happens to be
+        # listed first -- a partial verdict that looks like a full one, for as
+        # long as that one drift stayed unfixed. The PR that adds this lane
+        # already expects black to be the first drift on main, so the default
+        # would leave the other gates unmeasured indefinitely.
+        audit = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+        steps = audit["jobs"]["ratchet-gates"]["steps"]
+
+        gate_steps = [s for s in steps if "scripts/check_" in (s.get("run") or "")]
+        gate_steps += [s for s in steps if "pytest" in (s.get("run") or "")]
+        assert gate_steps, "found no gate steps to check"
+
+        for step in gate_steps:
+            condition = str(step.get("if", "")).replace(" ", "")
+            assert "!cancelled()" in condition, (
+                f"gate step {step.get('name')!r} runs on the default success() "
+                "condition, so an earlier drifting gate skips it and its own drift "
+                "goes unmeasured"
+            )

--- a/test/test_ratchet_scope.py
+++ b/test/test_ratchet_scope.py
@@ -192,6 +192,98 @@ class TestMergeShapes:
         assert paths == {"feature.py"}
 
 
+class TestWholeTreeOverride:
+    """A push to the base branch has no diff, and that is not a clean tree.
+
+    The Main Ratchet Audit lane runs on a push to ``main``, where the checkout
+    leaves HEAD, ``main`` and ``origin/main`` all at the pushed commit. The
+    three-dot fallback then succeeds with an EMPTY path set -- exit 0, no
+    attempt fails, nothing marks the answer as unusable -- and every consuming
+    ratchet filters its violations against that empty set and reports green
+    whatever the tree holds. The override is how a caller states that the
+    question really is about a whole tree, instead of inheriting an answer that
+    depends on which checkout shape a run happened to get.
+    """
+
+    def test_a_push_to_the_base_branch_resolves_to_an_empty_diff(self, repo: Path) -> None:
+        # The hazard itself, pinned: HEAD *is* origin/main, so the scope is
+        # empty rather than undeterminable, and a gate cannot tell the
+        # difference between this and a change that touched nothing.
+        _set_origin_main(repo)
+
+        paths, label = scope.changed_paths()
+
+        assert label == "origin/main...HEAD"
+        assert paths == set()
+
+    def test_the_override_answers_whole_tree(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_origin_main(repo)
+        monkeypatch.setenv(scope.WHOLE_TREE_ENV, "1")
+
+        paths, label = scope.changed_paths()
+
+        assert paths is None
+        assert scope.WHOLE_TREE_ENV in label
+
+    def test_the_override_wins_over_a_resolvable_diff(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # `feature` has a real diff against main, so without the override this
+        # shape scopes to one file. The answer must not depend on that: a caller
+        # asking for the whole tree gets it in every checkout shape.
+        _git(repo, "checkout", "feature")
+        _set_origin_main(repo)
+        monkeypatch.setenv(scope.WHOLE_TREE_ENV, "1")
+
+        paths, _ = scope.changed_paths()
+
+        assert paths is None
+
+    def test_a_blank_value_is_not_an_opt_in(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Actions writes an empty string for an unset expression, so a blank
+        # value must read as absent rather than silently widening every gate.
+        _set_origin_main(repo)
+        monkeypatch.setenv(scope.WHOLE_TREE_ENV, "  ")
+
+        paths, label = scope.changed_paths()
+
+        assert paths == set()
+        assert label == "origin/main...HEAD"
+
+    def test_the_whole_tree_label_is_not_read_as_a_diff_range(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # `added_lines` dispatches on the label, so an unrecognised one must
+        # degrade to None (the added-line rule is skipped) rather than being
+        # handed to `git diff` as a revision. The label comes from the resolver
+        # itself: a hardcoded copy would keep passing after the production
+        # label grew a `...`-shaped suffix that IS read as a revision.
+        _set_origin_main(repo)
+        monkeypatch.setenv(scope.WHOLE_TREE_ENV, "1")
+        _, label = scope.changed_paths()
+
+        assert scope.added_lines(label) is None
+
+    def test_the_audit_lane_opts_in(self) -> None:
+        # The wiring, not the mechanism: without this env the Main Ratchet Audit
+        # runs four gates over zero files and reports a green verdict on main
+        # that means nothing -- which is the exact false all-clear the lane
+        # exists to prevent.
+        workflow = ROOT / ".github" / "workflows" / "main-ratchet-audit.yml"
+        body = workflow.read_text(encoding="utf-8")
+
+        assert f"{scope.WHOLE_TREE_ENV}:" in body, (
+            f"{workflow.name} no longer sets {scope.WHOLE_TREE_ENV}, so its black / "
+            "subprocess-encoding / agent-SDK / sync-IO gates scope to the push's "
+            "own diff -- which on main is empty, making all four pass by measuring "
+            "nothing"
+        )
+
+
 class TestExplicitBase:
     """The env-base family's entry points: an EXPLICIT ref in, shared parsing out.
 


### PR DESCRIPTION
Closes #7511.

## Problem

`main`'s CI does not reliably render a verdict for the ratchet / ceiling / baseline gates, for two independent reasons:

1. **Supersession.** `ci.yml`'s concurrency group is keyed on the ref and `cancel-in-progress` is false for push, but GitHub still evicts the single *pending* run when a newer push queues. On a busy main (~1.4min median merge gap against a ~19min run) each run is superseded before its slower lanes report, so a commit's check runs end up mostly `cancelled`, never `failure`. A cancelled run is not a red X: main looks green-ish (many successes, zero failures) while drift accumulates unseen.
2. **Surface gating.** Since #7337 the lint lanes are surface-gated (`backend-lint` on `only_frontend != 'true'`, `frontend-lint` on `only_backend != 'true'`). On a single-surface push to main (e.g. a backend-only merge) the eslint ceiling is *skipped*, so it is never measured against the integrated tree at all.

The consequence is that drift surfaces later on an **unrelated** pull request (a PR runs against `merge(branch, main)` and inherits main's state), and the cheapest way out for that author is to raise the ceiling, exactly what a ratchet exists to prevent.

## Approach: separate measurement from judgment

A hybrid of the issue's **option 3** (corrected to run the gates *unconditionally*, closing the surface-gate hole) plus the documentation half of **option 4**.

### `.github/workflows/main-ratchet-audit.yml` (new)
- Triggers on push to `main` and `workflow_dispatch` (not on PRs, since a PR already runs these gates against its own diff; this lane's value is evaluating them on main's *integrated* tree).
- `concurrency` keyed on `github.sha` (not the ref) with `cancel-in-progress: false`, so a later push can never supersede an earlier push's audit: per-SHA serialization scoped only to the cheap ratchet lanes.
- Two gate jobs run **unconditionally** (both surfaces, no `only_backend`/`only_frontend` guard): the backend baselined gates (black baseline, subprocess-encoding, agent-SDK boundary, sync-IO-in-async, lockdown-before-publish) plus the census and config-baseline pytest ratchets; and the frontend eslint ceiling.
- A `report` job reconciles a single `ratchet-audit`-labeled tracking issue, so drift is visible on main and attributed to the push that caused it.

### `scripts/ratchet_scope.py`
- New `RATCHET_SCOPE_WHOLE_TREE` opt-in. **Without it this whole workflow measures nothing.** Four of the five backend gates scope their verdict to the files the change in front of them touches, and on a push to `main` that diff is *empty* — the checkout leaves `HEAD`, `main` and `origin/main` all at the pushed commit, so the three-dot fallback succeeds with an empty path set, exit 0, nothing marking the answer as unusable. Every consuming ratchet then filters its violations against that empty set and reports green whatever the tree holds. The audit lane sets the override so it judges the integrated tree, which is the only question a push to `main` can answer.

### `CONTRIBUTING.md` and `docs/ci/ci-and-reviews.md`
- The contributor-facing half: what a ratchet gate is, why one can go red for something outside your diff, and the low-friction path — land the correction as its own small PR rather than raising the ceiling inside an unrelated change. `ci-and-reviews.md` carries the mechanism next to the rest of the CI map.

## Expect the first run on `main` to be red, with an actionable list

Whole-tree scope is not cosmetic: it immediately finds **11 files that are unformatted and not in `.github/black-baseline.txt`**, which no pull request's diff-scoped gate can see. That is precisely the drift class #7511 is about, and the audit reporting it is the feature working. Per the path this PR documents, those 11 files are *not* reformatted here — that correction belongs in its own small PR rather than buried in a `ci:` change.

## The eslint ceiling is read, not transcribed

The first revision transcribed `--max-warnings 597` into the new workflow. `main` then burned the ceiling to zero (#7569), which is exactly the drift a second copy causes: the audit lane would have granted 597 warnings of slack against a tree `ci.yml` pins at zero — #7511's own failure mode, reproduced inside the lane added to prevent it. The value is now grepped out of `ci.yml` at run time (the same extraction the prepare-pr profile uses, except that an unreadable ceiling fails *closed*), so `ci.yml` stays the one numeric source. `test_eslint_warning_ceiling.py` gains `test_no_other_workflow_transcribes_the_ceiling`, which is checked at every value including zero — the early return that spared prose cannot cover a second *gate*.

## What this deliberately does NOT do (open maintainer decision)

Two of the issue's options are CI-budget rulings and were **not** taken here, so a maintainer can still layer them on top:

- **Option 1 (full serialization):** dropping `cancel-in-progress` for main entirely, or adding a per-SHA push group / merge queue on `ci.yml` itself. Full serialization raises the runner bill in proportion to merge rate, a budget/branch-protection call.
- **Option 2 (another full run):** `test-durations.yml` already runs the full backend pytest on main, but with `|| true` swallowing the verdict, and it cannot see the eslint ceiling. Adding another full run would re-pay those minutes for no new coverage.

## Testing
- **The reporter-step harness resolves its shell instead of naming it.** `test_main_ratchet_audit.py` pins the `report` step by executing it, and it spawned `bash` by bare name. On the Windows runner that lands on `C:\Windows\System32\bash.exe` — the WSL *launcher*, which `CreateProcess` searches before any PATH entry, so a probe approving Git Bash on PATH does not prevent it. It answers a UTF-16LE "Windows Subsystem for Linux has no installed distributions" on stderr and exits 1, leaving the stubbed `gh`'s call log empty: seven tests failed on a message about the shell, and an eighth (`test_a_superseded_drifting_run_does_not_touch_the_issue`, whose expectation *is* an empty call list) passed vacuously. Three changes, each verified locally against a stub that emits the launcher's UTF-16LE reply and exits 1 — reproducing the runner's exact 7-failed / 4-passed split before the fix:
  - The shell is resolved once to an **absolute path**, so PATH or `CreateProcess` search order can never substitute a different program for the one the precondition approved.
  - The shell precondition moves onto the four shell-executing classes and returns `None` on Windows, matching the nine sibling modules that execute a workflow `run:` block against a stubbed `gh` (the step is `runs-on: ubuntu-latest`, and the extensionless `#!` stub needs an execute bit `os.chmod` cannot grant there). The two workflow-parity classes read only YAML, so they stay measured on Windows.
  - `_run` asserts the call log is **non-empty**: the step's first action is always `gh label create`, so an empty log means the shell never ran the step rather than that the reporter chose to do nothing. This is what turns an unusable shell into one loud failure instead of a split verdict, and `TestABrokenShellIsNotAQuietReporter` pins it on every platform by supplying such a shell directly. Capture also decodes with `errors="replace"` so a non-UTF-8 reply is reported rather than raised over.
- `test/test_ratchet_scope.py::TestWholeTreeOverride` pins the hazard itself (a push to the base branch resolves to an *empty* diff, not a clean tree), the override's answer, that it wins over a resolvable diff, that a blank value is not an opt-in, that the label is never handed to `git diff` as a revision, and that the audit lane opts in.
- `test/test_eslint_warning_ceiling.py::test_no_other_workflow_transcribes_the_ceiling` closes the second-copy class for every workflow, not just this one.
- `test/test_workflow_checkout_credentials.py` (the repo-wide ratchet that caught the missing `persist-credentials: false` on the frontend job) is green.
- The four non-black backend gates (subprocess-encoding, agent-SDK-boundary, sync-IO-in-async, lockdown-before-publish) verified green in whole-tree mode as well as diff-scoped; black reports the 11 pre-existing offenders described above, which is the drift this lane exists to surface. The ceiling extraction verified to read `0` from `ci.yml` and to fail closed on an unreadable one; every `run:` block passes `bash -n`; the workflow parses as YAML.
- Full gate sweep green: isort, flake8, `mypy --platform linux`, the `scripts/check_*.py` family, `docs-lint.sh`, and the CI-structure / workflow-shape test families (`test_ci_surface_tests`, `test_ci_failure_annotations`, `test_local_gate`, `test_prepare_pr_profiles`, `test_ai_review_workflows`, `test_workflow_*`, `test_security_posture`, `test_config_baseline`).


