### PR TITLE
perf(test): route walk-tests through shared AST corpus

### DIFF
--- a/test/source_corpus.py
+++ b/test/source_corpus.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import ast
 import functools
+import unicodedata
 from collections.abc import Iterator, Sequence
 from pathlib import Path
 
@@ -78,6 +79,30 @@ def unreadable_files() -> tuple[Path, ...]:
     return _read_tree()[1]
 
 
+def _nfkc(text: str) -> str:
+    """NFKC-normalise, matching how CPython folds identifiers at parse time."""
+    return unicodedata.normalize("NFKC", text)
+
+
+@functools.lru_cache(maxsize=1)
+def _normalized_texts() -> tuple[str, ...]:
+    """NFKC-normalised copy of every file's text, in ``source_texts`` order.
+
+    A gate matches on a bare identifier, and CPython NFKC-folds identifiers at
+    parse time -- so a call written with a Unicode compatibility homoglyph of a
+    guarded name (``delete_items_b\uff41tch``) is that ASCII name in the AST but
+    NOT in the raw bytes. Filtering on raw text would skip the file and let the
+    offender through green. Normalising the haystack (here) and the needle (in
+    ``candidate_sources``) the same way closes that hole while keeping the
+    narrowing: NFKC is a fixpoint on ASCII, so every raw ASCII match is
+    preserved and only homoglyph spellings are newly caught. Computed once over
+    the whole tree (~0.3s) and cached, like the read itself. ``source_texts``
+    still returns the RAW text, which gates that scan comments or string
+    literals (a ``# render-ok`` marker, an import alias) depend on.
+    """
+    return tuple(_nfkc(text) for _path, text in source_texts())
+
+
 def candidate_sources(
     require_all: Sequence[str] = (),
     require_any: Sequence[str] = (),
@@ -87,11 +112,18 @@ def candidate_sources(
     An empty ``require_any`` imposes no alternation, so passing neither argument
     returns the whole corpus.
     """
+    # Match on the NFKC-normalised text with NFKC-normalised needles, so a call
+    # whose identifier is a Unicode compatibility homoglyph of a literal (which
+    # CPython folds to that literal at parse time, making it a real AST match) is
+    # not skipped by a raw-byte pre-filter. The yielded ``text`` stays RAW.
+    all_n = tuple(_nfkc(lit) for lit in require_all)
+    any_n = tuple(_nfkc(lit) for lit in require_any)
+    texts = source_texts()
+    norm = _normalized_texts()
     return tuple(
         (path, text)
-        for path, text in source_texts()
-        if all(lit in text for lit in require_all)
-        and (not require_any or any(lit in text for lit in require_any))
+        for (path, text), ntext in zip(texts, norm)
+        if all(lit in ntext for lit in all_n) and (not any_n or any(lit in ntext for lit in any_n))
     )
 
 

--- a/test/test_knowledge_delete_off_loop.py
+++ b/test/test_knowledge_delete_off_loop.py
@@ -21,11 +21,11 @@ from __future__ import annotations
 import ast
 import asyncio
 import json
-import pathlib
 import threading
 from unittest.mock import MagicMock
 
 import pytest
+from source_corpus import parsed_candidates, src_root
 
 from kiro_crew.knowledge.folder_watcher import FolderWatcher
 from kiro_crew.knowledge.store import KnowledgeStore
@@ -35,7 +35,7 @@ from kiro_crew.knowledge.store import KnowledgeStore
 # repo's other on-loop guards use.
 _NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
 
-_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+_SRC = src_root()
 
 
 def _called_names(body: list[ast.stmt]) -> set[tuple[str, int]]:
@@ -101,11 +101,11 @@ def _on_loop_call_sites(name: str) -> list[str]:
     reaches it (see ``_sync_helpers_reaching``).
     """
     found: list[str] = []
-    for path in sorted(_SRC.rglob("*.py")):
-        try:
-            tree = ast.parse(path.read_text(errors="replace"))
-        except SyntaxError:  # pragma: no cover - syntax is enforced elsewhere
-            continue
+    # Only files whose TEXT holds ``name`` can call it (directly, or through a
+    # same-module sync helper that does), so the shared corpus parses just those
+    # instead of re-walking all ~1250 modules for this gate. ``src_root()`` is the
+    # same tree the old ``_SRC`` named, so the relative paths below are unchanged.
+    for path, _text, tree in parsed_candidates(require_all=(name,)):
         indirect = _sync_helpers_reaching(tree, name)
         for fn in (n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)):
             for called, lineno in sorted(_called_names(fn.body), key=lambda c: c[1]):

--- a/test/test_slack_render_pipeline.py
+++ b/test/test_slack_render_pipeline.py
@@ -53,6 +53,7 @@ import re
 import tokenize
 
 import pytest
+from source_corpus import parsed_candidates
 
 from kiro_crew.slack.format import (
     CONTINUATION,
@@ -174,10 +175,15 @@ def find_violations(source: str, path: str = "<source>") -> list[tuple[str, int,
 
 def collect_repo_violations() -> list[tuple[str, int, str]]:
     """Scan every ``kiro_crew/**/*.py`` except the owning module."""
-    root = _src_root()
-    base = root.parent
+    base = _src_root().parent
     out: list[tuple[str, int, str]] = []
-    for py in sorted(root.rglob("*.py")):
+    # A direct call to to_slack_mrkdwn -- bare-imported or reached as
+    # ``<module>.to_slack_mrkdwn`` -- can only exist in a file whose TEXT holds the
+    # literal ``to_slack_mrkdwn`` (the import that binds the alias, or the attribute
+    # call itself), so the shared corpus parses just those files rather than
+    # re-walking the whole package for this one gate. Narrowing on the literal
+    # drops non-matches only (proved lossless in the PR body).
+    for py, text, _tree in parsed_candidates(require_all=(_BANNED_FUNC,)):
         try:
             rel = str(py.relative_to(base))
         except ValueError:  # pragma: no cover - defensive
@@ -185,11 +191,7 @@ def collect_repo_violations() -> list[tuple[str, int, str]]:
         if rel.replace("\\", "/").endswith(_OWNER_MODULE):
             continue
         try:
-            src = py.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):  # pragma: no cover - defensive
-            continue
-        try:
-            out.extend(find_violations(src, rel))
+            out.extend(find_violations(text, rel))
         except SyntaxError:  # pragma: no cover - defensive
             continue
     return out


### PR DESCRIPTION
## Problem

~49-62 test files each independently walk the whole `src/kiro_crew` tree (`Path.rglob("*.py")` -> `read_text` -> `ast.parse`) on every scan, re-parsing ~1250 modules per gate. `test/source_corpus.py` already exists to fix this -- one cached `rglob`+`read_text`, with `parsed_candidates(require_all=(literal,...))` yielding `(path, text, tree)` narrowed to files whose text holds the literals a gate can only match on -- but only ~5 files use it.

This is a **conservative** first migration: two clean, provably-lossless walkers. It deliberately does not attempt all ~60 files at once (each has different exclusions/patterns and per-file soundness risk).

## Files migrated

### `test/test_knowledge_delete_off_loop.py`
`_on_loop_call_sites(name)` now iterates `parsed_candidates(require_all=(name,))`. A call reaching `name` from an async body (directly, or via a same-module sync helper that calls it) can only exist in a file whose **text** contains the literal `name`, so the filter drops non-matches only. `_SRC` repointed to `source_corpus.src_root()` (same tree).

| scan | before | after |
|---|---|---|
| `delete_items_batch` | 14.97s | 1.23s |
| `_record_deduped_state` | 14.64s | 1.18s |
| `_resolve_old_item_ids` | 14.61s | 1.12s |

Whole-file suite: **38.11s -> 7.76s**.

### `test/test_slack_render_pipeline.py`
`collect_repo_violations()` now iterates `parsed_candidates(require_all=("to_slack_mrkdwn",))`. A direct `to_slack_mrkdwn` call -- bare-imported or reached as `<module>.to_slack_mrkdwn` -- can only exist in a file whose **text** holds that literal (the binding import, or the attribute call itself). `find_violations` is fed the corpus text (no second read).

`test_no_module_converts_slack_markdown_directly`: **14.47s -> 1.06s**.

## Lossless proof (per migrated scan, on the worktree tree the tests scan)

For each scan, the **old full-rglob walk result-set == the new corpus-narrowed result-set**, for the real target(s) AND a high-call-count **probe** symbol chosen so an unsound narrowing would drop offenders:

| scan | target(s) old==new | probe(s) old==new |
|---|---|---|
| pilot | `_record_deduped_state` 0==0, `delete_items_batch` 0==0, `_resolve_old_item_ids` 0==0 | `append` 1417==1417, `get` 6915==6915, `info` 850==850, `close` 308==308 |
| slack | `to_slack_mrkdwn` 0==0 | `escape_mrkdwn` 6==6, `extract_options` 7==7, `render_for_slack` 7==7 |

The `get` probe at 6915 call sites proves the text-narrowing loses nothing even at scale.

## Red-before (per migrated file)

Injected a real violation the gate exists to catch and confirmed the **migrated** test still FAILS on it (proving the corpus-narrowed scan still sees offenders), then restored:

- **pilot**: a direct `self.store.delete_items_batch(item_ids)` in async `_handle_deleted` -> FAIL at `folder_watcher.py:823`.
- **slack**: a direct `to_slack_mrkdwn("x")` in `subagent.py` -> FAIL at `subagent.py:2466`.

## Files deliberately SKIPPED (follow-up, not migrated here)

- **`test/test_lazy_data_home_paths.py`** -- `_transitive_path_factories()` builds a transitive closure over Path-returning functions across the whole tree; the forbidden set is derived dynamically and a factory can be named anything, so there is **no single text literal that bounds the scan** without risking a dropped offender.
- **`test/test_cron_store_unreadable_boundaries.py`** -- `_read_decide_write_callers()` flags a function calling both a `_CRON_READS` name and a `_CRON_WRITES` name: `require_any` over two separate name sets (needs >=1 read AND >=1 write literal). Expressible in principle but higher soundness risk; held for a dedicated review.
- **`test/test_jsondecodeerror_redundancy_ratchet.py`** -- scans **three** roots (`src/kiro_crew`, `test`, `scripts`); the shared corpus only covers `src/kiro_crew`, so routing it through the corpus would silently shrink its scope.

The rule applied throughout: **correctness over coverage** -- a silently-narrowed gate that stops catching real violations is worse than a slow test, so a file is migrated only when its full-walk result set is proven identical to the corpus-narrowed one.

## Tests / gates

- Migrated files: 82 (pilot) + 13 (slack scan family) green; `test/test_source_corpus.py` guard suite green.
- isort clean, flake8 clean, black baseline gate passed (both files stay in the black baseline; formatting untouched).
- mypy shows 2 errors on `run_to_completion(lambda: None)` -- **pre-existing, identical to base**, not in the migrated code.

## Note

The corpus cache is **per-xdist-worker** (each worker parses once) -- the accepted existing tradeoff, unchanged here.

Do not merge -- review-ready.


---

## Update — GPT 5.6 BLOCKING finding addressed (commit 8b27e8f85)

**Finding (legitimate):** `parsed_candidates(require_all=(name,))` pre-filtered files by RAW TEXT, but CPython NFKC-folds identifiers at parse time. A src call written with a Unicode compatibility **homoglyph** of a guarded name — e.g. `delete_items_bａtch` (fullwidth `ａ`, U+FF41) or `to_slａck_mrkdwn` — is the ASCII name in the AST (a real offender) yet the raw literal is absent from the bytes, so the file was skipped and the gate passed green while the unsafe call shipped. Reproduced and confirmed.

**Fix (keeps the speedup, closes the hole, general to every corpus consumer):** `source_corpus.candidate_sources` now matches `require_all`/`require_any` against an **NFKC-normalized** view of each file's text with NFKC-normalized needles. The normalized view is computed once over the tree (~0.3s) and cached like the read. `source_texts()` still returns **raw** text — gates that scan comments/strings (`# render-ok`, import aliases) depend on that. NFKC is a fixpoint on ASCII and never removes/merges ASCII letters, so every raw ASCII match is preserved and only homoglyph spellings are newly caught. Chose this over GPT's suggested "drop the text-filter" because it closes the hole **and** keeps the narrowing.

**Loses nothing (re-proved on the worktree tree):** old raw full-walk result-set == new normalized corpus-narrowed set, for targets AND high-call probes: `append` 1417==1417, `get` 6915==6915, `info` 850==850, `close` 308==308; slack `escape_mrkdwn` 6==6, `extract_options` 7==7, `render_for_slack` 7==7.

**Unicode red-before (hole closed):** injected homoglyph offenders and confirmed the migrated tests now FAIL:
- `delete_items_bａtch` in async `_handle_deleted` → FAIL at `folder_watcher.py:823`
- `_fmt.to_slａck_mrkdwn(...)` in `subagent.py` → FAIL at `subagent.py:2467`

then restored. The ASCII red-befores still fail as before.

**Speedup preserved:** pilot scan ~1.0s, slack scan ~0.6s (the one-time NFKC is amortized across scans; baseline was 14–15s).

**Verification note:** all runs used `PYTHONPATH=<worktree>/src` — the `.venv` is an editable install whose `.pth` points at the MAIN checkout, but under pytest `kiro_crew` resolves to the worktree src both with and without that prefix (confirmed via `find_spec`); the prefix makes it explicit. Gates: isort/flake8/black clean; mypy clean on `source_corpus.py`; 96 tests green (`test_source_corpus.py` + both migrated suites).
