### PR TITLE
fix(apps): promote inline srcDoc frames to their own layer (#8037)

### DIFF
--- a/website/src/apps/meetings/components/AgentPanel.tsx
+++ b/website/src/apps/meetings/components/AgentPanel.tsx
@@ -267,7 +267,14 @@ export default function AgentPanel({
             // boundary; the CSP above is the egress control the sandbox lacks.
             sandbox="allow-scripts"
             className="w-full border border-border rounded-md bg-white"
-            style={{ minHeight: 340, height: 340 }}
+            // The transform is the same compositing promotion every sandbox-doc
+            // frame carries: a laid-out document whose first paint is skipped
+            // shows an empty box (silent — correct height, no error state), and
+            // promoting the frame to its own layer is the remedy that needs no
+            // post-load timing. This frame builds its document inline (srcDoc,
+            // outside the sandbox-doc mint), so it was left out when the mint's
+            // consumers were promoted.
+            style={{ minHeight: 340, height: 340, transform: 'translateZ(0)' }}
           />
         ) : (
           <p className="text-[13px] text-muted">

--- a/website/src/apps/mochi/src/renderer/WidgetFrame.tsx
+++ b/website/src/apps/mochi/src/renderer/WidgetFrame.tsx
@@ -100,7 +100,21 @@ export const WidgetFrame: React.FC<WidgetFrameProps> = ({ html, title = 'Widget'
         ref={iframeRef}
         srcDoc={srcdoc}
         sandbox="allow-scripts"
-        style={{ width: '100%', height, border: 'none', background: '#fff', display: 'block' }}
+        style={{
+          width: '100%',
+          height,
+          border: 'none',
+          background: '#fff',
+          display: 'block',
+          // Same compositing promotion every sandbox-doc frame carries (see the
+          // dashboard WidgetFrame): an engine can lay this document out, run its
+          // scripts and report a correct height while never rasterizing it,
+          // which presents as an empty box rather than an error. Promoting the
+          // frame to its own layer is the one remedy that needs no timing. This
+          // frame builds its document inline (srcDoc, outside the sandbox-doc
+          // mint), so it was left out when the mint's consumers were promoted.
+          transform: 'translateZ(0)',
+        }}
         title={title}
       />
     </div>

--- a/website/src/apps/mochi/test/mochiWidgetFramePromotion.test.tsx
+++ b/website/src/apps/mochi/test/mochiWidgetFramePromotion.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Mochi WidgetFrame paint contract — the compositing promotion (#8037).
+ *
+ * The dashboard's sandbox-doc frames were all promoted to their own compositing
+ * layer (#7931) after an engine was measured laying a document out, running its
+ * scripts and reporting a correct height while rasterizing nothing — a
+ * correctly sized, visible frame painting an empty box, silent by construction.
+ * Mochi's widget frame renders the same kind of model-authored document but
+ * builds it inline via srcDoc, so it never reaches the mint and sat outside
+ * that PR's scope. It needs the same promotion for the same reason.
+ *
+ * A test DOM computes no layout and paints nothing, so dropping the property is
+ * invisible to every other assertion in this suite: the style assertion below
+ * is the whole guard.
+ */
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { WidgetFrame } from '../src/renderer/WidgetFrame'
+
+describe('mochi WidgetFrame paint contract', () => {
+  it('gives the frame its own compositing layer so a skipped first paint cannot blank it', () => {
+    const { container } = render(<WidgetFrame html="<p>promoted</p>" title="T" />)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    expect(iframe).not.toBeNull()
+    expect(iframe.style.transform).toBe('translateZ(0)')
+  })
+
+  it('keeps the promotion additive: the frame still fills its card and blocks out its height', () => {
+    // The transform must join the existing inline sizing, not replace it — a
+    // frame that lost `display: block` or its width would change geometry for
+    // every widget, which is a bigger regression than the one being fixed.
+    const { container } = render(<WidgetFrame html="<p>sized</p>" title="T" />)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    expect(iframe.style.display).toBe('block')
+    expect(iframe.style.width).toBe('100%')
+    // happy-dom serializes the `border` shorthand loosely, so match the style
+    // rather than the exact serialized string.
+    expect(iframe.style.borderStyle).toContain('none')
+    // The frame is the bottom element of a rounded, clipping card, so its
+    // bottom corners come from this wrapper. Promotion moves the frame onto
+    // its own layer, and rounded-clipping a composited descendant is
+    // compositor-side behaviour — pin the clip so the exposure stays guarded.
+    const wrapper = iframe.parentElement as HTMLElement
+    expect(wrapper.style.overflow).toBe('hidden')
+  })
+
+  it('keeps the frame sandboxed and its document minted, not the raw model HTML', () => {
+    // This file is the only test that mounts this component, so it also pins
+    // the security invariants the promotion must not disturb: the null-origin
+    // sandbox stays exactly allow-scripts, and the model HTML reaches the
+    // frame only through buildSrcdoc's document (CSP'd wrapper), never raw.
+    const { container } = render(<WidgetFrame html="<p>handoff</p>" title="T" />)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts')
+    const srcdoc = iframe.getAttribute('srcdoc')!
+    expect(srcdoc).not.toBe('<p>handoff</p>')
+    expect(srcdoc).toContain('<p>handoff</p>')
+  })
+})

--- a/website/src/test/MeetingsAgentPanel.test.tsx
+++ b/website/src/test/MeetingsAgentPanel.test.tsx
@@ -109,6 +109,24 @@ describe('AgentPanel — html output', () => {
     expect(container.querySelector('iframe')!.getAttribute('title')).toContain('Sketch Artist')
   })
 
+  it('gives the frame its own compositing layer so a skipped first paint cannot blank it', () => {
+    // Same mechanism and remedy as the dashboard's sandbox-doc frames (#7931):
+    // without layer promotion an engine can lay the document out, run its
+    // scripts and report a correct height while rasterizing nothing — a
+    // correctly sized, visible frame painting an empty box, silent by
+    // construction. This frame builds its document inline via srcDoc and never
+    // reaches the sandbox-doc mint, so it sat outside that PR's scope (#8037).
+    // Chromium in this DOM paints fine either way, so removing the property
+    // looks completely harmless here: this assertion is the whole guard.
+    const { container } = mount(HTML, { output: '<h1>promoted</h1>' })
+    const frame = container.querySelector('iframe') as HTMLIFrameElement
+    expect(frame.style.transform).toBe('translateZ(0)')
+    // The promotion is additive: the fixed sizing that reserves the panel's
+    // box must survive alongside it.
+    expect(frame.style.height).toBe('340px')
+    expect(frame.style.minHeight).toBe('340px')
+  })
+
   it('never hands the model document to srcDoc raw — it goes through buildSketchSrcdoc', () => {
     // This is the BLOCKING finding, as a test. The vulnerable version set
     // srcDoc={output} directly, so the srcdoc equalled the model HTML exactly


### PR DESCRIPTION
## Problem / Motivation

Two model-authored HTML frames build their document inline and hand it straight to `srcDoc`, never reaching the gateway sandbox-doc mint that #7931 covered:

| Frame | Site | Promotion before this PR |
|---|---|---|
| Mochi widget frame | `website/src/apps/mochi/src/renderer/WidgetFrame.tsx` (~:101) | **none** — no `transform` at all |
| Meetings agent panel (html widget) | `website/src/apps/meetings/components/AgentPanel.tsx` (~:251, `buildSketchSrcdoc` ~:260) | **none** — no `transform` at all |

Without layer promotion an engine can lay the document out, run its scripts, report a correct height, and never rasterize it: a correctly sized, visible frame painting an empty box, silent by construction — nothing fails, so there is no error state and no retry affordance. This is exactly the mechanism measured and fixed for the four `useSandboxDoc` consumers in #7931 (c222244568acf), whose commit message filed these inline frames as the tracked remainder: #8037.

## Why it matters

Both frames are model-output surfaces: Mochi's `<mcwidget>` renderer and the meetings sketch-artist panel. When the failure fires, the user's generated content silently doesn't exist — the worst kind of display bug, because the app looks healthy while showing nothing.

## What changed (motivation → approach → change)

Port #7931's exact remedy onto the two inline-srcDoc frames:

- `WidgetFrame.tsx`: add `transform: 'translateZ(0)'` to the iframe's inline style (composed into the existing style object; nothing dropped).
- `AgentPanel.tsx`: same one-line promotion on the html-output iframe.

Neither frame carried an existing transform, so the plain 3D form suffices (the compose-onto-`scale()` care #7931 needed on its gallery thumbnail does not apply here). Per #7931's invariants, **nothing** about sandbox flags, CSP, or how the documents are built changes — `buildSrcdoc` / `buildSketchSrcdoc` and both `sandbox` attributes are byte-identical.

**Scope.** This PR fixes the two frames #8037 names — the model-authored surfaces #7931's commit message filed as the remainder. The review pass for this PR enumerated the rest of the un-promoted inline-`srcDoc` population, which is deliberately out of scope here and filed as #8075: `McpAppFrame.tsx` (~:1018, the primary residual — `allow-scripts` + script-reported height), both `pptx-maker/BoardFrame.tsx` frames (2D `scale()` only, needs the compose treatment), and `FileRenderers.tsx` `HtmlViewer` (:267). Keeping this PR at the issue's two frames mirrors #7931's own scope discipline.

## Tests

- New `website/src/apps/mochi/test/mochiWidgetFramePromotion.test.tsx` — first test to mount this component:
  - pins `iframe.style.transform === 'translateZ(0)'` (the regression is invisible in Chromium and in a test DOM, so the style assertion is the whole guard, as #7931's tests state);
  - pins the promotion is additive (`display: block`, `width: 100%`, border style survive) and that the wrapper's `overflow: hidden` clip is still present (the frame's bottom corners come from the rounded card);
  - pins the security invariants the promotion must not disturb: `sandbox` is exactly `allow-scripts`, and the model HTML reaches the frame only through `buildSrcdoc`'s minted document, never raw.
- `website/src/test/MeetingsAgentPanel.test.tsx` — the html-output suite gains the same promotion pin plus the sizing-survives assertion.

Local gates, all green: `npx tsc -b`; full website vitest suite (1783 files) exit 0; `npx eslint src/ --max-warnings 597` → 0 errors, warnings at baseline; `npx jscpd .` → 0 clones; brand/feature-map/focus-cue root gates pass. Backend gates unaffected (frontend-only diff; CI skips backend jobs for this class).

## Manual verification

Rendered both components in the test DOM and inspected the produced inline styles; verified both `sandbox` attributes and both srcdoc builders are byte-unchanged against base (`git diff` shows style-object-only edits). The defect itself has no deterministic local reproduction (engine-dependent rasterization skip), which is why #7931 established source-level pins as the guard; this PR follows that precedent.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** `translateZ(0)` is a non-rendering compositing hint — on a correctly-rasterizing engine the before/after pixels are identical, so a screenshot pair would show two identical images (same waiver #7931 used for the same change class).

## Related Issues

Closes #8037
Refs #7931
Refs #8075 (follow-up: remaining un-promoted srcDoc frames, enumerated during this PR's review)

## Pattern harvest

The failure class is "sandboxed frame laid out but never rasterized"; the durable pattern is that every `srcDoc`/sandbox-doc frame needs `translateZ(0)` composed onto its transform, there is no enumerating test for the class, and each new frame must add its own pin. #8075 now carries the enumeration record for the remaining sites, so the next sweep starts from a list instead of a manual grep.

Rule candidate: every sandboxed `srcDoc`/sandbox-doc iframe must carry `translateZ(0)` composed onto its `transform` (a 2D transform alone makes a stacking context but does not promote), plus a source-level style assertion in its own test — the regression is invisible in Chromium and in a test DOM, so the pin is the whole guard.

## Checklist

- [x] Single commit, conventional-commit subject
- [x] Tests added mirroring #7931's promotion assertions
- [x] `npx tsc -b`, eslint ratchet, jscpd, full website suite green locally
- [x] No sandbox/CSP/document-construction changes
- [x] Brand name "Kiro Crew" respected; no hardcoded model IDs

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project license.

