### PR TITLE
fix(gateway): exit non-zero when the stale-asset watchdog requests a restart

### DIFF
--- a/src/kiro_crew/dashboard/stale_asset_watchdog.py
+++ b/src/kiro_crew/dashboard/stale_asset_watchdog.py
@@ -90,6 +90,7 @@ async def run_stale_asset_watchdog(
     count_in_flight: Callable[[], int] | None = None,
     drain_timeout: float = _DRAIN_TIMEOUT_SECS,
     drain_poll: float = _DRAIN_POLL_SECS,
+    on_confirmed_vanish: Callable[[], None] | None = None,
 ) -> None:
     """Background loop: check asset presence, trigger shutdown if stale.
 
@@ -132,6 +133,14 @@ async def run_stale_asset_watchdog(
         Max seconds to wait for in-flight work to finish. Default 120s.
     drain_poll:
         Seconds between in-flight re-counts while draining. Default 2s.
+    on_confirmed_vanish:
+        Optional callback invoked once a vanish is confirmed, immediately
+        before ``shutdown_event.set()``. The gateway uses this to mark the
+        eventual process exit as supervisor-restart-worthy: a plain
+        ``shutdown_event.set()`` looks identical to a SIGINT/SIGTERM here, and
+        those two cases need different exit codes so ``Restart=on-failure``
+        (the shipped systemd unit) fires for one and not the other. See
+        ``slack/gateway.py``'s ``_supervisor_restart_requested``.
     """
     if not assets_present():
         # Assets were never here — this is likely a dev/source install that
@@ -203,6 +212,8 @@ async def run_stale_asset_watchdog(
                 "pruned the running install. Initiating graceful shutdown "
                 "so a supervisor can restart a fresh gateway."
             )
+            if on_confirmed_vanish is not None:
+                on_confirmed_vanish()
             shutdown_event.set()
             return
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1648,6 +1648,15 @@ class GatewayOrchestrator:
         # tells the writer thread to self-clear after publishing, closing the
         # write-after-clear race without any event-loop dependency.
         self._marker_clear_pending = threading.Event()
+        # Set by the stale-asset watchdog right before it triggers shutdown_event,
+        # so the final os._exit() at the end of run() can exit non-zero instead of
+        # 0. Restart=on-failure (the shipped systemd unit) only respawns on a
+        # non-zero exit, a signal, or a watchdog timeout -- a clean exit(0) is
+        # "stop and stay stopped" to systemd, which is right for an operator-
+        # initiated SIGINT/SIGTERM but defeats the one purpose this watchdog
+        # exists for. Mirrors the same non-zero-exit-for-supervisor-restart idiom
+        # `_handle_restart` already uses for the Slack `/restart` command.
+        self._supervisor_restart_requested = False
         self._dashboard_runner: web.AppRunner | None = None
         self._handler_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         self._session_tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
@@ -10555,8 +10564,15 @@ class GatewayOrchestrator:
         # supervisor can restart a fresh process. It first drains in-flight
         # backend turns (count_in_flight) so active work isn't killed
         # mid-prompt by the restart.
+        def _mark_supervisor_restart_requested() -> None:
+            self._supervisor_restart_requested = True
+
         _watchdog = asyncio.create_task(
-            run_stale_asset_watchdog(shutdown_event, count_in_flight=self._count_in_flight_work)
+            run_stale_asset_watchdog(
+                shutdown_event,
+                count_in_flight=self._count_in_flight_work,
+                on_confirmed_vanish=_mark_supervisor_restart_requested,
+            )
         )
         self._background_tasks.add(_watchdog)
         _watchdog.add_done_callback(self._background_tasks.discard)
@@ -10651,7 +10667,14 @@ class GatewayOrchestrator:
         from kiro_crew.cli import drain_log_queue_before_hard_exit
 
         await drain_log_queue_before_hard_exit()
-        os._exit(0)
+        # Exit 1, not 0, when the stale-asset watchdog is why we're here: a
+        # clean exit(0) tells systemd's Restart=on-failure "stop and stay
+        # stopped" -- fine for an operator SIGINT/SIGTERM, but it defeats the
+        # one purpose this watchdog exists for (see
+        # _supervisor_restart_requested and stale_asset_watchdog.py). Same
+        # non-zero-exit-for-supervisor-restart idiom `_handle_restart` already
+        # uses for the Slack `/restart` command.
+        os._exit(1 if self._supervisor_restart_requested else 0)
 
     async def _start_channel_transports(
         self, descriptors: "tuple[ChannelDescriptor, ...] | None" = None

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -2609,6 +2609,93 @@ class TestRunMethod:
         orch._shutdown.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_run_exits_zero_on_ordinary_shutdown(self):
+        """An operator-initiated shutdown (SIGINT/SIGTERM) exits 0.
+
+        Restart=on-failure in the shipped systemd unit only respawns on a
+        non-zero exit; exit 0 must stay 0 here so a deliberate stop stays
+        stopped.
+        """
+        import kiro_crew
+
+        orch = _make_orchestrator()
+        orch._init_services = AsyncMock()
+        orch._start_embeddings = AsyncMock()
+        orch._auto_migrate_memory = AsyncMock()
+        orch._init_cron = AsyncMock()
+        orch._init_heartbeat = AsyncMock()
+        orch._init_mcp_discovery = MagicMock()
+        orch._init_subagents = MagicMock()
+        orch._init_task_runner = MagicMock()
+        orch._init_dashboard = AsyncMock()
+        orch._init_autonudge = AsyncMock()
+        orch._check_for_updates = AsyncMock()
+        orch._shutdown = AsyncMock()
+
+        assert orch._supervisor_restart_requested is False
+        kiro_crew.shutdown_event.set()
+        loop = asyncio.get_running_loop()
+        try:
+            with patch.object(loop, "add_signal_handler"):
+                with patch("kiro_crew.slack.events.init_socket_mode"):
+                    with patch("kiro_crew.slack.interactions.init"):
+                        with patch("kiro_crew.slack.events.SeenCache"):
+                            with patch("kiro_crew.session.cleanup_orphaned_sessions"):
+                                with patch("kiro_crew.dashboard.handlers._bg_mcp_probe", new_callable=AsyncMock):
+                                    with patch("os._exit") as mock_exit:
+                                        with patch("resource.getrlimit", return_value=(256, 10240)):
+                                            with patch("resource.setrlimit"):
+                                                await orch.run()
+        finally:
+            kiro_crew.shutdown_event.clear()
+
+        mock_exit.assert_called_once_with(0)
+
+    @pytest.mark.asyncio
+    async def test_run_exits_nonzero_when_supervisor_restart_requested(self):
+        """The stale-asset watchdog's restart request survives to the final exit.
+
+        Mirrors the ``os._exit(1)`` idiom ``_handle_restart`` already uses for
+        the Slack ``/restart`` command, so Restart=on-failure fires.
+        """
+        import kiro_crew
+
+        orch = _make_orchestrator()
+        orch._init_services = AsyncMock()
+        orch._start_embeddings = AsyncMock()
+        orch._auto_migrate_memory = AsyncMock()
+        orch._init_cron = AsyncMock()
+        orch._init_heartbeat = AsyncMock()
+        orch._init_mcp_discovery = MagicMock()
+        orch._init_subagents = MagicMock()
+        orch._init_task_runner = MagicMock()
+        orch._init_dashboard = AsyncMock()
+        orch._init_autonudge = AsyncMock()
+        orch._check_for_updates = AsyncMock()
+        orch._shutdown = AsyncMock()
+
+        # Simulates what the stale-asset watchdog's on_confirmed_vanish
+        # callback does before it sets shutdown_event.
+        orch._supervisor_restart_requested = True
+        kiro_crew.shutdown_event.set()
+        loop = asyncio.get_running_loop()
+        try:
+            with patch.object(loop, "add_signal_handler"):
+                with patch("kiro_crew.slack.events.init_socket_mode"):
+                    with patch("kiro_crew.slack.interactions.init"):
+                        with patch("kiro_crew.slack.events.SeenCache"):
+                            with patch("kiro_crew.session.cleanup_orphaned_sessions"):
+                                with patch("kiro_crew.dashboard.handlers._bg_mcp_probe", new_callable=AsyncMock):
+                                    with patch("os._exit") as mock_exit:
+                                        with patch("resource.getrlimit", return_value=(256, 10240)):
+                                            with patch("resource.setrlimit"):
+                                                await orch.run()
+        finally:
+            kiro_crew.shutdown_event.clear()
+
+        mock_exit.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
     async def test_run_no_dashboard_uses_api_server(self, tmp_path, monkeypatch):
         """--no-dashboard waits for and then clears its run marker."""
         import kiro_crew

--- a/test/test_stale_asset_watchdog.py
+++ b/test/test_stale_asset_watchdog.py
@@ -42,12 +42,56 @@ async def test_watchdog_shuts_down_when_assets_vanish():
 
 
 @pytest.mark.asyncio
+async def test_watchdog_calls_on_confirmed_vanish_before_shutdown():
+    """The gateway's supervisor-restart marker fires, and fires before shutdown.
+
+    A plain ``shutdown_event.set()`` looks identical whether it came from this
+    watchdog or from SIGINT/SIGTERM, so the gateway needs a distinct signal to
+    know it should exit non-zero (see ``slack/gateway.py``'s
+    ``_supervisor_restart_requested``). Ordering matters: the callback must run
+    BEFORE the event is set, since the gateway's shutdown path could otherwise
+    observe the event and race to exit before the flag is marked.
+    """
+    from kiro_crew.dashboard.stale_asset_watchdog import run_stale_asset_watchdog
+
+    shutdown = asyncio.Event()
+    call_count = 0
+    on_vanish_calls = []
+
+    def _mock_assets_present() -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count <= 1
+
+    def _on_confirmed_vanish() -> None:
+        on_vanish_calls.append(shutdown.is_set())
+
+    with patch(
+        "kiro_crew.dashboard.stale_asset_watchdog.assets_present",
+        side_effect=_mock_assets_present,
+    ):
+        await asyncio.wait_for(
+            run_stale_asset_watchdog(
+                shutdown,
+                interval=0.05,
+                confirm_delay=0.01,
+                on_confirmed_vanish=_on_confirmed_vanish,
+            ),
+            timeout=5.0,
+        )
+
+    assert shutdown.is_set()
+    assert on_vanish_calls == [False]  # called once, before the event was set
+
+
+@pytest.mark.asyncio
 async def test_watchdog_survives_transient_asset_gap():
     """A brief asset gap (e.g. frontend rebuild) does NOT shut the gateway down."""
     from kiro_crew.dashboard.stale_asset_watchdog import run_stale_asset_watchdog
 
     shutdown = asyncio.Event()
     call_count = 0
+    on_vanish_calls = []
 
     def _mock_assets_present() -> bool:
         nonlocal call_count
@@ -64,13 +108,22 @@ async def test_watchdog_survives_transient_asset_gap():
         side_effect=_mock_assets_present,
     ):
         await asyncio.wait_for(
-            run_stale_asset_watchdog(shutdown, interval=0.05, confirm_delay=0.01),
+            run_stale_asset_watchdog(
+                shutdown,
+                interval=0.05,
+                confirm_delay=0.01,
+                on_confirmed_vanish=on_vanish_calls.append,
+            ),
             timeout=5.0,
         )
 
     # Shutdown was set by the test (normal-shutdown path), not the watchdog:
     # the transient gap was re-checked, found recovered, and the loop resumed.
     assert call_count == 3
+    # A recovered gap is not a confirmed vanish -- the supervisor-restart
+    # marker must not fire, or an ordinary SIGTERM shutdown that merely raced
+    # a frontend rebuild would wrongly exit non-zero.
+    assert on_vanish_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

The stale-asset watchdog detects an update that pruned the running install
and initiates graceful shutdown "so a supervisor can restart a fresh
gateway" — but on a Linux service install, that restart never actually
happens. The watchdog's shutdown path ends in `os._exit(0)`, and the shipped
systemd unit uses `Restart=on-failure`, which only respawns on a non-zero
exit, a signal, or a watchdog timeout. Exit 0 is none of those, so the one
mechanism built specifically for this scenario cannot fire in it — the
gateway just stays down until an operator notices and restarts it by hand.

## Why it matters

An operator running `kirocrew service install` relies on this watchdog to
self-heal after a routine update prunes the running install's static assets.
Without this fix, every update-triggered restart silently fails to actually
restart the gateway, leaving the dashboard and any Slack/channel connections
and scheduled cron jobs down until a human intervenes — potentially for
hours if nobody is watching the service.

## What changed (motivation → approach → change)

Observed symptom: a pruned install triggers the watchdog, which logs a
CRITICAL warning and sets `shutdown_event`, but the process exits and stays
exited rather than being restarted by systemd.

Root cause: the final `os._exit(0)` in `gateway.run()` is shared by every
shutdown trigger — an operator SIGINT/SIGTERM AND the watchdog both flow
through the same `shutdown_event.wait()` → shutdown → exit path — and it
always exits 0, which `Restart=on-failure` never restarts.

I considered loosening the unit's policy to `Restart=always`, but rejected
it: that would also make systemd respawn the gateway after a bare
`kill <pid>` issued outside `systemctl`, a behavior change nothing today
relies on or expects.

Instead, the codebase already solves this exact class of problem elsewhere:
the Slack `/restart` command deliberately exits via `os._exit(1)` so
`Restart=on-failure` respawns it. I extended that same idiom here:
`run_stale_asset_watchdog` now accepts an `on_confirmed_vanish` callback,
invoked right before `shutdown_event.set()`; the gateway wires it to set a
new `_supervisor_restart_requested` flag, and the final `os._exit(...)` call
checks that flag to choose between exit 0 (ordinary shutdown) and exit 1
(please restart me). I also verified macOS's launchd config
(`KeepAlive=<true/>`) already respawns unconditionally regardless of exit
code, so it was never affected by this gap and needs no change.

## Tests

- `test_watchdog_calls_on_confirmed_vanish_before_shutdown` — the callback
  fires exactly once, and before `shutdown_event` is observed as set.
- Updated `test_watchdog_survives_transient_asset_gap` to assert the callback
  is NOT called when a gap turns out to be a transient rebuild, not a real
  vanish.
- `test_run_exits_zero_on_ordinary_shutdown` — a plain SIGINT/SIGTERM-style
  shutdown still exits 0.
- `test_run_exits_nonzero_when_supervisor_restart_requested` — the flag
  survives to the final exit and produces `os._exit(1)`.

## Manual verification

N/A — unit coverage sufficient. The behavior under test is pure exit-code
selection based on an in-process flag; the systemd side (`Restart=on-failure`
only respawning on non-zero exit) is documented, stable OS behavior rather
than something this repo controls or can integration-test in CI.

## Related Issues

Fixes #7986

## Pattern harvest

Rule candidate: review-prompt
Pattern: a background task that triggers process shutdown for a
"please restart me" reason must route through a distinguishable exit code
(or equivalent supervisor-visible signal), not a bare `shutdown_event.set()`
that is indistinguishable from an operator-initiated stop. Any new
self-healing/auto-restart mechanism should be checked against this before
assuming a plain graceful shutdown is sufficient.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no spec document covers this watchdog's restart behavior
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qj2fBtkAg8y3xRh4Xc41Wv
