### PR TITLE
ci: split the 3.12 backend test suite into 8 shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,9 +609,11 @@ jobs:
     name: Backend Tests
     needs: [changes]
     runs-on: ubuntu-latest
-    # The slowest 3.12 shard runs ~29 minutes, so a 30-minute cap kills the
-    # job at the coverage step with every test green and Coverage Gate then
-    # reds on the missing shard artifact. Same budget as backend-test-windows.
+    # A budget, not an estimate: at 8 shards the slowest one measures ~14
+    # minutes. The cap stays at 40 so a pathological shard finishes rather than
+    # being killed at the coverage step -- a killed job reds Coverage Gate on
+    # the missing shard artifact, which reads as a coverage fault instead of a
+    # slow test. Same budget as backend-test-windows.
     timeout-minutes: 40
     strategy:
       # Don't cancel sibling shards when one fails -- we want the full failure
@@ -619,13 +621,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
-        # Duration-balanced shards (pytest-split). 4 groups x 1 Python = 4
+        # Duration-balanced shards (pytest-split). 8 groups x 1 Python = 8
         # parallel jobs, each on its own runner (4 cores via -n auto). To add
         # shards, extend this list AND bump SHARD_COUNT to match -- mind the
         # ~20 concurrent-job ceiling for public repos.
-        group: [1, 2, 3, 4]
+        #
+        # Why 8 and not 4, measured over 58 full-scope runs: total test time is
+        # 6525s median while the slowest of four shards took ~29.5 minutes, so
+        # the suite ran at a quarter of the parallelism its own runtime affords.
+        # Per-shard fixed overhead is only ~28s (checkout + uv + scope select),
+        # so splitting further is close to free and 8 groups puts the critical
+        # path near 14 minutes. This also re-spends capacity the suite already
+        # had: it ran 8 concurrent test jobs (4 groups x 2 Pythons) until #7780
+        # dropped the 3.10 lane and left those four slots unused, so 8 is a
+        # level this workflow has run at before, inside the ~20 ceiling
+        # alongside backend-test-windows (4) and frontend-test (4).
+        group: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
-      SHARD_COUNT: 4
+      SHARD_COUNT: 8
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Problem / Motivation

The backend test gate is the critical path of CI, and it was running at a quarter of the parallelism its own runtime affords.

Measured across **58 full-scope CI runs** (the raw per-shard timings are in the audit referenced below):

| shard | mean | median |
|---|---|---|
| 1 | 1604s | 1698s |
| 2 | 1644s | 1743s |
| 3 | 1529s | 1620s |
| 4 | 1626s | 1696s |

Total test time is **6525s median** (~108 min) while the slowest shard took **~29.5 min**. `ci.yml` already recorded that symptom in a comment — "the slowest 3.12 shard runs ~29 minutes" — as a reason to hold `timeout-minutes` at 40.

## Why it matters

`Backend Tests` sets the wall-clock of the whole `CI` workflow (~33.6 min median), and `CI` is roughly two orders of magnitude more expensive in job-minutes than every AI review lane on a PR combined. With ~200 open PRs and a median of 3 pushes per PR, that critical path is paid 3-15 times per merged PR, so every minute on it is multiplied.

The four-shard split also sat close to its own ceiling: a 29.5 min shard under a 40 min cap is thin headroom, and a shard killed at the cap reds `Coverage Gate` on a missing shard artifact rather than reporting a test failure.

## What changed (motivation → approach → change)

**Symptom** → the backend gate takes ~30 min while the suite contains ~108 min of test time split four ways.

**Root cause** → shard count, not shard balance. The four shard means sit within **7.5%** of each other, so the split is already near-even; the per-run spread (20% median) is runner noise between identical machines. There is a mild systematic tilt (shard 2 slowest in 26 of 58 runs against 25% expected, shard 3 in only 3), but perfectly balancing four shards would recover just ~2.3 min. Splitting further is the lever worth ~15 min.

**Why splitting is nearly free** → per-shard fixed overhead is only ~28s (checkout + `setup-uv` + scope select), 5-7% of a shard, so eight groups put the projected critical path near **14 min**.

**Change** → `backend-test` goes from 4 to 8 matrix groups with `SHARD_COUNT: 8`. The comment block records the measurement so the next person changing it has the numbers.

**Why 8 is not a new concurrency risk** → this re-spends capacity the suite already had. It ran **8 concurrent backend test jobs** (4 groups × 2 Pythons) until #7780 dropped the 3.10 lane earlier today; `SHARD_COUNT` stayed at 4 and those four slots went unused. Eight is a level this workflow has already sustained, and it stays inside the `~20 concurrent-job ceiling` the file itself cites, alongside `backend-test-windows` (4) and `frontend-test` (4).

**Scope held deliberately narrow:**

- `backend-test-windows` stays at 4. Raising both would spend 20 slots on tests alone.
- `timeout-minutes` stays at 40. The projected shard is ~14 min, but a wide cap means a pathological shard finishes and reports rather than being killed at the coverage step.
- No `.test_durations` change here. That file does not exist on `main` at all, which is why pytest-split has been splitting by equal test count — worth fixing separately, and it matters *more* at 8 shards than at 4 since finer splits are more sensitive to bad per-test estimates.

## Tests

No new automated tests. This is a two-value CI matrix change with no product code in the diff, and there is no test that pins `SHARD_COUNT` or the matrix group list to assert against — verified by grepping `test/` for both.

The change is self-verifying in this PR's own CI run: eight `Backend Tests (3.12, N)` jobs must appear and `Coverage Combine` must succeed.

## Manual verification

Verified before pushing:

- **YAML parses and the values are the intended ones** — `backend-test` is `group: [1..8]` / `SHARD_COUNT: 8`; `backend-test-windows` is untouched at `[1..4]` / `4`.
- **No downstream shard-count coupling.** Shard coverage is uploaded as `coverage-shard-${{ matrix.group }}` (`ci.yml`:744) and consumed by `coverage-combine` via `pattern: coverage-shard-*` with `merge-multiple: true` (`ci.yml`:1035), so it picks up eight partials with no edit. No test references `SHARD_COUNT`.
- **No new workflow-security findings.** `zizmor .github/workflows/ci.yml` reports `16 findings (8 suppressed) ... 8 medium` on both this branch and `origin/main` — byte-identical counts, so nothing was introduced.

Not verified locally, stated plainly rather than implied: the backend suite could not be run on this machine. The project floor is Python 3.12 and the available interpreter is 3.9, so `pytest` aborts at `conftest.py` on `from contextlib import aclosing`. The eight-shard split itself is only meaningfully verifiable in CI, which this PR's own run does.

## Related Issues

no linked issue: performance work on the CI gate, found by measuring the queue rather than filed as a defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — N/A, no product code; no test pins the changed values
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the rationale lives in the `ci.yml` comment block next to the values
- [x] No secrets, credentials, or internal references in the diff
