### PR TITLE
feat(ci): flag possible same-issue PR overlap on open

### DIFF
--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -30,6 +30,20 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  # Re-dispatch entrypoint for the self-heal sweep (fork-review-heal.yml). When
+  # CI concludes success on a fork head but the `workflow_run: completed` event
+  # that would start this lane is dropped, the check-run is never posted and the
+  # fork PR's readiness freezes pending forever with no event able to recompute
+  # it. The sweep re-fires this lane keyed ONLY to the head SHA; the resolver
+  # below re-derives the PR from that SHA using the SAME open-PR-by-head-SHA
+  # match the trigger path uses, so this adds no new trust surface -- the head
+  # SHA is the only input the workflow_run path takes either.
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Fork PR head SHA to review (resolved to its open PR)."
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -39,7 +53,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: fork-design-review-${{ github.event.workflow_run.head_sha }}
+  group: fork-design-review-${{ github.event.workflow_run.head_sha || inputs.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -47,11 +61,14 @@ jobs:
     name: Fork Design Review
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request.
+    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request, OR a
+    # heal re-dispatch (which supplies the head SHA directly; the resolver still
+    # validates the SHA maps to an OPEN fork PR before any review runs).
     if: >-
-      github.event.workflow_run.event == 'pull_request'
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.head_repository.full_name != github.repository
+      && github.event.workflow_run.head_repository.full_name != github.repository)
     steps:
       # MUST be first: block egress except the endpoints the reviewer needs, so
       # an injection-driven exfil attempt fails at the network layer.
@@ -78,10 +95,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha || inputs.head_sha }}
         run: |
           set -uo pipefail
-          # head_sha from the triggering run is set by GitHub and is authoritative.
+          # head_sha from the triggering run is set by GitHub and is authoritative;
+          # on a heal re-dispatch it comes from the workflow_dispatch input, which
+          # is only ever a head SHA -- the resolver below still validates it maps
+          # to an OPEN fork PR, so a bad or superseded SHA fails closed.
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -30,6 +30,20 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  # Re-dispatch entrypoint for the self-heal sweep (fork-review-heal.yml). When
+  # CI concludes success on a fork head but the `workflow_run: completed` event
+  # that would start this lane is dropped, the check-run is never posted and the
+  # fork PR's readiness freezes pending forever with no event able to recompute
+  # it. The sweep re-fires this lane keyed ONLY to the head SHA; the resolver
+  # below re-derives the PR from that SHA using the SAME open-PR-by-head-SHA
+  # match the trigger path uses, so this adds no new trust surface -- the head
+  # SHA is the only input the workflow_run path takes either.
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Fork PR head SHA to review (resolved to its open PR)."
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -49,7 +63,7 @@ concurrency:
     fork-first-principles-review-${{
       github.event.workflow_run.head_repository.full_name
     }}-${{ github.event.workflow_run.head_branch }}-${{
-      github.event.workflow_run.head_sha
+      github.event.workflow_run.head_sha || inputs.head_sha
     }}
   cancel-in-progress: true
 
@@ -58,11 +72,14 @@ jobs:
     name: Fork First Principles Review
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request.
+    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request, OR a
+    # heal re-dispatch (which supplies the head SHA directly; the resolver still
+    # validates the SHA maps to an OPEN fork PR before any review runs).
     if: >-
-      github.event.workflow_run.event == 'pull_request'
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.head_repository.full_name != github.repository
+      && github.event.workflow_run.head_repository.full_name != github.repository)
     steps:
       # MUST be first: block egress except the endpoints the reviewer needs, so
       # an injection-driven exfil attempt fails at the network layer.
@@ -87,14 +104,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha || inputs.head_sha }}
           # Set by GitHub on every workflow_run, fork heads included; used below to
-          # disambiguate two open PRs that share a head commit.
+          # disambiguate two open PRs that share a head commit. Empty on a heal
+          # re-dispatch (which supplies only the head SHA), in which case the
+          # resolver falls back to a SHA-only match -- one open PR per source
+          # repository and branch is then the only remaining constraint.
           WR_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
           WR_HEAD_REF: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -uo pipefail
-          # head_sha from the triggering run is set by GitHub and is authoritative.
+          # head_sha from the triggering run is set by GitHub and is authoritative;
+          # on a heal re-dispatch it comes from the workflow_dispatch input, which
+          # is only ever a head SHA -- the resolver below still validates it maps
+          # to an OPEN fork PR, so a bad or superseded SHA fails closed.
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -32,6 +32,20 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  # Re-dispatch entrypoint for the self-heal sweep (fork-review-heal.yml). When
+  # CI concludes success on a fork head but the `workflow_run: completed` event
+  # that would start this lane is dropped, the check-run is never posted and the
+  # fork PR's readiness freezes pending forever with no event able to recompute
+  # it. The sweep re-fires this lane keyed ONLY to the head SHA; the resolver
+  # below re-derives the PR from that SHA using the SAME open-PR-by-head-SHA
+  # match the trigger path uses, so this adds no new trust surface -- the head
+  # SHA is the only input the workflow_run path takes either.
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Fork PR head SHA to review (resolved to its open PR)."
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -41,7 +55,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: fork-gpt-review-${{ github.event.workflow_run.head_sha }}
+  group: fork-gpt-review-${{ github.event.workflow_run.head_sha || inputs.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -52,11 +66,14 @@ jobs:
     # not the named pass timeout -- kills pass 2 and the job ends with no
     # verdict. Keep in sync with codex-review.yml.
     timeout-minutes: 130
-    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request.
+    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request, OR a
+    # heal re-dispatch (which supplies the head SHA directly; the resolver still
+    # validates the SHA maps to an OPEN fork PR before any review runs).
     if: >-
-      github.event.workflow_run.event == 'pull_request'
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.head_repository.full_name != github.repository
+      && github.event.workflow_run.head_repository.full_name != github.repository)
     steps:
       # MUST be first: block egress except the endpoints the reviewer needs, so
       # an injection-driven exfil attempt fails at the network layer.
@@ -83,10 +100,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha || inputs.head_sha }}
         run: |
           set -uo pipefail
-          # head_sha from the triggering run is set by GitHub and is authoritative.
+          # head_sha from the triggering run is set by GitHub and is authoritative;
+          # on a heal re-dispatch it comes from the workflow_dispatch input, which
+          # is only ever a head SHA -- the resolver below still validates it maps
+          # to an OPEN fork PR, so a bad or superseded SHA fails closed with
+          # "no open PR has head ...", never reviewing anything spurious.
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -29,6 +29,20 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  # Re-dispatch entrypoint for the self-heal sweep (fork-review-heal.yml). When
+  # CI concludes success on a fork head but the `workflow_run: completed` event
+  # that would start this lane is dropped, the check-run is never posted and the
+  # fork PR's readiness freezes pending forever with no event able to recompute
+  # it. The sweep re-fires this lane keyed ONLY to the head SHA; the resolver
+  # below re-derives the PR from that SHA using the SAME open-PR-by-head-SHA
+  # match the trigger path uses, so this adds no new trust surface -- the head
+  # SHA is the only input the workflow_run path takes either.
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Fork PR head SHA to review (resolved to its open PR)."
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -38,7 +52,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: fork-opus-review-${{ github.event.workflow_run.head_sha }}
+  group: fork-opus-review-${{ github.event.workflow_run.head_sha || inputs.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -51,11 +65,14 @@ jobs:
     # wall did, while still failing the gate closed on a true hang. Keep in sync
     # with claude-review.yml.
     timeout-minutes: 90
-    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request.
+    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request, OR a
+    # heal re-dispatch (which supplies the head SHA directly; the resolver still
+    # validates the SHA maps to an OPEN fork PR before any review runs).
     if: >-
-      github.event.workflow_run.event == 'pull_request'
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.head_repository.full_name != github.repository
+      && github.event.workflow_run.head_repository.full_name != github.repository)
     steps:
       # MUST be first: block egress except the endpoints the reviewer needs, so
       # an injection-driven exfil attempt fails at the network layer. Opus runs
@@ -83,10 +100,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha || inputs.head_sha }}
         run: |
           set -uo pipefail
-          # head_sha from the triggering run is set by GitHub and is authoritative.
+          # head_sha from the triggering run is set by GitHub and is authoritative;
+          # on a heal re-dispatch it comes from the workflow_dispatch input, which
+          # is only ever a head SHA -- the resolver below still validates it maps
+          # to an OPEN fork PR, so a bad or superseded SHA fails closed with
+          # "no open PR has head ...", never reviewing anything spurious.
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 

--- a/.github/workflows/fork-review-heal.yml
+++ b/.github/workflows/fork-review-heal.yml
@@ -1,0 +1,227 @@
+name: Fork Review Self-Heal Sweep
+
+# Backstop for a Stage-2 fork-review lane that NEVER FIRED.
+#
+# The Stage-2 fork AI reviewers (fork-opus-review.yml, fork-gpt-review.yml,
+# fork-design-review.yml, fork-ux-review.yml, fork-first-principles-review.yml)
+# trigger on `workflow_run` of CI with `conclusion == 'success'` and a fork
+# head. Each opens a check-run named exactly like its same-repo twin ("Opus 4.8
+# Review", "GPT 5.6 Review", "Design Review", "UX Review", "First Principles
+# Review"), keyed to the head SHA. `pr-readiness.yml` reads those check-runs for
+# a fork PR: a lane with NO check-run, or only the same-repo twin's `skipped`
+# one, is "(not started)" / "the real review has not posted yet" and counts as
+# PENDING -- which is the correct verdict rule.
+#
+# The gap this sweep closes: NOTHING makes the real review post when Stage-2
+# never fired. GitHub does not guarantee delivery of `workflow_run` events and
+# silently drops them under Actions load, so a fork head can have CI conclude
+# SUCCESS yet never start any fork reviewer. There is then no fork-review
+# check-run, no future event that can create one (the dropped event is gone),
+# and the fork PR's readiness is frozen `pending` forever -- so it cannot merge
+# and is eventually superseded by a later PR whose fork pipeline ran normally on
+# identical code. pr-readiness-sweep.yml rescues the same dropped-event class for
+# the AGGREGATOR, but it can only re-read EXISTING check-runs; it cannot
+# manufacture a never-fired Stage-2 review. This sweep is the missing rescuer for
+# that lane.
+#
+# WHAT IT DOES: for every OPEN fork PR whose latest CI run for the head SHA
+# concluded `success`, it checks the head SHA's check-runs for each of the five
+# review lanes and re-dispatches ONLY the lanes that never posted -- via each
+# reviewer's `workflow_dispatch` entrypoint, keyed to the head SHA. The reviewer
+# resolves its own PR from that SHA using the SAME open-PR-by-head-SHA resolver
+# its trigger path uses, so this adds NO new trust surface and NEVER checks out
+# or executes fork code -- it only reads and dispatches.
+#
+# SELF-TERMINATING / IDEMPOTENT: a lane counts as missing only when it has NO
+# check-run that is in_progress or completed with a real (non-`skipped`)
+# conclusion. The instant a reviewer starts it opens an `in_progress` check-run
+# keyed to the head SHA, so the very next sweep sees that lane as present and
+# does not dispatch again. A lane that is still running is therefore never
+# re-fired, and a lane that completed (pass, fail or neutral) is never re-fired.
+# Only the genuinely-never-started lane is dispatched, at most once per sweep,
+# bounded overall by MAX_DISPATCH.
+#
+# WHAT IT DELIBERATELY DOES NOT DO:
+#   * A fork PR whose CI has NOT concluded success is NOT dispatched and NOT
+#     forced to pass. Stage 2 is correctly gated off until CI passes, so the
+#     readiness `pending` for that PR is BY DESIGN and attributed to CI, not to a
+#     missing review. This sweep reports that state and leaves it pending.
+#   * A fork run that GitHub holds at `action_required` ("Approve and run") can
+#     only be released by a maintainer; automation cannot grant it. That case
+#     stays blocking-but-attributed in the aggregator (its `awaiting_approval`
+#     path) and is never auto-cleared here -- re-dispatching a lane whose run is
+#     awaiting approval would just queue another approval-gated run. See
+#     docs/ci/ci-and-reviews.md for that boundary.
+on:
+  schedule:
+    # Every 20 minutes. A normal fork fan-out posts its check-runs via the
+    # workflow_run event well inside this window; a lane still missing after a CI
+    # success older than STALE_MINUTES is treated as a dropped-event freeze and
+    # re-dispatched.
+    - cron: "7,27,47 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  actions: write        # dispatch the fork-*-review.yml workflows (workflow_dispatch)
+  contents: read
+  pull-requests: read   # list open PRs
+  checks: read          # read the head SHA's check-runs
+
+concurrency:
+  # Collapse an overlapping sweep into one. The sweep is idempotent, so
+  # cancelling an in-flight run is safe.
+  group: fork-review-heal
+  cancel-in-progress: true
+
+jobs:
+  heal:
+    name: Re-dispatch never-fired fork reviews
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Re-dispatch missing fork-review lanes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # A CI success older than this (minutes) whose lane is still missing is
+          # treated as a dropped-event freeze rather than an in-flight fan-out.
+          STALE_MINUTES: "20"
+          # Runaway backstop only -- one dispatch per missing lane, so five is the
+          # per-PR maximum. Sized to drain a real backlog of frozen fork PRs in
+          # one sweep while bounding a pathological run.
+          MAX_DISPATCH: "200"
+          # Ceiling for the open-PR listing. `gh pr list` returns newest-first and
+          # truncates SILENTLY, dropping the OLDEST PRs -- exactly the ones most
+          # likely to be frozen -- so this must stay well clear of the real count
+          # and a hit is reported as an action item.
+          PR_LIST_LIMIT: "900"
+        run: |
+          set -euo pipefail
+
+          now_epoch="$(date -u +%s)"
+          stale_seconds=$(( STALE_MINUTES * 60 ))
+
+          # The five fork-review lanes: "<check-run name>|<workflow file>". The
+          # check-run name is what pr-readiness.yml reads on the head SHA; the
+          # workflow file is the reviewer this sweep re-dispatches for that lane.
+          lanes=(
+            "Opus 4.8 Review|fork-opus-review.yml"
+            "GPT 5.6 Review|fork-gpt-review.yml"
+            "Design Review|fork-design-review.yml"
+            "UX Review|fork-ux-review.yml"
+            "First Principles Review|fork-first-principles-review.yml"
+          )
+
+          # Open fork PRs with their current head SHA. `isCrossRepository` is
+          # GitHub's own fork flag; a same-repo PR runs the same-repo reviewers
+          # and is out of scope here.
+          prs="$(gh pr list --repo "$REPO" --state open --limit "$PR_LIST_LIMIT" \
+            --json number,headRefOid,isCrossRepository)"
+
+          total="$(jq 'length' <<<"$prs")"
+          echo "Scanning $total open pull request(s) for never-fired fork reviews."
+          if [ "$total" -ge "$PR_LIST_LIMIT" ]; then
+            echo "::warning::Open-PR list hit its ceiling of $PR_LIST_LIMIT;" \
+              "the oldest open PRs were dropped and cannot be rescued." \
+              "Raise PR_LIST_LIMIT in fork-review-heal.yml."
+          fi
+
+          dispatched=0
+          skipped_cap=0
+
+          while read -r row; do
+            [ -n "$row" ] || continue
+            is_fork="$(jq -r '.isCrossRepository' <<<"$row")"
+            [ "$is_fork" = "true" ] || continue
+            number="$(jq -r '.number' <<<"$row")"
+            sha="$(jq -r '.headRefOid' <<<"$row")"
+            [ -n "$sha" ] && [ "$sha" != "null" ] || continue
+
+            # Latest CI run for this exact head SHA. Collapse to the newest by the
+            # monotonic run id (created_at has one-second granularity and can tie),
+            # mirroring pr-readiness.yml's own collapse. The read is captured
+            # before the filter so a transport failure is distinguishable from a
+            # genuinely absent run and never mistaken for "CI has not passed".
+            if ! ci_json="$(gh api --method GET \
+                "repos/$REPO/actions/workflows/ci.yml/runs?event=pull_request&head_sha=$sha&per_page=100" \
+                2>/dev/null)"; then
+              echo "PR #$number: CI runs lookup failed; skipping this sweep."
+              continue
+            fi
+            ci_run="$(jq -c '[.workflow_runs[]?] | max_by(.id) // empty' <<<"$ci_json")"
+
+            if [ -z "$ci_run" ]; then
+              echo "PR #$number: no CI run on $sha yet -> pending by design (CI has not started); not dispatching."
+              continue
+            fi
+            ci_status="$(jq -r '.status // ""' <<<"$ci_run")"
+            ci_conclusion="$(jq -r '.conclusion // ""' <<<"$ci_run")"
+            if [ "$ci_status" != "completed" ] || [ "$ci_conclusion" != "success" ]; then
+              # CI has NOT concluded success, so Stage 2 is correctly gated off.
+              # This is pending BY DESIGN and attributed to CI -- distinct from a
+              # missing review after a CI success. Never forced to a pass.
+              echo "PR #$number: CI is '$ci_status/$ci_conclusion' on $sha -> pending by design (CI has not passed); not dispatching."
+              continue
+            fi
+
+            # CI concluded success. Only treat a missing lane as a dropped-event
+            # freeze once the CI success is older than STALE_MINUTES, so a lane
+            # whose workflow_run event is still in flight is left alone.
+            ci_completed_at="$(jq -r '.updated_at // .created_at // empty' <<<"$ci_run")"
+            ci_epoch="$(date -u -d "$ci_completed_at" +%s 2>/dev/null || echo 0)"
+            if [ "$ci_epoch" -eq 0 ]; then
+              echo "PR #$number: CI success timestamp unreadable on $sha; skipping this sweep."
+              continue
+            fi
+            age=$(( now_epoch - ci_epoch ))
+            if [ "$age" -lt "$stale_seconds" ]; then
+              echo "PR #$number: CI passed ${age}s ago (< ${stale_seconds}s) on $sha -> fork reviews may still be fanning out; not dispatching yet."
+              continue
+            fi
+
+            # Read the head SHA's check-runs once; decide each lane from them. A
+            # lane is MISSING only when it has NO check-run that is in_progress or
+            # completed with a real (non-skipped) conclusion:
+            #   * total 0                       -> never fired
+            #   * only the same-repo twin's
+            #     `skipped` check-run present   -> the real review has not posted
+            # Both are the frozen-pending state. A lane with an in_progress or a
+            # completed non-skipped check-run has fired, so it is left alone --
+            # which is what makes this self-terminating: the reviewer opens an
+            # in_progress check-run immediately, so the next sweep sees the lane
+            # as present and does not re-dispatch.
+            if ! cr_json="$(gh api --method GET \
+                "repos/$REPO/commits/$sha/check-runs?per_page=100" --paginate --slurp \
+                2>/dev/null)"; then
+              echo "PR #$number: check-runs lookup failed; skipping this sweep."
+              continue
+            fi
+
+            for lane in "${lanes[@]}"; do
+              cname="${lane%%|*}"
+              wf="${lane#*|}"
+              # Count check-runs of this name that show the lane actually ran:
+              # any status other than a completed `skipped`. `--slurp` gives an
+              # outer array of pages, each `{"check_runs": [...]}`, so flatten
+              # with `.[].check_runs[]?`.
+              present="$(jq --arg n "$cname" '[.[].check_runs[]?
+                | select(.name == $n)
+                | select((.status != "completed")
+                    or (.conclusion != "skipped"))] | length' <<<"$cr_json")"
+              if [ "$present" -gt 0 ]; then
+                continue
+              fi
+              if [ "$dispatched" -ge "$MAX_DISPATCH" ]; then
+                skipped_cap=$(( skipped_cap + 1 ))
+                continue
+              fi
+              echo "PR #$number: '$cname' never fired though CI passed on $sha -> re-dispatching $wf."
+              if gh workflow run "$wf" --repo "$REPO" -f head_sha="$sha" >/dev/null 2>&1; then
+                dispatched=$(( dispatched + 1 ))
+              else
+                echo "PR #$number: failed to dispatch $wf (will retry next sweep)."
+              fi
+            done
+          done < <(jq -c '.[]' <<<"$prs")
+
+          echo "Re-dispatched $dispatched fork-review lane(s); $skipped_cap deferred to next sweep by MAX_DISPATCH=$MAX_DISPATCH."

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -29,6 +29,20 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  # Re-dispatch entrypoint for the self-heal sweep (fork-review-heal.yml). When
+  # CI concludes success on a fork head but the `workflow_run: completed` event
+  # that would start this lane is dropped, the check-run is never posted and the
+  # fork PR's readiness freezes pending forever with no event able to recompute
+  # it. The sweep re-fires this lane keyed ONLY to the head SHA; the resolver
+  # below re-derives the PR from that SHA using the SAME open-PR-by-head-SHA
+  # match the trigger path uses, so this adds no new trust surface -- the head
+  # SHA is the only input the workflow_run path takes either.
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Fork PR head SHA to review (resolved to its open PR)."
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -38,7 +52,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: fork-ux-review-${{ github.event.workflow_run.head_sha }}
+  group: fork-ux-review-${{ github.event.workflow_run.head_sha || inputs.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -46,11 +60,14 @@ jobs:
     name: Fork UX Review
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request.
+    # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request, OR a
+    # heal re-dispatch (which supplies the head SHA directly; the resolver still
+    # validates the SHA maps to an OPEN fork PR before any review runs).
     if: >-
-      github.event.workflow_run.event == 'pull_request'
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.head_repository.full_name != github.repository
+      && github.event.workflow_run.head_repository.full_name != github.repository)
     steps:
       # MUST be first: block egress except the endpoints the reviewer needs, so
       # an injection-driven exfil attempt fails at the network layer. UX/Fable
@@ -78,10 +95,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha || inputs.head_sha }}
         run: |
           set -uo pipefail
-          # head_sha from the triggering run is set by GitHub and is authoritative.
+          # head_sha from the triggering run is set by GitHub and is authoritative;
+          # on a heal re-dispatch it comes from the workflow_dispatch input, which
+          # is only ever a head SHA -- the resolver below still validates it maps
+          # to an OPEN fork PR, so a bad or superseded SHA fails closed.
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 

--- a/.github/workflows/pr-duplicate-detect.yml
+++ b/.github/workflows/pr-duplicate-detect.yml
@@ -183,9 +183,13 @@ jobs:
           # For each STRONG overlap: post the pointer comment FIRST (so the
           # overlap is recorded before any close), then close as superseded --
           # unless the PR carries the opt-out label, in which case leave it open
-          # and let a human close it. Collect the number for the co-authorship
-          # record regardless, so the shared work is still attributed.
-          superseded=""
+          # and let a human close it. Track closed vs. left-open separately so
+          # the co-authorship record below can word each accurately: an opted-out
+          # PR is attributed for the shared work but was NOT closed, so it must
+          # not be reported as "closed as superseded". Every overlapping PR is
+          # still recorded, so the shared work is attributed either way.
+          closed=""
+          left_open=""
           while read -r overlap; do
             [ -n "$overlap" ] || continue
             [ "$(jq -r '.strong' <<<"$overlap")" = "true" ] || continue
@@ -196,23 +200,33 @@ jobs:
               pointer="This PR overlaps #$PR_NUMBER, which has now merged and covers the same file(s) for the same issue: $files. It carries the \`$OPT_OUT_LABEL\` label, so it is being left open rather than auto-closed -- please close it yourself if the merged PR fully supersedes it, or carry on if not. This is an automated heads-up, not a judgement on the work."
               gh pr comment "$num" --repo "$REPO" --body "$pointer" >/dev/null
               echo "PR #$num: strongly overlaps merged #$PR_NUMBER but opted out of auto-close -> pointed only"
+              left_open="$left_open #$num"
             else
               pointer="This PR overlaps #$PR_NUMBER, which has now merged and covers the same file(s) for the same issue: $files. Closing it as superseded so review effort is not spent twice. If your change is not fully covered by the merged PR, please reopen or open a follow-up -- this is an automated heads-up, not a judgement on the work. To keep a future overlapping PR open, add the \`$OPT_OUT_LABEL\` label."
               gh pr comment "$num" --repo "$REPO" --body "$pointer" >/dev/null
               gh pr close "$num" --repo "$REPO" >/dev/null || true
               echo "PR #$num: strongly overlaps merged #$PR_NUMBER -> pointed and closed"
+              closed="$closed #$num"
             fi
-            superseded="$superseded #$num"
           done < <(jq -c '.overlaps[]' <<<"$result")
 
           # Record co-authorship on the MERGED PR. A workflow cannot rewrite the
           # squash-merge commit GitHub already composed from the PR title to add
           # a `Co-authored-by:` trailer, so attribution that a workflow CAN place
           # -- a durable comment naming the superseded author(s)' PRs -- is left
-          # here instead. Marker-keyed so a re-run updates in place.
-          if [ -n "$superseded" ]; then
+          # here instead. Marker-keyed so a re-run updates in place. Closed and
+          # left-open PRs are worded separately so the note never claims a close
+          # that did not happen for an opted-out PR.
+          if [ -n "$closed" ] || [ -n "$left_open" ]; then
             note="$COAUTHOR_MARKER
-          This PR merged work that also appeared in open PR(s) for the same issue, now closed as superseded:$superseded. Recording the overlap here so the earlier author(s)' effort is attributed. A workflow cannot edit the already-composed squash-merge commit to add a \`Co-authored-by:\` trailer, so this note is the durable record; a maintainer may add the trailer to the merge message by hand if warranted."
+          This PR merged work that also appeared in open PR(s) for the same issue. Recording the overlap here so the earlier author(s)' effort is attributed."
+            if [ -n "$closed" ]; then
+              note="$note Closed as superseded:$closed."
+            fi
+            if [ -n "$left_open" ]; then
+              note="$note Left open (opted out of auto-close via the \`$OPT_OUT_LABEL\` label):$left_open."
+            fi
+            note="$note A workflow cannot edit the already-composed squash-merge commit to add a \`Co-authored-by:\` trailer, so this note is the durable record; a maintainer may add the trailer to the merge message by hand if warranted."
             existing="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
               --jq "map(select(.body | contains(\"$COAUTHOR_MARKER\"))) | .[0].id // empty")"
             if [ -n "$existing" ]; then
@@ -222,5 +236,5 @@ jobs:
               gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
                 -f body="$note" >/dev/null
             fi
-            echo "PR #$PR_NUMBER: recorded co-authorship for superseded PR(s):$superseded"
+            echo "PR #$PR_NUMBER: recorded co-authorship for overlapping PR(s) -- closed:${closed:- none} left-open:${left_open:- none}"
           fi

--- a/.github/workflows/pr-duplicate-detect.yml
+++ b/.github/workflows/pr-duplicate-detect.yml
@@ -1,0 +1,199 @@
+name: PR Duplicate Detect
+
+# Two advisory, visibility-only lanes that share ONE detection engine
+# (scripts/detect_pr_overlap.py): given a PR, find the OTHER OPEN pull requests
+# that reference the SAME issue AND touch at least one of the SAME files. The
+# engine decides overlap; this workflow only chooses what to do with it.
+#
+#   ON OPEN (proposal 2, the higher-value/cheaper item): when a newly opened or
+#   synchronized PR overlaps an earlier open PR, upsert ONE marker-keyed comment
+#   on the new PR naming the earlier PR(s) and the shared files, so duplicated
+#   effort is caught before a reviewer reads two solutions to the same problem.
+#   If nothing overlaps, any stale marker comment is removed. This NEVER blocks
+#   merge -- it is a heads-up, not a gate, and phrased as one (a single issue may
+#   legitimately host stacked/companion PRs).
+#
+#   ON MERGE (proposal 1): when a PR merges, each OPEN same-issue PR whose files
+#   intersect the merged PR is pointed at the merge and closed as superseded.
+#
+# Trust + credit boundaries:
+#   * Runs from the trusted base context via pull_request_target, so it has the
+#     write token even for fork PRs, and it NEVER checks out or executes PR code
+#     -- it only reads PR metadata (numbers, bodies, changed-file lists, issue
+#     links) and writes comments / closes PRs. Mirrors fork-pr-label.yml.
+#   * Co-authored-by: this repo squash-merges using the PR TITLE as the commit
+#     message, and GitHub composes that squash commit at merge time. A workflow
+#     runs AFTER the merge, so it CANNOT rewrite the already-composed commit to
+#     inject a `Co-authored-by:` trailer -- that trailer would have to be present
+#     in the merge message GitHub builds, which only the merging maintainer (or
+#     the PR title/description) controls. What a workflow CAN place, and does
+#     here, is a durable co-authorship-recording comment on the merged PR naming
+#     the superseded author(s), so the shared work is attributed in a place the
+#     daily add-contributor sweep and any human can see. This workflow does NOT
+#     adjudicate credit beyond recording it; the reporter asked for tooling, not
+#     credit adjudication.
+
+on:
+  pull_request_target:
+    # opened/reopened/synchronize drive the on-open advisory; closed drives the
+    # on-merge handling (gated on merged == true in that job). Trusted base
+    # context -> write token even for fork PRs; no fork code is checked out.
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # Per-PR: serialize a PR's own events so the single marker comment is never
+  # double-posted by two overlapping runs. Safe to cancel in-flight -- the work
+  # is idempotent.
+  group: pr-duplicate-detect-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  on-open:
+    name: Flag a duplicate on open (advisory)
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Check out the trusted BASE tree only, for scripts/detect_pr_overlap.py.
+      # This is the base repo at the workflow ref, never the PR head, so no fork
+      # code runs. persist-credentials:false -- we only read a tracked script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Flag duplicate open PRs on the same issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Fixed hidden marker keys the ONE comment this lane owns, so a re-run
+          # UPDATES it in place instead of posting a second (same dedup idea as
+          # add-contributor's fixed-title issue and the review bots' markers).
+          MARKER: "<!-- pr-duplicate-detect -->"
+        run: |
+          set -euo pipefail
+
+          # The engine does all overlap logic; it reads PR metadata via `gh` and
+          # prints JSON. It never checks out or runs PR code.
+          result="$(python3 scripts/detect_pr_overlap.py --fetch --repo "$REPO" --pr "$PR_NUMBER")"
+          echo "$result"
+
+          # Find any comment this lane previously left, keyed on the marker.
+          existing="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty")"
+
+          has_overlap="$(jq -r '.has_overlap' <<<"$result")"
+
+          if [ "$has_overlap" != "true" ]; then
+            # No overlap: remove a stale warning so a corrected PR does not keep
+            # carrying it. Nothing to do if there was no prior comment.
+            if [ -n "$existing" ]; then
+              gh api --method DELETE "repos/$REPO/issues/comments/$existing" >/dev/null
+              echo "PR #$PR_NUMBER: no overlap -> removed stale duplicate-detect comment"
+            else
+              echo "PR #$PR_NUMBER: no overlap -> no comment"
+            fi
+            exit 0
+          fi
+
+          # Build a non-accusatory heads-up naming the earlier PR(s) and the
+          # specific shared files/count so it is actionable and falsifiable.
+          lines="$(jq -r '
+            .overlaps[]
+            | "- #\(.number) also touches \(.file_count) of the same file(s) for this issue: "
+              + (.files | map("`" + . + "`") | join(", "))
+              + (if .exact then " (identical changed-file set)" else "" end)
+          ' <<<"$result")"
+
+          body="$MARKER
+          Heads-up: this PR references the same issue as, and touches some of the same files as, one or more other open PRs. That often means the same problem is being solved twice, so it is worth a look before more review time is spent -- it may save either author's work, or these may be intentional companion PRs, in which case carry on.
+
+          Overlapping open PR(s):
+          $lines
+
+          This is an advisory note only; it does not block merge."
+
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+              -f body="$body" >/dev/null
+            echo "PR #$PR_NUMBER: overlap -> updated duplicate-detect comment $existing"
+          else
+            gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -f body="$body" >/dev/null
+            echo "PR #$PR_NUMBER: overlap -> posted duplicate-detect comment"
+          fi
+
+  on-merge:
+    name: Close superseded open PRs on merge
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Close open same-issue PRs whose files the merge superseded
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Marker for the co-authorship-recording comment left on the MERGED PR
+          # (see the Co-authored-by boundary in this file's header).
+          COAUTHOR_MARKER: "<!-- pr-duplicate-coauthor -->"
+        run: |
+          set -euo pipefail
+
+          result="$(python3 scripts/detect_pr_overlap.py --fetch --repo "$REPO" --pr "$PR_NUMBER")"
+          echo "$result"
+
+          if [ "$(jq -r '.has_overlap' <<<"$result")" != "true" ]; then
+            echo "PR #$PR_NUMBER merged with no overlapping open PR -> nothing to close"
+            exit 0
+          fi
+
+          # Close each overlapping open PR with a pointer to the merge, and
+          # collect its number for the co-authorship record.
+          superseded=""
+          while read -r overlap; do
+            [ -n "$overlap" ] || continue
+            num="$(jq -r '.number' <<<"$overlap")"
+            files="$(jq -r '.files | map("`" + . + "`") | join(", ")' <<<"$overlap")"
+            pointer="This PR overlaps #$PR_NUMBER, which has now merged and covers the same file(s) for the same issue: $files. Closing it as superseded so review effort is not spent twice. If your change is not fully covered by the merged PR, please reopen or open a follow-up -- this is an automated heads-up, not a judgement on the work."
+            gh pr comment "$num" --repo "$REPO" --body "$pointer" >/dev/null
+            gh pr close "$num" --repo "$REPO" >/dev/null || true
+            echo "PR #$num: overlaps merged #$PR_NUMBER -> pointed and closed"
+            superseded="$superseded #$num"
+          done < <(jq -c '.overlaps[]' <<<"$result")
+
+          # Record co-authorship on the MERGED PR. A workflow cannot rewrite the
+          # squash-merge commit GitHub already composed from the PR title to add
+          # a `Co-authored-by:` trailer, so attribution that a workflow CAN place
+          # -- a durable comment naming the superseded author(s)' PRs -- is left
+          # here instead. Marker-keyed so a re-run updates in place.
+          if [ -n "$superseded" ]; then
+            note="$COAUTHOR_MARKER
+          This PR merged work that also appeared in open PR(s) for the same issue, now closed as superseded:$superseded. Recording the overlap here so the earlier author(s)' effort is attributed. A workflow cannot edit the already-composed squash-merge commit to add a \`Co-authored-by:\` trailer, so this note is the durable record; a maintainer may add the trailer to the merge message by hand if warranted."
+            existing="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq "map(select(.body | contains(\"$COAUTHOR_MARKER\"))) | .[0].id // empty")"
+            if [ -n "$existing" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                -f body="$note" >/dev/null
+            else
+              gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+                -f body="$note" >/dev/null
+            fi
+            echo "PR #$PR_NUMBER: recorded co-authorship for superseded PR(s):$superseded"
+          fi

--- a/.github/workflows/pr-duplicate-detect.yml
+++ b/.github/workflows/pr-duplicate-detect.yml
@@ -13,8 +13,14 @@ name: PR Duplicate Detect
 #   merge -- it is a heads-up, not a gate, and phrased as one (a single issue may
 #   legitimately host stacked/companion PRs).
 #
-#   ON MERGE (proposal 1): when a PR merges, each OPEN same-issue PR whose files
-#   intersect the merged PR is pointed at the merge and closed as superseded.
+#   ON MERGE (proposal 1): when a PR merges, each OPEN same-issue PR whose
+#   overlap with the merged PR is STRONG -- an exact changed-file match, or the
+#   shared files cover at least half the merged PR's files -- is pointed at the
+#   merge and closed as superseded. A weaker single-file overlap is left open
+#   (it already got the on-open advisory), so a merge does not close
+#   legitimately-distinct companion work. A PR labelled `no-auto-close-duplicate`
+#   is never auto-closed: it still gets the pointer comment, but a human keeps
+#   control of the close. The pointer comment is always posted BEFORE any close.
 #
 # Trust + credit boundaries:
 #   * Runs from the trusted base context via pull_request_target, so it has the
@@ -153,28 +159,49 @@ jobs:
           # Marker for the co-authorship-recording comment left on the MERGED PR
           # (see the Co-authored-by boundary in this file's header).
           COAUTHOR_MARKER: "<!-- pr-duplicate-coauthor -->"
+          # A superseded PR carrying this label is NEVER auto-closed: the lane
+          # still posts the pointer comment (so the overlap is visible), but the
+          # author or a maintainer keeps control of the close. An opt-out, not a
+          # requirement -- the default stays "close a strongly-superseded PR".
+          OPT_OUT_LABEL: "no-auto-close-duplicate"
         run: |
           set -euo pipefail
 
           result="$(python3 scripts/detect_pr_overlap.py --fetch --repo "$REPO" --pr "$PR_NUMBER")"
           echo "$result"
 
-          if [ "$(jq -r '.has_overlap' <<<"$result")" != "true" ]; then
-            echo "PR #$PR_NUMBER merged with no overlapping open PR -> nothing to close"
+          # Only a STRONG overlap (exact changed-file match, or the shared files
+          # cover at least half of the merged PR's files -- see the engine's
+          # STRONG_OVERLAP_FRACTION) is auto-closed. A weaker single-file overlap
+          # already got the advisory on-open comment and is left open here, so a
+          # merge does not close legitimately-distinct companion work.
+          if [ "$(jq -r '.has_strong_overlap' <<<"$result")" != "true" ]; then
+            echo "PR #$PR_NUMBER merged with no strongly-overlapping open PR -> nothing to close"
             exit 0
           fi
 
-          # Close each overlapping open PR with a pointer to the merge, and
-          # collect its number for the co-authorship record.
+          # For each STRONG overlap: post the pointer comment FIRST (so the
+          # overlap is recorded before any close), then close as superseded --
+          # unless the PR carries the opt-out label, in which case leave it open
+          # and let a human close it. Collect the number for the co-authorship
+          # record regardless, so the shared work is still attributed.
           superseded=""
           while read -r overlap; do
             [ -n "$overlap" ] || continue
+            [ "$(jq -r '.strong' <<<"$overlap")" = "true" ] || continue
             num="$(jq -r '.number' <<<"$overlap")"
             files="$(jq -r '.files | map("`" + . + "`") | join(", ")' <<<"$overlap")"
-            pointer="This PR overlaps #$PR_NUMBER, which has now merged and covers the same file(s) for the same issue: $files. Closing it as superseded so review effort is not spent twice. If your change is not fully covered by the merged PR, please reopen or open a follow-up -- this is an automated heads-up, not a judgement on the work."
-            gh pr comment "$num" --repo "$REPO" --body "$pointer" >/dev/null
-            gh pr close "$num" --repo "$REPO" >/dev/null || true
-            echo "PR #$num: overlaps merged #$PR_NUMBER -> pointed and closed"
+            opted_out="$(jq -r --arg L "$OPT_OUT_LABEL" '(.labels // []) | index($L) | if . == null then "no" else "yes" end' <<<"$overlap")"
+            if [ "$opted_out" = "yes" ]; then
+              pointer="This PR overlaps #$PR_NUMBER, which has now merged and covers the same file(s) for the same issue: $files. It carries the \`$OPT_OUT_LABEL\` label, so it is being left open rather than auto-closed -- please close it yourself if the merged PR fully supersedes it, or carry on if not. This is an automated heads-up, not a judgement on the work."
+              gh pr comment "$num" --repo "$REPO" --body "$pointer" >/dev/null
+              echo "PR #$num: strongly overlaps merged #$PR_NUMBER but opted out of auto-close -> pointed only"
+            else
+              pointer="This PR overlaps #$PR_NUMBER, which has now merged and covers the same file(s) for the same issue: $files. Closing it as superseded so review effort is not spent twice. If your change is not fully covered by the merged PR, please reopen or open a follow-up -- this is an automated heads-up, not a judgement on the work. To keep a future overlapping PR open, add the \`$OPT_OUT_LABEL\` label."
+              gh pr comment "$num" --repo "$REPO" --body "$pointer" >/dev/null
+              gh pr close "$num" --repo "$REPO" >/dev/null || true
+              echo "PR #$num: strongly overlaps merged #$PR_NUMBER -> pointed and closed"
+            fi
             superseded="$superseded #$num"
           done < <(jq -c '.overlaps[]' <<<"$result")
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,19 @@ issue first and get a reaction to the approach. Nobody enjoys declining a
 finished pull request that went the wrong direction, and a maintainer can usually
 tell you in a paragraph.
 
+This rule binds automated and agent-assisted contributions exactly as it binds
+humans (see [Using AI Tools](#using-ai-tools)); an agent should check for prior
+work before it starts, and if you point one at an issue, hold it to the same
+heads-up. An open pull request that references the same issue is the
+machine-readable version of "someone is already on it", and the automated on-open
+duplicate-detection lane reads exactly that signal: when a new PR references the
+same issue and touches the same files as an earlier open PR, it posts a
+non-accusatory heads-up naming the overlap so the second effort is not spent
+twice. It is advisory and never blocks a merge, and companion PRs that split one
+issue across different files are expected. See
+[Duplicate and overlap detection](docs/ci/ci-and-reviews.md#duplicate-and-overlap-detection)
+for what the lane checks and surfaces.
+
 ## Prerequisites
 
 - macOS, Linux, or Windows — Windows builds and runs natively from source, with

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -727,6 +727,40 @@ Nothing the fork controls can influence these reviews:
   allowlist, plus short-lived Bedrock-only OIDC credentials, bound the blast radius
   of any prompt injection.
 
+**A fork-review lane that never fired is re-dispatched, so readiness cannot freeze
+pending forever.** Each Stage-2 reviewer starts only on the `workflow_run: completed`
+event of CI, and GitHub does not guarantee delivery of that event -- it is silently
+dropped under Actions load. When it is dropped after CI concludes success on a fork
+head, no fork-review check-run is ever posted, `pr-readiness.yml` reads the lane as
+"(not started)" / "the real review has not posted yet" and counts it pending, and no
+future event can create the missing run -- so the fork PR is frozen pending and can
+never merge. `fork-review-heal.yml` closes that gap: it sweeps open fork PRs on a
+schedule, and for a PR whose latest CI run for the head SHA concluded `success` it
+re-dispatches only the review lanes that never fired, via each reviewer's
+`workflow_dispatch` entrypoint keyed to the head SHA. The reviewer resolves its own PR
+from that SHA with the same open-PR-by-head-SHA match its trigger path uses, so the
+heal adds no new trust surface and never checks out or executes fork code. A lane
+counts as missing only when it has no check-run that is in progress or completed with
+a real (non-`skipped`) conclusion, and each reviewer opens an in-progress check-run
+the instant it starts, so the sweep is self-terminating: a lane that is still running
+or has already completed is never re-dispatched, and each never-fired lane is
+dispatched at most once per sweep (bounded by a dispatch cap). This mirrors
+`pr-readiness-sweep.yml`, which rescues the same dropped-event class for the aggregator
+but can only re-read existing check-runs; it cannot manufacture a never-fired review,
+which is what this sweep supplies.
+
+**A fork PR whose CI has not passed stays pending by design.** Stage 2 is gated on a
+successful CI run, so until CI passes the fork-review lanes are correctly not eligible.
+The heal sweep does not dispatch such a PR and never forces it to a pass; it reports
+the pending as attributed to CI, distinct from a review that is missing though CI
+passed. Two boundaries remain outside the sweep's reach and are handled by attribution
+rather than by a forced pass. A fork run that GitHub holds at `action_required`
+("Approve and run") can be released only by a maintainer, so `pr-readiness.yml` keeps
+that condition in its `awaiting_approval` verdict -- blocking but attributed, and never
+auto-cleared, since re-dispatching a lane whose run awaits approval would only queue
+another approval-gated run. GitHub may also decline to deliver a `workflow_dispatch`;
+the sweep is scheduled, so a dispatch that does not land is retried on the next pass.
+
 **`fork-workflow-guard.yml`** blocks a fork PR that modifies anything under
 `.github/**`, the vector a fork would use to fake basic-CI results (rewrite `ci.yml`
 to pass) or tamper with CODEOWNERS. It is deterministic on purpose: "does the diff

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -773,6 +773,57 @@ forge its verdict. A maintainer who has reviewed a legitimate workflow change ap
 the `allow-fork-workflow-change` label and the guard re-evaluates green; the label is
 stripped on a new revision, so the override cannot carry over.
 
+## Duplicate and overlap detection
+
+Two PRs can quietly solve the same issue by editing the same files, which wastes the
+second author's effort and makes a reviewer read two solutions to one problem.
+`pr-duplicate-detect.yml` surfaces that, in two advisory, visibility-only lanes that
+share one detection engine and never gate a PR.
+
+**One engine, two triggers.** `scripts/detect_pr_overlap.py` answers a single question
+about a PR: which OTHER open pull requests reference the same issue AND touch at least
+one of the same files? A candidate PR is reported only when BOTH hold -- same issue
+reference and a non-empty intersection of changed-file sets. Both are required on
+purpose: a shared issue alone is too noisy, since one issue legitimately hosts stacked
+or companion PRs that touch different files, and a shared file alone is too noisy, since
+unrelated PRs routinely edit a common file. The rule is intersection, not exact-set
+equality, so two PRs that edit the same file plus different neighbours still match; an
+exact set match is carried through as a stronger signal that the comment phrases more
+firmly, but it is not required to flag. A PR's referenced issues are the union of
+GitHub's `closingIssuesReferences` linkage and a closing-keyword parse of the PR body
+(`Fixes`/`Closes`/`Resolves #N`), because the linkage may not be populated on an
+unmerged PR. The triggering PR is never matched against itself, and only OPEN PRs are
+considered as candidates. The engine is pure and network-free -- it takes materialized
+PR records and returns overlaps -- so its `--fetch` mode does all `gh` I/O and the core
+is unit-tested against canned JSON.
+
+**On open (visibility, the higher-value lane).** On `opened`, `reopened` and
+`synchronize`, the workflow runs the engine for the triggering PR and, when it overlaps
+one or more earlier open PRs, upserts a single marker-keyed comment naming those PRs and
+the specific shared files and count, so the duplication is caught before review time is
+spent twice. The comment is keyed on a hidden marker, so a re-run updates it in place
+rather than posting a second, and when a corrected revision no longer overlaps, the
+stale comment is removed. The tone is a non-accusatory heads-up, matching
+CONTRIBUTING.md and acknowledging that companion PRs are legitimate; it is advisory only
+and never blocks merge.
+
+**On merge (close the superseded PR).** On a `closed` event where the PR merged, the
+same engine finds the open same-issue PRs whose files the merge intersects, points each
+at the merge with a comment, and closes it as superseded, leaving non-overlapping open
+PRs untouched. Attribution has a hard boundary: this repository squash-merges using the
+PR title as the commit message, and GitHub composes that commit at merge time, so a
+workflow -- which runs after the merge -- cannot rewrite it to add a `Co-authored-by:`
+trailer. The trailer would have to be present in the message GitHub builds, which only
+the merging maintainer or the PR title controls. What the workflow can place, and does,
+is a durable co-authorship-recording comment on the merged PR naming the superseded
+author's PRs, so the shared work is attributed where a human and the daily contributor
+sweep can see it. The workflow records the overlap; it does not adjudicate credit.
+
+Both lanes run from the trusted base context via `pull_request_target`, so they hold the
+write token even for a fork PR, and neither checks out or executes PR head code -- they
+read PR metadata and write comments or close PRs, the same trust posture as
+`fork-pr-label.yml`.
+
 ## Over-engineering resistance
 
 AI-native coding skews toward over-engineering, and a naive AI reviewer compounds it

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -827,9 +827,11 @@ PR title as the commit message, and GitHub composes that commit at merge time, s
 workflow -- which runs after the merge -- cannot rewrite it to add a `Co-authored-by:`
 trailer. The trailer would have to be present in the message GitHub builds, which only
 the merging maintainer or the PR title controls. What the workflow can place, and does,
-is a durable co-authorship-recording comment on the merged PR naming the superseded
+is a durable co-authorship-recording comment on the merged PR naming the overlapping
 author's PRs, so the shared work is attributed where a human and the daily contributor
-sweep can see it. The workflow records the overlap; it does not adjudicate credit.
+sweep can see it. That comment lists the PRs it closed and the PRs it left open under the
+opt-out label separately, so it never reports a close that did not happen. The workflow
+records the overlap; it does not adjudicate credit.
 
 Both lanes run from the trusted base context via `pull_request_target`, so they hold the
 write token even for a fork PR, and neither checks out or executes PR head code -- they

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -789,13 +789,18 @@ or companion PRs that touch different files, and a shared file alone is too nois
 unrelated PRs routinely edit a common file. The rule is intersection, not exact-set
 equality, so two PRs that edit the same file plus different neighbours still match; an
 exact set match is carried through as a stronger signal that the comment phrases more
-firmly, but it is not required to flag. A PR's referenced issues are the union of
+firmly, but it is not required to flag. Each overlap also carries a coverage fraction
+(how much of the subject PR's changed files the overlap shares) and a strong flag, which
+the on-merge lane uses to decide whether to close. A PR's referenced issues are the union of
 GitHub's `closingIssuesReferences` linkage and a closing-keyword parse of the PR body
 (`Fixes`/`Closes`/`Resolves #N`), because the linkage may not be populated on an
 unmerged PR. The triggering PR is never matched against itself, and only OPEN PRs are
 considered as candidates. The engine is pure and network-free -- it takes materialized
 PR records and returns overlaps -- so its `--fetch` mode does all `gh` I/O and the core
-is unit-tested against canned JSON.
+is unit-tested against canned JSON. To keep the API cost bounded on a busy repo, the
+`--fetch` path materializes every open PR's number, body, state, changed files and
+closing-issue linkage in a single `gh pr list` call, rather than a per-PR view plus a
+GraphQL call for each open PR.
 
 **On open (visibility, the higher-value lane).** On `opened`, `reopened` and
 `synchronize`, the workflow runs the engine for the triggering PR and, when it overlaps
@@ -808,9 +813,16 @@ CONTRIBUTING.md and acknowledging that companion PRs are legitimate; it is advis
 and never blocks merge.
 
 **On merge (close the superseded PR).** On a `closed` event where the PR merged, the
-same engine finds the open same-issue PRs whose files the merge intersects, points each
-at the merge with a comment, and closes it as superseded, leaving non-overlapping open
-PRs untouched. Attribution has a hard boundary: this repository squash-merges using the
+same engine finds the open same-issue PRs whose overlap with the merge is strong -- an
+exact changed-file match, or the shared files cover at least half of the merged PR's
+files -- points each at the merge with a comment, and closes it as superseded, leaving
+non-overlapping and weakly-overlapping open PRs untouched. Requiring a strong overlap,
+not a single shared file, keeps the close from ending legitimately-distinct companion
+work that happens to touch one common file for the same issue; a weaker overlap still
+surfaces in the on-open advisory. The pointer comment is always posted before the close.
+An open PR that carries the `no-auto-close-duplicate` label is never auto-closed: it
+still receives the pointer comment, but the author or a maintainer keeps control of the
+close. Attribution has a hard boundary: this repository squash-merges using the
 PR title as the commit message, and GitHub composes that commit at merge time, so a
 workflow -- which runs after the merge -- cannot rewrite it to add a `Co-authored-by:`
 trailer. The trailer would have to be present in the message GitHub builds, which only

--- a/scripts/detect_pr_overlap.py
+++ b/scripts/detect_pr_overlap.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Detect open pull requests that overlap a given PR on the same issue.
+
+This is the shared detection engine behind two advisory, visibility-only
+workflows (`.github/workflows/pr-duplicate-detect.yml`):
+
+  * ON OPEN (proposal 2): when a newly opened / synchronized PR shares an issue
+    and touches at least one of the same files as another OPEN PR, that new PR
+    gets a single heads-up comment naming the earlier PR(s), so duplicated
+    effort is caught before a reviewer reads two solutions to the same problem.
+  * ON MERGE (proposal 1): when a PR is merged, any OPEN PR against the same
+    issue whose changed-file set intersects the merged PR's is pointed at the
+    merge and closed as superseded.
+
+Both triggers ask the same question about one PR: *which OTHER open PRs target
+the same issue AND touch at least one of the same files?* That question is this
+script; the workflows only decide what to do with the answer (comment vs.
+comment-and-close). Keeping the logic here -- not inline in YAML -- makes the
+set-intersection and issue-linkage rules unit-testable via importlib against
+canned JSON, with no network (mirrors test/test_update_contributors.py).
+
+--------------------------------------------------------------------------------
+Matching rule (falsifiable, deliberately narrow)
+--------------------------------------------------------------------------------
+A candidate PR is reported as overlapping the subject PR when BOTH hold:
+
+  1. Same issue: the candidate references at least one issue that the subject
+     also references (set intersection of referenced issue numbers is
+     non-empty).
+  2. Intersecting files: the candidate's changed-file set and the subject's
+     changed-file set have a non-empty intersection (they touch >= 1 common
+     path).
+
+INTERSECTION, not exact-set-equality, is the trigger. Proposal 2 phrases this
+as "changed-file set matches" and proposal 1 as "intersects"; a strict exact
+match would miss the common real case where two PRs edit the same file plus
+different neighbours, which is still duplicated effort on that file. An exact
+set match is reported as a stronger `exact` signal on each overlap so a caller
+MAY phrase its message more firmly, but it is NOT required to flag.
+
+Both conditions are required. Same issue alone is too noisy -- a single issue
+legitimately hosts stacked or companion PRs that touch different files.
+Intersecting files alone is too noisy -- unrelated PRs routinely edit a shared
+file. Requiring both keeps the signal to "these PRs are solving the same issue
+by editing the same files", which is the duplicated effort the proposals target.
+
+The subject PR is NEVER matched against itself (its own number is excluded from
+the candidate set).
+
+--------------------------------------------------------------------------------
+Referenced issue(s)
+--------------------------------------------------------------------------------
+An issue is "referenced" by a PR when either holds:
+
+  * GitHub's own linkage (`closingIssuesReferences`, the same connection
+    add-contributor.yml reads) lists it. This is authoritative but is populated
+    from a "Fixes/Closes/Resolves #N" declaration, and for an UNMERGED PR the
+    connection may not be populated yet.
+  * The PR body contains a closing keyword + issue reference
+    ("Fixes #N", "Closes #N", "Resolves #N", case-insensitive, GitHub's own
+    keyword set). This body parse is the fallback that covers an open PR whose
+    connection has not populated.
+
+The union of both is the PR's referenced-issue set.
+
+--------------------------------------------------------------------------------
+I/O
+--------------------------------------------------------------------------------
+The engine is pure: it takes fully-materialized PR records and returns overlaps.
+All `gh`/GitHub I/O lives in the ``--fetch`` CLI path so the core stays
+network-free and unit-testable.
+
+Usage:
+    # Pure mode: analyze a pre-fetched bundle read as JSON from stdin, print the
+    # overlap result as JSON to stdout. This is the network-free path the tests
+    # (and, if pre-fetched, a workflow) use.
+    #   {"subject": <pr-record>, "candidates": [<pr-record>, ...]}
+    # where a <pr-record> is:
+    #   {"number": int, "body": str, "state": "OPEN"|"CLOSED"|"MERGED",
+    #    "files": [str, ...], "closingIssues": [int, ...]}
+    python3 scripts/detect_pr_overlap.py < bundle.json
+
+    # Fetch mode: materialize the subject PR and the open-PR candidate set from
+    # GitHub via `gh`, then run the same analysis. Used by the workflows.
+    python3 scripts/detect_pr_overlap.py --fetch --repo owner/name --pr 123
+
+    # Self-test (no repository or network needed):
+    python3 scripts/detect_pr_overlap.py --test
+
+Exit codes:
+    0  analysis completed (overlaps may be empty -- that is a normal answer)
+    1  malformed input
+    2  environment error (a `gh` call failed in --fetch mode)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+# GitHub's closing keywords, matched case-insensitively against the PR body as
+# the fallback for an unmerged PR whose closingIssuesReferences connection is
+# not yet populated. Same-repo references only ("#N"); a cross-repo
+# "owner/repo#N" is intentionally ignored because this repo's overlap question
+# is scoped to its own issues.
+_CLOSING_KEYWORDS = ("close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves",
+                     "resolved")
+_CLOSES_RE = re.compile(
+    r"\b(?:" + "|".join(_CLOSING_KEYWORDS) + r")\b\s*:?\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def referenced_issues(pr: dict[str, Any]) -> set[int]:
+    """Return the set of issue numbers a PR references.
+
+    Union of GitHub's ``closingIssues`` linkage and a closing-keyword parse of
+    the PR body (the fallback for an unmerged PR whose linkage is unpopulated).
+    """
+    issues: set[int] = set()
+    for num in pr.get("closingIssues") or []:
+        try:
+            issues.add(int(num))
+        except (TypeError, ValueError):
+            continue
+    body = pr.get("body") or ""
+    for match in _CLOSES_RE.finditer(body):
+        issues.add(int(match.group(1)))
+    return issues
+
+
+def changed_files(pr: dict[str, Any]) -> set[str]:
+    """Return the PR's changed-file path set."""
+    return {str(path) for path in (pr.get("files") or []) if path}
+
+
+def find_overlaps(subject: dict[str, Any], candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the OPEN candidate PRs that overlap ``subject`` on issue + files.
+
+    A candidate overlaps when it is OPEN, is not the subject itself, shares at
+    least one referenced issue, and shares at least one changed file. The result
+    is sorted by PR number ascending so the earliest-opened overlaps are named
+    first (their number is the lowest), which is the natural "you may be
+    duplicating this earlier PR" ordering.
+    """
+    subject_number = subject.get("number")
+    subject_issues = referenced_issues(subject)
+    subject_files = changed_files(subject)
+    overlaps: list[dict[str, Any]] = []
+    if not subject_issues or not subject_files:
+        # No issue link or no changed files -> nothing to correlate on.
+        return overlaps
+    for cand in candidates:
+        if cand.get("number") == subject_number:
+            continue  # never match the subject against itself
+        if (cand.get("state") or "").upper() != "OPEN":
+            continue  # only OTHER OPEN PRs are candidates
+        shared_issues = subject_issues & referenced_issues(cand)
+        if not shared_issues:
+            continue
+        shared_files = subject_files & changed_files(cand)
+        if not shared_files:
+            continue
+        cand_files = changed_files(cand)
+        overlaps.append(
+            {
+                "number": cand.get("number"),
+                "issues": sorted(shared_issues),
+                "files": sorted(shared_files),
+                "file_count": len(shared_files),
+                # Exact set match is a stronger signal a caller MAY phrase more
+                # firmly; it is not required to flag (intersection is the rule).
+                "exact": cand_files == subject_files and bool(cand_files),
+            }
+        )
+    overlaps.sort(key=lambda o: (o["number"] is None, o["number"]))
+    return overlaps
+
+
+def analyze(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Run the overlap analysis over a {"subject", "candidates"} bundle."""
+    subject = bundle.get("subject") or {}
+    candidates = bundle.get("candidates") or []
+    overlaps = find_overlaps(subject, candidates)
+    return {
+        "subject": subject.get("number"),
+        "issues": sorted(referenced_issues(subject)),
+        "files": sorted(changed_files(subject)),
+        "overlaps": overlaps,
+        "has_overlap": bool(overlaps),
+    }
+
+
+# --------------------------------------------------------------------------------
+# Fetch mode: the only code that touches the network, via `gh`. Kept out of the
+# pure core so the analysis stays unit-testable with canned JSON.
+# --------------------------------------------------------------------------------
+
+
+def _gh_json(args: list[str]) -> Any:
+    """Run a read-only `gh` command and parse its JSON stdout."""
+    proc = subprocess.run(  # noqa: S603 - fixed argv built from validated inputs
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {proc.stderr.strip()}")
+    out = proc.stdout.strip()
+    return json.loads(out) if out else None
+
+
+def _fetch_pr_record(repo: str, number: int) -> dict[str, Any]:
+    """Materialize one PR into an engine record via `gh`."""
+    view = _gh_json(
+        ["pr", "view", str(number), "--repo", repo, "--json", "number,body,state,files"]
+    )
+    files = [f.get("path") for f in (view.get("files") or []) if f.get("path")]
+    owner, name = repo.split("/", 1)
+    graph = _gh_json(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={number}",
+            "-f",
+            "query="
+            "query($owner:String!,$name:String!,$number:Int!){"
+            "repository(owner:$owner,name:$name){"
+            "pullRequest(number:$number){"
+            "closingIssuesReferences(first:50){nodes{number}}}}}",
+        ]
+    )
+    closing = []
+    try:
+        nodes = graph["data"]["repository"]["pullRequest"]["closingIssuesReferences"]["nodes"]
+        closing = [n["number"] for n in nodes if n.get("number") is not None]
+    except (KeyError, TypeError):
+        closing = []
+    return {
+        "number": view.get("number"),
+        "body": view.get("body") or "",
+        "state": view.get("state") or "OPEN",
+        "files": files,
+        "closingIssues": closing,
+    }
+
+
+def _fetch_bundle(repo: str, number: int, list_limit: int) -> dict[str, Any]:
+    """Build the {"subject", "candidates"} bundle from GitHub.
+
+    Candidates are every OTHER open PR, each materialized to a full record. This
+    is the read-only I/O the workflow needs; the analysis stays pure.
+    """
+    subject = _fetch_pr_record(repo, number)
+    open_prs = _gh_json(
+        ["pr", "list", "--repo", repo, "--state", "open", "--limit", str(list_limit),
+         "--json", "number"]
+    ) or []
+    candidates: list[dict[str, Any]] = []
+    for entry in open_prs:
+        cand_num = entry.get("number")
+        if cand_num is None or cand_num == number:
+            continue
+        candidates.append(_fetch_pr_record(repo, cand_num))
+    return {"subject": subject, "candidates": candidates}
+
+
+# --------------------------------------------------------------------------------
+# Self-test: exercises the pure core with canned data, no repo or network.
+# --------------------------------------------------------------------------------
+
+
+def _run_self_test() -> int:
+    failures: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        print(f"{'ok  ' if cond else 'FAIL'} {name}")
+        if not cond:
+            failures.append(name)
+
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py", "b.py"],
+               "closingIssues": [1]}
+    same_issue_intersect = {"number": 5, "body": "Closes #1", "state": "OPEN",
+                            "files": ["a.py", "c.py"], "closingIssues": []}
+    disjoint_files = {"number": 6, "body": "", "state": "OPEN", "files": ["z.py"],
+                      "closingIssues": [1]}
+    different_issue = {"number": 7, "body": "Fixes #2", "state": "OPEN", "files": ["a.py"],
+                       "closingIssues": [2]}
+    closed_pr = {"number": 8, "body": "Fixes #1", "state": "CLOSED", "files": ["a.py"],
+                 "closingIssues": [1]}
+    exact_match = {"number": 4, "body": "", "state": "OPEN", "files": ["b.py", "a.py"],
+                   "closingIssues": [1]}
+
+    res = analyze({"subject": subject, "candidates": [same_issue_intersect, disjoint_files,
+                                                      different_issue, closed_pr]})
+    nums = [o["number"] for o in res["overlaps"]]
+    check("same_issue_intersect_flagged", 5 in nums)
+    check("disjoint_files_not_flagged", 6 not in nums)
+    check("different_issue_not_flagged", 7 not in nums)
+    check("closed_pr_not_flagged", 8 not in nums)
+    check("has_overlap_true", res["has_overlap"] is True)
+
+    only = next((o for o in res["overlaps"] if o["number"] == 5), None)
+    check("overlap_names_shared_file", only is not None and only["files"] == ["a.py"])
+    check("overlap_reports_file_count", only is not None and only["file_count"] == 1)
+    check("intersect_not_exact", only is not None and only["exact"] is False)
+
+    # Body-keyword fallback finds the issue when closingIssues is empty.
+    check("body_fallback_issue_parsed", referenced_issues(same_issue_intersect) == {1})
+
+    # Exact set match is reported as a stronger signal.
+    res2 = analyze({"subject": subject, "candidates": [exact_match]})
+    exact = next((o for o in res2["overlaps"] if o["number"] == 4), None)
+    check("exact_set_match_flagged", exact is not None)
+    check("exact_flag_set", exact is not None and exact["exact"] is True)
+
+    # Self never matches self even if present in the candidate list.
+    res3 = analyze({"subject": subject, "candidates": [subject]})
+    check("self_never_matched", res3["overlaps"] == [])
+
+    # A subject with no issue reference correlates on nothing.
+    no_issue = {"number": 20, "body": "no link", "state": "OPEN", "files": ["a.py"],
+                "closingIssues": []}
+    res4 = analyze({"subject": no_issue, "candidates": [same_issue_intersect]})
+    check("no_issue_reference_no_overlap", res4["overlaps"] == [])
+
+    if failures:
+        print(f"\n{len(failures)} check(s) FAILED: {failures}")
+        return 1
+    print("\nall checks passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--test", action="store_true", help="run the network-free self-test")
+    parser.add_argument("--fetch", action="store_true",
+                        help="materialize the bundle from GitHub via gh")
+    parser.add_argument("--repo", help="owner/name (required with --fetch)")
+    parser.add_argument("--pr", type=int, help="subject PR number (required with --fetch)")
+    parser.add_argument("--limit", type=int, default=900,
+                        help="max open PRs to consider as candidates in --fetch mode")
+    args = parser.parse_args(argv[1:])
+
+    if args.test:
+        return _run_self_test()
+
+    if args.fetch:
+        if not args.repo or args.pr is None:
+            sys.stderr.write("--fetch requires --repo and --pr\n")
+            return 1
+        try:
+            bundle = _fetch_bundle(args.repo, args.pr, args.limit)
+        except (RuntimeError, ValueError) as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 2
+    else:
+        try:
+            bundle = json.load(sys.stdin)
+        except json.JSONDecodeError as exc:
+            sys.stderr.write(f"malformed JSON on stdin: {exc}\n")
+            return 1
+        if not isinstance(bundle, dict):
+            sys.stderr.write("stdin must be a JSON object with 'subject' and 'candidates'\n")
+            return 1
+
+    json.dump(analyze(bundle), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/detect_pr_overlap.py
+++ b/scripts/detect_pr_overlap.py
@@ -9,8 +9,11 @@ workflows (`.github/workflows/pr-duplicate-detect.yml`):
     gets a single heads-up comment naming the earlier PR(s), so duplicated
     effort is caught before a reviewer reads two solutions to the same problem.
   * ON MERGE (proposal 1): when a PR is merged, any OPEN PR against the same
-    issue whose changed-file set intersects the merged PR's is pointed at the
-    merge and closed as superseded.
+    issue whose overlap with the merged PR is STRONG (an exact changed-file
+    match, or the shared files cover at least STRONG_OVERLAP_FRACTION of the
+    merged PR's files) is pointed at the merge and closed as superseded. A
+    weaker single-file overlap is left to the advisory comment rather than
+    auto-closed, so distinct companion work is not closed.
 
 Both triggers ask the same question about one PR: *which OTHER open PRs target
 the same issue AND touch at least one of the same files?* That question is this
@@ -37,6 +40,12 @@ match would miss the common real case where two PRs edit the same file plus
 different neighbours, which is still duplicated effort on that file. An exact
 set match is reported as a stronger `exact` signal on each overlap so a caller
 MAY phrase its message more firmly, but it is NOT required to flag.
+
+Each overlap also carries a `coverage` (the fraction of the subject PR's files
+the overlap shares) and a `strong` flag (exact match, or coverage >=
+STRONG_OVERLAP_FRACTION). The on-open advisory flags on ANY overlap; the
+on-merge auto-close acts ONLY on a `strong` overlap, so a merge does not close
+an open PR that merely shares one file for the same issue.
 
 Both conditions are required. Same issue alone is too noisy -- a single issue
 legitimately hosts stacked or companion PRs that touch different files.
@@ -81,7 +90,10 @@ Usage:
     python3 scripts/detect_pr_overlap.py < bundle.json
 
     # Fetch mode: materialize the subject PR and the open-PR candidate set from
-    # GitHub via `gh`, then run the same analysis. Used by the workflows.
+    # GitHub via `gh`, then run the same analysis. Used by the workflows. The
+    # open-PR candidate set is materialized in a SINGLE `gh pr list` call (number
+    # + body + state + files + closing-issue linkage), not one call per PR, so
+    # the API cost stays bounded on a busy repo.
     python3 scripts/detect_pr_overlap.py --fetch --repo owner/name --pr 123
 
     # Self-test (no repository or network needed):
@@ -113,6 +125,17 @@ _CLOSES_RE = re.compile(
     r"\b(?:" + "|".join(_CLOSING_KEYWORDS) + r")\b\s*:?\s+#(\d+)\b",
     re.IGNORECASE,
 )
+
+# The on-merge lane auto-closes an overlapping open PR only on a STRONG signal,
+# not on a single shared file. An overlap is strong when it is an exact
+# changed-file match OR the shared files cover at least this fraction of the
+# subject PR's files (on the on-merge path the subject is the merged PR, so this
+# is the fraction of the merged PR's change the open PR duplicates). Weaker
+# overlaps still surface in the advisory on-open comment but do NOT trigger an
+# auto-close, so genuinely-distinct companion work sharing one file is not
+# closed. Every overlap still carries its `coverage`, so a caller may apply its
+# own bar; this constant is only the on-merge close threshold.
+STRONG_OVERLAP_FRACTION = 0.5
 
 
 def referenced_issues(pr: dict[str, Any]) -> set[int]:
@@ -166,15 +189,33 @@ def find_overlaps(subject: dict[str, Any], candidates: list[dict[str, Any]]) -> 
         if not shared_files:
             continue
         cand_files = changed_files(cand)
+        exact = cand_files == subject_files and bool(cand_files)
+        # Fraction of the SUBJECT's files that this candidate also touches. On
+        # the on-merge path the subject is the merged PR, so this is "how much of
+        # the merged PR's change this open PR covers" -- the signal the on-merge
+        # close gate uses (see STRONG_OVERLAP_FRACTION).
+        coverage = len(shared_files) / len(subject_files) if subject_files else 0.0
         overlaps.append(
             {
                 "number": cand.get("number"),
                 "issues": sorted(shared_issues),
                 "files": sorted(shared_files),
                 "file_count": len(shared_files),
+                # Candidate PR's labels, passed through so a caller (the on-merge
+                # lane) can honour a label-gated opt-out without a per-PR call.
+                "labels": [str(lbl) for lbl in (cand.get("labels") or []) if lbl],
                 # Exact set match is a stronger signal a caller MAY phrase more
                 # firmly; it is not required to flag (intersection is the rule).
-                "exact": cand_files == subject_files and bool(cand_files),
+                "exact": exact,
+                # Fraction of the subject's files covered by this overlap.
+                "coverage": round(coverage, 4),
+                # A "strong" overlap is one where the merge plausibly supersedes
+                # the open PR's work: an exact changed-file match, or the shared
+                # files cover at least STRONG_OVERLAP_FRACTION of the subject's
+                # files. The on-merge lane closes ONLY on a strong overlap and
+                # leaves weaker (single-file) overlaps to the advisory comment,
+                # so it does not auto-close legitimately-distinct companion work.
+                "strong": exact or coverage >= STRONG_OVERLAP_FRACTION,
             }
         )
     overlaps.sort(key=lambda o: (o["number"] is None, o["number"]))
@@ -192,6 +233,10 @@ def analyze(bundle: dict[str, Any]) -> dict[str, Any]:
         "files": sorted(changed_files(subject)),
         "overlaps": overlaps,
         "has_overlap": bool(overlaps),
+        # True when at least one overlap is strong enough for the on-merge lane
+        # to close it (see STRONG_OVERLAP_FRACTION). The on-open advisory uses
+        # has_overlap; the on-merge close uses this.
+        "has_strong_overlap": any(o["strong"] for o in overlaps),
     }
 
 
@@ -217,9 +262,10 @@ def _gh_json(args: list[str]) -> Any:
 def _fetch_pr_record(repo: str, number: int) -> dict[str, Any]:
     """Materialize one PR into an engine record via `gh`."""
     view = _gh_json(
-        ["pr", "view", str(number), "--repo", repo, "--json", "number,body,state,files"]
+        ["pr", "view", str(number), "--repo", repo, "--json", "number,body,state,files,labels"]
     )
     files = [f.get("path") for f in (view.get("files") or []) if f.get("path")]
+    labels = [lbl.get("name") for lbl in (view.get("labels") or []) if lbl.get("name")]
     owner, name = repo.split("/", 1)
     graph = _gh_json(
         [
@@ -251,26 +297,65 @@ def _fetch_pr_record(repo: str, number: int) -> dict[str, Any]:
         "state": view.get("state") or "OPEN",
         "files": files,
         "closingIssues": closing,
+        "labels": labels,
+    }
+
+
+def _record_from_list_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one `gh pr list --json ...` entry into an engine record.
+
+    `gh pr list` returns `files` as objects with a `path`,
+    `closingIssuesReferences` as objects with a `number`, and `labels` as
+    objects with a `name`, the same shapes `_fetch_pr_record` normalizes from
+    the per-PR calls.
+    """
+    files = [f.get("path") for f in (entry.get("files") or []) if f.get("path")]
+    closing = [
+        n.get("number")
+        for n in (entry.get("closingIssuesReferences") or [])
+        if n.get("number") is not None
+    ]
+    labels = [lbl.get("name") for lbl in (entry.get("labels") or []) if lbl.get("name")]
+    return {
+        "number": entry.get("number"),
+        "body": entry.get("body") or "",
+        "state": entry.get("state") or "OPEN",
+        "files": files,
+        "closingIssues": closing,
+        "labels": labels,
     }
 
 
 def _fetch_bundle(repo: str, number: int, list_limit: int) -> dict[str, Any]:
     """Build the {"subject", "candidates"} bundle from GitHub.
 
-    Candidates are every OTHER open PR, each materialized to a full record. This
-    is the read-only I/O the workflow needs; the analysis stays pure.
+    Candidates are the OTHER open PRs. To keep the API cost bounded on a busy
+    repo, this issues ONE `gh pr list` that materializes every open PR's number,
+    body, state, changed files and closing-issue linkage in a single call,
+    rather than a `pr view` + a GraphQL call per open PR (which scaled as
+    ~2x the open-PR count on every open/reopen/synchronize event). The subject
+    PR is taken from that same list when it is open; on the on-merge path it is
+    no longer open, so it alone is materialized with the per-PR reader.
     """
-    subject = _fetch_pr_record(repo, number)
     open_prs = _gh_json(
         ["pr", "list", "--repo", repo, "--state", "open", "--limit", str(list_limit),
-         "--json", "number"]
+         "--json", "number,body,state,files,closingIssuesReferences,labels"]
     ) or []
+
+    subject: dict[str, Any] | None = None
     candidates: list[dict[str, Any]] = []
     for entry in open_prs:
-        cand_num = entry.get("number")
-        if cand_num is None or cand_num == number:
+        record = _record_from_list_entry(entry)
+        if record["number"] == number:
+            subject = record  # the subject is open -> reuse the list record
             continue
-        candidates.append(_fetch_pr_record(repo, cand_num))
+        candidates.append(record)
+
+    if subject is None:
+        # On-merge (or a subject not returned by the open list): materialize the
+        # single subject PR directly. This is one PR, not the whole open set.
+        subject = _fetch_pr_record(repo, number)
+
     return {"subject": subject, "candidates": candidates}
 
 
@@ -313,6 +398,9 @@ def _run_self_test() -> int:
     check("overlap_names_shared_file", only is not None and only["files"] == ["a.py"])
     check("overlap_reports_file_count", only is not None and only["file_count"] == 1)
     check("intersect_not_exact", only is not None and only["exact"] is False)
+    # #5 shares a.py out of the subject's {a.py, b.py} -> coverage 0.5 -> strong.
+    check("overlap_reports_coverage", only is not None and only["coverage"] == 0.5)
+    check("half_coverage_is_strong", only is not None and only["strong"] is True)
 
     # Body-keyword fallback finds the issue when closingIssues is empty.
     check("body_fallback_issue_parsed", referenced_issues(same_issue_intersect) == {1})
@@ -322,6 +410,21 @@ def _run_self_test() -> int:
     exact = next((o for o in res2["overlaps"] if o["number"] == 4), None)
     check("exact_set_match_flagged", exact is not None)
     check("exact_flag_set", exact is not None and exact["exact"] is True)
+    check("exact_is_strong", exact is not None and exact["strong"] is True)
+
+    # A weak overlap: the merged subject touches many files, the candidate
+    # shares only one -> below STRONG_OVERLAP_FRACTION -> flagged (advisory) but
+    # NOT strong, so the on-merge lane would not auto-close it.
+    wide_subject = {"number": 30, "body": "Fixes #9", "state": "MERGED",
+                    "files": ["a.py", "b.py", "c.py", "d.py"], "closingIssues": [9]}
+    one_file = {"number": 31, "body": "Fixes #9", "state": "OPEN", "files": ["a.py", "e.py"],
+                "closingIssues": [9]}
+    res5 = analyze({"subject": wide_subject, "candidates": [one_file]})
+    weak = next((o for o in res5["overlaps"] if o["number"] == 31), None)
+    check("weak_overlap_flagged", weak is not None)
+    check("weak_overlap_not_strong", weak is not None and weak["strong"] is False)
+    check("weak_overlap_no_strong_overlap", res5["has_strong_overlap"] is False)
+    check("weak_overlap_has_overlap", res5["has_overlap"] is True)
 
     # Self never matches self even if present in the candidate list.
     res3 = analyze({"subject": subject, "candidates": [subject]})
@@ -347,8 +450,9 @@ def main(argv: list[str]) -> int:
                         help="materialize the bundle from GitHub via gh")
     parser.add_argument("--repo", help="owner/name (required with --fetch)")
     parser.add_argument("--pr", type=int, help="subject PR number (required with --fetch)")
-    parser.add_argument("--limit", type=int, default=900,
-                        help="max open PRs to consider as candidates in --fetch mode")
+    parser.add_argument("--limit", type=int, default=200,
+                        help="max open PRs to materialize as candidates in --fetch mode "
+                             "(one `gh pr list` call, not one call per PR)")
     args = parser.parse_args(argv[1:])
 
     if args.test:

--- a/test/test_fork_review_heal.py
+++ b/test/test_fork_review_heal.py
@@ -1,0 +1,570 @@
+"""Behavioural tests for .github/workflows/fork-review-heal.yml.
+
+The heal sweep's entire decision logic lives in one `run:` block of shell + jq
+that no other test touches. These tests extract that script and execute it for
+real with `gh` replaced by a stub, so the re-dispatch CONDITIONS are verified
+rather than assumed -- and the condition is the whole point: too narrow and a
+never-fired fork-review lane stays frozen pending forever, too broad and every
+fork PR re-dispatches its reviewers on every sweep.
+
+The freeze this sweep rescues: a fork PR's Stage-2 reviewers trigger on the
+`workflow_run: completed` event of CI, which GitHub silently drops under load.
+When that event is dropped after CI concludes success, no fork-review check-run
+is ever posted, `pr-readiness.yml` reads the lane as "(not started)" / "the real
+review has not posted yet" -> pending, and nothing can recompute it. The sweep
+finds those lanes and re-dispatches only them, keyed to the head SHA.
+
+Skipped where the POSIX toolchain the script needs (bash, jq, GNU `date -d`) is
+unavailable, which is the case on the Windows leg of the matrix. Mirrors the
+explicit nt guard in test_pr_readiness_sweep.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+try:
+    import pytest
+except ModuleNotFoundError:  # pragma: no cover - only when run as the __main__ driver
+    # The authoring sandbox cannot install pytest (INTEGRATIONS_ONLY blocks
+    # PyPI), so the standalone driver at the bottom of this file runs the same
+    # assertions without it. CI has pytest and uses the test functions directly.
+    pytest = None  # type: ignore[assignment]
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - PyYAML is absent in the sandbox
+    yaml = None  # type: ignore[assignment]
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "fork-review-heal.yml"
+)
+
+LANES = [
+    "Opus 4.8 Review",
+    "GPT 5.6 Review",
+    "Design Review",
+    "UX Review",
+    "First Principles Review",
+]
+
+
+def _gnu_date() -> bool:
+    """GNU `date -d` is required; BSD date uses -j -f and would silently differ."""
+    return (
+        subprocess.run(
+            ["date", "-u", "-d", "2026-01-01T00:00:00Z", "+%s"],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+if pytest is not None:
+    pytestmark = pytest.mark.skipif(
+        not WORKFLOW.exists()
+        or os.name == "nt"
+        or shutil.which("bash") is None
+        or shutil.which("jq") is None
+        or not _gnu_date(),
+        reason="requires the workflow plus a POSIX bash, jq and GNU date",
+    )
+
+# `gh` stub. Four shapes are served, keyed on the subcommand/URL:
+#   pr list                          -> the fixture open-PR list
+#   api .../workflows/ci.yml/runs    -> the fixture CI runs for the head SHA
+#   api .../check-runs               -> the fixture head-SHA check-runs
+#   workflow run                     -> RECORD the dispatch instead of firing it
+GH_STUB = r"""#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 ${2:-}" = "pr list" ]; then
+  cat "$FIXTURES/prs.json"
+  exit 0
+fi
+if [ "$1 ${2:-}" = "workflow run" ]; then
+  # Record the workflow file and every -f key=value so the test can assert which
+  # lane was re-dispatched and that head_sha was passed through.
+  printf '%s\n' "$*" >> "$FIXTURES/dispatched.txt"
+  exit 0
+fi
+if [ "$1" = "api" ]; then
+  for arg in "$@"; do
+    case "$arg" in
+      *"/workflows/ci.yml/runs"*) cat "$FIXTURES/ci_runs.json"; exit 0 ;;
+      *"/check-runs"*) cat "$FIXTURES/check_runs.json"; exit 0 ;;
+    esac
+  done
+fi
+echo "gh stub: unhandled: $*" >&2
+exit 90
+"""
+
+
+def _extract_run_blocks_stdlib(text: str) -> list[str]:
+    """PyYAML-free `run: |` literal-block extractor for the __main__ driver.
+
+    The sandbox that authors this change cannot install PyYAML, so the standalone
+    driver falls back to this. It handles ONLY the `run: |` literal-block style
+    these workflows use; the authoritative extraction is the PyYAML path CI runs.
+    """
+    lines = text.splitlines()
+    blocks: list[str] = []
+    i = 0
+    while i < len(lines):
+        if lines[i].strip().startswith("run: |"):
+            key_indent = len(lines[i]) - len(lines[i].lstrip(" "))
+            body: list[str] = []
+            body_indent: int | None = None
+            j = i + 1
+            while j < len(lines):
+                ln = lines[j]
+                if ln.strip() == "":
+                    body.append("")
+                    j += 1
+                    continue
+                ind = len(ln) - len(ln.lstrip(" "))
+                if ind <= key_indent:
+                    break
+                if body_indent is None:
+                    body_indent = ind
+                body.append(ln[body_indent:] if len(ln) >= body_indent else ln.lstrip(" "))
+                j += 1
+            while body and body[-1] == "":
+                body.pop()
+            blocks.append("\n".join(body))
+            i = j
+            continue
+        i += 1
+    return blocks
+
+
+def _script() -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    if yaml is not None:
+        spec = yaml.safe_load(text)
+        steps = spec["jobs"]["heal"]["steps"]
+        runs = [s["run"] for s in steps if "run" in s]
+    else:  # pragma: no cover - the sandbox's PyYAML-free fallback
+        runs = _extract_run_blocks_stdlib(text)
+    assert len(runs) == 1, f"heal step count changed: {len(runs)}"
+    return runs[0]
+
+
+def _fixture(*args, **kwargs):
+    """`pytest.fixture` under pytest; a passthrough decorator for the driver."""
+    if pytest is not None:
+        return pytest.fixture(*args, **kwargs)
+
+    def _identity(fn):  # pragma: no cover - only the __main__ driver hits this
+        return fn
+
+    # Support both `@_fixture` and `@_fixture(scope=...)` call styles.
+    if len(args) == 1 and callable(args[0]) and not kwargs:
+        return args[0]
+    return _identity
+
+
+@_fixture(scope="module")
+def script() -> str:
+    return _script()
+
+
+class Runner:
+    """Executes the heal sweep's one step against one fixture repository state."""
+
+    def __init__(self, root: Path, script: str) -> None:
+        self.script = script
+        self.fixtures = root / "fixtures"
+        self.work = root / "work"
+        bindir = root / "bin"
+        for d in (self.fixtures, self.work, bindir):
+            d.mkdir(parents=True)
+        stub = bindir / "gh"
+        stub.write_text(GH_STUB)
+        stub.chmod(0o755)
+        self.env = {
+            **os.environ,
+            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+            "FIXTURES": str(self.fixtures),
+            "REPO": "kirodotdev/KiroCrew",
+            "STALE_MINUTES": "20",
+            "MAX_DISPATCH": "200",
+            "PR_LIST_LIMIT": "900",
+        }
+
+    def sweep(
+        self,
+        *,
+        is_fork: bool = True,
+        ci_status: str | None = "completed",
+        ci_conclusion: str = "success",
+        ci_completed_at: str = "2020-01-01T00:00:00Z",
+        present_lanes: dict[str, str] | None = None,
+        pr: int = 7553,
+        sha: str = "abc123def456",
+        max_dispatch: str = "200",
+    ) -> list[str]:
+        """Run the heal over ONE fork PR; return the dispatch lines recorded.
+
+        `present_lanes` maps a lane name to the check-run STATE that already
+        exists on the head SHA: "in_progress", "success", "failure", "neutral",
+        or "skipped". A lane absent from the map has NO check-run at all. Only a
+        lane with no check-run, or only a completed `skipped` one, is missing.
+        `ci_status=None` means the head SHA carries NO CI run at all.
+        """
+        (self.fixtures / "prs.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "number": pr,
+                        "headRefOid": sha,
+                        "isCrossRepository": is_fork,
+                    }
+                ]
+            )
+        )
+        ci_runs = (
+            []
+            if ci_status is None
+            else [
+                {
+                    "id": 100,
+                    "status": ci_status,
+                    "conclusion": ci_conclusion,
+                    "updated_at": ci_completed_at,
+                    "created_at": ci_completed_at,
+                }
+            ]
+        )
+        (self.fixtures / "ci_runs.json").write_text(
+            json.dumps({"workflow_runs": ci_runs})
+        )
+        runs = []
+        for name, state in (present_lanes or {}).items():
+            if state == "in_progress":
+                runs.append({"name": name, "status": "in_progress", "conclusion": None})
+            else:
+                runs.append(
+                    {"name": name, "status": "completed", "conclusion": state}
+                )
+        # Slurped shape: an outer array of PAGES, each `{"check_runs": [...]}`.
+        (self.fixtures / "check_runs.json").write_text(
+            json.dumps([{"check_runs": runs}])
+        )
+        applied = self.fixtures / "dispatched.txt"
+        applied.unlink(missing_ok=True)
+
+        proc = subprocess.run(  # noqa: S603 - fixed argv, test-local stub
+            ["bash", "-c", self.script],
+            cwd=self.work,
+            env={**self.env, "MAX_DISPATCH": max_dispatch},
+            text=True,
+            capture_output=True,
+        )
+        # The sweep must never fail a run: a dispatch it cannot make is not an error.
+        assert proc.returncode == 0, proc.stderr
+        self.last_stdout = proc.stdout
+        if not applied.exists():
+            return []
+        return applied.read_text().splitlines()
+
+
+@_fixture
+def runner(tmp_path: Path, script: str) -> Runner:
+    return Runner(tmp_path, script)
+
+
+def _lanes_dispatched(lines: list[str]) -> set[str]:
+    """Return the set of workflow files that were re-dispatched."""
+    files = set()
+    for line in lines:
+        for tok in line.split():
+            if tok.endswith(".yml"):
+                files.add(tok)
+    return files
+
+
+# ── Scenario (a): CI success + missing lanes -> dispatch each missing lane once ─
+
+
+def test_ci_success_with_all_lanes_missing_dispatches_each_once(runner: Runner) -> None:
+    """The #7553 incident, reduced: CI passed, no fork-review lane ever fired.
+
+    All five lanes are missing, so each corresponding reviewer is re-dispatched
+    exactly once, keyed to the head SHA.
+    """
+    dispatched = runner.sweep(present_lanes=None)
+    assert len(dispatched) == 5
+    assert _lanes_dispatched(dispatched) == {
+        "fork-opus-review.yml",
+        "fork-gpt-review.yml",
+        "fork-design-review.yml",
+        "fork-ux-review.yml",
+        "fork-first-principles-review.yml",
+    }
+    for line in dispatched:
+        assert "head_sha=abc123def456" in line
+
+
+def test_only_missing_lanes_are_dispatched(runner: Runner) -> None:
+    """A lane that already posted a real verdict is left alone; only the ones that
+    never fired are re-dispatched."""
+    dispatched = runner.sweep(
+        present_lanes={
+            "Opus 4.8 Review": "success",
+            "GPT 5.6 Review": "failure",
+            "Design Review": "neutral",
+        }
+    )
+    assert _lanes_dispatched(dispatched) == {
+        "fork-ux-review.yml",
+        "fork-first-principles-review.yml",
+    }
+
+
+def test_a_skipped_only_lane_counts_as_never_fired(runner: Runner) -> None:
+    """A lane whose only check-run is the same-repo twin's `skipped` one has not
+    had its real review post yet -- exactly the pending state pr-readiness.yml
+    describes -- so it is re-dispatched."""
+    dispatched = runner.sweep(
+        present_lanes={name: "skipped" for name in LANES}
+    )
+    assert len(dispatched) == 5
+    assert _lanes_dispatched(dispatched) == {
+        "fork-opus-review.yml",
+        "fork-gpt-review.yml",
+        "fork-design-review.yml",
+        "fork-ux-review.yml",
+        "fork-first-principles-review.yml",
+    }
+
+
+# ── Scenario (b): CI success + all lanes present/complete -> no dispatch ──────
+
+
+def test_ci_success_with_all_lanes_present_dispatches_none(runner: Runner) -> None:
+    """A fully-reviewed fork PR is never re-dispatched."""
+    assert runner.sweep(present_lanes={name: "success" for name in LANES}) == []
+
+
+def test_an_in_progress_lane_is_not_re_dispatched(runner: Runner) -> None:
+    """The self-termination property: the instant a reviewer starts it opens an
+    in_progress check-run keyed to the head SHA, so the next sweep sees the lane
+    as present and does not re-dispatch it. Without this a still-running review
+    would be fired again on every sweep."""
+    assert runner.sweep(present_lanes={name: "in_progress" for name in LANES}) == []
+
+
+# ── Scenario (c): CI has not passed -> no dispatch, pending by design ─────────
+
+
+def test_ci_not_passed_dispatches_nothing_and_attributes_pending_to_ci(
+    runner: Runner,
+) -> None:
+    """A fork PR whose CI failed is NOT dispatched and NOT forced to pass; the
+    log attributes the pending to CI, distinct from a missing review."""
+    dispatched = runner.sweep(
+        ci_status="completed", ci_conclusion="failure", present_lanes=None
+    )
+    assert dispatched == []
+    assert "pending by design (CI has not passed)" in runner.last_stdout
+
+
+def test_ci_still_running_dispatches_nothing(runner: Runner) -> None:
+    """CI in flight means Stage 2 is correctly not eligible yet."""
+    dispatched = runner.sweep(
+        ci_status="in_progress", ci_conclusion="", present_lanes=None
+    )
+    assert dispatched == []
+    assert "pending by design (CI has not passed)" in runner.last_stdout
+
+
+def test_no_ci_run_at_all_dispatches_nothing(runner: Runner) -> None:
+    """No CI run on the head SHA yet -> pending by design (CI has not started)."""
+    dispatched = runner.sweep(ci_status=None, present_lanes=None)
+    assert dispatched == []
+    assert "pending by design (CI has not started)" in runner.last_stdout
+
+
+def test_a_fresh_ci_success_is_left_to_fan_out(runner: Runner) -> None:
+    """Inside STALE_MINUTES of the CI success the fork reviewers may genuinely
+    still be fanning out via the workflow_run event, so nothing is dispatched."""
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(minutes=2)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    dispatched = runner.sweep(ci_completed_at=recent, present_lanes=None)
+    assert dispatched == []
+    assert "may still be fanning out" in runner.last_stdout
+
+
+# ── A same-repo PR is out of scope ───────────────────────────────────────────
+
+
+def test_a_same_repo_pr_is_ignored(runner: Runner) -> None:
+    """Only fork PRs run the fork reviewers; a same-repo PR runs the same-repo
+    lanes and must never be dispatched here."""
+    assert runner.sweep(is_fork=False, present_lanes=None) == []
+
+
+# ── Scenario (d): idempotency across two consecutive sweeps ───────────────────
+
+
+def test_dispatch_is_self_terminating_across_two_sweeps(runner: Runner) -> None:
+    """First sweep re-dispatches the never-fired lanes; the reviewers then open
+    their in_progress check-runs, so the second sweep -- over that resulting
+    state -- dispatches nothing."""
+    first = runner.sweep(present_lanes=None)
+    assert len(first) == 5
+    # After the dispatch, every reviewer has opened an in_progress check-run
+    # keyed to the head SHA. The next sweep sees the lanes as present.
+    second = runner.sweep(present_lanes={name: "in_progress" for name in LANES})
+    assert second == []
+
+
+# ── The runaway backstop applies ─────────────────────────────────────────────
+
+
+def test_max_dispatch_caps_the_sweep(runner: Runner) -> None:
+    """The cap bounds a single sweep against a pathological run."""
+    assert runner.sweep(present_lanes=None, max_dispatch="0") == []
+
+
+def test_max_dispatch_of_two_dispatches_only_two_lanes(runner: Runner) -> None:
+    dispatched = runner.sweep(present_lanes=None, max_dispatch="2")
+    assert len(dispatched) == 2
+
+
+# ── It only ever nudges; it never publishes a verdict ────────────────────────
+
+
+def test_the_sweep_never_writes_a_check_run_or_status(script: str) -> None:
+    """The heal may only dispatch the reviewers; it must never manufacture a
+    verdict itself, which would be a second source of truth for a required
+    check."""
+    assert "gh workflow run" in script
+    for forbidden in ("check-runs\" -f", "--method POST", "-X POST", "-f status="):
+        assert forbidden not in script, f"heal must not write results: {forbidden}"
+
+
+def test_the_sweep_never_checks_out_or_executes_fork_code(script: str) -> None:
+    """The fork trust model: the sweep only reads and dispatches."""
+    for forbidden in ("actions/checkout", "git clone", "git fetch", "npm ", "pip "):
+        assert forbidden not in script, f"heal must not touch fork code: {forbidden}"
+
+
+# ── Standalone driver so the same assertions run without pytest ──────────────
+# The sandbox that authors this change cannot install pytest (INTEGRATIONS_ONLY
+# blocks PyPI), so `python3.12 test/test_fork_review_heal.py` runs the behavioural
+# checks directly against a plain-bash execution of the extracted step. CI runs
+# the pytest form above; this __main__ is the local substitute.
+if __name__ == "__main__":
+    import tempfile
+
+    if (
+        os.name == "nt"
+        or shutil.which("bash") is None
+        or shutil.which("jq") is None
+        or not _gnu_date()
+        or not WORKFLOW.exists()
+    ):
+        print("SKIP: requires the workflow plus a POSIX bash, jq and GNU date")
+        raise SystemExit(0)
+
+    script = _script()
+    failures: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        print(f"{'ok  ' if cond else 'FAIL'} {name}")
+        if not cond:
+            failures.append(name)
+
+    with tempfile.TemporaryDirectory() as td:
+        # Scenario (a): all lanes missing -> five dispatches.
+        r = Runner(Path(td) / "a", script)
+        d = r.sweep(present_lanes=None)
+        check("ci_success_all_missing_dispatches_five", len(d) == 5)
+        check(
+            "dispatch_carries_head_sha",
+            all("head_sha=abc123def456" in line for line in d),
+        )
+
+        # Only missing lanes dispatched.
+        r = Runner(Path(td) / "a2", script)
+        d = r.sweep(
+            present_lanes={
+                "Opus 4.8 Review": "success",
+                "GPT 5.6 Review": "failure",
+                "Design Review": "neutral",
+            }
+        )
+        check(
+            "only_missing_lanes_dispatched",
+            _lanes_dispatched(d)
+            == {"fork-ux-review.yml", "fork-first-principles-review.yml"},
+        )
+
+        # skipped-only counts as never fired.
+        r = Runner(Path(td) / "a3", script)
+        d = r.sweep(present_lanes={n: "skipped" for n in LANES})
+        check("skipped_only_counts_as_missing", len(d) == 5)
+
+        # Scenario (b): all present -> none.
+        r = Runner(Path(td) / "b", script)
+        check(
+            "all_present_dispatches_none",
+            r.sweep(present_lanes={n: "success" for n in LANES}) == [],
+        )
+        r = Runner(Path(td) / "b2", script)
+        check(
+            "in_progress_not_re_dispatched",
+            r.sweep(present_lanes={n: "in_progress" for n in LANES}) == [],
+        )
+
+        # Scenario (c): CI not passed -> none, attributed to CI.
+        r = Runner(Path(td) / "c", script)
+        d = r.sweep(ci_conclusion="failure", present_lanes=None)
+        check(
+            "ci_failed_dispatches_none_attributed_to_ci",
+            d == [] and "pending by design (CI has not passed)" in r.last_stdout,
+        )
+        r = Runner(Path(td) / "c2", script)
+        d = r.sweep(ci_status=None, present_lanes=None)
+        check(
+            "no_ci_run_dispatches_none",
+            d == [] and "pending by design (CI has not started)" in r.last_stdout,
+        )
+
+        # Same-repo PR ignored.
+        r = Runner(Path(td) / "c3", script)
+        check(
+            "same_repo_pr_ignored",
+            r.sweep(is_fork=False, present_lanes=None) == [],
+        )
+
+        # Scenario (d): idempotency across two sweeps.
+        r = Runner(Path(td) / "d", script)
+        first = r.sweep(present_lanes=None)
+        r2 = Runner(Path(td) / "d2", script)
+        second = r2.sweep(present_lanes={n: "in_progress" for n in LANES})
+        check(
+            "idempotent_across_two_sweeps",
+            len(first) == 5 and second == [],
+        )
+
+        # Cap.
+        r = Runner(Path(td) / "e", script)
+        check("max_dispatch_caps", r.sweep(present_lanes=None, max_dispatch="0") == [])
+
+    if failures:
+        print(f"\n{len(failures)} check(s) FAILED: {failures}")
+        raise SystemExit(1)
+    print("\nall checks passed")

--- a/test/test_pr_duplicate_detect.py
+++ b/test/test_pr_duplicate_detect.py
@@ -1,0 +1,588 @@
+"""Behavioural tests for .github/workflows/pr-duplicate-detect.yml plus unit
+tests for its shared engine scripts/detect_pr_overlap.py.
+
+The workflow's two lanes share ONE detection engine and differ only in what they
+do with its answer, so the engine is unit-tested directly (importlib against
+canned JSON, no network, mirroring test/test_update_contributors.py) and each
+lane's `run:` block is extracted and executed for real with `gh` replaced by a
+stub, so the comment/close DECISIONS and their idempotency are verified rather
+than assumed. The decision is the whole point: too broad and every stacked PR
+gets a false duplicate warning, too narrow and the duplicated effort the
+proposals target slips through.
+
+Both conditions must hold to flag -- same referenced issue AND a non-empty
+changed-file intersection -- and the triggering PR is never matched against
+itself; these tests pin exactly that.
+
+Skipped where the POSIX toolchain the steps need (bash, jq) or python3.12 is
+unavailable, e.g. the Windows leg of the matrix. Mirrors the nt guard in
+test_pr_readiness_sweep.py / test_fork_review_heal.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import pytest
+except ModuleNotFoundError:  # pragma: no cover - only when run as the __main__ driver
+    pytest = None  # type: ignore[assignment]
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - PyYAML is absent in the sandbox
+    yaml = None  # type: ignore[assignment]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "pr-duplicate-detect.yml"
+SCRIPT = _REPO_ROOT / "scripts" / "detect_pr_overlap.py"
+
+
+def _py312() -> str | None:
+    """The workflow pins python 3.12; the steps invoke `python3`. Prefer a real
+    3.12 on PATH so the extracted step runs the same interpreter CI uses."""
+    for cand in ("python3.12", "python3"):
+        exe = shutil.which(cand)
+        if exe is None:
+            continue
+        out = subprocess.run([exe, "--version"], capture_output=True, text=True)
+        if "3.12" in (out.stdout + out.stderr):
+            return exe
+    return None
+
+
+if pytest is not None:
+    pytestmark = pytest.mark.skipif(
+        not WORKFLOW.exists()
+        or not SCRIPT.exists()
+        or os.name == "nt"
+        or shutil.which("bash") is None
+        or shutil.which("jq") is None
+        or _py312() is None,
+        reason="requires the workflow + engine plus a POSIX bash, jq and python3.12",
+    )
+
+
+# --------------------------------------------------------------------------------
+# Engine unit tests (importlib, no network).
+# --------------------------------------------------------------------------------
+
+
+def _load_engine():
+    spec = importlib.util.spec_from_file_location("detect_pr_overlap", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["detect_pr_overlap"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_engine_same_issue_intersecting_files_is_flagged() -> None:
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN",
+               "files": ["a.py", "b.py"], "closingIssues": [1]}
+    cand = {"number": 5, "body": "Closes #1", "state": "OPEN",
+            "files": ["a.py", "c.py"], "closingIssues": []}
+    res = eng.analyze({"subject": subject, "candidates": [cand]})
+    assert res["has_overlap"] is True
+    assert [o["number"] for o in res["overlaps"]] == [5]
+    assert res["overlaps"][0]["files"] == ["a.py"]
+    assert res["overlaps"][0]["file_count"] == 1
+    assert res["overlaps"][0]["exact"] is False
+
+
+def test_engine_disjoint_files_not_flagged() -> None:
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py"],
+               "closingIssues": [1]}
+    cand = {"number": 5, "body": "Fixes #1", "state": "OPEN", "files": ["z.py"],
+            "closingIssues": [1]}
+    assert eng.analyze({"subject": subject, "candidates": [cand]})["overlaps"] == []
+
+
+def test_engine_different_issue_not_flagged() -> None:
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py"],
+               "closingIssues": [1]}
+    cand = {"number": 5, "body": "Fixes #2", "state": "OPEN", "files": ["a.py"],
+            "closingIssues": [2]}
+    assert eng.analyze({"subject": subject, "candidates": [cand]})["overlaps"] == []
+
+
+def test_engine_never_matches_self() -> None:
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py"],
+               "closingIssues": [1]}
+    assert eng.analyze({"subject": subject, "candidates": [subject]})["overlaps"] == []
+
+
+def test_engine_only_open_candidates() -> None:
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py"],
+               "closingIssues": [1]}
+    closed = {"number": 5, "body": "Fixes #1", "state": "CLOSED", "files": ["a.py"],
+              "closingIssues": [1]}
+    assert eng.analyze({"subject": subject, "candidates": [closed]})["overlaps"] == []
+
+
+def test_engine_body_keyword_fallback_when_linkage_empty() -> None:
+    eng = _load_engine()
+    # closingIssues empty; only the body "Resolves #3" links the issue.
+    subject = {"number": 10, "body": "Resolves #3", "state": "OPEN", "files": ["a.py"],
+               "closingIssues": []}
+    cand = {"number": 5, "body": "Fixes #3", "state": "OPEN", "files": ["a.py"],
+            "closingIssues": []}
+    res = eng.analyze({"subject": subject, "candidates": [cand]})
+    assert [o["number"] for o in res["overlaps"]] == [5]
+
+
+def test_engine_exact_set_match_is_a_stronger_signal() -> None:
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py", "b.py"],
+               "closingIssues": [1]}
+    cand = {"number": 5, "body": "Fixes #1", "state": "OPEN", "files": ["b.py", "a.py"],
+            "closingIssues": [1]}
+    res = eng.analyze({"subject": subject, "candidates": [cand]})
+    assert res["overlaps"][0]["exact"] is True
+
+
+# --------------------------------------------------------------------------------
+# Workflow step extraction + behavioural execution against a `gh` stub.
+# --------------------------------------------------------------------------------
+
+# The `gh` stub serves the reads the engine's --fetch path makes (pr view, pr
+# list, api graphql) from per-PR fixtures, and RECORDS every mutating call
+# (comment create/patch/delete, pr comment, pr close) to files the test asserts
+# on. Read shapes are keyed on argv; the graphql closingIssues come from the
+# per-PR fixture too.
+GH_STUB = r"""#!/usr/bin/env bash
+set -euo pipefail
+
+# --- pr list --state open --json number ---
+if [ "$1 ${2:-}" = "pr list" ]; then
+  cat "$FIXTURES/open_prs.json"
+  exit 0
+fi
+
+# --- pr view <n> --json number,body,state,files ---
+if [ "$1 ${2:-}" = "pr view" ]; then
+  cat "$FIXTURES/pr_$3.json"
+  exit 0
+fi
+
+# --- pr comment <n> --body ... (on-merge pointer) ---
+if [ "$1 ${2:-}" = "pr comment" ]; then
+  printf 'comment %s\n' "$3" >> "$FIXTURES/pr_comment.txt"
+  exit 0
+fi
+
+# --- pr close <n> (on-merge) ---
+if [ "$1 ${2:-}" = "pr close" ]; then
+  printf 'close %s\n' "$3" >> "$FIXTURES/pr_close.txt"
+  exit 0
+fi
+
+if [ "$1" = "api" ]; then
+  method="GET"
+  target=""
+  jqexpr=""
+  for ((i=1; i<=$#; i++)); do
+    a="${!i}"
+    case "$a" in
+      --method) j=$((i+1)); method="${!j}" ;;
+      --jq) j=$((i+1)); jqexpr="${!j}" ;;
+      graphql) target="graphql" ;;
+      repos/*) target="$a" ;;
+    esac
+  done
+
+  # Emit a fixture, applying the request's --jq like real `gh` does.
+  emit() {
+    if [ -n "$jqexpr" ]; then
+      jq -r "$jqexpr" "$1"
+    else
+      cat "$1"
+    fi
+  }
+
+  if [ "$target" = "graphql" ]; then
+    # Return the closingIssues fixture for the queried PR number (-F number=N).
+    num=""
+    for ((i=1; i<=$#; i++)); do
+      a="${!i}"
+      case "$a" in number=*) num="${a#number=}" ;; esac
+    done
+    emit "$FIXTURES/graphql_$num.json"
+    exit 0
+  fi
+
+  case "$method:$target" in
+    GET:repos/*/comments*)
+      # List existing marker comments for the subject PR.
+      emit "$FIXTURES/comments.json"
+      exit 0 ;;
+    POST:repos/*/comments*|POST:repos/*/issues/*/comments)
+      printf 'POST %s\n' "$target" >> "$FIXTURES/comment_write.txt" ;;
+    PATCH:repos/*/comments*)
+      printf 'PATCH %s\n' "$target" >> "$FIXTURES/comment_write.txt" ;;
+    DELETE:repos/*/comments*)
+      printf 'DELETE %s\n' "$target" >> "$FIXTURES/comment_write.txt" ;;
+    *)
+      # Fall through: POST/PATCH to issues/<n>/comments matches the first case.
+      case "$target" in
+        repos/*/comments*|repos/*)
+          printf '%s %s\n' "$method" "$target" >> "$FIXTURES/comment_write.txt" ;;
+        *)
+          echo "gh stub: unhandled api $method $target" >&2; exit 91 ;;
+      esac ;;
+  esac
+  exit 0
+fi
+
+echo "gh stub: unhandled: $*" >&2
+exit 90
+"""
+
+
+def _extract_run_blocks_stdlib(text: str) -> list[str]:
+    """PyYAML-free `run: |` literal-block extractor for the __main__ driver."""
+    lines = text.splitlines()
+    blocks: list[str] = []
+    i = 0
+    while i < len(lines):
+        if lines[i].strip().startswith("run: |"):
+            key_indent = len(lines[i]) - len(lines[i].lstrip(" "))
+            body: list[str] = []
+            body_indent: int | None = None
+            j = i + 1
+            while j < len(lines):
+                ln = lines[j]
+                if ln.strip() == "":
+                    body.append("")
+                    j += 1
+                    continue
+                ind = len(ln) - len(ln.lstrip(" "))
+                if ind <= key_indent:
+                    break
+                if body_indent is None:
+                    body_indent = ind
+                body.append(ln[body_indent:] if len(ln) >= body_indent else ln.lstrip(" "))
+                j += 1
+            while body and body[-1] == "":
+                body.pop()
+            blocks.append("\n".join(body))
+            i = j
+            continue
+        i += 1
+    return blocks
+
+
+def _step(job: str, marker: str) -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    if yaml is not None:
+        spec = yaml.safe_load(text)
+        runs = [s["run"] for s in spec["jobs"][job]["steps"] if "run" in s]
+    else:  # pragma: no cover - sandbox PyYAML-free fallback
+        runs = [b for b in _extract_run_blocks_stdlib(text) if marker in b]
+    matches = [r for r in runs if marker in r]
+    assert len(matches) == 1, f"expected one {job} step matching {marker!r}, got {len(matches)}"
+    return matches[0]
+
+
+def on_open_step() -> str:
+    return _step("on-open", "Find any comment this lane previously left")
+
+
+def on_merge_step() -> str:
+    return _step("on-merge", "Close each overlapping open PR with a pointer")
+
+
+class Harness:
+    """Runs one lane's step against one fixture repository state."""
+
+    def __init__(self, root: Path) -> None:
+        self.fixtures = root / "fixtures"
+        self.work = _REPO_ROOT  # steps cd nowhere; scripts/ path is repo-relative
+        bindir = root / "bin"
+        for d in (self.fixtures, bindir):
+            d.mkdir(parents=True)
+        stub = bindir / "gh"
+        stub.write_text(GH_STUB)
+        stub.chmod(0o755)
+        self.bindir = bindir
+        self.py = _py312() or sys.executable
+
+    def _write_prs(self, subject: dict, candidates: list[dict]) -> None:
+        all_prs = [subject, *candidates]
+        (self.fixtures / "open_prs.json").write_text(
+            json.dumps([{"number": p["number"]} for p in all_prs
+                        if (p.get("state") or "OPEN").upper() == "OPEN"])
+        )
+        for p in all_prs:
+            (self.fixtures / f"pr_{p['number']}.json").write_text(
+                json.dumps({
+                    "number": p["number"],
+                    "body": p.get("body", ""),
+                    "state": p.get("state", "OPEN"),
+                    "files": [{"path": f} for f in p.get("files", [])],
+                })
+            )
+            (self.fixtures / f"graphql_{p['number']}.json").write_text(
+                json.dumps({"data": {"repository": {"pullRequest": {
+                    "closingIssuesReferences": {
+                        "nodes": [{"number": n} for n in p.get("closingIssues", [])]
+                    }}}}})
+            )
+
+    def _env(self) -> dict:
+        # The step invokes `python3`; front-load a python3 -> python3.12 shim so
+        # the engine runs under 3.12 (the `from __future__` + typing is fine on
+        # 3.9 too, but pin the version CI uses).
+        return {
+            **os.environ,
+            "PATH": f"{self.bindir}{os.pathsep}{os.environ['PATH']}",
+            "FIXTURES": str(self.fixtures),
+            "GH_TOKEN": "x",
+            "REPO": "kirodotdev/KiroCrew",
+        }
+
+    def run_on_open(self, script: str, subject: dict, candidates: list[dict],
+                    existing_comment_id: int | None = None) -> subprocess.CompletedProcess:
+        self._write_prs(subject, candidates)
+        comments = ([{"id": existing_comment_id, "body": "<!-- pr-duplicate-detect --> old"}]
+                    if existing_comment_id is not None else [])
+        (self.fixtures / "comments.json").write_text(json.dumps(comments))
+        for f in ("comment_write.txt", "pr_comment.txt", "pr_close.txt"):
+            (self.fixtures / f).unlink(missing_ok=True)
+        env = {**self._env(), "PR_NUMBER": str(subject["number"]),
+               "MARKER": "<!-- pr-duplicate-detect -->"}
+        # Ensure `python3` resolves to a 3.12; put a shim in bindir if needed.
+        self._ensure_python3_shim()
+        return subprocess.run(  # noqa: S603 - fixed argv, test-local stub
+            ["bash", "-c", script], cwd=self.work, env=env, text=True, capture_output=True)
+
+    def run_on_merge(self, script: str, subject: dict, candidates: list[dict],
+                     existing_comment_id: int | None = None) -> subprocess.CompletedProcess:
+        self._write_prs(subject, candidates)
+        comments = ([{"id": existing_comment_id, "body": "<!-- pr-duplicate-coauthor --> old"}]
+                    if existing_comment_id is not None else [])
+        (self.fixtures / "comments.json").write_text(json.dumps(comments))
+        for f in ("comment_write.txt", "pr_comment.txt", "pr_close.txt"):
+            (self.fixtures / f).unlink(missing_ok=True)
+        env = {**self._env(), "PR_NUMBER": str(subject["number"]),
+               "COAUTHOR_MARKER": "<!-- pr-duplicate-coauthor -->"}
+        self._ensure_python3_shim()
+        return subprocess.run(  # noqa: S603 - fixed argv, test-local stub
+            ["bash", "-c", script], cwd=self.work, env=env, text=True, capture_output=True)
+
+    def _ensure_python3_shim(self) -> None:
+        shim = self.bindir / "python3"
+        if self.py != shutil.which("python3"):
+            shim.write_text(f'#!/usr/bin/env bash\nexec "{self.py}" "$@"\n')
+            shim.chmod(0o755)
+
+    def reads(self, name: str) -> list[str]:
+        f = self.fixtures / name
+        return f.read_text().splitlines() if f.exists() else []
+
+
+# ── on-open: overlap -> exactly one comment naming the earlier PR ─────────────
+
+
+def test_on_open_overlap_posts_one_comment(tmp_path: Path) -> None:
+    h = Harness(tmp_path)
+    subject = {"number": 10, "body": "Fixes #1", "files": ["a.py", "b.py"], "closingIssues": [1]}
+    earlier = {"number": 5, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}
+    proc = h.run_on_open(on_open_step(), subject, [earlier])
+    assert proc.returncode == 0, proc.stderr
+    writes = h.reads("comment_write.txt")
+    assert len(writes) == 1 and writes[0].startswith("POST"), writes
+    # The engine's JSON (echoed by the step) names the earlier PR #5 as the overlap.
+    assert '"number": 5' in proc.stdout
+
+
+def test_on_open_disjoint_files_posts_nothing(tmp_path: Path) -> None:
+    h = Harness(tmp_path)
+    subject = {"number": 10, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}
+    other = {"number": 5, "body": "Fixes #1", "files": ["z.py"], "closingIssues": [1]}
+    proc = h.run_on_open(on_open_step(), subject, [other])
+    assert proc.returncode == 0, proc.stderr
+    assert h.reads("comment_write.txt") == []
+
+
+def test_on_open_different_issue_posts_nothing(tmp_path: Path) -> None:
+    h = Harness(tmp_path)
+    subject = {"number": 10, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}
+    other = {"number": 5, "body": "Fixes #2", "files": ["a.py"], "closingIssues": [2]}
+    proc = h.run_on_open(on_open_step(), subject, [other])
+    assert proc.returncode == 0, proc.stderr
+    assert h.reads("comment_write.txt") == []
+
+
+def test_on_open_is_idempotent_updates_in_place(tmp_path: Path) -> None:
+    h = Harness(tmp_path)
+    subject = {"number": 10, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}
+    earlier = {"number": 5, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}
+    # A prior marker comment (id 999) already exists -> the re-run PATCHes it.
+    proc = h.run_on_open(on_open_step(), subject, [earlier], existing_comment_id=999)
+    assert proc.returncode == 0, proc.stderr
+    writes = h.reads("comment_write.txt")
+    assert len(writes) == 1 and writes[0].startswith("PATCH"), writes
+
+
+def test_on_open_removes_stale_comment_when_no_overlap(tmp_path: Path) -> None:
+    h = Harness(tmp_path)
+    subject = {"number": 10, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}
+    other = {"number": 5, "body": "Fixes #1", "files": ["z.py"], "closingIssues": [1]}
+    proc = h.run_on_open(on_open_step(), subject, [other], existing_comment_id=999)
+    assert proc.returncode == 0, proc.stderr
+    writes = h.reads("comment_write.txt")
+    assert len(writes) == 1 and writes[0].startswith("DELETE"), writes
+
+
+# ── on-merge: overlap -> close the earlier PR with a pointer ───────────────────
+
+
+def test_on_merge_closes_overlapping_open_pr(tmp_path: Path) -> None:
+    h = Harness(tmp_path)
+    merged = {"number": 10, "body": "Fixes #1", "state": "MERGED",
+              "files": ["a.py", "b.py"], "closingIssues": [1]}
+    earlier = {"number": 5, "body": "Fixes #1", "state": "OPEN",
+               "files": ["a.py"], "closingIssues": [1]}
+    proc = h.run_on_merge(on_merge_step(), merged, [earlier])
+    assert proc.returncode == 0, proc.stderr
+    assert h.reads("pr_close.txt") == ["close 5"]
+    assert h.reads("pr_comment.txt") == ["comment 5"]
+    # Co-authorship recorded on the merged PR.
+    assert any(w.startswith("POST") for w in h.reads("comment_write.txt"))
+
+
+def test_on_merge_leaves_non_overlapping_prs_untouched(tmp_path: Path) -> None:
+    h = Harness(tmp_path)
+    merged = {"number": 10, "body": "Fixes #1", "state": "MERGED",
+              "files": ["a.py"], "closingIssues": [1]}
+    disjoint = {"number": 5, "body": "Fixes #1", "state": "OPEN",
+                "files": ["z.py"], "closingIssues": [1]}
+    other_issue = {"number": 6, "body": "Fixes #2", "state": "OPEN",
+                   "files": ["a.py"], "closingIssues": [2]}
+    proc = h.run_on_merge(on_merge_step(), merged, [disjoint, other_issue])
+    assert proc.returncode == 0, proc.stderr
+    assert h.reads("pr_close.txt") == []
+    assert h.reads("pr_comment.txt") == []
+
+
+# ── the workflow never checks out or executes PR head code ────────────────────
+
+
+def test_workflow_never_executes_pr_head_code() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    # No PR-head checkout: checkout steps must not pass the PR ref, and there is
+    # no build/install of PR code. The engine only reads metadata via `gh`.
+    assert "ref: ${{ github.event.pull_request.head" not in text
+    for forbidden in ("git clone", "npm ci", "npm install", "pip install", "make build"):
+        assert forbidden not in text, f"must not build/execute PR code: {forbidden}"
+
+
+# ── Standalone driver so the same assertions run without pytest ───────────────
+if __name__ == "__main__":
+    import tempfile
+
+    if (
+        os.name == "nt"
+        or shutil.which("bash") is None
+        or shutil.which("jq") is None
+        or _py312() is None
+        or not WORKFLOW.exists()
+        or not SCRIPT.exists()
+    ):
+        print("SKIP: requires the workflow + engine plus a POSIX bash, jq and python3.12")
+        raise SystemExit(0)
+
+    failures: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        print(f"{'ok  ' if cond else 'FAIL'} {name}")
+        if not cond:
+            failures.append(name)
+
+    # Engine unit checks.
+    eng = _load_engine()
+    subj = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py", "b.py"],
+            "closingIssues": [1]}
+    c_int = {"number": 5, "body": "Closes #1", "state": "OPEN", "files": ["a.py", "c.py"],
+             "closingIssues": []}
+    c_disj = {"number": 6, "body": "Fixes #1", "state": "OPEN", "files": ["z.py"],
+              "closingIssues": [1]}
+    c_diff = {"number": 7, "body": "Fixes #2", "state": "OPEN", "files": ["a.py"],
+              "closingIssues": [2]}
+    c_closed = {"number": 8, "body": "Fixes #1", "state": "CLOSED", "files": ["a.py"],
+                "closingIssues": [1]}
+    r = eng.analyze({"subject": subj, "candidates": [c_int, c_disj, c_diff, c_closed]})
+    nums = [o["number"] for o in r["overlaps"]]
+    check("engine_intersect_flagged", nums == [5])
+    check("engine_disjoint_excluded", 6 not in nums)
+    check("engine_diff_issue_excluded", 7 not in nums)
+    check("engine_closed_excluded", 8 not in nums)
+    check("engine_self_excluded", eng.analyze({"subject": subj, "candidates": [subj]})["overlaps"] == [])
+
+    on_open = on_open_step()
+    on_merge = on_merge_step()
+
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "a")
+        p = h.run_on_open(on_open, {"number": 10, "body": "Fixes #1", "files": ["a.py", "b.py"],
+                                    "closingIssues": [1]},
+                          [{"number": 5, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}])
+        w = h.reads("comment_write.txt")
+        check("on_open_overlap_posts_one",
+              p.returncode == 0 and len(w) == 1 and w[0].startswith("POST"))
+
+        h = Harness(Path(td) / "b")
+        p = h.run_on_open(on_open, {"number": 10, "body": "Fixes #1", "files": ["a.py"],
+                                    "closingIssues": [1]},
+                          [{"number": 5, "body": "Fixes #1", "files": ["z.py"], "closingIssues": [1]}])
+        check("on_open_disjoint_no_comment", p.returncode == 0 and h.reads("comment_write.txt") == [])
+
+        h = Harness(Path(td) / "c")
+        p = h.run_on_open(on_open, {"number": 10, "body": "Fixes #1", "files": ["a.py"],
+                                    "closingIssues": [1]},
+                          [{"number": 5, "body": "Fixes #1", "files": ["a.py"], "closingIssues": [1]}],
+                          existing_comment_id=999)
+        w = h.reads("comment_write.txt")
+        check("on_open_idempotent_patch", p.returncode == 0 and len(w) == 1 and w[0].startswith("PATCH"))
+
+        h = Harness(Path(td) / "d")
+        p = h.run_on_open(on_open, {"number": 10, "body": "Fixes #1", "files": ["a.py"],
+                                    "closingIssues": [1]},
+                          [{"number": 5, "body": "Fixes #1", "files": ["z.py"], "closingIssues": [1]}],
+                          existing_comment_id=999)
+        w = h.reads("comment_write.txt")
+        check("on_open_removes_stale", p.returncode == 0 and len(w) == 1 and w[0].startswith("DELETE"))
+
+        h = Harness(Path(td) / "e")
+        p = h.run_on_merge(on_merge, {"number": 10, "body": "Fixes #1", "state": "MERGED",
+                                      "files": ["a.py", "b.py"], "closingIssues": [1]},
+                           [{"number": 5, "body": "Fixes #1", "state": "OPEN",
+                             "files": ["a.py"], "closingIssues": [1]}])
+        check("on_merge_closes_earlier",
+              p.returncode == 0 and h.reads("pr_close.txt") == ["close 5"]
+              and h.reads("pr_comment.txt") == ["comment 5"])
+
+        h = Harness(Path(td) / "f")
+        p = h.run_on_merge(on_merge, {"number": 10, "body": "Fixes #1", "state": "MERGED",
+                                      "files": ["a.py"], "closingIssues": [1]},
+                           [{"number": 5, "body": "Fixes #1", "state": "OPEN",
+                             "files": ["z.py"], "closingIssues": [1]}])
+        check("on_merge_leaves_disjoint",
+              p.returncode == 0 and h.reads("pr_close.txt") == [])
+
+    if failures:
+        print(f"\n{len(failures)} check(s) FAILED: {failures}")
+        raise SystemExit(1)
+    print("\nall checks passed")

--- a/test/test_pr_duplicate_detect.py
+++ b/test/test_pr_duplicate_detect.py
@@ -224,11 +224,13 @@ if [ "$1" = "api" ]; then
   method="GET"
   target=""
   jqexpr=""
+  body=""
   for ((i=1; i<=$#; i++)); do
     a="${!i}"
     case "$a" in
       --method) j=$((i+1)); method="${!j}" ;;
       --jq) j=$((i+1)); jqexpr="${!j}" ;;
+      -f) j=$((i+1)); v="${!j}"; case "$v" in body=*) body="${v#body=}" ;; esac ;;
       graphql) target="graphql" ;;
       repos/*) target="$a" ;;
     esac
@@ -260,9 +262,11 @@ if [ "$1" = "api" ]; then
       emit "$FIXTURES/comments.json"
       exit 0 ;;
     POST:repos/*/comments*|POST:repos/*/issues/*/comments)
-      printf 'POST %s\n' "$target" >> "$FIXTURES/comment_write.txt" ;;
+      printf 'POST %s\n' "$target" >> "$FIXTURES/comment_write.txt"
+      printf '%s' "$body" > "$FIXTURES/note_body.txt" ;;
     PATCH:repos/*/comments*)
-      printf 'PATCH %s\n' "$target" >> "$FIXTURES/comment_write.txt" ;;
+      printf 'PATCH %s\n' "$target" >> "$FIXTURES/comment_write.txt"
+      printf '%s' "$body" > "$FIXTURES/note_body.txt" ;;
     DELETE:repos/*/comments*)
       printf 'DELETE %s\n' "$target" >> "$FIXTURES/comment_write.txt" ;;
     *)
@@ -421,7 +425,7 @@ class Harness:
         comments = ([{"id": existing_comment_id, "body": "<!-- pr-duplicate-coauthor --> old"}]
                     if existing_comment_id is not None else [])
         (self.fixtures / "comments.json").write_text(json.dumps(comments))
-        for f in ("comment_write.txt", "pr_comment.txt", "pr_close.txt"):
+        for f in ("comment_write.txt", "pr_comment.txt", "pr_close.txt", "note_body.txt"):
             (self.fixtures / f).unlink(missing_ok=True)
         env = {**self._env(), "PR_NUMBER": str(subject["number"]),
                "COAUTHOR_MARKER": "<!-- pr-duplicate-coauthor -->",
@@ -439,6 +443,11 @@ class Harness:
     def reads(self, name: str) -> list[str]:
         f = self.fixtures / name
         return f.read_text().splitlines() if f.exists() else []
+
+    def note_body(self) -> str:
+        """The body of the last co-authorship note written to the merged PR."""
+        f = self.fixtures / "note_body.txt"
+        return f.read_text() if f.exists() else ""
 
 
 # ── on-open: overlap -> exactly one comment naming the earlier PR ─────────────
@@ -508,8 +517,12 @@ def test_on_merge_closes_overlapping_open_pr(tmp_path: Path) -> None:
     assert proc.returncode == 0, proc.stderr
     assert h.reads("pr_close.txt") == ["close 5"]
     assert h.reads("pr_comment.txt") == ["comment 5"]
-    # Co-authorship recorded on the merged PR.
+    # Co-authorship recorded on the merged PR, and it accurately reports the
+    # close (PR #5 was actually closed) with no left-open claim.
     assert any(w.startswith("POST") for w in h.reads("comment_write.txt"))
+    note = h.note_body()
+    assert "Closed as superseded: #5." in note
+    assert "Left open" not in note
 
 
 def test_on_merge_leaves_weakly_overlapping_pr_open(tmp_path: Path) -> None:
@@ -541,6 +554,11 @@ def test_on_merge_opt_out_label_points_but_does_not_close(tmp_path: Path) -> Non
     assert proc.returncode == 0, proc.stderr
     assert h.reads("pr_comment.txt") == ["comment 5"]  # still pointed at
     assert h.reads("pr_close.txt") == []               # but not closed
+    # The co-authorship note must NOT claim the opted-out PR was closed: it is
+    # recorded under "Left open", never under "Closed as superseded".
+    note = h.note_body()
+    assert "Left open" in note and "#5" in note
+    assert "Closed as superseded" not in note
 
 
 def test_on_merge_leaves_non_overlapping_prs_untouched(tmp_path: Path) -> None:
@@ -665,6 +683,9 @@ if __name__ == "__main__":
         check("on_merge_closes_earlier",
               p.returncode == 0 and h.reads("pr_close.txt") == ["close 5"]
               and h.reads("pr_comment.txt") == ["comment 5"])
+        check("on_merge_note_reports_close",
+              "Closed as superseded: #5." in h.note_body()
+              and "Left open" not in h.note_body())
 
         h = Harness(Path(td) / "f")
         p = h.run_on_merge(on_merge, {"number": 10, "body": "Fixes #1", "state": "MERGED",
@@ -695,6 +716,9 @@ if __name__ == "__main__":
         check("on_merge_opt_out_points_only",
               p.returncode == 0 and h.reads("pr_close.txt") == []
               and h.reads("pr_comment.txt") == ["comment 5"])
+        check("on_merge_note_opt_out_not_closed",
+              "Left open" in h.note_body() and "#5" in h.note_body()
+              and "Closed as superseded" not in h.note_body())
 
     if failures:
         print(f"\n{len(failures)} check(s) FAILED: {failures}")

--- a/test/test_pr_duplicate_detect.py
+++ b/test/test_pr_duplicate_detect.py
@@ -95,6 +95,10 @@ def test_engine_same_issue_intersecting_files_is_flagged() -> None:
     assert res["overlaps"][0]["files"] == ["a.py"]
     assert res["overlaps"][0]["file_count"] == 1
     assert res["overlaps"][0]["exact"] is False
+    # Subject touches {a.py, b.py}; shares a.py -> coverage 0.5 -> strong.
+    assert res["overlaps"][0]["coverage"] == 0.5
+    assert res["overlaps"][0]["strong"] is True
+    assert res["has_strong_overlap"] is True
 
 
 def test_engine_disjoint_files_not_flagged() -> None:
@@ -150,6 +154,34 @@ def test_engine_exact_set_match_is_a_stronger_signal() -> None:
             "closingIssues": [1]}
     res = eng.analyze({"subject": subject, "candidates": [cand]})
     assert res["overlaps"][0]["exact"] is True
+    assert res["overlaps"][0]["strong"] is True
+
+
+def test_engine_weak_overlap_is_flagged_but_not_strong() -> None:
+    # A single shared file out of many is a real overlap (advisory) but below
+    # the strong-close threshold, so has_overlap is True and has_strong_overlap
+    # is False -- the on-merge lane must not close on this.
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN",
+               "files": ["a.py", "b.py", "c.py", "d.py"], "closingIssues": [1]}
+    cand = {"number": 5, "body": "Fixes #1", "state": "OPEN", "files": ["a.py", "e.py"],
+            "closingIssues": [1]}
+    res = eng.analyze({"subject": subject, "candidates": [cand]})
+    assert res["has_overlap"] is True
+    assert res["overlaps"][0]["strong"] is False
+    assert res["has_strong_overlap"] is False
+
+
+def test_engine_carries_candidate_labels_for_opt_out() -> None:
+    # Candidate labels are passed through so the on-merge lane can honour a
+    # label-gated opt-out without a per-PR call.
+    eng = _load_engine()
+    subject = {"number": 10, "body": "Fixes #1", "state": "OPEN", "files": ["a.py"],
+               "closingIssues": [1]}
+    cand = {"number": 5, "body": "Fixes #1", "state": "OPEN", "files": ["a.py"],
+            "closingIssues": [1], "labels": ["no-auto-close-duplicate"]}
+    res = eng.analyze({"subject": subject, "candidates": [cand]})
+    assert res["overlaps"][0]["labels"] == ["no-auto-close-duplicate"]
 
 
 # --------------------------------------------------------------------------------
@@ -300,7 +332,7 @@ def on_open_step() -> str:
 
 
 def on_merge_step() -> str:
-    return _step("on-merge", "Close each overlapping open PR with a pointer")
+    return _step("on-merge", "Only a STRONG overlap")
 
 
 class Harness:
@@ -320,8 +352,23 @@ class Harness:
 
     def _write_prs(self, subject: dict, candidates: list[dict]) -> None:
         all_prs = [subject, *candidates]
+        # The engine's --fetch path issues ONE `gh pr list` that returns every
+        # open PR's number/body/state/files/closingIssuesReferences/labels, so
+        # the list fixture carries the FULL records (not just numbers). The
+        # per-PR `pr view` + graphql fixtures are the on-merge fallback for the
+        # subject, which is no longer OPEN and so not in the list.
+        def _list_entry(p: dict) -> dict:
+            return {
+                "number": p["number"],
+                "body": p.get("body", ""),
+                "state": p.get("state", "OPEN"),
+                "files": [{"path": f} for f in p.get("files", [])],
+                "closingIssuesReferences": [{"number": n} for n in p.get("closingIssues", [])],
+                "labels": [{"name": lbl} for lbl in p.get("labels", [])],
+            }
+
         (self.fixtures / "open_prs.json").write_text(
-            json.dumps([{"number": p["number"]} for p in all_prs
+            json.dumps([_list_entry(p) for p in all_prs
                         if (p.get("state") or "OPEN").upper() == "OPEN"])
         )
         for p in all_prs:
@@ -331,6 +378,7 @@ class Harness:
                     "body": p.get("body", ""),
                     "state": p.get("state", "OPEN"),
                     "files": [{"path": f} for f in p.get("files", [])],
+                    "labels": [{"name": lbl} for lbl in p.get("labels", [])],
                 })
             )
             (self.fixtures / f"graphql_{p['number']}.json").write_text(
@@ -376,7 +424,8 @@ class Harness:
         for f in ("comment_write.txt", "pr_comment.txt", "pr_close.txt"):
             (self.fixtures / f).unlink(missing_ok=True)
         env = {**self._env(), "PR_NUMBER": str(subject["number"]),
-               "COAUTHOR_MARKER": "<!-- pr-duplicate-coauthor -->"}
+               "COAUTHOR_MARKER": "<!-- pr-duplicate-coauthor -->",
+               "OPT_OUT_LABEL": "no-auto-close-duplicate"}
         self._ensure_python3_shim()
         return subprocess.run(  # noqa: S603 - fixed argv, test-local stub
             ["bash", "-c", script], cwd=self.work, env=env, text=True, capture_output=True)
@@ -463,6 +512,37 @@ def test_on_merge_closes_overlapping_open_pr(tmp_path: Path) -> None:
     assert any(w.startswith("POST") for w in h.reads("comment_write.txt"))
 
 
+def test_on_merge_leaves_weakly_overlapping_pr_open(tmp_path: Path) -> None:
+    # Merge touches four files; the open PR shares only one -> below the strong
+    # threshold, so the on-merge lane must NOT close it (it got the advisory on
+    # open). This is the finding-#2 guard: a single shared file is not enough to
+    # auto-close legitimately-distinct companion work.
+    h = Harness(tmp_path)
+    merged = {"number": 10, "body": "Fixes #1", "state": "MERGED",
+              "files": ["a.py", "b.py", "c.py", "d.py"], "closingIssues": [1]}
+    earlier = {"number": 5, "body": "Fixes #1", "state": "OPEN",
+               "files": ["a.py", "e.py"], "closingIssues": [1]}
+    proc = h.run_on_merge(on_merge_step(), merged, [earlier])
+    assert proc.returncode == 0, proc.stderr
+    assert h.reads("pr_close.txt") == []
+    assert h.reads("pr_comment.txt") == []
+
+
+def test_on_merge_opt_out_label_points_but_does_not_close(tmp_path: Path) -> None:
+    # A STRONG overlap that carries the opt-out label is pointed at but NOT
+    # closed -- the human keeps control of the close (finding #3).
+    h = Harness(tmp_path)
+    merged = {"number": 10, "body": "Fixes #1", "state": "MERGED",
+              "files": ["a.py", "b.py"], "closingIssues": [1]}
+    earlier = {"number": 5, "body": "Fixes #1", "state": "OPEN",
+               "files": ["a.py", "b.py"], "closingIssues": [1],
+               "labels": ["no-auto-close-duplicate"]}
+    proc = h.run_on_merge(on_merge_step(), merged, [earlier])
+    assert proc.returncode == 0, proc.stderr
+    assert h.reads("pr_comment.txt") == ["comment 5"]  # still pointed at
+    assert h.reads("pr_close.txt") == []               # but not closed
+
+
 def test_on_merge_leaves_non_overlapping_prs_untouched(tmp_path: Path) -> None:
     h = Harness(tmp_path)
     merged = {"number": 10, "body": "Fixes #1", "state": "MERGED",
@@ -530,6 +610,18 @@ if __name__ == "__main__":
     check("engine_diff_issue_excluded", 7 not in nums)
     check("engine_closed_excluded", 8 not in nums)
     check("engine_self_excluded", eng.analyze({"subject": subj, "candidates": [subj]})["overlaps"] == [])
+    # #5 shares a.py of the subject's {a.py, b.py} -> coverage 0.5 -> strong.
+    strong_only = next((o for o in r["overlaps"] if o["number"] == 5), None)
+    check("engine_half_coverage_strong",
+          strong_only is not None and strong_only["strong"] is True and r["has_strong_overlap"] is True)
+    wide = {"number": 30, "body": "Fixes #9", "state": "MERGED",
+            "files": ["a.py", "b.py", "c.py", "d.py"], "closingIssues": [9]}
+    onef = {"number": 31, "body": "Fixes #9", "state": "OPEN", "files": ["a.py", "e.py"],
+            "closingIssues": [9]}
+    rw = eng.analyze({"subject": wide, "candidates": [onef]})
+    check("engine_weak_flagged_not_strong",
+          rw["has_overlap"] is True and rw["overlaps"][0]["strong"] is False
+          and rw["has_strong_overlap"] is False)
 
     on_open = on_open_step()
     on_merge = on_merge_step()
@@ -581,6 +673,28 @@ if __name__ == "__main__":
                              "files": ["z.py"], "closingIssues": [1]}])
         check("on_merge_leaves_disjoint",
               p.returncode == 0 and h.reads("pr_close.txt") == [])
+
+        # Weak overlap (one shared file of four) -> not strong -> not closed.
+        h = Harness(Path(td) / "g")
+        p = h.run_on_merge(on_merge, {"number": 10, "body": "Fixes #1", "state": "MERGED",
+                                      "files": ["a.py", "b.py", "c.py", "d.py"],
+                                      "closingIssues": [1]},
+                           [{"number": 5, "body": "Fixes #1", "state": "OPEN",
+                             "files": ["a.py", "e.py"], "closingIssues": [1]}])
+        check("on_merge_leaves_weak_overlap_open",
+              p.returncode == 0 and h.reads("pr_close.txt") == []
+              and h.reads("pr_comment.txt") == [])
+
+        # Strong overlap but opt-out label -> pointed, not closed.
+        h = Harness(Path(td) / "h")
+        p = h.run_on_merge(on_merge, {"number": 10, "body": "Fixes #1", "state": "MERGED",
+                                      "files": ["a.py", "b.py"], "closingIssues": [1]},
+                           [{"number": 5, "body": "Fixes #1", "state": "OPEN",
+                             "files": ["a.py", "b.py"], "closingIssues": [1],
+                             "labels": ["no-auto-close-duplicate"]}])
+        check("on_merge_opt_out_points_only",
+              p.returncode == 0 and h.reads("pr_close.txt") == []
+              and h.reads("pr_comment.txt") == ["comment 5"])
 
     if failures:
         print(f"\n{len(failures)} check(s) FAILED: {failures}")


### PR DESCRIPTION
> [!IMPORTANT]
> **DRAFT — scope reset pending a maintainer decision on #8046.**
>
> Current head `68fc008a` is not a merge candidate. It is conflicted, five commits / 304 upstream commits behind, and still contains proposal 4 even though that proposal was withdrawn after #7982 was found to have already addressed the stated mechanism. It also contains on-merge close/attribution behavior whose authority exceeds the evidence available to an overlap detector.
>
> Please do not review the current diff. The intended replacement contract is recorded below; the original scope is preserved under **Superseded original scope** for the public timeline.

## Problem / Motivation

Contributors and agents can begin work on an issue while an earlier open PR already covers overlapping files. The issue cross-reference exists, but the later author may not see it before duplicated implementation, CI, and review effort accumulates.

## Why it matters

The repository loses contributor time and reviewer capacity, and whichever PR reaches the queue first can merge while the other remains open. This is a coordination failure, not evidence of misconduct or ownership.

## What changed

**No final implementation is proposed at the current head.** The current revision is being held only while maintainers decide this narrowed, advisory-only contract:

- On PR open/reopen/edit/synchronize, compare OPEN PR metadata.
- A candidate requires both a shared closing issue and at least one shared changed file.
- Upsert one marker-keyed “possible overlap” comment naming the earlier PR, shared issue, and shared files, and asking authors to compare scope and coordinate.
- Update or remove the same comment when overlap changes.
- Never block, label, close, rank, or attribute either PR.
- Never check out or execute fork code; treat all PR metadata as untrusted data.
- A detector/API failure must not make an unrelated contributor PR unmergeable.

If maintainers accept this contract on #8046, this branch will be rebuilt from current `main`; the fork-review healer and all on-merge close/attribution behavior will be removed, and the result will be squashed to one commit. If maintainers decline it, this PR will close without further implementation work.

## Tests

Pending the scope decision. The replacement must prove at least:

- same issue + shared files warns;
- same issue without shared files does not warn;
- shared files without a shared issue do not warn;
- self and closed PRs never match;
- one marker comment is updated rather than duplicated;
- stale overlap removes/resolves the warning;
- no fork code is checked out or executed;
- detector/API failure does not block readiness.

## Manual verification

Pending maintainer acceptance and branch reconstruction.

<!-- no-visual-delta -->
**Why no screenshot:** this is CI/process automation with no rendered UI change.

## Pattern harvest

Rule candidate: When automation can detect possible duplicate work but cannot prove intent or equivalence, prefer an early, idempotent advisory over auto-closing or auto-attributing contributions.

Related: #8046

<details>
<summary><strong>Superseded original scope at 68fc008a (preserved for the timeline)</strong></summary>

Implements the four process/tooling proposals from issue #8046. This is forward-looking automation, not credit adjudication. No misconduct is alleged by the reporter, and Case B (#7852/#7898) was retracted, so no action is taken on it.

### Proposal 4 (the plain bug): heal never-fired fork-review lanes

GitHub does not guarantee `workflow_run` delivery, so a fork PR can have CI conclude success yet never start any Stage-2 fork reviewer. With no review check-run and no future event to create one, `pr-readiness.yml` freezes that PR at `pending` forever, so it cannot merge and is eventually superseded (the #7553 case).

- New `.github/workflows/fork-review-heal.yml`: a scheduled, idempotent, self-terminating sweep that finds OPEN fork PRs whose CI succeeded but whose fork-review check-runs never posted, and re-dispatches only the missing lanes.
- Added a `workflow_dispatch(head_sha)` entrypoint to all five `fork-*-review.yml` reviewers, reusing their existing open-PR-by-head-SHA resolver. Fork code is never checked out or executed; a PR whose CI has not passed is left pending by design, never force-passed. The maintainer `action_required` and undelivered-dispatch boundaries are documented, not worked around.

### Proposals 2 and 1: duplicate / overlap detection

- New `scripts/detect_pr_overlap.py`: a pure, network-free, unit-tested engine. Overlap = same referenced issue (GraphQL `closingIssuesReferences` union a `Fixes/Closes/Resolves #N` body fallback) AND non-empty changed-file intersection; never self-matches; OPEN candidates only. Candidate set fetched in a single `gh pr list` call.
- New `.github/workflows/pr-duplicate-detect.yml`:
  - On open (proposal 2): upserts one marker-keyed advisory comment naming overlapping earlier open PRs and the shared files; removes it when a revision no longer overlaps. Never blocks merge.
  - On merge (proposal 1): closes each strongly overlapping open same-issue PR (exact changed-file match or >=50% file coverage) with a pointer, and records co-authorship in a marker comment on the merged PR. A weak single-file overlap is left open. A `no-auto-close-duplicate` label opts a PR out of auto-close (pointer only).
  - Co-authored-by feasibility boundary is documented: a workflow runs after the squash-merge commit is composed from the PR title and cannot rewrite it to inject the trailer, so the durable recording comment is the placeable attribution.

### Proposal 3: docs

- `CONTRIBUTING.md` binds the “already on it” rule to automated/agent contributors and explains that an open PR referencing the same issue is the machine-readable signal the on-open lane surfaces.
- `docs/ci/ci-and-reviews.md` documents both new mechanisms.

### Testing

Full pytest is deferred to CI because the authoring sandbox is network-restricted (PyPI blocked; pytest/PyYAML/yamllint/actionlint uninstallable). In-sandbox substitute all green: `bash -n` on every new/edited workflow run-script; engine self-test (20 checks); two behavioural drivers executing the real extracted steps against `gh` stubs (fork-review-heal 11 checks, pr-duplicate-detect 17 checks) covering dispatch/comment/close side-effects, idempotency, the strong-overlap gate, and the label opt-out; `py_compile`; docs lint (257 files). PyYAML+pytest tests are committed for CI (`test/test_fork_review_heal.py`, `test/test_pr_duplicate_detect.py`).

### Needs a repo admin at merge time (not code)

- Create the `no-auto-close-duplicate` label if it should exist before the on-merge lane runs (the workflow only reads it).
- Confirm the pinned action SHAs resolve on a networked runner (the authoring host had no network).

The revision declared #8046 as its closing target.

</details>
