### PR TITLE
fix(virtualizer): hold the reader by position when a prepend retires every key

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -194,12 +194,14 @@ const ANCHOR_RESTORE_SETTLE_FRAMES = 3
 // Pure over its inputs so it can run both from the hook's callbacks (live
 // items) and from the slot-switch flush, which must resolve keys against the
 // OUTGOING session's items snapshot. Returns null when no mounted row
-// qualifies or the environment has no layout (jsdom).
+// qualifies or the environment has no layout (jsdom). `index` is the row's
+// index as the mounted node carries it — the PREVIOUS commit's, for a caller
+// resolving across a list change.
 function captureTopAnchorFrom(
   el: HTMLDivElement,
   entries: Iterable<[Element, number]>,
   keyAt: (index: number) => string | null,
-): { key: string; top: number } | null {
+): { key: string; top: number; index: number } | null {
   if (typeof el.getBoundingClientRect !== 'function') return null
   const srTop = el.getBoundingClientRect().top
   let bestIdx = Infinity
@@ -219,7 +221,7 @@ function captureTopAnchorFrom(
       bestKey = key
     }
   }
-  return bestKey !== null ? { key: bestKey, top: bestTop } : null
+  return bestKey !== null ? { key: bestKey, top: bestTop, index: bestIdx } : null
 }
 
 /** Screen offset of the mounted row whose key matches, relative to the
@@ -539,6 +541,9 @@ export function useVirtualChat<T>(
    */
   const shiftAnchorRef = useRef<{ key: string; top: number } | null>(null)
   const shiftStageRef = useRef<'awaiting-rebase' | 'rebased' | 'ready' | null>(null)
+  /** How far DOWN the anchored row moved in the list (new index minus old), set
+   *  by TRIGGER 1's capture and consumed by part 1. Equal to the net count growth
+   *  only for a pure front insert. */
   const prependCountRef = useRef(0)
   /**
    * TRIGGER 6's invalidation key for part 2, bumped in the render that captures a
@@ -600,24 +605,83 @@ export function useVirtualChat<T>(
     !stickRef.current
   ) {
     const prependEl = scrollerRef.current
+    const inserted = itemCount - prependPrev.count
+    // Current key -> current index. Membership says a key SURVIVED the change;
+    // the index says where its row went. That displacement — not the net count
+    // growth, which equals it only for a pure front insert — is what the re-base
+    // and the correction have to move by: a rebuild that also grows the TAIL
+    // (a reconnect catching up on missed rows) moves the reader by less than the
+    // count grew.
+    // Last-wins on a duplicate key; callers keep keys unique (ChatPage through
+    // uniqueRowKeys), and a duplicate would already misroute part 2's key lookup.
+    const newIndexByKey = new Map<string, number>()
+    for (let i = 0; i < items.length; i++) newIndexByKey.set(getKey(items[i], i), i)
     // A turn takes its LEAD item's key, so a prepended message joining the top turn
     // renames that row: skip keys the new set retired and anchor on the next survivor.
-    const survivingKeys = new Set<string>()
-    for (let i = 0; i < items.length; i++) survivingKeys.add(getKey(items[i], i))
-    const prependAnchor = prependEl
+    let prependAnchor = prependEl
       ? captureTopAnchorFrom(prependEl, elIndexRef.current.entries(), (idx) => {
           const it = prependPrev.items[idx]
           if (!it) return null
           // Previous items resolve through the getKey captured WITH them — see
           // prependPrevRef's doc for why the current closure misnames them.
           const k = prependPrev.getKey(it, idx)
-          return survivingKeys.has(k) ? k : null
+          return newIndexByKey.has(k) ? k : null
         })
       : null
+    let prependShift = 0
     if (prependAnchor) {
+      prependShift = newIndexByKey.get(prependAnchor.key)! - prependAnchor.index
+    } else if (prependEl) {
+      // No visible row kept its key. That is the shape of a wholesale transcript
+      // rebuild (the post-turn refresh re-identifying every row it streamed)
+      // landing together with the front growth, and standing down here leaves the
+      // window and scrollTop where they were — which, with rows now in front, is
+      // the START of the transcript rather than the rows being read. So the
+      // topmost visible row is re-identified by POSITION: it moved by as much as
+      // the NEAREST row (by old index) whose key did survive, and its new key is
+      // whatever now sits at old index + that displacement. Only when no key
+      // survives anywhere does the net count stand in — the reader then keeps
+      // their distance from the END, the one thing a full re-identification of a
+      // chat transcript preserves.
+      const survivors: Array<[oldIndex: number, shift: number]> = []
+      const prev = prependPrev.items
+      for (let i = 0; i < prev.length; i++) {
+        const ni = newIndexByKey.get(prependPrev.getKey(prev[i], i))
+        if (ni !== undefined) survivors.push([i, ni - i])
+      }
+      // `survivors` is in ascending old index, so the nearest is one of the two
+      // neighbours of the insertion point; ties go to the row ABOVE the reader.
+      const shiftAt = (idx: number): number => {
+        if (!survivors.length) return inserted
+        let lo = 0
+        let hi = survivors.length
+        while (lo < hi) {
+          const mid = (lo + hi) >> 1
+          if (survivors[mid][0] < idx) lo = mid + 1
+          else hi = mid
+        }
+        const above = survivors[lo - 1]
+        const below = survivors[lo]
+        if (!above) return below[1]
+        if (!below) return above[1]
+        return below[0] - idx < idx - above[0] ? below[1] : above[1]
+      }
+      prependAnchor = captureTopAnchorFrom(prependEl, elIndexRef.current.entries(), (idx) => {
+        const j = idx + shiftAt(idx)
+        const it = items[j]
+        return it ? getKey(it, j) : null
+      })
+      if (prependAnchor) prependShift = shiftAt(prependAnchor.index)
+    }
+    // Part 1 re-bases by the reader's own displacement, in either direction —
+    // rows coalescing ABOVE the reader while the tail grows moves them UP even
+    // though the count grew — which is what keeps the anchored row mounted for
+    // part 2 to measure. A displacement of zero leaves nothing to re-base; a
+    // height change above an unmoved row is trigger 7's case, not this one.
+    if (prependAnchor && prependShift !== 0) {
       shiftAnchorRef.current = prependAnchor
       shiftStageRef.current = 'awaiting-rebase'
-      prependCountRef.current = itemCount - prependPrev.count
+      prependCountRef.current = prependShift
       anchorCapturedThisRender = true
     }
   }
@@ -820,7 +884,15 @@ export function useVirtualChat<T>(
   // against the range that is still on screen. Keyed on the range having
   // ACTUALLY moved up in committed state — not on a shift being scheduled —
   // which is what makes a no-op window commit incapable of stranding an anchor.
-  if (!anchorCapturedThisRender && windowRange.start < windowRangeRef.current.start && !stickRef.current) {
+  // A re-base in flight owns the slot: part 1 moving the range UP (a negative
+  // displacement) reads here exactly like a window shift, and capturing again
+  // would replace the prepend anchor with a row of the not-yet-corrected frame.
+  if (
+    !anchorCapturedThisRender &&
+    shiftStageRef.current !== 'rebased' &&
+    windowRange.start < windowRangeRef.current.start &&
+    !stickRef.current
+  ) {
     const shiftEl = scrollerRef.current
     const shiftAnchor = shiftEl
       ? captureTopAnchorFrom(shiftEl, elIndexRef.current.entries(), (idx) => {
@@ -950,7 +1022,9 @@ export function useVirtualChat<T>(
             const it = ctx.items[idx]
             return it ? ctx.getKey(it, idx) : null
           })
-          if (a) saveScrollAnchor(prevSession, a)
+          // The capture's `index` is the outgoing commit's and means nothing
+          // after a reload; persist the key/top pair only.
+          if (a) saveScrollAnchor(prevSession, { key: a.key, top: a.top })
         }
       }
     }
@@ -1822,26 +1896,28 @@ export function useVirtualChat<T>(
   }, [overscan, scrollerEl])
 
   /**
-   * Part 1 — TRIGGER 1 only: re-base the window by the inserted count so the
-   * rows being read stay mounted, including the anchor row that part 2 has to
-   * measure. Runs pre-paint, so the shifted-but-uncorrected frame is never
+   * Part 1 — TRIGGER 1 only: re-base the window by the anchored row's own
+   * displacement so the rows being read stay mounted, including the anchor row
+   * that part 2 has to measure. Runs pre-paint, so the shifted-but-uncorrected frame is never
    * shown. A window shift needs no equivalent: it IS a range change already.
    */
   useLayoutEffect(() => {
-    const inserted = prependCountRef.current
-    if (inserted <= 0) return
+    if (shiftStageRef.current !== 'awaiting-rebase') return
+    const shift = prependCountRef.current
     prependCountRef.current = 0
-    if (stickRef.current || !shiftAnchorRef.current) {
+    // Every exit from 'awaiting-rebase' clears the slot: an anchor left in that
+    // stage is one part 2 never consumes.
+    if (stickRef.current || !shiftAnchorRef.current || shift === 0) {
       shiftAnchorRef.current = null
       shiftStageRef.current = null
       return
     }
     shiftStageRef.current = 'rebased'
     rebaseScheduledRef.current = true
-    setWindowRange((r) => ({
-      start: Math.min(itemCount, r.start + inserted),
-      end: Math.min(itemCount, r.end + inserted),
-    }))
+    // Signed: the anchored row's displacement, so the re-based range contains it
+    // whichever way it moved. Clamped to the list on both ends.
+    const clamp = (i: number) => Math.max(0, Math.min(itemCount, i))
+    setWindowRange((r) => ({ start: clamp(r.start + shift), end: clamp(r.end + shift) }))
   }, [itemCount])
 
   /**

--- a/website/src/test/useVirtualChat.prependAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.prependAnchor.test.tsx
@@ -317,7 +317,7 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     expect(readScrollTop()).toBeGreaterThan(beforeTop)
   })
 
-  it('shows no blank band when a prepend retires EVERY visible key (no anchor to bind)', () => {
+  it('shows no blank band when a prepend retires EVERY visible key (positional anchor)', () => {
     const { el, view, scrollerRef, readScrollTop } = mountScrolledUp()
 
     const visible = visibleByIndex(el)
@@ -325,27 +325,27 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     const scrollBefore = readScrollTop()
 
     // A prepend whose commit ALSO retires every previously-visible key (a
-    // wholesale refresh regrouping the transcript). No anchor survives, so the
-    // capture stands down entirely: no stage is set, part 1 never shifts the
-    // window, and the reading position is (acceptably) lost — but the window
-    // must still resolve to a range that covers the viewport, not strand it in
-    // spacer. Pins the deliberate no-anchor design so a future change to the
-    // capture cannot introduce a shift-without-correction path unnoticed.
+    // wholesale refresh re-identifying the transcript). No key survives, so the
+    // anchor is re-found by POSITION (old index + inserted count) and the
+    // correction still runs; this pins that the shift-with-correction path
+    // leaves the window covering the viewport rather than stranded in spacer.
     act(() => {
       view.rerender(
         <Harness items={[...mkItems(10, 'p'), ...mkItems(30, 'r')]} scrollerRef={scrollerRef} />,
       )
     })
 
-    // Not vacuous: the old keys are genuinely gone (the anchor had nothing to
-    // bind to) and no correction moved the viewport.
+    // Not vacuous: the old keys are genuinely gone (no key-based anchor could
+    // bind), yet the correction moved the viewport over the inserted content.
     for (const v of visible) expect(screenTopOf(el, v.key)).toBeNull()
-    expect(readScrollTop()).toBe(scrollBefore)
+    expect(readScrollTop()).toBeGreaterThan(scrollBefore)
 
-    // No blank band: a mounted row still covers the viewport top.
+    // No blank band: a mounted row still covers the viewport top, and it is the
+    // positional successor of the row that was there.
     const after = visibleByIndex(el)
     expect(after.length).toBeGreaterThan(0)
     expect(after[0].top).toBeLessThanOrEqual(1)
+    expect(after[0].idx).toBe(visible[0].idx + 10)
   })
 
   it('holds the reading position across a prepend when getKey is INDEX-ADDRESSED (ChatPage shape)', () => {
@@ -467,6 +467,153 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     const after = screenTopOf(el, before!.key)
     expect(after).not.toBeNull()
     expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  it('holds the reader by POSITION when a front growth retires every visible key', () => {
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp()
+
+    const before = visibleByIndex(el)
+    expect(before.length).toBeGreaterThan(0)
+    const beforeTop = readScrollTop()
+
+    // A wholesale transcript rebuild: hundreds of older rows materialise in
+    // front AND every row the reader can see is re-identified (a streamed row
+    // replaced by its server copy under a different key). No key survives for
+    // the anchor to follow, so the row is re-found by where it now sits.
+    const inserted = 1000
+    act(() => {
+      view.rerender(
+        <Harness items={[...mkItems(inserted, 'p'), ...mkItems(30, 'r')]} scrollerRef={scrollerRef} />,
+      )
+    })
+
+    const after = visibleByIndex(el)
+    expect(after.length).toBeGreaterThan(0)
+    // The reader is still on the tail region, at the same offset from the end —
+    // not on the first page of the transcript, which is where an uncorrected
+    // window (old indices, old scrollTop) lands once `inserted` rows sit in front.
+    expect(after[0].idx).toBe(before[0].idx + inserted)
+    expect(after[0].key).toBe(`r${before[0].idx}`)
+    expect(Math.abs(after[0].top - before[0].top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
+  it('holds the reader by POSITION across a total key retirement when getKey is INDEX-ADDRESSED', () => {
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(mkItems(30), PositionalHarness)
+
+    const before = visibleByIndex(el)
+    expect(before.length).toBeGreaterThan(0)
+    const beforeTop = readScrollTop()
+
+    // The positional anchor names a row of the NEW list, so it must be priced by
+    // the CURRENT render's getKey paired with the current items. Pricing it
+    // through the getKey snapshotted with the PREVIOUS items (the pairing the
+    // surviving-key path correctly uses) reads the old list at an index past
+    // its end, yielding a key no mounted row carries: part 1 re-bases the window
+    // but part 2 has nothing to correct against, and the viewport is left in
+    // spacer. An identity getKey cannot tell the two pairings apart; this one can.
+    const inserted = 1000
+    act(() => {
+      view.rerender(
+        <PositionalHarness items={[...mkItems(inserted, 'p'), ...mkItems(30, 'r')]} scrollerRef={scrollerRef} />,
+      )
+    })
+
+    const after = visibleByIndex(el)
+    expect(after.length).toBeGreaterThan(0)
+    expect(after[0].idx).toBe(before[0].idx + inserted)
+    expect(after[0].key).toBe(`r${before[0].idx}`)
+    // No blank band and no lost correction: the same screen offset, reached by
+    // a scrollTop write over the inserted content.
+    expect(Math.abs(after[0].top - before[0].top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
+  it('moves the positional anchor by the nearest SURVIVOR\'s displacement, not the net count growth', () => {
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp()
+
+    const before = visibleByIndex(el)
+    expect(before.length).toBeGreaterThan(0)
+    const beforeTop = readScrollTop()
+    const firstVisible = before[0].idx
+
+    // Front growth of 10 AND tail growth of 5 in one commit (a reconnect refresh
+    // catching up on missed rows), with every VISIBLE row re-identified while the
+    // rows above the viewport keep their keys. The reader moved by 10 — the net
+    // count grew by 15. Anchoring by the net count would put them 5 rows past
+    // where they were reading.
+    const front = 10
+    const tail = 5
+    const kept = mkItems(30).slice(0, firstVisible)
+    const reidentified = mkItems(30, 'r').slice(firstVisible)
+    act(() => {
+      view.rerender(
+        <Harness
+          items={[...mkItems(front, 'p'), ...kept, ...reidentified, ...mkItems(tail, 't')]}
+          scrollerRef={scrollerRef}
+        />,
+      )
+    })
+
+    const after = visibleByIndex(el)
+    expect(after.length).toBeGreaterThan(0)
+    expect(after[0].idx).toBe(firstVisible + front)
+    expect(after[0].key).toBe(`r${firstVisible}`)
+    expect(Math.abs(after[0].top - before[0].top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
+  it('re-bases by the anchored row\'s own displacement when a surviving key is found', () => {
+    const { el, view, scrollerRef } = mountScrolledUp()
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+
+    // Front growth of 3 with a tail growth of 50: the visible row's key survives
+    // and it moved by 3. A re-base by the net count (53) would push the mounted
+    // window 50 rows past the anchor, leaving part 2 nothing to measure.
+    act(() => {
+      view.rerender(
+        <Harness items={[...mkItems(3, 'p'), ...mkItems(30), ...mkItems(50, 't')]} scrollerRef={scrollerRef} />,
+      )
+    })
+
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  it('holds the reader when rows ABOVE them coalesce while the tail grows (negative displacement)', () => {
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp()
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+    const beforeTop = readScrollTop()
+
+    // Three rows above the reader collapse into one (index 0 is renamed, the
+    // reader's row moves UP by two) while ten rows append at the tail, so the
+    // count still GROWS by eight. The reader's displacement is -2, not +8: a
+    // re-base by the net count would carry the mounted window eight rows past a
+    // row that moved the other way, and standing down would leave the reader
+    // two rows' height above where they were reading.
+    act(() => {
+      view.rerender(
+        <Harness
+          items={[{ id: 'c0' }, ...mkItems(30).slice(3), ...mkItems(10, 't')]}
+          scrollerRef={scrollerRef}
+        />,
+      )
+    })
+
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+    // The hold is a scrollTop write, not a coincidence of the geometry.
+    expect(readScrollTop()).not.toBe(beforeTop)
+    // And the correction left no blank band: a mounted row covers the top.
+    const visible = visibleByIndex(el)
+    expect(visible.length).toBeGreaterThan(0)
+    expect(visible[0].top).toBeLessThanOrEqual(1)
   })
 
   /** Lowest mounted virtual index — proves an upward shift actually happened,


### PR DESCRIPTION
## Problem / Motivation

Two power users report that, in a long session, the transcript "suddenly jumps back to the start of the session" with no scroll input, and they then have to click the jump-to-bottom arrow to get back to the latest message. The jump happens around the end of a turn.

## Why it matters

It hits exactly the people who use the dashboard the most: only a transcript longer than the entry page can grow in front, so short sessions never see it, while an all-day session pays it at turn boundaries. Losing the reading position to the very beginning of a transcript is the most disorienting form of a scroll defect, and it is what makes the surrounding follow/flicker behaviour visible in the first place (the user has to re-engage follow by hand).

## What changed (motivation → approach → change)

**Symptom → root cause.** `useVirtualChat`'s prepend trigger (TRIGGER 1) compensates a front growth by anchoring on the topmost visible row whose key **survives** into the new list. When a wholesale transcript rebuild lands together with the growth — the post-turn `refreshSlot` replacing a 100-row entry page with the whole transcript while every streamed row is re-identified by its server copy — no visible key survives. `captureTopAnchorFrom` returns `null`, the capture stands down, and neither the window nor `scrollTop` moves while hundreds of rows materialise in front. The old index range, unchanged, is now the **start** of the transcript.

Reproduced in the existing prepend harness: a 30-row tail behind 1000 new rows, follow released, every tail key changed — the reader landed on row 27 of 1030 with `scrollTop` untouched.

> The identity carry in `mergePreservedClientTs` is best-effort (it matches streamed rows to their server copies by role + content) and its own doc records the scroll jump that happens when it misses. The virtualizer's fallback for "no key survives" therefore has to hold position rather than give up.

**Change.** When no visible key survives, the topmost visible row is re-found by **position** and handed to the same Part 1 re-base and the same Part 2 correction the surviving-key case uses — no new path, no new consumer, no new invalidation key.

The displacement is **not** the net count growth. The net count equals a row's displacement only for a pure front insert; a rebuild that also grows the tail (a reconnect catching up on missed rows) would overshoot the reader by the tail growth — a shape where a naive positional anchor is worse than the old stand-down. So the displacement is read off the **nearest row (by old index) whose key did survive**; only when no key survives anywhere does the net count stand in, which keeps the reader's distance from the end. Both paths now re-base by that same measure — the anchored row's own displacement, **signed** — instead of the net count. Rows coalescing *above* the reader while the tail grows move them up although the count grew; a net-count re-base carried the window the wrong way past the anchor and left a blank band. Two guards make the signed re-base safe: TRIGGER 2 yields while a re-base is in flight (a negative re-base moves the range up, which TRIGGER 2 reads as a window shift and would otherwise overwrite the pending anchor), and Part 1 clears the slot on every exit from `'awaiting-rebase'` so no anchor can be stranded there.

- `website/src/hooks/virtualizer/useVirtualChat.ts` — TRIGGER 1: key→index map replaces the survivor set; positional fallback with nearest-survivor displacement (binary search over survivors in old-index order); signed re-base by displacement on both paths; TRIGGER 2 yields during a re-base; Part 1 stage-sentinel + unconditional clear. `captureTopAnchorFrom` also returns the captured row's index; the slot-switch anchor persists `{key, top}` only.

## Tests

- `useVirtualChat.prependAnchor.test.tsx`
  - **New** `holds the reader by POSITION when a front growth retires every visible key`: 1000 rows in front, every tail key changed; asserts new index `old + 1000`, the positional successor key, unchanged screen offset (±1px), `scrollTop` advanced.
  - **New** `... when getKey is INDEX-ADDRESSED` (ChatPage's `rowKeys[i]` shape): distinguishes pairing the new row with the *current* getKey from mispairing it with the previous render's — the latter yields a key no mounted row carries and leaves the viewport in spacer.
  - **New** `moves the positional anchor by the nearest SURVIVOR's displacement, not the net count growth`: front +10, tail +5, visible keys retired, rows above the viewport keep theirs; asserts the reader moved by 10.
  - **New** `re-bases by the anchored row's own displacement when a surviving key is found`: front +3, tail +50 with a surviving visible key; a net-count re-base would push the window 50 rows past the anchor.
  - **New** `holds the reader when rows ABOVE them coalesce while the tail grows (negative displacement)`: 3 rows above collapse to 1, tail +10 (count +8, displacement −2); asserts the row's screen offset is held and no blank band.
  - **Rewritten** `shows no blank band when a prepend retires EVERY visible key`: previously pinned the stand-down as an accepted loss of position; now pins that the correction runs *and* a mounted row still covers the viewport top.
- Mutation-verified, each mutation failing a distinct test: hook change reverted; fallback paired with `prependPrev.getKey`; `inserted - 1`; displacement replaced by the net count on the fallback path; displacement replaced by the net count on the surviving-key path; positive-only arming gate restored; TRIGGER 2's in-flight yield removed.
- Full `vitest run`: 27889 passed. `tsc -b`, `eslint src/ --max-warnings 597`, `jscpd` clean.

## Manual verification

Not reproduced in a live browser in this PR: the harness reproduces the mechanism (front growth + total key retirement with follow released), not the specific rebuild that produced it on the reporters' machines. Reporters are on `v0.5.0-insider.9`, whose virtualizer predates this and the other recent scroll fixes; a build carrying `main` is what lets them confirm.

## Related Issues

Related: #7045 (bubble vanish / reconciliation), #4394 (same-tick row key aliasing — a key-retirement source this fallback tolerates).

## Pattern harvest

Rule candidate: review-prompt
Pattern: a compensation path whose "anchor not found" branch is a silent no-op — on a list whose front grows, doing nothing is never neutral; fall back to a positional anchor or fail loudly.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no spec describes this trigger's fallback
- [x] No secrets, credentials, or internal references in the diff
