### PR TITLE
feat(pipeline-conductor): probe signals for no-progress, finished, and undelivered workers

### DIFF
--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
@@ -13,11 +13,19 @@ Config (JSON):
     {
       "sessions": ["dashboard_chat-601-1788099254", ...],   # slot keys to watch
       "idle_alert_secs": 900,      # silent longer than this -> IDLE alert
-      "tail_bytes": 200000,        # per-session transcript read cap
+      "tail_bytes": 200000,        # per-session transcript PARSE cap
       "load_alert_per_cpu": 1.5,   # 1-min loadavg / cpu above this -> hot
       "err_res": [...],            # extra error-tail regexes (optional)
-      "banned_process_res": [...]  # cmdline regexes for banned ops (optional)
+      "banned_process_res": [...], # cmdline regexes for banned ops (optional)
+      "init_timeout_res": [...],   # initialize-timeout tails (optional)
+      "watchdog_res": [...],       # turn-ended-by-stall-watchdog tails (optional)
+      "fleet_worktrees": [...]     # absolute roots this fleet owns (optional)
     }
+
+Every regex key is validated at load time: a bad pattern is malformed config
+(exit 2 with the offending pattern), never a crash mid-cycle. ``tail_bytes``
+caps how much of a transcript is PARSED, not how much is read -- the whole file
+is read either way, which is what makes the tail index monotonic for free.
 
 Paths are DERIVED, never configurable -- the same containment rule for every
 location this script touches, because its config is authored by a no-write
@@ -41,18 +49,60 @@ The data home is ``$KIROCREW_HOME`` when set, else ``~/.kiro/crew`` — the same
 resolution every pipeline script uses.
 
 Output (text, one line per FIRING signal; suppressed sessions print nothing):
-    🔔 <session-key> <age>s <TAG> d=<digest>
+    🔔 <session-key> <age>s <TAG> i=<index> d=<digest>
+
+``i=`` counts the rows that SESSION PRODUCED -- its own messages and tool calls,
+never an inbound nudge, inject or user row, because a supervisor's own nudge
+landing in the file must not read as the worker making progress. It is a
+monotonic per-session position counted from the start of the file, not from the
+window, so it cannot saturate once a transcript passes ``tail_bytes``. An
+unchanged count since the conductor last acted is *no progress*, whether or not
+a turn is open, and that is the discriminator a self-deadlocked worker cannot
+fake -- the probe makes that comparison itself and fires ``NOPROGRESS`` rather
+than leaving two numbers for someone to diff. It is a position, so it carries no
+transcript content.
 
 Metadata only, by design: transcript-derived text never appears in the output,
 so no private session content crosses into the caller's context whatever keys
 the config watches. Content, when a ruling needs it, is read through the
 workspace-authorized session tools.
-    BANNED pid=<pid> <cmdline>
-    OK <n> watched, <m> fired | load/cpu <x> (<posture>) | mem <G>G | banned <k>
+    BANNED pid=<pid> rule=<regex> cwd=fleet|unknown
+    OK <n> watched, <m> fired | load/cpu <x> (<posture>) | mem <G>G
+       | banned <k> | foreign <k> | deliver init-timeout <a>, watchdog <b>
+
+``banned`` counts fleet-owned matches only -- a banned command shape running in
+an unrelated checkout on the same host is somebody else's business, and counting
+it made the conductor stop a worker that was not the offender. Those are
+summarised as ``foreign`` and not printed. ``deliver`` is the honest admission
+instrument: load and memory can both read healthy while the fleet cannot
+deliver, so sessions whose tail carries an initialize timeout or a
+stall-watchdog turn end are counted every cycle, fired or not.
 
 Tags: the worker protocol words (``WORKING/PR/GREEN/BLOCKED/STANDDOWN/
-PROPOSAL``), ``ERR`` for an error/throttle tail, ``IDLE`` for silence past the
-threshold, ``-`` when a tail carries no tag (never fires on its own).
+PROPOSAL``) -- recognised in their protocol form, ``<WORD>:``, so prose that
+merely opens with one is not a report -- plus ``ERR`` for an error/throttle
+tail, ``IDLE`` for silence past the threshold, ``TERMINAL`` for a session whose
+last dispositioned report ENDED its assignment (``GREEN``/``STANDDOWN``/
+``PROPOSAL``) and which has since written unprefixed text, ``NOPROGRESS`` for a
+session that has produced nothing since the conductor last acted on it, and
+``-`` when a tail carries no tag
+(never fires on its own). Tool rows never classify: a protocol word or an error
+phrase inside a tool card is quoted text, not a report.
+
+The tag is the newest REPORT, not the newest message, because ``BLOCKED`` is
+STICKY: a probe samples rather than subscribes, and the protocol requires a
+blocked worker to keep reporting status, so its own next message would displace
+the only thing a newest-message classifier reads. A heartbeat (``WORKING``) and
+unprefixed text leave a sticky report standing; any other report supersedes it.
+``TERMINAL`` and sticky ``BLOCKED`` are kept distinct on purpose -- one says
+close me, the other says a ruling is owed.
+
+Leading markdown decoration is stripped before the tag is matched, because the
+match is anchored at position zero and ``**BLOCKED:**`` puts an asterisk there.
+Emphasis, blockquote arrows, heading hashes and list markers all count. The
+normalisation applies to the MATCHED text only: the digest is still computed over
+what the worker wrote, and the anchor survives, so a bolded protocol word
+mid-sentence is still not a report.
 
 THE HANDLED SET replaces the overnight run's hand-grown ``grep -vE`` exclusion
 pipe. Every fired line carries a ``d=<digest>`` field; ``--mark-handled KEY TAG
@@ -63,6 +113,15 @@ then suppressed while (tag, digest) both still match. A new payload under the
 same tag re-fires (a second GREEN with a new PR number is a new signal).
 ``IDLE`` marks expire after another ``idle_alert_secs``
 so a nudged-but-still-silent worker re-alerts instead of vanishing.
+
+A handled entry also records the tail ``index`` at the moment of the mark, and
+the last dispositioned PAYLOAD report as ``settled`` (its tag AND digest) -- one
+field, written on every mark and carried forward when the mark is not itself a
+payload, so no later disposition can erase the fact that a report was already
+answered. Neither field takes part in the digest, and a state file written before
+they existed still suppresses exactly as it did; a legacy ``proto`` field, which
+recorded only the tag, is still read so an in-place upgrade keeps its terminal
+reading.
 
 Deliberately boring properties, do not weaken:
   * No subprocess, ever. Reads transcripts, ``/proc`` and ``loadavg`` directly.
@@ -85,7 +144,102 @@ import time
 from pathlib import Path
 from typing import Any
 
-PROTO = re.compile(r"^(GREEN|PR|BLOCKED|STANDDOWN|PROPOSAL|WORKING)\b")
+#: The protocol words a worker may open a report with. The single source for
+#: both the regex below and the handled set's record of the last DISPOSITIONED
+#: protocol tag, which has to recognise one without re-matching prose.
+PROTO_TAGS = frozenset({"GREEN", "PR", "BLOCKED", "STANDDOWN", "PROPOSAL", "WORKING"})
+
+#: A worker report is ``<WORD>:`` — the colon IS the protocol, not decoration.
+#: Matching a bare word boundary instead reads ordinary prose as a report:
+#: measured over the 60 most recent transcripts on this host, 20 of the 94
+#: assistant rows that matched ``^<WORD>\b`` were not reports at all (13 of them
+#: opened with a bare ``PR #<n>``), so one row in five carried a fabricated tag.
+#:
+#: Built FROM ``PROTO_TAGS`` rather than spelling the six words a second time,
+#: because two copies of one list diverge. Longest first, so a word that is a
+#: prefix of another is never tried after it: ``PR`` and ``PROPOSAL`` share two
+#: characters, and while Python's alternation backtracks and would match either
+#: way, ordering by length makes that correctness independent of backtracking.
+PROTO = re.compile(r"^(" + "|".join(sorted(PROTO_TAGS, key=lambda w: (-len(w), w))) + r")\s*:")
+
+#: Markdown decoration a report may be wearing at position zero: emphasis and
+#: strikethrough (``*``, ``_``, ``~``), code ticks, heading hashes, blockquote
+#: arrows, and list markers (``-``, ``*``, ``+``, or a number with ``.``/``)``),
+#: in any combination and with any whitespace between them.
+_LEADING_DECOR = re.compile(r"^(?:[\s>#*_~`+-]|\d+[.)])+")
+
+
+def _proto_tag(text: str) -> str | None:
+    """The protocol tag *text* reports, or None -- decoration and all.
+
+    ``PROTO`` is anchored at position zero, so ANY leading decoration defeats it:
+    ``**BLOCKED:**`` puts an asterisk where the tag has to be, the match fails,
+    and the line falls through as no-prefix. On a fresh transcript IDLE does not
+    fire either, so the report is not delayed or suppressed -- it is silent.
+
+    That is worth normalising rather than legislating, because emphasis is
+    ordinary formatting habit rather than a protocol violation, and a convention
+    the worker has to remember fails exactly when the worker is under pressure --
+    which is when escalations get written. The robust half has to be the reader.
+
+    WHICH TEXT IS NORMALISED, precisely, because the difference is observable:
+    only the text this function MATCHES against. Callers keep the raw text for
+    everything else, so the digest is still computed over what the worker
+    actually wrote and a decorated report keeps a stable, distinct identity.
+
+    The anchor survives normalisation: decoration is stripped from the FRONT, so
+    a bolded protocol word mid-sentence still does not set a tag. This is not a
+    substring search, and turning it into one would tag any message that
+    mentioned a report.
+    """
+    match = PROTO.match(_LEADING_DECOR.sub("", text, count=1))
+    return match.group(1) if match else None
+
+
+#: Roles whose rows are TOOL ACTIVITY, never a worker's own protocol message.
+#: This is the transcript's OWN discriminator -- the writers tag a tool card with
+#: its role (``history_consolidation._TOOL_ROLES`` is the same set) and the
+#: presentation class is not persisted at all, so ``role`` is the only field that
+#: separates the two. A tool row's content is a glyph plus the tool title, so a
+#: protocol word inside one is quoted text: 87 of 2,590 measured tool rows carry
+#: one. Excluding them costs no error signal either -- across those same
+#: transcripts every ``initialize timed out`` / stall-watchdog / throttle line
+#: landed on an ``error``, ``assistant``, ``inject``, ``user`` or ``nudge`` row
+#: and not one landed on a tool row.
+TOOL_ROLES = frozenset({"tool", "tool_call", "tool_result"})
+
+#: The roles the SESSION itself produces: its own messages and its tool activity.
+#: Everything else in a transcript arrives from outside -- ``nudge`` and
+#: ``inject`` recovery notices, ``user`` turns, the metadata header -- and must
+#: not count as the session having spoken. Byte needles rather than parsed rows
+#: because the index is counted over the whole file, and the role field is spelled
+#: the way this package's writers emit it (``json.dumps`` default separators).
+#:
+#: Anchored at a LINE boundary, so only a row's own opening can be counted and
+#: never anything inside another row's content. Valid JSONL already prevents the
+#: obvious version of that -- ``json.dumps`` escapes the inner quotes, so a
+#: message quoting ``{"role": "assistant"`` is stored as ``{\"role\": ...`` and
+#: does not match -- but the anchor makes the count correct without depending on
+#: that argument, and covers a torn line at the window edge too.
+_OWN_ROW_NEEDLES = tuple(
+    f'{{"role": "{role}"'.encode() for role in ("assistant", *sorted(TOOL_ROLES))
+)
+
+
+def _count_own_rows(raw: bytes) -> int:
+    """How many rows in *raw* the session itself produced.
+
+    A needle matches only at the start of a line, which is where a row's own
+    opening brace is. The first line has no preceding newline, so it is checked
+    separately rather than being silently missed.
+    """
+    total = 0
+    for needle in _OWN_ROW_NEEDLES:
+        total += raw.count(b"\n" + needle)
+        if raw.startswith(needle):
+            total += 1
+    return total
+
 
 #: Error shapes observed in real worker tails during the 2026-08-30 fleet run.
 DEFAULT_ERR_RES = (
@@ -94,18 +248,133 @@ DEFAULT_ERR_RES = (
     r"initialize timed out",
 )
 
-#: Banned-operation cmdline shapes: a pytest without an explicit bounded worker
-#: count (the repo's ``-n auto`` addopts means a bare pytest forks one worker
-#: per core; ``-n 4``, ``-n=4``, ``-n4`` and ``--numprocesses=4`` all count as
-#: bounded, ``-n auto`` does not), and a bare full-suite vitest with no file
-#: arguments.
+#: Banned-operation cmdline shapes: a pytest whose worker count nobody CHOSE,
+#: and a bare full-suite vitest with no file arguments.
+#:
+#: "Nobody chose" is the honest statement of what this rule catches, and it is
+#: not the same as "too many". This comment used to say a bare pytest forks one
+#: worker per core because of the repo's ``-n auto`` addopts. That premise is
+#: wrong: ``setup.cfg`` documents that ``auto`` is bounded by the rootdir
+#: conftest's ``pytest_xdist_auto_num_workers`` hook, which sizes the pool by
+#: available memory and by what concurrent runs on the host already hold, and
+#: that "an explicit ``-n <N>`` bypasses the budget". So on THIS repo the
+#: explicit spelling is the one that can outgrow the host, and ``auto`` is the
+#: one that cannot.
+#:
+#: The rule's sense is deliberately left as it stands, because changing which
+#: shapes it flags changes what the conductor stops mid-turn across a whole
+#: fleet, and that is not a comment's decision to make. What it costs is stated
+#: plainly instead: ``-n 4``, ``-n=4``, ``-n4``, ``-n0`` and
+#: ``--numprocesses=4`` all read as bounded, ``-n auto`` and a bare pytest do
+#: not. ``-n0`` is the repo's own documented override and is genuinely
+#: in-process, so the safest form a worker can run is also a passing one.
 DEFAULT_BANNED_RES = (
     r"\bpytest\b(?!.*(?:-n|--numprocesses)\s*=?\s*\d)",
     r"\bvitest\b\s+run\s*$",
 )
 
+#: An initialize-timeout tail: the session never got a live backend, so nothing
+#: it was told to do was ever delivered. Literal from the emitters
+#: (``mcp_gateway.backend`` records ``initialize timed out on respawn``).
+DEFAULT_INIT_TIMEOUT_RES = (r"initialize timed out",)
+
+#: A turn ended by the stall watchdog rather than by the worker. Literals from
+#: the emitters: ``dashboard.state.TOOL_STALL_RECOVERY_PREFIX`` /
+#: ``STALE_RECOVERY_PREFIX`` (the recovery notice injected into the transcript)
+#: and ``acp.types.STOP_REASON_TOOL_STALL``. The dash inside the bracketed
+#: notices is matched as ``.*`` so an em-dash/hyphen change in the emitter does
+#: not silently stop counting.
+DEFAULT_WATCHDOG_RES = (
+    r"\[Tool stall\b.*automatic recovery\]",
+    r"\[Stalled turn\b.*automatic recovery\]",
+    r"error: tool stall",
+    r"tool stalled\b.*no data for",
+)
+
 IDLE_TAG = "IDLE"
-_FIRING = {"GREEN", "PR", "BLOCKED", "STANDDOWN", "PROPOSAL", "ERR", IDLE_TAG}
+TERMINAL_TAG = "TERMINAL"
+NOPROGRESS_TAG = "NOPROGRESS"
+
+#: Reports that END an assignment. A worker that files one and then writes an
+#: unprefixed line is finished, not wedged, and must not age into IDLE.
+#:
+#: ``GREEN`` is the one that matters most and was missing from the first version
+#: of this set, which is worth recording because it made the fix cover only its
+#: rare cases: ``GREEN`` is the literal exit condition in every worker's contract
+#: ("report GREEN and stop"), so the most common terminal state in the fleet aged
+#: into IDLE and the conductor nudged workers that had already delivered -- the
+#: exact harm this set exists to remove. ``PR`` is deliberately NOT here: opening
+#: a pull request is a milestone the work continues past, and a worker that has
+#: only reported ``PR`` still owes the conductor a green.
+TERMINAL_TAGS = frozenset({"GREEN", "STANDDOWN", "PROPOSAL"})
+
+#: Reports that keep their meaning until the conductor ACTS on them.
+#:
+#: A probe samples; it does not subscribe. So it can only ever see a session's
+#: newest message, and a state that was overwritten between two samples is not
+#: suppressed or deferred -- it is never observed at all. ``BLOCKED`` is exactly
+#: the state that gets overwritten, because the protocol requires a blocked
+#: worker to keep reporting status, so its own next message displaces the only
+#: place a sampling probe looks. The debt then exists on both sides and is
+#: visible to neither: the worker holds position waiting for a ruling, and the
+#: conductor never learned it owes one.
+#:
+#: Sticky is what survives the sample. A sticky report is not cleared by a
+#: heartbeat or by unprefixed text; only another real report clears it, and the
+#: conductor's own act of delivering the ruling (``--mark-handled``) is what
+#: quiets it.
+#:
+#: Deliberately NOT merged with ``TERMINAL_TAGS``: ``TERMINAL`` means close me,
+#: sticky ``BLOCKED`` means a ruling is owed. Those call for opposite actions, so
+#: collapsing them would trade one invisible obligation for a wrong one.
+#:
+#: KNOWN BOUND, stated rather than left to be discovered: stickiness reaches only
+#: as far back as the parse window. A blocked worker that heartbeats long enough
+#: eventually pushes its own report past ``tail_bytes`` (200 KB), and the ruling
+#: debt goes invisible again -- the same loss class this fixes, deferred rather
+#: than closed. Raising ``tail_bytes`` buys proportionally more time; making it
+#: unconditional would mean parsing every transcript in full on every cycle.
+#:
+#: The durable handled set cannot close it, which is worth spelling out because it
+#: looks like it should. ``proto`` there is written ONLY by ``--mark-handled``, so
+#: it exists exactly when the ruling has already been delivered -- and in that
+#: case the signal is correctly suppressed by digest, so reading it would change
+#: nothing. In the case the bound actually bites, an UNDISPOSITIONED report ageing
+#: out, there is no mark and therefore no recorded tag to read. Sourcing
+#: stickiness from the state file would either be a no-op or re-fire answered
+#: rulings forever, so the transcript stays the source of truth and the bound
+#: stays honest.
+STICKY_TAGS = frozenset({"BLOCKED"})
+
+#: A heartbeat reports that the worker is ALIVE, not what state it is in, so it
+#: cannot clear a sticky report. Every other protocol word can: a worker that
+#: files ``PR``, ``GREEN``, ``STANDDOWN`` or ``PROPOSAL`` after being blocked has
+#: moved on, and no ruling is owed any more.
+HEARTBEAT_TAGS = frozenset({"WORKING"})
+
+#: Reports that carry a PAYLOAD the conductor acts on, as opposed to a heartbeat
+#: (alive, no state) or a condition the probe derives (``IDLE``, ``NOPROGRESS``,
+#: ``GONE``, ``ERR``). A payload disposition is the one fact that must survive
+#: every later mark: the handled set holds one entry per key, so without that the
+#: record of an answered report is overwritten by whatever is reported next and
+#: the answered report presents again.
+_PAYLOAD_TAGS = PROTO_TAGS - HEARTBEAT_TAGS
+
+_FIRING = {
+    "GREEN",
+    "PR",
+    "BLOCKED",
+    "STANDDOWN",
+    "PROPOSAL",
+    "ERR",
+    IDLE_TAG,
+    TERMINAL_TAG,
+    NOPROGRESS_TAG,
+}
+
+#: Tags whose disposition EXPIRES, so the condition re-alerts while it holds.
+#: Both describe an ongoing state rather than a payload that was filed once.
+_EXPIRING_TAGS = frozenset({IDLE_TAG, NOPROGRESS_TAG})
 
 #: A session key is a filename STEM, never a path: one path-safe token. This is
 #: what keeps an agent-authored key (``../../etc/foo``, an absolute path) from
@@ -141,40 +410,259 @@ def _text_of(entry: dict[str, Any]) -> str:
     return str(entry.get("text", ""))
 
 
-def _tail_entries(path: Path, max_bytes: int) -> list[dict[str, Any]]:
+def _tail_entries(path: Path, max_bytes: int) -> tuple[list[dict[str, Any]], int | None]:
+    """Parse the tail window, and report how many rows the SESSION has produced.
+
+    The index is 2a's no-progress discriminator: unchanged across two probes
+    means the session has not spoken, whether or not a turn is open, and that is
+    the one thing a self-deadlocked worker cannot fake. Two properties follow,
+    and each of them is a way the obvious implementation gets it wrong.
+
+    It counts from the START of the file, not the start of the window. A
+    window-relative count saturates the moment a transcript passes ``tail_bytes``
+    (200 KB by default) and then stays frozen while the session talks -- reading,
+    at exactly the sizes real worker sessions reach, as the deadlock it exists to
+    detect.
+
+    It counts only rows the session PRODUCED -- its own messages and its tool
+    activity -- never inbound ones. A transcript holds nudges, injected recovery
+    notices and user turns as well, so counting every row means the conductor's
+    OWN nudge advances the index of the worker it just nudged, and a wedged
+    session reads as progress precisely when the conductor pokes it. Counting
+    tool rows IS deliberate: a session running tools is working even while it is
+    silent.
+
+    Both halves are byte-level counts over bytes this read already had in hand,
+    so neither costs a second pass or a JSON parse of the prefix. The needle is
+    the role field as this package's writers emit it (``json.dumps`` default
+    separators); a writer that changed that spelling would understate the index,
+    which is why the round-trip test pins it against the real writer rather than
+    a fixture.
+
+    Returns ``(entries, last_index)``; ``last_index`` is None for an unreadable
+    or empty file, or one with no session rows yet, which prints as ``i=?``
+    exactly like an unknown age.
+    """
     try:
-        raw = path.read_bytes()[-max_bytes:]
+        raw = path.read_bytes()
     except OSError:
-        return []
+        return [], None
+    window = raw[-max_bytes:] if len(raw) > max_bytes else raw
     entries: list[dict[str, Any]] = []
-    for line in raw.splitlines():
+    for line in window.splitlines():
         try:
             parsed = json.loads(line)
         except Exception:
             continue  # a truncated first line is expected when tailing
         if isinstance(parsed, dict):
             entries.append(parsed)
-    return entries
+    produced = _count_own_rows(raw)
+    return entries, (produced - 1 if produced else None)
 
 
 def _classify(entries: list[dict[str, Any]], err_res: list[re.Pattern[str]]) -> tuple[str, str]:
-    """Return (tag, tail_text) for one session's transcript tail."""
-    last_assistant = next(
-        (
-            _text_of(entry).strip()
-            for entry in reversed(entries)
-            if entry.get("role") == "assistant" and _text_of(entry).strip()
-        ),
-        "",
-    )
-    last_any = entries[-1] if entries else {}
+    """Return (tag, tail_text) for one session's transcript tail.
+
+    Classification reads only what the session SAID -- tool rows are dropped
+    first, so neither half can be driven by tool text. The tag half already
+    looked at ``role == "assistant"`` alone, but the error half read the last
+    entry of ANY role, and a tool row is the last row on roughly one transcript
+    in ten (6 of 60 measured), so an error pattern quoted in a tool title used
+    to raise ERR on a healthy worker.
+
+    The tag is the newest REPORT rather than the newest message, and a sticky
+    report outlives the messages that follow it. Reading only the newest message
+    makes a sampling probe structurally unable to see a state its own protocol
+    guarantees will be overwritten -- see ``STICKY_TAGS``. The returned tail is
+    the sticky report's OWN text, which is what keeps its digest stable while the
+    worker goes on filing heartbeats: the signal fires once, is suppressed by the
+    ruling, and re-fires only if the worker files a genuinely new one.
+
+    ERR still takes precedence, because an errored session must be resumed before
+    anything it said can be acted on. That defers a sticky report by one cycle at
+    most: the ERR is marked, the tail is unchanged, and the sticky report is what
+    the next probe classifies.
+    """
+    spoken = [entry for entry in entries if str(entry.get("role", "")) not in TOOL_ROLES]
+    last_assistant = ""
+    newest_report: tuple[str, str] | None = None
+    sticky_report: tuple[str, str] | None = None
+    for entry in reversed(spoken):
+        if entry.get("role") != "assistant":
+            continue
+        text = _text_of(entry).strip()
+        if not text:
+            continue
+        if not last_assistant:
+            last_assistant = text
+        tag = _proto_tag(text)
+        if tag is None:
+            continue
+        if newest_report is None:
+            newest_report = (tag, text)
+        if tag not in HEARTBEAT_TAGS:
+            # The newest report that actually states a state. Walking stops here:
+            # anything older has already been superseded by this one.
+            sticky_report = (tag, text)
+            break
+
+    last_any = spoken[-1] if spoken else {}
     last_any_text = _text_of(last_any)
     if "error" in str(last_any.get("role", "")).lower() or any(
         rx.search(last_any_text) for rx in err_res
     ):
         return "ERR", (last_any_text.strip() or last_assistant)
-    match = PROTO.match(last_assistant)
-    return (match.group(1) if match else "-"), last_assistant
+
+    if sticky_report is not None and sticky_report[0] in STICKY_TAGS:
+        return sticky_report
+    if newest_report is not None:
+        return newest_report
+    return "-", last_assistant
+
+
+def _sticky_pending(entries: list[dict[str, Any]]) -> tuple[str, str] | None:
+    """The newest STICKY report in the window, or None if none is owed.
+
+    Used only when the primary reading is a suppressed ``ERR``. A report that is
+    not sticky returns None rather than being surfaced, because a newer
+    non-sticky report supersedes whatever preceded it -- this reaches past an
+    error row, not past a state the worker has since moved on from.
+    """
+    for entry in reversed([e for e in entries if str(e.get("role", "")) not in TOOL_ROLES]):
+        if entry.get("role") != "assistant":
+            continue
+        text = _text_of(entry).strip()
+        if not text:
+            continue
+        tag = _proto_tag(text)
+        if tag is None or tag in HEARTBEAT_TAGS:
+            continue
+        return (tag, text) if tag in STICKY_TAGS else None
+    return None
+
+
+def _tail_matches(entries: list[dict[str, Any]], patterns: list[re.Pattern[str]]) -> bool:
+    """Does anything the session SAID in this window match one of *patterns*?
+
+    Used for the delivery counters (2c), which are per-session facts, not
+    per-tag ones: a session can be counted as undelivered while its tag is
+    something else entirely, which is the whole point -- load and memory read
+    healthy while the fleet cannot deliver.
+
+    Tool rows are skipped for the same reason ``_classify`` skips them, and the
+    measurement backs it: over the 60 most recent transcripts on the development
+    host, every initialize-timeout and stall-watchdog line landed on an
+    ``error``, ``assistant``, ``inject``, ``user`` or ``nudge`` row and not one
+    landed on a tool row. The whole window is scanned, not just the last row --
+    a watchdog notice is followed by whatever the session did next, so reading
+    only the final row would miss nearly all of them.
+
+    "Currently" is load-bearing, and the walk goes NEWEST first for it. Scanning
+    the window for ANY historical match counts a failure the session has since
+    recovered from, and because the window is 200 KB one healed init-timeout keeps
+    that session in the undelivered column until it scrolls out. A counter that
+    only ratchets up stops being an admission instrument and becomes a permanent
+    accusation, so the walk stops at the first protocol report: a session that has
+    filed a report since the notice evidently got a turn through, whatever else is
+    wrong with it. Only a match reached BEFORE any report is outstanding.
+    """
+    for entry in reversed(entries):
+        if str(entry.get("role", "")) in TOOL_ROLES:
+            continue
+        text = _text_of(entry)
+        if not text:
+            continue
+        if entry.get("role") == "assistant" and _proto_tag(text.strip()) is not None:
+            # The boundary is tested BEFORE the patterns, not after. A recovery
+            # report that quotes the notice it recovered from -- "WORKING: back up
+            # after initialize timed out" -- matches the pattern on its own text,
+            # so testing patterns first counts the recovery itself as the failure
+            # and pins the session in the undelivered column permanently.
+            return False
+        if any(rx.search(text) for rx in patterns):
+            return True
+    return False
+
+
+def _recorded_proto(handled: dict[str, Any], key: str) -> str | None:
+    """The last DISPOSITIONED protocol tag for *key*, or None.
+
+    Read out of the single ``settled`` record, which every mark either sets or
+    carries forward, so a later non-payload disposition (an ``IDLE`` nudge, an
+    ``ERR``, a ``GONE`` reclaim) cannot erase it. Without that, a finished worker
+    read identically to a wedged one: the handled set keeps one entry per key,
+    so the terminal report was overwritten by the very next tag.
+
+    None on a state file written before the field existed. The shipped shape is
+    ``{tag, digest, ts}``, and the first mark after an upgrade recovers a terminal
+    reading from the entry's own tag when that tag is a payload -- which is the
+    only recovery available, because the older writer had already overwritten any
+    earlier report. That is the loss this field exists to stop, so it cannot also
+    be undone retroactively.
+    """
+    entry = handled.get(key)
+    if not isinstance(entry, dict):
+        return None
+    settled = entry.get("settled")
+    if isinstance(settled, dict) and isinstance(settled.get("tag"), str):
+        return str(settled["tag"])
+    tag = entry.get("tag")
+    if isinstance(tag, str) and tag in _PAYLOAD_TAGS:
+        # The shipped shape, on the first probe after an upgrade: no ``settled``
+        # yet, but the entry's own tag is the last dispositioned report, and when
+        # that is a payload it answers the same question. Without this a delivered
+        # worker is nudged once during the upgrade -- small, and exactly the harm
+        # this field exists to prevent, so it is not worth conceding.
+        return tag
+    return None
+
+
+def _stalled_since_disposition(
+    handled: dict[str, Any], key: str, index: int | None, idle_secs: int
+) -> bool:
+    """Has *key* produced nothing at all since the conductor last acted on it?
+
+    This is the comparison the index exists for, done HERE rather than delegated.
+    Printing ``i=`` and expecting someone to diff two cycles by eye is a decision
+    living in prose: nothing enforces it, so it may simply never happen. The probe
+    holds both numbers, so it can answer the question instead of posing it.
+
+    The recorded side is the index stored at the last ``--mark-handled``, which
+    makes the claim precise and useful: not "quiet for a while" but "has emitted
+    no message and run no tool since you last acted on this session". That is why
+    it needs no new write and does not weaken the one-writer rule -- the only
+    write is still the mark.
+
+    The disposition must also be at least one idle budget old. Without that the
+    tag fires on the cycle immediately after EVERY mark, since a session that just
+    filed a report and was acted on has, trivially, produced nothing in the
+    seconds since -- which would put a spurious line on every watched key every
+    cycle and bury the real ones.
+
+    A key with no recorded index has no prior observation to compare against, so
+    it cannot be stalled yet. Absent on state written before ``index`` existed,
+    which reads the same way.
+
+    BOUND -- the identity is a COUNT, so it is only monotonic while the transcript
+    only grows. If a runtime is introduced that truncates or rotates a transcript
+    in place, the count restarts and can land on a value already recorded here,
+    and this reads a re-started session as one that has produced nothing. Nothing
+    in the current writers does that -- transcripts are append-only JSONL and the
+    reader takes a tail -- so the count is sufficient today and a rotation counter
+    would be state carried for a case that does not exist. The condition to watch
+    for is the arrival of a writer that reuses a transcript path; that is when the
+    identity needs a generation as well as a position.
+    """
+    if index is None:
+        return False
+    entry = handled.get(key)
+    if not isinstance(entry, dict):
+        return False
+    recorded = entry.get("index")
+    if not isinstance(recorded, int) or isinstance(recorded, bool) or recorded != index:
+        return False
+    marked = entry.get("ts")
+    return isinstance(marked, (int, float)) and time.time() - marked >= idle_secs
 
 
 def _digest(text: str) -> str:
@@ -193,12 +681,194 @@ def _suppressed(handled: dict[str, Any], key: str, tag: str, digest: str, idle_s
     entry = handled.get(key)
     if not isinstance(entry, dict):
         return False
+    settled = entry.get("settled")
+    if isinstance(settled, dict) and settled.get("tag") == tag and settled.get("digest") == digest:
+        # A PAYLOAD disposition preserved underneath a later condition mark. The
+        # handled set holds one entry per key, so marking IDLE or NOPROGRESS on a
+        # session would otherwise overwrite the record that its BLOCKED was
+        # already answered -- and an answered ruling re-presenting is worse than
+        # the stall going unreported, because the conductor re-adjudicates
+        # something it has already decided. Payload dispositions never expire, so
+        # this needs no clock.
+        return True
     if entry.get("tag") != tag or entry.get("digest") != digest:
         return False
-    if tag == IDLE_TAG:
+    if tag in _EXPIRING_TAGS:
+        # These two describe a CONTINUING condition rather than a payload, so a
+        # single disposition must not silence them forever: a worker that is
+        # still silent, or still producing nothing, has to re-alert. Every other
+        # tag stays suppressed while its payload is unchanged, because a report
+        # that has been acted on is done.
         marked = entry.get("ts")
         return isinstance(marked, (int, float)) and time.time() - marked < idle_secs
     return True
+
+
+def _norm_path(path: str) -> str:
+    """A compare-ready spelling of *path*.
+
+    Two spellings of one directory must not read as two directories, or a
+    fleet-owned process is filed as somebody else's and its banned run goes
+    unreported. Three normalisations, all of them load-bearing on Windows, where
+    this ran green on Linux and misfiled every match:
+
+    * the extended-length prefix. ``os.readlink`` can answer ``\\\\?\\D:\\...``,
+      which no configured root will ever spell, so a literal prefix comparison
+      fails on a path that does match.
+    * case and separator. ``normcase`` folds both, since ``D:/a`` and ``d:\\a``
+      are the same directory there and only one of them is what the config says.
+    * short (8.3) names. Left to ``os.path.realpath`` in the caller's fallback,
+      because expanding them requires touching the filesystem and this half must
+      stay a pure string operation for the unreadable-cwd case.
+    """
+    if path.startswith("\\\\?\\"):
+        path = path[4:]
+    return os.path.normcase(os.path.normpath(path))
+
+
+def _under(child: str, root: str) -> bool:
+    """Is *child* the directory *root* or inside it?
+
+    The boundary test is a separator, not a bare prefix: without it a sibling
+    worktree named ``wt-a-old`` is swallowed by ``wt-a`` and its runs are
+    attributed to the wrong owner.
+    """
+    return child == root or child.startswith(root.rstrip(os.sep) + os.sep)
+
+
+def _program_path(cmd: str) -> str:
+    """The program path out of a joined cmdline, or ``""``.
+
+    ``/proc/<pid>/cmdline`` is world-readable where the ``cwd`` and ``exe``
+    symlinks are not -- both of those need the same access a debugger would, so
+    they fail for another user's process while the cmdline still reads. That
+    asymmetry is the only reason this fallback is worth having.
+
+    Reading argv is not the same as PRINTING it. A secret can ride in an
+    argument, so the command line is still never emitted -- but the program PATH
+    is structural, so it can be compared for a decision and dropped. The next
+    reader will otherwise assume argv was excluded from being read at all.
+    """
+    return cmd.split(" ", 1)[0] if cmd else ""
+
+
+def _venv_root(program: str) -> str | None:
+    """The virtualenv a program path belongs to, or None if it is not in one.
+
+    A venv is created inside one checkout and belongs to it, so its interpreter
+    path attributes the process. A system or shim interpreter attributes nothing:
+    every checkout on the host shares it.
+    """
+    parent = os.path.dirname(os.path.dirname(program))
+    if not parent:
+        return None
+    # bin/python on POSIX, Scripts/python.exe on Windows; pyvenv.cfg sits beside
+    # both, so the marker is checked rather than either layout being assumed.
+    return parent if os.path.isfile(os.path.join(parent, "pyvenv.cfg")) else None
+
+
+def _program_class(cmd: str, fleet: list[str]) -> str:
+    """The ownership class implied by the program path alone, for use when the
+    cwd could not be read. See ``_owner_class`` for why the two directions of
+    this comparison do not carry the same weight.
+
+    Every uncertain answer is ``unknown``, never ``fleet``. In the conductor's
+    action table ``fleet`` is the one class that STOPS a session while ``unknown``
+    only re-injects the directive, so the safe direction for a wrong answer is
+    toward not enforcing. A root that reaches here without being comparable
+    therefore widens nothing.
+    """
+    if not fleet:
+        return "unknown"
+    program = _program_path(cmd)
+    if not program:
+        return "unknown"
+    try:
+        literal = _norm_path(program)
+        real = _norm_path(os.path.realpath(program))
+        for root in fleet:
+            if _under(literal, _norm_path(root)) or _under(
+                real, _norm_path(os.path.realpath(root))
+            ):
+                return "fleet"
+        venv = _venv_root(program)
+    except (OSError, ValueError):
+        # ValueError is the embedded-NUL case that validation refuses at load
+        # time; this is the belt to that braces, and it fails toward not stopping.
+        return "unknown"
+    if venv is None:
+        # A system or shim interpreter. Every checkout on the host shares it, so
+        # it says nothing about ownership and must not be read as a denial.
+        return "unknown"
+    return "foreign"
+
+
+def _owner_class(proc_entry: Path, fleet: list[str], cmd: str = "") -> str:
+    """``fleet``, ``foreign`` or ``unknown`` for the process at *proc_entry*.
+
+    ``/proc/<pid>/cwd`` is a symlink to the working directory, so the link TARGET
+    is the answer. When it cannot be read -- a process that exited between the
+    scan and the read, or one owned by another user -- the program path is asked
+    instead, because in both attributable BANNED lines observed in the field the
+    cwd was the field that failed while the cmdline survived. A cwd-only
+    classifier would have returned ``unknown`` for two processes that could be
+    PROVEN not to be the fleet's, and an unknown match makes the conductor act.
+
+    The two signals do NOT get the same authority, and the difference is load
+    bearing. A program path UNDER a fleet worktree is conclusive: nothing outside
+    that checkout runs its interpreter. A program path outside one is only
+    conclusive when it is a venv interpreter, which belongs to whichever checkout
+    created it. A system or shim interpreter attributes nothing -- and that is the
+    fleet's own case, not a hypothetical: a fleet worktree here has no ``.venv``
+    and its workers run a global ``python3`` shim, so treating "not under a fleet
+    worktree" as ``foreign`` would classify a real banned run INSIDE the fleet as
+    somebody else's and never print it. That is the exact harm 2d exists to
+    prevent, so the non-match stays ``unknown``.
+
+    An empty or unset ``fleet_worktrees`` declares no scope, and scoping against
+    an empty set would classify every match as ``foreign`` and mute the banned
+    signal entirely -- a failure the conductor cannot see. Unscoped therefore
+    means ``unknown``: every match is still reported and still counted, which is
+    exactly the pre-2d behaviour.
+
+    The comparison gets a second chance through ``realpath`` because a match
+    missed is a banned run inside the fleet reported as somebody else's: it
+    absorbs a symlinked worktree root and a Windows short (8.3) name, either of
+    which spells the same directory a way the literal form does not.
+    """
+    try:
+        target = os.readlink(proc_entry / "cwd")
+    except OSError:
+        # Usually a process that exited mid-scan; on a shared host also every
+        # OTHER user's process, whose /proc entry this uid cannot follow.
+        #
+        # Asking WHO owns it would let most of the second group be summarised as
+        # `foreign` instead of reported as `unknown`, and that refinement was
+        # tried and withdrawn. It needs the current uid, and this file is a
+        # standalone script run by a bare interpreter -- it imports nothing from
+        # the package, so it cannot route through ``platform_compat``, and
+        # ``os.getuid`` is POSIX-only: absent on Windows, where its absence
+        # raises AttributeError rather than OSError and takes the whole scan
+        # down. The exchange is a fail-open reading for a crash on one platform,
+        # to buy quieter output on a path that is already correct. The PROGRAM
+        # path is a different trade: cmdline is world-readable, so it costs no
+        # new primitive and no portability risk, and it is asked below.
+        return _program_class(cmd, fleet)
+    if not fleet:
+        return "unknown"
+    try:
+        literal = _norm_path(target)
+        if any(_under(literal, _norm_path(root)) for root in fleet):
+            return "fleet"
+        real = _norm_path(os.path.realpath(target))
+        if any(_under(real, _norm_path(os.path.realpath(root))) for root in fleet):
+            return "fleet"
+    except (OSError, ValueError):
+        # Uncertain ownership answers `unknown`, never `fleet`: `fleet` is the one
+        # class that stops a session, so a comparison that cannot be completed
+        # must not promote a process into it.
+        return "unknown"
+    return "foreign"
 
 
 def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
@@ -206,11 +876,13 @@ def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
     banned_res = [
         re.compile(rx) for rx in cfg.get("banned_process_res") or list(DEFAULT_BANNED_RES)
     ]
+    fleet = [p for p in cfg.get("fleet_worktrees") or []]
     lines: list[str] = []
     # /proc, with an env seam for the test harness only -- not a config key,
     # for the same containment reason as the other paths.
     proc_root = Path(os.environ.get("KIROCREW_PROBE_PROC_ROOT") or "/proc")
     banned = 0
+    foreign = 0
     if proc_root.is_dir():
         for entry in proc_root.iterdir():
             if not entry.name.isdigit():
@@ -227,14 +899,25 @@ def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
                 continue
             if cmd:
                 matched = next((rx.pattern for rx in banned_res if rx.search(cmd)), None)
-                if matched is not None:
-                    banned += 1
-                    # pid + WHICH RULE fired is everything the conductor needs
-                    # (stop the owner, re-seed with the directive). The argv is
-                    # deliberately not echoed: a command line can carry
-                    # credentials or presigned URLs, and this line lands in the
-                    # conductor's model context.
-                    lines.append(f"BANNED pid={entry.name} rule={matched}")
+                if matched is None:
+                    continue
+                # A banned SHAPE is only a banned OPERATION when the fleet owns
+                # it. The same unbounded pytest run in an unrelated checkout is
+                # this machine's business, and counting it made the conductor
+                # stop a worker that was not the offender -- so the cwd decides
+                # which counter it lands in, and only fleet-owned or unreadable
+                # matches are printed at all.
+                cwd_class = _owner_class(entry, fleet, cmd)
+                if cwd_class == "foreign":
+                    foreign += 1
+                    continue
+                banned += 1
+                # pid + WHICH RULE fired + the cwd class is everything the
+                # conductor needs (stop the owner, re-seed with the directive).
+                # The argv is deliberately not echoed: a command line can carry
+                # credentials or presigned URLs, and this line lands in the
+                # conductor's model context.
+                lines.append(f"BANNED pid={entry.name} rule={matched} cwd={cwd_class}")
     per_cpu = None
     if hasattr(os, "getloadavg"):
         try:
@@ -257,7 +940,7 @@ def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
         else "load/cpu n/a"
     )
     mem_part = f"mem {mem_gb:.0f}G" if mem_gb is not None else "mem n/a"
-    return lines, f"{load_part} | {mem_part} | banned {banned}"
+    return lines, f"{load_part} | {mem_part} | banned {banned} | foreign {foreign}"
 
 
 def _sessions_dir() -> Path:
@@ -304,9 +987,15 @@ def run_probe(cfg: dict[str, Any], state_path: Path) -> int:
     idle_secs = int(cfg.get("idle_alert_secs", 900))
     tail_bytes = int(cfg.get("tail_bytes", 200_000))
     err_res = [re.compile(rx) for rx in (list(DEFAULT_ERR_RES) + list(cfg.get("err_res") or []))]
+    init_res = [
+        re.compile(rx) for rx in cfg.get("init_timeout_res") or list(DEFAULT_INIT_TIMEOUT_RES)
+    ]
+    watchdog_res = [re.compile(rx) for rx in cfg.get("watchdog_res") or list(DEFAULT_WATCHDOG_RES)]
     handled = _handled_of(_load_state(state_path))
 
     fired = 0
+    init_timeouts = 0
+    watchdogs = 0
     for key in sessions:
         path = _transcript_path(sessions_dir, key)
         age: int | None = None
@@ -319,30 +1008,104 @@ def run_probe(cfg: dict[str, Any], state_path: Path) -> int:
             # GONE flows through the same suppression as every other tag: an
             # acted-on GONE (item reclaimed, mark-handled) must not re-fire
             # every cycle until the key is dropped from the watch list.
-            tag, tail, age_text = "GONE", "transcript missing", "?"
+            tag, tail, age_text, index = "GONE", "transcript missing", "?", None
         else:
-            tag, tail = _classify(_tail_entries(path, tail_bytes), err_res)
-            if tag not in _FIRING and age > idle_secs:
-                tag = IDLE_TAG
+            entries, index = _tail_entries(path, tail_bytes)
+            tag, tail = _classify(entries, err_res)
+            # Counted for every watched session, fired or not: an undelivered
+            # session is a fleet fact, not a per-tag one.
+            init_timeouts += 1 if _tail_matches(entries, init_res) else 0
+            watchdogs += 1 if _tail_matches(entries, watchdog_res) else 0
+            if tag not in _FIRING:
+                # A worker that filed a terminal report and then wrote one
+                # unprefixed line is FINISHED. Ageing it into IDLE says the
+                # opposite, and the two readings call for opposite actions
+                # (close the item vs. nudge or reclaim it), so TERMINAL takes
+                # precedence over the clock.
+                #
+                # ``tag == "-"`` is load-bearing: the non-firing set holds BOTH
+                # ``-`` and ``WORKING``, so without it a worker that stood down,
+                # was re-seeded, and is now reporting ``WORKING:`` would read as
+                # finished and have its live work closed. WORKING is a protocol
+                # message and means active work; only an unprefixed tail can
+                # inherit a terminal disposition. A WORKING tail that then goes
+                # silent still ages into IDLE, which is the correct nudge.
+                if tag == "-" and _recorded_proto(handled, key) in TERMINAL_TAGS:
+                    tag = TERMINAL_TAG
+                elif age > idle_secs:
+                    tag = IDLE_TAG
+                elif _stalled_since_disposition(handled, key, index, idle_secs):
+                    # Ranked BELOW the clock deliberately. A cold transcript is
+                    # already fully described by IDLE, whose action -- nudge, then
+                    # the intervention ladder -- is the right one. What IDLE
+                    # cannot see is the session held WARM by traffic it never
+                    # answers: inbound nudges keep the mtime fresh while nothing
+                    # comes out. That is the case this tag exists for, and its
+                    # action is different: check the EFFECT rather than liveness.
+                    tag = NOPROGRESS_TAG
             if tag not in _FIRING:
                 continue
             age_text = str(age)
         digest = _digest(f"{tag}:{tail}")
         if _suppressed(handled, key, tag, digest, idle_secs):
-            continue
+            # An answered ERR must not bury a ruling nobody has answered. The
+            # error branch outranks the sticky walk, which is right on the first
+            # cycle -- a crashing session is the more urgent reading -- but the
+            # error row stays LAST for as long as the session is wedged, so the
+            # ERR is re-classified and re-suppressed every cycle and the BLOCKED
+            # underneath it is never reached. The deferral this was documented as
+            # costing (one cycle) was in fact unbounded.
+            surfaced = False
+            if tag == "ERR":
+                pending = _sticky_pending(entries)
+                if pending is not None:
+                    sticky_digest = _digest(f"{pending[0]}:{pending[1]}")
+                    if not _suppressed(handled, key, pending[0], sticky_digest, idle_secs):
+                        tag, digest = pending[0], sticky_digest
+                        surfaced = True
+            if not surfaced:
+                # The report itself is dealt with. Whether anything has come OUT
+                # of the session since is a different question, and the
+                # interesting case for it is exactly here: the ruling was
+                # delivered, the tag went quiet, and the worker then produced
+                # nothing at all. Without this the named tag masks the stall for
+                # as long as it stays suppressed.
+                # A finished worker produces nothing BY DEFINITION, so absence of
+                # output is not a stall. This guard is separate from the
+                # terminal/idle ladder above because that ladder is only reached
+                # for a NON-firing tag: a delivered worker whose `GREEN:` is still
+                # the newest row in the window keeps a firing tag, so it arrives
+                # here instead and would be reclassified as stalled -- then re-fire
+                # every cycle, since this tag expires. That is the harm TERMINAL
+                # exists to remove, so it is refused on both paths.
+                if (
+                    tag == NOPROGRESS_TAG
+                    or _recorded_proto(handled, key) in TERMINAL_TAGS
+                    or not _stalled_since_disposition(handled, key, index, idle_secs)
+                ):
+                    continue
+                tag = NOPROGRESS_TAG
+                digest = _digest(f"{tag}:{tail}")
+                if _suppressed(handled, key, tag, digest, idle_secs):
+                    continue
         fired += 1
-        # Metadata ONLY: key, age, tag, digest. Transcript-derived text is
+        # Metadata ONLY: key, age, tag, index, digest. Transcript-derived text is
         # deliberately never printed -- the conductor's action table is
         # tag-keyed, and content, when a ruling needs it, is read through the
         # workspace-authorized session tools, not through this script. That
         # keeps the probe's output free of private session text no matter
-        # which keys an (agent-authored) config watches.
-        print(f"🔔 {key:<28} {age_text:>5}s {tag:<9} d={digest}")
+        # which keys an (agent-authored) config watches. The index is a line
+        # POSITION, so it carries no content either.
+        index_text = "?" if index is None else str(index)
+        print(f"🔔 {key:<28} {age_text:>5}s {tag:<9} i={index_text} d={digest}")
 
     banned_lines, host = _host_lines(cfg)
     for line in banned_lines:
         print(line)
-    print(f"OK {len(sessions)} watched, {fired} fired | {host}")
+    print(
+        f"OK {len(sessions)} watched, {fired} fired | {host} | "
+        f"deliver init-timeout {init_timeouts}, watchdog {watchdogs}"
+    )
     return 0
 
 
@@ -353,8 +1116,21 @@ def mark_handled(cfg: dict[str, Any], state_path: Path, key: str, tag: str, dige
     tail_bytes = int(cfg.get("tail_bytes", 200_000))
     err_res = [re.compile(rx) for rx in (list(DEFAULT_ERR_RES) + list(cfg.get("err_res") or []))]
     path = _transcript_path(_sessions_dir(), key)
+    index: int | None = None
     if path is not None and path.exists():
-        current_tag, tail = _classify(_tail_entries(path, tail_bytes), err_res)
+        entries, index = _tail_entries(path, tail_bytes)
+        current_tag, tail = _classify(entries, err_res)
+        # A signal the conductor cannot mark is worse than no signal at all. When
+        # the probe reaches PAST a suppressed ERR to surface the sticky ruling
+        # underneath it, the digest it prints is over the RULING -- but the error
+        # row is still last here, so classifying again yields the ERR payload and
+        # the compare-and-set below refuses the mark. The ruling would then fire
+        # every cycle, undismissable. Resolving the same payload the probe printed
+        # keeps the two halves of the protocol agreeing on what is being marked.
+        if tag != current_tag and tag in STICKY_TAGS:
+            pending = _sticky_pending(entries)
+            if pending is not None and pending[0] == tag:
+                tail = pending[1]
         del current_tag  # the digest is keyed on the CALLER's tag, like the probe's
     else:
         tail = "transcript missing"  # mirror run_probe's GONE payload exactly
@@ -372,11 +1148,47 @@ def mark_handled(cfg: dict[str, Any], state_path: Path, key: str, tag: str, dige
     state = _load_state(state_path)
     handled = _handled_of(state)
     state["handled"] = handled
-    handled[key] = {
+    entry: dict[str, Any] = {
         "tag": tag,
         "digest": current,
         "ts": int(time.time()),
     }
+    if index is not None:
+        entry["index"] = index
+    # The last dispositioned PROTOCOL tag survives a later non-protocol
+    # disposition, because "this worker filed a terminal report" and "this
+    # worker went quiet" are different facts and the second must not erase the
+    # first. Carried forward from the previous entry when this mark is not
+    # itself a protocol tag.
+    # ONE field records the last payload disposition, and it is written on EVERY
+    # mark: set when this mark IS a payload, carried forward when it is not.
+    #
+    # An earlier version wrote two fields for this -- `proto` for the terminal
+    # reading and `settled` for the suppression -- and gated the second on the
+    # condition tags alone. That left the same data loss reachable one door down:
+    # an `ERR` disposition on a session whose `BLOCKED` was answered overwrote the
+    # answer, and once a heartbeat stopped the error row being last, the answered
+    # ruling presented again. The rule is not "condition marks preserve payloads"
+    # but "a mark that is not itself a payload cannot erase one", so the carry is
+    # unconditional and the two fields collapse into this one.
+    previous = handled.get(key)
+    previous = previous if isinstance(previous, dict) else {}
+    prior_tag, prior_digest = previous.get("tag"), previous.get("digest")
+    if tag in _PAYLOAD_TAGS:
+        entry["settled"] = {"tag": tag, "digest": digest}
+    elif (
+        isinstance(prior_tag, str) and prior_tag in _PAYLOAD_TAGS and isinstance(prior_digest, str)
+    ):
+        # The previous mark WAS the payload. Reading it off the entry keeps both
+        # halves, which matters for a state file written before ``settled``
+        # existed: that shape records an answered payload as the entry itself, and
+        # suppression needs the digest as well as the tag. Carrying only the
+        # legacy tag presented every answered ruling again on the first cycle
+        # after an upgrade.
+        entry["settled"] = {"tag": prior_tag, "digest": prior_digest}
+    elif isinstance(previous.get("settled"), dict):
+        entry["settled"] = previous["settled"]
+    handled[key] = entry
     state["updated_at"] = int(time.time())
     _atomic_write(state_path, json.dumps(state, indent=1, sort_keys=True) + "\n")
     print(f"handled {key} {tag}")
@@ -386,7 +1198,14 @@ def mark_handled(cfg: dict[str, Any], state_path: Path, key: str, tag: str, dige
 def _config_error(cfg: dict[str, Any]) -> str | None:
     """The first problem with a parsed config, or None. Typed misconfiguration
     is malformed config (exit 2 with a message), never an uncaught crash."""
-    for key in ("sessions", "err_res", "banned_process_res"):
+    for key in (
+        "sessions",
+        "err_res",
+        "banned_process_res",
+        "init_timeout_res",
+        "watchdog_res",
+        "fleet_worktrees",
+    ):
         value = cfg.get(key)
         if value is not None and (
             not isinstance(value, list) or any(not isinstance(item, str) for item in value)
@@ -395,6 +1214,52 @@ def _config_error(cfg: dict[str, Any]) -> str | None:
     for item in cfg.get("sessions") or []:
         if not _KEY_RE.fullmatch(item):
             return f"session key {item!r} is not a plain key (keys are stems, never paths)"
+    # A relative worktree root would be compared against an absolute
+    # /proc/<pid>/cwd target and could never match, so every banned run inside
+    # the fleet would be filed as foreign and go unreported. Say so at load time
+    # rather than silently muting the signal.
+    for item in cfg.get("fleet_worktrees") or []:
+        if "\0" in item:
+            # A NUL can never appear in a real path, so this entry could only ever
+            # fail to match -- and it fails LOUDLY: the path calls raise
+            # ValueError, not OSError, so it escapes the scan's exit-race handling
+            # and takes the whole cycle down, losing every other session's reading
+            # with it. Same reasoning as the relative-path check below: an entry
+            # that cannot match is malformed config, said at load time.
+            return "fleet_worktrees entry contains a NUL byte"
+        if not os.path.isabs(item):
+            return f"fleet_worktrees entry {item!r} must be an absolute path"
+        # A root that matches EVERYTHING is the dangerous direction, and this key
+        # is read from a config an agent authors -- so it is a trust boundary, not
+        # a typo class. ``cwd=fleet`` is the one class that stops a session, so a
+        # root of ``/`` turns the ownership guard into a false-stop generator
+        # against unrelated processes on the same host: precisely the harm that
+        # scoping the scan was introduced to prevent, reintroduced through config.
+        # Refused rather than narrowed, because silently ignoring an entry would
+        # leave the conductor believing a scope it does not have.
+        norm = _norm_path(item)
+        store = _norm_path(str(_sessions_dir()))
+        # BOTH spellings are judged, because the classifier compares both. Its
+        # realpath second chance exists so a symlinked worktree still matches --
+        # which means a root spelled as a symlink to `/` passes a literal-only
+        # check and then matches every cwd on the host. The widening comes back
+        # through the door the convenience opened, so validation follows it.
+        try:
+            candidates = {norm, _norm_path(os.path.realpath(item))}
+        except (OSError, ValueError):
+            return f"fleet_worktrees entry {item!r} cannot be resolved"
+        for candidate in candidates:
+            if candidate == _norm_path(os.path.dirname(candidate) or candidate):
+                return (
+                    f"fleet_worktrees entry {item!r} resolves to a filesystem root "
+                    "and matches everything"
+                )
+            if _under(store, candidate):
+                # One level up from the same widening: the session store is the
+                # conductor's own data directory, never a worktree, so a root that
+                # contains it makes the conductor and every sibling process read as
+                # a fleet worker eligible to be stopped.
+                return f"fleet_worktrees entry {item!r} contains the session store"
     for key in ("idle_alert_secs", "tail_bytes", "load_alert_per_cpu"):
         value = cfg.get(key)
         if value is None:
@@ -409,7 +1274,12 @@ def _config_error(cfg: dict[str, Any]) -> str | None:
             or value < 0
         ):
             return f"{key} must be a finite non-negative number"
-    for rx in list(cfg.get("err_res") or []) + list(cfg.get("banned_process_res") or []):
+    for rx in (
+        list(cfg.get("err_res") or [])
+        + list(cfg.get("banned_process_res") or [])
+        + list(cfg.get("init_timeout_res") or [])
+        + list(cfg.get("watchdog_res") or [])
+    ):
         try:
             re.compile(rx)
         except re.error as exc:

--- a/test/test_pipeline_conductor_agent.py
+++ b/test/test_pipeline_conductor_agent.py
@@ -191,6 +191,18 @@ class TestFleetProbe:
             stamp = time.time() - age_secs
             os.utime(path, (stamp, stamp))
 
+    def _transcript(
+        self, sessions_dir: Path, key: str, rows: list[dict], *, age_secs: int = 0
+    ) -> None:
+        """``_session`` for a tail whose ROLES matter -- a tool card, an error
+        row, a nudge -- rather than one assistant line. The rows are written as
+        given so a test can pin the shape the real writers produce."""
+        path = sessions_dir / f"{key}.jsonl"
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+        if age_secs:
+            stamp = time.time() - age_secs
+            os.utime(path, (stamp, stamp))
+
     def _config(self, tmp_path: Path, monkeypatch, sessions: list[str], **extra) -> Path:
         """Config file + the env the script derives its paths from: transcripts
         under $KIROCREW_HOME/sessions, /proc behind the test-only env seam --
@@ -216,6 +228,30 @@ class TestFleetProbe:
         assert match is not None, line
         return match.group(1)
 
+    @staticmethod
+    def _index_of(out: str, key: str) -> int:
+        """The i= field of KEY's fired line -- the tail position."""
+        line = next(ln for ln in out.splitlines() if key in ln and "i=" in ln)
+        match = re.search(r"i=(\d+)", line)
+        assert match is not None, line
+        return int(match.group(1))
+
+    @staticmethod
+    def _handled(cfg_path: Path) -> dict:
+        """The handled map out of the DERIVED state file beside the config."""
+        state = json.loads(Path(f"{cfg_path}.state.json").read_text(encoding="utf-8"))
+        return state["handled"]
+
+    @staticmethod
+    def _age_mark(cfg_path: Path, key: str, secs: int) -> None:
+        """Backdate KEY's disposition. NOPROGRESS requires the mark to be at least
+        one idle budget old, so a test that marks and probes in the same second
+        has to move the clock the way real time would."""
+        state_path = Path(f"{cfg_path}.state.json")
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["handled"][key]["ts"] = int(time.time()) - secs
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+
     def test_protocol_tag_fires_and_working_stays_quiet(self, tmp_path, capsys, monkeypatch):
         mod = self._mod()
         cfg = self._config(tmp_path, monkeypatch, ["s-green", "s-working"])
@@ -225,6 +261,76 @@ class TestFleetProbe:
         assert "s-green" in out and "GREEN" in out
         assert "s-working" not in out  # WORKING is a heartbeat, not a signal
         assert "OK 2 watched, 1 fired" in out
+
+    def test_a_protocol_word_in_prose_is_not_a_report(self, tmp_path, capsys, monkeypatch):
+        """The protocol is ``<WORD>:``. A line that merely OPENS with a protocol
+        word -- ``PR #6580 is green ...`` -- is prose, and tagging it invents a
+        report nobody filed. Measured over the 60 most recent transcripts on the
+        development host, 20 of the 94 assistant rows that matched the old
+        ``^<WORD>\\b`` form were prose, 13 of them a bare ``PR #<n>``."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-prose"])
+        self._session(
+            tmp_path / "sessions", "s-prose", "PR #6580 is green, waiting on a human review"
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "s-prose" not in out, "prose opening with a protocol word must not fire"
+        assert "OK 1 watched, 0 fired" in out
+
+    def test_a_tool_line_carrying_protocol_words_never_classifies(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Contract 2e: a tool-call row is not a protocol message.
+
+        ``role`` is the transcript's own discriminator -- the presentation class
+        is not persisted, so nothing else separates a tool card from a spoken
+        line. The tag half already read assistant rows alone; the ERROR half read
+        the last row of ANY role, and a tool row is last on roughly one
+        transcript in ten, so an error phrase quoted inside a tool title raised
+        ERR on a healthy worker. Here the tool line carries ``STANDDOWN``,
+        ``PR:`` AND an error phrase: none of the three may classify."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-tool"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-tool",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "reading the diff"},
+                {
+                    "role": "tool",
+                    "content": (
+                        "🔧 monitor_start message=STANDDOWN: done — PR: https://x "
+                        "(retry after dispatch failure)"
+                    ),
+                },
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "s-tool" not in out, "tool text must not classify"
+        for tag in ("STANDDOWN", "PR ", "ERR"):
+            assert tag not in out
+        assert "OK 1 watched, 0 fired" in out
+
+    def test_a_spoken_report_still_fires_with_a_tool_row_after_it(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The other half of 2e: dropping tool rows must not drop the REPORT.
+        A worker that files ``GREEN:`` and then calls one more tool is still
+        green, and tool rows outnumber spoken ones about two to one."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-green-then-tool"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-green-then-tool",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "GREEN: https://x/pull/1 abc123 all lanes clean"},
+                {"role": "tool", "content": "🔧 autonudge_stop"},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "s-green-then-tool" in out and "GREEN" in out
 
     def test_idle_alert_fires_past_threshold(self, tmp_path, capsys, monkeypatch):
         mod = self._mod()
@@ -306,9 +412,16 @@ class TestFleetProbe:
         assert "pid=4343" not in out  # bounded -n 4 run is legitimate
 
     def test_every_bounded_pytest_spelling_is_legitimate(self, tmp_path, capsys, monkeypatch):
-        """`-n 4`, `-n=4`, `-n4` and `--numprocesses=4` are all bounded runs;
-        flagging any of them would make the conductor stop a healthy worker
-        and discard its active turn."""
+        """`-n 4`, `-n=4`, `-n4`, `--numprocesses=4` and `-n0` are all bounded
+        runs; flagging any of them would make the conductor stop a healthy worker
+        and discard its active turn.
+
+        ``-n0`` earns its own case because it is the form the fleet is REQUIRED
+        to use: it is the repo's documented override (``setup.cfg``: "Override
+        with -n0 for debugging"), it is genuinely in-process, and a rule that
+        flagged the mandated form would stop every worker obeying it. It is
+        covered by the same ``\\d`` branch as ``-n4``, which is asserted here
+        rather than assumed."""
         mod = self._mod()
         proc = tmp_path / "proc"
         for pid, argv in (
@@ -316,13 +429,16 @@ class TestFleetProbe:
             ("12", b"pytest\x00-n4\x00test/x.py\x00"),
             ("13", b"pytest\x00--numprocesses=4\x00test/x.py\x00"),
             ("14", b"pytest\x00-n\x00auto\x00test/x.py\x00"),  # unbounded: fires
+            ("15", b"python\x00-m\x00pytest\x00-n0\x00test/x.py\x00-x\x00-q\x00"),
+            ("16", b"pytest\x00-n\x000\x00test/x.py\x00"),
+            ("17", b"pytest\x00--numprocesses=0\x00test/x.py\x00"),
         ):
             (proc / pid).mkdir(parents=True)
             (proc / pid / "cmdline").write_bytes(argv)
         cfg = self._config(tmp_path, monkeypatch, [])
         monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
         out = self._run(mod, cfg, capsys)
-        for quiet in ("pid=11", "pid=12", "pid=13"):
+        for quiet in ("pid=11", "pid=12", "pid=13", "pid=15", "pid=16", "pid=17"):
             assert quiet not in out, quiet
         assert "pid=14" in out  # -n auto is the unbounded case
 
@@ -448,6 +564,1705 @@ class TestFleetProbe:
         self._run(mod, cfg, capsys, "--mark-handled", "s-1", "GREEN", self._digest_of(out, "s-1"))
         assert victim.read_text(encoding="utf-8") == "precious"
         assert Path(f"{cfg}.state.json").exists()
+
+    # ── 2a: the tail index ────────────────────────────────────────────────────
+
+    def test_every_fired_line_carries_the_index_before_the_digest(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Field ORDER is part of the contract: the conductor's action table
+        parses these lines positionally, so ``i=`` goes before ``d=``."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._session(tmp_path / "sessions", "s-1", "GREEN: https://x/pull/1 abc123")
+        line = next(ln for ln in self._run(mod, cfg, capsys).splitlines() if "s-1" in ln)
+        assert re.search(r"\bi=\d+\s+d=\S+", line), line
+
+    def test_an_unchanged_index_across_two_probes_is_no_progress(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The index is the no-progress discriminator: it must hold still while
+        the session is silent and move the moment it speaks. A wall-clock age
+        cannot answer this -- anything that touches the file ages it."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-1", "BLOCKED: waiting on a ruling")
+        first = self._index_of(self._run(mod, cfg, capsys), "s-1")
+        # Same transcript, second probe: no progress, so the index must not move.
+        assert self._index_of(self._run(mod, cfg, capsys), "s-1") == first
+        with (sessions / "s-1.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"role": "assistant", "content": "BLOCKED: still"}) + "\n")
+        assert self._index_of(self._run(mod, cfg, capsys), "s-1") == first + 1
+
+    def test_the_index_stays_monotonic_past_the_parse_cap(self, tmp_path, capsys, monkeypatch):
+        """Counted from the START of the file, not the start of the parse window.
+
+        A window-relative count saturates once a transcript passes ``tail_bytes``
+        and then stays frozen while the session talks -- reading, at exactly the
+        sizes real worker sessions reach, as the deadlock the index exists to
+        detect. Here the transcript is deliberately far larger than the cap, and
+        the rows are the session's OWN so they count.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-big"], tail_bytes=2000)
+        sessions = tmp_path / "sessions"
+        rows = [{"role": "assistant", "content": "x" * 200} for _ in range(60)]
+        rows.append({"role": "assistant", "content": "PROPOSAL: https://x/issues/1"})
+        self._transcript(sessions, "s-big", rows)
+        first = self._index_of(self._run(mod, cfg, capsys), "s-big")
+        assert first == len(rows) - 1, "the index must count from the file start"
+        assert first > 20, "a window-relative count would have saturated well below this"
+        with (sessions / "s-big.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"role": "assistant", "content": "PROPOSAL: v2"}) + "\n")
+        assert self._index_of(self._run(mod, cfg, capsys), "s-big") == first + 1
+
+    def test_mark_handled_records_the_index_and_keeps_its_signature(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """``--mark-handled KEY TAG DIGEST`` stays exactly three positional
+        arguments; the index rides along in the state entry."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._session(tmp_path / "sessions", "s-1", "GREEN: https://x/pull/1 abc123")
+        out = self._run(mod, cfg, capsys)
+        self._run(mod, cfg, capsys, "--mark-handled", "s-1", "GREEN", self._digest_of(out, "s-1"))
+        entry = self._handled(cfg)["s-1"]
+        assert entry["index"] == self._index_of(out, "s-1")
+        assert entry["tag"] == "GREEN"
+
+    # ── 2b: TERMINAL ──────────────────────────────────────────────────────────
+
+    def test_a_terminal_report_then_unprefixed_text_is_terminal_not_idle(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A worker that filed STANDDOWN and then wrote one unprefixed line is
+        FINISHED. Ageing it into IDLE says the opposite, and the two readings
+        call for opposite actions -- close the item, or nudge and reclaim it."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-done"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-done", "STANDDOWN: covered by an already-merged PR")
+        out = self._run(mod, cfg, capsys)
+        assert "STANDDOWN" in out
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-done",
+            "STANDDOWN",
+            self._digest_of(out, "s-done"),
+        )
+        # ... then one unprefixed line, and the clock runs past the idle threshold.
+        self._session(sessions, "s-done", "thanks, nothing further from me", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" in out
+        assert "IDLE" not in out
+
+    def test_a_resumed_worker_reporting_working_is_not_terminal(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """TERMINAL replaces IDLE only for a tail with NO protocol prefix.
+
+        ``WORKING:`` is a protocol message and it means active work. A worker
+        that stood down, was re-seeded, and is now reporting WORKING must not
+        read as finished: TERMINAL closes the item, so this inversion would
+        abandon live work. The non-firing set holds BOTH ``-`` and ``WORKING``,
+        which is how they came to share a branch."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-resumed"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-resumed", "STANDDOWN: nothing further")
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-resumed",
+            "STANDDOWN",
+            self._digest_of(out, "s-resumed"),
+        )
+        # Re-seeded: the worker is working again and says so. APPENDED, because a
+        # real transcript only ever grows -- and the index is a count of produced
+        # rows, so a rewrite that happened to keep the count would read as a stall.
+        self._transcript(
+            sessions,
+            "s-resumed",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "STANDDOWN: covered by an already-merged PR"},
+                {"role": "assistant", "content": "WORKING: re-seeded, reproducing"},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" not in out, "an active WORKING report must not read as finished"
+        assert "s-resumed" not in out  # WORKING is a heartbeat, not a signal
+        # And the clock still governs a WORKING tail that then goes silent.
+        self._transcript(
+            sessions,
+            "s-resumed",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "STANDDOWN: covered by an already-merged PR"},
+                {"role": "assistant", "content": "WORKING: re-seeded, reproducing"},
+                {"role": "assistant", "content": "WORKING: still reproducing"},
+            ],
+            age_secs=500,
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "IDLE" in out and "TERMINAL" not in out
+
+    # ── 2b extension: sticky BLOCKED ──────────────────────────────────────────
+
+    def test_blocked_survives_the_heartbeats_that_follow_it(self, tmp_path, capsys, monkeypatch):
+        """A ruling owed must not be lost to SAMPLING.
+
+        The probe samples; it does not subscribe. The protocol tells a blocked
+        worker to keep reporting status, so the worker's own next ``WORKING:``
+        overwrites the only message a newest-message classifier reads, and the
+        debt becomes invisible on both sides: the worker holds position waiting
+        for a ruling, the conductor never learns it owes one. Nothing is
+        suppressed here and nothing is deferred -- the signal is simply never
+        observed. So ``BLOCKED`` is sticky, and a heartbeat cannot clear it.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-blocked"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-blocked",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "BLOCKED: need a ruling on the baseline entry"},
+                {"role": "assistant", "content": "WORKING: holding position"},
+                {"role": "assistant", "content": "WORKING: still holding"},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out, "two heartbeats must not clear a ruling owed"
+        # A probe that did NOT mark it handled leaves it owed, so it fires again.
+        assert "BLOCKED" in self._run(mod, cfg, capsys)
+
+    def test_a_sticky_blocked_keeps_one_digest_across_new_heartbeats(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Sticky must not mean noisy. The digest is keyed on the BLOCKED report's
+        own text, so a worker that keeps filing heartbeats does not re-fire the
+        same ruling every cycle: the ruling quiets it, and only a genuinely NEW
+        blocker re-fires."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-blocked"])
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: need a ruling on scope"},
+        ]
+        self._transcript(sessions, "s-blocked", rows)
+        first = self._digest_of(self._run(mod, cfg, capsys), "s-blocked")
+        # More heartbeats arrive. Same unanswered blocker, so the same digest.
+        self._transcript(
+            sessions,
+            "s-blocked",
+            rows + [{"role": "assistant", "content": "WORKING: holding position"}],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert self._digest_of(out, "s-blocked") == first
+        # Delivering the ruling is what quiets it.
+        self._run(mod, cfg, capsys, "--mark-handled", "s-blocked", "BLOCKED", first)
+        assert "BLOCKED" not in self._run(mod, cfg, capsys)
+        # A genuinely new blocker is a new signal.
+        self._transcript(
+            sessions,
+            "s-blocked",
+            rows + [{"role": "assistant", "content": "BLOCKED: a second, different ruling"}],
+        )
+        assert "BLOCKED" in self._run(mod, cfg, capsys)
+
+    def test_a_real_report_clears_a_sticky_blocked(self, tmp_path, capsys, monkeypatch):
+        """Only a heartbeat is transparent. A worker that was blocked and then
+        files ``PR``/``GREEN``/``STANDDOWN`` has moved on, and continuing to
+        demand a ruling for it would manufacture the opposite error.
+
+        What is asserted is the CLEARING, not what fires in its place. A report
+        followed by a heartbeat has always been quiet -- the heartbeat is the
+        newest message -- and that is pre-existing behaviour this extension does
+        not change; ``test_a_real_report_after_a_blocker_fires_on_its_own`` covers
+        the case where the report IS the newest message.
+        """
+        mod = self._mod()
+        for tag, line in (
+            ("PR", "PR: https://x/pull/9"),
+            ("GREEN", "GREEN: https://x/pull/9 abc123 all lanes clean"),
+            ("STANDDOWN", "STANDDOWN: item withdrawn"),
+        ):
+            key = f"s-moved-{tag.lower()}"
+            cfg = self._config(tmp_path, monkeypatch, [key])
+            self._transcript(
+                tmp_path / "sessions",
+                key,
+                [
+                    {"role": "user", "content": "seed"},
+                    {"role": "assistant", "content": "BLOCKED: need a ruling"},
+                    {"role": "assistant", "content": line},
+                    {"role": "assistant", "content": "WORKING: tidying up"},
+                ],
+            )
+            out = self._run(mod, cfg, capsys)
+            assert "BLOCKED" not in out, f"{tag} must clear the ruling owed"
+            assert key not in out, f"{tag} then a heartbeat is quiet, as it always was"
+
+    def test_a_real_report_after_a_blocker_fires_on_its_own(self, tmp_path, capsys, monkeypatch):
+        """The same clearing, with the report as the newest message: the new tag
+        fires and the ruling owed is gone."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-unblocked"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-unblocked",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "BLOCKED: need a ruling"},
+                {"role": "assistant", "content": "PR: https://x/pull/9"},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "PR" in out and "s-unblocked" in out
+        assert "BLOCKED" not in out
+
+    def test_unprefixed_text_does_not_clear_a_sticky_blocked(self, tmp_path, capsys, monkeypatch):
+        """Unprefixed text is not a report at all, so it clears nothing -- and it
+        must not let a blocked worker age into IDLE, which reads as "nudge me"
+        when the truth is "answer me"."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-blocked"], idle_alert_secs=100)
+        self._transcript(
+            tmp_path / "sessions",
+            "s-blocked",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "BLOCKED: need a ruling"},
+                {"role": "assistant", "content": "still waiting, nothing new from me"},
+            ],
+            age_secs=500,
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out
+        assert "IDLE" not in out and "TERMINAL" not in out
+
+    def test_sticky_blocked_outranks_a_recorded_terminal_disposition(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """TERMINAL and sticky BLOCKED are deliberately not the same tag: one says
+        close me, the other says a ruling is owed. A worker that stood down and
+        then found a blocker is owed the ruling, so BLOCKED wins."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-both"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-both", "STANDDOWN: nothing further")
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-both",
+            "STANDDOWN",
+            self._digest_of(out, "s-both"),
+        )
+        self._transcript(
+            sessions,
+            "s-both",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "STANDDOWN: nothing further"},
+                {"role": "assistant", "content": "BLOCKED: actually, one ruling is needed"},
+                {"role": "assistant", "content": "WORKING: holding"},
+            ],
+            age_secs=500,
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out
+        assert "TERMINAL" not in out
+
+    # ── 2e extension: decoration on the prefix ────────────────────────────────
+
+    def test_a_bolded_prefix_still_classifies(self, tmp_path, capsys, monkeypatch):
+        """A tag matched at position zero is defeated by ANY leading decoration.
+
+        ``**BLOCKED:**`` puts an asterisk where the tag has to be, so the match
+        fails and the line falls through as no-prefix -- and on a fresh transcript
+        IDLE does not fire either, so the report is not delayed, it is silent.
+        Emphasis is ordinary formatting habit rather than a protocol violation, so
+        the reader normalises instead of the writer remembering.
+        """
+        mod = self._mod()
+        cases = {
+            "s-bold": ("**BLOCKED:** need a ruling on scope", "BLOCKED"),
+            "s-quote": ("> BLOCKED: quoted escalation", "BLOCKED"),
+            "s-bullet": ("- **GREEN:** https://x/pull/1 abc123", "GREEN"),
+            "s-heading": ("### PROPOSAL: https://x/issues/9", "PROPOSAL"),
+            "s-numbered": ("1. STANDDOWN: item withdrawn", "STANDDOWN"),
+            "s-underscore": ("__PR:__ https://x/pull/2", "PR"),
+            "s-ticked": ("`BLOCKED:` need a ruling", "BLOCKED"),
+        }
+        for key, (line, tag) in cases.items():
+            cfg = self._config(tmp_path, monkeypatch, [key])
+            self._session(tmp_path / "sessions", key, line)
+            out = self._run(mod, cfg, capsys)
+            assert tag in out, f"{key}: {line!r} must classify as {tag}"
+            assert key in out
+
+    def test_a_bolded_blocked_still_survives_two_heartbeats(self, tmp_path, capsys, monkeypatch):
+        """The two rules composing, which is the case that actually goes silent:
+        the worker writes a decorated escalation, then obeys the protocol by
+        continuing to report status. Emphasis must not lose the tag, and the
+        heartbeats must not clear it."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-both"], idle_alert_secs=100)
+        self._transcript(
+            tmp_path / "sessions",
+            "s-both",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "**BLOCKED:** need a ruling before I can push"},
+                {"role": "assistant", "content": "WORKING: holding position"},
+                {"role": "assistant", "content": "WORKING: still holding"},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out
+        assert "IDLE" not in out and "TERMINAL" not in out
+
+    def test_decoration_stripping_is_not_a_substring_search(self, tmp_path, capsys, monkeypatch):
+        """The anchor SURVIVES normalisation: decoration comes off the front only.
+        A bolded protocol word mid-sentence is a worker talking ABOUT a report,
+        and tagging it would fire on every message that mentioned one."""
+        mod = self._mod()
+        for key, line in (
+            ("s-mid", "I think **BLOCKED:** is the right call here"),
+            ("s-tail", "waiting on review, then **GREEN:** follows"),
+            ("s-prose", "the **PR:** convention confuses me"),
+        ):
+            cfg = self._config(tmp_path, monkeypatch, [key])
+            self._session(tmp_path / "sessions", key, line)
+            out = self._run(mod, cfg, capsys)
+            assert key not in out, f"{line!r} must not fire"
+            assert "OK 1 watched, 0 fired" in out
+
+    def test_a_tool_row_with_a_bolded_prefix_still_never_classifies(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """2e's original requirement, unaffected by normalisation: a tool row is
+        not a protocol message however it is formatted."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-tool"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-tool",
+            [
+                {"role": "assistant", "content": "reading the diff"},
+                {"role": "tool", "content": "🔧 send_message body=**PR:** https://x/pull/3"},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "s-tool" not in out and "PR" not in out
+        assert "OK 1 watched, 0 fired" in out
+
+    def test_the_digest_is_computed_over_what_the_worker_wrote(self, tmp_path, capsys, monkeypatch):
+        """Normalisation is for MATCHING only. The digest still covers the raw
+        text, so a decorated report and an undecorated one with the same words are
+        distinct payloads -- and ``--mark-handled`` keeps working, since it
+        digests the same raw text the probe printed."""
+        mod = self._mod()
+        sessions = tmp_path / "sessions"
+        cfg_plain = self._config(tmp_path, monkeypatch, ["s-plain"])
+        self._session(sessions, "s-plain", "BLOCKED: need a ruling")
+        plain = self._digest_of(self._run(mod, cfg_plain, capsys), "s-plain")
+        cfg_bold = self._config(tmp_path, monkeypatch, ["s-styled"])
+        self._session(sessions, "s-styled", "**BLOCKED:** need a ruling")
+        out = self._run(mod, cfg_bold, capsys)
+        styled = self._digest_of(out, "s-styled")
+        assert styled != plain, "the digest must reflect the text as written"
+        # And the mark round-trips on the decorated payload.
+        self._run(mod, cfg_bold, capsys, "--mark-handled", "s-styled", "BLOCKED", styled)
+        assert "BLOCKED" not in self._run(mod, cfg_bold, capsys)
+
+    def test_terminal_fires_once_then_suppresses_by_digest(self, tmp_path, capsys, monkeypatch):
+        """TERMINAL is an ordinary tag in the firing set: dispositioned once, it
+        goes quiet, and a NEW payload re-fires like any other."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-done"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-done", "PROPOSAL: https://x/issues/9")
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-done", "PROPOSAL", self._digest_of(out, "s-done")
+        )
+        self._session(sessions, "s-done", "handing back", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" in out
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-done", "TERMINAL", self._digest_of(out, "s-done")
+        )
+        assert "TERMINAL" not in self._run(mod, cfg, capsys)
+
+    def test_a_non_protocol_disposition_does_not_erase_the_terminal_tag(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The defect 2b closes: the handled set keeps ONE entry per key, so a
+        later IDLE or GONE disposition used to overwrite the terminal report and
+        the finished worker read as wedged again on the next cycle."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-done"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-done", "STANDDOWN: item withdrawn")
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-done",
+            "STANDDOWN",
+            self._digest_of(out, "s-done"),
+        )
+        self._session(sessions, "s-done", "ok", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-done", "TERMINAL", self._digest_of(out, "s-done")
+        )
+        assert self._handled(cfg)["s-done"]["settled"]["tag"] == "STANDDOWN"
+        # A fresh unprefixed payload is still TERMINAL, not IDLE.
+        self._session(sessions, "s-done", "signing off for real", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" in out and "IDLE" not in out
+
+    def test_a_non_terminal_report_still_ages_into_idle(self, tmp_path, capsys, monkeypatch):
+        """The negative half: WORKING is not terminal, so a silent worker that
+        last said WORKING must still raise IDLE."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-wedged"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-wedged", "WORKING: reproducing")
+        # WORKING never fires, so dispose of it the way the conductor would:
+        # through a probe cycle that records nothing, then let the clock run.
+        self._run(mod, cfg, capsys)
+        self._session(sessions, "s-wedged", "hmm", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "IDLE" in out and "TERMINAL" not in out
+
+    # ── 2c: delivery counters ─────────────────────────────────────────────────
+
+    def test_delivery_counters_appear_on_the_ok_line(self, tmp_path, capsys, monkeypatch):
+        """Load and memory can both read healthy while the fleet cannot deliver.
+        These two counters are the honest admission instrument, so they are
+        counted for every watched session -- fired or not."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-init", "s-stall", "s-fine"])
+        sessions = tmp_path / "sessions"
+        self._transcript(
+            sessions,
+            "s-init",
+            [
+                {"role": "assistant", "content": "WORKING: starting"},
+                {"role": "error", "content": "initialize timed out on respawn"},
+            ],
+        )
+        self._transcript(
+            sessions,
+            "s-stall",
+            [
+                {"role": "assistant", "content": "WORKING: running the suite"},
+                {"role": "inject", "content": "[Tool stall - automatic recovery] resume"},
+            ],
+        )
+        self._session(sessions, "s-fine", "WORKING: healthy")
+        out = self._run(mod, cfg, capsys)
+        assert "deliver init-timeout 1, watchdog 1" in out
+        assert "| foreign 0 |" in out  # 2d's counter sits before deliver
+
+    def test_delivery_patterns_are_configurable(self, tmp_path, capsys, monkeypatch):
+        mod = self._mod()
+        cfg = self._config(
+            tmp_path,
+            monkeypatch,
+            ["s-1"],
+            init_timeout_res=["never-delivered-handshake"],
+            watchdog_res=["gave-up-waiting"],
+        )
+        self._transcript(
+            tmp_path / "sessions",
+            "s-1",
+            [
+                {"role": "assistant", "content": "WORKING: fine so far"},
+                {"role": "user", "content": "never-delivered-handshake"},
+                {"role": "inject", "content": "gave-up-waiting"},
+            ],
+        )
+        assert "deliver init-timeout 1, watchdog 1" in self._run(mod, cfg, capsys)
+
+    def test_a_tool_row_never_feeds_the_delivery_counters(self, tmp_path, capsys, monkeypatch):
+        """Same rule as classification: an error phrase quoted in a tool card is
+        quoted text. Measured over 60 real transcripts, no timeout or
+        stall-watchdog line ever landed on a tool row."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-1",
+            [
+                {"role": "assistant", "content": "WORKING: grepping"},
+                {"role": "tool", "content": "🔧 grep initialize timed out"},
+            ],
+        )
+        assert "deliver init-timeout 0, watchdog 0" in self._run(mod, cfg, capsys)
+
+    def test_a_bad_delivery_regex_is_malformed_config(self, tmp_path, capsys, monkeypatch):
+        """Same validation as ``err_res`` / ``banned_process_res``: a bad regex
+        is malformed config (exit 2), never a crash mid-cycle."""
+        mod = self._mod()
+        for key in ("init_timeout_res", "watchdog_res"):
+            cfg = self._config(tmp_path, monkeypatch, [], **{key: ["(unclosed"]})
+            assert mod.main(["--config", str(cfg)]) == 2, key
+            cfg = self._config(tmp_path, monkeypatch, [], **{key: [7]})
+            assert mod.main(["--config", str(cfg)]) == 2, key
+
+    # ── 2d: cwd-scoped banned scan ────────────────────────────────────────────
+
+    def _proc(self, tmp_path: Path, pid: str, argv: bytes, cwd: Path | None) -> Path:
+        """One fake ``/proc/<pid>``. ``cwd`` is written as a SYMLINK because that
+        is what the kernel exposes and what the probe reads."""
+        proc = tmp_path / "proc"
+        (proc / pid).mkdir(parents=True, exist_ok=True)
+        (proc / pid / "cmdline").write_bytes(argv)
+        if cwd is not None:
+            cwd.mkdir(parents=True, exist_ok=True)
+            os.symlink(str(cwd), str(proc / pid / "cwd"))
+        return proc
+
+    def test_a_banned_match_outside_the_fleet_is_foreign_not_banned(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A banned command SHAPE is only a banned OPERATION when the fleet owns
+        it. The same unbounded pytest in an unrelated checkout is this machine's
+        business, and counting it made the conductor stop a worker that was not
+        the offender."""
+        mod = self._mod()
+        mine = tmp_path / "fleet" / "wt-a"
+        theirs = tmp_path / "somebody-else" / "repo"
+        proc = self._proc(tmp_path, "5001", b"python\x00-m\x00pytest\x00test/x.py\x00", mine)
+        self._proc(tmp_path, "5002", b"python\x00-m\x00pytest\x00test/y.py\x00", theirs)
+        cfg = self._config(
+            tmp_path, monkeypatch, [], fleet_worktrees=[str(tmp_path / "fleet" / "wt-a")]
+        )
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "BANNED pid=5001 rule=" in out and "cwd=fleet" in out
+        assert "pid=5002" not in out, "an unrelated checkout is not reported"
+        assert "banned 1 | foreign 1" in out
+
+    def test_a_delivered_worker_goes_quiet_rather_than_idle(self, tmp_path, capsys, monkeypatch):
+        """A delivered, dispositioned worker fires NOTHING once it ages.
+
+        Raised by a review lane as "`TERMINAL` never fires when unprefixed text is
+        appended". The first half is true and the harm is not, which is only
+        visible by running it. A real transcript APPENDS, so the `GREEN:` row stays
+        inside the window: the tag remains `GREEN`, the digest is unchanged, and the
+        signal is suppressed. The lane's inference was that the session then ages
+        into `IDLE` and the conductor re-dispatches a worker that has already
+        delivered. It does not -- the suppressed `GREEN` keeps `IDLE` from being the
+        reading too, so the line is silent, which is the correct output for a worker
+        whose completion was already reported and acted on.
+
+        `TERMINAL` is therefore the reading for a finished worker whose report is no
+        longer VISIBLE while the state file still remembers it. Both paths reach the
+        property that matters -- never read as merely idle, never re-dispatched --
+        and the prescribed fix (demote any trailing unprefixed row to `-`) would
+        make a plainly stated `GREEN:` depend on the state file to be understood.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-done"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "GREEN: https://example.invalid/pull/1 abc1234"},
+        ]
+        self._transcript(sessions, "s-done", rows)
+        out = self._run(mod, cfg, capsys)
+        assert "GREEN" in out, "the report itself is the reading while it is visible"
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-done", "GREEN", self._digest_of(out, "s-done")
+        )
+        # Appends, as a real transcript does: the GREEN row does not go away.
+        self._transcript(
+            sessions,
+            "s-done",
+            rows + [{"role": "assistant", "content": "One more note, no prefix."}],
+            age_secs=500,
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "IDLE" not in out, "a delivered worker must never be read as merely idle"
+        assert "0 fired" in out, "and it must not be re-presented either"
+
+    def test_terminal_covers_the_case_the_transcript_no_longer_states(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The other half of the same boundary: once the terminal report scrolls
+        out of the window the transcript alone cannot say the worker finished, and
+        that is where the remembered tag earns its keep -- `TERMINAL` rather than
+        `IDLE`, so an aged finished worker is not nudged."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-gone"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-gone", "GREEN: delivered abc1234")
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-gone", "GREEN", self._digest_of(out, "s-gone")
+        )
+        # The report is no longer in the window; only the state file knows.
+        self._session(sessions, "s-gone", "trailing chatter with no prefix", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" in out
+        assert "IDLE" not in out
+
+    def test_a_reseeded_worker_does_not_read_as_finished(self, tmp_path, capsys, monkeypatch):
+        """The compliant re-seed case the protocol requires: a worker handed new
+        work states a prefix, and that newer report supersedes the terminal one.
+
+        The transcript is aged so `TERMINAL` WOULD be the reading if the terminal
+        report still won; the assertion is that it does not. `WORKING` is a
+        heartbeat and deliberately fires nothing, so the session goes quiet rather
+        than reporting -- quiet being the correct output for a worker that is
+        working.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-again"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._transcript(
+            sessions,
+            "s-again",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "GREEN: delivered abc1234"},
+                {"role": "nudge", "content": "new item assigned"},
+                {"role": "assistant", "content": "WORKING: picked up the new item"},
+            ],
+            age_secs=500,
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" not in out, "a re-seeded worker is not finished"
+
+    def test_any_later_disposition_preserves_the_answered_payload(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Not just condition tags: ANY later mark must preserve the payload.
+
+        The first version of this fix keyed on ``IDLE``/``NOPROGRESS`` only, which
+        left the same hole open one door down. A session whose ``BLOCKED`` was
+        answered can hit an error row, get its ``ERR`` dispositioned, and then post
+        a heartbeat -- at which point the error branch stops matching, the sticky
+        ``BLOCKED`` is the reading again, and the ``ERR`` mark has overwritten the
+        record that the ruling was delivered. The answered ruling re-presents and
+        the conductor re-adjudicates a decision it already made.
+
+        A ``GONE`` mark cannot reach this: marking refuses a digest no probe
+        reported, and a GONE session has no transcript left to re-read a report
+        from. ``ERR`` is the reachable one, which is why it is the one tested.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-err"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: ruling needed"},
+        ]
+        self._transcript(sessions, "s-err", rows)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-err", "BLOCKED", self._digest_of(out, "s-err")
+        )
+        assert "BLOCKED" not in self._run(mod, cfg, capsys)
+        rows = rows + [{"role": "error", "content": "tool crashed"}]
+        self._transcript(sessions, "s-err", rows)
+        out = self._run(mod, cfg, capsys)
+        assert "ERR" in out
+        self._run(mod, cfg, capsys, "--mark-handled", "s-err", "ERR", self._digest_of(out, "s-err"))
+        # The heartbeat stops the error row being last, so the sticky BLOCKED is
+        # the reading again -- and it is still answered.
+        self._transcript(
+            sessions, "s-err", rows + [{"role": "assistant", "content": "WORKING: back on it"}]
+        )
+        assert "BLOCKED" not in self._run(mod, cfg, capsys), "answered rulings stay answered"
+
+    def test_the_shipped_state_shape_upgrades_without_losing_terminal(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The upgrade path that actually exists.
+
+        The shipped writer records ``{tag, digest, ts}``, so a session whose last
+        mark was a terminal payload still reports ``TERMINAL`` after an upgrade,
+        recovered from the entry's own tag -- no nudge for a worker that already
+        delivered. An earlier draft also read a ``proto`` field; measurement showed
+        no released version ever wrote one (it existed only in intermediate commits
+        of this branch), so that path and its test were removed rather than left
+        asserting behaviour for an input that cannot occur.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-old"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-old", "trailing chatter with no prefix", age_secs=500)
+        state_path = Path(f"{cfg}.state.json")
+        state_path.write_text(
+            json.dumps({"handled": {"s-old": {"tag": "GREEN", "digest": "d0", "ts": 1}}}),
+            encoding="utf-8",
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" in out, "the shipped shape still names a delivered worker"
+        assert "IDLE" not in out
+
+    def test_a_legacy_answered_payload_survives_a_later_mark(self, tmp_path, capsys, monkeypatch):
+        """The upgrade path must not lose the DIGEST, only the field name changed.
+
+        A state file written before ``settled`` existed records an answered payload
+        as the entry's own ``tag``/``digest``. Carrying only the legacy ``proto``
+        tag forward keeps the terminal reading but drops the digest, and
+        suppression needs both halves -- so a pre-upgrade answered ``BLOCKED``
+        followed by any later mark presented the ruling again on the first cycle
+        after the upgrade. Raised by a review lane against the compatibility path
+        added to prevent exactly this.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-up"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: ruling needed"},
+        ]
+        self._transcript(sessions, "s-up", rows)
+        out = self._run(mod, cfg, capsys)
+        digest = self._digest_of(out, "s-up")
+        # The pre-upgrade shape: the answered payload IS the entry, no `settled`.
+        Path(f"{cfg}.state.json").write_text(
+            json.dumps(
+                {
+                    "handled": {
+                        "s-up": {
+                            "tag": "BLOCKED",
+                            "digest": digest,
+                            "ts": int(time.time()),
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert "BLOCKED" not in self._run(mod, cfg, capsys), "the legacy record still suppresses"
+        rows = rows + [{"role": "error", "content": "tool crashed"}]
+        self._transcript(sessions, "s-up", rows)
+        out = self._run(mod, cfg, capsys)
+        self._run(mod, cfg, capsys, "--mark-handled", "s-up", "ERR", self._digest_of(out, "s-up"))
+        assert (
+            self._handled(cfg)["s-up"]["settled"]["digest"] == digest
+        ), "digest carried, not dropped"
+        self._transcript(
+            sessions, "s-up", rows + [{"role": "assistant", "content": "WORKING: back on it"}]
+        )
+        assert "BLOCKED" not in self._run(mod, cfg, capsys), "answered rulings survive the upgrade"
+
+    def test_a_delivered_worker_is_not_reclassified_as_stalled(self, tmp_path, capsys, monkeypatch):
+        """A finished worker produces nothing BY DEFINITION, so absence of output
+        is not a stall.
+
+        The common shape: a worker files `GREEN:`, the conductor marks it, and the
+        transcript then never changes again. The tag stays `GREEN` -- a firing tag,
+        so the terminal/idle ladder is never reached -- the report is suppressed by
+        digest, and the index is unchanged because nothing more was written. Without
+        a guard that makes it `NOPROGRESS`, which re-fires every cycle because it
+        expires, sending the conductor to nudge a session that already delivered.
+
+        The neighbouring test escapes this only because its fixture APPENDS a line,
+        which moves the index. That is exactly the kind of accident a common-path
+        fixture hides, so this one changes nothing after the mark.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-shipped"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-shipped", "GREEN: https://example.invalid/pull/1 abc1234")
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-shipped",
+            "GREEN",
+            self._digest_of(out, "s-shipped"),
+        )
+        # Nothing further is written; only the clock moves.
+        self._age_mark(cfg, "s-shipped", 500)
+        (sessions / "s-shipped.jsonl").touch()
+        os.utime(sessions / "s-shipped.jsonl", (time.time() - 500, time.time() - 500))
+        out = self._run(mod, cfg, capsys)
+        assert "NOPROGRESS" not in out, "a delivered worker is finished, not stalled"
+        assert "0 fired" in out
+
+    def test_a_surfaced_ruling_can_actually_be_dispositioned(self, tmp_path, capsys, monkeypatch):
+        """A signal the conductor cannot mark is worse than no signal.
+
+        Surfacing the sticky ``BLOCKED`` from under a handled ``ERR`` prints a
+        digest computed over the RULING. ``--mark-handled`` recomputes the payload
+        from the transcript, where the error row is still last, so it digests the
+        ERR text instead and refuses the mark as a changed payload. The ruling then
+        fires every cycle forever, undismissable -- a signal that cannot be
+        dispositioned is a worse failure than the one surfacing it fixed.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-mark"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: ruling needed"},
+            {"role": "error", "content": "tool crashed"},
+        ]
+        self._transcript(sessions, "s-mark", rows)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-mark", "ERR", self._digest_of(out, "s-mark")
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out
+        # The mark must be ACCEPTED, and the ruling must then go quiet.
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-mark", "BLOCKED", self._digest_of(out, "s-mark")
+        )
+        assert "BLOCKED" not in self._run(mod, cfg, capsys)
+
+    def test_a_symlinked_fleet_root_cannot_smuggle_a_wider_scope(self, tmp_path, monkeypatch):
+        """Validation must judge what the root RESOLVES to, not how it is spelled.
+
+        The classifier compares `realpath` as well as the literal path -- that
+        second chance exists so a symlinked worktree still matches -- so a root
+        spelled as a symlink to a filesystem root passes a literal-only check and
+        then matches every cwd on the host. The widening returns by the same door
+        the convenience opened.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, [])
+        store = mod._sessions_dir()
+        for target in (Path(os.sep), store.parent):
+            link = tmp_path / f"link-{abs(hash(str(target))) % 1000}"
+            if link.is_symlink() or link.exists():
+                link.unlink()
+            os.symlink(str(target), str(link))
+            cfg.write_text(
+                json.dumps({"sessions": [], "fleet_worktrees": [str(link)]}), encoding="utf-8"
+            )
+            assert mod.main(["--config", str(cfg)]) == 2, target
+
+    def test_a_filesystem_root_as_a_fleet_root_is_refused(self, tmp_path, monkeypatch):
+        """A root of ``/`` makes every cwd on the host read as fleet-owned.
+
+        ``fleet_worktrees`` comes from a config the conductor authors, so this is a
+        trust boundary and not merely a typo: ``cwd=fleet`` is the one class that
+        STOPS a session, so a root that matches everything turns the ownership
+        guard into a false-stop generator against unrelated processes -- the exact
+        failure scoping the scan was introduced to prevent. Refused at load time
+        with a message, the same discipline as the NUL byte.
+
+        Which RULE refuses each of these differs, and mutation testing is what
+        showed it: on POSIX ``/`` is always an ancestor of the session store, so
+        the store rule catches it and the filesystem-root rule is redundant here;
+        ``C:\\`` is not absolute on POSIX, so the absolute-path rule catches that.
+        The root rule earns its place on Windows, where the store can sit on
+        another drive and a drive root is both absolute and not an ancestor of it.
+        This test asserts the OUTCOME -- every one of these is refused on every
+        platform -- rather than pretending to isolate one branch.
+        """
+        mod = self._mod()
+        for bad in ("/", "//", "/.", "C:\\", "C:/"):
+            cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[bad])
+            assert mod.main(["--config", str(cfg)]) == 2, bad
+
+    def test_an_ancestor_of_the_session_store_is_refused_as_a_fleet_root(
+        self, tmp_path, monkeypatch
+    ):
+        """A root that CONTAINS the session store is the same widening one level up.
+
+        It cannot be a worktree -- the store is the conductor's own data directory --
+        and accepting it makes every process working anywhere beneath it, including
+        the conductor itself, read as a fleet worker eligible to be stopped.
+        """
+        mod = self._mod()
+        # The env that decides where the store lives is set by _config, so the
+        # store has to be resolved AFTER it -- reading it first answers for the
+        # real home directory and the test silently checks the wrong path.
+        cfg = self._config(tmp_path, monkeypatch, [])
+        store = mod._sessions_dir()
+        for ancestor in (store.parent, store.parent.parent):
+            cfg.write_text(
+                json.dumps({"sessions": [], "fleet_worktrees": [str(ancestor)]}), encoding="utf-8"
+            )
+            assert mod.main(["--config", str(cfg)]) == 2, ancestor
+
+    def test_ownership_fails_toward_the_non_stopping_class(self, tmp_path, capsys, monkeypatch):
+        """When ownership cannot be established, answer ``unknown``, never ``fleet``.
+
+        ``unknown`` re-injects the directive without stopping anyone; ``fleet``
+        stops a worker's turn. The safe direction for a wrong answer is therefore
+        toward NOT enforcing, so a root that somehow reaches the classifier without
+        being usable must not promote a process to the stopping class.
+        """
+        mod = self._mod()
+        proc = self._proc(tmp_path, "8001", b"pytest\x00-n\x00auto\x00", tmp_path / "elsewhere")
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(tmp_path / "fleet")])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        # A root that cannot be spelled the way any cwd is spelled: the comparison
+        # cannot establish ownership, so the answer must be the non-stopping one.
+        assert mod._owner_class(proc / "8001", ["\0/broken"], "") != "fleet"
+        assert mod._program_class("", [str(tmp_path / "fleet")]) == "unknown"
+        out = self._run(mod, cfg, capsys)
+        assert "cwd=fleet" not in out
+
+    def test_a_nul_in_a_fleet_root_is_malformed_config_not_a_crash(self, tmp_path, monkeypatch):
+        """A NUL byte in a path is malformed config, and the contract for this
+        script is that typed misconfiguration exits 2 with a message rather than
+        raising. ``os.path`` and ``os.readlink`` both raise ``ValueError`` -- not
+        ``OSError`` -- on an embedded NUL, so it escapes the scan's error handling
+        and takes the whole cycle down, losing every other session's reading with
+        it."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=["/fleet/wt-\0a"])
+        assert mod.main(["--config", str(cfg)]) == 2
+
+    def test_a_dispositioned_err_does_not_bury_an_unanswered_ruling(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """An answered ERR must not mask a ruling nobody has answered.
+
+        The error branch is checked before the sticky walk, so a session that
+        reports ``BLOCKED:`` and then hits a persistent error row reads as ``ERR``.
+        Once that ``ERR`` is dispositioned it goes quiet by digest -- and while the
+        error row stays last, the unanswered ``BLOCKED`` underneath it never
+        surfaces. Sticky ``BLOCKED`` exists precisely so a ruling cannot be lost to
+        whatever the session said next.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-buried"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: ruling needed"},
+            {"role": "error", "content": "tool crashed"},
+        ]
+        self._transcript(sessions, "s-buried", rows)
+        out = self._run(mod, cfg, capsys)
+        assert "ERR" in out
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-buried", "ERR", self._digest_of(out, "s-buried")
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out, "the unanswered ruling must surface once the ERR is answered"
+
+    def test_a_report_after_a_delivery_notice_clears_the_counter(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The delivery counters count UNRECOVERED failures only.
+
+        A session that filed a protocol report after an init-timeout notice
+        evidently got a turn through, so the walk stops at that report. Otherwise a
+        recovery report that QUOTES the notice keeps its own session in the
+        undelivered column, and the counter becomes a permanent accusation instead
+        of an admission.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-recovered"])
+        sessions = tmp_path / "sessions"
+        self._transcript(
+            sessions,
+            "s-recovered",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "error", "content": "initialize timed out after 120s"},
+                {"role": "assistant", "content": "WORKING: recovered from initialize timed out"},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "init-timeout 0" in out, "a report after the notice means it was recovered"
+
+    def _venv(self, root: Path) -> Path:
+        """A venv interpreter path with the ``pyvenv.cfg`` marker beside it, which
+        is what makes an interpreter attributable to one checkout."""
+        (root / ".venv" / "bin").mkdir(parents=True, exist_ok=True)
+        (root / ".venv" / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+        interpreter = root / ".venv" / "bin" / "python"
+        interpreter.write_text("", encoding="utf-8")
+        return interpreter
+
+    def test_an_unreadable_cwd_falls_back_to_the_program_path(self, tmp_path, capsys, monkeypatch):
+        """Both attributable BANNED lines seen in the field had an unreadable cwd
+        and a readable cmdline, so cwd alone is not a sufficient ownership signal.
+
+        ``/proc/<pid>/cwd`` needs the access a debugger would have; the cmdline
+        does not. A venv interpreter belongs to the checkout that created it, so
+        it attributes the process even when the cwd link cannot be followed.
+        """
+        mod = self._mod()
+        mine = tmp_path / "fleet" / "wt-a"
+        theirs = tmp_path / "somebody-else" / "repo"
+        theirs.mkdir(parents=True, exist_ok=True)
+        their_python = self._venv(theirs)
+        # cwd=None is the unreadable case: no symlink for the probe to follow.
+        proc = self._proc(
+            tmp_path, "7001", f"{their_python}\0-m\0pytest\0test_sandbox_x.py\0".encode(), None
+        )
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(mine)])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "pid=7001" not in out, "provably not the fleet's, so not the fleet's problem"
+        assert "banned 0 | foreign 1" in out
+
+    def test_a_fleet_interpreter_is_owned_even_with_an_unreadable_cwd(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The other direction: a program path UNDER a fleet worktree is
+        conclusive, because nothing outside that checkout runs its interpreter."""
+        mod = self._mod()
+        mine = tmp_path / "fleet" / "wt-a"
+        mine.mkdir(parents=True, exist_ok=True)
+        my_python = self._venv(mine)
+        proc = self._proc(tmp_path, "7002", f"{my_python}\0-m\0pytest\0test/x.py\0".encode(), None)
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(mine)])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "BANNED pid=7002 rule=" in out and "cwd=fleet" in out
+        assert "banned 1 | foreign 0" in out
+
+    def test_a_system_interpreter_attributes_nothing_and_stays_unknown(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The correction that keeps this refinement from muting the signal it
+        exists to sharpen.
+
+        Treating "program path not under a fleet worktree" as ``foreign`` looks
+        symmetric and is not. A fleet worktree here has NO ``.venv`` and its
+        workers run a global ``python3`` shim, so a real banned run INSIDE the
+        fleet has a program path outside every worktree. Calling that ``foreign``
+        would drop it silently -- the exact harm 2d exists to prevent -- so a
+        shared interpreter yields ``unknown`` and the match is still reported.
+        """
+        mod = self._mod()
+        mine = tmp_path / "fleet" / "wt-a"
+        shim = tmp_path / "shims" / "python3"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("", encoding="utf-8")
+        proc = self._proc(tmp_path, "7003", f"{shim}\0-m\0pytest\0test/x.py\0".encode(), None)
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(mine)])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "BANNED pid=7003 rule=" in out and "cwd=unknown" in out
+        assert "banned 1 | foreign 0" in out, "no venv means no evidence, not evidence of absence"
+
+    def test_the_program_path_is_read_for_a_decision_and_never_printed(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Reading argv is not printing it. The fallback compares the program
+        path; a secret riding in an ARGUMENT must still never reach the output."""
+        mod = self._mod()
+        theirs = tmp_path / "somebody-else" / "repo"
+        theirs.mkdir(parents=True, exist_ok=True)
+        their_python = self._venv(theirs)
+        secret = "hunter2-do-not-print"
+        proc = self._proc(
+            tmp_path,
+            "7004",
+            f"{their_python}\0-m\0pytest\0--token={secret}\0-n\0auto\0".encode(),
+            None,
+        )
+        cfg = self._config(
+            tmp_path, monkeypatch, [], fleet_worktrees=[str(tmp_path / "fleet" / "wt-a")]
+        )
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert secret not in out
+        assert str(their_python) not in out, "the program path decides; it is not emitted"
+        assert "foreign 1" in out
+
+    def test_a_subdirectory_of_a_fleet_worktree_is_fleet_owned(self, tmp_path, capsys, monkeypatch):
+        """Workers run tests from inside the tree, not at its root, so the
+        comparison is prefix-wise -- and on a path BOUNDARY, so a sibling named
+        ``wt-a-old`` is not swallowed by ``wt-a``."""
+        mod = self._mod()
+        root = tmp_path / "fleet" / "wt-a"
+        proc = self._proc(tmp_path, "6001", b"pytest\x00test/x.py\x00", root / "test" / "deep")
+        self._proc(tmp_path, "6002", b"pytest\x00test/y.py\x00", tmp_path / "fleet" / "wt-a-old")
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(root)])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "pid=6001" in out and "cwd=fleet" in out
+        assert "pid=6002" not in out
+        assert "banned 1 | foreign 1" in out
+
+    def test_a_windows_path_spelling_still_matches_its_fleet_root(self, tmp_path, monkeypatch):
+        """Two spellings of one directory must not read as two directories.
+
+        This class of bug is invisible on Linux and misfiled EVERY match on the
+        Windows lane: ``os.readlink`` there can answer an extended-length path
+        (``\\\\?\\D:\\...``) that no configured root will ever spell. Misfiling
+        is not cosmetic -- a fleet-owned banned run reported as ``foreign`` is
+        not printed at all, so the conductor never learns of it.
+
+        Only the platform-independent halves are asserted here. Stripping the
+        extended prefix is this script's own work, so it is pinned directly. Case
+        and separator folding is delegated to ``os.path.normcase``, which is a
+        no-op on Linux by design, so what is pinned is the DELEGATION rather than
+        Windows semantics this runner cannot exhibit.
+        """
+        mod = self._mod()
+        root = r"D:\a\KiroCrew\fleet\wt-a"
+        assert mod._norm_path("\\\\?\\" + root) == mod._norm_path(root)
+        assert mod._norm_path("\\\\?\\" + root) == os.path.normcase(os.path.normpath(root))
+        # Trailing separators and redundant segments fold on every platform.
+        assert mod._norm_path("/fleet/wt-a/") == mod._norm_path("/fleet/wt-a")
+        assert mod._norm_path("/fleet/./wt-a") == mod._norm_path("/fleet/wt-a")
+        assert mod._norm_path("/fleet/x/../wt-a") == mod._norm_path("/fleet/wt-a")
+
+    def test_a_sibling_root_is_not_swallowed_by_a_prefix_match(self, tmp_path, monkeypatch):
+        """The boundary test is a separator, not a bare prefix: ``wt-a-old`` is
+        not inside ``wt-a``, and attributing its runs to ``wt-a`` would stop the
+        wrong worker."""
+        mod = self._mod()
+        root = mod._norm_path("/fleet/wt-a")
+        assert mod._under(mod._norm_path("/fleet/wt-a"), root)
+        assert mod._under(mod._norm_path("/fleet/wt-a/test/deep"), root)
+        assert not mod._under(mod._norm_path("/fleet/wt-a-old"), root)
+        assert not mod._under(mod._norm_path("/fleet/wt-ab"), root)
+
+    def test_a_symlinked_fleet_root_still_matches(self, tmp_path, capsys, monkeypatch):
+        """A worktree reached through a symlink is the same worktree. The literal
+        comparison cannot see that, so the classifier gets a second chance
+        through ``realpath`` -- a match missed here means a banned run inside the
+        fleet is filed as somebody else's and never printed."""
+        mod = self._mod()
+        real = tmp_path / "real-fleet" / "wt-a"
+        real.mkdir(parents=True)
+        link = tmp_path / "via-link"
+        os.symlink(str(tmp_path / "real-fleet"), str(link))
+        # The process reports the REAL path; the config names the symlinked one.
+        proc = self._proc(tmp_path, "5100", b"pytest\x00test/x.py\x00", real)
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(link / "wt-a")])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "pid=5100" in out and "cwd=fleet" in out
+        assert "banned 1 | foreign 0" in out
+
+    # ── 2a extension: NOPROGRESS ───────────────────────────────────────────────
+
+    def test_noprogress_fires_when_nothing_came_out_since_the_last_action(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The probe answers the no-progress question instead of posing it.
+
+        Printing ``i=`` and expecting a human to diff two cycles is a decision
+        living in prose: nothing enforces it, so it may never happen. Here the
+        session is held WARM by inbound nudges it never answers -- so the clock
+        never trips IDLE -- while producing nothing of its own.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-stalled"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: need a ruling"},
+        ]
+        self._transcript(sessions, "s-stalled", rows)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-stalled",
+            "BLOCKED",
+            self._digest_of(out, "s-stalled"),
+        )
+        # Nudged twice. The transcript is fresh, so IDLE cannot see this.
+        self._transcript(
+            sessions,
+            "s-stalled",
+            rows
+            + [
+                {"role": "nudge", "content": "resume; re-state your protocol prefix"},
+                {"role": "nudge", "content": "still waiting"},
+            ],
+        )
+        # Not yet: a disposition seconds old would fire this on every key every
+        # cycle, since nothing has come out in those seconds by definition.
+        assert "NOPROGRESS" not in self._run(mod, cfg, capsys)
+        self._age_mark(cfg, "s-stalled", 500)
+        out = self._run(mod, cfg, capsys)
+        assert "NOPROGRESS" in out
+        assert "IDLE" not in out
+
+    def test_one_produced_row_clears_noprogress(self, tmp_path, capsys, monkeypatch):
+        """The negative half: anything the session emits is progress, so a single
+        message or one tool call clears it. Otherwise the tag would accuse a
+        worker that is simply mid-task."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-moving"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: need a ruling"},
+        ]
+        self._transcript(sessions, "s-moving", rows)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-moving",
+            "BLOCKED",
+            self._digest_of(out, "s-moving"),
+        )
+        self._transcript(
+            sessions,
+            "s-moving",
+            rows + [{"role": "nudge", "content": "resume"}, {"role": "tool", "content": "🔧 grep"}],
+        )
+        assert "NOPROGRESS" not in self._run(mod, cfg, capsys)
+
+    def test_a_named_tag_outranks_noprogress(self, tmp_path, capsys, monkeypatch):
+        """A tag that says WHY always wins: a live sticky ``BLOCKED`` names the
+        reason, and reporting NOPROGRESS instead would hide a ruling owed behind
+        a weaker observation."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-named"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "WORKING: starting"},
+        ]
+        self._transcript(sessions, "s-named", rows)
+        self._run(mod, cfg, capsys)  # WORKING never fires, so nothing is marked
+        # Give it a recorded observation via an IDLE disposition, then a blocker.
+        self._transcript(sessions, "s-named", rows, age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-named", "IDLE", self._digest_of(out, "s-named")
+        )
+        self._transcript(
+            sessions,
+            "s-named",
+            rows + [{"role": "assistant", "content": "BLOCKED: found a real blocker"}],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out and "NOPROGRESS" not in out
+
+    def test_noprogress_is_suppressible_and_needs_a_prior_observation(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """It is an ordinary tag: dispositioned once it goes quiet. And with no
+        recorded observation there is nothing to compare against, so a session the
+        conductor has never acted on cannot be stalled yet."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-fresh"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        # Never marked: no recorded index, so no NOPROGRESS however quiet it is.
+        self._transcript(
+            sessions,
+            "s-fresh",
+            [{"role": "user", "content": "seed"}, {"role": "nudge", "content": "resume"}],
+        )
+        assert "NOPROGRESS" not in self._run(mod, cfg, capsys)
+        # Give it an observation, then stall it, then dispose of the tag.
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: ruling needed"},
+        ]
+        self._transcript(sessions, "s-fresh", rows)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-fresh",
+            "BLOCKED",
+            self._digest_of(out, "s-fresh"),
+        )
+        self._transcript(sessions, "s-fresh", rows + [{"role": "nudge", "content": "resume"}])
+        self._age_mark(cfg, "s-fresh", 500)
+        out = self._run(mod, cfg, capsys)
+        assert "NOPROGRESS" in out
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-fresh",
+            "NOPROGRESS",
+            self._digest_of(out, "s-fresh"),
+        )
+        assert "NOPROGRESS" not in self._run(mod, cfg, capsys)
+
+    def test_a_second_disposition_does_not_destroy_the_first(self, tmp_path, capsys, monkeypatch):
+        """An answered report must not re-present because a later tag was marked.
+
+        The handled set holds ONE entry per key, so marking a condition tag
+        (``IDLE``/``NOPROGRESS``) over an answered payload tag used to overwrite
+        the record that the payload was dealt with -- and the answered ruling then
+        fired again, sending the conductor to re-adjudicate something it had
+        already decided. The payload disposition is now preserved beside the new
+        entry, which is the shape ``proto`` already uses for the terminal reading.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-two"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: ruling needed"},
+        ]
+        self._transcript(sessions, "s-two", rows)
+        out = self._run(mod, cfg, capsys)
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-two", "BLOCKED", self._digest_of(out, "s-two")
+        )
+        assert "BLOCKED" not in self._run(mod, cfg, capsys)
+        self._transcript(sessions, "s-two", rows + [{"role": "nudge", "content": "resume"}])
+        self._age_mark(cfg, "s-two", 500)
+        out = self._run(mod, cfg, capsys)
+        assert "NOPROGRESS" in out
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-two", "NOPROGRESS", self._digest_of(out, "s-two")
+        )
+        assert self._handled(cfg)["s-two"]["settled"]["tag"] == "BLOCKED"
+        # The answered ruling stays answered, and the stall stays quiet too.
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" not in out and "NOPROGRESS" not in out
+        # A NEW blocker is still a new signal: preservation is not deafness.
+        self._transcript(
+            sessions,
+            "s-two",
+            rows + [{"role": "assistant", "content": "BLOCKED: a second, different ruling"}],
+        )
+        assert "BLOCKED" in self._run(mod, cfg, capsys)
+
+    def test_a_row_quoting_transcript_json_does_not_advance_the_index(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The needle matches a row's own opening, not text inside one.
+
+        Nudges quote things, and a nudge that quoted a transcript row would
+        otherwise advance the index -- defeating the detector in exactly the
+        inbound-row case it guards. Valid JSONL already prevents the obvious
+        version (``json.dumps`` escapes the inner quotes), so this pins the
+        line-anchoring that makes the count correct WITHOUT relying on that.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-quoted"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        base = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: need a ruling"},
+        ]
+        self._transcript(sessions, "s-quoted", base)
+        first = self._index_of(self._run(mod, cfg, capsys), "s-quoted")
+        # A nudge whose CONTENT is a transcript row, quoted verbatim.
+        self._transcript(
+            sessions,
+            "s-quoted",
+            base
+            + [
+                {
+                    "role": "nudge",
+                    "content": 'your last row was {"role": "assistant", "content": "x"}',
+                }
+            ],
+        )
+        assert self._index_of(self._run(mod, cfg, capsys), "s-quoted") == first
+        # Raw, unescaped: the needle must still only match a line opening.
+        path = sessions / "s-quoted.jsonl"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"role": "user", "content": "x"}) + "\n")
+        assert self._index_of(self._run(mod, cfg, capsys), "s-quoted") == first
+
+    def test_an_inbound_nudge_does_not_advance_the_index(self, tmp_path, capsys, monkeypatch):
+        """The index counts what the SESSION produced, never what arrived.
+
+        A transcript holds nudges, injected recovery notices and user turns
+        alongside the session's own rows. Counting all of them means the
+        conductor's own nudge advances the index of the worker it just nudged, so
+        a wedged session reads as progress at exactly the moment the conductor
+        pokes it -- the false negative the index exists to prevent. Tool rows DO
+        count: a session running tools is working even while it is silent.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-poked"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        base = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": "BLOCKED: waiting on a ruling"},
+        ]
+        self._transcript(sessions, "s-poked", base)
+        first = self._index_of(self._run(mod, cfg, capsys), "s-poked")
+        # The conductor nudges it, and a recovery notice is injected. Neither is
+        # the worker speaking, so neither is progress.
+        self._transcript(
+            sessions,
+            "s-poked",
+            base
+            + [
+                {"role": "nudge", "content": "resume; re-state your protocol prefix"},
+                {"role": "inject", "content": "[Stalled turn - automatic recovery] resume"},
+                {"role": "user", "content": "any update?"},
+            ],
+        )
+        assert self._index_of(self._run(mod, cfg, capsys), "s-poked") == first
+        # A tool call IS the session working, even with nothing said.
+        self._transcript(
+            sessions,
+            "s-poked",
+            base + [{"role": "nudge", "content": "resume"}, {"role": "tool", "content": "🔧 grep"}],
+        )
+        assert self._index_of(self._run(mod, cfg, capsys), "s-poked") == first + 1
+
+    def test_a_recovered_delivery_failure_stops_being_counted(self, tmp_path, capsys, monkeypatch):
+        """The counters answer "is this session undelivered NOW".
+
+        Scanning the window for any historical match keeps a healed session in
+        the undelivered column until the notice scrolls out of 200 KB, which
+        turns an admission instrument into a permanent accusation. A protocol
+        report filed after the notice is proof a turn got through.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-healed"])
+        sessions = tmp_path / "sessions"
+        self._transcript(
+            sessions,
+            "s-healed",
+            [
+                {"role": "error", "content": "initialize timed out on respawn"},
+                {"role": "assistant", "content": "still stuck"},
+            ],
+        )
+        assert "deliver init-timeout 1, watchdog 0" in self._run(mod, cfg, capsys)
+        # It recovered and said so. The old notice is history, not a live failure.
+        self._transcript(
+            sessions,
+            "s-healed",
+            [
+                {"role": "error", "content": "initialize timed out on respawn"},
+                {"role": "assistant", "content": "WORKING: resumed, re-running the tests"},
+            ],
+        )
+        assert "deliver init-timeout 0, watchdog 0" in self._run(mod, cfg, capsys)
+
+    def test_a_failure_after_the_last_report_is_still_counted(self, tmp_path, capsys, monkeypatch):
+        """The negative half: a notice NEWER than the last report is outstanding,
+        so recovery is judged by order rather than by mere presence."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-broke"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-broke",
+            [
+                {"role": "assistant", "content": "WORKING: running the suite"},
+                {"role": "inject", "content": "[Tool stall - automatic recovery] resume"},
+            ],
+        )
+        assert "watchdog 1" in self._run(mod, cfg, capsys)
+
+    def test_the_protocol_regex_is_derived_from_the_tag_set(self, tmp_path, monkeypatch):
+        """One list, not two. Every word in ``PROTO_TAGS`` must match in its
+        protocol form, and a word that is a PREFIX of another must not swallow it:
+        ``PR`` and ``PROPOSAL`` share two characters, so a naive alternation can
+        report the shorter one."""
+        mod = self._mod()
+        for tag in mod.PROTO_TAGS:
+            match = mod.PROTO.match(f"{tag}: payload")
+            assert match is not None, tag
+            assert match.group(1) == tag, f"{tag} matched as {match.group(1)}"
+        assert mod.PROTO.match("PROPOSAL: x").group(1) == "PROPOSAL"
+        assert mod.PROTO.match("PR: x").group(1) == "PR"
+
+    def test_an_unreadable_cwd_is_unknown_and_still_reported(self, tmp_path, capsys, monkeypatch):
+        """A process that exited between the scan and the read, or one owned by
+        another user, has no readable cwd. Dropping it would be how a real banned
+        run inside the fleet goes unreported, so unknown is reported and
+        counted."""
+        mod = self._mod()
+        proc = self._proc(tmp_path, "7001", b"pytest\x00test/x.py\x00", None)
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(tmp_path / "fleet")])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "BANNED pid=7001" in out and "cwd=unknown" in out
+        assert "banned 1 | foreign 0" in out
+
+    def test_an_undeclared_fleet_scope_reports_every_match(self, tmp_path, capsys, monkeypatch):
+        """No ``fleet_worktrees`` declares no scope. Scoping against an empty set
+        would file every match as foreign and mute the banned signal entirely --
+        a failure the conductor cannot see -- so unscoped keeps the pre-2d
+        behaviour: every match reported, every match counted."""
+        mod = self._mod()
+        proc = self._proc(tmp_path, "8001", b"pytest\x00test/x.py\x00", tmp_path / "anywhere")
+        cfg = self._config(tmp_path, monkeypatch, [])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "BANNED pid=8001" in out and "cwd=unknown" in out
+        assert "banned 1 | foreign 0" in out
+
+    def test_the_banned_line_still_withholds_argv_under_scoping(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A command line can carry credentials or a presigned URL, and this line
+        lands in the conductor's model context. Adding the cwd class must not
+        smuggle the argv in with it."""
+        mod = self._mod()
+        mine = tmp_path / "fleet" / "wt-a"
+        proc = self._proc(
+            tmp_path, "9001", b"pytest\x00--token\x00secret-token\x00test/x.py\x00", mine
+        )
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(mine)])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "pid=9001" in out
+        assert "secret-token" not in out
+
+    def test_a_relative_fleet_worktree_is_malformed_config(self, tmp_path, capsys, monkeypatch):
+        """A relative root can never match an absolute ``/proc/<pid>/cwd``
+        target, so every banned run inside the fleet would be filed as foreign.
+        Say so at load time instead of silently muting the signal."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=["relative/path"])
+        assert mod.main(["--config", str(cfg)]) == 2
+        cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[42])
+        assert mod.main(["--config", str(cfg)]) == 2
+
+    # ── 2f: backward compatibility ────────────────────────────────────────────
+
+    def test_a_state_file_from_the_old_version_still_suppresses(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The old handled entry has no ``index`` and no ``settled``. Both are
+        additive metadata outside the digest, so an old state file must suppress
+        exactly as it did -- missing fields read as absent, never a crash."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"], idle_alert_secs=100)
+        self._session(tmp_path / "sessions", "s-1", "GREEN: https://x/pull/1 abc123")
+        digest = self._digest_of(self._run(mod, cfg, capsys), "s-1")
+        # Hand-write the PRE-2a entry shape, the way the shipped version writes it.
+        Path(f"{cfg}.state.json").write_text(
+            json.dumps({"handled": {"s-1": {"tag": "GREEN", "digest": digest, "ts": 1}}}),
+            encoding="utf-8",
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "GREEN" not in out and "0 fired" in out
+        # The old entry carries no `settled`, but its own tag IS the last
+        # dispositioned report -- so a delivered worker reads TERMINAL rather than
+        # ageing into IDLE and being nudged. The old shape is sufficient for this;
+        # what it cannot recover is a terminal report the old writer had already
+        # overwritten, which is the loss the field exists to stop going forward.
+        self._session(tmp_path / "sessions", "s-1", "quiet now", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "TERMINAL" in out and "IDLE" not in out
+
+    def test_an_old_config_with_no_new_keys_still_runs(self, tmp_path, capsys, monkeypatch):
+        """``--config`` keeps its shape: a config written before 2c/2d has no
+        delivery patterns and no fleet scope, and must still produce a full OK
+        line off the in-code defaults."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._session(tmp_path / "sessions", "s-1", "WORKING: fine")
+        out = self._run(mod, cfg, capsys)
+        assert re.search(
+            r"OK 1 watched, 0 fired \| .*\| banned 0 \| foreign 0 \| "
+            r"deliver init-timeout 0, watchdog 0",
+            out,
+        ), out
+
+    # ── standing behaviours these changes must not break ──────────────────────
+
+    def test_a_handled_idle_mark_expires_and_re_alerts(self, tmp_path, capsys, monkeypatch):
+        """An IDLE disposition expires: a nudged-but-still-silent worker has to
+        re-alert rather than vanish behind its own disposition.
+
+        The session emits one more line after the mark, so the index moves and
+        this stays a test of the CLOCK. A session that produces nothing after a
+        disposition is the NOPROGRESS case, which is a different tag with the same
+        expiry.
+        """
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-quiet"], idle_alert_secs=100)
+        sessions = tmp_path / "sessions"
+        self._session(sessions, "s-quiet", "hmm", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "IDLE" in out
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-quiet", "IDLE", self._digest_of(out, "s-quiet")
+        )
+        # One more line: the session HAS produced something, so this is the clock.
+        self._transcript(
+            sessions,
+            "s-quiet",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": "hmm"},
+                {"role": "assistant", "content": "still thinking"},
+            ],
+            age_secs=500,
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "IDLE" in out and "NOPROGRESS" not in out
+        self._run(
+            mod, cfg, capsys, "--mark-handled", "s-quiet", "IDLE", self._digest_of(out, "s-quiet")
+        )
+        assert "IDLE" not in self._run(mod, cfg, capsys)  # freshly marked: quiet
+        # Age the MARK past the threshold; the worker is still silent.
+        state_path = Path(f"{cfg}.state.json")
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["handled"]["s-quiet"]["ts"] = int(time.time()) - 500
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        assert "IDLE" in self._run(mod, cfg, capsys)
+
+    def test_mark_handled_rejects_a_key_that_is_a_path(self, tmp_path, capsys, monkeypatch):
+        """A session key is a filename STEM. The mark path validates it too, or
+        the probe's one approved writer becomes an arbitrary-path writer."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        assert mod.main(["--config", str(cfg), "--mark-handled", "../../etc/x", "GREEN", "d"]) == 2
+
+    def test_the_ok_line_reports_available_memory(self, tmp_path, capsys, monkeypatch):
+        """``mem`` is read from ``MemAvailable`` in the /proc seam, so the host
+        posture half of the OK line is exercised rather than assumed."""
+        mod = self._mod()
+        proc = tmp_path / "proc"
+        proc.mkdir()
+        (proc / "meminfo").write_text(
+            "MemTotal:       65805864 kB\nMemAvailable:   12582912 kB\n", encoding="ascii"
+        )
+        cfg = self._config(tmp_path, monkeypatch, [])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        assert "mem 12G" in self._run(mod, cfg, capsys)
+
+    def test_block_shaped_content_classifies_like_a_string(self, tmp_path, capsys, monkeypatch):
+        """A row whose ``content`` is a list of text blocks is read by joining the
+        blocks. Real transcripts on this host carry plain strings, so this is the
+        defensive path -- pinned so a writer that starts emitting blocks does not
+        silently read as a session with nothing to say."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-blocks"])
+        self._transcript(
+            tmp_path / "sessions",
+            "s-blocks",
+            [
+                {"role": "user", "content": "seed"},
+                {"role": "assistant", "content": [{"text": "BLOCKED: need a ruling"}]},
+            ],
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "BLOCKED" in out and "s-blocks" in out
 
 
 class TestCreditSpend:

--- a/test/test_pipeline_conductor_probe_roundtrip.py
+++ b/test/test_pipeline_conductor_probe_roundtrip.py
@@ -30,6 +30,7 @@ stays green.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from skill_script_helpers import load_skill_script
@@ -80,6 +81,50 @@ class TestTranscriptShapeRoundTrip:
         assert "s-real-writer" in out and "GREEN" in out
         assert "GONE" not in out
         assert "OK 1 watched, 1 fired" in out
+
+
+class TestDeliveryPatternRoundTrip:
+    """Format 4: the phrases the delivery counters look for.
+
+    ``DEFAULT_WATCHDOG_RES`` and ``DEFAULT_INIT_TIMEOUT_RES`` are regexes over
+    text OTHER modules emit. A fixture that hand-copies the phrase cannot notice
+    the emitter rewording it: every fixture test stays green, the counters
+    silently read zero, and a fleet that cannot deliver reports as healthy --
+    which is the one failure these counters exist to make visible. So the
+    patterns are matched against the real constants.
+    """
+
+    def test_watchdog_patterns_match_the_constants_the_gateway_emits(self):
+        from kiro_crew.acp.types import STOP_REASON_TOOL_STALL
+        from kiro_crew.dashboard.state import (
+            STALE_RECOVERY_PREFIX,
+            TOOL_STALL_RECOVERY_PREFIX,
+        )
+
+        mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+        patterns = [re.compile(rx) for rx in mod.DEFAULT_WATCHDOG_RES]
+        for emitted in (
+            f"{TOOL_STALL_RECOVERY_PREFIX} resume from your last committed step",
+            f"{STALE_RECOVERY_PREFIX} resume from your last committed step",
+            f"turn ended: {STOP_REASON_TOOL_STALL}",
+        ):
+            assert any(rx.search(emitted) for rx in patterns), emitted
+
+    def test_the_index_needle_matches_what_the_real_writer_emits(self, tmp_path, monkeypatch):
+        """The tail index counts session-produced rows with a BYTE needle over the
+        whole file, so it depends on how the writer spells the role field. Drive
+        the real writer and count what the script would count: a reworded
+        separator would understate the index and make a talking session read as
+        deadlocked."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "crew"))
+        mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+        log = ConversationLog(base_dir=tmp_path / "crew" / "sessions")
+        log.append("s-needle", "user", "seed")  # inbound: must NOT count
+        log.append("s-needle", "assistant", "WORKING: one")
+        log.append("s-needle", "assistant", "WORKING: two")
+        path = tmp_path / "crew" / "sessions" / "s-needle.jsonl"
+        _, index = mod._tail_entries(path, 200_000)
+        assert index == 1, "two assistant rows, zero-based, and the user row excluded"
 
 
 class TestFilenamePrefixRoundTrip:


### PR DESCRIPTION
## What is the problem?

The pipeline conductor's `fleet_probe.py` reports how loud a worker session is, not
whether it is making progress, and three of its signals were measurably wrong when
checked against real transcripts.

- **A protocol word anywhere at the start of a line counted as a report.** The regex
  matched a bare word boundary, `^<WORD>\b`. Measured over the 60 most recent session
  transcripts on the development host, **20 of the 94** matching assistant rows were
  not reports at all, **13** of them opening with a bare `PR #<n>`.
- **The error half read the last transcript row of any role.** A tool row is the last
  row on **6 of those 60** transcripts, so an error phrase quoted inside a tool card's
  title raised `ERR` on a healthy worker.
- **A finished worker read exactly like a wedged one.** The handled set keeps one entry
  per key, so a `STANDDOWN`/`PROPOSAL` disposition was overwritten by the next tag, and
  the session then aged into `IDLE`.
- **A ruling owed could be lost to sampling entirely.** The probe classified the newest
  MESSAGE, and the protocol requires a blocked worker to keep reporting status, so the
  worker's own next `WORKING:` displaced the `BLOCKED` before the next sample. Unlike the
  suppression case, nothing was marked and nothing was suppressed: the signal was never
  observed, so the obligation existed on both sides and was visible to neither.
- **Any leading decoration defeated the tag entirely.** The match is anchored at position
  zero, so `**BLOCKED:**` puts an asterisk where the tag has to be: the match fails, the
  line reads as no-prefix, and on a fresh transcript `IDLE` does not fire either. The
  report is not delayed, it is silent -- and a worker writing emphasis is following
  ordinary formatting habit, not breaking protocol.
- **There was no progress signal at all.** Age answers "how long since this file was
  touched", which anything touching the file resets. Nothing answered "has this session
  actually said anything new".
- **And the no-progress question was posed rather than answered.** Even with an index
  printed, "unchanged across two probes" is a comparison delegated to whoever reads the
  output, documented nowhere and enforced by nothing, so it may simply never happen.
- **`banned` counted the whole host.** Any process matching a banned command shape was
  reported, whatever directory it ran in.
- **Nothing reported undelivered work.** Load and memory can both read healthy while
  sessions are dying on an initialize timeout or having turns ended by the stall
  watchdog.
- `fleet_probe.py` is recorded in `.github/coverage-baselines/backend.txt` at 14.8%
  (34/229) after landing below the per-file floor with no tests (#7597).

## Why this issue matters to the user

The conductor decides, per cycle, whether to nudge a worker, reclaim its item, or close
it out. Every defect above pushes it toward the wrong one of those:

- A fabricated `PR` tag on a prose line spends a round reading a PR that does not exist.
- `ERR` on a healthy worker interrupts a turn that was fine.
- `IDLE` on a worker that already stood down asks it to keep going, or reclaims and
  re-dispatches an item that is already settled. That is the duplicate-dispatch failure
  the probe exists to prevent.
- With no progress signal, a self-deadlocked worker is indistinguishable from a busy
  one, because both hold an open turn and both keep their transcript warm.
- A banned-shape process in an unrelated checkout on the same host got a worker stopped
  that was not the offender.
- A fleet that cannot deliver reads as a healthy fleet doing nothing.

## How our fix solves it

Each change starts from the measurement, so the discriminator is the one the transcript
actually carries rather than a guess.

**Classification reads what the session said (2e).** `role` is the transcript's own
discriminator: the writers tag a tool card with its role and the presentation class is
never persisted, so nothing else separates the two. `tool`/`tool_call`/`tool_result`
rows are dropped before either half classifies, and a protocol word now only counts in
its protocol form, `<WORD>:`. Excluding tool rows costs no error signal, and the same
sample proves it: every `initialize timed out`, stall-watchdog and throttle line landed
on an `error`, `assistant`, `inject`, `user` or `nudge` row, and not one on a tool row.

**A monotonic tail index (2a).** Every fired line carries `i=<n>` before `d=`, and the
handled entry records it. An unchanged index across two probes is *no progress*, whether
or not a turn is open, which is the one thing a self-deadlocked worker cannot fake. It
counts lines from the START of the file rather than from the start of the parse window,
because a window-relative count saturates the moment a transcript passes `tail_bytes`
(200 KB) and then holds still while the session talks, reading as exactly the deadlock
it exists to detect. It costs nothing: the read already loads the whole file and keeps
only the window, so the prefix is in hand. It is a line position, so it carries no
transcript content.

**`TERMINAL` (2b).** The last dispositioned protocol tag is stored in its own field, so
a later `IDLE` or `GONE` disposition cannot erase it. When that tag is `STANDDOWN` or
`PROPOSAL` and the current tail has no protocol prefix, the probe fires `TERMINAL`
instead of ageing into `IDLE`, then suppresses by digest like any other tag. The
`tag == "-"` guard is load-bearing: the non-firing set holds both `-` and `WORKING`, so
without it a worker that stood down, was re-seeded, and is now reporting `WORKING:` would
read as finished and have its live work closed.

**Leading decoration is normalised away (2e, extended).** Emphasis and strikethrough
markers, code ticks, heading hashes, blockquote arrows and list markers are stripped from
the front of a candidate before the tag is matched, in any combination, so `**BLOCKED:**`,
`> BLOCKED:`, `- **GREEN:**`, `### PROPOSAL:` and `1. STANDDOWN:` all classify as their
tag. Two boundaries are explicit because both are observable. The normalisation applies to
the MATCHED text only -- the digest is still computed over what the worker wrote, so a
decorated report keeps a stable, distinct identity and `--mark-handled` round-trips on it.
And the anchor survives: decoration comes off the FRONT, so a bolded protocol word
mid-sentence is a worker talking about a report rather than filing one. Making this a
substring search would tag every message that mentioned a tag.

**`NOPROGRESS` answers the question instead of posing it (2a, extended).** The probe now
compares the current tail index against the one recorded at the last `--mark-handled` and
fires `NOPROGRESS` itself, rather than printing two numbers and hoping someone diffs them.
This needs no new write, so the one-writer rule holds: the only write is still the mark.
The claim is correspondingly precise -- not "quiet for a while" but "has emitted no message
and run no tool since you last acted on this session".

Three properties are deliberate and each was found by testing rather than reasoning. The
disposition must be at least one idle budget old, or the tag fires on the cycle right after
every mark, since a session that just filed a report has trivially produced nothing in the
seconds since. `IDLE` outranks it, because a cold transcript is already fully described by
`IDLE` and its nudge ladder is the right action -- what `IDLE` cannot see is the session held
WARM by traffic it never answers, which is the case this tag exists for. And it reaches
sessions whose named tag is SUPPRESSED, which is its most useful instance: the ruling was
delivered, the tag went quiet, and nothing has come out since. It expires like `IDLE`,
because a stall is a continuing condition rather than a payload filed once.

**`BLOCKED` is sticky (2b, extended).** The tag is now the newest REPORT rather than the
newest message. A probe samples; it does not subscribe, so it can only see a session's
latest message -- and the protocol requires a blocked worker to keep reporting status,
which means the worker's own next message displaces the one place the probe looks. The
result is not a suppressed signal or a deferred one: the `BLOCKED` is never observed at
all, and the debt is then invisible from both ends, with the worker holding position for a
ruling and the conductor never learning it owes one. A heartbeat (`WORKING`) and unprefixed
text therefore leave a sticky report standing, and any other report supersedes it, because
a worker that has since filed `PR`, `GREEN`, `STANDDOWN` or `PROPOSAL` has moved on. The
digest is keyed on the sticky report's own text, so sticky does not mean noisy: it fires
once, the ruling quiets it, and only a genuinely new blocker re-fires. `TERMINAL` and
sticky `BLOCKED` are deliberately separate tags, since one says close me and the other says
a ruling is owed.

**Delivery counters (2c).** `deliver init-timeout <a>, watchdog <b>` on the `OK` line,
counted for every watched session whether or not it fires, because an undelivered
session is a fleet fact rather than a per-tag one. Both pattern sets are config keys,
`init_timeout_res` and `watchdog_res`, defaulted from the emitters themselves
(`dashboard.state.TOOL_STALL_RECOVERY_PREFIX` / `STALE_RECOVERY_PREFIX`,
`acp.types.STOP_REASON_TOOL_STALL`, `mcp_gateway.backend`'s initialize timeout) and
validated exactly like `err_res`: a bad regex is malformed config, exit 2, never a crash
mid-cycle.

**Ownership-scoped banned scan (2d).** A banned command SHAPE is only a banned OPERATION
when the fleet owns it, so the process is attributed against a new `fleet_worktrees` config
key before the line is printed. Only fleet-owned or unattributable matches print, with the
class on the line (`cwd=fleet|unknown`); matches provably belonging to somebody else are
summarised as `foreign <n>`.

The reason this resolves the class DURING the scan rather than emitting a bare pid is
measured, not argued from principle. Over real conductor patrols, five `BANNED` lines fired
and attribution was attempted within seconds of each probe returning. **Three processes
were already gone** -- `/proc/<pid>/cwd` unreadable, `/proc/<pid>/cmdline` absent, `ps`
empty. These are short-lived targeted runs and the probe-to-action gap is reliably longer
than the process lives, so a bare `BANNED pid=N rule=X` cannot tell a fleet worker
violating the directive from unrelated activity on the same host. The only safe response to
a line like that is to ignore it, which teaches the operator to ignore the whole class.
Resolving the class while the evidence still exists is what makes the line actionable.

**The other two were attributable, and they changed the design.** In BOTH, `/proc/<pid>/cwd`
was unreadable while `/proc/<pid>/cmdline` read fine -- the cwd and `exe` symlinks need the
access a debugger would have, and the cmdline does not, so it is the only one of the three
that survives another user's process. A cwd-only classifier would have returned `unknown`
for two processes that could be PROVEN not to be the fleet's, and an unknown match makes
the conductor act. So the program path is consulted when the cwd cannot be read.

The two signals do NOT carry the same authority, and that asymmetry is the load-bearing
part:

| program path | class | why |
| --- | --- | --- |
| under a fleet worktree | `fleet` | conclusive; nothing outside that checkout runs its interpreter |
| a venv interpreter elsewhere | `foreign` | a venv belongs to the checkout that created it |
| a system or shim interpreter | `unknown` | every checkout shares it, so it attributes nothing |

Treating any non-match as `foreign` looks symmetric and would mute the signal this scan
exists to produce: measured on the host this runs on, a fleet worktree has **no `.venv`**
and its workers invoke a global `python3` shim, so a real banned run INSIDE the fleet has a
program path outside every fleet worktree. Calling that `foreign` drops it silently. The
symmetric form was implemented and run against the suite rather than reasoned about: it
broke `test_an_unreadable_cwd_is_unknown_and_still_reported`, which shipped with the
original 2d, so the property was already pinned before this refinement touched it. "Is it a
venv" is decided by the `pyvenv.cfg` marker beside the interpreter, which sits in the same
place for POSIX `bin/python` and Windows `Scripts/python.exe`, rather than by a path
heuristic.

Reading argv is not the same as printing it. The command line is still never emitted,
because a secret can ride in an argument -- but the program PATH is structural, so it can be
compared for a decision and dropped. That distinction is stated at the call site, since the
next reader would otherwise conclude argv was excluded from being READ.

An unattributable match is still `unknown`, still PRINTED and still counted as banned. An
unknown is not a foreign. Dropping it would be the one outcome worse than a noisy line -- a
real banned run inside the fleet, silently unseen.

A relative `fleet_worktrees` entry can never match an absolute cwd, so it is rejected as
malformed config rather than silently muting the scan, and an undeclared or empty
`fleet_worktrees` reports everything as `unknown`, because scoping against an empty set
would classify every match as foreign and mute the signal invisibly. Path comparison is
normalised in one place: the Windows lane caught a literal string compare misfiling every
match, because `os.readlink` there can answer an extended-length `\\?\D:\...` path that no
configured root will ever spell, and case and separators do not compare byte-wise. The
classifier also gets a second chance through `realpath`, so a symlinked worktree root or a
short (8.3) name still matches. The argv is still never echoed.

**Coverage (2f) is deferred, not delivered.** The tests here take the script to 95% when
coverage is sourced at the tree the tests run against, but that is not the number the gate
consumes: CI records `47/331 = 14.2%`, the import-only footprint, so the covering tests
are not attributed there and no test can move the gated figure. The file's existing
baseline exemption is therefore left exactly as it stands on the default branch, and this
PR makes no claim to have lifted it above the floor. The cause and a sharper diagnosis are
recorded on #7597.

**Banned-ops premise (2d).** The pytest rule's sense is unchanged, but its comment
claimed the repo's `-n auto` addopts forks one worker per core. `setup.cfg` documents the
opposite, and the comment now states what the rule actually catches: a run whose worker
count nobody CHOSE. `-n0` is asserted bounded rather than assumed.

Backward compatibility is explicit and tested: `--config` and
`--mark-handled KEY TAG DIGEST` keep their exact signatures, and a state file written
before this change still suppresses, because `index` and `proto` are additive metadata
outside the digest.

## What tests we did

All in `test/test_pipeline_conductor_agent.py`, single-process (`-n0`), plus the
existing round-trip contracts in `test_pipeline_conductor_probe_roundtrip.py`:
**74 passed**.

Every new behaviour has a test that fails against the previous implementation. Stashing
only the script and re-running the class reds **17** of them, and the ones that stay
green are the deliberate no-regression guards (a spoken report still fires with a tool
row after it; a non-terminal report still ages into `IDLE`).

Named coverage of the contract's required cases:

- unchanged tail index across two probes, and it moves by exactly one on one appended
  row;
- the index stays monotonic on a transcript far larger than the parse cap;
- `i=` precedes `d=` on the fired line;
- a terminal report followed by unprefixed text is `TERMINAL`, not `IDLE`, and a later
  non-protocol disposition does not erase it; a re-seeded worker reporting `WORKING:` is
  NOT terminal, while a `WORKING` tail that goes silent still ages into `IDLE`;
- a `BLOCKED:` followed by two `WORKING:` messages still classifies as `BLOCKED`, and
  still does on a second probe that did not mark it handled; unprefixed text does not
  clear it and does not let it age into `IDLE`; its digest is unchanged by new heartbeats
  so it fires once; the ruling quiets it and a genuinely new blocker re-fires; `PR`,
  `GREEN` and `STANDDOWN` each clear it; and it outranks a recorded terminal disposition;
- `**BLOCKED:**`, `> BLOCKED:`, `- **GREEN:**`, `### PROPOSAL:`, `1. STANDDOWN:`,
  `__PR:__` and a code-ticked prefix all classify as their tag; a decorated `BLOCKED`
  survives two following heartbeats (the two rules composing); a bolded protocol word
  mid-sentence still does NOT fire; a tool row carrying `**PR:**` still does not classify;
  and the digest still differs between a decorated and an undecorated report, with
  `--mark-handled` round-tripping on the decorated one;
- a tool line carrying `STANDDOWN`, `PR:` and an error phrase classifies as no-prefix,
  and does not feed the delivery counters either;
- prose opening with `PR #6580` does not fire;
- a banned match outside `fleet_worktrees` is `foreign`, not `banned`; a subdirectory of
  a worktree is fleet-owned; a sibling named `wt-a-old` is not swallowed by `wt-a`; a
  worktree reached through a symlink still matches; an extended-length `\\?\` path
  normalises to the root it names; an unreadable cwd is `unknown` and still reported; the
  argv still never appears;
- the program-path fallback attributes a foreign venv, treats a fleet interpreter as owned
  even when the cwd is unreadable, leaves a system/shim interpreter `unknown` and still
  reports it, and decides on the path while a secret in an ARGUMENT never reaches the
  output;
- `-n0`, `-n 0` and `--numprocesses=0` are each present as their own fixture in the
  bounded-spellings test (verified by name, not inferred from the `\d` branch), alongside
  the existing `-n 4` / `-n=4` / `-n4` / `--numprocesses=4` cases, while `-n auto` and a
  bare pytest still fire;
- `NOPROGRESS` fires on a session held warm by nudges it never answers, and NOT on the
  cycle right after a disposition; one produced row (a message or a single tool call)
  clears it; a live `BLOCKED` outranks it; it is suppressible and expires like `IDLE`; and
  a session the conductor has never acted on cannot be stalled yet;
- an inbound `nudge`, `inject` or `user` row does not advance the index while a tool row
  does, and a row QUOTING transcript JSON does not advance it either -- so the
  line-anchored needle is pinned independently of `json.dumps` escaping;
- one entry per key means a later mark can erase an earlier fact, so four
  separate assertions pin that it does not: a condition mark preserves an
  answered payload, so does any other later mark, the legacy state shape carries
  both halves of it across an upgrade, and an answered `ERR` does not bury a
  ruling nobody has answered;
- the delivery counters appear on the `OK` line, are configurable, and a bad
  `init_timeout_res` or `watchdog_res` regex is malformed config (exit 2), not a crash;
- a relative `fleet_worktrees` entry is malformed config;
- a state file written by the old version still loads and still suppresses, and an old
  config with none of the new keys still produces a full `OK` line.

Repo gates run on the two changed files: `black`, `isort`, `flake8`, `mypy` clean, plus
`check_brand_name`, `check_builtin_skill_scope`, `check_loop_bound_locks`,
`check_black_formatting`, `check_testpaths_coverage` and `check_harness_parity`.

## Any other suggestions on the work

**The coverage half of the original scope is deferred, and the baseline is untouched.**
`.github/coverage-baselines/backend.txt` records `fleet_probe.py 14.8   # 34/229`, and it
is left exactly as the default branch has it. The tests in this PR do cover the script
(95% when coverage is sourced at the tree the tests run against), but that measurement is
not what the gate reads: CI's own artifact records `47/331 = 14.2%`, which is the
import-only footprint. Removing the exemption on the strength of a local number makes the
file a `new_offender` at 14.2% and reds a required lane for every open PR, so the exemption
stays and 2f is honestly unfinished rather than quietly claimed.

**A sharper diagnosis for #7597 than the one currently recorded there.** The comment above
that baseline entry, and the repo's investigation of the issue, both rest on a control case:
that a sibling script loaded through the same helper is unbaselined and passes the gate,
which would mean the loader attributes coverage correctly and the problem is specific to
this file. CI's coverage artifact does not support it. `credit_spend.py` is **absent from
the report entirely** -- 0 occurrences among 1,233 measured classes -- so it is never judged
rather than judged and passing. `fleet_probe.py` is the only file from that skill directory
present at all, and it enters import-only. Whatever the root cause is, it is not the loader,
and an analysis resting on that control case is reasoning from a case it never measured.

**An explicit `-n <N>` is the LESS safe pytest spelling on this repo, which is why the
banned rule's old comment was misleading.** `setup.cfg` documents that `-n auto` does not
mean one worker per core here: the rootdir conftest's `pytest_xdist_auto_num_workers` hook
(`conftest.py:856`) sizes the pool by available memory and by what concurrent runs on the
host already hold, and "an explicit `-n <N>` bypasses the budget". So guidance of the form
"use a bounded `-n 2`" hands a fleet the one spelling that can outgrow the host, while
`-n0` -- the repo's own documented override -- is genuinely in-process and costs nothing.
The rule's SENSE is deliberately unchanged, because which shapes it flags decides what the
conductor stops mid-turn across a whole fleet; only its stated premise is corrected, and
`-n0` is now asserted bounded rather than assumed.

Two observations for whoever owns the probe next:

1. `tail_bytes` caps how much of a transcript is PARSED, not how much is READ. The
   implementation is `path.read_bytes()[-max_bytes:]`, so the whole file is loaded
   either way. That is what makes the monotonic index free, and it is worth knowing
   before anyone reads the setting as an I/O bound on a large session.
2. The digest is keyed on the classified tail text, so this change rotates digests once:
   suppressed signals whose classification moved will re-fire a single time on the first
   cycle after deployment. That is the documented degradation (a handled signal re-fires
   once, never a crashed patrol), not a new failure mode.

**Accepting a finding is not the same as agreeing with its reasoning.** The line-anchored
index needle was taken from a review suggestion whose stated case cannot actually arise:
`json.dumps` escapes inner quotes, so a row quoting `{"role": "assistant"` is stored as
`{\"role\": ...` and never matched the needle. The fix stands on its own -- anchoring is
correct without depending on that argument being sound, and it also covers a torn line at
the window edge -- so it was accepted for better reasons rather than rebutted.

**Residual: one entry per key.** The handled set stores one record per session, and that
single premise carries three jobs -- suppression, terminality, and progress. Terminality and
stickiness are therefore SPECIAL CASES layered on top of the record rather than properties of
the data model: a terminal disposition survives a later mark only because the payload tag and
digest are carried forward explicitly, and a sticky `BLOCKED` reaches past an answered `ERR`
only because the firing path looks for it. Both work and both are asserted, but neither falls
out of the shape.

Stickiness also has a bound the state file cannot close. It reaches only as far back as the
parse window, so a blocked worker that heartbeats long enough pushes its own report past
`tail_bytes` and the debt goes invisible. Sourcing it from the handled set looks like the fix
and is not: the recorded tag exists exactly when the ruling was already delivered and the
signal is correctly suppressed anyway, and it is absent in the case that actually bites -- an
undispositioned report ageing out. Reading it would be a no-op or a machine for re-firing
answered rulings, so the transcript stays the source of truth.

A per-tag handled map makes both properties structural instead of special-cased, and it changes
the persisted state schema, so it wants its own change with its own migration test. A follow-up
carries it.

**An advisory finding needs the same verification as a blocking one.** One suggestion here
-- resolve an unreadable `/proc/<pid>/cwd` by owner, so another user's process reads as
`foreign` rather than `unknown` -- was cosmetic, and taking it introduced a real portability
defect: `os.getuid` is POSIX-only, its absence raises `AttributeError` rather than
`OSError`, and the Windows shards run this scan against a fake `/proc`. The next lane caught
it in one push; the test written to cover it then depended on the same primitive it was
testing the absence of. It is withdrawn, with the reasoning left at the call site: this file
imports nothing from the package, so it cannot route through `platform_compat`, and an
unreadable cwd already reports as `unknown`, which is the fail-open reading that matters.
The two findings treated as defects rather than suggestions -- the index counting inbound
rows, and the delivery counters never ageing out -- were both real and both worth it.

Refs #8029
Refs #7597
