### PR TITLE
fix(skills): sync an installed builtin when only its scripts change

### DIFF
--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -1073,6 +1073,70 @@ def _claim_dir_for_replacement(dest_dir: Path) -> Path | None:
     return claim
 
 
+def _manifest_is_newer(src_file: Path, dest_file: Path) -> bool:
+    """Whether the packaged manifest is newer than the installed one.
+
+    Both stats are guarded because this runs on the gateway's startup path while
+    another process (the CLI syncing the same home) may be claiming the very
+    destination being measured. The two outcomes are deliberately different:
+
+    * an unreadable DESTINATION means it vanished or was claimed mid-sync, so
+      installing the packaged version is the correct answer -- update-due;
+    * an unreadable SOURCE means the package itself cannot be read, and there is
+      nothing to install from, so the destination is left alone.
+
+    Raising instead would abort the whole sync for every remaining skill, which
+    is what an unguarded ``stat`` did once the tree walks widened the window
+    between the destination check and this comparison.
+    """
+    try:
+        dest_mtime = dest_file.stat().st_mtime
+    except OSError:
+        return True
+    try:
+        return src_file.stat().st_mtime > dest_mtime
+    except OSError:
+        return False
+
+
+def _tree_newest_mtime(root: Path) -> float | None:
+    """Newest mtime of any regular file in *root*, or None when unprovable.
+
+    The update gate needs to know whether a PACKAGED skill changed at all, not
+    whether its ``SKILL.md`` did: a skill directory ships scripts, profiles and
+    references alongside the manifest, and those are the files that carry the
+    behaviour. Walking for the newest mtime is what makes a script-only release
+    visible to the gate.
+
+    The provenance marker is excluded for the same reason
+    ``_tree_entries`` excludes it: the sync writes it AFTER copying, so its
+    mtime is install time and would dominate every destination tree, making a
+    later package update read as older than the copy it should replace — the
+    gate would then never fire again.
+
+    Returns None when the tree cannot be measured: an unreadable entry, or more
+    entries than ``_FINGERPRINT_MAX_ENTRIES``. None is not a comparable value,
+    so the caller falls back to the manifest comparison rather than guessing.
+    """
+    newest: float | None = None
+    entries = 0
+    for rel, kind, _value in _tree_entries(root):
+        entries += 1
+        if entries > _FINGERPRINT_MAX_ENTRIES:
+            return None
+        if kind == "unreadable":
+            return None
+        if kind != "file":
+            continue
+        try:
+            mtime = os.lstat(root / rel).st_mtime
+        except OSError:
+            return None
+        if newest is None or mtime > newest:
+            newest = mtime
+    return newest
+
+
 def _tree_has_content(root: Path) -> bool:
     """True when the tree holds anything worth preserving.
 
@@ -1269,17 +1333,47 @@ def _ensure_builtin_skills(base: Path) -> None:
     ``_FINGERPRINT_MAX_BYTES`` / ``_FINGERPRINT_MAX_ENTRIES``.
     """
     source_names: set[str] = set()
+    supplied: set[str] = set()
     for src_root in (_project_skills_dir(), _BUILTIN_SKILLS_DIR):
         if not src_root or not src_root.exists():
             continue
         for name, src_file in _iter_skill_files(src_root):
             source_names.add(name)
+            # First source root to ship a name owns it for this run. Without
+            # this, the second root races the copy the first just made: the
+            # destination is no longer user data but this run's own output, and
+            # which tree ends up installed is decided by comparing mtimes
+            # across two unrelated source trees. The project dir is iterated
+            # first, so a project skill is no longer replaced by a packaged
+            # one that merely carries a newer file.
+            if name in supplied:
+                continue
+            supplied.add(name)
             src_dir = src_file.parent
             dest_dir = base / name
             dest_file = dest_dir / "SKILL.md"
-            update_due = (
-                not dest_file.exists() or src_file.stat().st_mtime > dest_file.stat().st_mtime
-            )
+            # The manifest's own mtime is not a proxy for the skill's: a
+            # release that only changes ``scripts/`` leaves ``SKILL.md``
+            # byte-identical with its packaged mtime, so a manifest-only
+            # comparison reports "up to date" and the installed skill keeps
+            # running superseded code indefinitely. Observed on prepare-pr,
+            # whose extractor was fixed in the package while every install
+            # kept the previous copy and failed against the current workflow.
+            #
+            # Both arms are kept, OR-ed: the tree arm adds the updates the
+            # manifest arm cannot see, and the manifest arm still governs when
+            # the tree is unmeasurable or when a locally edited destination
+            # carries an mtime newer than anything the package ships. Since
+            # ``copytree`` copies with ``copy2``, an unmodified install
+            # fingerprints mtime-equal to its package, so a steady state does
+            # not re-copy on every startup.
+            update_due = not dest_file.exists()
+            if not update_due:
+                src_newest = _tree_newest_mtime(src_dir)
+                dest_newest = _tree_newest_mtime(dest_dir)
+                update_due = (
+                    src_newest is not None and dest_newest is not None and src_newest > dest_newest
+                ) or _manifest_is_newer(src_file, dest_file)
             if not update_due:
                 # First-install migration adoption: an up-to-date destination
                 # with no marker is from a pre-provenance install. Record

--- a/test/test_builtin_skill_sync_safety.py
+++ b/test/test_builtin_skill_sync_safety.py
@@ -351,6 +351,144 @@ class TestLegitimateUpdatesStillHappen:
         assert not (user / _PROVENANCE_MARKER).exists()
         assert "USER own" in (user / "SKILL.md").read_text(encoding="utf-8")
 
+    def test_script_only_package_update_reaches_the_install(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The manifest is NOT a version stamp for the skill. A release that
+        # only touches a bundled script leaves SKILL.md byte-identical with its
+        # packaged mtime, and a manifest-only update gate then reports "up to
+        # date" forever -- the install keeps executing superseded code. Broke
+        # prepare-pr in practice: its extractor was fixed in the package while
+        # every install kept the previous copy and failed against CI's current
+        # workflow.
+        src = _make_skill(builtin_root, "helper", "v1", {"scripts/tool.py": "# v1"})
+        _ensure_builtin_skills(base)
+        assert (base / "helper" / "scripts" / "tool.py").read_text(encoding="utf-8") == "# v1"
+
+        script = src / "scripts" / "tool.py"
+        script.write_text("# v2", encoding="utf-8")
+        _bump_mtime(script)
+        manifest_mtime = (src / "SKILL.md").stat().st_mtime
+
+        _ensure_builtin_skills(base)
+
+        assert (base / "helper" / "scripts" / "tool.py").read_text(encoding="utf-8") == "# v2"
+        # The manifest genuinely never moved, so the update cannot have come
+        # from the manifest arm of the gate.
+        assert (src / "SKILL.md").stat().st_mtime == manifest_mtime
+        assert not os.path.lexists(base / ".helper.user-backup")
+
+    def test_provenance_marker_mtime_cannot_suppress_an_update(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # The marker is written AFTER the copy, so its mtime is install time.
+        # Counting it would make every destination newer than the package it
+        # came from and the tree arm would never fire again.
+        src = _make_skill(builtin_root, "helper", "v1", {"scripts/tool.py": "# v1"})
+        _ensure_builtin_skills(base)
+        _bump_mtime(base / "helper" / _PROVENANCE_MARKER, seconds=600.0)
+
+        script = src / "scripts" / "tool.py"
+        script.write_text("# v2", encoding="utf-8")
+        _bump_mtime(script)
+
+        _ensure_builtin_skills(base)
+
+        assert (base / "helper" / "scripts" / "tool.py").read_text(encoding="utf-8") == "# v2"
+
+    def test_unchanged_install_is_not_recopied_each_sync(
+        self, builtin_root: Path, base: Path
+    ) -> None:
+        # Widening the gate must not make a steady state churn: copytree copies
+        # with copy2, so an untouched install is mtime-equal to its package and
+        # nothing is due. A re-copy would rotate the retirement slot on every
+        # startup, quietly discarding the previous cycle's parked tree.
+        _make_skill(
+            builtin_root,
+            "helper",
+            "v1",
+            # A script NEWER than the manifest is the ordinary packaged shape,
+            # and the one that would loop if the tree arm compared the source's
+            # newest file against the destination's manifest.
+            {"scripts/tool.py": "# v1"},
+        )
+        _bump_mtime(builtin_root / "helper" / "scripts" / "tool.py")
+        _ensure_builtin_skills(base)
+
+        _ensure_builtin_skills(base)
+
+        assert not os.path.lexists(base / ".helper.superseded")
+
+    def test_first_source_root_owns_a_colliding_name(
+        self, builtin_root: Path, base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Two source roots shipping one name must not race each other's copy
+        # inside a single run. Once the project pass installs, the destination is
+        # this run's own output rather than user data, so letting the packaged
+        # pass replace it decides the winner by comparing mtimes across two
+        # unrelated trees -- and a project skill loses to a packaged one that
+        # merely carries a newer auxiliary file.
+        project = tmp_project = base.parent / "project-skills"
+        project.mkdir()
+        _make_skill(project, "helper", "PROJECT", {"scripts/tool.py": "# project"})
+        packaged = _make_skill(
+            builtin_root, "helper", "PACKAGED", {"scripts/tool.py": "# packaged"}
+        )
+        # Both the manifest arm and the tree arm would otherwise fire.
+        _bump_mtime(packaged / "SKILL.md")
+        _bump_mtime(packaged / "scripts" / "tool.py")
+        monkeypatch.setattr(skills_mod, "_project_skills_dir", lambda: tmp_project)
+
+        _ensure_builtin_skills(base)
+
+        installed = (base / "helper" / "SKILL.md").read_text(encoding="utf-8")
+        assert "PROJECT" in installed, installed
+        assert (
+            base / "helper" / "scripts" / "tool.py"
+        ).read_text(encoding="utf-8") == "# project"
+
+    def test_destination_vanishing_mid_sync_does_not_abort_the_run(
+        self, builtin_root: Path, base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The gateway and the CLI sync the same home concurrently, so the
+        # destination can be claimed between the exists() check and the manifest
+        # comparison -- a window the tree walks widened. An unguarded stat raises
+        # FileNotFoundError out of the startup sync, losing every skill queued
+        # behind it, so the vanished destination must read as update-due instead.
+        _make_skill(builtin_root, "aaa-helper", "v1")
+        _make_skill(builtin_root, "zzz-later", "v1")
+        _ensure_builtin_skills(base)
+
+        real_stat = Path.stat
+        vanished = base / "aaa-helper" / "SKILL.md"
+        seen = [0]
+
+        def _vanish(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+            # The FIRST stat of the destination is the sync's own exists()
+            # probe, which must succeed -- otherwise the manifest comparison is
+            # never reached and this test proves nothing. Every stat after it
+            # raises, which is the real race: the destination was claimed while
+            # the tree walks ran in between.
+            if self == vanished:
+                seen[0] += 1
+                if seen[0] > 1:
+                    raise FileNotFoundError(2, "No such file or directory", str(self))
+            return real_stat(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "stat", _vanish)
+        (builtin_root / "zzz-later" / "SKILL.md").write_text(
+            "---\nname: zzz-later\n---\nv2\n", encoding="utf-8"
+        )
+        _bump_mtime(builtin_root / "zzz-later" / "SKILL.md")
+
+        _ensure_builtin_skills(base)  # must not raise
+        monkeypatch.undo()
+
+        # The comparison past the exists() probe was actually reached.
+        assert seen[0] > 1, f"manifest comparison never stat'd the destination ({seen[0]})"
+        # The skill queued after the vanished one was still processed.
+        assert "v2" in (base / "zzz-later" / "SKILL.md").read_text(encoding="utf-8")
+
 
 class TestFingerprint:
     """The fingerprint covers the full tree, excludes only the marker, and can


### PR DESCRIPTION
## Problem

`_ensure_builtin_skills` decided whether a packaged builtin was newer than the installed copy by comparing `SKILL.md` mtimes and nothing else:

```python
update_due = (
    not dest_file.exists() or src_file.stat().st_mtime > dest_file.stat().st_mtime
)
```

A skill directory is not its manifest. It ships `scripts/`, `profiles/` and `references/`, and those are the files that carry the behaviour. A release that changes only a bundled script leaves `SKILL.md` byte-identical with its packaged mtime, so the gate reports "up to date" — and there is no path back to current, because `shutil.copytree` copies with `copy2`: the stale copy's manifest mtime equals the package's forever.

### How it surfaced

`kirocrew-dev/prepare-pr`'s `local_review.py` extractor was repointed at the current `codex-review.yml` shape in 76e4c0376 (#7719), which split the discovery and falsification passes into separate `run:` blocks and taught `_run_block_with` to look inside `cat`-spliced prompt files. `SKILL.md` was untouched by that commit, so no install ever received it.

The observed state on this machine — manifest identical, script stale:

| file | packaged mtime | installed mtime | bytes equal |
| --- | --- | --- | --- |
| `SKILL.md` | 1788190328 | 1788190328 | yes |
| `scripts/local_review.py` | 1788365329 | 1788111003 | **no** |
| `scripts/pr_status.py` | 1788190328 | 1788190328 | yes |

The consequence is not a cosmetic version lag. The stale extractor calls `_run_block_with(scalars, needle, contract)` with the pre-split signature and cannot find `FALSIFICATION PASS` in any `run:` block, because today's workflow keeps that instruction in `.github/review-prompts/gpt-falsification-mandate.md` and only `cat`s it. It exits 40 (PARITY FAILURE), so prepare-pr's Phase-2 local AI-review gate refuses to emit a brief and every run falls back to hand-written charters that may not match what CI enforces. Running the **packaged** copy of the same script against the same worktree assembles both briefs cleanly, which is what identified the sync rather than the extractor as the defect.

## Fix

The gate additionally compares the newest file mtime across the whole packaged tree against the destination's. Both arms are OR-ed, so this only ever *adds* updates:

- the manifest arm still governs when either tree is unmeasurable (unreadable entry, or more entries than `_FINGERPRINT_MAX_ENTRIES`), and when a locally edited destination carries an mtime newer than anything the package ships;
- the tree arm adds the updates the manifest arm structurally cannot see.

The provenance marker is excluded from the walk for the same reason `_tree_entries` excludes it: it is written *after* the copy, so its mtime is install time. Counting it would make every destination newer than the package it came from and the new arm would never fire again.

**Destruction is unchanged.** A diverged or user-edited destination is still claimed, verified against the packaged fingerprint, and quarantined to `.<name>.user-backup` rather than replaced in place. The only behaviour change is which destinations are *considered* for update.

### Two consequences of the widened comparison, closed here

Both are reachable from this change rather than pre-existing risks left for a follow-up, so they are fixed in the same commit.

**The first source root to ship a name now owns it for the run.** Two roots are iterated — the project dir (`$KIROCREW_PROJECT_DIR/skills/`), then the packaged tree. Once the first has copied, the destination is this run's own output rather than user data, so letting the second root replace it decides the winner by comparing mtimes across two unrelated source trees. Verified against the pre-fix code, which already had this hole in its manifest arm:

| scenario | pre-fix winner | with tree arm, no ownership rule | now |
| --- | --- | --- | --- |
| nothing bumped | project | project | project |
| packaged **manifest** newer | **packaged** | packaged | project |
| packaged **script** newer only | project | **packaged** | project |

There are no colliding names between the two roots in the tree today (11 project skills, 26 packaged, zero overlap), so this changes no shipped install.

**The manifest comparison no longer stats the destination unguarded.** The gateway and the CLI sync the same home concurrently, and the two tree walks widened the window between the `exists()` check and the comparison. A destination claimed in between raised `FileNotFoundError` out of `_ensure_builtin_skills`, which runs on the gateway's startup thread — losing every skill queued behind it. An unreadable destination now reads as update-due (installing the packaged version is correct); an unreadable *source* leaves the destination alone, because there is nothing to install from.

## Scope decision

I did not switch the gate to a content comparison, which would be the airtight answer. It costs a full-tree hash of every installed skill on every startup, and this path already has a deliberately bounded cost model (marker read in the steady state, stat-level walk on divergence, hashing only for trees whose stat manifest already matches). An mtime walk keeps the same cost class and closes the reported defect. If mtime granularity ever proves insufficient, the fingerprint machinery to do it properly is already in the file.

## Verification

Five regression tests in `test/test_builtin_skill_sync_safety.py`, each pinning a distinct wrong shape rather than restating the fix:

1. `test_script_only_package_update_reaches_the_install` — a script-only package update reaches the install, and asserts the manifest mtime never moved, so the update cannot have come from the manifest arm.
2. `test_provenance_marker_mtime_cannot_suppress_an_update` — a future-dated marker on the destination does not suppress a real update.
3. `test_unchanged_install_is_not_recopied_each_sync` — an untouched install is not re-copied. This is the guard against the naive tree arm (source's newest file vs the destination's *manifest*), which detects the update but rotates the retirement slot on every startup for any package whose newest file is not `SKILL.md` — the ordinary shape.
4. `test_first_source_root_owns_a_colliding_name` — a name shipped by both roots keeps the first root's copy even when the second's manifest *and* script are both newer.
5. `test_destination_vanishing_mid_sync_does_not_abort_the_run` — the run survives a destination claimed mid-sync, and the skill queued behind it is still processed.

Test 5 was vacuous on its first draft and the revert-verify is what caught it: `Path.exists()` routes through `Path.stat`, so a stub that raised on every call short-circuited at the `exists()` probe and never reached the comparison under test. It now fails only *after* the first stat and asserts the comparison was actually reached, so it cannot go vacuous again if `exists()` stops using `Path.stat`.

Revert-verified, four mutations:

| mutation | tests that failed |
| --- | --- |
| manifest-only gate restored verbatim (pre-fix code) | 1, 2 |
| provenance marker counted in the mtime walk | 2 |
| naive arm: source newest vs destination manifest | 3 |
| first-root ownership removed | 4 |
| manifest stat left unguarded (pre-fix form) | 5 |

Fix restored, all five pass. Each test is load-bearing and no two are redundant.

End-to-end on the real trees: copying the actual stale `prepare-pr` install into a temp base and running the fixed sync against the packaged source replaces `scripts/local_review.py` with the packaged bytes (69607 → 70920), through the quarantine path as designed.

Gates on the rebased head: black gate, `check_brand_name`, `check_focus_cue`, `check_changelog_history`, `check_harness_parity`, `check_builtin_skill_scope`, `check_sync_io_in_async`, `check_loop_bound_locks`, `check_feature_map`, `docs-lint` all pass with base refs exported; `isort`, `flake8`, `mypy` clean on both touched files; 531 passed / 2 skipped across `test_builtin_skill_sync_safety.py`, `test_skills.py`, `test_builtin_skill_packaging.py`, `test_app_bridges.py`, `test_skill_trust_store.py`.

## Pattern harvest

Rule candidate: semgrep
Pattern: freshness comparison between a directory pair that reads the mtime of one designated file inside each, rather than the newest mtime in the tree — a manifest is not a version stamp for the directory that contains it.

The same shape would also be a defect in any other "is the source newer than the copy" check over a multi-file unit: a lockfile against a package tree, a schema file against a migrations directory. The concrete variant to detect is a `stat().st_mtime` comparison whose two operands are a fixed filename joined onto two different roots, used to gate a whole-directory copy.

## Not in scope

`monitor_start` failing to arm on this backend is a separate defect in the dashboard chat runner's directive application, not a skill or sync problem. Untouched here.
