### PR TITLE
fix(dashboard): quarantine ownerless subagent replay

### DIFF
--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -180,6 +180,24 @@ SIDE_QUEUE_EVENT = "chat.side_queue"
 SIDE_KIND = "side"
 
 
+def _subagent_replay_has_owner(frame: object) -> bool:
+    """Whether a replay frame names the chat that owns the subagent.
+
+    ``spawn_run`` can continue in degraded mode when caller identity cannot be
+    resolved, leaving ``parent_session_key == ""``. Such a run is visible in the
+    global spawn inventory, but it has no session-scoped destination. Sending an
+    empty ``slot`` to a chat client is unsafe: older reducers interpreted it as
+    the currently active slot, so a fresh popout adopted unrelated agents.
+    """
+    if not isinstance(frame, dict):
+        return False
+    data = frame.get("data")
+    if not isinstance(data, dict):
+        return False
+    slot = data.get("slot")
+    return isinstance(slot, str) and bool(slot.strip())
+
+
 def build_subagent_snapshot(a: Any, *, now: float | None = None) -> dict:
     """Build the ``subagent_snapshot`` replay frame's ``data`` for one agent.
 
@@ -965,10 +983,18 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                         # replay writes to the socket directly, so it must
                         # apply the same check. Dashboard users pass through
                         # ``_ws_client_allowed`` unconditionally.
+                        #
+                        # Ownership is a separate prerequisite: an unresolved
+                        # parent produces ``slot: ''``. That run remains visible
+                        # through the global spawn inventory, but there is no
+                        # chat authorized to adopt it. Filter before batching so
+                        # even an older client with an empty-slot fallback never
+                        # receives the orphan as session-scoped state.
                         _replay = [
                             _f
                             for _f in _replay
-                            if state._ws_client_allowed(
+                            if _subagent_replay_has_owner(_f)
+                            and state._ws_client_allowed(
                                 ws, str(_f.get("type", "")), _f.get("data", {})
                             )
                         ]

--- a/test/test_subagent_snapshot_idle_secs.py
+++ b/test/test_subagent_snapshot_idle_secs.py
@@ -24,7 +24,7 @@ from types import SimpleNamespace
 # every green consumer uses, and keeps this file collectable when a
 # pytest-xdist worker imports it before any other dashboard module.
 import kiro_crew.dashboard.handlers  # noqa: F401
-from kiro_crew.dashboard.ws import build_subagent_snapshot
+from kiro_crew.dashboard.ws import _subagent_replay_has_owner, build_subagent_snapshot
 
 
 def _agent(**over):
@@ -135,3 +135,25 @@ def test_snapshot_requested_model_is_empty_string_when_unset():
     a = _agent(requested_model="")
     data = build_subagent_snapshot(a, now=1000.0)
     assert data["requested_model"] == ""
+
+
+def test_replay_accepts_a_frame_with_an_owning_slot():
+    frame = {"type": "subagent_snapshot", "data": {"id": "a1", "slot": "chat-7"}}
+    assert _subagent_replay_has_owner(frame) is True
+
+
+def test_replay_rejects_an_ownerless_snapshot():
+    """An unresolved parent must stay global instead of being adopted by the
+    active chat in an older frontend."""
+    frame = {"type": "subagent_snapshot", "data": {"id": "orphan", "slot": ""}}
+    assert _subagent_replay_has_owner(frame) is False
+
+
+def test_replay_rejects_malformed_frames_without_guessing_an_owner():
+    assert _subagent_replay_has_owner({"type": "subagent_snapshot"}) is False
+    assert _subagent_replay_has_owner({"type": "subagent_snapshot", "data": []}) is False
+    assert (
+        _subagent_replay_has_owner({"type": "subagent_snapshot", "data": {"slot": None}}) is False
+    )
+    assert _subagent_replay_has_owner({"type": "subagent_snapshot", "data": {"slot": 7}}) is False
+    assert _subagent_replay_has_owner(None) is False

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -4237,8 +4237,14 @@ const chatSlice = createSlice({
     },
     sseSubagentSnapshot(state, action: PayloadAction<{ id: string; slot: string; task: string; agent: string; model?: string; requested_model?: string; child_session?: string; streaming: string; last_tool: string; started: number; tool_count?: number; stalled?: boolean; idle_secs?: number }>) {
       const d = action.payload
-      if (isUnsafeKey(d.slot) || isUnsafeKey(d.id)) return
-      const subs = d.slot && d.slot !== state.activeSlot
+      // A snapshot without an owning slot is an orphan, not evidence that it
+      // belongs to whichever chat this browser happens to show. Popout windows
+      // cold-subscribe to the complete replay after activating their own slot;
+      // treating `slot: ''` as the active map made every such window adopt all
+      // unresolved-parent agents. Fail closed: ownerless runs remain available
+      // through the global spawn inventory, but never appear inside a chat.
+      if (!d.slot || isUnsafeKey(d.slot) || isUnsafeKey(d.id)) return
+      const subs = d.slot !== state.activeSlot
         ? (state.slotActivity[safeKey(d.slot)] ??= { toolLog: [], subagents: {} }).subagents
         : state.subagents
       const existing = subs[d.id]

--- a/website/src/store/subagentActivity.test.ts
+++ b/website/src/store/subagentActivity.test.ts
@@ -11,6 +11,7 @@ import chatReducer, {
   setActiveSlot,
   switchSlot,
   sseSubagentSpawn,
+  sseSubagentSnapshot,
   sseSubagentDone,
   sseSubagentQueued,
   selectSubagentActivityCount,
@@ -113,5 +114,38 @@ describe('sseSubagentQueued on partial preloaded state', () => {
     store.dispatch(setActiveSlot('a'))
     expect(() => store.dispatch(sseSubagentQueued({ slot: 'a', queued: 2 }))).not.toThrow()
     expect(count(store)).toBe(2)
+  })
+})
+
+describe('subagent snapshot ownership', () => {
+  const snapshot = (slot: string) => sseSubagentSnapshot({
+    slot,
+    id: 'orphan-1',
+    task: 'read-only audit',
+    agent: 'kirocrew',
+    streaming: '',
+    last_tool: 'WorkspaceSearch',
+    started: 1000,
+  })
+
+  it('does not attach an ownerless replay snapshot to the active session', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('new-session'))
+
+    store.dispatch(snapshot(''))
+
+    expect(store.getState().chat.subagents).toEqual({})
+    expect(store.getState().chat.slotActivity['']).toBeUndefined()
+    expect(count(store)).toBe(0)
+  })
+
+  it('still routes a snapshot whose owner is the active session', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('owned-session'))
+
+    store.dispatch(snapshot('owned-session'))
+
+    expect(store.getState().chat.subagents['orphan-1']?.task).toBe('read-only audit')
+    expect(count(store)).toBe(1)
   })
 })

--- a/website/src/test/SubagentProgress.reducers.test.tsx
+++ b/website/src/test/SubagentProgress.reducers.test.tsx
@@ -10,9 +10,16 @@
  */
 import { describe, it, expect } from 'vitest'
 import { createTestStore } from './helpers'
-import { sseSubagentSpawn, sseSubagentTool, sseSubagentStalled, sseSubagentSnapshot } from '../store/chatSlice'
+import { setActiveSlot, sseSubagentSpawn, sseSubagentTool, sseSubagentStalled, sseSubagentSnapshot } from '../store/chatSlice'
 
 const ID = 'a1b2c3d4'
+const SNAPSHOT_SLOT = 'chat-subagent-progress'
+
+function snapshotStore() {
+  const store = createTestStore()
+  store.dispatch(setActiveSlot(SNAPSHOT_SLOT))
+  return store
+}
 
 function spawn(store: ReturnType<typeof createTestStore>) {
   const SLOT = store.getState().chat.activeSlot
@@ -79,8 +86,8 @@ describe('subagent progress reducers', () => {
   })
 
   it('sseSubagentSnapshot keeps the idle span across a reconnect', () => {
-    const store = createTestStore()
-    const SLOT = store.getState().chat.activeSlot
+    const store = snapshotStore()
+    const SLOT = SNAPSHOT_SLOT
     store.dispatch(sseSubagentSnapshot(snap({ slot: SLOT, stalled: true, idle_secs: 117 })))
     const a = sub(store)
     expect(a.stalled).toBe(true)
@@ -91,8 +98,8 @@ describe('subagent progress reducers', () => {
   })
 
   it('sseSubagentSnapshot leaves a healthy row without an idle span', () => {
-    const store = createTestStore()
-    const SLOT = store.getState().chat.activeSlot
+    const store = snapshotStore()
+    const SLOT = SNAPSHOT_SLOT
     store.dispatch(sseSubagentSnapshot(snap({ slot: SLOT, stalled: false, idle_secs: 117 })))
     const a = sub(store)
     expect(a.stalled).toBe(false)
@@ -104,8 +111,8 @@ describe('subagent progress reducers', () => {
     // The fallback wording must stay reachable: an older gateway sends
     // `stalled` with no span, and the row should say "no activity" rather than
     // "no activity for undefineds".
-    const store = createTestStore()
-    const SLOT = store.getState().chat.activeSlot
+    const store = snapshotStore()
+    const SLOT = SNAPSHOT_SLOT
     store.dispatch(sseSubagentSnapshot(snap({ slot: SLOT, stalled: true })))
     const a = sub(store)
     expect(a.stalled).toBe(true)


### PR DESCRIPTION
## Problem / Motivation

A newly created chat opened in a popout window can display subagents launched by an unrelated session. The popout correctly identifies the new chat, but a cold WebSocket replay can place ownerless subagent activity into that chat's active Redux bucket.

## Why it matters

The UI presents one session's work as belonging to another session and can expose internal task text in an unrelated chat surface. Session ownership must not be inferred from whichever browser tab happens to be active.

## What changed (motivation → approach → change)

The affected agents have an unresolved parent session, which the gateway replay encoded as `slot: ""`. The frontend snapshot reducer treated that empty value as the active foreground bucket.

This change fails closed at both boundaries:

- the gateway removes replay frames that do not carry a concrete string owner before per-client filtering and batching, while leaving those runs available through the global spawn inventory;
- the frontend snapshot reducer rejects an empty owner instead of using the active session as a fallback;
- focused tests cover owned, empty, null, numeric, and malformed slot values.

## Tests

- `pytest -q test/test_subagent_snapshot_idle_secs.py test/test_dashboard_state_ws.py` — 94 passed
- `vitest run src/test/SubagentProgress.reducers.test.tsx src/store/subagentActivity.test.ts src/test/chatSlice.test.ts` — 274 passed
- TypeScript project check — passed
- Changed-file ESLint — passed
- Black, isort, Flake8, and mypy — passed
- Production frontend build — passed
- `push_guard.py --base main --require-single-on-base` — passed

The repository-wide backend suite also completed 81,706 tests successfully but reported 170 pre-existing host-environment failures because this agent shell exposes the live data home, inherited shell-function variables, and `/local/home` ownership layout. None touched the changed ownership/replay tests; the isolated focused suites above are green on the final rebased SHA.

## Manual verification

The original report was traced against live persisted subagent records: every incorrectly displayed agent had an empty parent session. The screenshot path was reproduced conceptually through the cold popout replay sequence. The live gateway was intentionally not modified or restarted.

All current-head CI, coverage, packaging, portability, and automated review lanes passed on `4fe27e0d8c17657ac1ee92287179a1f6c72b9c63`; no unresolved review threads remain.

## Screenshots / video

![Redacted reproduction: new session popout displaying unrelated subagents](https://github.com/user-attachments/assets/545759b3-8005-46da-9fe0-7ab792e3248b)

## Related Issues

Fixes #8018

## Pattern harvest

Rule candidate: review-prompt
Pattern: A session-scoped event with an unresolved owner must be quarantined, never assigned to the currently active session.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — behavior is internal ownership routing and is covered by code comments and regression tests)
- [x] No secrets, credentials, or internal references in the diff
