### PR TITLE
fix(dashboard): deliver every chat_message through one identity-carrying door

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -243,7 +243,6 @@ src/kiro_crew/dashboard/terminal_commands.py
 src/kiro_crew/dashboard/theme_validate.py
 src/kiro_crew/dashboard/token_secret.py
 src/kiro_crew/dashboard/urls.py
-src/kiro_crew/dashboard/workflow_inject.py
 src/kiro_crew/dashboard/ws_event_scope.py
 src/kiro_crew/deploy/__init__.py
 src/kiro_crew/deploy/engine.py
@@ -366,7 +365,6 @@ src/kiro_crew/slack/blocks.py
 src/kiro_crew/slack/client.py
 src/kiro_crew/slack/enterprise.py
 src/kiro_crew/slack/events.py
-src/kiro_crew/slack/handler.py
 src/kiro_crew/slack/interactions.py
 src/kiro_crew/slack/sessions_view.py
 src/kiro_crew/subagent_persistence.py

--- a/src/kiro_crew/crew_chat.py
+++ b/src/kiro_crew/crew_chat.py
@@ -1160,14 +1160,21 @@ class CrewOrchestrator:
             # logical message, one identity, so a bounded slot-detail read
             # matches the persisted row by id instead of re-appending the
             # forward.
-            window_mid = row_mid(slot.append("assistant", content, cls, broadcast=False, meta=meta))
+            _row = slot.append("assistant", content, cls, broadcast=False, meta=meta)
+            window_mid = row_mid(_row)
+            # Ship the APPENDED row's meta on the frame, not the pre-append
+            # dict: append mints ``meta.mid`` into a new dict, so the local
+            # ``meta`` has no id and a mid-less frame defeats the client's
+            # redelivery guard (#5981 family) — the window rebuild would then
+            # render this forward a second time.
+            _frame_meta = _row.get("meta") if isinstance(_row.get("meta"), dict) else meta
             self._state.broadcast_ws(
                 "chat_message",
                 {"slot": slot.key, "role": "assistant", "content": content,
                  # Both fields ride the frame: the store reducer reads each off
                  # the payload, and `meta` is the one that survives every
                  # persistence path (see the comment above).
-                 "cls": cls, "meta": meta, "kind": kind},
+                 "cls": cls, "meta": _frame_meta, "kind": kind},
             )
         except Exception:
             logger.warning("crew: transcript post failed for %s", slot.key, exc_info=True)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -95,6 +95,7 @@ from kiro_crew.dashboard.state import (
     _ChatSlot,
     _mark_permission_resolved,
     _normalize_slot_key,
+    append_and_surface,
     durable_row_count,
     is_stop_event_row,
     is_turn_interrupted,
@@ -782,10 +783,7 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                 if t and not t.done():
                     t.cancel()
         stop_msg = "🛑 [SYSTEM] Orchestration stopped by user."
-        slot.append("assistant", stop_msg, "msg msg-a")
-        state.broadcast_ws(
-            "chat_message", {"slot": slot.key, "role": "assistant", "content": stop_msg}
-        )
+        append_and_surface(state, slot, "assistant", stop_msg, "msg msg-a")
         state.broadcast_ws("chat_done", {"slot": slot.key})
         return web.json_response({"ok": True, "stopped": True})
 

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -13,7 +13,7 @@ from aiohttp import web
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.context_management import OrchestrationTracker
 from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
-from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot, append_and_surface
 from kiro_crew.dashboard.turn_dispatch import _bounded_turn
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
@@ -234,8 +234,7 @@ async def _exit_cancelled_plan(state: "DashboardState", slot: "_ChatSlot") -> No
     helper's own flush-above-drain ordering.
     """
     stop_msg = "🛑 This plan was already cancelled — ask for a new plan to continue."
-    slot.append("assistant", stop_msg, "msg msg-a")
-    state.broadcast_ws("chat_message", {"slot": slot.key, "role": "assistant", "content": stop_msg})
+    append_and_surface(state, slot, "assistant", stop_msg, "msg msg-a")
     # Same owner-guard as the loop finally: flush only when the registered task
     # is ours / absent / done, so a turn someone else owns keeps its notes.
     _own_task = slot.task
@@ -804,11 +803,7 @@ async def _stage_loop(
                     )
                     done_msg, _ = redact_exfiltration_urls(done_msg)
                     done_msg, _ = redact_credentials(done_msg)
-                    slot.append("assistant", done_msg, "msg msg-a")
-                    state.broadcast_ws(
-                        "chat_message",
-                        {"slot": slot.key, "role": "assistant", "content": done_msg},
-                    )
+                    append_and_surface(state, slot, "assistant", done_msg, "msg msg-a")
                     _paused = True
                     return  # User's next "Go" click will re-enter _stage_loop
         else:
@@ -842,11 +837,7 @@ async def _stage_loop(
                 done_msg = "\n".join(summary_lines)
                 done_msg, _ = redact_exfiltration_urls(done_msg)
                 done_msg, _ = redact_credentials(done_msg)
-                slot.append("assistant", done_msg, "msg msg-a")
-                state.broadcast_ws(
-                    "chat_message",
-                    {"slot": slot.key, "role": "assistant", "content": done_msg},
-                )
+                append_and_surface(state, slot, "assistant", done_msg, "msg msg-a")
                 sel().log(
                     SecurityEvent(
                         event_id=uuid.uuid4().hex,
@@ -1017,10 +1008,7 @@ async def api_chat_plan_action(request: web.Request) -> web.Response:
                     t.cancel()
         if not already_cancelled:
             stop_msg = "🛑 Plan cancelled."
-            slot.append("assistant", stop_msg, "msg msg-a")
-            state.broadcast_ws(
-                "chat_message", {"slot": slot.key, "role": "assistant", "content": stop_msg}
-            )
+            append_and_surface(state, slot, "assistant", stop_msg, "msg msg-a")
             state.broadcast_ws("chat_done", {"slot": slot.key})
         return web.json_response({"ok": True, "cancelled": True})
 
@@ -1064,8 +1052,7 @@ async def api_chat_plan_action(request: web.Request) -> web.Response:
         )
 
     _label = "Go All" if is_auto else "Go"
-    slot.append("user", _label, "msg msg-u")
-    state.broadcast_ws("chat_message", {"slot": slot.key, "role": "user", "content": _label})
+    append_and_surface(state, slot, "user", _label, "msg msg-u", broadcast_user=True)
     if not is_auto:
         sel().log(
             SecurityEvent(

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -139,6 +139,7 @@ from kiro_crew.dashboard.state import (
     DashboardState,
     _ChatSlot,
     _mark_permission_resolved,
+    append_and_surface,
     build_refusal_recovery_prompt,
     build_refusal_steer_notice,
     build_stale_recovery_prompt,
@@ -8432,11 +8433,13 @@ async def _run_chat(
                 assistant_text = ""
                 _wsred.reset()
                 _produced_visible_output = True
-                slot.append("assistant", "🗑️ Conversation cleared.", "msg msg-a")
+                # slot_clear FIRST: it wipes the client's message list, so the
+                # confirmation row must be delivered after it on every path
+                # (append's own broadcast and the reader-suppressed frame alike)
+                # or the wipe erases the confirmation it announces.
                 state.broadcast_ws("slot_clear", {"slot": slot.key})
-                state.broadcast_ws(
-                    "chat_message",
-                    {"slot": slot.key, "role": "assistant", "content": "🗑️ Conversation cleared."},
+                append_and_surface(
+                    state, slot, "assistant", "🗑️ Conversation cleared.", "msg msg-a"
                 )
             elif event.kind == EVENT_AGENT_SWITCHED:
                 new_agent, _ = redact_credentials(event.text)

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -36,6 +36,7 @@ from kiro_crew.dashboard.state import (
     DashboardState,
     _ChatSlot,
     _normalize_slot_key,
+    append_and_surface,
     parse_cls_meta,
 )
 from kiro_crew.history import transcript_sort_key
@@ -405,16 +406,8 @@ def _append_compaction_notice(
     msg_text, _ = redact_credentials(msg_text)
     msg_text, _ = redact_exfiltration_urls(msg_text)
     meta = {"kind": "compaction"}
-    slot.append("assistant", msg_text, "msg msg-a", meta=meta)
-    state.broadcast_ws(
-        "chat_message",
-        {
-            "slot": slot.key,
-            "role": "assistant",
-            "content": msg_text,
-            "kind": "compaction",
-            "meta": meta,
-        },
+    append_and_surface(
+        state, slot, "assistant", msg_text, "msg msg-a", meta=meta, extra={"kind": "compaction"}
     )
 
 

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -37,7 +37,7 @@ from kiro_crew.dashboard.chat_utils import dashboard_slot_key
 from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
 from kiro_crew.dashboard.handlers._shared import _probe_persisted_session
 from kiro_crew.dashboard.origin import is_direct_local_request
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, append_and_surface
 from kiro_crew.doc_parser import extract_text
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes, safe_read_prefix
 from kiro_crew.messaging.display_safety import redact_for_display
@@ -319,16 +319,11 @@ async def api_outbox_notify(request: web.Request) -> web.Response:
             # extra credential regexes scrub the broadcast file JSON too — the
             # same overlay-aware pass the filename/path/description gates use.
             redacted_file_json = redact(json.dumps(file_data))
-            active.append("file", redacted_file_json)
-            # Only broadcast explicitly when _has_reader suppresses append's
-            # built-in _on_message callback. Avoids duplicate file cards.
-            if getattr(active, "_has_reader", False):
-                state.broadcast_ws("chat_message", {
-                    "slot": active.key,
-                    "role": "file",
-                    "content": redacted_file_json,
-                    "ts": active.messages[-1]["ts"],
-                })
+            # append_and_surface = the same conditional-broadcast pattern this
+            # site pioneered, now also stamping ``ts`` + ``meta.mid`` on the
+            # reader-suppressed frame so a client seeing the row through two
+            # doors recognises it instead of rendering a duplicate card.
+            append_and_surface(state, active, "file", redacted_file_json)
 
     _sel().log_tool_invocation(
         session_key="api",

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2169,6 +2169,72 @@ def row_mid(row: Any) -> str | None:
     return mid if isinstance(mid, str) and mid else None
 
 
+def append_and_surface(
+    state: "DashboardState",
+    slot: "_ChatSlot",
+    role: str,
+    content: str,
+    cls: str = "",
+    *,
+    meta: dict | None = None,
+    broadcast_user: bool = False,
+    extra: dict | None = None,
+) -> dict[str, Any]:
+    """Append a row and surface it live -- through exactly one identity-carrying door.
+
+    The ONE way to append a window row that must also render in the open chat
+    immediately. ``_ChatSlot.append`` already delivers a live ``chat_message``
+    (via ``_on_message`` -> ``_broadcast_chat_message``, carrying the minted
+    ``meta.mid``) whenever ``not slot._has_reader`` -- so an unconditional
+    manual ``broadcast_ws("chat_message", ...)`` after an append ships the SAME
+    row a second time. Worse, the hand-built frames carried no ``meta.mid``,
+    and the frontend's redelivery guard declines mid-less frames rather than
+    guessing (``isRedeliveredMessage``), so each extra copy rendered as a new
+    bubble (#5981).
+
+    The manual frame is emitted only in the one case append's own callback is
+    suppressed (``slot._has_reader``: an HTTP stream reader is draining
+    ``_pending`` for the actively streaming client, and other windows still
+    need the row) -- mirroring the pattern at ``handlers/files.py`` -- and it
+    carries the appended row's ``ts`` + ``meta`` (mid included), so a client
+    that receives the row through two doors can now recognise "this row again"
+    instead of rendering a duplicate.
+
+    ``user`` rows: ``append`` skips broadcasting them by default because the
+    composer that submitted them already rendered them optimistically -- true
+    only of a message typed in THIS dashboard. Callers surfacing a user row
+    that originated elsewhere (a channel mirror, a Go-button label) pass
+    ``broadcast_user=True`` and get the same single identity-carrying delivery.
+
+    Redaction is the caller's job (unchanged from the sites this replaces):
+    content passed here must already be display-safe. The append path re-redacts
+    non-user content in ``_broadcast_chat_message``; the reader-suppressed frame
+    below does not, matching the manual frames it replaces.
+
+    Returns the appended row (so callers can read ``row_mid`` off it).
+    """
+    if broadcast_user:
+        msg = slot.append(role, content, cls, broadcast_user=True, meta=meta)
+    else:
+        msg = slot.append(role, content, cls, meta=meta)
+    if getattr(slot, "_has_reader", False):
+        frame: dict[str, Any] = {
+            "slot": slot.key,
+            "role": role,
+            "content": content,
+            "ts": msg.get("ts", ""),
+        }
+        if cls:
+            frame["cls"] = cls
+        row_meta = msg.get("meta")
+        if isinstance(row_meta, dict) and row_meta:
+            frame["meta"] = row_meta
+        if extra:
+            frame.update(extra)
+        state.broadcast_ws("chat_message", frame)
+    return msg
+
+
 #: Roles whose LIVE append starts the slot's next turn, and so consumes the answer
 #: channel an unanswered stateless question card was waiting on. Mirrors the
 #: frontend's ``QUESTION_RETIRING_ROLES``: the two must agree, or a session reports

--- a/src/kiro_crew/dashboard/workflow_inject.py
+++ b/src/kiro_crew/dashboard/workflow_inject.py
@@ -18,7 +18,7 @@ import re
 from typing import Any, Callable, Optional
 
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
-from kiro_crew.dashboard.state import DashboardState, row_mid
+from kiro_crew.dashboard.state import DashboardState, append_and_surface, row_mid
 from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -163,19 +163,21 @@ def inject_workflow_result(
             # return via ``row_mid``) onto the durable copy below: one logical
             # message, one identity, so the bounded-read identity walk
             # recognises the persisted row instead of re-appending the
-            # injection.
-            window_mid = row_mid(slot.append("assistant", msg, "msg msg-a"))
-            # Live: surface it in the open chat without a reload (mirrors how a
-            # normal assistant turn is pushed). slot.append already broadcasts via
-            # _pending flush, but an explicit chat_message guarantees the live UI
-            # renders it into the originating conversation immediately.
-            try:
-                state.broadcast_ws(
-                    "chat_message",
-                    {"slot": slot.key, "role": "assistant", "content": msg, "kind": "workflow_result"},
+            # injection. append_and_surface delivers the live copy through
+            # exactly one identity-carrying door — the old unconditional
+            # explicit frame here carried no ``meta.mid``, so the client
+            # rendered the same result twice whenever append's own broadcast
+            # also fired (#5981 family).
+            window_mid = row_mid(
+                append_and_surface(
+                    state,
+                    slot,
+                    "assistant",
+                    msg,
+                    "msg msg-a",
+                    extra={"kind": "workflow_result"},
                 )
-            except Exception:  # noqa: BLE001
-                pass
+            )
             # Persist so a follow-up chat turn has the result as context.
             try:
                 if state.conversation_log is not None:

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -64,6 +64,7 @@ from kiro_crew.dashboard.chat_utils import (
     remember_slack_options,
     run_config_write,
 )
+from kiro_crew.dashboard.state import append_and_surface
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import (
@@ -2252,9 +2253,7 @@ async def _handle_compact_command(
                 outcome = "completed"
             elif cr["type"] == "failed":
                 error = cr.get("summary", "")
-                result_text = (
-                    f"❌ Compaction failed: {error}" if error else "❌ Compaction failed."
-                )
+                result_text = f"❌ Compaction failed: {error}" if error else "❌ Compaction failed."
                 outcome = "failed"
             else:
                 result_text = "⚠️ Compaction timed out."
@@ -2534,8 +2533,13 @@ async def maybe_route_linked_thread(
     # context). The LLM's own output is redacted before display.
     _safe_text, _ = redact_exfiltration_urls(text)
     _safe_text, _ = redact_credentials(_safe_text)
-    _linked_slot.append("user", _safe_text, "msg msg-u")
-    _dashboard_state.broadcast_ws("chat_message", {"slot": _linked_slot_key, "role": "user", "content": _safe_text, "cls": "msg msg-u"})  # type: ignore[attr-defined]
+    # Nothing rendered this Slack-typed row optimistically in the dashboard, so
+    # broadcast_user=True: append delivers the ONE identity-carrying frame
+    # (the old manual frame here carried no ``meta.mid``, so a client receiving
+    # the row through a second door rendered a duplicate — #5981 family).
+    append_and_surface(
+        _dashboard_state, _linked_slot, "user", _safe_text, "msg msg-u", broadcast_user=True  # type: ignore[arg-type]
+    )
     if not _linked_slot.running:
         from kiro_crew.dashboard.chat import _run_chat
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -5791,13 +5791,17 @@ class TestRunChatCompactDeferredWait:
         compaction_msgs = [m for m in assistant_msgs if "Conversation compacted" in m["content"]]
         assert compaction_msgs
         assert all(m.get("meta", {}).get("kind") == "compaction" for m in compaction_msgs)
+        # The appended row carries a minted ``meta.mid``: the live copy is
+        # delivered through append's own identity-carrying door (_on_message),
+        # so no hand-built duplicate ``chat_message`` frame may fire — a
+        # mid-less manual frame rendered the notice twice (#5981 family).
+        assert all(m.get("meta", {}).get("mid") for m in compaction_msgs)
         assistant_broadcasts = [
             c
             for c in state.broadcast_ws.call_args_list
             if c.args and c.args[0] == "chat_message" and c.args[1].get("role") == "assistant"
         ]
-        assert assistant_broadcasts
-        assert all(c.args[1].get("kind") == "compaction" for c in assistant_broadcasts)
+        assert assistant_broadcasts == []
         # Updated context% must be broadcast so the dashboard bar refreshes.
         ws_kinds = [c.args[0] for c in state.broadcast_ws.call_args_list]
         assert "context_usage" in ws_kinds

--- a/test/test_handler_link_intercept.py
+++ b/test/test_handler_link_intercept.py
@@ -262,8 +262,13 @@ class TestLinkedThreadIntercept:
                 "msg1",
                 "U1",
             )
-            # UI gets redacted text
-            slot.append.assert_called_once_with("user", "[REDACTED]", "msg msg-u")
+            # UI gets redacted text — via append_and_surface, which passes
+            # broadcast_user=True so the channel-typed row (never rendered
+            # optimistically here) still reaches open dashboard windows through
+            # append's own mid-carrying delivery.
+            slot.append.assert_called_once_with(
+                "user", "[REDACTED]", "msg msg-u", broadcast_user=True, meta=None
+            )
             # LLM gets original text
             assert mock_run_chat.call_args[0][2] == "hello http://evil.com"
 

--- a/test/test_midless_broadcast_dedup.py
+++ b/test/test_midless_broadcast_dedup.py
@@ -1,0 +1,158 @@
+"""One identity-carrying delivery per appended row (#5981).
+
+The dashboard's redelivery guard keys on ``meta.mid`` and DECLINES mid-less
+frames rather than guessing, so any ``chat_message`` frame that ships without
+the appended row's mid renders as a NEW bubble whenever the same row reaches
+the client through a second door. A family of call sites appended a row and
+then hand-built a second, mid-less ``broadcast_ws("chat_message", ...)`` frame
+-- double-delivering the row with an identity the client cannot match
+(``slot.append`` already delivers one mid-carrying frame via ``_on_message``
+whenever no HTTP stream reader is active).
+
+``append_and_surface`` is the one door: append (identity minted, single
+delivery) plus a manual frame ONLY when ``_has_reader`` suppresses append's
+own callback -- and that frame carries the row's ``ts`` + ``meta`` (mid
+included), so over-delivery is recognisable instead of duplicating.
+
+Red-before-green: with the fix reverted (sites hand-building unconditional
+mid-less frames), test_compaction_notice_delivers_exactly_once and
+test_no_reader_no_manual_frame fail on the extra/mid-less frame.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kiro_crew.dashboard.state import _ChatSlot, append_and_surface, row_mid
+
+
+class _StateStub:
+    """Records broadcast_ws calls; quacks enough for append_and_surface."""
+
+    def __init__(self) -> None:
+        self.frames: list[tuple[str, Any]] = []
+
+    def broadcast_ws(self, msg_type: str, data: object) -> None:
+        self.frames.append((msg_type, data))
+
+    def chat_frames(self) -> list[dict]:
+        return [d for t, d in self.frames if t == "chat_message"]
+
+
+def _slot_with_callback(key: str = "s1") -> tuple[_ChatSlot, list[dict]]:
+    """A slot whose _on_message deliveries are captured (the SSE door)."""
+    slot = _ChatSlot(key)
+    delivered: list[dict] = []
+    slot._on_message = lambda _key, msg: delivered.append(msg)
+    return slot, delivered
+
+
+class TestAppendAndSurface:
+    def test_no_reader_no_manual_frame(self) -> None:
+        """Without a reader, append's own delivery is the ONLY one."""
+        state = _StateStub()
+        slot, delivered = _slot_with_callback()
+        msg = append_and_surface(state, slot, "assistant", "hello", "msg msg-a")  # type: ignore[arg-type]
+        assert state.chat_frames() == []  # no hand-built second frame
+        assert len(delivered) == 1  # append's single identity-carrying delivery
+        assert row_mid(delivered[0]) == row_mid(msg)
+        assert row_mid(msg)  # identity was minted
+
+    def test_reader_suppressed_frame_carries_identity(self) -> None:
+        """With a reader, exactly one manual frame -- carrying the row's mid + ts."""
+        state = _StateStub()
+        slot, delivered = _slot_with_callback()
+        slot._has_reader_flag = True
+        msg = append_and_surface(state, slot, "assistant", "hello", "msg msg-a")  # type: ignore[arg-type]
+        assert delivered == []  # append's callback suppressed by the reader
+        frames = state.chat_frames()
+        assert len(frames) == 1
+        frame = frames[0]
+        assert frame["meta"]["mid"] == row_mid(msg)
+        assert frame["ts"] == msg["ts"]
+        assert frame["slot"] == slot.key
+        assert frame["cls"] == "msg msg-a"
+
+    def test_user_row_broadcast_user_delivers_once(self) -> None:
+        """A non-locally-typed user row (channel mirror, Go label) delivers once."""
+        state = _StateStub()
+        slot, delivered = _slot_with_callback()
+        msg = append_and_surface(
+            state, slot, "user", "Go", "msg msg-u", broadcast_user=True  # type: ignore[arg-type]
+        )
+        assert state.chat_frames() == []
+        assert len(delivered) == 1
+        assert row_mid(delivered[0]) == row_mid(msg)
+
+    def test_user_row_default_stays_optimistic(self) -> None:
+        """Without broadcast_user, a user row is NOT broadcast (composer rendered it)."""
+        state = _StateStub()
+        slot, delivered = _slot_with_callback()
+        append_and_surface(state, slot, "user", "typed here", "msg msg-u")  # type: ignore[arg-type]
+        assert state.chat_frames() == []
+        assert delivered == []
+
+    def test_extra_fields_ride_the_reader_frame(self) -> None:
+        """extra= (e.g. kind=compaction) lands on the manual frame only."""
+        state = _StateStub()
+        slot, _ = _slot_with_callback()
+        slot._has_reader_flag = True
+        msg = append_and_surface(
+            state,
+            slot,
+            "assistant",
+            "compacted",
+            "msg msg-a",
+            meta={"kind": "compaction"},
+            extra={"kind": "compaction"},  # type: ignore[arg-type]
+        )
+        frame = state.chat_frames()[0]
+        assert frame["kind"] == "compaction"
+        assert frame["meta"]["kind"] == "compaction"
+        assert frame["meta"]["mid"] == row_mid(msg)  # mid minted alongside caller meta
+
+
+class TestConvertedSites:
+    def test_compaction_notice_delivers_exactly_once(self) -> None:
+        """The compaction chokepoint no longer double-delivers (site-level red-before).
+
+        Old code: slot.append (one _on_message delivery) + an unconditional
+        hand-built mid-less frame = two renderable copies. New: one delivery,
+        mid-carrying.
+        """
+        from kiro_crew.dashboard.chat_utils import _append_compaction_notice
+
+        state = _StateStub()
+        slot, delivered = _slot_with_callback()
+        _append_compaction_notice(state, slot, "✅ Conversation compacted.")  # type: ignore[arg-type]
+        total = len(delivered) + len(state.chat_frames())
+        assert total == 1, f"expected exactly one delivery, got {total}"
+        only = (delivered + state.chat_frames())[0]
+        meta = only.get("meta")
+        assert isinstance(meta, dict) and meta.get("mid"), "delivery must carry meta.mid"
+        assert meta.get("kind") == "compaction"
+
+    def test_crew_chat_frame_meta_carries_mid(self) -> None:
+        """crew_chat's deliberate manual frame now ships the appended row's mid."""
+        # Mirror the site's exact sequence: append(broadcast=False) then a frame
+        # built from the APPENDED row's meta (not the pre-append dict).
+        state = _StateStub()
+        slot, delivered = _slot_with_callback()
+        meta = {"crew_reply": True}
+        row = slot.append("assistant", "fwd", "msg msg-a", broadcast=False, meta=meta)
+        frame_meta = row.get("meta") if isinstance(row.get("meta"), dict) else meta
+        state.broadcast_ws(
+            "chat_message",
+            {
+                "slot": slot.key,
+                "role": "assistant",
+                "content": "fwd",
+                "cls": "msg msg-a",
+                "meta": frame_meta,
+                "kind": "k",
+            },
+        )
+        assert delivered == []  # broadcast=False honored
+        frame = state.chat_frames()[0]
+        assert frame["meta"].get("mid") == row_mid(row)
+        assert frame["meta"].get("crew_reply") is True

--- a/test/test_outbox_notify_broadcast.py
+++ b/test/test_outbox_notify_broadcast.py
@@ -31,9 +31,17 @@ def _make_state_with_slot(has_reader=True):
     slot._has_reader = has_reader
     slot.messages = [{"role": "assistant", "content": "hello", "ts": "2026-05-27T20:00:00+00:00"}]
 
-    def fake_append(role, content, **kwargs):
-        msg = {"role": role, "content": content, "ts": "2026-05-27T20:42:33.357701+00:00"}
+    def fake_append(role, content, cls="", **kwargs):
+        # Mirror the real ``_ChatSlot.append`` contract: mint ``meta.mid`` and
+        # return the appended row (append_and_surface reads ts/meta off it).
+        msg = {
+            "role": role,
+            "content": content,
+            "ts": "2026-05-27T20:42:33.357701+00:00",
+            "meta": {**(kwargs.get("meta") or {}), "mid": f"m-test-{len(slot.messages)}"},
+        }
         slot.messages.append(msg)
+        return msg
 
     slot.append = MagicMock(side_effect=fake_append)
     state = MagicMock()
@@ -48,9 +56,15 @@ def _make_state_with_two_slots():
     slot_1.key = "chat-1"
     slot_1.messages = [{"role": "assistant", "content": "older", "ts": "2026-05-27T20:00:00+00:00"}]
 
-    def fake_append_1(role, content, **kwargs):
-        msg = {"role": role, "content": content, "ts": "2026-05-27T20:42:33.357701+00:00"}
+    def fake_append_1(role, content, cls="", **kwargs):
+        msg = {
+            "role": role,
+            "content": content,
+            "ts": "2026-05-27T20:42:33.357701+00:00",
+            "meta": {**(kwargs.get("meta") or {}), "mid": f"m-t1-{len(slot_1.messages)}"},
+        }
         slot_1.messages.append(msg)
+        return msg
 
     slot_1.append = MagicMock(side_effect=fake_append_1)
 
@@ -58,9 +72,15 @@ def _make_state_with_two_slots():
     slot_2.key = "chat-2"
     slot_2.messages = [{"role": "assistant", "content": "newer", "ts": "2026-05-27T21:00:00+00:00"}]
 
-    def fake_append_2(role, content, **kwargs):
-        msg = {"role": role, "content": content, "ts": "2026-05-27T21:42:33.357701+00:00"}
+    def fake_append_2(role, content, cls="", **kwargs):
+        msg = {
+            "role": role,
+            "content": content,
+            "ts": "2026-05-27T21:42:33.357701+00:00",
+            "meta": {**(kwargs.get("meta") or {}), "mid": f"m-t2-{len(slot_2.messages)}"},
+        }
         slot_2.messages.append(msg)
+        return msg
 
     slot_2.append = MagicMock(side_effect=fake_append_2)
 
@@ -80,10 +100,15 @@ def _make_state_with_cron_and_chat_slots():
     cron_slot.key = "cron-daily-digest"
     cron_slot.messages = [{"role": "assistant", "content": "digest", "ts": "2026-05-27T20:00:00+00:00"}]
 
-    def fake_append_cron(role, content, **kwargs):
-        cron_slot.messages.append(
-            {"role": role, "content": content, "ts": "2026-05-27T20:42:33.357701+00:00"}
-        )
+    def fake_append_cron(role, content, cls="", **kwargs):
+        msg = {
+            "role": role,
+            "content": content,
+            "ts": "2026-05-27T20:42:33.357701+00:00",
+            "meta": {**(kwargs.get("meta") or {}), "mid": f"m-tc-{len(cron_slot.messages)}"},
+        }
+        cron_slot.messages.append(msg)
+        return msg
 
     cron_slot.append = MagicMock(side_effect=fake_append_cron)
 
@@ -91,10 +116,15 @@ def _make_state_with_cron_and_chat_slots():
     chat_slot.key = "chat-2"
     chat_slot.messages = [{"role": "assistant", "content": "newer", "ts": "2026-05-27T21:00:00+00:00"}]
 
-    def fake_append_chat(role, content, **kwargs):
-        chat_slot.messages.append(
-            {"role": role, "content": content, "ts": "2026-05-27T21:42:33.357701+00:00"}
-        )
+    def fake_append_chat(role, content, cls="", **kwargs):
+        msg = {
+            "role": role,
+            "content": content,
+            "ts": "2026-05-27T21:42:33.357701+00:00",
+            "meta": {**(kwargs.get("meta") or {}), "mid": f"m-tt-{len(chat_slot.messages)}"},
+        }
+        chat_slot.messages.append(msg)
+        return msg
 
     chat_slot.append = MagicMock(side_effect=fake_append_chat)
 
@@ -111,10 +141,15 @@ def _make_state_with_empty_slot(has_reader=True):
     slot._has_reader = has_reader
     slot.messages = []
 
-    def fake_append(role, content, **kwargs):
-        slot.messages.append(
-            {"role": role, "content": content, "ts": "2026-05-27T20:42:33.357701+00:00"}
-        )
+    def fake_append(role, content, cls="", **kwargs):
+        msg = {
+            "role": role,
+            "content": content,
+            "ts": "2026-05-27T20:42:33.357701+00:00",
+            "meta": {**(kwargs.get("meta") or {}), "mid": f"m-test-{len(slot.messages)}"},
+        }
+        slot.messages.append(msg)
+        return msg
 
     slot.append = MagicMock(side_effect=fake_append)
     state = MagicMock()

--- a/test/test_slack_handler_more_coverage.py
+++ b/test/test_slack_handler_more_coverage.py
@@ -1208,8 +1208,17 @@ class _Slot:
         self.appended: list[tuple[str, str]] = []
         self.queued: list[str] = []
 
-    def append(self, role, text, cls):
+    def append(self, role, text, cls="", *, broadcast_user=False, meta=None):
+        # Mirror the real ``_ChatSlot.append`` contract enough for
+        # append_and_surface: accept the delivery kwargs and return the
+        # appended row with a minted ``meta.mid``.
         self.appended.append((role, text))
+        return {
+            "role": role,
+            "content": text,
+            "ts": "",
+            "meta": {**(meta or {}), "mid": f"m-slot-{len(self.appended)}"},
+        }
 
     def queue_append(self, text, *, meta=None, directive_user_origin):
         assert directive_user_origin is True

--- a/test/test_workflows_inject.py
+++ b/test/test_workflows_inject.py
@@ -23,17 +23,29 @@ class _FakeSlot:
         self.messages: list[dict] = []
         self.linked_session_key = ""
         self.title = ""
+        # Mirror the delivery seam append_and_surface reads: append's own
+        # broadcast callback (the SSE door, mid-carrying) and the reader flag
+        # that suppresses it. Deliveries land in ``delivered`` so tests can
+        # assert the row went out exactly once, with identity.
+        self._has_reader = False
+        self.delivered: list[dict] = []
 
-    def append(self, role, content, cls="", ts="", *, broadcast=True, meta=None):
-        # Mirror the real ``_ChatSlot.append`` contract: mint ``meta.mid`` and
-        # hand the appended row back — the injector reads the id off the return
-        # to stamp the durable transcript copy with the same identity.
+    def _on_message(self, _key, msg) -> None:
+        self.delivered.append(msg)
+
+    def append(self, role, content, cls="", ts="", *, broadcast=True, broadcast_user=False, meta=None):
+        # Mirror the real ``_ChatSlot.append`` contract: mint ``meta.mid``, hand
+        # the appended row back, and deliver ONE live copy via ``_on_message``
+        # when no reader is draining (the injector reads the id off the return
+        # to stamp the durable transcript copy with the same identity).
         msg = {
             "role": role,
             "content": content,
             "meta": {**(meta or {}), "mid": f"m-test-{len(self.messages)}"},
         }
         self.messages.append(msg)
+        if broadcast and (role != "user" or broadcast_user) and not self._has_reader:
+            self._on_message(self.key, msg)
         return msg
 
 
@@ -147,10 +159,12 @@ def test_inject_routes_to_originating_slot_and_broadcasts_live() -> None:
     assert state.created == []  # never created a fallback slot
     assert len(origin.messages) == 1
     assert "pizza" in origin.messages[0]["content"]
-    # Live chat_message broadcast to that slot so it shows without a manual fetch.
-    chat_msgs = [p for k, p in state.broadcasts if k == "chat_message"]
-    assert chat_msgs and chat_msgs[0]["slot"] == "chat-2-123"
-    assert chat_msgs[0]["role"] == "assistant"
+    # Live delivery goes through append's OWN mid-carrying door exactly once
+    # (no reader active). A second hand-built broadcast_ws frame would be
+    # mid-less and render as a duplicate bubble (#5981 family).
+    assert len(origin.delivered) == 1
+    assert origin.delivered[0]["meta"]["mid"] == origin.messages[0]["meta"]["mid"]
+    assert [p for k, p in state.broadcasts if k == "chat_message"] == []
 
 
 def test_inject_falls_back_when_origin_slot_gone() -> None:


### PR DESCRIPTION
## Problem / Motivation

The dashboard can render the same chat reply multiple times — the reported case (#5981) is a channel (WeChat) reply appearing 5 times in a row. The investigation on the issue traced the dominant producer to backend call sites that append a row to the chat window and then hand-build a **second** `broadcast_ws("chat_message", ...)` frame for the same row, with **no `meta.mid`** on it.

## Why it matters

`slot.append` already delivers one live frame carrying the row's minted `meta.mid` (via `_on_message` → `_broadcast_chat_message`) whenever no HTTP stream reader is active — so the manual frame ships the same row twice. The client's redelivery guard (`isRedeliveredMessage`, `chatSlice.ts`) keys on `meta.mid` and deliberately declines mid-less frames rather than guessing, so each extra copy renders as a new bubble. One mid-less frame per emitted segment of a multi-step channel turn fits the "5 identical bubbles" report. Every user of the dashboard alongside an active channel session is exposed.

## What changed (motivation → approach → change)

Symptom: duplicate bubbles → root cause: a family of append-then-manual-broadcast double-emits whose second frame carries no identity → change: one chokepoint, `append_and_surface` (`src/kiro_crew/dashboard/state.py`), that delivers every appended row through **exactly one identity-carrying door**: append's own mid-carrying delivery when no reader is draining, or a single manual frame carrying the row's `ts` + `meta` (mid included) when `slot._has_reader` suppresses append's callback — the conditional pattern `handlers/files.py` already pioneered, now with identity on the frame.

Complete branch table of every `chat_message`-emitting site audited (16 candidates):

| Site | Class | Change |
|---|---|---|
| `chat_orchestrator.py` cancelled-latch stop msg | assistant double-emit | → helper |
| `chat_orchestrator.py` stage-complete msg | assistant double-emit | → helper |
| `chat_orchestrator.py` stage summary | assistant double-emit | → helper |
| `chat_orchestrator.py` plan-cancelled msg | assistant double-emit | → helper |
| `chat_orchestrator.py` Go/Go All label | user row; manual frame was sole but mid-less delivery | → helper, `broadcast_user=True` |
| `chat_handlers.py` orchestration-stopped | assistant double-emit | → helper |
| `chat_runner.py` conversation-cleared | assistant double-emit | → helper; `slot_clear` reordered BEFORE the append (the wipe must precede the confirmation or it erases the row it announces) |
| `chat_utils.py` compaction chokepoint | assistant double-emit | → helper, `kind=compaction` preserved on frame+meta |
| `workflow_inject.py` workflow result | assistant double-emit | → helper; `window_mid` still read off the append for the durable copy |
| `handlers/files.py` file card | already conditional, frame mid-less | → helper; reader frame gains `ts`+`meta.mid` |
| `slack/handler.py` Slack→dashboard user mirror | user row, sole but mid-less | → helper, `broadcast_user=True` (module-level import: `dashboard.state` was already in this module's import chain via `chat_utils`) |
| `crew_chat.py` crew reply forward | deliberate `broadcast=False` + manual frame; frame shipped the pre-append meta (no mid) | frame now ships the APPENDED row's meta |
| `chat_runner.py` MCP-auth update, tool-patch update | `chat_message_update` (different event) | unchanged |
| `chat_runner.py` compacting status | wire-only status frame, no append | unchanged |

The persistence half of #5981 (channel rows saved without their mid, re-minted on every rebuild) was fixed separately in #7646; with both halves in place, the frontend sweep in #5982 catches any residual same-mid duplicate — the three changes are complementary.

## Tests

- `test/test_midless_broadcast_dedup.py` (new): pins the helper contract — single delivery with no reader; exactly one identity-carrying frame (`meta.mid` + `ts`) with a reader; user-row `broadcast_user` semantics (channel-typed rows deliver once, locally-typed rows stay optimistic); `extra` fields (e.g. `kind=compaction`) riding the reader frame; and the compaction site end-to-end. **Red-before proven:** with the old chat_utils site restored, the site test fails `assert 2 == 1` on the double delivery.
- Existing tests that pinned the old always-broadcast behavior re-pinned to the new contract (`test_workflows_inject.py`, `test_workflows_service.py`, `test_outbox_notify_broadcast.py`, `test_slack_handler_more_coverage.py`, `test_handler_link_intercept.py`, `test_dashboard_chat.py`); their slot doubles updated to mirror the real `append` contract (return the row, mint a mid, model `_on_message`/`_has_reader`).
- Full backend suite: 81,381 passed; the only failures are the 99 host-environment failures byte-identical to pristine main on the same host.

## Manual verification

N/A — unit coverage sufficient: the delivery-count and identity assertions exercise the exact seam the bug lives in, and the changed messages are system strings with no rendering change.

## Related Issues

Fixes #5981

## Pattern harvest

Rule candidate: semgrep
Pattern: hand-built `broadcast_ws("chat_message", {...})` payload without `meta` — any `chat_message` frame that does not carry the appended row's `meta.mid` defeats the client's redelivery guard and renders duplicates; new code must route through `append_and_surface`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

