### PR TITLE
feat: crew members drive worker sessions with zero configuration

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -581,7 +581,7 @@ Managed servers, registered by `agent._MANAGED_MCP_SERVERS` and installed into
 | Server | Process | Tools |
 |--------|---------|-------|
 | `kirocrew-cron` | `kirocrew mcp-cron` (`mcp_cron.py`) | `cron_add`, `cron_list`, `cron_update`, `cron_remove`, `cron_remove_all`, `cron_pause`, `cron_resume`, `cron_trigger` |
-| `kirocrew-core` | `kirocrew mcp-core` (`mcp_core.py` + `mcp_tools/`) | spawn/subagent, learn, task, messaging, artifact, workflow, knowledge and session-directive tools (see below) |
+| `kirocrew-core` | `kirocrew mcp-core` (`mcp_core.py` + `mcp_tools/`) | spawn/subagent, learn, task, messaging, artifact, workflow, knowledge and session-directive tools, plus the crew-member worker tools `worker_create`, `worker_send`, `worker_read`, `worker_stop` — stateless forwarders to the session-control endpoints, authorized server-side by the member `created_by` ownership boundary (see [session-control](../system-specs/modules/session-control.md)) (see below) |
 | `kirocrew-computer` | `kirocrew mcp-computer` (`mcp_computer.py`) | `computer_list_apps`, `computer_launch_app`, `computer_get_state`, `computer_click`, `computer_drag`, `computer_type_text`, `computer_press_key`, `computer_set_value`, `computer_scroll`, `computer_perform_action`, `computer_end_turn` |
 | `kirocrew-dashboard` | `kirocrew mcp-dashboard` (`mcp_dashboard.py`) | `chat_folder_tree`, `chat_folder_create`, `chat_folder_move`, `chat_folder_move_session` |
 

--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -88,7 +88,7 @@ that is out of bounds is visible after the fact even though nothing happened.
 
 | Refusal | Status | Why |
 |---------|--------|-----|
-| Config switch off (`agent.session_control`) | 403 | Operator opted out |
+| Config switch off (`agent.session_control`) | 403 | Operator opted out. **Exception:** a crew-member DM slot (`member-*` caller key) bypasses this switch — see "Member callers" below |
 | Caller session cannot be identified | 403 | An unidentifiable caller makes the self-target guard blind |
 | Caller is an unattended session (`cron-*`, `workflow-*`) | 403 | A scheduled job acting on live conversations is not a handoff |
 | Caller is itself incognito, temporary, or app-scoped | 403 | Caller-side isolation — the direction the target-side checks cannot see |
@@ -106,6 +106,36 @@ that is out of bounds is visible after the fact even though nothing happened.
 | Target is in another workspace | 403 | Workspaces are the memory boundary |
 | Target names no open session | 404 | A mistake, not an authorization failure |
 | Title matches more than one session | 409 | Guessing means acting on the wrong conversation |
+
+### Member callers: switch bypass, bounded by creator ownership
+
+A crew member's pinned DM slot (caller key prefixed `member-`, created only by
+`POST /api/members/{slug}/thread`) is a **conductor by design**: it dispatches
+work into worker sessions it creates, patrols them, and reports back, with no
+operator configuration. Two rules give it that shape:
+
+- **The `agent.session_control` switch does not gate a member caller.** Members
+  work out of the box — this is the zero-configuration contract, and it is a
+  deliberate trade-off: an operator who turned session control off has NOT
+  thereby disabled member dispatch. There is currently no separate switch for
+  it; disabling a member disables its dispatch.
+- **A member caller may only act on sessions it created.** Slot creation records
+  `created_by` (the creator's caller key) in the slot's birth metadata; it is
+  persisted with the session and rehydrated on restart (both restore paths).
+  `authorize_target` refuses a member caller whose key does not match the
+  target's `created_by` (`not_creator`, 403) — and this ownership boundary binds
+  **even when the global switch is enabled**, so a member never widens to the
+  ordinary caller's reach. Every other refusal in the table above still applies
+  to member callers unchanged.
+
+Ordinary (non-member) callers are untouched: they still require the switch.
+The member-facing tool surface is the `worker_create` / `worker_send` /
+`worker_read` / `worker_stop` set on `kirocrew-core` (stateless forwarders to
+the same endpoints), so members need no server assignment either. Those tools
+refuse a non-member caller outright — even with `agent.session_control`
+enabled, an ordinary agent reaches session control only through the assigned
+`kirocrew-dashboard` `session_*` tools, preserving the two-part grant (the
+switch AND the per-agent server assignment).
 
 Two notes on scope:
 

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -2307,6 +2307,38 @@ class ContextBuilder:
                 f"or the task requires it.\n\n"
             )
 
+        # Crew-member operating mode — injected only for a member's pinned DM
+        # session (mode carries the slot's mode; "member" slots are born only
+        # through the members thread route). The member is a CONTROLLER: its
+        # DM thread stays the identity/management loop while real work runs in
+        # worker sessions it dispatches and patrols. The worker_* tools this
+        # block names are authorized for member sessions automatically
+        # (dashboard/session_control.py), bounded to workers the member
+        # created itself — so the instructions hold with zero configuration.
+        #
+        # circular import: members' module graph is heavy and this file
+        # sits below it in the layering (the same cycle-break
+        # chat_persistence uses for the members module).
+        from kiro_crew.members import DM_SLOT_MODE as _member_mode
+
+        if mode == _member_mode:
+            parts.append(
+                f"[CREW MEMBER OPERATING MODE]\n"
+                f'You are the crew member "{agent_label}". This pinned conversation is '
+                f"your DM thread with the user — your identity, your inbox, and your "
+                f"ledger. Keep it for decisions, reports, and escalations; do NOT run "
+                f"long or heavy work inline here.\n"
+                f"When real work arrives (a task to implement, an investigation to "
+                f"run), DISPATCH it: open a worker session with worker_create, seed "
+                f"it with a self-contained brief via worker_send (the worker has "
+                f"none of this thread's context), then PATROL your workers with "
+                f"worker_read on a monitor_start loop — you own noticing a worker "
+                f"that stalled or died, restarting it, or escalating. Stop a runaway "
+                f"with worker_stop. You can only control workers you created.\n"
+                f"Report outcomes back in this thread when work completes or needs "
+                f"a decision only the user can make.\n\n"
+            )
+
         # User profile — onboarding answers (role + technical comfort).
         # Injected for ALL agents like date/agent identity: it describes the
         # person, not the project or workspace. Empty (no block at all) when

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -965,6 +965,12 @@ def _rehydrate_slot_from_history(
             slot.project = meta["project"]
         if meta.get("mode") and _member_identity is None:
             slot.mode = meta["mode"]
+        if meta.get("created_by"):
+            # Creator attribution restored so the member ownership boundary in
+            # session-control authorization survives a restart: without it every
+            # worker a member dispatched would come back unowned and the
+            # fail-closed `not_creator` check would strand them.
+            slot._created_by = str(meta["created_by"])
         if meta.get("folder_id"):
             slot.folder_id = meta["folder_id"]
         if meta.get("channel_folder_filed"):
@@ -1444,6 +1450,12 @@ def _apply_recent_session(
         slot.project = meta["project"]
     if meta.get("mode") and _member_identity is None:
         slot.mode = meta["mode"]
+    if meta.get("created_by"):
+        # Same rehydration as _rehydrate_slot_from_history: without it a
+        # member-created worker restored through the recent-session path
+        # loses its creator binding and authorize_target refuses the
+        # legitimate member with not_creator.
+        slot._created_by = str(meta["created_by"])
     if meta.get("folder_id"):
         slot.folder_id = meta["folder_id"]
     if meta.get("channel_folder_filed"):
@@ -2690,6 +2702,11 @@ def _save_slot_to_history(
                     fields["app"] = slot._app
                 if slot._origin:
                     fields["origin"] = slot._origin
+                if getattr(slot, "_created_by", ""):
+                    # Creator attribution: the member ownership boundary in
+                    # session-control authorization reads it, so dropping it here
+                    # would orphan a member's workers on the next restart.
+                    fields["created_by"] = slot._created_by
                 if slot.linked_session_key:
                     fields["linked_session_key"] = slot.linked_session_key
                 if getattr(slot, "channel_origin", False):
@@ -2981,6 +2998,10 @@ def _save_slot_to_history(
             # slot would lose the CRON tag that keeps it out of ``slots:user``.
             if slot._origin:
                 meta_line["origin"] = slot._origin
+            if getattr(slot, "_created_by", ""):
+                # Creator attribution — read by the member ownership boundary in
+                # session-control authorization; see the partial-save mirror above.
+                meta_line["created_by"] = slot._created_by
             # Artifact companion binding — persisted so a bound
             # session restored after a gateway restart (or resumed from the
             # History page) comes back as the artifact's active bound session.

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -82,6 +82,26 @@ MAX_READ_CONTENT_CHARS = 4000
 # (``send_message``), not session control.
 UNATTENDED_SLOT_PREFIXES = ("cron-", "workflow-")
 
+
+def _member_caller(caller_key: str) -> bool:
+    """Whether *caller_key* is a crew member's pinned DM slot.
+
+    A member DM session dispatches its real work into worker sessions it
+    creates and patrols — that is the member operating model, not an optional
+    capability — so the surface authorizes it WITHOUT the global
+    ``agent.session_control`` opt-in. What bounds it instead is ownership:
+    :func:`authorize_target` restricts a member caller to slots it created
+    itself, so the automatic grant never reaches the user's own sessions.
+
+    Spelled through the members module's own prefix constant (imported
+    lazily — members imports validation which sits below this module in the
+    layering) rather than a restated literal, so the two cannot drift.
+    """
+    from kiro_crew.members import DM_SLOT_KEY_PREFIX
+
+    return caller_key.startswith(DM_SLOT_KEY_PREFIX)
+
+
 # Roles a read must not count, taken from the persistence layer's own list rather
 # than restated here: those are exactly the rows rehydration DROPS, so any cursor
 # that counted them would name a different position after a restart than before
@@ -629,15 +649,21 @@ async def create_session(
     already refused above it -- an app-scoped caller cannot create a session at
     all (`app_scoped_caller`).
     """
-    if not session_control_enabled():
-        raise SessionControlError(
-            "session control is disabled in config (agent.session_control)",
-            code="session_control_disabled",
-        )
     caller_key = caller_slot_key(state, caller_session_key)
     if not caller_key:
         raise SessionControlError(
             "caller session could not be identified", code="caller_unidentified"
+        )
+    # The caller is resolved BEFORE the config gate so a member DM session —
+    # for which dispatching work into workers is the operating model, not an
+    # opt-in — passes without `agent.session_control`. Every other caller
+    # still needs the switch. The member's automatic grant is bounded by
+    # ownership in `authorize_target`, not here: creation makes the caller
+    # the owner by construction.
+    if not session_control_enabled() and not _member_caller(caller_key):
+        raise SessionControlError(
+            "session control is disabled in config (agent.session_control)",
+            code="session_control_disabled",
         )
     if caller_key.startswith(UNATTENDED_SLOT_PREFIXES):
         raise SessionControlError(
@@ -929,6 +955,11 @@ async def create_session(
                     # the filing would not survive a restart: for an idle newborn
                     # THIS dict is the only record of the placement on disk.
                     **({"folder_id": slot.folder_id} if slot.folder_id else {}),
+                    # Creator attribution, only when this entry point set it. The
+                    # member ownership boundary in `authorize_target` reads it, so
+                    # losing it on restart would strand every worker a member
+                    # dispatched — controllable in memory, orphaned after reboot.
+                    **({"created_by": slot._created_by} if slot._created_by else {}),
                 },
             )
         except Exception:
@@ -1040,18 +1071,21 @@ def authorize_target(
         )
         return SessionControlError(reason, status=status, code=code)
 
-    if not skip_enabled_check and not session_control_enabled():
-        raise deny(
-            "session control is disabled in config (agent.session_control)",
-            "session_control_disabled",
-        )
-
     caller_key = caller_slot_key(state, caller_session_key)
     if not caller_key:
         # Without a resolved caller the self-target guard is blind, and a session
         # that can reach every peer while being unidentifiable is exactly the
         # shape this surface must not have.
         raise deny("caller session could not be identified", "caller_unidentified")
+    # Resolved before the config gate: a member DM session is authorized
+    # WITHOUT `agent.session_control` — dispatching and patrolling workers is
+    # its operating model — and is bounded instead by the ownership check
+    # below, which restricts it to slots it created itself.
+    if not skip_enabled_check and not session_control_enabled() and not _member_caller(caller_key):
+        raise deny(
+            "session control is disabled in config (agent.session_control)",
+            "session_control_disabled",
+        )
     if caller_key.startswith(UNATTENDED_SLOT_PREFIXES):
         raise deny(
             "unattended sessions (scheduled runs) cannot control other sessions",
@@ -1151,6 +1185,16 @@ def authorize_target(
         # Workspaces are the memory boundary; reaching across one would let a
         # session act on work it cannot see.
         raise deny("target session belongs to a different workspace", "workspace_mismatch")
+    if _member_caller(caller_key) and getattr(slot, "_created_by", "") != caller_key:
+        # The member's automatic authorization reaches ONLY the workers it
+        # created itself (`created_by` is written at birth and rehydrated on
+        # restart). Always enforced for member callers — even when the global
+        # switch is on — so a member's reach never silently widens to the
+        # user's own sessions because of an unrelated opt-in.
+        raise deny(
+            "a crew member can only control worker sessions it created itself",
+            "not_creator",
+        )
 
     return slot
 

--- a/src/kiro_crew/mcp_tools/__init__.py
+++ b/src/kiro_crew/mcp_tools/__init__.py
@@ -25,6 +25,7 @@ DOMAIN_MODULES: tuple[str, ...] = (
     "artifacts",
     "knowledge",
     "sessions",
+    "workers",
     "workflows",
     "apps",
     "browser",

--- a/src/kiro_crew/mcp_tools/workers.py
+++ b/src/kiro_crew/mcp_tools/workers.py
@@ -1,0 +1,277 @@
+"""Worker-session tools: how a crew member dispatches and patrols real work.
+
+``schemas()`` returns the ADVERTISEMENT half of each tool -- its name, the
+model-facing description, and the JSON Schema a call is validated against.
+``HANDLERS`` maps each of those names to the function that runs it. Both halves
+of a tool live here so its contract and its behavior are read together, and
+``test_mcp_tool_registry`` fails if one arrives without the other.
+
+These are the member-facing spellings of the session-control surface that
+``@kirocrew-dashboard`` exposes to conductor agents. They live on
+``kirocrew-core`` -- which every agent template already references -- so a crew
+member's pinned DM session can dispatch work with ZERO spec or config changes.
+Authorization is entirely server-side (``dashboard/session_control.py``): a
+member DM session is authorized automatically and bounded to the workers it
+created itself; any other caller needs the ``agent.session_control`` opt-in.
+The tools therefore mount everywhere but only ANSWER for callers the gateway
+authorizes -- the same mounted-but-gated posture the conductor's withheld
+verbs take.
+
+Handlers reach this server's shared plumbing as attributes of ``mcp_core`` --
+``mcp_core._post``, the identity resolvers. That is deliberate rather than
+untidy: an attribute lookup resolves at CALL time, so a test that rebinds one
+on the module still intercepts the handler.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import quote
+
+from kiro_crew import mcp_core
+from kiro_crew.validation import (
+    WORKER_CREATE_SCHEMA,
+    WORKER_READ_SCHEMA,
+    WORKER_SEND_SCHEMA,
+    WORKER_STOP_SCHEMA,
+    validate_tool_args,
+)
+
+
+def schemas() -> list[dict[str, Any]]:
+    """Descriptors for the worker-session tools."""
+    return [
+        {
+            "name": "worker_create",
+            "description": (
+                "Open a WORKER session for a piece of real work you are dispatching "
+                "(fixing an issue, running an investigation) instead of doing it in "
+                "this conversation. The worker appears in the user's sidebar, runs "
+                "with full tool access, and is YOURS to drive: seed it with "
+                "worker_send, watch it with worker_read, and stop a runaway with "
+                "worker_stop. Keep this conversation for decisions and reports; put "
+                "the heavy lifting in workers. A crew member's DM session may call "
+                "this without any configuration; it can only control workers it "
+                "created itself."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Short human-readable name for the work item.",
+                    },
+                    "agent": {
+                        "type": "string",
+                        "description": (
+                            "Agent for the worker (defaults to the workspace default). "
+                            "Use a name from the crew registry."
+                        ),
+                    },
+                },
+            },
+        },
+        {
+            "name": "worker_send",
+            "description": (
+                "Send instructions to a worker session you created -- the seed brief "
+                "after worker_create, or a mid-flight course correction. The text "
+                "runs as that worker's next user-role turn. Write briefs that stand "
+                "alone: the worker has none of this conversation's context."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Worker session key from worker_create.",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The instruction to run as the worker's next turn.",
+                    },
+                },
+                "required": ["target", "message"],
+            },
+        },
+        {
+            "name": "worker_read",
+            "description": (
+                "Read a worker session's recent transcript to check on its progress "
+                "-- your patrol primitive. Returns whether it is running, queued "
+                "message depth, and the latest messages. Pass the returned "
+                "next_since cursor on your next read to resume from where you left "
+                "off. A worker that stopped answering or died mid-task is YOURS to "
+                "notice: restart it with worker_send or escalate to the user."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Worker session key to read.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max messages to return (default 20).",
+                    },
+                    "since": {
+                        "type": "integer",
+                        "description": "Cursor from a previous read's next_since.",
+                    },
+                },
+                "required": ["target"],
+            },
+        },
+        {
+            "name": "worker_stop",
+            "description": (
+                "Stop a worker session's in-flight turn -- for a worker that went "
+                "off the rails or whose work is no longer needed. The stop cancels "
+                "cooperatively and DISCARDS the turn's unfinished work, so prefer a "
+                "worker_send course correction when the work should continue."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Worker session key to stop.",
+                    },
+                },
+                "required": ["target"],
+            },
+        },
+    ]
+
+
+def _member_caller_key() -> str:
+    """The calling session's key, or ``""`` unless it is a member DM thread.
+
+    The ``worker_*`` tools are the MEMBER-facing spelling of session control.
+    They mount on ``kirocrew-core`` (which every agent references), so without
+    this check an ordinary agent would gain session control the moment the
+    operator enables ``agent.session_control`` — bypassing the second half of
+    that grant, the deliberate per-agent ``kirocrew-dashboard`` server
+    assignment. Refusing non-member callers here restores the two-key model:
+    ordinary agents reach session control only through the assigned
+    ``session_*`` tools; members only through ``worker_*``, bounded
+    server-side to the workers they created.
+    """
+    caller_key = mcp_core._resolve_session_key_strict()
+    if not caller_key:
+        return ""
+    # circular import: members' module graph is heavy, resolve at call time.
+    from kiro_crew.members import DM_SLOT_KEY_PREFIX
+
+    slot_part = caller_key.split("_", 1)[1] if caller_key.startswith("dashboard_") else caller_key
+    if not slot_part.startswith(DM_SLOT_KEY_PREFIX):
+        return ""
+    return caller_key
+
+
+_NOT_A_MEMBER = (
+    "Error: the worker_* tools answer only for a crew member's DM session. "
+    "This session is not one; use the session_* tools (kirocrew-dashboard "
+    "server, agent.session_control opt-in) for ordinary session control."
+)
+
+
+def worker_create(name: str, args: dict[str, Any]) -> str:
+    args = validate_tool_args(args, WORKER_CREATE_SCHEMA)
+    caller_key = _member_caller_key()
+    if not caller_key:
+        return _NOT_A_MEMBER
+    payload: dict[str, Any] = {}
+    if args.get("title"):
+        payload["title"] = args["title"]
+    if args.get("agent"):
+        payload["agent"] = args["agent"]
+    resp = mcp_core._post("/api/session-control/create", payload, session_key=caller_key)
+    if resp.get("error"):
+        return f"Error: could not create a worker: {resp['error']}"
+    return (
+        f"Opened worker `{resp.get('target')}` ({resp.get('title')}). It is empty "
+        "and waiting: seed it with worker_send, then patrol it with worker_read."
+    )
+
+
+def worker_send(name: str, args: dict[str, Any]) -> str:
+    args = validate_tool_args(args, WORKER_SEND_SCHEMA)
+    caller_key = _member_caller_key()
+    if not caller_key:
+        return _NOT_A_MEMBER
+    resp = mcp_core._post(
+        "/api/session-control/send",
+        {"target": args["target"], "message": args["message"]},
+        session_key=caller_key,
+    )
+    if resp.get("error"):
+        return f"Error: could not send to that worker: {resp['error']}"
+    target = resp.get("target", args["target"])
+    if resp.get("started"):
+        return f"Delivered to `{target}` — it started a turn. Watch it with worker_read."
+    return (
+        f"Queued for `{target}` — it is mid-turn, so the message runs when the "
+        "current turn ends. Poll with worker_read."
+    )
+
+
+def worker_read(name: str, args: dict[str, Any]) -> str:
+    args = validate_tool_args(args, WORKER_READ_SCHEMA)
+    caller_key = _member_caller_key()
+    if not caller_key:
+        return _NOT_A_MEMBER
+    query = f"target={quote(str(args['target']))}&limit={args.get('limit', 20)}"
+    if args.get("since") is not None:
+        query += f"&since={int(args['since'])}"
+    resp = mcp_core._get(f"/api/session-control/read?{query}", caller_key)
+    if resp.get("error"):
+        return f"Error: could not read that worker: {resp['error']}"
+    rows = resp.get("messages") or []
+    state_line = "still working" if resp.get("running") else "idle"
+    queued = resp.get("queue_depth", 0)
+    if queued:
+        state_line += f", {queued} message(s) queued"
+    head = (
+        f"Worker `{resp.get('target', '')}` — {resp.get('title', '')} "
+        f"({state_line}; total={resp.get('total', 0)})"
+    )
+    lines = [head]
+    for row in rows:
+        role = row.get("role", "?")
+        content = str(row.get("content", ""))
+        lines.append(f"[{role}] {content}")
+    if not rows:
+        lines.append("No messages in that window yet.")
+    if "next_since" in resp:
+        lines.append(f"Pass since={resp['next_since']} on your next read to resume from here.")
+    return "\n".join(lines)
+
+
+def worker_stop(name: str, args: dict[str, Any]) -> str:
+    args = validate_tool_args(args, WORKER_STOP_SCHEMA)
+    caller_key = _member_caller_key()
+    if not caller_key:
+        return _NOT_A_MEMBER
+    resp = mcp_core._post(
+        "/api/session-control/stop", {"target": args["target"]}, session_key=caller_key
+    )
+    if resp.get("error"):
+        return f"Error: could not stop that worker: {resp['error']}"
+    target = resp.get("target", args["target"])
+    info = resp.get("info")
+    if info:
+        if resp.get("already_stopping"):
+            return f"`{target}`: {info} — the earlier stop still stands."
+        return f"`{target}`: {info} — nothing to stop."
+    return f"Stop sent to `{target}`."
+
+
+HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {
+    "worker_create": worker_create,
+    "worker_send": worker_send,
+    "worker_read": worker_read,
+    "worker_stop": worker_stop,
+}

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2708,6 +2708,44 @@ SESSION_READ_MESSAGE_SCHEMA = ToolSchema(
     ],
 )
 
+# The kirocrew-core spellings of the session-control surface, sized identically
+# to their @kirocrew-dashboard counterparts above: the two servers hit the same
+# gateway endpoints, so a payload one accepts and the other rejects would make
+# the bound depend on which server the caller happened to reach. worker_create
+# deliberately omits `folder`: a member's workers land unfiled in v1, and the
+# folder reference would drag the whole folder-path resolution surface along.
+WORKER_CREATE_SCHEMA = ToolSchema(
+    tool_name="worker_create",
+    fields=[
+        FieldSpec("title", str, required=False, default="", max_len=200),
+        FieldSpec("agent", str, required=False, default="", max_len=MAX_SHORT_STRING),
+    ],
+)
+
+WORKER_SEND_SCHEMA = ToolSchema(
+    tool_name="worker_send",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+        FieldSpec("message", str, required=True, max_len=MAX_LONG_STRING),
+    ],
+)
+
+WORKER_READ_SCHEMA = ToolSchema(
+    tool_name="worker_read",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+        FieldSpec("limit", int, required=False, min_val=1, max_val=100, default=20),
+        FieldSpec("since", int, required=False, min_val=0),
+    ],
+)
+
+WORKER_STOP_SCHEMA = ToolSchema(
+    tool_name="worker_stop",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+    ],
+)
+
 # ── Schema Registry ──
 
 MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
@@ -2742,6 +2780,10 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "search_chat_history": SEARCH_CHAT_HISTORY_SCHEMA,
     "get_chat_session": GET_CHAT_SESSION_SCHEMA,
     "list_sessions": LIST_SESSIONS_SCHEMA,
+    "worker_create": WORKER_CREATE_SCHEMA,
+    "worker_send": WORKER_SEND_SCHEMA,
+    "worker_read": WORKER_READ_SCHEMA,
+    "worker_stop": WORKER_STOP_SCHEMA,
     "set_project": SET_PROJECT_SCHEMA,
     "reset_conversation": RESET_CONVERSATION_SCHEMA,
     "suggest_followup": SUGGEST_FOLLOWUP_SCHEMA,

--- a/test/test_member_session_control.py
+++ b/test/test_member_session_control.py
@@ -1,0 +1,343 @@
+"""Member sessions get session control automatically, bounded by ownership.
+
+The crew-member operating model — the DM thread dispatches real work into
+worker sessions it creates and patrols — holds with ZERO configuration: a
+member caller passes the session-control gates without the global
+``agent.session_control`` opt-in, and is bounded to the workers it created
+itself instead. These tests pin the three halves of that contract:
+
+* the gate bypass (member caller passes with the switch off; an ordinary
+  caller still needs it),
+* the ownership boundary (a member cannot touch a slot it did not create,
+  even when the global switch is ON),
+* the persistence of the boundary's input (``created_by`` written at birth
+  and restored on rehydrate — without it every worker a member dispatched
+  would come back unowned after a restart and the fail-closed check would
+  strand them).
+
+The worker_* kirocrew-core tools ride the same server-side authorization, so
+tool-level coverage here is registration only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.dashboard import session_control as sc
+from kiro_crew.members import DM_SLOT_KEY_PREFIX
+
+
+class TestMemberCallerPredicate:
+    def test_member_slot_key_is_a_member_caller(self):
+        assert sc._member_caller(DM_SLOT_KEY_PREFIX + "radar")
+
+    def test_ordinary_and_unattended_slots_are_not(self):
+        assert not sc._member_caller("chat-1-abc")
+        assert not sc._member_caller("cron-xyz")
+        assert not sc._member_caller("")
+
+
+def _slot(key: str, *, created_by: str = "", workspace: str = "default") -> SimpleNamespace:
+    return SimpleNamespace(
+        key=key,
+        workspace=workspace,
+        memory_mode="persistent",
+        _app="",
+        linked_session_key="",
+        _created_by=created_by,
+        mode="",
+        running=False,
+        messages=[],
+    )
+
+
+class _State:
+    def __init__(self, slots: dict[str, SimpleNamespace]):
+        self._slots = slots
+
+    def get_slot(self, key: str):
+        return self._slots.get(key)
+
+
+class TestAuthorizeTargetMemberPath:
+    """Drive authorize_target through the real gate order with a fake state."""
+
+    def _authorize(self, state, caller_key, target_key):
+        # caller_slot_key maps a session key to an open slot; the member path
+        # is exercised below the identity resolution, so pin the mapping and
+        # the workspace reads to keep the fixture at the authorization layer.
+        with (
+            patch.object(sc, "caller_slot_key", return_value=caller_key),
+            patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "_resolve_slot", return_value=state._slots.get(target_key)),
+        ):
+            return sc.authorize_target(
+                state,
+                caller_session_key="dashboard:whatever",
+                target=target_key,
+                operation="send",
+            )
+
+    def test_member_controls_its_own_worker_with_switch_off(self):
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        worker = _slot("chat-1-w1", created_by=member)
+        state = _State({member: _slot(member), "chat-1-w1": worker})
+        try:
+            self._authorize(state, member, "chat-1-w1")
+        except sc.SessionControlError as exc:
+            # Workspace plumbing differs per deployment; the pin is that the
+            # member path got PAST the config gate and the ownership check.
+            assert exc.code not in ("session_control_disabled", "not_creator"), exc.code
+
+    def test_member_cannot_touch_a_slot_it_did_not_create(self):
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        foreign = _slot("chat-1-user", created_by="")
+        state = _State({member: _slot(member), "chat-1-user": foreign})
+        with pytest.raises(sc.SessionControlError) as exc_info:
+            self._authorize(state, member, "chat-1-user")
+        assert exc_info.value.code == "not_creator"
+
+    def test_ownership_binds_even_when_globally_enabled(self):
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        foreign = _slot("chat-1-user", created_by="")
+        state = _State({member: _slot(member), "chat-1-user": foreign})
+        with (
+            patch.object(sc, "caller_slot_key", return_value=member),
+            patch.object(sc, "session_control_enabled", return_value=True),
+            patch.object(sc, "_resolve_slot", return_value=foreign),
+        ):
+            with pytest.raises(sc.SessionControlError) as exc_info:
+                sc.authorize_target(
+                    _State(state._slots),
+                    caller_session_key="dashboard:whatever",
+                    target="chat-1-user",
+                    operation="send",
+                )
+        assert exc_info.value.code == "not_creator"
+
+    def test_ordinary_caller_still_needs_the_switch(self):
+        state = _State({"chat-1-a": _slot("chat-1-a"), "chat-1-b": _slot("chat-1-b")})
+        with pytest.raises(sc.SessionControlError) as exc_info:
+            self._authorize(state, "chat-1-a", "chat-1-b")
+        assert exc_info.value.code == "session_control_disabled"
+
+
+class TestWorkerToolsRegistered:
+    def test_worker_tools_advertised_on_kirocrew_core(self):
+        from kiro_crew.mcp_tools import build_tool_list
+
+        names = {t["name"] for t in build_tool_list()}
+        assert {"worker_create", "worker_send", "worker_read", "worker_stop"} <= names
+
+    def test_worker_domain_schema_and_handlers_agree(self):
+        from kiro_crew.mcp_tools import workers
+
+        advertised = {t["name"] for t in workers.schemas()}
+        assert advertised == set(workers.HANDLERS)
+
+
+class TestCreatedByRecentSessionRestore:
+    """created_by must survive the bulk recent-session restore path too.
+
+    _rehydrate_slot_from_history restores it, but the startup path is
+    _apply_recent_session — a member-created worker restored there without
+    created_by comes back unowned, and authorize_target then refuses the
+    legitimate creator with not_creator.
+    """
+
+    def test_recent_session_restore_rehydrates_created_by(self, tmp_path, monkeypatch):
+        import json as _json
+        from unittest.mock import AsyncMock, MagicMock
+
+        from kiro_crew.dashboard.chat import restore_recent_sessions
+        from kiro_crew.dashboard.state import DashboardState
+        from kiro_crew.history import ConversationLog
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        meta_line = {
+            "_type": "metadata",
+            "created_at": "2026-03-23T10:00:00",
+            "last_consolidated": 0,
+            "title": "Worker",
+            "agent": "kirocrew",
+            "created_by": "member-autofix",
+        }
+        rows = [
+            _json.dumps(meta_line),
+            _json.dumps({"role": "user", "content": "task", "ts": "2026-03-23T10:00:00"}),
+        ]
+        path = tmp_path / "dashboard_chat-1-worker.jsonl"
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        path.touch()
+
+        sessions = MagicMock(count=0)
+        sessions.get_pid = MagicMock(return_value=None)
+        sessions.remove = AsyncMock()
+        state = DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=ConversationLog(base_dir=tmp_path),
+        )
+        assert restore_recent_sessions(state, window_minutes=60) == 1
+        assert state._slots["chat-1-worker"]._created_by == "member-autofix"
+
+
+class TestWorkerHandlers:
+    """Behavioral coverage of the four handlers.
+
+    Handlers reach shared plumbing as call-time attributes of ``mcp_core``
+    (by design -- see workers.py's module docstring), so patching the
+    attributes on the module intercepts every call. Each handler shares the
+    identity/error shape, so those are pinned once on worker_create and the
+    tool-specific reply branches are pinned per tool.
+    """
+
+    def _patch(self, monkeypatch, *, caller="member-autofix", post=None, get=None):
+        from kiro_crew import mcp_core
+
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: caller)
+        recorded: dict[str, object] = {}
+        if post is not None:
+
+            def _post(path, payload, session_key=""):
+                recorded["path"] = path
+                recorded["payload"] = payload
+                recorded["session_key"] = session_key
+                return post
+
+            monkeypatch.setattr(mcp_core, "_post", _post)
+        if get is not None:
+
+            def _get(path, session_key=""):
+                recorded["path"] = path
+                recorded["session_key"] = session_key
+                return get
+
+            monkeypatch.setattr(mcp_core, "_get", _get)
+        return recorded
+
+    def test_create_success_names_the_worker(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        rec = self._patch(monkeypatch, post={"target": "chat-1-w1", "title": "Fix issue"})
+        out = workers.worker_create("worker_create", {"title": "Fix issue"})
+        assert "chat-1-w1" in out and "worker_send" in out
+        assert rec["path"] == "/api/session-control/create"
+        assert rec["payload"] == {"title": "Fix issue"}
+        assert rec["session_key"] == "member-autofix"
+
+    def test_create_error_is_reported_not_raised(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        self._patch(monkeypatch, post={"error": "forbidden"})
+        out = workers.worker_create("worker_create", {})
+        assert out.startswith("Error:") and "forbidden" in out
+
+    def test_non_member_and_unidentified_callers_are_refused_before_any_request(self, monkeypatch):
+        from kiro_crew import mcp_core
+        from kiro_crew.mcp_tools import workers
+
+        def _boom(*a, **k):  # pragma: no cover - must not be reached
+            raise AssertionError("no request may leave without a member identity")
+
+        monkeypatch.setattr(mcp_core, "_post", _boom)
+        monkeypatch.setattr(mcp_core, "_get", _boom)
+        # An ordinary chat session, a session-key-prefixed ordinary session,
+        # and an unidentifiable caller are all refused with the same pointer
+        # to the assigned session_* surface — worker_* answers only members.
+        for caller in ("chat-1-ordinary", "dashboard_chat-1-ordinary", ""):
+            monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda c=caller: c)
+            for handler, args in (
+                (workers.worker_create, {}),
+                (workers.worker_send, {"target": "t", "message": "m"}),
+                (workers.worker_read, {"target": "t"}),
+                (workers.worker_stop, {"target": "t"}),
+            ):
+                out = handler("x", args)
+                assert "answer only for a crew member" in out
+
+    def test_member_key_accepted_in_both_spellings(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        for caller in ("member-autofix", "dashboard_member-autofix"):
+            rec = self._patch(monkeypatch, caller=caller, post={"target": "w"})
+            workers.worker_stop("worker_stop", {"target": "w"})
+            assert rec["session_key"] == caller
+
+    def test_send_distinguishes_started_from_queued(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        self._patch(monkeypatch, post={"target": "chat-1-w1", "started": True})
+        started = workers.worker_send("worker_send", {"target": "chat-1-w1", "message": "go"})
+        assert "started a turn" in started
+
+        self._patch(monkeypatch, post={"target": "chat-1-w1", "started": False})
+        queued = workers.worker_send("worker_send", {"target": "chat-1-w1", "message": "go"})
+        assert "Queued" in queued
+
+    def test_read_renders_transcript_state_and_cursor(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        rec = self._patch(
+            monkeypatch,
+            get={
+                "target": "chat-1-w1",
+                "title": "Fix issue",
+                "running": True,
+                "queue_depth": 2,
+                "total": 5,
+                "messages": [{"role": "assistant", "content": "done step 1"}],
+                "next_since": 5,
+            },
+        )
+        out = workers.worker_read("worker_read", {"target": "chat-1-w1", "limit": 10, "since": 3})
+        assert "still working" in out and "2 message(s) queued" in out
+        assert "[assistant] done step 1" in out
+        assert "since=5" in out
+        assert "target=chat-1-w1" in str(rec["path"]) and "since=3" in str(rec["path"])
+
+    def test_read_empty_window_and_idle_state(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        self._patch(
+            monkeypatch,
+            get={"target": "chat-1-w1", "title": "t", "running": False, "messages": []},
+        )
+        out = workers.worker_read("worker_read", {"target": "chat-1-w1"})
+        assert "idle" in out and "No messages in that window yet." in out
+
+    def test_read_error_is_reported(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        self._patch(monkeypatch, get={"error": "not_creator"})
+        out = workers.worker_read("worker_read", {"target": "chat-1-x"})
+        assert out.startswith("Error:") and "not_creator" in out
+
+    def test_stop_branches_sent_already_stopping_and_noop(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        self._patch(monkeypatch, post={"target": "chat-1-w1"})
+        assert "Stop sent" in workers.worker_stop("worker_stop", {"target": "chat-1-w1"})
+
+        self._patch(
+            monkeypatch,
+            post={"target": "chat-1-w1", "info": "already stopping", "already_stopping": True},
+        )
+        assert "still stands" in workers.worker_stop("worker_stop", {"target": "chat-1-w1"})
+
+        self._patch(monkeypatch, post={"target": "chat-1-w1", "info": "no turn running"})
+        assert "nothing to stop" in workers.worker_stop("worker_stop", {"target": "chat-1-w1"})
+
+    def test_send_error_is_reported(self, monkeypatch):
+        from kiro_crew.mcp_tools import workers
+
+        self._patch(monkeypatch, post={"error": "workspace_mismatch"})
+        out = workers.worker_send("worker_send", {"target": "t", "message": "m"})
+        assert out.startswith("Error:") and "workspace_mismatch" in out

--- a/test/test_queue_drain_revalidation.py
+++ b/test/test_queue_drain_revalidation.py
@@ -639,6 +639,11 @@ _NON_CONTAINMENT_REFUSALS = {
     "linked_session_caller",
     "mirrored_caller",
     "caller_gone",
+    # Caller-relative ownership: fires only for member callers, comparing the
+    # caller's key to the target's created_by. Both are written once at birth
+    # and never mutate, so the relation that admitted an entry cannot flip
+    # while it waits -- and the drain has no caller left to re-evaluate.
+    "not_creator",
     # Not containment: global config state, a resolution failure, and the
     # self-target guard. None of the three can change while an entry waits in a
     # queue in a way the drain could act on.


### PR DESCRIPTION
## Problem / Motivation

A crew member's pinned DM thread can only converse today. The intended operating
model — the member is a conductor that dispatches real work into separate worker
sessions, patrols them, and reports back — has no supported path: the
`session_*` control tools live only on the opt-in `kirocrew-dashboard` server
that conductor-type templates reference, and every call is gated behind the
global `agent.session_control` switch. A member therefore either does heavy
work inline in its own DM thread (blocking the conversation) or fails with a
config error the user never opted into resolving.

## Why it matters

Crew members are the product's face for delegation ("DM the autofix member and
it handles the pipeline"). Without dispatch, a member is a chat skin. Requiring
operators to hand-edit agent templates and flip a global switch before a member
can work contradicts the zero-configuration contract members are sold on — and
flipping the global switch would also grant session control to surfaces the
operator never intended.

## What changed (motivation → approach → change)

Goal: members operate as conductors with zero configuration, without widening
what ordinary callers can do.

Approach: ride the existing session-control engine rather than building a new
one, mount member-facing tools on the one server every template already
references (`kirocrew-core`), and replace the global-switch grant with a
narrower server-side boundary — creator ownership.

Changes:

- **`worker_create` / `worker_send` / `worker_read` / `worker_stop`** — a new
  `workers` domain in `mcp_tools/` (stateless forwarders resolving identity per
  call via `_resolve_session_key_strict`, mirroring the `session_*` tools), with
  schemas registered in `validation.py`.
- **Member gate bypass + ownership boundary** in `session_control.py`: a caller
  whose slot key carries the member DM prefix passes `create_session` and
  `authorize_target` without `agent.session_control`, but `authorize_target`
  additionally refuses a member caller when the target slot's `created_by` does
  not match its own key (`not_creator`). The ownership check binds even when the
  global switch is enabled. Ordinary callers are unchanged.
- **`created_by` persistence**: written into slot birth metadata at creation,
  saved on both persistence paths, and rehydrated by both restore paths
  (`_rehydrate_slot_from_history` and `_apply_recent_session` — the latter was
  initially missed; a member-created worker restored through the bulk
  recent-session path would have come back unowned, stranding its creator).
- **Member operating mode injection**: `build_session_context` injects a
  `[CREW MEMBER OPERATING MODE]` block for `mode="member"` sessions (first
  consumer of the `mode` parameter), teaching the dispatch → patrol → report
  protocol.
- **Specs updated in the same commit**: `session-control.md` documents the
  member bypass (including the deliberate trade-off that turning the global
  switch off does not disable member dispatch) and the ownership boundary;
  `mcp.md` lists the `worker_*` tools.

## Tests

`test/test_member_session_control.py` pins the contract:

- member caller predicate (prefix-driven, spelled through the members module's
  own constant),
- `authorize_target` bypass with the switch off; ordinary caller still refused,
- ownership boundary: member cannot touch a slot it did not create, even with
  the global switch ON,
- `created_by` survives the bulk recent-session restore path
  (mutation-verified: reverting the `_apply_recent_session` fix turns it red),
- `workers` domain registration and schema/handler agreement.

Existing suites re-run green: `test_session_control.py`,
`test_session_restore.py`, `test_mcp_tool_registry.py`, `test_context.py`.

## Manual verification

End-to-end demo on an isolated pod (`agent.session_control` left at its
default OFF): a member DM was given a task; the member created a worker
(`worker_create`), dispatched a brief (`worker_send`), patrolled it
(`worker_read` ×6), stopped a stalled turn (`worker_stop`), re-dispatched, and
finally reported honestly with the worker session key when the pod's
read-only sandbox blocked the worker's shell — the full
dispatch → patrol → intervene → escalate loop, driven purely by the injected
operating-mode block. Recorded video available in the review thread.

## Related Issues

no linked issue: implements the crew-member conductor operating model agreed in
design discussion; no tracking issue was filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a field persisted at creation must be restored by EVERY rehydration
path — grep for all readers of the metadata dict when adding a key" (the
`_apply_recent_session` gap was exactly this class).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
