### PR TITLE
style(aws-control): icon-only view toggle, borderless file table

### DIFF
--- a/website/src/apps/aws-control/DrivePage.tsx
+++ b/website/src/apps/aws-control/DrivePage.tsx
@@ -179,6 +179,7 @@ function ViewModeToggle({ section, mode, onChange }: {
       onChange={onChange}
       layoutId={`aws-drive-view-${section}`}
       collapse={false}
+      iconOnly
     />
   )
 }
@@ -1581,7 +1582,11 @@ export function DriveSectionView({ account, bucket }: { account: string; bucket:
       )}
 
       {mode === 'list' && (folders.length > 0 || files.length > 0) && (
-        <div ref={attachScroller} className="overflow-x-auto rounded-md border border-border bg-card" data-testid="drive-listing">
+        /* Borderless, the stock shadcn table posture: row dividers only, no
+           frame and no card fill — the heavy outer border read as chrome on a
+           page that is mostly this one table. The div stays: it is the
+           horizontal scroll container the pinned Actions seam measures. */
+        <div ref={attachScroller} className="overflow-x-auto" data-testid="drive-listing">
           <table className="w-full border-collapse text-[13px]">
             {/* Shared head, drive columns. No column is sortable and `sort` is
                 null on purpose: the listing is paged server-side and S3 returns

--- a/website/src/components/SegmentedControl.tsx
+++ b/website/src/components/SegmentedControl.tsx
@@ -43,11 +43,18 @@ interface SegmentedControlProps<T extends string = string> {
    * has already made.
    */
   compact?: boolean
+  /**
+   * Hide EVERY segment's label, the selected one included — the control is a
+   * row of icon buttons. Each label moves to the segment's `aria-label` and
+   * `title`, so the name survives for readers and hover. For a pair whose
+   * icons are self-evident (grid/list) where even the selected label is noise.
+   */
+  iconOnly?: boolean
 }
 
 type Mode = 'full' | 'compact' | 'dropdown'
 
-export default function SegmentedControl<T extends string = string>({ segments, value, onChange, layoutId = 'segment', collapse = true, compact = false }: SegmentedControlProps<T>) {
+export default function SegmentedControl<T extends string = string>({ segments, value, onChange, layoutId = 'segment', collapse = true, compact = false, iconOnly = false }: SegmentedControlProps<T>) {
   const containerRef = useRef<HTMLDivElement>(null)
   // The label below animates its WIDTH while clipping overflow, so until it
   // settles the text is genuinely cut off. Anything measuring layout in that
@@ -146,10 +153,11 @@ export default function SegmentedControl<T extends string = string>({ segments, 
           const isActive = s.key === value
           const isDisabled = s.disabled === true
           // Compact hides an unselected segment's label, leaving an icon-only
-          // button. Name it explicitly rather than leaning on `title` as the
-          // accessible-name fallback: the tooltip never appears on touch, which
-          // is the form factor compact exists for.
-          const labelShown = mode === 'full' || isActive
+          // button; `iconOnly` hides every label. Name it explicitly rather
+          // than leaning on `title` as the accessible-name fallback: the
+          // tooltip never appears on touch, which is the form factor compact
+          // exists for.
+          const labelShown = !iconOnly && (mode === 'full' || isActive)
           return (
             <motion.button
               key={s.key}


### PR DESCRIPTION
## Summary

Two PM-directed polish items on the drive surfaces (follow-up to #7801):

- **Icon-only view toggle**: the Files/Library grid–list switch drops its text labels — a pair whose icons are self-evident, where even the selected label was noise. `SegmentedControl` gains an `iconOnly` prop (labels move to `aria-label` + `title`, so the accessible name and hover hint survive).
- **Borderless file table**: the file listing sheds its outer `rounded-md border bg-card` frame for the stock shadcn table posture — row dividers only. The heavy border read as chrome on a page that is mostly this one table. The horizontal scroll container stays (the pinned Actions seam measures it).

## Demo (GIF)

![toggle-demo](https://raw.githubusercontent.com/kirodotdev/KiroCrew/897f4efa607a0913d6d3f085cf1800bdc96c4db1/temp-evidence/toggle-demo.gif)

The icon-only grid/list pair switching both ways, over the borderless table.

recorded from ba70d56b2b7774301b85cc263fefc537c06450aa · fix/drive-view-menu · built dist + API fixtures (no gateway), real clicks · dark

## Screenshot (dark, fixtures)

![files](https://raw.githubusercontent.com/kirodotdev/KiroCrew/7834d9db4a7cdcbde6bb85ac408ab9cc02a1a14a/temp-evidence/files-iconony-borderless.png)

Evidence is pinned to a superseded PR-head SHA GitHub retains — no evidence rides the branch.

## Tested

- `vitest` aws-control: **156/156** (existing grid-mode tests click by `title`, which iconOnly preserves)
- `npx tsc -b` clean; capture harness full tour passing (0 mismatches) against the built dist

