### PR TITLE
feat: extract ChatPage transcript scroll shell behind a characterization net

### DIFF
--- a/docs/feature-map/README.md
+++ b/docs/feature-map/README.md
@@ -57,7 +57,7 @@ this area is reached from inside it unless stated otherwise.
 
 | Feature | What it is | Reach it | Page | Handler | Endpoints |
 |---|---|---|---|---|---|
-| Sessions | Multi-slot agent chat, one slot per conversation | `/chat/:slug?` — rail **Sessions** | `pages/ChatPage.tsx`, `pages/ChatSidebar.tsx` | `chat_handlers.py`, `ws.py` | `POST /api/chat`, `GET,POST /api/chat/slots`, `GET /api/ws` |
+| Sessions | Multi-slot agent chat, one slot per conversation | `/chat/:slug?` — rail **Sessions** | `pages/ChatPage.tsx`, `pages/ChatSidebar.tsx`, `pages/chat/TranscriptScrollShell.tsx` (internal split of ChatPage — the transcript scroller skeleton, no new user-facing feature) | `chat_handlers.py`, `ws.py` | `POST /api/chat`, `GET,POST /api/chat/slots`, `GET /api/ws` |
 | Session folders | User-defined folders grouping session rows | Sidebar folder header → drag a row | `pages/chat/FolderPanel.tsx` | `chat_folders.py` | `GET,POST /api/chat/folders`, `PATCH /api/chat/slots/{slot}/folder` |
 | Session tags | Colored labels on sessions, filterable | Sidebar row context menu → Tags | `pages/chat/SessionFlyout.tsx` | `chat_tags.py` | `GET,POST /api/chat/tags`, `PUT /api/chat/slots/{slot}/tags` |
 | Pinned messages | Pin a message; pins panel per session | Message hover → pin; header pin count | `pages/chat/PinnedMessagesPanel.tsx` | `chat_pins.py` | `GET,POST /api/chat/pins`, `DELETE /api/chat/pins/{id}` |

--- a/website/capture/chatpage-scroll-shell.html
+++ b/website/capture/chatpage-scroll-shell.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>ChatPage scroll-shell golden frames</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/capture/chatpage-scroll-shell.tsx"></script>
+  </body>
+</html>

--- a/website/capture/chatpage-scroll-shell.tsx
+++ b/website/capture/chatpage-scroll-shell.tsx
@@ -1,0 +1,98 @@
+/**
+ * Isolated capture entry for ChatPage's transcript SCROLL SHELL golden frames.
+ *
+ * Mounts the REAL ChatPage (not a mock of it) with a preloaded store and a
+ * deterministic fixture transcript; the capture script answers its API calls
+ * via page.route. Golden frames are the visual half of the characterization
+ * net: the migration re-captures the same scenes and compares pixels, so
+ * everything nondeterministic is pinned here — animations off, fixed
+ * timestamps, fixed viewport, DSF 1.
+ */
+import { createRoot } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { initI18n } from '../src/i18n'
+import chatReducer from '../src/store/chatSlice'
+import dashboardReducer from '../src/store/dashboardSlice'
+import notificationsReducer from '../src/store/notificationsSlice'
+import { ThemeProvider } from '../src/hooks/useTheme'
+import type { RootState } from '../src/store'
+import ChatPage from '../src/pages/ChatPage'
+import '../src/index.css'
+
+initI18n('en')
+
+const params = new URLSearchParams(location.search)
+const theme = params.get('theme') || 'dark'
+const scene = params.get('scene') || 'long' // long | short | paging
+// ThemeProvider derives the root theme from its OWN preference store
+// (localStorage 'mc-theme', falling back to 'system') and rewrites the
+// data-theme attribute on mount — so setting the attribute alone is
+// overwritten and every frame silently renders in the system theme.
+// Seed the preference the provider actually reads; the attribute below
+// only covers the pre-mount paint.
+localStorage.setItem('mc-theme', theme)
+document.documentElement.setAttribute('data-theme', theme)
+
+// Deterministic pixels: no entrance eases, no pulsing dots, no smooth scroll.
+const style = document.createElement('style')
+style.textContent = '*, *::before, *::after { animation: none !important; transition: none !important; scroll-behavior: auto !important; }'
+document.head.appendChild(style)
+
+type Msg = { role: string; content: string; cls: string; ts: string }
+const pad = (n: number) => String(n).padStart(2, '0')
+const mkLong = (): Msg[] => Array.from({ length: 16 }, (_, i) => ([
+  { role: 'user', content: `Status check #${i + 1}: anything new in the queue?`, cls: '', ts: `2026-08-27T01:${pad(10 + i)}:00Z` },
+  { role: 'assistant', content: `Sweep ${i + 1} done.\n\n- two issues triaged as duplicates\n- one PR moved to review-ready\n- CI green on the retry`, cls: '', ts: `2026-08-27T01:${pad(10 + i)}:30Z` },
+])).flat()
+const mkShort = (): Msg[] => mkLong().slice(0, 2)
+
+const messages = scene === 'short' ? mkShort() : mkLong()
+;(window as unknown as { __CAPTURE_MESSAGES__: Msg[] }).__CAPTURE_MESSAGES__ = messages
+
+const store = configureStore({
+  reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+  preloadedState: {
+    dashboard: {
+      status: null,
+      slots: [{ key: 'slot-a', title: 'scroll-shell fixture', messages: messages.length, running: false, mode: '', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
+      slotsLoaded: true,
+      unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+    } as unknown as RootState['dashboard'],
+    chat: {
+      activeSlot: 'slot-a', messages,
+      slotRunning: false, slotStopping: false, slotState: 'idle',
+      history: [], historyHasMore: false, pendingInput: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+      // The paging scene photographs the two states the shell extraction moved
+      // across the file boundary: the earlier-messages bar (aboveRows slot,
+      // gated on slotHasMore) and the sticky older-messages spinner
+      // (loadingOlder). Only the loadOlderMessages thunk flips loadingOlder,
+      // so a preloaded true survives the mount refetch.
+      slotHasMore: scene === 'paging', slotOldestIndex: scene === 'paging' ? 4 : 0, loadingOlder: scene === 'paging',
+      slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+      historyOffset: 0, _wsChunkedDuringFetch: false,
+      slotMessages: {}, slotLoading: false,
+    } as unknown as RootState['chat'],
+    notifications: { items: [] } as unknown as RootState['notifications'],
+  },
+})
+
+const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+createRoot(document.getElementById('root')!).render(
+  <QueryClientProvider client={qc}>
+    <Provider store={store}>
+      <ThemeProvider>
+        <MemoryRouter>
+          <div data-capture-root style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+            <ChatPage />
+          </div>
+        </MemoryRouter>
+      </ThemeProvider>
+    </Provider>
+  </QueryClientProvider>,
+)

--- a/website/package.json
+++ b/website/package.json
@@ -50,7 +50,9 @@
     "verify:tool-blocked-cause": "node scripts/capture-tool-blocked-cause.mjs",
     "verify:topbar-badge-overhang": "node scripts/capture-topbar-badge-overhang.mjs",
     "verify:user-bubble-mobile-overflow": "node scripts/capture-user-bubble-mobile-overflow.mjs",
-    "pretest": "npm run jscpd"
+    "pretest": "npm run jscpd",
+    "mutation:scroll-shell": "node scripts/mutation-check-scroll-shell.mjs",
+    "golden:scroll-shell": "node scripts/capture-chatpage-scroll-shell.mjs"
   },
   "files": [
     "dist/"

--- a/website/scripts/capture-chatpage-scroll-shell.mjs
+++ b/website/scripts/capture-chatpage-scroll-shell.mjs
@@ -1,0 +1,200 @@
+/**
+ * Golden frames for ChatPage's transcript scroll shell.
+ *
+ * CAPTURE (default): shoots the shell's visual states off the isolated entry
+ * (capture/chatpage-scroll-shell.html — the REAL ChatPage, deterministic
+ * fixture, animations off). Every frame asserts its state before writing:
+ *   01-bottom       long transcript auto-pinned to the bottom (±2px), bottom
+ *                   mask present above the composer
+ *   02-pill         scrolled up 600px: jump pill visible, top fade under header
+ *   03-short        transcript too short to scroll: fades still lay out sanely
+ *   (x2 themes: dark, light)
+ *
+ * COMPARE (--compare <baselineDir> <candidateDir>): byte-compares same-named
+ * frames — the migration gate. Run capture on the base commit into A, on the
+ * migrated commit into B (same machine, same Chromium), then compare. Any
+ * mismatch exits 1 and names the frame; the two files are on disk for a human
+ * or reviewer to eyeball.
+ *
+ * Usage (from website/):
+ *   npx vite --host 127.0.0.1 --port 6832 --strictPort     # another shell
+ *   node scripts/capture-chatpage-scroll-shell.mjs http://127.0.0.1:6832 ../temp-screenshots/chatpage-scroll-shell-golden
+ *   node scripts/capture-chatpage-scroll-shell.mjs --compare dirA dirB
+ */
+import { chromium } from 'playwright'
+import { resolve as resolvePath } from 'node:path'
+import { mkdirSync, readFileSync, readdirSync, rmSync, renameSync, existsSync } from 'node:fs'
+
+const EXPECTED_FRAMES = ['dark', 'light'].flatMap(t => [`01-bottom-${t}.png`, `02-pill-${t}.png`, `03-short-${t}.png`, `04-paging-${t}.png`]).sort()
+
+if (process.argv[2] === '--compare') {
+  const [a, b] = [process.argv[3], process.argv[4]]
+  if (!a || !b) { console.error('--compare needs <baselineDir> <candidateDir>'); process.exit(1) }
+  if (resolvePath(a) === resolvePath(b)) { console.error('--compare needs two DIFFERENT directories (same dir passes trivially)'); process.exit(1) }
+  // A vacuous pass is worse than a failure: an empty baseline, a missing
+  // candidate frame, or a stray extra frame must all fail loudly. Both dirs
+  // must contain EXACTLY the expected frames, each non-empty.
+  let bad = 0
+  for (const [name, dir] of [['baseline', a], ['candidate', b]]) {
+    let got
+    try { got = readdirSync(dir).filter(f => f.endsWith('.png')).sort() }
+    catch { console.error(`${name} dir ${dir} is not readable — check the path`); process.exit(1) }
+    if (JSON.stringify(got) !== JSON.stringify(EXPECTED_FRAMES)) {
+      console.error(`${name} dir ${dir} does not hold exactly the expected frames.\n  expected: ${EXPECTED_FRAMES.join(', ')}\n  got:      ${got.join(', ') || '(none)'}`)
+      bad++
+    }
+  }
+  if (bad) process.exit(1)
+  for (const f of EXPECTED_FRAMES) {
+    const [fa, fb] = [readFileSync(`${a}/${f}`), readFileSync(`${b}/${f}`)]
+    if (!fa.length || !fb.length) { console.error(`${f}: empty file`); bad++; continue }
+    const same = fa.equals(fb)
+    console.log(`${f}: ${same ? 'identical' : 'DIFFERS'}`)
+    if (!same) bad++
+  }
+  process.exit(bad ? 1 : 0)
+}
+
+const BASE = process.argv[2] || 'http://127.0.0.1:6832'
+const FINAL_OUT = process.argv[3] || '../temp-screenshots/chatpage-scroll-shell-golden'
+// Shoot into a temp dir and PROMOTE only after every check passes: writing
+// frames straight to the target means a failed run still overwrites the
+// goldens, and a later --compare then blesses wrong-state pixels.
+const OUT = `${FINAL_OUT}.capturing-${process.pid}`
+mkdirSync(OUT, { recursive: true })
+
+const browser = await chromium.launch()
+let failed = false
+const check = (name, ok, detail) => { console.log(`${name}: ${ok ? 'OK' : 'MISMATCH'} ${detail}`); if (!ok) failed = true }
+
+const SCROLLER = '.chat-container'
+
+/** Must be byte-equal to the entry's fixture: ChatPage refetches the slot on
+ *  mount and the response REPLACES chat.messages, so a null/empty answer here
+ *  silently blanks the preloaded transcript (the continueGate suite's trap). */
+const pad = (n) => String(n).padStart(2, '0')
+const fixture = (scene) => {
+  const long = Array.from({ length: 16 }, (_, i) => ([
+    { role: 'user', content: `Status check #${i + 1}: anything new in the queue?`, cls: '', ts: `2026-08-27T01:${pad(10 + i)}:00Z` },
+    { role: 'assistant', content: `Sweep ${i + 1} done.\n\n- two issues triaged as duplicates\n- one PR moved to review-ready\n- CI green on the retry`, cls: '', ts: `2026-08-27T01:${pad(10 + i)}:30Z` },
+  ])).flat()
+  return scene === 'short' ? long.slice(0, 2) : long
+}
+const geom = (page) => page.evaluate((sel) => {
+  const el = document.querySelector(sel)
+  return el ? { top: el.scrollTop, height: el.scrollHeight, client: el.clientHeight } : null
+}, SCROLLER)
+
+async function newPage(theme, scene) {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 }, deviceScaleFactor: 1 })
+  await page.route(u => new URL(u).pathname.startsWith('/api/'), route => {
+    const path = new URL(route.request().url()).pathname
+    if (/^\/api\/chat\/slots\/[^/]+$/.test(path)) {
+      const msgs = fixture(scene)
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ key: 'slot-a', title: 'scroll-shell fixture', running: false, has_more: scene === 'paging', total: msgs.length, messages: msgs }) })
+    }
+    // Bare-array endpoints: their consumers type the response as T[] directly.
+    if (/\/api\/chat\/(tags|pins|folders|tag-columns)$/.test(path)) return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    const isList = /commands|skills|agents$|sessions|files|history|models|artifacts|folders|slots$/.test(path)
+    return route.fulfill({ status: 200, contentType: 'application/json', body: isList ? '[]' : '{}' })
+  })
+  await page.goto(`${BASE}/capture/chatpage-scroll-shell.html?theme=${theme}&scene=${scene}`)
+  await page.waitForSelector('[data-capture-root]')
+  await page.getByText(scene === 'short' ? 'Status check #1:' : 'Sweep 16 done.').first().waitFor()
+  await page.waitForTimeout(250) // one RO/layout settle; animations are globally off
+  // ThemeProvider re-derives the root theme from its own preference store —
+  // verify the REQUESTED mode actually survived provider mount, or the
+  // "dark" frames are silently light duplicates. The resolved attribute is
+  // "<colorTheme>-<mode>" (e.g. kiro-dark), so match the mode suffix.
+  const applied = await page.evaluate(() => document.documentElement.getAttribute('data-theme'))
+  check(`theme-applied ${theme}/${scene}`, applied === theme || !!applied?.endsWith(`-${theme}`), `data-theme=${applied}`)
+  // The entry's fixture and this script's route answer MUST be byte-equal
+  // (the mount refetch REPLACES the store messages) — enforce instead of
+  // trusting the duplicated literals to stay in sync.
+  const parity = await page.evaluate(() => JSON.stringify(window.__CAPTURE_MESSAGES__))
+  check(`fixture-parity ${theme}/${scene}`, parity === JSON.stringify(fixture(scene)), parity === JSON.stringify(fixture(scene)) ? 'ok' : 'entry fixture != script fixture')
+  return page
+}
+
+for (const theme of ['dark', 'light']) {
+  // 01 — long transcript lands at the bottom
+  {
+    const page = await newPage(theme, 'long')
+    const g = await geom(page)
+    check(`01-${theme} scroller`, !!g && g.height > g.client, JSON.stringify(g))
+    check(`01-${theme} pinned to bottom`, !!g && Math.abs(g.top - (g.height - g.client)) <= 2, `top=${g?.top} bottom=${g ? g.height - g.client : '-'}`)
+    const mask = await page.locator('[data-capture-root] .bg-gradient-to-t.from-bg').count()
+    check(`01-${theme} bottom mask mounted`, mask >= 1, `masks=${mask}`)
+    await page.screenshot({ path: `${OUT}/01-bottom-${theme}.png` })
+    await page.close()
+  }
+  // 02 — scrolled up: pill + top fade
+  {
+    const page = await newPage(theme, 'long')
+    await page.evaluate((sel) => {
+      // ABSOLUTE offset, not bottom-relative: the pinned-prompt band updates in
+      // a scroll rAF, and a bottom-relative target lands the boundary bubble a
+      // sub-pixel apart between runs — the one nondeterminism the golden
+      // comparison cannot tolerate. 1200 puts the boundary mid-bubble
+      // deterministically.
+      const el = document.querySelector(sel)
+      el.scrollTop = 1200
+      el.dispatchEvent(new Event('scroll'))
+    }, SCROLLER)
+    await page.getByLabel('Scroll to bottom').waitFor()
+    // Let the pinned-band rAF chain settle before shooting.
+    await page.evaluate(() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r))))
+    await page.waitForTimeout(120)
+    const topFade = await page.locator('[data-capture-root] .bg-gradient-to-b.from-bg').count()
+    check(`02-${theme} top fade mounted`, topFade >= 1, `fades=${topFade}`)
+    await page.screenshot({ path: `${OUT}/02-pill-${theme}.png` })
+    await page.close()
+  }
+  // 03 — short transcript: nothing to scroll, no pill, fades behave
+  {
+    const page = await newPage(theme, 'short')
+    const g = await geom(page)
+    check(`03-${theme} no scroll needed`, !!g && g.height <= g.client + 2, JSON.stringify(g))
+    const pill = await page.getByLabel('Scroll to bottom').count()
+    check(`03-${theme} no pill`, pill === 0, `pills=${pill}`)
+    await page.screenshot({ path: `${OUT}/03-short-${theme}.png` })
+    await page.close()
+  }
+  // 04 — paging state: the two pieces the extraction moved across the file
+  // boundary are BOTH on screen — the earlier-messages bar (aboveRows slot)
+  // and the sticky older-messages spinner (loadingOlder).
+  {
+    const page = await newPage(theme, 'paging')
+    await page.evaluate((sel) => { const el = document.querySelector(sel); el.scrollTop = 0; el.dispatchEvent(new Event('scroll')) }, SCROLLER)
+    await page.evaluate(() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r))))
+    const bar = await page.getByTestId('load-earlier-messages').count()
+    check(`04-${theme} earlier-messages bar mounted`, bar === 1, `bars=${bar}`)
+    const spinner = await page.getByTestId('older-messages-loading').count()
+    check(`04-${theme} older-messages spinner mounted`, spinner === 1, `spinners=${spinner}`)
+    const spinnerVisible = spinner === 1 && await page.getByTestId('older-messages-loading').isVisible()
+    check(`04-${theme} spinner visible (sticky under header)`, spinnerVisible, '')
+    await page.screenshot({ path: `${OUT}/04-paging-${theme}.png` })
+    await page.close()
+  }
+}
+
+await browser.close()
+// The two themes must produce DIFFERENT pixels: identical pairs mean the
+// theme never took effect and the "dark" goldens are counterfeit light ones.
+// Derived from EXPECTED_FRAMES so a new scene cannot ship without this check.
+for (const frame of [...new Set(EXPECTED_FRAMES.map(f => f.replace(/-(dark|light)\.png$/, '')))]) {
+  const same = readFileSync(`${OUT}/${frame}-dark.png`).equals(readFileSync(`${OUT}/${frame}-light.png`))
+  check(`${frame} dark differs from light`, !same, same ? 'byte-identical' : 'ok')
+}
+if (failed) {
+  console.error(`CAPTURE FAILED: a frame did not match its asserted state — goldens NOT updated (frames left in ${OUT})`)
+  process.exit(1)
+}
+// Promote by directory swap, not per-file copy: an interrupted copy would
+// leave a MIXED old/new baseline, and a renamed frame would leave a ghost
+// PNG. Keep the previous baseline as .old until the swap lands, then drop it.
+const OLD = `${FINAL_OUT}.old-${process.pid}`
+if (existsSync(FINAL_OUT)) renameSync(FINAL_OUT, OLD)
+renameSync(OUT, FINAL_OUT)
+rmSync(OLD, { recursive: true, force: true })
+console.log(`all golden frames verified — promoted to ${FINAL_OUT}`)

--- a/website/scripts/mutation-check-scroll-shell.mjs
+++ b/website/scripts/mutation-check-scroll-shell.mjs
@@ -1,0 +1,256 @@
+/**
+ * Mutation check for the ChatPage scroll-shell characterization net.
+ *
+ * Proves the net has teeth line by line: for EVERY code line in the shell
+ * region (header fade → jump pill), delete that line and require at least one
+ * pinning test to fail. A mutant that survives is a hole in the net — the
+ * harness exits 1 and lists it, so the fix is to add a pin (or explicitly
+ * scope the line out below, with a reason).
+ *
+ * A mutant that breaks compilation counts as caught: vitest fails on it, and a
+ * migration that broke compilation could never ship either. Comment-only and
+ * whitespace lines are skipped (they are not code).
+ *
+ * Usage (from website/):
+ *   node scripts/mutation-check-scroll-shell.mjs            # full run
+ *   node scripts/mutation-check-scroll-shell.mjs --list     # show target lines, run nothing
+ */
+import { readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { execSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { createRequire } from 'node:module'
+
+/** A mutant that no longer PARSES is caught by construction: `tsc -b` blocks
+ *  the push gate and CI, so a migration that broke the syntax could never
+ *  ship. Checking it here (fast, ~100ms via the project's own TypeScript
+ *  parser) keeps the per-line guarantee honest without running the full
+ *  type-checker per mutant. */
+const ts = createRequire(import.meta.url)('typescript')
+const parses = (src) => {
+  const out = ts.transpileModule(src, {
+    compilerOptions: { jsx: ts.JsxEmit.Preserve, target: ts.ScriptTarget.ESNext },
+    reportDiagnostics: true,
+    fileName: 'ChatPage.tsx',
+  })
+  return (out.diagnostics ?? []).length === 0
+}
+
+// The shell region may live in ChatPage or, post-extraction, in the shell
+// component; mutate whichever file currently holds each region's anchors.
+const FILES = ['src/pages/ChatPage.tsx', 'src/pages/chat/TranscriptScrollShell.tsx'].map(f => resolve(f))
+const SUITES = [
+  'src/test/ChatPage.scrollShell.recipe.test.tsx',
+  'src/test/ChatPage.scrollShell.render.test.tsx',
+  'src/test/ChatPage.fadeClearance.test.tsx',
+]
+
+const START = '{/* Header fade'
+const END = 'Status chrome never claims'
+
+/** The shell is SIX sub-regions, each an explicit (start, end) anchor pair —
+ *  exactly the pieces the migration moves. Code between them (PinnedPrompt,
+ *  WelcomeView, drop overlay) stays on the page verbatim and is out of scope.
+ *  `includeEnd` pulls the end-anchor line itself into scope — used where that
+ *  line is load-bearing code, so the anchor choice cannot exempt it. */
+const REGIONS = [
+  { name: 'header-fade', start: '<EdgeFade side="top"', end: '{/* Fold sentinel' },
+  // The shell IMPORT on the page — one line, but deleting it is precisely the
+  // "extraction silently undone" mutation, so it gets its own region.
+  { name: 'shell-import', start: "import TranscriptScrollShell", end: 'import { useVirtualChat' },
+  // The prop-plumbing seam the split invented: the wiring interface, the
+  // component signature, and the destructured parameter list. This block did
+  // not exist pre-extraction — anchoring the skeleton region below it would
+  // exempt exactly the code under review via anchor PLACEMENT (the exclusion
+  // channel the deadExclusions guard cannot see).
+  { name: 'shell-props-seam', start: 'export interface TranscriptVirtWiring', end: 'return (' },
+  // The scroller SKELETON lives in TranscriptScrollShell; rows/footer are
+  // CONTENT threaded through as slots (their wrapper contract is pinned by the
+  // recipe suite's row-wrapper tests, their props by their own suites).
+  // includeEnd: `{belowRows}` is the line that mounts the below slot — its
+  // deletion must be a caught mutant, not an anchor exemption.
+  { name: 'scroller-skeleton', start: 'ref={scrollerRef}', end: '{belowRows}', includeEnd: true },
+  // The page keeps the scalar wiring props on the call site.
+  { name: 'shell-call-props', start: '<TranscriptScrollShell', end: 'aboveRows={' },
+  // The slot BODIES on the call site: the earlier-messages gate/bar, footer,
+  // survey, tail spacer. This is the cross-file seam the extraction created —
+  // exactly where a silent drop or slot swap would live. Ends at the children
+  // boundary: the message-row body was NOT moved by the extraction and stays
+  // pinned by the row-wrapper recipe tests and the page's own suites.
+  { name: 'call-site-slots', start: 'aboveRows={', end: '{/* Message items' },
+  { name: 'bottom-mask', start: '{/* Transcript bottom mask', end: '<div className="relative">' },
+  { name: 'jump-pill', start: '<JumpToBottomButton', end: '{/* Status chrome' },
+]
+
+/** Lines that are CONTENT rendered inside the shell, not the shell itself —
+ *  the later migration moves the shell around them and leaves them verbatim,
+ *  so their props are pinned by their own component suites, not this net.
+ *  Every entry needs a reason; an unexplained exclusion defeats the harness. */
+const OUT_OF_SCOPE = [
+  { match: /^\s*(key=|sessionId=|kiroCrewVersion=|turnCount=|slotOrigin=|onLayoutChange=)/, reason: 'SessionPulseSurveyCard props — content child, pinned by its own suite' },
+  { match: /^\s*<ChatFooter .*\/>$/, reason: 'whole footer line — presence+slot membership pinned by the render suite; props by ChatFooter suites' },
+  { match: /^\s*<SessionPulseSurveyCard$/, reason: 'opening tag only; presence+order IS pinned, props are the child suite\'s' },
+]
+
+const sources = FILES.map(f => { try { return { file: f, text: readFileSync(f, 'utf8') } } catch { return null } }).filter(Boolean)
+
+const isCode = (line, inComment) => {
+  const t = line.trim()
+  if (inComment.on) {
+    if (t.endsWith('*/') || t.endsWith('*/}')) inComment.on = false
+    return false
+  }
+  if ((t.startsWith('{/*') || t.startsWith('/*')) && !(t.endsWith('*/}') || t.endsWith('*/'))) { inComment.on = true; return false }
+  if (t === '' || t === '}' || t === ')}' || t === ')' || t === '>' || t === '/>' || t === '})}') return false
+  if (t.startsWith('//') || t.startsWith('*') || t.startsWith('{/*') || t.endsWith('*/}')) return false
+  return true
+}
+
+const targets = []
+for (const region of REGIONS) {
+  // Find the ONE file currently holding this region's anchors.
+  const holder = sources.find(s => {
+    const i = s.text.indexOf(region.start)
+    return i >= 0 && s.text.indexOf(region.end, i) > i
+  })
+  if (!holder) {
+    console.error(`anchor not found for region ${region.name} in any shell file — update REGIONS`)
+    process.exit(2)
+  }
+  const lines = holder.text.split('\n')
+  const startIdx = lines.findIndex(l => l.includes(region.start))
+  const endIdx = lines.findIndex((l, i) => i > startIdx && l.includes(region.end))
+  const inComment = { on: false }
+  const stopIdx = region.includeEnd ? endIdx + 1 : endIdx
+  for (let i = startIdx; i < stopIdx; i++) {
+    const line = lines[i]
+    if (!isCode(line, inComment)) continue
+    const excluded = OUT_OF_SCOPE.find(e => e.match.test(line))
+    if (excluded) { targets.push({ i, line, file: holder.file, region: region.name, skip: excluded.reason }); continue }
+    targets.push({ i, line, file: holder.file, region: region.name })
+  }
+}
+
+// A documented exclusion that matches nothing is dead config: it means the
+// region layout shifted and the harness silently lost the scope the exclusion
+// was written for (exactly how "0 scoped out" once masked an unmutated seam).
+const deadExclusions = OUT_OF_SCOPE.filter(e => !targets.some(t => t.skip === e.reason))
+if (deadExclusions.length) {
+  console.error('DEAD OUT_OF_SCOPE entries (match no in-region line — fix REGIONS or delete the entry):')
+  for (const e of deadExclusions) console.error(`  ${e.match} — ${e.reason}`)
+  process.exit(2)
+}
+
+if (process.argv.includes('--list')) {
+  for (const t of targets) console.log(`${t.i + 1}: ${t.skip ? `[SKIP: ${t.skip}] ` : ''}${t.line.trim().slice(0, 100)}`)
+  console.log(`\n${targets.filter(t => !t.skip).length} mutation targets, ${targets.filter(t => t.skip).length} scoped out`)
+  process.exit(0)
+}
+
+/** Thrown when vitest did not run to completion — the caller must restore the
+ *  mutant FIRST and only then exit. process.exit() inside this function would
+ *  skip the caller's finally block and leave a mutated source file on disk
+ *  (this exact failure happened: mutant #1's giant assertion diff overflowed
+ *  the execSync pipe buffer, the truncated output carried no failure summary,
+ *  and the abort path exited without restoring). */
+class InfraError extends Error {}
+
+/** Verdicts come from the JSON reporter ON DISK, not from parsing the pipe: a
+ *  red toContain against a whole-file source dump prints the entire file per
+ *  failing test (tens of MB with ANSI codes), which overflows any reasonable
+ *  pipe buffer and truncates away the console summary line. The JSON file is
+ *  immune to that, and lets us demand NAMED failing tests as the evidence. */
+const RESULT_FILE = resolve(tmpdir(), `mutation-scroll-shell-${process.pid}.json`)
+const run = () => {
+  rmSync(RESULT_FILE, { force: true })
+  let exitedNonzero = false
+  try {
+    execSync(`npx vitest run ${SUITES.join(' ')} --silent --reporter=json --outputFile="${RESULT_FILE}"`, { stdio: 'pipe', timeout: 120_000, maxBuffer: 64 * 1024 * 1024 })
+  } catch (err) {
+    if (err.killed || err.signal) throw new InfraError(`vitest did not run to completion (${err.signal || 'timeout'})`)
+    exitedNonzero = true
+  }
+  let report
+  try {
+    report = JSON.parse(readFileSync(RESULT_FILE, 'utf8'))
+  } catch {
+    throw new InfraError('vitest produced no readable JSON report — runner/config error, not a red test')
+  }
+  if (!exitedNonzero && report.numFailedTests === 0 && report.numFailedTestSuites === 0) return 'green'
+  // NAMED failing tests are the strong evidence — a pin went red.
+  if (report.numFailedTests > 0) return 'caught-test'
+  // A suite that fails to COLLECT (deleted line broke the import surface)
+  // names no test and exercises no pin; it could never ship (tsc/CI), but it
+  // must not be laundered into the pin-caught number.
+  if (report.numFailedTestSuites > 0) return 'caught-collect'
+  throw new InfraError('vitest exited nonzero but its report names no failing test — infra error')
+}
+
+console.log('baseline run (must be green)...')
+if (run() !== 'green') { console.error('baseline is RED — fix the suites before mutation-checking'); process.exit(2) }
+
+const survivors = []
+let caughtParse = 0
+let caughtTest = 0
+let caughtCollect = 0
+let done = 0
+const active = targets.filter(t => !t.skip)
+// Crash/termination safety: while a mutant is on disk the working tree is
+// corrupted (one deleted line, possibly uncommitted). Restore in finally AND
+// on every catchable termination signal — SIGTERM/SIGHUP during execSync
+// would otherwise bypass finally and leave the deleted line on disk.
+// Restoration is GUARDED: it only overwrites the file if it still holds the
+// mutant we wrote. An editor autosave landing during the vitest window means
+// the file is no longer ours to clobber — warn and leave it for the human.
+let restore = null
+const safeRestore = (r) => {
+  let now
+  try { now = readFileSync(r.file, 'utf8') } catch { return }
+  if (now === r.mutated) { writeFileSync(r.file, r.original); return }
+  if (now !== r.original) console.error(`NOT restoring ${r.file}: it changed while a mutant was on disk (concurrent edit?) — recover the deleted line manually`)
+}
+for (const [sig, code] of [['SIGINT', 130], ['SIGTERM', 143], ['SIGHUP', 129]]) {
+  process.on(sig, () => { if (restore) safeRestore(restore); process.exit(code) })
+}
+for (const t of active) {
+  const original = readFileSync(t.file, 'utf8')
+  const mutated = original.split('\n')
+  mutated.splice(t.i, 1)
+  const mutatedSrc = mutated.join('\n')
+  done++
+  if (!parses(mutatedSrc)) {
+    caughtParse++
+    console.log(`[${done}/${active.length}] caught (parse)  L${t.i + 1}`)
+    continue
+  }
+  let verdict
+  restore = { file: t.file, original, mutated: mutatedSrc }
+  try {
+    writeFileSync(t.file, mutatedSrc)
+    verdict = run()
+  } finally {
+    safeRestore(restore)
+    restore = null
+  }
+  if (verdict === 'green') {
+    survivors.push(t)
+    console.log(`[${done}/${active.length}] SURVIVED  L${t.i + 1}: ${t.line.trim().slice(0, 90)}`)
+  } else if (verdict === 'caught-collect') {
+    caughtCollect++
+    console.log(`[${done}/${active.length}] caught (collect) L${t.i + 1}`)
+  } else {
+    caughtTest++
+    console.log(`[${done}/${active.length}] caught (test)   L${t.i + 1}`)
+  }
+}
+
+// Parse-caught mutants are guaranteed by the tsc push/CI gate, not by the
+// pins — report the split so the headline number cannot launder one as the
+// other (a net that is mostly parse-caught has few real teeth).
+console.log(`\n=== mutation report: ${caughtParse + caughtTest + caughtCollect}/${active.length} caught (${caughtTest} by tests, ${caughtParse} by parse/tsc, ${caughtCollect} by collection failure), ${survivors.length} survived, ${targets.length - active.length} scoped out ===`)
+if (survivors.length) {
+  console.log('SURVIVORS (add a pin or scope out with a reason):')
+  for (const s of survivors) console.log(`  L${s.i + 1}: ${s.line.trim()}`)
+  process.exit(1)
+}
+console.log('net verified: every in-scope line deletion turns at least one test red')

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -72,6 +72,7 @@ import { useScrollManager } from './chat/useScrollManager'
 import { useBubbleVanishProbe } from './chat/useBubbleVanishProbe'
 import { shouldPaginateOlder, canForkAtWindow, searchScopeIsLimited } from './chat/pagination'
 import EarlierMessagesBar from './chat/EarlierMessagesBar'
+import TranscriptScrollShell from './chat/TranscriptScrollShell'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
 import { addPendingFile, parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, buildRelMap, findUnreferencedAttachments, hasExactRelMention, normalizeWindowsPath, parseDirTokens, serializeDirTokens, parseDirs, resolveDirSegment, spliceDirTokens, VIDEO_EXT } from '../utils/fileTokens'
 import { classifyDrop } from '../utils/dropClassify'
@@ -8060,74 +8061,64 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 />
               </motion.div>
             ) : (
-            <div
-              ref={scrollerRef}
-              // -1 so the bar can hand focus here on unmount without adding a tab stop.
-              tabIndex={-1}
-              // stable theming hook 'chat-container' — see website/docs/theming-contract.md
-              className="chat-container"
-              style={{
-                flex: 1,
-                // Second half of the fade-band clearance, alongside
-                // TRANSCRIPT_TAIL_SPACER_PX. Unlike the tail spacer this one also
-                // applies to a transcript short enough not to scroll, so both are
-                // needed for the last line to clear the band in every state.
-                paddingBottom: 16,
-                overflowY: 'auto',
-                // overflow-x must be pinned, not left to default `visible`: with
-                // overflowY `auto`, CSS forces the `visible` axis to compute to
-                // `auto`, so one over-wide child (a long path, a wide code block,
-                // a widget) gives the whole list a draggable horizontal scrollbar
-                // above the composer. The conversation never pans sideways —
-                // wide children scroll within themselves.
-                overflowX: 'hidden',
-                // Reserve a stable scrollbar gutter so the 6px scrollbar always
-                // occupies the same right-edge column the title overlay is inset
-                // from (see the right-1.5 inset above) — keeps the thumb visible
-                // and grabbable at the top instead of hidden behind the header.
-                scrollbarGutter: 'stable',
-                // Native scroll anchoring: when items above the viewport
-                // resize (e.g. widget iframes loading async), the browser
-                // adjusts scrollTop to keep the user's content stable.
-                // This is more precise than item-level anchoring because
-                // it works at the DOM-element granularity.
-                overflowAnchor: 'auto',
-                // Keep wheel/touch momentum inside the message list. Without
-                // this, a delta that arrives at the top or bottom edge chains
-                // to the nearest scrollable ancestor — the document, which
-                // `body{overflow-y:auto}` leaves scrollable — and drags the
-                // whole app shell by however many pixels of slack exist
-                // (a browser-extension node parked past the shell is enough).
-                overscrollBehavior: 'contain',
-              } as React.CSSProperties}
-              aria-label={i18nT('pages.chatPage.chat_messages')}
-              aria-live="polite"
+            <TranscriptScrollShell
+              scrollerRef={scrollerRef}
               onScroll={onScrollPin}
-            >
-              {/* Header spacer */}
-              <div className="h-16" />
+              virt={virt}
+              loadingOlder={loadingOlder}
+              // Second half of the fade-band clearance, alongside
+              // TRANSCRIPT_TAIL_SPACER_PX. Unlike the tail spacer this one also
+              // applies to a transcript short enough not to scroll, so both are
+              // needed for the last line to clear the band in every state.
+              scrollerStyle={{ paddingBottom: 16 }}
+              aboveRows={<>
               {/* Mid-switch `slotHasMore` still describes the outgoing chat, so the cursor
                   key gates the bar to match the paging thunk's own precondition. */}
               {slotHasMore && cursorIsForActiveSlot && (
                 <EarlierMessagesBar loading={loadingOlder} failed={olderFailed} onLoad={handleLoadEarlier} onFocusRelease={() => scrollerRef.current?.focus()} />
               )}
-              {/* Top sentinel: drives upward window expansion via virtualizer's IO. */}
-              <div ref={virt.topSentinelRef} aria-hidden style={{ height: 1 }} />
-              {/* top-16 matches the h-16 header spacer above, so the pinned spinner
-                  clears the overlay header instead of sitting under it.
-                  overflow-anchor:none so appearing/vanishing here cannot become the
-                  browser's scroll anchor and jump the list mid-fetch. */}
-              {loadingOlder && (
-                <div className="sticky top-16 z-[1] flex justify-center py-2" data-testid="older-messages-loading" role="status" aria-label={i18nT('pages.chatPage.loading_earlier_messages')} style={{ overflowAnchor: 'none', background: 'var(--bg)' }}>
-                  <Loader size={16} className="animate-spin text-muted" />
+              </>}
+              belowRows={<>
+              {/* Footer */}
+              <ChatFooter running={slotRunning} stopping={slotStopping} state={slotState} lastRole={lastRole} streamTick={streamTick} regenerating={regenerating} stopState={currentSlot?.stop_state} />
+              {activeSlot && !slotLoading && !embedded && !popout && slotSwitchTarget !== activeSlot && (
+                <div className="px-4 mx-auto w-full" style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
+                  <SessionPulseSurveyCard
+                    // Remount on session switch: without this, React reuses
+                    // the same component instance across sessions, so an
+                    // in-progress rating/feedback/email from session A would
+                    // still be sitting in state when the user switches to
+                    // session B and hits Submit — attributing A's answers to
+                    // B's sessionId prop, which had already updated.
+                    //
+                    // Gated on !slotLoading: the card captures its baseline
+                    // turn count on FIRST MOUNT (see the component's own
+                    // comment), so mounting before history finishes loading
+                    // would baseline at 0 and then count every loaded
+                    // historical turn as "live" once the fetch resolves —
+                    // reintroducing the exact reopened-session bug the
+                    // baseline exists to prevent, just via a race instead of
+                    // a missing check.
+                    key={activeSlot}
+                    sessionId={activeSlot}
+                    kiroCrewVersion={kiroCrewVersion}
+                    turnCount={completedTurnCount}
+                    slotOrigin={currentSlot?.origin}
+                    onLayoutChange={handleSurveyLayoutChange}
+                  />
                 </div>
               )}
-              {/* Top spacer — reserves the height of all items above the mounted
-                  window so the scrollbar stays accurate while only the window
-                  renders real DOM (keeps fast scroll cheap — O(window) nodes).
-                  overflow-anchor:none so the browser anchors on real content,
-                  not on this spacer (which resizes as the window moves). */}
-              <div aria-hidden style={{ height: virt.offsetBefore, overflowAnchor: 'none' }} />
+              {/* Tail spacer, in px rather than vh. It plus the scroller's own
+                  bottom padding is the clearance between the last line of the
+                  transcript and the FIXED-height fade band below, so expressing it
+                  in `vh` made that clearance viewport-dependent: at 2vh + 8px it
+                  cleared a 24px band by 1px at 844px tall and cut INTO the last
+                  line on anything shorter (−1px at 740, −2px at 700, −5px at 560),
+                  which is the sliced-glyph hairline reported from a phone and the
+                  reason it looked mobile-only. */}
+              <div style={{ height: TRANSCRIPT_TAIL_SPACER_PX }} />
+              </>}
+            >
               {/* Message items — only the mounted window renders; everything
                   else is represented by the top/bottom spacers. */}
               {visibleDisplayItems.map((vi) => {
@@ -8193,50 +8184,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 >{item.msgs.map((m, j) => <div key={msgIdentityKey(m, stableMsgKey)}>{renderMessage(item.startIdx + j, m)}</div>)}</CollapsibleToolGroup>)
               })() : renderMessage(item.idx, item.msg)}</div>
               })}
-              {/* Bottom spacer — reserves the height of all items below the
-                  mounted window. overflow-anchor:none (see top spacer). */}
-              <div aria-hidden style={{ height: virt.offsetAfter, overflowAnchor: 'none' }} />
-              {/* Bottom sentinel: drives downward window expansion when in jump mode. */}
-              <div ref={virt.bottomSentinelRef} aria-hidden style={{ height: 1 }} />
-              {/* Footer */}
-              <ChatFooter running={slotRunning} stopping={slotStopping} state={slotState} lastRole={lastRole} streamTick={streamTick} regenerating={regenerating} stopState={currentSlot?.stop_state} />
-              {activeSlot && !slotLoading && !embedded && !popout && slotSwitchTarget !== activeSlot && (
-                <div className="px-4 mx-auto w-full" style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
-                  <SessionPulseSurveyCard
-                    // Remount on session switch: without this, React reuses
-                    // the same component instance across sessions, so an
-                    // in-progress rating/feedback/email from session A would
-                    // still be sitting in state when the user switches to
-                    // session B and hits Submit — attributing A's answers to
-                    // B's sessionId prop, which had already updated.
-                    //
-                    // Gated on !slotLoading: the card captures its baseline
-                    // turn count on FIRST MOUNT (see the component's own
-                    // comment), so mounting before history finishes loading
-                    // would baseline at 0 and then count every loaded
-                    // historical turn as "live" once the fetch resolves —
-                    // reintroducing the exact reopened-session bug the
-                    // baseline exists to prevent, just via a race instead of
-                    // a missing check.
-                    key={activeSlot}
-                    sessionId={activeSlot}
-                    kiroCrewVersion={kiroCrewVersion}
-                    turnCount={completedTurnCount}
-                    slotOrigin={currentSlot?.origin}
-                    onLayoutChange={handleSurveyLayoutChange}
-                  />
-                </div>
-              )}
-              {/* Tail spacer, in px rather than vh. It plus the scroller's own
-                  bottom padding is the clearance between the last line of the
-                  transcript and the FIXED-height fade band below, so expressing it
-                  in `vh` made that clearance viewport-dependent: at 2vh + 8px it
-                  cleared a 24px band by 1px at 844px tall and cut INTO the last
-                  line on anything shorter (−1px at 740, −2px at 700, −5px at 560),
-                  which is the sliced-glyph hairline reported from a phone and the
-                  reason it looked mobile-only. */}
-              <div style={{ height: TRANSCRIPT_TAIL_SPACER_PX }} />
-            </div>
+              
+            </TranscriptScrollShell>
             )}
             {/* Transcript bottom mask. Its box deliberately does NOT stop at the
                 scrollport's bottom edge — it reaches DOWN to the composer box, and

--- a/website/src/pages/chat/TranscriptScrollShell.tsx
+++ b/website/src/pages/chat/TranscriptScrollShell.tsx
@@ -1,0 +1,132 @@
+/**
+ * TranscriptScrollShell — the transcript scroller SKELETON for a virtualized
+ * chat surface: the scroll container's full style contract, the virtualizer's
+ * sentinel/spacer wiring, and the older-messages loading affordance.
+ *
+ * Extracted from the main chat page as one unit because these pieces only
+ * work as a set: the sentinels drive the window, the spacers reserve the
+ * unmounted height the sentinels are measured against, and the scroller's
+ * style contract is what keeps all of it scrollable, anchored, and contained.
+ * Page-owned content threads through as slots — `aboveRows` (paging bar),
+ * `children` (the mounted rows), `belowRows` (footer / survey / tail spacer) —
+ * so page state never leaks in here and the shell stays reusable by any host
+ * that runs useVirtualChat.
+ *
+ * The characterization net (ChatPage.scrollShell.recipe.test.tsx, the golden
+ * frames, and the mutation harness) pins this file's tokens byte-for-byte;
+ * fadeClearance geometry stays with the page, which supplies its clearance
+ * padding via `scrollerStyle`.
+ */
+import React from 'react'
+import { Loader } from 'lucide-react'
+import { i18nT } from '../../i18n/t'
+
+export interface TranscriptVirtWiring {
+  topSentinelRef: React.MutableRefObject<HTMLDivElement | null>
+  bottomSentinelRef: React.MutableRefObject<HTMLDivElement | null>
+  offsetBefore: number
+  offsetAfter: number
+}
+
+export default function TranscriptScrollShell({
+  scrollerRef,
+  onScroll,
+  virt,
+  loadingOlder,
+  scrollerStyle,
+  aboveRows,
+  belowRows,
+  children,
+}: {
+  /** The single scroll controller's element ref (owned by the host's virtualizer). */
+  scrollerRef: React.MutableRefObject<HTMLDivElement | null>
+  onScroll: () => void
+  virt: TranscriptVirtWiring
+  loadingOlder: boolean
+  /** Host-owned geometry merged onto the scroller (e.g. the fade-band clearance padding). */
+  scrollerStyle?: React.CSSProperties
+  /** Page content above the rows (the earlier-messages paging bar). */
+  aboveRows?: React.ReactNode
+  /** Page content below the rows (footer, survey, tail spacer). */
+  belowRows?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      ref={scrollerRef}
+      // -1 so the bar can hand focus here on unmount without adding a tab stop.
+      tabIndex={-1}
+      // stable theming hook 'chat-container' — see website/docs/theming-contract.md
+      className="chat-container"
+      style={{
+        // Host geometry merges FIRST so the shell's own tokens below always
+        // win: the scroll contract (overflow axes, anchoring, containment,
+        // gutter, and the flex-fill that makes the scroller consume its column
+        // — every current host mounts it in a flex column) is this component's
+        // whole reason to exist, and a consumer
+        // overriding e.g. overflowX would silently reinstate the horizontal
+        // scrollbar bug documented below. Hosts may only ADD properties the
+        // shell does not claim (like the fade-band clearance padding).
+        ...scrollerStyle,
+        flex: 1,
+        overflowY: 'auto',
+        // overflow-x must be pinned, not left to default `visible`: with
+        // overflowY `auto`, CSS forces the `visible` axis to compute to
+        // `auto`, so one over-wide child (a long path, a wide code block,
+        // a widget) gives the whole list a draggable horizontal scrollbar
+        // above the composer. The conversation never pans sideways —
+        // wide children scroll within themselves.
+        overflowX: 'hidden',
+        // Reserve a stable scrollbar gutter so the 6px scrollbar always
+        // occupies the same right-edge column the title overlay is inset
+        // from — keeps the thumb visible and grabbable at the top instead
+        // of hidden behind the header.
+        scrollbarGutter: 'stable',
+        // Native scroll anchoring: when items above the viewport
+        // resize (e.g. widget iframes loading async), the browser
+        // adjusts scrollTop to keep the user's content stable.
+        // This is more precise than item-level anchoring because
+        // it works at the DOM-element granularity.
+        overflowAnchor: 'auto',
+        // Keep wheel/touch momentum inside the message list. Without
+        // this, a delta that arrives at the top or bottom edge chains
+        // to the nearest scrollable ancestor — the document, which
+        // `body{overflow-y:auto}` leaves scrollable — and drags the
+        // whole app shell by however many pixels of slack exist
+        // (a browser-extension node parked past the shell is enough).
+        overscrollBehavior: 'contain',
+      } as React.CSSProperties}
+      aria-label={i18nT('pages.chatPage.chat_messages')}
+      aria-live="polite"
+      onScroll={onScroll}
+    >
+      {/* Header spacer */}
+      <div className="h-16" />
+      {aboveRows}
+      {/* Top sentinel: drives upward window expansion via virtualizer's IO. */}
+      <div ref={virt.topSentinelRef} aria-hidden style={{ height: 1 }} />
+      {/* top-16 matches the h-16 header spacer above, so the pinned spinner
+          clears the overlay header instead of sitting under it.
+          overflow-anchor:none so appearing/vanishing here cannot become the
+          browser's scroll anchor and jump the list mid-fetch. */}
+      {loadingOlder && (
+        <div className="sticky top-16 z-[1] flex justify-center py-2" data-testid="older-messages-loading" role="status" aria-label={i18nT('pages.chatPage.loading_earlier_messages')} style={{ overflowAnchor: 'none', background: 'var(--bg)' }}>
+          <Loader size={16} className="animate-spin text-muted" />
+        </div>
+      )}
+      {/* Top spacer — reserves the height of all items above the mounted
+          window so the scrollbar stays accurate while only the window
+          renders real DOM (keeps fast scroll cheap — O(window) nodes).
+          overflow-anchor:none so the browser anchors on real content,
+          not on this spacer (which resizes as the window moves). */}
+      <div aria-hidden style={{ height: virt.offsetBefore, overflowAnchor: 'none' }} />
+      {children}
+      {/* Bottom spacer — reserves the height of all items below the
+          mounted window. overflow-anchor:none (see top spacer). */}
+      <div aria-hidden style={{ height: virt.offsetAfter, overflowAnchor: 'none' }} />
+      {/* Bottom sentinel: drives downward window expansion when in jump mode. */}
+      <div ref={virt.bottomSentinelRef} aria-hidden style={{ height: 1 }} />
+      {belowRows}
+    </div>
+  )
+}

--- a/website/src/test/ChatPage.scrollShell.recipe.test.tsx
+++ b/website/src/test/ChatPage.scrollShell.recipe.test.tsx
@@ -1,0 +1,242 @@
+// Characterization net for ChatPage's transcript SCROLL SHELL — the region a
+// later refactor moves behind the shared chat scroll components. Written
+// against the CURRENT page and required to pass unmodified before and after
+// that move: these tests describe reality, not intention, and editing them in
+// the migration PR is itself a review red flag.
+//
+// Asserted against SOURCE TEXT (the fadeClearance suite's technique) because
+// most of the shell's load-bearing contracts are invisible to jsdom: it has no
+// layout engine, so `overscrollBehavior`, `scrollbarGutter`, gradient
+// geometry, and element ORDER inside the scroller can only be pinned where
+// they are written. Each assertion cites why the token is load-bearing, so a
+// legitimate future change knows what it is trading away.
+//
+// Companion: ChatPage.scrollShell.render.test.tsx pins the subset that IS
+// meaningful to render; scripts/mutation-check-scroll-shell.mjs proves the two
+// files together go red for every meaningful line mutation in the region.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// The shell's source may live inline in ChatPage or in extracted components —
+// the net follows the CODE, not the file: assertions are identical either way,
+// and a migration retargets nothing here.
+const SHELL_FILES = [
+  '../pages/ChatPage.tsx',
+  '../pages/chat/TranscriptScrollShell.tsx', // post-extraction home (absent pre-extraction)
+  '../app-sdk/ChatScrollChrome.tsx',
+]
+const SRC = SHELL_FILES.map((f) => {
+  // Fail LOUD on a missing file: a swallowed read would let a rename of any
+  // shell file silently shrink every pin in this suite to the remaining files.
+  return readFileSync(resolve(__dirname, f), 'utf8')
+}).join('\n// ---- file boundary ----\n')
+
+/** Slice the source between two unique anchors (inclusive of neither).
+ *  Failing to find an anchor is itself a pin: renaming or deleting the
+ *  anchored construct must turn this suite red, not silently shrink it. */
+function between(startAnchor: string | RegExp, endAnchor: string | RegExp): string {
+  const startMatch = typeof startAnchor === 'string' ? { index: SRC.indexOf(startAnchor), len: startAnchor.length } : (() => { const m = startAnchor.exec(SRC); return m ? { index: m.index, len: m[0].length } : { index: -1, len: 0 } })()
+  expect(startMatch.index, `start anchor not found: ${startAnchor}`).toBeGreaterThanOrEqual(0)
+  const rest = SRC.slice(startMatch.index + startMatch.len)
+  const endIdx = typeof endAnchor === 'string' ? rest.indexOf(endAnchor) : (endAnchor.exec(rest)?.index ?? -1)
+  expect(endIdx, `end anchor not found after start: ${endAnchor}`).toBeGreaterThanOrEqual(0)
+  return rest.slice(0, endIdx)
+}
+
+/** Pins match against the concatenated shell sources: every pinned token is
+ *  unique across them, so WHERE the code lives is free to change while WHAT
+ *  it says is not. Ordering assertions hold because each ordered group lives
+ *  (and moves) together in one file. */
+const SHELL = SRC
+
+describe('scroll shell: header fade', () => {
+  it('mounts the shared top fade anchored to the header row bottom edge', () => {
+    // anchor="below" (not the overlay default): in-flow or top-anchored
+    // variants consumed 24px of layout and pushed the pinned card off the
+    // header. The gradient recipe itself is pinned in ChatScrollChrome's
+    // consumer suites; what belongs to THIS page is the anchored mount.
+    expect(SRC).toContain('<EdgeFade side="top" anchor="below" />')
+  })
+})
+
+describe('scroll shell: the scroller element contract', () => {
+  const scroller = () => between('ref={scrollerRef}', '{/* Header spacer */}')
+
+  it('is focusable for bar-unmount focus handoff without adding a tab stop', () => {
+    expect(scroller()).toContain('tabIndex={-1}')
+  })
+
+  it('keeps the stable theming hook class', () => {
+    // website/docs/theming-contract.md: third-party themes select on it.
+    expect(scroller()).toContain('className="chat-container"')
+  })
+
+  it('owns the flexible column: flex 1 is what lets the transcript fill and shrink', () => {
+    expect(scroller()).toContain('flex: 1,')
+  })
+
+  it('carries the second half of the fade-band clearance as px padding', () => {
+    // Pairs with TRANSCRIPT_TAIL_SPACER_PX; unlike the tail spacer it also
+    // applies to a transcript too short to scroll (fadeClearance pins the sum).
+    // HOST-owned geometry: the page supplies it, wherever the scroller lives.
+    expect(SRC).toContain('paddingBottom: 16')
+  })
+
+  it('pins overflow-x so one over-wide child cannot give the list a horizontal scrollbar', () => {
+    expect(scroller()).toContain("overflowY: 'auto'")
+    expect(scroller()).toContain("overflowX: 'hidden'")
+  })
+
+  it('reserves a stable scrollbar gutter so the thumb is not hidden behind the header', () => {
+    expect(scroller()).toContain("scrollbarGutter: 'stable'")
+  })
+
+  it('keeps native scroll anchoring on for async resizes above the viewport', () => {
+    expect(scroller()).toContain("overflowAnchor: 'auto'")
+  })
+
+  it('contains overscroll so edge momentum cannot drag the app shell', () => {
+    expect(scroller()).toContain("overscrollBehavior: 'contain'")
+  })
+
+  it('is an accessible live region wired to the pin-scroll handler', () => {
+    expect(scroller()).toContain("aria-label={i18nT('pages.chatPage.chat_messages')}")
+    expect(scroller()).toContain('aria-live="polite"')
+    // PAGE-owned wiring: the single scroll controller's handler reaches the
+    // scroller no matter which file renders the element.
+    expect(SRC).toContain('onScrollPin}')
+  })
+})
+
+describe('scroll shell: element order inside the scroller', () => {
+  it('keeps the SKELETON sequence that moves as one unit: header spacer, top sentinel, loading, top spacer, bottom spacer, bottom sentinel', () => {
+    // Order is the contract the virtualizer's IO wiring assumes; a reorder can
+    // compile, render, and still break window expansion. Anchors here are the
+    // skeleton pieces that live (and move) TOGETHER, so the pin holds whether
+    // the skeleton sits inline in ChatPage or in an extracted shell component.
+    // Cross-boundary order (earlier bar above the rows, footer below them) is
+    // pinned by ChatPage.scrollShell.render.test.tsx, which mounts the shell
+    // and asserts the scroller's actual child order plus which call-site slot
+    // each piece of page content lives in.
+    const anchors = [
+      '<div className="h-16" />',
+      'ref={virt.topSentinelRef}',
+      'data-testid="older-messages-loading"',
+      'height: virt.offsetBefore',
+      'height: virt.offsetAfter',
+      'ref={virt.bottomSentinelRef}',
+    ]
+    let cursor = -1
+    for (const a of anchors) {
+      const idx = SHELL.indexOf(a, cursor + 1)
+      expect(idx, `out of order or missing: ${a}`).toBeGreaterThan(cursor)
+      cursor = idx
+    }
+  })
+
+  it('keeps the page-owned tail composition: footer, survey width cap, px tail spacer', () => {
+    expect(SHELL).toContain('<ChatFooter')
+    expect(SHELL).toContain('<SessionPulseSurveyCard')
+    expect(SHELL).toContain('<div style={{ height: TRANSCRIPT_TAIL_SPACER_PX }} />')
+  })
+
+  it('keeps both sentinels 1px, decorative, and bound to the virtualizer refs', () => {
+    expect(SHELL).toContain('<div ref={virt.topSentinelRef} aria-hidden style={{ height: 1 }} />')
+    expect(SHELL).toContain('<div ref={virt.bottomSentinelRef} aria-hidden style={{ height: 1 }} />')
+  })
+
+  it('keeps both window spacers exempt from browser scroll anchoring', () => {
+    // The spacers resize as the window moves; letting the browser anchor on
+    // them (rather than real content) is the mid-fetch jump this exempts.
+    expect(SHELL).toContain("<div aria-hidden style={{ height: virt.offsetBefore, overflowAnchor: 'none' }} />")
+    expect(SHELL).toContain("<div aria-hidden style={{ height: virt.offsetAfter, overflowAnchor: 'none' }} />")
+  })
+
+  it('gates the earlier-messages bar on the cursor belonging to the active slot', () => {
+    // Mid-switch slotHasMore still describes the OUTGOING chat; the cursor key
+    // gate mirrors the paging thunk's own precondition.
+    expect(SHELL).toContain('{slotHasMore && cursorIsForActiveSlot && (')
+  })
+
+  it('keeps the loading spinner sticky below the header, anchor-exempt, on an opaque bg', () => {
+    // Slice the WHOLE conditional block (gate to the next skeleton comment) so
+    // the class is bound to the spinner element itself — a SHELL-wide contain
+    // would stay green with the literal parked in a comment anywhere.
+    const spinner = between('{loadingOlder && (', '{/* Top spacer')
+    expect(spinner).toContain('className="sticky top-16 z-[1] flex justify-center py-2"')
+    expect(spinner).toContain('data-testid="older-messages-loading"')
+    expect(spinner).toContain("overflowAnchor: 'none'")
+    expect(spinner).toContain("background: 'var(--bg)'")
+    expect(spinner).toContain('<Loader size={16} className="animate-spin text-muted" />')
+  })
+})
+
+describe('scroll shell: row wrapper contract (what the shell must pass through)', () => {
+  // Rows themselves are content, but their WRAPPERS are the virtualizer's
+  // render contract: identity key, measureRef, the debug index, and the
+  // unmounted-row placeholder. A migration that re-wraps rows must keep these.
+  it('mounts only windowed rows; unmounted rows render null (spacers stand in)', () => {
+    expect(SHELL).toContain('if (!vi.mounted) return null')
+  })
+
+  it('keeps key + measureRef + data-display-index on BOTH row shapes (turn and single)', () => {
+    const wrappers = SHELL.match(/key=\{vi\.key\} ref=\{virt\.measureRef\(vi\.index\)\} data-display-index=\{displayIdx\}/g) ?? []
+    expect(wrappers.length).toBe(2)
+  })
+
+  it('caps single rows at the theme content width', () => {
+    expect(SHELL).toContain("maxWidth: 'var(--mc-content-width, 900px)'")
+  })
+})
+
+describe('scroll shell: extraction wiring (the seams the split created)', () => {
+  // Each of these lines compiles away silently if deleted — the type system
+  // accepts a shell that ignores a prop — but the transcript then breaks at
+  // runtime (no rows, no follow, no paging). The pins make every seam a test.
+  it('shell renders all three slots in skeleton order and spreads host geometry', () => {
+    const shellOrder = ['{aboveRows}', 'height: virt.offsetBefore', '{children}', 'height: virt.offsetAfter', '{belowRows}']
+    let cursor = -1
+    for (const a of shellOrder) {
+      const idx = SHELL.indexOf(a, cursor + 1)
+      expect(idx, `out of order or missing: ${a}`).toBeGreaterThan(cursor)
+      cursor = idx
+    }
+    expect(SHELL).toContain('...scrollerStyle,')
+    // onScroll must be ON THE SCROLLER ELEMENT, not merely present somewhere:
+    // relocated onto any other element, follow/pin/paging all die at runtime
+    // while a whole-source contain() stays green. Slice the scroller's own
+    // attribute span (its ref up to the first child) and pin it there. The
+    // render suite additionally proves it fires (dispatch a scroll event).
+    expect(between('ref={scrollerRef}', '{/* Header spacer */}')).toContain('onScroll={onScroll}')
+  })
+
+  it('page threads the controller wiring onto the shell call', () => {
+    // The import IS the extraction: its deletion is the "silently undone"
+    // mutation, and a collection failure alone names no pin.
+    expect(SRC).toContain("import TranscriptScrollShell from './chat/TranscriptScrollShell'")
+    expect(SRC).toContain('scrollerRef={scrollerRef}')
+    expect(SRC).toContain('virt={virt}')
+    // Two consumers thread loadingOlder (the pinned-banner row props and the
+    // shell call); a bare contain() would let either deletion hide behind the
+    // other, so pin the count.
+    expect((SRC.match(/loadingOlder=\{loadingOlder\}/g) ?? []).length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('scroll shell: bottom mask and jump pill', () => {
+  it('keeps the measured-mask recipe (geometry itself is pinned by fadeClearance)', () => {
+    expect(SHELL).toContain('className="bg-gradient-to-t from-bg from-[62%] to-transparent pointer-events-none relative z-[1]"')
+    // Decorative: the mask must never be announced by a screen reader.
+    const mask = between('{/* Transcript bottom mask', '<div className="relative">')
+    expect(mask).toContain('aria-hidden')
+  })
+
+  it('mounts the shared jump pill: visible only away from the bottom of a non-empty transcript, jump = forced pin through the single scroll controller', () => {
+    // The pill's own markup (geometry, classes, catalog label) is pinned by
+    // the ChatScrollChrome consumers' suites; what belongs to THIS page is the
+    // visibility gate and the controller wiring.
+    expect(SRC).toContain('<JumpToBottomButton visible={!isAtBottom && messages.length > 0} onClick={() => scrollBottom(true)} />')
+  })
+})

--- a/website/src/test/ChatPage.scrollShell.render.test.tsx
+++ b/website/src/test/ChatPage.scrollShell.render.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * ChatPage scroll-shell RENDER pins — the DOM half of the characterization net.
+ *
+ * The recipe suite (ChatPage.scrollShell.recipe.test.tsx) pins the shell's
+ * source tokens; this suite pins what those tokens must DO when mounted:
+ * the scroller's child order (slots included), the older-messages spinner's
+ * mount condition, and the ref/spacer wiring. It also slices the page's
+ * <TranscriptScrollShell> invocation and pins WHICH slot each piece of page
+ * content lives in — the cross-file seam the source-token pins cannot see
+ * (swapping aboveRows/belowRows bodies keeps every toContain green; it does
+ * not keep these pins green).
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import React from 'react'
+import TranscriptScrollShell from '../pages/chat/TranscriptScrollShell'
+import { initI18n } from '../i18n'
+
+initI18n('en')
+
+const ref = () => ({ current: null as HTMLDivElement | null })
+
+function mount(loadingOlder: boolean) {
+  const scrollerRef = ref()
+  const virt = { topSentinelRef: ref(), bottomSentinelRef: ref(), offsetBefore: 123, offsetAfter: 456 }
+  const utils = render(
+    <TranscriptScrollShell
+      scrollerRef={scrollerRef}
+      onScroll={() => {}}
+      virt={virt}
+      loadingOlder={loadingOlder}
+      scrollerStyle={{ paddingBottom: 16 }}
+      aboveRows={<div data-testid="slot-above" />}
+      belowRows={<div data-testid="slot-below" />}
+    >
+      <div data-testid="slot-rows" />
+    </TranscriptScrollShell>,
+  )
+  return { scrollerRef, virt, ...utils }
+}
+
+describe('TranscriptScrollShell DOM contract', () => {
+  it('renders the skeleton in order: header spacer, aboveRows, top sentinel, top spacer, rows, bottom spacer, bottom sentinel, belowRows', () => {
+    const { scrollerRef, virt } = mount(false)
+    const scroller = scrollerRef.current!
+    expect(scroller).toBeTruthy()
+    const kids = Array.from(scroller.children)
+    const at = (el: Element | null) => kids.indexOf(el as Element)
+
+    const headerSpacer = kids.find(k => k.className.includes('h-16'))!
+    const above = screen.getByTestId('slot-above')
+    const topSentinel = virt.topSentinelRef.current!
+    const rows = screen.getByTestId('slot-rows')
+    const bottomSentinel = virt.bottomSentinelRef.current!
+    const below = screen.getByTestId('slot-below')
+    const topSpacer = kids.find(k => (k as HTMLElement).style.height === '123px')!
+    const bottomSpacer = kids.find(k => (k as HTMLElement).style.height === '456px')!
+
+    // Every piece must be a DIRECT child of the scroller...
+    for (const el of [headerSpacer, above, topSentinel, topSpacer, rows, bottomSpacer, bottomSentinel, below]) {
+      expect(at(el)).toBeGreaterThanOrEqual(0)
+    }
+    // ...in exactly this order. This is the invariant the virtualizer's
+    // sentinel/spacer geometry depends on, and the one a slot swap breaks.
+    const order = [headerSpacer, above, topSentinel, topSpacer, rows, bottomSpacer, bottomSentinel, below].map(at)
+    expect(order).toEqual([...order].sort((a, b) => a - b))
+    expect(new Set(order).size).toBe(order.length)
+  })
+
+  it('mounts the older-messages spinner between the top sentinel and the top spacer only while loadingOlder', () => {
+    const off = mount(false)
+    expect(off.queryByTestId('older-messages-loading')).toBeNull()
+    off.unmount()
+
+    const { scrollerRef, virt, queryByTestId } = mount(true)
+    const spinner = queryByTestId('older-messages-loading')!
+    expect(spinner).toBeTruthy()
+    const kids = Array.from(scrollerRef.current!.children)
+    const spinnerIdx = kids.indexOf(spinner)
+    const sentinelIdx = kids.indexOf(virt.topSentinelRef.current!)
+    const topSpacerIdx = kids.findIndex(k => (k as HTMLElement).style.height === '123px')
+    expect(spinnerIdx).toBeGreaterThan(sentinelIdx)
+    expect(spinnerIdx).toBeLessThan(topSpacerIdx)
+  })
+
+  it('fires onScroll from the scroller element itself', () => {
+    // A handler that merely EXISTS in source can sit on the wrong element;
+    // prove the scroller's own scroll event reaches the host callback.
+    const scrollerRef = ref()
+    let calls = 0
+    render(
+      <TranscriptScrollShell
+        scrollerRef={scrollerRef}
+        onScroll={() => { calls++ }}
+        virt={{ topSentinelRef: ref(), bottomSentinelRef: ref(), offsetBefore: 0, offsetAfter: 0 }}
+        loadingOlder={false}
+      >
+        <div />
+      </TranscriptScrollShell>,
+    )
+    fireEvent.scroll(scrollerRef.current!)
+    expect(calls).toBe(1)
+  })
+
+  it('keeps the shell-owned scroll contract even when the host tries to override it via scrollerStyle', () => {
+    const scrollerRef = ref()
+    render(
+      <TranscriptScrollShell
+        scrollerRef={scrollerRef}
+        onScroll={() => {}}
+        virt={{ topSentinelRef: ref(), bottomSentinelRef: ref(), offsetBefore: 0, offsetAfter: 0 }}
+        loadingOlder={false}
+        scrollerStyle={{ overflowX: 'auto', overflowY: 'visible', paddingBottom: 16 } as React.CSSProperties}
+      >
+        <div />
+      </TranscriptScrollShell>,
+    )
+    const s = scrollerRef.current!.style
+    // Shell tokens win (spread-first): the scroll contract is not overridable.
+    expect(s.overflowX).toBe('hidden')
+    expect(s.overflowY).toBe('auto')
+    // Host-added geometry the shell does not claim still lands.
+    expect(s.paddingBottom).toBe('16px')
+  })
+})
+
+describe('ChatPage invocation: slot membership and prop threading', () => {
+  const src = readFileSync(resolve(__dirname, '../pages/ChatPage.tsx'), 'utf8')
+  const open = src.indexOf('<TranscriptScrollShell')
+  const close = src.indexOf('</TranscriptScrollShell>')
+  const inv = src.slice(open, close)
+
+  it('slices exactly one invocation', () => {
+    expect(open).toBeGreaterThan(0)
+    expect(close).toBeGreaterThan(open)
+    expect(src.indexOf('<TranscriptScrollShell', open + 1)).toBe(-1)
+  })
+
+  it('threads every wiring prop exactly once', () => {
+    for (const pin of [
+      'scrollerRef={scrollerRef}',
+      'onScroll={onScrollPin}',
+      'virt={virt}',
+      'loadingOlder={loadingOlder}',
+      'scrollerStyle={{ paddingBottom: 16 }}',
+    ]) {
+      expect(inv.split(pin).length - 1, pin).toBe(1)
+    }
+  })
+
+  it('puts each piece of page content INSIDE its slot body — membership, not just source order', () => {
+    // Slice the actual slot fragment bodies. Order-only index checks pass a
+    // mutant that empties belowRows and reparents the footer as a plain child
+    // before the rows; membership + negative assertions do not.
+    const body = (attr: string) => {
+      const start = inv.indexOf(`${attr}={<>`)
+      expect(start, `${attr} fragment opens`).toBeGreaterThan(-1)
+      const end = inv.indexOf('</>}', start)
+      expect(end, `${attr} fragment closes`).toBeGreaterThan(start)
+      return inv.slice(start, end)
+    }
+    const above = body('aboveRows')
+    const below = body('belowRows')
+    // children = everything after the opening tag closes (past both slot
+    // fragments) up to </TranscriptScrollShell>.
+    const childrenRegion = inv.slice(inv.indexOf('</>}', inv.indexOf('belowRows={<>')) + 4)
+
+    // aboveRows: the paging bar and its cursor gate — and nothing footer-shaped.
+    expect(above).toContain('slotHasMore && cursorIsForActiveSlot')
+    expect(above).toContain('<EarlierMessagesBar')
+    expect(above).not.toContain('<ChatFooter')
+
+    // belowRows: footer -> survey -> tail spacer, in order, and no paging bar.
+    const iFooter = below.indexOf('<ChatFooter')
+    const iSurvey = below.indexOf('<SessionPulseSurveyCard')
+    const iTail = below.indexOf('height: TRANSCRIPT_TAIL_SPACER_PX')
+    expect(iFooter).toBeGreaterThan(-1)
+    expect(iSurvey).toBeGreaterThan(iFooter)
+    expect(iTail).toBeGreaterThan(iSurvey)
+    expect(below).not.toContain('<EarlierMessagesBar')
+
+    // The children region carries rows ONLY — reparenting any slot content
+    // there (where it would enter the virtualized row geometry) is a red.
+    for (const token of ['<EarlierMessagesBar', '<ChatFooter', '<SessionPulseSurveyCard', 'height: TRANSCRIPT_TAIL_SPACER_PX']) {
+      expect(childrenRegion, `children region must not contain ${token}`).not.toContain(token)
+    }
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** behavior-preserving extraction — JSX moves verbatim behind a component seam with byte-identical DOM; the mounted-DOM render suite pins child order and the golden-frame harness (follow-up baseline) is the visual evidence mechanism itself.

## What

Extracts ChatPage's transcript **scroll shell** — the scroll container's full style contract, the virtualizer's sentinel/spacer wiring, and the older-messages loading affordance — into `website/src/pages/chat/TranscriptScrollShell.tsx`. Page content threads through three slots (`aboveRows` / `children` / `belowRows`), so page state never leaks into the shell and any host running `useVirtualChat` can reuse it. Behavior-preserving by design: the extracted region renders byte-identical DOM.

Follow-up to #7567 (shared scroll chrome); this is phase 2 of the chat-core render unification.

## The characterization net (written FIRST, then the extraction landed under it)

| Layer | File | What it pins |
|---|---|---|
| Source-token recipe (23 pins) | `website/src/test/ChatPage.scrollShell.recipe.test.tsx` | every load-bearing token of the shell, sliced to the owning element (onScroll on the scroller, spinner class on the spinner) |
| Mounted-DOM render suite | `website/src/test/ChatPage.scrollShell.render.test.tsx` | scroller child order incl. slots, spinner mount condition, a dispatched scroll event reaching the host callback, `scrollerStyle` override resistance (spread-first), slot MEMBERSHIP with negative assertions on the children region |
| Mutation harness | `website/scripts/mutation-check-scroll-shell.mjs` (`npm run mutation:scroll-shell`) | line-deletion mutants across 83 targets incl. the prop-plumbing seam and the shell import; verdicts from vitest's JSON report; caught split reported as tests / parse / collection so nothing launders the pin score; dead-exclusion detection; crash-safe restore |
| Golden frames | `website/scripts/capture-chatpage-scroll-shell.mjs` (`npm run golden:scroll-shell`) + `website/capture/chatpage-scroll-shell.tsx` | 8 self-asserting themed frames (bottom-pinned / jump-pill / short / paging with the earlier-messages bar AND sticky spinner on screen); per-frame theme-applied + fixture-parity checks; dark≠light byte-difference derived from the frame manifest; capture promotes by directory swap only when every check passes; `--compare` enforces the exact manifest and refuses identical dirs |

Last full local run before test execution moved to CI: mutation 53/53 caught 0 survivors (pre-expansion; targets now 83), 55 files / 525 tests green, `tsc -b` and eslint clean, goldens byte-deterministic across consecutive captures.

## Adversarial review

4 rounds × 4 cross-vendor blind reviewers (claude-opus-5 / gpt-5.6-sol / deepseek-3.2 / qwen3-coder-next), fix-and-re-review loop per round. Round-4 verdict: the extraction itself reads clean (both blocking-grade reviewers); every remaining actionable was a net-quality item and was fixed (spinner-class pin de-vacuated, prop-plumbing seam + import added to mutation scope, collection-failure verdicts split out, capture-script drift + non-atomic promotion fixed). Notable catches across rounds: counterfeit dark-theme goldens (ThemeProvider overrode the manual `data-theme`), a paging scene missing from the visual net, and an EdgeFade reparenting regression introduced (and reverted byte-identically) during the loop.

## Deferred to follow-up (deliberate)

- **Golden baseline PNGs are NOT committed here**: the local baseline predates the final tree state. Capture on this head via `npm run golden:scroll-shell` and commit in a follow-up (harness + npm entry ship in this PR).
- A mounted parentage assertion for the header EdgeFade (`offsetParent` = title row).
- SIGTERM/SIGHUP restore handlers in the mutation harness (SIGINT + finally are handled).
- Wiring `mutation:scroll-shell` / `golden:scroll-shell` into CI workflows.
- Generalizing the shell's i18n keys / `chat-container` class when a second consumer adopts it (YAGNI until then).

No visual delta intended: this PR moves JSX verbatim behind a component seam; the render suite and (follow-up) goldens are the evidence.

no linked issue: phase-2 refactor tracked in the chat-core RFC, not a GitHub issue.

