### PR TITLE
fix(dev-fleet): probe build state for the main checkout too

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
@@ -969,8 +969,12 @@ async def _build_fleet() -> dict:
         # Build state is a plain filesystem check (``.venv`` binary present /
         # ``static/dist`` directory present) and is therefore knowable on EVERY
         # platform — report it even where pods cannot run, so the Fleet view
-        # still tells the truth about which worktrees are built.
-        if runtime._POD_IMPORTED and not is_main:
+        # still tells the truth about which worktrees are built. That includes
+        # the MAIN checkout (#8058): during a cutover the panel is exactly the
+        # surface a human checks, and reporting main as unprovisioned reads as
+        # "the cutover failed". The ``not is_main`` restriction belongs to the
+        # POD-state check below (pods never run on main), not to these probes.
+        if runtime._POD_IMPORTED:
             try:
                 has_venv = await loop.run_in_executor(
                     subprocess_executor(), runtime.prov.has_venv, Path(path)

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -6439,6 +6439,36 @@ async def test_build_state_is_reported_even_where_pods_cannot_run(tmp_path):
     assert row["port"] is None
 
 
+@pytest.mark.asyncio
+async def test_main_checkout_build_state_is_probed(tmp_path):
+    """Regression (#8058): the build-state probes were gated on ``not is_main``,
+    so a fully provisioned MAIN checkout always rendered as unprovisioned —
+    during a cutover that reads as "the cutover failed". Build state is a plain
+    filesystem check and is knowable for every worktree, main included; only
+    the POD-state check legitimately skips main."""
+    main_co = tmp_path / "repo"
+    binp = main_co / ".venv" / ("Scripts" if platform_compat.IS_WINDOWS else "bin")
+    binp.mkdir(parents=True)
+    exe = binp / ("kirocrew.exe" if platform_compat.IS_WINDOWS else "kirocrew")
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    (main_co / "src" / "kiro_crew" / "static" / "dist").mkdir(parents=True)
+
+    fleet = await _fleet_with(
+        [{"path": str(main_co), "branch": "main", "is_main": True}],
+        _POD_AVAILABLE=False,
+        _POD_ERROR="pods require Linux systemd",
+        _load_cfg=lambda: None,
+    )
+    (row,) = fleet["worktrees"]
+    assert row["is_main"] is True
+    assert row["has_venv"] is True
+    assert row["has_dist"] is True
+    # Pod state still never applies to main.
+    assert row["running"] is False
+    assert row["port"] is None
+
+
 # =============================================================================
 # Regression: _find_cli must target a RUNNABLE entry point (issue #220)
 # =============================================================================


### PR DESCRIPTION
## Problem / Motivation

The Dev Fleet panel always shows the **main checkout** as not provisioned (no venv / no dist), regardless of its actual state. `fleet_state.py` gated the build-state probes on `runtime._POD_IMPORTED and not is_main`, so `has_venv`/`has_dist` stayed at their `False` initializers for main — while the comment directly above the gate states the opposite intent ("knowable on EVERY platform — report it even where pods cannot run"). Fixes #8058.

## Why it matters

During a cutover this actively misleads: after pointing `live_target` at the main checkout and restarting, the panel still says "not provisioned", which reads as "the cutover did not work" when it did. The reporter had to verify the cutover by matching served bundle hashes by hand.

## What changed (motivation → approach → change)

- **Motivation**: build state is a plain filesystem check and is knowable for every worktree, main included. Only POD state legitimately skips main (pods never run on the main checkout).
- **Approach**: the smallest correct change — move the `not is_main` restriction out of the build-state gate; the pod-state gate below keeps it.
- **Change** (`src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py`): the build-state probes now run whenever `runtime._POD_IMPORTED`, for main and non-main rows alike. The comment is extended to record why main is included and where `not is_main` still belongs.

## Tests

- `test_main_checkout_build_state_is_probed` — a provisioned main checkout reports `has_venv`/`has_dist` `True` while pod state stays `False`/`None`; fails on the previous gate.
- The sibling regression test for the same defect family (`test_build_state_is_reported_even_where_pods_cannot_run`, the off-Linux variant) still passes unchanged.
- Full `test/test_dev_fleet_app.py`: 418 passed, 1 skipped.
- Lint floor: black gate, isort, flake8, mypy clean on both changed files.

## Manual verification

Not run against a live gateway (the defect and fix are fully covered by the endpoint-level test through `_fleet_with`, which drives the same code path the panel polls). The reporter's live-gateway evidence in #8058 documents the user-visible symptom.

## Screenshots / video

Not applicable — backend field values; the visible effect is the Fleet row for main showing its true build state, asserted by the test.

## Related Issues

Fixes #8058. Sibling report from the same session: #8057 (Make Live EBUSY under the sandboxed backend) — NOT addressed here; that fix is a security-architecture choice (brokered write vs gateway-route) best made by maintainers, and this PR neither helps nor hinders either direction.

## Pattern harvest

Rule candidate: when a boolean gate contradicts the comment above it, the comment usually records the intent of a later, partial refactor — fix the gate to match the documented intent and say in the new comment where the removed clause still belongs, so the next reader does not "fix" it back.

## Checklist

- [x] Tests added/updated and passing locally
- [x] Lint/format gates run on all changed files
- [x] No unrelated changes bundled
- [x] PR body follows the template

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's contribution license agreement.
