### PR TITLE
fix(voice): pin ffmpeg-macos-x86_64-v7.1 in the desktop ffmpeg allow-list

### DIFF
--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -134,6 +134,10 @@ _PACKAGED_FFMPEG_ARTIFACTS: dict[str, tuple[int, str]] = {
         49_368_728,
         "6d175a4743ca50256e89a8cdd731100f9cee33bd79aeea46894d209410dc6617",
     ),
+    "ffmpeg-macos-x86_64-v7.1": (
+        75_991_688,
+        "4a4a968b98859588e98500ae25973d80a5ca5eed0724222b9f76360dcb72a001",
+    ),
     "ffmpeg-linux-aarch64-v7.0.2": (
         51_134_160,
         "6bb182d0d75d23028db82e9e4f723ca69b853d055698486e6984ddb2c06fb8ce",
@@ -164,7 +168,9 @@ _PACKAGED_FFMPEG_ARTIFACTS: dict[str, tuple[int, str]] = {
 #   - a valid Developer ID signature from our own team on the exact bytes staged
 #     for execution, which is what a released app carries.
 # Neither anchor is a path or a filesystem-permission claim.
-_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS: frozenset[str] = frozenset({"ffmpeg-macos-aarch64-v7.1"})
+_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS: frozenset[str] = frozenset(
+    {"ffmpeg-macos-aarch64-v7.1", "ffmpeg-macos-x86_64-v7.1"}
+)
 
 # Upper bound on a signer-rewritten payload, whose exact size is unknowable in
 # source. Signing appends a code-signature superblob to a ~50 MB executable, so


### PR DESCRIPTION
## Problem / Motivation

Dictation fails on Intel Mac desktop builds with "The bundled audio decoder is missing or damaged." The bundled `ffmpeg-macos-x86_64-v7.1` binary inside the app is intact and runs correctly (confirmed: 76,604,752 bytes, executable, `ffmpeg version 7.1` runs fine), but `_PACKAGED_FFMPEG_ARTIFACTS` in `src/kiro_crew/transcribe.py` has no entry for it — only `ffmpeg-macos-aarch64-v7.1`, `ffmpeg-linux-aarch64-v7.0.2`, `ffmpeg-linux-x86_64-v7.0.2`, and `ffmpeg-win-x86_64-v7.1.exe` are pinned. Because of that, `_open_packaged_ffmpeg_resource()` never authenticates the Intel Mac binary and treats it as absent, so every dictation/transcription request on that platform fails closed with a generic "missing or damaged decoder" error.

## Why it matters

Every Intel Mac desktop user is affected: dictation and voice-memo transcription (dashboard push-to-talk, Slack voice memos) are completely broken on that platform, with no workaround available inside the desktop app itself (the code deliberately fails closed instead of falling back to an ambient system ffmpeg). Users are left with keyboard-only input or have to downgrade to an older release, run a second parallel gateway, or wait for a fix — none of which is a real substitute for the built-in feature working. The bug has been present since the allow-list was introduced and is still on `main`, not exclusive to any pre-release channel.

## What changed (motivation → approach → change)

**Symptom → root cause:** the "missing or damaged decoder" message is misleading — the binary isn't missing or damaged, it's simply not in the allow-list `_open_packaged_ffmpeg_resource()` checks against, so it's silently skipped and treated the same as if it didn't exist.

**Approach:** the aarch64 macOS artifact already solves the exact same problem (the code signer rewrites the binary's bytes on the way into a signed release, so a plain upstream digest pin can't authenticate the released artifact). The fix mirrors that existing, already-shipped pattern for the Intel artifact instead of inventing a new authentication path:

1. Add the corrected upstream `(size, sha256)` pin for `ffmpeg-macos-x86_64-v7.1` to `_PACKAGED_FFMPEG_ARTIFACTS` — `75_991_688` bytes, SHA-256 `4a4a968b98859588e98500ae25973d80a5ca5eed0724222b9f76360dcb72a001`. Taken from the `imageio_ffmpeg==0.6.0` macOS x86_64 wheel's own `RECORD` file (base64url digest `SkqWi5iFlYjphQCuJZc9gKXKXu0HJCIrn3Y2DctyoAE`, correctly padded and decoded — an earlier report of mine had this decoded wrong, dropping the last byte, corrected here) and independently cross-checked against the wheel published on PyPI.
2. Add `ffmpeg-macos-x86_64-v7.1` to `_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS`, since the macOS Developer ID signer rewrites this artifact's bytes the same way it rewrites the aarch64 one. Confirmed directly against an installed Intel Mac desktop build (`0.5.0-insider.9`): the signed binary on disk is 76,604,752 bytes with SHA-256 `1688889d9582aca6374bcf310c67864c8be68d9e9fc61f24939ca906ed1eda65` — neither value matches the upstream wheel, exactly the pattern already documented for aarch64. Without this second entry, the upstream pin alone authenticates a local/unsigned build but not a released, signed one, and the bug would persist for real users. With it, `_authenticated_ffmpeg()` falls through to `_macos_developer_id_authentic()` (Developer ID signature check) for the signed artifact, and to the upstream pin for an unsigned/local build — the same dual-anchor authentication the aarch64 artifact already gets.

## Tests

No new automated test was added. This module's ffmpeg authentication path (`_authenticated_ffmpeg`, `_open_packaged_ffmpeg_resource`) is exercised by macOS-signed-binary-dependent logic (`_macos_developer_id_authentic` calls `/usr/bin/codesign` against the actual signed artifact), which isn't something I can meaningfully unit-test outside a real signed Intel Mac desktop build — the existing aarch64 entry in `_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS` doesn't appear to have dedicated unit coverage either, from what I could find in this diff's neighborhood. I don't have write access to this repo to run its CI/build gate on the fork branch. See "Manual verification" below for what was actually exercised.

## Manual verification

- Confirmed the installed `ffmpeg-macos-x86_64-v7.1` binary inside a real Intel Mac desktop install (`0.5.0-insider.9`) is present, executable, and runs `ffmpeg -version` successfully (76,604,752 bytes).
- Independently fetched and decoded the upstream `imageio_ffmpeg==0.6.0` macOS x86_64 wheel's `RECORD` digest for this exact file, and cross-checked it against the wheel metadata published on PyPI (`https://pypi.org/pypi/imageio-ffmpeg/0.6.0/json`).
- Confirmed the size/SHA-256 mismatch between the signed installed binary and the upstream wheel, establishing that the second change (`_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS`) is necessary and not just the pin alone.
- Have not run this exact patched build end-to-end on the Intel Mac (I can't build/sign a full desktop release from this fork) — a maintainer with build access should confirm dictation actually succeeds on an Intel Mac with this change before merging.

## Screenshots / video

N/A — this is a backend authentication-logic fix with no UI surface.

## Related Issues

Fixes #8028

## Pattern harvest

Pattern: a per-platform authentication allow-list (`_PACKAGED_FFMPEG_ARTIFACTS` / `_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS`) silently omitting one platform variant fails closed with a generic, misleading error ("missing or damaged") instead of naming the real cause (not in the allow-list). Rule candidate: review-prompt — when a fix adds a new platform/artifact identifier to an existing per-platform allow-list or dispatch table, check whether every other platform variant produced by the same build matrix already has a corresponding entry, since a missing entry for a shipped artifact produces exactly this class of silent failure.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality — no new tests added; see "Tests" above for why, and manual verification performed in lieu of automated coverage
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs describe this allow-list
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — placeholder pending OSPO/Legal wording per the template; happy to sign once provided.
