### PR TITLE
fix(sandbox): seal the crew-home ceilings that do not exist yet

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -250,6 +250,340 @@ _CREW_HIDDEN_DIRS: list[str] = _crew_home_entries(_CREW_HIDDEN_LEAVES)
 #: Exposed read-only in every mode.
 _CREW_READONLY_TARGETS: list[str] = _crew_home_entries(_CREW_READONLY_LEAVES)
 
+#: The subset of ``_CREW_READONLY_LEAVES`` the launcher may CREATE in order to seal.
+#:
+#: ``mount(2)`` cannot target a path that does not exist, so the READONLY seal below
+#: skips an absent ceiling and leaves the data home writable at that name — which is
+#: the whole hole on a default install, where none of these has been written yet.
+#: Materialising the path first closes it, and that is only sound for a leaf that
+#: clears BOTH of the following.
+#:
+#: 1. An EMPTY document must mean what an ABSENT file means to the reader:
+#:
+#:    * ``profiles`` — an empty dir yields no profile, same as no dir;
+#:    * ``computer_use.json`` — ``computer_use.enable_state.load_state`` reads ``{}``
+#:      as DISABLED, which is what an absent keystone means;
+#:    * ``oauth_endpoints.json`` — ``security._validate_operator_oauth_entries``
+#:      extends trust by nothing for ``{}``;
+#:    * ``aws_service_consent.json`` — ``aws_consent._read_all`` returns ``{}`` for
+#:      both absent and empty, so every service stays unconfirmed.
+#:
+#: 2. A STALE read of that empty document must fail toward refusal. The seal is a
+#:    bind mount, which pins the INODE for the sandbox's lifetime, while every
+#:    dashboard writer publishes through ``atomic_write`` (temp + rename), i.e. a NEW
+#:    inode. So a sandboxed reader keeps seeing the empty document even after the
+#:    operator writes the real one. For the three files above that freezes them at
+#:    "disabled" / "no consent" / "no extra endpoints" — narrower than the truth. The
+#:    empty ``profiles`` dir is exempt from the concern entirely: a directory bind
+#:    shows live contents, so a profile added later is visible.
+#:
+#: DELIBERATELY EXCLUDED, and each for a different one of those two reasons:
+#:
+#:   * ``denied_commands.json`` — clears (1) but fails (2), which is the direction
+#:     that matters: in-sandbox ``mcp_cron`` reads it to decide whether a command is
+#:     denied, so a pinned ``{}`` would report "nothing is denied" for the rest of the
+#:     sandbox's life even after the operator denies a command. Sealing it would trade
+#:     an agent-authored deny list for a stale one, so it keeps the pre-existing gap;
+#:   * ``security_policy.json`` — fails (1). ``governance.load_security_policy`` reads
+#:     the file whenever it exists and fails CLOSED on a parse or version mismatch, so
+#:     a ``{}`` stub raises ``PlatformCompositionError`` out of a function that runs at
+#:     boot AND per app callback;
+#:   * ``app_admission.json`` — fails (1). Absent means ``open_default()`` (admit),
+#:     while present-but-unreadable means deny-all; a stub would refuse every app;
+#:   * ``admission_policy.json`` — already seeded at first run by
+#:     ``platform.admission.seed_default_policy``, so it is not absent to begin with.
+#:
+#: The same ``mount(2)`` limit leaves the ``SENSITIVE_DIRS`` / ``SENSITIVE_FILES``
+#: mask loops skipping their own absent targets. That is a real sibling gap, not one
+#: this list closes: a mask needs the opposite treatment (an empty bind OVER the
+#: name), and ``_CREW_HIDDEN_LEAVES`` has no reader to prove an empty document is
+#: absent-equivalent, so each leaf needs its own argument.
+_CREW_PRECREATE_READONLY_DIR_LEAVES: tuple[str, ...] = ("profiles",)
+_CREW_PRECREATE_READONLY_FILE_LEAVES: tuple[str, ...] = (
+    "computer_use.json",
+    "oauth_endpoints.json",
+    "aws_service_consent.json",
+)
+
+#: What a materialised ceiling holds — the empty JSON object every reader above
+#: already treats as its absent default. NOT a zero-byte file, which is not valid
+#: JSON and would read as CORRUPT rather than as absent.
+_EMPTY_CEILING_DOCUMENT: bytes = b"{}\n"
+
+
+def _sealable_absent_ceilings() -> tuple[list[str], list[str]]:
+    """Resolved (dir, file) ceiling paths that may be created so the seal can apply.
+
+    Resolved through ``config_dir()`` — the LIVE data home — rather than expanded over
+    both ``_CREW_HOME_PREFIXES`` the way the deny lists are. A deny rule covers both
+    spellings because either tree may still hold bytes; creation has the opposite
+    requirement, since a stub in the deprecated ``~/.kirocrew`` of a migrated host is a
+    file nothing will ever read. Whichever spelling ``config_dir()`` resolves to is
+    already in the launcher's ``READONLY_DIRS``: both ``$HOME``-relative prefixes are
+    listed there, and ``_relocated_crew_targets`` adds a data home that escapes
+    ``$HOME``.
+
+    Never raises: an unresolvable data home yields nothing and the seal behaves exactly
+    as it did before this function existed.
+    """
+    try:
+        root = str(config_dir())
+    except Exception:  # pragma: no cover - defensive; a spawn must not fail on this
+        logger.debug("could not resolve the crew data home for ceiling sealing", exc_info=True)
+        return ([], [])
+    return (
+        [os.path.join(root, leaf) for leaf in _CREW_PRECREATE_READONLY_DIR_LEAVES],
+        [os.path.join(root, leaf) for leaf in _CREW_PRECREATE_READONLY_FILE_LEAVES],
+    )
+
+
+class SandboxCeilingUnsealable(RuntimeError):
+    """A governance ceiling could not be made sealable, so the sandbox refuses to launch.
+
+    The seal exists because an unsealed ceiling is a self-elevation hole: a sandboxed
+    process that can write ``computer_use.json`` turns on desktop control for itself.
+    Launching anyway would run the agent with that hole open while every log line said
+    the ceiling was protected, so this is the ``_mount_or_die`` case rather than the
+    best-effort one — a control was requested and could not be established.
+
+    Raised out of ``namespace_argv``, so it surfaces to whichever ``wrap_argv`` caller
+    asked for the spawn. Those callers report a failed operation; none of them falls back
+    to running the command unconfined, which is what makes refusing safe here.
+
+    The two states that reach it are both actionable by an operator, and the message
+    names the path for that reason: a DANGLING SYMLINK squatting a ceiling path (either
+    tampering, or a link whose destination went away), and a data home where creation
+    itself fails (a read-only mount, or a filesystem with no hardlink support).
+    """
+
+
+def _warn_unsealed_ceiling(target: str, exc: "OSError | None") -> None:
+    """Say WHY the spawn is being refused: this ceiling could not be made sealable.
+
+    Called immediately before :class:`SandboxCeilingUnsealable` is raised, so the spawn
+    does NOT proceed — the log line carries the path and the errno that the exception
+    message alone would not, and an operator reading it is the only one who can fix the
+    data home. ``warning`` rather than ``debug`` for that reason: a refused spawn with no
+    explanation is indistinguishable from an unrelated failure.
+
+    Per spawn rather than once per process, matching the launcher's own ``EXPOSE_FILES``
+    pre-read warning — a host where this keeps happening has a real problem, and
+    de-duplicating it would hide how often the control cannot be established.
+    """
+    logger.warning(
+        "sandbox: REFUSING to launch — could not create the governance ceiling %s (%s). "
+        "mount(2) cannot seal a path that does not exist, so proceeding would leave it "
+        "writable inside the sandbox",
+        target,
+        exc if exc is not None else "publish failed",
+    )
+
+
+def _warn_if_alias_backed(target: str) -> None:
+    """Warn when an ALREADY-PRESENT ceiling is reachable under a second name.
+
+    ``MS_RDONLY`` binds a MOUNT, not an inode, so the seal only covers the path it was
+    established on. Two shapes therefore survive it, and both are invisible to the seal
+    loop because the path resolves and reads as present:
+
+    * the ceiling is a **symlink**. The launcher seals the inode it resolves to, but the
+      link NAME lives in the writable data home, so a sandboxed process can unlink it and
+      put a real file of its own there instead;
+    * the ceiling is a **regular file with another hardlink**. The alias is a different
+      path, so it is outside the read-only mount, and a write through it changes the very
+      inode the ceiling exposes.
+
+    Reported, not refused, and deliberately so. Refusing would break the ordinary reasons
+    a config file has a second name — a dotfile manager such as chezmoi or GNU stow, or a
+    snapshot tool holding a hardlink — by turning them into a hard spawn failure, which is
+    a much wider blast radius than the exposure. Neither shape is introduced here either:
+    the ceilings this module publishes end at ``st_nlink == 1`` and are never symlinks, so
+    this is a PRE-EXISTING property of every entry in ``READONLY_DIRS``, reachable only on
+    a host where something else already created the ceiling that way. Closing it needs the
+    data-home root sealed, which is a different change.
+
+    The warning exists because the alternative is worse than the hole: without it the log
+    says the ceiling is sealed while it is writable under another name.
+    """
+    try:
+        info = os.lstat(target)
+    except OSError:
+        return
+    if stat.S_ISLNK(info.st_mode):
+        logger.warning(
+            "sandbox: the governance ceiling %s is a SYMLINK. The seal covers the file it "
+            "resolves to, but the link itself sits in a writable directory, so a sandboxed "
+            "process can replace the name. Make it a regular file to close that.",
+            target,
+        )
+    elif stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+        logger.warning(
+            "sandbox: the governance ceiling %s has %d hardlinks. The seal covers this "
+            "path only, so a write through another name reaches the same inode. Remove the "
+            "extra link to close that.",
+            target,
+            info.st_nlink,
+        )
+
+
+def _refuse_if_dangling_symlink(target: str) -> None:
+    """Refuse the spawn when *target* is a symlink that resolves to nothing.
+
+    A RESOLVING symlink is left alone deliberately: it reads as present, so the launcher
+    seals the inode it resolves to. The residual exposure there — the link NAME stays
+    replaceable in a writable parent — is pre-existing for every ceiling, not specific to
+    one this function materialises, and closing it needs the data-home root sealed.
+    """
+    if not os.path.islink(target) or os.path.exists(target):
+        return
+    pointed_at = "(unreadable)"
+    with contextlib.suppress(OSError):
+        pointed_at = os.readlink(target)
+    raise SandboxCeilingUnsealable(
+        f"the governance ceiling {target} is a DANGLING symlink -> {pointed_at}. "
+        "mount(2) cannot seal it and it would leave the path writable inside the "
+        "sandbox. Remove or repoint it, or lower sandbox_level to run without the seal "
+        "deliberately."
+    )
+
+
+def _publish_empty_ceiling(target: str, parent: str) -> bool:
+    """Write the empty document to a sibling temp file, then link it into place.
+
+    Two steps rather than ``open(target, O_CREAT | O_EXCL)`` followed by a write,
+    because the one-step form publishes the NAME before the BYTES: a crash, a full
+    disk, or a signal in between leaves a zero-length file at the ceiling path, and
+    zero length is not valid JSON — the reader would see corrupt where this function
+    means absent. Here the target only ever appears once its content is complete.
+
+    ``os.link`` is the publish because it is the no-clobber one: unlike ``os.replace``
+    it fails with ``EEXIST`` instead of overwriting, so a racing spawn — or an operator
+    writing the real document in the same instant — keeps its file. That is also why
+    the ``os.path.exists`` pre-check upstream is an optimisation and not the guard.
+
+    ``mkstemp`` creates the temp file 0o600 before the first byte, so no separate
+    lockdown call is needed (and none may be added: a lockdown applied after content
+    reaches a published path is the defect ``scripts/check_lockdown_before_publish.py``
+    refuses). The mode needs no reassertion either — a umask can only clear bits, never
+    add them.
+
+    Returns ``False`` on any failure, having published nothing. The caller decides what
+    a failure means; this function's only contract is that the ceiling path is either
+    absent or holds the complete document.
+    """
+    fd = -1
+    tmp = ""
+    try:
+        fd, tmp = tempfile.mkstemp(dir=parent, prefix=".kirocrew-ceiling-", suffix=".tmp")
+        # ``os.write`` is not obliged to consume the whole buffer, and a short write is
+        # not an error — it returns a count. Taking that count for success would link a
+        # TRUNCATED document, which reads as corrupt rather than as absent and is the
+        # exact outcome the temp-then-link shape exists to prevent. Loop, and treat zero
+        # progress as an error so a filesystem that accepts nothing cannot spin here.
+        view = memoryview(_EMPTY_CEILING_DOCUMENT)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                raise OSError(errno.EIO, "short write to a ceiling temp file", tmp)
+            view = view[written:]
+        os.close(fd)
+        fd = -1
+        os.link(tmp, target)
+        return True
+    except OSError:
+        return False
+    finally:
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        if tmp:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+
+
+def _materialize_sealable_ceilings() -> list[str]:
+    """Create every absent sealable ceiling; return the paths actually created.
+
+    Runs on the Linux spawn path only, immediately before the launcher builds its
+    ``READONLY_DIRS`` mount sequence, so a ceiling that did not exist a moment ago is
+    a read-only mountpoint by the time the sandboxed command runs.
+
+    **Fail-closed.** If a ceiling cannot be made sealable this raises
+    :class:`SandboxCeilingUnsealable` and the spawn does not happen. That is a
+    deliberate reversal of an earlier best-effort version, which warned and continued:
+    continuing means the launcher's ``os.path.exists`` guard skips the path, so the
+    sandboxed process runs with a writable governance keystone and nothing downstream
+    notices. An unsealed ceiling is the one thing this function exists to prevent, so it
+    refuses for the same reason ``_mount_or_die`` refuses a failed hiding mount.
+
+    Two states trigger it:
+
+    * a **dangling symlink** squatting a ceiling path. ``os.path.exists`` follows
+      symlinks, so it reads as absent to this function AND to the launcher's guard,
+      while ``os.link`` refuses the name as ``EEXIST`` — the sandboxed process's write
+      then follows the link and the host reads the result back through the ceiling path.
+      It is not removed here: ``islink`` followed by ``unlink`` is not atomic, and the
+      dashboard publishes a real keystone over that same name with ``atomic_write``, so
+      a removal racing a validated operator write would delete the operator's new
+      settings. POSIX offers no unlink-only-if-still-a-symlink, so the safe answer is to
+      refuse and let a human resolve it;
+    * a **creation failure** other than ``EEXIST`` — a read-only mount, or a filesystem
+      with no hardlink support.
+
+    ``EEXIST`` is the one benign outcome, in both loops: the racing spawn that got there
+    first, or the operator's real document. Either way the path now exists, so the
+    launcher seals it and there is nothing to report.
+
+    Never TRUNCATES and never REMOVES: an existing ceiling is left byte-for-byte alone,
+    so this can only ever add the absent default.
+    """
+    created: list[str] = []
+    dir_targets, file_targets = _sealable_absent_ceilings()
+
+    for target in dir_targets:
+        _refuse_if_dangling_symlink(target)
+        if os.path.exists(target):
+            # Present, so the launcher will seal it -- but say so when the seal is
+            # reachable around rather than through this path.
+            _warn_if_alias_backed(target)
+            continue
+        if not os.path.isdir(os.path.dirname(target)):
+            continue
+        try:
+            # 0o700 needs no reassertion: a umask can only clear bits, never add them.
+            os.mkdir(target, 0o700)
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            _warn_unsealed_ceiling(target, exc)
+            raise SandboxCeilingUnsealable(
+                f"cannot create the governance ceiling {target}: {exc}"
+            ) from exc
+        created.append(target)
+
+    for target in file_targets:
+        parent = os.path.dirname(target)
+        _refuse_if_dangling_symlink(target)
+        if os.path.exists(target):
+            _warn_if_alias_backed(target)
+            continue
+        if not os.path.isdir(parent):
+            continue
+        if _publish_empty_ceiling(target, parent):
+            created.append(target)
+        elif not os.path.exists(target):
+            # Absent after a failed publish, so nothing won the race: the seal really
+            # did not apply. ``exists`` rather than a plumbed-through errno because the
+            # publish is two syscalls and only the OUTCOME decides whether this matters.
+            _warn_unsealed_ceiling(target, None)
+            raise SandboxCeilingUnsealable(
+                f"cannot publish the governance ceiling {target}; it would stay writable "
+                "inside the sandbox"
+            )
+
+    return created
+
+
 _STRICT_DIRS: list[str] = [
     ".kiro/crew-auth-staging",
     ".aws",
@@ -3227,6 +3561,17 @@ def namespace_argv(
     resolved_argv = list(argv)
     if resolved_argv:
         resolved_argv[0] = _resolve_agent_executable(resolved_argv[0])
+
+    # Give the seal something to mount ON, or refuse the spawn. ``READONLY_DIRS`` is
+    # guarded on
+    # ``os.path.exists`` in the launcher (a ceiling may be a plain file, so the guard
+    # cannot be ``isdir``), and an absent ceiling therefore gets no bind + remount pair
+    # at all — leaving the data home writable at that name for the whole sandbox.
+    # Materialising the sealable subset first is what makes the seal non-vacuous on a
+    # default install. Runs before the script is built so the paths exist by the time
+    # the child mounts, and raises ``SandboxCeilingUnsealable`` rather than launching
+    # with a keystone the seal could not cover.
+    _materialize_sealable_ceilings()
 
     script = _build_launcher_script(
         sandbox_level,

--- a/test/test_sandbox_absent_ceiling_seal.py
+++ b/test/test_sandbox_absent_ceiling_seal.py
@@ -1,0 +1,575 @@
+"""An ABSENT crew-home ceiling is still sealed read-only by the Linux launcher.
+
+``mount(2)`` cannot target a path that does not exist, so the ``READONLY_DIRS`` loop's
+``if os.path.exists(target)`` guard silently skips a ceiling that has never been written
+— and on a default install that is most of them, which left the data home writable at
+exactly the names the seal exists to protect. ``_materialize_sealable_ceilings()`` closes
+that by creating the absent ceiling first, but only for the leaves that clear both tests
+the production comment states: an empty document must mean what an absent file means, and
+a STALE read of it must fail toward refusal.
+
+The load-bearing test here is
+:meth:`TestSealAppliesToAPreviouslyAbsentCeiling.test_bind_and_remount_pair_is_emitted`:
+it executes the launcher's own seal loop (extracted from the generated script, so the
+production source is what runs) against a real filesystem, with ``_mount_or_die``
+replaced by a recorder. Delete the materialiser and that loop records nothing, because
+the guard falls through — which is the whole defect.
+
+:class:`TestCeilingsThatMustNotBeMaterialized` is the fence in the opposite direction,
+and it is the one to read before adding a leaf: three ceilings read a present-but-empty
+file as something other than absent, and a fourth would be pinned stale in the dangerous
+direction by the bind mount itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import sandbox
+
+_POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX launcher only")
+
+#: Flag values the launcher defines for itself; mirrored so the extracted loop can run.
+_MS_RDONLY = 1
+_MS_REMOUNT = 32
+_MS_BIND = 4096
+
+
+@pytest.fixture()
+def crew_home(tmp_path, monkeypatch):
+    """Point ``config_dir()`` — the live data home — at a scratch tree."""
+    home = tmp_path / ".kiro" / "crew"
+    home.mkdir(parents=True)
+    monkeypatch.setattr(sandbox, "config_dir", lambda: home)
+    return home
+
+
+def _seal_loop_source() -> str:
+    """The launcher's ``READONLY_DIRS`` loop body, ready to run.
+
+    Pulled out of the generated script rather than restated, so this test cannot pass
+    against a loop the launcher no longer contains.
+    """
+    script = sandbox._build_launcher_script("strict")
+    loop = (
+        "for d in READONLY_DIRS:"
+        + script.split("for d in READONLY_DIRS:", 1)[1].split("\n\n", 1)[0]
+    )
+    return textwrap.dedent(loop)
+
+
+def _run_seal_loop(targets: list[str]) -> list[tuple[str, int]]:
+    """Execute the launcher's seal loop over *targets*, recording every mount call."""
+    calls: list[tuple[str, int]] = []
+
+    def _record(source, target, flags, what):
+        assert source == target, "a ceiling is bound over ITSELF, not over an empty source"
+        calls.append((os.fsdecode(target), flags))
+
+    # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
+    exec(  # noqa: S102 - running the launcher's OWN generated source is the assertion
+        _seal_loop_source(),
+        {
+            "os": os,
+            "READONLY_DIRS": targets,
+            "_mount_or_die": _record,
+            "_MS_BIND": _MS_BIND,
+            "_MS_REMOUNT": _MS_REMOUNT,
+            "_MS_RDONLY": _MS_RDONLY,
+        },
+    )
+    return calls
+
+
+@_POSIX_ONLY
+class TestSealAppliesToAPreviouslyAbsentCeiling:
+    def test_bind_and_remount_pair_is_emitted(self, crew_home):
+        """The seal reaches a ceiling that did not exist when the spawn started.
+
+        Both calls are asserted, not just the first: ``MS_RDONLY`` is ignored on the
+        initial ``MS_BIND``, so a bind without the remount grants exactly the write
+        access the loop exists to withhold.
+        """
+        target = str(crew_home / "computer_use.json")
+        assert not os.path.exists(target)
+
+        assert target in sandbox._materialize_sealable_ceilings()
+        calls = _run_seal_loop([target])
+
+        assert calls == [
+            (target, _MS_BIND),
+            (target, _MS_REMOUNT | _MS_BIND | _MS_RDONLY),
+        ]
+
+    def test_loop_skips_the_ceiling_when_it_was_never_materialized(self, crew_home):
+        """The defect, pinned: no target on disk means no seal at all."""
+        target = str(crew_home / "computer_use.json")
+
+        assert _run_seal_loop([target]) == []
+
+    def test_every_sealable_leaf_is_created(self, crew_home):
+        created = sandbox._materialize_sealable_ceilings()
+
+        for leaf in sandbox._CREW_PRECREATE_READONLY_FILE_LEAVES:
+            path = crew_home / leaf
+            assert str(path) in created
+            assert json.loads(path.read_text(encoding="utf-8")) == {}
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+        for leaf in sandbox._CREW_PRECREATE_READONLY_DIR_LEAVES:
+            path = crew_home / leaf
+            assert str(path) in created
+            assert path.is_dir()
+            assert stat.S_IMODE(path.stat().st_mode) == 0o700
+
+    def test_created_ceilings_are_in_the_launcher_readonly_list(self, crew_home):
+        """Creating a path is only useful if the seal loop is handed it."""
+        created = sandbox._materialize_sealable_ceilings()
+        script = sandbox._build_launcher_script("strict")
+        match = re.search(r"READONLY_DIRS = (\[.*?\])\n", script, re.S)
+        assert match
+        readonly = set(json.loads(match.group(1)))
+
+        assert set(created) <= readonly
+
+    def test_namespace_argv_materializes_before_the_launcher_runs(self, crew_home):
+        """The production wiring, not just the helper.
+
+        The seal happens in the launcher CHILD after ``namespace_argv`` returns, so the
+        creation has to be on this path — a helper nobody calls seals nothing.
+        """
+        sandbox.namespace_argv(["/bin/true"])
+
+        assert (crew_home / "computer_use.json").is_file()
+        assert (crew_home / "profiles").is_dir()
+
+    def test_relocated_data_home_is_covered(self, tmp_path, monkeypatch):
+        """A data home that escapes ``$HOME`` gets the same treatment.
+
+        Without this the fleets that relocate the data home — the ones most likely to
+        care about a governance ceiling — would be the only ones left unsealed.
+        """
+        relocated = tmp_path / "srv" / "crew"
+        relocated.mkdir(parents=True)
+        monkeypatch.setattr(sandbox, "config_dir", lambda: relocated)
+
+        assert str(relocated / "computer_use.json") in sandbox._materialize_sealable_ceilings()
+
+    def test_deprecated_home_spelling_gains_no_stubs(self, crew_home, tmp_path):
+        """Only the LIVE data home is materialised.
+
+        The deny lists cover both ``_CREW_HOME_PREFIXES`` because either tree may hold
+        bytes, but creation is the opposite case: a stub under a migrated host's leftover
+        ``~/.kirocrew`` is a file nothing will ever read.
+        """
+        legacy = tmp_path / ".kirocrew"
+        legacy.mkdir()
+
+        sandbox._materialize_sealable_ceilings()
+
+        assert list(legacy.iterdir()) == []
+
+
+@_POSIX_ONLY
+class TestPublishIsAllOrNothing:
+    """The ceiling path never appears holding anything but the complete document."""
+
+    def test_partial_write_publishes_nothing(self, crew_home, monkeypatch):
+        """A zero-length ``*.json`` would read as CORRUPT, not as absent."""
+
+        def _boom(fd, data):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "write", _boom)
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable):
+            sandbox._materialize_sealable_ceilings()
+
+        for leaf in sandbox._CREW_PRECREATE_READONLY_FILE_LEAVES:
+            assert not (crew_home / leaf).exists()
+
+    def test_no_temp_file_is_left_behind(self, crew_home, monkeypatch):
+        """The temp sibling is reclaimed on the failure path as well as the success one."""
+
+        def _boom(src, dst):
+            raise OSError("cross-device link")
+
+        monkeypatch.setattr(os, "link", _boom)
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable):
+            sandbox._materialize_sealable_ceilings()
+
+        assert [p.name for p in crew_home.iterdir() if p.name.startswith(".kirocrew-ceiling")] == []
+
+    def test_publish_never_clobbers_a_racing_writer(self, crew_home):
+        """``os.link`` fails with EEXIST rather than overwriting.
+
+        The upstream ``os.path.exists`` check is an optimisation, not the guard — a
+        second spawn, or an operator writing the real document, can land between it and
+        the publish.
+        """
+        target = crew_home / "computer_use.json"
+        target.write_text('{"enabled": true}', encoding="utf-8")
+
+        assert sandbox._publish_empty_ceiling(str(target), str(crew_home)) is False
+        assert target.read_text(encoding="utf-8") == '{"enabled": true}'
+
+    def test_existing_ceiling_is_left_byte_for_byte_alone(self, crew_home):
+        """Never a truncate: an operator's document outranks the absent default."""
+        target = crew_home / "aws_service_consent.json"
+        target.write_text('{"s3": "confirmed"}', encoding="utf-8")
+
+        created = sandbox._materialize_sealable_ceilings()
+
+        assert str(target) not in created
+        assert target.read_text(encoding="utf-8") == '{"s3": "confirmed"}'
+
+
+@_POSIX_ONLY
+class TestAShortWriteNeverPublishes:
+    """``os.write`` may consume part of the buffer and report it as success."""
+
+    def test_partial_progress_is_completed_not_published_short(self, crew_home):
+        """The loop finishes the document; a one-byte-at-a-time write still lands whole."""
+        real_write = os.write
+        calls: list[int] = []
+
+        def _one_byte(fd, data):
+            calls.append(len(data))
+            return real_write(fd, bytes(data[:1]))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "write", _one_byte)
+            assert sandbox._publish_empty_ceiling(
+                str(crew_home / "computer_use.json"), str(crew_home)
+            )
+
+        assert len(calls) > 1, "a short write must be retried, not accepted"
+        assert (crew_home / "computer_use.json").read_bytes() == sandbox._EMPTY_CEILING_DOCUMENT
+
+    def test_zero_progress_publishes_nothing(self, crew_home, monkeypatch):
+        """A filesystem accepting nothing must fail, not spin forever."""
+        monkeypatch.setattr(os, "write", lambda fd, data: 0)
+
+        assert (
+            sandbox._publish_empty_ceiling(str(crew_home / "computer_use.json"), str(crew_home))
+            is False
+        )
+        assert not (crew_home / "computer_use.json").exists()
+
+
+@_POSIX_ONLY
+class TestAnUnsealedCeilingIsNeverSilent:
+    """A seal that could not be established is logged, because nothing else reports it.
+
+    Raising instead would reach far past this seal: ``namespace_argv`` runs under
+    ``wrap_argv``, whose callers catch narrowly and degrade their own operation, so an
+    additive control would take every sandboxed spawn on the host down with it.
+    """
+
+    def test_failed_dir_creation_warns(self, crew_home, monkeypatch, caplog):
+        monkeypatch.setattr(
+            os, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only fs"))
+        )
+
+        with caplog.at_level("WARNING", logger="kiro_crew.sandbox"):
+            with pytest.raises(sandbox.SandboxCeilingUnsealable):
+                sandbox._materialize_sealable_ceilings()
+
+        assert "REFUSING to launch" in caplog.text
+        assert "profiles" in caplog.text
+
+    def test_failed_publish_warns(self, crew_home, monkeypatch, caplog):
+        monkeypatch.setattr(
+            os, "link", lambda *a, **k: (_ for _ in ()).throw(OSError("no hardlinks"))
+        )
+
+        with caplog.at_level("WARNING", logger="kiro_crew.sandbox"):
+            with pytest.raises(sandbox.SandboxCeilingUnsealable):
+                sandbox._materialize_sealable_ceilings()
+
+        # Only the FIRST unsealable ceiling is reached: the refusal is immediate, which is
+        # the point -- the loop must not carry on creating the rest behind a known hole.
+        assert "REFUSING to launch" in caplog.text
+        assert sandbox._CREW_PRECREATE_READONLY_FILE_LEAVES[0] in caplog.text
+
+    def test_success_is_quiet(self, crew_home, caplog):
+        with caplog.at_level("WARNING", logger="kiro_crew.sandbox"):
+            sandbox._materialize_sealable_ceilings()
+
+        assert "REFUSING to launch" not in caplog.text
+
+
+@_POSIX_ONLY
+class TestACreationFailureRefusesTheSpawn:
+    """A ceiling that cannot be created is a ceiling that will not be sealed.
+
+    Earlier revisions warned and continued here. That is the shape where the launcher's
+    ``exists`` guard silently skips the path and the agent runs with a writable keystone,
+    so the failure is fatal to the spawn instead — the ``_mount_or_die`` posture. No
+    ``wrap_argv`` caller falls back to running the command unconfined, so refusing costs
+    the operation, never the confinement.
+    """
+
+    def test_unwritable_data_home_refuses(self, crew_home, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(os, "mkdir", _boom)
+        monkeypatch.setattr(tempfile, "mkstemp", _boom)
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable):
+            sandbox._materialize_sealable_ceilings()
+
+    def test_a_failed_publish_refuses(self, crew_home, monkeypatch):
+        monkeypatch.setattr(
+            os, "link", lambda *a, **k: (_ for _ in ()).throw(OSError("no hardlinks"))
+        )
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable):
+            sandbox._materialize_sealable_ceilings()
+
+    def test_a_race_that_another_writer_won_is_benign(self, crew_home, monkeypatch):
+        """``EEXIST`` means the path now exists, so the launcher seals it: nothing to do."""
+        target = crew_home / "computer_use.json"
+
+        def _link_but_someone_won(src_path, dst):
+            # Honour the dst actually being published: every ceiling in the loop goes
+            # through this stub, and a stub that only ever creates ONE of them leaves the
+            # others genuinely unsealable -- which is a different scenario.
+            Path(os.fsdecode(dst)).write_text('{"enabled": false}', encoding="utf-8")
+            raise FileExistsError("raced")
+
+        monkeypatch.setattr(os, "link", _link_but_someone_won)
+
+        created = sandbox._materialize_sealable_ceilings()
+
+        assert str(target) not in created
+        assert target.read_text(encoding="utf-8") == '{"enabled": false}'
+
+    def test_an_existing_dir_ceiling_is_benign(self, crew_home):
+        (crew_home / "profiles").mkdir()
+
+        created = sandbox._materialize_sealable_ceilings()
+
+        assert str(crew_home / "profiles") not in created
+
+    def test_absent_data_home_is_not_created(self, tmp_path, monkeypatch):
+        missing = tmp_path / "nope" / "crew"
+        monkeypatch.setattr(sandbox, "config_dir", lambda: missing)
+
+        assert sandbox._materialize_sealable_ceilings() == []
+        assert not missing.exists()
+
+    def test_unresolvable_data_home_yields_nothing(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("no data home")
+
+        monkeypatch.setattr(sandbox, "config_dir", _boom)
+
+        assert sandbox._sealable_absent_ceilings() == ([], [])
+        assert sandbox._materialize_sealable_ceilings() == []
+
+
+@_POSIX_ONLY
+class TestADanglingSymlinkRefusesTheSpawn:
+    """The one state that defeats every ``os.path.exists`` guard on this path at once.
+
+    ``exists`` FOLLOWS symlinks, so a dangling link reports as absent: the materialiser
+    tries to create and ``os.link`` refuses with ``EEXIST``, the launcher's seal loop
+    emits no mount, and the sandboxed process's write then follows the link to a file the
+    host afterwards reads through the ceiling path. The link is plantable through the very
+    hole this change closes, so an agent on an earlier build could pre-arm it.
+
+    It is REFUSED, not removed. ``islink`` followed by ``unlink`` is not atomic and the
+    dashboard publishes a real keystone over that same name with ``atomic_write``, so a
+    removal racing a validated operator write would delete the operator's new settings —
+    and POSIX has no unlink-only-if-still-a-symlink to close that window with.
+    """
+
+    def test_the_unguarded_chain_really_is_exploitable(self, crew_home):
+        """Pin the mechanism itself, so the refusal below is not guarding a phantom."""
+        target = crew_home / "computer_use.json"
+        victim = crew_home / "elsewhere.json"
+        target.symlink_to(victim)
+
+        assert os.path.lexists(target) is True
+        assert os.path.exists(target) is False, "exists() follows the link -> reads as absent"
+        # The launcher's own guard therefore skips it: no bind, no remount.
+        assert _run_seal_loop([str(target)]) == []
+        # And a write through the link lands where the host will read it back.
+        target.write_text('{"enabled": true}', encoding="utf-8")
+        assert victim.exists()
+        assert target.read_text(encoding="utf-8") == '{"enabled": true}'
+
+    def test_a_file_ceiling_squatter_refuses(self, crew_home):
+        target = crew_home / "computer_use.json"
+        target.symlink_to(crew_home / "elsewhere.json")
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable) as err:
+            sandbox._materialize_sealable_ceilings()
+
+        assert "computer_use.json" in str(err.value)
+        assert "elsewhere.json" in str(err.value), "the destination is the diagnostic value"
+
+    def test_a_dir_ceiling_squatter_refuses(self, crew_home):
+        target = crew_home / "profiles"
+        target.symlink_to(crew_home / "no-such-dir")
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable):
+            sandbox._materialize_sealable_ceilings()
+
+    def test_the_squatter_is_never_removed(self, crew_home):
+        """Removing it is the data-loss path this refusal exists to avoid."""
+        target = crew_home / "computer_use.json"
+        target.symlink_to(crew_home / "elsewhere.json")
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable):
+            sandbox._materialize_sealable_ceilings()
+
+        assert target.is_symlink(), "the link is the operator's to resolve, not ours to delete"
+        assert not (crew_home / "elsewhere.json").exists(), "nothing written through the link"
+
+    def test_namespace_argv_refuses_rather_than_launching(self, crew_home):
+        """The refusal has to reach the spawn path, or it protects nothing."""
+        (crew_home / "computer_use.json").symlink_to(crew_home / "elsewhere.json")
+
+        with pytest.raises(sandbox.SandboxCeilingUnsealable):
+            sandbox.namespace_argv(["/bin/true"])
+
+    def test_a_resolving_symlink_is_left_alone(self, crew_home):
+        """It reads as present, so the launcher seals the inode it resolves to.
+
+        The remaining exposure — the link NAME stays replaceable in a writable parent — is
+        pre-existing for every ceiling and cannot be closed without sealing the data-home
+        root, so this change must neither refuse nor delete on account of it.
+        """
+        real = crew_home / "elsewhere.json"
+        real.write_text('{"enabled": false}', encoding="utf-8")
+        target = crew_home / "computer_use.json"
+        target.symlink_to(real)
+
+        created = sandbox._materialize_sealable_ceilings()
+
+        assert str(target) not in created
+        assert target.is_symlink()
+        assert real.read_text(encoding="utf-8") == '{"enabled": false}'
+
+
+@_POSIX_ONLY
+class TestAnAliasBackedCeilingIsReported:
+    """``MS_RDONLY`` binds a MOUNT, not an inode, so a second name survives the seal.
+
+    Both shapes are PRE-EXISTING -- the ceilings this module publishes end at
+    ``st_nlink == 1`` and are never symlinks (pinned below) -- so they are reported rather
+    than refused: a dotfile manager or a snapshot tool giving a config file a second name
+    is ordinary, and failing the spawn over it is a far wider blast radius than the hole.
+    """
+
+    def test_what_this_module_publishes_is_never_alias_backed(self, crew_home):
+        """The premise of reporting rather than refusing: we never create the shape."""
+        sandbox._materialize_sealable_ceilings()
+
+        for leaf in sandbox._CREW_PRECREATE_READONLY_FILE_LEAVES:
+            path = crew_home / leaf
+            assert path.stat().st_nlink == 1, "a published ceiling must have no alias"
+            assert not path.is_symlink()
+        assert [p.name for p in crew_home.iterdir() if p.name.startswith(".kirocrew-ceiling")] == []
+
+    def test_a_symlinked_ceiling_is_reported(self, crew_home, caplog):
+        real = crew_home / "elsewhere.json"
+        real.write_text("{}", encoding="utf-8")
+        (crew_home / "computer_use.json").symlink_to(real)
+
+        with caplog.at_level("WARNING", logger="kiro_crew.sandbox"):
+            sandbox._materialize_sealable_ceilings()
+
+        assert "is a SYMLINK" in caplog.text
+        assert "computer_use.json" in caplog.text
+
+    def test_a_hardlinked_ceiling_is_reported(self, crew_home, caplog):
+        target = crew_home / "computer_use.json"
+        target.write_text("{}", encoding="utf-8")
+        os.link(target, crew_home / "alias.json")
+        assert target.stat().st_nlink == 2
+
+        with caplog.at_level("WARNING", logger="kiro_crew.sandbox"):
+            sandbox._materialize_sealable_ceilings()
+
+        assert "hardlinks" in caplog.text
+        assert "computer_use.json" in caplog.text
+
+    def test_a_symlinked_dir_ceiling_is_reported(self, crew_home, caplog):
+        real = crew_home / "real-profiles"
+        real.mkdir()
+        (crew_home / "profiles").symlink_to(real)
+
+        with caplog.at_level("WARNING", logger="kiro_crew.sandbox"):
+            sandbox._materialize_sealable_ceilings()
+
+        assert "is a SYMLINK" in caplog.text
+        assert "profiles" in caplog.text
+
+    def test_reporting_never_refuses_and_never_removes(self, crew_home):
+        """The whole point of warning: an ordinary dotfile-manager host still runs."""
+        real = crew_home / "elsewhere.json"
+        real.write_text('{"enabled": false}', encoding="utf-8")
+        link = crew_home / "computer_use.json"
+        link.symlink_to(real)
+
+        sandbox._materialize_sealable_ceilings()  # must not raise
+
+        assert link.is_symlink()
+        assert real.read_text(encoding="utf-8") == '{"enabled": false}'
+
+    def test_an_ordinary_single_link_ceiling_is_quiet(self, crew_home, caplog):
+        (crew_home / "computer_use.json").write_text("{}", encoding="utf-8")
+
+        with caplog.at_level("WARNING", logger="kiro_crew.sandbox"):
+            sandbox._materialize_sealable_ceilings()
+
+        assert "SYMLINK" not in caplog.text
+        assert "hardlinks" not in caplog.text
+
+
+@_POSIX_ONLY
+class TestCeilingsThatMustNotBeMaterialized:
+    """Four ceilings the seal deliberately does not reach, for two distinct reasons.
+
+    ``denied_commands.json`` reads ``{}`` as its absent default, but a bind mount pins
+    the INODE while every dashboard writer publishes a NEW one through ``atomic_write``,
+    so a sealed stub would report "nothing is denied" to in-sandbox ``mcp_cron`` for the
+    rest of the sandbox's life. The other three read a present-but-empty file as
+    something other than absent: ``security_policy.json`` raises
+    ``PlatformCompositionError`` out of ``governance.load_security_policy`` (which reruns
+    at boot and per app callback), ``app_admission.json`` flips ``open_default()`` into
+    deny-all, and ``admission_policy.json`` is already seeded at first run.
+    """
+
+    EXCLUDED = (
+        "denied_commands.json",
+        "security_policy.json",
+        "app_admission.json",
+        "admission_policy.json",
+    )
+
+    @pytest.mark.parametrize("leaf", EXCLUDED)
+    def test_leaf_is_not_in_the_precreate_set(self, leaf):
+        assert leaf in sandbox._CREW_READONLY_LEAVES
+        assert leaf not in sandbox._CREW_PRECREATE_READONLY_FILE_LEAVES
+        assert leaf not in sandbox._CREW_PRECREATE_READONLY_DIR_LEAVES
+
+    @pytest.mark.parametrize("leaf", EXCLUDED)
+    def test_leaf_is_not_written_to_disk(self, leaf, crew_home):
+        sandbox._materialize_sealable_ceilings()
+
+        assert not (crew_home / leaf).exists()


### PR DESCRIPTION
## Problem / Motivation

The Linux launcher's `READONLY_DIRS` seal loop is guarded on `os.path.exists(target)`. That guard is right about file-vs-dir — a governance ceiling can be a plain file, and an `isdir` guard would silently skip every one of them — and wrong about **absent**: `mount(2)` cannot target a path that does not exist, so a ceiling nobody has written yet gets no `MS_BIND` + `MS_REMOUNT|MS_BIND|MS_RDONLY` pair at all, and the crew data home stays writable at that name in every sandbox mode.

Most of `_CREW_READONLY_LEAVES` is absent on a default install, so the seal was weakest in exactly the state it exists to cover.

## Why it matters

`computer_use.json` is the sharp one. It is absent until the operator first enables desktop control, so on a default install the sandboxed process can create it. `enable_state.load_state()` re-reads per dispatch, so writing `{"enabled": true}` turns desktop control on with no restart and no operator action. `aws_service_consent.json`, `oauth_endpoints.json` and `profiles/` are the same shape: consent and trust-extension surfaces the agent could author for itself.

The agent-tool gate in `security.py` fences these paths for a `file_write` tool call and for a path appearing literally in a bash command string, but an OS write from a script file — where the path is computed at runtime — never routes through it. Closing that bypass is what the mount seal is for.

macOS is unaffected: seatbelt `deny` already applies to a path that does not exist, which is why only the Linux branch was wrong.

## What changed

`namespace_argv` materialises the absent sealable ceilings just before it builds the launcher, so the existing loop finds a mountpoint and seals them. **The seal loop itself is untouched** — the `exists` guard and the comment explaining why it is not `isdir` both stay exactly as they are.

Pre-creating (rather than binding an empty read-only dir over the writable surface) is the option that fits: the "writable surface" for an absent leaf is the crew data home root, and a read-only remount of a bind is recursive over its subtree, so sealing the parent would take every write under the data home with it — sessions, history, memory, `crons.json`.

### Which leaves, and why only these

A leaf is materialised only if it clears **both** tests:

1. **An empty document must mean what an absent file means.** `profiles/` (empty dir → no profile), `computer_use.json` (`load_state` reads `{}` as DISABLED), `oauth_endpoints.json` (`_validate_operator_oauth_entries` extends trust by nothing), `aws_service_consent.json` (`_read_all` returns `{}` for absent and empty alike).
2. **A stale read of it must fail toward refusal.** The seal is a bind mount, which pins the *inode*, while every dashboard writer publishes through `atomic_write` (temp + rename) — a *new* inode. So a sandboxed reader keeps seeing the empty document after the operator writes the real one. For the three files above that freezes them at "disabled" / "no consent" / "no extra endpoints", all narrower than the truth. The empty `profiles/` dir is exempt: a directory bind shows live contents.

Content is `{}`, **never a 0-byte file** — zero length is not valid JSON, so a reader would see *corrupt* where this means *absent*.

### Four ceilings deliberately left unsealed

| ceiling | why not |
| --- | --- |
| `denied_commands.json` | Clears (1), fails (2), in the direction that matters: in-sandbox `mcp_cron` reads it to decide whether a command is denied, so a pinned `{}` would report "nothing is denied" for the rest of the sandbox's life even after the operator denies a command. Sealing it would trade an agent-authored deny list for a stale one. |
| `security_policy.json` | Fails (1). `governance.load_security_policy` calls `_read_json_file` whenever `home_path.exists()` and fails closed; `{}` fails `version != POLICY_VERSION`. `PlatformCompositionError` would escape a function that runs at boot **and per app callback**. |
| `app_admission.json` | Fails (1). Absent means `open_default()` (admit); present-but-unreadable means `_fail_closed_policy()` (deny-all). A stub refuses every app. |
| `admission_policy.json` | Not absent to begin with — `platform.admission.seed_default_policy` seeds it at first run. |

Sealing those needs a real default document seeded at install time, which is a governance decision rather than a sandbox patch. See "Open items" below.

**Named, not fixed:** the `SENSITIVE_DIRS` / `SENSITIVE_FILES` mask loops skip their own absent targets for the identical `mount(2)` reason (~27 hidden leaves). That is a real sibling gap and it is out of scope here, because a mask needs the opposite treatment — an empty bind *over* the name — and `_CREW_HIDDEN_LEAVES` has no reader to prove an empty document is absent-equivalent, so each leaf needs its own argument.

### A dangling symlink refuses the spawn

`os.path.exists` **follows** symlinks, so a dangling one is the single state that defeats every guard on this path at once — and it is plantable through the very hole this change closes, meaning an agent on an earlier build could pre-arm it and keep a writable `computer_use.json` after the seal ships. Verified end to end against the kernel:

| step | observed |
| --- | --- |
| `lexists` / `exists` on a dangling link | `True` / **`False`** — reads as absent |
| `os.link` publish over that name | `FileExistsError` (errno 17) — nothing published |
| launcher seal loop | emits **no** bind and no remount |
| sandboxed write through the link | creates the link's target; the host then reads `{"enabled": true}` back through the ceiling path |

It is **refused, not removed.** Removing it was the first attempt and it is unsound: `islink` followed by `unlink` is not atomic, and the dashboard publishes a real keystone over that same name with `atomic_write`, so a removal racing a validated operator write deletes the operator's new settings. POSIX offers no unlink-only-if-still-a-symlink, so the window cannot be closed — which leaves refusing as the only correct disposition.

A **resolving** symlink is deliberately left alone: it reads as present, so the launcher seals the inode it resolves to. The residual exposure — the link *name* stays replaceable in a writable parent — is pre-existing for every ceiling, not specific to one this change materialises, and cannot be closed without sealing the data-home root.

### An alias-backed ceiling is reported

`MS_RDONLY` binds a **mount**, not an inode, so the seal only covers the path it was established on. Two shapes survive it, and both read as present so the seal loop never notices: a ceiling that is a **symlink** (the launcher seals what it resolves to, but the link name sits in the writable data home and can be replaced), and a ceiling that is a **regular file with another hardlink** (the alias is a different path, outside the mount, and a write through it changes the same inode).

Both are **reported, not refused**, and neither is introduced here — the ceilings this module publishes end at `st_nlink == 1` and are never symlinks, which is pinned by a test. So this is a pre-existing property of every entry in `READONLY_DIRS`, reachable only where something else already created the ceiling that way. Refusing would turn ordinary setups into a hard spawn failure — a dotfile manager such as chezmoi or GNU stow, or a snapshot tool holding a hardlink — which is a far wider blast radius than the exposure. Closing it properly needs the data-home root sealed, which is a different change.

The warning earns its place because the alternative is worse than the hole: without it the log says the ceiling is sealed while it is writable under another name.

### Publish is all-or-nothing

The document is written to a sibling `mkstemp` temp (0o600 before the first byte) and published with `os.link`. `os.link` is the *no-clobber* publish — unlike `os.replace` it fails `EEXIST` rather than overwriting — so a racing spawn or an operator writing the real document keeps its file, and the `os.path.exists` pre-check is an optimisation rather than the guard. The write is a `memoryview` loop that treats zero progress as `EIO`, because `os.write` may consume part of the buffer and report it as success; taking that count would link a truncated document. No post-write `chmod`: `mkstemp` already restricts, and a umask can only clear bits.

Resolution goes through `config_dir()` — the live data home — not the two-prefix expansion the deny lists use, so a migrated host's leftover `~/.kirocrew` gains no stubs.

### Failure is fail-closed

If a ceiling cannot be made sealable, `_materialize_sealable_ceilings` raises `SandboxCeilingUnsealable` and **the spawn does not happen**. Two states reach it: a dangling symlink squatting a ceiling path, and a creation failure other than `EEXIST` (a read-only mount, or a filesystem with no hardlink support). `EEXIST` is the one benign errno — the racing spawn that got there first, or the operator's real document — and is not reported, because the path then exists and the launcher seals it.

This reverses an earlier revision of this PR that warned and continued. Continuing is the shape where the launcher's `exists` guard skips the path, so the agent runs with a writable governance keystone while the log says the ceiling is protected — the one outcome the seal exists to prevent. It is therefore the `_mount_or_die` posture rather than the best-effort one: a control was requested and could not be established.

The cost is real and worth stating plainly: on a host whose data home cannot hold these files, sandboxed spawns now fail instead of running unsealed, and the operator has to resolve it (the message names the path, and lowering `sandbox_level` is the documented way to run without the seal deliberately). What makes that safe rather than a silent downgrade is that no `wrap_argv` caller falls back to running the command unconfined — `cron_script` marks the job failed, `file_explorer` reports a git-status error, and the app-backend and `cloud/aws.py` paths fail their own operation. Refusing costs the operation, never the confinement.

## Tests

`test/test_sandbox_absent_ceiling_seal.py` — 42 tests.

The load-bearing one extracts the launcher's own `for d in READONLY_DIRS:` loop out of the generated script and runs it against a real filesystem with `_mount_or_die` replaced by a recorder, asserting the full call sequence:

```
[(target, MS_BIND), (target, MS_REMOUNT | MS_BIND | MS_RDONLY)]
```

Both calls are asserted, because `MS_RDONLY` is ignored on the initial bind — a bind without the remount grants exactly the write access the loop withholds. Pulling the loop from the generated source rather than restating it means the test cannot pass against a loop the launcher no longer contains. The real mounts cannot run in CI (unprivileged `unshare(CLONE_NEWUSER)` is EPERM there), which is why this asserts the call sequence rather than the mount.

`TestADanglingSymlinkRefusesTheSpawn` pins the unguarded exploit chain itself first, so the refusal is not guarding a phantom, then asserts the refusal reaches `namespace_argv`, the squatter is never removed, nothing is written through the link, and a resolving operator symlink survives untouched.

Also covered: every sealable leaf created with the right content and mode; the production wiring in `namespace_argv`; a relocated data home; no stubs in the deprecated home spelling; short and zero-progress writes; no temp file left behind; `os.link` refusing to clobber a racing writer; an existing ceiling left byte-for-byte alone; a creation failure and a failed publish each refusing, an absent or unresolvable data home yielding nothing without refusing, a failed seal always logged and a successful one quiet; and a parametrised fence that all four excluded leaves are neither in the pre-create tuples nor on disk afterwards.

### Revert-verification

Ten mutations, each reverting one decision, run against the suite:

| mutation | result |
| --- | --- |
| baseline | 42 passed, 0 failed |
| materialiser neutered to `return []` | 5 failed |
| `namespace_argv` call site removed | 2 failed |
| one-step publish (name before bytes) | 8 failed |
| `denied_commands.json` added back to the pre-create set | 2 failed |
| short write accepted instead of looped | 2 failed |
| dir creation failure no longer refuses | 2 failed |
| publish failure no longer refuses | 4 failed |
| dangling symlink no longer refuses (file ceiling) | 1 failed |
| dangling symlink no longer refuses (dir ceiling) | 1 failed |
| a *resolving* operator symlink refused too | 1 failed |
| alias detector removed (file loop) | 1 failed |
| alias detector removed (dir loop) | 1 failed |
| hardlink branch dropped | 1 failed |
| alias detection escalated to a refusal | 4 failed |
| restored | 42 passed, 0 failed |

Fourteen rather than one because the pieces are separately load-bearing — a helper nobody calls seals nothing, the two-step publish is what keeps a partial file off the ceiling path, and the last two rows are the guards against over-reaching into operator state — one against deleting a resolving symlink, one against escalating a report into a refusal.

## Manual verification

N/A — unit coverage is sufficient and the real mount cannot run unprivileged. The one thing unit tests could not establish, the dangling-symlink syscall chain, was verified directly against the kernel with a standalone probe and the observed values are in the table above.

## Review history

Three GPT rounds landed in the same span, and the third made the pattern legible: each round handed back a sibling of the same defect, and each point-fix contradicted the previous one (warn-and-continue, then clear-the-squatter, then a data-loss race in the clearing). Rather than patch a fourth instance, the findings were collapsed into the single invariant that makes all of them unreachable — **a ceiling that cannot be sealed refuses the spawn** — which is what the current revision implements. That shrank the diff: the symlink-clearing helper and its tests are gone rather than hardened.

Round 4 then asked for all symlink ceilings and all multiply-linked ceilings to be refused. The mechanism is real and is documented above, but it is pre-existing rather than introduced here, and the remedy as asked would fail spawns on any host using a dotfile manager or a snapshot tool. The in-scope half — not claiming protection this seal does not provide — is implemented as a warning instead. That split is the disposition, and clearing the resulting `[BLOCK-MERGE]` needs a repository writer's `/ai-review override`.

Round 1 asked for exactly this propagation and it was refused on blast-radius grounds. That refusal is withdrawn: round 3's data-loss finding showed the narrower scope could not be made correct, and the skill's own rule is not to decline a reviewer's wider scope without a failing test proving the narrower one suffices. No such test exists here.

## Open items

- **`needs-a-decision`** — Design Review's first watch item: excluding `denied_commands.json` trades one harm for another. A writable `denied_commands.json` lets an auto-approved agent set `disable_all` permanently; sealing it hides operator-added rules from in-sandbox readers for the sandbox's lifetime. GPT asked for the exclusion, Fable questions it. Put to the maintainer rather than decided here, because it is a ranking of two harms, not a fact about the code.
- **`accepted-and-deferred`** — Design Review's second watch item: seeding valid defaults at install time is the durable fix for all four excluded ceilings, and it is genuinely out of scope for a sandbox patch. To be tracked as a `deferred-finding` issue with an owner and a due date.

## Pattern harvest

Two rule candidates, both generalisable beyond this file.

Rule candidate: semgrep — a reachability guard that silently follows symlinks.
Pattern: `os.path.exists(p)` / `os.path.isfile(p)` used to decide whether a *security-relevant* path needs protecting. Both follow symlinks, so a dangling link at `p` reports as absent and the protection is skipped while the name is still writable — a later write through that link then lands somewhere the guard never considered. The safe spelling for "does this name need handling?" is `os.path.lexists`, with `islink` deciding what kind. This is what made the third finding on this PR reachable, and it is what makes `mount(2)`-based masking skippable in general.

Rule candidate: semgrep — publishing a name before its bytes.
Pattern: `open(final_path, O_CREAT|O_EXCL)` or `open(final_path, "w")` followed by a `write` to that same path. The name becomes visible before the content is complete, so an interrupted write leaves a truncated file where other readers treat it as authoritative. The safe shape is write-to-temp then `os.link` / `os.replace`. This is the mirror image of the shape `scripts/check_lockdown_before_publish.py` already refuses (lockdown *after* content at a published path): both are "the published path is observable before it is correct", and that checker's AST walk already tracks the write-then-act relationship this rule needs, so it belongs next to it rather than as a fresh gate.

Not generalizable: the `{}`-versus-0-byte choice and the per-leaf exclusion table, which turn on these specific readers' semantics and are pinned by tests instead.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend path is touched and nothing renders differently.

no linked issue: found by post-merge patrol on PR #7439 rather than filed as an issue; the follow-up deferral above will carry its own issue.
