### PR TITLE
feat(pipeline-conductor): ask all five claim questions, not one

### DIFF
--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/claim_preflight.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/claim_preflight.py
@@ -1,0 +1,1469 @@
+#!/usr/bin/env python3
+"""Claim preflight — the deterministic claim predicate for the pipeline conductor.
+
+One invocation answers every cheap question about one candidate work item and
+returns ONE verdict, so a worker dispatch is never spent discovering that the
+work does not exist.
+
+WHY FIVE QUESTIONS AND NOT ONE. The predicate this replaces was a single prose
+line, ``gh pr list --search``, and it was blind in three directions at once.
+Each blind spot cost a whole dispatch to discover:
+
+  * an item already fixed by a MERGED PR was claimed and dispatched days later
+    — an ``--state open`` query structurally cannot see a merged PR — with the
+    reporter's own "happy to have it closed" sitting on the thread;
+  * four dispatches went to items that each had an OPEN PR carrying
+    ``Fixes #N``, because the predicate read one field
+    (``closedByPullRequestsReferences``) that came back empty for all of them.
+    It still does: measured on this repo, two items closed by merged PRs both
+    answer ``[]``. That is why this script never asks that question at all — it
+    reads the item's TIMELINE, which sees both the fork PRs and the merged ones;
+  * three items said "I am claiming this issue" / "Ownership claimed by @X" in
+    PROSE, in the body, which no label or field query sees.
+
+The lesson those three share, and the design rule of this script: **one
+question with an empty answer is not permission.** So it asks all five, and an
+unanswerable question yields UNKNOWN — never CLAIM.
+
+Usage:
+    python3 claim_preflight.py --repo <owner/repo> --item <N>
+                              [--default-branch main]
+                              [--repo-dir <path to a clone of the base>]
+                              [--json]
+
+    --repo            ``owner/name`` of the forge repository holding the item
+    --item            the issue number
+    --default-branch  the git rev a worker would branch from, as it is spelled
+                      in ``--repo-dir`` (``main``, ``origin/main``, …)
+    --repo-dir        a clone of the base. Needed only for the two questions
+                      git can answer: whether a merged PR actually LANDED on
+                      that branch, and whether a symbol the item names exists
+                      there. Omitting it is not an error — but if the item has
+                      a merged PR or names a symbol, the answer becomes
+                      UNKNOWN rather than a guess. The clone is read as-is and
+                      never fetched: keeping it current is the caller's job,
+                      and a merge commit missing from a stale clone reports
+                      UNKNOWN, never "did not land".
+    --json            print exactly one JSON object instead of the human line
+
+Exit codes (the conductor branches on these):
+
+    0   CLAIM    — dispatch it
+   10   SKIP     — covered or not workable; do not dispatch
+   11   CLOSE    — triage debt: already fixed, or the reporter asked to close
+    2            — malformed arguments or config
+    3   UNKNOWN  — a check could not be answered (forge unreachable, rate
+                   limited, no clone for a question only git can answer)
+
+The five checks, all of them, every call:
+
+  1. ``open_prs``      open PRs referencing the item, FORK PRs included, with
+                       ``is_cross_repository`` and author per hit, plus
+                       ``untrusted_fork`` when a cross-repository PR's author
+                       has no standing. That last one changes no verdict: it
+                       makes the suppression LOUD, because opening a fork PR
+                       needs no permission and a silent SKIP anybody can cause
+                       is how an item leaves the queue with nobody told.
+  2. ``merged_prs``    MERGED PRs referencing the item, each annotated
+                       ``landed`` by ``git merge-base --is-ancestor`` and
+                       ``closes_item`` by a closing keyword aimed at this item.
+                       BOTH are load-bearing: a PR merged somewhere other than
+                       the branch a worker would start from is not coverage, and
+                       a PR that merely MENTIONS the item is not closure.
+  3. ``prose_claim``   the body and the NEWEST human comment, scanned for
+                       self-claim phrases and for closure requests — over what
+                       the author SAYS, with code fences, backtick spans,
+                       blockquotes and quoted spans removed first, because a
+                       phrase inside them is being cited. BOTH phrase sets need
+                       standing (the reporter, or a repository insider), for
+                       opposite reasons: CLOSE acts on live work, and a SKIP any
+                       commenter can cast is a denial-of-work channel.
+  4. ``symbol_on_base``every symbol the item names, by ``git grep`` on the
+                       default branch. Absent means the target code may live
+                       only on an unmerged branch — but that reading holds only
+                       for a BUG-class item, so absence vetoes only when the
+                       item's own metadata corroborates that class. Otherwise it
+                       downgrades to ``CLAIM risk=high``: a feature request
+                       names the symbol it PROPOSES to add, and parking it would
+                       be a permanent false veto on a whole item class.
+  5. ``recency``       age and ``authorAssociation``. A freshly opened item
+                       from an active contributor is a high self-claim risk —
+                       surfaced as ``risk=high``, never a veto on its own. The
+                       consumer is the skill: ``risk=high`` means the item is
+                       not batched, it gets a live re-check immediately before
+                       the atomic claim.
+
+Verdict precedence, first match wins (see :func:`verdict`, a pure function of
+the checks dict so every branch is unit-testable with no forge access):
+
+  1. ``merged_prs`` LANDED and CLOSES it       → CLOSE ``already-fixed``
+  2. any ``open_prs`` entry                  → SKIP  ``open-pr``, marked
+                                               ``untrusted-fork`` at
+                                               ``risk=high`` when the PR is an
+                                               unvouched fork
+  3. ``prose_claim.closure_requested``       → CLOSE ``reporter-asked-close``
+  4. ``prose_claim.claimed_by_other``        → SKIP  ``prose-claim``
+  5. ``symbol_on_base.missing`` AND bug-class→ SKIP  ``symbol-absent``
+  6. any check errored                       → UNKNOWN
+  7. otherwise                               → CLAIM, annotated with ``risk``,
+                                               which an UNCORROBORATED absent
+                                               symbol or an UNAUTHORIZED claim
+                                               forces to ``high``
+
+Rules 2 and 4 both suppress work on evidence anybody can manufacture, and both
+answer it the same way rather than by refusing to look: the finding stands, and
+the doubt is published alongside it. A verdict that acts while doubting has to
+say so, or the doubt is only in this docstring.
+
+Note that 6 sits BELOW the positive findings on purpose: a definite answer to
+one question outranks a partial view of another, and no error path can reach
+CLAIM.
+
+Deliberately boring properties, do not weaken:
+
+  * Forge access goes through ``gh``; no hand-rolled HTTP and no token is ever
+    read by this script. ``run_gh`` refuses a mutating argv outright, so the
+    no-write property is enforced rather than merely intended: this script
+    never labels, assigns, comments, or closes.
+  * At most one forge call per question. The timeline is fetched once and
+    answers checks 1 and 2 together; each referencing PR is then detailed once,
+    because fork-ness and the merge commit exist only on the pull object.
+  * No user-authored PROSE reaches stdout. Failures are reported as SLUGS
+    rather than forge stderr, a prose match reports the PATTERN that fired
+    rather than the sentence, and a bug-class match reports this module's own
+    TERM rather than the label's text — this output lands in an agent's context.
+    What DOES appear is identifiers: logins, PR numbers, commit prefixes,
+    comment ids and symbol names extracted from the item. Those are the evidence
+    a conductor needs to check the verdict, and a login is chosen by its owner
+    rather than written for this item. The claim is deliberately narrower than
+    "nothing user-authored": the wider version was in this docstring first, and
+    an invariant that overclaims is how a leak of user-written LABEL text once
+    shipped past it.
+  * A closed-unmerged PR is neither coverage nor a claim. It is abandoned work
+    and it frees the item, so it appears in neither list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+#: What a closure request has to be ABOUT. Measured: `\bplease\s+close\b` alone
+#: fired on "Please close the file after reading it" and "Remember to please
+#: close the connection in the finally block" -- ordinary sentences in a bug
+#: report about this kind of software -- and returned CLOSE, exit 11, on a live
+#: item. The verb is not the signal; its OBJECT is. So the close-family patterns
+#: require an issue-shaped object or a clause end, and anything unrecognised is
+#: NOT a closure request: that direction costs one dispatch, the other closes
+#: work in flight.
+#:
+#: Bare ``it`` and bare ``that`` are deliberately NOT objects, which cost a
+#: round to learn: the first version of this list accepted them, and "The
+#: connection leaks. Please close it." closed the item. A bare pronoun resolves
+#: to whatever was last mentioned, and in a bug report that is usually a socket,
+#: a file or a handle. ``this`` is kept because it points at the thread's topic
+#: rather than at the previous noun, and ``that issue`` still works with the noun
+#: present. The noun alternatives come FIRST so "this issue" is not consumed by
+#: bare ``this`` and then failed on the clause end.
+_ISSUE_OBJECT = (
+    r"(?:this|that|the)\s+(?:issue|ticket|item|bug|report|one)"
+    r"|(?:the\s+)?(?:issue|ticket|item|bug|report)"
+    r"|this"
+    r"|#\d+"
+)
+_CLAUSE_END = r"(?:\s*(?:[.,;:!?)\]\"]|$)|\s+(?:as|since|because|please))"
+_CLOSE_OBJECT = rf"(?:\s+(?:{_ISSUE_OBJECT}))?{_CLAUSE_END}"
+
+#: What may FOLLOW "this is resolved/fixed" for it to be a statement about the
+#: item's state. An allowlist, not a list of exclusions, because two exclusions
+#: were already not enough here. Measured misses it fixes: "This is fixed-width
+#: layout" closed live items, because ``\b`` matches happily before a hyphen and
+#: the word is an ADJECTIVE there, not a verdict. ``by`` is absent on purpose --
+#: "this is resolved by upgrading it in your own fork" hands over a workaround
+#: and leaves the item open -- while ``in`` is present, so "fixed in the 0.7
+#: release" still reads as closure.
+_STATE_END = r"(?:\s*(?:[.,;:!?)\]\"]|$)|\s+(?:in|on|at|since|as|now|already|and|so|--))"
+
+#: Self-claim prose, from the three items that were dispatched on top of
+#: someone else's declared ownership. Patterns, not the matched text, are what
+#: gets reported.
+#: Negation and hedging that INVERT a phrase this scanner would otherwise read
+#: as a verdict. Measured: "I don't think this is resolved", "I am not sure this
+#: is fixed" and "nobody said this is resolved" all closed live items, because
+#: the phrase patterns match a SUBSTRING while English puts the negation earlier
+#: in the sentence. Python's ``re`` has no variable-width lookbehind, so this is
+#: applied as a window check over the text PRECEDING each match rather than as
+#: part of the pattern.
+#:
+#: This is the OPPOSITE choice from :func:`closing_reference_re`, deliberately.
+#: There, negation-blindness matches GitHub's own parser, which closes an item
+#: for "does not close #N" anyway, so agreeing with the forge keeps the two
+#: readings identical. Here nothing else is doing the reading and the verdict
+#: writes to somebody's live work.
+_NEGATOR_RE = re.compile(
+    r"\b(?:not|never|nobody|none|cannot|doubt|unsure|unclear|unless|whether)\b|n't\b",
+    re.IGNORECASE,
+)
+
+#: How far back a negation reaches. Wide enough for "I don't think this is
+#: resolved", short enough that an unrelated "no" two sentences earlier does not
+#: veto a real request. A false veto costs one dispatch, which is the side to
+#: err on.
+_NEGATION_WINDOW = 60
+
+SELF_CLAIM_RES: tuple[str, ...] = (
+    r"\bI(?:'m| am)\s+claiming\b",
+    r"\bclaiming\s+(?:this|it)\b",
+    r"\b(?:I|we)\s+(?:have\s+)?claimed\s+(?:this|it)\b",
+    r"\bownership\s+claimed\s+by\b",
+    r"\bI(?:'m| am)\s+working\s+on\s+(?:this|it)\b",
+    r"\bworking\s+on\s+(?:this|it)\s+(?:now|already)\b",
+    r"\bI(?:'ll| will)\s+(?:take|pick\s+up|handle|fix)\s+(?:this|it)\b",
+    r"\b(?:taking|picking)\s+(?:this|it)\s+up\b",
+    r"\bassigned\s+(?:this\s+)?to\s+myself\b",
+)
+
+#: A claim being GIVEN UP. Recovering the newest standing claim must not step
+#: over one of these: an owner who says "dropping this" has released the item,
+#: and treating their earlier claim as live parks it on nobody.
+WITHDRAWAL_RES: tuple[str, ...] = (
+    r"\b(?:dropping|unclaiming|abandoning)\s+(?:this|it)\b",
+    r"\bno\s+longer\s+working\s+on\s+(?:this|it)\b",
+    r"\bnot\s+working\s+on\s+(?:this|it)\b",
+    r"\bI(?:'m| am)\s+off\s+(?:this|it)\b",
+    r"\bunassigning\s+myself\b",
+)
+
+#: Closure requests, from the item whose reporter had already said it was done.
+#: Every pattern that can produce CLOSE carries a continuation guard, because
+#: CLOSE is the one verdict that writes to somebody else's live work and this
+#: list has now produced four separate false positives without one.
+CLOSURE_RES: tuple[str, ...] = (
+    rf"\bthis\s+(?:is|was)\s+(?:already\s+)?(?:resolved|fixed)\b{_STATE_END}",
+    rf"\bhappy\s+to\s+have\s+(?:{_ISSUE_OBJECT})\s+closed\b",
+    rf"\bplease\s+close\b{_CLOSE_OBJECT}",
+    rf"\b(?:can|could|should)\s+(?:we|you|this)\s+(?:be\s+)?close[d]?\b{_CLOSE_OBJECT}",
+    rf"\bthis\s+can\s+be\s+closed\b{_STATE_END}",
+    # "no longer an issue" and "no longer reproducible" are about the ITEM by
+    # construction. "needed" and "relevant" are not: "the workaround is no
+    # longer needed" describes a workaround and closed live items, so those two
+    # require the item as their subject.
+    r"\bno\s+longer\s+(?:an\s+issue|reproducible)\b",
+    r"\bthis\s+(?:is\s+)?no\s+longer\s+(?:needed|relevant)\b",
+)
+
+#: Patterns above that name the item in their own words rather than through
+#: ``_ISSUE_OBJECT`` or a guard. The ratchet test uses this: every closure
+#: pattern must either carry a guard or be listed here WITH a reason, so the next
+#: phrase added to the list cannot quietly ship without one. Six separate
+#: false-CLOSE defects reached review because a pattern was added without a
+#: guard and nothing checked.
+ITEM_SCOPED_CLOSURE_RES: frozenset[str] = frozenset(
+    {
+        # "an issue" and "reproducible" can only describe the item itself.
+        r"\bno\s+longer\s+(?:an\s+issue|reproducible)\b",
+        # Subject is a literal "this ... no longer", so the object is inherent.
+        r"\bthis\s+(?:is\s+)?no\s+longer\s+(?:needed|relevant)\b",
+    }
+)
+
+#: An association that makes a fresh item a plausible self-claim in flight.
+ACTIVE_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"})
+
+#: Standing to ask for closure on somebody else's item. Narrower than
+#: ACTIVE_ASSOCIATIONS on purpose: CONTRIBUTOR means "has had a PR merged here
+#: once", which is not authority to close another person's report, while CLOSE
+#: is the one verdict that acts on live work.
+INSIDER_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+#: GitHub's closing keywords. A merged PR is coverage only if it CLAIMS to close
+#: the item; a bare cross-reference ("see #123", "related to #123") is a mention
+#: and decides nothing. Deliberately negation-blind, matching GitHub's own
+#: parser: "does not close #123" links and closes #123 there too, so treating it
+#: as a claim keeps this script's reading and the forge's reading identical.
+_CLOSING_WORDS = "close[sd]?|fix(?:e[sd])?|resolve[sd]?"
+
+
+def closing_reference_re(repo: str, item: int) -> re.Pattern[str]:
+    """A pattern matching a closing keyword aimed at THIS item.
+
+    Covers the three spellings GitHub honours: ``#N``, ``owner/repo#N``, and the
+    full issue URL. ``\\b`` after the number stops ``#12`` matching ``#123``.
+    """
+    owner_repo = re.escape(repo)
+    target = (
+        rf"(?:#{item}\b"
+        rf"|{owner_repo}#{item}\b"
+        rf"|https?://github\.com/{owner_repo}/issues/{item}\b)"
+    )
+    return re.compile(rf"\b(?:{_CLOSING_WORDS})\s*:?\s+{target}", re.IGNORECASE)
+
+
+RECENT_DAYS = 14
+MAX_SYMBOLS = 8
+MAX_PR_DETAILS = 20
+
+#: Comments per page. The maximum the endpoint allows, so the common item costs
+#: exactly one call and only a genuinely chatty thread pays for a second --
+#: needed because the endpoint has no usable sort and the NEWEST comment is the
+#: one this check wants (see :func:`last_human_comment`). ``gh --paginate``
+#: merges JSON array pages into one document, measured across four pages on
+#: gh 2.96.0, so a paginated read stays a single parse.
+COMMENT_PAGE = 100
+
+CHECK_NAMES = (
+    "open_prs",
+    "merged_prs",
+    "prose_claim",
+    "symbol_on_base",
+    "recency",
+)
+
+EXIT_CODES = {"CLAIM": 0, "SKIP": 10, "CLOSE": 11, "UNKNOWN": 3}
+
+#: ``gh`` shapes this script is allowed to run. Everything else — including
+#: every write verb — is refused before the subprocess starts.
+_READ_SHAPES = (
+    ("api",),
+    ("issue", "view"),
+    ("issue", "list"),
+    ("pr", "view"),
+    ("pr", "list"),
+)
+_WRITE_METHODS = {"POST", "PATCH", "PUT", "DELETE"}
+#: ``gh api -f/-F/--field/--raw-field`` implies POST, so a "GET" argv carrying
+#: one of these is a write.
+_FIELD_FLAGS = {"-f", "-F", "--field", "--raw-field", "--input"}
+
+
+def run(args: list[str], cwd: str | None = None) -> tuple[int, str, str]:
+    """(rc, stdout, stderr) with a missing binary as rc 127, never a traceback."""
+    try:
+        done = subprocess.run(
+            args, capture_output=True, text=True, encoding="utf-8", errors="replace", cwd=cwd
+        )
+    except OSError as exc:
+        return 127, "", f"{args[0]}: {exc}"
+    return done.returncode, (done.stdout or "").strip(), (done.stderr or "").strip()
+
+
+def is_read_only(args: list[str]) -> bool:
+    """Whether ``args`` is one of the read shapes this script may run.
+
+    The no-write rule is a property of the script, not a promise in its
+    docstring: an argv that could mutate the forge is refused here, before any
+    subprocess exists. That also means a future edit cannot add a write without
+    also editing this allowlist, where the intent is obvious in review.
+    """
+    if len(args) < 2 or args[0] != "gh":
+        return False
+    if not any(tuple(args[1 : 1 + len(shape)]) == shape for shape in _READ_SHAPES):
+        return False
+    if args[1] != "api":
+        return True
+    for index, token in enumerate(args):
+        if token in _FIELD_FLAGS:
+            return False
+        if token in ("-X", "--method"):
+            following = args[index + 1] if index + 1 < len(args) else ""
+            if following.upper() in _WRITE_METHODS:
+                return False
+        if token.startswith("--method=") and token.split("=", 1)[1].upper() in _WRITE_METHODS:
+            return False
+    return True
+
+
+def run_gh(args: list[str]) -> tuple[int, str, str]:
+    """``run`` for ``gh``, refusing anything that is not a read."""
+    if not is_read_only(args):
+        return 126, "", "refused: claim_preflight performs no writes"
+    return run(args)
+
+
+def error_slug(rc: int, err: str) -> str:
+    """A slug for a failed forge call. Never the stderr text.
+
+    The caller prints this into an agent's context, and forge stderr can carry
+    a URL with a token in it. A slug plus the exit code is enough to act on.
+    """
+    low = err.lower()
+    if rc == 126:
+        return "refused-write"
+    if rc == 127:
+        return "gh-missing"
+    if "rate limit" in low or "429" in low:
+        return "rate-limited"
+    if "401" in low or "gh auth login" in low or "authentication" in low:
+        return "not-authenticated"
+    if "404" in low or "not found" in low:
+        return "not-found"
+    for token in ("could not resolve", "dial tcp", "timeout", "timed out", "connection refused"):
+        if token in low:
+            return "forge-unreachable"
+    return f"gh-error-rc{rc}"
+
+
+def parse_pages(out: str) -> Any:
+    """Parse ``gh`` output that is ONE JSON document or several concatenated.
+
+    ``gh api --paginate`` MERGES JSON array pages into a single document:
+    measured on gh 2.96.0, the timeline of a real item at ``per_page=8`` came
+    back as one parseable array of 33 events across 4 pages, and the comments
+    endpoint at ``per_page=5`` as one array of 12 across 3. So the
+    single-document path is the one that runs, and no ``--slurp`` is needed --
+    which is just as well, since gh refuses ``--slurp`` together with ``--jq``.
+
+    The concatenated shape is tolerated anyway, and deliberately: this script
+    pins no gh version, the failure mode if a version does split pages is that a
+    covered item silently reports UNKNOWN, and being right about today's gh is a
+    worse guarantee than not caring which gh it is.
+    """
+    try:
+        return json.loads(out)
+    except ValueError:
+        pass
+    decoder = json.JSONDecoder()
+    merged: list[Any] = []
+    index, length = 0, len(out)
+    while index < length:
+        while index < length and out[index].isspace():
+            index += 1
+        if index >= length:
+            break
+        # A ValueError here is a genuinely unparseable payload; it propagates to
+        # gh_json, which reports it as a failed answer rather than as no data.
+        value, index = decoder.raw_decode(out, index)
+        merged.extend(value) if isinstance(value, list) else merged.append(value)
+    return merged
+
+
+def gh_json(args: list[str]) -> tuple[Any, str | None]:
+    """(parsed, None) or (None, slug). Unparseable output is a failed answer."""
+    rc, out, err = run_gh(args)
+    if rc != 0:
+        return None, error_slug(rc, err)
+    try:
+        return parse_pages(out or "null"), None
+    except ValueError:
+        return None, "unparseable-json"
+
+
+def git(repo_dir: str, args: list[str]) -> tuple[int, str, str]:
+    return run(["git", "-C", repo_dir, *args])
+
+
+# --------------------------------------------------------------------------- #
+# checks 1 + 2 — referencing PRs, and whether a merged one actually landed
+# --------------------------------------------------------------------------- #
+
+
+_API_REPO_RE = re.compile(r"/repos/([^/]+/[^/]+)/(?:issues|pulls)/\d+")
+
+
+def repo_from_api_url(url: Any) -> str | None:
+    """``owner/repo`` out of a forge API URL, or None.
+
+    The timeline's nested ``repository`` object is not guaranteed to be present,
+    and the fallback that treated its absence as "same repository" turned a
+    reference from ANOTHER repo into a fetch of this repo's PR with the same
+    NUMBER -- a different pull request entirely, which could SKIP a live item.
+    Returning None here is the honest answer and the caller skips the reference.
+    """
+    if not isinstance(url, str):
+        return None
+    found = _API_REPO_RE.search(url)
+    return found.group(1) if found else None
+
+
+def referencing_prs(repo: str, item: int) -> tuple[list[dict], list[dict], str | None]:
+    """(open, merged, error slug) for PRs that reference ``item``.
+
+    ONE timeline call finds every cross-reference — fork PRs included, which is
+    the half the old ``--state open`` search could not see — and one detail call
+    per referenced PR supplies the two fields the timeline omits: the merge
+    commit, and the head repository that makes a PR a fork PR.
+
+    A reference to a PR in ANOTHER repository is skipped: it cannot land code
+    on this repo's default branch, so it is not coverage of this item.
+    """
+    data, error = gh_json(["gh", "api", f"repos/{repo}/issues/{item}/timeline", "--paginate"])
+    if error:
+        return [], [], error
+    numbers: list[int] = []
+    for entry in data if isinstance(data, list) else []:
+        if not isinstance(entry, dict) or entry.get("event") != "cross-referenced":
+            continue
+        source = entry.get("source")
+        issue = source.get("issue") if isinstance(source, dict) else None
+        if not isinstance(issue, dict) or not isinstance(issue.get("pull_request"), dict):
+            continue
+        where = issue.get("repository")
+        full_name = where.get("full_name") if isinstance(where, dict) else None
+        if full_name is None:
+            # The nested repository object is not guaranteed. Falling back to
+            # "assume local" fetched repos/<this repo>/pulls/<N> and could pull
+            # an UNRELATED local PR that merely shares the number, which then
+            # SKIPped a live item. The URL carries the owner and repo, so read
+            # it from there and skip the reference when neither source can
+            # establish it: an unidentifiable reference is not coverage.
+            full_name = repo_from_api_url(issue.get("url"))
+        if full_name != repo:
+            continue
+        number = issue.get("number")
+        if isinstance(number, int) and number not in numbers:
+            numbers.append(number)
+    if len(numbers) > MAX_PR_DETAILS:
+        # A scan that would drop references cannot claim completeness, and an
+        # incomplete coverage answer must not read as "no coverage".
+        return [], [], "too-many-references"
+    open_prs: list[dict] = []
+    merged_prs: list[dict] = []
+    closing_re = closing_reference_re(repo, item)
+    for number in numbers:
+        detail, error = gh_json(["gh", "api", f"repos/{repo}/pulls/{number}"])
+        if error or not isinstance(detail, dict):
+            # An OPEN PR already confirmed is a definite answer, and the module's
+            # precedence puts a definite answer above a partial view: discarding
+            # it here turned a SKIP into UNKNOWN over a later PR that could not
+            # have changed it. The accumulated hits travel with the error, and
+            # the caller keeps the finding while marking the merged side
+            # unanswered. Rule 1 outranks rule 2, so a CLOSE can still be missed
+            # this way -- that costs an item left open, never a false close.
+            return open_prs, merged_prs, (error or "unparseable-json")
+        head = detail.get("head") or {}
+        base = detail.get("base") or {}
+        head_repo = (head.get("repo") or {}).get("full_name") if isinstance(head, dict) else None
+        base_repo = (base.get("repo") or {}).get("full_name") if isinstance(base, dict) else None
+        user = detail.get("user") or {}
+        hit = {
+            "number": number,
+            "author": user.get("login") if isinstance(user, dict) else None,
+            # A deleted head repo reads as cross-repository, the safe side.
+            "is_cross_repository": head_repo != base_repo,
+            # Read by annotate_untrusted_forks, never printed: an association is
+            # a forge enum, but the trust decision belongs in one place.
+            "author_association": detail.get("author_association"),
+        }
+        if detail.get("merged"):
+            hit["merge_commit_sha"] = detail.get("merge_commit_sha")
+            # A merged PR is coverage only if it CLAIMS to close the item. A
+            # bare cross-reference is a mention, and a mention decides nothing:
+            # reading it as coverage would CLOSE live work, and reading it as a
+            # claim would starve an item whose fix was only partial. So it is
+            # recorded and left to fall through to the remaining checks.
+            claimed = f"{detail.get('title') or ''}\n{detail.get('body') or ''}"
+            hit["closes_item"] = bool(closing_re.search(claimed))
+            merged_prs.append(hit)
+        elif detail.get("state") == "open":
+            open_prs.append(hit)
+        # A closed-unmerged PR is abandoned work: neither coverage nor a claim.
+    return open_prs, merged_prs, None
+
+
+def annotate_untrusted_forks(open_prs: list[dict], reporter: str | None) -> None:
+    """Set ``untrusted_fork`` on each open hit. Annotation only, by design.
+
+    Opening a fork PR needs no permission, so a cross-repository PR that merely
+    MENTIONS an item is a suppression channel available to anybody: the item
+    SKIPs and leaves the queue. The tempting fix -- stop trusting fork PRs -- is
+    the wrong trade. In a public repository most genuine coverage arrives as a
+    fork PR, and dropping those reinstates the duplicate-dispatch class this
+    whole script was built from, repeatedly, to close a channel that costs an
+    outsider one throwaway PR.
+
+    So the verdict does not move: an open PR still SKIPs, fork PRs included, as
+    the skill's check list requires. What changes is that the suppression stops
+    being SILENT -- it carries ``risk=high`` and an ``untrusted-fork`` marker, so
+    the conductor reviews it as a triage signal instead of watching the item
+    vanish. The objection worth answering was never the detection; it was a
+    response that was both unconditional and unreported.
+
+    Standing is an insider association or the item's own reporter, since a
+    reporter fixing their own bug from a fork is the ordinary case, not an
+    attack. An unknown reporter annotates MORE items, never fewer.
+    """
+    for hit in open_prs:
+        if not hit.get("is_cross_repository"):
+            hit["untrusted_fork"] = False
+            continue
+        association = str(hit.get("author_association") or "")
+        author = hit.get("author")
+        trusted = association in INSIDER_ASSOCIATIONS or (
+            reporter is not None and author == reporter
+        )
+        hit["untrusted_fork"] = not trusted
+
+
+def annotate_landed(merged: list[dict], repo_dir: str | None, default_branch: str) -> str | None:
+    """Set ``landed`` on each merged hit that CLAIMS closure; error slug or None.
+
+    ``landed`` is the difference between coverage and a merge that went
+    somewhere else. Only three answers are possible and the third is not
+    ``False``: an ancestry question git cannot answer (a merge commit absent
+    from a stale clone) must degrade to UNKNOWN, because reading it as "did not
+    land" is exactly how an already-fixed item got dispatched.
+
+    Only closure-claiming entries are asked, and that scoping is the point: a
+    merged PR that merely MENTIONS the item cannot reach rule 1 whatever its
+    ancestry, so letting its unanswerable ancestry return an error made the
+    whole check UNKNOWN over a fact that could not have changed the verdict. An
+    error is reserved for a question whose answer matters.
+    """
+    claiming = [hit for hit in merged if hit.get("closes_item")]
+    if not claiming:
+        return None
+    if repo_dir is None:
+        return "no-repo-dir"
+    if git(repo_dir, ["rev-parse", "--verify", "--quiet", f"{default_branch}^{{commit}}"])[0] != 0:
+        return "unknown-default-branch"
+    for hit in claiming:
+        sha = hit.get("merge_commit_sha")
+        if not isinstance(sha, str) or not sha:
+            return "no-merge-commit"
+        rc = git(repo_dir, ["merge-base", "--is-ancestor", sha, default_branch])[0]
+        if rc == 0:
+            hit["landed"] = True
+        elif rc == 1:
+            hit["landed"] = False
+        else:
+            return "ancestry-unknown"
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# check 3 — prose
+# --------------------------------------------------------------------------- #
+
+
+#: Markdown shapes that CITE text rather than say it. Stripped before any prose
+#: match, because a phrase in a code fence, a backtick span, a blockquote or a
+#: pair of quotation marks belongs to whoever is being quoted. The span patterns
+#: also exclude newlines, which :func:`plain_prose` has already collapsed by the
+#: time they run — belt and braces, so each pattern is correct read alone.
+#: HTML comments, stripped BEFORE everything else. A comment is invisible to
+#: every human reader of the item, so nothing inside one is a statement its
+#: author is making -- and this repository's issue templates ship instructional
+#: comments, so "<!-- please close this issue when done -->" arrives in the body
+#: of real items and closed them. First in the order because a comment can
+#: contain a fence, a quote or a backtick span and must not be parsed as one.
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_FENCE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+#: Paired backtick RUNS of equal length, not single backticks. Markdown lets an
+#: author write ``this can be closed`` with doubled delimiters, and the
+#: single-backtick pattern consumed each `` pair as an empty span, leaving the
+#: quoted phrase behind as prose -- so a citation of the phrases this scanner
+#: looks for closed a live item. The backreference makes the closing run match
+#: the opening one, which is the rule Markdown itself uses.
+_INLINE_CODE_RE = re.compile(r"(`+)[^`]*?\1")
+_BLOCKQUOTE_RE = re.compile(r"^[ \t]*>.*$", re.MULTILINE)
+#: Deliberately UNBOUNDED between the delimiters. A length cap here is a
+#: false-CLOSE channel: a reporter who quotes "please close" inside a quotation
+#: longer than the cap has the phrase read as their OWN prose, and this verdict
+#: performs a write on live work. Linear despite the ``*`` because the class is
+#: negated -- there is no nested quantifier to backtrack through.
+_QUOTED_RE = re.compile('["\u201c\u201d][^"\u201c\u201d\n]*["\u201c\u201d]')
+#: An UNMATCHED opening delimiter is the same channel by the other door: a
+#: citation whose closing quote the author forgot (or that a smart-quote pair
+#: broke) matches nothing above, so the phrase survives as the author's own
+#: words. Everything from a leftover delimiter to the end is therefore dropped
+#: too. This is the deliberately lossy direction -- prose after an unbalanced
+#: quote can hide a REAL closure request, which costs one dispatch, where the
+#: other reading closes somebody's live work.
+_UNCLOSED_QUOTE_RE = re.compile('["\u201c\u201d].*$', re.DOTALL)
+
+
+def plain_prose(text: str) -> str:
+    """What the author SAYS, with what they QUOTE removed.
+
+    Measured on the item that specified this script: its body quotes the very
+    closure phrases the check looks for ("this is resolved / happy to have it
+    closed", as a description of what to detect), and scanning it raw produced
+    CLOSE on a live item. A false CLOSE closes work in flight; a missed one only
+    costs the dispatch that discovers the work is done — so citations come out
+    before matching, and the asymmetry runs the cheap way.
+
+    Line structure first, then whitespace, then spans. Fences and blockquotes
+    are line-shaped, so they have to go while the newlines are still there.
+    Quotation marks are not, and markdown hard-wraps prose, so a quoted phrase
+    routinely straddles a line break: collapsing whitespace before matching the
+    spans is what makes the stripper as newline-tolerant as the ``\\s+`` in the
+    phrases it defends. Without that step it missed the very body that found
+    this bug, where the quote broke mid-phrase.
+
+    Balanced spans go first, then any LEFTOVER delimiter takes the rest of the
+    text with it. Both halves matter and the second was missing: an unclosed
+    citation matches no pair, so the phrase inside it used to survive as the
+    author's own words and returned CLOSE on a live item. Every span rule here
+    is therefore allowed to strip too MUCH, never too little -- over-stripping
+    can hide a real closure request and cost one dispatch, while under-stripping
+    closes somebody's work in flight.
+    """
+    text = _HTML_COMMENT_RE.sub(" ", text)
+    text = _FENCE_RE.sub(" ", text)
+    text = _BLOCKQUOTE_RE.sub(" ", text)
+    text = re.sub(r"\s+", " ", text)
+    text = _INLINE_CODE_RE.sub(" ", text)
+    text = _QUOTED_RE.sub(" ", text)
+    return _UNCLOSED_QUOTE_RE.sub(" ", text)
+
+
+def _first_match(patterns: tuple[str, ...], text: str) -> str | None:
+    """The first pattern that fires UNNEGATED on ``text``, or None.
+
+    Returns the PATTERN: the matched text is user-authored and never leaves this
+    function. A match preceded by a negator inside the window is skipped rather
+    than returned, and the scan continues -- "I don't think this is resolved, but
+    please close this issue" should still be read as a request.
+    """
+    for pattern in patterns:
+        for found in re.finditer(pattern, text, re.IGNORECASE):
+            window = text[max(0, found.start() - _NEGATION_WINDOW) : found.start()]
+            if _NEGATOR_RE.search(window):
+                continue
+            return pattern
+    return None
+
+
+def _is_bot(user: Any) -> bool:
+    if not isinstance(user, dict):
+        return False
+    login = str(user.get("login") or "")
+    return user.get("type") == "Bot" or login.endswith("[bot]")
+
+
+def withdrawals_by_author(comments: Any) -> dict[str, str]:
+    """login -> newest timestamp at which that login GAVE UP the item.
+
+    Shared by the two places that need it, so the rule cannot drift between
+    them: the claim recovery, and the check that retires a claim written in the
+    issue BODY.
+    """
+    found: dict[str, str] = {}
+    if not isinstance(comments, list):
+        return found
+    for comment in comments:
+        if not isinstance(comment, dict) or _is_bot(comment.get("user")):
+            continue
+        if _first_match(WITHDRAWAL_RES, plain_prose(str(comment.get("body") or ""))) is None:
+            continue
+        user = comment.get("user")
+        login = user.get("login") if isinstance(user, dict) else None
+        if not isinstance(login, str):
+            continue
+        when = str(comment.get("created_at") or "")
+        if login not in found or when > found[login]:
+            found[login] = when
+    return found
+
+
+def body_claim_withdrawn(comments: Any, reporter: str | None) -> bool:
+    """Has the BODY's author since given the item up?
+
+    The body predates every comment by construction, so any withdrawal from its
+    author retires the claim it contains -- no timestamp comparison needed. This
+    closes a permanent suppression: a reporter who wrote "Ownership claimed by
+    me" and later commented "dropping this" left the item SKIPping forever,
+    which is the indefinite-suppression harm rather than a wasted dispatch.
+    """
+    if reporter is None:
+        return False
+    return reporter in withdrawals_by_author(comments)
+
+
+def newest_authorized_claim(comments: Any, reporter: str | None) -> dict | None:
+    """The newest non-bot comment bearing a self-claim from someone with standing.
+
+    :func:`last_human_comment` answers "what is the latest word", which is the
+    right question for closure but the wrong one for ownership: measured, an
+    insider comment "I am claiming this one" followed by a passer-by's "any
+    update on this?" left the claim unscanned and the verdict CLAIM, dispatching
+    a second worker onto work already in flight -- the exact class this script
+    exists to remove.
+
+    So ownership gets its own selector. A claim is a statement that stays true
+    until withdrawn, not a line in a transcript that a later remark overwrites.
+    "Until withdrawn" is enforced rather than assumed: a newer comment giving the
+    item up ("dropping this", "no longer working on this") retires that AUTHOR's
+    older claims, so recovery cannot park an item on somebody who already walked
+    away.
+
+    A withdrawal only ever releases its OWN author's claim. The first version
+    applied any withdrawal to every earlier claim, which handed a stranger the
+    power to erase a maintainer's claim by typing "dropping this" -- the same
+    denial-of-work shape as an unauthorized claim, running the other direction
+    and costing a duplicate dispatch instead of a suppression. You can only give
+    up what you hold.
+    """
+    if not isinstance(comments, list):
+        return None
+    withdrawn_by = withdrawals_by_author(comments)
+    best: dict | None = None
+    best_key: tuple[str, int] | None = None
+    for index, comment in enumerate(comments):
+        if not isinstance(comment, dict) or _is_bot(comment.get("user")):
+            continue
+        body = plain_prose(str(comment.get("body") or ""))
+        if _first_match(SELF_CLAIM_RES, body) is None:
+            continue
+        when = str(comment.get("created_at") or "")
+        user = comment.get("user")
+        login = user.get("login") if isinstance(user, dict) else None
+        released = withdrawn_by.get(login) if isinstance(login, str) else None
+        if released is not None and when <= released:
+            continue
+        association = str(comment.get("author_association") or "")
+        if association not in INSIDER_ASSOCIATIONS and not (
+            reporter is not None and login == reporter
+        ):
+            continue
+        key = (str(comment.get("created_at") or ""), index)
+        if best_key is None or key > best_key:
+            best, best_key = comment, key
+    return best
+
+
+def last_human_comment(comments: Any) -> dict | None:
+    """The NEWEST non-bot comment, chosen by timestamp rather than by position.
+
+    Two measurements shaped this. First, the per-issue comments endpoint
+    documents only ``since``, ``per_page`` and ``page``: it silently IGNORES
+    ``sort`` and ``direction`` and answers oldest-first. An earlier version of
+    this function asked for ``direction=desc`` and took the first element, and
+    on a real item that returned the OLDEST of twelve comments (2026-09-01
+    10:40) against a newest of 2026-09-03 00:56 — so a reporter's later "please
+    close" was invisible to the check that exists to find it. Second, this
+    repository's triage bot comments on issues, and its summary was the OLDEST
+    entry rather than the newest, so skipping bots is right but reading from
+    either end is not.
+
+    Hence selection by ``max(created_at)`` over non-bot comments and never by
+    position: an endpoint that changes its order, or a client that merges pages
+    in another sequence, cannot bring the bug back. Position breaks ties only
+    when a timestamp is missing.
+    """
+    if not isinstance(comments, list):
+        return None
+    newest: dict | None = None
+    best: tuple[str, int] | None = None
+    for index, comment in enumerate(comments):
+        if not isinstance(comment, dict) or _is_bot(comment.get("user")):
+            continue
+        stamp = comment.get("created_at")
+        # ISO-8601 Z timestamps sort lexicographically exactly as they sort
+        # chronologically. A missing one sorts lowest, so any timestamped
+        # comment outranks it, and among timestampless comments the latest
+        # POSITION wins.
+        key = (stamp if isinstance(stamp, str) else "", index)
+        if best is None or key > best:
+            newest, best = comment, key
+    return newest
+
+
+def scan_prose(
+    issue: dict,
+    comment: dict | None,
+    me: str | None,
+    body_withdrawn: bool = False,
+) -> dict:
+    """The ``prose_claim`` check value. Pure: no forge access.
+
+    ``me`` is the authenticated login. When it is unknown, a self-claim counts
+    as somebody else's — the fail-safe direction is SKIP, never CLAIM.
+
+    BOTH phrase sets need STANDING (the item's own author, always true of the
+    body, or a repository insider by ``author_association``) but for opposite
+    reasons, and the asymmetry is the point:
+
+    * a closure request produces CLOSE, which acts on live work, so "please
+      close" from a passer-by must not fire it;
+    * a self-claim produces SKIP, and a veto anyone can cast is a
+      denial-of-work channel -- one comment would suppress a queued item
+      indefinitely with nothing downstream reporting the suppression.
+
+    So an unauthorized claim is not discarded and not obeyed: it sets
+    ``claim_without_standing``, which annotates ``risk=high`` and sends the item
+    to the live recheck instead of parking it.
+    """
+    body = plain_prose(str(issue.get("body") or ""))
+    body_author = (
+        (issue.get("user") or {}).get("login") if isinstance(issue.get("user"), dict) else None
+    )
+    comment_body = plain_prose(str(comment.get("body") or "")) if comment else ""
+    comment_author = None
+    comment_id = None
+    comment_standing = False
+    if comment:
+        user = comment.get("user")
+        comment_author = user.get("login") if isinstance(user, dict) else None
+        comment_id = comment.get("id")
+        association = str(comment.get("author_association") or "")
+        comment_standing = (
+            comment_author is not None and comment_author == body_author
+        ) or association in INSIDER_ASSOCIATIONS
+
+    result: dict[str, Any] = {
+        "closure_requested": False,
+        "claimed_by_other": False,
+        "claim_without_standing": False,
+        "claimed_by": None,
+        "closure_by": None,
+        "where": None,
+        "comment_id": None,
+        "pattern": None,
+    }
+
+    # The comment is the fresher statement, so it is consulted first for both
+    # phrase sets and its evidence wins when both sources match. The body's
+    # author is the reporter by definition, so the body always has standing.
+    #
+    # For CLOSURE the body is consulted only when there is no newer human
+    # comment at all. The body is the OLDEST text on the item, and a reporter
+    # who wrote "this is resolved" and later commented "still broken on 0.8" has
+    # reopened it -- reading the body then closed live work. A later comment is
+    # the item's current state whether or not it happens to contain a phrase
+    # this scanner knows, so its mere existence retires the body's request. The
+    # CLAIM loop below still reads the body, because a claim is a statement of
+    # ownership that holds until withdrawn rather than a status.
+    closure_sources = [
+        ("comment", comment_body, comment_author, comment_id, comment_standing),
+    ]
+    if comment is None:
+        closure_sources.append(("body", body, body_author, None, True))
+    for where, text, author, ident, standing in closure_sources:
+        if not text or result["closure_requested"]:
+            continue
+        pattern = _first_match(CLOSURE_RES, text)
+        if pattern and standing:
+            result.update(
+                closure_requested=True,
+                closure_by=author,
+                where=where,
+                comment_id=ident,
+                pattern=pattern,
+            )
+    claim_sources = [
+        ("comment", comment_body, comment_author, comment_id, comment_standing),
+    ]
+    if not body_withdrawn:
+        # A claim in the body outlives later chatter, but not its own author's
+        # withdrawal: a reporter who claimed the item and later commented
+        # "dropping this" left it SKIPping forever, which is indefinite
+        # suppression rather than a wasted dispatch.
+        claim_sources.append(("body", body, body_author, None, True))
+    for where, text, author, ident, standing in claim_sources:
+        if not text or result["claimed_by_other"]:
+            continue
+        pattern = _first_match(SELF_CLAIM_RES, text)
+        if not pattern or (me is not None and author == me):
+            continue
+        if standing:
+            result.update(claimed_by_other=True, claimed_by=author, claimed_by_where=where)
+            if not result["closure_requested"]:
+                result.update(where=where, comment_id=ident, pattern=pattern)
+        elif not result["claim_without_standing"]:
+            # A veto anyone can cast is a denial-of-work channel: one comment
+            # from a passer-by would suppress a queued item indefinitely and
+            # nothing downstream would report that it had been suppressed. So an
+            # unauthorized claim annotates risk=high and takes the live recheck
+            # instead of parking the item.
+            result.update(claim_without_standing=True, claimed_by=author)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# check 4 — symbols on the base
+# --------------------------------------------------------------------------- #
+
+
+_SYMBOL_TOKEN_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)(?:\(\))?`")
+
+
+def looks_like_symbol(token: str) -> bool:
+    """Whether a backticked token is plausibly an identifier and not English.
+
+    Deliberately narrow: a false symbol would park a workable item. An
+    underscore or a camel hump is the signal; ``main`` and ``true`` are not
+    symbols however they are quoted.
+    """
+    if len(token) < 4:
+        return False
+    if "_" in token:
+        return True
+    return bool(re.search(r"[a-z][A-Z]", token))
+
+
+def named_symbols(text: str, limit: int = MAX_SYMBOLS) -> list[str]:
+    """Identifiers the item names, in first-appearance order, capped."""
+    found: list[str] = []
+    for token in _SYMBOL_TOKEN_RE.findall(text or ""):
+        if looks_like_symbol(token) and token not in found:
+            found.append(token)
+            if len(found) >= limit:
+                break
+    return found
+
+
+#: Bug-class metadata. Matched against LABEL names and the issue type only --
+#: never prose. A label is a deliberate act by a human triaging the item, which
+#: is what makes it corroboration; guessing the class from wording would put an
+#: unmeasured heuristic in front of a veto, and the veto is the thing that was
+#: over-applied in the first place.
+BUG_CLASS_RE = re.compile(r"\b(?:bug|defect|regression|crash)\b", re.IGNORECASE)
+
+
+def bug_class_of(issue: dict) -> tuple[bool, str | None]:
+    """Whether the item is corroborated as bug-class, and by what.
+
+    Only a bug item supports the inference "this symbol is absent, so the target
+    code lives on an unmerged branch". A FEATURE REQUEST names the symbol it
+    proposes to ADD, so absence is expected and vetoing on it would park that
+    whole item class permanently -- it would still be absent on the next pass,
+    and the one after.
+
+    Corroboration is explicit metadata, so an item nobody has triaged is simply
+    not corroborated. That direction is the cheap one: the item is dispatched
+    with ``risk=high`` and a worker may find the code is not on the base, which
+    costs one dispatch, against a park that costs the item.
+
+    What comes back is the MATCHED TERM, never the label's own text: a label
+    name is user-authored, and this value is printed. The issue type
+    ``type: Bug (urgent!)`` reports ``type:bug`` and a label ``Bug (urgent!)``
+    reports ``label:bug`` -- the vocabulary is this module's, which is the same
+    rule the prose scan follows when it reports a pattern rather than a
+    sentence.
+    """
+    kind = issue.get("type")
+    if isinstance(kind, dict):
+        name = kind.get("name")
+        if isinstance(name, str):
+            hit = BUG_CLASS_RE.search(name)
+            if hit:
+                return True, f"type:{hit.group(0).lower()}"
+    for label in issue.get("labels") or []:
+        name = label.get("name") if isinstance(label, dict) else label
+        if isinstance(name, str):
+            hit = BUG_CLASS_RE.search(name)
+            if hit:
+                return True, f"label:{hit.group(0).lower()}"
+    return False, None
+
+
+def symbols_on_base(
+    symbols: list[str],
+    repo_dir: str | None,
+    default_branch: str,
+    *,
+    bug_class: bool = False,
+    bug_class_by: str | None = None,
+) -> dict:
+    """The ``symbol_on_base`` check value: which named symbols exist on base.
+
+    ``bug_class`` rides along rather than being consulted here, because this
+    function answers a question of fact and :func:`verdict` decides what the
+    fact is worth.
+    """
+    corroboration = {"bug_class": bug_class, "bug_class_by": bug_class_by}
+    if not symbols:
+        return {"symbols": [], "present": [], "missing": [], **corroboration}
+    if repo_dir is None:
+        return {"error": "no-repo-dir", "symbols": symbols, **corroboration}
+    if git(repo_dir, ["rev-parse", "--verify", "--quiet", f"{default_branch}^{{commit}}"])[0] != 0:
+        return {"error": "unknown-default-branch", "symbols": symbols, **corroboration}
+    present: list[str] = []
+    missing: list[str] = []
+    for symbol in symbols:
+        rc = git(repo_dir, ["grep", "-l", "-F", "-e", symbol, default_branch, "--"])[0]
+        if rc == 0:
+            present.append(symbol)
+        elif rc == 1:
+            missing.append(symbol)
+        else:
+            # git could not answer; an unsearchable tree is not an absent
+            # symbol, and absence is what parks the item.
+            return {"error": "grep-failed", "symbols": symbols, **corroboration}
+    return {"symbols": symbols, "present": present, "missing": missing, **corroboration}
+
+
+# --------------------------------------------------------------------------- #
+# check 5 — recency and self-claim risk
+# --------------------------------------------------------------------------- #
+
+
+def _age_days(created_at: Any, now: datetime) -> int | None:
+    if not isinstance(created_at, str) or not created_at:
+        return None
+    try:
+        stamp = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return max(int((now - stamp).total_seconds() // 86400), 0)
+
+
+def scan_recency(issue: dict, now: datetime | None = None) -> dict:
+    """The ``recency`` check value. Pure: age, association, and the risk it implies."""
+    now = now or datetime.now(timezone.utc)
+    age = _age_days(issue.get("created_at"), now)
+    association = str(issue.get("author_association") or "") or None
+    if age is None:
+        # An unparseable timestamp cannot veto anything, but it also cannot
+        # certify low risk. Say so rather than defaulting to reassurance.
+        return {"age_days": None, "author_association": association, "risk": "high"}
+    fresh = age <= RECENT_DAYS
+    active = (association or "") in ACTIVE_ASSOCIATIONS
+    return {
+        "age_days": age,
+        "author_association": association,
+        "risk": "high" if (fresh and active) else "low",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# the verdict — pure function of the checks
+# --------------------------------------------------------------------------- #
+
+
+def entries(value: Any) -> list[dict]:
+    """The hits in a list-shaped check, or none when the check errored."""
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def errored(value: Any) -> str | None:
+    """The error slug of a check that could not be answered, or None."""
+    if isinstance(value, dict) and value.get("error"):
+        return str(value["error"])
+    return None
+
+
+def uncorroborated_absent_symbols(checks: dict) -> list[str]:
+    """Symbols absent from the base on an item NOT corroborated as bug-class.
+
+    Not a veto (see :func:`bug_class_of`) but not nothing either: the item may
+    target code that is not on the base, so it is dispatched with ``risk=high``
+    rather than parked or waved through as routine.
+    """
+    symbols = checks.get("symbol_on_base")
+    if not isinstance(symbols, dict) or errored(symbols) or symbols.get("bug_class"):
+        return []
+    missing = symbols.get("missing")
+    return [item for item in missing if isinstance(item, str)] if isinstance(missing, list) else []
+
+
+def unauthorized_claim(checks: dict) -> str | None:
+    """The login of someone who claimed the item without standing, or None.
+
+    Not a veto (see :func:`scan_prose`) but not nothing: the claim may be real,
+    so the item is dispatched at ``risk=high`` for the live recheck rather than
+    parked on an unauthorized commenter's word.
+    """
+    prose = checks.get("prose_claim")
+    if not isinstance(prose, dict) or errored(prose):
+        return None
+    if not prose.get("claim_without_standing"):
+        return None
+    who = prose.get("claimed_by")
+    return str(who) if who else "unknown"
+
+
+def untrusted_fork_skip(checks: dict) -> int | None:
+    """The number of the first open PR whose SKIP is an untrusted fork, or None.
+
+    The counterpart to :func:`unauthorized_claim`: both name a finding this
+    script acts on while doubting, so the doubt has to travel with the verdict.
+    """
+    for hit in entries(checks.get("open_prs")):
+        if hit.get("untrusted_fork"):
+            number = hit.get("number")
+            return number if isinstance(number, int) else None
+    return None
+
+
+def risk_of(checks: dict) -> str:
+    """``low`` or ``high``, from check 5, from an uncorroborated absent symbol,
+    from an unauthorized self-claim, and from an untrusted-fork suppression,
+    defaulting to the cautious side."""
+    if uncorroborated_absent_symbols(checks) or unauthorized_claim(checks):
+        return "high"
+    if untrusted_fork_skip(checks) is not None:
+        return "high"
+    recency = checks.get("recency")
+    if not isinstance(recency, dict) or errored(recency):
+        return "high"
+    return "high" if recency.get("risk") == "high" else "low"
+
+
+def verdict(checks: dict) -> tuple[str, str, dict]:
+    """(verdict, reason, evidence) — the whole decision, first match wins.
+
+    Pure: a dict of fabricated checks in, a verdict out, no forge and no git.
+    Every branch below is a dispatch the old single-question predicate would
+    have made.
+    """
+    for hit in entries(checks.get("merged_prs")):
+        if hit.get("landed") is True and hit.get("closes_item") is True:
+            # BOTH conditions are load-bearing: a PR merged somewhere other than
+            # the base is not coverage, and a PR that merely MENTIONS the item is
+            # not closure. A mention falls through to the remaining checks.
+            return (
+                "CLOSE",
+                "already-fixed",
+                {
+                    "pr": hit.get("number"),
+                    "sha": (str(hit.get("merge_commit_sha") or ""))[:10],
+                    "landed": True,
+                },
+            )
+    for hit in entries(checks.get("open_prs")):
+        return (
+            "SKIP",
+            "open-pr",
+            {
+                "pr": hit.get("number"),
+                "fork": bool(hit.get("is_cross_repository")),
+                "author": hit.get("author"),
+                "untrusted_fork": bool(hit.get("untrusted_fork")),
+            },
+        )
+    prose = checks.get("prose_claim")
+    if isinstance(prose, dict) and not errored(prose):
+        if prose.get("closure_requested"):
+            return (
+                "CLOSE",
+                "reporter-asked-close",
+                {"comment_id": prose.get("comment_id"), "where": prose.get("where")},
+            )
+        if prose.get("claimed_by_other"):
+            return (
+                "SKIP",
+                "prose-claim",
+                {
+                    "claimed_by": prose.get("claimed_by"),
+                    "where": prose.get("claimed_by_where") or prose.get("where"),
+                },
+            )
+    symbols = checks.get("symbol_on_base")
+    if isinstance(symbols, dict) and not errored(symbols):
+        missing = symbols.get("missing")
+        if isinstance(missing, list) and missing and symbols.get("bug_class"):
+            # Corroborated bug item: absence really does mean the target span
+            # lives somewhere other than the base. An UNCORROBORATED item falls
+            # through instead, and risk_of() turns its absence into risk=high.
+            return (
+                "SKIP",
+                "symbol-absent",
+                {
+                    "symbol": missing[0],
+                    "missing": list(missing),
+                    "bug_class_by": symbols.get("bug_class_by"),
+                },
+            )
+    # Only now: a definite finding outranks a partial view, and no error path
+    # may reach CLAIM.
+    for name in CHECK_NAMES:
+        slug = errored(checks.get(name))
+        if slug:
+            return "UNKNOWN", slug, {"check": name, "reason": slug}
+    evidence: dict[str, Any] = {"risk": risk_of(checks)}
+    uncorroborated = uncorroborated_absent_symbols(checks)
+    if uncorroborated:
+        # Say WHY the risk is high. The human line is one field wide by
+        # contract, so the reason lives in --json rather than being dropped.
+        evidence["symbol_absent_uncorroborated"] = uncorroborated
+    claimed = unauthorized_claim(checks)
+    if claimed:
+        evidence["claim_without_standing"] = claimed
+    return "CLAIM", "clean", evidence
+
+
+def human_line(item: int, name: str, reason: str, evidence: dict, risk: str) -> str:
+    """The one-line human form. Field names are the contract's, values are
+    metadata only — never user-authored text."""
+    if name == "CLAIM":
+        return f"CLAIM {item} risk={risk}"
+    if name == "UNKNOWN":
+        return f"UNKNOWN {item} check={evidence.get('check')} reason={evidence.get('reason')}"
+    if reason == "already-fixed":
+        return (
+            f"CLOSE {item} merged-pr=#{evidence.get('pr')} "
+            f"sha={evidence.get('sha')} landed=true"
+        )
+    if reason == "open-pr":
+        fork = "true" if evidence.get("fork") else "false"
+        line = (
+            f"SKIP {item} open-pr=#{evidence.get('pr')} fork={fork} author={evidence.get('author')}"
+        )
+        if evidence.get("untrusted_fork"):
+            # Only the doubtful case is annotated: a marker on every routine
+            # SKIP is noise, and this exists so the one that needs a look does
+            # not read identically to the hundred that do not.
+            line += f" untrusted-fork=true risk={risk}"
+        return line
+    if reason == "reporter-asked-close":
+        ident = evidence.get("comment_id")
+        tail = f"comment-id={ident}" if ident is not None else f"where={evidence.get('where')}"
+        return f"CLOSE {item} reporter-asked-close {tail}"
+    if reason == "prose-claim":
+        return (
+            f"SKIP {item} prose-claim claimed-by={evidence.get('claimed_by')} "
+            f"where={evidence.get('where')}"
+        )
+    if reason == "symbol-absent":
+        return f"SKIP {item} symbol-absent={evidence.get('symbol')}"
+    return f"{name} {item} {reason}"  # pragma: no cover - every reason above is covered
+
+
+# --------------------------------------------------------------------------- #
+# collection — thin IO around the pure parts
+# --------------------------------------------------------------------------- #
+
+
+def whoami() -> str | None:
+    """The authenticated login, or None. Called only when a self-claim phrase
+    already matched, so the common path pays nothing for it."""
+    data, error = gh_json(["gh", "api", "user"])
+    if error or not isinstance(data, dict):
+        return None
+    login = data.get("login")
+    return login if isinstance(login, str) and login else None
+
+
+def collect(repo: str, item: int, default_branch: str, repo_dir: str | None) -> dict:
+    """Run all five checks. A check that cannot be answered carries ``error``."""
+    checks: dict[str, Any] = {}
+
+    open_prs, merged_prs, prs_error = referencing_prs(repo, item)
+    if prs_error:
+        # A confirmed open PR survives the error: the precedence rule that puts
+        # a definite finding above a partial view applies to a half-finished
+        # scan too, so the SKIP is kept and only the merged side reads unknown.
+        checks["open_prs"] = open_prs if open_prs else {"error": prs_error}
+        checks["merged_prs"] = {"error": prs_error}
+    else:
+        landed_error = annotate_landed(merged_prs, repo_dir, default_branch)
+        checks["open_prs"] = open_prs
+        checks["merged_prs"] = (
+            {"error": landed_error, "count": len(merged_prs)} if landed_error else merged_prs
+        )
+
+    issue, issue_error = gh_json(["gh", "api", f"repos/{repo}/issues/{item}"])
+    if issue_error or not isinstance(issue, dict):
+        slug = issue_error or "unparseable-json"
+        checks["prose_claim"] = {"error": slug}
+        checks["recency"] = {"error": slug}
+        checks["symbol_on_base"] = {"error": slug}
+        # An open PR still SKIPs when the item itself cannot be read, so the
+        # suppression still needs its marker. Nobody is known to be the
+        # reporter here, which annotates more forks rather than fewer.
+        #
+        # Keyed on the HITS, not on the absence of an error: a half-finished scan
+        # can now return a confirmed open PR alongside its error, and gating on
+        # `not prs_error` emitted that SKIP as a routine low-risk one. The loud
+        # suppression has to survive the degraded path, or it is missing in
+        # exactly the conditions that make a suppression hard to notice.
+        annotate_untrusted_forks(open_prs, None)
+    else:
+        reporter = (issue.get("user") or {}).get("login") if isinstance(issue, dict) else None
+        annotate_untrusted_forks(open_prs, reporter if isinstance(reporter, str) else None)
+        comments, comments_error = gh_json(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/issues/{item}/comments?per_page={COMMENT_PAGE}",
+                "--paginate",
+            ]
+        )
+        if comments_error:
+            # The body alone is half the question; half an answer to a question
+            # about ownership is not permission.
+            checks["prose_claim"] = {"error": comments_error}
+        else:
+            comment = last_human_comment(comments)
+            withdrawn = body_claim_withdrawn(comments, reporter)
+            prose = scan_prose(issue, comment, None, withdrawn)
+            if not prose["claimed_by_other"] and not prose["closure_requested"]:
+                # The latest word answers closure; ownership needs its own
+                # lookup, because any later remark would otherwise bury a
+                # standing claim and send a second worker onto live work.
+                claimed = newest_authorized_claim(comments, reporter)
+                if claimed is not None and claimed is not comment:
+                    recovered = scan_prose(issue, claimed, None, withdrawn)
+                    if recovered["claimed_by_other"]:
+                        comment, prose = claimed, recovered
+            if prose["claimed_by_other"]:
+                # Re-scan knowing who we are: our own claim is not somebody
+                # else's. One extra call, only when it can change the verdict.
+                prose = scan_prose(issue, comment, whoami(), withdrawn)
+            checks["prose_claim"] = prose
+        checks["recency"] = scan_recency(issue)
+        text = f"{issue.get('title') or ''}\n{issue.get('body') or ''}"
+        bug_class, bug_class_by = bug_class_of(issue)
+        checks["symbol_on_base"] = symbols_on_base(
+            named_symbols(text),
+            repo_dir,
+            default_branch,
+            bug_class=bug_class,
+            bug_class_by=bug_class_by,
+        )
+    return checks
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Claim preflight for one work item.")
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--item", required=True, type=int, help="issue number")
+    parser.add_argument("--default-branch", default="main")
+    parser.add_argument("--repo-dir", default=None, help="a clone of the base, read-only")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    if not _REPO_RE.match(args.repo):
+        print(f"malformed --repo {args.repo!r}: expected owner/name", file=sys.stderr)
+        return 2
+    if args.item <= 0:
+        print(f"malformed --item {args.item}: expected a positive issue number", file=sys.stderr)
+        return 2
+    if not args.default_branch.strip():
+        print("malformed --default-branch: expected a git rev", file=sys.stderr)
+        return 2
+    if args.repo_dir is not None:
+        # A path the caller passed that is not a git work tree is malformed
+        # config (exit 2), unlike an OMITTED clone, which is a question this run
+        # simply cannot answer (UNKNOWN).
+        if run(["git", "-C", args.repo_dir, "rev-parse", "--git-dir"])[0] != 0:
+            print(f"malformed --repo-dir {args.repo_dir!r}: not a git repository", file=sys.stderr)
+            return 2
+
+    checks = collect(args.repo, args.item, args.default_branch, args.repo_dir)
+    name, reason, evidence = verdict(checks)
+    risk = risk_of(checks)
+    if args.as_json:
+        print(
+            json.dumps(
+                {
+                    "item": args.item,
+                    "verdict": name,
+                    "reason": reason,
+                    "risk": risk,
+                    "checks": checks,
+                    "evidence": evidence,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        print(human_line(args.item, name, reason, evidence, risk))
+    return EXIT_CODES[name]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_pipeline_conductor_claim_preflight.py
+++ b/test/test_pipeline_conductor_claim_preflight.py
@@ -1,0 +1,2496 @@
+"""Claim preflight — the conductor's deterministic claim predicate.
+
+Every verdict branch gets a test, and each of those tests also asserts that the
+single-question predicate this script replaces would have said CLAIM on the same
+item. That second assertion is the point: the three real failures behind the
+script (a merged PR an ``--state open`` query cannot see, an open PR the one
+field read came back empty for, a claim written in prose) are all shaped the
+same way, so a test that only checks the new answer would not notice the script
+regressing back into the old blind spot.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from skill_script_helpers import load_skill_script
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "pipeline-conductor"
+    / "scripts"
+    / "claim_preflight.py"
+)
+
+REPO = "kirodotdev/KiroCrew"
+ITEM = 8029
+
+
+@pytest.fixture
+def mod():
+    return load_skill_script("claim_preflight", SCRIPT)
+
+
+def naive_claim(checks: dict) -> bool:
+    """The predicate this script replaces: ONE question, and an empty answer
+    read as permission.
+
+    The old skill line was `gh pr list --search ... --state open`, so it could
+    see exactly one thing: a same-repo OPEN pull request. It could not see a
+    merged PR (wrong state), a fork PR (the search missed them, and the single
+    field it fell back on measured empty), a claim written in prose, or a symbol
+    that is not on the base.
+
+    Every branch test asserts this returns True, i.e. the old predicate would
+    have burned a dispatch on the item.
+    """
+    hits = checks.get("open_prs")
+    if not isinstance(hits, list):
+        return True
+    return not [hit for hit in hits if isinstance(hit, dict) and not hit.get("is_cross_repository")]
+
+
+# --------------------------------------------------------------------------- #
+# fixtures for fabricated checks
+# --------------------------------------------------------------------------- #
+
+
+def clean_checks(**overrides) -> dict:
+    checks = {
+        "open_prs": [],
+        "merged_prs": [],
+        "prose_claim": {
+            "closure_requested": False,
+            "claimed_by_other": False,
+            "claim_without_standing": False,
+            "claimed_by": None,
+            "where": None,
+            "comment_id": None,
+            "pattern": None,
+        },
+        "symbol_on_base": {
+            "symbols": [],
+            "present": [],
+            "missing": [],
+            "bug_class": False,
+            "bug_class_by": None,
+        },
+        "recency": {"age_days": 200, "author_association": "NONE", "risk": "low"},
+    }
+    checks.update(overrides)
+    return checks
+
+
+class TestVerdictPrecedence:
+    """One test per precedence branch, on fabricated checks — no forge, no git."""
+
+    def test_merged_pr_that_landed_is_already_fixed(self, mod):
+        checks = clean_checks(
+            merged_prs=[
+                {
+                    "number": 7900,
+                    "author": "somebody",
+                    "is_cross_repository": False,
+                    "merge_commit_sha": "abc1234def567890",
+                    "landed": True,
+                    "closes_item": True,
+                }
+            ]
+        )
+        assert naive_claim(checks) is True  # the old predicate would dispatch
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("CLOSE", "already-fixed")
+        assert evidence == {"pr": 7900, "sha": "abc1234def", "landed": True}
+        assert mod.EXIT_CODES[name] == 11
+        assert (
+            mod.human_line(ITEM, name, reason, evidence, "low")
+            == f"CLOSE {ITEM} merged-pr=#7900 sha=abc1234def landed=true"
+        )
+
+    def test_a_merged_pr_that_only_mentions_the_item_is_not_coverage(self, mod):
+        """A mention is not closure. Reading it as coverage would CLOSE live
+        work; reading it as a claim would starve an item whose fix was partial.
+        So it decides nothing and falls through."""
+        checks = clean_checks(
+            merged_prs=[
+                {
+                    "number": 7902,
+                    "merge_commit_sha": "abc1234def567890",
+                    "landed": True,
+                    "closes_item": False,
+                }
+            ]
+        )
+        name, reason, _ = mod.verdict(checks)
+        assert (name, reason) == ("CLAIM", "clean")
+        assert mod.EXIT_CODES[name] == 0
+
+    def test_merged_pr_that_did_not_land_is_not_coverage(self, mod):
+        """A PR merged into somewhere other than the base is not coverage.
+
+        This is the branch that keeps the check honest in the other direction:
+        ``merged`` alone must not park a workable item.
+        """
+        checks = clean_checks(
+            merged_prs=[
+                {
+                    "number": 7901,
+                    "author": "somebody",
+                    "is_cross_repository": False,
+                    "merge_commit_sha": "deadbeefcafe",
+                    "landed": False,
+                }
+            ]
+        )
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("CLAIM", "clean")
+        assert evidence == {"risk": "low"}
+        assert mod.EXIT_CODES[name] == 0
+
+    def test_open_fork_pr_skips(self, mod):
+        checks = clean_checks(
+            open_prs=[
+                {
+                    "number": 8100,
+                    "author": "someone",
+                    "is_cross_repository": True,
+                    "untrusted_fork": False,
+                }
+            ]
+        )
+        assert naive_claim(checks) is True
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("SKIP", "open-pr")
+        assert evidence == {
+            "pr": 8100,
+            "fork": True,
+            "author": "someone",
+            "untrusted_fork": False,
+        }
+        assert mod.EXIT_CODES[name] == 10
+        assert (
+            mod.human_line(ITEM, name, reason, evidence, "low")
+            == f"SKIP {ITEM} open-pr=#8100 fork=true author=someone"
+        )
+
+    def test_landed_merged_pr_outranks_an_open_one(self, mod):
+        """Precedence 1 before 2: already-fixed is triage debt, not a skip."""
+        checks = clean_checks(
+            merged_prs=[
+                {
+                    "number": 7900,
+                    "merge_commit_sha": "aaaabbbbcccc",
+                    "landed": True,
+                    "closes_item": True,
+                }
+            ],
+            open_prs=[{"number": 8100, "author": "x", "is_cross_repository": False}],
+        )
+        assert mod.verdict(checks)[:2] == ("CLOSE", "already-fixed")
+
+    def test_prose_self_claim_by_another_user_skips(self, mod):
+        checks = clean_checks(
+            prose_claim={
+                "closure_requested": False,
+                "claimed_by_other": True,
+                "claimed_by": "otherdev",
+                "claimed_by_where": "body",
+                "where": "body",
+                "comment_id": None,
+                "pattern": SELF_CLAIM_SAMPLE_PATTERN,
+            }
+        )
+        assert naive_claim(checks) is True
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("SKIP", "prose-claim")
+        assert evidence == {"claimed_by": "otherdev", "where": "body"}
+        assert mod.EXIT_CODES[name] == 10
+        assert "prose-claim claimed-by=otherdev where=body" in mod.human_line(
+            ITEM, name, reason, evidence, "low"
+        )
+
+    def test_closure_request_outranks_a_prose_claim(self, mod):
+        """Precedence 3 before 4: if the reporter says it is done, it is triage
+        debt even when somebody also said they were working on it."""
+        checks = clean_checks(
+            prose_claim={
+                "closure_requested": True,
+                "claimed_by_other": True,
+                "claimed_by": "otherdev",
+                "where": "comment",
+                "comment_id": 123456,
+                "pattern": "x",
+            }
+        )
+        assert naive_claim(checks) is True
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("CLOSE", "reporter-asked-close")
+        assert evidence == {"comment_id": 123456, "where": "comment"}
+        assert mod.EXIT_CODES[name] == 11
+        assert (
+            mod.human_line(ITEM, name, reason, evidence, "low")
+            == f"CLOSE {ITEM} reporter-asked-close comment-id=123456"
+        )
+
+    def test_closure_request_in_the_body_reports_where_instead_of_an_id(self, mod):
+        evidence = {"comment_id": None, "where": "body"}
+        assert (
+            mod.human_line(ITEM, "CLOSE", "reporter-asked-close", evidence, "low")
+            == f"CLOSE {ITEM} reporter-asked-close where=body"
+        )
+
+    def test_absent_symbol_skips_only_for_a_corroborated_bug_item(self, mod):
+        checks = clean_checks(
+            symbol_on_base={
+                "symbols": ["_merge_notifications", "run_probe"],
+                "present": ["run_probe"],
+                "missing": ["_merge_notifications"],
+                "bug_class": True,
+                "bug_class_by": "label:bug",
+            }
+        )
+        assert naive_claim(checks) is True
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("SKIP", "symbol-absent")
+        assert evidence == {
+            "symbol": "_merge_notifications",
+            "missing": ["_merge_notifications"],
+            "bug_class_by": "label:bug",
+        }
+        assert mod.EXIT_CODES[name] == 10
+        assert (
+            mod.human_line(ITEM, name, reason, evidence, "low")
+            == f"SKIP {ITEM} symbol-absent=_merge_notifications"
+        )
+
+    def test_an_absent_symbol_on_an_uncorroborated_item_claims_at_high_risk(self, mod):
+        """The feature-request case that the unconditional veto parked forever.
+
+        An item proposing to ADD `_merge_notifications` names a symbol that is
+        absent by definition, so it would be absent on this pass and every pass
+        after it. It must be dispatched, and flagged, not parked.
+        """
+        checks = clean_checks(
+            symbol_on_base={
+                "symbols": ["_merge_notifications"],
+                "present": [],
+                "missing": ["_merge_notifications"],
+                "bug_class": False,
+                "bug_class_by": None,
+            }
+        )
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("CLAIM", "clean")
+        assert mod.EXIT_CODES[name] == 0
+        assert evidence["risk"] == "high"
+        assert evidence["symbol_absent_uncorroborated"] == ["_merge_notifications"]
+        # The human line stays one field wide, so the reason rides in --json.
+        assert mod.human_line(ITEM, name, reason, evidence, "high") == f"CLAIM {ITEM} risk=high"
+
+    def test_an_uncorroborated_absent_symbol_forces_high_risk(self, mod):
+        """Even a stale item from a stranger, which recency alone calls low."""
+        checks = clean_checks(
+            symbol_on_base={
+                "symbols": ["Thing_One"],
+                "present": [],
+                "missing": ["Thing_One"],
+                "bug_class": False,
+            },
+            recency={"age_days": 900, "author_association": "NONE", "risk": "low"},
+        )
+        assert mod.risk_of(checks) == "high"
+        assert mod.uncorroborated_absent_symbols(checks) == ["Thing_One"]
+
+    def test_a_present_symbol_leaves_risk_alone(self, mod):
+        checks = clean_checks(
+            symbol_on_base={
+                "symbols": ["run_probe"],
+                "present": ["run_probe"],
+                "missing": [],
+                "bug_class": False,
+            }
+        )
+        assert mod.uncorroborated_absent_symbols(checks) == []
+        assert mod.risk_of(checks) == "low"
+
+    def test_uncorroborated_absent_symbols_ignores_an_errored_check(self, mod):
+        checks = clean_checks(symbol_on_base={"error": "grep-failed", "bug_class": False})
+        assert mod.uncorroborated_absent_symbols(checks) == []
+
+    @pytest.mark.parametrize(
+        "name",
+        ["open_prs", "merged_prs", "prose_claim", "symbol_on_base", "recency"],
+    )
+    def test_any_errored_check_is_unknown_never_claim(self, mod, name):
+        checks = clean_checks(**{name: {"error": "rate-limited"}})
+        assert naive_claim(checks) is True
+        got, reason, evidence = mod.verdict(checks)
+        assert got == "UNKNOWN"
+        assert reason == "rate-limited"
+        assert evidence == {"check": name, "reason": "rate-limited"}
+        assert mod.EXIT_CODES[got] == 3
+        assert (
+            mod.human_line(ITEM, got, reason, evidence, "high")
+            == f"UNKNOWN {ITEM} check={name} reason=rate-limited"
+        )
+
+    def test_a_definite_finding_outranks_an_errored_check(self, mod):
+        """Precedence 6 sits BELOW the positive findings: a partial view of one
+        question does not erase a definite answer to another."""
+        checks = clean_checks(
+            open_prs=[{"number": 8100, "author": "x", "is_cross_repository": False}],
+            recency={"error": "rate-limited"},
+        )
+        assert mod.verdict(checks)[:2] == ("SKIP", "open-pr")
+
+    def test_clean_item_claims_and_carries_its_risk(self, mod):
+        checks = clean_checks(
+            recency={"age_days": 1, "author_association": "CONTRIBUTOR", "risk": "high"}
+        )
+        name, reason, evidence = mod.verdict(checks)
+        assert (name, reason) == ("CLAIM", "clean")
+        assert evidence == {"risk": "high"}
+        assert mod.risk_of(checks) == "high"
+        assert mod.EXIT_CODES[name] == 0
+        assert mod.human_line(ITEM, name, reason, evidence, "high") == f"CLAIM {ITEM} risk=high"
+
+    def test_the_unreliable_field_is_not_a_check_at_all(self, mod):
+        """`closedByPullRequestsReferences` measured `[]` on two items that WERE
+        closed by merged PRs, so it is dropped rather than carried as a bonus: a
+        per-candidate forge call that cannot change the verdict is pure cost
+        against a shared rate limit. Five checks, and none of them is that one.
+        """
+        assert mod.CHECK_NAMES == (
+            "open_prs",
+            "merged_prs",
+            "prose_claim",
+            "symbol_on_base",
+            "recency",
+        )
+        source = SCRIPT.read_text(encoding="utf-8")
+        assert "closed_by" not in source
+        # The field survives in the rationale only, as the question this script
+        # refuses to ask -- never as a call.
+        assert "closedByPullRequestsReferences" in source
+        assert 'gh_json(\n        [\n            "gh",\n            "issue",' not in source
+
+    def test_no_file_claims_a_check_count_the_code_does_not_have(self, mod):
+        """A ratchet, because this exact leftover shipped once.
+
+        Removing one of the checks left the OLD count behind in a docstring and
+        in a test name, which a premise-level reviewer correctly reads as the
+        description contradicting the diff. Counting words are cheap to forget
+        and cheap to pin, so pin them: no line of the script or of this file may
+        name a check count other than the real one.
+
+        (This docstring deliberately does not spell any wrong count, since the
+        scan reads its own file too.)
+        """
+        wrong = {"six": 6, "four": 4, "seven": 7}
+        for path in (SCRIPT, Path(__file__).resolve()):
+            text = path.read_text(encoding="utf-8")
+            for word, count in wrong.items():
+                if count == len(mod.CHECK_NAMES):
+                    continue
+                for line in text.splitlines():
+                    lowered = line.lower()
+                    if word in lowered and "check" in lowered:
+                        raise AssertionError(f"{path.name}: stale check count -- {line.strip()!r}")
+
+    def test_risk_defaults_to_high_when_recency_is_unavailable(self, mod):
+        assert mod.risk_of(clean_checks(recency={"error": "rate-limited"})) == "high"
+        assert mod.risk_of(clean_checks(recency="nonsense")) == "high"
+
+    def test_entries_and_errored_tolerate_the_error_shape(self, mod):
+        assert mod.entries({"error": "x"}) == []
+        assert mod.entries([{"a": 1}, "junk"]) == [{"a": 1}]
+        assert mod.errored({"error": "x"}) == "x"
+        assert mod.errored({}) is None
+        assert mod.errored([]) is None
+
+
+SELF_CLAIM_SAMPLE_PATTERN = r"\bI(?:'m| am)\s+claiming\b"
+
+
+# --------------------------------------------------------------------------- #
+# the prose scanner
+# --------------------------------------------------------------------------- #
+
+
+def an_issue(**overrides) -> dict:
+    issue = {
+        "number": ITEM,
+        "title": "the probe cannot tell a finished worker from a wedged one",
+        "body": "The handled set keeps one entry per key.",
+        "user": {"login": "reporter"},
+        "created_at": "2026-01-01T00:00:00Z",
+        "author_association": "NONE",
+        "labels": [],
+        "type": None,
+    }
+    issue.update(overrides)
+    return issue
+
+
+def a_comment(
+    body: str,
+    *,
+    login="reporter",
+    ident=123456,
+    kind="User",
+    created="2026-09-02T00:00:00Z",
+    association=None,
+) -> dict:
+    """A comment payload. ``association`` defaults to OWNER only so the many
+    tests that just need SOME closure request keep standing; the standing rule
+    itself is pinned by its own tests, which pass it explicitly.
+    """
+    return {
+        "id": ident,
+        "body": body,
+        "user": {"login": login, "type": kind},
+        "created_at": created,
+        "author_association": "OWNER" if association is None else association,
+    }
+
+
+class TestProseScan:
+    def test_self_claim_in_the_body_by_another_user(self, mod):
+        issue = an_issue(
+            body="I'm claiming this issue, patch coming today.", user={"login": "otherdev"}
+        )
+        prose = mod.scan_prose(issue, None, "us")
+        assert prose["claimed_by_other"] is True
+        assert prose["claimed_by"] == "otherdev"
+        assert prose["claimed_by_where"] == "body"
+        assert prose["closure_requested"] is False
+        # The PATTERN is reported, never the user's sentence: this lands in an
+        # agent's context.
+        assert prose["pattern"] in mod.SELF_CLAIM_RES
+        assert "claiming this issue" not in json.dumps(prose)
+
+    def test_our_own_self_claim_is_not_somebody_elses(self, mod):
+        issue = an_issue(body="I am claiming this one.", user={"login": "us"})
+        assert mod.scan_prose(issue, None, "us")["claimed_by_other"] is False
+
+    def test_an_unknown_identity_reads_a_self_claim_as_somebody_elses(self, mod):
+        """Fail-safe direction: not knowing who we are must produce SKIP, not
+        CLAIM."""
+        issue = an_issue(body="I am claiming this one.", user={"login": "us"})
+        assert mod.scan_prose(issue, None, None)["claimed_by_other"] is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "This is resolved, thanks!",
+            "happy to have this closed",
+            "Please close this one.",
+            "this can be closed",
+            "no longer reproducible on main",
+        ],
+    )
+    def test_closure_requests_in_the_last_comment(self, mod, text):
+        prose = mod.scan_prose(an_issue(), a_comment(text), "us")
+        assert prose["closure_requested"] is True
+        assert prose["where"] == "comment"
+        assert prose["comment_id"] == 123456
+
+    def test_a_comment_outranks_the_body_as_evidence(self, mod):
+        prose = mod.scan_prose(an_issue(body="this is resolved"), a_comment("please close"), "us")
+        assert prose["where"] == "comment"
+        assert prose["comment_id"] == 123456
+
+    def test_ordinary_prose_claims_nothing(self, mod):
+        prose = mod.scan_prose(an_issue(), a_comment("Reproduced on 0.6.0, logs attached."), "us")
+        assert prose["closure_requested"] is False
+        assert prose["claimed_by_other"] is False
+
+    def test_a_quoted_phrase_is_a_citation_not_a_request(self, mod):
+        """The regression that found this: the item SPECIFYING this script quotes
+        the closure phrases as a description of what to detect, and a raw scan
+        returned CLOSE on a live item. Verbatim from that body — including the
+        LINE BREAK inside the quotation, which markdown's hard wrap put there and
+        which the first version of the stripper walked straight past.
+        """
+        body = (
+            "- A claim written in **prose** -- an assignee in the body, "
+            '"this is\n  resolved, please close" in the last comment -- is '
+            "invisible to every label and field query.\n"
+            'Scan the body and the last comment for "this is resolved / happy '
+            'to have it closed".'
+        )
+        prose = mod.scan_prose(an_issue(body=body), None, "us")
+        assert prose["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "```\nplease close\n```",
+            "~~~\nthis is resolved\n~~~",
+            "the phrase `please close` fires the check",
+            "> this is resolved\n\nbut it is not",
+            'they said "please close" and I disagree',
+            "they said \u201cplease close\u201d and I disagree",
+        ],
+    )
+    def test_cited_closure_phrases_do_not_request_closure(self, mod, body):
+        assert mod.scan_prose(an_issue(body=body), None, "us")["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "This is resolved, thanks for the quick turnaround.",
+            "Please close this one.",
+            "> irrelevant quoted line\n\nthis was fixed in the 0.7 release",
+        ],
+    )
+    def test_an_unquoted_closure_request_still_fires(self, mod, body):
+        """The stripper must not swallow the sentence the check exists to find."""
+        assert mod.scan_prose(an_issue(body=body), None, "us")["closure_requested"] is True
+
+    def test_a_cited_self_claim_is_not_a_claim(self, mod):
+        body = 'three items said "I am claiming this issue" in prose'
+        assert mod.scan_prose(an_issue(body=body), None, "us")["claimed_by_other"] is False
+
+    def test_plain_prose_keeps_unquoted_text(self, mod):
+        assert "kept" in mod.plain_prose("kept `dropped` kept")
+        assert "dropped" not in mod.plain_prose("kept `dropped` kept")
+        assert mod.plain_prose("") == ""
+
+    @pytest.mark.parametrize("pad", [0, 200, 400, 2000])
+    def test_a_long_quotation_does_not_escape_the_stripper(self, mod, pad):
+        """A length cap on the quotation pattern is a false-CLOSE channel.
+
+        The stripper once bounded the span at 200 characters, so a reporter who
+        quoted a closure phrase deep inside a long quotation had it read as
+        their OWN prose -- and this verdict performs a write on live work. The
+        pad crosses that old bound in both directions, so the test would have
+        failed at 400 and 2000 before the bound was removed.
+        """
+        body = 'The spec says "' + ("context " * (pad // 8)) + 'please close this" -- discuss.'
+        assert "please close" not in mod.plain_prose(body)
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            'he said "this is resolved and I never closed the quote',
+            'the doc said "please close this -- anyway, moving on',
+            "the doc said \u201cthis is resolved and on it went",
+            'ok "happy to have it closed',
+        ],
+    )
+    def test_an_unclosed_quotation_does_not_escape_the_stripper(self, mod, body):
+        """The other door into the same false-CLOSE channel, and the one my own
+        earlier test missed by asserting ``in (True, False)`` -- which no
+        behaviour can fail.
+
+        An unclosed citation matches no balanced pair, so before the fix the
+        quoted phrase survived as the author's own words and the verdict was
+        CLOSE on live work. Measured, not reasoned: exit 11 on all four bodies.
+        """
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+        name, _, _ = mod.verdict(clean_checks(prose_claim=got))
+        assert name == "CLAIM"
+
+    def test_over_stripping_is_the_chosen_direction(self, mod):
+        """A leftover delimiter takes the rest of the text with it, so a REAL
+        request sitting after an unbalanced quote is lost. That is deliberate:
+        losing it costs one dispatch, keeping it can close somebody's work."""
+        body = 'he said "something odd -- and separately, this is resolved'
+        assert "this is resolved" not in mod.plain_prose(body)
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    def test_the_newest_human_comment_is_used_not_the_bot_summary(self, mod):
+        """Selection is by timestamp, not position, and bots are skipped.
+
+        Both halves are measured, not assumed. The per-issue comments endpoint
+        IGNORES `sort`/`direction` and answers OLDEST-first, so an earlier
+        version of this function that asked for `direction=desc` and took the
+        first element read the oldest of twelve comments; and this repo's triage
+        bot summary was the OLDEST entry, not the newest. The timestamps below
+        are that real thread's first and last.
+        """
+        oldest_first = [
+            a_comment(
+                "**Automated triage summary**",
+                login="github-actions[bot]",
+                kind="Bot",
+                created="2026-09-01T10:40:23Z",
+            ),
+            a_comment("reproduced on 0.6.0", ident=111, created="2026-09-01T11:19:53Z"),
+            a_comment("some-app[bot] body", login="some-app[bot]", created="2026-09-02T04:22:10Z"),
+            a_comment(
+                "please close, I fixed this myself", ident=999, created="2026-09-03T00:56:58Z"
+            ),
+        ]
+        found = mod.last_human_comment(oldest_first)
+        assert found is not None and found["id"] == 999
+
+    def test_selection_survives_either_page_order(self, mod):
+        """The bug this replaces was an ordering ASSUMPTION. Reversing the input
+        must not change the answer -- that is what makes the fix a fix rather
+        than the opposite assumption.
+        """
+        page = [
+            a_comment("older", ident=111, created="2026-09-01T11:19:53Z"),
+            a_comment("newer", ident=999, created="2026-09-03T00:56:58Z"),
+        ]
+        assert mod.last_human_comment(page)["id"] == 999
+        assert mod.last_human_comment(list(reversed(page)))["id"] == 999
+
+    def test_position_breaks_ties_only_when_a_timestamp_is_missing(self, mod):
+        undated = [
+            a_comment("first", ident=1, created=None),
+            a_comment("last", ident=2, created=None),
+        ]
+        assert mod.last_human_comment(undated)["id"] == 2
+        mixed = [
+            a_comment("dated", ident=1, created="2026-09-01T00:00:00Z"),
+            a_comment("undated", ident=2, created=None),
+        ]
+        assert mod.last_human_comment(mixed)["id"] == 1
+
+    def test_last_human_comment_degrades_on_junk(self, mod):
+        assert mod.last_human_comment([]) is None
+        assert mod.last_human_comment("nonsense") is None
+        assert mod.last_human_comment([{"user": {"type": "Bot"}}]) is None
+        assert mod.last_human_comment(["junk"]) is None
+        # A deleted account leaves ``user: null``. That is not a bot, and the
+        # sentence it left behind still counts.
+        orphaned = mod.last_human_comment([{"id": 5, "user": None}])
+        assert orphaned is not None and orphaned["id"] == 5
+
+    def test_a_closure_request_needs_standing(self, mod):
+        """CLOSE acts on live work, so "please close" from a passer-by is not
+        enough. The reporter and a repository insider both have standing."""
+        issue = an_issue(user={"login": "reporter"})
+        reporter = a_comment("please close", login="reporter", association="NONE")
+        assert mod.scan_prose(issue, reporter, "us")["closure_requested"] is True
+
+        maintainer = a_comment("this was fixed in 0.7", login="boss", association="MEMBER")
+        got = mod.scan_prose(issue, maintainer, "us")
+        assert got["closure_requested"] is True
+        assert got["closure_by"] == "boss"
+
+        passerby = a_comment("please close", login="stranger", association="NONE")
+        assert mod.scan_prose(issue, passerby, "us")["closure_requested"] is False
+
+    def test_contributor_association_alone_is_not_standing_to_close(self, mod):
+        """CONTRIBUTOR only means "has had a PR merged here once", which is not
+        authority over another person's report."""
+        drive_by = a_comment("please close", login="stranger", association="CONTRIBUTOR")
+        got = mod.scan_prose(an_issue(user={"login": "reporter"}), drive_by, "us")
+        assert got["closure_requested"] is False
+
+    def test_a_self_claim_needs_standing_too_but_downgrades_instead(self, mod):
+        """Both phrase sets need standing, for OPPOSITE reasons.
+
+        My first version waved self-claims through on the reasoning that SKIP is
+        the cheap direction. That was wrong about the cost: a veto anyone can
+        cast is a denial-of-work channel -- one comment from a passer-by would
+        suppress a queued item indefinitely, and nothing downstream reports the
+        suppression. So an unauthorized claim is neither obeyed nor discarded: it
+        downgrades to risk=high and takes the live recheck.
+        """
+        issue = an_issue(user={"login": "reporter"})
+
+        insider = a_comment("I am claiming this one", login="boss", association="MEMBER")
+        got = mod.scan_prose(issue, insider, "us")
+        assert got["claimed_by_other"] is True
+        assert got["claim_without_standing"] is False
+
+        stranger = a_comment("I am claiming this one", login="stranger", association="NONE")
+        got = mod.scan_prose(issue, stranger, "us")
+        assert got["claimed_by_other"] is False
+        assert got["claim_without_standing"] is True
+        assert got["claimed_by"] == "stranger"
+
+    def test_a_self_claim_in_the_body_always_has_standing(self, mod):
+        """The body's author IS the reporter, so the three items that started
+        this -- all of which declared ownership in the BODY -- still SKIP."""
+        issue = an_issue(body="Ownership claimed by @otherdev", user={"login": "otherdev"})
+        got = mod.scan_prose(issue, None, "us")
+        assert got["claimed_by_other"] is True
+        assert got["claim_without_standing"] is False
+
+
+class TestBugClassCorroboration:
+    """Explicit metadata only. A label is a human's deliberate triage act, which
+    is what makes it corroboration; wording is not."""
+
+    @pytest.mark.parametrize(
+        "label,term",
+        [
+            ("bug", "bug"),
+            ("Bug", "bug"),
+            ("type: bug", "bug"),
+            ("kind/bug", "bug"),
+            ("defect", "defect"),
+            ("regression", "regression"),
+            ("crash", "crash"),
+        ],
+    )
+    def test_a_bug_label_corroborates(self, mod, label, term):
+        got, by = mod.bug_class_of(an_issue(labels=[{"name": label}]))
+        assert got is True
+        # The MATCHED TERM, from this module's own vocabulary -- never the
+        # label's text, which is user-authored and this value is printed.
+        assert by == f"label:{term}"
+
+    def test_the_corroboration_never_echoes_the_label_text(self, mod):
+        """The script's own contract is that nothing user-authored reaches
+        stdout. A label name is user-authored, so only the matched term rides."""
+        noisy = "type: Bug -- customer ACME, see ticket 4471 (bob@example.invalid)"
+        got, by = mod.bug_class_of(an_issue(labels=[{"name": noisy}]))
+        assert (got, by) == (True, "label:bug")
+        for leaked in ("ACME", "4471", "bob@example.invalid", noisy):
+            assert leaked not in str(by)
+
+    @pytest.mark.parametrize(
+        "label",
+        ["enhancement", "feature request", "documentation", "good first issue", "debugging"],
+    )
+    def test_a_non_bug_label_does_not_corroborate(self, mod, label):
+        assert mod.bug_class_of(an_issue(labels=[{"name": label}])) == (False, None)
+
+    def test_an_issue_type_corroborates(self, mod):
+        got, by = mod.bug_class_of(an_issue(type={"name": "Bug"}))
+        assert (got, by) == (True, "type:bug")
+
+    def test_a_feature_type_does_not(self, mod):
+        assert mod.bug_class_of(an_issue(type={"name": "Feature"})) == (False, None)
+
+    def test_no_metadata_does_not_corroborate(self, mod):
+        """An untriaged item is not corroborated, and that is the CHEAP
+        direction: it is dispatched with risk=high, not parked."""
+        assert mod.bug_class_of(an_issue()) == (False, None)
+
+    def test_junk_metadata_degrades_quietly(self, mod):
+        assert mod.bug_class_of(an_issue(labels="nonsense")) == (False, None)
+        assert mod.bug_class_of(an_issue(labels=[None, 7, {"no": "name"}])) == (False, None)
+        assert mod.bug_class_of(an_issue(type="nonsense")) == (False, None)
+        assert mod.bug_class_of(an_issue(labels=["bug"])) == (True, "label:bug")
+
+    def test_the_corroboration_rides_on_the_check_value(self, mod):
+        got = mod.symbols_on_base([], None, "main", bug_class=True, bug_class_by="label:bug")
+        assert got["bug_class"] is True
+        assert got["bug_class_by"] == "label:bug"
+        # Also present on the error shapes, so the verdict never reads a missing
+        # key as "not a bug".
+        assert mod.symbols_on_base(["X_Y"], None, "main", bug_class=True)["bug_class"] is True
+
+
+class TestClosureNeedsAnIssueAsItsObject:
+    """The verb was never the signal; its OBJECT is."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Please close the file after reading it, otherwise the handle leaks.",
+            "Remember to please close the connection in the finally block.",
+            "Can you close the socket before returning?",
+            "should we close the stream here",
+            "this is resolved by upgrading the pinned dep in your own fork",
+        ],
+    )
+    def test_a_closure_verb_aimed_elsewhere_is_not_a_request(self, mod, body):
+        """Measured before this rule existed: every one of these returned
+        CLOSE, exit 11, on a live item. They are ordinary sentences in a bug
+        report about this kind of software, not requests to close anything."""
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+        assert mod.verdict(clean_checks(prose_claim=got))[0] == "CLAIM"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Please close this issue, it is a duplicate.",
+            "please close this",
+            "Please close.",
+            "please close #8029",
+            "can this be closed?",
+            "should we close the ticket",
+            "this is resolved",
+            "this was fixed in the 0.7 release",
+            "this can be closed",
+            "happy to have this closed",
+            "no longer an issue",
+        ],
+    )
+    def test_a_real_request_still_fires(self, mod, body):
+        """The guard must not buy safety by going deaf: closure detection is
+        what saves the dispatch, so each phrasing that names the item is kept."""
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is True
+
+    def test_resolved_by_a_means_differs_from_resolved_as_a_state(self, mod):
+        """`in` reports where the fix landed; `by` hands over a workaround and
+        leaves the item open. One word apart, opposite verdicts."""
+        state = mod.scan_prose(an_issue(body="this is fixed in 0.7"), None, "us")
+        means = mod.scan_prose(an_issue(body="this is fixed by pinning it yourself"), None, "us")
+        assert state["closure_requested"] is True
+        assert means["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "The connection leaks. Please close it.",
+            "Please close it, the handle stays open otherwise.",
+            "The stream stays open. Please close that.",
+            "The socket is still open -- can you close it?",
+        ],
+    )
+    def test_a_bare_pronoun_is_not_an_issue(self, mod, body):
+        """A bare pronoun resolves to whatever was last mentioned, and in a bug
+        report that is usually a socket, a file or a handle.
+
+        This cost a round to learn: the first version of the object rule
+        accepted `it` and `that`, so fixing "please close the file" left "please
+        close it" closing live items. Narrowing the object was the fix, not
+        widening the clause end.
+        """
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        ["Please close this.", "please close that issue", "please close the item"],
+    )
+    def test_this_and_an_explicit_noun_still_count(self, mod, body):
+        """`this` points at the thread's topic rather than the previous noun, and
+        a pronoun WITH the noun present is unambiguous."""
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is True
+
+    def test_happy_to_have_it_closed_is_now_a_deliberate_miss(self, mod):
+        """The last pattern that hardcoded a bare pronoun.
+
+        In an issue thread "happy to have it closed" usually does mean the item,
+        so this loses a real request -- but the same words describe a socket a
+        reporter is happy to see closed, and that reading closed live work. The
+        deictic form still fires, which is the phrasing to prefer, and the miss
+        costs one dispatch.
+        """
+        assert (
+            mod.scan_prose(an_issue(body="happy to have it closed"), None, "us")[
+                "closure_requested"
+            ]
+            is False
+        )
+        assert (
+            mod.scan_prose(an_issue(body="happy to have this closed"), None, "us")[
+                "closure_requested"
+            ]
+            is True
+        )
+        assert (
+            mod.scan_prose(an_issue(body="happy to have the issue closed"), None, "us")[
+                "closure_requested"
+            ]
+            is True
+        )
+
+    def test_a_post_positioned_please_is_a_known_miss(self, mod):
+        """ "close the ticket please" is not detected: the pattern is `please
+        close`, and the list is hand-written English rather than a parser.
+
+        Pinned rather than fixed, because it fails in the direction this file
+        chose everywhere else -- a missed closure request costs one dispatch,
+        and widening the verb forms widens the false-CLOSE surface that has now
+        produced three separate defects here. If it turns up in real items, the
+        evidence is the reason to add it.
+        """
+        got = mod.scan_prose(an_issue(body="close the ticket please"), None, "us")
+        assert got["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "This is fixed-width layout and hard to read",
+            "this is fixed-size buffers again",
+            "this is fixed-point arithmetic, not floating",
+        ],
+    )
+    def test_an_adjectival_fixed_is_not_a_verdict(self, mod, body):
+        r"""``\b`` matches happily before a hyphen, so "this is fixed-width" read
+        as "this is fixed" and closed live items. The word is an ADJECTIVE in
+        these sentences, and the state patterns now require a continuation that
+        a hyphen cannot satisfy."""
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "this is resolved",
+            "this is resolved, closing",
+            "this was fixed in the 0.7 release",
+            "this is resolved -- closing now",
+            "this is already fixed on main",
+        ],
+    )
+    def test_a_state_statement_still_closes(self, mod, body):
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is True
+
+
+class TestReferenceRepositoryMustBeKnown:
+    """A reference whose repository cannot be established is not coverage."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://api.github.com/repos/other/Repo/issues/12", "other/Repo"),
+            ("https://api.github.com/repos/kirodotdev/KiroCrew/pulls/8036", REPO),
+            ("https://api.github.com/repos/a/b/issues/1/comments", "a/b"),
+            (None, None),
+            ("garbage", None),
+            ("", None),
+            (12, None),
+        ],
+    )
+    def test_the_repo_is_read_from_the_api_url(self, mod, url, expected):
+        assert mod.repo_from_api_url(url) == expected
+
+    def test_a_reference_with_no_repository_at_all_is_skipped(self, mod, monkeypatch):
+        """The old fallback treated a missing nested repository as "same repo"
+        and fetched repos/<this repo>/pulls/<N> -- a DIFFERENT pull request that
+        merely shares the number, which then SKIPped a live item. With neither
+        the object nor a usable URL, the reference decides nothing."""
+        entry = {
+            "event": "cross-referenced",
+            "source": {"issue": {"number": 999, "pull_request": {}, "url": "garbage"}},
+        }
+        assert run_main(mod, monkeypatch, Forge(timeline=[entry], pulls={})) == 0
+
+    def test_a_reference_from_another_repo_by_url_is_skipped(self, mod, monkeypatch):
+        entry = {
+            "event": "cross-referenced",
+            "source": {
+                "issue": {
+                    "number": 999,
+                    "pull_request": {},
+                    "url": "https://api.github.com/repos/somebody/Else/issues/999",
+                }
+            },
+        }
+        assert run_main(mod, monkeypatch, Forge(timeline=[entry], pulls={})) == 0
+
+    def test_a_local_reference_identified_only_by_url_is_kept(self, mod, monkeypatch, capsys):
+        """The guard must not become deaf to real local references."""
+        entry = {
+            "event": "cross-referenced",
+            "source": {
+                "issue": {
+                    "number": 8100,
+                    "pull_request": {},
+                    "url": f"https://api.github.com/repos/{REPO}/issues/8100",
+                }
+            },
+        }
+        forge = Forge(timeline=[entry], pulls={8100: a_pull(8100)})
+        assert run_main(mod, monkeypatch, forge) == 10
+        assert "open-pr=#8100" in capsys.readouterr().out
+
+
+class TestClaimSurvivesLaterChatter:
+    """A claim is a statement that holds until withdrawn, not a transcript line
+    that the next remark overwrites."""
+
+    def a_comment_at(self, text, login, association, ident, when):
+        got = a_comment(text, login=login, association=association, ident=ident)
+        got["created_at"] = when
+        return got
+
+    def test_a_later_outsider_remark_does_not_erase_an_insider_claim(self, mod):
+        """Measured: an insider's claim followed by "any update on this?" left
+        the claim unscanned and the verdict CLAIM -- a second worker dispatched
+        onto work already in flight, which is the class this script removes."""
+        claim = self.a_comment_at(
+            "I am claiming this one", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z"
+        )
+        later = self.a_comment_at(
+            "any update on this?", "passerby", "NONE", 2, "2026-09-02T10:00:00Z"
+        )
+        assert mod.last_human_comment([claim, later])["id"] == 2
+        got = mod.newest_authorized_claim([claim, later], "reporter")
+        assert got is not None and got["id"] == 1
+
+    def test_the_reporters_own_claim_is_recovered_too(self, mod):
+        claim = self.a_comment_at(
+            "I am working on this", "reporter", "NONE", 1, "2026-09-01T10:00:00Z"
+        )
+        later = self.a_comment_at("thanks!", "someone", "NONE", 2, "2026-09-02T10:00:00Z")
+        assert mod.newest_authorized_claim([claim, later], "reporter")["id"] == 1
+
+    def test_an_unauthorized_claim_is_not_recovered_into_a_veto(self, mod):
+        """The recovery must not become the denial-of-work channel that ruling
+        on the prose rule closed: standing is still required here."""
+        stranger = self.a_comment_at(
+            "I am claiming this", "drifter", "NONE", 3, "2026-09-02T11:00:00Z"
+        )
+        assert mod.newest_authorized_claim([stranger], "reporter") is None
+
+    def test_the_newest_authorized_claim_wins(self, mod):
+        older = self.a_comment_at("I am claiming this", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z")
+        newer = self.a_comment_at("I am claiming this", "chief", "OWNER", 2, "2026-09-02T10:00:00Z")
+        assert mod.newest_authorized_claim([older, newer], None)["id"] == 2
+
+    def test_a_bot_claim_is_ignored(self, mod):
+        bot = self.a_comment_at(
+            "I am claiming this", "triage[bot]", "MEMBER", 9, "2026-09-09T00:00:00Z"
+        )
+        assert mod.newest_authorized_claim([bot], None) is None
+
+    def test_quoted_claims_do_not_count_here_either(self, mod):
+        """The recovery reads the same stripped prose as everything else, so a
+        comment CITING the phrases this check looks for is not a claim."""
+        citing = self.a_comment_at(
+            'the script matches "I am claiming this"', "boss", "MEMBER", 1, "2026-09-01T10:00:00Z"
+        )
+        assert mod.newest_authorized_claim([citing], None) is None
+
+    def test_no_comments_is_not_a_claim(self, mod):
+        assert mod.newest_authorized_claim([], None) is None
+        assert mod.newest_authorized_claim(None, None) is None
+
+
+class TestNegatedProseIsNotAVerdict:
+    """English puts the negation before the phrase, and these patterns match a
+    SUBSTRING, so "I don't think this is resolved" read as "this is resolved"."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "I don't think this is resolved",
+            "I am not sure this is fixed",
+            "nobody said this is resolved",
+            "this is not resolved yet",
+            "I doubt this is resolved",
+            "unclear whether this is fixed",
+            "I cannot say this is resolved",
+            "never said please close this issue",
+        ],
+    )
+    def test_a_negated_closure_phrase_does_not_close(self, mod, body):
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+        assert mod.verdict(clean_checks(prose_claim=got))[0] == "CLAIM"
+
+    @pytest.mark.parametrize(
+        "body",
+        ["I am not working on this", "I don't think I am claiming this"],
+    )
+    def test_a_negated_claim_does_not_park(self, mod, body):
+        """Same rule on the claim side. Less destructive than a false CLOSE, but
+        a phrase that says the opposite of what it is read as is still wrong."""
+        got = mod.scan_prose(an_issue(body=body, user={"login": "other"}), None, "us")
+        assert got["claimed_by_other"] is False
+
+    def test_a_nearby_hedge_vetoes_even_a_genuine_later_request(self, mod):
+        """A disclosed miss, pinned rather than fixed.
+
+        I first wrote this test expecting "I don't think this is resolved, but
+        please close this issue as a duplicate" to close, on the reasoning that
+        the scan continues past a negated match. It does continue -- but the
+        window is measured in characters, and "don't" sits 35 of them before
+        "please close", so the hedge vetoes the later request too.
+
+        That is the direction to fail in: this misses a real request and costs
+        one dispatch, where the alternative reading closes live work. Making the
+        window clause-aware would need sentence segmentation, which is a bigger
+        claim about English than this file should make.
+        """
+        body = "I don't think this is resolved, but please close this issue as a duplicate"
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    def test_a_request_past_the_window_still_fires(self, mod):
+        """The veto is bounded: the same request further from the hedge fires."""
+        body = "I don't think this is resolved. " + ("More detail here. " * 4) + "please close this"
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is True
+
+    def test_the_negation_window_is_bounded(self, mod):
+        """A negation two sentences away must not veto: it is a window, not a
+        whole-text search, or any comment containing "not" would go deaf."""
+        body = (
+            "There is not much documentation here. " + ("padding text. " * 6) + "this is resolved"
+        )
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is True
+
+
+class TestTheBodyIsTheOldestText:
+    """A closure request in the body is a status, and a later comment supersedes
+    it whether or not that comment contains a phrase this scanner knows."""
+
+    def test_a_newer_comment_retires_a_body_closure_request(self, mod):
+        """Measured: body "this is resolved" plus the reporter's later "still
+        broken on 0.8" returned CLOSE, exit 11, on work they had just reopened."""
+        reopen = a_comment("still broken on 0.8", login="reporter", association="MEMBER", ident=1)
+        got = mod.scan_prose(an_issue(body="this is resolved"), reopen, "us")
+        assert got["closure_requested"] is False
+        assert got["where"] is None
+
+    def test_the_body_still_closes_when_nobody_commented(self, mod):
+        """The item that motivated this check had its request in the body, so the
+        rule narrows the source rather than removing it."""
+        got = mod.scan_prose(an_issue(body="this is resolved"), None, "us")
+        assert got["closure_requested"] is True
+        assert got["where"] == "body"
+
+    def test_a_comment_can_still_supply_the_request(self, mod):
+        ask = a_comment("please close this issue", login="reporter", association="MEMBER", ident=2)
+        got = mod.scan_prose(an_issue(body="something broke"), ask, "us")
+        assert got["closure_requested"] is True
+        assert got["where"] == "comment"
+
+    def test_a_body_claim_survives_a_later_comment(self, mod):
+        """Ownership is not a status: the three items that motivated the prose
+        check declared ownership in the BODY, so a later remark must not retire
+        it the way it retires a closure request."""
+        chatter = a_comment("any update?", login="passerby", association="NONE", ident=3)
+        issue = an_issue(body="Ownership claimed by @otherdev", user={"login": "otherdev"})
+        got = mod.scan_prose(issue, chatter, "us")
+        assert got["claimed_by_other"] is True
+
+
+class TestClaimWithdrawal:
+    def a_comment_at(self, text, login, association, ident, when):
+        got = a_comment(text, login=login, association=association, ident=ident)
+        got["created_at"] = when
+        return got
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "dropping this, sorry",
+            "no longer working on this",
+            "not working on this any more",
+            "I am off this",
+            "unassigning myself",
+        ],
+    )
+    def test_a_newer_withdrawal_retires_an_older_claim(self, mod, text):
+        """The cost the first version of the recovery disclosed and accepted --
+        an abandoned claim parking the item forever -- did not have to be paid."""
+        claim = self.a_comment_at("I am claiming this", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z")
+        drop = self.a_comment_at(text, "boss", "MEMBER", 2, "2026-09-02T10:00:00Z")
+        assert mod.newest_authorized_claim([claim, drop], "reporter") is None
+
+    def test_a_claim_NEWER_than_the_withdrawal_still_counts(self, mod):
+        """Somebody picking the item back up after releasing it owns it again."""
+        drop = self.a_comment_at("dropping this", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z")
+        claim = self.a_comment_at("I am claiming this", "boss", "MEMBER", 2, "2026-09-02T10:00:00Z")
+        got = mod.newest_authorized_claim([drop, claim], "reporter")
+        assert got is not None and got["id"] == 2
+
+    def test_a_withdrawal_by_a_bot_is_ignored(self, mod):
+        claim = self.a_comment_at("I am claiming this", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z")
+        drop = self.a_comment_at(
+            "dropping this", "triage[bot]", "MEMBER", 2, "2026-09-02T10:00:00Z"
+        )
+        assert mod.newest_authorized_claim([claim, drop], "reporter")["id"] == 1
+
+    def test_a_stranger_cannot_release_somebody_elses_claim(self, mod):
+        """You can only give up what you hold.
+
+        The first version applied any withdrawal to every earlier claim, so a
+        passer-by typing "dropping this" erased a maintainer's claim and the item
+        was dispatched on top of live work -- the denial-of-work shape again,
+        running the other direction.
+        """
+        claim = self.a_comment_at("I am claiming this", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z")
+        drop = self.a_comment_at("dropping this", "drifter", "NONE", 2, "2026-09-02T10:00:00Z")
+        got = mod.newest_authorized_claim([claim, drop], "reporter")
+        assert got is not None and got["id"] == 1
+
+    def test_an_insider_cannot_release_another_insiders_claim(self, mod):
+        """Standing is authority over the ITEM, not over another person's
+        commitment, so it does not transfer here."""
+        claim = self.a_comment_at("I am claiming this", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z")
+        drop = self.a_comment_at("dropping this", "chief", "OWNER", 2, "2026-09-02T10:00:00Z")
+        got = mod.newest_authorized_claim([claim, drop], "reporter")
+        assert got is not None and got["id"] == 1
+
+    def test_two_claimants_are_tracked_separately(self, mod):
+        """One person leaving must not release the other's claim."""
+        gone = self.a_comment_at("I am claiming this", "boss", "MEMBER", 1, "2026-09-01T10:00:00Z")
+        drop = self.a_comment_at("dropping this", "boss", "MEMBER", 2, "2026-09-02T10:00:00Z")
+        still = self.a_comment_at("I am claiming this", "chief", "OWNER", 3, "2026-09-01T11:00:00Z")
+        got = mod.newest_authorized_claim([gone, drop, still], "reporter")
+        assert got is not None and got["id"] == 3
+
+    def test_a_body_claim_is_retired_by_its_own_authors_withdrawal(self, mod):
+        """The one case the comment path could not reach.
+
+        A claim in the BODY outlives later chatter by design, so before this the
+        reporter who claimed an item and then commented "dropping this" left it
+        SKIPping forever. That is indefinite suppression, not a wasted dispatch,
+        which is the harm this file treats as the serious one. The body predates
+        every comment by construction, so any withdrawal from its author retires
+        it and no timestamp comparison is needed.
+        """
+        issue = an_issue(body="Ownership claimed by @otherdev", user={"login": "otherdev"})
+        drop = self.a_comment_at("dropping this", "otherdev", "MEMBER", 1, "2026-09-02T10:00:00Z")
+
+        assert mod.body_claim_withdrawn([drop], "otherdev") is True
+        assert mod.scan_prose(issue, drop, "us", True)["claimed_by_other"] is False
+
+    def test_a_body_claim_survives_somebody_elses_withdrawal(self, mod):
+        issue = an_issue(body="Ownership claimed by @otherdev", user={"login": "otherdev"})
+        drop = self.a_comment_at("dropping this", "stranger", "NONE", 1, "2026-09-02T10:00:00Z")
+
+        assert mod.body_claim_withdrawn([drop], "otherdev") is False
+        assert mod.scan_prose(issue, drop, "us", False)["claimed_by_other"] is True
+
+    def test_the_withdrawal_map_is_shared_by_both_call_sites(self, mod):
+        """One rule, one implementation: the recovery and the body check read the
+        same map, so they cannot drift apart."""
+        drop = self.a_comment_at("dropping this", "boss", "MEMBER", 1, "2026-09-02T10:00:00Z")
+        assert mod.withdrawals_by_author([drop]) == {"boss": "2026-09-02T10:00:00Z"}
+        assert mod.withdrawals_by_author([]) == {}
+        assert mod.withdrawals_by_author(None) == {}
+
+    def test_an_unknown_reporter_retires_nothing(self, mod):
+        drop = self.a_comment_at("dropping this", "boss", "MEMBER", 1, "2026-09-02T10:00:00Z")
+        assert mod.body_claim_withdrawn([drop], None) is False
+
+
+class TestHtmlCommentsAreInvisible:
+    """A comment is invisible to every human reader of the item, so nothing
+    inside one is a statement its author is making."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "<!-- please close this issue when done -->\n\nThe button is misaligned.",
+            "<!-- this is resolved -->\nStill broken for me.",
+            "<!--\nplease close this\n-->\nreal report here",
+            "text <!-- this is resolved --> more text",
+        ],
+    )
+    def test_a_phrase_inside_a_comment_does_not_close(self, mod, body):
+        """This repository's issue templates ship instructional comments, so
+        "<!-- please close this issue when done -->" arrives in the body of real
+        items. Reading it closed them."""
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    def test_a_real_request_outside_a_comment_still_fires(self, mod):
+        body = "<!-- template: describe the bug -->\nplease close this issue"
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is True
+
+    def test_a_comment_is_stripped_before_the_fence_pattern_sees_it(self, mod):
+        """Ordering, not just presence: a comment can CONTAIN a fence, a quote or
+        a backtick span, and must not be parsed as one."""
+        assert mod.plain_prose("<!-- ```this is resolved``` -->\nreal text").strip() == "real text"
+        assert "resolved" not in mod.plain_prose('<!-- "this is resolved" -->')
+
+    def test_a_claim_inside_a_comment_does_not_park_the_item(self, mod):
+        issue = an_issue(body="<!-- I am claiming this -->", user={"login": "other"})
+        assert mod.scan_prose(issue, None, "us")["claimed_by_other"] is False
+
+
+class TestNoClosurePatternShipsUnguarded:
+    """The class-level answer to a defect that recurred six times.
+
+    Every round of review found one more closure phrase that matched prose about
+    something other than the item -- a file, a socket, a workaround, a layout.
+    Each was fixed individually and the next round found another, because nothing
+    checked the property itself. These two tests check it.
+    """
+
+    RESOURCES = (
+        "the file",
+        "the socket",
+        "the connection",
+        "the stream",
+        "the handle",
+        "the cursor",
+        "the session",
+        "the channel",
+        "the temp file",
+    )
+
+    TEMPLATES = (
+        "please close {r} after the read",
+        "{r} can be closed once we are done",
+        "can you close {r} in the finally block",
+        "should we close {r} here",
+        "happy to have {r} closed by then",
+        "{r} is no longer needed",
+        "{r} is no longer relevant",
+        "this is fixed-width in {r}",
+    )
+
+    def test_no_template_about_a_resource_ever_closes(self, mod):
+        """The property, stated once: prose about a RESOURCE is not a request to
+        close the ITEM. 72 combinations, none may CLOSE."""
+        leaks = []
+        for resource in self.RESOURCES:
+            for template in self.TEMPLATES:
+                body = template.format(r=resource)
+                got = mod.scan_prose(an_issue(body=body), None, "us")
+                if got["closure_requested"]:
+                    leaks.append(body)
+        assert leaks == []
+
+    def test_every_closure_pattern_carries_a_guard_or_is_declared(self, mod):
+        """A ratchet on the LIST, not on a behaviour.
+
+        A new closure phrase added without a guard is the exact mistake that
+        shipped six times. Each pattern must either embed one of the shared
+        guards or be declared item-scoped with a reason, so the omission fails
+        here instead of in review.
+        """
+        guards = (mod._STATE_END, mod._CLOSE_OBJECT, mod._ISSUE_OBJECT)
+        unguarded = [
+            pattern
+            for pattern in mod.CLOSURE_RES
+            if not any(guard in pattern for guard in guards)
+            and pattern not in mod.ITEM_SCOPED_CLOSURE_RES
+        ]
+        assert unguarded == []
+
+    def test_the_declared_set_does_not_drift_from_the_list(self, mod):
+        """A pattern declared item-scoped but no longer present would leave the
+        ratchet passing over a phrase nobody ships."""
+        assert mod.ITEM_SCOPED_CLOSURE_RES <= set(mod.CLOSURE_RES)
+
+
+class TestTechnicalProseIsNotClosure:
+    """The last two patterns without a guard, and the citation form that got
+    past the stripper."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "The temp file can be closed after the read",
+            "the workaround is no longer needed",
+            "that helper is no longer relevant",
+        ],
+    )
+    def test_prose_about_something_else_does_not_close(self, mod, body):
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "this can be closed",
+            "this is no longer needed",
+            "no longer an issue",
+            "no longer reproducible",
+        ],
+    )
+    def test_the_item_scoped_forms_still_close(self, mod, body):
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is True
+
+    @pytest.mark.parametrize("ticks", ["`", "``", "```` "])
+    def test_a_backtick_run_of_any_length_is_stripped(self, mod, ticks):
+        """Markdown pairs a closing run with the opening one. The single-backtick
+        pattern consumed each `` pair as an EMPTY span and left the quoted phrase
+        behind as prose, so citing the phrases this scanner looks for closed a
+        live item -- the same class as the quotation bug, in code delimiters."""
+        run = ticks.strip()
+        body = f"the script matches {run}this can be closed{run} in the body"
+        assert "this can be closed" not in mod.plain_prose(body)
+        got = mod.scan_prose(an_issue(body=body), None, "us")
+        assert got["closure_requested"] is False
+
+    def test_real_inline_code_is_still_stripped_not_kept(self, mod):
+        assert "dropped" not in mod.plain_prose("kept `dropped` kept")
+        assert "kept" in mod.plain_prose("kept `dropped` kept")
+
+
+class TestAPartialScanKeepsWhatItConfirmed:
+    def test_a_confirmed_open_pr_survives_a_later_detail_failure(self, mod, monkeypatch, capsys):
+        """A definite finding outranks a partial view, which the module's own
+        precedence already says. Discarding the confirmed hit turned a SKIP into
+        UNKNOWN over a later PR that could not have changed it."""
+        forge = Forge(
+            timeline=[a_xref(8100), a_xref(8101)],
+            pulls={8100: a_pull(8100)},
+            failures={"/pulls/8101": "API rate limit exceeded"},
+        )
+        assert run_main(mod, monkeypatch, forge) == 10
+        assert "open-pr=#8100" in capsys.readouterr().out
+
+    def test_the_merged_side_still_reads_unknown(self, mod, monkeypatch, capsys):
+        """The error is not swallowed, only kept off the answer it cannot
+        change: the merged check reports it, and rule 1 can still miss a CLOSE
+        this way, which costs an item left open rather than a false close."""
+        forge = Forge(
+            timeline=[a_xref(8100), a_xref(8101)],
+            pulls={8100: a_pull(8100)},
+            failures={"/pulls/8101": "API rate limit exceeded"},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--json"]) == 10
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["checks"]["merged_prs"] == {"error": "rate-limited"}
+        assert payload["checks"]["open_prs"][0]["number"] == 8100
+
+    def test_a_failure_before_anything_is_confirmed_is_still_unknown(
+        self, mod, monkeypatch, capsys
+    ):
+        forge = Forge(
+            timeline=[a_xref(8101)],
+            failures={"/pulls/8101": "API rate limit exceeded"},
+        )
+        assert run_main(mod, monkeypatch, forge) == 3
+
+    def test_the_fork_marker_survives_the_degraded_path(self, mod, monkeypatch, capsys):
+        """The loud suppression has to survive the half-finished scan.
+
+        Keeping a confirmed open PR through a later detail failure created this
+        gap: the annotation was gated on there being NO error, so the SKIP came
+        out as a routine low-risk one. The marker was therefore missing in
+        exactly the conditions that make a suppression hard to notice.
+        """
+        forge = Forge(
+            timeline=[a_xref(8100), a_xref(8101)],
+            pulls={8100: a_pull(8100, head="leozhad/KiroCrew", user="leozhad")},
+            failures={"/pulls/8101": "API rate limit exceeded"},
+        )
+        assert run_main(mod, monkeypatch, forge) == 10
+        out = capsys.readouterr().out.strip()
+        assert "untrusted-fork=true" in out
+        assert "risk=high" in out
+
+
+class TestUntrustedForkAnnotation:
+    """The suppression stays; its silence does not.
+
+    A fork PR needs no permission, so rule 2 is a channel anybody can use to
+    take an item out of the queue. Refusing to trust fork PRs would cost more
+    than the attack does -- most real coverage in a public repo IS a fork PR --
+    so the verdict is unchanged and the doubt is published instead.
+    """
+
+    def test_a_same_repo_pr_is_never_untrusted(self, mod):
+        prs = [{"number": 1, "is_cross_repository": False, "author_association": "NONE"}]
+        mod.annotate_untrusted_forks(prs, "reporter")
+        assert prs[0]["untrusted_fork"] is False
+
+    @pytest.mark.parametrize("association", ["OWNER", "MEMBER", "COLLABORATOR"])
+    def test_an_insider_fork_is_trusted(self, mod, association):
+        prs = [{"number": 2, "is_cross_repository": True, "author_association": association}]
+        mod.annotate_untrusted_forks(prs, "reporter")
+        assert prs[0]["untrusted_fork"] is False
+
+    @pytest.mark.parametrize("association", ["CONTRIBUTOR", "NONE", "FIRST_TIME_CONTRIBUTOR", ""])
+    def test_an_outsider_fork_is_untrusted(self, mod, association):
+        prs = [
+            {
+                "number": 3,
+                "is_cross_repository": True,
+                "author_association": association,
+                "author": "stranger",
+            }
+        ]
+        mod.annotate_untrusted_forks(prs, "reporter")
+        assert prs[0]["untrusted_fork"] is True
+
+    def test_the_reporters_own_fork_is_trusted(self, mod):
+        """Fixing your own bug from a fork is the ordinary case, not an attack."""
+        prs = [
+            {
+                "number": 4,
+                "is_cross_repository": True,
+                "author_association": "NONE",
+                "author": "reporter",
+            }
+        ]
+        mod.annotate_untrusted_forks(prs, "reporter")
+        assert prs[0]["untrusted_fork"] is False
+
+    def test_an_unknown_reporter_annotates_more_not_fewer(self, mod):
+        """When the item itself could not be read, nobody is known to be the
+        reporter -- so the fork is marked, and a marked SKIP only costs a look."""
+        prs = [
+            {
+                "number": 5,
+                "is_cross_repository": True,
+                "author_association": "NONE",
+                "author": "reporter",
+            }
+        ]
+        mod.annotate_untrusted_forks(prs, None)
+        assert prs[0]["untrusted_fork"] is True
+
+    def test_the_verdict_does_not_move(self, mod):
+        """The whole point: SKIP open-pr either way. If this ever reads CLAIM,
+        the duplicate-dispatch class this script was built from is back."""
+        for untrusted in (True, False):
+            checks = clean_checks(
+                open_prs=[
+                    {
+                        "number": 8100,
+                        "author": "stranger",
+                        "is_cross_repository": True,
+                        "untrusted_fork": untrusted,
+                    }
+                ]
+            )
+            name, reason, evidence = mod.verdict(checks)
+            assert (name, reason) == ("SKIP", "open-pr")
+            assert mod.EXIT_CODES[name] == 10
+            assert evidence["untrusted_fork"] is untrusted
+
+    def test_an_untrusted_fork_forces_high_risk_and_says_so(self, mod):
+        checks = clean_checks(
+            open_prs=[
+                {
+                    "number": 8100,
+                    "author": "stranger",
+                    "is_cross_repository": True,
+                    "untrusted_fork": True,
+                }
+            ]
+        )
+        assert mod.untrusted_fork_skip(checks) == 8100
+        assert mod.risk_of(checks) == "high"
+        name, reason, evidence = mod.verdict(checks)
+        assert mod.human_line(ITEM, name, reason, evidence, mod.risk_of(checks)) == (
+            f"SKIP {ITEM} open-pr=#8100 fork=true author=stranger untrusted-fork=true risk=high"
+        )
+
+    def test_a_routine_skip_carries_no_marker(self, mod):
+        """A marker on every SKIP is noise; this exists so the one that needs a
+        look does not read identically to the hundred that do not."""
+        checks = clean_checks(
+            open_prs=[
+                {
+                    "number": 8035,
+                    "author": "teammate",
+                    "is_cross_repository": False,
+                    "untrusted_fork": False,
+                }
+            ]
+        )
+        assert mod.untrusted_fork_skip(checks) is None
+        assert mod.risk_of(checks) == "low"
+        name, reason, evidence = mod.verdict(checks)
+        line = mod.human_line(ITEM, name, reason, evidence, mod.risk_of(checks))
+        assert line == f"SKIP {ITEM} open-pr=#8035 fork=false author=teammate"
+        assert "untrusted-fork" not in line
+
+    def test_the_marker_names_no_user_authored_text(self, mod):
+        """Same rule as everywhere else here: an association is a forge enum and
+        is used to DECIDE, but only metadata is printed."""
+        checks = clean_checks(
+            open_prs=[
+                {
+                    "number": 8100,
+                    "author": "stranger",
+                    "is_cross_repository": True,
+                    "author_association": "NONE",
+                    "untrusted_fork": True,
+                }
+            ]
+        )
+        name, reason, evidence = mod.verdict(checks)
+        assert "author_association" not in evidence
+        assert "NONE" not in mod.human_line(ITEM, name, reason, evidence, "high")
+
+
+class TestClosingReference:
+    """A merged PR is coverage only if it CLAIMS to close the item."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Fixes #8029",
+            "fixes #8029",
+            "Closes #8029",
+            "closed #8029",
+            "Resolves #8029",
+            "resolve #8029",
+            "Fixes: #8029",
+            "Fixes kirodotdev/KiroCrew#8029",
+            "Fixes https://github.com/kirodotdev/KiroCrew/issues/8029",
+            "some prose\n\nFixes #8029\n",
+        ],
+    )
+    def test_a_closing_keyword_is_recognised(self, mod, text):
+        assert mod.closing_reference_re(REPO, ITEM).search(text)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Related to #8029",
+            "See #8029",
+            "#8029",
+            "Fixes #8030",
+            "Refs #8029",
+            "part of the work for #8029",
+            "",
+        ],
+    )
+    def test_a_bare_mention_is_not_a_closing_keyword(self, mod, text):
+        assert not mod.closing_reference_re(REPO, ITEM).search(text)
+
+    def test_a_prefix_number_does_not_match(self, mod):
+        """`#802` must not satisfy a pattern aimed at `#8029`, and `#80291`
+        must not either."""
+        assert not mod.closing_reference_re(REPO, 802).search("Fixes #8029")
+        assert not mod.closing_reference_re(REPO, ITEM).search("Fixes #80291")
+
+    def test_negation_is_deliberately_invisible(self, mod):
+        """Matching GitHub's own parser, which closes the item regardless: this
+        script's reading and the forge's reading stay identical."""
+        assert mod.closing_reference_re(REPO, ITEM).search("This does not close #8029")
+
+
+class TestSymbolExtraction:
+    @pytest.mark.parametrize(
+        "token,expected",
+        [
+            ("_merge_notifications", True),
+            ("PER_FILE_MIN", True),
+            ("runProbe", True),
+            ("main", False),
+            ("true", False),
+            ("PR", False),
+        ],
+    )
+    def test_looks_like_symbol(self, mod, token, expected):
+        assert mod.looks_like_symbol(token) is expected
+
+    def test_named_symbols_takes_backticked_identifiers_in_order(self, mod):
+        text = (
+            "`_merge_notifications()` is gone, so `runProbe` and `main` and `_merge_notifications`"
+        )
+        assert mod.named_symbols(text) == ["_merge_notifications", "runProbe"]
+
+    def test_named_symbols_is_capped(self, mod):
+        text = " ".join(f"`sym_{index}`" for index in range(20))
+        assert len(mod.named_symbols(text, limit=3)) == 3
+        assert mod.named_symbols("") == []
+
+
+class TestRecency:
+    def test_fresh_item_from_an_active_contributor_is_high_risk(self, mod):
+        now = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        issue = an_issue(
+            created_at=(now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            author_association="CONTRIBUTOR",
+        )
+        got = mod.scan_recency(issue, now=now)
+        assert got == {"age_days": 1, "author_association": "CONTRIBUTOR", "risk": "high"}
+
+    def test_old_item_from_an_active_contributor_is_low_risk(self, mod):
+        now = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        issue = an_issue(created_at="2026-01-01T00:00:00Z", author_association="MEMBER")
+        assert mod.scan_recency(issue, now=now)["risk"] == "low"
+
+    def test_fresh_item_from_a_stranger_is_low_risk(self, mod):
+        now = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        issue = an_issue(
+            created_at=(now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            author_association="NONE",
+        )
+        assert mod.scan_recency(issue, now=now)["risk"] == "low"
+
+    def test_an_unparseable_timestamp_does_not_certify_low_risk(self, mod):
+        assert mod.scan_recency(an_issue(created_at="not a date"))["risk"] == "high"
+        assert mod.scan_recency(an_issue(created_at=None))["age_days"] is None
+
+    def test_a_naive_timestamp_is_read_as_utc(self, mod):
+        now = datetime(2026, 9, 3, tzinfo=timezone.utc)
+        assert (
+            mod.scan_recency(an_issue(created_at="2026-09-01T00:00:00"), now=now)["age_days"] == 2
+        )
+
+
+# --------------------------------------------------------------------------- #
+# the read-only guard — the no-write property, enforced not promised
+# --------------------------------------------------------------------------- #
+
+
+class TestNoWrites:
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["gh", "api", "repos/o/r/issues/1"],
+            ["gh", "api", "repos/o/r/issues/1/timeline", "--paginate"],
+            ["gh", "issue", "view", "1", "--repo", "o/r", "--json", "number"],
+            ["gh", "api", "user"],
+            ["gh", "api", "repos/o/r/pulls/2", "-X", "GET"],
+        ],
+    )
+    def test_reads_are_allowed(self, mod, argv):
+        assert mod.is_read_only(argv) is True
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["gh", "issue", "close", "1"],
+            ["gh", "issue", "edit", "1", "--add-label", "claimed"],
+            ["gh", "issue", "comment", "1", "--body", "mine"],
+            ["gh", "pr", "merge", "2"],
+            ["gh", "api", "repos/o/r/issues/1/labels", "-X", "POST"],
+            ["gh", "api", "repos/o/r/issues/1", "--method", "PATCH"],
+            ["gh", "api", "repos/o/r/issues/1", "--method=DELETE"],
+            ["gh", "api", "repos/o/r/issues/1/labels", "-f", "labels[]=claimed"],
+            ["gh", "api", "repos/o/r/issues/1", "--field", "state=closed"],
+            ["curl", "https://api.github.com"],
+            ["gh"],
+        ],
+    )
+    def test_writes_are_refused(self, mod, argv):
+        assert mod.is_read_only(argv) is False
+
+    def test_a_refused_argv_never_reaches_a_subprocess(self, mod, monkeypatch):
+        monkeypatch.setattr(
+            mod, "run", lambda *a, **k: pytest.fail("a refused argv reached subprocess")
+        )
+        rc, out, err = mod.run_gh(["gh", "issue", "close", "1"])
+        assert (rc, out) == (126, "")
+        assert "no writes" in err
+        assert mod.error_slug(rc, err) == "refused-write"
+
+    def test_the_script_source_contains_no_write_verb(self, mod):
+        """A source-level backstop for the guard: a future edit that adds a
+        write has to defeat both."""
+        source = SCRIPT.read_text(encoding="utf-8")
+        for forbidden in (
+            "issue close",
+            "issue edit",
+            "issue comment",
+            "pr merge",
+            "--add-label",
+            "--add-assignee",
+            "--remove-label",
+        ):
+            assert f'"{forbidden}"' not in source
+            assert f"'{forbidden}'" not in source
+
+    def test_a_full_run_issues_only_reads(self, mod, monkeypatch):
+        forge = Forge()
+        monkeypatch.setattr(mod, "run", forge)
+        assert mod.main(["--repo", REPO, "--item", str(ITEM)]) == 0
+        assert forge.calls, "the run made no calls at all"
+        for argv in forge.calls:
+            if argv[0] == "gh":
+                assert mod.is_read_only(argv), argv
+            else:
+                # git, and only ever read verbs on a clone we do not own.
+                assert argv[:2] == ["git", "-C"]
+                assert argv[3] in {"rev-parse", "merge-base", "grep"}, argv
+
+
+# --------------------------------------------------------------------------- #
+# end to end, over a stubbed forge
+# --------------------------------------------------------------------------- #
+
+
+def a_pull(
+    number: int,
+    *,
+    state: str = "open",
+    merged: bool = False,
+    sha: str | None = None,
+    head: str | None = REPO,
+    user: str = "someone",
+    draft: bool = False,
+    closes: int | None = ITEM,
+    association: str = "NONE",
+) -> dict:
+    """A pull payload. ``closes`` puts a closing keyword for that item in the
+    body (None for a bare mention), because a merged PR is coverage only if it
+    claims to close the item. ``association`` is the author's standing, which
+    decides whether a FORK PR's SKIP is marked unvouched."""
+    return {
+        "number": number,
+        "state": state,
+        "merged": merged,
+        "merge_commit_sha": sha,
+        "draft": draft,
+        "title": f"fix something in {number}",
+        "body": (f"Fixes #{closes}" if closes is not None else f"Related to #{ITEM}"),
+        "user": {"login": user},
+        "author_association": association,
+        "head": {"repo": {"full_name": head} if head else None},
+        "base": {"repo": {"full_name": REPO}},
+    }
+
+
+def a_xref(number: int, *, repo: str = REPO) -> dict:
+    return {
+        "event": "cross-referenced",
+        "source": {
+            "type": "issue",
+            "issue": {
+                "number": number,
+                "pull_request": {"url": f"https://api.github.com/repos/{repo}/pulls/{number}"},
+                "repository": {"full_name": repo},
+            },
+        },
+    }
+
+
+class Forge:
+    """A stand-in for the module's ``run``: routes an argv to canned output.
+
+    Records every call so a test can assert on what the script asked, including
+    that it never asked for a write.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeline: list | None = None,
+        pulls: dict | None = None,
+        issue: dict | None = None,
+        comments: list | None = None,
+        login: str = "us",
+        failures: dict | None = None,
+        git_rc: dict | None = None,
+    ):
+        self.timeline = timeline if timeline is not None else []
+        self.pulls = pulls or {}
+        self.issue = issue if issue is not None else an_issue()
+        self.comments = comments if comments is not None else []
+        self.login = login
+        self.failures = failures or {}
+        self.git_rc = git_rc or {}
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, cwd=None):
+        self.calls.append(list(argv))
+        if argv[0] == "git":
+            # ``rev-parse --git-dir`` is the --repo-dir validation and
+            # ``rev-parse --verify`` the default-branch check: two different
+            # questions, so a test can fail one without failing the other.
+            verb = "git-dir" if "--git-dir" in argv else argv[3]
+            return self.git_rc.get(verb, 0), "", ""
+        target = argv[2] if len(argv) > 2 else ""
+        for needle, slug in self.failures.items():
+            if needle in " ".join(argv):
+                return 1, "", slug
+        if "/timeline" in target:
+            return 0, json.dumps(self.timeline), ""
+        if "/pulls/" in target:
+            number = int(target.rsplit("/", 1)[1])
+            return 0, json.dumps(self.pulls[number]), ""
+        if "/comments" in target:
+            return 0, json.dumps(self.comments), ""
+        if target == "user":
+            return 0, json.dumps({"login": self.login}), ""
+        if target.startswith("repos/") and "/issues/" in target:
+            return 0, json.dumps(self.issue), ""
+        raise AssertionError(f"unrouted argv: {argv}")  # pragma: no cover
+
+
+def run_main(mod, monkeypatch, forge: Forge, extra: list[str] | None = None) -> int:
+    monkeypatch.setattr(mod, "run", forge)
+    return mod.main(["--repo", REPO, "--item", str(ITEM), *(extra or [])])
+
+
+class TestEndToEnd:
+    def test_clean_item_exits_zero_and_prints_the_claim_line(self, mod, monkeypatch, capsys):
+        fresh = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        forge = Forge(issue=an_issue(created_at=fresh, author_association="CONTRIBUTOR"))
+        assert run_main(mod, monkeypatch, forge) == 0
+        assert capsys.readouterr().out.strip() == f"CLAIM {ITEM} risk=high"
+
+    def test_a_merged_landed_pr_exits_eleven(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            timeline=[a_xref(7900)],
+            pulls={7900: a_pull(7900, state="closed", merged=True, sha="abc1234def567890")},
+            git_rc={"merge-base": 0},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 11
+        assert (
+            capsys.readouterr().out.strip()
+            == f"CLOSE {ITEM} merged-pr=#7900 sha=abc1234def landed=true"
+        )
+
+    def test_a_merged_pr_that_landed_elsewhere_still_claims(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            timeline=[a_xref(7901)],
+            pulls={7901: a_pull(7901, state="closed", merged=True, sha="deadbeefcafe")},
+            git_rc={"merge-base": 1},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 0
+        assert capsys.readouterr().out.strip().startswith(f"CLAIM {ITEM}")
+
+    def test_a_merged_pr_that_only_mentions_the_item_still_claims(self, mod, monkeypatch, capsys):
+        """End to end for the mention path: landed on the base, but the body
+        only says "Related to", so it is not coverage."""
+        forge = Forge(
+            timeline=[a_xref(7902)],
+            pulls={7902: a_pull(7902, state="closed", merged=True, sha="abc1234def", closes=None)},
+            git_rc={"merge-base": 0},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 0
+        assert capsys.readouterr().out.strip().startswith(f"CLAIM {ITEM}")
+
+    def test_an_unauthorized_claim_claims_at_high_risk(self, mod, monkeypatch, capsys):
+        """A SKIP any commenter can cast is a denial-of-work channel, so an
+        unauthorized claim annotates instead of parking."""
+        forge = Forge(
+            comments=[
+                a_comment(
+                    "I am claiming this issue",
+                    login="stranger",
+                    association="NONE",
+                    ident=555,
+                )
+            ]
+        )
+        assert run_main(mod, monkeypatch, forge) == 0
+        assert capsys.readouterr().out.strip() == f"CLAIM {ITEM} risk=high"
+
+    def test_an_insider_claim_still_skips(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            comments=[
+                a_comment("I am claiming this issue", login="boss", association="MEMBER", ident=556)
+            ]
+        )
+        assert run_main(mod, monkeypatch, forge) == 10
+        out = capsys.readouterr().out.strip()
+        assert out.startswith(f"SKIP {ITEM} prose-claim claimed-by=boss")
+
+    def test_a_buried_insider_claim_still_skips(self, mod, monkeypatch, capsys):
+        """End to end for the recovery, which is the half a unit test on the
+        selector cannot show: the newest comment is the passer-by's, so the
+        claim is found only because ownership gets its own lookup."""
+        claim = a_comment("I am claiming this issue", login="boss", association="MEMBER", ident=1)
+        claim["created_at"] = "2026-09-01T10:00:00Z"
+        later = a_comment("any update on this?", login="passerby", association="NONE", ident=2)
+        later["created_at"] = "2026-09-02T10:00:00Z"
+
+        assert run_main(mod, monkeypatch, Forge(comments=[claim, later])) == 10
+        assert (
+            capsys.readouterr().out.strip().startswith(f"SKIP {ITEM} prose-claim claimed-by=boss")
+        )
+
+    def test_a_buried_unauthorized_claim_does_not_skip(self, mod, monkeypatch, capsys):
+        """The recovery must not resurrect a veto anybody can cast."""
+        claim = a_comment("I am claiming this issue", login="drifter", association="NONE", ident=1)
+        claim["created_at"] = "2026-09-01T10:00:00Z"
+        later = a_comment("any update on this?", login="passerby", association="NONE", ident=2)
+        later["created_at"] = "2026-09-02T10:00:00Z"
+
+        assert run_main(mod, monkeypatch, Forge(comments=[claim, later])) == 0
+        assert capsys.readouterr().out.strip() == f"CLAIM {ITEM} risk=low"
+
+    def test_an_open_fork_pr_exits_ten(self, mod, monkeypatch, capsys):
+        """An outsider's fork PR still SKIPs -- and now says it is unvouched, so
+        the suppression reaches the conductor instead of only the queue."""
+        forge = Forge(
+            timeline=[a_xref(8100)],
+            pulls={8100: a_pull(8100, head="leozhad/KiroCrew", user="leozhad")},
+        )
+        assert run_main(mod, monkeypatch, forge) == 10
+        assert capsys.readouterr().out.strip() == (
+            f"SKIP {ITEM} open-pr=#8100 fork=true author=leozhad untrusted-fork=true risk=high"
+        )
+
+    def test_an_insiders_fork_pr_skips_quietly(self, mod, monkeypatch, capsys):
+        """A maintainer working from a fork is not a suppression risk, so the
+        marker stays off and the line is the routine one."""
+        forge = Forge(
+            timeline=[a_xref(8100)],
+            pulls={
+                8100: a_pull(8100, head="leozhad/KiroCrew", user="leozhad", association="MEMBER")
+            },
+        )
+        assert run_main(mod, monkeypatch, forge) == 10
+        out = capsys.readouterr().out.strip()
+        assert out == f"SKIP {ITEM} open-pr=#8100 fork=true author=leozhad"
+        assert "untrusted-fork" not in out
+
+    def test_a_deleted_head_repo_reads_as_a_fork(self, mod, monkeypatch, capsys):
+        forge = Forge(timeline=[a_xref(8101)], pulls={8101: a_pull(8101, head=None)})
+        assert run_main(mod, monkeypatch, forge) == 10
+        assert "fork=true" in capsys.readouterr().out
+
+    def test_a_closed_unmerged_pr_frees_the_item(self, mod, monkeypatch):
+        forge = Forge(
+            timeline=[a_xref(8102)], pulls={8102: a_pull(8102, state="closed", merged=False)}
+        )
+        assert run_main(mod, monkeypatch, forge) == 0
+
+    def test_a_reference_from_another_repository_is_not_coverage(self, mod, monkeypatch):
+        forge = Forge(timeline=[a_xref(5, repo="someone/else")], pulls={})
+        assert run_main(mod, monkeypatch, forge) == 0
+
+    def test_the_other_timeline_events_are_ignored(self, mod, monkeypatch):
+        """A real timeline is mostly not cross-references. Measured on one item
+        of this repo: 11 ``commented``, 7 ``labeled``, 2 ``referenced``, 5
+        ``cross-referenced`` — and one of those five pointed at an ISSUE, not a
+        PR. Every shape but the PR cross-reference must pass through untouched.
+        """
+        issue_to_issue = a_xref(4242)
+        issue_to_issue["source"]["issue"].pop("pull_request")
+        forge = Forge(
+            timeline=[
+                {"event": "commented", "body": "still broken"},
+                {"event": "labeled", "label": {"name": "bug"}},
+                {"event": "referenced", "commit_id": "abc"},
+                issue_to_issue,
+                {"event": "cross-referenced", "source": None},
+                {"event": "cross-referenced", "source": {"issue": "junk"}},
+                "not even a dict",
+                a_xref(8100),
+                a_xref(8100),  # the same PR twice: one detail call, not two
+            ],
+            pulls={8100: a_pull(8100, user="someone")},
+        )
+        assert run_main(mod, monkeypatch, forge) == 10
+        detail_calls = [c for c in forge.calls if len(c) > 2 and "/pulls/" in c[2]]
+        assert detail_calls == [["gh", "api", f"repos/{REPO}/pulls/8100"]]
+
+    def test_a_failure_detailing_one_pr_is_unknown(self, mod, monkeypatch, capsys):
+        """The reference exists but its fork-ness and merge commit are unknown:
+        a half-read coverage answer must not read as "no coverage"."""
+        forge = Forge(
+            timeline=[a_xref(8100)],
+            pulls={8100: a_pull(8100)},
+            failures={"/pulls/8100": "API rate limit exceeded"},
+        )
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert "check=open_prs reason=rate-limited" in capsys.readouterr().out
+
+    def test_unparseable_pr_detail_is_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(timeline=[a_xref(8100)], pulls={8100: ["not", "an", "object"]})
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert "reason=unparseable-json" in capsys.readouterr().out
+
+    def test_prose_claim_by_another_user_exits_ten(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            issue=an_issue(body="Ownership claimed by @otherdev", user={"login": "otherdev"}),
+            login="us",
+        )
+        assert run_main(mod, monkeypatch, forge) == 10
+        out = capsys.readouterr().out.strip()
+        assert out == f"SKIP {ITEM} prose-claim claimed-by=otherdev where=body"
+
+    def test_reporter_asked_close_in_the_last_comment_exits_eleven(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            comments=[
+                a_comment("automated triage summary", login="github-actions[bot]", kind="Bot"),
+                a_comment("happy to have this closed", ident=777),
+            ]
+        )
+        assert run_main(mod, monkeypatch, forge) == 11
+        assert (
+            capsys.readouterr().out.strip() == f"CLOSE {ITEM} reporter-asked-close comment-id=777"
+        )
+
+    def test_an_absent_symbol_on_a_labelled_bug_exits_ten(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            issue=an_issue(
+                body="`_merge_notifications` never fires.",
+                labels=[{"name": "bug"}],
+            ),
+            git_rc={"grep": 1},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 10
+        assert capsys.readouterr().out.strip() == f"SKIP {ITEM} symbol-absent=_merge_notifications"
+
+    def test_an_absent_symbol_on_an_unlabelled_item_claims_at_high_risk(
+        self, mod, monkeypatch, capsys
+    ):
+        """End to end for the item class the unconditional veto parked: nothing
+        corroborates bug-class, so it is dispatched and flagged, not parked."""
+        forge = Forge(
+            issue=an_issue(body="Please add `_merge_notifications` so the digest can batch."),
+            git_rc={"grep": 1},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 0
+        assert capsys.readouterr().out.strip() == f"CLAIM {ITEM} risk=high"
+
+    def test_an_issue_type_corroborates_bug_class_too(self, mod, monkeypatch):
+        forge = Forge(
+            issue=an_issue(
+                body="`_merge_notifications` never fires.",
+                type={"name": "Bug"},
+            ),
+            git_rc={"grep": 1},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 10
+
+    def test_a_present_symbol_claims(self, mod, monkeypatch):
+        forge = Forge(issue=an_issue(body="`_merge_notifications` misfires."), git_rc={"grep": 0})
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 0
+
+    def test_a_named_symbol_without_a_clone_is_unknown(self, mod, monkeypatch, capsys):
+        """The honest half of ``--repo-dir`` being optional: a question git alone
+        can answer, with no git, is UNKNOWN — not a guess in either direction."""
+        forge = Forge(issue=an_issue(body="`_merge_notifications` never fires."))
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert "check=symbol_on_base reason=no-repo-dir" in capsys.readouterr().out
+
+    def test_a_merged_pr_without_a_clone_is_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            timeline=[a_xref(7900)],
+            pulls={7900: a_pull(7900, state="closed", merged=True, sha="abc1234def")},
+        )
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert "check=merged_prs reason=no-repo-dir" in capsys.readouterr().out
+
+    def test_an_unresolvable_ancestry_is_unknown_not_did_not_land(self, mod, monkeypatch, capsys):
+        """A stale clone missing the merge commit must not read as "did not
+        land" — that reading is exactly how an already-fixed item was
+        dispatched."""
+        forge = Forge(
+            timeline=[a_xref(7900)],
+            pulls={7900: a_pull(7900, state="closed", merged=True, sha="abc1234def")},
+            git_rc={"merge-base": 128},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 3
+        assert "reason=ancestry-unknown" in capsys.readouterr().out
+
+    def test_a_merged_pr_with_no_merge_commit_is_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            timeline=[a_xref(7900)],
+            pulls={7900: a_pull(7900, state="closed", merged=True, sha=None)},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 3
+        assert "reason=no-merge-commit" in capsys.readouterr().out
+
+    def test_an_unknown_default_branch_is_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            timeline=[a_xref(7900)],
+            pulls={7900: a_pull(7900, state="closed", merged=True, sha="abc1234def")},
+            git_rc={"rev-parse": 1},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 3
+        assert "reason=unknown-default-branch" in capsys.readouterr().out
+
+    def test_a_failed_grep_is_unknown_not_an_absent_symbol(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            issue=an_issue(body="`_merge_notifications` never fires."), git_rc={"grep": 2}
+        )
+        assert run_main(mod, monkeypatch, forge, ["--repo-dir", "/clone"]) == 3
+        assert "reason=grep-failed" in capsys.readouterr().out
+
+    def test_a_rate_limited_timeline_is_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(failures={"/timeline": "API rate limit exceeded"})
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert (
+            capsys.readouterr().out.strip() == f"UNKNOWN {ITEM} check=open_prs reason=rate-limited"
+        )
+
+    def test_an_unreachable_issue_endpoint_is_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(failures={f"repos/{REPO}/issues/{ITEM}": "could not resolve host"})
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert "reason=forge-unreachable" in capsys.readouterr().out
+
+    def test_a_failed_comment_fetch_is_unknown_not_half_an_answer(self, mod, monkeypatch, capsys):
+        forge = Forge(failures={"/comments": "server error"})
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert "check=prose_claim" in capsys.readouterr().out
+
+    def test_the_dropped_check_costs_no_forge_call(self, mod, monkeypatch):
+        """The reason it was dropped: a call that cannot change the verdict is
+        pure cost against a shared rate limit. Assert the call is not made."""
+        forge = Forge()
+        assert run_main(mod, monkeypatch, forge) == 0
+        for argv in forge.calls:
+            assert "closedByPullRequestsReferences" not in " ".join(argv)
+            assert argv[:2] != ["gh", "issue"]
+
+    def test_too_many_references_is_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(timeline=[a_xref(n) for n in range(9000, 9000 + mod.MAX_PR_DETAILS + 1)])
+        assert run_main(mod, monkeypatch, forge) == 3
+        assert "reason=too-many-references" in capsys.readouterr().out
+
+    def test_unparseable_forge_output_is_unknown(self, mod, monkeypatch):
+        forge = Forge()
+
+        def broken(argv, cwd=None):
+            forge.calls.append(list(argv))
+            if "/timeline" in " ".join(argv):
+                return 0, "{not json", ""
+            return forge(argv, cwd)
+
+        monkeypatch.setattr(mod, "run", broken)
+        assert mod.main(["--repo", REPO, "--item", str(ITEM)]) == 3
+
+    def test_json_mode_prints_exactly_one_object(self, mod, monkeypatch, capsys):
+        forge = Forge(
+            timeline=[a_xref(8100)],
+            pulls={8100: a_pull(8100, head="leozhad/KiroCrew", user="leozhad")},
+        )
+        assert run_main(mod, monkeypatch, forge, ["--json"]) == 10
+        out = capsys.readouterr().out
+        payload = json.loads(out)  # one object, or this raises
+        assert out.strip().count("\n") == 0
+        assert payload["item"] == ITEM
+        assert payload["verdict"] == "SKIP"
+        assert payload["reason"] == "open-pr"
+        assert payload["risk"] in {"low", "high"}
+        assert set(payload["checks"]) == set(mod.CHECK_NAMES)
+        assert payload["evidence"] == {
+            "pr": 8100,
+            "fork": True,
+            "author": "leozhad",
+            "untrusted_fork": True,
+        }
+        # The machine form and the human form must agree about the doubt.
+        assert payload["risk"] == "high"
+
+    def test_json_mode_reports_the_five_checks_even_on_unknown(self, mod, monkeypatch, capsys):
+        forge = Forge(failures={"/timeline": "API rate limit exceeded"})
+        assert run_main(mod, monkeypatch, forge, ["--json"]) == 3
+        payload = json.loads(capsys.readouterr().out)
+        assert set(payload["checks"]) == set(mod.CHECK_NAMES)
+        assert payload["checks"]["open_prs"] == {"error": "rate-limited"}
+
+
+class TestArgumentHandling:
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--repo", "not-a-repo", "--item", "1"],
+            ["--repo", REPO, "--item", "0"],
+            ["--repo", REPO, "--item", "-3"],
+            ["--repo", REPO, "--item", "1", "--default-branch", "  "],
+        ],
+    )
+    def test_malformed_arguments_exit_two(self, mod, monkeypatch, argv, capsys):
+        monkeypatch.setattr(mod, "run", lambda *a, **k: pytest.fail("ran before validating"))
+        assert mod.main(argv) == 2
+        assert capsys.readouterr().err.strip().startswith("malformed")
+
+    def test_a_repo_dir_that_is_not_a_clone_exits_two(self, mod, monkeypatch, capsys):
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (128, "", "not a git repository"))
+        assert mod.main(["--repo", REPO, "--item", "1", "--repo-dir", "/nope"]) == 2
+        assert "not a git repository" in capsys.readouterr().err
+
+    def test_a_non_numeric_item_is_rejected_by_argparse(self, mod):
+        with pytest.raises(SystemExit) as excinfo:
+            mod.main(["--repo", REPO, "--item", "eight"])
+        assert excinfo.value.code == 2
+
+    def test_exit_codes_are_the_documented_ones(self, mod):
+        assert mod.EXIT_CODES == {"CLAIM": 0, "SKIP": 10, "CLOSE": 11, "UNKNOWN": 3}
+
+
+class TestForgeHelpers:
+    def test_run_reports_a_missing_binary_instead_of_raising(self, mod):
+        rc, out, err = mod.run(["definitely-not-a-real-binary-9f3a"])
+        assert rc == 127
+        assert out == ""
+        assert mod.error_slug(rc, err) == "gh-missing"
+
+    @pytest.mark.parametrize(
+        "rc,err,slug",
+        [
+            (1, "API rate limit exceeded for user", "rate-limited"),
+            (1, "HTTP 429 Too Many Requests", "rate-limited"),
+            (1, "gh auth login required", "not-authenticated"),
+            (1, "HTTP 404: Not Found", "not-found"),
+            (1, "dial tcp: lookup api.github.com", "forge-unreachable"),
+            (1, "context deadline exceeded: timed out", "forge-unreachable"),
+            (7, "something else entirely", "gh-error-rc7"),
+        ],
+    )
+    def test_error_slugs_never_echo_the_stderr(self, mod, rc, err, slug):
+        got = mod.error_slug(rc, err)
+        assert got == slug
+        assert " " not in got
+
+    def test_gh_json_parses_and_reports(self, mod, monkeypatch):
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (0, '{"a": 1}', ""))
+        assert mod.gh_json(["gh", "api", "user"]) == ({"a": 1}, None)
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (0, "", ""))
+        assert mod.gh_json(["gh", "api", "user"]) == (None, None)
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (0, "{", ""))
+        assert mod.gh_json(["gh", "api", "user"]) == (None, "unparseable-json")
+
+    def test_pagination_survives_either_output_shape(self, mod):
+        """`gh api --paginate` MERGES array pages into one document -- measured on
+        gh 2.96.0, a 4-page timeline came back as one array of 33. This pins that
+        path AND the concatenated-documents shape, because the script pins no gh
+        version and a page boundary must never turn a covered item into UNKNOWN.
+        """
+        merged = mod.parse_pages('[{"n": 1}, {"n": 2}, {"n": 3}]')
+        assert merged == [{"n": 1}, {"n": 2}, {"n": 3}]
+
+        concatenated = mod.parse_pages('[{"n": 1}, {"n": 2}]\n[{"n": 3}]\n')
+        assert concatenated == [{"n": 1}, {"n": 2}, {"n": 3}]
+
+        # A single object, and several of them, both survive.
+        assert mod.parse_pages('{"login": "us"}') == {"login": "us"}
+        assert mod.parse_pages('{"a": 1}\n{"b": 2}') == [{"a": 1}, {"b": 2}]
+        assert mod.parse_pages("null") is None
+
+    def test_a_torn_page_is_still_a_failed_answer(self, mod, monkeypatch):
+        """Tolerating page boundaries must not tolerate garbage: an unparseable
+        payload stays UNKNOWN rather than becoming an empty result."""
+        with pytest.raises(ValueError):
+            mod.parse_pages('[{"n": 1}] [{"n": 2}')
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (0, '[{"n": 1}] [{"n": 2}', ""))
+        assert mod.gh_json(["gh", "api", "x"]) == (None, "unparseable-json")
+
+    def test_a_multi_page_timeline_still_finds_its_references(self, mod, monkeypatch):
+        """End to end over the concatenated shape: the covering PR is found, so a
+        page boundary cannot produce a false CLAIM."""
+        pages = json.dumps([a_xref(8100)]) + "\n" + json.dumps([a_xref(8101)])
+        forge = Forge(
+            pulls={
+                8100: a_pull(8100, state="closed", merged=False),
+                8101: a_pull(8101, user="someone"),
+            }
+        )
+
+        def paged(argv, cwd=None):
+            forge.calls.append(list(argv))
+            if len(argv) > 2 and "/timeline" in argv[2]:
+                return 0, pages, ""
+            return forge(argv, cwd)
+
+        monkeypatch.setattr(mod, "run", paged)
+        assert mod.main(["--repo", REPO, "--item", str(ITEM)]) == 10
+
+    def test_whoami_degrades_to_none(self, mod, monkeypatch):
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (0, '{"login": "us"}', ""))
+        assert mod.whoami() == "us"
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (1, "", "boom"))
+        assert mod.whoami() is None
+        monkeypatch.setattr(mod, "run", lambda argv, cwd=None: (0, "[]", ""))
+        assert mod.whoami() is None
+
+
+class TestAgainstRealGit:
+    """The git flags, over a real repository.
+
+    Everything else stubs ``run``, which cannot catch a wrong flag: a bad
+    ``git grep`` invocation returns a non-zero code that the stub would never
+    produce, and ``--is-ancestor`` reversed would read every landed merge as
+    unlanded. One small real repo pins both.
+    """
+
+    @pytest.fixture
+    def clone(self, tmp_path):
+        root = tmp_path / "clone"
+        root.mkdir()
+
+        def run_git(*args):
+            rc, out, err = 0, "", ""
+            rc, out, err = _git(root, list(args))
+            assert rc == 0, f"git {args} failed: {err}"
+            return out
+
+        run_git("init", "--initial-branch=main", "-q")
+        run_git("config", "user.email", "preflight@example.invalid")
+        run_git("config", "user.name", "preflight")
+        (root / "landed.py").write_text("def _merge_notifications():\n    pass\n", encoding="utf-8")
+        run_git("add", "landed.py")
+        run_git("commit", "-q", "-m", "landed")
+        on_main = run_git("rev-parse", "HEAD")
+        run_git("checkout", "-q", "-b", "sidetrack")
+        (root / "elsewhere.py").write_text("SIDE = 1\n", encoding="utf-8")
+        run_git("add", "elsewhere.py")
+        run_git("commit", "-q", "-m", "elsewhere")
+        off_main = run_git("rev-parse", "HEAD")
+        run_git("checkout", "-q", "main")
+        return root, on_main, off_main
+
+    def test_ancestry_distinguishes_landed_from_elsewhere(self, mod, clone):
+        root, on_main, off_main = clone
+        merged = [
+            {"number": 1, "merge_commit_sha": on_main, "closes_item": True},
+            {"number": 2, "merge_commit_sha": off_main, "closes_item": True},
+        ]
+        assert mod.annotate_landed(merged, str(root), "main") is None
+        assert merged[0]["landed"] is True
+        assert merged[1]["landed"] is False
+
+    def test_a_commit_absent_from_the_clone_is_not_did_not_land(self, mod, clone):
+        root, _, _ = clone
+        merged = [{"number": 3, "merge_commit_sha": "0" * 40, "closes_item": True}]
+        assert mod.annotate_landed(merged, str(root), "main") == "ancestry-unknown"
+        assert "landed" not in merged[0]
+
+    def test_an_unknown_branch_is_reported(self, mod, clone):
+        root, on_main, _ = clone
+        merged = [{"number": 1, "merge_commit_sha": on_main, "closes_item": True}]
+        assert mod.annotate_landed(merged, str(root), "no-such-branch") == "unknown-default-branch"
+
+    def test_a_mention_only_merge_is_never_asked_about_ancestry(self, mod, clone):
+        """A merged PR that only MENTIONS the item cannot reach rule 1 whatever
+        its ancestry, so an unanswerable question about it must not turn the
+        whole check UNKNOWN. An error is for a question whose answer matters."""
+        root, _, _ = clone
+        mention = [{"number": 4, "merge_commit_sha": "0" * 40, "closes_item": False}]
+        assert mod.annotate_landed(mention, str(root), "main") is None
+        assert mod.annotate_landed(mention, None, "main") is None
+        assert mod.annotate_landed(mention, str(root), "no-such-branch") is None
+        assert "landed" not in mention[0]
+
+    def test_a_claiming_merge_alongside_a_mention_is_still_asked(self, mod, clone):
+        """The scoping must not become a way to skip the check that matters."""
+        root, on_main, _ = clone
+        merged = [
+            {"number": 4, "merge_commit_sha": "0" * 40, "closes_item": False},
+            {"number": 5, "merge_commit_sha": on_main, "closes_item": True},
+        ]
+        assert mod.annotate_landed(merged, str(root), "main") is None
+        assert merged[1]["landed"] is True
+        assert "landed" not in merged[0]
+
+    def test_no_merged_prs_needs_no_clone(self, mod):
+        assert mod.annotate_landed([], None, "main") is None
+
+    def test_git_grep_finds_a_symbol_on_the_branch_only(self, mod, clone):
+        root, _, _ = clone
+        got = mod.symbols_on_base(["_merge_notifications", "SIDE"], str(root), "main")
+        assert got["present"] == ["_merge_notifications"]
+        assert got["missing"] == ["SIDE"]
+        assert mod.symbols_on_base(["SIDE"], str(root), "sidetrack")["present"] == ["SIDE"]
+
+    def test_symbols_on_base_needs_no_clone_when_nothing_is_named(self, mod):
+        assert mod.symbols_on_base([], None, "main") == {
+            "symbols": [],
+            "present": [],
+            "missing": [],
+            "bug_class": False,
+            "bug_class_by": None,
+        }
+
+    def test_symbols_on_base_reports_an_unknown_branch(self, mod, clone):
+        root, _, _ = clone
+        got = mod.symbols_on_base(["SIDE"], str(root), "no-such-branch")
+        assert got["error"] == "unknown-default-branch"
+
+
+def _git(root: Path, args: list[str]):
+    """Run git against ``root``, contained two ways.
+
+    ``-C root`` already makes git run as if started there, so the operation
+    targets the fixture. ``cwd=root`` is belt and braces: it means a future
+    call site that forgets ``-C`` still cannot reach the checkout, which is
+    what the no-test-side-effects rule is protecting.
+    """
+    import subprocess
+
+    done = subprocess.run(
+        ["git", "-C", str(root), *args],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return done.returncode, (done.stdout or "").strip(), (done.stderr or "").strip()


### PR DESCRIPTION
## Problem / Motivation

The pipeline conductor decides whether to claim a work item with one question.
Its predicate is a single prose line in the skill body, `gh pr list --search`,
and an empty answer is read as permission to dispatch a worker. That predicate
is blind in three directions at once, and each blind spot has already cost a
whole dispatch to discover the work did not exist:

- **A merged PR is invisible.** An item already fixed was claimed and dispatched
  days later, with the reporter's own "happy to have it closed" sitting on the
  thread. An `--state open` query structurally cannot see a merged PR.
- **One field answered empty for items that had an open PR.** Four dispatches
  went to items that each carried `Fixes #N` on an OPEN PR, because the
  predicate read `closedByPullRequestsReferences`. That field still answers
  empty: measured on this repo just now, items 7597 and 8007 are both closed by
  merged PRs and both answer `[]`.
- **A claim written in prose is invisible.** Three items said "I am claiming
  this issue" / "Ownership claimed by @X" in the body, which no label or field
  query sees.

## Why it matters

A wrong claim is not a cheap mistake. It stands up a worker session, clones a
worktree, burns credits and an agent's whole context, and ends with the worker
discovering there was nothing to do -- or worse, opening a second PR against a
file another PR already owns. The three failures above are not three bugs; they
are one design defect appearing three times, and the defect is asking a single
question and treating silence as a yes.

## What changed

Motivation, then approach, then the change.

Goal: a claim decision that cannot be wrong in a way one more cheap question
would have prevented.

Approach: ask **all five** questions in one call and return **one** verdict, and
make an unanswerable question return UNKNOWN rather than fall through to CLAIM.
The alternative -- adding a second query to the existing prose predicate -- was
rejected because it fixes one blind spot and leaves the shape that produces
them: prose in a skill body cannot be tested, and the next missing question
costs another dispatch to find.

What was built: `claim_preflight.py`, one new script in the pipeline-conductor
skill.

```
python3 claim_preflight.py --repo owner/name --item N [--default-branch main]
                          [--repo-dir <clone of the base>] [--json]
```

The verdict rides the exit code, because that is what the conductor branches on:
`0` CLAIM, `10` SKIP, `11` CLOSE (triage debt), `3` UNKNOWN, `2` malformed
arguments. Human form is one line (`CLOSE 8088 merged-pr=#8092 sha=06065e5165
landed=true`); `--json` prints exactly one object carrying all five checks.

The five checks, and what each one is for:

1. `open_prs` -- open PRs referencing the item, **fork PRs included**, with
   author and `is_cross_repository` per hit.
2. `merged_prs` -- merged PRs, each annotated `landed` by
   `git merge-base --is-ancestor <mergeCommit> <default-branch>` and
   `closes_item` by a closing keyword aimed at this item. Both are load-bearing:
   a PR merged somewhere other than the branch a worker would start from is not
   coverage, and a PR that merely MENTIONS the item is not closure either.
3. `prose_claim` -- the body and the NEWEST human comment, for self-claim
   phrases and closure requests, both of which require standing (the reporter or
   a repository insider) for opposite reasons.
4. `symbol_on_base` -- every symbol the item names, by `git grep` on the default
   branch. Absence means the target code MAY live only on an unmerged branch --
   but that reading holds for a bug item, not for a feature request naming the
   symbol it proposes to add, so it vetoes only when the item's own metadata
   corroborates bug-class, and otherwise downgrades to `CLAIM risk=high`.
5. `recency` -- age and `authorAssociation`. A fresh item from an active
   contributor is a high self-claim risk, surfaced as `risk=high`, never a veto.
   The consumer is the skill: `risk=high` means the item is not batched -- it
   gets a live re-check immediately before the atomic claim.

`closedByPullRequestsReferences` is deliberately **not** a check. It measured
`[]` on two items that were closed by merged PRs, and a per-candidate forge call
that cannot change the verdict is pure cost against a shared rate limit. The
timeline answers the same question correctly, including for fork PRs.

Precedence is first-match-wins and lives in `verdict(checks)`, a pure function
of a dict: merged-and-landed gives CLOSE, an open PR gives SKIP, a closure
request gives CLOSE, a prose claim gives SKIP, an absent symbol on a
corroborated bug item gives SKIP, any errored check gives UNKNOWN, and otherwise
CLAIM. The error rule sits **below**
the positive findings on purpose: a definite answer to one question outranks a
partial view of another, and no error path can reach CLAIM.

Six properties worth naming, because they are where this kind of script usually
goes wrong. The last four are rules that measurement produced and reasoning did
not:

- **Unknown is not "no".** Three answers are possible for ancestry, and the
  third is not `False`. A merge commit missing from a stale clone reports
  UNKNOWN, never "did not land" -- reading it as "did not land" is precisely how
  the already-fixed item got dispatched. Same rule for a failed `git grep`: an
  unsearchable tree is not an absent symbol.
- **No writes, enforced rather than promised.** `run_gh` refuses any argv that
  is not on a read allowlist before a subprocess exists, so a mutating method,
  a `-f` field (which makes `gh api` a POST), or an `issue close` is rejected in
  process. A future edit that adds a write has to defeat the allowlist, the
  source-level test, and the test that inspects every argv of a full run.
- **The prose scan reads what an author SAYS, not what they QUOTE.** Code
  fences, backtick spans, blockquotes and quoted spans come out before matching.
  See Manual verification: the item specifying this script quotes the closure
  phrases as a description of what to detect, and a raw scan returned CLOSE on
  live work.
- **The newest human comment is chosen by timestamp, never by position.** The
  per-issue comments endpoint documents only `since`/`per_page`/`page`: it
  silently ignores `sort`/`direction` and answers oldest-first. Selecting by
  `max(created_at)` means an endpoint that changes its order cannot reintroduce
  the bug, which is stronger than flipping to the opposite assumption.
- **A merged PR is coverage only if it CLAIMS to close the item.** A closing
  keyword (`Closes #N`, `Fixes #N`, including the `owner/repo#N` and full-URL
  spellings) in the PR title or body, not a bare cross-reference. A mention
  decides nothing and falls through: reading it as coverage closes live work, and
  reading it as a claim starves an item whose fix was only partial. The match is
  deliberately negation-blind, matching GitHub's own parser, so this script's
  reading and the forge's reading stay identical.
- **Both prose phrase sets need standing, for opposite reasons.** A closure
  request produces CLOSE, which acts on live work, so "please close" from a
  passer-by must not fire it. A self-claim produces SKIP, and a veto any
  commenter can cast is a denial-of-work channel -- one comment would suppress a
  queued item indefinitely with nothing downstream reporting the suppression. So
  an unauthorized claim is neither obeyed nor discarded: it annotates `risk=high`
  and takes the live recheck. Standing is the item's own author (always true of
  the body) or an insider by `author_association`; CONTRIBUTOR alone is not
  authority over another person's report.
- **An open fork PR still SKIPs, but not silently.** Opening a fork PR needs no
  permission, so this check is a suppression channel anybody can use: mention an
  item from a throwaway fork and it leaves the queue. Refusing to trust fork PRs
  is the wrong trade -- 192 of this repository's 301 open PRs come from forks, so
  dropping them reinstates the duplicate-dispatch class this script was built
  from, repeatedly, to close a channel that costs an outsider one PR. The
  objection worth answering was never the DETECTION; it was a response that was
  unconditional AND silent. So the verdict does not move and the doubt is
  published with it: an unvouched fork's SKIP carries `untrusted-fork=true
  risk=high`. Standing is an insider association or the item's own reporter,
  since fixing your own bug from a fork is the ordinary case rather than an
  attack, and an unknown reporter marks MORE items rather than fewer.

  The annotation's consumer is the conductor's review of untrusted-fork
  suppressions, specified in the conductor's protocol now and landing in the
  skill in a follow-up. A printed annotation nothing acts on would be the same
  defect this PR removed elsewhere, so it is named rather than assumed.
- **An absent symbol vetoes only a corroborated bug item.** The evidence behind
  that check was bug items whose target span lives on an unmerged branch.
  Applied unconditionally it parks any feature request naming a symbol it
  proposes to add -- and parks it on every pass, not once, because the symbol
  stays absent. Corroboration is explicit metadata (a bug/defect/regression/
  crash label, or the issue type), never prose: guessing the class would put an
  unmeasured heuristic in front of the very veto that was over-applied. An
  uncorroborated item is dispatched at `risk=high` instead, which costs at most
  one dispatch against a park that costs the item.
- **Nothing user-authored reaches stdout.** Failures are reported as slugs, not
  forge stderr, and a prose match reports the *pattern* that fired, never the
  matched sentence. This output lands in an agent's context.

`--repo-dir` is optional in a precise sense: it is needed only for the two
questions git can answer, so an item with no merged PR and no named symbol never
needs a clone. When one of those questions does arise and there is no clone, the
answer is UNKNOWN rather than a guess in either direction.

## Tests

`test/test_pipeline_conductor_claim_preflight.py`, 203 tests, 99% line coverage
on the new file (the two uncovered lines are `sys.exit(main())` and one partial
branch). Every precedence branch has a test that **also asserts the old
single-question predicate would have said CLAIM** on the same item -- a test
that only checked the new answer would not notice the script regressing back
into the old blind spot.

- Verdict branches: merged-and-landed gives CLOSE `already-fixed`; merged but
  landed elsewhere falls through to CLAIM; an open fork PR gives SKIP `open-pr`;
  a prose self-claim by another user gives SKIP `prose-claim`; a closure request
  in the newest comment gives CLOSE `reporter-asked-close`; an absent symbol on
  a bug-labelled item gives SKIP `symbol-absent`; each of the five checks
  erroring gives UNKNOWN and exit 3; a clean item gives CLAIM with `risk=high`
  for a fresh item from an active contributor.
- The item class an unconditional symbol veto parked: an absent symbol with no
  bug-class metadata gives `CLAIM risk=high`, not SKIP, both as a verdict-level
  test and end to end. A bug LABEL and an issue TYPE each corroborate; seven
  bug-ish label spellings are accepted and five non-bug ones (`enhancement`,
  `feature request`, `documentation`, ...) are not; junk metadata degrades to
  "not corroborated" rather than raising.
- Precedence pins: landed-merged outranks an open PR; a closure request outranks
  a prose claim; a definite finding outranks an errored check. The dropped field
  is pinned as dropped: five check names, absent from the source, and no run
  issues that forge call.
- Comment selection: the newest human comment wins over an older one and over
  two bot comments, with the real thread's own timestamps; **reversing the input
  list does not change the answer**, which is what makes the fix order
  independent rather than the opposite assumption; position breaks ties only
  when a timestamp is absent.
- Standing: the reporter and an insider (MEMBER) can both request closure; a
  stranger with NONE and a drive-by with CONTRIBUTOR cannot. A self-claim needs
  no standing, because it produces SKIP, which is the cheap direction.
- Citations: a quoted closure phrase, one broken across a line break exactly as
  markdown hard-wrapped it in the real body, a fenced block, an inline code
  span, a blockquote and a curly-quoted span all fail to request closure, while
  the same sentences unquoted still do.
- Every exit code asserted explicitly (0/10/11/2/3), including malformed
  `--repo`, a non-positive `--item`, a blank `--default-branch`, and a
  `--repo-dir` that is not a clone.
- `--json` emits exactly one parseable object with all five checks present, on
  the UNKNOWN path too.
- No writes: the read allowlist accepts five real read shapes and rejects ten
  write shapes; a refused argv is proven never to reach a subprocess; the script
  source is scanned for write verbs; and a full run's every argv is asserted to
  be a read.
- Against real git (a two-branch repository built in `tmp_path`), because a
  stubbed `run` cannot catch a wrong flag: `--is-ancestor` distinguishes landed
  from merged-elsewhere, a commit absent from the clone reports
  `ancestry-unknown` rather than `landed: false`, and `git grep` finds a symbol
  on one branch and not the other.
- The forge shapes are fixtures taken from real responses on this repo, not
  invented: a timeline whose events are mostly `commented`, `labeled` and
  `referenced` with one cross-reference pointing at an issue rather than a PR,
  and a duplicated reference that must produce one detail call, not two.

## Manual verification

Ran against live items, which is what produced two of the rules above.

| item | verdict | what it proves |
|---|---|---|
| 8088 | `CLOSE 8088 merged-pr=#8092 sha=06065e5165 landed=true` | blind spot 1: a merged PR carrying `Closes #8088` that landed on the base, which an `--state open` query cannot see |
| 7597 | `SKIP 7597 open-pr=#8035 fork=false author=chenmingwei23` | the closing-keyword condition, on the item that exposed its absence -- see below |
| 8029 | `SKIP 8029 open-pr=#8035 fork=false author=chenmingwei23` | blind spot 2, detected through the timeline rather than the empty field |
| 8031 | `CLAIM 8031 risk=high` | the false-park class, on a real item: its only labels are `readiness: checking` and `fork`, so nothing corroborates bug-class. An unconditional symbol veto answered `SKIP symbol-absent=PARTIAL_TURN_MARKER` here |
| 8007 | `CLAIM 8007 risk=low` | the clean path |

**The fork marker on live data.** Items 6799 and 6509 answer
`SKIP open-pr=#8146 fork=true author=LuisBrel untrusted-fork=true risk=high` and
the equivalent for #8140 -- both first-time-contributor fork PRs, so the
suppression now arrives with its own doubt attached. Item 8071 is the control: it
is also behind an open fork PR (#8107) and is deliberately NOT marked, because
`catoneone` both reported 8071 and is fixing it from their fork. The verdict is
`SKIP open-pr` in all three cases -- the marker changes what the conductor is
told, never what the script decides.

**A merged PR that only mentions the item.** Item 7597 is why the
closing-keyword condition exists, and it caught a false CLOSE in this script's own
earlier behaviour. It has TWO landed merged PRs referencing it -- #7613, titled
`docs: investigation for #7597`, and #7313 -- and neither carries a closing
keyword. Without the condition the verdict was `CLOSE 7597 merged-pr=#7613
landed=true`, which would have closed an item still being fixed in open PR #8035.
With it, both are recorded `landed: true, closes_item: false` and decide nothing,
so the open PR is what produces the SKIP.

**Citations.** The first run of item 8029 returned `CLOSE ...
reporter-asked-close`, which was wrong: that item's body is this script's own
specification, so it quotes the closure phrases as a description of what to
detect. A false CLOSE closes work in flight, so the scanner now removes
citations before matching. The first version of that stripper still missed the
real body, because markdown hard-wrapped the quotation across a line break while
the phrase patterns matched across it; whitespace is now collapsed before the
span strip, so the stripper is exactly as newline-tolerant as the phrases it
defends.

**Comment ordering.** Measured directly against the endpoint: item 7597 has 12
comments, and `?per_page=1&sort=created&direction=desc` returned id 5492699917
at `2026-09-01T10:40:23Z` -- the OLDEST -- against a newest of id 5518670706 at
`2026-09-03T00:56:58Z`. The parameters are silently ignored. Re-verified after
the fix against the same live thread: the selector now returns 5518670706. A
reporter's later "please close" was previously unreachable by the check that
exists to find it.

**Pagination.** `gh api --paginate` on these array endpoints merges pages into a
single JSON document: measured on gh 2.96.0, the timeline of item 7597 at
`per_page=8` returned 4 pages as one parseable array of 33 events, and the
comments endpoint at `per_page=5` returned 3 pages as one array of 12. So a
paginated read stays a single parse and needs no `--slurp` -- which is in any
case rejected in combination with `--jq`.

Also verified locally on the rebased tree: `black`, `isort`, `flake8`, `mypy`,
the black gate, the agent-sdk-boundary gate, the builtin-skill-scope gate (this
script ships to every install, so it names no repository path), the testpaths
coverage gate, the loop-bound-locks gate, and
`test_spawn_audit.py::test_bundled_skill_assets_are_not_imported`.

## Related Issues

Refs #8029

## Any other suggestions

- **The script does not check whether the item is open.** Item 8007 is closed and
  answers CLAIM. That is correct against the contract -- the conductor feeds it
  candidates from an open-item query -- but the issue payload it already fetches
  carries `state`, so a seventh check is nearly free. I left it out rather than
  widen the verdict surface unilaterally while the skill documentation for these
  exit codes is being written in parallel.
- **The closure and self-claim phrase lists are English and hand-written.** They
  cover the phrasings actually observed. A phrasing outside them yields CLAIM,
  which is the cheap failure direction, but the lists will need to grow from real
  misses rather than from imagination.
- **The clone is read, never fetched.** Keeping `--repo-dir` current is the
  caller's job. A stale clone degrades to UNKNOWN rather than to a wrong answer,
  which is the right failure, but a conductor that never fetches will see UNKNOWN
  on every recently merged PR.
- **`recency` is annotation only.** It reports `risk=high` and nothing acts on it
  yet. It earns its place when something does -- the dispatch decision, or a
  pre-dispatch comment asking the author whether they are already on it.


