### PR TITLE
fix(dashboard): redact known-path listings segment-wise so deep paths survive

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -3536,8 +3536,10 @@ def _project_git_branch(base: str) -> dict:
     # ``root`` is derived from an allow-listed project directory, but a directory
     # NAME is itself agent-influenceable via set_project and this value is echoed
     # to the dashboard, so it goes through the same egress redaction as the branch
-    # label. A normal path is unchanged.
-    out: dict = {"repo": True, "repoRoot": redact(root)}
+    # label. A normal path is unchanged. Path-aware (the caller proves ``root``
+    # is a filesystem path), matching the identical ``repoRoot`` display value in
+    # ``api_project_git_status`` — a deep slash-only root must render intact.
+    out: dict = {"repo": True, "repoRoot": _redact_path_display(root)}
     head_path = _git_head_path(root)
     if head_path is None:
         return out
@@ -3629,8 +3631,11 @@ async def api_project_git(request: web.Request) -> web.Response:
         # Redacted like every other echoed path: this arm is reachable whenever a
         # known project directory is deleted or replaced between the allow-list
         # match and the stat, so it is a live egress surface, not a dead branch.
+        # Path-aware (``base`` is an allow-listed project directory, same
+        # provenance as the ``repoRoot``/``root`` display values): a deep
+        # slash-only project path must render intact, not as a placeholder.
         return web.json_response(
-            {"error": "Not a directory", "path": redact(base)}, status=400
+            {"error": "Not a directory", "path": _redact_path_display(base)}, status=400
         )
     if status == "sensitive":
         _sel().log_api_access(
@@ -3646,7 +3651,8 @@ async def api_project_git(request: web.Request) -> web.Response:
     )
     # The SEL audit above records the real path; the response body is an egress
     # surface the dashboard renders, so the echoed path is redacted like the rest.
-    return web.json_response({"path": redact(base), **info})
+    # Path-aware for the same reason as the 400 arm above.
+    return web.json_response({"path": _redact_path_display(base), **info})
 
 
 async def api_browse_files(request: web.Request) -> web.Response:
@@ -4575,6 +4581,34 @@ def _repo_declares_filter_driver(git_cmd: list[str], base: str, env: dict) -> bo
     return False
 
 
+def _redact_path_display(path: str) -> str:
+    """Redact a value KNOWN to be a project-relative POSIX path, segment-wise.
+
+    ``redact()``'s bare-secret matcher treats ``/`` as a payload character
+    (it is in the base64 alphabet), so a deep path whose directory chain
+    carries no ``.``/``-``/``_`` chains into ONE candidate run; the
+    whole-run amplification in ``redact_credentials`` then replaces the
+    entire path with a single placeholder, collapsing genuinely different
+    files into byte-identical keys (#8042; the render crash this used to
+    cause was fixed by #7678, which left this matcher alone on purpose).
+
+    Here the caller PROVES the value is a path (git/walk-derived listing),
+    so a separator is a hard boundary: on the slow path each ``/``-separated
+    segment is redacted independently. A genuine >=40-char secret appearing
+    as a single segment still redacts; segments that are ordinary names
+    survive, so distinct paths keep distinct outputs. The general
+    ``redact()`` behaviour for unknown-provenance text is untouched.
+
+    Fast path: the overwhelmingly common case is a path ``redact()`` leaves
+    unchanged - return it after one call, so the listing endpoints do not
+    pay per-segment scanning on every entry.
+    """
+    red = redact(path)
+    if red == path:
+        return path
+    return "/".join(redact(segment) for segment in path.split("/"))
+
+
 async def api_project_git_status(request: web.Request) -> web.Response:
     """GET /api/project/git/status?path=... - working tree status for a project dir.
 
@@ -4778,8 +4812,14 @@ async def api_project_git_status(request: web.Request) -> web.Response:
     # so it goes through the same redaction as api_project_git. Normal values
     # pass through unchanged.
     if result.get("repoRoot"):
-        result["repoRoot"] = redact(result["repoRoot"])
+        result["repoRoot"] = _redact_path_display(result["repoRoot"])
     if result.get("branch"):
+        # Whole-string redact(), NOT the path helper: a branch NAME is
+        # free-form text, not a provable path — it can itself BE a
+        # slash-bearing 40-char secret, and segment-wise splitting would
+        # render it raw (GPT review finding on #8055). The provenance
+        # argument that justifies segment-wise treatment holds only for
+        # values the caller derived from the filesystem/git listing.
         result["branch"] = redact(result["branch"])
     # Redact each file path, then drop entries that duplicate an earlier one
     # (preserving order and first occurrence). Same collision class as
@@ -4801,7 +4841,7 @@ async def api_project_git_status(request: web.Request) -> web.Response:
     deduped_files: list[dict] = []
     seen_keys: set[tuple[str, str | None, bool | None]] = set()
     for f in result.get("files", []):
-        f["path"] = redact(f["path"])
+        f["path"] = _redact_path_display(f["path"])
         key = (f["path"], f.get("status"), f.get("staged"))
         if key in seen_keys:
             continue
@@ -4887,7 +4927,9 @@ async def api_project_tree(request: web.Request) -> web.Response:
         caller=caller, operation="project_tree", outcome="allowed", resources=base
     )
     if not await asyncio.to_thread(os.path.isdir, base):
-        return web.json_response({"root": redact(base), "paths": [], "repo": False})
+        return web.json_response(
+            {"root": _redact_path_display(base), "paths": [], "repo": False}
+        )
 
     def _run() -> dict:
         # git listing first: honors .gitignore, includes tracked-but-deleted
@@ -4944,7 +4986,7 @@ async def api_project_tree(request: web.Request) -> web.Response:
     result = await asyncio.to_thread(_run)
     # Egress redaction, same rationale as api_project_git_status: listed names
     # are repo content and this body is rendered by the dashboard.
-    result["root"] = redact(result["root"])
+    result["root"] = _redact_path_display(result["root"])
     # De-duplicate after redaction, preserving order and first occurrence.
     # redact() collapses each matched token to a fixed placeholder, so two
     # genuinely-different project-relative paths (e.g. a src/ vs target/ Maven
@@ -4953,7 +4995,7 @@ async def api_project_tree(request: web.Request) -> web.Response:
     # @pierre/trees, whose appendPresortedPaths throws "Duplicate path" on
     # adjacent identical entries. dict.fromkeys keeps first occurrence. This
     # does not affect "truncated": the cap is applied to the raw listing above.
-    result["paths"] = list(dict.fromkeys(redact(p) for p in result["paths"]))
+    result["paths"] = list(dict.fromkeys(_redact_path_display(p) for p in result["paths"]))
     return web.json_response(result)
 
 

--- a/test/test_project_tree.py
+++ b/test/test_project_tree.py
@@ -224,6 +224,68 @@ class TestProjectTree:
         assert "src/mod.py" in paths
 
     @pytest.mark.asyncio
+    async def test_deep_paths_are_not_collapsed_into_one_key(self, repo, mock_sel):
+        """#8042: a deep slash-only path must NOT be swallowed as one secret run.
+
+        ``redact()``'s bare-secret matcher has ``/`` in its payload class, so a
+        directory chain with no ``.``/``-``/``_`` scans as ONE >=40-char run and
+        the whole-run amplification replaces the entire path. Two genuinely
+        different vendored binaries then collapse to a byte-identical key and
+        the de-dup (above) silently drops the second file from the tree.
+        The path-aware listing endpoints now redact SEGMENT-WISE, so ordinary
+        path segments survive and distinct files stay distinct.
+        """
+        from kiro_crew.dashboard.handlers.files import _redact_path_display
+        from kiro_crew.platform import redact_via_context
+
+        deep = "Binaries/ThirdParty/OpenSSL/Win64/VS2015"
+        path_a = f"{deep}/libeay32.dll"
+        path_b = f"{deep}/ssleay32.dll"
+        # Premise check: the general matcher DOES mangle this shape (it is the
+        # #8042 mechanism). If this stops holding, the fixture no longer
+        # exercises the slow path and needs a deeper chain.
+        assert redact_via_context(path_a) != path_a
+        # The path-aware redactor keeps every ordinary segment.
+        assert _redact_path_display(path_a) == path_a
+        assert _redact_path_display(path_b) == path_b
+
+        d = repo / deep
+        d.mkdir(parents=True)
+        (d / "libeay32.dll").write_text("one\n")
+        (d / "ssleay32.dll").write_text("two\n")
+        async with TestClient(TestServer(_make_app(str(repo)))) as client:
+            resp = await client.get(f"/api/project/tree?path={repo}")
+            data = await resp.json()
+        paths = data["paths"]
+        assert path_a in paths
+        assert path_b in paths
+        assert len(paths) == len(set(paths))
+
+    def test_redact_path_display_still_redacts_a_secret_segment(self):
+        """Segment-wise redaction is not a coverage hole: a credential-shaped
+        SINGLE segment still redacts (the separator is a boundary, not an
+        exemption)."""
+        from kiro_crew.dashboard.handlers.files import _redact_path_display
+
+        # Documented example AWS id (Semgrep-allowlisted fixture value).
+        secret_path = "config/AKIAIOSFODNN7EXAMPLE_model.txt"
+        out = _redact_path_display(secret_path)
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+        assert out.startswith("config/")  # the ordinary segment survives
+
+    def test_redact_path_display_keeps_a_deep_root_value(self):
+        """The single-path display values (``root``/``repoRoot``/``branch``)
+        route through the same helper (Design/FP advisory on #8055): a deep
+        slash-only absolute root must render intact, not as a placeholder."""
+        from kiro_crew.dashboard.handlers.files import _redact_path_display
+        from kiro_crew.platform import redact_via_context
+
+        deep_root = "/srv/Binaries/ThirdParty/OpenSSL/Win64/VS2015/build"
+        # Premise: the general matcher mangles this shape (same #8042 run).
+        assert redact_via_context(deep_root) != deep_root
+        assert _redact_path_display(deep_root) == deep_root
+
+    @pytest.mark.asyncio
     async def test_walk_caps_entries_and_flags_truncation(self, tmp_path, mock_sel, monkeypatch):
         from kiro_crew.dashboard.handlers import files as files_mod
 


### PR DESCRIPTION
## Problem / Motivation

`redact()`'s bare-secret matcher (`_BARE_SECRET_RUN_RE`) has `/` inside its payload character class (it is a base64 alphabet character), so a deep slash-separated path whose directory chain carries no `.`/`-`/`_` scans as **one** candidate run of 40+ characters. `redact_credentials` pass 3's whole-run amplification — correct for a real secret glued to adjacent base64 characters — then replaces the **entire path** with a single `[REDACTED: credential]` placeholder.

Two genuinely different files (`.../libeay32.dll` and `.../ssleay32.dll` under a stock vendored `Binaries/ThirdParty/OpenSSL/Win64/VS2015/` chain) collapse to a byte-identical key. #7678's de-duplication then resolves the collision by dropping the later entries — so post-#7678 the failure mode is no longer a loud render crash but the workspace tree **silently omitting real files** (the reporter measured 237 mangled paths → 158 duplicate keys → ~79 files invisible on one large vendored tree). Fixes #8042.

## Why it matters

Files that exist on disk vanish from the file picker with no error, no log line, and no visual hint. The threshold behaviour (exactly one extra directory level flips a path from intact to destroyed) makes it look intermittent and unreportable to most users.

## What changed (motivation → approach → change)

- **Motivation**: the whole-run amplification must stay for unknown-provenance text (it is what stops a 41-char key leaking verbatim), so the general matcher cannot simply drop `/` from its class — splitting a real slash-carrying base64 secret into sub-40-char pieces would leak it. The fix has to live where the value is *provably* a path.
- **Approach**: the reporter's suggested direction 1 — the listing endpoints (`api_project_tree`, `api_project_git_status`) know they hold project-relative POSIX path lists, so a separator is a hard boundary *there*, and only there.
- **Change** (`src/kiro_crew/dashboard/handlers/files.py`): new module helper `_redact_path_display(path)` — fast path returns after a single `redact()` call when the value is unchanged (the overwhelmingly common case, so the 10k-entry tree does not pay per-segment scanning); slow path redacts each `/`-separated segment independently. Both endpoints' path mutations now route through it. The general `redact()` and `_BARE_SECRET_RUN_RE` are untouched.

## Tests

- `test_deep_paths_are_not_collapsed_into_one_key` — reproduces the #8042 shape end-to-end through `GET /api/project/tree`: two vendored-binary paths under a deep slash-only chain both survive intact and distinct. Includes a **premise assert** that the general `redact()` still mangles the raw path, so the test provably exercises the slow path (and flags fixture rot if the matcher ever changes).
- `test_redact_path_display_still_redacts_a_secret_segment` — coverage-hole guard: a credential-shaped single segment still redacts; the ordinary neighbouring segment survives.
- Full `test/test_project_tree.py` suite: 10 passed (including #7678's existing collision-dedup test, which still passes — an in-segment credential collision still collapses and dedups exactly as before).
- Lint floor: black gate, isort, flake8, mypy all clean on both changed files.

## Manual verification

Ran the reporter's repro semantics via the new premise assert: `redact_via_context("Binaries/ThirdParty/OpenSSL/Win64/VS2015/libeay32.dll")` mangles the path on this branch's base (confirming the live bug), while `_redact_path_display` returns both example paths intact and distinct.

## Screenshots / video

Not applicable — backend response content; the observable effect is files no longer disappearing from the tree, covered by the endpoint-level test.

## Related Issues

Fixes #8042. Context: #7671 (original render crash), #7678 (crash fix via de-dup; explicitly scoped away from this matcher), #6350 (prior separator-related fence issue in the same module, different function).

## Pattern harvest

Rule candidate: a redaction/sanitization heuristic tuned for unknown-provenance text should get a provenance-aware wrapper at call sites that KNOW the value's type (here: paths), rather than weakening the general matcher — the type knowledge is what makes a separator a safe hard boundary. Second occurrence of this shape in `security.py`-adjacent code (#7912's shell-vs-source-body context split is the same lesson).

## Checklist

- [x] Tests added/updated and passing locally
- [x] Lint/format gates run on all changed files
- [x] No unrelated changes bundled
- [x] PR body follows the template

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's contribution license agreement.
