### PR TITLE
fix: treat a serve config naming only other ports as a free 443

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -376,6 +376,14 @@ the same and the difference is the whole security story:
   something else there by hand, `up` and `down` both stop and print the command
   instead of overwriting or deleting your mapping.
 
+  A serve configuration that sits entirely on **other** ports — another project
+  on this machine published on port 80 or 8443, say — blocks neither direction.
+  Publishing touches only `443/`, so when Tailscale's own status shows every
+  mapping on some other port, the card and `tailnet up` treat 443 as free and
+  proceed, and `down` leaves the other mappings alone. Only a serve entry
+  naming port 443, or a status this build cannot read or attribute, triggers
+  the refusal.
+
   At startup the setting reads your own MagicDNS name from the local Tailscale
   daemon and trusts `https://<that name>` as an origin, so you do **not** have to
   look the name up and hand-write `dashboard.url`. The Overview one-click flow

--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -106,6 +106,7 @@ def _derive_step(
     trusted: bool,
     startup_host: str,
     published: bool | None,
+    port_free: bool | None,
 ) -> Step:
     """The one next action, derived HERE and nowhere else.
 
@@ -133,7 +134,12 @@ def _derive_step(
     6. ``occupied`` — serve holds this port/mount for something that is not this
        dashboard, or its state could not be determined. Publishing would REPLACE
        it, so this refuses and the card renders the manual command
-       (``kirocrew tailnet up``) for the operator to run deliberately.
+       (``kirocrew tailnet up``) for the operator to run deliberately. Decided
+       on ``port_free``, not on ``published`` alone: a stranger's handler at the
+       mount reads ``published=False`` exactly as a free port does, and offering
+       the publish button for it walked the operator into ``publish()``'s own
+       refusal one click later. Serve config that sits entirely on OTHER ports
+       is neither — it is invisible to this write and derives ``publish``.
     7. ``publish`` — everything is in place; one action left.
     8. ``ready`` — published and trusted.
     """
@@ -169,10 +175,12 @@ def _derive_step(
         return "restart_gateway"
     if published is True:
         return "ready"
-    # ``published is None`` is "could not tell", which is NOT "free". Publishing
-    # over an unknown mount is the destructive direction, so an undetermined
-    # state lands with the occupied case — same refusal, same manual escape.
-    return "publish" if published is False else "occupied"
+    # Only a provably free port earns the publish button; ``None`` ("could not
+    # tell") and ``False`` (something else holds the mount) are both the
+    # destructive direction and land with the occupied case — same refusal,
+    # same manual escape. This mirrors ``publish()``'s own guard, so the card
+    # never offers an action the write side will refuse.
+    return "publish" if (published is False and port_free is True) else "occupied"
 
 
 def _dashboard_port(request: web.Request) -> int:
@@ -347,6 +355,7 @@ async def _live_state(request: web.Request, port: int) -> _LiveState:
         name="", installed=False, reachable=False, logged_in=False, detail=""
     )
     published: bool | None = None
+    port_free: bool | None = None
     serve_detail = ""
     if not pinned:
         # Both are subprocess round trips; neither may run on the event loop.
@@ -354,6 +363,7 @@ async def _live_state(request: web.Request, port: int) -> _LiveState:
         if probe.name and port:
             state = await asyncio.to_thread(tailnet_serve.serve_state, port)
             published = state.published
+            port_free = state.port_free
             serve_detail = state.detail
 
     startup_host = tailnet.running_tailnet_origin(request.app)[0]
@@ -363,6 +373,7 @@ async def _live_state(request: web.Request, port: int) -> _LiveState:
         trusted=trusted,
         startup_host=startup_host,
         published=published,
+        port_free=port_free,
     )
     return _LiveState(
         step=step,

--- a/src/kiro_crew/dashboard/tailnet_serve.py
+++ b/src/kiro_crew/dashboard/tailnet_serve.py
@@ -19,9 +19,11 @@ documented contract is the opposite of what a write path needs:
   those to a bare "failed" would reproduce the unexplained-refusal problem this
   feature exists to remove.
 
-Two consequences of never having seen this daemon's real output on a live tailnet
-(this repo's dev host has no Tailscale) shape the code, and both are deliberate
-rather than provisional:
+Two consequences of having seen almost none of this daemon's real output shape
+the code, and both are deliberate rather than provisional (one real status
+document — a Windows 1.x daemon holding a single port-80 mapping — is pinned in
+the test suite, and it is what justifies the one evidence-based narrowing here,
+:func:`_has_port_shaped_keys`; everything else stays schema-agnostic):
 
 **The daemon's own output is always passed through verbatim.** ``code`` is a
 best-effort classification for the UI to branch on; ``detail`` carries what
@@ -44,6 +46,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -129,11 +132,22 @@ class ServeState:
     ``published=False, configured=True`` is the dangerous middle: something is
     served here and it is not ours, so a blind withdrawal could delete a mapping
     the operator set up by hand.
+
+    ``port_free`` narrows ``configured`` to the one port this module manages:
+    ``True`` means the status document provably holds no configuration for
+    ``SERVE_HTTPS_PORT`` — either no serve config exists at all, or every
+    configured mapping names some *other* port — so publishing replaces nothing.
+    ``False`` means the port carries some configuration (ours or a stranger's);
+    ``None`` means we could not determine it, which the write guards treat
+    exactly like ``False``. The field exists because ``configured`` alone made
+    a machine whose only serve mapping sits on port 80 indistinguishable from
+    one whose 443 is genuinely occupied, and both were refused.
     """
 
     published: bool | None
     configured: bool | None
     detail: str
+    port_free: bool | None = None
 
 
 def _stream_text(stream: str | bytes | None) -> str:
@@ -306,13 +320,79 @@ def _port_scoped_subtrees(node: Any, port: int) -> list[Any]:
     if isinstance(node, dict):
         for k, v in node.items():
             key = str(k)
-            if key == str(port) or key.endswith(f":{port}"):
+            # The single shared parse, so this detector and the port-evidence
+            # read (`_has_port_shaped_keys`) cannot disagree about a key — see
+            # `_key_port`. It is a strict superset of the bare-``"443"`` and
+            # ``endswith(":443")`` string forms (every shape they match parses
+            # here too, and it additionally catches e.g. ``"host:0443"``), so no
+            # separate string comparison is needed.
+            if _key_port(key) == port:
                 found.append(v)
             found.extend(_port_scoped_subtrees(v, port))
     elif isinstance(node, list):
         for v in node:
             found.extend(_port_scoped_subtrees(v, port))
     return found
+
+
+#: A dict key that names a port the way serve-status documents name them: a bare
+#: port number (the ``TCP`` map: ``"80"``) or a ``host:port`` suffix (the ``Web``
+#: and ``AllowFunnel`` maps: ``"desk.tail.ts.net:80"``). ASCII digits only and
+#: anchored with ``\Z``: ``\d`` admits Unicode decimal digits and ``$`` matches
+#: before a trailing newline, and either quirk would let a key parse as port
+#: evidence here while escaping the string comparisons in
+#: :func:`_port_scoped_subtrees`.
+_KEY_PORT_RE = re.compile(r"(?:^|:)([0-9]{1,5})\Z")
+
+
+def _key_port(key: str) -> int | None:
+    """The port a dict key names, or ``None`` when it names no port.
+
+    THE one key→port parse, shared by both predicates built on it. The free
+    determination in :func:`serve_state` is only sound while "this key is port
+    evidence" (:func:`_has_port_shaped_keys`) and "this key names OUR port"
+    (:func:`_port_scoped_subtrees`) agree about every key — a key that parses
+    as 443 for one predicate while escaping the other (a leading-zero
+    ``"host:0443"``, say) would count as evidence of a port-keyed schema while
+    hiding the very mapping the evidence is about. Parsing once and comparing
+    the integer removes the axis such a disagreement would turn on.
+    """
+    m = _KEY_PORT_RE.search(key)
+    if not m:
+        return None
+    port = int(m.group(1))
+    return port if 0 < port <= 65535 else None
+
+
+def _has_port_shaped_keys(node: Any) -> bool:
+    """Whether any dict key anywhere in *node* names a port.
+
+    The evidence read that lets :func:`serve_state` answer "our port is free"
+    instead of "unknown" when a document holds serve config only for OTHER
+    ports. The reasoning is schema self-evidence, not a hardcoded key path: one
+    document does not record one port in its keys and another port somewhere
+    else, so a document that demonstrably keys mappings by port (a real one from
+    a Windows Tailscale 1.102 daemon reads ``{"TCP": {"80": …}, "Web":
+    {"host:80": …}}``) and contains no key naming ours has nothing on ours.
+    A document with no port-shaped keys at all offers no such evidence, and the
+    caller keeps reporting ``unknown`` for it — the conservative floor is
+    narrowed, never removed. Values are never consulted: a proxy target like
+    ``http://127.0.0.1:9980`` names a port too, but only *keys* carry the
+    document's own indexing shape. The premise is deliberately loose in one
+    direction — a short numeric key that is not a port index (a counter, a
+    numeric session id) also reads as evidence — which is safe only because
+    every schema that records a mapping on a port also keys it, so the
+    443-detector fires before this evidence is consulted.
+    """
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if _key_port(str(k)) is not None:
+                return True
+            if _has_port_shaped_keys(v):
+                return True
+    elif isinstance(node, list):
+        return any(_has_port_shaped_keys(v) for v in node)
+    return False
 
 
 def _mount_subtrees(node: Any, mount: str) -> list[Any]:
@@ -368,7 +448,7 @@ def serve_state(port: int) -> ServeState:
         # is a genuine "nothing configured" rather than an unknown. Anything else
         # unparseable is unknown.
         if not (out or "").strip():
-            return ServeState(False, False, "No serve configuration is active.")
+            return ServeState(False, False, "No serve configuration is active.", port_free=True)
         # ``configured=True``: the daemon DID answer, we just cannot read its shape.
         # That distinction is load-bearing for the publish/withdraw guards — it
         # separates "something is there that this build cannot attribute" (dangerous,
@@ -378,7 +458,7 @@ def serve_state(port: int) -> ServeState:
             None, True, "tailscale serve status returned output this build cannot read."
         )
     if doc in (None, {}, []):
-        return ServeState(False, False, "No serve configuration is active.")
+        return ServeState(False, False, "No serve configuration is active.", port_free=True)
     needles = (f"http://127.0.0.1:{port}", f"http://localhost:{port}")
     # Two narrowings, and each closes a way the previous predicate was wrong.
     #
@@ -392,6 +472,22 @@ def serve_state(port: int) -> ServeState:
     # touches: is the handler at SERVE_MOUNT, on SERVE_HTTPS_PORT, ours?
     scoped = _port_scoped_subtrees(doc, SERVE_HTTPS_PORT)
     if not scoped:
+        # No key names our port. When the document demonstrably keys mappings by
+        # port (see _has_port_shaped_keys), that absence is a determination, not
+        # an unknown: everything serve holds sits on other ports, and the write
+        # guards may treat our port as free without endangering any of it. This
+        # is the dev-machine case — another project published on port 80 must
+        # not read as "something is on 443". A document with no port-shaped keys
+        # anywhere stays unknown, because the assumption a determination needs
+        # (mappings record their port in a key) has no evidence in it.
+        if _has_port_shaped_keys(doc):
+            return ServeState(
+                False,
+                True,
+                f"Serve is configured for other ports only; nothing is on port "
+                f"{SERVE_HTTPS_PORT}.",
+                port_free=True,
+            )
         return ServeState(
             None,
             True,
@@ -405,6 +501,7 @@ def serve_state(port: int) -> ServeState:
             True,
             f"Serve is configured on port {SERVE_HTTPS_PORT}, but this build could "
             f"not identify the handler at {SERVE_MOUNT}.",
+            port_free=False,
         )
     if any(_find_proxy_target(m, needles) for m in mounts):
         return ServeState(
@@ -412,12 +509,14 @@ def serve_state(port: int) -> ServeState:
             True,
             f"Serve is proxying {SERVE_HTTPS_PORT}{SERVE_MOUNT} to the dashboard "
             f"on port {port}.",
+            port_free=False,
         )
     return ServeState(
         False,
         True,
         f"Serve is configured on {SERVE_HTTPS_PORT}{SERVE_MOUNT}, but not for "
         f"this dashboard.",
+        port_free=False,
     )
 
 
@@ -458,10 +557,13 @@ def publish(port: int, *, audit_tool: str = "tailnet_publish") -> ServeResult:
             "nothing was published. Install Tailscale, or publish the dashboard "
             "yourself and set dashboard.url instead.",
         )
-    # Proceed ONLY when the mount is explicitly free or already ours. Anything else
-    # — including a state we could not determine — refuses, because the costs are not
-    # symmetric: overwriting destroys configuration the operator rebuilds from
-    # memory, while refusing costs one copy-pasted command, which the refusal prints.
+    # Proceed ONLY when OUR PORT is explicitly free or the mount is already ours.
+    # Anything else — including a state we could not determine — refuses, because the
+    # costs are not symmetric: overwriting destroys configuration the operator
+    # rebuilds from memory, while refusing costs one copy-pasted command, which the
+    # refusal prints. ``port_free`` is the deciding read, not ``configured``: serve
+    # config that sits entirely on other ports (another project on this machine) is
+    # untouched by this write and must not block it.
     #
     # An earlier revision keyed this on ``configured is True``, reasoning that when
     # the daemon gives no usable answer the publish call would fail anyway and report
@@ -471,8 +573,7 @@ def publish(port: int, *, audit_tool: str = "tailnet_publish") -> ServeResult:
     # "No answer" is not "no daemon", and the permissive branch existed largely
     # because it made this module's own failure-mode tests simpler.
     state = serve_state(port)
-    _free = state.published is False and state.configured is False
-    if not (state.published is True or _free):
+    if not (state.published is True or state.port_free is True):
         return ServeResult(
             False,
             "not_ours",
@@ -605,8 +706,9 @@ def unpublish(port: int, *, audit_tool: str = "tailnet_unpublish") -> ServeResul
     at the mount actually being removed.
 
     An **undetermined** state refuses too, and that is the deliberate half. This
-    code has never seen a real ``tailscale serve status --json``, so "I could not
-    tell" must not be treated as "go ahead": the two costs are not symmetric —
+    code has seen almost none of the real ``tailscale serve status --json``
+    shapes in the wild (one document is pinned in the test suite), so "I could
+    not tell" must not be treated as "go ahead": the two costs are not symmetric —
     wrongly proceeding destroys configuration the operator has to rebuild from
     memory, while wrongly refusing costs one copy-pasted command, which the
     refusal prints.
@@ -625,6 +727,17 @@ def unpublish(port: int, *, audit_tool: str = "tailnet_unpublish") -> ServeResul
         # caller's goal ("not published") already holds.
         return ServeResult(
             True, "ok", "Nothing is published — no serve configuration is active."
+        )
+    if state.published is False and state.port_free is True:
+        # The same idempotent no-op one level narrower: serve IS configured, but
+        # everything it holds sits on other ports. There is nothing on our port
+        # to withdraw, and running the removal anyway would be a write against
+        # config that belongs to something else on this machine.
+        return ServeResult(
+            True,
+            "ok",
+            f"Nothing is published on port {SERVE_HTTPS_PORT} — serve's "
+            f"configuration is for other ports only, and it is left alone.",
         )
     if state.published is not True:
         return ServeResult(

--- a/test/test_tailnet_mobile.py
+++ b/test/test_tailnet_mobile.py
@@ -103,6 +103,7 @@ def _step(**kw) -> str:
         "trusted": True,
         "startup_host": _HOST,
         "published": True,
+        "port_free": True,
     }
     args.update(kw)
     return tailnet_mobile._derive_step(**args)  # type: ignore[arg-type]
@@ -419,6 +420,21 @@ class TestUndeterminedIsNotFree:
         assert _step(published=None) != "ready"
 
 
+class TestOccupiedIsNotOfferedThePublishButton:
+    """The card must never offer an action ``publish()`` will refuse.
+
+    ``published=False`` covers two opposite situations — the port is free, and a
+    stranger's handler sits at the mount — and the old derivation offered the
+    publish button for both, walking the second into a refusal one click later.
+    """
+
+    def test_a_strangers_handler_derives_occupied(self) -> None:
+        assert _step(published=False, port_free=False) == "occupied"
+
+    def test_an_undetermined_port_derives_occupied(self) -> None:
+        assert _step(published=False, port_free=None) == "occupied"
+
+
 class TestRestartIsNotReady:
     """The boot race: resolvable now, absent from the startup allowlist."""
 
@@ -653,7 +669,18 @@ def _machine(
         patch.object(
             tailnet_mobile.tailnet_serve,
             "serve_state",
-            return_value=SimpleNamespace(published=published, configured=True, detail=detail),
+            # A REAL ServeState, not a namespace double, so a field added to the
+            # dataclass cannot drift past this fixture unnoticed. ``port_free``
+            # mirrors the real producer's invariant: a published port is
+            # occupied (by us), an unpublished one is free here because this
+            # fixture's ``published=False`` means "ready to publish", and an
+            # undetermined ``published`` leaves the port undetermined too.
+            return_value=tailnet_mobile.tailnet_serve.ServeState(
+                published=published,
+                configured=True,
+                detail=detail,
+                port_free=(True if published is False else (False if published is True else None)),
+            ),
         ),
     ):
         yield
@@ -1701,7 +1728,9 @@ class TestStatusIsOwnerOnly:
             patch.object(
                 tailnet_mobile.tailnet_serve,
                 "serve_state",
-                return_value=SimpleNamespace(published=True, configured=True, detail="ours"),
+                return_value=tailnet_mobile.tailnet_serve.ServeState(
+                    published=True, configured=True, detail="ours", port_free=False
+                ),
             ),
         ):
             return await tailnet_mobile.api_tailnet_mobile_status(_request(**req_kw))

--- a/test/test_tailnet_serve.py
+++ b/test/test_tailnet_serve.py
@@ -18,10 +18,13 @@ weighting is inverted, because a publish that fails silently is the bug:
   derived origin (which carries no port) match, and the upstream target is
   loopback so publishing never widens the gateway's bind.
 * :class:`TestPublishedDetection` pins that an unreadable status document reports
-  ``None`` rather than ``False``. This code has never seen a real
-  ``tailscale serve status --json``, so "we could not tell" has to be
-  representable — reporting "not published" for a published node is the
-  checked-but-never-ran defect in a new costume.
+  ``None`` rather than ``False``. This code has seen exactly one real
+  ``tailscale serve status --json`` (embedded in
+  ``test_other_ports_only_reads_our_port_as_free``), so "we could not tell" has
+  to stay representable — reporting "not published" for a published node is the
+  checked-but-never-ran defect in a new costume — while the one determination
+  the real document licenses (port-shaped keys, none of them ours, means our
+  port is free) reads as free rather than unknown.
 """
 
 from __future__ import annotations
@@ -490,9 +493,36 @@ class TestPublishDoesNotOverwrite:
             return tailnet_serve.publish(_PORT), m
 
     def test_a_free_mount_is_published(self) -> None:
-        result, run = self._publish_with_state(ServeState(False, False, "nothing configured"))
+        result, run = self._publish_with_state(
+            ServeState(False, False, "nothing configured", port_free=True)
+        )
         assert result.ok
         run.assert_called_once()
+
+    def test_other_ports_only_is_published(self) -> None:
+        """Serve config that sits entirely on other ports does not block ours.
+
+        The dev-machine case: another project published on port 80, and the old
+        ``configured is False`` guard read that as "443 might be taken" and
+        refused a publish that would have replaced nothing.
+        """
+        result, run = self._publish_with_state(
+            ServeState(False, True, "other ports only", port_free=True)
+        )
+        assert result.ok
+        run.assert_called_once()
+
+    def test_an_inconsistent_state_without_the_free_reading_refuses(self) -> None:
+        """``configured=False`` alone is not the deciding read — ``port_free`` is.
+
+        A state object that claims nothing is configured but carries no explicit
+        port-free determination is one this module's own reader never produces,
+        and the guard takes the refusing direction for it.
+        """
+        result, run = self._publish_with_state(ServeState(False, False, "no determination"))
+        assert not result.ok
+        assert result.code == "not_ours"
+        run.assert_not_called()
 
     def test_republishing_our_own_mount_is_allowed(self) -> None:
         """Idempotent: `up` twice must not be a refusal."""
@@ -557,7 +587,9 @@ class TestLaunchFailureIsNotReportedAsMissing:
     def test_publish_says_it_could_not_launch(self) -> None:
         cli, run = _patch_cli(side_effect=OSError("Exec format error"))
         with cli, run, patch.object(
-            tailnet_serve, "serve_state", return_value=ServeState(False, False, "free")
+            tailnet_serve,
+            "serve_state",
+            return_value=ServeState(False, False, "free", port_free=True),
         ), patch.object(tailnet_serve, "is_governance_pinned_off", return_value=False):
             result = tailnet_serve.publish(_PORT)
         assert result.code != "no_cli"
@@ -665,6 +697,14 @@ class TestWithdrawalSafety:
         assert result.code == "failed"
         assert result.detail == "something nobody predicted"
 
+    def test_other_ports_only_is_an_idempotent_success(self) -> None:
+        """Nothing on our port to withdraw; the other ports' config is not touched."""
+        result, run = self._unpublish_with_state(
+            ServeState(False, True, "other ports only", port_free=True)
+        )
+        assert result.ok
+        run.assert_not_called()
+
 
 class TestPublishedDetection:
     def _state(self, stdout: str = "", returncode: int = 0, stderr: str = ""):
@@ -734,6 +774,113 @@ class TestPublishedDetection:
         st = self._state(_doc("http://127.0.0.1:9999"))
         assert st.published is False
         assert st.configured is True
+        # 443 carries a stranger's handler, so the port is NOT free.
+        assert st.port_free is False
+
+    def test_other_ports_only_reads_our_port_as_free(self) -> None:
+        """A real status document from a Windows tailscale 1.x daemon (hostname
+        anonymized).
+
+        One mapping on HTTP 80, nothing anywhere naming 443. The document keys
+        its mappings by port in both maps (``TCP`` by bare number, ``Web`` by
+        ``host:port``), which is the evidence that lets the absent 443 key be a
+        determination — the port is free — rather than an unknown.
+        """
+        doc = {
+            "TCP": {"80": {"HTTP": True}},
+            "Web": {
+                "desk.tail1a2b3c.ts.net:80": {
+                    "Handlers": {"/": {"Proxy": "http://127.0.0.1:9980"}}
+                }
+            },
+        }
+        st = self._state(json.dumps(doc))
+        assert st.published is False
+        assert st.configured is True
+        assert st.port_free is True
+
+    def test_a_foreground_serve_on_another_port_reads_as_free(self) -> None:
+        """``Foreground`` nests whole ServeConfigs under session ids; the port
+        keys inside them are recursed into like any others."""
+        doc = {
+            "Foreground": {
+                "session-abc123def": {
+                    "TCP": {"8080": {"HTTP": True}},
+                    "Web": {"desk.tail1a2b3c.ts.net:8080": {"Handlers": {"/": {"Proxy": "x"}}}},
+                }
+            }
+        }
+        st = self._state(json.dumps(doc))
+        assert st.published is False
+        assert st.port_free is True
+
+    def test_a_services_only_document_reads_as_free(self) -> None:
+        """The tailscale/tailscale#18289 shape: ``Services`` (virtual-IP
+        services) is the only content, with a bare TCP port key, while plain
+        ``serve status`` says "No serve config" and the node's own 443 is free.
+        """
+        doc = {"Services": {"svc:mything": {"TCP": {"27224": {"HTTP": True}}}}}
+        st = self._state(json.dumps(doc))
+        assert st.published is False
+        assert st.port_free is True
+
+    def test_the_free_reading_requires_port_shaped_evidence(self) -> None:
+        """Six digits is not a port, so it is not evidence of a port-keyed schema."""
+        st = self._state(json.dumps({"Sessions": {"123456": {"proxy": "somewhere"}}}))
+        assert st.published is None
+        assert st.port_free is None
+
+    def test_an_out_of_range_number_is_not_port_evidence(self) -> None:
+        st = self._state(json.dumps({"Things": {"host:99999": {"x": 1}}}))
+        assert st.published is None
+        assert st.port_free is None
+
+    def test_a_key_that_is_evidence_of_our_port_is_never_invisible_to_it(self) -> None:
+        """The invariant the free determination stands on, pinned as a property.
+
+        Any key the evidence read parses to OUR port must also be found by the
+        port detector — otherwise one key could simultaneously be the hidden
+        443 and the port-shaped evidence used to declare 443 free. The
+        adversarial shapes here (leading zeros, a trailing newline that ``$``
+        would match before, Unicode decimal digits that ``\\d`` and ``int()``
+        both accept) are exactly the classes where the two predicates used to
+        be able to disagree.
+        """
+        adversarial = [
+            "443",
+            "host:443",
+            "host:0443",
+            "0443",
+            "443\n",
+            "host:443\n",
+            "host:٤٤٣",  # Arabic-Indic digits: int("٤٤٣") == 443
+            "[::1]:443",
+            ":443",
+            "svc:00443",
+        ]
+        port = tailnet_serve.SERVE_HTTPS_PORT
+        for key in adversarial:
+            evidence_port = tailnet_serve._key_port(key)
+            if evidence_port == port:
+                assert tailnet_serve._port_scoped_subtrees({key: {}}, port), (
+                    f"key {key!r} parses as port {port} for the evidence read "
+                    f"but the port detector does not find it"
+                )
+
+    def test_a_leading_zero_443_key_is_detected_not_free(self) -> None:
+        """``host:0443`` names 443; it must land on the refusing path, never on
+        the free one."""
+        doc = {"Web": {"host:0443": {"Handlers": {"/": {"Proxy": "http://127.0.0.1:3000"}}}}}
+        st = self._state(json.dumps(doc))
+        assert st.port_free is not True
+
+    def test_a_trailing_newline_key_is_not_port_evidence(self) -> None:
+        st = self._state(json.dumps({"TCP": {"443\n": {"HTTPS": True}}}))
+        assert st.port_free is not True
+
+    def test_unicode_digit_keys_are_not_port_evidence(self) -> None:
+        st = self._state(json.dumps({"Web": {"host:٤٤٣": {"x": 1}}}))
+        assert st.port_free is not True
 
     def test_our_handler_beside_a_strangers_at_the_mount_is_not_ours(self) -> None:
         """Ours at `/api`, a stranger's at `/` — the mount we would remove.
@@ -768,6 +915,9 @@ class TestPublishedDetection:
         st = self._state(json.dumps({"Foreign": {"proxy": f"http://127.0.0.1:{_PORT}"}}))
         assert st.published is None
         assert st.configured is True
+        # Only dict KEYS carry the document's indexing shape; the ``:5476`` in
+        # the proxy VALUE above must not count as port-keyed evidence.
+        assert st.port_free is None
 
     @pytest.mark.parametrize("stdout", ["not json at all", "<html>nope</html>"])
     def test_unreadable_output_is_unknown_not_negative(self, stdout: str) -> None:


### PR DESCRIPTION
## Problem / Motivation

On a machine where another project already uses `tailscale serve` on any
non-443 port (e.g. `tailscale serve --bg --http=80 …`), Settings → Overview →
**Phone access** and `kirocrew tailnet up` refuse to publish with:

> Serve is configured, but this build could not identify what is on port 443.
> Refusing to publish…

Port 443 is actually free — running the refusal's own suggested command
(`tailscale serve --bg --https=443 http://127.0.0.1:<port>`) succeeds and both
services coexist, because Tailscale serves each port independently. So the
refusal is a false conflict, and it fires on exactly the machines most likely to
run Kiro Crew: developer workstations with existing `tailscale serve` usage.

Reproduce anywhere:

```
tailscale serve --bg --http=80 http://127.0.0.1:9980
# then open the Phone access card, or run:
kirocrew tailnet up
```

## Why it matters

Phone access is a headline one-click flow, and this refusal blocks it before the
operator can do anything about it — the card shows "Needs attention / Something
else is already served here" on a host where 443 is vacant. The population hit is
not random: it is developers who already use `tailscale serve` for something
else, i.e. a large share of the people setting Kiro Crew up on their own machine.

## What changed (motivation → approach → change)

**Root cause.** `serve_state()` treats "no key names port 443" as *unknown*
rather than *vacant* (`_port_scoped_subtrees(doc, 443)` empty →
`published=None`), and `publish()`'s free test additionally required
`configured is False`. So any unrelated serve config — a mapping on port 80 —
poisoned publishing.

**Approach — schema self-evidence, not a hardcoded key path.** The module already
assumes "a mapping on port P records P in a dict key somewhere" (documented at
`_port_scoped_subtrees`). A parsed status document that demonstrably keys its
mappings by port (`TCP` by bare number, `Web`/`AllowFunnel` by `host:port`) and
records **no** 443 key is therefore *positive evidence* that 443 is vacant — not
a guess. A document with serve content but **no** port-shaped keys at all offers
no such evidence and keeps refusing, so the conservative floor is narrowed, never
removed. One subtlety mattered enough to pin: the "is this port evidence" read
and the "does this key name 443" detector must agree about every key, so both are
built on a single `_key_port()` parser (ASCII digits, `\Z`-anchored) — otherwise
a key like `host:0443` could count as evidence of a port-keyed schema while
hiding the very 443 mapping the evidence is about.

**Change.**
- `ServeState` gains a `port_free: bool | None` field: `True` when the document
  provably holds no configuration for 443, `False` when 443 carries a mapping,
  `None` when undetermined (treated as `False` by the write guards).
- `serve_state()` sets it, using `_has_port_shaped_keys()` to distinguish
  "other ports only → free" from "no evidence → unknown".
- `publish()` proceeds on `published is True or port_free is True` (was
  `published is True or (published is False and configured is False)`), and
  `unpublish()` gains a port-scoped idempotent no-op so it leaves other ports'
  config alone.
- `handlers/tailnet_mobile._derive_step()` takes `port_free`, so the card offers
  the publish button only for a provably free port. A stranger's handler at
  `443/` now derives `occupied` up front instead of offering a Publish button
  that fails one click later (a latent card/guard mismatch).

## Tests

`test/test_tailnet_serve.py` / `test/test_tailnet_mobile.py`:

- `test_other_ports_only_reads_our_port_as_free` — a real `serve status --json`
  from a Windows Tailscale 1.x daemon (one HTTP-80 mapping): our port reads free.
- `test_a_foreground_serve_on_another_port_reads_as_free`,
  `test_a_services_only_document_reads_as_free` — `Foreground`-nested and VIP
  `Services` shapes (the latter is the live tailscale/tailscale#18289 document,
  which today also trips the refusal).
- `test_a_key_that_is_evidence_of_our_port_is_never_invisible_to_it` plus
  leading-zero / trailing-newline / Unicode-digit cases — pin that the evidence
  read and the 443 detector can never disagree.
- `test_the_free_reading_requires_port_shaped_evidence`,
  `test_an_out_of_range_number_is_not_port_evidence` — a document with no
  port-shaped keys stays `unknown` (the floor is narrowed, not removed).
- `test_other_ports_only_is_published` / `_is_an_idempotent_success`,
  `TestOccupiedIsNotOfferedThePublishButton` — the publish/unpublish guards and
  the card step for the other-ports and stranger-at-443 cases.

## Manual verification

`tailscale serve --bg --http=80 http://127.0.0.1:9980`, then `kirocrew tailnet up`
publishes on 443 and leaves the port-80 mapping intact; `kirocrew tailnet down`
removes only the 443 handler. No new UI surface — the Phone access card renders
the existing step set; only which step it derives changes, which unit tests
cover.

## Related Issues

N/A — no existing issue found for this false conflict. Deliberately distinct from
#7244 / #7254 (stopped-daemon-reads-healthy), which rewrote the same file for a
different case and never touched the port-scoping branch; this change applies
cleanly on top of it.

## Pattern harvest

Not a mechanical lint rule — a design lesson, stated so the next occurrence is
recognized:

A schema-agnostic "is X present?" probe should distinguish **"the document does
not index this dimension"** (unknown) from **"the document indexes this
dimension and X is absent"** (proven absent), rather than collapsing both into a
single negative. Here "no key names 443" was read as *unknown* when the document
demonstrably keys mappings by port and simply has none for 443 — a *proven*
absence. The three-valued `port_free: bool | None` plus the `_has_port_shaped_keys`
evidence read encode that distinction.

Sub-lesson (from review): when two predicates independently parse the same token
(a dict key → port, for "is this evidence?" and "does this name our port?"), they
must share one parser or they can disagree on adversarial input (`host:0443`). The
shared `_key_port()` closes that and a property test pins the agreement.

Not generalizable: neither lesson reduces to a semgrep pattern (both are
semantic, not syntactic), so this is guidance rather than a lint rule.

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title
- [x] Tests added that fail before and pass after
- [x] Docs updated in the same change (`docs/guides/remote-and-mobile.md`)
- [x] No secrets, credentials, or real hostnames in the diff

