### PR TITLE
perf(test): bound window-wait in computer-use launch tests

### DIFF
--- a/src/kiro_crew/computer_use/backend.py
+++ b/src/kiro_crew/computer_use/backend.py
@@ -384,6 +384,8 @@ def run_launch(
     permit: "Callable[[LaunchIdentity], str | None] | None" = None,
     identity: "Callable[[str, str], LaunchIdentity] | None" = None,
     refuse_launched: "Callable[[AppRef], str | None] | None" = None,
+    window_timeout: float = LAUNCH_WINDOW_TIMEOUT_SECS,
+    window_poll_interval: float = LAUNCH_POLL_INTERVAL_SECS,
 ) -> DriverResult:
     """The whole ``launch_app`` flow, once, for every platform to reuse.
 
@@ -415,6 +417,9 @@ def run_launch(
     different argument: a real ``AppRef``, whose ``window_title`` is the only place a
     packaged app's name appears. See the comment at the call site for why that cannot be
     folded into the pre-spawn check.
+
+    *window_timeout* and *window_poll_interval* bound the post-spawn window wait; they
+    default to the production values and exist so tests can shrink the no-window wait.
     """
     try:
         target, name = resolve(query)
@@ -481,7 +486,9 @@ def run_launch(
             ok=False, text=ERR_LAUNCH_FAILED.format(app=name, detail=exc.strerror or exc)
         )
 
-    appeared, waited = await_launched_window(lambda: find(name))
+    appeared, waited = await_launched_window(
+        lambda: find(name), timeout=window_timeout, interval=window_poll_interval
+    )
     if appeared is None:
         # A SUCCESS with a caveat, not a failure. The process did start; reporting
         # failure is what makes a model launch again, and the second attempt is what

--- a/test/test_computer_use_launch.py
+++ b/test/test_computer_use_launch.py
@@ -1385,6 +1385,8 @@ class TestResolvedIdentityReachesThePolicy:
             permit=permit,
             identity=identity,
             refuse_launched=refuse_launched,
+            window_timeout=0.02,
+            window_poll_interval=0.005,
         )
         return result, spawned, seen
 


### PR DESCRIPTION
## Problem
`TestResolvedIdentityReachesThePolicy` injects a `find()` that returns `None` forever, so `run_launch`'s `await_launched_window` polled until the 30s production timeout expired for each of `test_the_identity_supplier_is_what_the_policy_SEES` and `test_NO_supplier_degrades_to_the_display_name_only` — ~30s dead-wait each. Both tests only assert `seen` (what `permit` was handed), which is populated BEFORE the wait, so the wait was pure dead time.

No linked issue: internal test-suite speedup, not tracked by a GitHub issue.

## Change
`run_launch` gains two optional keyword params, `window_timeout` (default `LAUNCH_WINDOW_TIMEOUT_SECS`) and `window_poll_interval` (default `LAUNCH_POLL_INTERVAL_SECS`), threaded into the existing `await_launched_window` call. Both drivers (`macos_driver.py`, `windows_driver.py`) call `run_launch` by keyword and keep the defaults, so production behaviour is unchanged. The test `_run` helper passes `window_timeout=0.02, window_poll_interval=0.005`; the real no-window code path (`find` returns `None`) still executes and the exact `seen ==` assertions are preserved.

## Before / after (whole file, sandbox-unset)
| | time |
|---|---|
| before | 67.24s (two tests 30.02s + 30.01s) |
| after | 6.78s (two tests off the slowest-5 entirely) |

`98 passed / 8 skipped`, unchanged.

## Tests / verification
- `pytest test/test_computer_use_launch.py -p no:randomly -q`: 98 passed, 8 skipped, ~6s.
- black / isort / flake8: clean on both changed files. mypy: 0 new errors (the 2 reported on lines 405/1174 are pre-existing on `origin/main`, unrelated to this diff).
- **Red-before**: breaking the production identity wiring (`permit` handed a `WRONG-SUPPLIER` identity) made both updated tests FAIL on the `seen ==` assertion (`assert [('WRONG-SUPPLIER', '')] == [('Foo', 'foo.bin')]`), proving the low timeout did not remove the real policy check. Production restored exactly before commit.

## Pattern harvest
Not a fix/revert PR — no defect prevented, no rule candidate. A dead-wait in a test that never needs the timeout to fire; the fix bounds the wait via optional kwargs that default to prod values.
