### PR TITLE
ci: close the built-in app set with no-new-builtin-apps rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,10 @@ This repo is the de-Amazoned public fork of an internal package. Never re-add:
 - **OSS-flipped defaults:** always-on in-process embeddings, Piper TTS by default,
   a default-open Slack enterprise gate, lazy STT extras.
 - **Fork UX divergences:** the Channels app is hidden from the App Store and the
-  Board app is removed. An upstream sync must not restore them.
+  Board app is removed. An upstream sync must not restore them. The
+  `no-new-builtin-apps` rule in `AUTOSDE.yaml` blocks this in review — and
+  blocks any NEW built-in app: the built-in set is closed, and new apps ship
+  as external apps through the KiroCrewApps registry.
 
 `scripts/scrub-lint.sh` gates `src/`, `website/src/`, `scripts/`, `config/`,
 `packaging/`, and the top level; keep `docs/` clean by convention. Rationale for

--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -462,3 +462,33 @@ custom-rules:
       here or in semgrep/). Sentinel-return misuse (str.find/rfind -1 in a
       boolean context) is deliberately NOT listed: semgrep owns it
       (semgrep/find-sentinel-truthiness.yaml).
+
+  - id: no-new-builtin-apps
+    blocking: true
+    file-patterns:
+      - "src/kiro_crew/apps/builtins/**"
+    rule: |
+      The set of built-in apps is CLOSED. A new app ships as an EXTERNAL app
+      published through the KiroCrewApps registry (what the App Store's
+      Discover page lists), never as a new built-in in this repo. A built-in
+      rides the wheel: it grows every user's install footprint, cannot be
+      uninstalled (only disabled), and couples the app's release and fix
+      cadence to Kiro Crew releases — the registry exists precisely so an app
+      can be listed, updated, and corrected with a catalog publish instead of
+      a client ship.
+
+      - FLAG any PR that adds a new app directory under
+        src/kiro_crew/apps/builtins/ (a new app.json). The publishing path is
+        the KiroCrewApps registry; point the author there. An explicit
+        maintainer decision recorded on the PR (the /ai-review override flow)
+        is the only exception — the default is closed.
+      - FLAG restoring a withdrawn built-in (the Board app) or un-hiding the
+        Channels app from the App Store (flipping "hidden": true in
+        src/kiro_crew/apps/builtins/channels/app.json). Both are deliberate
+        fork divergences an upstream sync must not undo.
+
+      Allowed (do NOT flag):
+      - Changes inside an EXISTING built-in app directory: fixes, features,
+        tests, i18n, refactors.
+      - Deleting an existing built-in, or moving one OUT of the repo to the
+        registry — that is the direction this rule pushes.


### PR DESCRIPTION
## Summary

Adds a blocking AUTOSDE review rule `no-new-builtin-apps`: the set of built-in apps is closed. Any PR adding a new app directory under `src/kiro_crew/apps/builtins/` (a new `app.json`) is flagged by both blocking AI review lanes and pointed at the KiroCrewApps registry as the publishing path.

## Why

- A built-in rides the wheel: it grows every user's install footprint, can only be disabled (never uninstalled), and couples the app's release and fix cadence to KiroCrew releases.
- The registry exists precisely so an app can be listed, updated, and corrected with a catalog publish instead of a client ship.
- The rule also pins the two deliberate fork divergences (Board removed, Channels hidden from the store) so an upstream sync cannot silently restore them.

## What it does NOT block

- Changes inside existing built-in app directories (fixes, features, tests, i18n, refactors).
- Deleting a built-in or migrating one out to the registry — the direction the rule pushes.
- An explicit maintainer exception via the `/ai-review override` flow.

`AGENTS.md`'s never-re-introduce section now references the rule (same-commit doc sync).

## Testing

- `scripts/docs-lint.sh` — all documentation checks passed
- `scripts/scrub-lint.sh --no-history` — all checks passed
- AUTOSDE.yaml parses as valid YAML (8 rules)

Docs/rules-only change; no runtime code touched.
