### PR TITLE
fix(ci): give the same-repo review lanes a distinct check name on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,15 +55,31 @@ jobs:
     # --model below is bumped and this name changes with it, the required-check
     # list AND the `workflow_run.workflows:` array in pr-readiness.yml must be
     # updated in the same change.
-    name: Opus 4.8 Review
+    # BRANCH-PROTECTION NAME COLLISION -- keep this conditional. Two workflows
+    # publish the protected check name "Opus 4.8 Review": this same-repo lane
+    # and the privileged Stage-2 fork-opus-review.yml. GitHub resolves a
+    # required status check to the NEWEST check-run carrying that name, and the
+    # fork guard below reports
+    # `skipped`, which branch protection treats as satisfied. Any `pull_request`
+    # event that fires AFTER the fork lane published its verdict (a reopen, and
+    # for codex-review an `edited` title/body) would therefore make `skipped`
+    # the newest run under the protected name and satisfy the gate on a review
+    # that never ran. Naming this job differently on a fork PR leaves exactly
+    # ONE publisher of the protected name per PR type: this lane for same-repo
+    # PRs, the Stage-2 lane for forks. `pr-readiness.yml` is unaffected -- it
+    # already collapses every check-run of the name for forks and treats a name
+    # with no completed run as pending, never as passed.
+    name: "${{ github.event.pull_request.head.repo.full_name == github.repository && 'Opus 4.8 Review' || 'Opus 4.8 Review (same-repo lane, not applicable to forks)' }}"
     runs-on: ubuntu-latest
     # Same-repo PRs only (not forks). Fork PRs get NO OIDC/secrets access from
     # GitHub, so the Bedrock role assumption below can never succeed — without
     # this guard the review step is skipped and the fail-closed gate turns the
     # required check RED on every external contribution. Skipping the whole job
-    # instead reports the required "Opus 4.8 Review" check as "skipped", which
-    # branch protection treats as satisfied. Mirrors the fork guard in
-    # codex-review.yml and design-review.yml. Dependabot PRs are same-repo
+    # reports `skipped` instead -- which is why this job renames itself on a
+    # fork PR: a fork's real verdict comes from fork-opus-review.yml, and a
+    # `skipped` run under the same name could otherwise outrank it (see the
+    # name: comment above). Mirrors the fork guard in codex-review.yml and
+    # design-review.yml. Dependabot PRs are same-repo
     # (branch lives in this repo) so they still enter the job and are handled by
     # the step-level dependabot skip + gate pass below.
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -41,7 +41,21 @@ concurrency:
 
 jobs:
   codex-review:
-    name: GPT 5.6 Review
+    # BRANCH-PROTECTION NAME COLLISION -- keep this conditional. Two workflows
+    # publish the protected check name "GPT 5.6 Review": this same-repo lane
+    # and the privileged Stage-2 fork-gpt-review.yml. GitHub resolves a
+    # required status check to the NEWEST check-run carrying that name, and the
+    # fork guard below reports
+    # `skipped`, which branch protection treats as satisfied. Any `pull_request`
+    # event that fires AFTER the fork lane published its verdict (a reopen, and
+    # for codex-review an `edited` title/body) would therefore make `skipped`
+    # the newest run under the protected name and satisfy the gate on a review
+    # that never ran. Naming this job differently on a fork PR leaves exactly
+    # ONE publisher of the protected name per PR type: this lane for same-repo
+    # PRs, the Stage-2 lane for forks. `pr-readiness.yml` is unaffected -- it
+    # already collapses every check-run of the name for forks and treats a name
+    # with no completed run as pending, never as passed.
+    name: "${{ github.event.pull_request.head.repo.full_name == github.repository && 'GPT 5.6 Review' || 'GPT 5.6 Review (same-repo lane, not applicable to forks)' }}"
     runs-on: ubuntu-latest
     # Runaway/hang backstop only, NOT a per-review budget: each pass carries its
     # own PASS_WALL and self-terminates first. This wall MUST therefore stay

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -26,7 +26,21 @@ concurrency:
 
 jobs:
   design-review:
-    name: Design Review
+    # BRANCH-PROTECTION NAME COLLISION -- keep this conditional. Two workflows
+    # publish the protected check name "Design Review": this same-repo lane and
+    # the privileged Stage-2 fork-design-review.yml. GitHub resolves a required
+    # status check to the NEWEST check-run carrying that name, and the fork
+    # guard below reports
+    # `skipped`, which branch protection treats as satisfied. Any `pull_request`
+    # event that fires AFTER the fork lane published its verdict (a reopen, and
+    # for codex-review an `edited` title/body) would therefore make `skipped`
+    # the newest run under the protected name and satisfy the gate on a review
+    # that never ran. Naming this job differently on a fork PR leaves exactly
+    # ONE publisher of the protected name per PR type: this lane for same-repo
+    # PRs, the Stage-2 lane for forks. `pr-readiness.yml` is unaffected -- it
+    # already collapses every check-run of the name for forks and treats a name
+    # with no completed run as pending, never as passed.
+    name: "${{ github.event.pull_request.head.repo.full_name == github.repository && 'Design Review' || 'Design Review (same-repo lane, not applicable to forks)' }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Same-repo PRs only (not forks): fork PRs have no OIDC/secrets access, and

--- a/.github/workflows/first-principles-review.yml
+++ b/.github/workflows/first-principles-review.yml
@@ -50,7 +50,22 @@ concurrency:
 
 jobs:
   first-principles-review:
-    name: First Principles Review
+    # BRANCH-PROTECTION NAME COLLISION -- keep this conditional. Two workflows
+    # publish the protected check name "First Principles Review": this
+    # same-repo lane and the privileged Stage-2
+    # fork-first-principles-review.yml. GitHub resolves a required status check
+    # to the NEWEST check-run carrying that name, and the fork guard below
+    # reports
+    # `skipped`, which branch protection treats as satisfied. Any `pull_request`
+    # event that fires AFTER the fork lane published its verdict (a reopen, and
+    # for codex-review an `edited` title/body) would therefore make `skipped`
+    # the newest run under the protected name and satisfy the gate on a review
+    # that never ran. Naming this job differently on a fork PR leaves exactly
+    # ONE publisher of the protected name per PR type: this lane for same-repo
+    # PRs, the Stage-2 lane for forks. `pr-readiness.yml` is unaffected -- it
+    # already collapses every check-run of the name for forks and treats a name
+    # with no completed run as pending, never as passed.
+    name: "${{ github.event.pull_request.head.repo.full_name == github.repository && 'First Principles Review' || 'First Principles Review (same-repo lane, not applicable to forks)' }}"
     runs-on: ubuntu-latest
     # Consumer counting is grep-heavy, so this lane runs more turns than the
     # other advisory lanes; keep headroom for the model-latency fat tail.

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -35,7 +35,21 @@ concurrency:
 
 jobs:
   ux-review:
-    name: UX Review
+    # BRANCH-PROTECTION NAME COLLISION -- keep this conditional. Two workflows
+    # publish the protected check name "UX Review": this same-repo lane and the
+    # privileged Stage-2 fork-ux-review.yml. GitHub resolves a required status
+    # check to the NEWEST check-run carrying that name, and the fork guard
+    # below reports
+    # `skipped`, which branch protection treats as satisfied. Any `pull_request`
+    # event that fires AFTER the fork lane published its verdict (a reopen, and
+    # for codex-review an `edited` title/body) would therefore make `skipped`
+    # the newest run under the protected name and satisfy the gate on a review
+    # that never ran. Naming this job differently on a fork PR leaves exactly
+    # ONE publisher of the protected name per PR type: this lane for same-repo
+    # PRs, the Stage-2 lane for forks. `pr-readiness.yml` is unaffected -- it
+    # already collapses every check-run of the name for forks and treats a name
+    # with no completed run as pending, never as passed.
+    name: "${{ github.event.pull_request.head.repo.full_name == github.repository && 'UX Review' || 'UX Review (same-repo lane, not applicable to forks)' }}"
     runs-on: ubuntu-latest
     # Model-call latency has a fat tail: ~18 min observed max, and a killed
     # review surfaces as a RED required check, so keep generous headroom.

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -466,6 +466,16 @@ check on that pairing mis-fires whenever the model quotes prior text.
   **skips** on a fork rather than failing an unsatisfiable credential step. GitHub
   treats a skipped required check as satisfied, which is why fork coverage needs
   the separate `fork-*` pipeline below.
+- **The job name is conditional on the head repository**, so a fork PR gets
+  `<check> (same-repo lane, not applicable to forks)` instead of the protected
+  name. Same-repo PRs keep the exact protected name. Without this, both lanes
+  publish one name and GitHub resolves a required status check to the **newest**
+  check-run of that name: a `pull_request` event firing after the fork lane
+  posted its verdict (a reopen, or an `edited` title/body on `codex-review.yml`)
+  would make the same-repo lane's `skipped` run the newest one and satisfy the
+  gate on a review that never ran. `pr-readiness.yml` was never fooled by this
+  -- it collapses every check-run of the name and treats "no completed run" as
+  pending -- so the rename closes the branch-protection half of the gate.
 - `persist-credentials: false` on checkout, so `actions/checkout` never writes the
   token into `.git/config` where a reviewer reading untrusted PR content could find
   it.
@@ -696,7 +706,10 @@ privileged from the default branch (stage 2), gated on
 named exactly like its same-repo twin (`Opus 4.8 Review`, `GPT 5.6 Review`,
 `Design Review`, `UX Review`), so branch protection is satisfied on either path, and
 it opens that check-run as early as possible keyed to `head_sha` so a job that dies
-still leaves a fail-closed result.
+still leaves a fail-closed result. On a fork PR this lane is the **only** publisher
+of that name -- the same-repo twin renames itself (see the reviewer-job security
+posture above) -- so the protected status can only be reported by a review that
+actually ran.
 
 Nothing the fork controls can influence these reviews:
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -2892,3 +2892,94 @@ class TestLedgerReadFailureFailsClosed:
         assert 'issues/$PR/comments" --paginate 2>/dev/null' not in block
         assert "|| true" not in block
         assert "|| printf" not in block
+
+
+class TestProtectedCheckNameHasOnePublisherPerPrType:
+    """A required review status must never be satisfied by the OTHER lane's skip.
+
+    Each AI review is published by two workflows: the same-repo lane and the
+    privileged Stage-2 ``fork-*-review.yml``. GitHub resolves a required status
+    check to the NEWEST check-run of that name, and the same-repo lane's fork
+    guard reports ``skipped`` -- which branch protection treats as satisfied.
+    While the two lanes share a name, any ``pull_request`` event firing after
+    the fork lane posted its verdict (a reopen; an ``edited`` title/body on
+    codex-review) makes ``skipped`` the newest run and clears the gate on a
+    review that never ran. The same-repo lane therefore renames itself on a
+    fork PR, leaving exactly one publisher of the protected name per PR type.
+    """
+
+    # (same-repo workflow, protected check name, Stage-2 fork workflow)
+    PAIRS = (
+        ("codex-review.yml", "GPT 5.6 Review", "fork-gpt-review.yml"),
+        ("claude-review.yml", "Opus 4.8 Review", "fork-opus-review.yml"),
+        ("design-review.yml", "Design Review", "fork-design-review.yml"),
+        (
+            "first-principles-review.yml",
+            "First Principles Review",
+            "fork-first-principles-review.yml",
+        ),
+        ("ux-review.yml", "UX Review", "fork-ux-review.yml"),
+    )
+
+    GUARD = "github.event.pull_request.head.repo.full_name == github.repository"
+
+    def _job(self, workflow: str) -> dict:
+        spec = yaml.safe_load(_workflow(workflow))
+        jobs = spec["jobs"]
+        assert len(jobs) == 1, f"{workflow}: expected a single review job"
+        return next(iter(jobs.values()))
+
+    @pytest.mark.parametrize("workflow,check,fork", PAIRS)
+    def test_same_repo_lane_keeps_the_protected_name_only_for_same_repo_prs(
+        self, workflow: str, check: str, fork: str
+    ) -> None:
+        job = self._job(workflow)
+        name = job["name"]
+
+        # The name is CONDITIONAL on the head repo, not a constant.
+        assert self.GUARD in name, workflow
+        # Same-repo PRs keep the exact protected name -- branch protection keys
+        # its required status check on this string, so it must not drift.
+        assert f"&& '{check}'" in name, workflow
+        # Fork PRs get a name branch protection does not require, so this
+        # lane's `skipped` run can never stand in for the real fork verdict.
+        alias = f"{check} (same-repo lane, not applicable to forks)"
+        assert f"|| '{alias}'" in name, workflow
+        assert alias != check
+
+        # The fork guard itself stays -- the rename is defence on top of it,
+        # not a replacement for keeping fork code out of this privileged lane.
+        assert self.GUARD in job["if"], workflow
+
+    @pytest.mark.parametrize("workflow,check,fork", PAIRS)
+    def test_fork_lane_still_publishes_the_protected_name(
+        self, workflow: str, check: str, fork: str
+    ) -> None:
+        # With the same-repo lane renamed on forks, the Stage-2 lane is the ONLY
+        # publisher of the protected name on a fork PR. If it stopped posting
+        # under that exact name, every fork PR would block on a status that is
+        # never reported.
+        assert f'-f name="{check}"' in _workflow(fork), fork
+
+    @pytest.mark.parametrize("workflow,check,fork", PAIRS)
+    def test_readiness_still_reads_the_protected_name_on_forks(
+        self, workflow: str, check: str, fork: str
+    ) -> None:
+        # Readiness reads fork verdicts from the head SHA's check-runs by name.
+        # It collapses every run of the name and treats "no completed run" as
+        # pending, so the rename removes a `skipped` row without making a
+        # missing review look green.
+        readiness = _workflow("pr-readiness.yml")
+        assert f'"checkrun:{check}|{check}"' in readiness, check
+        assert '[ "$total" -eq 0 ] || [ "$incomplete" -gt 0 ]' in readiness
+        assert 'pending+=("$label (not started)")' in readiness
+
+    def test_no_lane_claims_a_skipped_run_satisfies_the_gate(self) -> None:
+        # This was true before the Stage-2 fork lanes existed and is exactly the
+        # hazard now closed; leaving it recorded as fact invites a revert.
+        for workflow, _check, _fork in self.PAIRS:
+            flat = _flat(_workflow(workflow))
+            assert (
+                'check as "skipped", which branch protection treats as satisfied'
+                not in flat
+            ), workflow


### PR DESCRIPTION
## Problem / Motivation

Two workflows publish each AI review's check name. The same-repo lane (`codex-review.yml`, `claude-review.yml`, `design-review.yml`, `ux-review.yml`, `first-principles-review.yml`) is guarded by `head.repo.full_name == github.repository` and so reports **`skipped`** under the protected name on a fork PR. The privileged Stage-2 lane (`fork-*-review.yml`) posts its real verdict under the **same** name.

GitHub resolves a required status check to the **newest** check-run of that name. On [PR #7353](https://github.com/kirodotdev/KiroCrew/pull/7353), commit `f67eefae5` carries three check-runs all named `GPT 5.6 Review`: the fork lane's `failure` (completed 19:36) and two `skipped` runs from `codex-review.yml` (17:09). The fork verdict happens to be newest there, so the gate reads red correctly — but the ordering is not guaranteed. `codex-review.yml` triggers on `edited` as well as `synchronize`, so a title/body edit (or a reopen on any of the five lanes) after the fork lane has posted creates a **newer** `skipped` run under the protected name and satisfies branch protection on a review that never ran.

## Why it matters

An external contribution could clear a required AI-review status without any review having examined it, purely by editing its own PR description at the right moment. `pr-readiness.yml` was never fooled — it collapses every check-run of the name and treats "no completed run" as pending — but branch protection, the other half of the gate, was.

## What changed (motivation → approach → change)

Root cause is one name with two publishers per PR. The fix leaves exactly **one** publisher per PR type instead of trying to order them.

Each same-repo lane's job `name` becomes conditional on the head repository:

- same-repo PR → the exact protected name (`GPT 5.6 Review`, …), unchanged, because branch protection keys its required context on that string;
- fork PR → `<check> (same-repo lane, not applicable to forks)`, a name branch protection does not require, so this lane's `skipped` run can no longer stand in for the fork verdict.

The fork guard on `if:` is untouched — the rename is defence on top of it, not a replacement. On a fork PR the protected status is then reported only by the Stage-2 lane, which always finalizes its check-run fail-closed.

Two knock-on notes:

- Readiness needs no change: for forks it reads `checkrun:<name>` specs, and `total == 0` already resolves to `pending (not started)`, so removing a `skipped` row never makes a missing review look green.
- `ai-review-human-override.yml` is unaffected: it selects fork check-runs by `external_id == "<lane>-pr-<n>"`, which the same-repo lane never sets.

`claude-review.yml` carried the pre-fork-lane rationale as fact ("Skipping the whole job instead reports the required check as `skipped`, which branch protection treats as satisfied"). That sentence is the hazard being closed, so it is rewritten rather than left as an invitation to revert.

## Tests

`test/test_ai_review_workflows.py::TestProtectedCheckNameHasOnePublisherPerPrType`, parametrized over all five lane pairs:

- `test_same_repo_lane_keeps_the_protected_name_only_for_same_repo_prs` — the job name is an expression on `head.repo.full_name == github.repository`, its true branch is the exact protected name, its false branch is the fork alias, and the `if:` fork guard is still present. Mutation-verified: restoring `name: UX Review` as a constant fails it.
- `test_fork_lane_still_publishes_the_protected_name` — each `fork-*-review.yml` still opens its check-run with `-f name="<protected>"`; if it stopped, every fork PR would block on a status nobody reports.
- `test_readiness_still_reads_the_protected_name_on_forks` — the `checkrun:` spec and the `total == 0 → pending` branch are both still in `pr-readiness.yml`.
- `test_no_lane_claims_a_skipped_run_satisfies_the_gate` — pins out the stale rationale so it cannot come back as a comment.

## Manual verification

N/A — unit coverage sufficient. The behavior is a GitHub check-name resolution rule; the observed three-check-run collision on `f67eefae5` of [PR #7353](https://github.com/kirodotdev/KiroCrew/pull/7353) is the evidence, and this PR's own checks exercise the same-repo branch of the expression (the protected names must still appear unchanged on this PR).

## Pattern harvest

Rule candidate: review-prompt
Pattern: two workflows publishing one required check name, where the lane that does no work reports a conclusion branch protection accepts — the guard that "skips safely" becomes the bypass once a second publisher appears.

## Related Issues

no linked issue: found while explaining the duplicate `GPT 5.6 Review` rows on [PR #7353](https://github.com/kirodotdev/KiroCrew/pull/7353).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- rebase-note -->
### Rebase note

Rebased onto `origin/main` at `680baf944` after [PR #7854](https://github.com/kirodotdev/KiroCrew/pull/7854) merged (it touched all five same-repo review lanes plus `test/test_ai_review_workflows.py`). Head `b49f7e5ea`, still one commit, diff byte-identical at +186/-9.

The five workflow hunks auto-merged. The one conflict was in `test/test_ai_review_workflows.py`: both sides append a class at end of file, so both are kept in order (`TestOverrideReadFailureFailsClosed` / `TestLedgerReadFailureFailsClosed` from #7854, then `TestProtectedCheckNameHasOnePublisherPerPrType`). No assertion from either side was altered.

Re-verified on the new base: 863 tests pass across every test file referencing these workflows, all five job names still resolve through the head-repo conditional, and isort / flake8 / black / docs-lint / brand / changelog gates are green.
