### PR TITLE
fix(security): bound sensitive-path symlink resolution off the event loop

### DIFF
--- a/src/kiro_crew/executors.py
+++ b/src/kiro_crew/executors.py
@@ -86,6 +86,7 @@ __all__ = [
     "embed_executor",
     "image_executor",
     "stt_executor",
+    "path_resolve_executor",
     "governance_executor",
     "cron_gate_executor",
     "CronGateTimeout",
@@ -244,6 +245,25 @@ _MAX_IMAGE_WORKERS = 2
 # to starve other STT work.
 _MAX_STT_WORKERS = 2
 
+# Symlink resolution for the sensitive-path gates (``security._candidate_forms``).
+# ``os.path.realpath`` walks every component with ``lstat``, and a component that
+# lands on a stalled automount (macOS ``/home`` autofs backed by an unreachable
+# directory server, a dead NFS/SSHFS mount, a disconnected Windows mapped drive)
+# blocks in the kernel for as long as the mount does -- effectively unbounded.
+# The gate runs SYNCHRONOUSLY inside ``on_tool_call`` on the event loop, so that
+# block was a loop wedge -> watchdog dump-then-exit (ten identical crash dumps
+# on a corp macOS around a VPN transition, the path tokens being the remote
+# side of an ``ssh host 'cd /home/...'`` command that never existed locally).
+# The caller bounds its wait and REFUSES the path on timeout (fail-closed --
+# a lexical-only fallback would let a symlink into a credential store ride a
+# stall; only a resolution that FAILS with OSError keeps the lexical forms);
+# the wait does NOT free the worker, so this is its OWN tiny pool: a wedged
+# resolution can only ever starve other path resolution, never the sweeps or
+# the default executor's DNS.  Two workers is deliberate -- healthy resolution is
+# microseconds, so the cap only bites when the filesystem is wedged, which is
+# exactly when queueing behind a wedged sibling is the correct outcome.
+_MAX_PATH_RESOLVE_WORKERS = 2
+
 _lock = threading.Lock()
 _pool: ThreadPoolExecutor | None = None
 _subprocess_pool: ThreadPoolExecutor | None = None
@@ -254,6 +274,7 @@ _image_pool: ThreadPoolExecutor | None = None
 _stt_pool: ThreadPoolExecutor | None = None
 _governance_pool: ThreadPoolExecutor | None = None
 _cron_gate_pool: ThreadPoolExecutor | None = None
+_path_resolve_pool: ThreadPoolExecutor | None = None
 
 
 def configure_default_executor() -> None:
@@ -403,6 +424,33 @@ def stt_executor() -> ThreadPoolExecutor:
                 )
                 atexit.register(shutdown_maintenance_executor)
     return _stt_pool
+
+
+def path_resolve_executor() -> ThreadPoolExecutor:
+    """Return the process-wide sensitive-path symlink-resolution pool, creating it on first use.
+
+    Threads are named ``mc-pathres``.  Serves ``security._candidate_forms``, whose
+    ``os.path.realpath`` / ``Path.resolve`` on an agent-supplied path token used
+    to run inline on the event loop and could block in the kernel for as long as
+    a stalled automount did.  The caller bounds its wait
+    (``security._PATH_RESOLVE_TIMEOUT_SECS``) and refuses the path on timeout
+    (fail-closed; only a resolution that FAILS keeps the lexical forms); the
+    wait releases the CALLER, never the thread, which is why this
+    work gets a pool it can only starve for itself -- on
+    :func:`subprocess_executor` a wedged ``lstat`` would consume one of the PTY
+    teardown workers, and on the default executor it would starve the loop's own
+    DNS resolution.
+    """
+    global _path_resolve_pool
+    if _path_resolve_pool is None:
+        with _lock:
+            if _path_resolve_pool is None:
+                _path_resolve_pool = ThreadPoolExecutor(
+                    max_workers=_MAX_PATH_RESOLVE_WORKERS,
+                    thread_name_prefix="mc-pathres",
+                )
+                atexit.register(shutdown_maintenance_executor)
+    return _path_resolve_pool
 
 
 def embed_executor() -> ThreadPoolExecutor:
@@ -767,7 +815,7 @@ def shutdown_maintenance_executor() -> None:
     loop and shut down by asyncio when the loop closes.
     """
     global _pool, _subprocess_pool, _cron_pool, _discovery_pool, _embed_pool
-    global _governance_pool, _image_pool, _cron_gate_pool, _stt_pool
+    global _governance_pool, _image_pool, _cron_gate_pool, _stt_pool, _path_resolve_pool
     with _lock:
         pool, _pool = _pool, None
         subprocess_pool, _subprocess_pool = _subprocess_pool, None
@@ -778,6 +826,7 @@ def shutdown_maintenance_executor() -> None:
         image_pool, _image_pool = _image_pool, None
         cron_gate_pool, _cron_gate_pool = _cron_gate_pool, None
         stt_pool, _stt_pool = _stt_pool, None
+        path_resolve_pool, _path_resolve_pool = _path_resolve_pool, None
     if pool is not None:
         pool.shutdown(wait=False, cancel_futures=True)
     if subprocess_pool is not None:
@@ -796,3 +845,5 @@ def shutdown_maintenance_executor() -> None:
         cron_gate_pool.shutdown(wait=False, cancel_futures=True)
     if stt_pool is not None:
         stt_pool.shutdown(wait=False, cancel_futures=True)
+    if path_resolve_pool is not None:
+        path_resolve_pool.shutdown(wait=False, cancel_futures=True)

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -15,9 +15,12 @@ import shlex
 import socket
 import string
 import sys
+import threading
 import time
 import uuid
 from collections import Counter
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import asdict, dataclass
 
 try:
@@ -30,7 +33,11 @@ from typing import TYPE_CHECKING, NamedTuple
 from urllib.parse import parse_qs, unquote, unquote_plus, urlparse
 
 from kiro_crew.credential_patterns import AWS_KEY_ID, JWT_MULTI_SEGMENT
-from kiro_crew.executors import maintenance_executor
+from kiro_crew.executors import (
+    _MAX_PATH_RESOLVE_WORKERS,
+    maintenance_executor,
+    path_resolve_executor,
+)
 from kiro_crew.identity_stores import fenced_home_dirs
 from kiro_crew.sel import SecurityEvent, SecurityEventLog
 from kiro_crew.trust_patterns import ENV_ASSIGNMENT_RE
@@ -7453,6 +7460,248 @@ def _get_sensitive_re() -> re.Pattern[str]:
     return _SENSITIVE_RE
 
 
+# ── Bounded symlink resolution for the sensitive-path gates ──
+#
+# ``os.path.realpath`` / ``Path.resolve`` ``lstat`` every component of the path
+# they are handed.  The path gates hand them AGENT-SUPPLIED tokens -- including
+# tokens that name nothing on this host at all, like the remote side of
+# ``ssh host 'cd /home/user/ws && ...'`` -- and a component that lands on a
+# stalled automount (macOS ``/home`` is an autofs map resolved through
+# opendirectoryd; a dead NFS/SSHFS mount; a disconnected mapped drive) blocks in
+# the kernel for as long as the mount does.  No exception is raised, so the
+# ``except OSError`` around the call never fired: the call simply never
+# returned.  Because :func:`is_sensitive_path` / :func:`is_sensitive_bash_command`
+# run synchronously inside ``on_tool_call`` on the event loop, that was a loop
+# wedge and the stall watchdog's dump-then-exit -- ten identical crash dumps on
+# a corp macOS during a VPN transition, the loop parked in ``_joinrealpath`` for
+# the full watchdog budget.  Widening the budget only moved the crash.
+#
+# So resolution runs on its own tiny pool and the caller waits a BOUNDED time.
+# A timeout is NOT treated like the ``OSError`` fallback (lexical forms only):
+# that would make the degraded state a lever -- stall one token under a wedged
+# mount and, for the cooldown, a workspace symlink into a credential store
+# would pass on its lexical spelling.  A path whose canonical form cannot be
+# established is instead REFUSED (:class:`PathResolutionStalled`, fail-closed
+# in every gate), the same posture the rest of this module takes when a proof
+# is missing.  The cost is a false refusal of paths under a wedged mount for
+# the cooldown window -- the ``ssh`` command above is refused for 30s during a
+# VPN transition instead of killing the gateway -- and the refusal names why.
+#
+# A timeout also opens a short cooldown during which paths under the SAME
+# prefix are refused without touching the filesystem: one bash command can
+# carry many path tokens against the same wedged mount, each of which would
+# otherwise pay the full timeout -- ten tokens at 2s would put the loop back
+# past the watchdog.  The cooldown is scoped to the stalled prefix
+# (:func:`_stall_prefix`), never process-wide, so a stall on ``/home/<user>``
+# leaves ``/tmp`` and the workspace fully resolved.  It doubles on every
+# repeat stall under the same prefix (up to the cap below) and a re-probe is
+# only attempted while it leaves a worker free, because a timed-out worker is
+# NOT reclaimed: a mount that stays dead would otherwise be handed a fresh
+# worker every cooldown until every worker is pinned and every healthy path
+# queues behind wedged futures -- the per-prefix isolation would hold only
+# while free workers remained.
+#
+# The thread is NOT freed by the timeout (a started future cannot be cancelled);
+# that is why this has its own pool -- see ``executors.path_resolve_executor``.
+_PATH_RESOLVE_TIMEOUT_SECS = 2.0
+_PATH_RESOLVE_COOLDOWN_SECS = 30.0
+_PATH_RESOLVE_COOLDOWN_MAX_SECS = 1800.0
+# stall prefix -> (monotonic deadline until which paths under it are refused,
+# consecutive stalls recorded under it -- drives the exponential backoff)
+_path_resolve_degraded: dict[str, tuple[float, int]] = {}
+# futures that timed out and still hold an mc-pathres worker; pruned as they finish
+_path_resolve_wedged: list[Future[set[str]]] = []
+_path_resolve_lock = threading.Lock()
+_path_resolve_clock: Callable[[], float] = time.monotonic  # tests advance this
+
+
+def _resolved_spellings(expanded: str) -> set[str]:
+    """Symlink-resolved spellings of *expanded*; runs on the ``mc-pathres`` pool."""
+    out: set[str] = set()
+    try:
+        out.add(os.path.realpath(expanded))
+    except (OSError, ValueError):
+        pass
+    try:
+        # Guarded false-positive: this resolve() is INSIDE is_sensitive_path — the
+        # sanitizer itself — building candidate forms to CHECK a path against the
+        # sensitive denylist. It performs no read/write. CodeQL surfaces
+        # py/path-injection here only because a new caller (artifact relocate)
+        # reaches it with user input; the function's whole purpose is to vet that
+        # input, so suppress the alert on the resolution step.
+        out.add(str(Path(expanded).resolve()))  # lgtm[py/path-injection]
+    except (OSError, ValueError, RuntimeError):
+        pass
+    return out
+
+
+class PathResolutionStalled(RuntimeError):
+    """Symlink resolution of an agent-supplied path did not complete in time.
+
+    Raised by :func:`_resolved_forms_bounded` when the bounded ``realpath``
+    times out, and for the cooldown that follows under the same path prefix.
+    The sensitive-path gates treat it as FAIL-CLOSED: a path whose canonical
+    form cannot be established is refused, never matched on its lexical
+    spelling alone -- a lexical-only match would let a workspace symlink into a
+    credential store pass while the mount it does not even live on is wedged.
+    """
+
+    def __init__(self, path: str, prefix: str) -> None:
+        super().__init__(
+            f"symlink resolution of {path!r} is unavailable (stalled mount under {prefix!r})"
+        )
+        self.path = path
+        self.prefix = prefix
+
+
+def _stall_prefix(expanded: str) -> str:
+    """The path prefix a stall is charged to: the first two components.
+
+    A wedged mount stalls everything beneath its mount point, and mount points
+    sit at depth one or two (``/home/<user>`` autofs, ``/Volumes/<share>``,
+    ``/net/<host>``, ``C:\\Users``), so two components is the narrowest key
+    that still covers the whole stalled subtree.  Scoping the cooldown here is
+    what keeps a stall on the REMOTE half of an ``ssh`` command from switching
+    resolution off for the local workspace where a bypass symlink would live.
+    """
+    normalized = os.path.normpath(expanded)
+    parts = normalized.split(os.sep)
+    keep = 3 if parts and parts[0] == "" else 2  # leading "" for an absolute path
+    return os.sep.join(parts[:keep]) or normalized
+
+
+def _wedged_workers() -> int:
+    """How many ``mc-pathres`` workers are still pinned by a timed-out resolution.
+
+    A future that timed out is not cancelled -- its thread stays in the kernel
+    until the mount answers -- so it is kept here and forgotten once it finally
+    completes.  The count gates re-probes: a mount that stays dead (hard NFS,
+    not the transient VPN case) must not be handed a fresh worker every cooldown
+    until none is left and every healthy path queues behind wedged futures.
+    """
+    with _path_resolve_lock:
+        _path_resolve_wedged[:] = [f for f in _path_resolve_wedged if not f.done()]
+        return len(_path_resolve_wedged)
+
+
+def _mark_stalled(prefix: str, budget: float) -> None:
+    """Record an OBSERVED stall under *prefix*: back off exponentially on repeats.
+
+    Only a resolution that actually timed out is recorded.  A refusal issued
+    because every worker was already pinned costs nothing (nothing is
+    submitted) and must not charge the refused prefix -- often the local
+    workspace -- a backoff it never earned, or a transient dual-mount outage
+    would keep refusing healthy paths for the accrued window after the mounts
+    recover.  The log line deliberately omits the path: the token is
+    agent-supplied and is what the gates exist to keep out of clear-text logs.
+    """
+    now = _path_resolve_clock()
+    with _path_resolve_lock:
+        if len(_path_resolve_degraded) > 64:
+            _path_resolve_degraded.clear()
+        _, stalls = _path_resolve_degraded.get(prefix, (0.0, 0))
+        stalls += 1
+        cooldown = min(
+            _PATH_RESOLVE_COOLDOWN_SECS * (2 ** (stalls - 1)),
+            _PATH_RESOLVE_COOLDOWN_MAX_SECS,
+        )
+        _path_resolve_degraded[prefix] = (now + cooldown, stalls)
+    logger.warning(
+        "sensitive-path symlink resolution did not complete in %.1fs (stalled "
+        "mount?); refusing paths under the stalled prefix for the next %.0fs "
+        "(stall #%d, %d resolver worker(s) pinned)",
+        budget,
+        cooldown,
+        stalls,
+        len(_path_resolve_wedged),
+    )
+
+
+_UNC_PREFIX_RE = re.compile(r"^[\\/]{2}[^\\/]")
+_ON_WINDOWS = os.name == "nt"
+
+
+def _is_unc_path(expanded: str) -> bool:
+    """``\\\\server\\share\\...`` in either separator spelling.
+
+    On Windows ``os.path.realpath`` on a UNC path opens it
+    (``GetFinalPathNameByHandle``), which is a network round-trip to the named
+    host -- a dead or slow host stalls the caller for the SMB timeout, and a
+    UNC token in an agent's command is the ordinary way to name a share, not a
+    symlink-bypass vector: the fence's targets are local drive spellings that a
+    UNC realpath never produces (``\\\\?\\UNC\\...``).  So a UNC token is matched
+    lexically and never probed, the same stance the mapped-drive fence below
+    takes for a foreign drive letter.
+    """
+    return bool(_UNC_PREFIX_RE.match(expanded))
+
+
+def _resolved_forms_bounded(expanded: str) -> set[str]:
+    """Return the symlink-resolved spellings of *expanded*, or an empty set.
+
+    Empty means resolution FAILED (``OSError``/``ValueError`` inside the
+    worker, or the pool refusing work at interpreter exit) or was deliberately
+    not attempted (a UNC path on Windows -- see :func:`_is_unc_path`): the
+    caller keeps the lexical forms, exactly as before the bound existed.  A
+    resolution that does not COMPLETE is different and raises
+    :class:`PathResolutionStalled` instead, both on the timing-out call and,
+    without touching the filesystem, for every later call under the same
+    :func:`_stall_prefix` until the cooldown lapses.  Repeated stalls under one
+    prefix double the cooldown up to ``_PATH_RESOLVE_COOLDOWN_MAX_SECS``, and a
+    prefix with a stall history is only re-probed while that leaves at least one
+    worker free for everything else -- so a permanently dead mount is probed
+    rarely and can never pin the whole pool.  Never blocks the caller for longer
+    than ``_PATH_RESOLVE_TIMEOUT_SECS``.  Tests swap :func:`_resolved_spellings`
+    at module level for a blocking stub and advance ``_path_resolve_clock``.
+    """
+    if _ON_WINDOWS and _is_unc_path(expanded):
+        return set()
+    budget = _PATH_RESOLVE_TIMEOUT_SECS
+    now = _path_resolve_clock()
+    prefix = _stall_prefix(expanded)
+    with _path_resolve_lock:
+        history = _path_resolve_degraded.get(prefix)
+    if history is not None and now < history[0]:
+        raise PathResolutionStalled(expanded, prefix)
+    wedged = _wedged_workers()
+    if wedged >= _MAX_PATH_RESOLVE_WORKERS or (history is not None and wedged >= _MAX_PATH_RESOLVE_WORKERS - 1):
+        # Every worker is pinned, or this re-probe of a known-stalled prefix
+        # would pin the last free one.  Queueing behind a wedged future can only
+        # time out, so refuse now.  Nothing was submitted, so nothing is charged
+        # to the prefix: the next call re-evaluates the gate for free.
+        logger.debug(
+            "sensitive-path symlink resolution refused without probing: %d of %d "
+            "resolver worker(s) pinned by earlier stalls",
+            wedged,
+            _MAX_PATH_RESOLVE_WORKERS,
+        )
+        raise PathResolutionStalled(expanded, prefix)
+    try:
+        future = path_resolve_executor().submit(_resolved_spellings, expanded)
+    except RuntimeError:
+        # Pool already shut down (interpreter exit).  Lexical forms only.
+        return set()
+    try:
+        forms = future.result(timeout=budget)
+    except FutureTimeoutError:
+        with _path_resolve_lock:
+            _path_resolve_wedged.append(future)
+        _mark_stalled(prefix, budget)
+        raise PathResolutionStalled(expanded, prefix) from None
+    except Exception:
+        # The worker's own exceptions are already swallowed inside
+        # _resolved_spellings; anything else here is a pool fault, and the gate's
+        # contract is to keep the lexical forms rather than fail the tool call.
+        logger.debug("sensitive-path symlink resolution failed", exc_info=True)
+        return set()
+    if history is not None:
+        # The mount answered again: forget the stall history so the next stall
+        # starts from the base cooldown rather than an inherited backoff.
+        with _path_resolve_lock:
+            _path_resolve_degraded.pop(prefix, None)
+    return forms
+
+
 def _candidate_forms(path_str: str, base_dir: str | None = None) -> set[str]:
     """Expand *path_str* into every candidate form the sensitive-path gates match.
 
@@ -7476,23 +7725,14 @@ def _candidate_forms(path_str: str, base_dir: str | None = None) -> set[str]:
         expanded = os.path.join(os.path.abspath(base_dir), expanded)
 
     # Build the candidate forms.  Symlink-resolved forms defeat a link bypass;
-    # the lexical forms are the fail-safe fallback when resolution cannot
-    # complete (over-matching a sensitive-looking path is the safe direction).
-    candidates: set[str] = set()
-    try:
-        candidates.add(os.path.realpath(expanded))
-    except (OSError, ValueError):
-        pass
-    try:
-        # Guarded false-positive: this resolve() is INSIDE is_sensitive_path — the
-        # sanitizer itself — building candidate forms to CHECK a path against the
-        # sensitive denylist. It performs no read/write. CodeQL surfaces
-        # py/path-injection here only because a new caller (artifact relocate)
-        # reaches it with user input; the function's whole purpose is to vet that
-        # input, so suppress the alert on the resolution step.
-        candidates.add(str(Path(expanded).resolve()))  # lgtm[py/path-injection]
-    except (OSError, ValueError, RuntimeError):
-        pass
+    # the lexical forms are the fail-safe fallback when resolution FAILS
+    # (over-matching a sensitive-looking path is the safe direction).
+    # Resolution is BOUNDED -- see _resolved_forms_bounded: an unbounded lstat on
+    # a stalled automount used to wedge the event loop from inside on_tool_call.
+    # A resolution that does not COMPLETE raises PathResolutionStalled through
+    # here, and every gate turns that into a refusal: no lexical-only matching
+    # of a path whose canonical form is unknown.
+    candidates: set[str] = _resolved_forms_bounded(expanded)
     candidates.add(os.path.normpath(expanded))
     candidates.add(expanded)
     return candidates
@@ -7500,7 +7740,7 @@ def _candidate_forms(path_str: str, base_dir: str | None = None) -> set[str]:
 
 def _home_dir_targets_uncached(
     home_dirs: list[str],
-    roots: tuple[str, str | None, str | None] | None = None,
+    roots: tuple[str, str | None, str | None, str] | None = None,
 ) -> set[str]:
     """Anchor the ``$HOME``-relative *home_dirs* entries into absolute, casefolded
     on-disk targets.
@@ -7528,9 +7768,9 @@ def _home_dir_targets_uncached(
     this is a no-op there.
     """
     if roots is not None:
-        home, crew_home, kiro_home_override = roots
+        home, crew_home, kiro_home_override, logical_home = roots
     else:
-        home, crew_home, kiro_home_override = _resolved_root_key()
+        home, crew_home, kiro_home_override, logical_home = _resolved_root_key()
 
     def _anchor(root: str, d: str) -> str:
         return os.path.join(root, *d.split("/")).casefold()
@@ -7539,6 +7779,15 @@ def _home_dir_targets_uncached(
     home_real = os.path.realpath(home)
     if home_real.casefold() != home.casefold():
         sensitive_targets |= {_anchor(home_real, d) for d in home_dirs}
+    # ``home`` arrives RESOLVED (the cache is keyed on the resolved roots), so
+    # the realpath above is normally a no-op and the LOGICAL spelling of a
+    # symlinked ``$HOME`` was never anchored -- a gap masked as long as every
+    # candidate was itself resolved.  Candidate resolution is now bounded and
+    # degrades to the lexical spelling, so anchor the logical home explicitly:
+    # ``~/.ssh/id_rsa`` spelled through ``/home/x`` must match even when
+    # ``/home/x -> /local/home/x`` could not be followed in time.
+    if logical_home.casefold() != home.casefold():
+        sensitive_targets |= {_anchor(logical_home, d) for d in home_dirs}
     # When KIROCREW_HOME points to a non-default path, the keystone secrets
     # (token_signing.key, refresh_chains.json, .local_secret, sel_hmac.key,
     # security_policy.json etc.) live directly under it — NOT under either of
@@ -7634,8 +7883,8 @@ _HOME_TARGETS_TTL_SECS = 0.1
 _home_targets_cache: dict[tuple[object, ...], tuple[float, set[str]]] = {}
 
 
-def _resolved_root_key() -> tuple[str, str | None, str | None]:
-    """Return the (home, crew_home, kiro_home) roots the target set is anchored on.
+def _resolved_root_key() -> tuple[str, str | None, str | None, str]:
+    """Return the (home, crew_home, kiro_home, logical_home) roots the target set is anchored on.
 
     Mirrors how :func:`_home_dir_targets_uncached` derives its anchors, so the
     cache key changes exactly when the anchors would. Falls back to the
@@ -7647,11 +7896,22 @@ def _resolved_root_key() -> tuple[str, str | None, str | None]:
     must invalidate the cache. No validity check here (an unsafe value falls back
     to ``~/.kiro`` in ``kiro_home()``, already covered by the default form); it is
     resolved only so a symlinked override keys and anchors identically.
+
+    ``logical_home`` is ``Path.home()`` UNRESOLVED.  It is a separate anchor, not
+    a duplicate: on a host where ``$HOME`` is itself a symlink (``/home/x`` ->
+    ``/local/home/x`` on cloud desktops) the resolved home spells every target
+    one way while an agent-supplied ``~/.ssh/id_rsa`` spells it the other.  The
+    resolved CANDIDATE normally bridges that -- but candidate resolution is
+    bounded (:func:`_resolved_forms_bounded`) and degrades to the lexical
+    spelling, which must still hit a target or the gate fails OPEN on exactly
+    the hosts where ``$HOME`` is a link.  Keyed here so an env change that
+    moves the logical spelling invalidates the cache like any other anchor.
     """
+    logical_home = str(Path.home())
     try:
         home = str(Path.home().resolve())
     except (OSError, ValueError):
-        home = str(Path.home())
+        home = logical_home
     crew_env = os.environ.get("KIROCREW_HOME")
     if crew_env:
         try:
@@ -7668,7 +7928,7 @@ def _resolved_root_key() -> tuple[str, str | None, str | None]:
             kiro = os.path.abspath(os.path.expanduser(kiro_env))
     else:
         kiro = None
-    return home, crew, kiro
+    return home, crew, kiro, logical_home
 
 
 def _home_dir_targets(home_dirs: list[str]) -> set[str]:
@@ -7735,7 +7995,13 @@ def _path_in_home_dirs(path_str: str, home_dirs: list[str], base_dir: str | None
     if not path_str:
         return False
 
-    candidates = _candidate_forms(path_str, base_dir)
+    try:
+        candidates = _candidate_forms(path_str, base_dir)
+    except PathResolutionStalled:
+        # Canonical form unavailable (wedged mount under the path): refuse.  A
+        # lexical-only match here would pass a workspace symlink into a
+        # credential store for the length of the stall.
+        return True
     sensitive_targets = _home_dir_targets(home_dirs)
 
     # Case-fold both sides for the membership test.  On a case-insensitive
@@ -7778,7 +8044,11 @@ def _is_keystone_publish_artifact(path_str: str, base_dir: str | None = None) ->
     if not path_str:
         return False
     artifact_parents = _home_dir_targets(_KEYSTONE_ARTIFACT_PARENTS)
-    for cand in _candidate_forms(path_str, base_dir):
+    try:
+        candidates = _candidate_forms(path_str, base_dir)
+    except PathResolutionStalled:
+        return True  # fail closed: see _path_in_home_dirs
+    for cand in candidates:
         cand_cf = cand.casefold()
         # Suffixes are authored lowercase and the candidate is casefolded, so this is
         # the same case-insensitive comparison the rest of the gate makes -- on
@@ -7844,7 +8114,11 @@ def path_contains_sensitive(dir_str: str, base_dir: str | None = None) -> bool:
     if not dir_str:
         return False
     sensitive_targets = _home_dir_targets(_SENSITIVE_HOME_DIRS)
-    for cand in _candidate_forms(dir_str, base_dir):
+    try:
+        candidates = _candidate_forms(dir_str, base_dir)
+    except PathResolutionStalled:
+        return True  # fail closed: see _path_in_home_dirs
+    for cand in candidates:
         # Normalize away a trailing separator so `/home/u/` and `/home/u`
         # produce the same prefix (a bare `/` or `C:\` root rstrips to ""/"C:",
         # whose prefix form still matches everything under it — correct: every
@@ -9011,10 +9285,14 @@ def _dir_holds_sensitive_leaf(directory: str) -> bool:
     # targets are anchored against the RESOLVED home, and a home reached through a
     # symlink (`/home/x` -> `/local/home/x`) spells the same directory two ways.
     candidates = {os.path.normpath(probe)}
+    # Bounded for the same reason as _candidate_forms: this probe is an
+    # agent-supplied token checked synchronously on the event loop, and a
+    # stalled automount under it would otherwise wedge the loop.  A stall is
+    # fail-closed here too: the directory is treated as holding a leaf.
     try:
-        candidates.add(os.path.realpath(probe))
-    except OSError:
-        pass
+        candidates |= _resolved_forms_bounded(probe)
+    except PathResolutionStalled:
+        return True
     return any(candidate.casefold() in targets for candidate in candidates)
 
 

--- a/test/test_executors.py
+++ b/test/test_executors.py
@@ -76,6 +76,29 @@ def test_pools_execute_work() -> None:
     assert ex.cron_executor().submit(lambda: 2 + 3).result(timeout=5) == 5
 
 
+def test_path_resolve_pool_is_isolated_bounded_named_and_reset() -> None:
+    # The sensitive-path gates' realpath used to run inline on the event loop and
+    # could block in the kernel on a stalled automount for as long as the mount
+    # did.  The caller now bounds its wait, but a timed-out future does NOT free
+    # its thread -- so a wedged lstat must only ever be able to starve OTHER
+    # path resolution, never the sweeps, teardown, or the default executor.
+    pool = ex.path_resolve_executor()
+    assert pool is ex.path_resolve_executor()
+    for other in (
+        ex.maintenance_executor(),
+        ex.subprocess_executor(),
+        ex.cron_executor(),
+        ex.discovery_executor(),
+        ex.governance_executor(),
+    ):
+        assert pool is not other
+    assert pool._max_workers == ex._MAX_PATH_RESOLVE_WORKERS
+    assert pool._thread_name_prefix == "mc-pathres"
+    assert pool.submit(lambda: 6 * 7).result(timeout=5) == 42
+    ex.shutdown_maintenance_executor()
+    assert ex.path_resolve_executor() is not pool
+
+
 def test_governance_pool_is_isolated_bounded_and_reset() -> None:
     # GPT round-7 pass 3: the governance pool (externally-paced inbound channels
     # gate + dashboard governance GETs) must be a DISTINCT, bounded, shutdown-

--- a/test/test_security_path_resolve_bounded.py
+++ b/test/test_security_path_resolve_bounded.py
@@ -1,0 +1,337 @@
+"""The sensitive-path gates must never block the event loop on a stalled mount.
+
+Field report (macOS, 0.6.x): ten identical watchdog crash dumps, the loop
+parked in ``posixpath._joinrealpath`` under ``on_tool_call ->
+is_sensitive_bash_command -> ... -> _candidate_forms``.  The tool call was
+``ssh host 'cd /home/<user>/ws && ...'``; the gate ``realpath``'d the REMOTE
+path token locally, ``/home`` on macOS is an autofs map answered by
+opendirectoryd, and the directory server was unreachable during a VPN
+transition -- so ``lstat`` blocked in the kernel for longer than the watchdog
+budget.  No exception, so the ``except OSError`` never fired.  Widening the
+watchdog budget from 25s to 90s only moved the crash.
+
+These tests pin the fix: resolution is bounded; a stall is FAIL-CLOSED (the
+gate refuses the path rather than matching its lexical spelling, so a
+workspace symlink into a credential store cannot ride a stall); the cooldown a
+stall opens is scoped to the stalled path prefix, so one wedged mount costs
+one timeout per window without switching resolution off anywhere else; and a
+resolution that merely FAILS (OSError) still falls back to the lexical forms,
+which must fence a symlinked ``$HOME`` by its logical spelling.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Iterator
+
+import pytest
+
+import kiro_crew.executors as ex
+from kiro_crew import security
+
+
+@pytest.fixture(autouse=True)
+def _fresh_resolver_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(security, "_path_resolve_degraded", {})
+    monkeypatch.setattr(security, "_path_resolve_wedged", [])
+    # Short budgets keep the stall tests fast; the production values are pinned
+    # separately below.
+    monkeypatch.setattr(security, "_PATH_RESOLVE_TIMEOUT_SECS", 0.2)
+    monkeypatch.setattr(security, "_PATH_RESOLVE_COOLDOWN_SECS", 30.0)
+    yield
+    # A stubbed resolver may still hold an mc-pathres worker; drop the pool so
+    # the wedge cannot leak into the next test's timing.
+    ex.shutdown_maintenance_executor()
+
+
+class _StalledResolver:
+    """Stands in for ``os.path.realpath`` on a wedged automount: never returns
+    until released, raises nothing."""
+
+    def __init__(self) -> None:
+        self.release = threading.Event()
+        self.calls: list[str] = []
+        self._lock = threading.Lock()
+
+    def __call__(self, expanded: str) -> set[str]:
+        with self._lock:
+            self.calls.append(expanded)
+        self.release.wait()
+        return {expanded}
+
+
+def test_symlink_alias_is_still_resolved_on_a_healthy_filesystem(tmp_path) -> None:
+    # The whole point of the resolved forms is defeating a link bypass; bounding
+    # the wait must not cost that on a filesystem that answers.
+    target = tmp_path / "real"
+    target.mkdir()
+    link = tmp_path / "alias"
+    link.symlink_to(target, target_is_directory=True)
+    forms = security._candidate_forms(str(link / "id_rsa"))
+    assert str(target / "id_rsa") in forms
+    assert str(link / "id_rsa") in forms  # the lexical form is kept alongside
+
+
+def test_a_stalled_resolution_is_refused_within_the_budget(monkeypatch) -> None:
+    stalled = _StalledResolver()
+    monkeypatch.setattr(security, "_resolved_spellings", stalled)
+    try:
+        started = time.monotonic()
+        with pytest.raises(security.PathResolutionStalled) as info:
+            security._candidate_forms("/home/someone/ws/../ws/file")
+        elapsed = time.monotonic() - started
+    finally:
+        stalled.release.set()
+    # Bounded: well under a second against a 0.2s budget, where the unbounded
+    # call would have sat for as long as the mount did.
+    assert elapsed < 1.5, f"caller blocked {elapsed:.2f}s on a stalled resolver"
+    assert info.value.prefix == os.path.normpath("/home/someone")
+    assert len(stalled.calls) == 1
+
+
+def test_every_gate_fails_closed_on_a_stall(monkeypatch) -> None:
+    # A path whose canonical form is unknown is REFUSED, never matched on its
+    # lexical spelling: that is what keeps a stall from being a lever for a
+    # workspace symlink into a credential store.
+    stalled = _StalledResolver()
+    monkeypatch.setattr(security, "_resolved_spellings", stalled)
+    try:
+        token = "/home/someone/ws/README.md"
+        assert security.is_sensitive_path(token)
+        assert security.is_sensitive_write_path(token)
+        assert security.path_contains_sensitive("/home/someone/ws")
+        assert security._is_keystone_publish_artifact("/home/someone/ws/x.tmp")
+        assert security._dir_holds_sensitive_leaf("/home/someone/ws")
+    finally:
+        stalled.release.set()
+
+
+def test_the_cooldown_is_scoped_to_the_stalled_prefix(monkeypatch, tmp_path) -> None:
+    # One bash command can carry many path tokens against the SAME wedged mount:
+    # paying the full timeout per token would put the loop straight back past
+    # the watchdog, so after the first timeout its siblings must be refused for
+    # free.  But the refusal must stop at that mount -- a stall on the remote
+    # half of an ssh command must not switch resolution off for the local
+    # workspace, which is exactly where a bypass symlink would live.
+    clock = [1000.0]
+    monkeypatch.setattr(security, "_path_resolve_clock", lambda: clock[0])
+    real_resolver = security._resolved_spellings
+    stalled = _StalledResolver()
+    monkeypatch.setattr(security, "_resolved_spellings", stalled)
+    try:
+        with pytest.raises(security.PathResolutionStalled):
+            security._candidate_forms("/home/a/one")  # times out -> opens cooldown
+        assert len(stalled.calls) == 1
+        for token in ("/home/a/two", "/home/a/deeper/three"):
+            started = time.perf_counter()
+            with pytest.raises(security.PathResolutionStalled):
+                security._candidate_forms(token)
+            assert time.perf_counter() - started < 0.05, "cooldown must not touch the pool"
+        assert len(stalled.calls) == 1, "no resolution may be attempted under the cooldown"
+    finally:
+        stalled.release.set()
+
+    # A different prefix is untouched by the cooldown: resolution still runs,
+    # and on a healthy filesystem a symlink there still resolves to its target.
+    monkeypatch.setattr(security, "_resolved_spellings", real_resolver)
+    target = tmp_path / "creds"
+    target.write_text("k")
+    link = tmp_path / "link"
+    link.symlink_to(target)
+    assert str(target) in security._candidate_forms(str(link))
+
+    # Past the cooldown the stalled prefix is tried again (once the released
+    # worker has actually returned, so a free worker exists for the re-probe).
+    deadline = time.monotonic() + 5
+    while security._wedged_workers() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    stalled2 = _StalledResolver()
+    monkeypatch.setattr(security, "_resolved_spellings", stalled2)
+    try:
+        clock[0] += security._PATH_RESOLVE_COOLDOWN_SECS + 1
+        with pytest.raises(security.PathResolutionStalled):
+            security._candidate_forms("/home/a/four")
+        assert len(stalled2.calls) == 1
+    finally:
+        stalled2.release.set()
+
+
+def test_stall_prefix_is_two_components() -> None:
+    assert security._stall_prefix("/home/user/ws/file") == os.path.normpath("/home/user")
+    assert security._stall_prefix("/Volumes/share/x/y") == os.path.normpath("/Volumes/share")
+    assert security._stall_prefix("/tmp") == os.path.normpath("/tmp")
+    assert security._stall_prefix("rel/path/file") == os.path.normpath("rel/path")
+
+
+def test_unc_paths_are_recognised_in_both_spellings() -> None:
+    assert security._is_unc_path("\\\\server\\share\\project\\readme.md")
+    assert security._is_unc_path("//server//share//project//readme.md")
+    assert not security._is_unc_path("/home/user/file")
+    assert not security._is_unc_path("C:\\Users\\user\\file")
+    assert not security._is_unc_path("/")
+
+
+def test_unc_paths_are_never_probed_on_windows(monkeypatch) -> None:
+    # On Windows realpath() on a UNC path is a network round-trip to the named
+    # host; a dead host would stall and, fail-closed, refuse an ordinary share
+    # reference.  Surfaced by main's own Windows test that expects
+    # ``Get-Content \\\\server\\share\\...`` to stay allowed.  UNC tokens are
+    # matched lexically and never handed to the resolver.
+    monkeypatch.setattr(security, "_ON_WINDOWS", True)
+    stalled = _StalledResolver()
+    monkeypatch.setattr(security, "_resolved_spellings", stalled)
+    try:
+        token = "//server//share//project//readme.md"
+        forms = security._candidate_forms(token)
+        assert forms == {os.path.normpath(token), token}
+        assert not security.is_sensitive_path(token)
+        assert stalled.calls == []
+    finally:
+        stalled.release.set()
+
+
+def test_repeated_stalls_back_off_exponentially_and_recovery_resets(monkeypatch) -> None:
+    # A mount that stays dead is probed rarely, not every 30s: each re-probe
+    # that stalls doubles the refusal window up to the cap.  Once the mount
+    # answers again the history is dropped so a later stall starts small.
+    clock = [1000.0]
+    monkeypatch.setattr(security, "_path_resolve_clock", lambda: clock[0])
+    base = security._PATH_RESOLVE_COOLDOWN_SECS
+    monkeypatch.setattr(security, "_PATH_RESOLVE_COOLDOWN_MAX_SECS", base * 4)
+    stubs: list[_StalledResolver] = []
+    try:
+        expected = [base, base * 2, base * 4, base * 4]  # capped at the fourth
+        for n, want in enumerate(expected, start=1):
+            stub = _StalledResolver()
+            stubs.append(stub)
+            monkeypatch.setattr(security, "_resolved_spellings", stub)
+            with pytest.raises(security.PathResolutionStalled):
+                security._candidate_forms("/home/user/x")
+            until, stalls = security._path_resolve_degraded[os.path.normpath("/home/user")]
+            assert stalls == n
+            assert until == pytest.approx(clock[0] + want)
+            # Release THIS stall so the worker is free again, then step past
+            # the window: the next iteration is a genuine re-probe.
+            stub.release.set()
+            deadline = time.monotonic() + 5
+            while security._wedged_workers() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert security._wedged_workers() == 0
+            clock[0] = until + 1
+        # Recovery: a resolution that completes clears the history.
+        monkeypatch.setattr(security, "_resolved_spellings", lambda e: {e})
+        security._candidate_forms("/home/user/x")
+        assert os.path.normpath("/home/user") not in security._path_resolve_degraded
+    finally:
+        for stub in stubs:
+            stub.release.set()
+
+
+def test_a_known_stalled_prefix_is_not_reprobed_onto_the_last_free_worker(
+    monkeypatch, tmp_path
+) -> None:
+    # A timed-out worker is never reclaimed.  With two workers, re-probing a
+    # dead mount every cooldown would pin the second within two cycles and
+    # leave every healthy path queueing behind wedged futures -- the per-prefix
+    # isolation would hold only while free workers remained.  So a prefix with
+    # a stall history is re-probed only while that leaves one worker free, and
+    # once every worker is pinned nothing is submitted at all.
+    assert security._MAX_PATH_RESOLVE_WORKERS == 2
+    clock = [1000.0]
+    monkeypatch.setattr(security, "_path_resolve_clock", lambda: clock[0])
+    real_resolver = security._resolved_spellings
+    first = _StalledResolver()
+    second = _StalledResolver()
+    try:
+        monkeypatch.setattr(security, "_resolved_spellings", first)
+        with pytest.raises(security.PathResolutionStalled):
+            security._candidate_forms("/home/user/x")  # worker 1 pinned
+        assert security._wedged_workers() == 1
+        clock[0] += security._PATH_RESOLVE_COOLDOWN_SECS + 1
+        # Re-probe would pin the last free worker: refused without a submit,
+        # and NOT charged as a stall -- nothing was observed, so the backoff
+        # stays where the real stall left it.
+        with pytest.raises(security.PathResolutionStalled):
+            security._candidate_forms("/home/user/y")
+        assert len(first.calls) == 1
+        assert security._path_resolve_degraded[os.path.normpath("/home/user")][1] == 1
+        # The free worker still serves a healthy prefix.
+        monkeypatch.setattr(security, "_resolved_spellings", real_resolver)
+        target = tmp_path / "creds"
+        target.write_text("k")
+        link = tmp_path / "link"
+        link.symlink_to(target)
+        assert str(target) in security._candidate_forms(str(link))
+        # A SECOND dead mount may take the last worker (no history yet) ...
+        monkeypatch.setattr(security, "_resolved_spellings", second)
+        with pytest.raises(security.PathResolutionStalled):
+            security._candidate_forms("/net/other/z")
+        assert security._wedged_workers() == 2
+        # ... after which a fresh prefix is refused immediately rather than
+        # queued behind two wedged futures: nothing reaches the resolver.
+        started = time.perf_counter()
+        with pytest.raises(security.PathResolutionStalled):
+            security._candidate_forms("/srv/fresh/w")
+        assert time.perf_counter() - started < 0.05
+        assert len(second.calls) == 1
+        # ... and that healthy prefix is not charged a stall it never had, so
+        # it is served again the moment a worker frees up.
+        assert os.path.normpath("/srv/fresh") not in security._path_resolve_degraded
+    finally:
+        first.release.set()
+        second.release.set()
+
+
+def test_a_failed_resolution_still_falls_back_to_lexical_forms(monkeypatch) -> None:
+    # FAILURE (OSError inside the worker -> empty set) is not a STALL: it keeps
+    # the pre-existing lexical fallback and never refuses.
+    monkeypatch.setattr(security, "_resolved_spellings", lambda e: set())
+    token = "/home/someone/ws/../ws/README.md"
+    assert security._candidate_forms(token) == {os.path.normpath(token), token}
+    assert not security.is_sensitive_path(token)
+    assert security.is_sensitive_path("~/.aws/credentials")
+
+
+def test_symlinked_home_is_fenced_by_its_logical_spelling_when_resolution_fails(
+    monkeypatch, tmp_path
+) -> None:
+    # Found while writing these tests on a cloud desktop where
+    # ``/home/x -> /local/home/x``: the target set was anchored on the RESOLVED
+    # home only (the cache keys on resolved roots), so once the candidate could
+    # not be resolved, a key path spelled through the link matched nothing -- a
+    # fail-OPEN that predates the bound and was merely masked by candidate
+    # resolution always completing.  The logical spelling is now an anchor.
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    (real_home / ".ssh").mkdir()
+    (real_home / ".ssh" / "id_rsa").write_text("k")
+    link_home = tmp_path / "link-home"
+    link_home.symlink_to(real_home, target_is_directory=True)
+    # Path.home() reads HOME on POSIX and USERPROFILE on Windows; set both so
+    # the logical home is the link on every platform.
+    monkeypatch.setenv("HOME", str(link_home))
+    monkeypatch.setenv("USERPROFILE", str(link_home))
+    security._home_targets_cache.clear()
+    assert str(security._resolved_root_key()[0]) == str(real_home.resolve())
+
+    monkeypatch.setattr(security, "_resolved_spellings", lambda e: set())
+    try:
+        # Spelled through the LINK, unresolvable: must still be denied.
+        assert security.is_sensitive_path(str(link_home / ".ssh" / "id_rsa"))
+        # Spelled through the REAL home: denied as before.
+        assert security.is_sensitive_path(str(real_home / ".ssh" / "id_rsa"))
+        # And an ordinary file under either spelling stays allowed.
+        assert not security.is_sensitive_path(str(link_home / "ws" / "README.md"))
+    finally:
+        security._home_targets_cache.clear()
+
+
+def test_production_budgets_sit_under_the_watchdog(monkeypatch) -> None:
+    # The gate runs on the event loop.  Its one paid timeout per cooldown
+    # window has to land below the watchdog's 15s enrichment tier, with room
+    # for the rest of the tool call, or the fix merely narrows the crash.
+    monkeypatch.undo()
+    assert 0 < security._PATH_RESOLVE_TIMEOUT_SECS <= 5.0
+    assert security._PATH_RESOLVE_COOLDOWN_SECS >= 10.0


### PR DESCRIPTION
## Summary

`is_sensitive_path` / `is_sensitive_bash_command` run synchronously inside `on_tool_call` on the event loop and `realpath()`'d every agent-supplied path token inline. `realpath` `lstat`s each component; a component on a stalled automount blocks in the kernel for as long as the mount does. No exception is raised, so the surrounding `except OSError` never fired -- the call simply never returned, the loop wedged, and the stall watchdog dump-then-exited the gateway.

Field report (macOS, 0.6.x, 10 identical crash dumps): the loop parked in `posixpath._joinrealpath` under `_candidate_forms`. The tool call was `ssh host 'cd /home/<user>/ws && cr ...'`; the gate resolved the REMOTE path token locally, `/home` on macOS is an autofs map answered by opendirectoryd, and the directory server was unreachable during a VPN transition. Raising `dashboard.loop_stall_exit_after_secs` to 90 only moved the crash (post-90s dump: same frame, full 90s).

## Fix

- `executors.path_resolve_executor()`: a 2-worker `mc-pathres` pool of its own. A timed-out future does not free its thread, so a wedged `lstat` must only ever be able to starve other path resolution -- never the sweeps, PTY teardown, or the default executor's DNS.
- `security._resolved_forms_bounded()`: submits `realpath` / `Path.resolve` to that pool and waits at most `_PATH_RESOLVE_TIMEOUT_SECS` (2s). **A timeout is fail-closed**: it raises `PathResolutionStalled`, and every gate (`_path_in_home_dirs`, `_is_keystone_publish_artifact`, `path_contains_sensitive`, `_dir_holds_sensitive_leaf`) turns that into a refusal. It is deliberately not the lexical-only fallback the `OSError` path takes: that would make the degraded state a lever (stall one token under a wedged mount, then a workspace symlink into a credential store passes on its lexical spelling). A path whose canonical form cannot be established is refused, and the warning names why. The cost is a false refusal of paths under a wedged mount for the cooldown window, instead of a dead gateway.
- A timeout opens a 30s cooldown during which paths under the **same prefix** (`_stall_prefix`: first two components, i.e. the mount point) are refused without touching the filesystem, so one command carrying many tokens against one wedged mount costs one timeout rather than one per token (ten tokens at 2s would be back past the watchdog). The cooldown is scoped, never process-wide: a stall on `/home/<user>` leaves `/tmp` and the workspace fully resolved.
- A timed-out worker is never reclaimed, so a mount that **stays** dead must not be handed a fresh worker every cooldown until the pool is pinned and every healthy path queues behind wedged futures (Design Review's concern on the previous head). Repeat stalls under one prefix double the cooldown (cap 30 min), a prefix with a stall history is re-probed only while that leaves a worker free, and once every worker is pinned nothing is submitted at all. A resolution that completes clears the prefix's history.
- A UNC path (`\\\\server\\share`, either separator) is never probed on Windows: `realpath()` on it is a network round-trip to the named host, so a dead host would stall and, fail-closed, refuse an ordinary share reference (main's own Windows test expects `Get-Content \\\\server\\share\\...` to stay allowed). UNC tokens match lexically, the stance the mapped-drive fence already takes for a foreign drive letter.

## Second bug the new tests exposed

On a host where `$HOME` is itself a symlink (`/home/x -> /local/home/x`, the standard cloud-desktop layout), `_home_dir_targets` was anchored on the RESOLVED home only (the TTL cache keys on resolved roots). When candidate resolution FAILED (`OSError` -> lexical forms), a sensitive path spelled through the link matched nothing -- fail-open. The docstring promised "both the logical home and its realpath"; the cache refactor had silently dropped the logical one. `_resolved_root_key` now carries the unresolved `Path.home()` as a fourth anchor and the builder anchors on it too. This predates the bound and was masked only by candidate resolution always completing.

## Tests

`test/test_security_path_resolve_bounded.py`: healthy symlink still resolves; a stalled resolution is refused within the budget; every gate fails closed on a stall; the cooldown is scoped to the stalled prefix (a symlink under another prefix still resolves) and reopens after it; repeat stalls back off exponentially and recovery resets; a known-stalled prefix is not re-probed onto the last free worker; a failed resolution still falls back to lexical forms, which fence a symlinked `$HOME` by its logical spelling; production budgets sit under the watchdog's 15s tier. `test_executors.py`: the new pool is isolated, bounded, named and reset with the others.

Ran locally: the 142 test files touching the path gates / executors, mypy clean, flake8 / isort clean, and the baselined black / sync-io / encoding / sdk-boundary gates all pass on this diff.

## Pattern harvest

Rule candidate: sync-io-in-async gate -- flag `os.path.realpath` / `Path.resolve` / `os.stat` on a non-literal path reached from an event-loop hook (`on_tool_call` and the handlers it calls), not only inside `async def`. The existing gate scopes to `async def` bodies; this wedge sat in a plain `def` called synchronously from the loop, which is the same defect with a different spelling.

## Not in scope

The remaining `realpath` calls in `_home_dir_targets_uncached` / `_resolved_root_key` resolve `$HOME`, `KIROCREW_HOME` and `KIRO_HOME` -- operator-configured local roots, not agent tokens -- and stay inline.
