### PR TITLE
fix(apps): Stop app backends on gateway shutdown

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -1475,6 +1475,33 @@ def stop_app_backend(app_name: str) -> bool:
     return True
 
 
+def stop_all_app_backends() -> list[str]:
+    """Stop every running app backend process. Best-effort: a failure stopping one
+    app is logged and never blocks the rest.
+
+    Called on gateway shutdown. Without it, backends spawned by
+    ``start_enabled_app_backends`` outlive the gateway — reparented to init and left
+    listening on their ports — until ``_reap_stale_app_backends`` clears them at the
+    NEXT startup. Returns the names whose live process was stopped.
+    """
+    # Snapshot the names under the lock, then release it before stopping: each
+    # ``stop_app_backend`` re-acquires ``_lock`` (and ``_health_reconcile_lock``), so
+    # calling it while holding ``_lock`` would deadlock (the lock is non-reentrant).
+    with _lock:
+        names = list(_processes.keys())
+
+    stopped: list[str] = []
+    for name in names:
+        try:
+            if stop_app_backend(name):
+                stopped.append(name)
+        except Exception:
+            logger.exception(
+                "Failed to stop app backend %r during gateway shutdown", name
+            )
+    return stopped
+
+
 def get_app_process(app_name: str) -> AppProcess | None:
     """Get the process info for a running app backend."""
     with _lock:

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from aiohttp import web
 
+from kiro_crew.apps.backend import stop_all_app_backends
 from kiro_crew.apps.bridges import (
     disarm_app_crons_for_execution,
     register_app_crons_with_service,
@@ -34,6 +35,7 @@ from kiro_crew.apps.lifecycle import LifecycleDispatcher
 from kiro_crew.apps.manager import app_dir, list_apps
 from kiro_crew.apps.route_registry import RouteRegistry
 from kiro_crew.cron import CronStoreBusy, CronStoreUnreadable
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -615,14 +617,31 @@ async def on_gateway_startup(
 
 
 async def on_gateway_shutdown() -> None:
-    """Called during gateway shutdown — invoke on_shutdown hooks for all enabled apps."""
-    if not _lifecycle_dispatcher:
-        return
+    """Called during gateway shutdown — invoke on_shutdown hooks for all enabled
+    apps, then stop their backend PROCESSES so none survive as orphans.
 
-    # list_apps() walks the apps dir (two file reads per app) — off the loop.
-    installed = await asyncio.to_thread(list_apps)
-    enabled = [a for a in installed if a.get("enabled")]
-    if enabled:
-        invoked = await _lifecycle_dispatcher.dispatch_shutdown(enabled)
-        if invoked:
-            logger.info("Shutdown hooks invoked for: %s", ", ".join(invoked))
+    Ordering mirrors ``teardown_app_runtime``: hooks first (each app shuts down
+    cleanly), then the process. The backend stop runs unconditionally — a missing
+    lifecycle dispatcher only skips the hooks, never the process teardown.
+    """
+    if _lifecycle_dispatcher:
+        # list_apps() walks the apps dir (two file reads per app) — off the loop.
+        installed = await asyncio.to_thread(list_apps)
+        enabled = [a for a in installed if a.get("enabled")]
+        if enabled:
+            invoked = await _lifecycle_dispatcher.dispatch_shutdown(enabled)
+            if invoked:
+                logger.info("Shutdown hooks invoked for: %s", ", ".join(invoked))
+
+    # Stop the backend processes. Previously on_gateway_shutdown only ran hooks, so
+    # backends spawned by start_enabled_app_backends() were left running (reparented
+    # to init, still bound to their ports) until the next startup reap. Offloaded to
+    # the subprocess executor — stop_app_backend blocks on SIGTERM + up to a 5s wait
+    # per app (matches teardown_app_runtime's offload).
+    loop = asyncio.get_running_loop()
+    try:
+        stopped = await loop.run_in_executor(subprocess_executor(), stop_all_app_backends)
+        if stopped:
+            logger.info("Stopped app backends on shutdown: %s", ", ".join(stopped))
+    except Exception:
+        logger.exception("Failed to stop app backends during gateway shutdown")

--- a/test/test_lifecycle_hooks.py
+++ b/test/test_lifecycle_hooks.py
@@ -1061,3 +1061,61 @@ class TestLifecycleHookTimeout:
         )
         await asyncio.sleep(0)
         assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+
+class TestGatewayShutdownStopsBackends:
+    """Regression: ``on_gateway_shutdown`` must stop app backend PROCESSES, not
+    only run shutdown hooks.
+
+    Before the fix it returned early when no lifecycle dispatcher was set and never
+    stopped backends on any path, so backends spawned by ``start_enabled_app_backends``
+    were orphaned (reparented to init, still bound to their ports) until the next
+    startup reap.
+    """
+
+    @pytest.mark.asyncio
+    async def test_shutdown_stops_backends_after_hooks(self) -> None:
+        """Hooks are dispatched first, then the backend processes are stopped."""
+        from unittest.mock import MagicMock, patch
+
+        import kiro_crew.apps.hooks_integration as hi
+
+        order: list[str] = []
+
+        async def _dispatch_shutdown(enabled: list[dict[str, Any]]) -> list[str]:
+            order.append("hooks")
+            return [a["name"] for a in enabled]
+
+        dispatcher = MagicMock()
+        dispatcher.dispatch_shutdown = _dispatch_shutdown
+
+        def _stop_all() -> list[str]:
+            order.append("stop")
+            return ["app-a"]
+
+        stop_all = MagicMock(side_effect=_stop_all)
+
+        with patch.object(hi, "_lifecycle_dispatcher", dispatcher), patch.object(
+            hi, "list_apps", return_value=[{"name": "app-a", "enabled": True}]
+        ), patch.object(hi, "stop_all_app_backends", stop_all):
+            await hi.on_gateway_shutdown()
+
+        assert order == ["hooks", "stop"], "hooks must run before backends are stopped"
+        stop_all.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_stops_backends_without_lifecycle_dispatcher(self) -> None:
+        """The core regression: with no lifecycle dispatcher, backends are STILL
+        stopped. The old early ``return`` skipped process teardown entirely."""
+        from unittest.mock import MagicMock, patch
+
+        import kiro_crew.apps.hooks_integration as hi
+
+        stop_all = MagicMock(return_value=[])
+
+        with patch.object(hi, "_lifecycle_dispatcher", None), patch.object(
+            hi, "stop_all_app_backends", stop_all
+        ):
+            await hi.on_gateway_shutdown()
+
+        stop_all.assert_called_once_with()


### PR DESCRIPTION
on_gateway_shutdown only dispatched app on_shutdown hooks and returned early when no lifecycle dispatcher was set; it never stopped the backend processes spawned by start_enabled_app_backends. On gateway stop those backends were left running -- reparented to init and still bound to their ports -- until _reap_stale_app_backends cleared them at the next startup, surfacing as false "connected" state in downstream clients.

Add stop_all_app_backends() in apps/backend.py: snapshot the process registry under _lock, release it, then stop_app_backend each best-effort so one failure cannot block the rest. Call it from on_gateway_shutdown after the shutdown hooks and unconditionally -- a missing dispatcher now only skips hooks, not process teardown. Offloaded to the subprocess executor, mirroring teardown_app_runtime's hooks-then-process ordering. _reap_stale_app_backends remains as the crash safety net.

## Problem / Motivation

App backend processes are orphaned after the gateway stops. When the gateway shuts down (`kirocrew stop` → SIGTERM), the backends it spawned at boot via `start_enabled_app_backends()` are **not** terminated. They survive, get reparented to PID 1, and keep running — still bound to their assigned ports. `kirocrew status` correctly reports the gateway as stopped while the orphaned backends silently keep serving (e.g. still answering their health endpoint and heartbeating downstream clients), which manifests as a false "connected" state in anything talking to them. Reproduced with the default `lifecycle: "gateway"`.

## Why it matters

Every enabled app with a `backend` block leaks a live process on every gateway stop/restart. The orphans hold their ports and keep emitting traffic, so clients see a running backend when the gateway is down; a subsequent gateway start then contends with (or reaps) the stragglers. It affects every install, is silent, and compounds across restarts.

## What changed (motivation → approach → change)

- **Symptom:** after `kirocrew stop`, an app backend PID is still alive with PPID 1, still listening on its port.
- **Root cause:** the gateway-shutdown path (`dashboard/server.py` `_hooks_shutdown` → `apps/hooks_integration.py::on_gateway_shutdown`) only dispatches each app's `on_shutdown` hook, and returns early when `_lifecycle_dispatcher` is unset. It never calls `stop_app_backend` / any process teardown. Backends were only reaped lazily at the *next* startup via `_reap_stale_app_backends`. `apps/teardown.py` does stop backends for every app, but teardown is not invoked on gateway shutdown.
- **Change:**
  - New `stop_all_app_backends()` in `apps/backend.py` — snapshots the `_processes` names under `_lock`, releases the lock (each `stop_app_backend` re-acquires the non-reentrant `_lock`, so holding it would deadlock), then stops each best-effort so one app's failure can't block the rest.
  - `on_gateway_shutdown()` now runs the shutdown **hooks first**, then stops the backend **processes**, and does so **unconditionally** — the early `return` is gone, so a missing lifecycle dispatcher only skips hooks, not process teardown. The blocking stop is offloaded to the `subprocess_executor`, matching `teardown_app_runtime`'s hooks-then-process ordering and offload.
  - `_reap_stale_app_backends` is kept as the crash/hard-kill safety net.

## Tests

`test/test_lifecycle_hooks.py::TestGatewayShutdownStopsBackends`:
- `test_shutdown_stops_backends_after_hooks` — locks in the ordering (shutdown hooks dispatched **before** backends are stopped) and that `stop_all_app_backends` is invoked.
- `test_shutdown_stops_backends_without_lifecycle_dispatcher` — the core regression guard: with `_lifecycle_dispatcher` unset, backends are **still** stopped (the old early `return` skipped process teardown entirely).

Full file passes (28 tests); the previously-passing `test_apps_instances_loop_offload` and `test_dashboard_server_startup_coverage` remain green.

## Manual verification

Reproduced on macOS with an enabled app that declares a `backend` block, running the gateway from source:

1. `kirocrew gateway` → confirm the backend is a child of the gateway: `pgrep -f "apps/<app>/backend/server.py"` shows PID with PPID == gateway PID.
2. `kirocrew stop`.
3. Re-check the PID.

- **Before this change:** the backend PID is still alive with **PPID 1** and still listening on its port (orphan).
- **After this change:** the backend PID is **gone** immediately after `kirocrew stop`; no app-backend processes remain.

## Related Issues

Fixes #<issue-number> <!-- replace with the filed "App backend processes are orphaned after the gateway stops" issue -->

## Pattern harvest

Rule candidate: review-prompt / semgrep
Pattern: a lifecycle/shutdown handler guarded by an early `return` on an *optional* collaborator (here `if not _lifecycle_dispatcher: return`) that also skips *mandatory, unrelated* teardown below it. Cleanup that must always run should sit outside such guards; guard only the concern the collaborator owns. Generalizes to any `on_*_shutdown`/`on_cleanup` that both runs hooks and must release OS resources (processes, sockets, temp files).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
