### PR TITLE
fix: stop gateway-spawned app backends on gateway shutdown

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -568,6 +568,35 @@ successful async startup hook that returns within the deadline is unaffected.
 
 Writer: `apps/lifecycle.py::LifecycleDispatcher._invoke`.
 
+After the hook sweep, graceful shutdown stops the backend **processes this
+gateway spawned** (`apps/hooks_integration.py::on_gateway_shutdown` →
+`stop_app_backend`). Spawned backends are gateway children: without this stop
+they reparent to PID 1 when the gateway exits and keep listening on their
+ports, and the startup stale-reap only recovers them at the **next** boot.
+Ordering is deliberate — hooks first, so an app's `on_shutdown` still has its
+own backend alive. Stop targets come from the runtime tracking table
+(`apps/backend.py::spawned_backend_names`), never from persisted `enabled`
+metadata: the metadata filter is wrong in both directions (it would signal an
+**adopted** externally-managed backend, whose contract is to survive gateway
+exit and be re-adopted on the next start, and it would miss a still-running
+child whose app was disabled cross-process, metadata-only). Driving the sweep
+from the tracking table also keeps `stop_app_backend`'s pidfile-record erasure
+away from apps with nothing running, so a retained prior-generation orphan
+record stays recoverable by the stale-reap. The stops are offloaded to the
+subprocess executor and run **concurrently under one shared deadline**
+(`_BACKEND_STOP_BUDGET_SECS`, kept under the gateway's 10-second cooperative
+shutdown budget): a serial sweep would multiply the per-app SIGTERM grace by
+the number of apps, and the supervisor's force-exit would orphan every backend
+the sweep had not reached. The sweep runs in a `finally` around hook dispatch,
+so a wedged or failing `on_shutdown` hook (dispatch awaits an invoked hook to
+completion) cannot skip it — the shutdown deadline's cancellation still reaches
+the sweep on its way out. The stop futures are shielded from the deadline: the
+executor is shared with the rest of shutdown, so a stop can still be queued
+when the budget fires, and cancelling it then would mean that backend is never
+signalled at all — instead the sweep returns and the stops finish in the
+background. The sweep is not gated on the lifecycle dispatcher being
+initialized, and one app's failing stop does not skip the rest.
+
 ## 8. An app's EventBus only exists with a real broadcast function
 
 `build_app_context` returns `events=None` when `broadcast_fn` is None, and

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -1487,6 +1487,26 @@ def list_app_processes() -> list[dict[str, Any]]:
         return [ap.to_dict() for ap in _processes.values()]
 
 
+def spawned_backend_names() -> list[str]:
+    """App names whose backend THIS gateway process spawned (``proc`` set).
+
+    The gateway-shutdown sweep stops exactly these. Adopted records
+    (``proc is None``) are deliberately excluded: an adopted backend is an
+    externally managed instance whose contract is to SURVIVE gateway exit and
+    be re-probed and re-adopted on the next start (see the adoption comment in
+    ``_start_app_backend_body``) — signalling it from shutdown would take down
+    an independent service. Deriving the sweep from this tracking table rather
+    than from persisted ``enabled`` metadata also keeps it honest in both
+    directions: a child whose app was disabled cross-process (metadata-only)
+    is still stopped, and an app with nothing running is never passed to
+    :func:`stop_app_backend`, whose ``_forget_app_pid`` would otherwise erase
+    the pidfile record that lets ``_reap_stale_app_backends`` recover a
+    prior-generation orphan.
+    """
+    with _lock:
+        return sorted(name for name, ap in _processes.items() if ap.proc is not None)
+
+
 def get_app_backend_port(app_name: str) -> int | None:
     """Get the port for a running app backend (used by reverse proxy)."""
     with _lock:

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from aiohttp import web
 
+from kiro_crew.apps.backend import spawned_backend_names, stop_app_backend
 from kiro_crew.apps.bridges import (
     disarm_app_crons_for_execution,
     register_app_crons_with_service,
@@ -34,6 +35,7 @@ from kiro_crew.apps.lifecycle import LifecycleDispatcher
 from kiro_crew.apps.manager import app_dir, list_apps
 from kiro_crew.apps.route_registry import RouteRegistry
 from kiro_crew.cron import CronStoreBusy, CronStoreUnreadable
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -614,15 +616,106 @@ async def on_gateway_startup(
         )
 
 
-async def on_gateway_shutdown() -> None:
-    """Called during gateway shutdown — invoke on_shutdown hooks for all enabled apps."""
-    if not _lifecycle_dispatcher:
-        return
+#: One shared deadline for the whole backend-stop sweep at gateway shutdown.
+#: The sweep runs inside the gateway's cooperative shutdown, which
+#: ``GRACEFUL_SHUTDOWN_SECS`` caps at 10s before the supervisor force-exits;
+#: each individual stop can spend up to the 5s SIGTERM grace before its SIGKILL
+#: escalation, so the stops run concurrently and this bound keeps the sweep as
+#: a whole from consuming the budget the rest of cleanup still needs.
+_BACKEND_STOP_BUDGET_SECS = 6.0
 
+
+async def on_gateway_shutdown() -> None:
+    """Called during gateway shutdown — invoke on_shutdown hooks for enabled
+    apps, then stop the backend processes this gateway spawned.
+
+    The backend stop is the load-bearing half. Spawned backends are child
+    processes of the gateway: without an explicit stop they reparent to PID 1
+    when the gateway exits and keep listening on their ports, so anything
+    probing those ports reads a stopped gateway as "connected". The next boot
+    reaps them only lazily (``_reap_stale_app_backends``), which does not help
+    a gateway that stays down. Hooks run FIRST so an app's ``on_shutdown``
+    still has its own backend alive.
+
+    Stop targets come from the runtime tracking table
+    (:func:`spawned_backend_names`), never from persisted ``enabled`` metadata:
+    the metadata filter is wrong in both directions here (it would signal an
+    ADOPTED externally-managed backend whose contract is to survive gateway
+    exit, and it would miss a still-running child whose app was disabled
+    cross-process, metadata-only). It also keeps :func:`stop_app_backend` — and
+    its pidfile-record erasure — away from apps with nothing running, so a
+    retained prior-generation orphan record stays recoverable by the next
+    boot's stale-reap.
+    """
     # list_apps() walks the apps dir (two file reads per app) — off the loop.
     installed = await asyncio.to_thread(list_apps)
     enabled = [a for a in installed if a.get("enabled")]
-    if enabled:
-        invoked = await _lifecycle_dispatcher.dispatch_shutdown(enabled)
-        if invoked:
-            logger.info("Shutdown hooks invoked for: %s", ", ".join(invoked))
+
+    try:
+        if _lifecycle_dispatcher and enabled:
+            invoked = await _lifecycle_dispatcher.dispatch_shutdown(enabled)
+            if invoked:
+                logger.info("Shutdown hooks invoked for: %s", ", ".join(invoked))
+    finally:
+        # The sweep MUST run even when hook dispatch hangs or raises: hooks are
+        # third-party code, and dispatch awaits an invoked on_shutdown hook to
+        # completion — so a wedged hook would hold this coroutine until the
+        # gateway's graceful-shutdown deadline CANCELS it right here. Running
+        # the sweep from the finally block means that cancellation still stops
+        # the spawned backends (a task may keep awaiting during cleanup after
+        # a single cancel request), instead of force-exiting with every one of
+        # them orphaned — the exact defect this function exists to fix.
+        await _stop_spawned_backends()
+
+
+async def _stop_spawned_backends() -> None:
+    """Stop every backend this gateway spawned, concurrently, under one budget.
+
+    Deliberately NOT gated on ``_lifecycle_dispatcher`` or on the enabled list:
+    backends are started by the boot path independently of the hooks system, so
+    neither absence may leave them orphaned. The tracking-table read takes the
+    module lock — off the loop like every other blocking step.
+    """
+    names = await asyncio.to_thread(spawned_backend_names)
+    if not names:
+        return
+
+    # Each stop signals a process group and waits on it — blocking syscalls,
+    # so offloaded to the subprocess executor. All stops start CONCURRENTLY
+    # under ONE shared deadline: awaiting them serially would multiply the
+    # per-app SIGTERM grace by the number of apps and blow the gateway's
+    # cooperative shutdown budget, so the supervisor's force-exit would orphan
+    # every backend the sweep had not reached yet.
+    loop = asyncio.get_running_loop()
+    stops = [loop.run_in_executor(subprocess_executor(), stop_app_backend, name) for name in names]
+    gathered = asyncio.gather(*stops, return_exceptions=True)
+    try:
+        # The gather is SHIELDED so a deadline overrun (or a cancellation of
+        # this coroutine) releases the caller WITHOUT cancelling the stops.
+        # The executor is shared with the rest of shutdown, so a stop can
+        # still be QUEUED when the deadline fires — cancelling it then would
+        # drop it before stop_app_backend ever ran, and that backend would
+        # never be signalled at all. A running stop's thread cannot be
+        # interrupted anyway; the shield extends the same guarantee to the
+        # queued ones, which keep running in the background.
+        results = await asyncio.wait_for(
+            asyncio.shield(gathered),
+            timeout=_BACKEND_STOP_BUDGET_SECS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "app backend stop sweep did not finish within %.0fs at gateway "
+            "shutdown; unfinished stops continue in the background: %s",
+            _BACKEND_STOP_BUDGET_SECS,
+            ", ".join(names),
+        )
+        return
+    for name, result in zip(names, results):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "stopping backend for app %r on gateway shutdown failed: %s",
+                name,
+                result,
+            )
+        elif result:
+            logger.info("Stopped app backend on gateway shutdown: %s", name)

--- a/test/test_lifecycle_hooks.py
+++ b/test/test_lifecycle_hooks.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -1061,3 +1062,252 @@ class TestLifecycleHookTimeout:
         )
         await asyncio.sleep(0)
         assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+
+class TestGatewayShutdownBackendSweep:
+    """Gateway shutdown must stop the backends it spawned, not just run hooks.
+
+    Spawned backends are gateway children: without an explicit stop they
+    reparent to PID 1 when the gateway exits and keep listening on their ports.
+    """
+
+    @pytest.mark.asyncio
+    async def test_shutdown_stops_spawned_backends_after_hooks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hooks are dispatched FIRST (an app's on_shutdown still has its
+        backend alive), then every gateway-spawned backend is stopped, off the
+        event loop thread."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        order: list[str] = []
+        stop_threads: list[threading.Thread] = []
+
+        class _Dispatcher:
+            async def dispatch_shutdown(self, apps: list[dict[str, Any]]) -> list[str]:
+                order.append("hooks")
+                return []
+
+        def fake_stop(name: str) -> bool:
+            order.append(f"stop:{name}")
+            stop_threads.append(threading.current_thread())
+            return True
+
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", _Dispatcher())
+        monkeypatch.setattr(integration, "list_apps", lambda: [_make_app_info("app-a")])
+        monkeypatch.setattr(
+            integration, "spawned_backend_names", lambda: ["app-a", "app-b"]
+        )
+        monkeypatch.setattr(integration, "stop_app_backend", fake_stop)
+
+        loop_thread = threading.current_thread()
+        await integration.on_gateway_shutdown()
+
+        # Hooks first; the stops run concurrently, so only membership is
+        # asserted — a total order over them would pin an accident.
+        assert order[0] == "hooks"
+        assert set(order[1:]) == {"stop:app-a", "stop:app-b"}
+        # The stop blocks in the kernel (process-group signal + wait) — it must
+        # run on an executor thread, never on the event loop thread.
+        assert all(t is not loop_thread for t in stop_threads)
+
+    @pytest.mark.asyncio
+    async def test_stop_targets_come_from_the_tracking_table_not_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sweep is driven by what the gateway actually spawned, so a child
+        whose app was disabled cross-process (metadata-only) is still stopped,
+        and an enabled app with nothing running is never passed to
+        stop_app_backend (whose pidfile erasure would destroy the stale-reap's
+        record of a prior-generation orphan)."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        stopped: list[str] = []
+
+        def fake_stop(name: str) -> bool:
+            stopped.append(name)
+            return True
+
+        # Metadata says "enabled-idle" is enabled; the tracking table says only
+        # "disabled-but-running" has a spawned backend.
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", None)
+        monkeypatch.setattr(
+            integration, "list_apps", lambda: [_make_app_info("enabled-idle")]
+        )
+        monkeypatch.setattr(
+            integration, "spawned_backend_names", lambda: ["disabled-but-running"]
+        )
+        monkeypatch.setattr(integration, "stop_app_backend", fake_stop)
+
+        await integration.on_gateway_shutdown()
+
+        assert stopped == ["disabled-but-running"]
+
+    def test_spawned_backend_names_excludes_adopted_backends(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Adopted records (proc=None) are externally managed instances whose
+        contract is to SURVIVE gateway exit and be re-adopted on the next
+        start; the shutdown sweep must never signal them."""
+        import kiro_crew.apps.backend as backend
+
+        spawned = backend.AppProcess(app_name="spawned-app", proc=object())  # type: ignore[arg-type]
+        adopted = backend.AppProcess(
+            app_name="adopted-app", proc=None, port=4242, adopted_pids=[123]
+        )
+        monkeypatch.setattr(
+            backend, "_processes", {"spawned-app": spawned, "adopted-app": adopted}
+        )
+
+        assert backend.spawned_backend_names() == ["spawned-app"]
+
+    @pytest.mark.asyncio
+    async def test_one_failing_stop_does_not_skip_the_rest(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One app's failing backend stop must not leave the others running."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        stopped: list[str] = []
+
+        def fake_stop(name: str) -> bool:
+            if name == "app-a":
+                raise RuntimeError("stop failed")
+            stopped.append(name)
+            return True
+
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", None)
+        monkeypatch.setattr(integration, "list_apps", lambda: [])
+        monkeypatch.setattr(
+            integration, "spawned_backend_names", lambda: ["app-a", "app-b"]
+        )
+        monkeypatch.setattr(integration, "stop_app_backend", fake_stop)
+
+        await integration.on_gateway_shutdown()
+
+        assert stopped == ["app-b"]
+
+    @pytest.mark.asyncio
+    async def test_the_sweep_shares_one_deadline_instead_of_stacking_waits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A wedged backend's stop cannot hold the sweep past its shared
+        budget: the sweep returns (logging a warning) so the rest of gateway
+        cleanup still gets its share of the 10s cooperative window, rather
+        than multiplying the per-app SIGTERM grace by the number of apps."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        release = threading.Event()
+
+        def wedged_stop(name: str) -> bool:
+            release.wait(timeout=5.0)
+            return True
+
+        monkeypatch.setattr(integration, "_BACKEND_STOP_BUDGET_SECS", 0.05)
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", None)
+        monkeypatch.setattr(integration, "list_apps", lambda: [])
+        monkeypatch.setattr(integration, "spawned_backend_names", lambda: ["wedged"])
+        monkeypatch.setattr(integration, "stop_app_backend", wedged_stop)
+
+        try:
+            await asyncio.wait_for(integration.on_gateway_shutdown(), timeout=2.0)
+        finally:
+            # Unblock the executor thread so it does not outlive the test.
+            release.set()
+
+    @pytest.mark.asyncio
+    async def test_sweep_runs_even_when_hook_dispatch_fails_or_is_cancelled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hook dispatch awaits third-party on_shutdown hooks; a wedged hook is
+        cancelled by the gateway's shutdown deadline and a broken dispatcher can
+        raise. Neither may skip the backend sweep, or every spawned backend is
+        orphaned — the defect this path exists to fix."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        stopped: list[str] = []
+
+        def fake_stop(name: str) -> bool:
+            stopped.append(name)
+            return True
+
+        class _RaisingDispatcher:
+            async def dispatch_shutdown(self, apps: list[dict[str, Any]]) -> list[str]:
+                raise RuntimeError("dispatcher broke")
+
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", _RaisingDispatcher())
+        monkeypatch.setattr(integration, "list_apps", lambda: [_make_app_info("app-a")])
+        monkeypatch.setattr(integration, "spawned_backend_names", lambda: ["app-a"])
+        monkeypatch.setattr(integration, "stop_app_backend", fake_stop)
+
+        with pytest.raises(RuntimeError, match="dispatcher broke"):
+            await integration.on_gateway_shutdown()
+        assert stopped == ["app-a"]
+
+        # Cancellation (the shutdown deadline cutting off a hanging hook) also
+        # reaches the sweep on its way out.
+        stopped.clear()
+        hook_started = asyncio.Event()
+
+        class _HangingDispatcher:
+            async def dispatch_shutdown(self, apps: list[dict[str, Any]]) -> list[str]:
+                hook_started.set()
+                await asyncio.Event().wait()  # never returns
+                return []
+
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", _HangingDispatcher())
+        task = asyncio.ensure_future(integration.on_gateway_shutdown())
+        await asyncio.wait_for(hook_started.wait(), timeout=2.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=2.0)
+        assert stopped == ["app-a"]
+
+    @pytest.mark.asyncio
+    async def test_budget_overrun_does_not_cancel_queued_stops(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The stop futures share the executor with the rest of shutdown, so a
+        stop can still be QUEUED when the budget fires. The timeout must
+        release the sweep without cancelling that queued stop — a cancelled
+        queued future never runs stop_app_backend and its backend is never
+        signalled at all."""
+        import concurrent.futures
+
+        import kiro_crew.apps.hooks_integration as integration
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        release = threading.Event()
+        queued_ran = threading.Event()
+        ran: list[str] = []
+
+        def fake_stop(name: str) -> bool:
+            if name == "a-wedged":
+                release.wait(timeout=5.0)
+            ran.append(name)
+            if name == "b-queued":
+                queued_ran.set()
+            return True
+
+        monkeypatch.setattr(integration, "subprocess_executor", lambda: pool)
+        monkeypatch.setattr(integration, "_BACKEND_STOP_BUDGET_SECS", 0.05)
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", None)
+        monkeypatch.setattr(integration, "list_apps", lambda: [])
+        monkeypatch.setattr(
+            integration, "spawned_backend_names", lambda: ["a-wedged", "b-queued"]
+        )
+        monkeypatch.setattr(integration, "stop_app_backend", fake_stop)
+
+        try:
+            # The single-worker pool holds "a-wedged" running and "b-queued"
+            # queued when the 0.05s budget fires; the sweep must return anyway.
+            await asyncio.wait_for(integration.on_gateway_shutdown(), timeout=2.0)
+            release.set()
+            assert queued_ran.wait(timeout=2.0), (
+                "the sweep timeout cancelled a queued stop; that backend would "
+                "never be signalled"
+            )
+            assert ran == ["a-wedged", "b-queued"]
+        finally:
+            release.set()
+            pool.shutdown(wait=True)


### PR DESCRIPTION
## Problem / Motivation

When the gateway stops, the app backend processes it spawned at boot are not terminated. `on_gateway_shutdown` only dispatches each enabled app's `on_shutdown` hook; nothing on the gateway cleanup path stops the backend process itself. The backends reparent to PID 1, keep listening on their ports, and anything probing those ports reads a stopped gateway as "connected". The startup stale-reap (`_reap_stale_app_backends`) only recovers them at the NEXT boot, which does not help a gateway that stays down.

## Why it matters

An operator who stops Kiro Crew reasonably expects its children to stop with it. Instead, orphaned backends hold their ports (which can then block the next start's port allocation or adoption), keep executing third-party app code with no supervising gateway, and produce false "connected" state downstream. This happens on every graceful shutdown for every enabled app with a `backend.entryPoint` -- five builtin apps ship one.

## What changed (motivation -> approach -> change)

`on_gateway_shutdown` (`src/kiro_crew/apps/hooks_integration.py`) now stops the backend processes this gateway spawned, after the hook sweep -- hooks first, so an app's `on_shutdown` still has its own backend alive.

Two design points, both load-bearing:

- **Stop targets come from the runtime tracking table, not persisted `enabled` metadata.** A new accessor `spawned_backend_names()` (`src/kiro_crew/apps/backend.py`) returns the apps whose backend this gateway spawned (`proc is not None`, read under the module lock). The metadata filter would be wrong in both directions: it would signal an ADOPTED externally-managed backend whose documented contract is to survive gateway exit and be re-adopted on the next start, and it would miss a still-running child whose app was disabled cross-process (`kirocrew app disable` is metadata-only). It would also route apps with nothing running into `stop_app_backend`, whose `_forget_app_pid` runs before its `if not ap` return -- erasing the retained pidfile record that lets the stale-reap recover a prior-generation orphan.
- **The stops run concurrently under one shared deadline** (`_BACKEND_STOP_BUDGET_SECS = 6.0`, under the gateway's 10s cooperative shutdown budget), offloaded to the subprocess executor. A serial sweep would multiply the per-app 5s SIGTERM grace by the number of apps, and the supervisor's force-exit would orphan every backend the sweep had not reached. On deadline overrun the unfinished stops continue on executor threads while the rest of cleanup proceeds. The sweep is not gated on the lifecycle dispatcher, and one app's failing stop does not skip the rest.

The module spec (`docs/system-specs/modules/app-kit-platform.md` section graceful shutdown) is updated in the same commit.

## Tests

- `test/test_lifecycle_hooks.py::TestGatewayShutdownBackendSweep` (new, 5 tests): hooks-then-stops ordering with stops off the event-loop thread; stop targets derived from the tracking table (disabled-but-running child stopped, enabled-idle app never passed to `stop_app_backend`); `spawned_backend_names()` excludes adopted records; one failing stop does not skip the rest; a wedged stop cannot hold the sweep past its shared budget.
- Full backend gate run locally: `check_black_formatting` / `check_subprocess_encoding` / `isort` / `flake8` clean; `mypy` reports only 4 pre-existing errors in unrelated files (`transcribe.py`, `cloudwatch.py`, boto3-stubs environment skew); full `pytest`: 81365 passed, 92 failed + 2 errors verified byte-identical on pristine main in the same environment (host-environment-owned: `/local/home` uid quirk, missing `qrcode` extra, AF_UNIX path length), zero regressions from this diff. Brand, harness-parity, and docs-lint gates green.

## Manual verification

Verified the failure mechanism and fix shape against source: `_hooks_shutdown` (`dashboard/server.py`) is the only gateway cleanup caller of `on_gateway_shutdown`; the aiohttp cleanup runs under `GRACEFUL_SHUTDOWN_SECS = 10` with `os._exit(0)` on overrun; `stop_app_backend`'s adopted branch signals recorded PIDs (why adopted records are excluded) and its `_forget_app_pid` precedes the `if not ap` return (why untracked apps never reach it).

## Screenshots / video

Backend-only change; no UI surface.

## Related Issues

Closes #7953

## Pattern harvest

Rule candidate: a bulk stop/cleanup sweep must derive its targets from the runtime tracking table (what this process actually owns), never from persisted enable/installed metadata -- the metadata filter is wrong in both directions at once (it acts on things the process does not own, and misses things it does own), and it routes entries with nothing running into destructive bookkeeping such as record erasure.

## Checklist

- [x] Tests added/updated for the change
- [x] Spec updated in the same commit (`docs/system-specs/modules/app-kit-platform.md`)
- [x] Local gates pass (black gate, isort, flake8, mypy, pytest)
- [x] Single conventional commit

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
