### PR TITLE
feat: rearm dead warm sessions mid-visit

### DIFF
--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -210,11 +210,21 @@ quietly drop the filesystem work the guard's coverage rests on without failing i
 gone rather than on a cause, which is what covers a process that went away by a route no expiry
 path anticipated. PR #5899 is a different cause and a different table: it owns
 **Disconnect-driven grant revocation**, and the two meet only where a revoke should re-warm.
-**Proactive refresh** attaches to `_warm_mint_reaper`, which now exists. The dependent
-resilience slice remains deliberately absent: a mid-visit supervisor must detect a shared
-session that dies after the page's initial warm and re-arm a replacement activation without a
-Connect click. This slice only re-drains a session that is still live; it neither supervises nor
-re-arms one.
+
+**Mid-visit resilience** is owned by the reaper and the runtime it already supervises. Every
+explicit page premint arms one automatic replacement. When that generation dies, the reaper
+reserves a single-flight task and reuses the ordinary `mintable_providers` scan plus
+`warm_mint_all`, so the replacement covers only providers whose grant absence is confirmed by
+the existing tri-state eligibility check. A present grant and an unreadable grant cache are both
+skipped. The replacement call does not re-arm the budget, so a second death cannot form a
+restart loop; another explicit page premint is the only thing that grants a fresh attempt.
+Concurrent observers receive the same task, while a generation mismatch, a live replacement, or
+an explicit warm already holding the lifecycle lock suppresses duplicate work. Hard shutdown
+disarms recovery, cancels and settles an in-flight task, then retires the process. This is all
+internal lifecycle state -- the card and status APIs expose no provider-level warming status.
+
+**Proactive refresh** remains deferred and attaches to `_warm_mint_reaper` independently of the
+death-only replacement.
 
 Three residuals the lifecycle slice was required to close, and did:
 

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -107,6 +107,12 @@ warms is :func:`adopt_shared_mint`, which ``POST /api/connections/mint`` tries B
 a row of its own -- without it that endpoint's ``reserve_mint_row`` popped the shared row and
 disposed the very URL the click had been warmed for. A table miss re-drains the newest live
 shared session that activated the provider and retries adoption before the dedicated cold path.
+
+RESILIENCE is lifecycle-owned by the same reaper that detects process death. An explicit page
+warm arms ONE automatic replacement. The dead generation reserves one single-flight re-arm task,
+which reuses the ordinary tri-state candidate scan and ``warm_mint_all`` path without granting
+itself another attempt. Concurrent observers share that task; deliberate shutdown disarms and
+cancels it before retiring the process. No provider-level recovery state crosses the API.
 Proactive refresh attaches in :func:`_warm_mint_reaper` when its dependent slice lands.
 
 TWO AXES, and conflating them is what the handoff had to separate. ``shared`` is OWNERSHIP: an
@@ -131,6 +137,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew import agent as _agent
+from kiro_crew import hooks
 from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.agent_files import AGENT_FILENAME
 from kiro_crew.config.loader import data_home
@@ -196,6 +203,9 @@ _WARM_IDLE_GRACE_SECONDS = _MINT_TTL_SECONDS / 10
 #: One respawn, then the cold path -- a second death means the process cannot stay
 #: up, and a Connect is better served by its own dedicated spawn.
 _WARM_ACTIVATION_ATTEMPTS = 2
+#: One automatic replacement per explicit page warm. The replacement does not re-arm this
+#: budget, so a repeatedly dying process cannot turn the reaper into a restart loop.
+_WARM_REARM_ATTEMPTS = 1
 #: Generation key for a process that never became ``self._runtime`` -- an abandoned spawn,
 #: which owns no rows. NEGATIVE because generations only ever increment from zero, so no row
 #: can carry it: ``_generation_holds_live_rows`` reads it as needed by nobody, and the sweep
@@ -401,9 +411,26 @@ def _current_warm_redrain_entry(slug: str) -> dict[str, Any] | None:
     return _warm_spec_plan([provider]).entries.get(mcp_server_alias(slug))
 
 
+_GRANT_PRESENCE_READ_ID = "connections_premint.oauth_grant_presence"
+
+
 def mintable_providers() -> list[Provider]:
     """Providers an activation should warm right now, registry order."""
     return _warm_candidate_scan()[1]
+
+
+def _audited_mintable_providers() -> tuple[list[Provider], bool]:
+    """Return candidates and whether their acted-on grant scan was SEL-audited.
+
+    The explicit page warm and its one automatic replacement are one page-owned
+    lifecycle, so both use the premint read id. An empty scan drives no action and
+    therefore owes no event.
+    """
+    candidates = mintable_providers()
+    if not candidates:
+        return candidates, True
+    recorded = hooks.emit_internal_read_audit(_GRANT_PRESENCE_READ_ID, "success")
+    return candidates, recorded
 
 
 def _wanted_aliases(providers: list[Provider]) -> frozenset[str]:
@@ -855,6 +882,14 @@ class _WarmMintRuntime:
         self._activation_seq = 0
         self._lock = asyncio.Lock()
         self._reaper: Any = None
+        #: Armed only by an explicit page warm. A replacement inherits the lifecycle but not
+        #: another attempt, which bounds unattended recovery to one process per page request.
+        self._supervision_armed = False
+        self._rearms_remaining = 0
+        #: Strong reference and single-flight identity for a replacement activation. The
+        #: reaper can cancel itself while the child replaces its dead generation, so the task
+        #: cannot be owned only by the awaiting reaper.
+        self._rearm_task: asyncio.Task[list[str]] | None = None
 
     def is_alive(self) -> bool:
         return _runtime_alive(self._runtime)
@@ -892,6 +927,58 @@ class _WarmMintRuntime:
         current process is gone and no new mint will sweep them.
         """
         return len(self._retiring)
+
+    def arm_supervision(self) -> None:
+        """Allow one automatic replacement for the current explicit page warm."""
+        self._supervision_armed = True
+        self._rearms_remaining = _WARM_REARM_ATTEMPTS
+
+    def start_rearm(self, generation: int) -> asyncio.Task[list[str]] | None:
+        """Return the one replacement task for ``generation``, or decline recovery.
+
+        The state transition is synchronous, so concurrent observers on the event loop either
+        receive the same task or see the budget already consumed. A generation mismatch means
+        another path already replaced the dead process; a held runtime lock means an explicit
+        warm is already deciding the replacement and must not be followed by a second session.
+        """
+        task = self._rearm_task
+        if task is not None and not task.done():
+            return task
+        if task is not None:
+            self._rearm_task = None
+        if (
+            not self._supervision_armed
+            or self._rearms_remaining <= 0
+            or generation != self._generation
+            or self.is_alive()
+            or self._lock.locked()
+        ):
+            return None
+        self._rearms_remaining -= 1
+        task = asyncio.get_running_loop().create_task(_rearm_dead_warm_mint(generation))
+        self._rearm_task = task
+        task.add_done_callback(self._finish_rearm)
+        return task
+
+    def _finish_rearm(self, task: asyncio.Task[list[str]]) -> None:
+        """Release the single-flight slot and surface an otherwise-unobserved failure."""
+        if self._rearm_task is task:
+            self._rearm_task = None
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.debug(
+                "warm mint automatic re-arm failed",
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    def _disarm_supervision(self) -> asyncio.Task[list[str]] | None:
+        """Prevent resurrection and detach the task shutdown must settle."""
+        self._supervision_armed = False
+        self._rearms_remaining = 0
+        task, self._rearm_task = self._rearm_task, None
+        return task
 
     async def settle_activation(self, activation: int, in_use: set[int]) -> None:
         """Mark ``activation`` absorbed, then collect the sessions nothing needs."""
@@ -1257,8 +1344,17 @@ class _WarmMintRuntime:
         return None
 
     async def shutdown(self) -> None:
-        async with self._lock:
-            await self._retire_locked()
+        """Disarm recovery, settle its task, then retire every owned process."""
+        rearm = self._disarm_supervision()
+        try:
+            if rearm is not None and rearm is not asyncio.current_task() and not rearm.done():
+                rearm.cancel()
+                # ``return_exceptions`` consumes the CHILD cancellation. Cancellation of this
+                # shutdown still raises from gather and reaches the hard teardown in finally.
+                await asyncio.gather(rearm, return_exceptions=True)
+        finally:
+            async with self._lock:
+                await self._retire_locked()
 
     async def sweep_retiring(self) -> None:
         """Kill parked generations nothing is waiting on any more."""
@@ -1565,6 +1661,37 @@ async def _drain_parked_generations() -> None:
         await _warm_mint.sweep_sessions(in_use)
 
 
+async def _rearm_dead_warm_mint(generation: int) -> list[str]:
+    """Re-warm the still-unconnected eligible roster after one process death.
+
+    Candidate selection reuses the ordinary tri-state grant scan: only a confirmed absence
+    initiates consent, while a present or unreadable grant is skipped. ``arm_supervision`` is
+    false so this replacement cannot recursively earn another automatic replacement.
+    """
+    try:
+        candidates, audit_recorded = await asyncio.to_thread(_audited_mintable_providers)
+    except Exception:  # noqa: BLE001 -- the cold path remains available to every Connect
+        logger.debug("warm mint re-arm candidate scan failed", exc_info=True)
+        return []
+    if not candidates:
+        logger.info(
+            "Shared mint generation %d died; no confirmed-unconnected providers need re-arm",
+            generation,
+        )
+        return []
+    if not audit_recorded:
+        logger.warning(
+            "grant-presence audit for the automatic re-arm scan could not be recorded; "
+            "proceeding unaudited"
+        )
+    logger.warning(
+        "Shared mint generation %d died; re-arming %d eligible provider(s)",
+        generation,
+        len(candidates),
+    )
+    return await warm_mint_all(candidates, arm_supervision=False)
+
+
 async def _warm_mint_reaper(generation: int) -> None:
     """Retire the shared process once no card is waiting on it.
 
@@ -1587,6 +1714,19 @@ async def _warm_mint_reaper(generation: int) -> None:
             await _warm_mint.sweep_sessions(in_use)
             if not _warm_mint.is_alive():
                 await _expire_shared_mints("mint_process_gone", generation=generation)
+                rearm = _warm_mint.start_rearm(generation)
+                if rearm is not None:
+                    # Shielded because replacing the dead generation cancels THIS reaper.
+                    # The runtime owns the strong reference, and the replacement must finish
+                    # even after the obsolete observer exits.
+                    try:
+                        await asyncio.shield(rearm)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:  # noqa: BLE001 -- the cold path remains the fallback
+                        logger.debug("warm mint automatic re-arm failed", exc_info=True)
+                    if _warm_mint.is_alive():
+                        return
                 await _drain_parked_generations()
                 return
             if _shared_mints_pending():
@@ -1898,7 +2038,9 @@ async def _recover_redrained_requests(result: _WarmMintResult) -> list[str]:
     return minted
 
 
-async def warm_mint_all(providers: list[Provider] | None = None) -> list[str]:
+async def warm_mint_all(
+    providers: list[Provider] | None = None, *, arm_supervision: bool = True
+) -> list[str]:
     """Warm every mintable provider's approval URL in ONE activation.
 
     Returns the slugs now holding a URL. Never raises for a mint failure -- that leaves the
@@ -1913,13 +2055,22 @@ async def warm_mint_all(providers: list[Provider] | None = None) -> list[str]:
 
     ``POST /api/connections/premint`` passes the candidates it scanned, so an explicit
     ``providers`` is the ordinary call shape; ``None`` re-scans for a caller that has no
-    list of its own.
+    list of its own. ``arm_supervision`` is false only for the automatic replacement: the
+    replacement inherits the page-owned lifecycle without recursively earning another retry.
     """
-    candidates = (
-        await asyncio.to_thread(mintable_providers) if providers is None else list(providers)
-    )
+    if providers is None:
+        candidates, audit_recorded = await asyncio.to_thread(_audited_mintable_providers)
+        if candidates and not audit_recorded:
+            logger.warning(
+                "grant-presence audit for the implicit warm scan could not be recorded; "
+                "proceeding unaudited"
+            )
+    else:
+        candidates = list(providers)
     if not candidates:
         return []
+    if arm_supervision:
+        _warm_mint.arm_supervision()
 
     claims, displaced = await _claim_shared_mints([provider["slug"] for provider in candidates])
     if not claims:

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -12,7 +12,6 @@ from urllib.parse import parse_qs, urlsplit
 
 from aiohttp import web
 
-from kiro_crew import hooks
 from kiro_crew.connections import get_provider
 from kiro_crew.connections.ownership import remove_provider_entry
 from kiro_crew.connections.registry import Provider
@@ -700,13 +699,13 @@ async def api_connections_premint(request: web.Request) -> web.Response:
     # scope then adds the ACP runtime and the MCP inventory on top -- the heaviest
     # half of Connections. test_the_handlers_package_does_not_import_the_warm_engine
     # enforces it in a subprocess; hoisting this to module scope turns that red.
-    from kiro_crew.connections.warm import mintable_providers, warm_mint_all
+    from kiro_crew.connections.warm import _audited_mintable_providers, warm_mint_all
 
     # Off the loop: the scan reads the user's MCP config and stats kiro-cli's OAuth
     # artifact directory, either of which can sit on a network mount where a stat is
     # unbounded. warm.py routes the same call through a thread for this reason and
     # pins it with a drift guard.
-    candidates = await asyncio.to_thread(mintable_providers)
+    candidates, audit_recorded = await asyncio.to_thread(_audited_mintable_providers)
     slugs = [str(provider["slug"]) for provider in candidates]
     if not slugs:
         # Nothing to warm: an activation with an empty claim set would spawn a
@@ -728,9 +727,7 @@ async def api_connections_premint(request: web.Request) -> web.Response:
     # opened, so no credential material crosses this boundary, and refusing to warm on
     # an SEL outage would make every Connect pay a cold spawn instead. An unaudited
     # boolean is the lesser failure, and it leaves a warning behind.
-    if not await asyncio.to_thread(
-        hooks.emit_internal_read_audit, _GRANT_PRESENCE_READ_ID, "success"
-    ):
+    if not audit_recorded:
         logger.warning(
             "grant-presence audit for the premint scan could not be recorded; "
             "proceeding unaudited"

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -62,18 +62,23 @@ def _clean_warm_runtime():
         "_sessions",
         "_activation_seq",
         "_reaper",
+        "_supervision_armed",
+        "_rearms_remaining",
+        "_rearm_task",
     )
     saved: dict[str, Any] = {name: getattr(warm._warm_mint, name) for name in tracked}
     saved["_retiring"] = list(saved["_retiring"])
     saved["_sessions"] = dict(saved["_sessions"])
     warm._warm_mint._lock = asyncio.Lock()
     yield
-    reaper = warm._warm_mint._reaper
-    if reaper is not None and reaper is not saved["_reaper"] and not reaper.done():
+    for task_name in ("_reaper", "_rearm_task"):
+        task = getattr(warm._warm_mint, task_name)
+        if task is None or task is saved[task_name] or task.done():
+            continue
         try:
             # Cancelled HERE, while the loop that owns it is still this test's. Cancelling it
             # from a later test's loop is the "Event loop is closed" face above, not the cure.
-            reaper.cancel()
+            task.cancel()
         except RuntimeError:
             # The loop is already gone; dropping the reference below is what matters.
             pass
@@ -247,6 +252,7 @@ def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
     fs_helpers = {name for name, hit in touches.items() if hit}
     # The known set, so a helper silently losing its filesystem work -- and with it
     # this guard's coverage -- is visible rather than a quietly weaker test.
+    # `_audited_mintable_providers` couples that filesystem scan to its SEL event.
     assert fs_helpers == {
         "_log_warm_event",
         "_disabled_provider_slugs",
@@ -255,6 +261,7 @@ def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
         "_warm_candidate_scan",
         "_current_warm_redrain_entry",
         "mintable_providers",
+        "_audited_mintable_providers",
         "_warm_spec_plan",
         "_warm_spec_is_foreign",
         "_unowned_plan_specs",
@@ -1290,6 +1297,193 @@ async def test_the_reaper_drains_parked_generations_after_the_current_process_di
     assert warm._warm_mint._sessions == {}, "its sessions own the loopback servers"
 
 
+# ── a dead shared process is re-armed once during the page-owned lifecycle ──
+
+
+@pytest.mark.asyncio
+async def test_the_reaper_rearms_a_dead_generation_once(monkeypatch: pytest.MonkeyPatch):
+    """The page already paid for warming, so a mid-visit death is replaced without a click."""
+    rearmed: list[int] = []
+
+    async def _record_rearm(generation: int) -> list[str]:
+        rearmed.append(generation)
+        return ["linear"]
+
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm, "_rearm_dead_warm_mint", _record_rearm)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 6)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    warm._warm_mint.arm_supervision()
+
+    await asyncio.wait_for(warm._warm_mint_reaper(6), timeout=5)
+
+    assert rearmed == [6]
+    assert warm._warm_mint._rearms_remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_reaper_audits_the_grant_scan_before_replacement_warm(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A page-owned re-arm acts on the same credential observation as premint."""
+    from kiro_crew import hooks
+
+    assert warm._GRANT_PRESENCE_READ_ID in hooks._AUDIT_ONLY_READ_IDS
+    provider = _provider("linear")
+    events: list[tuple[Any, ...]] = []
+
+    def _audit(read_id: str, outcome: str) -> bool:
+        events.append(("audit", read_id, outcome))
+        return True
+
+    async def _record_warm(
+        providers: list[Provider] | None = None, *, arm_supervision: bool = True
+    ) -> list[str]:
+        events.append(("warm", [item["slug"] for item in providers or []], arm_supervision))
+        warm._warm_mint._runtime = _Runtime(True)
+        return ["linear"]
+
+    monkeypatch.setattr(hooks, "emit_internal_read_audit", _audit)
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [provider])
+    monkeypatch.setattr(warm, "warm_mint_all", _record_warm)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 6)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    warm._warm_mint.arm_supervision()
+
+    await asyncio.wait_for(warm._warm_mint_reaper(6), timeout=5)
+
+    assert events == [
+        ("audit", "connections_premint.oauth_grant_presence", "success"),
+        ("warm", ["linear"], False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rearm_is_single_flight_and_cannot_form_a_restart_loop(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Concurrent observers share one replacement, and its death spends no hidden retry."""
+    gate = asyncio.Event()
+    calls: list[int] = []
+
+    async def _gated_rearm(generation: int) -> list[str]:
+        calls.append(generation)
+        await gate.wait()
+        return []
+
+    monkeypatch.setattr(warm, "_rearm_dead_warm_mint", _gated_rearm)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    warm._warm_mint.arm_supervision()
+
+    first = warm._warm_mint.start_rearm(3)
+    second = warm._warm_mint.start_rearm(3)
+
+    assert first is not None and second is first
+    await asyncio.sleep(0)
+    assert calls == [3]
+    gate.set()
+    await first
+    await asyncio.sleep(0)
+
+    assert warm._warm_mint.start_rearm(3) is None
+    assert calls == [3], "one automatic replacement must not recursively earn another"
+
+
+@pytest.mark.asyncio
+async def test_rearm_skips_connected_and_indeterminate_providers(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation: None
+):
+    """Recovery initiates consent only for a grant whose absence was confirmed."""
+    universe = [_provider("fresh"), _provider("granted"), _provider("unreadable")]
+    reads: list[str] = []
+
+    def _presence(url: str) -> bool | None:
+        reads.append(url)
+        if "unreadable" in url:
+            return None
+        return "granted" in url
+
+    monkeypatch.setattr(warm, "warm_spec_providers", lambda: universe)
+    monkeypatch.setattr(warm, "grant_present", _presence)
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result(
+                [universe[0]],
+                [{"serverName": "fresh", "oauthUrl": "https://fresh.example/consent"}],
+                generation=5,
+                activation=7,
+            )
+        ),
+    )
+    monkeypatch.setattr(warm._warm_mint, "_supervision_armed", True)
+    monkeypatch.setattr(warm._warm_mint, "_rearms_remaining", 0)
+
+    assert await warm._rearm_dead_warm_mint(4) == ["fresh"]
+
+    assert list(_mints) == ["fresh"]
+    assert _mints["fresh"]["state"] == "waiting"
+    assert _mints["fresh"]["generation"] == 5
+    assert warm._warm_mint._rearms_remaining == 0
+    assert sorted(reads) == sorted(provider["mcp_url"] for provider in universe)
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_page_warm_arms_one_replacement(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation: None
+):
+    monkeypatch.setattr(warm, "_warm_activate", _returns(None))
+
+    assert await warm.warm_mint_all([_provider("linear")]) == []
+    assert warm._warm_mint._supervision_armed is True
+    assert warm._warm_mint._rearms_remaining == warm._WARM_REARM_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_an_inflight_rearm_and_disarms_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _blocked_rearm(generation: int) -> list[str]:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def _kill(runtime: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(warm, "_rearm_dead_warm_mint", _blocked_rearm)
+    monkeypatch.setattr(warm, "_kill_quietly", _kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 8)
+    warm._warm_mint.arm_supervision()
+    task = warm._warm_mint.start_rearm(8)
+    assert task is not None
+    await started.wait()
+
+    await warm._warm_mint.shutdown()
+
+    assert cancelled.is_set()
+    assert task.cancelled()
+    assert warm._warm_mint._rearm_task is None
+    assert warm._warm_mint._supervision_armed is False
+    assert warm._warm_mint._rearms_remaining == 0
+    assert warm._warm_mint.start_rearm(8) is None
+
+
 @pytest.mark.asyncio
 async def test_a_failed_respawn_still_drains_the_generation_it_parked(
     monkeypatch: pytest.MonkeyPatch,
@@ -1780,6 +1974,7 @@ _MUST_BE_PROTECTED = [
     ),
     ("_ensure_locked", "_write_warm_mint_specs", warm._WarmMintRuntime._ensure_locked),
     ("_ensure_locked", "runtime.spawn()", warm._WarmMintRuntime._ensure_locked),
+    ("shutdown", "asyncio.gather(rearm", warm._WarmMintRuntime.shutdown),
     ("_sweep_retiring_locked", "_kill_generation", warm._WarmMintRuntime._sweep_retiring_locked),
     ("_park_or_kill_locked", "_kill_generation", warm._WarmMintRuntime._park_or_kill_locked),
     ("_retire_locked", "_kill_quietly", warm._WarmMintRuntime._retire_locked),


### PR DESCRIPTION
## Problem / Motivation

A Connections page visit pre-mints approval links through one shared warm helper. If that helper dies while the user remains on the page, every remaining card silently loses its pre-minted link; a later Connect then falls back to the roughly eight-second cold path.

## Why it matters

A transient helper death currently erases the latency benefit for the rest of the visit without any visible signal or automatic recovery. Users encounter an unexpectedly slow Connect even though the page already initiated warming.

## What changed (motivation → approach → change)

- Arm one automatic replacement whenever an explicit page warm starts.
- Let the existing reaper detect a dead shared generation and reserve one single-flight re-arm task, so concurrent observers share the same replacement.
- Reuse the existing tri-state eligibility scan: only confirmed-unconnected providers are warmed; connected providers and providers with unknown authorization state remain skipped.
- Couple every acted-on warm candidate scan to the existing registered premint grant-presence SEL event, so explicit warming and its automatic replacement share one audit invariant.
- Call the ordinary `warm_mint_all` path with supervision disabled for the replacement, preventing a second death from becoming a retry loop. A later explicit page warm is the only way to grant another attempt.
- Disarm recovery and cancel/settle an in-flight replacement during shutdown before retiring owned processes.
- Keep recovery observability internal through existing logs; this adds no customer-facing warm indicator or provider-level API state.
- Document the lifecycle ownership and one-shot recovery contract in the warm-table design note.

The replay preserves the merged late-request harvest behavior: collection remains progress-driven with a roster-scaled hard bound, and adoption-miss re-drain still validates the requested provider's current authorization shape and returns only that validated provider.

## Tests

- `python -m pytest -q test/test_connections_warm.py test/test_connections_handoff.py test/test_security_posture.py test/test_spawn_audit.py` — **207 passed**.
- Added coverage for one-shot dead-generation replacement, single-flight sharing, no recursive restart loop, tri-state eligibility reuse, grant-presence SEL ordering before replacement warm, explicit-warm arming, and shutdown cancellation/disarming.
- Extended the cancellation-protection audit for shutdown settlement and deliberately pinned the new shared audited-scan helper in the filesystem-hop contract.
- `isort --check-only src/kiro_crew test` — passed.
- `flake8 src/kiro_crew test` — passed.
- `python -m mypy src/kiro_crew` — passed (1,269 source files).
- `python3 scripts/check_black_formatting.py` — passed.
- `python3 scripts/check_subprocess_encoding.py` — passed.
- `bash scripts/scrub-lint.sh --no-history` — passed.
- `bash scripts/docs-lint.sh` — passed (257 Markdown files).

## Manual verification

N/A — deterministic unit tests simulate helper death, concurrent observers, eligibility states, and shutdown while the re-arm task is in flight; no UI surface changes.

<!-- no-visual-delta -->
No visual delta: the changed surfaces are the internal warm runtime/reaper, its tests, and the architecture design note; no customer-facing component or status field changes.

## Related Issues

N/A — follows the G1 warm-session resilience slice.

no linked issue: G1 bug-bash follow-up tracked in the pre-G2 program, no standalone issue

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
