### PR TITLE
refactor(dashboard): flatten chained ternaries in fork and approval paths

### DIFF
--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -229,10 +229,11 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             # without marking dirty. There is deliberately no ``_dirty`` gate on
             # the merge below: the boundary alone is authoritative and the slice is
             # empty when everything is persisted, so a flush clearing ``_dirty``
-            # mid-read can no longer skip the reconciliation and drop the tail.
+            # mid-read cannot skip the reconciliation and drop the tail.
             # ``pending_retry`` carries a SUSPICION across the ``continue`` below.
-            # The save at :209 clears ``_pending_rewrite`` unconditionally once the
-            # archive-safe rewrite succeeds (``chat_persistence``: ``if rewrite:
+            # The pending-rewrite save below clears ``_pending_rewrite``
+            # unconditionally once the archive-safe rewrite succeeds
+            # (``chat_persistence``: ``if rewrite:
             # slot._pending_rewrite = False``) with NO check that the flag it clears
             # is the one its own snapshot was taken for. So a rewind landing while
             # that save is suspended has its flag erased, and without this carry the
@@ -355,8 +356,8 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                 if disk_len_before <= count_before:
                     # The boundary is a usable index and authoritative: the slice
                     # is empty exactly when everything is persisted. Deliberately
-                    # NO ``_dirty`` gate here -- that is what let a flush clearing
-                    # ``_dirty`` mid-read skip the merge and drop the tail.
+                    # NO ``_dirty`` gate here -- a gate is what lets a flush
+                    # clearing ``_dirty`` mid-read skip the merge and drop the tail.
                     tail = list(slot.messages[disk_len_before:])
                 elif slot._dirty:
                     # The boundary can run AHEAD of the resident window, and is
@@ -508,12 +509,15 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             # callers MUST treat the result as immutable and slice or ``list(...)``
             # it before mutating.
             #
-            # Base mutated it here too, but base always took the durable save when
-            # dirty, and that save invalidates the entry -- so the mutation was
-            # transient and self-healing. The skip-the-save branch below is
-            # deliberate and correct, and it is also what removes the eviction that
-            # used to hide this: nothing corrects the entry, so every later reader
-            # of this key sees the UNPERSISTED tail as though it were history.
+            # An in-place mutation is unsafe here because this handler can finish
+            # with no durable save at all, and only a save invalidates the cache
+            # entry: the skip-the-save branch below is deliberate, and both save
+            # arms are gated on ``slot._dirty``, so neither runs when it is
+            # already False -- while the tail snapshot above is ungated and can
+            # still be non-empty. Nothing in this handler then corrects the entry,
+            # so readers of this key see the UNPERSISTED tail as though it were
+            # history until the next write to this transcript invalidates it, or
+            # the LRU evicts it.
             #
             # A rebind rather than ``list(all_messages)`` + ``extend``: one
             # expression, the surrounding control flow untouched, and it leaves no
@@ -666,21 +670,24 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     elif at_index is not None:
         visible = visible[: at_index + 1]
 
+    # A fork of a member DM thread is an ordinary chat, never a second "member"
+    # slot: the fork mints a chat-* key, so member mode would make it invisible
+    # everywhere (excluded from Sessions by surface mode, and absent from the
+    # roster, whose threads live only on member-<slug> keys). The override
+    # allowlist deliberately cannot name "member".
+    if mode_override is not None:
+        fork_mode = mode_override
+    elif slot.mode == "member":
+        fork_mode = ""
+    else:
+        fork_mode = slot.mode
+
     new_slot = state.get_or_create_slot(
         name=None,
         agent=slot.agent,
         workspace=slot.workspace,
         model=slot.model,
-        # A fork of a member DM thread is an ordinary chat, never a second
-        # "member" slot: the fork mints a chat-* key, so member mode would make
-        # it invisible everywhere (excluded from Sessions by surface mode, and
-        # absent from the roster, whose threads live only on member-<slug>
-        # keys). The override allowlist deliberately cannot name "member".
-        mode=(
-            mode_override
-            if mode_override is not None
-            else ("" if slot.mode == "member" else slot.mode)
-        ),
+        mode=fork_mode,
         app=request_app,
         origin=request_slot_origin(request_app),
         # Human request-layer path: a person forking a conversation. The

--- a/src/kiro_crew/dashboard/interaction_coordinator.py
+++ b/src/kiro_crew/dashboard/interaction_coordinator.py
@@ -104,7 +104,12 @@ class ApprovalCoordinator:
         rejected_once: bool,
         permission_marker: Callable[[list[dict], str, str], bool],
     ) -> bool:
-        decision = "approved" if approved else ("rejected_once" if rejected_once else "rejected")
+        if approved:
+            decision = "approved"
+        elif rejected_once:
+            decision = "rejected_once"
+        else:
+            decision = "rejected"
         if state.resolve_state_approval(approval_id, approved):
             if rejected_once:
                 state._log.warning(

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -13488,6 +13488,49 @@ class TestForkSlot:
         assert new_slot.mode == "custom-mode"
 
     @pytest.mark.asyncio
+    async def test_fork_of_member_slot_is_not_member_mode(self, tmp_path):
+        """A fork of a member DM thread must be an ordinary chat, never a second
+        "member" slot: the fork mints a chat-* key, so member mode would make it
+        invisible everywhere (excluded from Sessions by surface mode, and absent
+        from the roster, whose threads live only on member-<slug> keys)."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.mode = "member"
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={})
+            assert resp.status == 200
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot is not None
+        assert new_slot.mode == ""
+
+    @pytest.mark.asyncio
+    async def test_fork_mode_override_wins_over_inheritance(self, tmp_path):
+        """An allowlisted ``mode`` in the body overrides the source slot's mode.
+        The empty string is a legal override, so the override arm is selected on
+        ``is not None``, not on truthiness."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.mode = "orchestrator"
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={"mode": ""})
+            assert resp.status == 200
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot is not None
+        assert new_slot.mode == ""
+
+    @pytest.mark.asyncio
     async def test_fork_inherits_folder(self, tmp_path):
         """Fork must land in the same project folder as the source slot."""
         state = _make_state(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

Two spots in the dashboard package computed a three-way value inside a nested
conditional expression, so a reader had to re-derive the precedence from the
parentheses before they could tell which branch wins:

- `dashboard/chat_fork.py` decided the forked slot's `mode` inline, as one of
  `get_or_create_slot`'s keyword arguments, with the explanation of *why* a
  `"member"` slot must not be inherited sitting above the argument rather than
  above the decision.
- `dashboard/interaction_coordinator.py` spelled the approval decision label as
  `"approved" if approved else ("rejected_once" if rejected_once else "rejected")`.

`chat_fork.py` also carried three comment defects around those lines: two blocks
described an earlier shape of the code ("Base mutated it here too, but base
always took the durable save…", "the eviction that used to hide this") instead of
the constraint that holds now, and one carried a `:209` back-reference to a line
that is a comment, not the save it names.

## Why it matters

Both sites sit on paths where getting the branch wrong is expensive and silent.
The fork mode decides whether a forked conversation is visible in Sessions and in
the roster at all; the approval label is what is handed to the waiting future and
written to the audit broadcast. Code whose branch order has to be reconstructed
from nesting is where a later edit inverts a case without anyone noticing — and
in this file the branch that matters most had no test at all, so nothing would
have gone red if it had been inverted.

## What changed (motivation → approach → change)

A behavior-preserving readability change from the module-simplification sweep.
Both sites are the `chained-ternary` class: an `IfExp` whose `orelse` is itself an
`IfExp`. The rewrite is `if`/`elif`/`else`, preserving branch order, precedence
and short-circuiting exactly.

- **`chat_fork.py`** — hoist the fork's slot mode into an `if`/`elif`/`else` above
  the `get_or_create_slot` call and pass `mode=fork_mode`. The comment explaining
  why a fork of a member DM must not become a second `"member"` slot moves with
  the decision it explains. Hoisting is unobservable here: `mode_override` is a
  plain local (validated at `chat_fork.py:142` against the
  `("", "orchestrator", "crew")` allowlist, which cannot name `"member"`) and
  `_ChatSlot.mode` is a `__slots__` attribute assigned unconditionally in
  `__init__`, not a property — so evaluating it ahead of the call's other
  arguments (`slot.agent`, `slot.workspace`, `slot.model`, all equally plain
  reads) cannot raise, cannot have a side effect, and cannot observe different
  state. The relative order against the one *call* in the argument list,
  `origin=request_slot_origin(request_app)`, is unchanged. `fork_mode` is a new
  name occurring nowhere else in the repo, and the handler contains no nested
  `def` or `lambda`, so no closure read changes.
- **`interaction_coordinator.py`** — spell the approval decision as
  `if`/`elif`/`else`. Same three outcomes (`"approved"`, `"rejected_once"`,
  `"rejected"`) under the same predicates in the same order, so the downgrade
  warning, `future.set_result`, `permission_marker` and
  `_audit_and_broadcast_approval` all see exactly the value set they saw before —
  in particular the `decision or (…)` fallback on the SEL emit path stays
  unreachable from this call site, as before.
- **Comment accuracy in `chat_fork.py`**, the file already being edited for a
  structural reason. Beyond dropping the "used to / base always" narration
  `AGENTS.md` forbids, three claims were made true rather than merely
  present-tense:
  - the cache-poisoning window is now stated as **bounded** — "until the next
    write to this transcript invalidates it, or the LRU evicts it" — because
    every committed `_save_slot_to_history` calls `_invalidate_cache`, which pops
    `_msg_cache` across the identity closure and bumps the generation. The old
    "nothing corrects it, so *every* later reader…" was permanent, and false.
    What survives is the part that is right: an in-memory `extend` writes no file
    and bumps no generation, so `_read_messages`' mtime + `_cache_gen` check
    passes and hands back the poisoned list.
  - the hazard is no longer attributed to the skip-the-save branch alone. Both
    save arms are gated on `slot._dirty`, so **neither** runs when it is already
    False, while the tail snapshot above them is deliberately ungated and can
    still be non-empty.
  - the `:209` back-reference is replaced with the name of the save it means. A
    bare line number has nothing keeping it fresh; that one had been wrong since
    the commit that introduced it.
  - one untouched sibling sentence, `# NO ``_dirty`` gate here -- that is what
    let a flush…`, is put in the present tense too, so the file no longer states
    the same fact in two tenses.

No behavior change, no public surface change, no dependency or config change. No
import line is added, removed, or moved.

## Tests

Two tests in `test/test_dashboard_chat.py::TestForkSlot`, pinning the two arms the
rewrite touched that nothing in the repo covered — so the review of this diff no
longer rests on derivation alone:

- `test_fork_of_member_slot_is_not_member_mode` — forking a slot whose `mode` is
  `"member"` mints a fork with `mode == ""`. This is the security-relevant arm:
  member mode on a `chat-*` key would make the fork invisible in Sessions and
  absent from the roster.
- `test_fork_mode_override_wins_over_inheritance` — an allowlisted body `mode`
  beats the source slot's mode, using `""` as the override. `""` is a *legal*
  override, which is why the arm must be selected on `is not None` and not on
  truthiness; a truthiness rewrite would have routed `mode: ""` into the member
  check instead.

Both were mutation-checked: inverting the `"member"` comparison reds the first,
and changing `if mode_override is not None:` to `if mode_override:` reds the
second. Together they also keep the diff coverage-neutral — flattening one
statement into five otherwise moved `chat_fork.py` from 90.40% to 89.66% line
coverage.

Gate run (Python 3.12, CI-parity venv): `flake8`, `isort --check-only`, `mypy`
(1266 files, clean), `check_black_formatting.py`, `check_subprocess_encoding.py`,
`check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`,
`docs-lint.sh`, `check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history` — all exit 0. Targeted suites: `test_dashboard_chat`,
`test_chat_fork_error_codes`, `test_fork_reconciles_after_flush`,
`test_session_transfer`, `test_session_control`, `test_session_pulse_session_count`,
`test_members_dm_thread`, `test_orphaned_approval_card`, `test_dashboard_approval`,
`test_approval_threading`, `test_ws_event_scoping` — **1409 passed**.

## Manual verification

N/A — unit coverage sufficient. The change is two conditional expressions
rewritten to the equivalent statement form plus comment text; equivalence is
established by inspection (documented above) and the two arms that had no test
now have one each, mutation-checked.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — two Python modules under
`src/kiro_crew/dashboard/` plus one test file, nothing under `website/`, so there
is no rendered delta to capture.

## Related Issues

no linked issue: routine readability sweep, not a tracked defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

---

### Pre-open review fleet

Five parallel read-only reviewers ran against this diff before it was opened, each
briefed on a distinct lens and grounded in the repo's own contracts
(`AUTOSDE.yaml` blocking rules, `code-review.yml`'s deterministic greps,
`AGENTS.md`): AUTOSDE/blocking rules, behavior preservation, import semantics and
test observability, security keystone and boot path, and comment accuracy. Each
finding then went to an independent refuter that defaulted to *refuted*.

**Confirmed and fixed** — the three comment-accuracy defects above (overstated
permanence of the cache poisoning, the over-narrowed "specifically because",
the stale `:209` reference), plus the two missing tests that three separate
lenses independently flagged as the reason the review rested on derivation.

**Refuted and dropped** — the challenge to the *mechanism* half of the
cache-mutation comment: `_read_messages`' mtime + `_cache_gen` validation was
offered as evidence the entry self-heals, but both validators derive from file
state and write events, so an in-memory `extend` passes them. That sentence
stayed.

**Out of scope, deliberately not fixed** — `test/test_fork_reconciles_after_flush.py`
carries the same "base always took the durable save…" narration this diff removed
from the production comment. It is in a different tree and untouched here;
widening a one-module sweep into `test/` prose is what keeps these diffs
reviewable.
