### PR TITLE
perf(test): cache repo walk in omit-contract test

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -568,7 +568,6 @@ test/test_context_marker_neutralization.py
 test/test_context_ui_language.py
 test/test_continuable_followups.py
 test/test_conversation.py
-test/test_coverage_omit_contract.py
 test/test_crash_dump_store.py
 test/test_crash_guard.py
 test/test_credential_scrub_sync.py

--- a/test/test_coverage_omit_contract.py
+++ b/test/test_coverage_omit_contract.py
@@ -42,6 +42,8 @@ job's argv.
 from __future__ import annotations
 
 import configparser
+import functools
+import os
 import re
 from pathlib import Path
 
@@ -172,13 +174,71 @@ def test_run_and_report_omit_lists_agree() -> None:
     assert sorted(_cfg_omit("coverage:run")) == sorted(_cfg_omit("coverage:report"))
 
 
+#: Top-level directories the repo walk skips. Each is a heavy tree that holds no
+#: committed ``test_*.py`` (``.git``, dependency and virtualenv trees, and build /
+#: cache output), so skipping them narrows the walk to the source and test trees the
+#: omit patterns actually target. Anchored at the repo root, not matched by name at
+#: every depth: a nested ``docs/build`` or ``website/electron/build`` is a real
+#: directory the walk must still descend, and an omit target under one must still be
+#: found.
+_WALK_PRUNE_ROOTS = {
+    ".git",
+    "node_modules",
+    ".venv",
+    "build",
+    ".mypy_cache",
+    ".pytest_cache",
+    "__pycache__",
+    ".ruff_cache",
+    "htmlcov",
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _all_repo_files() -> tuple[str, ...]:
+    """Every repo-relative file path (posix) outside the pruned top-level trees.
+
+    One walk serves every omit pattern; the callers filter its result in memory.
+    Cached because the tree is static within a test run, and each xdist worker builds
+    its own cache.
+    """
+    out: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        if dirpath == str(REPO_ROOT):
+            dirnames[:] = [d for d in dirnames if d not in _WALK_PRUNE_ROOTS]
+        rel_dir = os.path.relpath(dirpath, REPO_ROOT)
+        for fn in filenames:
+            rel = fn if rel_dir == "." else f"{rel_dir}/{fn}"
+            out.append(rel.replace(os.sep, "/"))
+    return tuple(out)
+
+
 def _repo_files_matching(pattern: str) -> list[Path]:
-    """Every tracked test file the omit *pattern* would exclude."""
-    tail = pattern[2:] if pattern.startswith("*/") else pattern
+    """Every tracked test file the omit *pattern* would exclude.
+
+    Every committed omit basename is a glob-free literal (enforced by
+    ``test_omit_patterns_do_not_swallow_product_code``, which requires each to be a
+    specific ``test_*.py`` name), so a basename match against the cached walk selects the
+    same files a basename glob would, and the unchanged ``_matches`` suffix check then
+    applies the full pattern. A basename carrying a glob metachar falls back to ``fnmatch``.
+    """
+    basename = (pattern[2:] if pattern.startswith("*/") else pattern).rsplit("/", 1)[-1]
+    has_glob = any(ch in basename for ch in "*?[")
+    if has_glob:
+        import fnmatch
+
+        def _name_ok(name: str) -> bool:
+            return fnmatch.fnmatch(name, basename)
+
+    else:
+
+        def _name_ok(name: str) -> bool:
+            return name == basename
+
     return [
-        path
-        for path in REPO_ROOT.rglob(tail.rsplit("/", 1)[-1])
-        if _matches(pattern, path.relative_to(REPO_ROOT).as_posix())
+        REPO_ROOT / rel
+        for rel in _all_repo_files()
+        if _name_ok(rel.rsplit("/", 1)[-1]) and _matches(pattern, rel)
     ]
 
 
@@ -201,9 +261,7 @@ def test_every_omitted_test_file_carries_a_capability_guard() -> None:
         matched = _repo_files_matching(pattern)
         if not matched:
             unjustified.append(f"{pattern} (matches no file in the repo)")
-        elif not any(
-            _CAPABILITY_GUARD in path.read_text(encoding="utf-8") for path in matched
-        ):
+        elif not any(_CAPABILITY_GUARD in path.read_text(encoding="utf-8") for path in matched):
             unjustified.append(f"{pattern} (no {_CAPABILITY_GUARD} guard)")
     assert not unjustified, (
         f"these omit patterns exempt a test file with nothing to justify it: {unjustified}. "


### PR DESCRIPTION
## Problem

`test_every_omitted_test_file_carries_a_capability_guard` in `test/test_coverage_omit_contract.py` calls `_repo_files_matching` once per non-exempt omit pattern (6 today). Each call ran `REPO_ROOT.rglob(basename)`, walking the **entire** repo -- `.git`, `node_modules`, `.venv`, build and cache trees -- before stat-filtering. Six full-tree walks dominated the test's runtime.

## What changed

Serve every omit pattern from **one** `os.walk`, cached via `functools.lru_cache`, filtered in memory. The walk prunes the heavy top-level trees that hold no committed test file (`.git`, dependency/virtualenv trees, `build`, and the caches). The prune is **anchored at the repo root**, so a nested `docs/build` or `website/electron/build` is still descended and an omit target under one is still found.

Semantics preserved: every committed omit basename is a glob-free literal (enforced by `test_omit_patterns_do_not_swallow_product_code`), so a basename match against the cached walk selects the same files a basename glob would, and the unchanged `_matches` suffix check then applies the full pattern. A basename carrying a glob metachar falls back to `fnmatch`. **Verified:** the file set `_repo_files_matching` returns for all 8 committed patterns is byte-identical to the old `rglob` implementation.

Two files:
- `test/test_coverage_omit_contract.py` -- the optimization.
- `.github/black-baseline.txt` -- the reformat makes the test file black-clean, so its line is pruned from the baseline (per `AGENTS.md`); a graduated baseline file left listed reds the black gate.

## Tests

Before/after (sandbox-env unset, `-p no:randomly`):

| | before | after |
|---|---|---|
| target test `call` | 2.54s | 0.21s |
| whole file | 6.62s | 3.72s |

(The original Cluster D reading was 21.85s -> 0.24s on the source checkout, whose `.git`/worktree tree is larger; same proportional win.)

- Whole file: **8 passed** before and after.
- black (`--target-version py310 --line-length 100`) / isort / flake8 / mypy: clean on the changed file.

### Red-before

Temporarily adding a fake omit entry `*/test_acp_auth_failure_on_stderr.py` (a real test file with **no** `userns_available` guard) to both coverage sections makes the test FAIL:

```
AssertionError: these omit patterns exempt a test file with nothing to justify it:
['*/test_acp_auth_failure_on_stderr.py (no userns_available guard)'].
```

This proves the cached walk still **finds** the file and still **enforces** the guard. The entry was reverted; `setup.cfg` is unchanged in this PR.

no linked issue: internal test-suite speedup, no tracked issue
