### PR TITLE
docs(pipeline-conductor): promote the conductor's prose predicates into checks

### DIFF
--- a/docs/design/pipeline-conductor.md
+++ b/docs/design/pipeline-conductor.md
@@ -84,36 +84,118 @@ security invariants:
 ## The harness
 
 The `pipeline-conductor` skill is the operating procedure: idempotent pickup, the work-order brief
-(one item / one worktree / one PR, six-word report protocol), the probe cycle and its action
-table, independent green verification, the intervention ladder, the adjudication and override
-protocol, the resource-posture table, the credit budget rules, steering-as-mode-change, and merge
-cleanup. Two subprocess-free scripts do the bookkeeping:
+(one item / one worktree / one PR, six-prefix report protocol), the probe cycle and its action
+table, independent green verification, the intervention ladder, outage recovery and loop liveness,
+the adjudication and override protocol, the admission table, the credit budget rules,
+steering-as-mode-change, and merge cleanup. The design puts the bookkeeping in three
+subprocess-free scripts:
 
-- `scripts/fleet_probe.py` — one call per cycle: tail-classifies every worker session, computes
-  idle age, flags error tails, scans for banned processes, reads host load. Handled signals live
-  in a state file the script owns. All paths are derived, never configurable: transcripts only
-  from this gateway's own session store (keys are validated stems; a candidate resolving outside
-  the store — a symlink — reads as missing), state only beside the config file.
+- `scripts/claim_preflight.py` — one deterministic verdict per candidate item, from five checks in
+  one invocation: open PRs (fork PRs included), merged PRs tested for having actually landed on the
+  default branch, prose self-claims and closure requests in the body and last comment (a closure
+  request counting only from the reporter or a repository insider, since closing an item is a write
+  driven by ingested text), the named symbol's presence on the default branch, and a
+  recency/authorship risk flag. The verdict is a pure function of the checks, so every branch is
+  unit-testable, and the exit codes are the interface: `CLAIM` / `SKIP` / `CLOSE` / `UNKNOWN`, where
+  `UNKNOWN` is never reported as `CLAIM`. Two of those checks are deliberately non-vetoing: symbol
+  absence downgrades to a high-risk claim unless the item is corroborated as bug-class, because a
+  feature request names the symbol it proposes to add, and `risk=high` routes the item out of the
+  batch to its own live recheck rather than merely annotating the line.
+- `scripts/fleet_probe.py` — one call per cycle: tail-classifies every worker session, emits the
+  tail's message index, computes idle age, flags error tails, distinguishes a terminal report from
+  an idle one, scans for banned processes scoped to the fleet's own worktrees, and reads host load
+  plus per-cycle delivery counters. Handled signals live in a state file the script owns. All paths
+  are derived, never configurable: transcripts only from this gateway's own session store (keys are
+  validated stems; a candidate resolving outside the store — a symlink — reads as missing), state
+  only beside the config file.
 - `scripts/credit_spend.py` — per-item credit rollup with budget verdicts `within` / `exhausted` /
   `truncated` (a bounded scan never claims `within`) / `unmetered` (absent metering is unknown,
   not zero).
 
+The design rule the three share: **a decision expressed as prose in the skill rots silently, and a
+decision computed by a script can be tested.** Each script exists because a predicate the skill
+used to state in prose was found to be answering one question and treating an empty answer as
+permission.
+
 Decisions worth naming, in the skill's own sections:
 
+- **Claim**: the preflight's verdict plus a four-way collision check (open PR, merged PR already on
+  the base, branch, worktree), then an atomic claim — lock label and assignee in ONE call, because
+  two calls leave a window another operator dispatches into. A batch preflight orders the queue; a
+  per-item live recheck immediately before the claim is what authorizes it. An item that is open,
+  claimed and already fixed is triage debt: the verdict is close-with-evidence, not dispatch.
 - **Verification**: a worker's GREEN is never trusted — check-runs collapsed per lane (newest run
   wins), head SHA pinned, reviewer verdicts read from job logs and marker comments.
+- **Progress vs liveness**: the probe reports an absolute per-session message counter, and an
+  unchanged counter across two probes is no progress whether or not a turn is open. It is the one
+  discriminator a self-deadlocked worker cannot fake, and it moves the next step from checking
+  liveness to checking effect (did the artifact appear, did the remote head move). Absolute rather
+  than window-relative on purpose: a window-relative index saturates once a session outgrows the
+  tail bound and then reads as precisely the frozen counter the field exists to detect. It is also
+  free, because the bundled probe's tail read slices a file it has already loaded whole — so
+  `tail_bytes` caps how much is PARSED, not how much is read, which is worth stating because the
+  name and the setting's own description both suggest otherwise.
 - **Intervention**: nudge → a read-only inspector subagent (enforced via `allowed_tools`) →
   ruling: sharpened re-dispatch, adjudicate, open-issue descope, or reclaim. Two sessions on one
-  item: decide ownership once.
+  item: decide ownership once. A terminal report is closed out, never nudged — a monitor loop is
+  only correct while something external can still change.
 - **Adjudication**: overrides only when every lane is settled, the finding is the sole red, the
   head SHA is pinned, the rationale is public, and the branch is push-frozen after. A base-owned
-  red is proven three ways and fixed once for the whole fleet.
-- **Governance**: posture ladder ample/tight/critical → dispatch / hold admission / stop the
-  expensive items; banned-operation response is stop + cooldown + directive re-injection, acting
-  only on fleet-owned processes.
+  red is proven three ways and fixed once for the whole fleet. When review rounds keep reopening in
+  one function span, the convergent ruling is subtraction — consecutive rounds in one place indicate
+  one unwritten contract, not N mistakes.
+- **Governance**: delivery capacity is the primary admission instrument (below); the load/memory
+  ladder ample/tight/critical is secondary; banned-operation response is stop + cooldown +
+  directive re-injection, acting only on processes whose cwd is inside the fleet's worktree set.
 - **Budgets**: a per-item credit allowance (default 100). Exhaustion triggers a burn review —
   progressing items get a recorded top-up, thrashing items get stopped, not refilled; past the
   top-up ceiling the decision escalates to the human with the burn history.
+
+## Admission is sized on delivery, not on load
+
+The obvious instrument for admission is the host's load average and free memory, and at fleet scale
+it is the wrong one: the skill's admission section carries the causal claim and the posture table.
+What belongs here is the design consequence. Because the saturating resource is invisible to the
+instruments an operator reaches for first, the fix is not a better threshold on load but a DIFFERENT
+counter, which is why the probe had to grow one: an admission rule can only be as good as the
+cheapest signal that actually correlates with the ceiling. Load and memory stay in the ladder as a
+secondary check, because a memory-starved host is a real condition too; they are simply not the
+ceiling the fleet hits first.
+
+The same reasoning caps the conductor's own forge calls. A dozen worker babysit loops and the
+conductor all poll one account, so the conductor bounds its own PR sweeps per cycle, staggers them,
+prefers REST over GraphQL and search, and runs the greens sweep only when the human is actually
+approving. Rate limit is a shared, invisible resource, and the conductor is the only participant in
+a position to see the aggregate.
+
+## Conductor-owned state: `conductor-status/v1`
+
+The session ledger records the work items. It does not record the conductor's own obligations, and
+those turn out to be the ones that go missing, for a structural reason rather than a careless one:
+the probe deliberately does not re-fire a signal already marked handled, and that suppression is
+what keeps a quiet cycle at one line of output. A worker waiting on an adjudication therefore goes
+silent BY DESIGN, and the debt the conductor owes it becomes invisible. The probe tracks the fleet;
+nothing tracked the conductor.
+
+`conductor-status/v1` is that store. The skill defines its fields — as a schema, so a rewrite cannot
+quietly drop one; this document carries only why the two load-bearing ones exist. **`open_rulings`**
+(`{worker, pr, question, asked_at}`) is reviewed every cycle independently of what the probe fired,
+and an entry clears when the ruling is DELIVERED rather than when it is decided, because the silence
+it covers is the probe working correctly. **`last_index`** holds the previous cycle's probe index, so
+the no-progress test is a comparison against a recorded value rather than something the agent has to
+remember across a compaction. The rest of the file is bookkeeping the human's "where are the other N"
+question is answered from, plus the conductor's own task list; where it restates per-item state the
+ledger already holds, the ledger is authoritative and the status file is a one-cycle cache.
+
+Merge reconciliation follows from the same principle. It runs every cycle and **unfiltered** — one
+`gh pr list --author <me> --state all` call, explicitly limited and listing merges since a
+timestamp — rather than on a schedule against a hand-maintained set of PR numbers, because
+filtering the reconcile to the PRs already tracked reproduces the original defect one level down: a
+merge of a fleet PR that never made the watchlist cannot be seen by construction. The explicit
+limit matters for the same reason the filter does: the default page is 30 and an over-long list is
+trimmed silently, so a full page has to be read as truncation rather than as an answer.
+`mergeable=UNKNOWN` fanning out across the open PRs stays useful as a secondary trigger meaning
+"the base moved", never as the detector.
 
 ## The template: PipelineSpec
 
@@ -144,8 +226,10 @@ invariant stays out of the template: the forge is the cross-operator lock (claim
 
 - **M0** — the agent and the harness: the generated `kirocrew-pipeline-conductor` spec (installer,
   filename constant, roster hiding, docs registry, installer tests mirroring the existing
-  conductor's) and the `pipeline-conductor` builtin skill with its two scripts, behavior pinned by
-  tests (probe classification, handled-set suppression, key containment, budget verdicts).
+  conductor's) and the `pipeline-conductor` builtin skill with its three scripts, behavior pinned by
+  tests (claim verdict precedence, probe classification, handled-set suppression, key containment,
+  budget verdicts) and the skill's own contract pinned by tests over its text, so a rewrite cannot
+  silently drop a clause the scripts depend on.
 - **M1** — `PipelineSpec` file consumed by the scripts; SQLite event store (append-only `events`,
   `issues` as a fold, `decisions` first-class, `dispatch_id UNIQUE`); the board becomes a
   generated view.
@@ -168,3 +252,9 @@ invariant stays out of the template: the forge is the cross-operator lock (claim
    per-request token metrics work; budgets meanwhile bind what the shards see.
 4. **Digest surface**: chat today; a merge-queue/proposal-queue report page is an Auto Triage
    Pipeline app extension once the event store exists.
+5. **External watchdog on loop liveness.** An approval or transport outage kills every monitor loop
+   on the host, the conductor's patrol loop included, and the skill states that limit and closes what
+   procedure can close: recovery is a fleet-wide resume-and-re-arm sweep, and the re-arm is
+   conditional on there being something external left to watch. The residual hole needs a watcher
+   OUTSIDE the loop, which is a product capability rather than a skill clause — hence a decision
+   rather than a documentation gap.

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -5184,11 +5184,16 @@ worker's tail and its PR state and returns a verdict — spawn it with an
 not assumed of the prompt.
 
 **Scripts are the deterministic half of your loop.** Shell access exists to
-run the `pipeline-conductor` skill's two bundled scripts:
-`scripts/fleet_probe.py` (the ONE batch probe per patrol cycle — worker tails,
-idle age, error tails, banned-process scan, host load) and
-`scripts/credit_spend.py` (per-item credit rollups and budget verdicts). Read
-their output; never re-derive what they compute from transcripts.
+run the scripts the `pipeline-conductor` skill carries:
+`scripts/claim_preflight.py` (ONE verdict per candidate item before you dispatch
+it — CLAIM / SKIP / CLOSE / UNKNOWN, branched on the exit code, and UNKNOWN is
+never permission), `scripts/fleet_probe.py` (the ONE batch probe per patrol
+cycle — worker tails, tail index, idle age, error tails, banned-process scan,
+host load, delivery counters) and `scripts/credit_spend.py` (per-item credit
+rollups and budget verdicts). Read their output; never re-derive what they
+compute from transcripts. A script your install does not carry reads as UNKNOWN
+for the questions it answers — never as permission; the skill says what to do
+in that case.
 
 **Patrol with `monitor_start`, never with `wait`.** Arm it with the full cycle
 instructions AND the exit condition, then end the turn; call `autonudge_stop`
@@ -5214,9 +5219,11 @@ Your tools:
 - `tool_search` loads a tool that is not in your list yet.
 
 The `pipeline-conductor` skill carries the operating procedure — the pipeline
-spec, the work-order brief, the probe cycle and its action table, the
-intervention ladder, the adjudication and override protocol, the
-resource-posture table, the credit budget rules, and the cleanup steps. Read
+spec, the claim preflight, the work-order brief, the probe cycle and its action
+table, the intervention ladder, outage recovery and loop liveness, the
+adjudication and override protocol, the delivery-based admission table, the
+credit budget rules, the `conductor-status/v1` file that records your OWN
+obligations, and the cleanup steps. Read
 it before acting on a pipeline. The user can message you at any time: a
 steering message is a MODE CHANGE — fold it into the standing patrol
 instruction with `monitor_update` so every later cycle honors it.

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pipeline-conductor
-description: Operating procedure for the kirocrew-pipeline-conductor agent - run one issue/PR pipeline on one repository as a supervised fleet. Auto-pick items, stand up one worker session per item in a dedicated folder, probe them each cycle with one script call, verify claimed greens independently, intervene when a worker loops or stalls, adjudicate blocked items under the override protocol, throttle admission on host posture, enforce per-item credit budgets, digest verified greens to the human, and clean up on merge. Use when a pipeline conductor session is being seeded, or when inspecting/debugging one.
+description: Operating procedure for the kirocrew-pipeline-conductor agent - run one issue/PR pipeline on one repository as a supervised fleet. Auto-pick items, preflight every candidate to one deterministic claim verdict, stand up one worker session per item in a dedicated folder, probe them each cycle with one script call, verify claimed greens independently, intervene when a worker loops or stalls, adjudicate blocked items under the override protocol, throttle admission on delivery capacity, enforce per-item credit budgets, track the conductor's own obligations in a status file, digest verified greens to the human, and clean up on merge. Use when a pipeline conductor session is being seeded, or when inspecting/debugging one.
 ---
 
 # Pipeline Conductor
@@ -10,12 +10,21 @@ file edits, no builds, no fixes in your own turns. Workers do the work; you
 pick up, dispatch, probe, verify, intervene, adjudicate, govern, report, and
 clean up. Every rule below closes a named failure mode.
 
-Your two bundled scripts are the deterministic half of the loop — run them via
-`execute_bash`, read their output, never re-derive what they compute:
+The scripts below are the deterministic half of the loop — run them via
+`execute_bash`, read their output, never re-derive what they compute. Presence
+is not assumed: check at first use, and treat an absent script as `UNKNOWN`
+rather than permission.
 
+- `scripts/claim_preflight.py` — one verdict per candidate item before you
+  dispatch it: `CLAIM` / `SKIP` / `CLOSE` / `UNKNOWN`.
 - `scripts/fleet_probe.py` — batch worker-tail classification + idle age +
-  error tails + banned-process scan + host load, in ONE call per cycle.
+  error tails + banned-process scan + host load + delivery counters, in ONE
+  call per cycle.
 - `scripts/credit_spend.py` — per-item credit rollup + budget verdict.
+
+A decision this procedure states as prose rots silently; a decision a script
+computes can be tested. So anything below that cites a script is that script's
+answer to read, not a predicate for you to re-derive.
 
 ## The pipeline spec
 
@@ -49,7 +58,9 @@ spec file's directory is your working state home: write the probe config as
 2. Build the queue from the work source (or adopt the operator's seeded
    backlog). Record every item in the session ledger:
    `{item, state: queued, evidence}`.
-3. Arm the patrol: `monitor_start` (interval ~90s) with the standing
+3. Open your own status file beside the spec — `conductor-status/v1`, schema
+   below. The ledger tracks the items; the status file tracks YOU.
+4. Arm the patrol: `monitor_start` (interval ~90s) with the standing
    instruction below. **Patrol with `monitor_start`, never `wait`.** Call
    `autonudge_stop` yourself when the exit condition fires — coasting into the
    cycle cap is a failure, not a finish.
@@ -59,31 +70,221 @@ via `monitor_update`, see "Live steering"):
 
 > PROBE FIRST: one `fleet_probe.py --config <path>` call. Act only on 🔔/BANNED
 > lines: ERR → batch resume; PR → record; GREEN → verify independently then
-> digest + backfill; STANDDOWN/PROPOSAL → disposition + backfill; BLOCKED →
-> adjudicate; IDLE → intervention ladder. Mark each acted signal handled.
+> digest + backfill; STANDDOWN/PROPOSAL → disposition + backfill; TERMINAL →
+> close it out, never nudge; BLOCKED → adjudicate; IDLE → intervention ladder.
+> Diff each fired line's `i=` against the recorded one: unchanged index is no
+> progress. Mark each acted signal handled.
+> THEN, every cycle regardless of what fired: review `open_rulings` and deliver
+> any ruling still owed; run the unfiltered merge reconcile.
 > Check budgets on items with open sessions every ~5 cycles. Admission per the
-> posture table. Quiet cycle = one line, end turn. EXIT when queue empty and
-> fleet drained: final tally, then `autonudge_stop`.
+> delivery counters first, load/memory second. Quiet cycle = one line, end
+> turn. EXIT when queue empty and fleet drained: final tally, then
+> `autonudge_stop`.
+
+## Conductor-owned state: `conductor-status/v1`
+
+The ledger records the items. This file records **your own** obligations, and it
+is a schema rather than a convention — write it beside the spec, rewrite it
+whole each cycle:
+
+| Field | Holds |
+| --- | --- |
+| `schema` | `conductor-status/v1`. |
+| `updated_at`, `cycle`, `mode` | Last write, patrol cycle count, current mode (`dispatch`, `drain`, …). `mode` is where a steering message lands. |
+| `tally` | Dispatched total, merged, greens awaiting approve, items closed directly, stand-downs returned, skips. This is what answers the human's "where are the other N". |
+| `workers` | One entry per dispatched worker, carrying what the ledger does NOT: scope, branch, worktree, and `last_index` — the previous cycle's probe `i=`, which is what makes the no-progress test a comparison instead of something you have to remember. Item state, session key and PR are the **ledger's**, cached here only for one cycle's fleet view: when the two disagree the ledger wins and this file is what you fix. Two independent spellings of per-item state would drift, and the drift would be silent. |
+| `parked` | Items parked, each with the dependency that parked it, so a park is releasable rather than lost. |
+| `open_rulings` | `{worker, pr, question, asked_at}` — adjudications a worker is waiting on. |
+| `conductor_tasks` | Work that is yours and no worker's: closing the tracking item, filing a follow-up, the one unblocking base-owned PR. |
+| `events_tail` | Bounded, newest first: decisions and their reasons, one line each. |
+| `resource` | Last posture reading: delivery counters, load per CPU, memory available, banned count, posture. |
+
+**`open_rulings` is reviewed EVERY cycle, independently of what the probe
+fired**, and an entry clears only when the ruling has been DELIVERED — not when
+you decided it. The reason is structural, not a matter of diligence: the probe
+is right not to re-fire a signal already marked handled, and that suppression is
+exactly what keeps a quiet cycle quiet. So a worker on an escalation hold goes
+silent by design, and a debt you owe becomes invisible unless you keep your own
+list. The probe tracks the fleet; nothing but this file tracks you.
+
+**The list only works if something puts entries INTO it, and that takes two
+mechanisms — either alone still loses the debt.** The probe classifies from the
+newest protocol message, so:
+
+- `BLOCKED` must be **sticky across samples**. Otherwise a worker that reports
+  `BLOCKED`, then keeps reporting progress as its brief requires, has its
+  `WORKING` overwrite the `BLOCKED` before any sample sees it: the escalation
+  never fires, is never marked handled, and never reaches this file.
+- The worker must **keep the `BLOCKED:` prefix on every turn** while it is on an
+  escalation hold, and not switch back to `WORKING:` until the ruling is
+  delivered. Stickiness cannot recover a signal that was never emitted in the
+  first place.
+
+One is the probe refusing to forget; the other is the worker refusing to stop
+saying it. A debt survives only when both hold.
 
 ## Pickup and dispatch
 
-Dispatch is **idempotent** — all four checks, every time (skipping them is how
-two sessions end up on one item and mutual-yield deadlock):
+Dispatch is **idempotent** — every check, every time (skipping them is how two
+sessions end up on one item and mutual-yield deadlock):
 
 1. Ledger state is `queued` — anything else, skip.
 2. The backlog/findings store (when the pipeline has one) still says the item
    is open — a queue snapshot goes stale the moment it is built.
-3. No open PR, branch, or worktree already covers it (`gh pr list --search`,
-   branch glob from `branch_pattern`).
-4. In-flight count < `max_in_flight`, this cycle's dispatches <
-   `max_per_cycle`, and posture admits (see governance).
+3. `claim_preflight.py` returns `CLAIM` for the item (below). That verdict
+   replaces the old one-question "is there an open PR" predicate, which was
+   blind to a covering PR that already merged, to a claim written in prose, and
+   to target code that does not exist on the base yet. **If the script is absent
+   from your install** — an older build, or an install where it did not land —
+   that is `UNKNOWN` for every question only it can answer, and `UNKNOWN` is
+   never permission: answer the merged-PR and prose-claim arms yourself before
+   claiming (they are the two the old predicate missed), or park the item and
+   tell the operator the script is missing. Never fall through to a bare open-PR
+   search, which is the predicate this step exists to replace.
+4. The **four-way collision check**: no open PR, no merged PR already on
+   `{default_branch}`, no branch matching `branch_pattern`, no worktree at
+   `worktree_pattern`. The preflight answers the two PR arms; the branch and
+   worktree arms are local and yours.
+5. In-flight count < `max_in_flight`, this cycle's dispatches <
+   `max_per_cycle`, and admission admits (see governance).
 
-Then: `session_create` (titled `{id}: {item}`, filed into the pipeline
-folder), seed it with the work-order brief, record
-`{state: dispatched, session, ts}` in the ledger. Worker sessions must be
-granted **trust mode before seeding** — an unattended session stuck on an
-approval prompt runs zero turns; if you cannot grant it, tell the operator
-instead of seeding sessions that will hang.
+Then **claim atomically** — the lock label and the assignee in ONE call, never
+two. The forge is the cross-operator lock and your ledger is only a cache of
+it; a claim written as two calls is a window another operator dispatches into.
+Only after the claim lands: `session_create` (titled `{id}: {item}`, filed into
+the pipeline folder), seed it with the work-order brief, record
+`{state: dispatched, session, ts}` in the ledger.
+
+**The claim is only valid while a worker holds it.** If ANY post-claim step
+fails — session create refused, create rate limit hit, seed rejected, trust grant
+unavailable — unclaim before you move on, label and assignee both, exactly as you
+would on a stand-down. A claim with no session behind it is indistinguishable
+from work in progress to every other operator, and nothing later in the cycle
+looks for one: the ledger never recorded a dispatch, so no probe line, no SLA
+timer and no reclaim path covers it.
+
+On any stand-down, **unclaim promptly** — label and assignee both — and leave an
+evidence comment on the item. An item released silently reads as still-yours to
+the next operator, and an item disposed of with no evidence reads as abandoned
+rather than as decided.
+
+### Preflight: `claim_preflight.py`
+
+One call answers every cheap question about one candidate and returns ONE
+verdict. Branch on the exit code, never on the prose:
+
+```
+python3 scripts/claim_preflight.py --repo <owner/repo> --item <N> \
+    [--default-branch main] [--repo-dir <clone of the base>] [--json]
+```
+
+| Exit | Verdict | What you do |
+| --- | --- | --- |
+| 0 | `CLAIM` | Dispatch it. `risk=high` on the line means self-claim collision risk: that item is NOT batched — it goes to the live recheck on its own, immediately before claiming. |
+| 10 | `SKIP` | Covered, or not workable. Leave it alone; record the reason. |
+| 11 | `CLOSE` | Triage debt, not work. Close the item with the evidence the script printed. |
+| 2 | malformed | YOUR arguments or config are wrong. Fix the call — a bad call is not a verdict about the item. |
+| 3 | `UNKNOWN` | A check could not be answered (forge unreachable, rate limited). **Never treat this as permission.** Re-run it later or park the item. |
+
+Exit 3 is why the verdicts are exit codes at all: an unanswerable question is
+not a green light, and partial data yields `UNKNOWN` rather than `CLAIM`.
+
+Five checks run on every call, and the verdict is the FIRST match down this
+precedence list:
+
+1. `merged_prs` — a MERGED PR that CLAIMS TO CLOSE the item (a closing keyword
+   for this item in its title or body, not a bare cross-reference) whose merge
+   commit is an ancestor of `{default_branch}` → **CLOSE** `already-fixed`. Two
+   conditions, and both are load-bearing: a merged PR that did not land on the
+   base a worker would branch from is not coverage, and a merged PR that merely
+   MENTIONS the item is not closure. A mention decides nothing here — it is
+   neither CLOSE nor SKIP, so it falls through to the remaining checks, because
+   treating it as coverage closes live work and treating it as a claim starves an
+   item whose fix was only partial.
+2. `open_prs` — any open PR referencing it, **fork PRs included** → **SKIP**
+   `open-pr`.
+3. `prose_claim` — a closure request in the body or the last comment ("this is
+   resolved", "please close") **from the item's own reporter or a repository
+   insider** → **CLOSE** `reporter-asked-close`. The authorization condition is
+   load-bearing, not decoration: anyone can comment on a public item, closing one
+   is a WRITE, and this verdict would otherwise let ingested untrusted text drive
+   that write on an unattended cycle. A closure phrase from anybody else is not a
+   closure request — it falls through to the remaining checks.
+4. `prose_claim` — a self-claim ("I'm claiming this", "working on this") **from
+   the item's reporter or a repository insider** → **SKIP** `prose-claim`. A claim
+   written in prose is invisible to every label and field query that exists, which
+   is why it is scanned for rather than inferred. From anybody else it is NOT a
+   veto: annotate the item `risk=high` and let it take the live recheck instead.
+   The reason is that a veto anyone can cast is a denial-of-work channel — a
+   single comment would suppress a queued item indefinitely, and nothing in the
+   pipeline would ever report that it had been suppressed. Downgrading keeps the
+   collision protection where the claim is credible without handing an arbitrary
+   commenter a mute button.
+5. `symbol_on_base` — a symbol the item names is absent from
+   `{default_branch}`. **Absence alone is not a SKIP.** Corroborated as
+   bug-class, it is **SKIP** `symbol-absent`: the target code lives only on an
+   unmerged branch, so that is a park, not a dispatch. Uncorroborated it
+   downgrades to **CLAIM** `risk=high`, because a feature request names the
+   symbol it PROPOSES to add — vetoing on absence alone would permanently park
+   every item of that class.
+6. any check errored → **UNKNOWN**.
+7. otherwise → **CLAIM**, annotated with `risk` from the `recency` check (a
+   recently opened item from an active contributor is a high self-claim risk).
+
+**`risk=high` is a decision, not a note.** A high-risk `CLAIM` is NOT batched:
+it goes to the live per-item recheck immediately before the atomic claim, on its
+own. An annotation nothing acts on is the same defect as a prose predicate — it
+reads as caution and changes nothing.
+
+**A batch snapshot is never the authority.** Preflighting a batch is how you
+order a queue; a per-item live recheck immediately before the atomic claim stays
+mandatory, because coverage can appear in the seconds between the batch and the
+claim, and on a queue other operators work, it does.
+
+**An item that is open, claimed and already fixed is triage debt, not a work
+item.** Its verdict is CLOSE with the landing-commit evidence, and closing it IS
+the work. Dispatching a worker to rediscover that the work does not exist spends
+a whole session — create, seed, preflight, stand down, unclaim — to learn
+nothing, and leaves claim churn on a repository other operators are reading.
+
+### Dispatch mechanics
+
+- `session_create` MUST pass the worker agent explicitly. An unset agent binds
+  the worker to YOUR agent, which has no file-writing tool, and the entire batch
+  then refuses the work with a plausible-sounding explanation of why it cannot
+  edit files.
+- Validate with ONE canary dispatch before a batch. A wrong agent or a broken
+  brief costs one session that way, and the whole batch otherwise.
+- Respect the session-create rate limit: dispatch in small batches with other
+  work interleaved, never the whole queue at once.
+- Worker sessions must be granted **trust mode before seeding** — an unattended
+  session stuck on an approval prompt runs zero turns; if you cannot grant it,
+  tell the operator instead of seeding sessions that will hang.
+- Before commissioning a fix for a base-wide breakage, search open PRs for one
+  that already exists. Fleet-wide breakage is visible to the wider community
+  too, and two identical fixes waste a worker and a review lane.
+
+### Partitioning one change across several workers
+
+When one change is too large for one worker, split it by **exclusive file
+ownership**: every file belongs to exactly one worker, and nobody edits outside
+their own set — not a one-line mention, not a docstring cross-reference. Two
+workers on one file is the merge-conflict version of two sessions on one item.
+
+**Exclusive ownership removes merge conflicts. It does NOT remove a review-order
+dependency, and that is the trap.** A premise-level reviewer counts a
+mechanism's CONSUMERS in the base, so the PR that BUILDS a mechanism reads as
+dead code until the PR that WIRES it has landed: nothing in the base invokes it,
+the zero option is behaviorally identical, and the reviewer is right on the
+evidence available to it. So a partition ships with a **merge ORDER**: the wiring
+PR lands before or with the building PR.
+
+The remedy for a block of that shape is sequencing, and sequencing is YOURS. A
+worker must never move another worker's hunk into its own PR to satisfy a
+reviewer — that dissolves the ownership split, creates the conflict the split
+existed to prevent, and hides a review-order problem as a code change. Land the
+wiring PR; the same reviewer's own grep then finds the consumers and the block
+dissolves with neither PR changing content.
 
 ### The work-order brief (seed message skeleton)
 
@@ -99,42 +300,137 @@ Fill `{...}` from the spec; keep every clause — each one closes a failure mode
 > `PROPOSAL: <link>` (write the proposal on the item; do not build).
 > IMPLEMENT in your own worktree (`{worktree_pattern}`, branch
 > `{branch_pattern}` from `{default_branch}`): root-cause fix; regression test
-> red-on-base and mutation-verified; targeted tests ONLY — never the full
-> suite; `pytest` always with a bounded `-n`.
+> red-on-base and mutation-verified. TESTS: your own changed test files, BY
+> PATH, and nothing else. Name the ban rather than implying it — no `make test`,
+> no `tox`, no `nox`, no `run-tests`/`local-gate`/"run the gates" wrapper of any
+> kind: a wrapper that escalates to the full suite satisfies the letter of a
+> targeted-only brief. Pass `-n0` **explicitly** on every run: omitting `-n`
+> does not mean single process, it inherits whatever the project's pytest
+> `addopts` sets, and `-n auto` is a common default. Canonical line —
+> `timeout 900 python3 -m pytest -n0 <test file> -x -q </dev/null`. Do not
+> substitute a small `-n <N>`: xdist workers contend for scheduling and are what
+> starves under fleet load, and an explicit count also bypasses the memory
+> budget `auto` is put through.
+> REMOTES: `export GIT_TERMINAL_PROMPT=0` and confirm `gh auth setup-git` has
+> run before any push — a bare https push does not use the CLI's token and hangs
+> on an interactive prompt indefinitely. If a push exceeds ~2 minutes, time the
+> actual pre-push hook over the real payload before naming a cause: process
+> liveness cannot distinguish a credential prompt from a slow hook.
 > PR: English body (What/Why/How/Tests/Other), `Closes #{n}`, full URL in
-> your reply. Babysit to green (`monitor_start` ~300s). Fix every
+> your reply. Babysit to green (`monitor_start` ~300s, staggered off a round
+> number so a dozen loops do not poll in lockstep, preferring REST over
+> GraphQL/search — the whole fleet shares one account's rate limit). Fix every
 > Critical/High; disposition every advisory explicitly; read reviewer JOB
 > LOGS for the current head, not check conclusions; rebut with measurement,
-> never assertion; NEVER `/ai-review override` without the conductor's
+> never assertion; before re-running any CI job ask what the re-run REPLACES,
+> not what it retries; NEVER `/ai-review override` without the conductor's
 > sign-off — a blocking finding you dispute is `BLOCKED: <evidence + 2-4
 > options>`.
-> REPORT in exactly six words — `WORKING: / PR: / GREEN: / BLOCKED: /
-> STANDDOWN: / PROPOSAL:` — and RE-STATE the prefix on EVERY later turn while
-> this assignment is open (an unprefixed turn reads as "no status"). GREEN
-> must carry the PR URL, head SHA, and a 3-6 step plain-language summary.
+> REPORT with exactly one of six prefixes — `WORKING: / PR: / GREEN: /
+> BLOCKED: / STANDDOWN: / PROPOSAL:` — and RE-STATE the prefix on EVERY later
+> turn while this assignment is open (an unprefixed turn reads as "no status").
+> Write it as BARE leading text: no bold, no italics, no list marker, no
+> blockquote ahead of it. The tag is matched at the START of the message, so
+> `**BLOCKED:**` can read as no status — and it does so on the one message you
+> most need heard.
+> Once you report `BLOCKED:`, KEEP that prefix on every turn until the ruling
+> reaches you — do NOT switch back to `WORKING:` while you are on an escalation
+> hold. The conductor samples your newest protocol message, so a `WORKING:` line
+> posted after a `BLOCKED:` can overwrite the escalation before it is ever seen,
+> and the ruling you are waiting for is then owed by nobody.
+> GREEN must carry the PR URL, head SHA, and a 3-6 step plain-language summary.
 
 ## The probe cycle
 
 One `fleet_probe.py` call. Keep `probe-config.json`'s `sessions` list synced
 with the ledger's open sessions (add on dispatch, drop on close). Fired lines
-carry **metadata only** (key, age, tag, digest) — the probe never emits
-transcript text; when a ruling needs content, read the session through the
-workspace-authorized session tools. Action
-table — act, then `--mark-handled KEY TAG DIGEST` (DIGEST is the `d=` field on
-the fired line), or the signal re-fires forever. A stale digest is refused
-(exit 3): the payload moved on since you read it — re-probe and act on what is
-there now, never mark blind:
+carry **metadata only** — the probe never emits transcript text:
+
+```
+🔔 <key>  <age>s <TAG> i=<index> d=<digest12>
+BANNED pid=<pid> rule=<regex> cwd=fleet|unknown
+OK <n> watched, <m> fired | load/cpu <x> (ok|hot) | mem <n>G | banned <n> | foreign <n> | deliver init-timeout <a>, watchdog <b>
+```
+
+When a ruling needs content, read that one session through the
+workspace-authorized session tools. Act, then `--mark-handled KEY TAG DIGEST`
+(DIGEST is the `d=` field on the fired line), or the signal re-fires forever. A
+stale digest is refused (exit 3): the payload moved on since you read it —
+re-probe and act on what is there now, never mark blind.
+
+**Classification anchors at the START of a worker's message, and tolerates
+leading markdown.** A worker that writes `**BLOCKED:**` is following the protocol
+and must be read as blocked, so the classifier strips leading emphasis, list
+markers and blockquote marks before matching. That belongs in the probe rather
+than in the brief: a rule the worker has to remember fails exactly under the
+pressure that produces escalations, and the message that goes unseen is then the
+escalation itself. The brief asks for a bare prefix as well, but as the weaker
+half of the pair.
+
+`i=` is an **absolute per-session message counter, counted from the start of the
+transcript** — not an offset within the tail window. That distinction is the
+whole rule: a window-relative index saturates once a session grows past
+`tail_bytes` and then reads as a frozen number, which is exactly the
+no-progress deadlock the field exists to detect. Absolute counting costs nothing
+extra, because `tail_bytes` bounds how much of the file is PARSED, not how much
+is read from disk — the read loads the whole transcript either way. The index is
+carried into the handled-set entry as well, so the comparison is available next
+cycle without you having to hold it.
+
+**An unchanged index across two probes is no progress**, whether or not a turn
+is open — it is the one discriminator a self-deadlocked worker cannot fake,
+because producing a message is the thing it cannot do. When the index has not
+moved, check the EFFECT and never liveness: did the artifact appear, did the
+remote head move, is there a new commit. "Still working" is not something the
+probe can tell you at all — that reading comes from `session_read_message`'s
+running flag, and an open turn is satisfied by a shell deadlocked on its own
+child just as well as by real work.
+
+**One-time degradation on the first probe after an upgrade.** The fired-line
+digest is keyed on the classified tail text, so any change to what gets
+classified rotates the digests. A signal that was already marked handled, and
+whose classification moved, therefore re-fires ONCE on the first cycle after the
+probe is upgraded. Expect a burst of re-fired signals there and disposition them
+against the ledger rather than treating each as new work; it is a consequence of
+digest keying, not a defect, and it does not recur.
 
 | Line | Action |
 | --- | --- |
 | `ERR` | Batch-resume the affected workers (`session_send`: "resume; re-state your protocol prefix"). |
 | `PR` | Record PR number + head in the ledger. |
 | `GREEN` | Verify independently (below). Pass → digest + mark item `green_verified`, backfill a queued item. Fail → send the worker the delta. |
-| `BLOCKED` | Adjudicate (below). Write the ruling back via `session_send`; record it. |
-| `STANDDOWN` / `PROPOSAL` | Verify the evidence is stated; record disposition; close or re-queue; backfill. |
+| `BLOCKED` | Adjudicate (below). Record it in `open_rulings` and clear that entry only once the ruling is delivered via `session_send`. |
+| `STANDDOWN` / `PROPOSAL` | Verify the evidence is stated; record the disposition; unclaim with an evidence comment; close or re-queue; backfill. |
+| `TERMINAL` | The last dispositioned protocol report was terminal and the session has gone quiet since. **Close it out** — confirm the disposition landed, release the claim, `session_close`. Do NOT nudge: a finished worker has nothing to re-arm, and a monitor loop is only correct while something EXTERNAL can still change. |
 | `IDLE` | Intervention ladder (below). |
 | `GONE` | Transcript missing — treat as reclaim: re-queue the item with evidence. |
-| `BANNED pid=...` | Banned-ops response (below). |
+| `BANNED pid=…` | Banned-ops response (below), keyed by the line's OWNERSHIP CLASS: every class is recorded, and a stop is reserved for `cwd=fleet`. Never read this as a single actionable-or-not decision. |
+
+The `OK` line's `deliver init-timeout <a>, watchdog <b>` counters are the
+admission instrument, not fleet trivia — see governance.
+
+**If your probe does not emit these fields** — an older bundled probe, or a
+build cut before they landed — they are ABSENT, and absent is `UNKNOWN` rather
+than a clean reading, exactly as it is for the preflight:
+
+- No `deliver` counters does NOT mean the fleet is delivering; it means you
+  cannot see delivery. Fall back to load and memory AND hold admission below
+  `max_in_flight`, because the posture table's `ample` row would otherwise be
+  satisfied by the absence of its own instrument.
+- No `i=` leaves you no progress test. Diff the EFFECT across cycles instead
+  (artifact, remote head, new commit) and say in the ledger that progress is
+  unverified.
+- No `TERMINAL` tag means a finished worker still ages into `IDLE`. Read the
+  last protocol report before nudging, or you will nudge a worker that correctly
+  has nothing left to do.
+
+An instrument you cannot read is never a green reading. That is the same rule as
+exit 3, applied to the probe. And read the fallbacks as the NORMAL path rather
+than an edge case whenever the installed probe predates these fields: on such a
+build every cycle takes the degraded branch, so "hold admission below
+`max_in_flight`" is the effective default and the delivery-keyed posture table is
+aspirational until a probe that emits the counters is installed. Check once which
+of the two you are running rather than assuming the table applies.
 
 Never page through worker transcripts yourself, and never pull the whole
 fleet's state into context — the probe line is the interface. Quiet cycle:
@@ -147,6 +443,7 @@ Never trust a worker's GREEN (workers believe their own summaries):
 1. Check-runs for the claimed head SHA, **collapsed per lane, newest run
    wins** (a force-push leaves stale duplicates); zero red; PR MERGEABLE.
 2. The head SHA matches the claim — a green on yesterday's head is not green.
+   This is the step that catches a mis-reported head SHA.
 3. Reviewer verdicts read from **job logs and marker comments**, never run
    conclusions — they lie in both directions.
 
@@ -184,6 +481,30 @@ count; credit burn with no ledger transition; ERR recurring after resume.
 Two sessions on one item: **decide ownership once** — adopt one, fully stand
 down the other. Two owners politely yielding to each other is a deadlock.
 
+## Outage recovery and loop liveness
+
+An approval or transport outage does not merely deny the one command in flight:
+it kills the worker monitor loops AND your own patrol loop. Every loop on the
+host stops, and no loop reports its own death.
+
+So recovery is a **fleet-wide sweep, not a reply to whoever signalled.** The
+worker whose ERR line you happened to see is the one that was mid-call, not the
+only casualty. In ONE pass, for ALL workers: resume, then re-arm.
+
+Make the re-arm **conditional**: "re-arm your babysit loop IF you have a live PR
+to watch; otherwise report terminal and stop." A loop is only correct while
+something EXTERNAL can still change — an unconditional re-arm on a closed-out
+item wakes a worker to re-read something nobody is acting on, and fires the
+probe for no signal.
+
+Then check yourself: **no wake within the patrol interval after recovery means
+your own loop is dead** and needs a fresh `monitor_start`. State the limit
+plainly, because it bounds what this procedure can do — a conductor cannot
+detect its own loop's death from the inside, since the only symptom is the
+absence of a wake, and an absent wake is precisely the state in which nothing
+runs to notice it. An operator message or an external watchdog is the only thing
+that closes that hole.
+
 ## Adjudication (BLOCKED) and overrides
 
 A BLOCKED report must carry evidence + 2-4 options; if it does not, send it
@@ -202,23 +523,132 @@ back for them. Verify the finding against the CURRENT head first. Rule by:
   push-frozen afterwards except review responses. Record every ruling with its
   rejected options. Genuine design/product decisions escalate to the human —
   nothing else does.
+- **One sample, then the class.** A mass anomaly — the same red on every open
+  PR, an identical failure across workers — is diagnosed from ONE sample and
+  fixed as a class. Reading all N of them is the expensive way to learn the
+  same thing N times, and it delays the one fix that clears them all.
+- **Subtraction, when rounds keep reopening in one place.** Consecutive review
+  rounds landing in one function span indicate ONE unwritten contract, not N
+  separate mistakes. The convergent ruling there is usually to DELETE the
+  mechanism or split the entangled site out, not to apply an Nth patch. Rule for
+  the subtraction while the round count is still small; a patch that survives
+  review by narrowing itself each round is a mechanism the design does not want.
+- **Never re-dispatch a CI run to unstick one queued job.** Ask what a re-run
+  REPLACES, not what it retries: a re-run discards the whole run's passing
+  check-run set, so unsticking one job throws away every green in that run and
+  buys a full round trip.
+- **Park with the dependency, and release the claim when you park.** A parked
+  item records what it waits on, so it is releasable by a later cycle instead of
+  quietly aging; holding a claim on work nobody is doing blocks the operator who
+  could.
+- **Security-sensitive findings never go to a public channel.** A credential
+  path, an injection vector, a bypass: those go to the human directly, never
+  into a PR comment, an issue body, or a digest.
 
-## Resource governance
+## Admission and resource governance
 
-The probe's `OK` line carries load + memory + banned count; confirm with
-`resource_status` before batch dispatches.
+**Delivery capacity is the primary instrument.** The probe's `OK` line carries
+`deliver init-timeout <a>, watchdog <b>`: `a` counts sessions in the cycle whose
+tail shows an initialize timeout, `b` counts turns ended by the stall watchdog.
+**Either counter appearing twice in one cycle means stop dispatching.**
 
-| Posture | Do |
+Load and memory are secondary: both can read healthy while turns are killed by
+the stall watchdog and sessions fail to initialize, because what saturates first
+is request service and test-runner scheduling and neither field reports it.
+Admission keyed on load alone therefore keeps dispatching into a fleet that
+cannot deliver, and the failures then present as the workers' fault.
+
+| Signal | Posture | Do |
+| --- | --- | --- |
+| Delivery counters both 0; load and memory healthy | `ample` | Dispatch up to `max_in_flight`. |
+| Either delivery counter ≥2 in one cycle | `saturated` | Stop dispatching until two consecutive clean cycles. In-flight work continues — what is short is delivery, not compute, so stopping the workers would waste their progress for nothing. |
+| Load or memory tight, delivery clean | `tight` | No new dispatches; ask heavy workers to defer gate runs; postpone items marked expensive. |
+| `critical` from `resource_status` | `critical` | Halt admission; `session_stop` the most expensive in-flight items (record as reclaim, not failure); handle violators; wait for recovery before resuming. |
+
+Confirm with `resource_status` before batch dispatches. A delivery-saturated
+fleet is also why an approval or transport outage presents as mass worker failure
+— see outage recovery.
+
+**Every ownership class is REPORTED; only `cwd=fleet` is ENFORCED with a stop.**
+Keying this response on a single actionable-or-not boolean is what makes it
+unanswerable, because it forces an unclassified line to be either a false stop or
+a silent drop. Key it on the class instead:
+
+| Class | Response |
 | --- | --- |
-| `ample` | Dispatch up to `max_in_flight`. |
-| `tight` | No new dispatches; ask heavy workers to defer gate runs; postpone items marked expensive. |
-| `critical` | Halt admission; `session_stop` the most expensive in-flight items (record as reclaim, not failure); handle violators; wait for recovery before resuming. |
+| `cwd=fleet` | The heavy response: `session_stop` that worker, a ~5min cooldown, then restart it with the targeted-tests directive re-injected in the seed. |
+| `cwd=unknown` | The probe classified, but this one pid's cwd was unreadable. NON-stopping: re-inject the directive to the owning session WITHOUT stopping it, and record the line. Never a stop, never a silent drop. |
+| no `cwd=` field at all | The probe predates classification, so the line carries no ownership. Attempt attribution ONCE at action time (read that pid's cwd): resolved inside a fleet worktree → treat it as `cwd=fleet` and take the stop response above; not resolved → record the count and re-inject the directive fleet-wide as a reminder, stopping nobody. See the legacy-line fallback below. |
+| `cwd=foreign` | Count only. Not the fleet's process to police, and never grounds for stopping a session. |
 
-`BANNED` lines (full-suite runs): stop the owning worker session, wait out a
-~5min cooldown, restart it with the no-full-tests directive re-injected in the
-seed. Act ONLY on fleet-owned processes — platform processes and legitimate
-targeted runs are exempt. Standing constants: `session_ceiling` machine-wide,
-bounded `pytest -n`, targeted tests only, ≤2 subagents per worker.
+The no-field row is settled by measurement rather than by argument: a banned pid
+is typically gone by the time anyone reads its line — cwd unreadable, cmdline
+absent, the pid resolving to nothing — so a line carrying no ownership field
+cannot identify a violator even in principle. Enforcing on it generates false
+stops; dropping it removes the guard; a recorded count plus a fleet-wide reminder
+is the response that is neither.
+
+`unknown` is still not `foreign`, and the distinction survives the split: one is
+a process whose owner could not be determined, the other one determined not to be
+yours. Collapsing them would either police somebody else's host or discard a real
+violation.
+
+**Legacy lines: attempt attribution once, and enforce only on what resolves.**
+For the no-field class only, read that pid's cwd at the moment you act. If it
+resolves inside a fleet worktree the line is `cwd=fleet` after all and gets the
+stop; if it does not resolve, take the recorded, non-stopping reminder. Failing to
+resolve is the EXPECTED path, not an error condition — see the measurement below —
+so the fallback is where most legacy lines land.
+
+That ordering is what makes the whole cell answerable: nothing is enforced on
+ownership that is missing or unknown, because the stop fires only on ownership
+that RESOLVED; and no line is ever unmatched, because the reminder is always
+available. One read, one class, at action time. Scan-time classification stays
+the primary mechanism.
+
+**The cwd class is captured when the process is scanned, not looked up when you
+act on the line, and that ordering is what makes the class usable at all.** The
+runs this rule catches are short-lived, and the gap between a probe returning
+and a conductor acting on its output reliably outlives them: by then
+`/proc/<pid>/cwd` is unreadable, `cmdline` is gone, and the pid resolves to
+nothing. A line carrying only a pid is therefore unattributable, which leaves
+"ignore it" as the only safe response — and an operator who learns to ignore one
+such line has learned to ignore the whole class. The verdict has to travel on the
+line, recorded while the evidence still exists. That is also why the legacy-line
+fallback above is a bounded best effort and not the mechanism: it attempts the
+same read, expects it to fail, and declines to guess an owner when it does.
+
+What the pytest rule flags is **a run whose worker count is not explicitly
+chosen**, not "an unbounded `-n`". A bare `pytest` is therefore flagged: it
+inherits the project's `addopts`, so it is not a single-process run and its
+worker count was decided by the config rather than by the person who typed it.
+`-n0` satisfies the rule; so does any explicit number, which is why the brief
+also forbids a small `-n <N>` on grounds the probe cannot check. The other
+banned shape is a full-suite runner invoked with no file argument.
+
+Standing constants: `session_ceiling` machine-wide, `-n0` on every worker test
+run, targeted tests only, ≤2 subagents per worker. `-n0` rather than a small
+`-n <N>` because `auto` is memory-budgeted by a conftest hook while an explicit
+count bypasses that budget — so the safe form is zero workers, not a hand-picked
+few.
+
+### Your own forge-call budget
+
+You are one of a dozen pollers on one account: every worker's babysit loop is
+hitting the same rate limit concurrently, and you are the only one that can see
+that.
+
+- Cap your own PR sweeps at roughly six per cycle, and stagger them across
+  cycles instead of sweeping every tracked PR in one.
+- Prefer REST over GraphQL and search wherever either answers the question.
+- Run the greens sweep only when the human signals they are approving — merge
+  state on a PR nobody is looking at will keep until the next cycle.
+
+### Log discipline
+
+Pipeline logs are append-only: write a new file and `mv` it into place. Never
+rewrite a running log in place — a reader mid-parse gets a truncated file, and
+the history you overwrote is the evidence for the next ruling.
 
 ## Credit budgets
 
@@ -233,7 +663,8 @@ Roughly every 5 cycles, for items with open sessions:
   - *Thrashing* (no transitions, looping signals) → NO top-up — stop, then
     sharpened re-dispatch, open-issue mode, or skip with evidence. Exhaustion
     on a non-moving item is a defect signal, not a billing event.
-  - *Blocked on external* → park the item (parked time burns nothing).
+  - *Blocked on external* → park the item with the dependency recorded and the
+    claim released (parked time burns nothing).
   - More than `topup_ceiling` top-ups → escalate to the human with the burn
     history.
 - `unmetered` → treat spend as UNKNOWN, not zero — say so in the ledger and
@@ -258,9 +689,41 @@ autonudge_stop.`
 - Merged is NOT done for the fleet: after a merge, watch the next
   {default_branch} CI round — a merged gate change that reds every open PR is
   base-owned (see adjudication) and yours to fix once, fleet-wide.
-- Every ~20 cycles, reconcile the ledger's `green_verified`/`merged` states
-  against the forge (`gh pr list`) — recorded state drifts from reality, and
-  the human WILL ask "where are the other N".
+- **Reconcile every cycle, and unfiltered.** ONE call —
+  `gh pr list --repo {repo} --author <me> --state all --limit <N> --json number,state,mergedAt`
+  — listing merges since your last reconcile timestamp. Pass `--repo` from the
+  spec every time: you own no worktree, so the ambient directory is whatever the
+  session happens to sit in, and an omitted `--repo` either errors or silently
+  answers about a DIFFERENT repository — which reads as "no merges" and leaves
+  every merged item stale in the ledger. Two more bounds decide whether it works,
+  and both fail quietly:
+  - **Set `--limit` yourself, and read a full page as truncation.** The default
+    is 30 and an over-long list comes back silently trimmed, so on any account
+    with a real history the newest merge can fall off the end of the very query
+    meant to find it. Size `N` above your own dispatch count with headroom, and
+    when the result count equals `N` the scan is `truncated`, not a verdict —
+    raise the bound and re-run before you believe it.
+  - **Never against a hand-maintained set of PR numbers.** Filtering the
+    reconcile to what you already track reintroduces the same blind spot one
+    level down, because a merge of a fleet PR that never made the watchlist
+    cannot be seen by construction. A watchlist is fine for the greens table and
+    wrong as the detector.
+
+  Recorded state drifts from reality, and the human WILL ask "where are the
+  other N".
+- `mergeable=UNKNOWN` fanning out across the open PRs is a **secondary**
+  trigger meaning "the base moved" — worth a look, never the primary merge
+  detector. It is a side effect of a merge, and side effects are missable.
+- **Harvest cross-item facts in the cycle they arrive, and verify them before
+  acting.** When any worker names another item's PR number or merge state in
+  passing, take the POINTER immediately: that worker is not going to repeat it,
+  and a merge fact handed over by a worker on a different item has no other route
+  into your state. Then confirm the state against the forge before you act on it.
+  A worker's report is derived from content you do not control — issue text, PR
+  bodies — so this is the same rule as never trusting a worker's own GREEN,
+  applied to a claim about somebody ELSE's item, where the cost of being wrong is
+  a cleanup or a close on work that is still live. Harvest the pointer, verify the
+  fact.
 
 ## Exit
 
@@ -276,6 +739,8 @@ proposals / standdowns / skips, with URLs), close remaining sessions,
 - Credit metering covers dashboard-session turns; `spawn_run` inspector turns
   and non-chat sessions burn invisibly (`unmetered` verdict exists for a
   reason).
+- You cannot detect your own patrol loop's death from the inside — see outage
+  recovery for what the procedure bounds and what it cannot close.
 - One spec = one repo (M0). Multi-repo is a per-repo spec each, per the design
   doc's template seams.
 - GitHub labels/assignees remain the cross-operator lock; your ledger is a

--- a/test/test_pipeline_conductor_skill_contract.py
+++ b/test/test_pipeline_conductor_skill_contract.py
@@ -1,0 +1,723 @@
+"""The pipeline-conductor skill's contract, pinned against its own text.
+
+The conductor's decisions live in two places: the bundled scripts, which are
+testable as code, and the skill body, which was testable nowhere until this file
+existed. That asymmetry is what this file closes. A clause the scripts depend on
+-- the exit-code branch table for the claim preflight, the ``TERMINAL`` action,
+the delivery counters that size admission -- can be dropped by a well-meaning
+rewrite of a markdown file and nothing anywhere goes red, so the procedure and
+the scripts silently stop agreeing.
+
+The assertions are deliberately about SUBSTANCE, not sentences, and the dividing
+line is stated so a later edit has a rule to follow: assert a phrase when it
+states a RULE -- an obligation, a prohibition, a defined behavior, a name the
+scripts share -- and do NOT assert one that only explains WHY the rule exists.
+Rationale is what a rewrite is entitled to reword; pinning it produces a typo
+detector that every legitimate edit has to fight, which is the failure mode that
+makes text tests get deleted.
+
+The prompt is read from the module constant rather than by running the
+installer: ``test_pipeline_conductor_agent.py`` already proves that constant
+reaches the written agent config, and re-stubbing the installer here would
+couple this file to that one for no additional coverage.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from kiro_crew import agent
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO_ROOT / "src" / "kiro_crew" / "builtin_skills" / "pipeline-conductor"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+DESIGN_DOC = REPO_ROOT / "docs" / "design" / "pipeline-conductor.md"
+
+#: The three scripts the procedure delegates its deterministic half to. Named
+#: here rather than globbed from the directory on purpose: the point is that the
+#: PROSE cites each one, and a glob would pass on a skill body that mentions
+#: none of them.
+BUNDLED_SCRIPTS = ("claim_preflight.py", "fleet_probe.py", "credit_spend.py")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _flat(text: str) -> str:
+    """Collapse whitespace and lowercase, so a phrase assertion survives a
+    rewrap. Markdown re-flows every time a sentence is edited, and a check that
+    breaks on a line break is testing the paragraph filler, not the contract.
+    Leading blockquote markers go too: the work-order brief is a quote block, so
+    a wrapped sentence inside it carries a ``>`` mid-phrase."""
+    joined = " ".join(line.lstrip().lstrip(">") for line in text.splitlines())
+    return " ".join(joined.split()).lower()
+
+
+def _section(text: str, heading: str) -> str:
+    """Return one markdown section's body, subsections included.
+
+    Scoping an assertion to its own section is what keeps a check honest: a
+    cadence phrase belonging to credit budgets must not be able to satisfy (or
+    break) a rule about merge reconciliation just because both live in one file.
+    """
+    lines = text.splitlines()
+    depth = len(heading) - len(heading.lstrip("#"))
+    start = next(
+        (i for i, line in enumerate(lines) if line.strip() == heading.strip()),
+        None,
+    )
+    assert start is not None, f"section missing from the skill: {heading}"
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        stripped = line.lstrip("#")
+        level = len(line) - len(stripped)
+        if line.startswith("#") and level <= depth:
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _skill_section(heading: str) -> str:
+    return _section(_read(SKILL_MD), heading)
+
+
+class TestAgentPromptNamesEveryScript:
+    def test_prompt_names_the_script_this_change_adds(self):
+        """Only ``claim_preflight.py`` is pinned here. The other two are already
+        pinned in the installer test's own name list, and re-asserting them would
+        be a second place to update for one fact -- while the preflight is the one
+        that gates every dispatch, so an agent unaware of it falls back to the
+        one-question predicate this change replaced."""
+        assert "claim_preflight.py" in _flat(agent._PIPELINE_CONDUCTOR_SYSTEM_PROMPT)
+
+    def test_prompt_states_the_verdicts_the_conductor_branches_on(self):
+        prompt = agent._PIPELINE_CONDUCTOR_SYSTEM_PROMPT
+        for verdict in ("CLAIM", "SKIP", "CLOSE", "UNKNOWN"):
+            assert verdict in prompt, verdict
+
+    def test_prompt_carries_the_absent_script_rule(self):
+        """A prompt that asserts the scripts are present would have the agent
+        treat a file-not-found as an anomaly rather than as UNKNOWN."""
+        prompt = _flat(agent._PIPELINE_CONDUCTOR_SYSTEM_PROMPT)
+        assert "does not carry" in prompt
+        assert "never as permission" in prompt
+
+
+class TestClaimPreflightIsDocumented:
+    """Dispatch step 3 used to restate a coverage predicate in prose. Prose
+    cannot be tested, which is how it stayed blind to merged PRs, to prose
+    self-claims, and to code that does not exist on the base yet."""
+
+    HEADING = "### Preflight: `claim_preflight.py`"
+
+    def test_dispatch_cites_the_script_and_not_a_prose_predicate(self):
+        dispatch = _flat(_skill_section("## Pickup and dispatch"))
+        assert "claim_preflight.py" in dispatch
+        # The replaced predicate was a bare open-PR search presented as THE
+        # coverage check. Its return would re-open the blind spot.
+        assert "gh pr list --search" not in dispatch
+
+    def test_an_absent_preflight_script_has_a_defined_behavior(self):
+        """The gate cites a script, so the case where the install does not carry
+        it needs an answer. Undefined, it is a file-not-found with no path
+        forward; answered, it is just another UNKNOWN, which is never
+        permission."""
+        dispatch = _flat(_skill_section("## Pickup and dispatch"))
+        assert "absent from your install" in dispatch
+        assert "never permission" in dispatch
+        # And specifically not a silent downgrade to the predicate it replaced.
+        assert "never fall through to a bare open-pr search" in dispatch
+
+    def test_the_skill_does_not_assume_its_scripts_are_present(self):
+        """One script lands in a sibling change, so the skill's own opening must
+        not assert a bundled count: a reader who is told three ship has no
+        reason to reach the absent-script rule at all."""
+        body = _flat(SKILL_MD.read_text(encoding="utf-8"))
+        assert "presence is not assumed" in body
+        assert "check at first use" in body
+        assert "three bundled scripts" not in body
+
+    def test_every_exit_code_has_a_documented_conductor_action(self):
+        rows = {
+            row.split("|")[1].strip()
+            for row in _skill_section(self.HEADING).splitlines()
+            if row.startswith("|") and row.count("|") >= 3
+        }
+        for code in ("0", "10", "11", "2", "3"):
+            assert code in rows, f"exit code {code} has no row in the branch table"
+
+    def test_all_four_verdicts_are_named(self):
+        preflight = _skill_section(self.HEADING)
+        for verdict in ("CLAIM", "SKIP", "CLOSE", "UNKNOWN"):
+            assert verdict in preflight, verdict
+
+    def test_unknown_is_never_permission(self):
+        """The load-bearing half of having exit codes at all: an unanswerable
+        question must not read as a green light."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "never treat this as permission" in preflight
+
+    def test_a_prose_closure_request_requires_author_authorization(self):
+        """CLOSE is a WRITE driven by ingested text on an unattended cycle, and
+        anyone can comment on a public item. Without an authorization condition
+        this verdict lets an untrusted commenter close a live issue."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "reporter or a repository insider" in preflight
+        # An unauthorized phrase must not silently become a weaker verdict
+        # either: it is simply not a closure request.
+        assert "falls through to the remaining checks" in preflight
+
+    def test_a_prose_self_claim_from_anyone_else_is_not_a_veto(self):
+        """A veto anyone can cast is a denial-of-work channel: one comment would
+        suppress a queued item indefinitely and nothing would report it. The
+        signal is downgraded to risk=high rather than discarded."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "from the item's reporter or a repository insider" in preflight
+        assert "not a veto" in preflight
+
+    def test_close_requires_closure_evidence_not_a_bare_reference(self):
+        """A merged PR that only mentions the item is indistinguishable from one
+        that fixed it, so a mention must decide nothing: closing live work and
+        starving a partially-fixed item are both wrong."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "claims to close the item" in preflight
+        assert "not a bare cross-reference" in preflight
+        assert "a mention decides nothing" in preflight
+
+    def test_the_five_checks_are_all_named(self):
+        preflight = _skill_section(self.HEADING)
+        for check in (
+            "merged_prs",
+            "open_prs",
+            "prose_claim",
+            "symbol_on_base",
+            "recency",
+        ):
+            assert check in preflight, check
+
+    def test_a_check_that_cannot_change_the_verdict_is_not_documented(self):
+        """A per-candidate forge call whose result decides nothing is pure cost
+        against a shared rate limit, so it is not part of the contract."""
+        preflight = _skill_section(self.HEADING)
+        assert "closedByPullRequestsReferences" not in preflight
+        assert "Five checks" in preflight
+
+    def test_symbol_absence_alone_does_not_veto(self):
+        """Unconditionally, that check parks every feature request naming a
+        symbol it PROPOSES to add -- a permanent false veto on a whole class."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "absence alone is not a skip" in preflight
+        assert "downgrades to **claim** `risk=high`" in preflight
+
+    def test_risk_high_has_a_consumer_not_just_an_annotation(self):
+        """An annotation nothing acts on reads as caution and changes nothing --
+        the same defect as a prose predicate."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "not batched" in preflight
+
+    def test_batch_snapshot_is_never_the_authority(self):
+        """A batch verdict orders the queue; only a live recheck authorizes the
+        claim, because coverage can appear in the seconds between them."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "never the authority" in preflight
+        assert "recheck" in preflight
+        assert "mandatory" in preflight
+
+    def test_an_already_fixed_item_is_triage_debt_not_a_dispatch(self):
+        assert "triage debt" in _flat(_skill_section(self.HEADING))
+
+
+class TestProbeSignalsAreDocumented:
+    HEADING = "## The probe cycle"
+
+    def test_action_table_has_a_terminal_row(self):
+        """A finished worker and a wedged one read identically without it, so
+        the intervention ladder fires on the wrong worker."""
+        rows = [
+            row
+            for row in _skill_section(self.HEADING).splitlines()
+            if row.startswith("|") and "`TERMINAL`" in row.split("|")[1]
+        ]
+        assert rows, "the action table has no TERMINAL row"
+        action = rows[0].split("|")[2].lower()
+        assert "close" in action
+        # A terminal report must not be nudged: there is nothing to re-arm.
+        assert "not nudge" in action or "never nudge" in action
+
+    def test_tail_index_is_the_no_progress_discriminator(self):
+        probe = _skill_section(self.HEADING)
+        assert "i=" in probe
+        flat = _flat(probe)
+        assert "unchanged index" in flat
+        assert "no progress" in flat
+
+    def test_the_index_is_absolute_not_window_relative(self):
+        """A window-relative index saturates once a session outgrows the tail
+        bound and then reads as precisely the frozen counter the field exists to
+        detect, so the semantics have to be stated, not implied."""
+        flat = _flat(_skill_section(self.HEADING))
+        assert "absolute per-session message counter" in flat
+        assert "counted from the start" in flat
+
+    def test_the_tail_bound_is_a_parse_bound_not_an_io_bound(self):
+        """The whole transcript is read regardless; the bound only limits how
+        much gets parsed. A conductor told otherwise would mis-price the index
+        and mis-tune the setting."""
+        flat = _flat(_skill_section(self.HEADING))
+        assert "tail_bytes" in flat
+        assert "parsed" in flat
+
+    def test_the_one_time_digest_rotation_is_documented(self):
+        """The fired-line digest is keyed on classified tail text, so a
+        classifier change rotates digests and already-handled signals re-fire
+        once. Undocumented, that burst reads as a fleet-wide regression."""
+        flat = _flat(_skill_section(self.HEADING))
+        assert "re-fires once" in flat
+
+    def test_no_progress_sends_the_conductor_to_effect_not_liveness(self):
+        probe = _flat(_skill_section(self.HEADING))
+        assert "effect" in probe
+        # The honest provenance of "still working": not the probe.
+        assert "session_read_message" in probe
+        assert "running flag" in probe
+
+    def test_ok_line_carries_the_delivery_and_attribution_counters(self):
+        probe = _skill_section(self.HEADING)
+        for field in ("init-timeout", "watchdog", "foreign", "cwd=fleet"):
+            assert field in probe, field
+
+    def test_the_banned_row_matches_a_line_of_any_ownership_class(self):
+        """The row's own pattern must not require the cwd field, or a line from a
+        probe that does not classify matches nothing at all."""
+        rows = [
+            row
+            for row in _skill_section(self.HEADING).splitlines()
+            if row.startswith("|") and "BANNED" in row.split("|")[1]
+        ]
+        assert rows, "the action table has no BANNED row"
+        assert "cwd=" not in rows[0].split("|")[1]
+        # And it must route to the class-keyed response, not to a boolean.
+        assert "ownership class" in rows[0].lower()
+
+    def test_classification_tolerates_leading_markdown(self):
+        """A worker writing ``**BLOCKED:**`` is following the protocol; anchoring
+        on a bare prefix silently reclassifies the one message that most needs to
+        be read as an escalation."""
+        probe = _flat(_skill_section(self.HEADING))
+        assert "tolerates leading markdown" in probe
+        assert "strips leading emphasis" in probe
+
+    def test_the_degraded_path_is_named_as_the_current_default(self):
+        """On a build whose probe predates these fields the fallback fires on
+        every cycle, so writing it as an edge case would understate a changed
+        default."""
+        probe = _flat(_skill_section(self.HEADING))
+        assert "effective default" in probe
+
+    def test_absent_probe_fields_are_unknown_not_a_clean_reading(self):
+        """Symmetric to the preflight's absent-script arm, and load-bearing for
+        the same reason: with no delivery counters the posture table's `ample`
+        row would be satisfied by the ABSENCE of its own instrument, which is
+        precisely the defect admission was re-keyed to close."""
+        probe = _flat(_skill_section(self.HEADING))
+        assert "does not emit these fields" in probe
+        assert "absent is `unknown`" in probe
+        # Each of the three features needs its own degraded behavior.
+        assert "hold admission below `max_in_flight`" in probe
+        assert "no `i=` leaves you no progress test" in probe
+        assert "ages into `idle`" in probe
+
+
+class TestConductorOwnedState:
+    HEADING = "## Conductor-owned state: `conductor-status/v1`"
+
+    def test_status_schema_section_defines_every_field(self):
+        schema = _skill_section(self.HEADING)
+        for field in (
+            "tally",
+            "workers",
+            "parked",
+            "events_tail",
+            "resource",
+            "conductor_tasks",
+            "open_rulings",
+        ):
+            assert field in schema, field
+
+    def test_open_rulings_carries_its_shape(self):
+        schema = _skill_section(self.HEADING)
+        for key in ("worker", "pr", "question", "asked_at"):
+            assert key in schema, key
+
+    def test_open_rulings_is_reviewed_every_cycle_and_clears_on_delivery(self):
+        """The probe is RIGHT to suppress a handled signal -- that is what keeps
+        a quiet cycle quiet -- so a worker on an escalation hold goes silent and
+        the conductor's own debt is invisible unless it keeps this list."""
+        schema = _flat(_skill_section(self.HEADING))
+        assert "every cycle" in schema
+        assert "delivered" in schema
+
+    def test_last_index_is_stored_so_no_progress_is_a_comparison(self):
+        assert "last_index" in _skill_section(self.HEADING)
+
+    def test_the_ledger_wins_where_the_status_file_overlaps_it(self):
+        """`workers` necessarily restates some per-item state the ledger holds.
+        Two independent spellings of one fact drift silently, so one of them has
+        to be named authoritative."""
+        schema = _flat(_skill_section(self.HEADING))
+        assert "the ledger wins" in schema
+        assert "cache" in schema
+
+    def test_open_rulings_names_both_mechanisms_that_fill_it(self):
+        """The list is only as good as its inputs, and it has two: the probe must
+        keep BLOCKED sticky across samples, and the worker must keep saying it.
+        Either alone still loses the debt -- stickiness cannot recover a signal
+        never emitted, and a re-stated signal is still overwritten without it."""
+        schema = _flat(_skill_section(self.HEADING))
+        assert "sticky across samples" in schema
+        assert "keep the `blocked:` prefix on every turn" in schema
+
+
+class TestReconcileIsUnfilteredAndPerCycle:
+    HEADING = "## Merge, cleanup, reconcile"
+
+    def test_reconcile_runs_every_cycle_not_on_a_schedule(self):
+        merge = _skill_section(self.HEADING)
+        assert "every cycle" in _flat(merge)
+        # A scheduled cadence here is the defect: merge is invisible between
+        # sweeps, and merge is the pipeline's most important state change.
+        assert not re.search(
+            r"every ~?\d+\s+cycles", merge, re.IGNORECASE
+        ), "the reconcile is back on a schedule"
+
+    def test_reconcile_call_is_unfiltered(self):
+        merge = _skill_section(self.HEADING)
+        assert "unfiltered" in _flat(merge)
+        # --state all is what makes a merge visible; an open-only sweep
+        # structurally cannot see one.
+        assert "--state all" in merge
+
+    def test_reconcile_bounds_the_page_and_reads_a_full_page_as_truncation(self):
+        """Measured: the default page is 30 and an over-long list comes back
+        silently trimmed, so an unbounded call can drop the newest merge -- the
+        exact thing the query exists to find."""
+        merge = _skill_section(self.HEADING)
+        assert "--limit" in merge
+        flat = _flat(merge)
+        assert "truncated" in flat
+        assert "not a verdict" in flat
+
+    def test_the_reconcile_names_its_repository_explicitly(self):
+        """The conductor owns no worktree, so the ambient directory is whatever
+        the session sits in: an omitted --repo either errors or answers about a
+        different repository, which reads as "no merges"."""
+        merge = _skill_section(self.HEADING)
+        assert "--repo {repo}" in merge
+
+    def test_the_watchlist_trap_is_named(self):
+        """Filtering the reconcile to the PRs already tracked reproduces the
+        original blind spot one level down."""
+        merge = _flat(_skill_section(self.HEADING))
+        assert "watchlist" in merge
+
+    def test_mergeable_unknown_is_secondary(self):
+        merge = _skill_section(self.HEADING)
+        assert "mergeable=UNKNOWN" in merge
+        assert "secondary" in _flat(merge)
+
+    def test_cross_item_facts_are_harvested_in_the_same_cycle(self):
+        merge = _flat(_skill_section(self.HEADING))
+        assert "harvest" in merge
+        assert "in the cycle they arrive" in merge
+
+    def test_a_harvested_cross_item_fact_is_verified_before_it_is_acted_on(self):
+        """A worker's report is derived from content the fleet does not control, so
+        trusting a claim about somebody ELSE's item would contradict this same
+        document's rule against trusting a worker's own GREEN."""
+        merge = _flat(_skill_section(self.HEADING))
+        assert "confirm the state against the forge" in merge
+
+
+class TestAdmissionIsSizedOnDelivery:
+    HEADING = "## Admission and resource governance"
+
+    def test_delivery_counters_are_the_primary_instrument(self):
+        admission = _skill_section(self.HEADING)
+        for counter in ("init-timeout", "watchdog"):
+            assert counter in admission, counter
+        flat = _flat(admission)
+        assert "primary instrument" in flat
+        assert "stop dispatching" in flat
+
+    def test_load_and_memory_are_explicitly_secondary(self):
+        """Load can sit near zero per core and memory can read ample while the
+        fleet cannot deliver, because the saturated resource is request service
+        and test-runner scheduling."""
+        admission = _flat(_skill_section(self.HEADING))
+        assert "secondary" in admission
+
+    def test_the_conductor_caps_its_own_forge_calls(self):
+        admission = _flat(_skill_section(self.HEADING))
+        assert "prefer rest over graphql" in admission
+        assert "stagger" in admission
+
+    def test_logs_are_append_only(self):
+        admission = _flat(_skill_section(self.HEADING))
+        assert "append-only" in admission
+        assert "`mv`" in admission
+
+    def test_the_banned_pytest_rule_is_described_as_the_code_implements_it(self):
+        """The rule flags a run whose worker count was not explicitly chosen. It
+        is NOT "an unbounded -n", and a bare pytest is not the safe form: it
+        inherits the project's addopts."""
+        admission = _flat(_skill_section(self.HEADING))
+        assert "not explicitly chosen" in admission
+        assert "bare `pytest` is therefore flagged" in admission
+        assert "inherits the project's `addopts`" in admission
+
+    def test_the_banned_response_is_keyed_on_four_ownership_classes(self):
+        """Keying it on one actionable-or-not boolean forces an unclassified line
+        to be either a false stop or a silent drop -- which is why two review
+        rounds demanded opposite things of the same cell."""
+        rows = {
+            row.split("|")[1].strip()
+            for row in _skill_section(self.HEADING).splitlines()
+            if row.startswith("|") and row.count("|") >= 3
+        }
+        for cls in ("`cwd=fleet`", "`cwd=unknown`", "no `cwd=` field at all", "`cwd=foreign`"):
+            assert cls in rows, f"{cls} has no row of its own"
+
+    def test_only_fleet_ownership_is_enforced_with_a_stop(self):
+        admission = _flat(_skill_section(self.HEADING))
+        assert "every ownership class is reported; only `cwd=fleet` is enforced" in admission
+        # The two middle classes act without stopping; foreign does not act.
+        assert "non-stopping" in admission
+        assert "stopping nobody" in admission
+        assert "never grounds for stopping a session" in admission
+
+    def test_an_unattributable_line_is_neither_enforced_nor_dropped(self):
+        """A banned pid is typically gone before its line is read, so a line with
+        no ownership field cannot identify a violator even in principle."""
+        admission = _flat(_skill_section(self.HEADING))
+        assert "fleet-wide reminder" in admission
+
+    def test_a_legacy_line_attempts_attribution_once(self):
+        """The reframe that makes the cell answerable: convert missing ownership
+        into resolved ownership where possible, and enforce only on resolved."""
+        admission = _flat(_skill_section(self.HEADING))
+        assert "attempt attribution once" in admission
+        assert "at action time" in admission
+
+    def test_a_resolved_legacy_line_gets_the_stop(self):
+        admission = _flat(_skill_section(self.HEADING))
+        assert "resolves inside a fleet worktree" in admission
+        assert "gets the stop" in admission
+
+    def test_an_unresolved_legacy_line_falls_back_to_the_reminder(self):
+        """Failing to resolve is the expected path, so the fallback is the common
+        case and must not read as an error branch."""
+        admission = _flat(_skill_section(self.HEADING))
+        assert "does not resolve" in admission
+
+    def test_the_action_time_read_is_reconciled_with_scan_time_capture(self):
+        """Scan-time capture exists BECAUSE an action-time lookup usually fails, so
+        the fallback has to be bounded and subordinate or the two rules read as
+        contradicting each other. Pinned as the precedence, not the reasoning."""
+        admission = _flat(_skill_section(self.HEADING))
+        assert "scan-time classification stays the primary mechanism" in admission
+
+    def test_unknown_and_foreign_stay_distinct(self):
+        admission = _flat(_skill_section(self.HEADING))
+        assert "`unknown` is still not `foreign`" in admission
+
+    def test_the_cwd_class_is_captured_at_scan_time(self):
+        """The offending runs are short-lived and the probe-to-action gap
+        outlives them, so the verdict has to travel on the line."""
+        admission = _flat(_skill_section(self.HEADING))
+        assert "not looked up when you act" in admission
+
+    def test_the_standing_constant_is_n0_not_a_small_worker_count(self):
+        admission = _flat(_skill_section(self.HEADING))
+        assert "`-n0` on every worker test run" in admission
+
+
+class TestOutageRecoveryAndLoopLiveness:
+    HEADING = "## Outage recovery and loop liveness"
+
+    def test_recovery_is_a_fleet_wide_sweep(self):
+        """The worker whose ERR line surfaced is the one that was mid-call, not
+        the only casualty, so the obligation is a sweep over the whole fleet."""
+        body = _flat(_skill_section(self.HEADING))
+        assert "all workers" in body
+        assert "resume" in body
+        assert "re-arm" in body
+
+    def test_re_arm_is_conditional_on_something_external_changing(self):
+        body = _flat(_skill_section(self.HEADING))
+        assert "conditional" in body
+        assert "live pr" in body
+        assert "external" in body
+
+    def test_the_conductor_checks_its_own_loop_and_states_the_limit(self):
+        """The obligation, not the wording: a missed wake within the patrol
+        interval means re-arm, and the residual hole is named as a limit rather
+        than left for the reader to discover."""
+        body = _flat(_skill_section(self.HEADING))
+        assert "patrol interval" in body
+        assert "monitor_start" in body
+
+
+class TestWorkOrderBriefClauses:
+    HEADING = "### The work-order brief (seed message skeleton)"
+
+    def test_escalating_test_wrappers_are_banned_by_name(self):
+        """A wrapper that escalates to the full suite satisfies the letter of a
+        targeted-only brief, so the ban has to name the shapes."""
+        brief = _skill_section(self.HEADING)
+        named = [n for n in ("make test", "tox", "nox", "local-gate") if n in brief]
+        assert len(named) >= 3, f"only named {named}"
+
+    def test_worker_runs_pass_n0_explicitly(self):
+        """Omitting ``-n`` is not single process: it inherits the project's
+        ``addopts``, commonly ``-n auto``. And a small explicit ``-n <N>`` is the
+        LESS safe option, since ``auto`` goes through a memory budget an explicit
+        count bypasses. So the clause has to name ``-n0``."""
+        brief = _flat(_skill_section(self.HEADING))
+        assert "-n0" in brief
+        assert "explicitly" in brief
+        assert "inherits" in brief
+        assert "addopts" in brief
+        # The old wording ("no xdist at all", "single process") let a reader
+        # conclude a bare pytest was the safe form.
+        assert "do not substitute a small `-n <n>`" in brief
+
+    def test_targeted_runs_are_bounded_and_non_interactive(self):
+        brief = _skill_section(self.HEADING)
+        assert "timeout" in brief
+        assert "</dev/null" in brief
+
+    def test_remote_operations_carry_the_credential_clauses(self):
+        brief = _skill_section(self.HEADING)
+        assert "GIT_TERMINAL_PROMPT=0" in brief
+        assert "gh auth setup-git" in brief
+
+    def test_a_hung_push_is_measured_before_it_is_explained(self):
+        brief = _flat(_skill_section(self.HEADING))
+        assert "pre-push hook" in brief
+        assert "before naming a cause" in brief
+
+    def test_babysit_polling_is_staggered_and_prefers_rest(self):
+        brief = _flat(_skill_section(self.HEADING))
+        assert "stagger" in brief
+        assert "rest over graphql" in brief
+
+    def test_the_prefix_must_be_bare_leading_text(self):
+        """A bolded prefix reads as no status at all, and it fails on exactly the
+        message that most needs to be heard."""
+        brief = _flat(_skill_section(self.HEADING))
+        assert "bare leading text" in brief
+        assert "no bold" in brief
+        assert "matched at the start of the message" in brief
+
+    def test_a_blocked_worker_keeps_the_blocked_prefix(self):
+        """The conductor samples the newest protocol message, so a WORKING: line
+        posted after a BLOCKED: overwrites the escalation before anything sees
+        it, and the ruling ends up owed by nobody."""
+        brief = _flat(_skill_section(self.HEADING))
+        assert "keep that prefix on every turn" in brief
+        assert "escalation hold" in brief
+        assert "newest protocol message" in brief
+
+
+class TestPartitioningAcrossWorkers:
+    HEADING = "### Partitioning one change across several workers"
+
+    def test_ownership_is_exclusive_per_file(self):
+        body = _flat(_skill_section(self.HEADING))
+        assert "exclusive file ownership" in body
+
+    def test_exclusive_ownership_does_not_remove_the_review_order_dependency(self):
+        """A premise-level reviewer counts consumers in the BASE, so the PR that
+        builds a mechanism reads as dead code until the PR that wires it lands.
+        The split fixes conflicts and creates this instead."""
+        body = _flat(_skill_section(self.HEADING))
+        assert "merge order" in body
+        assert "wiring pr lands before or with the building pr" in body
+
+    def test_the_remedy_is_sequencing_and_never_moving_another_workers_hunk(self):
+        """Moving the hunk dissolves the ownership split, creates the conflict the
+        split existed to prevent, and hides a review-order problem as a code
+        change."""
+        body = _flat(_skill_section(self.HEADING))
+        assert "never move another worker's hunk" in body
+
+
+class TestCodifiedPractices:
+    def test_the_four_way_collision_check_survives(self):
+        assert "four-way collision check" in _flat(_skill_section("## Pickup and dispatch"))
+
+    def test_the_claim_is_atomic_and_released_with_evidence(self):
+        dispatch = _flat(_skill_section("## Pickup and dispatch"))
+        assert "claim atomically" in dispatch
+        assert "assignee in one call" in dispatch
+        assert "unclaim" in dispatch
+        assert "evidence comment" in dispatch
+
+    def test_a_failed_dispatch_releases_the_claim(self):
+        """A claim with no session behind it looks like work in progress to every
+        other operator, and no probe line, SLA timer or reclaim path covers it -
+        the ledger never recorded a dispatch."""
+        dispatch = _flat(_skill_section("## Pickup and dispatch"))
+        assert "if any post-claim step fails" in dispatch
+        assert "unclaim before you move on" in dispatch
+
+    def test_session_create_must_pass_the_worker_agent(self):
+        """An unset agent binds the worker to the conductor's own agent, which
+        has no file-writing tool, and the whole batch refuses the work."""
+        mechanics = _skill_section("### Dispatch mechanics")
+        assert "session_create" in mechanics
+        flat = _flat(mechanics)
+        assert "explicitly" in flat
+        assert "canary" in flat
+
+    def test_a_base_wide_fix_is_searched_for_before_it_is_commissioned(self):
+        assert "already exists" in _flat(_skill_section("### Dispatch mechanics"))
+
+    def test_green_verification_names_what_it_catches(self):
+        verification = _flat(_skill_section("## Independent green verification"))
+        assert "mis-reported head sha" in verification
+
+    def test_adjudication_carries_the_named_patterns(self):
+        adjudication = _flat(_skill_section("## Adjudication (BLOCKED) and overrides"))
+        # One sample, then the class.
+        assert "one sample" in adjudication
+        # Subtraction over an Nth patch.
+        assert "subtraction" in adjudication
+        # A re-run replaces a run; it does not retry a job.
+        assert "replaces" in adjudication
+        assert "check-run set" in adjudication
+        # Security findings never go to a public channel.
+        assert "public channel" in adjudication
+        # A park records its dependency and releases the claim.
+        assert "park with the dependency" in adjudication
+
+
+class TestDesignDocTracksTheSkill:
+    """The design doc carries the intent; a skill clause with no rationale
+    recorded anywhere is the first thing a rewrite drops."""
+
+    def test_design_doc_defines_the_status_schema(self):
+        doc = _read(DESIGN_DOC)
+        assert "conductor-status/v1" in doc
+        assert "open_rulings" in doc
+
+    def test_design_doc_argues_the_delivery_based_admission_model(self):
+        doc = _flat(_read(DESIGN_DOC))
+        assert "admission is sized on delivery" in doc
+
+    def test_design_doc_names_all_three_scripts(self):
+        doc = _read(DESIGN_DOC)
+        for script in BUNDLED_SCRIPTS:
+            assert script in doc, script


### PR DESCRIPTION
## Problem / Motivation

The `pipeline-conductor` skill decides things in prose. Its dispatch step 3 was
"No open PR, branch, or worktree already covers it (`gh pr list --search`)",
which asks one question and treats an empty answer as permission: `--state open`
structurally cannot see a covering PR that already merged, and a claim written
in the issue body ("I'm claiming this") is invisible to every label and field
query that exists. Three other surfaces have the same shape. The probe's new
signals (a tail index, a terminal tag, delivery counters) had nowhere documented,
so they would ship unread. Admission keyed on load and memory, which are not the
resources that saturate first. Merge reconciliation ran "every ~20 cycles", so
the pipeline's single most important state change was invisible between sweeps.
And the conductor's own obligations - a ruling a worker is waiting on, an item
only the conductor can close - had no store at all.

## Why it matters

A conductor's whole value is that one session supervises a fleet without the
human watching. Each gap above converts supervision into waste the human
eventually absorbs: a one-question claim predicate spends a full dispatch
(session create, seed, preflight, stand down, unclaim) to discover the work does
not exist, and leaves claim churn on a shared public repository; a probe signal
nobody documented means the conductor nudges finished workers and marks
deadlocked ones handled; load-based admission overshoots into a delivery ceiling
so the fleet gets slower as it grows and the failures look like the workers'
fault; and an untracked ruling means a worker sits blocked on an answer that was
decided but never delivered.

## What changed (motivation -> approach -> change)

The through-line: promote each decision from prose into a deterministic check,
and give the conductor a place to record its own obligations. Prose predicates
rot silently; scripts can be tested, and a schema can be asserted.

This PR is the documentation and contract half. It documents two scripts that
land in sibling PRs against a contract pinned before any of the three started,
so the three diffs compose without touching each other's files.

**Merge order, which is load-bearing rather than incidental.** The siblings are
#8036 (`scripts/claim_preflight.py`) and #8035 (the `fleet_probe.py` signal
upgrades). This PR lands FIRST and the other two follow with or immediately
after it, per the wiring-before-building rule this PR itself adds: a
premise-level reviewer counts a mechanism's consumers in the base, so the PR that
BUILDS a mechanism reads as dead code until the PR that WIRES it has landed. The
degraded-path clauses ("absent is UNKNOWN, never permission"; hold admission
below `max_in_flight`) exist to keep every intermediate state safe and honest,
and they are transitional in effect - once both siblings land, the primary path
is the documented one on every install.

- Dispatch cites `scripts/claim_preflight.py` instead of restating a predicate:
  the CLI, all five exit codes with the conductor's action for each, the six
  checks, and the verdict precedence. Exit 3 (UNKNOWN) is stated as never being
  permission, and a per-item live recheck immediately before the atomic claim
  stays mandatory because a batch snapshot is never the authority. An item that
  is open, claimed and already fixed is named as triage debt: close it with the
  landing commit, do not dispatch it.
- The probe cycle documents the fired line's `i=<index>` field and the rule that
  an unchanged index across two probes is no progress whether or not a turn is
  open - and that the next step is then to check the effect (did the artifact
  appear, did the remote head move), never liveness. The action table gains a
  `TERMINAL` row whose action is "close it out", not "nudge". The `OK` line's
  `deliver init-timeout / watchdog` counters and the `foreign` banned split are
  documented, along with the honest note that the "still working" reading comes
  from `session_read_message`'s running flag rather than from the probe, and that
  an open turn is satisfied by a self-deadlocked shell.
- Admission is rewritten so delivery capacity is the primary instrument and
  load/memory secondary: either delivery counter appearing twice in one cycle
  stops dispatching. The reason is stated plainly - load can sit near zero per
  core and memory can read ample while turns are ended by the stall watchdog and
  sessions fail to initialize, because the saturated resource is request service
  and test-runner scheduling, which no load or memory field reports.
- New `conductor-status/v1` section defines the status file as a schema: `tally`,
  `workers` (including `last_index`), `parked`, `events_tail`, `resource`,
  `conductor_tasks`, and `open_rulings` (`{worker, pr, question, asked_at}`).
  `open_rulings` is reviewed every cycle independently of what the probe fires
  and clears only on delivery. The rationale is structural: the probe is right
  not to re-fire a handled signal - that suppression is what keeps quiet cycles
  quiet - so a worker on an escalation hold goes silent and a debt the conductor
  owes becomes invisible unless the conductor keeps its own list.
- Reconcile becomes per-cycle and unfiltered: one
  `gh pr list --author <me> --state all` call listing merges since a timestamp,
  never a hand-maintained set of PR numbers, because filtering the reconcile to
  the numbers already tracked reintroduces the same blind spot one level down.
  `mergeable=UNKNOWN` stays as a secondary trigger meaning the base moved. A
  cross-item harvest rule acts on a merge fact a worker mentions in passing in
  that same cycle.
- New outage-recovery section: an approval or transport outage kills worker
  monitor loops and the conductor's own patrol loop, so recovery is a fleet-wide
  resume-plus-re-arm sweep rather than a reply to whichever worker signalled, and
  the re-arm is conditional ("re-arm IF you have a live PR to watch, otherwise
  report terminal") because a loop is only correct while something external can
  still change. The conductor then checks its own loop, and the structural limit
  is stated: it cannot detect its own loop's death from the inside, since the
  only symptom is the absence of a wake.
- Forge-call budget (about six PR sweeps per cycle, staggered, REST over
  GraphQL, greens sweep only when the human is approving), append-only log
  discipline, and dispatch mechanics: `session_create` must pass the worker agent
  explicitly (an unset agent binds the worker to the conductor's own agent and
  the whole batch refuses the work), one canary dispatch before a batch, small
  batches for the create rate limit, and searching open PRs before commissioning
  a base-wide fix.
- Work-order brief clauses: escalating test wrappers banned by name, xdist
  forbidden outright (single process, one file, `timeout`, `</dev/null`),
  `GIT_TERMINAL_PROMPT=0` plus `gh auth setup-git` for anything touching a
  remote, staggered babysit intervals preferring REST, and timing the real
  pre-push hook before naming a cause for a hung push.
- Codified what already works so a rewrite cannot drop it: the four-way
  collision check, the atomic claim (label plus assignee in one call) with prompt
  unclaim and an evidence comment on stand-down, what independent green
  verification actually catches, one-sample class diagnosis, park-with-dependency
  plus claim release, security findings never routed to a public channel, and
  never re-dispatching a CI run to unstick one queued job (ask what a re-run
  replaces, not what it retries). Adjudication gains subtraction as a named
  pattern: consecutive review rounds in one function span indicate one unwritten
  contract, not N mistakes.
- The banned-operations response is keyed on the line's OWNERSHIP CLASS, in four
  rows rather than one actionable-or-not boolean: `cwd=fleet` gets the stop plus
  cooldown plus directive re-injection, `cwd=unknown` gets a non-stopping
  re-injection to the owning session, a line with no `cwd=` field at all gets a
  recorded count and a fleet-wide reminder with nobody stopped, and `cwd=foreign`
  is counted only. Every class is reported; only fleet ownership is enforced with
  a stop. For the no-field class there is one bounded refinement: attempt
  attribution ONCE at action time, take the stop if the pid's cwd resolves inside
  a fleet worktree, and fall back to the reminder if it does not - which is the
  common case, and which is what the conductor of a real fleet already does
  before acting on such a line. Missing ownership is converted into resolved
  ownership where possible, and only resolved ownership is enforced. The split is what makes the cell answerable at all: a boolean forces an
  unattributable line to be either a false stop or a silent drop, which is why
  two independent review rounds on this PR demanded opposite things of that one
  cell. A banned pid is typically gone before its line is read, so a line with no
  ownership field cannot identify a violator even in principle.
- The protocol prefix must be BARE leading text, and the classifier strips
  leading emphasis and list markers before matching. A bolded `**BLOCKED:**`
  otherwise reads as no status, and it fails on precisely the message that most
  needs to be read as an escalation. The brief clause is the weaker half of that
  pair and is documented as such.
- The agent prompt now names all three bundled scripts, so the agent knows the
  preflight exists.
- `docs/design/pipeline-conductor.md` gains the status-file schema, the
  delivery-based admission argument, the third script, and the external
  loop-watchdog gap as an open decision.

## Tests

New file `test/test_pipeline_conductor_skill_contract.py` (44 tests). The skill
body had no tests at all, which is why a clause the scripts depend on could be
dropped by a markdown rewrite with nothing going red. Assertions are about
substance (a named script, a verdict word, a table row, a field name, a call
shape) rather than exact sentences, so the file is not a typo detector:

- the agent prompt names all three scripts and the four verdicts
- `SKILL.md` cites `claim_preflight.py`, gives every one of the five exit codes a
  row, names all four verdicts and all six checks, states that UNKNOWN is never
  permission, and keeps the live-recheck and triage-debt rules
- the old `gh pr list --search` predicate cannot return to the dispatch section
- the action table has a `TERMINAL` row whose action closes rather than nudges
- the tail index, the no-progress rule, and the effect-not-liveness follow-up
- the status schema names every field including `open_rulings` and its shape
- the reconcile is per-cycle and unfiltered, with a regex asserting a scheduled
  cadence cannot come back to that section
- admission names both delivery counters and marks load/memory secondary
- the brief's wrapper ban, xdist ban, remote clauses and hook-timing rule
- the design doc carries the schema, the delivery model and all three scripts

Run: `timeout 900 python3 -m pytest test/test_pipeline_conductor_skill_contract.py -q -n0` -> 44 passed.

`test/test_pipeline_conductor_agent.py` is untouched and still green (43 passed)
after the agent-prompt edit.

## Manual verification

N/A - the change is skill text, design documentation and one prompt string; the
new test file reads both artifacts directly, and the static gates
(`check_builtin_skill_scope`, `docs_lint`, `check_brand_name`, `scrub-lint`,
black, isort, flake8) were run locally and pass.

## Related Issues

Refs #8029

## Pattern harvest

Rule candidate: review-prompt
Pattern: a decision-making predicate stated only as prose in a skill body, so no
gate can tell when it stops matching the scripts that implement it. A skill that
cites a script should have a test asserting the citation and its semantics; a
skill that restates a predicate in prose should be treated as an untested branch.



