### PR TITLE
fix(context): skip full session-context re-injection on resumed sessions

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -2726,9 +2726,20 @@ class ContextBuilder:
 
         # Session context on first message only
         if is_new_session:
+            # Resumed sessions (ACP ``session/load`` restored the full native
+            # transcript) already carry the original session-start injection —
+            # agent prompt, memory, lessons, and skills are all preserved in
+            # the restored history. Re-injecting the full session context on
+            # every idle-expire → resume cycle stacks ~40K duplicate tokens
+            # into the same window and accelerates compaction. Inject only the
+            # minimal header (fresh date/time + identity) plus a resume marker
+            # so the model knows where the full context lives.
+            slim_resume = resumed and not minimal_context
             # Agent prompt goes BEFORE session context wrapper
             # so the LLM treats it as its identity, not background info.
-            if is_cc:
+            if slim_resume:
+                agent_prompt = ""
+            elif is_cc:
                 # CC gets the SAME KiroCrew persona prompt as kiro — including
                 # the Output Format rules (diff blocks, image embeds, OPTIONS)
                 # which are dashboard UI contracts, not kiro-specific. Only the
@@ -2769,7 +2780,7 @@ class ContextBuilder:
                 mode=mode,
                 blocks_reads=blocks_reads,
                 provider_type=provider_type,
-                minimal_context=minimal_context,
+                minimal_context=minimal_context or slim_resume,
                 runtime_source=runtime_source,
                 exclude_last_n=exclude_last_n,
                 model_window=model_window,
@@ -2802,7 +2813,27 @@ class ContextBuilder:
                     )
                 else:
                     session_ctx = _neutralize_structural_markers(session_ctx)
-                if minimal_context:
+                if slim_resume:
+                    # Re-anchor the critical rules (dashboard/Slack UI
+                    # contracts: diff blocks, [OPTIONS:] buttons, absolute
+                    # paths). They were injected at the original session start
+                    # but sit deep in — and may be compacted out of — the
+                    # restored transcript; at ~1.5K chars they are cheap
+                    # insurance against output-format drift. Same variant
+                    # selection and per-agent opt-out gate as session start.
+                    _resume_rules = (
+                        _critical_rules_for(session_key, runtime_source)
+                        if _agent_includes_crew_context(agent)
+                        else ""
+                    )
+                    parts.append(
+                        "[SESSION RESUMED — the full session context (agent "
+                        "system prompt, memory, lessons, skills) was injected "
+                        "at the original session start and is preserved in the "
+                        "restored conversation history above. Refreshed rules "
+                        "and date/identity follow.]\n" + _resume_rules + session_ctx
+                    )
+                elif minimal_context:
                     parts.append(session_ctx)
                 else:
                     parts.append(

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -360,6 +360,30 @@ class TestContextBuilder:
         assert "lobsters" in msg
         assert "hello" in msg
 
+    def test_build_message_resumed_session_slim_injection(self, tmp_path):
+        """A resumed session (ACP session/load restored native history) must
+        NOT re-inject the full session context — the restored transcript
+        already contains the original session-start injection. Only the
+        minimal header (date/identity) plus a resume marker is injected."""
+        ws = tmp_path / "ws"
+        store = MemoryStore(workspace=ws)
+        store.write("# Memory\n\nUser likes lobsters.")
+        builder = ContextBuilder(
+            memory=store,
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+        )
+        msg, _ = builder.build_message("hello", is_new_session=True, resumed=True)
+        assert "[SESSION RESUMED" in msg, "resume marker missing"
+        assert "[AGENT SYSTEM PROMPT]" not in msg, "persona must not be re-injected"
+        assert "lobsters" not in msg, "memory must not be re-injected"
+        assert "[CURRENT DATE]" in msg, "minimal date header missing"
+        assert "[CRITICAL RULES" in msg, "UI-contract rules must be re-anchored on resume"
+        assert "hello" in msg
+        # Control: a genuinely new (non-resumed) session keeps the full injection.
+        msg_full, _ = builder.build_message("hello", is_new_session=True, resumed=False)
+        assert "lobsters" in msg_full
+        assert "[SESSION RESUMED" not in msg_full
+
     def test_build_message_injects_folder_breadcrumb(self, tmp_path):
         builder = ContextBuilder(
             memory=MemoryStore(workspace=tmp_path / "ws"),


### PR DESCRIPTION
## Problem / Motivation

A session idle-expired and later resumed via ACP `session/load` restores the full native transcript, which already contains the original session-start injection (agent system prompt, memory, lessons, skills — ~45K tokens). `build_message()` treats every `is_new_session=True` as a cold start and re-injects the entire block, so **each idle-expire → resume cycle stacks another ~45K duplicate tokens into the same context window**.

The `resumed=True` flag today only skips the text thread-history fallback in `build_session_context` — the persona, memory, lessons, and skills are all re-injected on top of a transcript that already carries them.

## Why it matters

Any user who leaves a dashboard/Slack session idle past the eviction timeout (default 60 min) and comes back pays ~45K duplicate tokens per resume, on top of the per-request MCP tool-schema overhead. A long-lived session that cycles idle→resume a few times a day burns a large fraction of its effective context window on redundant copies of the same injection, accelerating compaction — which in turn degrades the model's recall of the real conversation. The cost of the injected block has grown roughly 10x since the resume path was first designed (more lessons, a much larger skills catalog), so what was once a cheap freshness guarantee is now a leading driver of context exhaustion.

## What changed (motivation → approach → change)

Observed symptom: resumed sessions re-carry the full session-start injection every cycle. Root cause: `build_message()` keys the full injection off `is_new_session` alone; `resumed` (native history restored by `session/load`) never reaches the injection decision. Approach: extend the same dedup principle `session/load` already applies to thread history — content preserved in the restored transcript is not injected a second time. Considered simply raising the idle timeout (works but only dilutes the cost) and skipping injection entirely on resume (rejected: the UI-contract rules may be compacted out of the restored transcript, and the model needs a fresh date).

The change, in `build_message()`:
- `slim_resume = resumed and not minimal_context` — on a resumed session, skip the agent-prompt injection and pass `minimal_context=True` to `build_session_context` (reusing the existing minimal path: fresh date/time + agent identity + runtime, ~200 tokens).
- Prepend a `[SESSION RESUMED]` marker pointing the model at the restored history.
- Re-anchor the critical-rules block (diff blocks, `[OPTIONS:]` buttons, absolute paths) — it may sit deep in, or be compacted out of, the restored transcript; ~1.5K chars is cheap insurance against output-format drift. Uses the same surface-variant selection (`_critical_rules_for`) and per-agent `includeCrewContext` opt-out gate as session start.
- Non-resumed cold starts keep the full injection unchanged.

## Tests

- New `test_build_message_resumed_session_slim_injection` locks in: a resumed session does NOT re-inject the persona (`[AGENT SYSTEM PROMPT]` absent) or memory (sentinel string absent), DOES carry the `[SESSION RESUMED]` marker + `[CRITICAL RULES` block + `[CURRENT DATE]` header, and the user text survives; a control assertion verifies a genuinely new (non-resumed) session keeps the full injection with memory present and no resume marker.
- Regression sweep: 205 passed across `test_context*.py`, `test_cron_minimal_context.py`, `test_subagent_context_groups.py`; 360 passed across `test_chat_runner_coverage.py`, `test_eager_spawn.py`, `test_subagent_continuable.py` (all files exercising `resumed=True`). flake8 clean on both changed files.

## Manual verification

The same change has been running on a production gateway (internal deployment of the vendored core) since 2026-08-31: after a gateway restart, the first resumed session was confirmed via logs to receive only the slim header (~200 tokens vs ~45K), with correct `[OPTIONS:]` / diff-block behavior in subsequent turns and no output-format drift.

## Pattern harvest

Not generalizable: the defect is cost drift on a deliberate design decision — full re-injection on resume was cheap when the injected block was small, and grew ~10x as lessons/skills accumulated — rather than a code pattern a scanner can match. The durable guard is the new regression test (`test_build_message_resumed_session_slim_injection`), which pins the resumed path to the slim injection so a future refactor of `build_message()` cannot silently reintroduce the full re-injection.
