### PR TITLE
test: key feishu rollback injection to behavior, not call order (#7944)

### DIFF
--- a/test/test_feishu_config_handlers.py
+++ b/test/test_feishu_config_handlers.py
@@ -614,7 +614,19 @@ def test_rollback_keeps_a_concurrent_edit_it_does_not_own(tmp_path: Path, monkey
     `allow_group`, and our .env write fails. Rolling the whole section back would
     discard their change; the rollback compares per key, so `enabled` reverts and
     `allow_group` keeps THEIR value.
+
+    The injection is keyed to observed behavior, not call order: the save's apply
+    is the only write that leaves `allow_group` as True in THIS test's config, so
+    the foreign edit lands right after that call returns, strictly before the
+    handler proceeds to the failing .env write and the rollback. `loader` is
+    patched module-wide, so a leaked background writer from a sibling test in the
+    same worker process can also reach `_interleave`; a call-count heuristic let
+    such a caller suppress the injection entirely (issue #7944), and an unlocked
+    read-modify-write could lose it. Hence the once-gate under a lock and the
+    injection going through the real locked primitive.
     """
+    import threading
+
     import kiro_crew.dashboard.handlers.messaging as mod
 
     cfg = tmp_path / "config.json"
@@ -623,17 +635,28 @@ def test_rollback_keeps_a_concurrent_edit_it_does_not_own(tmp_path: Path, monkey
     )
 
     real_update = loader.update_config_locked
-    calls: list[int] = []
+    inject_gate = threading.Lock()
+    injected: list[bool] = []
+
+    def _set_foreign(data: dict) -> dict:
+        # Stand in for `kirocrew config set feishu.allow_group true` landing
+        # after our write and before our rollback.
+        data.setdefault("feishu", {})["allow_group"] = "set-by-someone-else"
+        return data
 
     def _interleave(*a, **kw):
         result = real_update(*a, **kw)
-        calls.append(len(calls))
-        if len(calls) == 1:
-            # Stand in for `kirocrew config set feishu.allow_group true` landing
-            # after our write and before our rollback.
-            data = json.loads(cfg.read_text(encoding="utf-8"))
-            data["feishu"]["allow_group"] = "set-by-someone-else"
-            cfg.write_text(json.dumps(data), encoding="utf-8")
+        target = a[0] if a else kw.get("path")
+        section = result.get("feishu") if isinstance(result, dict) else None
+        with inject_gate:
+            if (
+                not injected
+                and target == cfg
+                and isinstance(section, dict)
+                and section.get("allow_group") is True
+            ):
+                injected.append(True)
+                real_update(cfg, mutate=_set_foreign)
         return result
 
     async def _boom(updates):
@@ -665,6 +688,7 @@ def test_rollback_keeps_a_concurrent_edit_it_does_not_own(tmp_path: Path, monkey
 
     status = asyncio.run(_run())
     assert status >= 500, status
+    assert injected, "the foreign concurrent edit was never injected"
 
     out = json.loads(cfg.read_text(encoding="utf-8"))["feishu"]
     # Ours: reverted. Theirs: untouched.


### PR DESCRIPTION
## Problem / Motivation

`test/test_feishu_config_handlers.py::test_rollback_keeps_a_concurrent_edit_it_does_not_own` fails intermittently under sharded CI with `AssertionError: assert False == 'set-by-someone-else'` (e.g. run 33653173828, Backend Tests (3.12, 2)). It passes in isolation and with its whole file; it only loses under parallel load, redding the shard and dragging the required Coverage Gate down with it.

## Why it matters

A flaky required shard blocks unrelated PRs: the referenced failure landed on a frontend-only diff with zero Python changes, and it was the third distinct infra flake to red that PR's rounds in one day. Every false red costs a full re-run round of CI and reviewer attention.

## What changed (motivation -> approach -> change)

Symptom: the rollback intermittently observes `allow_group` as `False` instead of the injected concurrent writer's value.

Root cause (reproduced, not inferred): the test's `_interleave` wrapper keyed its one-shot injection off a shared call counter -- `calls.append(len(calls))` followed by `if len(calls) == 1`. The wrapper is installed on `loader.update_config_locked` module-wide, so a leaked background config writer from a sibling test in the same xdist worker can call it concurrently; an append landing between the apply call's own append and its check makes BOTH callers see `len(calls) == 2`, the injection never fires, and the rollback -- now the sole owner of `allow_group` -- correctly reverts it to `False`. A probe hammering the patched attribute from background threads (GIL switch interval 1e-6) reproduced the exact CI assertion at iteration 979/2000. The old injection was also an unlocked read-modify-write on the config file, a second (lost-update) hazard on the same path.

Change, confined to the test's interleaving harness:
- Key the injection to observed behavior instead of call order: it fires after the call that leaves `feishu.allow_group` as `True` in this test's config file, which is uniquely the handler's apply write (the rollback restores `False`; foreign callers target other paths or do not set it to `True`).
- Gate it once under a `threading.Lock`, closing the check-then-act window.
- Perform the injection through the real `update_config_locked`, so it is itself an atomic locked read-modify-write that cannot be lost to a concurrent writer.
- Add `assert injected` so a future handler change that stops the apply from qualifying fails loudly with a named reason instead of the confusing value comparison.

The product property under test (a failed save's rollback reverts per key and preserves a concurrent writer's edit) is unchanged; the two load-bearing assertions are byte-identical.

## Tests

- The changed test itself: 27/27 file green (`-n0`), 5 consecutive file runs under `-n 2` all green.
- Reproduction probe (original test + concurrent hammer on the patched `loader.update_config_locked`): fails with the exact CI assertion against the old harness (iteration 979/2000), 2000/2000 green against the fixed one.
- Gates: isort, flake8 clean; mypy output byte-identical to clean main (the 4 pre-existing errors are environment-owned boto3 stubs, untouched by this test-only diff).

## Manual verification

N/A -- unit coverage sufficient: the change is a test-only synchronization fix, exercised directly by the test and the probe above.

Closes #7944
