### PR TITLE
fix(dashboard): pin remaining slot metadata writes

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -688,6 +688,12 @@ Each chat tab gets its own kiro-cli session keyed by `dashboard:{slot_key}` with
 4. **Resume**: user clicks history item → JSONL loaded into slot (same key) → new kiro-cli session created with history re-injected (if already active, returns existing — no duplicate)
 5. **Close again**: saved back to SAME JSONL file → same history entry (no duplicates)
 6. **Gateway shutdown**: all active slots saved to JSONL
+
+**Guarded metadata writes:** slot metadata endpoints mutate the live slot before
+their history write. While a write is pinned to an authorized transcript key, the
+periodic unpinned flush skips that slot; this prevents a rebind from making the
+provisional value durable in a different transcript. A refused pinned write rolls
+back its endpoint-owned value before a later flush may resume.
 7. **Idle expiry**: per-tab sessions expire after `session.timeout_secs` (default 60 min) like any other session; on next message a fresh session is created with history re-injected
 
 Cross-tab context: **removed** (budget redistributed to other caps). Previously injected recent messages from other dashboard tabs; this block was eliminated and its 6,000-char budget absorbed into the raised memory/lessons caps above.

--- a/src/kiro_crew/crew_chat.py
+++ b/src/kiro_crew/crew_chat.py
@@ -33,7 +33,7 @@ from kiro_crew.atomic_write import read_bytes_with_retry, replace_with_retry
 from kiro_crew.config.loader import KiroCrewConfig, resolve_agent_bindings
 from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
-from kiro_crew.dashboard.chat_utils import effective_session_key
+from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
 from kiro_crew.dashboard.state import row_mid
 from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.llm_helpers import _extract_json_of_type, run_bg_oneliner
@@ -1115,9 +1115,15 @@ class CrewOrchestrator:
                 # decides durability, so a lock timeout here is not fatal.
                 logger.warning("crew: durable transcript append failed", exc_info=True)
         try:
-            await save_slot_off_loop(
-                self._state, slot, force=True, best_effort=False
+            persisted = await save_slot_off_loop(
+                self._state,
+                slot,
+                force=True,
+                best_effort=False,
+                expected_history_key=slot_history_key(slot),
             )
+            if not persisted:
+                return False
         except Exception:
             logger.warning("crew: durable slot save failed", exc_info=True)
             return False

--- a/src/kiro_crew/dashboard/chat_auto_tag.py
+++ b/src/kiro_crew/dashboard/chat_auto_tag.py
@@ -27,6 +27,7 @@ from kiro_crew.dashboard.chat_tags import (
     persist_tags_snapshot_unlocked,
     tags_write_lock,
 )
+from kiro_crew.dashboard.chat_utils import slot_history_key
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -134,7 +135,21 @@ async def _auto_tag_inner(state: Any, slot: Any) -> None:
         current_tags.append(tag_id)
         slot.tags = current_tags
         slot._auto_tagged = True
-        await save_slot_off_loop(state, slot, force=True)
+        # Auto-tagging is asynchronous.  Pin the history target at the point
+        # the metadata is applied so a concurrent session rebind cannot make
+        # this background task write its tag onto a different transcript.
+        persisted = await save_slot_off_loop(
+            state,
+            slot,
+            force=True,
+            expected_history_key=slot_history_key(slot),
+        )
+        if not persisted:
+            # The slot rebound while the guarded write waited.  Leave no
+            # provisional tag on the newly bound live conversation.
+            slot.tags = [value for value in slot.tags if value != tag_id]
+            slot._auto_tagged = False
+            return
 
         # Push update to connected clients
         push = getattr(state, "push_slots_update", None)

--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -1271,7 +1271,12 @@ async def api_chat_slot_pin(request: web.Request) -> web.Response:
                 {"error": "session was deleted or rebound", "code": "session_gone"}, status=409
             )
         prior_pinned = slot.pinned
-        new_pinned = bool(body.get("pinned", False))
+        new_pinned = body.get("pinned", False)
+        # Do not use Python truthiness for API booleans: JSON strings such as
+        # "false" are non-empty and therefore truthy.  The sibling metadata
+        # fields validate their types before mutating; pin must do the same.
+        if not isinstance(new_pinned, bool):
+            return web.json_response({"error": "pinned must be a boolean"}, status=400)
         slot.pinned = new_pinned
         if not await save_slot_off_loop(
             state, slot, force=True, expected_history_key=authorized_history_key

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2306,7 +2306,16 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
     # write, a restart rehydrates the previous title with a refreshable "auto"
     # origin and the background refresh may rewrite the pin.
     if folder_id or title:
-        await save_slot_off_loop(state, slot, force=True)
+        # The create/recreate request has been authorized against this
+        # transcript.  Do not let a rebind while the off-loop write waits on
+        # the history lock redirect its newly supplied metadata to another
+        # session.
+        await save_slot_off_loop(
+            state,
+            slot,
+            force=True,
+            expected_history_key=slot_history_key(slot),
+        )
     # Speculative session creation: overlap the ACP handshake with the user's
     # think-time before their first message. No-op unless session.eager_spawn.
     schedule_eager_spawn(state, slot)

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -3405,6 +3405,7 @@ async def save_slot_off_loop(
             expected_history_key=expected_history_key,
         )
 
+    guarded_metadata = expected_history_key is not None
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -3427,6 +3428,8 @@ async def save_slot_off_loop(
                 return True
         return _do()
     if best_effort:
+        if guarded_metadata:
+            slot._metadata_persist_inflight += 1
         try:
             return await loop.run_in_executor(None, _do)
         except Exception:  # noqa: BLE001 - best-effort durable copy
@@ -3437,9 +3440,18 @@ async def save_slot_off_loop(
                 "save_slot_off_loop: offloaded save failed slot=%s", slot.key, exc_info=True
             )
             return True
+        finally:
+            if guarded_metadata:
+                slot._metadata_persist_inflight -= 1
     # Non-best-effort: propagate so the caller can roll back (do NOT remove the
     # session until the durable write is confirmed).
-    return await loop.run_in_executor(None, _do)
+    if guarded_metadata:
+        slot._metadata_persist_inflight += 1
+    try:
+        return await loop.run_in_executor(None, _do)
+    finally:
+        if guarded_metadata:
+            slot._metadata_persist_inflight -= 1
 
 
 def _build_history_prefix(slot: _ChatSlot) -> str:

--- a/src/kiro_crew/dashboard/dashboard_persistence.py
+++ b/src/kiro_crew/dashboard/dashboard_persistence.py
@@ -90,6 +90,11 @@ class DashboardPersistenceCoordinator:
 
     def flush_slot_now(self, owner: Any, slot: Any) -> None:
         """Write one dirty slot and clear only the generation that was saved."""
+        # Endpoint metadata is applied to the live slot before its guarded
+        # history write.  Do not let this unpinned periodic writer make that
+        # provisional value durable while the guarded writer is still waiting.
+        if getattr(slot, "_metadata_persist_inflight", 0):
+            return
         if not owner.conversation_log or not slot._dirty or not slot.messages:
             return
         save_slot_to_history = self._slot_saver_provider()

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3036,6 +3036,7 @@ class _ChatSlot:
         "_prefetch_ttl_task",
         "_dirty_flag",
         "_dirty_gen",
+        "_metadata_persist_inflight",
         "_orch_tracker",
         "_plan_cancelled",
         "_auto_run",
@@ -3347,6 +3348,10 @@ class _ChatSlot:
         # Bumped by the _dirty setter on every True. Lets the periodic flush tell
         # "the True I started this save under" from "a NEW True set during it".
         self._dirty_gen: int = 0
+        # A guarded metadata write has changed this live slot but has not yet
+        # committed.  The periodic writer must not serialize that provisional
+        # state to an unpinned transcript while the guarded write waits.
+        self._metadata_persist_inflight: int = 0
         self._orch_tracker: Any = None  # OrchestrationTracker, set by gateway
         # Plan-cancel latch closing the cancel/Go race (#6046): the Cancel
         # handler can only stop a tracker that exists, but _stage_loop creates

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -12244,6 +12244,20 @@ class TestFolderCRUD:
             assert state._slots["myslot"].pinned is False
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["false", "true", 0, 1, None, []])
+    async def test_pin_slot_rejects_non_boolean_values(self, tmp_path, monkeypatch, value):
+        """The API must not apply Python truthiness to JSON metadata."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("myslot")
+        app = _make_folder_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.patch("/api/chat/slots/myslot/pin", json={"pinned": value})
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "pinned must be a boolean"
+        assert slot.pinned is False
+
+    @pytest.mark.asyncio
     async def test_slots_include_pinned(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         state = _make_state(tmp_path)

--- a/test/test_tag_session.py
+++ b/test/test_tag_session.py
@@ -99,6 +99,7 @@ class TestAutoTagDerivation:
         written = json.loads(tags_file.read_text())
         assert len(written) == 1
         assert written[0]["name"] == "MyRepo"
+        assert patch_save_slot.await_args.kwargs["expected_history_key"] == "dashboard:test-slot"
 
     async def test_no_project_is_noop(self, patch_save_slot):
         state = _make_state()


### PR DESCRIPTION
## Problem / Motivation

Slot metadata was applied to live state before a forced persistence write completed. A periodic unpinned flush could persist that provisional state after the slot had rebound to another transcript.

## Why it matters

A tag, folder, pin, or other metadata change could become durable on a transcript the request did not authorize.

## What changed (motivation → approach → change)

Guarded metadata persistence now marks the slot while a transcript-pinned save is in flight. The periodic flush skips marked slots until that write completes, so only the authorized write can commit provisional metadata. The remaining forced-save sites pass the history-key pin, refused auto-tag writes roll back, and the pin endpoint accepts only JSON booleans.

## Tests

- Existing forced-save/rebind suite verifies endpoint refusal and rollback behavior.
- Auto-tag regression verifies its save is history-key pinned.
- Pin endpoint regression rejects non-boolean JSON values.

## Manual verification

N/A — persistence behavior is covered by focused automated tests.

## Screenshots / video

N/A — no user-visible UI change.

## Related Issues

Fixes #7772

## Pattern harvest

Rule candidate: review-prompt
Pattern: a forced persistence write that mutates live metadata must prevent an unpinned background flush from committing provisional state.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff