### PR TITLE
fix(knowledge): take the folder scan's state reads and writes off the event loop

### DIFF
--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -19,7 +19,7 @@ from kiro_crew.sel import sel
 
 from .chunker import CHUNK_TOKEN_SIZE, MAX_CHUNKS_PER_FILE
 from .dedup import dedup_document
-from .ingestion import DUPLICATE_JOB_STATUS, run_to_completion
+from .ingestion import run_to_completion
 from .kiroignore import KIROIGNORE_FILENAME
 from .kiroignore import load as load_kiroignore
 from .readers import FileReader
@@ -360,8 +360,13 @@ class FolderWatcher:
             discovered = discovered[:max_files]
             logger.warning("Source %s: capped at %d files (%d skipped)", source_id, max_files, capped)
 
-        # 3. Load existing state
-        existing = self._load_state(source_id)
+        # 3. Load existing state. Every ``folder_file_state`` read and write in
+        # this sweep is offloaded: ``store.db`` holds a per-thread autocommit
+        # connection whose busy_timeout is 10s, and a query that waits on the
+        # writer lock (a concurrent import_bundle, a dedup collapse) blocks the
+        # whole event loop for that wait -- past the loop-stall watchdog on a
+        # slow disk. The store's on-loop guard names this exact frame.
+        existing = await asyncio.to_thread(self._load_state, source_id)
         now = datetime.now().isoformat()
 
         stats: dict[str, int] = {"new": 0, "changed": 0, "deleted": 0, "skipped": 0, "capped": capped, "failed": 0}
@@ -382,7 +387,7 @@ class FolderWatcher:
         # once up front, then only every _PAUSE_RECHECK_FILES files: a pause
         # still takes effect within a bounded number of files instead of costing
         # a query per file.
-        paused = self._is_paused(source_id)
+        paused = await asyncio.to_thread(self._is_paused, source_id)
         # ``last_seen`` touches for unchanged files are accumulated and flushed
         # as a single executemany instead of one UPDATE per file. They carry no
         # per-row logic and were already committed in the batch commit below, so
@@ -390,7 +395,7 @@ class FolderWatcher:
         last_seen_batch: list[tuple[str, str, str]] = []
         for idx, (file_path, mtime) in enumerate(discovered):
             if idx and idx % _PAUSE_RECHECK_FILES == 0:
-                paused = self._is_paused(source_id)
+                paused = await asyncio.to_thread(self._is_paused, source_id)
             if paused:
                 await asyncio.to_thread(
                     self._flush_last_seen_and_commit, last_seen_batch)
@@ -450,7 +455,7 @@ class FolderWatcher:
                     # count onto the row would make the user's retry -- which clears
                     # the status but not the count -- re-enter the scan already over
                     # budget and be retired again by the very next sweep.
-                    self._update_state(
+                    await self._persist_state(
                         source_id, file_path, content_hash, mtime,
                         state.get("item_ids", "[]") or "[]", now, "failed",
                         f"ingestion did not complete after {MAX_SCAN_ATTEMPTS} attempts",
@@ -460,7 +465,7 @@ class FolderWatcher:
 
             if state and state.get("status") == "done" and content_hash == state.get("content_hash"):
                 # Touched but content unchanged
-                self._update_state(source_id, file_path, content_hash, mtime, state.get("item_ids", "[]"), now, "done", commit=False)
+                await self._persist_state(source_id, file_path, content_hash, mtime, state.get("item_ids", "[]"), now, "done", commit=False)
                 continue
 
             # A row that owned nothing holds a claim for its PREVIOUS content. The
@@ -489,9 +494,9 @@ class FolderWatcher:
             # The incremented attempt count rides along, so the row itself carries how
             # much of its retry budget is left even though nothing else in this sweep
             # survives an abrupt exit.
-            self._update_state(source_id, file_path, content_hash, mtime,
-                               json.dumps(old_ids), now, "scanning",
-                               attempts=prior_attempts + 1)
+            await self._persist_state(source_id, file_path, content_hash, mtime,
+                                      json.dumps(old_ids), now, "scanning",
+                                      attempts=prior_attempts + 1)
 
             item_ids, outcome = await self._ingest_file(
                 file_path, source_id, namespace, props, old_ids, root=uri,
@@ -504,11 +509,17 @@ class FolderWatcher:
                 # keeps the marker is re-ingested, at full cost, on every later sweep.
                 # Writing it from the caller also restores the content hash and mtime
                 # the marker carried, which is what lets the UI say WHICH version of
-                # the file failed. The reason recorded by _ingest_file is preserved.
-                self._update_state(
-                    source_id, file_path, content_hash, mtime, json.dumps(old_ids),
-                    now, "failed", self._current_error(source_id, file_path),
-                    commit=False)
+                # the file failed. The reason recorded by _ingest_file is preserved:
+                # read and re-written inside ONE worker hop, so the read cannot be
+                # split from the write by a cancellation between two awaits.
+                def _fail_preserving_reason(
+                        _sid=source_id, _fp=file_path, _ch=content_hash, _mt=mtime,
+                        _ids=json.dumps(old_ids), _now=now) -> None:
+                    self._update_state(
+                        _sid, _fp, _ch, _mt, _ids, _now, "failed",
+                        self._current_error(_sid, _fp), commit=False)
+
+                await run_to_completion(_fail_preserving_reason)
                 stats["failed"] += 1
             elif outcome == "deduped":
                 # Refused by the pre-ingest gate: this exact content is already in
@@ -521,7 +532,7 @@ class FolderWatcher:
                 # here would leave that commit unrecorded.
                 stats["skipped"] += 1
             else:
-                self._update_state(source_id, file_path, content_hash, mtime, json.dumps(item_ids), now, "done", commit=False)
+                await self._persist_state(source_id, file_path, content_hash, mtime, json.dumps(item_ids), now, "done", commit=False)
                 ingested_paths.append(file_path)
                 if chunk_budget:
                     chunks_ingested += len(item_ids)
@@ -677,10 +688,27 @@ class FolderWatcher:
         return row["error_message"] if row else None
 
     def _update_state(self, source_id: str, file_path: str, content_hash: str, mtime: float, item_ids: str, now: str, status: str = "done", error_message: str | None = None, *, attempts: int = 0, commit: bool = True):
+        """Write one state row. Synchronous: callers on the event loop use
+        :meth:`_persist_state`, which runs this on a worker thread."""
         self._write_state_row(source_id, file_path, content_hash, mtime, item_ids, now,
                               status, error_message, attempts=attempts)
         if commit:
             self.store.db.commit()
+
+    async def _persist_state(self, *args, **kwargs) -> None:
+        """:meth:`_update_state`, off the event loop and drained under cancellation.
+
+        ``run_to_completion`` rather than a bare ``to_thread``: every row this
+        writes is a marker the NEXT sweep reads to decide whether to re-ingest
+        (``scanning`` = interrupted, retry; ``done``/``failed`` = terminal). A
+        cancellation that dropped the write while it was still queued would
+        leave the previous marker standing over data that has already moved on
+        -- the same orphan window the ingest finalizers close the same way.
+        ``store.db`` is per-thread and autocommit, so the write is complete when
+        the hop returns; the ``commit`` flag is honoured but has nothing left to
+        flush on that connection.
+        """
+        await run_to_completion(lambda: self._update_state(*args, **kwargs))
 
     def _deduped_text_hash(self, content_hash: str) -> str | None:
         """Text hash for a row the pre-ingest gate refused, or ``None``.
@@ -885,9 +913,9 @@ class FolderWatcher:
                                f"reason=outside_root_toctou"),
                 )
                 now = datetime.now().isoformat()
-                self._update_state(source_id, file_path, "", 0,
-                                   json.dumps(old_item_ids), now, "failed",
-                                   "path resolved outside the source root")
+                await self._persist_state(source_id, file_path, "", 0,
+                                          json.dumps(old_item_ids), now, "failed",
+                                          "path resolved outside the source root")
                 return None, "failed"
         if is_sensitive_path(resolved):
             logger.warning("TOCTOU: sensitive path blocked at ingest time: %s -> %s", file_path, resolved)
@@ -898,7 +926,7 @@ class FolderWatcher:
                 resources=f"source_id={source_id} file_path={file_path} reason=sensitive_path_toctou",
             )
             now = datetime.now().isoformat()
-            self._update_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", "sensitive path blocked")
+            await self._persist_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", "sensitive path blocked")
             return None, "failed"
 
         # The pipeline reports the items it created through `on_committed`, which
@@ -913,13 +941,17 @@ class FolderWatcher:
         #   ~20k rows apiece on a large folder source, measured at >1s each --
         #   synchronously on the event loop, which trips the loop-stall watchdog
         #   and crash-loops the gateway.
-        # * No await after the commit. ANY await between the pipeline's commit
-        #   and this function's return is an orphan window: a shutdown cancelling
-        #   there leaves committed items that no `folder_file_state` row names,
-        #   so the next scan re-ingests the file and duplicates them while the
-        #   first group stays untracked and undeletable. Offloading the reads
-        #   would have introduced exactly that window; not needing them removes
-        #   it. `test_knowledge_ingest_scan_off_loop.py` ratchets both properties.
+        # * No skippable await after the commit. An await between the pipeline's
+        #   commit and this function's return that a cancellation can skip past
+        #   is an orphan window: a shutdown cancelling there leaves committed
+        #   items that no `folder_file_state` row names, so the next scan
+        #   re-ingests the file and duplicates them while the first group stays
+        #   untracked and undeletable. Offloading the reads with a bare
+        #   `to_thread` would have introduced exactly that window; not needing
+        #   them removes it. The failure branches below DO await, but only
+        #   `_persist_state` (`run_to_completion`-backed, so the write drains
+        #   under cancellation) and only where nothing was committed.
+        #   `test_knowledge_ingest_scan_off_loop.py` ratchets both properties.
         #
         # `on_committed` fires only on the fully-successful branch, so it also
         # replaces the `sources.sync_status` read that used to detect a partial
@@ -983,20 +1015,36 @@ class FolderWatcher:
                     "commit callback; deferring to the caller's state write",
                     file_path, exc_info=True)
 
+        # The pre-ingest gate reports a refusal the same way the commit path reports
+        # its ids: through a callback invoked INSIDE the gate's own transaction, on
+        # its worker thread. Latching it here replaces the `get_job_status` read-back
+        # this frame used to do after the pipeline returned -- a synchronous sqlite
+        # round-trip on the event loop for every ingested file, which is exactly
+        # the class of call the store's on-loop guard flags. The callback is the
+        # only place `DUPLICATE_JOB_STATUS` is ever written, so the latch is the
+        # status; nothing has to be read back, and no await is added after the
+        # commit (the ratchet in `test_knowledge_ingest_scan_off_loop.py`).
+        refused = False
+
+        def _record_refused(text_hash: str) -> None:
+            nonlocal refused
+            refused = True
+            if on_duplicate is not None:
+                on_duplicate(text_hash)
+
         try:
             # Hand the pipeline the path that was just validated, not the one that
             # was validated a moment earlier -- re-deriving it there would reopen the
             # window this check closed. The display name still comes from the logical
             # path, so a symlinked document keeps the name the user sees in the folder.
-            job_id = await self.pipeline.ingest_file(
+            await self.pipeline.ingest_file(
                 resolved, source_id=source_id, namespace=namespace,
                 original_name=Path(file_path).name,
                 old_item_ids=old_item_ids,
                 on_committed=_record_committed,
-                on_duplicate=on_duplicate)
+                on_duplicate=_record_refused)
 
-            if job_id and (self.pipeline.get_job_status(job_id) or {}).get(
-                    "status") == DUPLICATE_JOB_STATUS:
+            if refused:
                 return [], "deduped"
 
             # Detect partial failure (pipeline rolls back but doesn't raise): the
@@ -1004,14 +1052,14 @@ class FolderWatcher:
             # commits one, so an unset `committed` IS the rollback signal.
             if committed is None:
                 now = datetime.now().isoformat()
-                self._update_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", "partial ingestion failure")
+                await self._persist_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", "partial ingestion failure")
                 return None, "failed"
 
             return committed, "done"
         except Exception as e:
             logger.exception("Failed to ingest %s", file_path)
             now = datetime.now().isoformat()
-            self._update_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", str(e)[:500])
+            await self._persist_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", str(e)[:500])
             return None, "failed"
 
     @staticmethod

--- a/test/test_folder_watcher_off_loop_guard.py
+++ b/test/test_folder_watcher_off_loop_guard.py
@@ -1,0 +1,179 @@
+"""The folder scan must take no knowledge-store connection on the event loop.
+
+``KnowledgeStore.db`` is a per-thread autocommit sqlite connection with a 10s
+``busy_timeout``. Taken on the event loop, a query that waits on the writer lock
+(a concurrent ``import_bundle``, a dedup collapse) blocks every task -- the
+watchdog heartbeat included -- for that whole wait, and past
+``dashboard.loop_stall_exit_after_secs`` the watchdog kills the gateway.
+
+The store's accessor carries an on-loop guard for exactly this
+(``kiro_crew.on_loop_db``). In production it only WARNS, so a regression here is
+one log line an operator never reads. These tests arm the store's strict switch,
+which turns the warning into ``OnLoopStoreError``, and then drive a scan through
+every state transition the watcher persists (new -> done, unchanged, changed,
+deleted, failed, paused). Any ``folder_file_state`` read or write that slipped
+back onto the loop raises.
+
+This is the behavioral half of the ``test_knowledge_ingest_scan_off_loop`` AST
+ratchets: those see a query only where it is written lexically inside an
+``async def``, and every call in the scan path is one frame down inside a sync
+helper -- the interprocedural gap the runtime guard exists to close.
+
+The tests' OWN store access goes through :func:`off` for the same reason: under
+the armed guard a test-side ``store.db`` on the loop would raise and be
+indistinguishable from a watcher regression.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.knowledge.folder_watcher import FolderWatcher
+from kiro_crew.knowledge.ingestion import IngestionPipeline
+from kiro_crew.knowledge.store import KnowledgeStore
+from kiro_crew.on_loop_db import STORE_STRICT_ENV, OnLoopStoreError
+
+pytestmark = pytest.mark.asyncio
+
+
+async def off(fn, *args):
+    """Run a test-side store access on a worker thread."""
+    return await asyncio.to_thread(fn, *args)
+
+
+@pytest.fixture()
+def strict_store(monkeypatch, tmp_path):
+    """A store whose on-loop guard RAISES. Built and closed off-loop (sync fixture)."""
+    monkeypatch.setenv(STORE_STRICT_ENV, "1")
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    yield store
+    store.close()
+
+
+def _pipeline(store: KnowledgeStore, *, fail: bool = False) -> IngestionPipeline:
+    extractor = MagicMock()
+    extractor._pool = None
+    extractor.extract_batch = AsyncMock(
+        return_value=[{"category": "document", "summary": "s", "entities": []}]
+    )
+    chunker = MagicMock()
+    _one_chunk = lambda text, **kw: [  # noqa: E731
+        {"content": text, "chunk_index": 0, "section_title": None, "line_start": 0, "line_end": 0}
+    ]
+    chunker.chunk.side_effect = _one_chunk
+    chunker.chunk_markdown.side_effect = _one_chunk
+    reader = MagicMock()
+    if fail:
+        reader.read.side_effect = RuntimeError("reader exploded")
+    else:
+        reader.read.return_value = ("some body", {})
+    return IngestionPipeline(
+        store=store, extractor=extractor, chunker=chunker, reader=reader, embedder=None
+    )
+
+
+def _add_source(store: KnowledgeStore, folder) -> dict:
+    source_id = store.add_source("folder", "local_folder", str(folder))
+    return {"id": source_id, "uri": str(folder), "source_type": "local_folder", "properties": "{}"}
+
+
+def _rows(store: KnowledgeStore, source_id: str) -> dict[str, dict]:
+    return {
+        r["file_path"]: dict(r)
+        for r in store.db.execute(
+            "SELECT file_path, status, error_message FROM folder_file_state WHERE source_id = ?",
+            (source_id,),
+        ).fetchall()
+    }
+
+
+def _pause(store: KnowledgeStore, source_id: str) -> None:
+    store.db.execute(
+        "UPDATE sources SET properties = ? WHERE id = ?",
+        (json.dumps({"scan_paused": True}), source_id),
+    )
+    store.db.commit()
+
+
+async def test_strict_guard_is_actually_armed(strict_store):
+    """An on-loop take must raise, or every test below passes vacuously."""
+    with pytest.raises(OnLoopStoreError):
+        strict_store.db
+    # ...and the same take off-loop is the sanctioned path.
+    assert await off(lambda: strict_store.db) is not None
+
+
+async def test_full_scan_lifecycle_takes_no_connection_on_the_loop(strict_store, tmp_path):
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    (folder / "a.md").write_text("alpha", encoding="utf-8")
+    (folder / "b.md").write_text("beta", encoding="utf-8")
+    source = await off(_add_source, strict_store, folder)
+    watcher = FolderWatcher(strict_store, _pipeline(strict_store))
+
+    # new -> done
+    stats = await watcher.scan_source(source)
+    assert stats["new"] == 2 and stats["failed"] == 0
+
+    # unchanged: the last_seen batch path
+    stats = await watcher.scan_source(source)
+    assert stats["new"] == 0 and stats["changed"] == 0
+
+    # changed: release_stale_claim + re-ingest
+    (folder / "a.md").write_text("alpha, revised", encoding="utf-8")
+    future = time.time() + 5
+    os.utime(folder / "a.md", (future, future))
+    stats = await watcher.scan_source(source)
+    assert stats["changed"] == 1
+
+    # deleted: _handle_deleted
+    (folder / "b.md").unlink()
+    stats = await watcher.scan_source(source)
+    assert stats["deleted"] == 1
+
+    rows = await off(_rows, strict_store, source["id"])
+    assert set(rows) == {str(folder / "a.md")}
+    assert rows[str(folder / "a.md")]["status"] == "done"
+
+
+async def test_failed_ingest_records_its_reason_off_the_loop(strict_store, tmp_path):
+    """The 'failed' branch reads the recorded reason back and re-writes the row.
+
+    Both used to run on the loop, and the read feeds the write across what is
+    now a single worker hop -- the reason must survive that move intact.
+    """
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    (folder / "bad.md").write_text("boom", encoding="utf-8")
+    source = await off(_add_source, strict_store, folder)
+    watcher = FolderWatcher(strict_store, _pipeline(strict_store, fail=True))
+
+    stats = await watcher.scan_source(source)
+    assert stats["failed"] == 1
+
+    rows = await off(_rows, strict_store, source["id"])
+    row = rows[str(folder / "bad.md")]
+    assert row["status"] == "failed"
+    assert "reader exploded" in (row["error_message"] or ""), (
+        "the reason _ingest_file recorded was lost when the terminal 'failed' row "
+        f"was re-written: {row['error_message']!r}"
+    )
+
+
+async def test_pause_check_takes_no_connection_on_the_loop(strict_store, tmp_path):
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    (folder / "a.md").write_text("alpha", encoding="utf-8")
+    source = await off(_add_source, strict_store, folder)
+    await off(_pause, strict_store, source["id"])
+    watcher = FolderWatcher(strict_store, _pipeline(strict_store))
+
+    stats = await watcher.scan_source(source)
+    assert stats.get("status") == "paused"
+    assert stats["new"] == 0

--- a/test/test_knowledge_ingest_scan_off_loop.py
+++ b/test/test_knowledge_ingest_scan_off_loop.py
@@ -134,27 +134,38 @@ def test_ingest_file_issues_no_sqlite_call_on_the_event_loop():
 
 
 def test_ingest_file_never_awaits_after_the_pipeline_commits():
-    """Ratchet: exactly one await, the pipeline call itself.
+    """Ratchet: the only awaits are the pipeline call and drained state writes.
 
     This is the invariant that makes the orphan window unreachable rather than
     merely unlikely. The caller writes the ``folder_file_state`` row naming the new
-    items only after this function RETURNS, so a second await -- however cheap, and
-    including an ``asyncio.to_thread`` hop added in good faith to get a query off
-    the loop -- lets a shutdown cancel the coroutine after the pipeline has already
-    committed. The items survive, nothing names them, and the next scan re-ingests
-    the file alongside them.
+    items only after this function RETURNS, so an await that a cancellation can
+    SKIP PAST -- a bare ``asyncio.to_thread`` hop added in good faith to get a
+    query off the loop -- lets a shutdown cancel the coroutine after the pipeline
+    has already committed. The items survive, nothing names them, and the next
+    scan re-ingests the file alongside them.
+
+    ``_persist_state`` is admitted because it is the opposite shape: it is
+    ``run_to_completion``-backed, so the state write it carries runs to completion
+    even when the coroutine is cancelled mid-await -- the same guarantee the
+    pipeline's own finalize hop relies on. It is how the failure branches record
+    their terminal ``failed`` row without a synchronous sqlite call on the loop
+    (the sqlite ratchet above), and every such branch is one where the pipeline
+    never committed, so there is no committed group for the await to orphan.
     """
     tree = ast.parse(_WATCHER_SRC.read_text(errors="replace"))
     fn = _async_def(tree, "_ingest_file")
     awaits = _awaits(fn)
     rendered = ", ".join(f"line {ln}: await {name}(...)" for ln, name in awaits)
-    assert [name for _, name in awaits] == ["ingest_file"], (
+    names = [name for _, name in awaits]
+    assert names.count("ingest_file") == 1 and set(names) <= {"ingest_file", "_persist_state"}, (
         f"_ingest_file has awaits other than the pipeline call ({rendered}).\n"
-        "Every await after the pipeline's commit is an orphan window: a shutdown "
-        "cancelling there leaves committed items that no folder_file_state row "
-        "names, so the next scan duplicates them and the first group is "
-        "undeletable. If you need data the pipeline holds, take it through a "
-        "callback that runs inside its finalize hop -- do not read it back."
+        "Every await after the pipeline's commit that a cancellation can skip is an "
+        "orphan window: a shutdown cancelling there leaves committed items that no "
+        "folder_file_state row names, so the next scan duplicates them and the "
+        "first group is undeletable. If you need data the pipeline holds, take it "
+        "through a callback that runs inside its finalize hop -- do not read it "
+        "back. A state WRITE belongs in `_persist_state`, which drains under "
+        "cancellation."
     )
 
 
@@ -318,11 +329,17 @@ async def test_ingest_file_still_reports_a_refused_duplicate_as_deduped(tmp_path
 
     The pre-ingest gate refuses the write and never commits a group, so
     ``on_committed`` does not fire there either -- the same condition as a
-    rollback. The duplicate check must therefore keep winning, or a legitimately
-    refused file would be recorded ``failed`` and retried on every scan.
-    """
-    from kiro_crew.knowledge.ingestion import DUPLICATE_JOB_STATUS
+    rollback. The refusal is reported the same way the commit is: through
+    ``on_duplicate``, invoked inside the gate's own transaction (the only place
+    ``DUPLICATE_JOB_STATUS`` is ever written). The duplicate check must therefore
+    keep winning, or a legitimately refused file would be recorded ``failed`` and
+    retried on every scan.
 
+    The fake follows the real gate's contract and fires the callback. It also
+    exposes ``get_job_status`` and asserts it is never consulted: reading the
+    status back after the pipeline returned was a synchronous sqlite round-trip
+    on the event loop for every ingested file.
+    """
     store = KnowledgeStore(str(tmp_path / "knowledge.db"))
     try:
         doc = tmp_path / "doc.md"
@@ -330,6 +347,8 @@ async def test_ingest_file_still_reports_a_refused_duplicate_as_deduped(tmp_path
         source_id = store.add_source("folder", "local_folder", str(tmp_path))
 
         class _RefusingPipeline:
+            status_reads = 0
+
             async def ingest_file(
                 self,
                 path,
@@ -341,12 +360,16 @@ async def test_ingest_file_still_reports_a_refused_duplicate_as_deduped(tmp_path
                 on_committed=None,
                 on_duplicate=None,
             ):
+                assert on_duplicate is not None, "the watcher no longer listens for a refusal"
+                on_duplicate("text-hash-of-body")
                 return "job-dupe"
 
             def get_job_status(self, job_id):
-                return {"status": DUPLICATE_JOB_STATUS}
+                self.status_reads += 1
+                return {"status": "skipped_duplicate"}
 
-        watcher = FolderWatcher(store, _RefusingPipeline())
+        pipeline = _RefusingPipeline()
+        watcher = FolderWatcher(store, pipeline)
         item_ids, outcome = await watcher._ingest_file(str(doc), source_id, "default", {}, [])
 
         assert outcome == "deduped", (
@@ -354,6 +377,43 @@ async def test_ingest_file_still_reports_a_refused_duplicate_as_deduped(tmp_path
             "make every scan retry a write the gate will refuse again"
         )
         assert item_ids == [], f"a deduped file claimed ownership of {item_ids!r}"
+        assert pipeline.status_reads == 0, (
+            "the watcher read the job status back after the pipeline returned -- a "
+            "synchronous sqlite query on the event loop; the refusal arrives through "
+            "on_duplicate"
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_ingest_file_forwards_the_refusal_to_the_callers_on_duplicate(tmp_path):
+    """Latching the refusal must not swallow the caller's own ``on_duplicate``.
+
+    ``_do_scan`` passes one that writes the 'deduped' state row inside the gate's
+    transaction; a wrapper that only set its flag would leave that row unwritten.
+    """
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        doc = tmp_path / "doc.md"
+        doc.write_text("body", encoding="utf-8")
+        source_id = store.add_source("folder", "local_folder", str(tmp_path))
+
+        class _RefusingPipeline:
+            async def ingest_file(self, path, *, on_duplicate=None, **kw):
+                on_duplicate("text-hash-of-body")
+                return "job-dupe"
+
+        seen: list[str] = []
+        watcher = FolderWatcher(store, _RefusingPipeline())
+        _, outcome = await watcher._ingest_file(
+            str(doc), source_id, "default", {}, [], on_duplicate=seen.append
+        )
+        assert outcome == "deduped"
+        assert seen == ["text-hash-of-body"], (
+            f"the caller's on_duplicate saw {seen!r}; the text hash the gate matched "
+            "must reach it unchanged"
+        )
     finally:
         store.close()
 


### PR DESCRIPTION
## Problem / Motivation

On every gateway boot the knowledge store's on-loop guard (`kiro_crew.on_loop_db`) fires from the folder watcher's first sweep:

```
WARNING kiro_crew.on_loop_db: knowledge store: connection taken ON the event loop without offloading; a contended query here blocks every task (including the watchdog heartbeat) for the connection's whole busy timeout.
  File "kiro_crew/knowledge/folder_watcher.py", line 662, in _load_state
    rows = self.store.db.execute(
  File "kiro_crew/knowledge/store.py", line 360, in db
    _ON_LOOP_DB_GUARD.check()
```

`store.db` is a per-thread autocommit sqlite connection with `busy_timeout=10000`. Taken on the event loop, any query that waits on the writer lock (a concurrent `import_bundle`, a dedup collapse, a slow disk) blocks every task -- the watchdog heartbeat included -- for that whole wait.

## Why it matters

A stall past `dashboard.loop_stall_exit_after_secs` makes the watchdog kill the gateway and drop every in-flight turn on every channel (#1572, #3057). The folder sweep runs on boot and every `interval` seconds against every registered folder source, so this is a standing exposure on any host with a large knowledge library, not an edge case. Today it surfaces only as a warning line an operator never reads.

## What changed (motivation -> approach -> change)

The scan was a hybrid. File walking, hashing, the `last_seen` flush and the dedup pass were already offloaded, but the `folder_file_state` reads and writes still ran on the loop one frame down inside sync helpers -- exactly the interprocedural gap `scripts/check_sync_io_in_async.py` cannot see (it only catches calls written lexically inside an `async def`) and the runtime guard exists to close.

- **Reads** (`_load_state`, `_is_paused`) move to `asyncio.to_thread`.
- **Writes** move to a new `_persist_state`, built on the module's existing `run_to_completion`. A bare `to_thread` is the wrong shape here: every row it writes is a marker the NEXT sweep reads to decide whether to re-ingest (`scanning` = interrupted, retry; `done`/`failed` = terminal), so a cancellation must drain the write, not drop it. `store.db` is per-thread and autocommit, so each hop is a complete unit.
- The `failed` branch in `_do_scan` reads the recorded reason back and re-writes the row **inside one worker hop**, so the read cannot be split from the write by a cancellation between two awaits.
- The strict-mode regression test then surfaced a fifth on-loop site the static pass missed: `_ingest_file` called `pipeline.get_job_status(job_id)` after every successful ingest to detect a refused duplicate. The pre-ingest gate already reports that refusal through `on_duplicate`, invoked **inside its own transaction** (the only place `DUPLICATE_JOB_STATUS` is ever written). The refusal is now latched in a closure that wraps the caller's `on_duplicate`, and the read-back is gone -- no query, and no await added after the pipeline commits.

The await ratchet in `test_knowledge_ingest_scan_off_loop.py` is refined rather than removed. It guards against awaits a cancellation can SKIP after the pipeline committed (a `to_thread` read-back). `_persist_state` is the opposite shape -- it drains under cancellation -- and every call site of it inside `_ingest_file` is a branch where nothing was committed. The ratchet now admits exactly `ingest_file` plus `_persist_state` and its message says why.

## Tests

- **New** `test/test_folder_watcher_off_loop_guard.py`: arms `KIROCREW_STRICT_ON_LOOP_STORE` so the store's guard RAISES instead of warning, verifies the arming is real (a direct on-loop take raises, the same take off-loop does not), then drives a scan through every state transition -- new -> done, unchanged (last_seen batch), changed (`release_stale_claim` + re-ingest), deleted (`_handle_deleted`), failed (reason preserved across the hop), paused. Any `folder_file_state` access that slips back onto the loop raises. This is the behavioral half of the existing AST ratchets.
- **Updated** `test_knowledge_ingest_scan_off_loop.py`: `test_ingest_file_never_awaits_after_the_pipeline_commits` admits `_persist_state` (docstring explains the distinction); `test_ingest_file_still_reports_a_refused_duplicate_as_deduped` now follows the real gate's callback contract and asserts `get_job_status` is never consulted; new `test_ingest_file_forwards_the_refusal_to_the_callers_on_duplicate` locks in that the wrapper does not swallow the caller's own `on_duplicate` (which `_do_scan` uses to write the `deduped` row inside the gate's transaction).

Ran: flake8, isort, mypy on `folder_watcher.py`, `scripts/check_sync_io_in_async.py`, the four folder-watcher test files (101 passed), and the full knowledge/watcher/ingest/source test surface (79 files, 3093 passed, 0 failed).

## Manual verification

N/A -- the strict-guard test exercises the exact production code path (`FolderWatcher.scan_source` against a real `KnowledgeStore` and `IngestionPipeline`) with the runtime guard armed, which is a stronger check than watching a gateway log for the warning's absence.

## Related Issues

Related: #3057 (remedy A -- the accessor guard that made this visible), #7019 (knowledge on-loop cleanup). `folder_watcher.py` was never in `.github/sync-io-in-async-baseline.txt` because its offenders are one frame down; nothing to prune there.

**Deliberately left for #7019 (out of scope here):** the same `get_job_status` read-back pattern survives at four sibling on-loop sites -- `knowledge/artifact_ingest.py:480`, `knowledge/artifact_ingest.py:828`, `knowledge/agent_source.py:387`, `knowledge/sync.py:51`. The first three already receive the `on_duplicate` / `on_committed` callbacks, so the latch-instead-of-read-back change here transplants directly; they are not folded in so this PR stays one defect in one module with its own strict-guard test.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a sync helper that touches `store.db` is called directly from an `async def` -- the lexical scanner cannot see it; ask "is every `self._<helper>()` call in this coroutine either offloaded or provably non-blocking?" A second, narrower pattern: reading a status back from the store after a pipeline call when the pipeline already reports that status through a callback inside its finalize hop.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A -- no user-facing behavior change)
- [x] No secrets, credentials, or internal references in the diff

